### PR TITLE
Backport: Navigation link: add support to style current menu item via theme.json

### DIFF
--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -1185,8 +1185,10 @@ class WP_Theme_JSON {
 			if ( isset( static::VALID_BLOCK_CUSTOM_STATES[ $block ] ) ) {
 				foreach ( static::VALID_BLOCK_CUSTOM_STATES[ $block ] as $custom_state ) {
 					$custom_state_schema = $styles_non_top_level;
-					// The same pseudo-selectors valid for the block at the top level
-					// are also valid within each custom state.
+					/*
+					 * The same pseudo-selectors valid for the block at the top level
+					 * are also valid within each custom state.
+					 */
 					if ( isset( static::VALID_BLOCK_PSEUDO_SELECTORS[ $block ] ) ) {
 						foreach ( static::VALID_BLOCK_PSEUDO_SELECTORS[ $block ] as $pseudo ) {
 							$custom_state_schema[ $pseudo ] = $styles_non_top_level;
@@ -3275,6 +3277,7 @@ class WP_Theme_JSON {
 								'path'       => array( 'styles', 'blocks', $name, $custom_state ),
 								'selector'   => $custom_css_selector,
 								'selectors'  => $feature_selectors,
+								'elements'   => $selectors[ $name ]['elements'] ?? array(),
 								'duotone'    => $duotone_selector,
 								'variations' => $variation_selectors,
 								'css'        => $custom_css_selector,
@@ -3290,6 +3293,7 @@ class WP_Theme_JSON {
 											'path'       => array( 'styles', 'blocks', $name, $custom_state, $pseudo ),
 											'selector'   => $compound_css_selector,
 											'selectors'  => $feature_selectors,
+											'elements'   => $selectors[ $name ]['elements'] ?? array(),
 											'duotone'    => $duotone_selector,
 											'variations' => $variation_selectors,
 											'css'        => $compound_css_selector,

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -641,7 +641,30 @@ class WP_Theme_JSON {
 	 * @var array
 	 */
 	const VALID_BLOCK_PSEUDO_SELECTORS = array(
-		'core/button' => array( ':hover', ':focus', ':focus-visible', ':active' ),
+		'core/button'          => array( ':hover', ':focus', ':focus-visible', ':active' ),
+		'core/navigation-link' => array( ':hover', ':focus', ':focus-visible', ':active' ),
+	);
+
+	/**
+	 * Custom states for blocks that map to CSS class selectors rather than
+	 * CSS pseudo-selectors. Values use the '-' prefix (e.g. '-current') to
+	 * distinguish them from real CSS pseudo-selectors and breakpoint states.
+	 *
+	 * The CSS selector for each state is defined in the block's block.json
+	 * under `selectors.states`, e.g.:
+	 *
+	 *   "selectors": { "states": { "-current": ".some-css-selector" } }
+	 *
+	 * This constant controls which states are valid in theme.json for a given
+	 * block. Blocks listed here also inherit their VALID_BLOCK_PSEUDO_SELECTORS
+	 * as valid sub-states, producing compound selectors such as
+	 * `.wp-block-navigation-item.current-menu-item:hover`.
+	 *
+	 * @since 7.1.0
+	 * @var array
+	 */
+	const VALID_BLOCK_CUSTOM_STATES = array(
+		'core/navigation-link' => array( '-current' ),
 	);
 
 	/**
@@ -1157,6 +1180,21 @@ class WP_Theme_JSON {
 					$schema_styles_blocks[ $block ][ $pseudo_selector ] = $styles_non_top_level;
 				}
 			}
+
+			// Add custom states for blocks that support them (e.g. '-current' for navigation).
+			if ( isset( static::VALID_BLOCK_CUSTOM_STATES[ $block ] ) ) {
+				foreach ( static::VALID_BLOCK_CUSTOM_STATES[ $block ] as $custom_state ) {
+					$custom_state_schema = $styles_non_top_level;
+					// The same pseudo-selectors valid for the block at the top level
+					// are also valid within each custom state.
+					if ( isset( static::VALID_BLOCK_PSEUDO_SELECTORS[ $block ] ) ) {
+						foreach ( static::VALID_BLOCK_PSEUDO_SELECTORS[ $block ] as $pseudo ) {
+							$custom_state_schema[ $pseudo ] = $styles_non_top_level;
+						}
+					}
+					$schema_styles_blocks[ $block ][ $custom_state ] = $custom_state_schema;
+				}
+			}
 		}
 
 		$block_style_variation_styles             = static::VALID_STYLES;
@@ -1555,6 +1593,11 @@ class WP_Theme_JSON {
 
 			if ( ! empty( $style_selectors ) ) {
 				static::$blocks_metadata[ $block_name ]['styleVariations'] = $style_selectors;
+			}
+
+			// If the block has custom states defined in block.json, store their selectors.
+			if ( ! empty( $block_type->selectors['states'] ) && is_array( $block_type->selectors['states'] ) ) {
+				static::$blocks_metadata[ $block_name ]['states'] = $block_type->selectors['states'];
 			}
 		}
 
@@ -3214,6 +3257,45 @@ class WP_Theme_JSON {
 									'variations'  => $variation_selectors,
 									'css'         => static::append_to_selector( $selector, $pseudo_selector ),
 								);
+							}
+						}
+					}
+				}
+
+				// Handle custom states (e.g. '-current' for navigation).
+				if ( isset( static::VALID_BLOCK_CUSTOM_STATES[ $name ] ) ) {
+					foreach ( static::VALID_BLOCK_CUSTOM_STATES[ $name ] as $custom_state ) {
+						if (
+							isset( $theme_json['styles']['blocks'][ $name ][ $custom_state ] ) &&
+							isset( $selectors[ $name ]['states'][ $custom_state ] )
+						) {
+							$custom_css_selector = $selectors[ $name ]['states'][ $custom_state ];
+							$nodes[]             = array(
+								'name'       => $name,
+								'path'       => array( 'styles', 'blocks', $name, $custom_state ),
+								'selector'   => $custom_css_selector,
+								'selectors'  => $feature_selectors,
+								'duotone'    => $duotone_selector,
+								'variations' => $variation_selectors,
+								'css'        => $custom_css_selector,
+							);
+
+							// Sub-pseudo-selectors within the custom state.
+							if ( isset( static::VALID_BLOCK_PSEUDO_SELECTORS[ $name ] ) ) {
+								foreach ( static::VALID_BLOCK_PSEUDO_SELECTORS[ $name ] as $pseudo ) {
+									if ( isset( $theme_json['styles']['blocks'][ $name ][ $custom_state ][ $pseudo ] ) ) {
+										$compound_css_selector = static::append_to_selector( $custom_css_selector, $pseudo );
+										$nodes[]               = array(
+											'name'       => $name,
+											'path'       => array( 'styles', 'blocks', $name, $custom_state, $pseudo ),
+											'selector'   => $compound_css_selector,
+											'selectors'  => $feature_selectors,
+											'duotone'    => $duotone_selector,
+											'variations' => $variation_selectors,
+											'css'        => $compound_css_selector,
+										);
+									}
+								}
 							}
 						}
 					}

--- a/tests/phpunit/tests/theme/wpThemeJson.php
+++ b/tests/phpunit/tests/theme/wpThemeJson.php
@@ -7570,4 +7570,129 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 		$this->assertStringNotContainsString( 'padding', $result, 'Boolean value should be skipped' );
 		$this->assertStringNotContainsString( 'gap', $result, 'Array value should be skipped' );
 	}
+
+	/**
+	 * Test that block custom states (e.g. -current) are processed correctly.
+	 */
+	public function test_block_custom_states_are_processed() {
+		// Only -current styles, no base block styles, so we can assert the
+		// output uses the current-menu-item selector and not the block selector.
+		$theme_json = new WP_Theme_JSON(
+			array(
+				'version' => WP_Theme_JSON::LATEST_SCHEMA,
+				'styles'  => array(
+					'blocks' => array(
+						'core/navigation-link' => array(
+							'-current' => array(
+								'color' => array(
+									'text'       => 'red',
+									'background' => 'blue',
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$stylesheet = $theme_json->get_stylesheet( array( 'styles' ), null, array( 'skip_root_layout_styles' => true ) );
+		$expected   = ':root :where(.wp-block-navigation .current-menu-item){background-color: blue;color: red;}';
+		$this->assertSame( $expected, $stylesheet );
+	}
+
+	/**
+	 * Test that block custom states compound correctly with pseudo-selectors (e.g. -current + :hover).
+	 */
+	public function test_block_custom_states_compound_with_pseudo_selectors() {
+		$theme_json = new WP_Theme_JSON(
+			array(
+				'version' => WP_Theme_JSON::LATEST_SCHEMA,
+				'styles'  => array(
+					'blocks' => array(
+						'core/navigation-link' => array(
+							'-current' => array(
+								'color'  => array(
+									'text'       => 'red',
+									'background' => 'blue',
+								),
+								':hover' => array(
+									'color' => array(
+										'text'       => 'blue',
+										'background' => 'white',
+									),
+								),
+								':focus' => array(
+									'color' => array(
+										'text'       => 'green',
+										'background' => 'yellow',
+									),
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$expected = ':root :where(.wp-block-navigation .current-menu-item){background-color: blue;color: red;}:root :where(.wp-block-navigation .current-menu-item:hover){background-color: white;color: blue;}:root :where(.wp-block-navigation .current-menu-item:focus){background-color: yellow;color: green;}';
+		$this->assertSame( $expected, $theme_json->get_stylesheet( array( 'styles' ), null, array( 'skip_root_layout_styles' => true ) ) );
+	}
+
+	/**
+	 * Test that non-whitelisted custom states are ignored, and that custom states
+	 * are ignored on blocks that do not declare support for them.
+	 */
+	public function test_block_custom_states_ignores_non_whitelisted() {
+		// A non-whitelisted state key on a block that supports custom states.
+		$theme_json_bogus_state = new WP_Theme_JSON(
+			array(
+				'version' => WP_Theme_JSON::LATEST_SCHEMA,
+				'styles'  => array(
+					'blocks' => array(
+						'core/navigation-link' => array(
+							'color'  => array(
+								'text' => 'black',
+							),
+							'-bogus' => array(
+								'color' => array(
+									'text' => 'yellow',
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$stylesheet_bogus = $theme_json_bogus_state->get_stylesheet( array( 'styles' ), null, array( 'skip_root_layout_styles' => true ) );
+		$this->assertStringNotContainsString( '-bogus', $stylesheet_bogus );
+		$this->assertStringNotContainsString( 'yellow', $stylesheet_bogus );
+
+		// A valid custom state key on a block that does not support custom states.
+		$theme_json_unsupported_block = new WP_Theme_JSON(
+			array(
+				'version' => WP_Theme_JSON::LATEST_SCHEMA,
+				'styles'  => array(
+					'blocks' => array(
+						'core/paragraph' => array(
+							'color'    => array(
+								'text' => 'black',
+							),
+							'-current' => array(
+								'color' => array(
+									'text' => 'red',
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$stylesheet_unsupported = $theme_json_unsupported_block->get_stylesheet( array( 'styles' ), null, array( 'skip_root_layout_styles' => true ) );
+		$expected               = ':root :where(p){color: black;}';
+		$this->assertSame( $expected, $stylesheet_unsupported );
+		$this->assertStringNotContainsString( '-current', $stylesheet_unsupported );
+		$this->assertStringNotContainsString( 'current-menu-item', $stylesheet_unsupported );
+	}
 }

--- a/tests/phpunit/tests/theme/wpThemeJson.php
+++ b/tests/phpunit/tests/theme/wpThemeJson.php
@@ -7573,6 +7573,10 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 
 	/**
 	 * Test that block custom states (e.g. -current) are processed correctly.
+	 *
+	 * @covers WP_Theme_JSON::get_styles_for_block
+	 *
+	 * @ticket 64806
 	 */
 	public function test_block_custom_states_are_processed() {
 		// Only -current styles, no base block styles, so we can assert the
@@ -7595,13 +7599,21 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 			)
 		);
 
-		$stylesheet = $theme_json->get_stylesheet( array( 'styles' ), null, array( 'skip_root_layout_styles' => true ) );
-		$expected   = ':root :where(.wp-block-navigation .current-menu-item){background-color: blue;color: red;}';
-		$this->assertSame( $expected, $stylesheet );
+		$current_node = array(
+			'path'     => array( 'styles', 'blocks', 'core/navigation-link', '-current' ),
+			'selector' => '.wp-block-navigation .current-menu-item',
+		);
+		$expected     = ':root :where(.wp-block-navigation .current-menu-item){background-color: blue;color: red;}';
+
+		$this->assertSame( $expected, $theme_json->get_styles_for_block( $current_node ) );
 	}
 
 	/**
 	 * Test that block custom states compound correctly with pseudo-selectors (e.g. -current + :hover).
+	 *
+	 * @covers WP_Theme_JSON::get_styles_for_block
+	 *
+	 * @ticket 64806
 	 */
 	public function test_block_custom_states_compound_with_pseudo_selectors() {
 		$theme_json = new WP_Theme_JSON(
@@ -7634,13 +7646,37 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 			)
 		);
 
-		$expected = ':root :where(.wp-block-navigation .current-menu-item){background-color: blue;color: red;}:root :where(.wp-block-navigation .current-menu-item:hover){background-color: white;color: blue;}:root :where(.wp-block-navigation .current-menu-item:focus){background-color: yellow;color: green;}';
-		$this->assertSame( $expected, $theme_json->get_stylesheet( array( 'styles' ), null, array( 'skip_root_layout_styles' => true ) ) );
+		$current_node = array(
+			'path'     => array( 'styles', 'blocks', 'core/navigation-link', '-current' ),
+			'selector' => '.wp-block-navigation .current-menu-item',
+		);
+		$hover_node   = array(
+			'path'     => array( 'styles', 'blocks', 'core/navigation-link', '-current', ':hover' ),
+			'selector' => '.wp-block-navigation .current-menu-item:hover',
+		);
+		$focus_node   = array(
+			'path'     => array( 'styles', 'blocks', 'core/navigation-link', '-current', ':focus' ),
+			'selector' => '.wp-block-navigation .current-menu-item:focus',
+		);
+
+		$expected  = ':root :where(.wp-block-navigation .current-menu-item){background-color: blue;color: red;}';
+		$expected .= ':root :where(.wp-block-navigation .current-menu-item:hover){background-color: white;color: blue;}';
+		$expected .= ':root :where(.wp-block-navigation .current-menu-item:focus){background-color: yellow;color: green;}';
+
+		$actual  = $theme_json->get_styles_for_block( $current_node );
+		$actual .= $theme_json->get_styles_for_block( $hover_node );
+		$actual .= $theme_json->get_styles_for_block( $focus_node );
+
+		$this->assertSame( $expected, $actual );
 	}
 
 	/**
 	 * Test that non-whitelisted custom states are ignored, and that custom states
 	 * are ignored on blocks that do not declare support for them.
+	 *
+	 * @covers WP_Theme_JSON::get_stylesheet
+	 *
+	 * @ticket 64806
 	 */
 	public function test_block_custom_states_ignores_non_whitelisted() {
 		// A non-whitelisted state key on a block that supports custom states.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

This backports the relevant changes from https://github.com/WordPress/gutenberg/pull/75736, updated to match the current Gutenberg trunk state after:

- https://github.com/WordPress/gutenberg/pull/79210, which changed the custom state key from `@current` to `-current`.
- https://github.com/WordPress/wordpress-develop/pull/11706, which backported responsive global block styles from https://github.com/WordPress/gutenberg/pull/77513.


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Theme authors need a way to style the active/current menu item differently from the rest of the navigation, including controlling its hover, focus, and active states.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
No UI changes are included; this is theme.json only.

A new `VALID_BLOCK_CUSTOM_STATES` constant whitelists `-`-prefixed states per block in theme.json, playing the same role that `VALID_BLOCK_PSEUDO_SELECTORS` plays for CSS pseudo-selectors. The `-` prefix distinguishes these class-based custom states from real CSS pseudo-selectors and responsive breakpoint states.

Each block declares its state CSS selectors in `block.json` under `selectors.states`, following the existing [Selectors API](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-selectors/) pattern, which `get_blocks_metadata()` reads into block metadata and `get_block_nodes()` uses to generate CSS.

Blocks listed in `VALID_BLOCK_CUSTOM_STATES` also inherit their `VALID_BLOCK_PSEUDO_SELECTORS` as valid sub-states, producing compound selectors like `.wp-block-navigation-item.current-menu-item:hover`.

The PHPUnit tests use `get_styles_for_block()` with explicit style nodes so they do not depend on block metadata that will arrive through the Gutenberg sync.

We've had initial discussions on how the UI for this scenario would look like [over here](https://github.com/WordPress/gutenberg/pull/75627#issuecomment-3926949649).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->

Run the relevant PHP unit tests for `WP_Theme_JSON`, especially the custom-state tests added in this PR.

The following theme.json snippets show the intended public API once the corresponding `selectors.states` metadata for `core/navigation-link` is available in Core through the Gutenberg sync.

Current item base styles:
```
"core/navigation-link": {
  "-current": {
    "color": { "text": "#ff0000" }
  }
}
```

Current item hover:
```
"core/navigation-link": {
  "-current": {
    ":hover": {
      "color": { "text": "#0000ff" }
    }
  }
}
```

Current item focus:
```
"core/navigation-link": {
  "-current": {
    ":focus": {
      "color": { "text": "#00aa00" }
    }
  }
}
```

All combined:
```
"core/navigation-link": {
  "-current": {
    "color": { "text": "#ff0000" },
    "typography": { "fontWeight": "700" },
    ":hover": {
      "color": { "text": "#0000ff" }
    },
    ":focus": {
      "color": { "text": "#00aa00" }
    },
    ":active": {
      "color": { "text": "#ff6600" }
    }
  }
}
```

Test for navigation link items with and without submenus. Try other styles that aren't just the text color.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->


<img width="1423" height="404" alt="Screenshot 2026-02-19 at 18 02 17" src="https://github.com/user-attachments/assets/6f32a0fb-825c-4c12-b79c-474c5249abc7" />
<img width="1338" height="442" alt="Screenshot 2026-02-19 at 18 02 23" src="https://github.com/user-attachments/assets/32f615b1-f76f-4b47-91dc-a59b016793c8" />
<!-- Insert a description of your changes here -->

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->
https://core.trac.wordpress.org/ticket/64806
