### PR TITLE
Convert visual tabs into tablist and tabpanel in taxonomies

### DIFF
--- a/src/js/_enqueues/admin/link.js
+++ b/src/js/_enqueues/admin/link.js
@@ -25,7 +25,6 @@ jQuery( function($) {
 			event.preventDefault();
 			$('#category-tabs a').removeAttr( 'aria-selected' ).attr( 'tabindex', '-1' );
 			$(this).attr( 'aria-selected', 'true' ).removeAttr( 'tabindex' );
-			$(this).attr( 'aria-selected', 'true' );
 			$(this).parent().addClass('tabs').siblings('li').removeClass('tabs');
 			$('.tabs-panel').hide();
 			$(t).show();

--- a/src/js/_enqueues/admin/link.js
+++ b/src/js/_enqueues/admin/link.js
@@ -41,10 +41,10 @@ jQuery( function($) {
 			let next = $(this).parent('li').next();
 			let prev = $(this).parent('li').prev();
 			if ( next.length > 0 ) {
-				next.find('a').removeAttr( 'tabindex')
+				next.find('a').removeAttr( 'tabindex');
 				next.find('a').trigger( 'focus' );
 			} else {
-				prev.find('a').removeAttr( 'tabindex')
+				prev.find('a').removeAttr( 'tabindex');
 				prev.find('a').trigger( 'focus' );
 			}
 		}

--- a/src/js/_enqueues/admin/link.js
+++ b/src/js/_enqueues/admin/link.js
@@ -19,16 +19,35 @@ jQuery( function($) {
 	 *
 	 * @return {boolean} Always returns false to prevent the default behavior.
 	 */
-	$('#category-tabs a').on( 'click', function(){
+	$('#category-tabs a').on( 'click keyup keydown', function( event ){
 		var t = $(this).attr('href');
-		$(this).parent().addClass('tabs').siblings('li').removeClass('tabs');
-		$('.tabs-panel').hide();
-		$(t).show();
-		if ( '#categories-all' == t )
-			deleteUserSetting('cats');
-		else
-			setUserSetting('cats','pop');
-		return false;
+		if ( ( event.type === 'keyup' && event.key === ' ' ) || ( event.type === 'keydown' && event.key === 'Enter' ) || event.type === 'click' ) {
+			event.preventDefault();
+			$('#category-tabs a').removeAttr( 'aria-selected' ).attr( 'tabindex', '-1' );
+			$(this).attr( 'aria-selected', 'true' ).removeAttr( 'tabindex' );
+			$(this).attr( 'aria-selected', 'true' );
+			$(this).parent().addClass('tabs').siblings('li').removeClass('tabs');
+			$('.tabs-panel').hide();
+			$(t).show();
+			if ( '#categories-all' == t ) {
+				deleteUserSetting('cats');
+			} else {
+				setUserSetting('cats','pop');
+			}
+			return false;
+		}
+		if ( event.type === 'keyup' && ( event.key === 'ArrowRight' || event.key === 'ArrowLeft' ) ) {
+			$(this).attr( 'tabindex', '-1' );
+			let next = $(this).parent('li').next();
+			let prev = $(this).parent('li').prev();
+			if ( next.length > 0 ) {
+				next.find('a').removeAttr( 'tabindex')
+				next.find('a').trigger( 'focus' );
+			} else {
+				prev.find('a').removeAttr( 'tabindex')
+				prev.find('a').trigger( 'focus' );
+			}
+		}
 	});
 	if ( getUserSetting('cats') )
 		$('#category-tabs a[href="#categories-pop"]').trigger( 'click' );

--- a/src/js/_enqueues/admin/link.js
+++ b/src/js/_enqueues/admin/link.js
@@ -21,6 +21,9 @@ jQuery( function($) {
 	 */
 	$('#category-tabs a').on( 'click keyup keydown', function( event ){
 		var t = $(this).attr('href');
+		if ( event.type === 'keydown' && event.key === ' ' ) {
+			event.preventDefault();
+		}
 		if ( ( event.type === 'keyup' && event.key === ' ' ) || ( event.type === 'keydown' && event.key === 'Enter' ) || event.type === 'click' ) {
 			event.preventDefault();
 			$('#category-tabs a').removeAttr( 'aria-selected' ).attr( 'tabindex', '-1' );

--- a/src/js/_enqueues/admin/post.js
+++ b/src/js/_enqueues/admin/post.js
@@ -566,16 +566,32 @@ jQuery( function($) {
 		}
 
 		// @todo Move to jQuery 1.3+, support for multiple hierarchical taxonomies, see wp-lists.js.
-		$('a', '#' + taxonomy + '-tabs').on( 'click', function( e ) {
-			e.preventDefault();
+		$('a', '#' + taxonomy + '-tabs').on( 'click keyup keydown', function( event ) {
 			var t = $(this).attr('href');
-			$(this).parent().addClass('tabs').siblings('li').removeClass('tabs');
-			$('#' + taxonomy + '-tabs').siblings('.tabs-panel').hide();
-			$(t).show();
-			if ( '#' + taxonomy + '-all' == t ) {
-				deleteUserSetting( settingName );
-			} else {
-				setUserSetting( settingName, 'pop' );
+			if ( ( event.type === 'keyup' && event.key === ' ' ) || ( event.type === 'keydown' && event.key === 'Enter' ) || event.type === 'click' ) {
+				event.preventDefault();
+				$('#' + taxonomy + '-tabs a').removeAttr( 'aria-selected' ).attr( 'tabindex', '-1' );
+				$(this).attr( 'aria-selected', 'true' ).removeAttr( 'tabindex' );
+				$(this).parent().addClass('tabs').siblings('li').removeClass('tabs');
+				$('#' + taxonomy + '-tabs').siblings('.tabs-panel').hide();
+				$(t).show();
+				if ( '#' + taxonomy + '-all' == t ) {
+					deleteUserSetting( settingName );
+				} else {
+					setUserSetting( settingName, 'pop' );
+				}
+			}
+			if ( event.type === 'keyup' && ( event.key === 'ArrowRight' || event.key === 'ArrowLeft' ) ) {
+				$(this).attr( 'tabindex', '-1' );
+				let next = $(this).parent('li').next();
+				let prev = $(this).parent('li').prev();
+				if ( next.length > 0 ) {
+					next.find('a').removeAttr( 'tabindex')
+					next.find('a').trigger( 'focus' );
+				} else {
+					prev.find('a').removeAttr( 'tabindex')
+					prev.find('a').trigger( 'focus' );
+				}
 			}
 		});
 

--- a/src/js/_enqueues/admin/post.js
+++ b/src/js/_enqueues/admin/post.js
@@ -568,6 +568,9 @@ jQuery( function($) {
 		// @todo Move to jQuery 1.3+, support for multiple hierarchical taxonomies, see wp-lists.js.
 		$('a', '#' + taxonomy + '-tabs').on( 'click keyup keydown', function( event ) {
 			var t = $(this).attr('href');
+			if ( event.type === 'keydown' && event.key === ' ' ) {
+				event.preventDefault();
+			}
 			if ( ( event.type === 'keyup' && event.key === ' ' ) || ( event.type === 'keydown' && event.key === 'Enter' ) || event.type === 'click' ) {
 				event.preventDefault();
 				$('#' + taxonomy + '-tabs a').removeAttr( 'aria-selected' ).attr( 'tabindex', '-1' );

--- a/src/js/_enqueues/admin/post.js
+++ b/src/js/_enqueues/admin/post.js
@@ -586,10 +586,10 @@ jQuery( function($) {
 				let next = $(this).parent('li').next();
 				let prev = $(this).parent('li').prev();
 				if ( next.length > 0 ) {
-					next.find('a').removeAttr( 'tabindex')
+					next.find('a').removeAttr( 'tabindex');
 					next.find('a').trigger( 'focus' );
 				} else {
-					prev.find('a').removeAttr( 'tabindex')
+					prev.find('a').removeAttr( 'tabindex');
 					prev.find('a').trigger( 'focus' );
 				}
 			}

--- a/src/wp-admin/includes/meta-boxes.php
+++ b/src/wp-admin/includes/meta-boxes.php
@@ -644,18 +644,18 @@ function post_categories_meta_box( $post, $box ) {
 	$taxonomy    = get_taxonomy( $parsed_args['taxonomy'] );
 	?>
 	<div id="taxonomy-<?php echo $tax_name; ?>" class="categorydiv">
-		<ul id="<?php echo $tax_name; ?>-tabs" class="category-tabs">
-			<li class="tabs"><a href="#<?php echo $tax_name; ?>-all"><?php echo $taxonomy->labels->all_items; ?></a></li>
-			<li class="hide-if-no-js"><a href="#<?php echo $tax_name; ?>-pop"><?php echo esc_html( $taxonomy->labels->most_used ); ?></a></li>
+		<ul id="<?php echo $tax_name; ?>-tabs" class="category-tabs" role="tablist">
+			<li class="tabs"><a href="#<?php echo $tax_name; ?>-all" role="tab"  aria-selected="true" aria-controls="<?php echo $tax_name; ?>-all"><?php echo $taxonomy->labels->all_items; ?></a></li>
+			<li class="hide-if-no-js"><a href="#<?php echo $tax_name; ?>-pop" role="tab" aria-controls="<?php echo $tax_name; ?>-pop"><?php echo esc_html( $taxonomy->labels->most_used ); ?></a></li>
 		</ul>
 
-		<div id="<?php echo $tax_name; ?>-pop" class="tabs-panel" style="display: none;">
+		<div id="<?php echo $tax_name; ?>-pop" class="tabs-panel" style="display: none;" role="tabpanel">
 			<ul id="<?php echo $tax_name; ?>checklist-pop" class="categorychecklist form-no-clear" >
 				<?php $popular_ids = wp_popular_terms_checklist( $tax_name ); ?>
 			</ul>
 		</div>
 
-		<div id="<?php echo $tax_name; ?>-all" class="tabs-panel">
+		<div id="<?php echo $tax_name; ?>-all" class="tabs-panel" role="tabpanel">
 			<?php
 			$name = ( 'category' === $tax_name ) ? 'post_category' : 'tax_input[' . $tax_name . ']';
 			// Allows for an empty term set to be sent. 0 is an invalid term ID and will be ignored by empty() checks.
@@ -1176,12 +1176,12 @@ function link_submit_meta_box( $link ) {
 function link_categories_meta_box( $link ) {
 	?>
 <div id="taxonomy-linkcategory" class="categorydiv">
-	<ul id="category-tabs" class="category-tabs">
-		<li class="tabs"><a href="#categories-all"><?php _e( 'All categories' ); ?></a></li>
-		<li class="hide-if-no-js"><a href="#categories-pop"><?php _ex( 'Most Used', 'categories' ); ?></a></li>
+	<ul id="category-tabs" class="category-tabs" role="tablist">
+		<li class="tabs"><a href="#categories-all" role="tab" aria-controls="categories-all" aria-selected="true"><?php _e( 'All categories' ); ?></a></li>
+		<li class="hide-if-no-js"><a href="#categories-pop" role="tab" aria-controls="categories-pop"><?php _ex( 'Most Used', 'categories' ); ?></a></li>
 	</ul>
 
-	<div id="categories-all" class="tabs-panel">
+	<div id="categories-all" class="tabs-panel" role="tabpanel">
 		<ul id="categorychecklist" data-wp-lists="list:category" class="categorychecklist form-no-clear">
 			<?php
 			if ( isset( $link->link_id ) ) {
@@ -1193,7 +1193,7 @@ function link_categories_meta_box( $link ) {
 		</ul>
 	</div>
 
-	<div id="categories-pop" class="tabs-panel" style="display: none;">
+	<div id="categories-pop" class="tabs-panel" style="display: none;" role="tabpanel">
 		<ul id="categorychecklist-pop" class="categorychecklist form-no-clear">
 			<?php wp_popular_terms_checklist( 'link_category' ); ?>
 		</ul>

--- a/src/wp-admin/includes/meta-boxes.php
+++ b/src/wp-admin/includes/meta-boxes.php
@@ -645,7 +645,7 @@ function post_categories_meta_box( $post, $box ) {
 	?>
 	<div id="taxonomy-<?php echo $tax_name; ?>" class="categorydiv">
 		<ul id="<?php echo $tax_name; ?>-tabs" class="category-tabs" role="tablist">
-			<li class="tabs"><a href="#<?php echo $tax_name; ?>-all" role="tab"  aria-selected="true" aria-controls="<?php echo $tax_name; ?>-all"><?php echo $taxonomy->labels->all_items; ?></a></li>
+			<li class="tabs"><a href="#<?php echo $tax_name; ?>-all" role="tab" aria-selected="true" aria-controls="<?php echo $tax_name; ?>-all"><?php echo $taxonomy->labels->all_items; ?></a></li>
 			<li class="hide-if-no-js"><a href="#<?php echo $tax_name; ?>-pop" role="tab" aria-controls="<?php echo $tax_name; ?>-pop"><?php echo esc_html( $taxonomy->labels->most_used ); ?></a></li>
 		</ul>
 


### PR DESCRIPTION
The tab list for switching between the term list and frequently used lists in classic editor views needs to be marked up as a list of tabpanels.

Trac ticket: https://core.trac.wordpress.org/ticket/63981

## Use of AI Tools

none

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
