### PR TITLE
Connectors: Dynamically register providers from WP AI Client registry

### DIFF
--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -271,7 +271,7 @@ function _wp_connectors_validate_keys_in_rest( WP_REST_Response $response, WP_RE
 
 	foreach ( _wp_connectors_get_connector_settings() as $connector_id => $connector_data ) {
 		$auth = $connector_data['authentication'];
-		if ( 'ai_provider' !== $connector_data['type'] ||'api_key' !== $auth['method'] || empty( $auth['setting_name'] ) ) {
+		if ( 'ai_provider' !== $connector_data['type'] || 'api_key' !== $auth['method'] || empty( $auth['setting_name'] ) ) {
 			continue;
 		}
 

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -340,7 +340,7 @@ function _wp_register_default_connector_settings(): void {
 		add_filter( "option_{$setting_name}", '_wp_connectors_mask_api_key' );
 	}
 }
-add_action( 'init', '_wp_register_default_connector_settings' );
+add_action( 'init', '_wp_register_default_connector_settings', 20 );
 
 /**
  * Passes stored connector API keys to the WP AI client.
@@ -375,7 +375,7 @@ function _wp_connectors_pass_default_keys_to_ai_client(): void {
 			wp_trigger_error( __FUNCTION__, $e->getMessage() );
 	}
 }
-add_action( 'init', '_wp_connectors_pass_default_keys_to_ai_client' );
+add_action( 'init', '_wp_connectors_pass_default_keys_to_ai_client', 20 );
 
 /**
  * Exposes connector settings to the connectors-wp-admin script module.

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -131,7 +131,6 @@ function _wp_connectors_get_real_api_key( string $option_name, callable $mask_ca
  *
  *                 @type string   $label       The setting label.
  *                 @type string   $description The setting description.
- *                 @type callable $mask        Callback to mask the stored value.
  *                 @type callable $sanitize    Callback to sanitize the input value.
  *             }
  *         }
@@ -168,11 +167,26 @@ function _wp_connectors_get_provider_settings(): array {
 			continue;
 		}
 
-		$providers[ $provider_id ] = array(
-			'name'            => $provider_metadata->getName(),
-			'description'     => '', // TODO: Retrieve description from provider metadata when available.
-			'credentials_url' => $provider_metadata->getCredentialsUrl(),
+		$registry_data = array_filter(
+			array(
+				'name'            => $provider_metadata->getName(),
+				'credentials_url' => $provider_metadata->getCredentialsUrl(),
+			)
 		);
+
+		if ( isset( $providers[ $provider_id ] ) ) {
+			// Merge non-empty registry data over hardcoded fallbacks.
+			$providers[ $provider_id ] = array_merge( $providers[ $provider_id ], $registry_data );
+		} else {
+			$providers[ $provider_id ] = array_merge(
+				array(
+					'name'            => '',
+					'description'     => '',
+					'credentials_url' => null,
+				),
+				$registry_data
+			);
+		}
 	}
 
 	$provider_settings = array();
@@ -195,8 +209,7 @@ function _wp_connectors_get_provider_settings(): array {
 						__( 'API key for the %s AI provider.' ),
 						$data['name']
 					),
-					'mask'        => '_wp_connectors_mask_api_key',
-					'sanitize'    => static function ( string $value ) use ( $provider ): string {
+					'sanitize' => static function ( string $value ) use ( $provider ): string {
 						$value = sanitize_text_field( $value );
 						if ( '' === $value ) {
 							return $value;
@@ -259,7 +272,7 @@ function _wp_connectors_validate_keys_in_rest( WP_REST_Response $response, WP_RE
 				continue;
 			}
 
-			$real_key = _wp_connectors_get_real_api_key( $setting_name, $config['mask'] );
+			$real_key = _wp_connectors_get_real_api_key( $setting_name, '_wp_connectors_mask_api_key' );
 			if ( '' === $real_key ) {
 				continue;
 			}
@@ -300,7 +313,7 @@ function _wp_register_default_connector_settings(): void {
 					'sanitize_callback' => $config['sanitize'],
 				)
 			);
-			add_filter( "option_{$setting_name}", $config['mask'] );
+			add_filter( "option_{$setting_name}", '_wp_connectors_mask_api_key' );
 		}
 	}
 }
@@ -320,7 +333,7 @@ function _wp_connectors_pass_default_keys_to_ai_client(): void {
 		$registry = AiClient::defaultRegistry();
 		foreach ( _wp_connectors_get_provider_settings() as $provider => $provider_data ) {
 			foreach ( $provider_data['settings'] as $setting_name => $config ) {
-				$api_key = _wp_connectors_get_real_api_key( $setting_name, $config['mask'] );
+				$api_key = _wp_connectors_get_real_api_key( $setting_name, '_wp_connectors_mask_api_key' );
 				if ( '' === $api_key || ! $registry->hasProvider( $provider ) ) {
 					continue;
 				}

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -139,6 +139,18 @@ function _wp_connectors_get_real_api_key( string $option_name, callable $mask_ca
  */
 function _wp_connectors_get_connector_settings(): array {
 	$connectors = array(
+		'anthropic' => array(
+			'name'           => 'Anthropic',
+			'description'    => __( 'Text generation with Claude.' ),
+			'type'           => 'ai_provider',
+			'plugin'         => array(
+				'slug' => 'ai-provider-for-anthropic',
+			),
+			'authentication' => array(
+				'method'          => 'api_key',
+				'credentials_url' => 'https://platform.claude.com/settings/keys',
+			),
+		),
 		'google'    => array(
 			'name'           => 'Google',
 			'description'    => __( 'Text and image generation with Gemini and Imagen.' ),
@@ -161,18 +173,6 @@ function _wp_connectors_get_connector_settings(): array {
 			'authentication' => array(
 				'method'          => 'api_key',
 				'credentials_url' => 'https://platform.openai.com/api-keys',
-			),
-		),
-		'anthropic' => array(
-			'name'           => 'Anthropic',
-			'description'    => __( 'Text generation with Claude.' ),
-			'type'           => 'ai_provider',
-			'plugin'         => array(
-				'slug' => 'ai-provider-for-anthropic',
-			),
-			'authentication' => array(
-				'method'          => 'api_key',
-				'credentials_url' => 'https://platform.claude.com/settings/keys',
 			),
 		),
 	);
@@ -221,6 +221,8 @@ function _wp_connectors_get_connector_settings(): array {
 			);
 		}
 	}
+
+	ksort( $connectors );
 
 	// Add setting_name for connectors that use API key authentication.
 	foreach ( $connectors as $connector_id => $connector ) {
@@ -304,7 +306,7 @@ add_filter( 'rest_post_dispatch', '_wp_connectors_validate_keys_in_rest', 10, 3 
 function _wp_register_default_connector_settings(): void {
 	foreach ( _wp_connectors_get_connector_settings() as $connector_id => $connector_data ) {
 		$auth = $connector_data['authentication'];
-		if ( 'api_key' !== $auth['method'] || empty( $auth['setting_name'] ) ) {
+		if ( 'ai_provider' !== $connector_data['type'] || 'api_key' !== $auth['method'] || empty( $auth['setting_name'] ) ) {
 			continue;
 		}
 

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -109,120 +109,115 @@ function _wp_connectors_get_real_api_key( string $option_name, callable $mask_ca
 }
 
 /**
- * Gets the registered connector provider settings.
+ * Gets the registered connector settings.
  *
  * @since 7.0.0
  * @access private
  *
  * @return array {
- *     Provider settings keyed by provider ID.
+ *     Connector settings keyed by connector ID.
  *
  *     @type array ...$0 {
- *         Data for a single provider.
+ *         Data for a single connector.
  *
- *         @type string      $name            The provider's display name.
- *         @type string      $description     The provider's description.
- *         @type string|null $credentials_url URL where users can obtain API credentials.
- *         @type array       $settings        {
- *             Settings keyed by setting name.
+ *         @type string $name           The connector's display name.
+ *         @type string $description    The connector's description.
+ *         @type string $type           The connector type: 'ai_provider'.
+ *         @type array  $authentication {
+ *             Authentication configuration. When method is 'api_key', includes
+ *             credentials_url and setting_name. When 'none', only method is present.
  *
- *             @type array ...$0 {
- *                 Data for a single setting.
- *
- *                 @type string   $label       The setting label.
- *                 @type string   $description The setting description.
- *                 @type callable $sanitize    Callback to sanitize the input value.
- *             }
+ *             @type string      $method          The authentication method: 'api_key' or 'none'.
+ *             @type string|null $credentials_url Optional. URL where users can obtain API credentials.
+ *             @type string      $setting_name    Optional. The setting name for the API key.
  *         }
  *     }
  * }
  */
-function _wp_connectors_get_provider_settings(): array {
-	$providers = array(
+function _wp_connectors_get_connector_settings(): array {
+	$connectors = array(
 		'google'    => array(
-			'name'            => 'Gemini',
-			'description'     => __( 'Content generation, translation, and vision with Google\'s Gemini.' ),
-			'credentials_url' => 'https://aistudio.google.com/',
+			'name'           => 'Gemini',
+			'description'    => __( 'Content generation, translation, and vision with Google\'s Gemini.' ),
+			'type'           => 'ai_provider',
+			'authentication' => array(
+				'method'          => 'api_key',
+				'credentials_url' => 'https://aistudio.google.com/api-keys',
+			),
 		),
 		'openai'    => array(
-			'name'            => 'OpenAI',
-			'description'     => __( 'Text, image, and code generation with GPT and DALL-E.' ),
-			'credentials_url' => 'https://platform.openai.com/',
+			'name'           => 'OpenAI',
+			'description'    => __( 'Text, image, and code generation with GPT and DALL-E.' ),
+			'type'           => 'ai_provider',
+			'authentication' => array(
+				'method'          => 'api_key',
+				'credentials_url' => 'https://platform.openai.com/api-keys',
+			),
 		),
 		'anthropic' => array(
-			'name'            => 'Claude',
-			'description'     => __( 'Writing, research, and analysis with Claude.' ),
-			'credentials_url' => 'https://console.anthropic.com/',
+			'name'           => 'Claude',
+			'description'    => __( 'Writing, research, and analysis with Claude.' ),
+			'type'           => 'ai_provider',
+			'authentication' => array(
+				'method'          => 'api_key',
+				'credentials_url' => 'https://platform.claude.com/settings/keys',
+			),
 		),
 	);
 
 	$registry = AiClient::defaultRegistry();
 
-	foreach ( $registry->getRegisteredProviderIds() as $provider_id ) {
-		$provider_class_name = $registry->getProviderClassName( $provider_id );
+	foreach ( $registry->getRegisteredProviderIds() as $connector_id ) {
+		$provider_class_name = $registry->getProviderClassName( $connector_id );
 		$provider_metadata   = $provider_class_name::metadata();
 
 		$auth_method = $provider_metadata->getAuthenticationMethod();
-		if ( null === $auth_method || ! $auth_method->isApiKey() ) {
-			continue;
+		$is_api_key  = null !== $auth_method && $auth_method->isApiKey();
+
+		if ( $is_api_key ) {
+			$credentials_url = $provider_metadata->getCredentialsUrl();
+			$authentication  = array(
+				'method'          => 'api_key',
+				'credentials_url' => $credentials_url ? $credentials_url : null,
+			);
+		} else {
+			$authentication = array( 'method' => 'none' );
 		}
 
-		$registry_data = array_filter(
-			array(
-				'name'            => $provider_metadata->getName(),
-				'credentials_url' => $provider_metadata->getCredentialsUrl(),
-			)
-		);
+		$name        = $provider_metadata->getName();
+		$description = method_exists( $provider_metadata, 'getDescription' ) ? $provider_metadata->getDescription() : null;
 
-		if ( isset( $providers[ $provider_id ] ) ) {
-			// Merge non-empty registry data over hardcoded fallbacks.
-			$providers[ $provider_id ] = array_merge( $providers[ $provider_id ], $registry_data );
+		if ( isset( $connectors[ $connector_id ] ) ) {
+			// Override fields with non-empty registry values.
+			if ( $name ) {
+				$connectors[ $connector_id ]['name'] = $name;
+			}
+			if ( $description ) {
+				$connectors[ $connector_id ]['description'] = $description;
+			}
+			// Always update auth method; keep existing credentials_url as fallback.
+			$connectors[ $connector_id ]['authentication']['method'] = $authentication['method'];
+			if ( ! empty( $authentication['credentials_url'] ) ) {
+				$connectors[ $connector_id ]['authentication']['credentials_url'] = $authentication['credentials_url'];
+			}
 		} else {
-			$providers[ $provider_id ] = array_merge(
-				array(
-					'name'            => '',
-					'description'     => '',
-					'credentials_url' => null,
-				),
-				$registry_data
+			$connectors[ $connector_id ] = array(
+				'name'           => $name ? $name : ucwords( $connector_id ),
+				'description'    => $description ? $description : '',
+				'type'           => 'ai_provider',
+				'authentication' => $authentication,
 			);
 		}
 	}
 
-	$provider_settings = array();
-	foreach ( $providers as $provider => $data ) {
-		$setting_name = "connectors_ai_{$provider}_api_key";
-
-		$provider_settings[ $provider ] = array(
-			'name'            => $data['name'],
-			'description'     => $data['description'],
-			'credentials_url' => $data['credentials_url'],
-			'settings'        => array(
-				$setting_name => array(
-					'label'       => sprintf(
-						/* translators: %s: AI provider name. */
-						__( '%s API Key' ),
-						$data['name']
-					),
-					'description' => sprintf(
-						/* translators: %s: AI provider name. */
-						__( 'API key for the %s AI provider.' ),
-						$data['name']
-					),
-					'sanitize' => static function ( string $value ) use ( $provider ): string {
-						$value = sanitize_text_field( $value );
-						if ( '' === $value ) {
-							return $value;
-						}
-
-						$valid = _wp_connectors_is_api_key_valid( $value, $provider );
-						return true === $valid ? $value : '';
-					},
-				),
-			),
-		);
+	// Add setting_name for connectors that use API key authentication.
+	foreach ( $connectors as $connector_id => $connector ) {
+		if ( 'api_key' === $connector['authentication']['method'] ) {
+			$connectors[ $connector_id ]['authentication']['setting_name'] = "connectors_ai_{$connector_id}_api_key";
+		}
 	}
-	return $provider_settings;
+
+	return $connectors;
 }
 
 /**
@@ -246,10 +241,6 @@ function _wp_connectors_validate_keys_in_rest( WP_REST_Response $response, WP_RE
 		return $response;
 	}
 
-	if ( ! class_exists( '\WordPress\AiClient\AiClient' ) ) {
-		return $response;
-	}
-
 	$fields = $request->get_param( '_fields' );
 	if ( ! $fields ) {
 		return $response;
@@ -266,20 +257,24 @@ function _wp_connectors_validate_keys_in_rest( WP_REST_Response $response, WP_RE
 		return $response;
 	}
 
-	foreach ( _wp_connectors_get_provider_settings() as $provider => $provider_data ) {
-		foreach ( $provider_data['settings'] as $setting_name => $config ) {
-			if ( ! in_array( $setting_name, $requested, true ) ) {
-				continue;
-			}
+	foreach ( _wp_connectors_get_connector_settings() as $connector_id => $connector_data ) {
+		$auth = $connector_data['authentication'];
+		if ( 'api_key' !== $auth['method'] || empty( $auth['setting_name'] ) ) {
+			continue;
+		}
 
-			$real_key = _wp_connectors_get_real_api_key( $setting_name, '_wp_connectors_mask_api_key' );
-			if ( '' === $real_key ) {
-				continue;
-			}
+		$setting_name = $auth['setting_name'];
+		if ( ! in_array( $setting_name, $requested, true ) ) {
+			continue;
+		}
 
-			if ( true !== _wp_connectors_is_api_key_valid( $real_key, $provider ) ) {
-				$data[ $setting_name ] = 'invalid_key';
-			}
+		$real_key = _wp_connectors_get_real_api_key( $setting_name, '_wp_connectors_mask_api_key' );
+		if ( '' === $real_key ) {
+			continue;
+		}
+
+		if ( true !== _wp_connectors_is_api_key_valid( $real_key, $connector_id ) ) {
+			$data[ $setting_name ] = 'invalid_key';
 		}
 	}
 
@@ -295,26 +290,42 @@ add_filter( 'rest_post_dispatch', '_wp_connectors_validate_keys_in_rest', 10, 3 
  * @access private
  */
 function _wp_register_default_connector_settings(): void {
-	if ( ! class_exists( '\WordPress\AiClient\AiClient' ) ) {
-		return;
-	}
-
-	foreach ( _wp_connectors_get_provider_settings() as $provider_data ) {
-		foreach ( $provider_data['settings'] as $setting_name => $config ) {
-			register_setting(
-				'connectors',
-				$setting_name,
-				array(
-					'type'              => 'string',
-					'label'             => $config['label'],
-					'description'       => $config['description'],
-					'default'           => '',
-					'show_in_rest'      => true,
-					'sanitize_callback' => $config['sanitize'],
-				)
-			);
-			add_filter( "option_{$setting_name}", '_wp_connectors_mask_api_key' );
+	foreach ( _wp_connectors_get_connector_settings() as $connector_id => $connector_data ) {
+		$auth = $connector_data['authentication'];
+		if ( 'api_key' !== $auth['method'] || empty( $auth['setting_name'] ) ) {
+			continue;
 		}
+
+		$setting_name = $auth['setting_name'];
+		register_setting(
+			'connectors',
+			$setting_name,
+			array(
+				'type'              => 'string',
+				'label'             => sprintf(
+					/* translators: %s: AI provider name. */
+					__( '%s API Key' ),
+					$connector_data['name']
+				),
+				'description'       => sprintf(
+					/* translators: %s: AI provider name. */
+					__( 'API key for the %s AI provider.' ),
+					$connector_data['name']
+				),
+				'default'           => '',
+				'show_in_rest'      => true,
+				'sanitize_callback' => static function ( string $value ) use ( $connector_id ): string {
+					$value = sanitize_text_field( $value );
+					if ( '' === $value ) {
+						return $value;
+					}
+
+					$valid = _wp_connectors_is_api_key_valid( $value, $connector_id );
+					return true === $valid ? $value : '';
+				},
+			)
+		);
+		add_filter( "option_{$setting_name}", '_wp_connectors_mask_api_key' );
 	}
 }
 add_action( 'init', '_wp_register_default_connector_settings' );
@@ -326,26 +337,62 @@ add_action( 'init', '_wp_register_default_connector_settings' );
  * @access private
  */
 function _wp_connectors_pass_default_keys_to_ai_client(): void {
-	if ( ! class_exists( '\WordPress\AiClient\AiClient' ) ) {
-		return;
-	}
 	try {
 		$registry = AiClient::defaultRegistry();
-		foreach ( _wp_connectors_get_provider_settings() as $provider => $provider_data ) {
-			foreach ( $provider_data['settings'] as $setting_name => $config ) {
-				$api_key = _wp_connectors_get_real_api_key( $setting_name, '_wp_connectors_mask_api_key' );
-				if ( '' === $api_key || ! $registry->hasProvider( $provider ) ) {
-					continue;
-				}
-
-				$registry->setProviderRequestAuthentication(
-					$provider,
-					new ApiKeyRequestAuthentication( $api_key )
-				);
+		foreach ( _wp_connectors_get_connector_settings() as $connector_id => $connector_data ) {
+			if ( 'ai_provider' !== $connector_data['type'] ) {
+				continue;
 			}
+
+			$auth = $connector_data['authentication'];
+			if ( 'api_key' !== $auth['method'] || empty( $auth['setting_name'] ) ) {
+				continue;
+			}
+
+			$api_key = _wp_connectors_get_real_api_key( $auth['setting_name'], '_wp_connectors_mask_api_key' );
+			if ( '' === $api_key || ! $registry->hasProvider( $connector_id ) ) {
+				continue;
+			}
+
+			$registry->setProviderRequestAuthentication(
+				$connector_id,
+				new ApiKeyRequestAuthentication( $api_key )
+			);
 		}
 	} catch ( Exception $e ) {
 			wp_trigger_error( __FUNCTION__, $e->getMessage() );
 	}
 }
 add_action( 'init', '_wp_connectors_pass_default_keys_to_ai_client' );
+
+/**
+ * Exposes connector settings to the connectors-wp-admin script module.
+ *
+ * @since 7.0.0
+ * @access private
+ *
+ * @param array $data Existing script module data.
+ * @return array Script module data with connectors added.
+ */
+function _wp_connectors_get_connector_script_module_data( array $data ): array {
+	$connectors = array();
+	foreach ( _wp_connectors_get_connector_settings() as $connector_id => $connector_data ) {
+		$auth     = $connector_data['authentication'];
+		$auth_out = array( 'method' => $auth['method'] );
+
+		if ( 'api_key' === $auth['method'] ) {
+			$auth_out['settingName']    = $auth['setting_name'] ?? '';
+			$auth_out['credentialsUrl'] = $auth['credentials_url'] ?? null;
+		}
+
+		$connectors[ $connector_id ] = array(
+			'name'           => $connector_data['name'],
+			'description'    => $connector_data['description'],
+			'type'           => $connector_data['type'],
+			'authentication' => $auth_out,
+		);
+	}
+	$data['connectors'] = $connectors;
+	return $data;
+}
+add_filter( 'script_module_data_connectors-wp-admin', '_wp_connectors_get_connector_script_module_data' );

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -60,7 +60,7 @@ function _wp_connectors_mask_api_key( string $key ): string {
  * @param string $provider_id The WP AI client provider ID.
  * @return bool|null True if valid, false if invalid, null if unable to determine.
  */
-function _wp_connectors_is_api_key_valid( string $key, string $provider_id ): ?bool {
+function _wp_connectors_is_ai_api_key_valid( string $key, string $provider_id ): ?bool {
 	try {
 		$registry = AiClient::defaultRegistry();
 
@@ -122,7 +122,10 @@ function _wp_connectors_get_real_api_key( string $option_name, callable $mask_ca
  *
  *         @type string $name           The connector's display name.
  *         @type string $description    The connector's description.
- *         @type string $type           The connector type: 'ai_provider'.
+ *         @type string $type           The connector type. Currently, only 'ai_provider' is supported.
+ *         @type array  $plugin         Optional. Plugin data for install/activate UI.
+ *             @type string $slug       The WordPress.org plugin slug.
+ *         }
  *         @type array  $authentication {
  *             Authentication configuration. When method is 'api_key', includes
  *             credentials_url and setting_name. When 'none', only method is present.
@@ -137,9 +140,12 @@ function _wp_connectors_get_real_api_key( string $option_name, callable $mask_ca
 function _wp_connectors_get_connector_settings(): array {
 	$connectors = array(
 		'google'    => array(
-			'name'           => 'Gemini',
-			'description'    => __( 'Content generation, translation, and vision with Google\'s Gemini.' ),
+			'name'           => 'Google',
+			'description'    => __( 'Text and image generation with Gemini and Imagen.' ),
 			'type'           => 'ai_provider',
+			'plugin'         => array(
+				'slug' => 'ai-provider-for-google',
+			),
 			'authentication' => array(
 				'method'          => 'api_key',
 				'credentials_url' => 'https://aistudio.google.com/api-keys',
@@ -147,17 +153,23 @@ function _wp_connectors_get_connector_settings(): array {
 		),
 		'openai'    => array(
 			'name'           => 'OpenAI',
-			'description'    => __( 'Text, image, and code generation with GPT and DALL-E.' ),
+			'description'    => __( 'Text and image generation with GPT and Dall-E.' ),
 			'type'           => 'ai_provider',
+			'plugin'         => array(
+				'slug' => 'ai-provider-for-openai',
+			),
 			'authentication' => array(
 				'method'          => 'api_key',
 				'credentials_url' => 'https://platform.openai.com/api-keys',
 			),
 		),
 		'anthropic' => array(
-			'name'           => 'Claude',
-			'description'    => __( 'Writing, research, and analysis with Claude.' ),
+			'name'           => 'Anthropic',
+			'description'    => __( 'Text generation with Claude.' ),
 			'type'           => 'ai_provider',
+			'plugin'         => array(
+				'slug' => 'ai-provider-for-anthropic',
+			),
 			'authentication' => array(
 				'method'          => 'api_key',
 				'credentials_url' => 'https://platform.claude.com/settings/keys',
@@ -259,7 +271,7 @@ function _wp_connectors_validate_keys_in_rest( WP_REST_Response $response, WP_RE
 
 	foreach ( _wp_connectors_get_connector_settings() as $connector_id => $connector_data ) {
 		$auth = $connector_data['authentication'];
-		if ( 'api_key' !== $auth['method'] || empty( $auth['setting_name'] ) ) {
+		if ( 'ai_provider' !== $connector_data['type'] ||'api_key' !== $auth['method'] || empty( $auth['setting_name'] ) ) {
 			continue;
 		}
 
@@ -273,7 +285,7 @@ function _wp_connectors_validate_keys_in_rest( WP_REST_Response $response, WP_RE
 			continue;
 		}
 
-		if ( true !== _wp_connectors_is_api_key_valid( $real_key, $connector_id ) ) {
+		if ( true !== _wp_connectors_is_ai_api_key_valid( $real_key, $connector_id ) ) {
 			$data[ $setting_name ] = 'invalid_key';
 		}
 	}
@@ -320,7 +332,7 @@ function _wp_register_default_connector_settings(): void {
 						return $value;
 					}
 
-					$valid = _wp_connectors_is_api_key_valid( $value, $connector_id );
+					$valid = _wp_connectors_is_ai_api_key_valid( $value, $connector_id );
 					return true === $valid ? $value : '';
 				},
 			)
@@ -385,12 +397,18 @@ function _wp_connectors_get_connector_script_module_data( array $data ): array {
 			$auth_out['credentialsUrl'] = $auth['credentials_url'] ?? null;
 		}
 
-		$connectors[ $connector_id ] = array(
+		$connector_out = array(
 			'name'           => $connector_data['name'],
 			'description'    => $connector_data['description'],
 			'type'           => $connector_data['type'],
 			'authentication' => $auth_out,
 		);
+
+		if ( ! empty( $connector_data['plugin'] ) ) {
+			$connector_out['plugin'] = $connector_data['plugin'];
+		}
+
+		$connectors[ $connector_id ] = $connector_out;
 	}
 	$data['connectors'] = $connectors;
 	return $data;

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -114,47 +114,99 @@ function _wp_connectors_get_real_api_key( string $option_name, callable $mask_ca
  * @since 7.0.0
  * @access private
  *
- * @return array<string, array{provider: string, label: string, description: string, mask: callable, sanitize: callable}> Provider settings keyed by setting name.
+ * @return array {
+ *     Provider settings keyed by provider ID.
+ *
+ *     @type array ...$0 {
+ *         Data for a single provider.
+ *
+ *         @type string      $name            The provider's display name.
+ *         @type string      $description     The provider's description.
+ *         @type string|null $credentials_url URL where users can obtain API credentials.
+ *         @type array       $settings        {
+ *             Settings keyed by setting name.
+ *
+ *             @type array ...$0 {
+ *                 Data for a single setting.
+ *
+ *                 @type string   $label       The setting label.
+ *                 @type string   $description The setting description.
+ *                 @type callable $mask        Callback to mask the stored value.
+ *                 @type callable $sanitize    Callback to sanitize the input value.
+ *             }
+ *         }
+ *     }
+ * }
  */
 function _wp_connectors_get_provider_settings(): array {
 	$providers = array(
 		'google'    => array(
-			'name' => 'Google',
+			'name'            => 'Gemini',
+			'description'     => __( 'Content generation, translation, and vision with Google\'s Gemini.' ),
+			'credentials_url' => 'https://aistudio.google.com/',
 		),
 		'openai'    => array(
-			'name' => 'OpenAI',
+			'name'            => 'OpenAI',
+			'description'     => __( 'Text, image, and code generation with GPT and DALL-E.' ),
+			'credentials_url' => 'https://platform.openai.com/',
 		),
 		'anthropic' => array(
-			'name' => 'Anthropic',
+			'name'            => 'Claude',
+			'description'     => __( 'Writing, research, and analysis with Claude.' ),
+			'credentials_url' => 'https://console.anthropic.com/',
 		),
 	);
+
+	$registry = AiClient::defaultRegistry();
+
+	foreach ( $registry->getRegisteredProviderIds() as $provider_id ) {
+		$provider_class_name = $registry->getProviderClassName( $provider_id );
+		$provider_metadata   = $provider_class_name::metadata();
+
+		$auth_method = $provider_metadata->getAuthenticationMethod();
+		if ( null === $auth_method || ! $auth_method->isApiKey() ) {
+			continue;
+		}
+
+		$providers[ $provider_id ] = array(
+			'name'            => $provider_metadata->getName(),
+			'description'     => '', // TODO: Retrieve description from provider metadata when available.
+			'credentials_url' => $provider_metadata->getCredentialsUrl(),
+		);
+	}
 
 	$provider_settings = array();
 	foreach ( $providers as $provider => $data ) {
 		$setting_name = "connectors_ai_{$provider}_api_key";
 
-		$provider_settings[ $setting_name ] = array(
-			'provider'    => $provider,
-			'label'       => sprintf(
-				/* translators: %s: AI provider name. */
-				__( '%s API Key' ),
-				$data['name']
-			),
-			'description' => sprintf(
-				/* translators: %s: AI provider name. */
-				__( 'API key for the %s AI provider.' ),
-				$data['name']
-			),
-			'mask'        => '_wp_connectors_mask_api_key',
-			'sanitize'    => static function ( string $value ) use ( $provider ): string {
-				$value = sanitize_text_field( $value );
-				if ( '' === $value ) {
-					return $value;
-				}
+		$provider_settings[ $provider ] = array(
+			'name'            => $data['name'],
+			'description'     => $data['description'],
+			'credentials_url' => $data['credentials_url'],
+			'settings'        => array(
+				$setting_name => array(
+					'label'       => sprintf(
+						/* translators: %s: AI provider name. */
+						__( '%s API Key' ),
+						$data['name']
+					),
+					'description' => sprintf(
+						/* translators: %s: AI provider name. */
+						__( 'API key for the %s AI provider.' ),
+						$data['name']
+					),
+					'mask'        => '_wp_connectors_mask_api_key',
+					'sanitize'    => static function ( string $value ) use ( $provider ): string {
+						$value = sanitize_text_field( $value );
+						if ( '' === $value ) {
+							return $value;
+						}
 
-				$valid = _wp_connectors_is_api_key_valid( $value, $provider );
-				return true === $valid ? $value : '';
-			},
+						$valid = _wp_connectors_is_api_key_valid( $value, $provider );
+						return true === $valid ? $value : '';
+					},
+				),
+			),
 		);
 	}
 	return $provider_settings;
@@ -201,18 +253,20 @@ function _wp_connectors_validate_keys_in_rest( WP_REST_Response $response, WP_RE
 		return $response;
 	}
 
-	foreach ( _wp_connectors_get_provider_settings() as $setting_name => $config ) {
-		if ( ! in_array( $setting_name, $requested, true ) ) {
-			continue;
-		}
+	foreach ( _wp_connectors_get_provider_settings() as $provider => $provider_data ) {
+		foreach ( $provider_data['settings'] as $setting_name => $config ) {
+			if ( ! in_array( $setting_name, $requested, true ) ) {
+				continue;
+			}
 
-		$real_key = _wp_connectors_get_real_api_key( $setting_name, $config['mask'] );
-		if ( '' === $real_key ) {
-			continue;
-		}
+			$real_key = _wp_connectors_get_real_api_key( $setting_name, $config['mask'] );
+			if ( '' === $real_key ) {
+				continue;
+			}
 
-		if ( true !== _wp_connectors_is_api_key_valid( $real_key, $config['provider'] ) ) {
-			$data[ $setting_name ] = 'invalid_key';
+			if ( true !== _wp_connectors_is_api_key_valid( $real_key, $provider ) ) {
+				$data[ $setting_name ] = 'invalid_key';
+			}
 		}
 	}
 
@@ -232,20 +286,22 @@ function _wp_register_default_connector_settings(): void {
 		return;
 	}
 
-	foreach ( _wp_connectors_get_provider_settings() as $setting_name => $config ) {
-		register_setting(
-			'connectors',
-			$setting_name,
-			array(
-				'type'              => 'string',
-				'label'             => $config['label'],
-				'description'       => $config['description'],
-				'default'           => '',
-				'show_in_rest'      => true,
-				'sanitize_callback' => $config['sanitize'],
-			)
-		);
-		add_filter( "option_{$setting_name}", $config['mask'] );
+	foreach ( _wp_connectors_get_provider_settings() as $provider_data ) {
+		foreach ( $provider_data['settings'] as $setting_name => $config ) {
+			register_setting(
+				'connectors',
+				$setting_name,
+				array(
+					'type'              => 'string',
+					'label'             => $config['label'],
+					'description'       => $config['description'],
+					'default'           => '',
+					'show_in_rest'      => true,
+					'sanitize_callback' => $config['sanitize'],
+				)
+			);
+			add_filter( "option_{$setting_name}", $config['mask'] );
+		}
 	}
 }
 add_action( 'init', '_wp_register_default_connector_settings' );
@@ -262,16 +318,18 @@ function _wp_connectors_pass_default_keys_to_ai_client(): void {
 	}
 	try {
 		$registry = AiClient::defaultRegistry();
-		foreach ( _wp_connectors_get_provider_settings() as $setting_name => $config ) {
-			$api_key = _wp_connectors_get_real_api_key( $setting_name, $config['mask'] );
-			if ( '' === $api_key || ! $registry->hasProvider( $config['provider'] ) ) {
-				continue;
-			}
+		foreach ( _wp_connectors_get_provider_settings() as $provider => $provider_data ) {
+			foreach ( $provider_data['settings'] as $setting_name => $config ) {
+				$api_key = _wp_connectors_get_real_api_key( $setting_name, $config['mask'] );
+				if ( '' === $api_key || ! $registry->hasProvider( $provider ) ) {
+					continue;
+				}
 
-			$registry->setProviderRequestAuthentication(
-				$config['provider'],
-				new ApiKeyRequestAuthentication( $api_key )
-			);
+				$registry->setProviderRequestAuthentication(
+					$provider,
+					new ApiKeyRequestAuthentication( $api_key )
+				);
+			}
 		}
 	} catch ( Exception $e ) {
 			wp_trigger_error( __FUNCTION__, $e->getMessage() );

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -185,7 +185,7 @@ function _wp_connectors_get_connector_settings(): array {
 		}
 
 		$name        = $provider_metadata->getName();
-		$description = method_exists( $provider_metadata, 'getDescription' ) ? $provider_metadata->getDescription() : null;
+		$description = $provider_metadata->getDescription();
 
 		if ( isset( $connectors[ $connector_id ] ) ) {
 			// Override fields with non-empty registry values.

--- a/tests/phpunit/includes/functions.php
+++ b/tests/phpunit/includes/functions.php
@@ -376,6 +376,18 @@ function _unhook_font_registration() {
 tests_add_filter( 'init', '_unhook_font_registration', 1000 );
 
 /**
+ * After the init action has been run once, trying to re-register connector settings can cause
+ * duplicate registrations. To avoid this, unhook the connector registration functions.
+ *
+ * @since 7.0.0
+ */
+function _unhook_connector_registration() {
+	remove_action( 'init', '_wp_register_default_connector_settings', 20 );
+	remove_action( 'init', '_wp_connectors_pass_default_keys_to_ai_client', 20 );
+}
+tests_add_filter( 'init', '_unhook_connector_registration', 1000 );
+
+/**
  * Before the abilities API categories init action runs, unhook the core ability
  * categories registration function to prevent core categories from being registered
  * during tests.

--- a/tests/phpunit/includes/wp-ai-client-mock-provider-trait.php
+++ b/tests/phpunit/includes/wp-ai-client-mock-provider-trait.php
@@ -169,4 +169,17 @@ trait WP_AI_Client_Mock_Provider_Trait {
 	private static function set_mock_provider_configured( bool $is_configured ): void {
 		Mock_Connectors_Test_Provider_Availability::$is_configured = $is_configured;
 	}
+
+	/**
+	 * Unregisters the mock provider's connector setting.
+	 *
+	 * Reverses the side effect of _wp_register_default_connector_settings()
+	 * for the mock provider so that subsequent test classes start with a clean slate.
+	 * Must be called from tear_down_after_class() after running tests.
+	 */
+	private static function unregister_mock_connector_setting(): void {
+		$setting_name = 'connectors_ai_mock_connectors_test_api_key';
+		unregister_setting( 'connectors', $setting_name );
+		remove_filter( "option_{$setting_name}", '_wp_connectors_mask_api_key' );
+	}
 }

--- a/tests/phpunit/tests/connectors/wpConnectorsGetConnectorSettings.php
+++ b/tests/phpunit/tests/connectors/wpConnectorsGetConnectorSettings.php
@@ -21,6 +21,14 @@ class Tests_Connectors_WpConnectorsGetConnectorSettings extends WP_UnitTestCase 
 	}
 
 	/**
+	 * Unregisters the mock provider setting added by `init`.
+	 */
+	public static function tear_down_after_class() {
+		self::unregister_mock_connector_setting();
+		parent::tear_down_after_class();
+	}
+
+	/**
 	 * @ticket 64730
 	 */
 	public function test_returns_expected_connector_keys() {

--- a/tests/phpunit/tests/connectors/wpConnectorsGetConnectorSettings.php
+++ b/tests/phpunit/tests/connectors/wpConnectorsGetConnectorSettings.php
@@ -8,7 +8,7 @@ require_once dirname( __DIR__, 2 ) . '/includes/wp-ai-client-mock-provider-trait
  * @group connectors
  * @covers ::_wp_connectors_get_connector_settings
  */
-class Tests_Connectors_WpConnectorsGetProviderSettings extends WP_UnitTestCase {
+class Tests_Connectors_WpConnectorsGetConnectorSettings extends WP_UnitTestCase {
 
 	use WP_AI_Client_Mock_Provider_Trait;
 

--- a/tests/phpunit/tests/connectors/wpConnectorsGetProviderSettings.php
+++ b/tests/phpunit/tests/connectors/wpConnectorsGetProviderSettings.php
@@ -1,4 +1,7 @@
 <?php
+
+require_once dirname( __DIR__, 2 ) . '/includes/wp-ai-client-mock-provider-trait.php';
+
 /**
  * Tests for _wp_connectors_get_provider_settings().
  *
@@ -7,28 +10,57 @@
  */
 class Tests_Connectors_WpConnectorsGetProviderSettings extends WP_UnitTestCase {
 
+	use WP_AI_Client_Mock_Provider_Trait;
+
+	/**
+	 * Registers the mock provider once before any tests in this class run.
+	 */
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+		self::register_mock_connectors_provider();
+	}
+
 	/**
 	 * @ticket 64730
 	 */
 	public function test_returns_expected_provider_keys() {
-		$settings = _wp_connectors_get_provider_settings();
+		$providers = _wp_connectors_get_provider_settings();
 
-		$this->assertArrayHasKey( 'connectors_ai_google_api_key', $settings );
-		$this->assertArrayHasKey( 'connectors_ai_openai_api_key', $settings );
-		$this->assertArrayHasKey( 'connectors_ai_anthropic_api_key', $settings );
-		$this->assertCount( 3, $settings );
+		$this->assertArrayHasKey( 'google', $providers );
+		$this->assertArrayHasKey( 'openai', $providers );
+		$this->assertArrayHasKey( 'anthropic', $providers );
+		$this->assertArrayHasKey( 'mock_connectors_test', $providers );
+		$this->assertCount( 4, $providers );
+	}
+
+	/**
+	 * @ticket 64730
+	 */
+	public function test_each_provider_has_required_fields() {
+		$providers = _wp_connectors_get_provider_settings();
+
+		foreach ( $providers as $provider_id => $provider_data ) {
+			$this->assertArrayHasKey( 'name', $provider_data, "Provider '{$provider_id}' is missing 'name'." );
+			$this->assertArrayHasKey( 'description', $provider_data, "Provider '{$provider_id}' is missing 'description'." );
+			$this->assertIsString( $provider_data['description'], "Provider '{$provider_id}' description should be a string." );
+			$this->assertArrayHasKey( 'credentials_url', $provider_data, "Provider '{$provider_id}' is missing 'credentials_url'." );
+			$this->assertArrayHasKey( 'settings', $provider_data, "Provider '{$provider_id}' is missing 'settings'." );
+			$this->assertIsArray( $provider_data['settings'], "Provider '{$provider_id}' settings should be an array." );
+		}
 	}
 
 	/**
 	 * @ticket 64730
 	 */
 	public function test_each_setting_has_required_fields() {
-		$settings      = _wp_connectors_get_provider_settings();
-		$required_keys = array( 'provider', 'label', 'description', 'mask', 'sanitize' );
+		$providers     = _wp_connectors_get_provider_settings();
+		$required_keys = array( 'label', 'description', 'mask', 'sanitize' );
 
-		foreach ( $settings as $setting_name => $config ) {
-			foreach ( $required_keys as $key ) {
-				$this->assertArrayHasKey( $key, $config, "Setting '{$setting_name}' is missing '{$key}'." );
+		foreach ( $providers as $provider_id => $provider_data ) {
+			foreach ( $provider_data['settings'] as $setting_name => $config ) {
+				foreach ( $required_keys as $key ) {
+					$this->assertArrayHasKey( $key, $config, "Setting '{$setting_name}' for provider '{$provider_id}' is missing '{$key}'." );
+				}
 			}
 		}
 	}
@@ -36,11 +68,25 @@ class Tests_Connectors_WpConnectorsGetProviderSettings extends WP_UnitTestCase {
 	/**
 	 * @ticket 64730
 	 */
-	public function test_provider_values_match_expected() {
-		$settings = _wp_connectors_get_provider_settings();
+	public function test_provider_names_match_expected() {
+		$providers = _wp_connectors_get_provider_settings();
 
-		$this->assertSame( 'google', $settings['connectors_ai_google_api_key']['provider'] );
-		$this->assertSame( 'openai', $settings['connectors_ai_openai_api_key']['provider'] );
-		$this->assertSame( 'anthropic', $settings['connectors_ai_anthropic_api_key']['provider'] );
+		$this->assertSame( 'Gemini', $providers['google']['name'] );
+		$this->assertSame( 'OpenAI', $providers['openai']['name'] );
+		$this->assertSame( 'Claude', $providers['anthropic']['name'] );
+	}
+
+	/**
+	 * @ticket 64730
+	 */
+	public function test_includes_registered_provider_from_registry() {
+		$providers = _wp_connectors_get_provider_settings();
+
+		$this->assertArrayHasKey( 'mock_connectors_test', $providers );
+		$this->assertSame( 'Mock Connectors Test', $providers['mock_connectors_test']['name'] );
+		$this->assertSame( '', $providers['mock_connectors_test']['description'] );
+		$this->assertNull( $providers['mock_connectors_test']['credentials_url'] );
+		$this->assertArrayHasKey( 'connectors_ai_mock_connectors_test_api_key', $providers['mock_connectors_test']['settings'] );
+		$this->assertSame( 'Mock Connectors Test API Key', $providers['mock_connectors_test']['settings']['connectors_ai_mock_connectors_test_api_key']['label'] );
 	}
 }

--- a/tests/phpunit/tests/connectors/wpConnectorsGetProviderSettings.php
+++ b/tests/phpunit/tests/connectors/wpConnectorsGetProviderSettings.php
@@ -88,9 +88,9 @@ class Tests_Connectors_WpConnectorsGetProviderSettings extends WP_UnitTestCase {
 	public function test_featured_provider_names_match_expected() {
 		$connectors = _wp_connectors_get_connector_settings();
 
-		$this->assertSame( 'Gemini', $connectors['google']['name'] );
+		$this->assertSame( 'Google', $connectors['google']['name'] );
 		$this->assertSame( 'OpenAI', $connectors['openai']['name'] );
-		$this->assertSame( 'Claude', $connectors['anthropic']['name'] );
+		$this->assertSame( 'Anthropic', $connectors['anthropic']['name'] );
 	}
 
 	/**

--- a/tests/phpunit/tests/connectors/wpConnectorsGetProviderSettings.php
+++ b/tests/phpunit/tests/connectors/wpConnectorsGetProviderSettings.php
@@ -54,7 +54,7 @@ class Tests_Connectors_WpConnectorsGetProviderSettings extends WP_UnitTestCase {
 	 */
 	public function test_each_setting_has_required_fields() {
 		$providers     = _wp_connectors_get_provider_settings();
-		$required_keys = array( 'label', 'description', 'mask', 'sanitize' );
+		$required_keys = array( 'label', 'description', 'sanitize' );
 
 		foreach ( $providers as $provider_id => $provider_data ) {
 			foreach ( $provider_data['settings'] as $setting_name => $config ) {

--- a/tests/phpunit/tests/connectors/wpConnectorsGetProviderSettings.php
+++ b/tests/phpunit/tests/connectors/wpConnectorsGetProviderSettings.php
@@ -3,10 +3,10 @@
 require_once dirname( __DIR__, 2 ) . '/includes/wp-ai-client-mock-provider-trait.php';
 
 /**
- * Tests for _wp_connectors_get_provider_settings().
+ * Tests for _wp_connectors_get_connector_settings().
  *
  * @group connectors
- * @covers ::_wp_connectors_get_provider_settings
+ * @covers ::_wp_connectors_get_connector_settings
  */
 class Tests_Connectors_WpConnectorsGetProviderSettings extends WP_UnitTestCase {
 
@@ -23,70 +23,88 @@ class Tests_Connectors_WpConnectorsGetProviderSettings extends WP_UnitTestCase {
 	/**
 	 * @ticket 64730
 	 */
-	public function test_returns_expected_provider_keys() {
-		$providers = _wp_connectors_get_provider_settings();
+	public function test_returns_expected_connector_keys() {
+		$connectors = _wp_connectors_get_connector_settings();
 
-		$this->assertArrayHasKey( 'google', $providers );
-		$this->assertArrayHasKey( 'openai', $providers );
-		$this->assertArrayHasKey( 'anthropic', $providers );
-		$this->assertArrayHasKey( 'mock_connectors_test', $providers );
-		$this->assertCount( 4, $providers );
+		$this->assertArrayHasKey( 'google', $connectors );
+		$this->assertArrayHasKey( 'openai', $connectors );
+		$this->assertArrayHasKey( 'anthropic', $connectors );
+		$this->assertArrayHasKey( 'mock_connectors_test', $connectors );
+		$this->assertCount( 4, $connectors );
 	}
 
 	/**
 	 * @ticket 64730
 	 */
-	public function test_each_provider_has_required_fields() {
-		$providers = _wp_connectors_get_provider_settings();
+	public function test_each_connector_has_required_fields() {
+		$connectors = _wp_connectors_get_connector_settings();
 
-		foreach ( $providers as $provider_id => $provider_data ) {
-			$this->assertArrayHasKey( 'name', $provider_data, "Provider '{$provider_id}' is missing 'name'." );
-			$this->assertArrayHasKey( 'description', $provider_data, "Provider '{$provider_id}' is missing 'description'." );
-			$this->assertIsString( $provider_data['description'], "Provider '{$provider_id}' description should be a string." );
-			$this->assertArrayHasKey( 'credentials_url', $provider_data, "Provider '{$provider_id}' is missing 'credentials_url'." );
-			$this->assertArrayHasKey( 'settings', $provider_data, "Provider '{$provider_id}' is missing 'settings'." );
-			$this->assertIsArray( $provider_data['settings'], "Provider '{$provider_id}' settings should be an array." );
+		$this->assertNotEmpty( $connectors, 'Connector settings should not be empty.' );
+
+		foreach ( $connectors as $connector_id => $connector_data ) {
+			$this->assertArrayHasKey( 'name', $connector_data, "Connector '{$connector_id}' is missing 'name'." );
+			$this->assertIsString( $connector_data['name'], "Connector '{$connector_id}' name should be a string." );
+			$this->assertNotEmpty( $connector_data['name'], "Connector '{$connector_id}' name should not be empty." );
+			$this->assertArrayHasKey( 'description', $connector_data, "Connector '{$connector_id}' is missing 'description'." );
+			$this->assertIsString( $connector_data['description'], "Connector '{$connector_id}' description should be a string." );
+			$this->assertArrayHasKey( 'type', $connector_data, "Connector '{$connector_id}' is missing 'type'." );
+			$this->assertContains( $connector_data['type'], array( 'ai_provider' ), "Connector '{$connector_id}' has unexpected type '{$connector_data['type']}'." );
+			$this->assertArrayHasKey( 'authentication', $connector_data, "Connector '{$connector_id}' is missing 'authentication'." );
+			$this->assertIsArray( $connector_data['authentication'], "Connector '{$connector_id}' authentication should be an array." );
+			$this->assertArrayHasKey( 'method', $connector_data['authentication'], "Connector '{$connector_id}' authentication is missing 'method'." );
+			$this->assertContains( $connector_data['authentication']['method'], array( 'api_key', 'none' ), "Connector '{$connector_id}' has unexpected authentication method." );
 		}
 	}
 
 	/**
 	 * @ticket 64730
 	 */
-	public function test_each_setting_has_required_fields() {
-		$providers     = _wp_connectors_get_provider_settings();
-		$required_keys = array( 'label', 'description', 'sanitize' );
+	public function test_api_key_connectors_have_setting_name_and_credentials_url() {
+		$connectors    = _wp_connectors_get_connector_settings();
+		$api_key_count = 0;
 
-		foreach ( $providers as $provider_id => $provider_data ) {
-			foreach ( $provider_data['settings'] as $setting_name => $config ) {
-				foreach ( $required_keys as $key ) {
-					$this->assertArrayHasKey( $key, $config, "Setting '{$setting_name}' for provider '{$provider_id}' is missing '{$key}'." );
-				}
+		foreach ( $connectors as $connector_id => $connector_data ) {
+			if ( 'api_key' !== $connector_data['authentication']['method'] ) {
+				continue;
 			}
+
+			++$api_key_count;
+
+			$this->assertArrayHasKey( 'setting_name', $connector_data['authentication'], "Connector '{$connector_id}' authentication is missing 'setting_name'." );
+			$this->assertSame(
+				"connectors_ai_{$connector_id}_api_key",
+				$connector_data['authentication']['setting_name'],
+				"Connector '{$connector_id}' setting_name does not match expected format."
+			);
+			$this->assertArrayHasKey( 'credentials_url', $connector_data['authentication'], "Connector '{$connector_id}' authentication is missing 'credentials_url'." );
 		}
+
+		$this->assertGreaterThan( 0, $api_key_count, 'At least one connector should use api_key authentication.' );
 	}
 
 	/**
 	 * @ticket 64730
 	 */
-	public function test_provider_names_match_expected() {
-		$providers = _wp_connectors_get_provider_settings();
+	public function test_featured_provider_names_match_expected() {
+		$connectors = _wp_connectors_get_connector_settings();
 
-		$this->assertSame( 'Gemini', $providers['google']['name'] );
-		$this->assertSame( 'OpenAI', $providers['openai']['name'] );
-		$this->assertSame( 'Claude', $providers['anthropic']['name'] );
+		$this->assertSame( 'Gemini', $connectors['google']['name'] );
+		$this->assertSame( 'OpenAI', $connectors['openai']['name'] );
+		$this->assertSame( 'Claude', $connectors['anthropic']['name'] );
 	}
 
 	/**
 	 * @ticket 64730
 	 */
 	public function test_includes_registered_provider_from_registry() {
-		$providers = _wp_connectors_get_provider_settings();
+		$connectors = _wp_connectors_get_connector_settings();
+		$mock       = $connectors['mock_connectors_test'];
 
-		$this->assertArrayHasKey( 'mock_connectors_test', $providers );
-		$this->assertSame( 'Mock Connectors Test', $providers['mock_connectors_test']['name'] );
-		$this->assertSame( '', $providers['mock_connectors_test']['description'] );
-		$this->assertNull( $providers['mock_connectors_test']['credentials_url'] );
-		$this->assertArrayHasKey( 'connectors_ai_mock_connectors_test_api_key', $providers['mock_connectors_test']['settings'] );
-		$this->assertSame( 'Mock Connectors Test API Key', $providers['mock_connectors_test']['settings']['connectors_ai_mock_connectors_test_api_key']['label'] );
+		$this->assertSame( 'Mock Connectors Test', $mock['name'] );
+		$this->assertSame( '', $mock['description'] );
+		$this->assertSame( 'ai_provider', $mock['type'] );
+		$this->assertSame( 'api_key', $mock['authentication']['method'] );
+		$this->assertNull( $mock['authentication']['credentials_url'] );
+		$this->assertSame( 'connectors_ai_mock_connectors_test_api_key', $mock['authentication']['setting_name'] );
 	}
 }

--- a/tests/phpunit/tests/connectors/wpConnectorsIsApiKeyValid.php
+++ b/tests/phpunit/tests/connectors/wpConnectorsIsApiKeyValid.php
@@ -3,10 +3,10 @@
 require_once dirname( __DIR__, 2 ) . '/includes/wp-ai-client-mock-provider-trait.php';
 
 /**
- * Tests for _wp_connectors_is_api_key_valid().
+ * Tests for _wp_connectors_is_ai_api_key_valid().
  *
  * @group connectors
- * @covers ::_wp_connectors_is_api_key_valid
+ * @covers ::_wp_connectors_is_ai_api_key_valid
  */
 class Tests_Connectors_WpConnectorsIsApiKeyValid extends WP_UnitTestCase {
 
@@ -34,9 +34,9 @@ class Tests_Connectors_WpConnectorsIsApiKeyValid extends WP_UnitTestCase {
 	 * @ticket 64730
 	 */
 	public function test_unregistered_provider_returns_null() {
-		$this->setExpectedIncorrectUsage( '_wp_connectors_is_api_key_valid' );
+		$this->setExpectedIncorrectUsage( '_wp_connectors_is_ai_api_key_valid' );
 
-		$result = _wp_connectors_is_api_key_valid( 'test-key', 'nonexistent_provider' );
+		$result = _wp_connectors_is_ai_api_key_valid( 'test-key', 'nonexistent_provider' );
 
 		$this->assertNull( $result );
 	}
@@ -49,7 +49,7 @@ class Tests_Connectors_WpConnectorsIsApiKeyValid extends WP_UnitTestCase {
 	public function test_configured_provider_returns_true() {
 		self::set_mock_provider_configured( true );
 
-		$result = _wp_connectors_is_api_key_valid( 'test-key', 'mock_connectors_test' );
+		$result = _wp_connectors_is_ai_api_key_valid( 'test-key', 'mock_connectors_test' );
 
 		$this->assertTrue( $result );
 	}
@@ -62,7 +62,7 @@ class Tests_Connectors_WpConnectorsIsApiKeyValid extends WP_UnitTestCase {
 	public function test_unconfigured_provider_returns_false() {
 		self::set_mock_provider_configured( false );
 
-		$result = _wp_connectors_is_api_key_valid( 'test-key', 'mock_connectors_test' );
+		$result = _wp_connectors_is_ai_api_key_valid( 'test-key', 'mock_connectors_test' );
 
 		$this->assertFalse( $result );
 	}

--- a/tests/phpunit/tests/rest-api/rest-settings-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-settings-controller.php
@@ -120,14 +120,11 @@ class WP_Test_REST_Settings_Controller extends WP_Test_REST_Controller_Testcase 
 			'default_comment_status',
 			'site_icon', // Registered in wp-includes/blocks/site-logo.php
 			'wp_enable_real_time_collaboration',
-			// Connectors API keys are registered dynamically in _wp_register_default_connector_settings() in wp-includes/connectors.php.
+			// Connectors API keys are registered in _wp_register_default_connector_settings() in wp-includes/connectors.php.
+			'connectors_ai_anthropic_api_key',
+			'connectors_ai_google_api_key',
+			'connectors_ai_openai_api_key',
 		);
-
-		foreach ( get_registered_settings() as $setting_name => $setting ) {
-			if ( 'connectors' === $setting['group'] ) {
-				$expected[] = $setting_name;
-			}
-		}
 
 		if ( ! is_multisite() ) {
 			$expected[] = 'url';

--- a/tests/phpunit/tests/rest-api/rest-settings-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-settings-controller.php
@@ -120,11 +120,14 @@ class WP_Test_REST_Settings_Controller extends WP_Test_REST_Controller_Testcase 
 			'default_comment_status',
 			'site_icon', // Registered in wp-includes/blocks/site-logo.php
 			'wp_enable_real_time_collaboration',
-			// Connectors API keys are registered in _wp_register_default_connector_settings() in wp-includes/connectors.php.
-			'connectors_ai_anthropic_api_key',
-			'connectors_ai_google_api_key',
-			'connectors_ai_openai_api_key',
+			// Connectors API keys are registered dynamically in _wp_register_default_connector_settings() in wp-includes/connectors.php.
 		);
+
+		foreach ( get_registered_settings() as $setting_name => $setting ) {
+			if ( 'connectors' === $setting['group'] ) {
+				$expected[] = $setting_name;
+			}
+		}
 
 		if ( ! is_multisite() ) {
 			$expected[] = 'url';

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -11065,6 +11065,12 @@ mockedApiResponse.Schema = {
                         "PATCH"
                     ],
                     "args": {
+                        "connectors_ai_anthropic_api_key": {
+                            "title": "Anthropic API Key",
+                            "description": "API key for the Anthropic AI provider.",
+                            "type": "string",
+                            "required": false
+                        },
                         "connectors_ai_google_api_key": {
                             "title": "Google API Key",
                             "description": "API key for the Google AI provider.",
@@ -11074,12 +11080,6 @@ mockedApiResponse.Schema = {
                         "connectors_ai_openai_api_key": {
                             "title": "OpenAI API Key",
                             "description": "API key for the OpenAI AI provider.",
-                            "type": "string",
-                            "required": false
-                        },
-                        "connectors_ai_anthropic_api_key": {
-                            "title": "Anthropic API Key",
-                            "description": "API key for the Anthropic AI provider.",
                             "type": "string",
                             "required": false
                         },
@@ -14653,9 +14653,9 @@ mockedApiResponse.CommentModel = {
 };
 
 mockedApiResponse.settings = {
+    "connectors_ai_anthropic_api_key": "",
     "connectors_ai_google_api_key": "",
     "connectors_ai_openai_api_key": "",
-    "connectors_ai_anthropic_api_key": "",
     "title": "Test Blog",
     "description": "",
     "url": "http://example.org",

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -11066,8 +11066,8 @@ mockedApiResponse.Schema = {
                     ],
                     "args": {
                         "connectors_ai_google_api_key": {
-                            "title": "Google API Key",
-                            "description": "API key for the Google AI provider.",
+                            "title": "Gemini API Key",
+                            "description": "API key for the Gemini AI provider.",
                             "type": "string",
                             "required": false
                         },
@@ -11078,8 +11078,8 @@ mockedApiResponse.Schema = {
                             "required": false
                         },
                         "connectors_ai_anthropic_api_key": {
-                            "title": "Anthropic API Key",
-                            "description": "API key for the Anthropic AI provider.",
+                            "title": "Claude API Key",
+                            "description": "API key for the Claude AI provider.",
                             "type": "string",
                             "required": false
                         },
@@ -11217,6 +11217,12 @@ mockedApiResponse.Schema = {
                             "title": "Icon",
                             "description": "Site icon.",
                             "type": "integer",
+                            "required": false
+                        },
+                        "connectors_ai_mock_connectors_test_api_key": {
+                            "title": "Mock Connectors Test API Key",
+                            "description": "API key for the Mock Connectors Test AI provider.",
+                            "type": "string",
                             "required": false
                         }
                     }
@@ -14676,5 +14682,6 @@ mockedApiResponse.settings = {
     "default_ping_status": "open",
     "default_comment_status": "open",
     "site_logo": null,
-    "site_icon": 0
+    "site_icon": 0,
+    "connectors_ai_mock_connectors_test_api_key": ""
 };

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -11066,8 +11066,8 @@ mockedApiResponse.Schema = {
                     ],
                     "args": {
                         "connectors_ai_google_api_key": {
-                            "title": "Gemini API Key",
-                            "description": "API key for the Gemini AI provider.",
+                            "title": "Google API Key",
+                            "description": "API key for the Google AI provider.",
                             "type": "string",
                             "required": false
                         },
@@ -11078,8 +11078,8 @@ mockedApiResponse.Schema = {
                             "required": false
                         },
                         "connectors_ai_anthropic_api_key": {
-                            "title": "Claude API Key",
-                            "description": "API key for the Claude AI provider.",
+                            "title": "Anthropic API Key",
+                            "description": "API key for the Anthropic AI provider.",
                             "type": "string",
                             "required": false
                         },

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -11218,12 +11218,6 @@ mockedApiResponse.Schema = {
                             "description": "Site icon.",
                             "type": "integer",
                             "required": false
-                        },
-                        "connectors_ai_mock_connectors_test_api_key": {
-                            "title": "Mock Connectors Test API Key",
-                            "description": "API key for the Mock Connectors Test AI provider.",
-                            "type": "string",
-                            "required": false
                         }
                     }
                 }
@@ -14682,6 +14676,5 @@ mockedApiResponse.settings = {
     "default_ping_status": "open",
     "default_comment_status": "open",
     "site_logo": null,
-    "site_icon": 0,
-    "connectors_ai_mock_connectors_test_api_key": ""
+    "site_icon": 0
 };


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/64730

Follow-up for https://github.com/WordPress/wordpress-develop/pull/11056.
Synced from https://github.com/WordPress/gutenberg/pull/76014.

## Summary

- Expand `_wp_connectors_get_provider_settings()` to dynamically fetch registered providers from the AI Client registry, in addition to the three hardcoded featured providers (Gemini, OpenAI, Claude).
- Restructure the return value to be keyed by provider ID with `name`, `description`, `credentials_url` at the top level and `settings` as a nested array.
- Filter out providers whose authentication method is not `api_key`.
- Update all consumer functions (`_wp_connectors_validate_keys_in_rest`, `_wp_register_default_connector_settings`, `_wp_connectors_pass_default_keys_to_ai_client`) to use the new structure.
- Update and expand unit tests to cover dynamically registered providers using the mock provider trait.

## Test plan

- [ ] Verify `npm run test:php -- --group connectors` passes (14 tests, 64 assertions).
- [ ] Confirm the three featured providers (google, openai, anthropic) still appear with correct names, descriptions, and credentials URLs.
- [ ] Confirm a third-party provider plugin registered via `AiClient::defaultRegistry()->registerProvider()` with API key auth appears in the settings.
- [ ] Confirm providers without API key authentication are excluded from the settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)