### PR TITLE
Options: Mask connector API keys on All Options screen

### DIFF
--- a/src/wp-admin/options.php
+++ b/src/wp-admin/options.php
@@ -425,7 +425,6 @@ foreach ( (array) $options as $option ) :
 		}
 	} elseif ( str_starts_with( $option->option_name, 'connectors_' )
 		&& str_ends_with( $option->option_name, '_api_key' )
-		&& function_exists( '_wp_connectors_mask_api_key' )
 	) {
 		// Mask connector API keys and prevent updates from this screen.
 		$value    = _wp_connectors_mask_api_key( $option->option_value );

--- a/src/wp-admin/options.php
+++ b/src/wp-admin/options.php
@@ -423,6 +423,13 @@ foreach ( (array) $options as $option ) :
 			$value    = 'SERIALIZED DATA';
 			$disabled = true;
 		}
+	} elseif ( str_starts_with( $option->option_name, 'connectors_' )
+		&& str_ends_with( $option->option_name, '_api_key' )
+		&& function_exists( '_wp_connectors_mask_api_key' )
+	) {
+		// Mask connector API keys and prevent updates from this screen.
+		$value    = _wp_connectors_mask_api_key( $option->option_value );
+		$disabled = true;
 	} else {
 		$value               = $option->option_value;
 		$options_to_update[] = $option->option_name;


### PR DESCRIPTION
## Summary
- Masks connector API keys on the `wp-admin/options.php` page using the existing `_wp_connectors_mask_api_key()` function
- Keys matching `connectors_*_api_key` pattern are displayed with bullets + last 4 chars
- Fields are disabled and excluded from form submission

Ticket: https://core.trac.wordpress.org/ticket/64793#ticket

## Test plan
- [ ] Navigate to `wp-admin/options.php`
- [ ] Verify connector API keys show masked values (e.g., `••••••••••••PDU'`)
- [ ] Verify the fields are disabled
- [ ] Verify the Connectors settings page still works normally

## Screenshot
<img width="1108" height="881" alt="Screenshot 2026-03-04 at 14 52 42" src="https://github.com/user-attachments/assets/b7127784-ac78-4845-b57d-d0258e16eb80" />
