### PR TITLE
Trim the 5.1 workflows

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -45,7 +45,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        php: [ '5.3', '5.4', '5.5', '7.1', '7.2', '7.3' ]
+        php: [ '5.3', '7.3' ]
         split_slow: [ false ]
         multisite: [ false, true ]
         memcached: [ false ]
@@ -96,26 +96,6 @@ jobs:
             multisite: false
           - php: '5.6'
             phpunit: '4-php-5.6'
-            os: ubuntu-latest
-            memcached: false
-            split_slow: true
-            multisite: true
-          - php: '5.5'
-            os: ubuntu-latest
-            memcached: false
-            split_slow: true
-            multisite: false
-          - php: '5.5'
-            os: ubuntu-latest
-            memcached: false
-            split_slow: true
-            multisite: true
-          - php: '5.4'
-            os: ubuntu-latest
-            memcached: false
-            split_slow: true
-            multisite: false
-          - php: '5.4'
             os: ubuntu-latest
             memcached: false
             split_slow: true


### PR DESCRIPTION
Previously: #10165

This trims the matrix down to PHP 5.3, 5.6, 7.0, and 7.3. The difference from later branches is the 5.6 and 7.0 jobs are built from the `include` directive instead of directly in the matrix due to the older PHPUnit version requirements.

- No workflow files need deleting from this branch.
- The e2e workflow doesn't exist in this branch.

Trac ticket: https://core.trac.wordpress.org/ticket/64083