### PR TITLE
Add wp prefix to enable_real_time_collaboration option.

### DIFF
--- a/src/wp-admin/includes/schema.php
+++ b/src/wp-admin/includes/schema.php
@@ -409,163 +409,163 @@ function populate_options( array $options = array() ) {
 	}
 
 	$defaults = array(
-		'siteurl'                         => $guessurl,
-		'home'                            => $guessurl,
-		'blogname'                        => __( 'My Site' ),
-		'blogdescription'                 => '',
-		'users_can_register'              => 0,
-		'admin_email'                     => 'you@example.com',
+		'siteurl'                           => $guessurl,
+		'home'                              => $guessurl,
+		'blogname'                          => __( 'My Site' ),
+		'blogdescription'                   => '',
+		'users_can_register'                => 0,
+		'admin_email'                       => 'you@example.com',
 		/* translators: Default start of the week. 0 = Sunday, 1 = Monday. */
-		'start_of_week'                   => _x( '1', 'start of week' ),
-		'use_balanceTags'                 => 0,
-		'use_smilies'                     => 1,
-		'require_name_email'              => 1,
-		'comments_notify'                 => 1,
-		'posts_per_rss'                   => 10,
-		'rss_use_excerpt'                 => 0,
-		'mailserver_url'                  => 'mail.example.com',
-		'mailserver_login'                => 'login@example.com',
-		'mailserver_pass'                 => '',
-		'mailserver_port'                 => 110,
-		'default_category'                => 1,
-		'default_comment_status'          => 'open',
-		'default_ping_status'             => 'open',
-		'default_pingback_flag'           => 1,
-		'posts_per_page'                  => 10,
+		'start_of_week'                     => _x( '1', 'start of week' ),
+		'use_balanceTags'                   => 0,
+		'use_smilies'                       => 1,
+		'require_name_email'                => 1,
+		'comments_notify'                   => 1,
+		'posts_per_rss'                     => 10,
+		'rss_use_excerpt'                   => 0,
+		'mailserver_url'                    => 'mail.example.com',
+		'mailserver_login'                  => 'login@example.com',
+		'mailserver_pass'                   => '',
+		'mailserver_port'                   => 110,
+		'default_category'                  => 1,
+		'default_comment_status'            => 'open',
+		'default_ping_status'               => 'open',
+		'default_pingback_flag'             => 1,
+		'posts_per_page'                    => 10,
 		/* translators: Default date format, see https://www.php.net/manual/datetime.format.php */
-		'date_format'                     => __( 'F j, Y' ),
+		'date_format'                       => __( 'F j, Y' ),
 		/* translators: Default time format, see https://www.php.net/manual/datetime.format.php */
-		'time_format'                     => __( 'g:i a' ),
+		'time_format'                       => __( 'g:i a' ),
 		/* translators: Links last updated date format, see https://www.php.net/manual/datetime.format.php */
-		'links_updated_date_format'       => __( 'F j, Y g:i a' ),
-		'comment_moderation'              => 0,
-		'moderation_notify'               => 1,
-		'permalink_structure'             => '',
-		'rewrite_rules'                   => '',
-		'hack_file'                       => 0,
-		'blog_charset'                    => 'UTF-8',
-		'moderation_keys'                 => '',
-		'active_plugins'                  => array(),
-		'category_base'                   => '',
-		'ping_sites'                      => 'https://rpc.pingomatic.com/',
-		'comment_max_links'               => 2,
-		'gmt_offset'                      => $gmt_offset,
+		'links_updated_date_format'         => __( 'F j, Y g:i a' ),
+		'comment_moderation'                => 0,
+		'moderation_notify'                 => 1,
+		'permalink_structure'               => '',
+		'rewrite_rules'                     => '',
+		'hack_file'                         => 0,
+		'blog_charset'                      => 'UTF-8',
+		'moderation_keys'                   => '',
+		'active_plugins'                    => array(),
+		'category_base'                     => '',
+		'ping_sites'                        => 'https://rpc.pingomatic.com/',
+		'comment_max_links'                 => 2,
+		'gmt_offset'                        => $gmt_offset,
 
 		// 1.5.0
-		'default_email_category'          => 1,
-		'recently_edited'                 => '',
-		'template'                        => $template,
-		'stylesheet'                      => $stylesheet,
-		'comment_registration'            => 0,
-		'html_type'                       => 'text/html',
+		'default_email_category'            => 1,
+		'recently_edited'                   => '',
+		'template'                          => $template,
+		'stylesheet'                        => $stylesheet,
+		'comment_registration'              => 0,
+		'html_type'                         => 'text/html',
 
 		// 1.5.1
-		'use_trackback'                   => 0,
+		'use_trackback'                     => 0,
 
 		// 2.0.0
-		'default_role'                    => 'subscriber',
-		'db_version'                      => $wp_db_version,
+		'default_role'                      => 'subscriber',
+		'db_version'                        => $wp_db_version,
 
 		// 2.0.1
-		'uploads_use_yearmonth_folders'   => 1,
-		'upload_path'                     => '',
+		'uploads_use_yearmonth_folders'     => 1,
+		'upload_path'                       => '',
 
 		// 2.1.0
-		'blog_public'                     => '1',
-		'default_link_category'           => 2,
-		'show_on_front'                   => 'posts',
+		'blog_public'                       => '1',
+		'default_link_category'             => 2,
+		'show_on_front'                     => 'posts',
 
 		// 2.2.0
-		'tag_base'                        => '',
+		'tag_base'                          => '',
 
 		// 2.5.0
-		'show_avatars'                    => '1',
-		'avatar_rating'                   => 'G',
-		'upload_url_path'                 => '',
-		'thumbnail_size_w'                => 150,
-		'thumbnail_size_h'                => 150,
-		'thumbnail_crop'                  => 1,
-		'medium_size_w'                   => 300,
-		'medium_size_h'                   => 300,
+		'show_avatars'                      => '1',
+		'avatar_rating'                     => 'G',
+		'upload_url_path'                   => '',
+		'thumbnail_size_w'                  => 150,
+		'thumbnail_size_h'                  => 150,
+		'thumbnail_crop'                    => 1,
+		'medium_size_w'                     => 300,
+		'medium_size_h'                     => 300,
 
 		// 2.6.0
-		'avatar_default'                  => 'mystery',
+		'avatar_default'                    => 'mystery',
 
 		// 2.7.0
-		'large_size_w'                    => 1024,
-		'large_size_h'                    => 1024,
-		'image_default_link_type'         => 'none',
-		'image_default_size'              => '',
-		'image_default_align'             => '',
-		'close_comments_for_old_posts'    => 0,
-		'close_comments_days_old'         => 14,
-		'thread_comments'                 => 1,
-		'thread_comments_depth'           => 5,
-		'page_comments'                   => 0,
-		'comments_per_page'               => 50,
-		'default_comments_page'           => 'newest',
-		'comment_order'                   => 'asc',
-		'sticky_posts'                    => array(),
-		'widget_categories'               => array(),
-		'widget_text'                     => array(),
-		'widget_rss'                      => array(),
-		'uninstall_plugins'               => array(),
+		'large_size_w'                      => 1024,
+		'large_size_h'                      => 1024,
+		'image_default_link_type'           => 'none',
+		'image_default_size'                => '',
+		'image_default_align'               => '',
+		'close_comments_for_old_posts'      => 0,
+		'close_comments_days_old'           => 14,
+		'thread_comments'                   => 1,
+		'thread_comments_depth'             => 5,
+		'page_comments'                     => 0,
+		'comments_per_page'                 => 50,
+		'default_comments_page'             => 'newest',
+		'comment_order'                     => 'asc',
+		'sticky_posts'                      => array(),
+		'widget_categories'                 => array(),
+		'widget_text'                       => array(),
+		'widget_rss'                        => array(),
+		'uninstall_plugins'                 => array(),
 
 		// 2.8.0
-		'timezone_string'                 => $timezone_string,
+		'timezone_string'                   => $timezone_string,
 
 		// 3.0.0
-		'page_for_posts'                  => 0,
-		'page_on_front'                   => 0,
+		'page_for_posts'                    => 0,
+		'page_on_front'                     => 0,
 
 		// 3.1.0
-		'default_post_format'             => 0,
+		'default_post_format'               => 0,
 
 		// 3.5.0
-		'link_manager_enabled'            => 0,
+		'link_manager_enabled'              => 0,
 
 		// 4.3.0
-		'finished_splitting_shared_terms' => 1,
-		'site_icon'                       => 0,
+		'finished_splitting_shared_terms'   => 1,
+		'site_icon'                         => 0,
 
 		// 4.4.0
-		'medium_large_size_w'             => 768,
-		'medium_large_size_h'             => 0,
+		'medium_large_size_w'               => 768,
+		'medium_large_size_h'               => 0,
 
 		// 4.9.6
-		'wp_page_for_privacy_policy'      => 0,
+		'wp_page_for_privacy_policy'        => 0,
 
 		// 4.9.8
-		'show_comments_cookies_opt_in'    => 1,
+		'show_comments_cookies_opt_in'      => 1,
 
 		// 5.3.0
-		'admin_email_lifespan'            => ( time() + 6 * MONTH_IN_SECONDS ),
+		'admin_email_lifespan'              => ( time() + 6 * MONTH_IN_SECONDS ),
 
 		// 5.5.0
-		'disallowed_keys'                 => '',
-		'comment_previously_approved'     => 1,
-		'auto_plugin_theme_update_emails' => array(),
+		'disallowed_keys'                   => '',
+		'comment_previously_approved'       => 1,
+		'auto_plugin_theme_update_emails'   => array(),
 
 		// 5.6.0
-		'auto_update_core_dev'            => 'enabled',
-		'auto_update_core_minor'          => 'enabled',
+		'auto_update_core_dev'              => 'enabled',
+		'auto_update_core_minor'            => 'enabled',
 		/*
 		 * Default to enabled for new installs.
 		 * See https://core.trac.wordpress.org/ticket/51742.
 		 */
-		'auto_update_core_major'          => 'enabled',
+		'auto_update_core_major'            => 'enabled',
 
 		// 5.8.0
-		'wp_force_deactivated_plugins'    => array(),
+		'wp_force_deactivated_plugins'      => array(),
 
 		// 6.4.0
-		'wp_attachment_pages_enabled'     => 0,
+		'wp_attachment_pages_enabled'       => 0,
 
 		// 6.9.0
-		'wp_notes_notify'                 => 1,
+		'wp_notes_notify'                   => 1,
 
 		// 7.0.0
-		'wp_enable_real_time_collaboration'  => 0,
+		'wp_enable_real_time_collaboration' => 0,
 	);
 
 	// 3.3.0

--- a/src/wp-admin/includes/schema.php
+++ b/src/wp-admin/includes/schema.php
@@ -565,7 +565,7 @@ function populate_options( array $options = array() ) {
 		'wp_notes_notify'                 => 1,
 
 		// 7.0.0
-		'enable_real_time_collaboration'  => 0,
+		'wp_enable_real_time_collaboration'  => 0,
 	);
 
 	// 3.3.0

--- a/src/wp-admin/options-writing.php
+++ b/src/wp-admin/options-writing.php
@@ -110,10 +110,10 @@ unset( $post_formats['standard'] );
 </td>
 </tr>
 <tr>
-<th scope="row"><label for="enable_real_time_collaboration"><?php _e( 'Collaboration' ); ?></label></th>
+<th scope="row"><label for="wp_enable_real_time_collaboration"><?php _e( 'Collaboration' ); ?></label></th>
 <td>
-	<input name="enable_real_time_collaboration" type="checkbox" id="enable_real_time_collaboration" value="1" <?php checked( '1', get_option( 'enable_real_time_collaboration' ) ); ?> />
-	<label for="enable_real_time_collaboration"><?php _e( 'Enable real-time collaboration' ); ?></label>
+	<input name="wp_enable_real_time_collaboration" type="checkbox" id="wp_enable_real_time_collaboration" value="1" <?php checked( '1', get_option( 'wp_enable_real_time_collaboration' ) ); ?> />
+	<label for="wp_enable_real_time_collaboration"><?php _e( 'Enable real-time collaboration' ); ?></label>
 </td>
 </tr>
 <?php

--- a/src/wp-admin/options.php
+++ b/src/wp-admin/options.php
@@ -153,7 +153,7 @@ $allowed_options            = array(
 		'default_email_category',
 		'default_link_category',
 		'default_post_format',
-		'enable_real_time_collaboration',
+		'wp_enable_real_time_collaboration',
 	),
 );
 $allowed_options['misc']    = array();

--- a/src/wp-includes/collaboration.php
+++ b/src/wp-includes/collaboration.php
@@ -14,7 +14,7 @@
  * @access private
  */
 function wp_collaboration_inject_setting() {
-	if ( get_option( 'enable_real_time_collaboration' ) ) {
+	if ( get_option( 'wp_enable_real_time_collaboration' ) ) {
 		wp_add_inline_script(
 			'wp-core-data',
 			'window._wpCollaborationEnabled = true;',

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -2887,7 +2887,7 @@ function register_initial_settings() {
 
 	register_setting(
 		'writing',
-		'enable_real_time_collaboration',
+		'wp_enable_real_time_collaboration',
 		array(
 			'type'              => 'boolean',
 			'description'       => __( 'Enable Real-Time Collaboration' ),

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -657,7 +657,7 @@ function create_initial_post_types() {
 		)
 	);
 
-	if ( get_option( 'enable_real_time_collaboration' ) ) {
+	if ( get_option( 'wp_enable_real_time_collaboration' ) ) {
 		register_post_type(
 			'wp_sync_storage',
 			array(
@@ -8669,7 +8669,7 @@ function wp_create_initial_post_meta() {
 		)
 	);
 
-	if ( get_option( 'enable_real_time_collaboration' ) ) {
+	if ( get_option( 'wp_enable_real_time_collaboration' ) ) {
 		register_meta(
 			'post',
 			'_crdt_document',

--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -430,7 +430,7 @@ function create_initial_rest_routes() {
 	$icons_controller->register_routes();
 
 	// Collaboration.
-	if ( get_option( 'enable_real_time_collaboration' ) ) {
+	if ( get_option( 'wp_enable_real_time_collaboration' ) ) {
 		$sync_storage = new WP_Sync_Post_Meta_Storage();
 		$sync_server  = new WP_HTTP_Polling_Sync_Server( $sync_storage );
 		$sync_server->register_routes();

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php
@@ -254,7 +254,7 @@ class WP_REST_Autosaves_Controller extends WP_REST_Revisions_Controller {
 		 *   the saved post. This diff is then applied to the in-memory CRDT
 		 *   document, which can lead to duplicate inserts or deletions.
 		 */
-		$is_collaboration_enabled = get_option( 'enable_real_time_collaboration' );
+		$is_collaboration_enabled = get_option( 'wp_enable_real_time_collaboration' );
 
 		if ( $is_draft && (int) $post->post_author === $user_id && ! $post_lock && ! $is_collaboration_enabled ) {
 			/*

--- a/tests/phpunit/tests/rest-api/rest-autosaves-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-autosaves-controller.php
@@ -570,8 +570,8 @@ class WP_Test_REST_Autosaves_Controller extends WP_Test_REST_Post_Type_Controlle
 	}
 
 	public function test_rest_autosave_draft_post_same_author() {
-		$original_option = get_option( 'enable_real_time_collaboration' );
-		update_option( 'enable_real_time_collaboration', false );
+		$original_option = get_option( 'wp_enable_real_time_collaboration' );
+		update_option( 'wp_enable_real_time_collaboration', false );
 
 		wp_set_current_user( self::$editor_id );
 
@@ -607,7 +607,7 @@ class WP_Test_REST_Autosaves_Controller extends WP_Test_REST_Post_Type_Controlle
 		$this->assertSame( $post_data['post_excerpt'], $post->post_excerpt );
 
 		wp_delete_post( $post_id );
-		update_option( 'enable_real_time_collaboration', $original_option );
+		update_option( 'wp_enable_real_time_collaboration', $original_option );
 	}
 
 	public function test_rest_autosave_draft_post_different_author() {
@@ -748,8 +748,8 @@ class WP_Test_REST_Autosaves_Controller extends WP_Test_REST_Post_Type_Controlle
 	}
 
 	public function test_update_item_draft_page_with_parent() {
-		$original_option = get_option( 'enable_real_time_collaboration' );
-		update_option( 'enable_real_time_collaboration', false );
+		$original_option = get_option( 'wp_enable_real_time_collaboration' );
+		update_option( 'wp_enable_real_time_collaboration', false );
 
 		wp_set_current_user( self::$editor_id );
 		$request = new WP_REST_Request( 'POST', '/wp/v2/pages/' . self::$child_draft_page_id . '/autosaves' );
@@ -768,7 +768,7 @@ class WP_Test_REST_Autosaves_Controller extends WP_Test_REST_Post_Type_Controlle
 
 		$this->assertSame( self::$child_draft_page_id, $data['id'] );
 		$this->assertSame( self::$parent_page_id, $data['parent'] );
-		update_option( 'enable_real_time_collaboration', $original_option );
+		update_option( 'wp_enable_real_time_collaboration', $original_option );
 	}
 
 	public function test_schema_validation_is_applied() {
@@ -934,8 +934,8 @@ class WP_Test_REST_Autosaves_Controller extends WP_Test_REST_Post_Type_Controlle
 	 * same author should create a revision instead of updating the post directly.
 	 */
 	public function test_rest_autosave_draft_post_same_author_with_rtc() {
-		$original_option = get_option( 'enable_real_time_collaboration' );
-		update_option( 'enable_real_time_collaboration', true );
+		$original_option = get_option( 'wp_enable_real_time_collaboration' );
+		update_option( 'wp_enable_real_time_collaboration', true );
 
 		wp_set_current_user( self::$editor_id );
 
@@ -974,7 +974,7 @@ class WP_Test_REST_Autosaves_Controller extends WP_Test_REST_Post_Type_Controlle
 		$this->assertSame( $post_data['post_excerpt'], $post->post_excerpt );
 
 		wp_delete_post( $post_id );
-		update_option( 'enable_real_time_collaboration', $original_option );
+		update_option( 'wp_enable_real_time_collaboration', $original_option );
 	}
 
 	/**
@@ -982,8 +982,8 @@ class WP_Test_REST_Autosaves_Controller extends WP_Test_REST_Post_Type_Controlle
 	 * a parent should create a revision instead of updating the page directly.
 	 */
 	public function test_update_item_draft_page_with_parent_with_rtc() {
-		$original_option = get_option( 'enable_real_time_collaboration' );
-		update_option( 'enable_real_time_collaboration', true );
+		$original_option = get_option( 'wp_enable_real_time_collaboration' );
+		update_option( 'wp_enable_real_time_collaboration', true );
 
 		wp_set_current_user( self::$editor_id );
 		$request = new WP_REST_Request( 'POST', '/wp/v2/pages/' . self::$child_draft_page_id . '/autosaves' );
@@ -1003,6 +1003,6 @@ class WP_Test_REST_Autosaves_Controller extends WP_Test_REST_Post_Type_Controlle
 		// With RTC enabled, a revision is created instead of updating the page.
 		$this->assertNotSame( self::$child_draft_page_id, $data['id'] );
 		$this->assertSame( self::$child_draft_page_id, $data['parent'] );
-		update_option( 'enable_real_time_collaboration', $original_option );
+		update_option( 'wp_enable_real_time_collaboration', $original_option );
 	}
 }

--- a/tests/phpunit/tests/rest-api/rest-settings-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-settings-controller.php
@@ -119,7 +119,7 @@ class WP_Test_REST_Settings_Controller extends WP_Test_REST_Controller_Testcase 
 			'default_ping_status',
 			'default_comment_status',
 			'site_icon', // Registered in wp-includes/blocks/site-logo.php
-			'enable_real_time_collaboration',
+			'wp_enable_real_time_collaboration',
 		);
 
 		if ( ! is_multisite() ) {

--- a/tests/phpunit/tests/rest-api/rest-sync-server.php
+++ b/tests/phpunit/tests/rest-api/rest-sync-server.php
@@ -14,7 +14,7 @@ class WP_Test_REST_Sync_Server extends WP_Test_REST_Controller_Testcase {
 	protected static $post_id;
 
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
-		update_option( 'enable_real_time_collaboration', true );
+		update_option( 'wp_enable_real_time_collaboration', true );
 
 		self::$editor_id     = $factory->user->create( array( 'role' => 'editor' ) );
 		self::$subscriber_id = $factory->user->create( array( 'role' => 'subscriber' ) );
@@ -25,7 +25,7 @@ class WP_Test_REST_Sync_Server extends WP_Test_REST_Controller_Testcase {
 		self::delete_user( self::$editor_id );
 		self::delete_user( self::$subscriber_id );
 		wp_delete_post( self::$post_id, true );
-		delete_option( 'enable_real_time_collaboration' );
+		delete_option( 'wp_enable_real_time_collaboration' );
 	}
 
 	public function set_up() {

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -11138,7 +11138,7 @@ mockedApiResponse.Schema = {
                             "type": "string",
                             "required": false
                         },
-                        "enable_real_time_collaboration": {
+                        "wp_enable_real_time_collaboration": {
                             "title": "",
                             "description": "Enable Real-Time Collaboration",
                             "type": "boolean",
@@ -14646,7 +14646,7 @@ mockedApiResponse.settings = {
     "use_smilies": true,
     "default_category": 1,
     "default_post_format": "0",
-    "enable_real_time_collaboration": false,
+    "wp_enable_real_time_collaboration": false,
     "posts_per_page": 10,
     "show_on_front": "posts",
     "page_on_front": 0,


### PR DESCRIPTION
Renames the option `enable_real_time_collaboration` to `wp_enable_real_time_collaboration` to follow convention since WordPress 5.8 to prefix new core options with `wp`.

Trac ticket: https://core.trac.wordpress.org/ticket/64622#comment:34

## Use of AI Tools

Nil.


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
