### PR TITLE
64805 Admin Reskin: Dismissible notices should use different Dashicon close icon

### DIFF
--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -809,8 +809,8 @@ img.emoji {
 .notice-dismiss:before {
 	background: none;
 	color: #1e1e1e;
-	content: "\f153";
-	content: "\f153" / '';
+	content: "\f335";
+	content: "\f335" / '';
 	display: block;
 	font: normal 20px/1 dashicons;
 	height: 1em;


### PR DESCRIPTION
Core trac: https://core.trac.wordpress.org/ticket/64805