### PR TITLE
Enable RTC by default, redo.

### DIFF
--- a/src/wp-admin/includes/schema.php
+++ b/src/wp-admin/includes/schema.php
@@ -565,7 +565,7 @@ function populate_options( array $options = array() ) {
 		'wp_notes_notify'                   => 1,
 
 		// 7.0.0
-		'wp_enable_real_time_collaboration' => 0,
+		'wp_enable_real_time_collaboration' => 1,
 	);
 
 	// 3.3.0

--- a/src/wp-admin/includes/schema.php
+++ b/src/wp-admin/includes/schema.php
@@ -563,6 +563,9 @@ function populate_options( array $options = array() ) {
 
 		// 6.9.0
 		'wp_notes_notify'                   => 1,
+
+		// 7.0.0
+		'wp_enable_real_time_collaboration' => 0,
 	);
 
 	// 3.3.0

--- a/src/wp-admin/options-writing.php
+++ b/src/wp-admin/options-writing.php
@@ -110,10 +110,10 @@ unset( $post_formats['standard'] );
 </td>
 </tr>
 <tr>
-<th scope="row"><label for="wp_disable_real_time_collaboration"><?php _e( 'Collaboration' ); ?></label></th>
+<th scope="row"><label for="wp_enable_real_time_collaboration"><?php _e( 'Collaboration' ); ?></label></th>
 <td>
-	<input name="wp_disable_real_time_collaboration" type="checkbox" id="wp_disable_real_time_collaboration" value="1" <?php checked( '1', get_option( 'wp_disable_real_time_collaboration' ) ); ?> />
-	<label for="wp_disable_real_time_collaboration"><?php _e( 'Disable real-time collaboration' ); ?></label>
+	<input name="wp_enable_real_time_collaboration" type="checkbox" id="wp_enable_real_time_collaboration" value="1" <?php checked( '1', get_option( 'wp_enable_real_time_collaboration' ) ); ?> />
+	<label for="wp_enable_real_time_collaboration"><?php _e( 'Enable real-time collaboration' ); ?></label>
 </td>
 </tr>
 <?php

--- a/src/wp-admin/options.php
+++ b/src/wp-admin/options.php
@@ -153,7 +153,7 @@ $allowed_options            = array(
 		'default_email_category',
 		'default_link_category',
 		'default_post_format',
-		'wp_disable_real_time_collaboration',
+		'wp_enable_real_time_collaboration',
 	),
 );
 $allowed_options['misc']    = array();

--- a/src/wp-includes/collaboration.php
+++ b/src/wp-includes/collaboration.php
@@ -14,7 +14,7 @@
  * @access private
  */
 function wp_collaboration_inject_setting() {
-	if ( ! boolval( get_option( 'wp_disable_real_time_collaboration' ) ) ) {
+	if ( get_option( 'wp_enable_real_time_collaboration' ) ) {
 		wp_add_inline_script(
 			'wp-core-data',
 			'window._wpCollaborationEnabled = true;',

--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -485,8 +485,9 @@ add_action( 'wp_head', 'wp_post_preview_js', 1 );
 // Timezone.
 add_filter( 'pre_option_gmt_offset', 'wp_timezone_override_offset' );
 
-// If the upgrade hasn't run yet, assume link manager is used.
-add_filter( 'default_option_link_manager_enabled', '__return_true' );
+// If the upgrade hasn't run yet, set some default options.
+add_filter( 'default_option_link_manager_enabled', '__return_true' ); // Assume link manager is used.
+add_filter( 'default_option_wp_enable_real_time_collaboration', '__return_true' ); // Enable real-time collaboration.
 
 // This option no longer exists; tell plugins we always support auto-embedding.
 add_filter( 'pre_option_embed_autourls', '__return_true' );

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -2887,10 +2887,10 @@ function register_initial_settings() {
 
 	register_setting(
 		'writing',
-		'wp_disable_real_time_collaboration',
+		'wp_enable_real_time_collaboration',
 		array(
 			'type'              => 'boolean',
-			'description'       => __( 'Disable real-time collaboration' ),
+			'description'       => __( 'Enable Real-Time Collaboration' ),
 			'sanitize_callback' => 'rest_sanitize_boolean',
 			'default'           => false,
 			'show_in_rest'      => true,

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -657,7 +657,7 @@ function create_initial_post_types() {
 		)
 	);
 
-	if ( ! boolval( get_option( 'wp_disable_real_time_collaboration' ) ) ) {
+	if ( get_option( 'wp_enable_real_time_collaboration' ) ) {
 		register_post_type(
 			'wp_sync_storage',
 			array(
@@ -8671,7 +8671,7 @@ function wp_create_initial_post_meta() {
 		)
 	);
 
-	if ( ! boolval( get_option( 'wp_disable_real_time_collaboration' ) ) ) {
+	if ( get_option( 'wp_enable_real_time_collaboration' ) ) {
 		register_meta(
 			'post',
 			'_crdt_document',

--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -430,7 +430,7 @@ function create_initial_rest_routes() {
 	$icons_controller->register_routes();
 
 	// Collaboration.
-	if ( ! boolval( get_option( 'wp_disable_real_time_collaboration' ) ) ) {
+	if ( get_option( 'wp_enable_real_time_collaboration' ) ) {
 		$sync_storage = new WP_Sync_Post_Meta_Storage();
 		$sync_server  = new WP_HTTP_Polling_Sync_Server( $sync_storage );
 		$sync_server->register_routes();

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php
@@ -254,9 +254,9 @@ class WP_REST_Autosaves_Controller extends WP_REST_Revisions_Controller {
 		 *   the saved post. This diff is then applied to the in-memory CRDT
 		 *   document, which can lead to duplicate inserts or deletions.
 		 */
-		$is_collaboration_disabled = boolval( get_option( 'wp_disable_real_time_collaboration' ) );
+		$is_collaboration_enabled = get_option( 'wp_enable_real_time_collaboration' );
 
-		if ( $is_draft && (int) $post->post_author === $user_id && ! $post_lock && $is_collaboration_disabled ) {
+		if ( $is_draft && (int) $post->post_author === $user_id && ! $post_lock && ! $is_collaboration_enabled ) {
 			/*
 			 * Draft posts for the same author: autosaving updates the post and does not create a revision.
 			 * Convert the post object to an array and add slashes, wp_update_post() expects escaped array.

--- a/tests/phpunit/tests/rest-api/rest-autosaves-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-autosaves-controller.php
@@ -570,7 +570,7 @@ class WP_Test_REST_Autosaves_Controller extends WP_Test_REST_Post_Type_Controlle
 	}
 
 	public function test_rest_autosave_draft_post_same_author() {
-		add_filter( 'pre_option_wp_enable_real_time_collaboration', '__return_false' );
+		add_filter( 'pre_option_wp_enable_real_time_collaboration', '__return_zero' ); // Zero as false doesn't work for pre-flight options.
 
 		wp_set_current_user( self::$editor_id );
 
@@ -746,7 +746,7 @@ class WP_Test_REST_Autosaves_Controller extends WP_Test_REST_Post_Type_Controlle
 	}
 
 	public function test_update_item_draft_page_with_parent() {
-		add_filter( 'pre_option_wp_enable_real_time_collaboration', '__return_false' );
+		add_filter( 'pre_option_wp_enable_real_time_collaboration', '__return_zero' ); // Zero as false doesn't work for pre-flight options.
 
 		wp_set_current_user( self::$editor_id );
 		$request = new WP_REST_Request( 'POST', '/wp/v2/pages/' . self::$child_draft_page_id . '/autosaves' );

--- a/tests/phpunit/tests/rest-api/rest-autosaves-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-autosaves-controller.php
@@ -570,8 +570,7 @@ class WP_Test_REST_Autosaves_Controller extends WP_Test_REST_Post_Type_Controlle
 	}
 
 	public function test_rest_autosave_draft_post_same_author() {
-		$original_option = get_option( 'wp_enable_real_time_collaboration' );
-		update_option( 'wp_enable_real_time_collaboration', false );
+		add_filter( 'pre_option_wp_enable_real_time_collaboration', '__return_false' );
 
 		wp_set_current_user( self::$editor_id );
 
@@ -607,7 +606,6 @@ class WP_Test_REST_Autosaves_Controller extends WP_Test_REST_Post_Type_Controlle
 		$this->assertSame( $post_data['post_excerpt'], $post->post_excerpt );
 
 		wp_delete_post( $post_id );
-		update_option( 'wp_enable_real_time_collaboration', $original_option );
 	}
 
 	public function test_rest_autosave_draft_post_different_author() {
@@ -748,8 +746,7 @@ class WP_Test_REST_Autosaves_Controller extends WP_Test_REST_Post_Type_Controlle
 	}
 
 	public function test_update_item_draft_page_with_parent() {
-		$original_option = get_option( 'wp_enable_real_time_collaboration' );
-		update_option( 'wp_enable_real_time_collaboration', false );
+		add_filter( 'pre_option_wp_enable_real_time_collaboration', '__return_false' );
 
 		wp_set_current_user( self::$editor_id );
 		$request = new WP_REST_Request( 'POST', '/wp/v2/pages/' . self::$child_draft_page_id . '/autosaves' );
@@ -768,7 +765,6 @@ class WP_Test_REST_Autosaves_Controller extends WP_Test_REST_Post_Type_Controlle
 
 		$this->assertSame( self::$child_draft_page_id, $data['id'] );
 		$this->assertSame( self::$parent_page_id, $data['parent'] );
-		update_option( 'wp_enable_real_time_collaboration', $original_option );
 	}
 
 	public function test_schema_validation_is_applied() {
@@ -934,8 +930,7 @@ class WP_Test_REST_Autosaves_Controller extends WP_Test_REST_Post_Type_Controlle
 	 * same author should create a revision instead of updating the post directly.
 	 */
 	public function test_rest_autosave_draft_post_same_author_with_rtc() {
-		$original_option = get_option( 'wp_enable_real_time_collaboration' );
-		update_option( 'wp_enable_real_time_collaboration', true );
+		add_filter( 'pre_option_wp_enable_real_time_collaboration', '__return_true' );
 
 		wp_set_current_user( self::$editor_id );
 
@@ -974,7 +969,6 @@ class WP_Test_REST_Autosaves_Controller extends WP_Test_REST_Post_Type_Controlle
 		$this->assertSame( $post_data['post_excerpt'], $post->post_excerpt );
 
 		wp_delete_post( $post_id );
-		update_option( 'wp_enable_real_time_collaboration', $original_option );
 	}
 
 	/**
@@ -982,8 +976,7 @@ class WP_Test_REST_Autosaves_Controller extends WP_Test_REST_Post_Type_Controlle
 	 * a parent should create a revision instead of updating the page directly.
 	 */
 	public function test_update_item_draft_page_with_parent_with_rtc() {
-		$original_option = get_option( 'wp_enable_real_time_collaboration' );
-		update_option( 'wp_enable_real_time_collaboration', true );
+		add_filter( 'pre_option_wp_enable_real_time_collaboration', '__return_true' );
 
 		wp_set_current_user( self::$editor_id );
 		$request = new WP_REST_Request( 'POST', '/wp/v2/pages/' . self::$child_draft_page_id . '/autosaves' );
@@ -1003,6 +996,5 @@ class WP_Test_REST_Autosaves_Controller extends WP_Test_REST_Post_Type_Controlle
 		// With RTC enabled, a revision is created instead of updating the page.
 		$this->assertNotSame( self::$child_draft_page_id, $data['id'] );
 		$this->assertSame( self::$child_draft_page_id, $data['parent'] );
-		update_option( 'wp_enable_real_time_collaboration', $original_option );
 	}
 }

--- a/tests/phpunit/tests/rest-api/rest-autosaves-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-autosaves-controller.php
@@ -570,7 +570,8 @@ class WP_Test_REST_Autosaves_Controller extends WP_Test_REST_Post_Type_Controlle
 	}
 
 	public function test_rest_autosave_draft_post_same_author() {
-		add_filter( 'pre_option_wp_disable_real_time_collaboration', '__return_true' );
+		$original_option = get_option( 'wp_enable_real_time_collaboration' );
+		update_option( 'wp_enable_real_time_collaboration', false );
 
 		wp_set_current_user( self::$editor_id );
 
@@ -606,7 +607,7 @@ class WP_Test_REST_Autosaves_Controller extends WP_Test_REST_Post_Type_Controlle
 		$this->assertSame( $post_data['post_excerpt'], $post->post_excerpt );
 
 		wp_delete_post( $post_id );
-		remove_filter( 'pre_option_wp_disable_real_time_collaboration', '__return_true' );
+		update_option( 'wp_enable_real_time_collaboration', $original_option );
 	}
 
 	public function test_rest_autosave_draft_post_different_author() {
@@ -747,7 +748,8 @@ class WP_Test_REST_Autosaves_Controller extends WP_Test_REST_Post_Type_Controlle
 	}
 
 	public function test_update_item_draft_page_with_parent() {
-		add_filter( 'pre_option_wp_disable_real_time_collaboration', '__return_true' );
+		$original_option = get_option( 'wp_enable_real_time_collaboration' );
+		update_option( 'wp_enable_real_time_collaboration', false );
 
 		wp_set_current_user( self::$editor_id );
 		$request = new WP_REST_Request( 'POST', '/wp/v2/pages/' . self::$child_draft_page_id . '/autosaves' );
@@ -766,8 +768,7 @@ class WP_Test_REST_Autosaves_Controller extends WP_Test_REST_Post_Type_Controlle
 
 		$this->assertSame( self::$child_draft_page_id, $data['id'] );
 		$this->assertSame( self::$parent_page_id, $data['parent'] );
-
-		remove_filter( 'pre_option_wp_disable_real_time_collaboration', '__return_true' );
+		update_option( 'wp_enable_real_time_collaboration', $original_option );
 	}
 
 	public function test_schema_validation_is_applied() {
@@ -933,7 +934,8 @@ class WP_Test_REST_Autosaves_Controller extends WP_Test_REST_Post_Type_Controlle
 	 * same author should create a revision instead of updating the post directly.
 	 */
 	public function test_rest_autosave_draft_post_same_author_with_rtc() {
-		add_filter( 'pre_option_wp_disable_real_time_collaboration', '__return_false' );
+		$original_option = get_option( 'wp_enable_real_time_collaboration' );
+		update_option( 'wp_enable_real_time_collaboration', true );
 
 		wp_set_current_user( self::$editor_id );
 
@@ -972,7 +974,7 @@ class WP_Test_REST_Autosaves_Controller extends WP_Test_REST_Post_Type_Controlle
 		$this->assertSame( $post_data['post_excerpt'], $post->post_excerpt );
 
 		wp_delete_post( $post_id );
-		remove_filter( 'pre_option_wp_disable_real_time_collaboration', '__return_false' );
+		update_option( 'wp_enable_real_time_collaboration', $original_option );
 	}
 
 	/**
@@ -980,7 +982,8 @@ class WP_Test_REST_Autosaves_Controller extends WP_Test_REST_Post_Type_Controlle
 	 * a parent should create a revision instead of updating the page directly.
 	 */
 	public function test_update_item_draft_page_with_parent_with_rtc() {
-		add_filter( 'pre_option_wp_disable_real_time_collaboration', '__return_false' );
+		$original_option = get_option( 'wp_enable_real_time_collaboration' );
+		update_option( 'wp_enable_real_time_collaboration', true );
 
 		wp_set_current_user( self::$editor_id );
 		$request = new WP_REST_Request( 'POST', '/wp/v2/pages/' . self::$child_draft_page_id . '/autosaves' );
@@ -1000,7 +1003,6 @@ class WP_Test_REST_Autosaves_Controller extends WP_Test_REST_Post_Type_Controlle
 		// With RTC enabled, a revision is created instead of updating the page.
 		$this->assertNotSame( self::$child_draft_page_id, $data['id'] );
 		$this->assertSame( self::$child_draft_page_id, $data['parent'] );
-
-		remove_filter( 'pre_option_wp_disable_real_time_collaboration', '__return_false' );
+		update_option( 'wp_enable_real_time_collaboration', $original_option );
 	}
 }

--- a/tests/phpunit/tests/rest-api/rest-settings-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-settings-controller.php
@@ -119,7 +119,7 @@ class WP_Test_REST_Settings_Controller extends WP_Test_REST_Controller_Testcase 
 			'default_ping_status',
 			'default_comment_status',
 			'site_icon', // Registered in wp-includes/blocks/site-logo.php
-			'wp_disable_real_time_collaboration',
+			'wp_enable_real_time_collaboration',
 			// Connectors API keys are registered in _wp_register_default_connector_settings() in wp-includes/connectors.php.
 			'connectors_ai_anthropic_api_key',
 			'connectors_ai_google_api_key',

--- a/tests/phpunit/tests/rest-api/rest-sync-server.php
+++ b/tests/phpunit/tests/rest-api/rest-sync-server.php
@@ -14,7 +14,7 @@ class WP_Test_REST_Sync_Server extends WP_Test_REST_Controller_Testcase {
 	protected static $post_id;
 
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
-		add_filter( 'pre_option_wp_disable_real_time_collaboration', '__return_false' );
+		update_option( 'wp_enable_real_time_collaboration', true );
 
 		self::$editor_id     = $factory->user->create( array( 'role' => 'editor' ) );
 		self::$subscriber_id = $factory->user->create( array( 'role' => 'subscriber' ) );
@@ -25,7 +25,7 @@ class WP_Test_REST_Sync_Server extends WP_Test_REST_Controller_Testcase {
 		self::delete_user( self::$editor_id );
 		self::delete_user( self::$subscriber_id );
 		wp_delete_post( self::$post_id, true );
-		remove_filter( 'pre_option_wp_disable_real_time_collaboration', '__return_false' );
+		delete_option( 'wp_enable_real_time_collaboration' );
 	}
 
 	public function set_up() {

--- a/tests/phpunit/tests/rest-api/rest-sync-server.php
+++ b/tests/phpunit/tests/rest-api/rest-sync-server.php
@@ -14,8 +14,6 @@ class WP_Test_REST_Sync_Server extends WP_Test_REST_Controller_Testcase {
 	protected static $post_id;
 
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
-		add_filter( 'pre_option_wp_enable_real_time_collaboration', '__return_true' );
-
 		self::$editor_id     = $factory->user->create( array( 'role' => 'editor' ) );
 		self::$subscriber_id = $factory->user->create( array( 'role' => 'subscriber' ) );
 		self::$post_id       = $factory->post->create( array( 'post_author' => self::$editor_id ) );
@@ -25,11 +23,13 @@ class WP_Test_REST_Sync_Server extends WP_Test_REST_Controller_Testcase {
 		self::delete_user( self::$editor_id );
 		self::delete_user( self::$subscriber_id );
 		wp_delete_post( self::$post_id, true );
-		remove_filter( 'pre_option_wp_enable_real_time_collaboration', '__return_true' );
 	}
 
 	public function set_up() {
 		parent::set_up();
+
+		// Enable option for tests.
+		add_filter( 'pre_option_wp_enable_real_time_collaboration', '__return_true' );
 
 		// Reset storage post ID cache to ensure clean state after transaction rollback.
 		$reflection = new ReflectionProperty( 'WP_Sync_Post_Meta_Storage', 'storage_post_ids' );

--- a/tests/phpunit/tests/rest-api/rest-sync-server.php
+++ b/tests/phpunit/tests/rest-api/rest-sync-server.php
@@ -14,7 +14,7 @@ class WP_Test_REST_Sync_Server extends WP_Test_REST_Controller_Testcase {
 	protected static $post_id;
 
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
-		update_option( 'wp_enable_real_time_collaboration', true );
+		add_filter( 'pre_option_wp_enable_real_time_collaboration', '__return_true' );
 
 		self::$editor_id     = $factory->user->create( array( 'role' => 'editor' ) );
 		self::$subscriber_id = $factory->user->create( array( 'role' => 'subscriber' ) );
@@ -25,7 +25,7 @@ class WP_Test_REST_Sync_Server extends WP_Test_REST_Controller_Testcase {
 		self::delete_user( self::$editor_id );
 		self::delete_user( self::$subscriber_id );
 		wp_delete_post( self::$post_id, true );
-		delete_option( 'wp_enable_real_time_collaboration' );
+		remove_filter( 'pre_option_wp_enable_real_time_collaboration', '__return_true' );
 	}
 
 	public function set_up() {

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -20,7 +20,8 @@ mockedApiResponse.Schema = {
         "wp/v2",
         "wp-site-health/v1",
         "wp-block-editor/v1",
-        "wp-abilities/v1"
+        "wp-abilities/v1",
+        "wp-sync/v1"
     ],
     "authentication": {
         "application-passwords": {
@@ -12770,6 +12771,114 @@ mockedApiResponse.Schema = {
                     }
                 }
             ]
+        },
+        "/wp-sync/v1": {
+            "namespace": "wp-sync/v1",
+            "methods": [
+                "GET"
+            ],
+            "endpoints": [
+                {
+                    "methods": [
+                        "GET"
+                    ],
+                    "args": {
+                        "namespace": {
+                            "default": "wp-sync/v1",
+                            "required": false
+                        },
+                        "context": {
+                            "default": "view",
+                            "required": false
+                        }
+                    }
+                }
+            ],
+            "_links": {
+                "self": [
+                    {
+                        "href": "http://example.org/index.php?rest_route=/wp-sync/v1"
+                    }
+                ]
+            }
+        },
+        "/wp-sync/v1/updates": {
+            "namespace": "wp-sync/v1",
+            "methods": [
+                "POST"
+            ],
+            "endpoints": [
+                {
+                    "methods": [
+                        "POST"
+                    ],
+                    "args": {
+                        "rooms": {
+                            "items": {
+                                "properties": {
+                                    "after": {
+                                        "minimum": 0,
+                                        "required": true,
+                                        "type": "integer"
+                                    },
+                                    "awareness": {
+                                        "required": true,
+                                        "type": [
+                                            "object",
+                                            "null"
+                                        ]
+                                    },
+                                    "client_id": {
+                                        "minimum": 1,
+                                        "required": true,
+                                        "type": "integer"
+                                    },
+                                    "room": {
+                                        "required": true,
+                                        "type": "string",
+                                        "pattern": "^[^/]+/[^/:]+(?::\\S+)?$"
+                                    },
+                                    "updates": {
+                                        "items": {
+                                            "properties": {
+                                                "data": {
+                                                    "type": "string",
+                                                    "required": true
+                                                },
+                                                "type": {
+                                                    "type": "string",
+                                                    "required": true,
+                                                    "enum": [
+                                                        "compaction",
+                                                        "sync_step1",
+                                                        "sync_step2",
+                                                        "update"
+                                                    ]
+                                                }
+                                            },
+                                            "required": true,
+                                            "type": "object"
+                                        },
+                                        "minItems": 0,
+                                        "required": true,
+                                        "type": "array"
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            "type": "array",
+                            "required": true
+                        }
+                    }
+                }
+            ],
+            "_links": {
+                "self": [
+                    {
+                        "href": "http://example.org/index.php?rest_route=/wp-sync/v1/updates"
+                    }
+                ]
+            }
         }
     },
     "image_sizes": {
@@ -14668,7 +14777,7 @@ mockedApiResponse.settings = {
     "use_smilies": true,
     "default_category": 1,
     "default_post_format": "0",
-    "wp_enable_real_time_collaboration": false,
+    "wp_enable_real_time_collaboration": true,
     "posts_per_page": 10,
     "show_on_front": "posts",
     "page_on_front": 0,

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -20,8 +20,7 @@ mockedApiResponse.Schema = {
         "wp/v2",
         "wp-site-health/v1",
         "wp-block-editor/v1",
-        "wp-abilities/v1",
-        "wp-sync/v1"
+        "wp-abilities/v1"
     ],
     "authentication": {
         "application-passwords": {
@@ -11158,9 +11157,9 @@ mockedApiResponse.Schema = {
                             "type": "string",
                             "required": false
                         },
-                        "wp_disable_real_time_collaboration": {
+                        "wp_enable_real_time_collaboration": {
                             "title": "",
-                            "description": "Disable real-time collaboration",
+                            "description": "Enable Real-Time Collaboration",
                             "type": "boolean",
                             "required": false
                         },
@@ -12771,114 +12770,6 @@ mockedApiResponse.Schema = {
                     }
                 }
             ]
-        },
-        "/wp-sync/v1": {
-            "namespace": "wp-sync/v1",
-            "methods": [
-                "GET"
-            ],
-            "endpoints": [
-                {
-                    "methods": [
-                        "GET"
-                    ],
-                    "args": {
-                        "namespace": {
-                            "default": "wp-sync/v1",
-                            "required": false
-                        },
-                        "context": {
-                            "default": "view",
-                            "required": false
-                        }
-                    }
-                }
-            ],
-            "_links": {
-                "self": [
-                    {
-                        "href": "http://example.org/index.php?rest_route=/wp-sync/v1"
-                    }
-                ]
-            }
-        },
-        "/wp-sync/v1/updates": {
-            "namespace": "wp-sync/v1",
-            "methods": [
-                "POST"
-            ],
-            "endpoints": [
-                {
-                    "methods": [
-                        "POST"
-                    ],
-                    "args": {
-                        "rooms": {
-                            "items": {
-                                "properties": {
-                                    "after": {
-                                        "minimum": 0,
-                                        "required": true,
-                                        "type": "integer"
-                                    },
-                                    "awareness": {
-                                        "required": true,
-                                        "type": [
-                                            "object",
-                                            "null"
-                                        ]
-                                    },
-                                    "client_id": {
-                                        "minimum": 1,
-                                        "required": true,
-                                        "type": "integer"
-                                    },
-                                    "room": {
-                                        "required": true,
-                                        "type": "string",
-                                        "pattern": "^[^/]+/[^/:]+(?::\\S+)?$"
-                                    },
-                                    "updates": {
-                                        "items": {
-                                            "properties": {
-                                                "data": {
-                                                    "type": "string",
-                                                    "required": true
-                                                },
-                                                "type": {
-                                                    "type": "string",
-                                                    "required": true,
-                                                    "enum": [
-                                                        "compaction",
-                                                        "sync_step1",
-                                                        "sync_step2",
-                                                        "update"
-                                                    ]
-                                                }
-                                            },
-                                            "required": true,
-                                            "type": "object"
-                                        },
-                                        "minItems": 0,
-                                        "required": true,
-                                        "type": "array"
-                                    }
-                                },
-                                "type": "object"
-                            },
-                            "type": "array",
-                            "required": true
-                        }
-                    }
-                }
-            ],
-            "_links": {
-                "self": [
-                    {
-                        "href": "http://example.org/index.php?rest_route=/wp-sync/v1/updates"
-                    }
-                ]
-            }
         }
     },
     "image_sizes": {
@@ -14777,7 +14668,7 @@ mockedApiResponse.settings = {
     "use_smilies": true,
     "default_category": 1,
     "default_post_format": "0",
-    "wp_disable_real_time_collaboration": false,
+    "wp_enable_real_time_collaboration": false,
     "posts_per_page": 10,
     "show_on_front": "posts",
     "page_on_front": 0,


### PR DESCRIPTION
Enable Real Time Collaboration by default.

Trac ticket: https://core.trac.wordpress.org/ticket/64622

* Reverts option name change
* Adds filter so default value of the option is true.
* Re-applies test changes from original commit to account for reversal of default. (Note: I've removed the `remove_filter()` calls as they are reset between tests in the test suites default tearDown method.)

## Use of AI Tools

None.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
