### PR TITLE
Trim the 5.9 workflows

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -45,7 +45,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        php: [ '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1' ]
+        php: [ '5.6', '7.0', '7.4', '8.0', '8.1' ]
         db-type: [ 'mysql' ]
         db-version: [ '5.7' ]
         multisite: [ false, true ]


### PR DESCRIPTION
Previously: #10165

- No workflow files need deleting from this branch.
- The e2e test workflow in this branch is already pinned to PHP 8.0.

Trac ticket: https://core.trac.wordpress.org/ticket/64083