### PR TITLE
Refactor: Remove unnecessary false check in oEmbed data fetching

### DIFF
--- a/src/wp-includes/class-wp-oembed.php
+++ b/src/wp-includes/class-wp-oembed.php
@@ -366,10 +366,6 @@ class WP_oEmbed {
 
 		$data = $this->fetch( $provider, $url, $args );
 
-		if ( false === $data ) {
-			return false;
-		}
-
 		return $data;
 	}
 

--- a/src/wp-includes/class-wp-oembed.php
+++ b/src/wp-includes/class-wp-oembed.php
@@ -364,9 +364,7 @@ class WP_oEmbed {
 			return false;
 		}
 
-		$data = $this->fetch( $provider, $url, $args );
-
-		return $data;
+		return $this->fetch( $provider, $url, $args );
 	}
 
 	/**


### PR DESCRIPTION
This pull request makes a small change to the `get_data` method in `class-wp-oembed.php`, simplifying the method by removing an unnecessary conditional check before returning the fetched data.

Trac ticket: https://core.trac.wordpress.org/ticket/64784

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
