### PR TITLE
Fix PHPStan undefined variables in menu.php and network.php

### DIFF
--- a/src/wp-admin/includes/menu.php
+++ b/src/wp-admin/includes/menu.php
@@ -42,6 +42,7 @@ if ( is_network_admin() ) {
 }
 
 // Create list of page plugin hook names.
+global $menu, $submenu, $compat;
 foreach ( $menu as $menu_page ) {
 	$pos = strpos( $menu_page[2], '?' );
 

--- a/src/wp-admin/includes/network.php
+++ b/src/wp-admin/includes/network.php
@@ -198,6 +198,9 @@ function network_step1( $errors = false ) {
 	} else {
 		$subdomain_install = false;
 		$got_mod_rewrite   = got_mod_rewrite();
+		$message           = '';
+		$message_class     = '';
+
 		if ( $got_mod_rewrite ) { // Dangerous assumptions.
 			$message_class = 'updated';
 			$message       = '<p><strong>' . __( 'Warning:' ) . '</strong> ';


### PR DESCRIPTION
This fixes a few PHPStan "variable might not be defined" warnings..
Changes:
- `src/wp-admin/includes/menu.php`: Added the `global` declaration for `$menu`, `$submenu`, and `$compat`.
- `src/wp-admin/includes/network.php`: Initialized the `$message` and `$message_class` variables to prevent them from being undefined when the condition isn't met.

Trac: https://core.trac.wordpress.org/ticket/64238