### PR TITLE
Change welcome panel background color to light gray

### DIFF
--- a/src/wp-admin/css/dashboard.css
+++ b/src/wp-admin/css/dashboard.css
@@ -140,7 +140,7 @@
 	position: relative;
 	overflow: auto;
 	margin: 16px 0;
-	background-color: #151515;
+	background-color: #c3c4c7;
 	border: 1px solid rgb(0, 0, 0, 0.1);
 	border-radius: 8px;
 	font-size: 14px;


### PR DESCRIPTION
I suggest matching the welcome panel's border color with the rest of the dashboard widgets.

Ticket: https://core.trac.wordpress.org/ticket/64741

| Before: White Background | After: Light Gray Background |
| :--- | :--- |
| ![dashboard-old](https://github.com/user-attachments/assets/dceb2af2-2850-4ef1-93be-55e9db558166) | ![dashboard-new](https://github.com/user-attachments/assets/a424a3ac-a1da-4564-a88c-5a0d146b4e94) |

