### PR TITLE
Docs: Clarify description of remove_all_filters() method in WP_Hook class

### DIFF
--- a/src/wp-includes/class-wp-hook.php
+++ b/src/wp-includes/class-wp-hook.php
@@ -262,11 +262,11 @@ final class WP_Hook implements Iterator, ArrayAccess {
 	}
 
 	/**
-	 * Checks if any callbacks have been registered for this hook.
+	 * Checks if any callbacks have been registered for the filter hook.
 	 *
 	 * @since 4.7.0
 	 *
-	 * @return bool True if callbacks have been registered for the current hook, otherwise false.
+	 * @return bool True if callbacks have been registered for the filter hook, otherwise false.
 	 */
 	public function has_filters() {
 		foreach ( $this->callbacks as $callbacks ) {

--- a/src/wp-includes/class-wp-hook.php
+++ b/src/wp-includes/class-wp-hook.php
@@ -279,7 +279,7 @@ final class WP_Hook implements Iterator, ArrayAccess {
 	}
 
 	/**
-	 * Removes all callbacks from the current filter.
+	 * Removes all callbacks registered on the filter hook.
 	 *
 	 * @since 4.7.0
 	 *


### PR DESCRIPTION
The phrase "current filter" is misleading, it sounds like it refers to whichever filter is currently executing, which is a different concept entirely. The `remove_all_filters` method simply removes all callbacks from that instance. This probably was copied from previous methods which refer to a specific hook, so this feels a little copy glitch 

Trac ticket: https://core.trac.wordpress.org/ticket/64717

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
