### PR TITLE
Add GitHub Action for JavaScript type checking via TypeScript

### DIFF
--- a/.github/workflows/javascript-type-checking.yml
+++ b/.github/workflows/javascript-type-checking.yml
@@ -16,6 +16,8 @@ on:
     paths:
       # This workflow only scans JavaScript files.
       - '**.js'
+      - '**.ts'
+      - '**.tsx'
       # These files configure npm. Changes could affect the outcome.
       - 'package*.json'
       - '.nvmrc'

--- a/.github/workflows/javascript-type-checking.yml
+++ b/.github/workflows/javascript-type-checking.yml
@@ -1,0 +1,98 @@
+name: JavaScript Type Checking
+
+on:
+  # JavaScript type checking was introduced in 7.0.0.
+  push:
+    branches:
+      - trunk
+      - '[7-9].[0-9]'
+    tags:
+      - '[7-9].[0-9]'
+      - '[7-9]+.[0-9].[0-9]+'
+  pull_request:
+    branches:
+      - trunk
+      - '[7-9].[0-9]'
+    paths:
+      # This workflow only scans JavaScript files.
+      - '**.js'
+      # These files configure npm. Changes could affect the outcome.
+      - 'package*.json'
+      - '.nvmrc'
+      # This file configures TypeScript. Changes could affect the outcome.
+      - 'tsconfig.json'
+      # This directory contains TypeScript definitions. Changes could affect the outcome.
+      - 'typings/**'
+      # Confirm any changes to relevant workflow files.
+      - '.github/workflows/javascript-type-checking.yml'
+      - '.github/workflows/reusable-javascript-type-checking.yml'
+  workflow_dispatch:
+
+# Cancels all previous workflow runs for pull requests that have not completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name for pull requests
+  # or the commit hash for any other events.
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: true
+
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
+jobs:
+  # Runs JavaScript type checking.
+  typecheck:
+    name: JavaScript type checking
+    uses: ./.github/workflows/reusable-javascript-type-checking.yml
+    permissions:
+      contents: read
+    if: ${{ github.repository == 'WordPress/wordpress-develop' || ( github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' ) }}
+
+  slack-notifications:
+    name: Slack Notifications
+    uses: ./.github/workflows/slack-notifications.yml
+    permissions:
+      actions: read
+      contents: read
+    needs: [ typecheck ]
+    if: ${{ github.repository == 'WordPress/wordpress-develop' && github.event_name != 'pull_request' && always() }}
+    with:
+      calling_status: ${{ contains( needs.*.result, 'cancelled' ) && 'cancelled' || contains( needs.*.result, 'failure' ) && 'failure' || 'success' }}
+    secrets:
+      SLACK_GHA_SUCCESS_WEBHOOK: ${{ secrets.SLACK_GHA_SUCCESS_WEBHOOK }}
+      SLACK_GHA_CANCELLED_WEBHOOK: ${{ secrets.SLACK_GHA_CANCELLED_WEBHOOK }}
+      SLACK_GHA_FIXED_WEBHOOK: ${{ secrets.SLACK_GHA_FIXED_WEBHOOK }}
+      SLACK_GHA_FAILURE_WEBHOOK: ${{ secrets.SLACK_GHA_FAILURE_WEBHOOK }}
+
+  failed-workflow:
+    name: Failed workflow tasks
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: write
+    needs: [ slack-notifications ]
+    if: |
+      always() &&
+      github.repository == 'WordPress/wordpress-develop' &&
+      github.event_name != 'pull_request' &&
+      github.run_attempt < 2 &&
+      (
+        contains( needs.*.result, 'cancelled' ) ||
+        contains( needs.*.result, 'failure' )
+      )
+
+    steps:
+      - name: Dispatch workflow run
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          retries: 2
+          retry-exempt-status-codes: 418
+          script: |
+            github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'failed-workflow.yml',
+              ref: 'trunk',
+              inputs: {
+                run_id: `${context.runId}`,
+              }
+            });

--- a/.github/workflows/phpstan-static-analysis.yml
+++ b/.github/workflows/phpstan-static-analysis.yml
@@ -81,7 +81,7 @@ jobs:
 
     steps:
       - name: Dispatch workflow run
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           retries: 2
           retry-exempt-status-codes: 418

--- a/.github/workflows/reusable-javascript-type-checking.yml
+++ b/.github/workflows/reusable-javascript-type-checking.yml
@@ -1,0 +1,112 @@
+##
+# A reusable workflow that runs JavaScript Type Checking.
+##
+name: JavaScript Type Checking
+
+on:
+  workflow_call:
+    inputs:
+      php-version:
+        description: 'The PHP version to use.'
+        required: false
+        type: 'string'
+        default: 'latest'
+
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
+jobs:
+  # Runs JavaScript type checking.
+  #
+  # Violations are reported inline with annotations.
+  #
+  # Performs the following steps:
+  # - Checks out the repository.
+  # - Sets up Node.js.
+  # - Sets up PHP.
+  # - Logs debug information.
+  # - Installs Composer dependencies.
+  # - Make Composer packages available globally.
+  # - Installs npm dependencies.
+  # - Build WordPress.
+  # - Configures caching for TypeScript build info.
+  # - Runs JavaScript type checking.
+  # - Saves the TypeScript build info.
+  # - Ensures version-controlled files are not modified or deleted.
+  typecheck:
+    name: Run JavaScript type checking
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+        with:
+          node-version-file: '.nvmrc'
+          cache: npm
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@20529878ed81ef8e78ddf08b480401e6101a850f # v2.35.3
+        with:
+          php-version: ${{ inputs.php-version }}
+          coverage: none
+
+      # This date is used to ensure that the Composer cache is cleared at least once every week.
+      # http://man7.org/linux/man-pages/man1/date.1.html
+      - name: "Get last Monday's date"
+        id: get-date
+        run: echo "date=$(/bin/date -u --date='last Mon' "+%F")" >> "$GITHUB_OUTPUT"
+
+      - name: Log debug information
+        run: |
+          npm --version
+          node --version
+          composer --version
+
+      # Since Composer dependencies are installed using `composer update` and no lock file is in version control,
+      # passing a custom cache suffix ensures that the cache is flushed at least once per week.
+      - name: Install Composer dependencies
+        uses: ramsey/composer-install@3cf229dc2919194e9e36783941438d17239e8520 # v3.1.1
+        with:
+          custom-cache-suffix: ${{ steps.get-date.outputs.date }}
+
+      - name: Make Composer packages available globally
+        run: echo "${PWD}/vendor/bin" >> "$GITHUB_PATH"
+
+      - name: Install npm dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Build WordPress
+        run: npm run build:dev
+
+      - name: Cache TypeScript build info
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: |
+            *.tsbuildinfo
+          key: "ts-build-info-${{ github.run_id }}"
+          restore-keys: |
+            ts-build-info-
+
+      - name: Run JavaScript type checking
+        run: npm run typecheck:js
+
+      - name: "Save result cache"
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        if: ${{ !cancelled() }}
+        with:
+          path: |
+            *.tsbuildinfo
+          key: "ts-build-info-${{ github.run_id }}"
+
+      - name: Ensure version-controlled files are not modified or deleted
+        run: git diff --exit-code

--- a/.github/workflows/reusable-javascript-type-checking.yml
+++ b/.github/workflows/reusable-javascript-type-checking.yml
@@ -5,12 +5,6 @@ name: JavaScript Type Checking
 
 on:
   workflow_call:
-    inputs:
-      php-version:
-        description: 'The PHP version to use.'
-        required: false
-        type: 'string'
-        default: 'latest'
 
 # Disable permissions for all available scopes by default.
 # Any needed permissions should be configured at the job level.
@@ -24,12 +18,8 @@ jobs:
   # Performs the following steps:
   # - Checks out the repository.
   # - Sets up Node.js.
-  # - Sets up PHP.
   # - Logs debug information.
-  # - Installs Composer dependencies.
-  # - Make Composer packages available globally.
   # - Installs npm dependencies.
-  # - Build WordPress.
   # - Configures caching for TypeScript build info.
   # - Runs JavaScript type checking.
   # - Saves the TypeScript build info.
@@ -54,39 +44,13 @@ jobs:
           node-version-file: '.nvmrc'
           cache: npm
 
-      - name: Set up PHP
-        uses: shivammathur/setup-php@20529878ed81ef8e78ddf08b480401e6101a850f # v2.35.3
-        with:
-          php-version: ${{ inputs.php-version }}
-          coverage: none
-
-      # This date is used to ensure that the Composer cache is cleared at least once every week.
-      # http://man7.org/linux/man-pages/man1/date.1.html
-      - name: "Get last Monday's date"
-        id: get-date
-        run: echo "date=$(/bin/date -u --date='last Mon' "+%F")" >> "$GITHUB_OUTPUT"
-
       - name: Log debug information
         run: |
           npm --version
           node --version
-          composer --version
-
-      # Since Composer dependencies are installed using `composer update` and no lock file is in version control,
-      # passing a custom cache suffix ensures that the cache is flushed at least once per week.
-      - name: Install Composer dependencies
-        uses: ramsey/composer-install@3cf229dc2919194e9e36783941438d17239e8520 # v3.1.1
-        with:
-          custom-cache-suffix: ${{ steps.get-date.outputs.date }}
-
-      - name: Make Composer packages available globally
-        run: echo "${PWD}/vendor/bin" >> "$GITHUB_PATH"
 
       - name: Install npm dependencies
         run: npm ci --ignore-scripts
-
-      - name: Build WordPress
-        run: npm run build:dev
 
       - name: Cache TypeScript build info
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0

--- a/.github/workflows/reusable-javascript-type-checking.yml
+++ b/.github/workflows/reusable-javascript-type-checking.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
-    timeout-minutes: 20
+    timeout-minutes: 10
 
     steps:
       - name: Checkout repository

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1556,6 +1556,7 @@ module.exports = function(grunt) {
 	grunt.registerTask( 'precommit:js', [
 		'webpack:prod',
 		'jshint:corejs',
+		'typecheck:js',
 		'uglify:imgareaselect',
 		'uglify:jqueryform',
 		'uglify:moment',
@@ -2008,6 +2009,18 @@ module.exports = function(grunt) {
 	);
 
 	grunt.registerTask( 'test', 'Runs all QUnit and PHPUnit tasks.', ['qunit:compiled', 'phpunit'] );
+
+	grunt.registerTask( 'typecheck:js', 'Runs TypeScript type checking.', function() {
+		var done = this.async();
+
+		grunt.util.spawn( {
+			cmd: 'npm',
+			args: [ 'run', 'typecheck:js' ],
+			opts: { stdio: 'inherit' }
+		}, function( error ) {
+			done( ! error );
+		} );
+	} );
 
 	grunt.registerTask( 'phpstan', 'Runs PHPStan on the entire codebase.', function() {
 		var done = this.async();

--- a/src/js/_enqueues/wp/code-editor.js
+++ b/src/js/_enqueues/wp/code-editor.js
@@ -419,8 +419,6 @@ if ( 'undefined' === typeof window.wp.codeEditor ) {
 			$textarea = $( textarea );
 		}
 
-		window.console.log( settings.doesNotExist );
-
 		/** @type {CodeEditorSettings} */
 		const instanceSettings = $.extend( true, {}, wp.codeEditor.defaultSettings, settings );
 

--- a/src/js/_enqueues/wp/code-editor.js
+++ b/src/js/_enqueues/wp/code-editor.js
@@ -419,6 +419,8 @@ if ( 'undefined' === typeof window.wp.codeEditor ) {
 			$textarea = $( textarea );
 		}
 
+		window.console.log( settings.doesNotExist );
+
 		/** @type {CodeEditorSettings} */
 		const instanceSettings = $.extend( true, {}, wp.codeEditor.defaultSettings, settings );
 


### PR DESCRIPTION
This introduces a new GitHub Action workflow for JavaScript type checking, mirroring the implementation for PHPStan. It also adds a `typecheck:js` Grunt task and includes it in the `precommit:js` task list.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/64662

## Use of AI Tools

Initial commit authored by Gemini CLI with prompt:

> Take a look at https://core.trac.wordpress.org/ticket/64662 and implement. You can see that `typecheck:js` npm script was added in b6c1bb776b360ef64a00468e6df72792511866d3. Similarly, you can see in 8a82e67cf65766fcb8a11e3fe5c6e2f48083fcdb how `typecheck:php` was introduced for PHPStan and a GitHub action was added to automatically run. What was done for PHPStan,  implement similarly for TypeScript.

And:

> Is installing composer and building WP really necessary?

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
