### PR TITLE
External Libraries: Update the Requests library to version 2.0.17.

### DIFF
--- a/src/wp-includes/Requests/src/IdnaEncoder.php
+++ b/src/wp-includes/Requests/src/IdnaEncoder.php
@@ -216,18 +216,18 @@ class IdnaEncoder {
 			}
 
 			if (// Non-shortest form sequences are invalid
-				$length > 1 && $character <= 0x7F
-				|| $length > 2 && $character <= 0x7FF
-				|| $length > 3 && $character <= 0xFFFF
+				($length > 1 && $character <= 0x7F)
+				|| ($length > 2 && $character <= 0x7FF)
+				|| ($length > 3 && $character <= 0xFFFF)
 				// Outside of range of ucschar codepoints
 				// Noncharacters
 				|| ($character & 0xFFFE) === 0xFFFE
-				|| $character >= 0xFDD0 && $character <= 0xFDEF
+				|| ($character >= 0xFDD0 && $character <= 0xFDEF)
 				|| (
 					// Everything else not in ucschar
-					$character > 0xD7FF && $character < 0xF900
+					($character > 0xD7FF && $character < 0xF900)
 					|| $character < 0x20
-					|| $character > 0x7E && $character < 0xA0
+					|| ($character > 0x7E && $character < 0xA0)
 					|| $character > 0xEFFFD
 				)
 			) {

--- a/src/wp-includes/Requests/src/Ipv6.php
+++ b/src/wp-includes/Requests/src/Ipv6.php
@@ -161,7 +161,7 @@ final class Ipv6 {
 		list($ipv6, $ipv4) = self::split_v6_v4($ip);
 		$ipv6              = explode(':', $ipv6);
 		$ipv4              = explode('.', $ipv4);
-		if (count($ipv6) === 8 && count($ipv4) === 1 || count($ipv6) === 6 && count($ipv4) === 4) {
+		if ((count($ipv6) === 8 && count($ipv4) === 1) || (count($ipv6) === 6 && count($ipv4) === 4)) {
 			foreach ($ipv6 as $ipv6_part) {
 				// The section can't be empty
 				if ($ipv6_part === '') {

--- a/src/wp-includes/Requests/src/Iri.php
+++ b/src/wp-includes/Requests/src/Iri.php
@@ -214,7 +214,7 @@ class Iri {
 			$return = null;
 		}
 
-		if ($return === null && isset($this->normalization[$this->scheme][$name])) {
+		if ($return === null && isset($this->scheme, $this->normalization[$this->scheme][$name])) {
 			return $this->normalization[$this->scheme][$name];
 		}
 		else {
@@ -669,26 +669,28 @@ class Iri {
 	}
 
 	protected function scheme_normalization() {
-		if (isset($this->normalization[$this->scheme]['iuserinfo']) && $this->iuserinfo === $this->normalization[$this->scheme]['iuserinfo']) {
-			$this->iuserinfo = null;
-		}
-		if (isset($this->normalization[$this->scheme]['ihost']) && $this->ihost === $this->normalization[$this->scheme]['ihost']) {
-			$this->ihost = null;
-		}
-		if (isset($this->normalization[$this->scheme]['port']) && $this->port === $this->normalization[$this->scheme]['port']) {
-			$this->port = null;
-		}
-		if (isset($this->normalization[$this->scheme]['ipath']) && $this->ipath === $this->normalization[$this->scheme]['ipath']) {
-			$this->ipath = '';
+		if (isset($this->scheme, $this->normalization[$this->scheme])) {
+			if (isset($this->normalization[$this->scheme]['iuserinfo']) && $this->iuserinfo === $this->normalization[$this->scheme]['iuserinfo']) {
+				$this->iuserinfo = null;
+			}
+			if (isset($this->normalization[$this->scheme]['ihost']) && $this->ihost === $this->normalization[$this->scheme]['ihost']) {
+				$this->ihost = null;
+			}
+			if (isset($this->normalization[$this->scheme]['port']) && $this->port === $this->normalization[$this->scheme]['port']) {
+				$this->port = null;
+			}
+			if (isset($this->normalization[$this->scheme]['ipath']) && $this->ipath === $this->normalization[$this->scheme]['ipath']) {
+				$this->ipath = '';
+			}
+			if (isset($this->normalization[$this->scheme]['iquery']) && $this->iquery === $this->normalization[$this->scheme]['iquery']) {
+				$this->iquery = null;
+			}
+			if (isset($this->normalization[$this->scheme]['ifragment']) && $this->ifragment === $this->normalization[$this->scheme]['ifragment']) {
+				$this->ifragment = null;
+			}
 		}
 		if (isset($this->ihost) && empty($this->ipath)) {
 			$this->ipath = '/';
-		}
-		if (isset($this->normalization[$this->scheme]['iquery']) && $this->iquery === $this->normalization[$this->scheme]['iquery']) {
-			$this->iquery = null;
-		}
-		if (isset($this->normalization[$this->scheme]['ifragment']) && $this->ifragment === $this->normalization[$this->scheme]['ifragment']) {
-			$this->ifragment = null;
 		}
 	}
 

--- a/src/wp-includes/Requests/src/Requests.php
+++ b/src/wp-includes/Requests/src/Requests.php
@@ -148,7 +148,7 @@ class Requests {
 	 *
 	 * @var string
 	 */
-	const VERSION = '2.0.11';
+	const VERSION = '2.0.17';
 
 	/**
 	 * Selected transport name

--- a/src/wp-includes/Requests/src/Response/Headers.php
+++ b/src/wp-includes/Requests/src/Response/Headers.php
@@ -35,7 +35,7 @@ class Headers extends CaseInsensitiveDictionary {
 			$offset = strtolower($offset);
 		}
 
-		if (!isset($this->data[$offset])) {
+		if (!isset($offset, $this->data[$offset])) {
 			return null;
 		}
 

--- a/src/wp-includes/Requests/src/Transport/Curl.php
+++ b/src/wp-includes/Requests/src/Transport/Curl.php
@@ -126,6 +126,7 @@ final class Curl implements Transport {
 	 */
 	public function __destruct() {
 		if (is_resource($this->handle)) {
+			// phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.curl_closeDeprecated,Generic.PHP.DeprecatedFunctions.Deprecated
 			curl_close($this->handle);
 		}
 	}
@@ -306,7 +307,10 @@ final class Curl implements Transport {
 				}
 
 				curl_multi_remove_handle($multihandle, $done['handle']);
-				curl_close($done['handle']);
+				if (is_resource($done['handle'])) {
+					// phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.curl_closeDeprecated,Generic.PHP.DeprecatedFunctions.Deprecated
+					curl_close($done['handle']);
+				}
 
 				if (!is_string($responses[$key])) {
 					$options['hooks']->dispatch('multiple.request.complete', [&$responses[$key], $key]);

--- a/src/wp-includes/Requests/src/Transport/Fsockopen.php
+++ b/src/wp-includes/Requests/src/Transport/Fsockopen.php
@@ -148,9 +148,11 @@ final class Fsockopen implements Transport {
 			// Ref: https://wiki.php.net/rfc/deprecate_functions_with_overloaded_signatures#stream_context_set_option
 			if (function_exists('stream_context_set_options')) {
 				// PHP 8.3+.
+				// phpcs:ignore PHPCompatibility.FunctionUse.NewFunctions.stream_context_set_optionsFound
 				stream_context_set_options($context, ['ssl' => $context_options]);
 			} else {
 				// PHP < 8.3.
+				// phpcs:ignore PHPCompatibility.FunctionUse.OptionalToRequiredFunctionParameters
 				stream_context_set_option($context, ['ssl' => $context_options]);
 			}
 		} else {

--- a/src/wp-includes/Requests/src/Utility/CaseInsensitiveDictionary.php
+++ b/src/wp-includes/Requests/src/Utility/CaseInsensitiveDictionary.php
@@ -49,6 +49,10 @@ class CaseInsensitiveDictionary implements ArrayAccess, IteratorAggregate {
 			$offset = strtolower($offset);
 		}
 
+		if ($offset === null) {
+			$offset = '';
+		}
+
 		return isset($this->data[$offset]);
 	}
 
@@ -62,6 +66,10 @@ class CaseInsensitiveDictionary implements ArrayAccess, IteratorAggregate {
 	public function offsetGet($offset) {
 		if (is_string($offset)) {
 			$offset = strtolower($offset);
+		}
+
+		if ($offset === null) {
+			$offset = '';
 		}
 
 		if (!isset($this->data[$offset])) {
@@ -101,6 +109,10 @@ class CaseInsensitiveDictionary implements ArrayAccess, IteratorAggregate {
 	public function offsetUnset($offset) {
 		if (is_string($offset)) {
 			$offset = strtolower($offset);
+		}
+
+		if ($offset === null) {
+			$offset = '';
 		}
 
 		unset($this->data[$offset]);

--- a/src/wp-includes/Requests/src/Utility/FilteredIterator.php
+++ b/src/wp-includes/Requests/src/Utility/FilteredIterator.php
@@ -28,13 +28,13 @@ final class FilteredIterator extends ArrayIterator {
 	/**
 	 * Create a new iterator
 	 *
-	 * @param array    $data     The array or object to be iterated on.
+	 * @param array    $data     The array to be iterated on.
 	 * @param callable $callback Callback to be called on each value
 	 *
 	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $data argument is not iterable.
 	 */
 	public function __construct($data, $callback) {
-		if (InputValidator::is_iterable($data) === false) {
+		if (is_object($data) === true || InputValidator::is_iterable($data) === false) {
 			throw InvalidArgument::create(1, '$data', 'iterable', gettype($data));
 		}
 


### PR DESCRIPTION
The most notable changes are PHP 8.5 compatibility fixes in version 2.0.16. Other releases between 2.0.11 and 2.0.17 contain only certificate bundle updates, which are skipped as WordPress manages its own certificate bundle (see #62812).

I basically downloaded the Requests package from GitHub and manually copied its contents to `src/wp-includes/Requests`, ignoring the `library/` directory, which appears to have been modified by WP Core to handle backward compatibility differently from upstream. I'm not sure if there is a better way to handle the Requests update. While doing it, I also had to manually ensure that the `__wakeup()` methods in `Hooks.php`, `Iri.php`, and `Session.php` added in https://core.trac.wordpress.org/changeset/56835 as security hardening are preserved in this update (related upstream ticket: https://github.com/WordPress/Requests/issues/949).

References:
- [Requests 2.0.12 release notes](https://github.com/WordPress/Requests/releases/tag/v2.0.12)
- [Requests 2.0.13 release notes](https://github.com/WordPress/Requests/releases/tag/v2.0.13)
- [Requests 2.0.14 release notes](https://github.com/WordPress/Requests/releases/tag/v2.0.14)
- [Requests 2.0.15 release notes](https://github.com/WordPress/Requests/releases/tag/v2.0.15)
- [Requests 2.0.16 release notes](https://github.com/WordPress/Requests/releases/tag/v2.0.16)
- [Requests 2.0.17 release notes](https://github.com/WordPress/Requests/releases/tag/v2.0.17)
- [Full list of changes since 2.0.11](https://github.com/WordPress/Requests/compare/v2.0.11...v2.0.17)

Trac ticket: https://core.trac.wordpress.org/ticket/64752

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
