### PR TITLE
Docs: Explicitly return `null` when documented instead of `void` in filesystem and category functions.

### DIFF
--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -2187,7 +2187,7 @@ function WP_Filesystem( $args = false, $context = false, $allow_relaxed_file_own
 		$abstraction_file = apply_filters( 'filesystem_method_file', ABSPATH . 'wp-admin/includes/class-wp-filesystem-' . $method . '.php', $method );
 
 		if ( ! file_exists( $abstraction_file ) ) {
-			return;
+			return null;
 		}
 
 		require_once $abstraction_file;

--- a/src/wp-admin/includes/plugin.php
+++ b/src/wp-admin/includes/plugin.php
@@ -926,7 +926,7 @@ function delete_plugins( $plugins, $deprecated = '' ) {
 			require_once ABSPATH . 'wp-admin/admin-footer.php';
 			exit;
 		}
-		return;
+		return null;
 	}
 
 	if ( ! WP_Filesystem( $credentials ) ) {
@@ -941,7 +941,7 @@ function delete_plugins( $plugins, $deprecated = '' ) {
 			require_once ABSPATH . 'wp-admin/admin-footer.php';
 			exit;
 		}
-		return;
+		return null;
 	}
 
 	if ( ! is_object( $wp_filesystem ) ) {

--- a/src/wp-admin/includes/theme.php
+++ b/src/wp-admin/includes/theme.php
@@ -40,7 +40,7 @@ function delete_theme( $stylesheet, $redirect = '' ) {
 			require_once ABSPATH . 'wp-admin/admin-footer.php';
 			exit;
 		}
-		return;
+		return null;
 	}
 
 	if ( ! WP_Filesystem( $credentials ) ) {
@@ -55,7 +55,7 @@ function delete_theme( $stylesheet, $redirect = '' ) {
 			require_once ABSPATH . 'wp-admin/admin-footer.php';
 			exit;
 		}
-		return;
+		return null;
 	}
 
 	if ( ! is_object( $wp_filesystem ) ) {

--- a/src/wp-includes/category.php
+++ b/src/wp-includes/category.php
@@ -144,7 +144,7 @@ function get_category_by_path( $category_path, $full_match = true, $output = OBJ
 	);
 
 	if ( empty( $categories ) ) {
-		return;
+		return null;
 	}
 
 	foreach ( $categories as $category ) {


### PR DESCRIPTION
The `@return` tags for these functions indicate they may return `null`.  
This fixes "Missing return argument" warnings that PHPStan (level 1) and IDEs report when a bare `return;` is used in a function documented to return a typed value including `null`.

## Affected Functions and Files

- `WP_Filesystem()` in `wp-admin/includes/file.php`
- `delete_plugins()` in `wp-admin/includes/plugin.php` (2 occurrences)
- `delete_theme()` in `wp-admin/includes/theme.php` (2 occurrences)
- `get_category_by_path()` in `wp-includes/category.php`

## Details

In each case, the function's `@return` tag already documents `null` as a possible return value (e.g. `@return bool|null|WP_Error`), but the early exit paths used a bare `return;`, which implicitly returns `void`.

Related: Trac [#64238](https://core.trac.wordpress.org/ticket/64238)