### PR TITLE
Add `@phpstan-assert-if-true` to `is_wp_error()`

### DIFF
--- a/src/wp-includes/load.php
+++ b/src/wp-includes/load.php
@@ -1798,6 +1798,8 @@ function wp_doing_cron() {
  *
  * @param mixed $thing The variable to check.
  * @return bool Whether the variable is an instance of WP_Error.
+ *
+ * @phpstan-assert-if-true WP_Error $thing
  */
 function is_wp_error( $thing ) {
 	$is_wp_error = ( $thing instanceof WP_Error );


### PR DESCRIPTION
This reduces the number of PHPStan errors at level 7 from 14,271 to 13,233 (-1,038 or -7.27%). See [error report diff](https://gist.github.com/westonruter/79f3434dac3587048848c7a7a183cfb6).

Trac ticket: https://core.trac.wordpress.org/ticket/64238

## Use of AI Tools

n/a

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
