### PR TITLE
Real-time collaboration: Remove ghost awareness state explicitly when refreshing

### DIFF
--- a/src/wp-includes/collaboration/class-wp-http-polling-sync-server.php
+++ b/src/wp-includes/collaboration/class-wp-http-polling-sync-server.php
@@ -122,7 +122,7 @@ class WP_HTTP_Polling_Sync_Server {
 			),
 			'awareness' => array(
 				'required' => true,
-				'type'     => 'object',
+				'type'     => array( 'object', 'null' ),
 			),
 			'client_id' => array(
 				'minimum'  => 1,


### PR DESCRIPTION
Backport of PHP changes from https://github.com/WordPress/gutenberg/pull/75883. Changes the real-time collaboration polling server endpoint to accept `null` for awareness values, which is used to explicitly disconnect users leaving the page and remove their awareness data more quickly.

Trac ticket: https://core.trac.wordpress.org/ticket/64622

## Use of AI Tools

Claude for the original PR.