### PR TITLE
Administration: Update .wp-filter component to use new admin color va…

### DIFF
--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -1094,7 +1094,7 @@ th.action-links {
 .filter-links li > a:focus,
 .show-filters .filter-links a.current:hover,
 .show-filters .filter-links a.current:focus {
-	color: #135e96;
+	color: var(--wp-admin-theme-color);
 }
 
 .wp-filter .search-form {
@@ -1174,7 +1174,7 @@ th.action-links {
 .wp-filter .button.drawer-toggle:focus,
 .wp-filter .drawer-toggle:focus:before {
 	background-color: transparent;
-	color: #135e96;
+	color: var(--wp-admin-theme-color);
 }
 
 .wp-filter .button.drawer-toggle:hover,
@@ -1234,7 +1234,7 @@ th.action-links {
 
 .show-filters .wp-filter .drawer-toggle:hover,
 .show-filters .wp-filter .drawer-toggle:focus {
-	background: #2271b1;
+	background: var(--wp-admin-theme-color);
 }
 
 .show-filters .wp-filter .drawer-toggle:before {


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/64788

## Summary

The `.wp-filter` component used on the Add Plugins and Add Themes screens
is still using legacy hardcoded color values instead of the new admin
color variables introduced as part of the admin reskin.

This causes visual inconsistencies with the updated admin color system.

## Changes

- Replaced hardcoded color values with the appropriate CSS custom properties:
  - `--wp-admin-theme-color`

- Ensured hover, focus, and active states use the new design tokens.
- No visual changes outside of the filter component.
