### PR TITLE
Fix: Dismiss text and close icon not vertically center aligned in Dashboard welcome banner

### DIFF
--- a/src/wp-admin/css/dashboard.css
+++ b/src/wp-admin/css/dashboard.css
@@ -219,10 +219,12 @@
 }
 
 .welcome-panel .welcome-panel-close {
+	display: flex;
+	align-items: center;
 	position: absolute;
 	top: 10px;
 	right: 10px;
-	padding: 10px 15px 10px 24px;
+	padding: 10px 15px;
 	font-size: 13px;
 	line-height: 1.23076923; /* Chrome rounding, needs to be 16px equivalent */
 	text-decoration: none;
@@ -230,9 +232,6 @@
 }
 
 .welcome-panel .welcome-panel-close:before {
-	position: absolute;
-	top: 8px;
-	left: 0;
 	transition: all .1s ease-in-out;
 	content: '\f335';
 	font-size: 24px;


### PR DESCRIPTION
Ticket: https://core.trac.wordpress.org/ticket/64681

## Summary

This patch corrects the vertical alignment of the “Dismiss” label and the close (“X”) icon in the Dashboard Welcome banner so both elements are visually centered and consistently aligned within the banner area.

## Description

On a fresh install of WordPress (7.0) with no plugins active and the default theme, the “Dismiss” text and associated close icon in the Dashboard welcome banner appear slightly misaligned vertically relative to each other and the banner height. This discrepancy is a CSS alignment issue that affects visual harmony and consistency with the admin UI.

This change updates the necessary CSS styles to ensure both the “Dismiss” text and the close icon are vertically center aligned within the welcome banner. It aligns visual layout with expected admin design standards without altering functional behavior.

## Changes Included

- Adjusted CSS rules for the Dashboard welcome banner to vertically center the “Dismiss” text and close (“X”) icon.
- No functional behavior changes beyond visual alignment adjustments.

## Rationale

- Improves visual consistency of the welcome banner.
- Ensures UI alignment matches WordPress admin styling norms.
- Eliminates a small but noticeable layout misalignment in the core Dashboard interface.

## Testing

- Tested in a clean WordPress 7.0 install with default theme and no active plugins.
- Verified vertical alignment of “Dismiss” text and close icon in multiple admin color schemes.
- Confirmed no regressions in adjacent UI elements. 

 ## Screenshot

<img width="1524" height="475" alt="image" src="https://github.com/user-attachments/assets/74acfc52-06bd-4bf0-8962-87ebd12570d2" />
