### PR TITLE
[Admin reskin] Add background color to notice in login

### DIFF
--- a/src/wp-admin/css/login.css
+++ b/src/wp-admin/css/login.css
@@ -66,6 +66,10 @@ p {
 	background-color: #eff9f1;
 }
 
+.login .notice {
+	background-color: #fff;
+}
+
 /* Match border color from common.css */
 .login .notice-error {
 	border-left-color: #cc1818;


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/64715

Adding background color to the `.notice` in the login.css file, as the notices there don't match the reskin (complete styles live in common.css).

|Before|After|
|-|-|
|<img width="1960" height="1400" alt="register-notice-before" src="https://github.com/user-attachments/assets/e5dd6f5f-53b7-44c5-9e9a-e87786e68075" />|<img width="1960" height="1400" alt="register-notice-after" src="https://github.com/user-attachments/assets/3ab7fd83-94e8-4425-9049-425b5e688dd5" />|

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
