### PR TITLE
Connectors: Change URL to options-connectors.php

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"url": "https://develop.svn.wordpress.org/trunk"
 	},
 	"gutenberg": {
-		"ref": "022d8dd3d461f91b15c1f0410649d3ebb027207f"
+		"ref": "95ecd95bc36c3e794be28250c10f4247761905c8"
 	},
 	"engines": {
 		"node": ">=20.10.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"url": "https://develop.svn.wordpress.org/trunk"
 	},
 	"gutenberg": {
-		"ref": "95ecd95bc36c3e794be28250c10f4247761905c8"
+		"ref": "dac03aacc29b71c1813366949a5bfc5afdac68eb"
 	},
 	"engines": {
 		"node": ">=20.10.0",

--- a/src/wp-admin/menu.php
+++ b/src/wp-admin/menu.php
@@ -404,6 +404,7 @@ if ( ! is_multisite() && defined( 'WP_ALLOW_MULTISITE' ) && WP_ALLOW_MULTISITE )
 
 $menu[80]                               = array( __( 'Settings' ), 'manage_options', 'options-general.php', '', 'menu-top menu-icon-settings', 'menu-settings', 'dashicons-admin-settings' );
 	$submenu['options-general.php'][10] = array( _x( 'General', 'settings screen' ), 'manage_options', 'options-general.php' );
+	$submenu['options-general.php'][12] = array( __( 'Connectors' ), 'manage_options', 'options-connectors.php' );
 	$submenu['options-general.php'][15] = array( __( 'Writing' ), 'manage_options', 'options-writing.php' );
 	$submenu['options-general.php'][20] = array( __( 'Reading' ), 'manage_options', 'options-reading.php' );
 	$submenu['options-general.php'][25] = array( __( 'Discussion' ), 'manage_options', 'options-discussion.php' );

--- a/src/wp-admin/options-connectors.php
+++ b/src/wp-admin/options-connectors.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Connectors administration screen.
+ *
+ * @package WordPress
+ * @subpackage Administration
+ * @since 7.0.0
+ */
+
+/** WordPress Administration Bootstrap */
+require_once __DIR__ . '/admin.php';
+
+if ( ! current_user_can( 'manage_options' ) ) {
+	wp_die(
+		'<h1>' . __( 'You need a higher level of permission.' ) . '</h1>' .
+		'<p>' . __( 'Sorry, you are not allowed to manage connectors on this site.' ) . '</p>',
+		403
+	);
+}
+
+if ( ! class_exists( '\WordPress\AiClient\AiClient' ) || ! function_exists( 'wp_options_connectors_wp_admin_render_page' ) ) {
+	wp_die(
+		'<h1>' . __( 'Connectors is not available.' ) . '</h1>' .
+		'<p>' . __( 'The Connectors page requires build files. Please run <code>npm install</code> to build the necessary files.' ) . '</p>',
+		503
+	);
+}
+
+// Set the page title.
+$title = __( 'Connectors' );
+
+// Set parent file for menu highlighting.
+$parent_file = 'options-general.php';
+
+require_once ABSPATH . 'wp-admin/admin-header.php';
+
+// Render the Connectors page.
+wp_options_connectors_wp_admin_render_page();
+
+require_once ABSPATH . 'wp-admin/admin-footer.php';

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -10,28 +10,6 @@
 use WordPress\AiClient\AiClient;
 use WordPress\AiClient\Providers\Http\DTO\ApiKeyRequestAuthentication;
 
-/**
- * Registers the Connectors menu item under Settings.
- *
- * @since 7.0.0
- * @access private
- */
-function _wp_connectors_add_settings_menu_item(): void {
-	if ( ! class_exists( '\WordPress\AiClient\AiClient' ) || ! function_exists( 'wp_connectors_wp_admin_render_page' ) ) {
-		return;
-	}
-
-	add_submenu_page(
-		'options-general.php',
-		__( 'Connectors' ),
-		__( 'Connectors' ),
-		'manage_options',
-		'connectors-wp-admin',
-		'wp_connectors_wp_admin_render_page',
-		1
-	);
-}
-add_action( 'admin_menu', '_wp_connectors_add_settings_menu_item' );
 
 /**
  * Masks an API key, showing only the last 4 characters.
@@ -415,4 +393,4 @@ function _wp_connectors_get_connector_script_module_data( array $data ): array {
 	$data['connectors'] = $connectors;
 	return $data;
 }
-add_filter( 'script_module_data_connectors-wp-admin', '_wp_connectors_get_connector_script_module_data' );
+add_filter( 'script_module_data_options-connectors-wp-admin', '_wp_connectors_get_connector_script_module_data' );


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/64730

Follow-up for https://github.com/WordPress/wordpress-develop/pull/11056.
Synced from https://github.com/WordPress/gutenberg/pull/76142.

Ticket: https://core.trac.wordpress.org/ticket/64790

## Summary

Changes the Connectors screen URL from a query parameter page to a direct file, following the Settings menu naming convention used by other settings pages (`options-general.php`, `options-writing.php`, etc.).

**Before:** `/wp-admin/admin.php?page=connectors-wp-admin`
**After:** `/wp-admin/options-connectors.php`

## Changes

- Add `src/wp-admin/options-connectors.php` direct admin file
- Add submenu entry in `menu.php` at position 1 (after General)
- Update `script_module_data` filter to `options-connectors-wp-admin`

## Test plan

- [ ] Navigate to Settings > Connectors
- [ ] Verify URL is `options-connectors.php`
- [ ] Verify connector cards appear (Anthropic, Google, OpenAI)
- [ ] Verify API key management works correctly