### PR TITLE
Trim the 5.3 workflows

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -43,7 +43,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        php: [ '5.6', '7.0', '7.1', '7.2', '7.3', '7.4' ]
+        php: [ '5.6', '7.0', '7.4' ]
         multisite: [ false, true ]
         split_slow: [ false ]
         memcached: [ false ]


### PR DESCRIPTION
Previously: #10165

- No workflow files need deleting from this branch.
- The e2e workflow doesn't exist in this branch.

Trac ticket: https://core.trac.wordpress.org/ticket/64083