### PR TITLE
64738 Widens application password input field

### DIFF
--- a/src/wp-admin/css/forms.css
+++ b/src/wp-admin/css/forms.css
@@ -1057,7 +1057,7 @@ table.form-table td .updated p {
 
 .application-password-display input.code {
 	margin-bottom: 6px;
-	width: 19em;
+	width: 20em;
 }
 
 .auth-app-card.card {


### PR DESCRIPTION
Adjusts the width of the application password display input. This provides better visual presentation and prevents content truncation.

Trac ticket: https://core.trac.wordpress.org/ticket/64738
