### PR TITLE
Fix PHPStan return.empty errors in core methods

### DIFF
--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -4816,7 +4816,7 @@ class WP_Query {
 	 * @global int     $numpages
 	 *
 	 * @param WP_Post|object|int $post WP_Post instance or Post ID/object.
-	 * @return true True when finished.
+	 * @return bool True on success, false on failure.
 	 */
 	public function setup_postdata( $post ) {
 		global $id, $authordata, $currentday, $currentmonth, $page, $pages, $multipage, $more, $numpages;
@@ -4826,12 +4826,12 @@ class WP_Query {
 		}
 
 		if ( ! $post ) {
-			return;
+			return false;
 		}
 
 		$elements = $this->generate_postdata( $post );
 		if ( false === $elements ) {
-			return;
+			return false;
 		}
 
 		$id           = $elements['id'];

--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -3095,7 +3095,7 @@ function _remove_theme_support( $feature ) {
 				return false;
 			}
 			add_theme_support( 'custom-header', array( 'uploads' => false ) );
-			return; // Do not continue - custom-header-uploads no longer exists.
+			return true; // Do not continue - custom-header-uploads no longer exists.
 	}
 
 	if ( ! isset( $_wp_theme_features[ $feature ] ) ) {


### PR DESCRIPTION
This PR addresses strict type `return.empty` violations reported by PHPStan, ensuring methods return their declared or documented types rather than relying on an empty `return;`. 
 Details
* **`src/wp-includes/class-wp-query.php`** (`WP_Query::setup_postdata`): 
  * Updated the PHPDoc to reflect that the method can return both `true` (success) and `false` (failure).
  * Replaced the early empty `return;` bail-outs with `return false;` when the post object is invalid or when `generate_postdata()` fails.
* **`src/wp-includes/theme.php`** (`_remove_theme_support`):
  * Replaced an empty `return;` inside the `custom-header-uploads` backward compatibility fallback with `return true;`. This matches the documented `bool` return type to indicate the feature support was successfully removed.
 Why this is needed
Using empty `return;` statements in methods/functions that have a declared or documented non-void return type causes static analysis tooling (like PHPStan) to flag them as errors. Returning explicit boolean values improves strict typing constraints and code clarity.

Trac ticket: https://core.trac.wordpress.org/ticket/64238

## Use of AI Tools
Use For PR Content.