### PR TITLE
Trim the 4.7 workflows

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -45,7 +45,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        php: [ '5.3', '5.4', '5.5' ]
+        php: [ '5.3' ]
         split_slow: [ false, true ]
         multisite: [ false, true ]
         memcached: [ false ]


### PR DESCRIPTION
Previously: #10165

This trims the matrix down to PHP 5.3, 5.6, 7.0, and 7.1. The 5.6 and 7.x jobs are built from the `include` directive.

- No workflow files need deleting from this branch.
- The e2e workflow doesn't exist in this branch.

Trac ticket: https://core.trac.wordpress.org/ticket/64083