### PR TITLE
RTC: Increase awareness timeout to avoid false disconnects

### DIFF
--- a/src/wp-includes/collaboration/class-wp-http-polling-sync-server.php
+++ b/src/wp-includes/collaboration/class-wp-http-polling-sync-server.php
@@ -24,10 +24,16 @@ class WP_HTTP_Polling_Sync_Server {
 	 * Awareness timeout in seconds. Clients that haven't updated
 	 * their awareness state within this time are considered disconnected.
 	 *
+	 * Background tabs poll every 30 s, but Chrome's intensive throttling
+	 * (after ~5 min in background) can delay polls to ~60 s. The timeout
+	 * must exceed that to avoid false disconnects.
+	 *
+	 * @see https://developer.chrome.com/blog/timer-throttling-in-chrome-88
+	 *
 	 * @since 7.0.0
 	 * @var int
 	 */
-	const AWARENESS_TIMEOUT = 30;
+	const AWARENESS_TIMEOUT = 70;
 
 	/**
 	 * Threshold used to signal clients to send a compaction update.


### PR DESCRIPTION
Backport for awareness timeout update from Gutenberg PR - https://github.com/WordPress/gutenberg/pull/76065

Trac: https://core.trac.wordpress.org/ticket/64622

> The 30 s awareness timeout matched the background-tab polling interval exactly, causing awareness entries to expire between polls and triggering false "X has left" notifications that resolved on the next poll cycle.
>
> Increase to 70 s to comfortably exceed the polling interval. The value accounts for Chrome's intensive throttling which can delay background tab timers to ~60 s