### PR TITLE
Use compact button in plugin cards

### DIFF
--- a/src/wp-admin/css/list-tables.css
+++ b/src/wp-admin/css/list-tables.css
@@ -1424,7 +1424,7 @@ ul.cat-checklist input[name="post_category[]"]:indeterminate::before {
 	content: "\f463";
 	content: "\f463" / '';
 	display: inline-block;
-	font: normal 20px/1.9 dashicons; /* line-height 1.9 = 38px to match button */
+	font: normal 16px/1.875 dashicons; /* line-height 1.875 = 30px to match button */
 	margin: 0 5px 0 -2px;
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
@@ -1565,6 +1565,13 @@ ul.cat-checklist input[name="post_category[]"]:indeterminate::before {
 div.action-links,
 .plugin-action-buttons {
 	margin: 0; /* Override existing margins */
+}
+
+/* Use compact size for space-constrained plugin cards */
+.plugin-action-buttons li .button {
+	min-height: 32px;
+	line-height: 2.30769231; /* 30px for 32px min-height */
+	padding: 0 12px;
 }
 
 .plugin-card h3 {


### PR DESCRIPTION
Switches to the compact button design in plugin cards.

The compact buttons are still a little wider, but it's less of an issue. Will probably need further tweaks; the old buttons had 20px of horizontal padding, the new compact buttons have 24.

Trac ticket: https://core.trac.wordpress.org/ticket/64686

## Use of AI Tools

None

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
