### PR TITLE
RTC: Update/add syncing post meta in slashed form.

### DIFF
--- a/src/wp-includes/collaboration/class-wp-sync-post-meta-storage.php
+++ b/src/wp-includes/collaboration/class-wp-sync-post-meta-storage.php
@@ -85,7 +85,7 @@ class WP_Sync_Post_Meta_Storage implements WP_Sync_Storage {
 			'value'     => $update,
 		);
 
-		return (bool) add_post_meta( $post_id, self::SYNC_UPDATE_META_KEY, $envelope, false );
+		return (bool) add_post_meta( $post_id, wp_slash( self::SYNC_UPDATE_META_KEY ), wp_slash( $envelope ), false );
 	}
 
 	/**
@@ -162,7 +162,7 @@ class WP_Sync_Post_Meta_Storage implements WP_Sync_Storage {
 		}
 
 		// update_post_meta returns false if the value is the same as the existing value.
-		update_post_meta( $post_id, self::AWARENESS_META_KEY, $awareness );
+		update_post_meta( $post_id, wp_slash( self::AWARENESS_META_KEY ), wp_slash( $awareness ) );
 		return true;
 	}
 
@@ -305,7 +305,7 @@ class WP_Sync_Post_Meta_Storage implements WP_Sync_Storage {
 		$all_updates = $this->get_all_updates( $room );
 
 		// Remove all updates for the room and re-store only those that are newer than the cursor.
-		if ( ! delete_post_meta( $post_id, self::SYNC_UPDATE_META_KEY ) ) {
+		if ( ! delete_post_meta( $post_id, wp_slash( self::SYNC_UPDATE_META_KEY ) ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
For historical reasons updating, adding and deleting post meta require both the meta key and meta value be in a slashed form.

For the keys this is pretty much to follow the docs, for the meta values it might be useful depending on the contents of an update.

Trac ticket: https://core.trac.wordpress.org/ticket/64783

## Use of AI Tools

Nup.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
