### PR TITLE
Advertise the command palette in the admin bar

### DIFF
--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -935,6 +935,45 @@ function wp_admin_bar_edit_menu( $wp_admin_bar ) {
 }
 
 /**
+ * Adds the command palette trigger button.
+ *
+ * Displays a button in the admin bar that shows the keyboard shortcut
+ * for opening the command palette.
+ *
+ * @since 7.0.0
+ *
+ * @param WP_Admin_Bar $wp_admin_bar The WP_Admin_Bar instance.
+ */
+function wp_admin_bar_command_palette_menu( $wp_admin_bar ) {
+	if ( ! is_admin() ) {
+		return;
+	}
+
+	$wp_admin_bar->add_node(
+		array(
+			'id'    => 'command-palette',
+			'title' => '<span class="ab-label" aria-hidden="true"></span>' .
+					'<span class="screen-reader-text">' .
+					/* translators: Hidden accessibility text. */
+					__( 'Open command palette' ) .
+					'</span>',
+			'href'  => '#',
+		)
+	);
+
+	wp_add_inline_script(
+		'admin-bar',
+		'( function() {
+			var isMac = window.navigator.platform.indexOf( "Mac" ) !== -1;
+			var label = document.querySelector( "#wp-admin-bar-command-palette .ab-label" );
+			if ( label ) {
+				label.textContent = isMac ? "\u2318K" : "Ctrl+K";
+			}
+		} )();'
+	);
+}
+
+/**
  * Adds "Add New" menu.
  *
  * @since 3.1.0

--- a/src/wp-includes/class-wp-admin-bar.php
+++ b/src/wp-includes/class-wp-admin-bar.php
@@ -661,6 +661,9 @@ class WP_Admin_Bar {
 		add_action( 'admin_bar_menu', 'wp_admin_bar_customize_menu', 40 );
 		add_action( 'admin_bar_menu', 'wp_admin_bar_updates_menu', 50 );
 
+		// Command palette.
+		add_action( 'admin_bar_menu', 'wp_admin_bar_command_palette_menu', 55 );
+
 		// Content-related.
 		if ( ! is_network_admin() && ! is_user_admin() ) {
 			add_action( 'admin_bar_menu', 'wp_admin_bar_comments_menu', 60 );


### PR DESCRIPTION
This PR adds a button to invoke the command palette from the admin bar. The button label renders the symbolic "Command K" for Mac and "Ctrl+K" on all other platforms.

@annezazu mentioned the possibility of using AI and Playground for addressing this ticket, and we gave it a shot with Claude. It took some correction, but the result seems simple enough. I'm not sure whether the hotkey text should be translatable but guess it does not.

Trac ticket: https://core.trac.wordpress.org/ticket/64672

## Use of AI Tools

This patch was generated using Claude Code with a few manual changes.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
