### PR TITLE
RTC: Check `wp_user_id` before accepting awareness update

### DIFF
--- a/src/wp-includes/collaboration/class-wp-http-polling-sync-server.php
+++ b/src/wp-includes/collaboration/class-wp-http-polling-sync-server.php
@@ -181,10 +181,25 @@ class WP_HTTP_Polling_Sync_Server {
 			);
 		}
 
-		$rooms = $request['rooms'];
+		$rooms      = $request['rooms'];
+		$wp_user_id = get_current_user_id();
 
 		foreach ( $rooms as $room ) {
-			$room         = $room['room'];
+			$client_id = $room['client_id'];
+			$room      = $room['room'];
+
+			// Check that the client_id is not already owned by another user.
+			$existing_awareness = $this->storage->get_awareness_state( $room );
+			foreach ( $existing_awareness as $entry ) {
+				if ( $client_id === $entry['client_id'] && $wp_user_id !== $entry['wp_user_id'] ) {
+					return new WP_Error(
+						'rest_cannot_edit',
+						__( 'Client ID is already in use by another user.' ),
+						array( 'status' => rest_authorization_required_code() )
+					);
+				}
+			}
+
 			$type_parts   = explode( '/', $room, 2 );
 			$object_parts = explode( ':', $type_parts[1] ?? '', 2 );
 
@@ -341,6 +356,7 @@ class WP_HTTP_Polling_Sync_Server {
 				'client_id'  => $client_id,
 				'state'      => $awareness_update,
 				'updated_at' => $current_time,
+				'wp_user_id' => get_current_user_id(),
 			);
 		}
 

--- a/tests/phpunit/tests/rest-api/rest-sync-server.php
+++ b/tests/phpunit/tests/rest-api/rest-sync-server.php
@@ -697,6 +697,31 @@ class WP_Test_REST_Sync_Server extends WP_Test_REST_Controller_Testcase {
 		$this->assertSame( array( 'cursor' => 'updated' ), $awareness[1] );
 	}
 
+	public function test_sync_awareness_client_id_cannot_be_used_by_another_user() {
+		wp_set_current_user( self::$editor_id );
+
+		$room = $this->get_post_room();
+
+		// Editor establishes awareness with client_id 1.
+		$this->dispatch_sync(
+			array(
+				$this->build_room( $room, 1, 0, array( 'name' => 'Editor' ) ),
+			)
+		);
+
+		// A different user tries to use the same client_id.
+		$editor_id_2 = self::factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $editor_id_2 );
+
+		$response = $this->dispatch_sync(
+			array(
+				$this->build_room( $room, 1, 0, array( 'name' => 'Impostor' ) ),
+			)
+		);
+
+		$this->assertErrorResponse( 'rest_cannot_edit', $response, 403 );
+	}
+
 	/*
 	 * Multiple rooms tests.
 	 */


### PR DESCRIPTION

Trac ticket: https://core.trac.wordpress.org/ticket/64782

Using the built-in HTTP polling sync server, awareness state is accepted and stored after the user is authorized. This state is keyed against their sync client ID, which is randomly generated.

However, nothing prevents a user from spoofing another client's client ID, which is discoverable by inspecting network responses. By replaying a sync request with a different client ID, they could temporarily overwrite another client's awareness state.

This change prevents this spoofing by storing and checking the user's WordPress user ID to ensure it matches the initial update.

Backport of https://github.com/WordPress/gutenberg/pull/76056