### PR TITLE
Classic Editor: set background, positioning and height for Skip to Editor link

### DIFF
--- a/src/wp-admin/css/edit.css
+++ b/src/wp-admin/css/edit.css
@@ -76,10 +76,16 @@
 	pointer-events: none;
 }
 
+#titlewrap .skiplink {
+	background: #fff;
+	line-height: 2.30769231;
+	min-height: 32px;
+	right: 4px;
+}
+
 #titlewrap .skiplink:focus {
 	clip: inherit;
 	clip-path: inherit;
-	right: 4px;
 	top: 4px;
 	width: auto;
 }
@@ -1060,10 +1066,6 @@ form#tags-filter {
 
 	#edit-slug-box {
 		padding: 0;
-	}
-
-	#titlewrap .skiplink:focus {
-		top: 5px;
 	}
 }
 

--- a/src/wp-admin/css/edit.css
+++ b/src/wp-admin/css/edit.css
@@ -78,7 +78,7 @@
 
 #titlewrap .skiplink {
 	background: #fff;
-	line-height: 2.30769231;  /* 30px for 32px min-height */
+	line-height: 2.30769231; /* 30px for 32px min-height */
 	min-height: 32px;
 	right: 4px;
 }

--- a/src/wp-admin/css/edit.css
+++ b/src/wp-admin/css/edit.css
@@ -78,7 +78,7 @@
 
 #titlewrap .skiplink {
 	background: #fff;
-	line-height: 2.30769231;
+	line-height: 2.30769231;  /* 30px for 32px min-height */
 	min-height: 32px;
 	right: 4px;
 }


### PR DESCRIPTION
- Assigns the `right` positioning value regardless of whether the link has focus, to avoid horizontal scroll.
- Sets the background color to white.
- Reduces the `line-height` and `min-height`.
- Keeps the `top` value of 4 pixels for any screen width.

[Trac 64727](https://core.trac.wordpress.org/ticket/64727)

Use of AI Tools: none

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**