### PR TITLE
Add command palette trigger button to admin bar

### DIFF
--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -951,20 +951,23 @@ function wp_admin_bar_command_palette_menu( WP_Admin_Bar $wp_admin_bar ): void {
 
 	$is_apple_os    = (bool) preg_match( '/Macintosh|Mac OS X|Mac_PowerPC/i', $_SERVER['HTTP_USER_AGENT'] ?? '' );
 	$shortcut_label = $is_apple_os
-		? _x( '⌘K', 'keyboard shortcut to open the command palette', 'gutenberg' )
-		: _x( 'Ctrl+K', 'keyboard shortcut to open the command palette', 'gutenberg' );
+		? _x( '⌘K', 'keyboard shortcut to open the command palette' )
+		: _x( 'Ctrl+K', 'keyboard shortcut to open the command palette' );
 	$title          = sprintf(
 		'<span class="ab-label"><kbd>%s</kbd><span class="screen-reader-text"> %s</span></span>',
 		$shortcut_label,
 		/* translators: Hidden accessibility text. */
-		__( 'Open command palette', 'gutenberg' ),
+		__( 'Open command palette' ),
 	);
 	$wp_admin_bar->add_node(
 		array(
 			'id'    => 'command-palette',
 			'title' => $title,
 			'href'  => '#',
-			'meta'  => array( 'class' => 'hide-if-no-js' ),
+			'meta'  => array(
+				'class'   => 'hide-if-no-js',
+				'onclick' => 'if ( window.wp && wp.data && wp.data.dispatch ) { var store = wp.data.dispatch( "core/commands" ); if ( store && typeof store.open === "function" ) { store.open(); } } return false;',
+			),
 		)
 	);
 }

--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -966,7 +966,7 @@ function wp_admin_bar_command_palette_menu( WP_Admin_Bar $wp_admin_bar ): void {
 			'href'  => '#',
 			'meta'  => array(
 				'class'   => 'hide-if-no-js',
-				'onclick' => 'if ( window.wp && wp.data && wp.data.dispatch ) { var store = wp.data.dispatch( "core/commands" ); if ( store && typeof store.open === "function" ) { store.open(); } } return false;',
+				'onclick' => 'wp.data.dispatch( "core/commands" ).open(); return false;',
 			),
 		)
 	);

--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -935,6 +935,41 @@ function wp_admin_bar_edit_menu( $wp_admin_bar ) {
 }
 
 /**
+ * Adds the command palette trigger button.
+ *
+ * Displays a button in the admin bar that shows the keyboard shortcut
+ * for opening the command palette.
+ *
+ * @since 7.0.0
+ *
+ * @param WP_Admin_Bar $wp_admin_bar The WP_Admin_Bar instance.
+ */
+function wp_admin_bar_command_palette_menu( WP_Admin_Bar $wp_admin_bar ): void {
+	if ( ! is_admin() ) {
+		return;
+	}
+
+	$is_apple_os    = (bool) preg_match( '/Macintosh|Mac OS X|Mac_PowerPC/i', $_SERVER['HTTP_USER_AGENT'] ?? '' );
+	$shortcut_label = $is_apple_os
+		? _x( '⌘K', 'keyboard shortcut to open the command palette', 'gutenberg' )
+		: _x( 'Ctrl+K', 'keyboard shortcut to open the command palette', 'gutenberg' );
+	$title          = sprintf(
+		'<span class="ab-label"><kbd>%s</kbd><span class="screen-reader-text"> %s</span></span>',
+		$shortcut_label,
+		/* translators: Hidden accessibility text. */
+		__( 'Open command palette', 'gutenberg' ),
+	);
+	$wp_admin_bar->add_node(
+		array(
+			'id'    => 'command-palette',
+			'title' => $title,
+			'href'  => '#',
+			'meta'  => array( 'class' => 'hide-if-no-js' ),
+		)
+	);
+}
+
+/**
  * Adds "Add New" menu.
  *
  * @since 3.1.0

--- a/src/wp-includes/class-wp-admin-bar.php
+++ b/src/wp-includes/class-wp-admin-bar.php
@@ -661,6 +661,9 @@ class WP_Admin_Bar {
 		add_action( 'admin_bar_menu', 'wp_admin_bar_customize_menu', 40 );
 		add_action( 'admin_bar_menu', 'wp_admin_bar_updates_menu', 50 );
 
+		// Command palette.
+		add_action( 'admin_bar_menu', 'wp_admin_bar_command_palette_menu', 55 );
+
 		// Content-related.
 		if ( ! is_network_admin() && ! is_user_admin() ) {
 			add_action( 'admin_bar_menu', 'wp_admin_bar_comments_menu', 60 );


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/64672

Alternatives to https://github.com/WordPress/wordpress-develop/pull/10985

## Use of AI Tools

This PR is to backport https://github.com/WordPress/gutenberg/pull/75757 into core and does not use any AI tools.

> [!NOTE]
> Note that in this PR, clicking the button does nothing - the event handler is considered to be executed on the client side, although it is also possible to write an event handler on the server side. See https://github.com/WordPress/gutenberg/pull/75757#discussion_r2859671045 for more details.


<img width="1354" height="271" alt="555512217-4577cbb2-bf08-470b-82d7-92e02c275c1a" src="https://github.com/user-attachments/assets/b7f20262-a4a0-438c-8ebe-f3774e6c48cb" />
