### PR TITLE
Darken colors for action separators & metabox handles

### DIFF
--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -2245,7 +2245,7 @@ html.wp-toolbar {
 
 .postbox .handle-order-higher,
 .postbox .handle-order-lower {
-	color: #787c82;
+	color: #646970;
 	width: 1.62rem;
 }
 
@@ -3659,7 +3659,7 @@ img {
 .postbox .handlediv.button-link,
 .item-edit,
 .toggle-indicator {
-	color: #787c82;
+	color: #646970;
 }
 
 .widget-action {

--- a/src/wp-admin/css/dashboard.css
+++ b/src/wp-admin/css/dashboard.css
@@ -637,7 +637,7 @@
 	margin-bottom: 0;
 	padding: 12px;
 	border-top: 1px solid #f0f0f1;
-	color: #dcdcde;
+	color: #646970;
 }
 
 /* Safari 10 + VoiceOver specific: without this, the hidden text gets read out before the link. */
@@ -962,7 +962,7 @@ body #dashboard-widgets .postbox form .submit {
 }
 
 .activity-block .subsubsub li {
-	color: #dcdcde;
+	color: #646970;
 }
 
 /* Dashboard activity widget - Comments */

--- a/src/wp-admin/css/list-tables.css
+++ b/src/wp-admin/css/list-tables.css
@@ -853,7 +853,7 @@ p.pagenav {
 }
 
 .row-actions {
-	color: #a7aaad;
+	color: #646970;
 	font-size: 13px;
 	padding: 2px 0 0;
 	position: relative;


### PR DESCRIPTION
While these colors don't technically violate WCAG, because the contexts they are in don't contain text, they do raise chronic errors in automated testing. The darker colors are more consistent with the new admin scheme, and resolve errors, making testing easier.


Trac ticket: https://core.trac.wordpress.org/ticket/64313

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
