### PR TITLE
Trim the 4.9 workflows

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -45,7 +45,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        php: [ '5.3', '5.4', '5.5' ]
+        php: [ '5.3' ]
         split_slow: [ false, true ]
         multisite: [ false, true ]
         memcached: [ false ]
@@ -73,18 +73,6 @@ jobs:
             split_slow: false
           - php: '7.2'
             phpunit: '6-php-7.2'
-            os: ubuntu-latest
-            memcached: false
-            multisite: true
-            split_slow: false
-          - php: '7.1'
-            phpunit: '6-php-7.1'
-            os: ubuntu-latest
-            memcached: false
-            multisite: false
-            split_slow: false
-          - php: '7.1'
-            phpunit: '6-php-7.1'
             os: ubuntu-latest
             memcached: false
             multisite: true


### PR DESCRIPTION
Previously: #10165

This trims the matrix down to PHP 5.3, 5.6, 7.0, and 7.2. Similarly to the 5.0 and 5.1 branches, the later jobs are built from the `include` directive instead of directly in the matrix due to the older PHPUnit version requirements.

- No workflow files need deleting from this branch.
- The e2e workflow doesn't exist in this branch.

Trac ticket: https://core.trac.wordpress.org/ticket/64083