### PR TITLE
Add the_password_form_redirect_url filter to get_the_password_form().…

### DIFF
--- a/src/wp-includes/post-template.php
+++ b/src/wp-includes/post-template.php
@@ -1803,9 +1803,20 @@ function get_the_password_form( $post = 0 ) {
 	}
 
 	if ( ! empty( $post->ID ) ) {
+
+		/**
+		 * Filters the redirect URL used in the post password form.
+		 *
+		 * @since 6.x.x
+		 *
+		 * @param string  $redirect_url The redirect URL. Default is the post permalink.
+		 * @param WP_Post $post         The post object.
+		 */
+		$redirect_url = apply_filters( 'the_password_form_redirect_url', get_permalink( $post->ID ), $post );
+
 		$redirect_field = sprintf(
 			'<input type="hidden" name="redirect_to" value="%s" />',
-			esc_attr( get_permalink( $post->ID ) )
+			esc_attr( $redirect_url )
 		);
 	}
 

--- a/tests/phpunit/tests/post/getThePasswordForm.php
+++ b/tests/phpunit/tests/post/getThePasswordForm.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @group post
+ * @group template
+ */
+class Tests_Post_GetThePasswordForm extends WP_UnitTestCase {
+
+	/**
+	 * Tests that the_password_form_redirect_url filter can modify the redirect destination.
+	 *
+	 * @ticket 64785
+	 */
+	public function test_the_password_form_redirect_url_filter() {
+		$post_id    = self::factory()->post->create();
+		$custom_url = 'https://example.com/custom-preview-link/';
+
+		$callback = function () use ( $custom_url ) {
+			return $custom_url;
+		};
+
+		add_filter( 'the_password_form_redirect_url', $callback );
+
+		$form = get_the_password_form( $post_id );
+
+		$this->assertStringContainsString( 'value="' . $custom_url . '"', $form );
+	}
+}


### PR DESCRIPTION
### Description
This PR introduces a new filter `the_password_form_redirect_url` in `get_the_password_form()` to allow developers to customize the redirect destination after a password has been entered.

Currently, this is hardcoded to the post's permalink. In scenarios like "Public Preview Links" or headless setups, the standard permalink might not be the correct return-to URL. This filter provides a clean way to modify the URL without parsing the entire HTML form.

Trac ticket: https://core.trac.wordpress.org/ticket/64785