### PR TITLE
Administration: Remove line-height from input elements.

### DIFF
--- a/src/wp-admin/css/forms.css
+++ b/src/wp-admin/css/forms.css
@@ -69,7 +69,6 @@ input[type="url"],
 input[type="week"] {
 	padding: 0 12px;
 	/* inherits font size 14px */
-	line-height: 2.71428571; /* 38px for 40px min-height */
 	min-height: 40px;
 }
 


### PR DESCRIPTION
## Description
Removes the `line-height: 2.71428571` declaration from standard admin input elements. Height remains 40px via `min-height`; only the line-height is removed.


## Changes
- **File:** `src/wp-admin/css/forms.css`
- Removed one `line-height` line from the rule that targets `input[type="datetime"]` through `input[type="week"]` (and related types).

## Testing
- Checked inputs on **Settings → General** and other admin forms.
- Confirmed input height unchanged (40px) and selection highlight no longer fills the full field.

Trac: https://core.trac.wordpress.org/ticket/64763

Fixes #64763