### PR TITLE
Admin: Fix community events form alignment for 40px design system update.

### DIFF
--- a/src/wp-admin/css/dashboard.css
+++ b/src/wp-admin/css/dashboard.css
@@ -500,7 +500,7 @@
 
 .community-events .spinner {
 	float: none;
-	margin: 5px 2px 0;
+	margin: 10px 2px 0;
 	vertical-align: top;
 }
 
@@ -524,7 +524,6 @@
 
 .community-events-form .regular-text {
 	width: 40%;
-	height: 29px;
 	margin: 0;
 	vertical-align: top;
 }
@@ -540,8 +539,8 @@
 .community-events-form label {
 	display: inline-block;
 	vertical-align: top;
-	line-height: 2.15384615;
-	height: 28px;
+	line-height: 2.92307692;
+	min-height: 40px;
 }
 
 .community-events .activity-block > p {
@@ -562,8 +561,8 @@
 #dashboard-widgets .community-events-cancel.button-link {
 	vertical-align: top;
 	/* Same properties as the submit button for cross-browsers alignment. */
-	line-height: 2;
-	height: 28px;
+	line-height: 2.92307692;
+	min-height: 40px;
 	text-decoration: underline;
 }
 
@@ -1450,12 +1449,8 @@ a.rsswidget {
 	}
 
 	.community-events-toggle-location {
-		height: 38px;
+		min-height: 40px;
 		vertical-align: baseline;
-	}
-
-	.community-events-form .regular-text {
-		height: 32px;
 	}
 
 	#community-events-submit {
@@ -1468,14 +1463,14 @@ a.rsswidget {
 	#dashboard-widgets .community-events-cancel.button-link {
 		/* Same properties as the submit button for cross-browsers alignment. */
 		font-size: 14px;
-		line-height: normal;
-		height: auto;
-		padding: 6px 0;
+		line-height: 2.92307692;
+		min-height: 40px;
+		padding: 0;
 		border: 1px solid transparent;
 	}
 
 	.community-events .spinner {
-		margin-top: 7px;
+		margin-top: 10px;
 	}
 }
 


### PR DESCRIPTION
Trac Ticket: https://core.trac.wordpress.org/ticket/64753

 **Testing**
1. Go to **Dashboard → WordPress Events and News** widget.
2. Click **Select location** to open the location form.
3. Verify the "City:" label, input field, "Submit" button, and "Cancel" link are all vertically aligned.
4. Resize the browser below 1180px and verify alignment remains consistent in the responsive layout.

**Before:**
<img width="942" height="992" alt="Huzaifa-20260227230017" src="https://github.com/user-attachments/assets/c935ac28-b452-4efb-abfa-cbb1df113b21" />


**After:**
<img width="1270" height="990" alt="Huzaifa-20260228000325" src="https://github.com/user-attachments/assets/615d83e4-4733-4308-b6c9-8d0bb4aeedad" />
