### PR TITLE
Cleanup: remove unused variable in wp_unique_filename function

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -2556,7 +2556,6 @@ function _wp_upload_dir( $time = null ) {
 function wp_unique_filename( $dir, $filename, $unique_filename_callback = null ) {
 	// Sanitize the file name before we begin processing.
 	$filename = sanitize_file_name( $filename );
-	$ext2     = null;
 
 	// Initialize vars used in the wp_unique_filename filter.
 	$number        = '';


### PR DESCRIPTION
The usage of `$ext2` in `wp_unique_filename()` was removed in https://core.trac.wordpress.org/changeset/51653
So we can remove this initialisation.

Trac ticket: https://core.trac.wordpress.org/ticket/64675

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
