### PR TITLE
Set the default background for `notice-info` to white

### DIFF
--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -1579,7 +1579,7 @@ div.error.notice-alt {
 }
 
 .notice-info.notice-alt {
-	background-color: transparent;
+	background-color: #fff;
 }
 
 #plugin-information-footer .update-now:not(.button-disabled):before {

--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -1575,7 +1575,7 @@ div.error.notice-alt {
 
 .notice-info {
 	border-left-color: #3858e9;
-	background-color: transparent;
+	background-color: #fff;
 }
 
 .notice-info.notice-alt {

--- a/src/wp-admin/css/login.css
+++ b/src/wp-admin/css/login.css
@@ -49,7 +49,7 @@ p {
 	margin-top: 0;
 	margin-left: 0;
 	margin-bottom: 20px;
-	background-color: transparent;
+	background-color: #fff;
 	word-wrap: break-word;
 }
 

--- a/src/wp-admin/css/login.css
+++ b/src/wp-admin/css/login.css
@@ -66,10 +66,6 @@ p {
 	background-color: #eff9f1;
 }
 
-.login .notice {
-	background-color: #fff;
-}
-
 /* Match border color from common.css */
 .login .notice-error {
 	border-left-color: #cc1818;


### PR DESCRIPTION
Changes the core notice info to have a white background.

This doesn't match the Gutenberg design specs, but because WordPress uses a gray background, it's not actually possible to meet those specs 100%, and this will be a less disruptive change for users.

Trac ticket: https://core.trac.wordpress.org/ticket/64678

## Use of AI Tools
none
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
