### PR TITLE
Exclude php-api-client from PHPStan analysis

### DIFF
--- a/tests/phpstan/base.neon
+++ b/tests/phpstan/base.neon
@@ -138,4 +138,4 @@ parameters:
 			- ../../src/wp-includes/SimplePie
 			- ../../src/wp-includes/sodium_compat
 			- ../../src/wp-includes/Text
-			- ../../src/wp-includes/php-ai-client/third-party
+			- ../../src/wp-includes/php-ai-client

--- a/tests/phpstan/base.neon
+++ b/tests/phpstan/base.neon
@@ -112,9 +112,15 @@ parameters:
 			- ../../src/wp-admin/includes/class-ftp-sockets.php
 			- ../../src/wp-admin/includes/class-ftp.php
 			- ../../src/wp-admin/includes/class-pclzip.php
+			- ../../src/wp-includes/ID3
+			- ../../src/wp-includes/IXR
+			- ../../src/wp-includes/PHPMailer
+			- ../../src/wp-includes/Requests
+			- ../../src/wp-includes/SimplePie
+			- ../../src/wp-includes/Text
 			- ../../src/wp-includes/atomlib.php
-			- ../../src/wp-includes/class-avif-info.php
 			- ../../src/wp-includes/class-IXR.php
+			- ../../src/wp-includes/class-avif-info.php
 			- ../../src/wp-includes/class-json.php
 			- ../../src/wp-includes/class-phpass.php
 			- ../../src/wp-includes/class-pop3.php
@@ -129,13 +135,7 @@ parameters:
 			- ../../src/wp-includes/class-wp-simplepie-sanitize-kses.php
 			- ../../src/wp-includes/class-wp-text-diff-renderer-inline.php
 			- ../../src/wp-includes/class-wp-text-diff-renderer-table.php
-			- ../../src/wp-includes/rss.php
-			- ../../src/wp-includes/ID3
-			- ../../src/wp-includes/IXR
-			- ../../src/wp-includes/PHPMailer
-			- ../../src/wp-includes/pomo
-			- ../../src/wp-includes/Requests
-			- ../../src/wp-includes/SimplePie
-			- ../../src/wp-includes/sodium_compat
-			- ../../src/wp-includes/Text
 			- ../../src/wp-includes/php-ai-client
+			- ../../src/wp-includes/pomo
+			- ../../src/wp-includes/rss.php
+			- ../../src/wp-includes/sodium_compat


### PR DESCRIPTION
This is a follow-up to https://github.com/WordPress/wordpress-develop/pull/10990 (r61712). The library update in r61776 re-introduced the following PHPStan issues which had previously been fixed:

```
 ------ ---------------------------------------------------------------------------------------------- 
  Line   wp-includes/php-ai-client/src/Providers/Http/Enums/RequestAuthenticationMethod.php            
 ------ ---------------------------------------------------------------------------------------------- 
  33     No error with identifier missingType.generics is reported on line 33.                         
         at src/wp-includes/php-ai-client/src/Providers/Http/Enums/RequestAuthenticationMethod.php:33  
 ------ ---------------------------------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------------- 
  Line   wp-includes/php-ai-client/src/Providers/Http/HttpTransporter.php             
 ------ ----------------------------------------------------------------------------- 
  263    No error to ignore is reported on line 263.                                  
         at src/wp-includes/php-ai-client/src/Providers/Http/HttpTransporter.php:263  
 ------ ----------------------------------------------------------------------------- 
```


I wasn't fully aware that `src/wp-includes/php-ai-client` is all a third party library pulled in from another source, not just `src/wp-includes/php-ai-client/third-party`. So in 6aee2e58e544e89417758fd6242fd46b45ccc4f6 the former path is excluded instead.

This also re-sorts the paths for third-party libraries in 56b149fa4fd804ead5e60082ae8d04963edf96c0.



Trac ticket: https://core.trac.wordpress.org/ticket/64591

## Use of AI Tools

n/a

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
