### PR TITLE
Replaces `void` return types with `null`

### DIFF
--- a/src/wp-includes/canonical.php
+++ b/src/wp-includes/canonical.php
@@ -37,13 +37,13 @@
  * @param string $requested_url Optional. The URL that was requested, used to
  *                              figure if redirect is needed.
  * @param bool   $do_redirect   Optional. Redirect to the new URL.
- * @return string|void The string of the URL, if redirect needed.
+ * @return string|null The string of the URL if redirect needed, null otherwise.
  */
 function redirect_canonical( $requested_url = null, $do_redirect = true ) {
 	global $wp_rewrite, $is_IIS, $wp_query, $wpdb, $wp;
 
 	if ( isset( $_SERVER['REQUEST_METHOD'] ) && ! in_array( strtoupper( $_SERVER['REQUEST_METHOD'] ), array( 'GET', 'HEAD' ), true ) ) {
-		return;
+		return null;
 	}
 
 	/*
@@ -62,7 +62,7 @@ function redirect_canonical( $requested_url = null, $do_redirect = true ) {
 	if ( is_admin() || is_search() || is_preview() || is_trackback() || is_favicon()
 		|| ( $is_IIS && ! iis7_supports_permalinks() )
 	) {
-		return;
+		return null;
 	}
 
 	if ( ! $requested_url && isset( $_SERVER['HTTP_HOST'] ) ) {
@@ -74,7 +74,7 @@ function redirect_canonical( $requested_url = null, $do_redirect = true ) {
 
 	$original = parse_url( $requested_url );
 	if ( false === $original ) {
-		return;
+		return null;
 	}
 
 	// Notice fixing.
@@ -771,7 +771,7 @@ function redirect_canonical( $requested_url = null, $do_redirect = true ) {
 	}
 
 	if ( ! $redirect_url || $redirect_url === $requested_url ) {
-		return;
+		return null;
 	}
 
 	// Hex-encoded octets are case-insensitive.
@@ -830,7 +830,7 @@ function redirect_canonical( $requested_url = null, $do_redirect = true ) {
 
 	// Yes, again -- in case the filter aborted the request.
 	if ( ! $redirect_url || strip_fragment_from_url( $redirect_url ) === strip_fragment_from_url( $requested_url ) ) {
-		return;
+		return null;
 	}
 
 	if ( $do_redirect ) {
@@ -841,7 +841,7 @@ function redirect_canonical( $requested_url = null, $do_redirect = true ) {
 		} else {
 			// Debug.
 			// die("1: $redirect_url<br />2: " . redirect_canonical( $redirect_url, false ) );
-			return;
+			return null;
 		}
 	} else {
 		return $redirect_url;

--- a/src/wp-includes/capabilities.php
+++ b/src/wp-includes/capabilities.php
@@ -1130,11 +1130,11 @@ function get_role( $role ) {
  * @param string                               $display_name Display name for role.
  * @param array<string,bool>|array<int,string> $capabilities Capabilities to be added to the role.
  *                                                           Default empty array.
- * @return WP_Role|void WP_Role object, if the role is added.
+ * @return WP_Role|null WP_Role object if the role is added, null otherwise.
  */
 function add_role( $role, $display_name, $capabilities = array() ) {
 	if ( empty( $role ) ) {
-		return;
+		return null;
 	}
 
 	return wp_roles()->add_role( $role, $display_name, $capabilities );

--- a/src/wp-includes/class-wp-roles.php
+++ b/src/wp-includes/class-wp-roles.php
@@ -171,11 +171,11 @@ class WP_Roles {
 	 * @param string                               $display_name Role display name.
 	 * @param array<string,bool>|array<int,string> $capabilities Capabilities to be added to the role.
 	 *                                                           Default empty array.
-	 * @return WP_Role|void WP_Role object, if the role is added.
+	 * @return WP_Role|null WP_Role object if the role is added, null otherwise.
 	 */
 	public function add_role( $role, $display_name, $capabilities = array() ) {
 		if ( empty( $role ) || isset( $this->roles[ $role ] ) ) {
-			return;
+			return null;
 		}
 
 		if ( wp_is_numeric_array( $capabilities ) ) {

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -6226,13 +6226,13 @@ function url_shorten( $url, $length = 35 ) {
 /**
  * Sanitizes a hex color.
  *
- * Returns either '', a 3 or 6 digit hex color (with #), or nothing.
+ * Returns either '', a 3 or 6 digit hex color (with #), or null.
  * For sanitizing values without a #, see sanitize_hex_color_no_hash().
  *
  * @since 3.4.0
  *
  * @param string $color
- * @return string|void
+ * @return string|null
  */
 function sanitize_hex_color( $color ) {
 	if ( '' === $color ) {
@@ -6243,6 +6243,8 @@ function sanitize_hex_color( $color ) {
 	if ( preg_match( '|^#([A-Fa-f0-9]{3}){1,2}$|', $color ) ) {
 		return $color;
 	}
+
+	return null;
 }
 
 /**

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -2994,7 +2994,7 @@ function wp_upload_bits( $name, $deprecated, $bits, $time = null ) {
  * @since 2.5.0
  *
  * @param string $ext The extension to search.
- * @return string|void The file type, example: audio, video, document, spreadsheet, etc.
+ * @return string|null The file type, example: audio, video, document, spreadsheet, etc. Null if not found.
  */
 function wp_ext2type( $ext ) {
 	$ext = strtolower( $ext );
@@ -3005,6 +3005,8 @@ function wp_ext2type( $ext ) {
 			return $type;
 		}
 	}
+
+	return null;
 }
 
 /**
@@ -8553,7 +8555,7 @@ function wp_get_default_update_php_url() {
  * @param string $after   Markup to output after the annotation. Default `</p>`.
  * @param bool   $display Whether to echo or return the markup. Default `true` for echo.
  *
- * @return string|void
+ * @return string|null The markup if `$display` is false, null otherwise.
  */
 function wp_update_php_annotation( $before = '<p class="description">', $after = '</p>', $display = true ) {
 	$annotation = wp_get_update_php_annotation();
@@ -8565,6 +8567,8 @@ function wp_update_php_annotation( $before = '<p class="description">', $after =
 			return $before . $annotation . $after;
 		}
 	}
+
+	return null;
 }
 
 /**

--- a/src/wp-includes/revision.php
+++ b/src/wp-includes/revision.php
@@ -125,34 +125,34 @@ function wp_save_post_revision_on_insert( $post_id, $post, $update ) {
  * @since 2.6.0
  *
  * @param int $post_id The ID of the post to save as a revision.
- * @return int|WP_Error|void Void or 0 if error, new revision ID, if success.
+ * @return int|WP_Error|null Null or 0 if error, new revision ID if success.
  */
 function wp_save_post_revision( $post_id ) {
 	if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
-		return;
+		return null;
 	}
 
 	// Prevent saving post revisions if revisions should be saved on wp_after_insert_post.
 	if ( doing_action( 'post_updated' ) && has_action( 'wp_after_insert_post', 'wp_save_post_revision_on_insert' ) ) {
-		return;
+		return null;
 	}
 
 	$post = get_post( $post_id );
 
 	if ( ! $post ) {
-		return;
+		return null;
 	}
 
 	if ( ! post_type_supports( $post->post_type, 'revisions' ) ) {
-		return;
+		return null;
 	}
 
 	if ( 'auto-draft' === $post->post_status ) {
-		return;
+		return null;
 	}
 
 	if ( ! wp_revisions_enabled( $post ) ) {
-		return;
+		return null;
 	}
 
 	/*
@@ -209,7 +209,7 @@ function wp_save_post_revision( $post_id ) {
 
 			// Don't save revision if post unchanged.
 			if ( ! $post_has_changed ) {
-				return;
+				return null;
 			}
 		}
 	}


### PR DESCRIPTION
Updates various functions to explicitly return `null` instead of implicitly returning `void` when no specific value is meant to be returned.

This change improves type consistency and clarity, better reflecting the function's actual behavior and aligning with modern PHP type-hinting practices.

Trac ticket: https://core.trac.wordpress.org/ticket/64704

