### PR TITLE
Update border color for welcome panel in dashboard CSS

### DIFF
--- a/src/wp-admin/css/dashboard.css
+++ b/src/wp-admin/css/dashboard.css
@@ -140,7 +140,6 @@
 	position: relative;
 	overflow: auto;
 	margin: 16px 0;
-	border: 1px solid #c3c4c7;
 	border-radius: 8px;
 	font-size: 14px;
 	line-height: 1.3;
@@ -288,6 +287,9 @@
 	gap: 32px;
 	align-self: flex-end;
 	background: #ffffff;
+	border: 1px solid #c3c4c7;
+	border-top: 0;
+	border-radius: 0 0 8px 8px;
 }
 
 [class*="welcome-panel-icon"] {

--- a/src/wp-admin/css/dashboard.css
+++ b/src/wp-admin/css/dashboard.css
@@ -1428,6 +1428,7 @@ a.rsswidget {
 	}
 
 	.welcome-panel .welcome-panel-close::before {
+		position: absolute;
 		top: 5px;
 		left: -35px;
 	}

--- a/src/wp-admin/css/dashboard.css
+++ b/src/wp-admin/css/dashboard.css
@@ -140,8 +140,7 @@
 	position: relative;
 	overflow: auto;
 	margin: 16px 0;
-	background-color: #c3c4c7;
-	border: 1px solid rgb(0, 0, 0, 0.1);
+	border: 1px solid #c3c4c7;
 	border-radius: 8px;
 	font-size: 14px;
 	line-height: 1.3;
@@ -259,6 +258,7 @@
 }
 
 .welcome-panel-content {
+	background-color: #151515;
 	min-height: 400px;
 	display: flex;
 	flex-direction: column;

--- a/src/wp-admin/css/dashboard.css
+++ b/src/wp-admin/css/dashboard.css
@@ -258,11 +258,14 @@
 }
 
 .welcome-panel-content {
-	background-color: #151515;
 	min-height: 400px;
 	display: flex;
 	flex-direction: column;
 	justify-content: space-between;
+}
+
+.welcome-panel-header-wrap {
+	background-color: #151515;
 }
 
 .welcome-panel-header {

--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -2075,19 +2075,21 @@ function wp_welcome_panel() {
 	$is_block_theme          = wp_is_block_theme();
 	?>
 	<div class="welcome-panel-content">
-	<div class="welcome-panel-header">
-		<div class="welcome-panel-header-image">
-			<?php echo file_get_contents( dirname( __DIR__ ) . '/images/dashboard-background.svg' ); ?>
+	<div class="welcome-panel-header-wrap">
+		<div class="welcome-panel-header">
+			<div class="welcome-panel-header-image">
+				<?php echo file_get_contents( dirname( __DIR__ ) . '/images/dashboard-background.svg' ); ?>
+			</div>
+			<h2><?php _e( 'Welcome to WordPress!' ); ?></h2>
+			<p>
+				<a href="<?php echo esc_url( admin_url( 'about.php' ) ); ?>">
+				<?php
+					/* translators: %s: Current WordPress version. */
+					printf( __( 'Learn more about the %s version.' ), esc_html( $display_version ) );
+				?>
+				</a>
+			</p>
 		</div>
-		<h2><?php _e( 'Welcome to WordPress!' ); ?></h2>
-		<p>
-			<a href="<?php echo esc_url( admin_url( 'about.php' ) ); ?>">
-			<?php
-				/* translators: %s: Current WordPress version. */
-				printf( __( 'Learn more about the %s version.' ), esc_html( $display_version ) );
-			?>
-			</a>
-		</p>
 	</div>
 	<div class="welcome-panel-column-container">
 		<div class="welcome-panel-column">


### PR DESCRIPTION
If we add `background-color: #151515` to `welcome-panel-content` to fix this: https://github.com/WordPress/wordpress-develop/pull/11105, it might be better to remove the background from `welcome-panel` and simply modify the border color instead. Does that make sense?

Trac ticket: https://core.trac.wordpress.org/ticket/64741