### PR TITLE
Docs: Correct parameter variable name in `WP_REST_Icons_Controller`

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-icons-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-icons-controller.php
@@ -72,7 +72,7 @@ class WP_REST_Icons_Controller extends WP_REST_Controller {
 	/**
 	 * Checks whether a given request has permission to read icons.
 	 *
-	 * @param WP_REST_Request $_request Full details about the request.
+	 * @param WP_REST_Request $request Full details about the request.
 	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
 	 */
 	public function get_items_permissions_check(


### PR DESCRIPTION
Changed the parameter name in the docblock from `$_request` to `$request` in the `get_items_permissions_check` method of `WP_REST_Icons_Controller` to match the actual parameter name.

Trac ticket: https://core.trac.wordpress.org/ticket/64224

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
