### PR TITLE
Only output sourceURL if `SCRIPT_DEBUG` enabled.

### DIFF
--- a/src/wp-content/themes/twentyfifteen/functions.php
+++ b/src/wp-content/themes/twentyfifteen/functions.php
@@ -413,7 +413,7 @@ endif;
  */
 function twentyfifteen_javascript_detection() {
 	$js  = "(function(html){html.className = html.className.replace(/\bno-js\b/,'js')})(document.documentElement);";
-	$js .= "\n//# sourceURL=" . rawurlencode( __FUNCTION__ );
+	$js .= SCRIPT_DEBUG ? "\n//# sourceURL=" . rawurlencode( __FUNCTION__ ) : '';
 
 	if ( function_exists( 'wp_print_inline_script_tag' ) ) {
 		wp_print_inline_script_tag( $js );

--- a/src/wp-content/themes/twentyseventeen/functions.php
+++ b/src/wp-content/themes/twentyseventeen/functions.php
@@ -407,7 +407,7 @@ add_filter( 'excerpt_more', 'twentyseventeen_excerpt_more' );
  */
 function twentyseventeen_javascript_detection() {
 	$js  = "(function(html){html.className = html.className.replace(/\bno-js\b/,'js')})(document.documentElement);";
-	$js .= "\n//# sourceURL=" . rawurlencode( __FUNCTION__ );
+	$js .= SCRIPT_DEBUG ? "\n//# sourceURL=" . rawurlencode( __FUNCTION__ ) : '';
 
 	if ( function_exists( 'wp_print_inline_script_tag' ) ) {
 		wp_print_inline_script_tag( $js );

--- a/src/wp-content/themes/twentysixteen/functions.php
+++ b/src/wp-content/themes/twentysixteen/functions.php
@@ -381,7 +381,7 @@ endif;
  */
 function twentysixteen_javascript_detection() {
 	$js  = "(function(html){html.className = html.className.replace(/\bno-js\b/,'js')})(document.documentElement);";
-	$js .= "\n//# sourceURL=" . rawurlencode( __FUNCTION__ );
+	$js .= SCRIPT_DEBUG ? "\n//# sourceURL=" . rawurlencode( __FUNCTION__ ) : '';
 
 	if ( function_exists( 'wp_print_inline_script_tag' ) ) {
 		wp_print_inline_script_tag( $js );

--- a/src/wp-content/themes/twentytwenty/inc/template-tags.php
+++ b/src/wp-content/themes/twentytwenty/inc/template-tags.php
@@ -662,7 +662,7 @@ add_filter( 'walker_nav_menu_start_el', 'twentytwenty_nav_menu_social_icons', 10
  */
 function twentytwenty_no_js_class() {
 	$js  = "document.documentElement.className = document.documentElement.className.replace( 'no-js', 'js' );";
-	$js .= "\n//# sourceURL=" . rawurlencode( __FUNCTION__ );
+	$js .= SCRIPT_DEBUG ? "\n//# sourceURL=" . rawurlencode( __FUNCTION__ ) : '';
 
 	if ( function_exists( 'wp_print_inline_script_tag' ) ) {
 		wp_print_inline_script_tag( $js );

--- a/src/wp-content/themes/twentytwentyone/classes/class-twenty-twenty-one-dark-mode.php
+++ b/src/wp-content/themes/twentytwentyone/classes/class-twenty-twenty-one-dark-mode.php
@@ -367,7 +367,7 @@ class Twenty_Twenty_One_Dark_Mode {
 	public function the_script() {
 		$path = 'assets/js/dark-mode-toggler.js';
 		$js   = rtrim( file_get_contents( trailingslashit( get_template_directory() ) . $path ) );
-		$js  .= "\n//# sourceURL=" . esc_url_raw( trailingslashit( get_template_directory_uri() ) . $path );
+		$js  .= SCRIPT_DEBUG ? "\n//# sourceURL=" . esc_url_raw( trailingslashit( get_template_directory_uri() ) . $path ) : '';
 		if ( function_exists( 'wp_print_inline_script_tag' ) ) {
 			wp_print_inline_script_tag( $js );
 		} else {

--- a/src/wp-content/themes/twentytwentyone/functions.php
+++ b/src/wp-content/themes/twentytwentyone/functions.php
@@ -600,7 +600,7 @@ function twentytwentyone_add_ie_class() {
 			document.body.classList.add('is-IE');
 		}
 	";
-	$script .= '//# sourceURL=' . rawurlencode( __FUNCTION__ );
+	$script .= SCRIPT_DEBUG ? "\n//# sourceURL=" . rawurlencode( __FUNCTION__ ) : '';
 
 	if ( function_exists( 'wp_print_inline_script_tag' ) ) {
 		wp_print_inline_script_tag( $script );

--- a/src/wp-content/themes/twentytwentyone/inc/template-functions.php
+++ b/src/wp-content/themes/twentytwentyone/inc/template-functions.php
@@ -75,7 +75,7 @@ add_action( 'wp_head', 'twenty_twenty_one_pingback_header' );
  */
 function twenty_twenty_one_supports_js() {
 	$js  = "document.body.classList.remove('no-js');";
-	$js .= "\n//# sourceURL=" . rawurlencode( __FUNCTION__ );
+	$js .= SCRIPT_DEBUG ? "\n//# sourceURL=" . rawurlencode( __FUNCTION__ ) : '';
 
 	if ( function_exists( 'wp_print_inline_script_tag' ) ) {
 		wp_print_inline_script_tag( $js );

--- a/src/wp-includes/class-wp-customize-manager.php
+++ b/src/wp-includes/class-wp-customize-manager.php
@@ -479,7 +479,7 @@ final class WP_Customize_Manager {
 			} )( wp.customize, <?php echo wp_json_encode( $settings, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ); ?> );
 			</script>
 			<?php
-			$message .= wp_get_inline_script_tag( wp_remove_surrounding_empty_script_tags( ob_get_clean() ) . "\n//# sourceURL=" . rawurlencode( __METHOD__ ) );
+			$message .= wp_get_inline_script_tag( wp_remove_surrounding_empty_script_tags( ob_get_clean() ) . ( SCRIPT_DEBUG ? "\n//# sourceURL=" . rawurlencode( __METHOD__ ) : '' ) );
 		}
 
 		wp_die( $message );
@@ -2105,7 +2105,7 @@ final class WP_Customize_Manager {
 		} )();
 		</script>
 		<?php
-		wp_print_inline_script_tag( wp_remove_surrounding_empty_script_tags( ob_get_clean() ) . "\n//# sourceURL=" . rawurlencode( __METHOD__ ) );
+		wp_print_inline_script_tag( wp_remove_surrounding_empty_script_tags( ob_get_clean() ) . ( SCRIPT_DEBUG ? "\n//# sourceURL=" . rawurlencode( __METHOD__ ) : '' ) );
 	}
 
 	/**
@@ -2227,7 +2227,7 @@ final class WP_Customize_Manager {
 			})( _wpCustomizeSettings.values );
 		</script>
 		<?php
-		wp_print_inline_script_tag( wp_remove_surrounding_empty_script_tags( ob_get_clean() ) . "\n//# sourceURL=" . rawurlencode( __METHOD__ ) );
+		wp_print_inline_script_tag( wp_remove_surrounding_empty_script_tags( ob_get_clean() ) . ( SCRIPT_DEBUG ? "\n//# sourceURL=" . rawurlencode( __METHOD__ ) : '' ) );
 	}
 
 	/**
@@ -5022,7 +5022,7 @@ final class WP_Customize_Manager {
 			?>
 		</script>
 		<?php
-		wp_print_inline_script_tag( wp_remove_surrounding_empty_script_tags( ob_get_clean() ) . "\n//# sourceURL=" . rawurlencode( __METHOD__ ) );
+		wp_print_inline_script_tag( wp_remove_surrounding_empty_script_tags( ob_get_clean() ) . ( SCRIPT_DEBUG ? "\n//# sourceURL=" . rawurlencode( __METHOD__ ) : '' ) );
 	}
 
 	/**

--- a/src/wp-includes/class-wp-customize-nav-menus.php
+++ b/src/wp-includes/class-wp-customize-nav-menus.php
@@ -1556,7 +1556,7 @@ final class WP_Customize_Nav_Menus {
 		$exports = array(
 			'navMenuInstanceArgs' => $this->preview_nav_menu_instance_args,
 		);
-		wp_print_inline_script_tag( sprintf( 'var _wpCustomizePreviewNavMenusExports = %s;', wp_json_encode( $exports, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ) ) . "\n//# sourceURL=" . rawurlencode( __METHOD__ ) );
+		wp_print_inline_script_tag( sprintf( 'var _wpCustomizePreviewNavMenusExports = %s;', wp_json_encode( $exports, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ) ) . ( SCRIPT_DEBUG ? "\n//# sourceURL=" . rawurlencode( __METHOD__ ) : '' ) );
 	}
 
 	/**

--- a/src/wp-includes/class-wp-customize-widgets.php
+++ b/src/wp-includes/class-wp-customize-widgets.php
@@ -1335,7 +1335,7 @@ final class WP_Customize_Widgets {
 			unset( $registered_widget['callback'] ); // May not be JSON-serializable.
 		}
 		wp_print_inline_script_tag(
-			sprintf( 'var _wpWidgetCustomizerPreviewSettings = %s;', wp_json_encode( $settings, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ) ) . "\n//# sourceURL=" . rawurlencode( __METHOD__ )
+			sprintf( 'var _wpWidgetCustomizerPreviewSettings = %s;', wp_json_encode( $settings, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ) ) . ( SCRIPT_DEBUG ? "\n//# sourceURL=" . rawurlencode( __METHOD__ ) : '' )
 		);
 	}
 

--- a/src/wp-includes/class-wp-scripts.php
+++ b/src/wp-includes/class-wp-scripts.php
@@ -233,7 +233,7 @@ class WP_Scripts extends WP_Dependencies {
 		 * The line-based sourceURL comments may break concatenated scripts
 		 * and do not make sense when multiple scripts are joined together.
 		 */
-		if ( ! $this->do_concat ) {
+		if ( ! $this->do_concat && SCRIPT_DEBUG ) {
 			$output .= sprintf(
 				"\n//# sourceURL=%s",
 				rawurlencode( "{$handle}-js-extra" )
@@ -362,7 +362,7 @@ class WP_Scripts extends WP_Dependencies {
 			 * Include the sourceURL comment here as it would be when printed directly.
 			 */
 			$source_url    = rawurlencode( "{$handle}-js-translations" );
-			$translations .= "\n//# sourceURL={$source_url}";
+			$translations .= SCRIPT_DEBUG ? "\n//# sourceURL={$source_url}" : '';
 			$translations  = wp_get_inline_script_tag( $translations, array( 'id' => "{$handle}-js-translations" ) );
 		}
 
@@ -569,10 +569,12 @@ class WP_Scripts extends WP_Dependencies {
 		 * Inline scripts prevent scripts from being concatenated, so
 		 * sourceURL comments are safe to print for inline scripts.
 		 */
-		$data[] = sprintf(
-			'//# sourceURL=%s',
-			rawurlencode( "{$handle}-js-{$position}" )
-		);
+		if ( SCRIPT_DEBUG ) {
+			$data[] = sprintf(
+				'//# sourceURL=%s',
+				rawurlencode( "{$handle}-js-{$position}" )
+			);
+		}
 
 		return trim( implode( "\n", $data ), "\n" );
 	}
@@ -756,7 +758,7 @@ JS;
 
 		if ( $display ) {
 			$source_url = rawurlencode( "{$handle}-js-translations" );
-			$output    .= "\n//# sourceURL={$source_url}";
+			$output    .= SCRIPT_DEBUG ? "\n//# sourceURL={$source_url}" : '';
 			wp_print_inline_script_tag( $output, array( 'id' => "{$handle}-js-translations" ) );
 		}
 

--- a/src/wp-includes/class-wp-styles.php
+++ b/src/wp-includes/class-wp-styles.php
@@ -320,10 +320,12 @@ class WP_Styles extends WP_Dependencies {
 				$source_url = rawurlencode( "{$handle}-inline-css" );
 			}
 
-			$output[] = sprintf(
-				'/*# sourceURL=%s */',
-				$source_url
-			);
+			if ( SCRIPT_DEBUG ) {
+				$output[] = sprintf(
+					'/*# sourceURL=%s */',
+					$source_url
+				);
+			}
 		}
 
 		$output = implode( "\n", $output );

--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -1374,7 +1374,7 @@ function wp_comment_form_unfiltered_html_nonce() {
 
 	if ( current_user_can( 'unfiltered_html' ) ) {
 		wp_nonce_field( 'unfiltered-html-comment_' . $post_id, '_wp_unfiltered_html_comment_disabled', false );
-		wp_print_inline_script_tag( "(function(){if(window===window.parent){document.getElementById('_wp_unfiltered_html_comment_disabled').name='_wp_unfiltered_html_comment';}})();\n//# sourceURL=" . rawurlencode( __FUNCTION__ ) );
+		wp_print_inline_script_tag( "(function(){if(window===window.parent){document.getElementById('_wp_unfiltered_html_comment_disabled').name='_wp_unfiltered_html_comment';}})();" . ( SCRIPT_DEBUG ? "\n//# sourceURL=" . rawurlencode( __FUNCTION__ ) : '' ) );
 	}
 }
 

--- a/src/wp-includes/customize/class-wp-customize-selective-refresh.php
+++ b/src/wp-includes/customize/class-wp-customize-selective-refresh.php
@@ -193,7 +193,13 @@ final class WP_Customize_Selective_Refresh {
 		);
 
 		// Export data to JS.
-		wp_print_inline_script_tag( sprintf( 'var _customizePartialRefreshExports = %s;', wp_json_encode( $exports, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ) ) . "\n//# sourceURL=" . rawurlencode( __METHOD__ ) );
+		wp_print_inline_script_tag(
+			sprintf(
+				'var _customizePartialRefreshExports = %s;',
+				wp_json_encode( $exports, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES )
+			) .
+			( SCRIPT_DEBUG ? "\n//# sourceURL=" . rawurlencode( __METHOD__ ) : '' )
+		);
 	}
 
 	/**

--- a/src/wp-includes/embed.php
+++ b/src/wp-includes/embed.php
@@ -531,7 +531,7 @@ function get_post_embed_html( $width, $height, $post = null ) {
 	 */
 	$js_path = '/js/wp-embed' . wp_scripts_get_suffix() . '.js';
 	$output .= wp_get_inline_script_tag(
-		trim( file_get_contents( ABSPATH . WPINC . $js_path ) ) . "\n//# sourceURL=" . esc_url_raw( includes_url( $js_path ) )
+		trim( file_get_contents( ABSPATH . WPINC . $js_path ) ) . ( SCRIPT_DEBUG ? "\n//# sourceURL=" . esc_url_raw( includes_url( $js_path ) ) : '' )
 	);
 
 	/**
@@ -1103,7 +1103,7 @@ function wp_enqueue_embed_styles() {
 function print_embed_scripts() {
 	$js_path = '/js/wp-embed-template' . wp_scripts_get_suffix() . '.js';
 	wp_print_inline_script_tag(
-		trim( file_get_contents( ABSPATH . WPINC . $js_path ) ) . "\n//# sourceURL=" . esc_url_raw( includes_url( $js_path ) )
+		trim( file_get_contents( ABSPATH . WPINC . $js_path ) ) . ( SCRIPT_DEBUG ? "\n//# sourceURL=" . esc_url_raw( includes_url( $js_path ) ) : '' )
 	);
 }
 

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -5983,8 +5983,8 @@ function _print_emoji_detection_script() {
 
 	$emoji_loader_script_path = '/js/wp-emoji-loader' . wp_scripts_get_suffix() . '.js';
 	wp_print_inline_script_tag(
-		rtrim( file_get_contents( ABSPATH . WPINC . $emoji_loader_script_path ) ) . "\n" .
-		'//# sourceURL=' . esc_url_raw( includes_url( $emoji_loader_script_path ) ),
+		rtrim( file_get_contents( ABSPATH . WPINC . $emoji_loader_script_path ) ) .
+		( SCRIPT_DEBUG ? "\n//# sourceURL=" . esc_url_raw( includes_url( $emoji_loader_script_path ) ) : '' ),
 		array(
 			'type' => 'module',
 		)

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -7830,7 +7830,11 @@ function wp_post_preview_js() {
 			window.addEventListener( 'pagehide', function() { window.name = ''; } );
 		}
 	}());
-	//# sourceURL=<?php echo rawurlencode( __FUNCTION__ ); ?>
+	<?php
+	if ( SCRIPT_DEBUG ) {
+		echo '//# sourceURL=' . rawurlencode( __FUNCTION__ ) . "\n";
+	}
+	?>
 	</script>
 	<?php
 	wp_print_inline_script_tag( wp_remove_surrounding_empty_script_tags( ob_get_clean() ) );

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2229,7 +2229,7 @@ function _print_scripts() {
 		if ( ! empty( $wp_scripts->print_code ) ) {
 			echo "\n<script>\n";
 			echo $wp_scripts->print_code;
-			echo sprintf( "\n//# sourceURL=%s\n", rawurlencode( 'js-inline-concat-' . $concat ) );
+			echo SCRIPT_DEBUG ? sprintf( "\n//# sourceURL=%s\n", rawurlencode( 'js-inline-concat-' . $concat ) ) : '';
 			echo "</script>\n";
 		}
 
@@ -2434,7 +2434,7 @@ function _print_styles() {
 			$processor = new WP_HTML_Tag_Processor( '<style></style>' );
 			$processor->next_tag();
 			$style_tag_contents = "\n{$wp_styles->print_code}\n"
-				. sprintf( "/*# sourceURL=%s */\n", rawurlencode( $concat_source_url ) );
+				. ( SCRIPT_DEBUG ? sprintf( "/*# sourceURL=%s */\n", rawurlencode( $concat_source_url ) ) : '' );
 			$processor->set_modifiable_text( $style_tag_contents );
 			echo "{$processor->get_updated_html()}\n";
 		}

--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -3812,7 +3812,7 @@ function wp_customize_support_script() {
 		}());
 	</script>
 	<?php
-	wp_print_inline_script_tag( wp_remove_surrounding_empty_script_tags( ob_get_clean() ) . "\n//# sourceURL=" . rawurlencode( __FUNCTION__ ) );
+	wp_print_inline_script_tag( wp_remove_surrounding_empty_script_tags( ob_get_clean() ) . ( SCRIPT_DEBUG ? "\n//# sourceURL=" . rawurlencode( __FUNCTION__ ) : '' ) );
 }
 
 /**

--- a/src/wp-includes/widgets/class-wp-widget-archives.php
+++ b/src/wp-includes/widgets/class-wp-widget-archives.php
@@ -137,7 +137,7 @@ class WP_Widget_Archives extends WP_Widget {
 })( <?php echo wp_json_encode( $dropdown_id, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ); ?> );
 </script>
 			<?php
-			wp_print_inline_script_tag( wp_remove_surrounding_empty_script_tags( ob_get_clean() ) . "\n//# sourceURL=" . rawurlencode( __METHOD__ ) );
+			wp_print_inline_script_tag( wp_remove_surrounding_empty_script_tags( ob_get_clean() ) . ( SCRIPT_DEBUG ? "\n//# sourceURL=" . rawurlencode( __METHOD__ ) : '' ) );
 		} else {
 			$format = current_theme_supports( 'html5', 'navigation-widgets' ) ? 'html5' : 'xhtml';
 

--- a/src/wp-includes/widgets/class-wp-widget-categories.php
+++ b/src/wp-includes/widgets/class-wp-widget-categories.php
@@ -125,7 +125,7 @@ class WP_Widget_Categories extends WP_Widget {
 </script>
 
 			<?php
-			wp_print_inline_script_tag( wp_remove_surrounding_empty_script_tags( ob_get_clean() ) . "\n//# sourceURL=" . rawurlencode( __METHOD__ ) );
+			wp_print_inline_script_tag( wp_remove_surrounding_empty_script_tags( ob_get_clean() ) . ( SCRIPT_DEBUG ? "\n//# sourceURL=" . rawurlencode( __METHOD__ ) : '' ) );
 		} else {
 			$format = current_theme_supports( 'html5', 'navigation-widgets' ) ? 'html5' : 'xhtml';
 


### PR DESCRIPTION
Modifies the sourceURL output so it's only done if the `SCRIPT_DEBUG` constant is set to true.

Trac ticket: https://core.trac.wordpress.org/ticket/64369

## Testing notes

1. Add `define( 'SCRIPT_DEBUG', false );` to your wp-config file
2. Generate some content with various block types
3. Activate a classic theme
4. Ensure the hoisted styles block do not include the sourceurl
5. Activate a block theme
6. Ensure the block styles do not include the sourceurl
7. Update the defintion above to `define( 'SCRIPT_DEBUG', true );`
8. Reload the page 
9. Ensure the block styles do include the sourceurl
10. Reactivate the classic theme
11. Ensure the hoisted block styles do include the sourceurl

## Use of AI Tools

Copilot helped with auto-complete/type ahead.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
