### PR TITLE
Fix: Inconsistent vertical spacing in “At a Glance” widget between he…

### DIFF
--- a/src/wp-admin/css/dashboard.css
+++ b/src/wp-admin/css/dashboard.css
@@ -721,14 +721,6 @@ body #dashboard-widgets .postbox form .submit {
 	margin-bottom: 10px;
 }
 
-#dashboard_right_now .inside {
-	padding: 0;
-}
-
-#dashboard_right_now .main {
-	padding: 16px 16px 11px;
-}
-
 #dashboard_right_now .main p {
 	margin: 0;
 }


### PR DESCRIPTION
Ticket : https://core.trac.wordpress.org/ticket/64682

## Summary

This patch standardizes the vertical spacing between the heading and the first content item in the “At a Glance” admin dashboard widget to match the spacing conventions used by other dashboard widgets.

## Description

The “At a Glance” widget currently exhibits noticeably larger vertical spacing between the widget title and its first content line (e.g., “1 Published post”) compared to other dashboard widgets. This inconsistency affects the visual rhythm of the admin dashboard and deviates from expected UI spacing standards.

This change adjusts the relevant CSS styles so that the spacing between the heading and content aligns with other widgets, improving visual consistency and coherence within the Dashboard.

## Changes Included

- Modified CSS for the “At a Glance” widget to reduce the vertical spacing between the widget heading and the first content element.
- Ensured the updated spacing matches that of other core dashboard widgets for a consistent layout.
- No functional behavior changes beyond visual spacing adjustments.

## Rationale

- Corrects a UI inconsistency introduced in the admin dashboard layout.
- Aligns the “At a Glance” widget with existing spacing conventions for better visual harmony and user experience.

## Testing

- Verified the updated spacing on a clean install of WordPress trunk (7.0), default theme, and no active plugins.
- Confirmed that the adjusted spacing matches other dashboard widgets without visual regressions.

## Screenshot

<img width="667" height="615" alt="image" src="https://github.com/user-attachments/assets/e9577658-9b55-40a3-9d7d-328f2046a92b" />
