### PR TITLE
Comments: Add default args to Walker_Comment methods to prevent PHP warnings

### DIFF
--- a/src/wp-includes/class-walker-comment.php
+++ b/src/wp-includes/class-walker-comment.php
@@ -53,7 +53,7 @@ class Walker_Comment extends Walker {
 			array(
 				'style'       => 'ul',
 				'avatar_size' => 32,
-				'format'      => 'xhtml',
+				'format'      => current_theme_supports( 'html5', 'comment-list' ) ? 'html5' : 'xhtml',
 				'short_ping'  => false,
 				'max_depth'   => '',
 			),

--- a/src/wp-includes/class-walker-comment.php
+++ b/src/wp-includes/class-walker-comment.php
@@ -41,6 +41,27 @@ class Walker_Comment extends Walker {
 	);
 
 	/**
+	 * Parses arguments with defaults.
+	 *
+	 * @since unreleased
+	 *
+	 * @param array $args Arguments to parse.
+	 * @return array Parsed arguments.
+	 */
+	protected function get_args( array $args ): array {
+		return array_merge(
+			array(
+				'style'       => 'ul',
+				'avatar_size' => 32,
+				'format'      => 'xhtml',
+				'short_ping'  => false,
+				'max_depth'   => '',
+			),
+			$args
+		);
+	}
+
+	/**
 	 * Starts the list before the elements are added.
 	 *
 	 * @since 2.7.0
@@ -53,12 +74,7 @@ class Walker_Comment extends Walker {
 	 * @param array  $args   Optional. Uses 'style' argument for type of HTML list. Default empty array.
 	 */
 	public function start_lvl( &$output, $depth = 0, $args = array() ) {
-		$args = wp_parse_args(
-			$args,
-			array(
-				'style' => 'ul',
-			)
-		);
+		$args = $this->get_args( $args );
 
 		$GLOBALS['comment_depth'] = $depth + 1;
 
@@ -89,12 +105,7 @@ class Walker_Comment extends Walker {
 	 *                       Default empty array.
 	 */
 	public function end_lvl( &$output, $depth = 0, $args = array() ) {
-		$args = wp_parse_args(
-			$args,
-			array(
-				'style' => 'ul',
-			)
-		);
+		$args = $this->get_args( $args );
 
 		$GLOBALS['comment_depth'] = $depth + 1;
 
@@ -185,13 +196,7 @@ class Walker_Comment extends Walker {
 	 * @param int        $current_object_id Optional. ID of the current comment. Default 0.
 	 */
 	public function start_el( &$output, $data_object, $depth = 0, $args = array(), $current_object_id = 0 ) {
-		$args = wp_parse_args(
-			$args,
-			array(
-				'short_ping' => false,
-				'format'     => 'xhtml',
-			)
-		);
+		$args = $this->get_args( $args );
 
 		// Restores the more descriptive, specific name for use within this method.
 		$comment = $data_object;
@@ -245,12 +250,7 @@ class Walker_Comment extends Walker {
 	 * @param array      $args        Optional. An array of arguments. Default empty array.
 	 */
 	public function end_el( &$output, $data_object, $depth = 0, $args = array() ) {
-		$args = wp_parse_args(
-			$args,
-			array(
-				'style' => 'ul',
-			)
-		);
+		$args = $this->get_args( $args );
 
 		if ( ! empty( $args['end-callback'] ) ) {
 			ob_start();
@@ -282,12 +282,7 @@ class Walker_Comment extends Walker {
 	 * @param array      $args    An array of arguments.
 	 */
 	protected function ping( $comment, $depth, $args ) {
-		$args = wp_parse_args(
-			$args,
-			array(
-				'style' => 'ul',
-			)
-		);
+		$args = $this->get_args( $args );
 
 		$tag = ( 'div' === $args['style'] ) ? 'div' : 'li';
 		?>
@@ -333,14 +328,7 @@ class Walker_Comment extends Walker {
 	 * @param array      $args    An array of arguments.
 	 */
 	protected function comment( $comment, $depth, $args ) {
-		$args = wp_parse_args(
-			$args,
-			array(
-				'style'       => 'ul',
-				'avatar_size' => 32,
-				'max_depth'   => '',
-			)
-		);
+		$args = $this->get_args( $args );
 
 		if ( 'div' === $args['style'] ) {
 			$tag       = 'div';
@@ -452,14 +440,7 @@ class Walker_Comment extends Walker {
 	 * @param array      $args    An array of arguments.
 	 */
 	protected function html5_comment( $comment, $depth, $args ) {
-		$args = wp_parse_args(
-			$args,
-			array(
-				'style'       => 'ul',
-				'avatar_size' => 32,
-				'max_depth'   => '',
-			)
-		);
+		$args = $this->get_args( $args );
 
 		$tag = ( 'div' === $args['style'] ) ? 'div' : 'li';
 

--- a/src/wp-includes/class-walker-comment.php
+++ b/src/wp-includes/class-walker-comment.php
@@ -53,6 +53,13 @@ class Walker_Comment extends Walker {
 	 * @param array  $args   Optional. Uses 'style' argument for type of HTML list. Default empty array.
 	 */
 	public function start_lvl( &$output, $depth = 0, $args = array() ) {
+		$args = wp_parse_args(
+			$args,
+			array(
+				'style' => 'ul',
+			)
+		);
+
 		$GLOBALS['comment_depth'] = $depth + 1;
 
 		switch ( $args['style'] ) {
@@ -82,6 +89,13 @@ class Walker_Comment extends Walker {
 	 *                       Default empty array.
 	 */
 	public function end_lvl( &$output, $depth = 0, $args = array() ) {
+		$args = wp_parse_args(
+			$args,
+			array(
+				'style' => 'ul',
+			)
+		);
+
 		$GLOBALS['comment_depth'] = $depth + 1;
 
 		switch ( $args['style'] ) {
@@ -171,6 +185,14 @@ class Walker_Comment extends Walker {
 	 * @param int        $current_object_id Optional. ID of the current comment. Default 0.
 	 */
 	public function start_el( &$output, $data_object, $depth = 0, $args = array(), $current_object_id = 0 ) {
+		$args = wp_parse_args(
+			$args,
+			array(
+				'short_ping' => false,
+				'format'     => 'xhtml',
+			)
+		);
+
 		// Restores the more descriptive, specific name for use within this method.
 		$comment = $data_object;
 
@@ -223,6 +245,13 @@ class Walker_Comment extends Walker {
 	 * @param array      $args        Optional. An array of arguments. Default empty array.
 	 */
 	public function end_el( &$output, $data_object, $depth = 0, $args = array() ) {
+		$args = wp_parse_args(
+			$args,
+			array(
+				'style' => 'ul',
+			)
+		);
+
 		if ( ! empty( $args['end-callback'] ) ) {
 			ob_start();
 			call_user_func(
@@ -253,6 +282,13 @@ class Walker_Comment extends Walker {
 	 * @param array      $args    An array of arguments.
 	 */
 	protected function ping( $comment, $depth, $args ) {
+		$args = wp_parse_args(
+			$args,
+			array(
+				'style' => 'ul',
+			)
+		);
+
 		$tag = ( 'div' === $args['style'] ) ? 'div' : 'li';
 		?>
 		<<?php echo $tag; ?> id="comment-<?php comment_ID(); ?>" <?php comment_class( '', $comment ); ?>>
@@ -297,6 +333,15 @@ class Walker_Comment extends Walker {
 	 * @param array      $args    An array of arguments.
 	 */
 	protected function comment( $comment, $depth, $args ) {
+		$args = wp_parse_args(
+			$args,
+			array(
+				'style'       => 'ul',
+				'avatar_size' => 32,
+				'max_depth'   => '',
+			)
+		);
+
 		if ( 'div' === $args['style'] ) {
 			$tag       = 'div';
 			$add_below = 'comment';
@@ -407,6 +452,15 @@ class Walker_Comment extends Walker {
 	 * @param array      $args    An array of arguments.
 	 */
 	protected function html5_comment( $comment, $depth, $args ) {
+		$args = wp_parse_args(
+			$args,
+			array(
+				'style'       => 'ul',
+				'avatar_size' => 32,
+				'max_depth'   => '',
+			)
+		);
+
 		$tag = ( 'div' === $args['style'] ) ? 'div' : 'li';
 
 		$commenter          = wp_get_current_commenter();

--- a/tests/phpunit/tests/comment/walker.php
+++ b/tests/phpunit/tests/comment/walker.php
@@ -54,6 +54,81 @@ class Tests_Comment_Walker extends WP_UnitTestCase {
 			array( $comment_child, $comment_parent )
 		);
 	}
+
+	/**
+	 * @ticket 56539
+	 */
+	public function test_start_lvl_with_empty_args_should_not_produce_warnings() {
+		$walker = new Walker_Comment();
+		$output = '';
+
+		$walker->start_lvl( $output, 0, array() );
+
+		$this->assertStringContainsString( '<ul class="children">', $output );
+	}
+
+	/**
+	 * @ticket 56539
+	 */
+	public function test_end_lvl_with_empty_args_should_not_produce_warnings() {
+		$walker = new Walker_Comment();
+		$output = '';
+
+		$walker->end_lvl( $output, 0, array() );
+
+		$this->assertStringContainsString( '</ul>', $output );
+	}
+
+	/**
+	 * @ticket 56539
+	 */
+	public function test_end_el_with_empty_args_should_not_produce_warnings() {
+		$comment_id = self::factory()->comment->create( array( 'comment_post_ID' => $this->post_id ) );
+		$comment    = get_comment( $comment_id );
+		$walker     = new Walker_Comment();
+		$output     = '';
+
+		$walker->end_el( $output, $comment, 0, array() );
+
+		$this->assertStringContainsString( '</li>', $output );
+	}
+
+	/**
+	 * @ticket 56539
+	 */
+	public function test_start_el_with_empty_args_should_not_produce_warnings() {
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID' => $this->post_id,
+				'comment_type'    => 'comment',
+			)
+		);
+		$comment    = get_comment( $comment_id );
+		$walker     = new Walker_Comment();
+		$output     = '';
+
+		$walker->start_el( $output, $comment, 0, array() );
+
+		$this->assertNotEmpty( $output );
+	}
+
+	/**
+	 * @ticket 56539
+	 */
+	public function test_walk_with_empty_args_should_not_produce_warnings() {
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID' => $this->post_id,
+				'comment_type'    => 'comment',
+			)
+		);
+		$comments   = array( get_comment( $comment_id ) );
+		$walker     = new Walker_Comment();
+
+		$output = $walker->walk( $comments, -1, array() );
+
+		$this->assertNotEmpty( $output );
+	}
 }
 
 class Comment_Callback_Test_Helper {


### PR DESCRIPTION
## Trac Ticket

https://core.trac.wordpress.org/ticket/56539

## Summary

Walker_Comment methods access $args keys (style, short_ping, format, avatar_size, max_depth) without verifying they exist. When called with an empty $args array (which is the documented default), this produces PHP warnings on PHP 8.0+.

## Changes

- Added `get_args()` helper method with a single list of defaults matching `wp_list_comments()`, including dynamic `format` detection via `current_theme_supports()`
- All 7 affected methods now use `$this->get_args( $args )` instead of duplicated defaults
- Added PHPUnit tests to verify no warnings when methods are called with empty args

## Notes

This is a cleaner alternative to PR #4126, which mixes the fix with unrelated whitespace/indentation changes. This PR only adds the defaults with no other modifications.