### PR TITLE
Docs: correct get_post_custom() return description

### DIFF
--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -2828,9 +2828,8 @@ function unregister_post_meta( $post_type, $meta_key ) {
  * @since 1.2.0
  *
  * @param int $post_id Optional. Post ID. Default is the ID of the global `$post`.
- * @return mixed An array of values.
- *               False for an invalid `$post_id` (non-numeric, zero, or negative value).
- *               An empty string if a valid but non-existing post ID is passed.
+ * @return array|false Array of post meta values keyed by meta key, or false on failure.
+ *                     Returns an empty array if the post has no custom fields.
  */
 function get_post_custom( $post_id = 0 ) {
 	$post_id = absint( $post_id );

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -2828,8 +2828,8 @@ function unregister_post_meta( $post_type, $meta_key ) {
  * @since 1.2.0
  *
  * @param int $post_id Optional. Post ID. Default is the ID of the global `$post`.
- * @return array|false Array of post meta values keyed by meta key, or false on failure.
- *                     Returns an empty array if the post has no custom fields.
+ * @return array<string, mixed>|false Array of post meta values keyed by meta key, or false on failure.
+ *                                    Returns an empty array if the post has no custom fields.
  */
 function get_post_custom( $post_id = 0 ) {
 	$post_id = absint( $post_id );

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -2828,8 +2828,11 @@ function unregister_post_meta( $post_type, $meta_key ) {
  * @since 1.2.0
  *
  * @param int $post_id Optional. Post ID. Default is the ID of the global `$post`.
- * @return array<string, mixed>|false Array of post meta values keyed by meta key, or false on failure.
- *                                    Returns an empty array if the post has no custom fields.
+ * @return array<string, array<int, string>>|false Array of post meta values keyed by meta key, or false on failure.
+ *                                                 Post meta values will always be strings, even for values which would
+ *                                                 otherwise be retrieved individually as arrays or objects via
+ *                                                 {@see get_post_meta()}. An empty array is returned if the post has
+ *                                                 no custom fields.
  */
 function get_post_custom( $post_id = 0 ) {
 	$post_id = absint( $post_id );

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -2832,7 +2832,7 @@ function unregister_post_meta( $post_type, $meta_key ) {
  *                                                 Post meta values will always be strings, even for values which would
  *                                                 otherwise be retrieved individually as arrays or objects via
  *                                                 {@see get_post_meta()}. An empty array is returned if the post has
- *                                                 no custom fields.
+ *                                                 no post meta.
  */
 function get_post_custom( $post_id = 0 ) {
 	$post_id = absint( $post_id );


### PR DESCRIPTION

Trac ticket: https://core.trac.wordpress.org/ticket/60646
### Summary
Updates the `get_post_custom()` docblock in `src/wp-includes/post.php` to remove the incorrect claim that negative post IDs are invalid. Negative IDs are normalized via `absint()` in the function, so they should not be documented as invalid.

### Changes
- Docblock only (no functional code changes)

### Tested
- Docs-only change (no runtime behavior affected)