### PR TITLE
Docs: Fix backwards default value for wp_list_users()::exclude_admin.

### DIFF
--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -894,7 +894,7 @@ function get_users( $args = array() ) {
  *                                 'display_name', 'post_count', 'ID', 'meta_value', 'user_login'. Default 'name'.
  *     @type string $order         Sorting direction for $orderby. Accepts 'ASC', 'DESC'. Default 'ASC'.
  *     @type int    $number        Maximum users to return or display. Default empty (all users).
- *     @type bool   $exclude_admin Whether to exclude the 'admin' account, if it exists. Default false.
+ *     @type bool   $exclude_admin Whether to exclude the 'admin' account, if it exists. Default true.
  *     @type bool   $show_fullname Whether to show the user's full name. Default false.
  *     @type string $feed          If not empty, show a link to the user's feed and use this text as the alt
  *                                 parameter of the link. Default empty.


### PR DESCRIPTION
Trac ticket: Core-64224

Resolves: https://github.com/WordPress/Documentation-Issue-Tracker/issues/1849

This was previosly listed as defaulting to `false` when in fact it defaults to `true.`

As this is a documentation-only change it should include no code or functionality changes.