### PR TITLE
Set a standard pretty permalink structure for the local dev environment.

### DIFF
--- a/.github/workflows/reusable-end-to-end-tests.yml
+++ b/.github/workflows/reusable-end-to-end-tests.yml
@@ -100,7 +100,7 @@ jobs:
 
       - name: Install Playwright browsers
         if: ${{ inputs.install-playwright }}
-        run: npx playwright install --with-deps
+        run: npx playwright install --with-deps chromium
 
       - name: Build WordPress
         run: npm run build

--- a/.github/workflows/reusable-performance-test-v2.yml
+++ b/.github/workflows/reusable-performance-test-v2.yml
@@ -227,9 +227,6 @@ jobs:
       - name: Deactivate WordPress Importer plugin
         run: npm run env:cli -- plugin deactivate wordpress-importer --path="/var/www/${LOCAL_DIR}"
 
-      - name: Update permalink structure
-        run: npm run env:cli -- rewrite structure '/%year%/%monthnum%/%postname%/' --path="/var/www/${LOCAL_DIR}"
-
       - name: Install additional languages
         run: |
           npm run env:cli -- language core install de_DE --path="/var/www/${LOCAL_DIR}"

--- a/.github/workflows/reusable-performance.yml
+++ b/.github/workflows/reusable-performance.yml
@@ -203,9 +203,6 @@ jobs:
       - name: Deactivate WordPress Importer plugin
         run: npm run env:cli -- plugin deactivate wordpress-importer --path="/var/www/${LOCAL_DIR}"
 
-      - name: Update permalink structure
-        run: npm run env:cli -- rewrite structure '/%year%/%monthnum%/%postname%/' --path="/var/www/${LOCAL_DIR}"
-
       - name: Install additional languages
         run: |
           npm run env:cli -- language core install de_DE --path="/var/www/${LOCAL_DIR}"

--- a/tools/local-env/scripts/install.js
+++ b/tools/local-env/scripts/install.js
@@ -46,6 +46,7 @@ wait_on( {
 		wp_cli( 'db reset --yes --defaults' );
 		const installCommand = process.env.LOCAL_MULTISITE === 'true'  ? 'multisite-install' : 'install';
 		wp_cli( `core ${ installCommand } --title="WordPress Develop" --admin_user=admin --admin_password=password --admin_email=test@example.com --skip-email --url=http://localhost:${process.env.LOCAL_PORT}` );
+		wp_cli( `rewrite structure '/%year%/%monthnum%/%postname%/'` );
 	} )
 	.catch( err => {
 		console.error( `Error: Unable to reset DB and install WordPress. Message: ${ err.message }` );


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/64227

This addresses two issues with the e2e test workflow.

## Tricky Trixie

[Last night at 01:11 UTC](https://github.com/WordPress/wpdev-docker-images/pull/174) the `latest` tag for the PHP-based `wordpressdevelop` Docker images was changed from 8.2 to 8.3. Merging this change causes all the images to be rebuilt in the same way as we saw for Core-63876.

[The e2e tests workflow doesn't specify a PHP version](https://github.com/WordPress/wordpress-develop/blob/6cd1f7d48cf58d3c9dee30e1c8e3eaf55ae8e523/.github/workflows/end-to-end-tests.yml#L58-L71), so runs after that point switched from PHP 8.2 to 8.3.

Switching from PHP 8.2 to 8.3 also meant switching from Debian Bullseye using cURL 7.74.0 to Debian Trixie using cURL 8.14.1. [In cURL 7.77.0 a change was made](https://github.com/curl/curl/pull/7039) that means localhost always resolves to either `127.0.0.1` or `::1` and never consults `/etc/hosts`.

In [the Docker config for the local dev environment](https://github.com/WordPress/wordpress-develop/blob/6cd1f7d48cf58d3c9dee30e1c8e3eaf55ae8e523/docker-compose.yml#L60-L62), `localhost` points to the host machine, not to 127.0.0.1. [We're not the only ones affected by this](https://github.com/curl/curl/issues/11104).

During installation, WordPress calls `wp_install_maybe_enable_pretty_permalinks()` which [performs a loopback request](https://github.com/WordPress/wordpress-develop/blob/6cd1f7d48cf58d3c9dee30e1c8e3eaf55ae8e523/src/wp-admin/includes/upgrade.php#L534-L547) to check that pretty permalinks work. If they do, they get enabled by default. Due to the above change in cURL, this loopback to `localhost:8889` doesn't resolve to the host as expected, and the request fails, preventing pretty permalinks from being enabled.

Then we finally get to the e2e tests. The e2e tests assume that pretty permalinks are enabled. They don't get enabled explicitly. When a test requests `/this-does-not-exist` it ironically receives an HTTP 200 response [rather than the expected 404](https://github.com/WordPress/wordpress-develop/blob/6cd1f7d48cf58d3c9dee30e1c8e3eaf55ae8e523/tests/e2e/specs/cache-control-headers-directives.test.js#L56-L63) because pretty permalinks are not enabled, causing URL path info to be ignored and the home page to be served.

This is why the the e2e tests that assume pretty permalinks are in place were passing on PHP 8.2 and now fail on the new PHP 8.3 image with cURL 8.

## Awkward apt-get

The e2e tests [only run on Chrome](https://github.com/WordPress/gutenberg/blob/0180c417fc4d2e704f3f8738ed09703ebeeda189/packages/scripts/config/playwright.config.js#L57).

The e2e workflow [installs browsers for Playwright](https://github.com/WordPress/wordpress-develop/blob/6cd1f7d48cf58d3c9dee30e1c8e3eaf55ae8e523/.github/workflows/reusable-end-to-end-tests.yml#L101-L104) using `npx playwright install --with-deps` in accordance with to [the Playwright documentation for CI](https://playwright.dev/docs/ci). This installs dependencies for running headless Chromium which aren't otherwise included by default on the container images.

[By default, Playwright installs Chromium, Firefox, and Webkit](https://github.com/microsoft/playwright/blob/f1e16b656369138224d671e9a23b87e683b22d81/packages/playwright-core/browsers.json), but we only need Chromium. By excluding Firefox and Webkit, a massively reduced set of dependencies are pulled in by apt-get. The affected step goes from [~15 minutes](https://github.com/WordPress/wordpress-develop/actions/runs/22366670561/job/64734399391#step:7:1) to [~30 seconds](https://github.com/WordPress/wordpress-develop/actions/runs/22369300296/job/64743630820?pr=11031#step:7:1).

This fix isn't technically needed to get the e2e tests passing again, but it does mean the workflow run doesn't bump right up against [the 20 minute timeout for the workflow](https://github.com/WordPress/wordpress-develop/blob/6cd1f7d48cf58d3c9dee30e1c8e3eaf55ae8e523/.github/workflows/reusable-end-to-end-tests.yml#L70).