### PR TITLE
Fix wp_dashboard_right_now() to correctly pass post type to the class

### DIFF
--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -326,7 +326,7 @@ function wp_dashboard_right_now() {
 					),
 					admin_url( 'edit.php' )
 				);
-				printf( '<li class="%1$s-count"><a href="%1$s">%2$s</a></li>', esc_url( $url ), esc_html( $text ) );
+				printf( '<li class="%1$s-count"><a href="%2$s">%3$s</a></li>', $post_type, esc_url( $url ), esc_html( $text ) );
 			} else {
 				printf( '<li class="%1$s-count"><span>%2$s</span></li>', $post_type, $text );
 			}


### PR DESCRIPTION
Before:
<img width="430" height="199" alt="Bildschirmfoto 2026-03-03 um 11 07 19" src="https://github.com/user-attachments/assets/7f2595af-733b-4c32-b6f6-766129532676" />


After:
<img width="433" height="196" alt="Bildschirmfoto 2026-03-03 um 11 07 28" src="https://github.com/user-attachments/assets/20cb2605-2956-4431-a4a8-183dc97401f4" />

Trac ticket: https://core.trac.wordpress.org/ticket/43084

Created during company contributor day with @karinchristen @krokodok @velthy @derpaschi.

## Use of AI Tools

None.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
