### PR TITLE
Enable RTC by default

### DIFF
--- a/src/wp-admin/includes/schema.php
+++ b/src/wp-admin/includes/schema.php
@@ -565,7 +565,7 @@ function populate_options( array $options = array() ) {
 		'wp_notes_notify'                   => 1,
 
 		// 7.0.0
-		'wp_enable_real_time_collaboration' => 0,
+		'wp_enable_real_time_collaboration' => 1,
 	);
 
 	// 3.3.0

--- a/src/wp-admin/includes/schema.php
+++ b/src/wp-admin/includes/schema.php
@@ -563,9 +563,6 @@ function populate_options( array $options = array() ) {
 
 		// 6.9.0
 		'wp_notes_notify'                   => 1,
-
-		// 7.0.0
-		'wp_enable_real_time_collaboration' => 1,
 	);
 
 	// 3.3.0

--- a/src/wp-admin/options-writing.php
+++ b/src/wp-admin/options-writing.php
@@ -110,10 +110,10 @@ unset( $post_formats['standard'] );
 </td>
 </tr>
 <tr>
-<th scope="row"><label for="wp_enable_real_time_collaboration"><?php _e( 'Collaboration' ); ?></label></th>
+<th scope="row"><label for="wp_disable_real_time_collaboration"><?php _e( 'Collaboration' ); ?></label></th>
 <td>
-	<input name="wp_enable_real_time_collaboration" type="checkbox" id="wp_enable_real_time_collaboration" value="1" <?php checked( '1', get_option( 'wp_enable_real_time_collaboration' ) ); ?> />
-	<label for="wp_enable_real_time_collaboration"><?php _e( 'Enable real-time collaboration' ); ?></label>
+	<input name="wp_disable_real_time_collaboration" type="checkbox" id="wp_disable_real_time_collaboration" value="1" <?php checked( '1', get_option( 'wp_disable_real_time_collaboration' ) ); ?> />
+	<label for="wp_disable_real_time_collaboration"><?php _e( 'Disable real-time collaboration' ); ?></label>
 </td>
 </tr>
 <?php

--- a/src/wp-admin/options.php
+++ b/src/wp-admin/options.php
@@ -153,7 +153,7 @@ $allowed_options            = array(
 		'default_email_category',
 		'default_link_category',
 		'default_post_format',
-		'wp_enable_real_time_collaboration',
+		'wp_disable_real_time_collaboration',
 	),
 );
 $allowed_options['misc']    = array();

--- a/src/wp-includes/collaboration.php
+++ b/src/wp-includes/collaboration.php
@@ -14,7 +14,7 @@
  * @access private
  */
 function wp_collaboration_inject_setting() {
-	if ( get_option( 'wp_enable_real_time_collaboration' ) ) {
+	if ( ! boolval( get_option( 'wp_disable_real_time_collaboration' ) ) ) {
 		wp_add_inline_script(
 			'wp-core-data',
 			'window._wpCollaborationEnabled = true;',

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -2892,7 +2892,7 @@ function register_initial_settings() {
 			'type'              => 'boolean',
 			'description'       => __( 'Enable Real-Time Collaboration' ),
 			'sanitize_callback' => 'rest_sanitize_boolean',
-			'default'           => false,
+			'default'           => true,
 			'show_in_rest'      => true,
 		)
 	);

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -2887,12 +2887,12 @@ function register_initial_settings() {
 
 	register_setting(
 		'writing',
-		'wp_enable_real_time_collaboration',
+		'wp_disable_real_time_collaboration',
 		array(
 			'type'              => 'boolean',
-			'description'       => __( 'Enable Real-Time Collaboration' ),
+			'description'       => __( 'Disable real-time collaboration' ),
 			'sanitize_callback' => 'rest_sanitize_boolean',
-			'default'           => true,
+			'default'           => false,
 			'show_in_rest'      => true,
 		)
 	);

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -657,7 +657,7 @@ function create_initial_post_types() {
 		)
 	);
 
-	if ( get_option( 'wp_enable_real_time_collaboration' ) ) {
+	if ( ! boolval( get_option( 'wp_disable_real_time_collaboration' ) ) ) {
 		register_post_type(
 			'wp_sync_storage',
 			array(
@@ -8671,7 +8671,7 @@ function wp_create_initial_post_meta() {
 		)
 	);
 
-	if ( get_option( 'wp_enable_real_time_collaboration' ) ) {
+	if ( ! boolval( get_option( 'wp_disable_real_time_collaboration' ) ) ) {
 		register_meta(
 			'post',
 			'_crdt_document',

--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -430,7 +430,7 @@ function create_initial_rest_routes() {
 	$icons_controller->register_routes();
 
 	// Collaboration.
-	if ( get_option( 'wp_enable_real_time_collaboration' ) ) {
+	if ( ! boolval( get_option( 'wp_disable_real_time_collaboration' ) ) ) {
 		$sync_storage = new WP_Sync_Post_Meta_Storage();
 		$sync_server  = new WP_HTTP_Polling_Sync_Server( $sync_storage );
 		$sync_server->register_routes();

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php
@@ -254,9 +254,9 @@ class WP_REST_Autosaves_Controller extends WP_REST_Revisions_Controller {
 		 *   the saved post. This diff is then applied to the in-memory CRDT
 		 *   document, which can lead to duplicate inserts or deletions.
 		 */
-		$is_collaboration_enabled = get_option( 'wp_enable_real_time_collaboration' );
+		$is_collaboration_disabled = boolval( get_option( 'wp_disable_real_time_collaboration' ) );
 
-		if ( $is_draft && (int) $post->post_author === $user_id && ! $post_lock && ! $is_collaboration_enabled ) {
+		if ( $is_draft && (int) $post->post_author === $user_id && ! $post_lock && $is_collaboration_disabled ) {
 			/*
 			 * Draft posts for the same author: autosaving updates the post and does not create a revision.
 			 * Convert the post object to an array and add slashes, wp_update_post() expects escaped array.

--- a/tests/phpunit/tests/rest-api/rest-autosaves-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-autosaves-controller.php
@@ -570,8 +570,7 @@ class WP_Test_REST_Autosaves_Controller extends WP_Test_REST_Post_Type_Controlle
 	}
 
 	public function test_rest_autosave_draft_post_same_author() {
-		$original_option = get_option( 'wp_enable_real_time_collaboration' );
-		update_option( 'wp_enable_real_time_collaboration', false );
+		add_filter( 'pre_option_wp_disable_real_time_collaboration', '__return_true' );
 
 		wp_set_current_user( self::$editor_id );
 
@@ -607,7 +606,7 @@ class WP_Test_REST_Autosaves_Controller extends WP_Test_REST_Post_Type_Controlle
 		$this->assertSame( $post_data['post_excerpt'], $post->post_excerpt );
 
 		wp_delete_post( $post_id );
-		update_option( 'wp_enable_real_time_collaboration', $original_option );
+		remove_filter( 'pre_option_wp_disable_real_time_collaboration', '__return_true' );
 	}
 
 	public function test_rest_autosave_draft_post_different_author() {
@@ -748,8 +747,7 @@ class WP_Test_REST_Autosaves_Controller extends WP_Test_REST_Post_Type_Controlle
 	}
 
 	public function test_update_item_draft_page_with_parent() {
-		$original_option = get_option( 'wp_enable_real_time_collaboration' );
-		update_option( 'wp_enable_real_time_collaboration', false );
+		add_filter( 'pre_option_wp_disable_real_time_collaboration', '__return_true' );
 
 		wp_set_current_user( self::$editor_id );
 		$request = new WP_REST_Request( 'POST', '/wp/v2/pages/' . self::$child_draft_page_id . '/autosaves' );
@@ -768,7 +766,8 @@ class WP_Test_REST_Autosaves_Controller extends WP_Test_REST_Post_Type_Controlle
 
 		$this->assertSame( self::$child_draft_page_id, $data['id'] );
 		$this->assertSame( self::$parent_page_id, $data['parent'] );
-		update_option( 'wp_enable_real_time_collaboration', $original_option );
+
+		remove_filter( 'pre_option_wp_disable_real_time_collaboration', '__return_true' );
 	}
 
 	public function test_schema_validation_is_applied() {
@@ -934,8 +933,7 @@ class WP_Test_REST_Autosaves_Controller extends WP_Test_REST_Post_Type_Controlle
 	 * same author should create a revision instead of updating the post directly.
 	 */
 	public function test_rest_autosave_draft_post_same_author_with_rtc() {
-		$original_option = get_option( 'wp_enable_real_time_collaboration' );
-		update_option( 'wp_enable_real_time_collaboration', true );
+		add_filter( 'pre_option_wp_disable_real_time_collaboration', '__return_false' );
 
 		wp_set_current_user( self::$editor_id );
 
@@ -974,7 +972,7 @@ class WP_Test_REST_Autosaves_Controller extends WP_Test_REST_Post_Type_Controlle
 		$this->assertSame( $post_data['post_excerpt'], $post->post_excerpt );
 
 		wp_delete_post( $post_id );
-		update_option( 'wp_enable_real_time_collaboration', $original_option );
+		remove_filter( 'pre_option_wp_disable_real_time_collaboration', '__return_false' );
 	}
 
 	/**
@@ -982,8 +980,7 @@ class WP_Test_REST_Autosaves_Controller extends WP_Test_REST_Post_Type_Controlle
 	 * a parent should create a revision instead of updating the page directly.
 	 */
 	public function test_update_item_draft_page_with_parent_with_rtc() {
-		$original_option = get_option( 'wp_enable_real_time_collaboration' );
-		update_option( 'wp_enable_real_time_collaboration', true );
+		add_filter( 'pre_option_wp_disable_real_time_collaboration', '__return_false' );
 
 		wp_set_current_user( self::$editor_id );
 		$request = new WP_REST_Request( 'POST', '/wp/v2/pages/' . self::$child_draft_page_id . '/autosaves' );
@@ -1003,6 +1000,7 @@ class WP_Test_REST_Autosaves_Controller extends WP_Test_REST_Post_Type_Controlle
 		// With RTC enabled, a revision is created instead of updating the page.
 		$this->assertNotSame( self::$child_draft_page_id, $data['id'] );
 		$this->assertSame( self::$child_draft_page_id, $data['parent'] );
-		update_option( 'wp_enable_real_time_collaboration', $original_option );
+
+		remove_filter( 'pre_option_wp_disable_real_time_collaboration', '__return_false' );
 	}
 }

--- a/tests/phpunit/tests/rest-api/rest-settings-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-settings-controller.php
@@ -119,7 +119,7 @@ class WP_Test_REST_Settings_Controller extends WP_Test_REST_Controller_Testcase 
 			'default_ping_status',
 			'default_comment_status',
 			'site_icon', // Registered in wp-includes/blocks/site-logo.php
-			'wp_enable_real_time_collaboration',
+			'wp_disable_real_time_collaboration',
 			// Connectors API keys are registered in _wp_register_default_connector_settings() in wp-includes/connectors.php.
 			'connectors_ai_anthropic_api_key',
 			'connectors_ai_google_api_key',

--- a/tests/phpunit/tests/rest-api/rest-sync-server.php
+++ b/tests/phpunit/tests/rest-api/rest-sync-server.php
@@ -14,7 +14,7 @@ class WP_Test_REST_Sync_Server extends WP_Test_REST_Controller_Testcase {
 	protected static $post_id;
 
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
-		update_option( 'wp_enable_real_time_collaboration', true );
+		add_filter( 'pre_option_wp_disable_real_time_collaboration', '__return_false' );
 
 		self::$editor_id     = $factory->user->create( array( 'role' => 'editor' ) );
 		self::$subscriber_id = $factory->user->create( array( 'role' => 'subscriber' ) );
@@ -25,7 +25,7 @@ class WP_Test_REST_Sync_Server extends WP_Test_REST_Controller_Testcase {
 		self::delete_user( self::$editor_id );
 		self::delete_user( self::$subscriber_id );
 		wp_delete_post( self::$post_id, true );
-		delete_option( 'wp_enable_real_time_collaboration' );
+		remove_filter( 'pre_option_wp_disable_real_time_collaboration', '__return_false' );
 	}
 
 	public function set_up() {

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -11158,9 +11158,9 @@ mockedApiResponse.Schema = {
                             "type": "string",
                             "required": false
                         },
-                        "wp_enable_real_time_collaboration": {
+                        "wp_disable_real_time_collaboration": {
                             "title": "",
-                            "description": "Enable Real-Time Collaboration",
+                            "description": "Disable real-time collaboration",
                             "type": "boolean",
                             "required": false
                         },
@@ -14777,7 +14777,7 @@ mockedApiResponse.settings = {
     "use_smilies": true,
     "default_category": 1,
     "default_post_format": "0",
-    "wp_enable_real_time_collaboration": true,
+    "wp_disable_real_time_collaboration": false,
     "posts_per_page": 10,
     "show_on_front": "posts",
     "page_on_front": 0,

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -20,7 +20,8 @@ mockedApiResponse.Schema = {
         "wp/v2",
         "wp-site-health/v1",
         "wp-block-editor/v1",
-        "wp-abilities/v1"
+        "wp-abilities/v1",
+        "wp-sync/v1"
     ],
     "authentication": {
         "application-passwords": {
@@ -12770,6 +12771,114 @@ mockedApiResponse.Schema = {
                     }
                 }
             ]
+        },
+        "/wp-sync/v1": {
+            "namespace": "wp-sync/v1",
+            "methods": [
+                "GET"
+            ],
+            "endpoints": [
+                {
+                    "methods": [
+                        "GET"
+                    ],
+                    "args": {
+                        "namespace": {
+                            "default": "wp-sync/v1",
+                            "required": false
+                        },
+                        "context": {
+                            "default": "view",
+                            "required": false
+                        }
+                    }
+                }
+            ],
+            "_links": {
+                "self": [
+                    {
+                        "href": "http://example.org/index.php?rest_route=/wp-sync/v1"
+                    }
+                ]
+            }
+        },
+        "/wp-sync/v1/updates": {
+            "namespace": "wp-sync/v1",
+            "methods": [
+                "POST"
+            ],
+            "endpoints": [
+                {
+                    "methods": [
+                        "POST"
+                    ],
+                    "args": {
+                        "rooms": {
+                            "items": {
+                                "properties": {
+                                    "after": {
+                                        "minimum": 0,
+                                        "required": true,
+                                        "type": "integer"
+                                    },
+                                    "awareness": {
+                                        "required": true,
+                                        "type": [
+                                            "object",
+                                            "null"
+                                        ]
+                                    },
+                                    "client_id": {
+                                        "minimum": 1,
+                                        "required": true,
+                                        "type": "integer"
+                                    },
+                                    "room": {
+                                        "required": true,
+                                        "type": "string",
+                                        "pattern": "^[^/]+/[^/:]+(?::\\S+)?$"
+                                    },
+                                    "updates": {
+                                        "items": {
+                                            "properties": {
+                                                "data": {
+                                                    "type": "string",
+                                                    "required": true
+                                                },
+                                                "type": {
+                                                    "type": "string",
+                                                    "required": true,
+                                                    "enum": [
+                                                        "compaction",
+                                                        "sync_step1",
+                                                        "sync_step2",
+                                                        "update"
+                                                    ]
+                                                }
+                                            },
+                                            "required": true,
+                                            "type": "object"
+                                        },
+                                        "minItems": 0,
+                                        "required": true,
+                                        "type": "array"
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            "type": "array",
+                            "required": true
+                        }
+                    }
+                }
+            ],
+            "_links": {
+                "self": [
+                    {
+                        "href": "http://example.org/index.php?rest_route=/wp-sync/v1/updates"
+                    }
+                ]
+            }
         }
     },
     "image_sizes": {
@@ -14668,7 +14777,7 @@ mockedApiResponse.settings = {
     "use_smilies": true,
     "default_category": 1,
     "default_post_format": "0",
-    "wp_enable_real_time_collaboration": false,
+    "wp_enable_real_time_collaboration": true,
     "posts_per_page": 10,
     "show_on_front": "posts",
     "page_on_front": 0,


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/64622

Enable RTC by default (opt-out). This reverses a previous decision for WP 7.0 Beta 1 to keep it opt-in.

Note that we must update the option name since the previous option name set a default value during database initialization. We have removed the option from initialization so that future updates will not require an option name change.