### PR TITLE
Connectors: Backport Gutenberg PR #75833 PHP integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"url": "https://develop.svn.wordpress.org/trunk"
 	},
 	"gutenberg": {
-		"ref": "23b566c72e9c4a36219ef5d6e62890f05551f6cb"
+		"ref": "336a47b80b566256ce5035cae56b2ab16f583dad"
 	},
 	"engines": {
 		"node": ">=20.10.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"url": "https://develop.svn.wordpress.org/trunk"
 	},
 	"gutenberg": {
-		"ref": "336a47b80b566256ce5035cae56b2ab16f583dad"
+		"ref": "4aa81f968a38960a7a3ee32f557a366f285dc08f"
 	},
 	"engines": {
 		"node": ">=20.10.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"url": "https://develop.svn.wordpress.org/trunk"
 	},
 	"gutenberg": {
-		"ref": "4aa81f968a38960a7a3ee32f557a366f285dc08f"
+		"ref": "23b566c72e9c4a36219ef5d6e62890f05551f6cb"
 	},
 	"engines": {
 		"node": ">=20.10.0",

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -148,114 +148,6 @@ function _wp_connectors_get_real_api_key( string $option_name, callable $mask_ca
 }
 
 /**
- * Masks the Gemini API key on read.
- *
- * @since 7.0.0
- * @access private
- *
- * @param string $value The raw option value.
- * @return string Masked key or empty string.
- */
-function _wp_connectors_mask_gemini_api_key( string $value ): string {
-	if ( '' === $value ) {
-		return $value;
-	}
-
-	return _wp_connectors_mask_api_key( $value );
-}
-
-/**
- * Sanitizes and validates the Gemini API key before saving.
- *
- * @since 7.0.0
- * @access private
- *
- * @param string $value The new value.
- * @return string The sanitized value, or empty string if the key is not valid.
- */
-function _wp_connectors_sanitize_gemini_api_key( string $value ): string {
-	$value = sanitize_text_field( $value );
-	if ( '' === $value ) {
-		return $value;
-	}
-
-	$valid = _wp_connectors_is_api_key_valid( $value, 'google' );
-	return true === $valid ? $value : '';
-}
-
-/**
- * Masks the OpenAI API key on read.
- *
- * @since 7.0.0
- * @access private
- *
- * @param string $value The raw option value.
- * @return string Masked key or empty string.
- */
-function _wp_connectors_mask_openai_api_key( string $value ): string {
-	if ( '' === $value ) {
-		return $value;
-	}
-
-	return _wp_connectors_mask_api_key( $value );
-}
-
-/**
- * Sanitizes and validates the OpenAI API key before saving.
- *
- * @since 7.0.0
- * @access private
- *
- * @param string $value The new value.
- * @return string The sanitized value, or empty string if the key is not valid.
- */
-function _wp_connectors_sanitize_openai_api_key( string $value ): string {
-	$value = sanitize_text_field( $value );
-	if ( '' === $value ) {
-		return $value;
-	}
-
-	$valid = _wp_connectors_is_api_key_valid( $value, 'openai' );
-	return true === $valid ? $value : '';
-}
-
-/**
- * Masks the Anthropic API key on read.
- *
- * @since 7.0.0
- * @access private
- *
- * @param string $value The raw option value.
- * @return string Masked key or empty string.
- */
-function _wp_connectors_mask_anthropic_api_key( string $value ): string {
-	if ( '' === $value ) {
-		return $value;
-	}
-
-	return _wp_connectors_mask_api_key( $value );
-}
-
-/**
- * Sanitizes and validates the Anthropic API key before saving.
- *
- * @since 7.0.0
- * @access private
- *
- * @param string $value The new value.
- * @return string The sanitized value, or empty string if the key is not valid.
- */
-function _wp_connectors_sanitize_anthropic_api_key( string $value ): string {
-	$value = sanitize_text_field( $value );
-	if ( '' === $value ) {
-		return $value;
-	}
-
-	$valid = _wp_connectors_is_api_key_valid( $value, 'anthropic' );
-	return true === $valid ? $value : '';
-}
-
-/**
  * Gets the provider connectors.
  *
  * @since 7.0.0
@@ -264,23 +156,29 @@ function _wp_connectors_sanitize_anthropic_api_key( string $value ): string {
  * @return array<string, array{provider: string, mask: callable, sanitize: callable}> Connectors.
  */
 function _wp_connectors_get_connectors(): array {
-	return array(
-		'connectors_gemini_api_key'    => array(
-			'provider' => 'google',
-			'mask'     => '_wp_connectors_mask_gemini_api_key',
-			'sanitize' => '_wp_connectors_sanitize_gemini_api_key',
-		),
-		'connectors_openai_api_key'    => array(
-			'provider' => 'openai',
-			'mask'     => '_wp_connectors_mask_openai_api_key',
-			'sanitize' => '_wp_connectors_sanitize_openai_api_key',
-		),
-		'connectors_anthropic_api_key' => array(
-			'provider' => 'anthropic',
-			'mask'     => '_wp_connectors_mask_anthropic_api_key',
-			'sanitize' => '_wp_connectors_sanitize_anthropic_api_key',
-		),
+	$providers = array(
+		'google'    => 'connectors_gemini_api_key',
+		'openai'    => 'connectors_openai_api_key',
+		'anthropic' => 'connectors_anthropic_api_key',
 	);
+
+	$connectors = array();
+	foreach ( $providers as $provider => $option_name ) {
+		$connectors[ $option_name ] = array(
+			'provider' => $provider,
+			'mask'     => '_wp_connectors_mask_api_key',
+			'sanitize' => static function ( string $value ) use ( $provider ): string {
+				$value = sanitize_text_field( $value );
+				if ( '' === $value ) {
+					return $value;
+				}
+
+				$valid = _wp_connectors_is_api_key_valid( $value, $provider );
+				return true === $valid ? $value : '';
+			},
+		);
+	}
+	return $connectors;
 }
 
 /**

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -90,45 +90,6 @@ function _wp_connectors_is_api_key_valid( string $key, string $provider_id ): ?b
 }
 
 /**
- * Sets API key authentication for a provider in the WP AI Client registry.
- *
- * @since 7.0.0
- * @access private
- *
- * @param string $key         The API key.
- * @param string $provider_id The WP AI client provider ID.
- * @return bool True if the key was set successfully, false otherwise.
- */
-function _wp_connectors_set_provider_api_key( string $key, string $provider_id ): bool {
-	try {
-		$registry = AiClient::defaultRegistry();
-
-		if ( ! $registry->hasProvider( $provider_id ) ) {
-			_doing_it_wrong(
-				__FUNCTION__,
-				sprintf(
-					/* translators: %s: AI provider ID. */
-					__( 'The provider "%s" is not registered in the AI client registry.' ),
-					$provider_id
-				),
-				'7.0.0'
-			);
-			return false;
-		}
-
-		$registry->setProviderRequestAuthentication(
-			$provider_id,
-			new ApiKeyRequestAuthentication( $key )
-		);
-
-		return true;
-	} catch ( Exception $e ) {
-		wp_trigger_error( __FUNCTION__, $e->getMessage() );
-		return false;
-	}
-}
-
-/**
  * Retrieves the real (unmasked) value of a connector API key.
  *
  * Temporarily removes the masking filter, reads the option, then re-adds it.
@@ -299,12 +260,21 @@ function _wp_connectors_pass_default_keys_to_ai_client(): void {
 	if ( ! class_exists( '\WordPress\AiClient\AiClient' ) ) {
 		return;
 	}
+	try {
+		$registry = AiClient::defaultRegistry();
+		foreach ( _wp_connectors_get_provider_settings() as $setting_name => $config ) {
+			$api_key = _wp_connectors_get_real_api_key( $setting_name, $config['mask'] );
+			if ( '' === $api_key || ! $registry->hasProvider( $config['provider'] ) ) {
+				continue;
+			}
 
-	foreach ( _wp_connectors_get_provider_settings() as $setting_name => $config ) {
-		$api_key = _wp_connectors_get_real_api_key( $setting_name, $config['mask'] );
-		if ( '' !== $api_key ) {
-			_wp_connectors_set_provider_api_key( $api_key, $config['provider'] );
+			$registry->setProviderRequestAuthentication(
+				$config['provider'],
+				new ApiKeyRequestAuthentication( $api_key )
+			);
 		}
+	} catch ( Exception $e ) {
+			wp_trigger_error( __FUNCTION__, $e->getMessage() );
 	}
 }
 add_action( 'init', '_wp_connectors_pass_default_keys_to_ai_client' );

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -65,6 +65,15 @@ function _wp_connectors_is_api_key_valid( string $key, string $provider_id ): ?b
 		$registry = AiClient::defaultRegistry();
 
 		if ( ! $registry->hasProvider( $provider_id ) ) {
+			_doing_it_wrong(
+				__FUNCTION__,
+				sprintf(
+					/* translators: %s: AI provider ID. */
+					__( 'The provider "%s" is not registered in the AI client registry.' ),
+					$provider_id
+				),
+				'7.0.0'
+			);
 			return null;
 		}
 
@@ -74,7 +83,8 @@ function _wp_connectors_is_api_key_valid( string $key, string $provider_id ): ?b
 		);
 
 		return $registry->isProviderConfigured( $provider_id );
-	} catch ( \Error $e ) {
+	} catch ( Exception $e ) {
+		wp_trigger_error( __FUNCTION__, $e->getMessage() );
 		return null;
 	}
 }
@@ -87,21 +97,34 @@ function _wp_connectors_is_api_key_valid( string $key, string $provider_id ): ?b
  *
  * @param string $key         The API key.
  * @param string $provider_id The WP AI client provider ID.
+ * @return bool True if the key was set successfully, false otherwise.
  */
-function _wp_connectors_set_provider_api_key( string $key, string $provider_id ): void {
+function _wp_connectors_set_provider_api_key( string $key, string $provider_id ): bool {
 	try {
 		$registry = AiClient::defaultRegistry();
 
 		if ( ! $registry->hasProvider( $provider_id ) ) {
-			return;
+			_doing_it_wrong(
+				__FUNCTION__,
+				sprintf(
+					/* translators: %s: AI provider ID. */
+					__( 'The provider "%s" is not registered in the AI client registry.' ),
+					$provider_id
+				),
+				'7.0.0'
+			);
+			return false;
 		}
 
 		$registry->setProviderRequestAuthentication(
 			$provider_id,
 			new ApiKeyRequestAuthentication( $key )
 		);
-	} catch ( \Error $e ) {
-		// WP AI Client not available.
+
+		return true;
+	} catch ( Exception $e ) {
+		wp_trigger_error( __FUNCTION__, $e->getMessage() );
+		return false;
 	}
 }
 

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -148,26 +148,47 @@ function _wp_connectors_get_real_api_key( string $option_name, callable $mask_ca
 }
 
 /**
- * Gets the provider connectors.
+ * Gets the registered connector provider settings.
  *
  * @since 7.0.0
  * @access private
  *
- * @return array<string, array{provider: string, mask: callable, sanitize: callable}> Connectors.
+ * @return array<string, array{provider: string, label: string, description: string, mask: callable, sanitize: callable}> Provider settings keyed by setting name.
  */
-function _wp_connectors_get_connectors(): array {
+function _wp_connectors_get_provider_settings(): array {
 	$providers = array(
-		'google'    => 'connectors_gemini_api_key',
-		'openai'    => 'connectors_openai_api_key',
-		'anthropic' => 'connectors_anthropic_api_key',
+		'google'    => array(
+			'slug' => 'gemini',
+			'name' => 'Gemini',
+		),
+		'openai'    => array(
+			'slug' => 'openai',
+			'name' => 'OpenAI',
+		),
+		'anthropic' => array(
+			'slug' => 'anthropic',
+			'name' => 'Anthropic',
+		),
 	);
 
-	$connectors = array();
-	foreach ( $providers as $provider => $option_name ) {
-		$connectors[ $option_name ] = array(
-			'provider' => $provider,
-			'mask'     => '_wp_connectors_mask_api_key',
-			'sanitize' => static function ( string $value ) use ( $provider ): string {
+	$provider_settings = array();
+	foreach ( $providers as $provider => $data ) {
+		$setting_name = "connectors_{$data['slug']}_api_key";
+
+		$provider_settings[ $setting_name ] = array(
+			'provider'    => $provider,
+			'label'       => sprintf(
+				/* translators: %s: AI provider name. */
+				__( '%s API Key' ),
+				$data['name']
+			),
+			'description' => sprintf(
+				/* translators: %s: AI provider name. */
+				__( 'API key for the %s AI provider.' ),
+				$data['name']
+			),
+			'mask'        => '_wp_connectors_mask_api_key',
+			'sanitize'    => static function ( string $value ) use ( $provider ): string {
 				$value = sanitize_text_field( $value );
 				if ( '' === $value ) {
 					return $value;
@@ -178,7 +199,7 @@ function _wp_connectors_get_connectors(): array {
 			},
 		);
 	}
-	return $connectors;
+	return $provider_settings;
 }
 
 /**
@@ -222,18 +243,18 @@ function _wp_connectors_validate_keys_in_rest( WP_REST_Response $response, WP_RE
 		return $response;
 	}
 
-	foreach ( _wp_connectors_get_connectors() as $option_name => $config ) {
-		if ( ! in_array( $option_name, $requested, true ) ) {
+	foreach ( _wp_connectors_get_provider_settings() as $setting_name => $config ) {
+		if ( ! in_array( $setting_name, $requested, true ) ) {
 			continue;
 		}
 
-		$real_key = _wp_connectors_get_real_api_key( $option_name, $config['mask'] );
+		$real_key = _wp_connectors_get_real_api_key( $setting_name, $config['mask'] );
 		if ( '' === $real_key ) {
 			continue;
 		}
 
 		if ( true !== _wp_connectors_is_api_key_valid( $real_key, $config['provider'] ) ) {
-			$data[ $option_name ] = 'invalid_key';
+			$data[ $setting_name ] = 'invalid_key';
 		}
 	}
 
@@ -253,18 +274,20 @@ function _wp_register_default_connector_settings(): void {
 		return;
 	}
 
-	foreach ( _wp_connectors_get_connectors() as $option_name => $config ) {
+	foreach ( _wp_connectors_get_provider_settings() as $setting_name => $config ) {
 		register_setting(
 			'connectors',
-			$option_name,
+			$setting_name,
 			array(
 				'type'              => 'string',
+				'label'             => $config['label'],
+				'description'       => $config['description'],
 				'default'           => '',
 				'show_in_rest'      => true,
 				'sanitize_callback' => $config['sanitize'],
 			)
 		);
-		add_filter( "option_{$option_name}", $config['mask'] );
+		add_filter( "option_{$setting_name}", $config['mask'] );
 	}
 }
 add_action( 'init', '_wp_register_default_connector_settings' );
@@ -280,8 +303,8 @@ function _wp_connectors_pass_default_keys_to_ai_client(): void {
 		return;
 	}
 
-	foreach ( _wp_connectors_get_connectors() as $option_name => $config ) {
-		$api_key = _wp_connectors_get_real_api_key( $option_name, $config['mask'] );
+	foreach ( _wp_connectors_get_provider_settings() as $setting_name => $config ) {
+		$api_key = _wp_connectors_get_real_api_key( $setting_name, $config['mask'] );
 		if ( '' !== $api_key ) {
 			_wp_connectors_set_provider_api_key( $api_key, $config['provider'] );
 		}

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -158,22 +158,19 @@ function _wp_connectors_get_real_api_key( string $option_name, callable $mask_ca
 function _wp_connectors_get_provider_settings(): array {
 	$providers = array(
 		'google'    => array(
-			'slug' => 'gemini',
-			'name' => 'Gemini',
+			'name' => 'Google',
 		),
 		'openai'    => array(
-			'slug' => 'openai',
 			'name' => 'OpenAI',
 		),
 		'anthropic' => array(
-			'slug' => 'anthropic',
 			'name' => 'Anthropic',
 		),
 	);
 
 	$provider_settings = array();
 	foreach ( $providers as $provider => $data ) {
-		$setting_name = "connectors_{$data['slug']}_api_key";
+		$setting_name = "connectors_ai_{$provider}_api_key";
 
 		$provider_settings[ $setting_name ] = array(
 			'provider'    => $provider,

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -1,0 +1,369 @@
+<?php
+/**
+ * Connectors API.
+ *
+ * @package WordPress
+ * @subpackage Connectors
+ * @since 7.0.0
+ */
+
+use WordPress\AiClient\AiClient;
+use WordPress\AiClient\Providers\Http\DTO\ApiKeyRequestAuthentication;
+
+/**
+ * Registers the Connectors menu item under Settings.
+ *
+ * @since 7.0.0
+ * @access private
+ */
+function _wp_connectors_add_settings_menu_item(): void {
+	if ( ! class_exists( '\WordPress\AiClient\AiClient' ) || ! function_exists( 'wp_connectors_wp_admin_render_page' ) ) {
+		return;
+	}
+
+	add_submenu_page(
+		'options-general.php',
+		__( 'Connectors' ),
+		__( 'Connectors' ),
+		'manage_options',
+		'connectors-wp-admin',
+		'wp_connectors_wp_admin_render_page',
+		1
+	);
+}
+add_action( 'admin_menu', '_wp_connectors_add_settings_menu_item' );
+
+/**
+ * Masks an API key, showing only the last 4 characters.
+ *
+ * @since 7.0.0
+ * @access private
+ *
+ * @param string $key The API key to mask.
+ * @return string The masked key, e.g. "************fj39".
+ */
+function _wp_connectors_mask_api_key( string $key ): string {
+	if ( strlen( $key ) <= 4 ) {
+		return $key;
+	}
+
+	return str_repeat( "\u{2022}", min( strlen( $key ) - 4, 16 ) ) . substr( $key, -4 );
+}
+
+/**
+ * Checks whether an API key is valid for a given provider.
+ *
+ * @since 7.0.0
+ * @access private
+ *
+ * @param string $key         The API key to check.
+ * @param string $provider_id The WP AI client provider ID.
+ * @return bool|null True if valid, false if invalid, null if unable to determine.
+ */
+function _wp_connectors_is_api_key_valid( string $key, string $provider_id ): ?bool {
+	try {
+		$registry = AiClient::defaultRegistry();
+
+		if ( ! $registry->hasProvider( $provider_id ) ) {
+			return null;
+		}
+
+		$registry->setProviderRequestAuthentication(
+			$provider_id,
+			new ApiKeyRequestAuthentication( $key )
+		);
+
+		return $registry->isProviderConfigured( $provider_id );
+	} catch ( \Error $e ) {
+		return null;
+	}
+}
+
+/**
+ * Sets API key authentication for a provider in the WP AI Client registry.
+ *
+ * @since 7.0.0
+ * @access private
+ *
+ * @param string $key         The API key.
+ * @param string $provider_id The WP AI client provider ID.
+ */
+function _wp_connectors_set_provider_api_key( string $key, string $provider_id ): void {
+	try {
+		$registry = AiClient::defaultRegistry();
+
+		if ( ! $registry->hasProvider( $provider_id ) ) {
+			return;
+		}
+
+		$registry->setProviderRequestAuthentication(
+			$provider_id,
+			new ApiKeyRequestAuthentication( $key )
+		);
+	} catch ( \Error $e ) {
+		// WP AI Client not available.
+	}
+}
+
+/**
+ * Retrieves the real (unmasked) value of a connector API key.
+ *
+ * Temporarily removes the masking filter, reads the option, then re-adds it.
+ *
+ * @since 7.0.0
+ * @access private
+ *
+ * @param string   $option_name   The option name for the API key.
+ * @param callable $mask_callback The mask filter function.
+ * @return string The real API key value.
+ */
+function _wp_connectors_get_real_api_key( string $option_name, callable $mask_callback ): string {
+	remove_filter( "option_{$option_name}", $mask_callback );
+	$value = get_option( $option_name, '' );
+	add_filter( "option_{$option_name}", $mask_callback );
+	return (string) $value;
+}
+
+/**
+ * Masks the Gemini API key on read.
+ *
+ * @since 7.0.0
+ * @access private
+ *
+ * @param string $value The raw option value.
+ * @return string Masked key or empty string.
+ */
+function _wp_connectors_mask_gemini_api_key( string $value ): string {
+	if ( '' === $value ) {
+		return $value;
+	}
+
+	return _wp_connectors_mask_api_key( $value );
+}
+
+/**
+ * Sanitizes and validates the Gemini API key before saving.
+ *
+ * @since 7.0.0
+ * @access private
+ *
+ * @param string $value The new value.
+ * @return string The sanitized value, or empty string if the key is not valid.
+ */
+function _wp_connectors_sanitize_gemini_api_key( string $value ): string {
+	$value = sanitize_text_field( $value );
+	if ( '' === $value ) {
+		return $value;
+	}
+
+	$valid = _wp_connectors_is_api_key_valid( $value, 'google' );
+	return true === $valid ? $value : '';
+}
+
+/**
+ * Masks the OpenAI API key on read.
+ *
+ * @since 7.0.0
+ * @access private
+ *
+ * @param string $value The raw option value.
+ * @return string Masked key or empty string.
+ */
+function _wp_connectors_mask_openai_api_key( string $value ): string {
+	if ( '' === $value ) {
+		return $value;
+	}
+
+	return _wp_connectors_mask_api_key( $value );
+}
+
+/**
+ * Sanitizes and validates the OpenAI API key before saving.
+ *
+ * @since 7.0.0
+ * @access private
+ *
+ * @param string $value The new value.
+ * @return string The sanitized value, or empty string if the key is not valid.
+ */
+function _wp_connectors_sanitize_openai_api_key( string $value ): string {
+	$value = sanitize_text_field( $value );
+	if ( '' === $value ) {
+		return $value;
+	}
+
+	$valid = _wp_connectors_is_api_key_valid( $value, 'openai' );
+	return true === $valid ? $value : '';
+}
+
+/**
+ * Masks the Anthropic API key on read.
+ *
+ * @since 7.0.0
+ * @access private
+ *
+ * @param string $value The raw option value.
+ * @return string Masked key or empty string.
+ */
+function _wp_connectors_mask_anthropic_api_key( string $value ): string {
+	if ( '' === $value ) {
+		return $value;
+	}
+
+	return _wp_connectors_mask_api_key( $value );
+}
+
+/**
+ * Sanitizes and validates the Anthropic API key before saving.
+ *
+ * @since 7.0.0
+ * @access private
+ *
+ * @param string $value The new value.
+ * @return string The sanitized value, or empty string if the key is not valid.
+ */
+function _wp_connectors_sanitize_anthropic_api_key( string $value ): string {
+	$value = sanitize_text_field( $value );
+	if ( '' === $value ) {
+		return $value;
+	}
+
+	$valid = _wp_connectors_is_api_key_valid( $value, 'anthropic' );
+	return true === $valid ? $value : '';
+}
+
+/**
+ * Gets the provider connectors.
+ *
+ * @since 7.0.0
+ * @access private
+ *
+ * @return array<string, array{provider: string, mask: callable, sanitize: callable}> Connectors.
+ */
+function _wp_connectors_get_connectors(): array {
+	return array(
+		'connectors_gemini_api_key'    => array(
+			'provider' => 'google',
+			'mask'     => '_wp_connectors_mask_gemini_api_key',
+			'sanitize' => '_wp_connectors_sanitize_gemini_api_key',
+		),
+		'connectors_openai_api_key'    => array(
+			'provider' => 'openai',
+			'mask'     => '_wp_connectors_mask_openai_api_key',
+			'sanitize' => '_wp_connectors_sanitize_openai_api_key',
+		),
+		'connectors_anthropic_api_key' => array(
+			'provider' => 'anthropic',
+			'mask'     => '_wp_connectors_mask_anthropic_api_key',
+			'sanitize' => '_wp_connectors_sanitize_anthropic_api_key',
+		),
+	);
+}
+
+/**
+ * Validates connector API keys in the REST response when explicitly requested.
+ *
+ * Runs on `rest_post_dispatch` for `/wp/v2/settings` requests that include connector
+ * fields via `_fields`. For each requested connector field, it validates the unmasked
+ * key against the provider and replaces the response value with `invalid_key` if
+ * validation fails.
+ *
+ * @since 7.0.0
+ * @access private
+ *
+ * @param WP_REST_Response $response The response object.
+ * @param WP_REST_Server   $server   The server instance.
+ * @param WP_REST_Request  $request  The request object.
+ * @return WP_REST_Response The potentially modified response.
+ */
+function _wp_connectors_validate_keys_in_rest( WP_REST_Response $response, WP_REST_Server $server, WP_REST_Request $request ): WP_REST_Response {
+	if ( '/wp/v2/settings' !== $request->get_route() ) {
+		return $response;
+	}
+
+	if ( ! class_exists( '\WordPress\AiClient\AiClient' ) ) {
+		return $response;
+	}
+
+	$fields = $request->get_param( '_fields' );
+	if ( ! $fields ) {
+		return $response;
+	}
+
+	if ( is_array( $fields ) ) {
+		$requested = $fields;
+	} else {
+		$requested = array_map( 'trim', explode( ',', $fields ) );
+	}
+
+	$data = $response->get_data();
+	if ( ! is_array( $data ) ) {
+		return $response;
+	}
+
+	foreach ( _wp_connectors_get_connectors() as $option_name => $config ) {
+		if ( ! in_array( $option_name, $requested, true ) ) {
+			continue;
+		}
+
+		$real_key = _wp_connectors_get_real_api_key( $option_name, $config['mask'] );
+		if ( '' === $real_key ) {
+			continue;
+		}
+
+		if ( true !== _wp_connectors_is_api_key_valid( $real_key, $config['provider'] ) ) {
+			$data[ $option_name ] = 'invalid_key';
+		}
+	}
+
+	$response->set_data( $data );
+	return $response;
+}
+add_filter( 'rest_post_dispatch', '_wp_connectors_validate_keys_in_rest', 10, 3 );
+
+/**
+ * Registers default connector settings and mask/sanitize filters.
+ *
+ * @since 7.0.0
+ * @access private
+ */
+function _wp_register_default_connector_settings(): void {
+	if ( ! class_exists( '\WordPress\AiClient\AiClient' ) ) {
+		return;
+	}
+
+	foreach ( _wp_connectors_get_connectors() as $option_name => $config ) {
+		register_setting(
+			'connectors',
+			$option_name,
+			array(
+				'type'              => 'string',
+				'default'           => '',
+				'show_in_rest'      => true,
+				'sanitize_callback' => $config['sanitize'],
+			)
+		);
+		add_filter( "option_{$option_name}", $config['mask'] );
+	}
+}
+add_action( 'init', '_wp_register_default_connector_settings' );
+
+/**
+ * Passes stored connector API keys to the WP AI client.
+ *
+ * @since 7.0.0
+ * @access private
+ */
+function _wp_connectors_pass_default_keys_to_ai_client(): void {
+	if ( ! class_exists( '\WordPress\AiClient\AiClient' ) ) {
+		return;
+	}
+
+	foreach ( _wp_connectors_get_connectors() as $option_name => $config ) {
+		$api_key = _wp_connectors_get_real_api_key( $option_name, $config['mask'] );
+		if ( '' !== $api_key ) {
+			_wp_connectors_set_provider_api_key( $api_key, $config['provider'] );
+		}
+	}
+}
+add_action( 'init', '_wp_connectors_pass_default_keys_to_ai_client' );

--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -294,6 +294,7 @@ require ABSPATH . WPINC . '/ai-client/adapters/class-wp-ai-client-event-dispatch
 require ABSPATH . WPINC . '/ai-client/class-wp-ai-client-ability-function-resolver.php';
 require ABSPATH . WPINC . '/ai-client/class-wp-ai-client-prompt-builder.php';
 require ABSPATH . WPINC . '/ai-client.php';
+require ABSPATH . WPINC . '/connectors.php';
 require ABSPATH . WPINC . '/class-wp-icons-registry.php';
 require ABSPATH . WPINC . '/widgets.php';
 require ABSPATH . WPINC . '/class-wp-widget.php';

--- a/tests/phpunit/includes/wp-ai-client-mock-provider-trait.php
+++ b/tests/phpunit/includes/wp-ai-client-mock-provider-trait.php
@@ -1,0 +1,172 @@
+<?php
+/**
+ * Trait for creating mock providers for testing.
+ *
+ * @package WordPress
+ * @subpackage AI
+ */
+
+use WordPress\AiClient\AiClient;
+use WordPress\AiClient\Providers\AbstractProvider;
+use WordPress\AiClient\Providers\Contracts\ModelMetadataDirectoryInterface;
+use WordPress\AiClient\Providers\Contracts\ProviderAvailabilityInterface;
+use WordPress\AiClient\Providers\DTO\ProviderMetadata;
+use WordPress\AiClient\Providers\Enums\ProviderTypeEnum;
+use WordPress\AiClient\Providers\Http\Enums\RequestAuthenticationMethod;
+use WordPress\AiClient\Providers\Models\Contracts\ModelInterface;
+use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
+
+/**
+ * Mock provider availability with a controllable flag.
+ *
+ * @since 7.0.0
+ */
+class Mock_Connectors_Test_Provider_Availability implements ProviderAvailabilityInterface {
+
+	/**
+	 * Whether the provider should report as configured.
+	 *
+	 * @var bool
+	 */
+	public static bool $is_configured = true;
+
+	/**
+	 * Checks if the provider is configured.
+	 *
+	 * @return bool
+	 */
+	public function isConfigured(): bool {
+		return self::$is_configured;
+	}
+}
+
+/**
+ * Mock model metadata directory that returns an empty list.
+ *
+ * @since 7.0.0
+ */
+class Mock_Connectors_Test_Model_Metadata_Directory implements ModelMetadataDirectoryInterface {
+
+	/**
+	 * Lists model metadata.
+	 *
+	 * @return array Empty array.
+	 */
+	public function listModelMetadata(): array {
+		return array();
+	}
+
+	/**
+	 * Checks if a model exists.
+	 *
+	 * @param string $modelId The model ID.
+	 * @return bool Always false.
+	 */
+	public function hasModelMetadata( string $modelId ): bool {
+		return false;
+	}
+
+	/**
+	 * Gets model metadata.
+	 *
+	 * @param string $modelId The model ID.
+	 * @throws \InvalidArgumentException Always, as no models are available.
+	 */
+	public function getModelMetadata( string $modelId ): ModelMetadata {
+		throw new \InvalidArgumentException( 'No models available.' );
+	}
+}
+
+/**
+ * Minimal mock provider for testing connector functions that interact
+ * with the AI Client registry.
+ *
+ * Uses API key authentication and delegates availability to
+ * Mock_Connectors_Test_Provider_Availability so tests can toggle
+ * the configured state.
+ *
+ * @since 7.0.0
+ */
+class Mock_Connectors_Test_Provider extends AbstractProvider {
+
+	/**
+	 * Creates the provider metadata.
+	 *
+	 * @return ProviderMetadata
+	 */
+	protected static function createProviderMetadata(): ProviderMetadata {
+		return new ProviderMetadata(
+			'mock_connectors_test',
+			'Mock Connectors Test',
+			ProviderTypeEnum::cloud(),
+			null,
+			RequestAuthenticationMethod::apiKey()
+		);
+	}
+
+	/**
+	 * Creates the provider availability checker.
+	 *
+	 * @return ProviderAvailabilityInterface
+	 */
+	protected static function createProviderAvailability(): ProviderAvailabilityInterface {
+		return new Mock_Connectors_Test_Provider_Availability();
+	}
+
+	/**
+	 * Creates the model metadata directory.
+	 *
+	 * @return ModelMetadataDirectoryInterface
+	 */
+	protected static function createModelMetadataDirectory(): ModelMetadataDirectoryInterface {
+		return new Mock_Connectors_Test_Model_Metadata_Directory();
+	}
+
+	/**
+	 * Creates a model instance.
+	 *
+	 * @param ModelMetadata    $modelMetadata    The model metadata.
+	 * @param ProviderMetadata $providerMetadata The provider metadata.
+	 * @throws \RuntimeException Always, as model creation is not needed for these tests.
+	 */
+	protected static function createModel(
+		ModelMetadata $modelMetadata,
+		ProviderMetadata $providerMetadata
+	): ModelInterface {
+		throw new \RuntimeException( 'Not implemented.' );
+	}
+}
+
+/**
+ * Trait providing a mock AI provider for testing connector functions.
+ *
+ * Registers a mock provider in the AI Client singleton registry with
+ * controllable availability. Tests can toggle the configured state via
+ * set_mock_provider_configured().
+ *
+ * @since 7.0.0
+ */
+trait WP_AI_Client_Mock_Provider_Trait {
+
+	/**
+	 * Registers the mock provider in the AI Client registry.
+	 *
+	 * Safe to call multiple times; skips registration if already done.
+	 * Must be called from set_up_before_class() after parent::set_up_before_class().
+	 */
+	private static function register_mock_connectors_provider(): void {
+		$registry = AiClient::defaultRegistry();
+		if ( ! $registry->hasProvider( 'mock_connectors_test' ) ) {
+			$registry->registerProvider( Mock_Connectors_Test_Provider::class );
+		}
+	}
+
+	/**
+	 * Sets whether the mock provider reports as configured.
+	 *
+	 * @param bool $is_configured Whether the provider should be configured.
+	 */
+	private static function set_mock_provider_configured( bool $is_configured ): void {
+		Mock_Connectors_Test_Provider_Availability::$is_configured = $is_configured;
+	}
+}

--- a/tests/phpunit/includes/wp-ai-client-mock-provider-trait.php
+++ b/tests/phpunit/includes/wp-ai-client-mock-provider-trait.php
@@ -59,20 +59,20 @@ class Mock_Connectors_Test_Model_Metadata_Directory implements ModelMetadataDire
 	/**
 	 * Checks if a model exists.
 	 *
-	 * @param string $modelId The model ID.
+	 * @param string $model_id The model ID.
 	 * @return bool Always false.
 	 */
-	public function hasModelMetadata( string $modelId ): bool {
+	public function hasModelMetadata( string $model_id ): bool {
 		return false;
 	}
 
 	/**
 	 * Gets model metadata.
 	 *
-	 * @param string $modelId The model ID.
+	 * @param string $model_id The model ID.
 	 * @throws \InvalidArgumentException Always, as no models are available.
 	 */
-	public function getModelMetadata( string $modelId ): ModelMetadata {
+	public function getModelMetadata( string $model_id ): ModelMetadata {
 		throw new \InvalidArgumentException( 'No models available.' );
 	}
 }
@@ -125,13 +125,13 @@ class Mock_Connectors_Test_Provider extends AbstractProvider {
 	/**
 	 * Creates a model instance.
 	 *
-	 * @param ModelMetadata    $modelMetadata    The model metadata.
-	 * @param ProviderMetadata $providerMetadata The provider metadata.
+	 * @param ModelMetadata    $model_metadata    The model metadata.
+	 * @param ProviderMetadata $provider_metadata The provider metadata.
 	 * @throws \RuntimeException Always, as model creation is not needed for these tests.
 	 */
 	protected static function createModel(
-		ModelMetadata $modelMetadata,
-		ProviderMetadata $providerMetadata
+		ModelMetadata $model_metadata,
+		ProviderMetadata $provider_metadata
 	): ModelInterface {
 		throw new \RuntimeException( 'Not implemented.' );
 	}

--- a/tests/phpunit/tests/connectors/wpConnectorsGetProviderSettings.php
+++ b/tests/phpunit/tests/connectors/wpConnectorsGetProviderSettings.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Tests for _wp_connectors_get_provider_settings().
+ *
+ * @group connectors
+ * @covers ::_wp_connectors_get_provider_settings
+ */
+class Tests_Connectors_WpConnectorsGetProviderSettings extends WP_UnitTestCase {
+
+	/**
+	 * @ticket 64730
+	 */
+	public function test_returns_expected_provider_keys() {
+		$settings = _wp_connectors_get_provider_settings();
+
+		$this->assertArrayHasKey( 'connectors_gemini_api_key', $settings );
+		$this->assertArrayHasKey( 'connectors_openai_api_key', $settings );
+		$this->assertArrayHasKey( 'connectors_anthropic_api_key', $settings );
+		$this->assertCount( 3, $settings );
+	}
+
+	/**
+	 * @ticket 64730
+	 */
+	public function test_each_setting_has_required_fields() {
+		$settings      = _wp_connectors_get_provider_settings();
+		$required_keys = array( 'provider', 'label', 'description', 'mask', 'sanitize' );
+
+		foreach ( $settings as $setting_name => $config ) {
+			foreach ( $required_keys as $key ) {
+				$this->assertArrayHasKey( $key, $config, "Setting '{$setting_name}' is missing '{$key}'." );
+			}
+		}
+	}
+
+	/**
+	 * @ticket 64730
+	 */
+	public function test_provider_values_match_expected() {
+		$settings = _wp_connectors_get_provider_settings();
+
+		$this->assertSame( 'google', $settings['connectors_gemini_api_key']['provider'] );
+		$this->assertSame( 'openai', $settings['connectors_openai_api_key']['provider'] );
+		$this->assertSame( 'anthropic', $settings['connectors_anthropic_api_key']['provider'] );
+	}
+}

--- a/tests/phpunit/tests/connectors/wpConnectorsGetProviderSettings.php
+++ b/tests/phpunit/tests/connectors/wpConnectorsGetProviderSettings.php
@@ -13,9 +13,9 @@ class Tests_Connectors_WpConnectorsGetProviderSettings extends WP_UnitTestCase {
 	public function test_returns_expected_provider_keys() {
 		$settings = _wp_connectors_get_provider_settings();
 
-		$this->assertArrayHasKey( 'connectors_gemini_api_key', $settings );
-		$this->assertArrayHasKey( 'connectors_openai_api_key', $settings );
-		$this->assertArrayHasKey( 'connectors_anthropic_api_key', $settings );
+		$this->assertArrayHasKey( 'connectors_ai_google_api_key', $settings );
+		$this->assertArrayHasKey( 'connectors_ai_openai_api_key', $settings );
+		$this->assertArrayHasKey( 'connectors_ai_anthropic_api_key', $settings );
 		$this->assertCount( 3, $settings );
 	}
 
@@ -39,8 +39,8 @@ class Tests_Connectors_WpConnectorsGetProviderSettings extends WP_UnitTestCase {
 	public function test_provider_values_match_expected() {
 		$settings = _wp_connectors_get_provider_settings();
 
-		$this->assertSame( 'google', $settings['connectors_gemini_api_key']['provider'] );
-		$this->assertSame( 'openai', $settings['connectors_openai_api_key']['provider'] );
-		$this->assertSame( 'anthropic', $settings['connectors_anthropic_api_key']['provider'] );
+		$this->assertSame( 'google', $settings['connectors_ai_google_api_key']['provider'] );
+		$this->assertSame( 'openai', $settings['connectors_ai_openai_api_key']['provider'] );
+		$this->assertSame( 'anthropic', $settings['connectors_ai_anthropic_api_key']['provider'] );
 	}
 }

--- a/tests/phpunit/tests/connectors/wpConnectorsIsApiKeyValid.php
+++ b/tests/phpunit/tests/connectors/wpConnectorsIsApiKeyValid.php
@@ -1,0 +1,69 @@
+<?php
+
+require_once dirname( __DIR__, 2 ) . '/includes/wp-ai-client-mock-provider-trait.php';
+
+/**
+ * Tests for _wp_connectors_is_api_key_valid().
+ *
+ * @group connectors
+ * @covers ::_wp_connectors_is_api_key_valid
+ */
+class Tests_Connectors_WpConnectorsIsApiKeyValid extends WP_UnitTestCase {
+
+	use WP_AI_Client_Mock_Provider_Trait;
+
+	/**
+	 * Registers the mock provider once before any tests in this class run.
+	 */
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+		self::register_mock_connectors_provider();
+	}
+
+	/**
+	 * Resets the mock availability flag before each test.
+	 */
+	public function set_up() {
+		parent::set_up();
+		self::set_mock_provider_configured( true );
+	}
+
+	/**
+	 * Tests that an unregistered provider returns null.
+	 *
+	 * @ticket 64730
+	 */
+	public function test_unregistered_provider_returns_null() {
+		$this->setExpectedIncorrectUsage( '_wp_connectors_is_api_key_valid' );
+
+		$result = _wp_connectors_is_api_key_valid( 'test-key', 'nonexistent_provider' );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * Tests that a registered and configured provider returns true.
+	 *
+	 * @ticket 64730
+	 */
+	public function test_configured_provider_returns_true() {
+		self::set_mock_provider_configured( true );
+
+		$result = _wp_connectors_is_api_key_valid( 'test-key', 'mock_connectors_test' );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Tests that a registered but unconfigured provider returns false.
+	 *
+	 * @ticket 64730
+	 */
+	public function test_unconfigured_provider_returns_false() {
+		self::set_mock_provider_configured( false );
+
+		$result = _wp_connectors_is_api_key_valid( 'test-key', 'mock_connectors_test' );
+
+		$this->assertFalse( $result );
+	}
+}

--- a/tests/phpunit/tests/connectors/wpConnectorsMaskApiKey.php
+++ b/tests/phpunit/tests/connectors/wpConnectorsMaskApiKey.php
@@ -33,12 +33,12 @@ class Tests_Connectors_WpConnectorsMaskApiKey extends WP_UnitTestCase {
 		$bullet = "\u{2022}";
 
 		return array(
-			'empty string'                    => array( '', '' ),
-			'1 char'                          => array( 'a', 'a' ),
-			'4 chars (boundary)'              => array( 'abcd', 'abcd' ),
-			'5 chars (1 bullet + last 4)'     => array( 'abcde', $bullet . 'bcde' ),
-			'20 chars (cap at 16 bullets)'    => array( '12345678901234567890', str_repeat( $bullet, 16 ) . '7890' ),
-			'30 chars (cap at 16 bullets)'    => array( str_repeat( 'x', 30 ), str_repeat( $bullet, 16 ) . 'xxxx' ),
+			'empty string'                 => array( '', '' ),
+			'1 char'                       => array( 'a', 'a' ),
+			'4 chars (boundary)'           => array( 'abcd', 'abcd' ),
+			'5 chars (1 bullet + last 4)'  => array( 'abcde', $bullet . 'bcde' ),
+			'20 chars (cap at 16 bullets)' => array( '12345678901234567890', str_repeat( $bullet, 16 ) . '7890' ),
+			'30 chars (cap at 16 bullets)' => array( str_repeat( 'x', 30 ), str_repeat( $bullet, 16 ) . 'xxxx' ),
 		);
 	}
 }

--- a/tests/phpunit/tests/connectors/wpConnectorsMaskApiKey.php
+++ b/tests/phpunit/tests/connectors/wpConnectorsMaskApiKey.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Tests for _wp_connectors_mask_api_key().
+ *
+ * @group connectors
+ * @covers ::_wp_connectors_mask_api_key
+ */
+class Tests_Connectors_WpConnectorsMaskApiKey extends WP_UnitTestCase {
+
+	/**
+	 * Tests that API keys are masked correctly.
+	 *
+	 * @ticket 64730
+	 *
+	 * @dataProvider data_mask_api_key
+	 *
+	 * @param string $input    API key to mask.
+	 * @param string $expected Expected masked result.
+	 */
+	public function test_mask_api_key( string $input, string $expected ) {
+		$this->assertSame( $expected, _wp_connectors_mask_api_key( $input ) );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[] Test parameters {
+	 *     @type string $input    API key to mask.
+	 *     @type string $expected Expected masked result.
+	 * }
+	 */
+	public function data_mask_api_key(): array {
+		$bullet = "\u{2022}";
+
+		return array(
+			'empty string'                    => array( '', '' ),
+			'1 char'                          => array( 'a', 'a' ),
+			'4 chars (boundary)'              => array( 'abcd', 'abcd' ),
+			'5 chars (1 bullet + last 4)'     => array( 'abcde', $bullet . 'bcde' ),
+			'20 chars (cap at 16 bullets)'    => array( '12345678901234567890', str_repeat( $bullet, 16 ) . '7890' ),
+			'30 chars (cap at 16 bullets)'    => array( str_repeat( 'x', 30 ), str_repeat( $bullet, 16 ) . 'xxxx' ),
+		);
+	}
+}

--- a/tests/phpunit/tests/rest-api/rest-settings-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-settings-controller.php
@@ -123,7 +123,7 @@ class WP_Test_REST_Settings_Controller extends WP_Test_REST_Controller_Testcase 
 			// Connectors API keys are registered in _wp_register_default_connector_settings() in wp-includes/connectors.php.
 			'connectors_anthropic_api_key',
 			'connectors_gemini_api_key',
-			'connectors_openai_api_key'
+			'connectors_openai_api_key',
 		);
 
 		if ( ! is_multisite() ) {

--- a/tests/phpunit/tests/rest-api/rest-settings-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-settings-controller.php
@@ -121,9 +121,9 @@ class WP_Test_REST_Settings_Controller extends WP_Test_REST_Controller_Testcase 
 			'site_icon', // Registered in wp-includes/blocks/site-logo.php
 			'wp_enable_real_time_collaboration',
 			// Connectors API keys are registered in _wp_register_default_connector_settings() in wp-includes/connectors.php.
-			'connectors_anthropic_api_key',
-			'connectors_gemini_api_key',
-			'connectors_openai_api_key',
+			'connectors_ai_anthropic_api_key',
+			'connectors_ai_google_api_key',
+			'connectors_ai_openai_api_key',
 		);
 
 		if ( ! is_multisite() ) {

--- a/tests/phpunit/tests/rest-api/rest-settings-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-settings-controller.php
@@ -120,6 +120,10 @@ class WP_Test_REST_Settings_Controller extends WP_Test_REST_Controller_Testcase 
 			'default_comment_status',
 			'site_icon', // Registered in wp-includes/blocks/site-logo.php
 			'wp_enable_real_time_collaboration',
+			// Connectors API keys are registered in _wp_register_default_connector_settings() in wp-includes/connectors.php.
+			'connectors_anthropic_api_key',
+			'connectors_gemini_api_key',
+			'connectors_openai_api_key'
 		);
 
 		if ( ! is_multisite() ) {

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -11065,20 +11065,20 @@ mockedApiResponse.Schema = {
                     ],
                     "args": {
                         "connectors_gemini_api_key": {
-                            "title": "",
-                            "description": "",
+                            "title": "Gemini API Key",
+                            "description": "API key for the Gemini AI provider.",
                             "type": "string",
                             "required": false
                         },
                         "connectors_openai_api_key": {
-                            "title": "",
-                            "description": "",
+                            "title": "OpenAI API Key",
+                            "description": "API key for the OpenAI AI provider.",
                             "type": "string",
                             "required": false
                         },
                         "connectors_anthropic_api_key": {
-                            "title": "",
-                            "description": "",
+                            "title": "Anthropic API Key",
+                            "description": "API key for the Anthropic AI provider.",
                             "type": "string",
                             "required": false
                         },

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -11064,6 +11064,24 @@ mockedApiResponse.Schema = {
                         "PATCH"
                     ],
                     "args": {
+                        "connectors_gemini_api_key": {
+                            "title": "",
+                            "description": "",
+                            "type": "string",
+                            "required": false
+                        },
+                        "connectors_openai_api_key": {
+                            "title": "",
+                            "description": "",
+                            "type": "string",
+                            "required": false
+                        },
+                        "connectors_anthropic_api_key": {
+                            "title": "",
+                            "description": "",
+                            "type": "string",
+                            "required": false
+                        },
                         "title": {
                             "title": "Title",
                             "description": "Site title.",
@@ -14634,6 +14652,9 @@ mockedApiResponse.CommentModel = {
 };
 
 mockedApiResponse.settings = {
+    "connectors_gemini_api_key": "",
+    "connectors_openai_api_key": "",
+    "connectors_anthropic_api_key": "",
     "title": "Test Blog",
     "description": "",
     "url": "http://example.org",

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -11064,19 +11064,19 @@ mockedApiResponse.Schema = {
                         "PATCH"
                     ],
                     "args": {
-                        "connectors_gemini_api_key": {
-                            "title": "Gemini API Key",
-                            "description": "API key for the Gemini AI provider.",
+                        "connectors_ai_google_api_key": {
+                            "title": "Google API Key",
+                            "description": "API key for the Google AI provider.",
                             "type": "string",
                             "required": false
                         },
-                        "connectors_openai_api_key": {
+                        "connectors_ai_openai_api_key": {
                             "title": "OpenAI API Key",
                             "description": "API key for the OpenAI AI provider.",
                             "type": "string",
                             "required": false
                         },
-                        "connectors_anthropic_api_key": {
+                        "connectors_ai_anthropic_api_key": {
                             "title": "Anthropic API Key",
                             "description": "API key for the Anthropic AI provider.",
                             "type": "string",
@@ -14652,9 +14652,9 @@ mockedApiResponse.CommentModel = {
 };
 
 mockedApiResponse.settings = {
-    "connectors_gemini_api_key": "",
-    "connectors_openai_api_key": "",
-    "connectors_anthropic_api_key": "",
+    "connectors_ai_google_api_key": "",
+    "connectors_ai_openai_api_key": "",
+    "connectors_ai_anthropic_api_key": "",
     "title": "Test Blog",
     "description": "",
     "url": "http://example.org",


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/64730
## Summary
- Backport the PHP integration pieces from Gutenberg PR https://github.com/WordPress/gutenberg/pull/75833.
- Register the Settings > Connectors submenu (options-general.php?page=connectors-wp-admin).
- Register default connector settings for:
  - connectors_openai_api_key
  - connectors_anthropic_api_key
  - connectors_gemini_api_key
- Add API key masking and server-side validation wiring for settings reads/writes.
- Expose invalid_key in /wp/v2/settings responses for requested connector fields when validation fails.
- Pass stored connector keys into the WP AI client provider registry on init.


## Notes
- JS/TS/runtime artifacts for Connectors will be included on the Gutenberg sync; this PR covers the missing PHP glue.
- Includes guard checks so behavior is a no-op when the AI client (or Connectors render callback) is unavailable.

## Testing Instructions
Visit wp-admin/options-general.php?page=connectors-wp-admin and verify the Connectors page appears under Settings.
Verify Connectors appears between General and Writing in the Settings submenu.
Install all AI provider plugins.
Set API keys for every supported provider.
Remove the key and set it again for every supported provider.
When a incorrect API key is provided then it isn't possible to save it.
API keys are properly masked on the frontend (including REST API response).
Deactivate the AI provider plugin from the Plugins screen and activate the plugin again from the Connectors screen.
Uninstall the AI provider plugin from the Plugins screen and install the plugin again from the Connectors screen.
Revoke a key that was valid on the provider website and veify the screen does not says connected anymore.
