### PR TITLE
Reset height and position for theme actions

### DIFF
--- a/src/wp-admin/css/list-tables.css
+++ b/src/wp-admin/css/list-tables.css
@@ -1452,6 +1452,14 @@ ul.cat-checklist input[name="post_category[]"]:indeterminate::before {
 	content: "\f147" / '';
 }
 
+.plugin-card .updated-message:before,
+.plugin-card .updating-message:before {
+	line-height: 1;
+	position: relative;
+	top: -2px;
+	vertical-align: middle;
+}
+
 .plugin-install-php #the-list {
 	display: flex;
 	flex-wrap: wrap;

--- a/src/wp-admin/css/themes.css
+++ b/src/wp-admin/css/themes.css
@@ -114,12 +114,22 @@ body.js .theme-browser.search-loading {
 }
 
 /* Use compact size for space-constrained theme cards */
+.theme-browser .theme .theme-actions .button.updated-message,
+.theme-browser .theme .theme-actions .button.updating-message,
 .theme-browser .theme .theme-actions .button {
 	float: none;
 	margin-left: 3px;
 	min-height: 32px;
 	line-height: 2.30769231; /* 30px for 32px min-height */
 	padding: 0 12px;
+}
+
+.theme-browser .theme .theme-actions .button.updated-message::before,
+.theme-browser .theme .theme-actions .button.updating-message::before {
+	line-height: 1;
+	vertical-align: text-bottom;
+	position: relative;
+	top: 2px;
 }
 
 /* Secondary buttons need white background for visibility on semi-transparent overlay */


### PR DESCRIPTION
Fixes shift of button size when installing/after installing themes or plugins.

Trac ticket: https://core.trac.wordpress.org/ticket/64687

## Use of AI Tools

None

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
