### PR TITLE
Connectors: Add connectors registry for extensibility

### DIFF
--- a/src/wp-includes/class-wp-connector-registry.php
+++ b/src/wp-includes/class-wp-connector-registry.php
@@ -18,6 +18,7 @@
  * @phpstan-type Connector array{
  *     name: string,
  *     description: string,
+ *     logo_url?: string|null,
  *     type: string,
  *     authentication: array{
  *         method: string,
@@ -61,6 +62,7 @@ final class WP_Connector_Registry {
 	 *
 	 *     @type string $name           Required. The connector's display name.
 	 *     @type string $description    Optional. The connector's description. Default empty string.
+	 *     @type string|null $logo_url  Optional. URL to the connector's logo image. Default null.
 	 *     @type string $type           Required. The connector type. Currently, only 'ai_provider' is supported.
 	 *     @type array  $authentication {
 	 *         Required. Authentication configuration.
@@ -150,6 +152,10 @@ final class WP_Connector_Registry {
 				'method' => $args['authentication']['method'],
 			),
 		);
+
+		if ( ! empty( $args['logo_url'] ) && is_string( $args['logo_url'] ) ) {
+			$connector['logo_url'] = $args['logo_url'];
+		}
 
 		if ( 'api_key' === $args['authentication']['method'] ) {
 			$connector['authentication']['credentials_url'] = $args['authentication']['credentials_url'] ?? null;

--- a/src/wp-includes/class-wp-connector-registry.php
+++ b/src/wp-includes/class-wp-connector-registry.php
@@ -1,0 +1,298 @@
+<?php
+/**
+ * Connectors API
+ *
+ * Defines WP_Connector_Registry class.
+ *
+ * @package WordPress
+ * @subpackage Connectors
+ * @since 7.0.0
+ */
+
+/**
+ * Manages the registration and lookup of connectors.
+ *
+ * @since 7.0.0
+ * @access private
+ */
+final class WP_Connector_Registry {
+	/**
+	 * The singleton instance of the registry.
+	 *
+	 * @since 7.0.0
+	 * @var self|null
+	 */
+	private static $instance = null;
+
+	/**
+	 * Holds the registered connectors.
+	 *
+	 * Each connector is stored as an associative array with keys:
+	 * name, description, type, authentication, and optionally plugin.
+	 *
+	 * @since 7.0.0
+	 * @var array[]
+	 */
+	private $registered_connectors = array();
+
+	/**
+	 * Registers a new connector.
+	 *
+	 * Do not use this method directly. Instead, use the `wp_register_connector()` function.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @see wp_register_connector()
+	 *
+	 * @param string $id   The unique connector identifier. Must contain only lowercase
+	 *                     alphanumeric characters and underscores.
+	 * @param array  $args {
+	 *     An associative array of arguments for the connector.
+	 *
+	 *     @type string $name           Required. The connector's display name.
+	 *     @type string $description    Optional. The connector's description. Default empty string.
+	 *     @type string $type           Required. The connector type. Currently, only 'ai_provider' is supported.
+	 *     @type array  $authentication {
+	 *         Required. Authentication configuration.
+	 *
+	 *         @type string      $method          Required. The authentication method: 'api_key' or 'none'.
+	 *         @type string|null $credentials_url Optional. URL where users can obtain API credentials.
+	 *     }
+	 *     @type array  $plugin         Optional. Plugin data for install/activate UI.
+	 *         @type string $slug       The WordPress.org plugin slug.
+	 *     }
+	 * }
+	 * @return array|null The registered connector data on success, null on failure.
+	 */
+	public function register( string $id, array $args ): ?array {
+		if ( ! preg_match( '/^[a-z0-9_]+$/', $id ) ) {
+			_doing_it_wrong(
+				__METHOD__,
+				__(
+					'Connector ID must contain only lowercase alphanumeric characters and underscores.'
+				),
+				'7.0.0'
+			);
+			return null;
+		}
+
+		if ( $this->is_registered( $id ) ) {
+			_doing_it_wrong(
+				__METHOD__,
+				/* translators: %s: Connector ID. */
+				sprintf( __( 'Connector "%s" is already registered.' ), esc_html( $id ) ),
+				'7.0.0'
+			);
+			return null;
+		}
+
+		// Validate required fields.
+		if ( empty( $args['name'] ) || ! is_string( $args['name'] ) ) {
+			_doing_it_wrong(
+				__METHOD__,
+				/* translators: %s: Connector ID. */
+				sprintf( __( 'Connector "%s" requires a non-empty "name" string.' ), esc_html( $id ) ),
+				'7.0.0'
+			);
+			return null;
+		}
+
+		if ( empty( $args['type'] ) || ! is_string( $args['type'] ) ) {
+			_doing_it_wrong(
+				__METHOD__,
+				/* translators: %s: Connector ID. */
+				sprintf( __( 'Connector "%s" requires a non-empty "type" string.' ), esc_html( $id ) ),
+				'7.0.0'
+			);
+			return null;
+		}
+
+		if ( ! isset( $args['authentication'] ) || ! is_array( $args['authentication'] ) ) {
+			_doing_it_wrong(
+				__METHOD__,
+				/* translators: %s: Connector ID. */
+				sprintf( __( 'Connector "%s" requires an "authentication" array.' ), esc_html( $id ) ),
+				'7.0.0'
+			);
+			return null;
+		}
+
+		if ( empty( $args['authentication']['method'] ) || ! in_array( $args['authentication']['method'], array( 'api_key', 'none' ), true ) ) {
+			_doing_it_wrong(
+				__METHOD__,
+				/* translators: %s: Connector ID. */
+				sprintf( __( 'Connector "%s" authentication method must be "api_key" or "none".' ), esc_html( $id ) ),
+				'7.0.0'
+			);
+			return null;
+		}
+
+		$connector = array(
+			'name'           => $args['name'],
+			'description'    => isset( $args['description'] ) && is_string( $args['description'] ) ? $args['description'] : '',
+			'type'           => $args['type'],
+			'authentication' => array(
+				'method' => $args['authentication']['method'],
+			),
+		);
+
+		if ( 'api_key' === $args['authentication']['method'] ) {
+			$connector['authentication']['credentials_url'] = isset( $args['authentication']['credentials_url'] ) ? $args['authentication']['credentials_url'] : null;
+			$connector['authentication']['setting_name']    = "connectors_ai_{$id}_api_key";
+		}
+
+		if ( ! empty( $args['plugin'] ) && is_array( $args['plugin'] ) ) {
+			$connector['plugin'] = $args['plugin'];
+		}
+
+		$this->registered_connectors[ $id ] = $connector;
+		return $connector;
+	}
+
+	/**
+	 * Unregisters a connector.
+	 *
+	 * Do not use this method directly. Instead, use the `wp_unregister_connector()` function.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @see wp_unregister_connector()
+	 *
+	 * @param string $id The connector identifier.
+	 * @return array|null The unregistered connector data on success, null on failure.
+	 */
+	public function unregister( string $id ): ?array {
+		if ( ! $this->is_registered( $id ) ) {
+			_doing_it_wrong(
+				__METHOD__,
+				/* translators: %s: Connector ID. */
+				sprintf( __( 'Connector "%s" not found.' ), esc_html( $id ) ),
+				'7.0.0'
+			);
+			return null;
+		}
+
+		$unregistered = $this->registered_connectors[ $id ];
+		unset( $this->registered_connectors[ $id ] );
+
+		return $unregistered;
+	}
+
+	/**
+	 * Retrieves the list of all registered connectors.
+	 *
+	 * Do not use this method directly. Instead, use the `wp_get_connectors()` function.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @see wp_get_connectors()
+	 *
+	 * @return array[] The array of registered connectors keyed by connector ID.
+	 */
+	public function get_all_registered(): array {
+		return $this->registered_connectors;
+	}
+
+	/**
+	 * Checks if a connector is registered.
+	 *
+	 * Do not use this method directly. Instead, use the `wp_has_connector()` function.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @see wp_has_connector()
+	 *
+	 * @param string $id The connector identifier.
+	 * @return bool True if the connector is registered, false otherwise.
+	 */
+	public function is_registered( string $id ): bool {
+		return isset( $this->registered_connectors[ $id ] );
+	}
+
+	/**
+	 * Retrieves a registered connector.
+	 *
+	 * Do not use this method directly. Instead, use the `wp_get_connector()` function.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @see wp_get_connector()
+	 *
+	 * @param string $id The connector identifier.
+	 * @return array|null The registered connector data, or null if it is not registered.
+	 */
+	public function get_registered( string $id ): ?array {
+		if ( ! $this->is_registered( $id ) ) {
+			_doing_it_wrong(
+				__METHOD__,
+				/* translators: %s: Connector ID. */
+				sprintf( __( 'Connector "%s" not found.' ), esc_html( $id ) ),
+				'7.0.0'
+			);
+			return null;
+		}
+		return $this->registered_connectors[ $id ];
+	}
+
+	/**
+	 * Utility method to retrieve the main instance of the registry class.
+	 *
+	 * The instance will be created if it does not exist yet.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @return WP_Connector_Registry|null The main registry instance, or null when `init` action has not fired.
+	 */
+	public static function get_instance(): ?self {
+		if ( ! did_action( 'init' ) ) {
+			_doing_it_wrong(
+				__METHOD__,
+				sprintf(
+					/* translators: %s: init action. */
+					__( 'Connector registry should not be initialized before the %s action has fired.' ),
+					'<code>init</code>'
+				),
+				'7.0.0'
+			);
+			return null;
+		}
+
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+
+			/**
+			 * Fires when preparing connector registry.
+			 *
+			 * Connectors should be registered on this action rather
+			 * than another action to ensure they're only loaded when needed.
+			 *
+			 * @since 7.0.0
+			 *
+			 * @param WP_Connector_Registry $instance Connector registry object.
+			 */
+			do_action( 'wp_connectors_init', self::$instance );
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Wakeup magic method.
+	 *
+	 * @since 7.0.0
+	 * @throws LogicException If the registry object is unserialized.
+	 */
+	public function __wakeup(): void {
+		throw new LogicException( __CLASS__ . ' should never be unserialized.' );
+	}
+
+	/**
+	 * Sleep magic method.
+	 *
+	 * @since 7.0.0
+	 * @throws LogicException If the registry object is serialized.
+	 */
+	public function __sleep(): array {
+		throw new LogicException( __CLASS__ . ' should never be serialized.' );
+	}
+}

--- a/src/wp-includes/class-wp-connector-registry.php
+++ b/src/wp-includes/class-wp-connector-registry.php
@@ -15,7 +15,19 @@
  * @since 7.0.0
  * @access private
  *
- * @phpstan-type Connector array{ name: string, description: string, type: string, authentication: array{ method: string, credentials_url?: string|null, setting_name?: string }, plugin?: array{ slug: string } }
+ * @phpstan-type Connector array{
+ *     name: string,
+ *     description: string,
+ *     type: string,
+ *     authentication: array{
+ *         method: string,
+ *         credentials_url?: string|null,
+ *         setting_name?: string
+ *     },
+ *     plugin?: array{
+ *         slug: string
+ *     }
+ * }
  */
 final class WP_Connector_Registry {
 	/**

--- a/src/wp-includes/class-wp-connector-registry.php
+++ b/src/wp-includes/class-wp-connector-registry.php
@@ -61,8 +61,10 @@ final class WP_Connector_Registry {
 	 *         @type string      $method          Required. The authentication method: 'api_key' or 'none'.
 	 *         @type string|null $credentials_url Optional. URL where users can obtain API credentials.
 	 *     }
-	 *     @type array  $plugin         Optional. Plugin data for install/activate UI.
-	 *         @type string $slug       The WordPress.org plugin slug.
+	 *     @type array  $plugin {
+	 *         Optional. Plugin data for install/activate UI.
+	 *
+	 *         @type string $slug The WordPress.org plugin slug.
 	 *     }
 	 * }
 	 * @return array|null The registered connector data on success, null on failure.

--- a/src/wp-includes/class-wp-connector-registry.php
+++ b/src/wp-includes/class-wp-connector-registry.php
@@ -14,6 +14,8 @@
  *
  * @since 7.0.0
  * @access private
+ *
+ * @phpstan-type Connector array{ name: string, description: string, type: string, authentication: array{ method: string, credentials_url?: string|null }, plugin?: array{ slug: string } }
  */
 final class WP_Connector_Registry {
 	/**
@@ -22,7 +24,7 @@ final class WP_Connector_Registry {
 	 * @since 7.0.0
 	 * @var self|null
 	 */
-	private static $instance = null;
+	private static ?WP_Connector_Registry $instance = null;
 
 	/**
 	 * Holds the registered connectors.
@@ -31,9 +33,10 @@ final class WP_Connector_Registry {
 	 * name, description, type, authentication, and optionally plugin.
 	 *
 	 * @since 7.0.0
-	 * @var array[]
+	 * @var array<string, array>
+	 * @phpstan-var array<string, Connector>
 	 */
-	private $registered_connectors = array();
+	private array $registered_connectors = array();
 
 	/**
 	 * Registers a new connector.
@@ -63,6 +66,9 @@ final class WP_Connector_Registry {
 	 *     }
 	 * }
 	 * @return array|null The registered connector data on success, null on failure.
+	 *
+	 * @phpstan-param Connector $args
+	 * @phpstan-return Connector|null
 	 */
 	public function register( string $id, array $args ): ?array {
 		if ( ! preg_match( '/^[a-z0-9_]+$/', $id ) ) {
@@ -137,7 +143,7 @@ final class WP_Connector_Registry {
 		);
 
 		if ( 'api_key' === $args['authentication']['method'] ) {
-			$connector['authentication']['credentials_url'] = isset( $args['authentication']['credentials_url'] ) ? $args['authentication']['credentials_url'] : null;
+			$connector['authentication']['credentials_url'] = $args['authentication']['credentials_url'] ?? null;
 			$connector['authentication']['setting_name']    = "connectors_ai_{$id}_api_key";
 		}
 
@@ -160,6 +166,8 @@ final class WP_Connector_Registry {
 	 *
 	 * @param string $id The connector identifier.
 	 * @return array|null The unregistered connector data on success, null on failure.
+	 *
+	 * @phpstan-return Connector|null
 	 */
 	public function unregister( string $id ): ?array {
 		if ( ! $this->is_registered( $id ) ) {
@@ -187,7 +195,8 @@ final class WP_Connector_Registry {
 	 *
 	 * @see wp_get_connectors()
 	 *
-	 * @return array[] The array of registered connectors keyed by connector ID.
+	 * @return array<string, array> The array of registered connectors keyed by connector ID.
+	 * @phpstan-return array<string, Connector>
 	 */
 	public function get_all_registered(): array {
 		return $this->registered_connectors;
@@ -220,6 +229,7 @@ final class WP_Connector_Registry {
 	 *
 	 * @param string $id The connector identifier.
 	 * @return array|null The registered connector data, or null if it is not registered.
+	 * @phpstan-return Connector|null
 	 */
 	public function get_registered( string $id ): ?array {
 		if ( ! $this->is_registered( $id ) ) {

--- a/src/wp-includes/class-wp-connector-registry.php
+++ b/src/wp-includes/class-wp-connector-registry.php
@@ -269,10 +269,10 @@ final class WP_Connector_Registry {
 	 * @param WP_Connector_Registry $registry The registry instance.
 	 */
 	public static function set_instance( WP_Connector_Registry $registry ): void {
-		if ( did_action( 'init' ) && ! doing_action( 'init' ) ) {
+		if ( ! doing_action( 'init' ) ) {
 			_doing_it_wrong(
 				__METHOD__,
-				__( 'The connector registry instance must be set before the <code>init</code> action.' ),
+				__( 'The connector registry instance must be set during the <code>init</code> action.' ),
 				'7.0.0'
 			);
 			return;

--- a/src/wp-includes/class-wp-connector-registry.php
+++ b/src/wp-includes/class-wp-connector-registry.php
@@ -15,7 +15,7 @@
  * @since 7.0.0
  * @access private
  *
- * @phpstan-type Connector array{ name: string, description: string, type: string, authentication: array{ method: string, credentials_url?: string|null }, plugin?: array{ slug: string } }
+ * @phpstan-type Connector array{ name: string, description: string, type: string, authentication: array{ method: string, credentials_url?: string|null, setting_name?: string }, plugin?: array{ slug: string } }
  */
 final class WP_Connector_Registry {
 	/**

--- a/src/wp-includes/class-wp-connector-registry.php
+++ b/src/wp-includes/class-wp-connector-registry.php
@@ -22,7 +22,6 @@ final class WP_Connector_Registry {
 	 * The singleton instance of the registry.
 	 *
 	 * @since 7.0.0
-	 * @var self|null
 	 */
 	private static ?WP_Connector_Registry $instance = null;
 

--- a/src/wp-includes/class-wp-connector-registry.php
+++ b/src/wp-includes/class-wp-connector-registry.php
@@ -158,11 +158,7 @@ final class WP_Connector_Registry {
 	/**
 	 * Unregisters a connector.
 	 *
-	 * Do not use this method directly. Instead, use the `wp_unregister_connector()` function.
-	 *
 	 * @since 7.0.0
-	 *
-	 * @see wp_unregister_connector()
 	 *
 	 * @param string $id The connector identifier.
 	 * @return array|null The unregistered connector data on success, null on failure.
@@ -205,11 +201,11 @@ final class WP_Connector_Registry {
 	/**
 	 * Checks if a connector is registered.
 	 *
-	 * Do not use this method directly. Instead, use the `wp_has_connector()` function.
+	 * Do not use this method directly. Instead, use the `wp_is_connector_registered()` function.
 	 *
 	 * @since 7.0.0
 	 *
-	 * @see wp_has_connector()
+	 * @see wp_is_connector_registered()
 	 *
 	 * @param string $id The connector identifier.
 	 * @return bool True if the connector is registered, false otherwise.
@@ -245,64 +241,25 @@ final class WP_Connector_Registry {
 	}
 
 	/**
-	 * Utility method to retrieve the main instance of the registry class.
-	 *
-	 * The instance will be created if it does not exist yet.
+	 * Retrieves the main instance of the registry class.
 	 *
 	 * @since 7.0.0
 	 *
-	 * @return WP_Connector_Registry|null The main registry instance, or null when `init` action has not fired.
+	 * @return WP_Connector_Registry|null The main registry instance, or null if not yet initialized.
 	 */
 	public static function get_instance(): ?self {
-		if ( ! did_action( 'init' ) ) {
-			_doing_it_wrong(
-				__METHOD__,
-				sprintf(
-					/* translators: %s: init action. */
-					__( 'Connector registry should not be initialized before the %s action has fired.' ),
-					'<code>init</code>'
-				),
-				'7.0.0'
-			);
-			return null;
-		}
-
-		if ( null === self::$instance ) {
-			self::$instance = new self();
-
-			/**
-			 * Fires when preparing connector registry.
-			 *
-			 * Connectors should be registered on this action rather
-			 * than another action to ensure they're only loaded when needed.
-			 *
-			 * @since 7.0.0
-			 *
-			 * @param WP_Connector_Registry $instance Connector registry object.
-			 */
-			do_action( 'wp_connectors_init', self::$instance );
-		}
-
 		return self::$instance;
 	}
 
 	/**
-	 * Wakeup magic method.
+	 * Sets the main instance of the registry class.
 	 *
 	 * @since 7.0.0
-	 * @throws LogicException If the registry object is unserialized.
-	 */
-	public function __wakeup(): void {
-		throw new LogicException( __CLASS__ . ' should never be unserialized.' );
-	}
-
-	/**
-	 * Sleep magic method.
+	 * @access private
 	 *
-	 * @since 7.0.0
-	 * @throws LogicException If the registry object is serialized.
+	 * @param WP_Connector_Registry $registry The registry instance.
 	 */
-	public function __sleep(): array {
-		throw new LogicException( __CLASS__ . ' should never be serialized.' );
+	public static function set_instance( WP_Connector_Registry $registry ): void {
+		self::$instance = $registry;
 	}
 }

--- a/src/wp-includes/class-wp-connector-registry.php
+++ b/src/wp-includes/class-wp-connector-registry.php
@@ -40,11 +40,7 @@ final class WP_Connector_Registry {
 	/**
 	 * Registers a new connector.
 	 *
-	 * Do not use this method directly. Instead, use the `wp_register_connector()` function.
-	 *
 	 * @since 7.0.0
-	 *
-	 * @see wp_register_connector()
 	 *
 	 * @param string $id   The unique connector identifier. Must contain only lowercase
 	 *                     alphanumeric characters and underscores.

--- a/src/wp-includes/class-wp-connector-registry.php
+++ b/src/wp-includes/class-wp-connector-registry.php
@@ -257,6 +257,15 @@ final class WP_Connector_Registry {
 	 * @param WP_Connector_Registry $registry The registry instance.
 	 */
 	public static function set_instance( WP_Connector_Registry $registry ): void {
+		if ( did_action( 'init' ) && ! doing_action( 'init' ) ) {
+			_doing_it_wrong(
+				__METHOD__,
+				__( 'The connector registry instance must be set before the <code>init</code> action.' ),
+				'7.0.0'
+			);
+			return;
+		}
+
 		self::$instance = $registry;
 	}
 }

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -11,76 +11,6 @@ use WordPress\AiClient\AiClient;
 use WordPress\AiClient\Providers\Http\DTO\ApiKeyRequestAuthentication;
 
 /**
- * Registers a new connector.
- *
- * Must be called during the `wp_connectors_init` action.
- *
- * Example:
- *
- *     function my_plugin_register_connectors(): void {
- *         wp_register_connector(
- *             'my_custom_ai',
- *             array(
- *                 'name'           => __( 'My Custom AI', 'my-plugin' ),
- *                 'description'    => __( 'Custom AI provider integration.', 'my-plugin' ),
- *                 'type'           => 'ai_provider',
- *                 'authentication' => array(
- *                     'method'          => 'api_key',
- *                     'credentials_url' => 'https://example.com/api-keys',
- *                 ),
- *             )
- *         );
- *     }
- *     add_action( 'wp_connectors_init', 'my_plugin_register_connectors' );
- *
- * @since 7.0.0
- *
- * @see WP_Connector_Registry::register()
- *
- * @param string $id   The unique connector identifier. Must contain only lowercase
- *                     alphanumeric characters and underscores.
- * @param array  $args {
- *     An associative array of arguments for the connector.
- *
- *     @type string $name           Required. The connector's display name.
- *     @type string $description    Optional. The connector's description. Default empty string.
- *     @type string $type           Required. The connector type. Currently, only 'ai_provider' is supported.
- *     @type array  $authentication {
- *         Required. Authentication configuration.
- *
- *         @type string      $method          Required. The authentication method: 'api_key' or 'none'.
- *         @type string|null $credentials_url Optional. URL where users can obtain API credentials.
- *     }
- *     @type array  $plugin         Optional. Plugin data for install/activate UI.
- *         @type string $slug       The WordPress.org plugin slug.
- *     }
- * }
- * @return array|null The registered connector data on success, null on failure.
- */
-function wp_register_connector( string $id, array $args ): ?array {
-	if ( ! doing_action( 'wp_connectors_init' ) ) {
-		_doing_it_wrong(
-			__FUNCTION__,
-			sprintf(
-				/* translators: 1: wp_connectors_init, 2: string value of the connector ID. */
-				__( 'Connectors must be registered on the %1$s action. The connector %2$s was not registered.' ),
-				'<code>wp_connectors_init</code>',
-				'<code>' . esc_html( $id ) . '</code>'
-			),
-			'7.0.0'
-		);
-		return null;
-	}
-
-	$registry = WP_Connector_Registry::get_instance();
-	if ( null === $registry ) {
-		return null;
-	}
-
-	return $registry->register( $id, $args );
-}
-
-/**
  * Checks if a connector is registered.
  *
  * @since 7.0.0
@@ -244,7 +174,24 @@ function _wp_connectors_init(): void {
 	 * Fires when the connector registry is ready for plugins to register connectors.
 	 *
 	 * Default connectors have already been registered at this point and cannot be
-	 * unhooked. Use `wp_register_connector()` within this action to add new connectors.
+	 * unhooked. Use `$registry->register()` within this action to add new connectors.
+	 *
+	 * Example usage:
+	 *
+	 *     add_action( 'wp_connectors_init', function ( WP_Connector_Registry $registry ) {
+	 *         $registry->register(
+	 *             'my_custom_ai',
+	 *             array(
+	 *                 'name'           => __( 'My Custom AI', 'my-plugin' ),
+	 *                 'description'    => __( 'Custom AI provider integration.', 'my-plugin' ),
+	 *                 'type'           => 'ai_provider',
+	 *                 'authentication' => array(
+	 *                     'method'          => 'api_key',
+	 *                     'credentials_url' => 'https://example.com/api-keys',
+	 *                 ),
+	 *             )
+	 *         );
+	 *     } );
 	 *
 	 * @since 7.0.0
 	 *

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -17,7 +17,7 @@ use WordPress\AiClient\Providers\Http\DTO\ApiKeyRequestAuthentication;
  *
  * Example:
  *
- *     function my_plugin_register_connectors( WP_Connector_Registry $registry ): void {
+ *     function my_plugin_register_connectors(): void {
  *         wp_register_connector(
  *             'my_custom_ai',
  *             array(
@@ -81,28 +81,6 @@ function wp_register_connector( string $id, array $args ): ?array {
 }
 
 /**
- * Unregisters a connector.
- *
- * Can be called at any time after the connector has been registered.
- *
- * @since 7.0.0
- *
- * @see WP_Connector_Registry::unregister()
- * @see wp_register_connector()
- *
- * @param string $id The connector identifier.
- * @return array|null The unregistered connector data on success, null on failure.
- */
-function wp_unregister_connector( string $id ): ?array {
-	$registry = WP_Connector_Registry::get_instance();
-	if ( null === $registry ) {
-		return null;
-	}
-
-	return $registry->unregister( $id );
-}
-
-/**
  * Checks if a connector is registered.
  *
  * @since 7.0.0
@@ -159,12 +137,17 @@ function wp_get_connectors(): array {
 }
 
 /**
- * Registers default connectors from Core and the AI Client registry.
+ * Initializes the connector registry with default connectors and fires the registration action.
+ *
+ * Creates the registry instance, registers built-in connectors (which cannot be unhooked),
+ * and then fires the `wp_connectors_init` action for plugins to register their own connectors.
  *
  * @since 7.0.0
  * @access private
  */
-function _wp_register_default_connectors(): void {
+function _wp_connectors_init(): void {
+	$registry = new WP_Connector_Registry();
+	WP_Connector_Registry::set_instance( $registry );
 	// Built-in connectors.
 	$defaults = array(
 		'anthropic' => array(
@@ -252,10 +235,22 @@ function _wp_register_default_connectors(): void {
 		}
 	}
 
-	// Register all connectors.
+	// Register all default connectors directly on the registry.
 	foreach ( $defaults as $id => $args ) {
-		wp_register_connector( $id, $args );
+		$registry->register( $id, $args );
 	}
+
+	/**
+	 * Fires when the connector registry is ready for plugins to register connectors.
+	 *
+	 * Default connectors have already been registered at this point and cannot be
+	 * unhooked. Use `wp_register_connector()` within this action to add new connectors.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param WP_Connector_Registry $registry Connector registry instance.
+	 */
+	do_action( 'wp_connectors_init', $registry );
 }
 
 /**

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -212,10 +212,27 @@ function _wp_connectors_get_connector_settings(): array {
 	 *
 	 * @since 7.0.0
 	 *
-	 * @param array $connectors Connector settings keyed by connector ID.
-	 *                          Each entry is an array with keys: name, description,
-	 *                          type, authentication (with method, and optionally
-	 *                          credentials_url), and optionally plugin.
+	 * @param array $connectors {
+	 *     Connector settings keyed by connector ID.
+	 *
+	 *     @type array ...$0 {
+	 *         Data for a single connector.
+	 *
+	 *         @type string $name           The connector's display name.
+	 *         @type string $description    The connector's description.
+	 *         @type string $type           The connector type. Currently, only 'ai_provider' is supported.
+	 *         @type array  $plugin         Optional. Plugin data for install/activate UI.
+	 *             @type string $slug       The WordPress.org plugin slug.
+	 *         }
+	 *         @type array  $authentication {
+	 *             Authentication configuration. When method is 'api_key', includes
+	 *             credentials_url. When 'none', only method is present.
+	 *
+	 *             @type string      $method          The authentication method: 'api_key' or 'none'.
+	 *             @type string|null $credentials_url Optional. URL where users can obtain API credentials.
+	 *         }
+	 *     }
+	 * }
 	 */
 	$connectors = apply_filters( 'wp_connectors_settings', $connectors );
 

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -316,9 +316,16 @@ add_filter( 'rest_post_dispatch', '_wp_connectors_validate_keys_in_rest', 10, 3 
  * @access private
  */
 function _wp_register_default_connector_settings(): void {
+	$registry = AiClient::defaultRegistry();
+
 	foreach ( _wp_connectors_get_connector_settings() as $connector_id => $connector_data ) {
 		$auth = $connector_data['authentication'];
 		if ( 'ai_provider' !== $connector_data['type'] || 'api_key' !== $auth['method'] || empty( $auth['setting_name'] ) ) {
+			continue;
+		}
+
+		// Skip registering the setting if the provider is not in the registry.
+		if ( ! $registry->hasProvider( $connector_id ) ) {
 			continue;
 		}
 
@@ -375,8 +382,12 @@ function _wp_connectors_pass_default_keys_to_ai_client(): void {
 				continue;
 			}
 
+			if ( ! $registry->hasProvider( $connector_id ) ) {
+				continue;
+			}
+
 			$api_key = _wp_connectors_get_real_api_key( $auth['setting_name'], '_wp_connectors_mask_api_key' );
-			if ( '' === $api_key || ! $registry->hasProvider( $connector_id ) ) {
+			if ( '' === $api_key ) {
 				continue;
 			}
 

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -200,6 +200,13 @@ function _wp_connectors_get_connector_settings(): array {
 		}
 	}
 
+	// Add setting_name for AI provider connectors that use API key authentication.
+	foreach ( $connectors as $connector_id => $connector ) {
+		if ( 'ai_provider' === $connector['type'] && 'api_key' === $connector['authentication']['method'] ) {
+			$connectors[ $connector_id ]['authentication']['setting_name'] = "connectors_ai_{$connector_id}_api_key";
+		}
+	}
+
 	ksort( $connectors );
 
 	/**
@@ -207,8 +214,8 @@ function _wp_connectors_get_connector_settings(): array {
 	 *
 	 * Allows plugins to add, modify, or remove connectors displayed
 	 * on the Connectors screen. Runs after built-in and AI Client
-	 * registry providers are collected, but before `setting_name` is
-	 * generated for API-key connectors.
+	 * registry providers are collected and fully populated with
+	 * `setting_name` for API-key connectors.
 	 *
 	 * @since 7.0.0
 	 *
@@ -226,22 +233,16 @@ function _wp_connectors_get_connector_settings(): array {
 	 *         }
 	 *         @type array  $authentication {
 	 *             Authentication configuration. When method is 'api_key', includes
-	 *             credentials_url. When 'none', only method is present.
+	 *             credentials_url and setting_name. When 'none', only method is present.
 	 *
 	 *             @type string      $method          The authentication method: 'api_key' or 'none'.
 	 *             @type string|null $credentials_url Optional. URL where users can obtain API credentials.
+	 *             @type string      $setting_name    Optional. The setting name for the API key. Present when method is 'api_key'.
 	 *         }
 	 *     }
 	 * }
 	 */
 	$connectors = apply_filters( 'wp_connectors_settings', $connectors );
-
-	// Add setting_name for AI provider connectors that use API key authentication.
-	foreach ( $connectors as $connector_id => $connector ) {
-		if ( 'ai_provider' === $connector['type'] && 'api_key' === $connector['authentication']['method'] ) {
-			$connectors[ $connector_id ]['authentication']['setting_name'] = "connectors_ai_{$connector_id}_api_key";
-		}
-	}
 
 	return $connectors;
 }

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -461,7 +461,7 @@ function _wp_connectors_pass_default_keys_to_ai_client(): void {
 			);
 		}
 	} catch ( Exception $e ) {
-			wp_trigger_error( __FUNCTION__, $e->getMessage() );
+		wp_trigger_error( __FUNCTION__, $e->getMessage() );
 	}
 }
 add_action( 'init', '_wp_connectors_pass_default_keys_to_ai_client', 20 );

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -205,12 +205,8 @@ function _wp_register_default_connectors(): void {
 		),
 	);
 
-	// Register built-in connectors first.
-	foreach ( $defaults as $id => $args ) {
-		wp_register_connector( $id, $args );
-	}
-
-	// Register connectors from the AI Client registry.
+	// Merge AI Client registry data on top of defaults.
+	// Registry values (from provider plugins) take precedence over hardcoded fallbacks.
 	$ai_registry = AiClient::defaultRegistry();
 
 	foreach ( $ai_registry->getRegisteredProviderIds() as $connector_id ) {
@@ -233,20 +229,32 @@ function _wp_register_default_connectors(): void {
 		$name        = $provider_metadata->getName();
 		$description = $provider_metadata->getDescription();
 
-		if ( wp_has_connector( $connector_id ) ) {
-			// Already registered as a built-in; skip to avoid duplicate registration error.
-			continue;
-		}
-
-		wp_register_connector(
-			$connector_id,
-			array(
+		if ( isset( $defaults[ $connector_id ] ) ) {
+			// Override fields with non-empty registry values.
+			if ( $name ) {
+				$defaults[ $connector_id ]['name'] = $name;
+			}
+			if ( $description ) {
+				$defaults[ $connector_id ]['description'] = $description;
+			}
+			// Always update auth method; keep existing credentials_url as fallback.
+			$defaults[ $connector_id ]['authentication']['method'] = $authentication['method'];
+			if ( ! empty( $authentication['credentials_url'] ) ) {
+				$defaults[ $connector_id ]['authentication']['credentials_url'] = $authentication['credentials_url'];
+			}
+		} else {
+			$defaults[ $connector_id ] = array(
 				'name'           => $name ? $name : ucwords( $connector_id ),
 				'description'    => $description ? $description : '',
 				'type'           => 'ai_provider',
 				'authentication' => $authentication,
-			)
-		);
+			);
+		}
+	}
+
+	// Register all connectors.
+	foreach ( $defaults as $id => $args ) {
+		wp_register_connector( $id, $args );
 	}
 }
 

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -10,6 +10,245 @@
 use WordPress\AiClient\AiClient;
 use WordPress\AiClient\Providers\Http\DTO\ApiKeyRequestAuthentication;
 
+/**
+ * Registers a new connector.
+ *
+ * Must be called during the `wp_connectors_init` action.
+ *
+ * Example:
+ *
+ *     function my_plugin_register_connectors( WP_Connector_Registry $registry ): void {
+ *         wp_register_connector(
+ *             'my_custom_ai',
+ *             array(
+ *                 'name'           => __( 'My Custom AI', 'my-plugin' ),
+ *                 'description'    => __( 'Custom AI provider integration.', 'my-plugin' ),
+ *                 'type'           => 'ai_provider',
+ *                 'authentication' => array(
+ *                     'method'          => 'api_key',
+ *                     'credentials_url' => 'https://example.com/api-keys',
+ *                 ),
+ *             )
+ *         );
+ *     }
+ *     add_action( 'wp_connectors_init', 'my_plugin_register_connectors' );
+ *
+ * @since 7.0.0
+ *
+ * @see WP_Connector_Registry::register()
+ *
+ * @param string $id   The unique connector identifier. Must contain only lowercase
+ *                     alphanumeric characters and underscores.
+ * @param array  $args {
+ *     An associative array of arguments for the connector.
+ *
+ *     @type string $name           Required. The connector's display name.
+ *     @type string $description    Optional. The connector's description. Default empty string.
+ *     @type string $type           Required. The connector type. Currently, only 'ai_provider' is supported.
+ *     @type array  $authentication {
+ *         Required. Authentication configuration.
+ *
+ *         @type string      $method          Required. The authentication method: 'api_key' or 'none'.
+ *         @type string|null $credentials_url Optional. URL where users can obtain API credentials.
+ *     }
+ *     @type array  $plugin         Optional. Plugin data for install/activate UI.
+ *         @type string $slug       The WordPress.org plugin slug.
+ *     }
+ * }
+ * @return array|null The registered connector data on success, null on failure.
+ */
+function wp_register_connector( string $id, array $args ): ?array {
+	if ( ! doing_action( 'wp_connectors_init' ) ) {
+		_doing_it_wrong(
+			__FUNCTION__,
+			sprintf(
+				/* translators: 1: wp_connectors_init, 2: string value of the connector ID. */
+				__( 'Connectors must be registered on the %1$s action. The connector %2$s was not registered.' ),
+				'<code>wp_connectors_init</code>',
+				'<code>' . esc_html( $id ) . '</code>'
+			),
+			'7.0.0'
+		);
+		return null;
+	}
+
+	$registry = WP_Connector_Registry::get_instance();
+	if ( null === $registry ) {
+		return null;
+	}
+
+	return $registry->register( $id, $args );
+}
+
+/**
+ * Unregisters a connector.
+ *
+ * Can be called at any time after the connector has been registered.
+ *
+ * @since 7.0.0
+ *
+ * @see WP_Connector_Registry::unregister()
+ * @see wp_register_connector()
+ *
+ * @param string $id The connector identifier.
+ * @return array|null The unregistered connector data on success, null on failure.
+ */
+function wp_unregister_connector( string $id ): ?array {
+	$registry = WP_Connector_Registry::get_instance();
+	if ( null === $registry ) {
+		return null;
+	}
+
+	return $registry->unregister( $id );
+}
+
+/**
+ * Checks if a connector is registered.
+ *
+ * @since 7.0.0
+ *
+ * @see WP_Connector_Registry::is_registered()
+ *
+ * @param string $id The connector identifier.
+ * @return bool True if the connector is registered, false otherwise.
+ */
+function wp_has_connector( string $id ): bool {
+	$registry = WP_Connector_Registry::get_instance();
+	if ( null === $registry ) {
+		return false;
+	}
+
+	return $registry->is_registered( $id );
+}
+
+/**
+ * Retrieves a registered connector.
+ *
+ * @since 7.0.0
+ *
+ * @see WP_Connector_Registry::get_registered()
+ *
+ * @param string $id The connector identifier.
+ * @return array|null The registered connector data, or null if not registered.
+ */
+function wp_get_connector( string $id ): ?array {
+	$registry = WP_Connector_Registry::get_instance();
+	if ( null === $registry ) {
+		return null;
+	}
+
+	return $registry->get_registered( $id );
+}
+
+/**
+ * Retrieves all registered connectors.
+ *
+ * @since 7.0.0
+ *
+ * @see WP_Connector_Registry::get_all_registered()
+ *
+ * @return array[] An array of registered connectors keyed by connector ID.
+ */
+function wp_get_connectors(): array {
+	$registry = WP_Connector_Registry::get_instance();
+	if ( null === $registry ) {
+		return array();
+	}
+
+	return $registry->get_all_registered();
+}
+
+/**
+ * Registers default connectors from Core and the AI Client registry.
+ *
+ * @since 7.0.0
+ * @access private
+ */
+function _wp_register_default_connectors(): void {
+	// Built-in connectors.
+	$defaults = array(
+		'anthropic' => array(
+			'name'           => 'Anthropic',
+			'description'    => __( 'Text generation with Claude.' ),
+			'type'           => 'ai_provider',
+			'plugin'         => array(
+				'slug' => 'ai-provider-for-anthropic',
+			),
+			'authentication' => array(
+				'method'          => 'api_key',
+				'credentials_url' => 'https://platform.claude.com/settings/keys',
+			),
+		),
+		'google'    => array(
+			'name'           => 'Google',
+			'description'    => __( 'Text and image generation with Gemini and Imagen.' ),
+			'type'           => 'ai_provider',
+			'plugin'         => array(
+				'slug' => 'ai-provider-for-google',
+			),
+			'authentication' => array(
+				'method'          => 'api_key',
+				'credentials_url' => 'https://aistudio.google.com/api-keys',
+			),
+		),
+		'openai'    => array(
+			'name'           => 'OpenAI',
+			'description'    => __( 'Text and image generation with GPT and Dall-E.' ),
+			'type'           => 'ai_provider',
+			'plugin'         => array(
+				'slug' => 'ai-provider-for-openai',
+			),
+			'authentication' => array(
+				'method'          => 'api_key',
+				'credentials_url' => 'https://platform.openai.com/api-keys',
+			),
+		),
+	);
+
+	// Register built-in connectors first.
+	foreach ( $defaults as $id => $args ) {
+		wp_register_connector( $id, $args );
+	}
+
+	// Register connectors from the AI Client registry.
+	$ai_registry = AiClient::defaultRegistry();
+
+	foreach ( $ai_registry->getRegisteredProviderIds() as $connector_id ) {
+		$provider_class_name = $ai_registry->getProviderClassName( $connector_id );
+		$provider_metadata   = $provider_class_name::metadata();
+
+		$auth_method = $provider_metadata->getAuthenticationMethod();
+		$is_api_key  = null !== $auth_method && $auth_method->isApiKey();
+
+		if ( $is_api_key ) {
+			$credentials_url = $provider_metadata->getCredentialsUrl();
+			$authentication  = array(
+				'method'          => 'api_key',
+				'credentials_url' => $credentials_url ? $credentials_url : null,
+			);
+		} else {
+			$authentication = array( 'method' => 'none' );
+		}
+
+		$name        = $provider_metadata->getName();
+		$description = $provider_metadata->getDescription();
+
+		if ( wp_has_connector( $connector_id ) ) {
+			// Already registered as a built-in; skip to avoid duplicate registration error.
+			continue;
+		}
+
+		wp_register_connector(
+			$connector_id,
+			array(
+				'name'           => $name ? $name : ucwords( $connector_id ),
+				'description'    => $description ? $description : '',
+				'type'           => 'ai_provider',
+				'authentication' => $authentication,
+			)
+		);
+	}
+}
 
 /**
  * Masks an API key, showing only the last 4 characters.
@@ -116,134 +355,8 @@ function _wp_connectors_get_real_api_key( string $option_name, callable $mask_ca
  * }
  */
 function _wp_connectors_get_connector_settings(): array {
-	$connectors = array(
-		'anthropic' => array(
-			'name'           => 'Anthropic',
-			'description'    => __( 'Text generation with Claude.' ),
-			'type'           => 'ai_provider',
-			'plugin'         => array(
-				'slug' => 'ai-provider-for-anthropic',
-			),
-			'authentication' => array(
-				'method'          => 'api_key',
-				'credentials_url' => 'https://platform.claude.com/settings/keys',
-			),
-		),
-		'google'    => array(
-			'name'           => 'Google',
-			'description'    => __( 'Text and image generation with Gemini and Imagen.' ),
-			'type'           => 'ai_provider',
-			'plugin'         => array(
-				'slug' => 'ai-provider-for-google',
-			),
-			'authentication' => array(
-				'method'          => 'api_key',
-				'credentials_url' => 'https://aistudio.google.com/api-keys',
-			),
-		),
-		'openai'    => array(
-			'name'           => 'OpenAI',
-			'description'    => __( 'Text and image generation with GPT and Dall-E.' ),
-			'type'           => 'ai_provider',
-			'plugin'         => array(
-				'slug' => 'ai-provider-for-openai',
-			),
-			'authentication' => array(
-				'method'          => 'api_key',
-				'credentials_url' => 'https://platform.openai.com/api-keys',
-			),
-		),
-	);
-
-	$registry = AiClient::defaultRegistry();
-
-	foreach ( $registry->getRegisteredProviderIds() as $connector_id ) {
-		$provider_class_name = $registry->getProviderClassName( $connector_id );
-		$provider_metadata   = $provider_class_name::metadata();
-
-		$auth_method = $provider_metadata->getAuthenticationMethod();
-		$is_api_key  = null !== $auth_method && $auth_method->isApiKey();
-
-		if ( $is_api_key ) {
-			$credentials_url = $provider_metadata->getCredentialsUrl();
-			$authentication  = array(
-				'method'          => 'api_key',
-				'credentials_url' => $credentials_url ? $credentials_url : null,
-			);
-		} else {
-			$authentication = array( 'method' => 'none' );
-		}
-
-		$name        = $provider_metadata->getName();
-		$description = $provider_metadata->getDescription();
-
-		if ( isset( $connectors[ $connector_id ] ) ) {
-			// Override fields with non-empty registry values.
-			if ( $name ) {
-				$connectors[ $connector_id ]['name'] = $name;
-			}
-			if ( $description ) {
-				$connectors[ $connector_id ]['description'] = $description;
-			}
-			// Always update auth method; keep existing credentials_url as fallback.
-			$connectors[ $connector_id ]['authentication']['method'] = $authentication['method'];
-			if ( ! empty( $authentication['credentials_url'] ) ) {
-				$connectors[ $connector_id ]['authentication']['credentials_url'] = $authentication['credentials_url'];
-			}
-		} else {
-			$connectors[ $connector_id ] = array(
-				'name'           => $name ? $name : ucwords( $connector_id ),
-				'description'    => $description ? $description : '',
-				'type'           => 'ai_provider',
-				'authentication' => $authentication,
-			);
-		}
-	}
-
-	// Add setting_name for AI provider connectors that use API key authentication.
-	foreach ( $connectors as $connector_id => $connector ) {
-		if ( 'ai_provider' === $connector['type'] && 'api_key' === $connector['authentication']['method'] ) {
-			$connectors[ $connector_id ]['authentication']['setting_name'] = "connectors_ai_{$connector_id}_api_key";
-		}
-	}
-
+	$connectors = wp_get_connectors();
 	ksort( $connectors );
-
-	/**
-	 * Filters the registered connector settings.
-	 *
-	 * Allows plugins to add, modify, or remove connectors displayed
-	 * on the Connectors screen. Runs after built-in and AI Client
-	 * registry providers are collected and fully populated with
-	 * `setting_name` for API-key connectors.
-	 *
-	 * @since 7.0.0
-	 *
-	 * @param array $connectors {
-	 *     Connector settings keyed by connector ID.
-	 *
-	 *     @type array ...$0 {
-	 *         Data for a single connector.
-	 *
-	 *         @type string $name           The connector's display name.
-	 *         @type string $description    The connector's description.
-	 *         @type string $type           The connector type. Currently, only 'ai_provider' is supported.
-	 *         @type array  $plugin         Optional. Plugin data for install/activate UI.
-	 *             @type string $slug       The WordPress.org plugin slug.
-	 *         }
-	 *         @type array  $authentication {
-	 *             Authentication configuration. When method is 'api_key', includes
-	 *             credentials_url and setting_name. When 'none', only method is present.
-	 *
-	 *             @type string      $method          The authentication method: 'api_key' or 'none'.
-	 *             @type string|null $credentials_url Optional. URL where users can obtain API credentials.
-	 *             @type string      $setting_name    Optional. The setting name for the API key. Present when method is 'api_key'.
-	 *         }
-	 *     }
-	 * }
-	 */
-	$connectors = apply_filters( 'wp_connectors_settings', $connectors );
-
 	return $connectors;
 }
 
@@ -317,7 +430,7 @@ add_filter( 'rest_post_dispatch', '_wp_connectors_validate_keys_in_rest', 10, 3 
  * @access private
  */
 function _wp_register_default_connector_settings(): void {
-	$registry = AiClient::defaultRegistry();
+	$ai_registry = AiClient::defaultRegistry();
 
 	foreach ( _wp_connectors_get_connector_settings() as $connector_id => $connector_data ) {
 		$auth = $connector_data['authentication'];
@@ -326,7 +439,7 @@ function _wp_register_default_connector_settings(): void {
 		}
 
 		// Skip registering the setting if the provider is not in the registry.
-		if ( ! $registry->hasProvider( $connector_id ) ) {
+		if ( ! $ai_registry->hasProvider( $connector_id ) ) {
 			continue;
 		}
 
@@ -372,7 +485,7 @@ add_action( 'init', '_wp_register_default_connector_settings', 20 );
  */
 function _wp_connectors_pass_default_keys_to_ai_client(): void {
 	try {
-		$registry = AiClient::defaultRegistry();
+		$ai_registry = AiClient::defaultRegistry();
 		foreach ( _wp_connectors_get_connector_settings() as $connector_id => $connector_data ) {
 			if ( 'ai_provider' !== $connector_data['type'] ) {
 				continue;
@@ -383,7 +496,7 @@ function _wp_connectors_pass_default_keys_to_ai_client(): void {
 				continue;
 			}
 
-			if ( ! $registry->hasProvider( $connector_id ) ) {
+			if ( ! $ai_registry->hasProvider( $connector_id ) ) {
 				continue;
 			}
 
@@ -392,7 +505,7 @@ function _wp_connectors_pass_default_keys_to_ai_client(): void {
 				continue;
 			}
 
-			$registry->setProviderRequestAuthentication(
+			$ai_registry->setProviderRequestAuthentication(
 				$connector_id,
 				new ApiKeyRequestAuthentication( $api_key )
 			);

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -183,7 +183,7 @@ function _wp_connectors_init(): void {
 
 		$name        = $provider_metadata->getName();
 		$description = $provider_metadata->getDescription();
-		$logo_url    = method_exists( $provider_metadata, 'getLogoPath' ) && $provider_metadata->getLogoPath()
+		$logo_url    = $provider_metadata->getLogoPath()
 			? _wp_connectors_resolve_ai_provider_logo_url( $provider_metadata->getLogoPath() )
 			: null;
 

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -202,9 +202,26 @@ function _wp_connectors_get_connector_settings(): array {
 
 	ksort( $connectors );
 
-	// Add setting_name for connectors that use API key authentication.
+	/**
+	 * Filters the registered connector settings.
+	 *
+	 * Allows plugins to add, modify, or remove connectors displayed
+	 * on the Connectors screen. Runs after built-in and AI Client
+	 * registry providers are collected, but before `setting_name` is
+	 * generated for API-key connectors.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param array $connectors Connector settings keyed by connector ID.
+	 *                          Each entry is an array with keys: name, description,
+	 *                          type, authentication (with method, and optionally
+	 *                          credentials_url), and optionally plugin.
+	 */
+	$connectors = apply_filters( 'wp_connectors_settings', $connectors );
+
+	// Add setting_name for AI provider connectors that use API key authentication.
 	foreach ( $connectors as $connector_id => $connector ) {
-		if ( 'api_key' === $connector['authentication']['method'] ) {
+		if ( 'ai_provider' === $connector['type'] && 'api_key' === $connector['authentication']['method'] ) {
 			$connectors[ $connector_id ]['authentication']['setting_name'] = "connectors_ai_{$connector_id}_api_key";
 		}
 	}

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -67,6 +67,48 @@ function wp_get_connectors(): array {
 }
 
 /**
+ * Resolves an AI provider logo file path to a URL.
+ *
+ * Converts an absolute file path to a plugin URL. The path must reside within
+ * the plugins or must-use plugins directory.
+ *
+ * @since 7.0.0
+ * @access private
+ *
+ * @param string $path Absolute path to the logo file.
+ * @return string|null The URL to the logo file, or null if the path is invalid.
+ */
+function _wp_connectors_resolve_ai_provider_logo_url( string $path ): ?string {
+	if ( ! $path ) {
+		return null;
+	}
+
+	$path = wp_normalize_path( $path );
+
+	if ( ! file_exists( $path ) ) {
+		return null;
+	}
+
+	$mu_plugin_dir = wp_normalize_path( WPMU_PLUGIN_DIR );
+	if ( str_starts_with( $path, $mu_plugin_dir . '/' ) ) {
+		return plugins_url( substr( $path, strlen( $mu_plugin_dir ) ), WPMU_PLUGIN_DIR . '/.' );
+	}
+
+	$plugin_dir = wp_normalize_path( WP_PLUGIN_DIR );
+	if ( str_starts_with( $path, $plugin_dir . '/' ) ) {
+		return plugins_url( substr( $path, strlen( $plugin_dir ) ) );
+	}
+
+	_doing_it_wrong(
+		__FUNCTION__,
+		__( 'Provider logo path must be located within the plugins or must-use plugins directory.' ),
+		'7.0.0'
+	);
+
+	return null;
+}
+
+/**
  * Initializes the connector registry with default connectors and fires the registration action.
  *
  * Creates the registry instance, registers built-in connectors (which cannot be unhooked),
@@ -141,6 +183,9 @@ function _wp_connectors_init(): void {
 
 		$name        = $provider_metadata->getName();
 		$description = $provider_metadata->getDescription();
+		$logo_url    = $provider_metadata->getLogoPath()
+			? _wp_connectors_resolve_ai_provider_logo_url( $provider_metadata->getLogoPath() )
+			: null;
 
 		if ( isset( $defaults[ $connector_id ] ) ) {
 			// Override fields with non-empty registry values.
@@ -149,6 +194,9 @@ function _wp_connectors_init(): void {
 			}
 			if ( $description ) {
 				$defaults[ $connector_id ]['description'] = $description;
+			}
+			if ( $logo_url ) {
+				$defaults[ $connector_id ]['logo_url'] = $logo_url;
 			}
 			// Always update auth method; keep existing credentials_url as fallback.
 			$defaults[ $connector_id ]['authentication']['method'] = $authentication['method'];
@@ -161,6 +209,7 @@ function _wp_connectors_init(): void {
 				'description'    => $description ? $description : '',
 				'type'           => 'ai_provider',
 				'authentication' => $authentication,
+				'logo_url'       => $logo_url,
 			);
 		}
 	}

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -112,7 +112,7 @@ function wp_unregister_connector( string $id ): ?array {
  * @param string $id The connector identifier.
  * @return bool True if the connector is registered, false otherwise.
  */
-function wp_has_connector( string $id ): bool {
+function wp_is_connector_registered( string $id ): bool {
 	$registry = WP_Connector_Registry::get_instance();
 	if ( null === $registry ) {
 		return false;

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -183,7 +183,7 @@ function _wp_connectors_init(): void {
 
 		$name        = $provider_metadata->getName();
 		$description = $provider_metadata->getDescription();
-		$logo_url    = $provider_metadata->getLogoPath()
+		$logo_url    = method_exists( $provider_metadata, 'getLogoPath' ) && $provider_metadata->getLogoPath()
 			? _wp_connectors_resolve_ai_provider_logo_url( $provider_metadata->getLogoPath() )
 			: null;
 

--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -539,6 +539,9 @@ add_action( 'parse_request', 'rest_api_loaded' );
 add_action( 'wp_abilities_api_categories_init', 'wp_register_core_ability_categories' );
 add_action( 'wp_abilities_api_init', 'wp_register_core_abilities' );
 
+// Connectors API.
+add_action( 'wp_connectors_init', '_wp_register_default_connectors' );
+
 // Sitemaps actions.
 add_action( 'init', 'wp_sitemaps_get_server' );
 

--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -540,7 +540,7 @@ add_action( 'wp_abilities_api_categories_init', 'wp_register_core_ability_catego
 add_action( 'wp_abilities_api_init', 'wp_register_core_abilities' );
 
 // Connectors API.
-add_action( 'wp_connectors_init', '_wp_register_default_connectors' );
+add_action( 'init', '_wp_connectors_init' );
 
 // Sitemaps actions.
 add_action( 'init', 'wp_sitemaps_get_server' );

--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -294,6 +294,7 @@ require ABSPATH . WPINC . '/ai-client/adapters/class-wp-ai-client-event-dispatch
 require ABSPATH . WPINC . '/ai-client/class-wp-ai-client-ability-function-resolver.php';
 require ABSPATH . WPINC . '/ai-client/class-wp-ai-client-prompt-builder.php';
 require ABSPATH . WPINC . '/ai-client.php';
+require ABSPATH . WPINC . '/class-wp-connector-registry.php';
 require ABSPATH . WPINC . '/connectors.php';
 require ABSPATH . WPINC . '/class-wp-icons-registry.php';
 require ABSPATH . WPINC . '/widgets.php';

--- a/tests/phpunit/includes/wp-ai-client-mock-provider-trait.php
+++ b/tests/phpunit/includes/wp-ai-client-mock-provider-trait.php
@@ -155,9 +155,26 @@ trait WP_AI_Client_Mock_Provider_Trait {
 	 * Must be called from set_up_before_class() after parent::set_up_before_class().
 	 */
 	private static function register_mock_connectors_provider(): void {
-		$registry = AiClient::defaultRegistry();
-		if ( ! $registry->hasProvider( 'mock_connectors_test' ) ) {
-			$registry->registerProvider( Mock_Connectors_Test_Provider::class );
+		$ai_registry = AiClient::defaultRegistry();
+		if ( ! $ai_registry->hasProvider( 'mock_connectors_test' ) ) {
+			$ai_registry->registerProvider( Mock_Connectors_Test_Provider::class );
+		}
+
+		// Also register in the WP connector registry if not already present.
+		$connector_registry = WP_Connector_Registry::get_instance();
+		if ( null !== $connector_registry && ! $connector_registry->is_registered( 'mock_connectors_test' ) ) {
+			$connector_registry->register(
+				'mock_connectors_test',
+				array(
+					'name'           => 'Mock Connectors Test',
+					'description'    => '',
+					'type'           => 'ai_provider',
+					'authentication' => array(
+						'method'          => 'api_key',
+						'credentials_url' => null,
+					),
+				)
+			);
 		}
 	}
 

--- a/tests/phpunit/tests/connectors/wpConnectorRegistry.php
+++ b/tests/phpunit/tests/connectors/wpConnectorRegistry.php
@@ -332,6 +332,15 @@ class Tests_Connectors_WpConnectorRegistry extends WP_UnitTestCase {
 	/**
 	 * @ticket 64791
 	 */
+	public function test_set_instance_rejects_after_init() {
+		$this->setExpectedIncorrectUsage( 'WP_Connector_Registry::set_instance' );
+
+		WP_Connector_Registry::set_instance( new WP_Connector_Registry() );
+	}
+
+	/**
+	 * @ticket 64791
+	 */
 	public function test_get_instance_returns_same_instance() {
 		$instance1 = WP_Connector_Registry::get_instance();
 		$instance2 = WP_Connector_Registry::get_instance();

--- a/tests/phpunit/tests/connectors/wpConnectorRegistry.php
+++ b/tests/phpunit/tests/connectors/wpConnectorRegistry.php
@@ -5,22 +5,23 @@
  * @covers WP_Connector_Registry
  *
  * @group connectors
+ *
+ * @phpstan-import-type Connector from WP_Connector_Registry
  */
 class Tests_Connectors_WpConnectorRegistry extends WP_UnitTestCase {
 
 	/**
 	 * Connector registry instance.
-	 *
-	 * @var WP_Connector_Registry
 	 */
-	private $registry = null;
+	private WP_Connector_Registry $registry;
 
 	/**
 	 * Default valid connector args for testing.
 	 *
-	 * @var array
+	 * @var array<string, mixed>
+	 * @phpstan-var Connector
 	 */
-	private static $default_args = array();
+	private static array $default_args;
 
 	/**
 	 * Set up each test method.

--- a/tests/phpunit/tests/connectors/wpConnectorRegistry.php
+++ b/tests/phpunit/tests/connectors/wpConnectorRegistry.php
@@ -1,0 +1,340 @@
+<?php
+/**
+ * Tests for the WP_Connector_Registry class.
+ *
+ * @covers WP_Connector_Registry
+ *
+ * @group connectors
+ */
+class Tests_Connectors_WpConnectorRegistry extends WP_UnitTestCase {
+
+	/**
+	 * Connector registry instance.
+	 *
+	 * @var WP_Connector_Registry
+	 */
+	private $registry = null;
+
+	/**
+	 * Default valid connector args for testing.
+	 *
+	 * @var array
+	 */
+	private static $default_args = array();
+
+	/**
+	 * Set up each test method.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		$this->registry = new WP_Connector_Registry();
+
+		self::$default_args = array(
+			'name'           => 'Test Provider',
+			'description'    => 'A test AI provider.',
+			'type'           => 'ai_provider',
+			'authentication' => array(
+				'method'          => 'api_key',
+				'credentials_url' => 'https://example.com/keys',
+			),
+		);
+	}
+
+	/**
+	 * @ticket 64791
+	 */
+	public function test_register_returns_connector_data() {
+		$result = $this->registry->register( 'test_provider', self::$default_args );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'Test Provider', $result['name'] );
+		$this->assertSame( 'A test AI provider.', $result['description'] );
+		$this->assertSame( 'ai_provider', $result['type'] );
+		$this->assertSame( 'api_key', $result['authentication']['method'] );
+		$this->assertSame( 'https://example.com/keys', $result['authentication']['credentials_url'] );
+		$this->assertSame( 'connectors_ai_test_provider_api_key', $result['authentication']['setting_name'] );
+	}
+
+	/**
+	 * @ticket 64791
+	 */
+	public function test_register_generates_setting_name_for_api_key() {
+		$result = $this->registry->register( 'my_ai', self::$default_args );
+
+		$this->assertSame( 'connectors_ai_my_ai_api_key', $result['authentication']['setting_name'] );
+	}
+
+	/**
+	 * @ticket 64791
+	 */
+	public function test_register_no_setting_name_for_none_auth() {
+		$args   = array(
+			'name'           => 'No Auth Provider',
+			'type'           => 'ai_provider',
+			'authentication' => array( 'method' => 'none' ),
+		);
+		$result = $this->registry->register( 'no_auth', $args );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayNotHasKey( 'setting_name', $result['authentication'] );
+	}
+
+	/**
+	 * @ticket 64791
+	 */
+	public function test_register_defaults_description_to_empty_string() {
+		$args = array(
+			'name'           => 'Minimal',
+			'type'           => 'ai_provider',
+			'authentication' => array( 'method' => 'none' ),
+		);
+
+		$result = $this->registry->register( 'minimal', $args );
+
+		$this->assertSame( '', $result['description'] );
+	}
+
+	/**
+	 * @ticket 64791
+	 */
+	public function test_register_includes_plugin_data() {
+		$args           = self::$default_args;
+		$args['plugin'] = array( 'slug' => 'my-plugin' );
+
+		$result = $this->registry->register( 'with_plugin', $args );
+
+		$this->assertArrayHasKey( 'plugin', $result );
+		$this->assertSame( array( 'slug' => 'my-plugin' ), $result['plugin'] );
+	}
+
+	/**
+	 * @ticket 64791
+	 */
+	public function test_register_omits_plugin_when_not_provided() {
+		$result = $this->registry->register( 'no_plugin', self::$default_args );
+
+		$this->assertArrayNotHasKey( 'plugin', $result );
+	}
+
+	/**
+	 * @ticket 64791
+	 */
+	public function test_register_rejects_invalid_id_with_uppercase() {
+		$this->setExpectedIncorrectUsage( 'WP_Connector_Registry::register' );
+
+		$result = $this->registry->register( 'InvalidId', self::$default_args );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * @ticket 64791
+	 */
+	public function test_register_rejects_invalid_id_with_dashes() {
+		$this->setExpectedIncorrectUsage( 'WP_Connector_Registry::register' );
+
+		$result = $this->registry->register( 'my-provider', self::$default_args );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * @ticket 64791
+	 */
+	public function test_register_rejects_empty_id() {
+		$this->setExpectedIncorrectUsage( 'WP_Connector_Registry::register' );
+
+		$result = $this->registry->register( '', self::$default_args );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * @ticket 64791
+	 */
+	public function test_register_rejects_duplicate_id() {
+		$this->setExpectedIncorrectUsage( 'WP_Connector_Registry::register' );
+
+		$this->registry->register( 'duplicate', self::$default_args );
+		$result = $this->registry->register( 'duplicate', self::$default_args );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * @ticket 64791
+	 */
+	public function test_register_rejects_missing_name() {
+		$this->setExpectedIncorrectUsage( 'WP_Connector_Registry::register' );
+
+		$args = self::$default_args;
+		unset( $args['name'] );
+
+		$result = $this->registry->register( 'no_name', $args );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * @ticket 64791
+	 */
+	public function test_register_rejects_empty_name() {
+		$this->setExpectedIncorrectUsage( 'WP_Connector_Registry::register' );
+
+		$args         = self::$default_args;
+		$args['name'] = '';
+
+		$result = $this->registry->register( 'empty_name', $args );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * @ticket 64791
+	 */
+	public function test_register_rejects_missing_type() {
+		$this->setExpectedIncorrectUsage( 'WP_Connector_Registry::register' );
+
+		$args = self::$default_args;
+		unset( $args['type'] );
+
+		$result = $this->registry->register( 'no_type', $args );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * @ticket 64791
+	 */
+	public function test_register_rejects_missing_authentication() {
+		$this->setExpectedIncorrectUsage( 'WP_Connector_Registry::register' );
+
+		$args = self::$default_args;
+		unset( $args['authentication'] );
+
+		$result = $this->registry->register( 'no_auth', $args );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * @ticket 64791
+	 */
+	public function test_register_rejects_invalid_auth_method() {
+		$this->setExpectedIncorrectUsage( 'WP_Connector_Registry::register' );
+
+		$args                             = self::$default_args;
+		$args['authentication']['method'] = 'oauth';
+
+		$result = $this->registry->register( 'bad_auth', $args );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * @ticket 64791
+	 */
+	public function test_is_registered_returns_true_for_registered() {
+		$this->registry->register( 'exists', self::$default_args );
+
+		$this->assertTrue( $this->registry->is_registered( 'exists' ) );
+	}
+
+	/**
+	 * @ticket 64791
+	 */
+	public function test_is_registered_returns_false_for_unregistered() {
+		$this->assertFalse( $this->registry->is_registered( 'does_not_exist' ) );
+	}
+
+	/**
+	 * @ticket 64791
+	 */
+	public function test_get_registered_returns_connector_data() {
+		$this->registry->register( 'my_connector', self::$default_args );
+
+		$result = $this->registry->get_registered( 'my_connector' );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'Test Provider', $result['name'] );
+	}
+
+	/**
+	 * @ticket 64791
+	 */
+	public function test_get_registered_returns_null_for_unregistered() {
+		$this->setExpectedIncorrectUsage( 'WP_Connector_Registry::get_registered' );
+
+		$result = $this->registry->get_registered( 'nonexistent' );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * @ticket 64791
+	 */
+	public function test_get_all_registered_returns_all_connectors() {
+		$this->registry->register( 'first', self::$default_args );
+
+		$args         = self::$default_args;
+		$args['name'] = 'Second Provider';
+		$this->registry->register( 'second', $args );
+
+		$all = $this->registry->get_all_registered();
+
+		$this->assertCount( 2, $all );
+		$this->assertArrayHasKey( 'first', $all );
+		$this->assertArrayHasKey( 'second', $all );
+	}
+
+	/**
+	 * @ticket 64791
+	 */
+	public function test_get_all_registered_returns_empty_when_none() {
+		$this->assertSame( array(), $this->registry->get_all_registered() );
+	}
+
+	/**
+	 * @ticket 64791
+	 */
+	public function test_unregister_removes_connector() {
+		$this->registry->register( 'to_remove', self::$default_args );
+
+		$result = $this->registry->unregister( 'to_remove' );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'Test Provider', $result['name'] );
+		$this->assertFalse( $this->registry->is_registered( 'to_remove' ) );
+	}
+
+	/**
+	 * @ticket 64791
+	 */
+	public function test_unregister_returns_null_for_unregistered() {
+		$this->setExpectedIncorrectUsage( 'WP_Connector_Registry::unregister' );
+
+		$result = $this->registry->unregister( 'nonexistent' );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * @ticket 64791
+	 */
+	public function test_get_instance_returns_registry() {
+		$instance = WP_Connector_Registry::get_instance();
+
+		$this->assertInstanceOf( WP_Connector_Registry::class, $instance );
+	}
+
+	/**
+	 * @ticket 64791
+	 */
+	public function test_get_instance_returns_same_instance() {
+		$instance1 = WP_Connector_Registry::get_instance();
+		$instance2 = WP_Connector_Registry::get_instance();
+
+		$this->assertSame( $instance1, $instance2 );
+	}
+}

--- a/tests/phpunit/tests/connectors/wpConnectorRegistry.php
+++ b/tests/phpunit/tests/connectors/wpConnectorRegistry.php
@@ -99,6 +99,40 @@ class Tests_Connectors_WpConnectorRegistry extends WP_UnitTestCase {
 	/**
 	 * @ticket 64791
 	 */
+	public function test_register_includes_logo_url() {
+		$args             = self::$default_args;
+		$args['logo_url'] = 'https://example.com/logo.png';
+
+		$result = $this->registry->register( 'with_logo', $args );
+
+		$this->assertArrayHasKey( 'logo_url', $result );
+		$this->assertSame( 'https://example.com/logo.png', $result['logo_url'] );
+	}
+
+	/**
+	 * @ticket 64791
+	 */
+	public function test_register_omits_logo_url_when_not_provided() {
+		$result = $this->registry->register( 'no_logo', self::$default_args );
+
+		$this->assertArrayNotHasKey( 'logo_url', $result );
+	}
+
+	/**
+	 * @ticket 64791
+	 */
+	public function test_register_omits_logo_url_when_empty() {
+		$args             = self::$default_args;
+		$args['logo_url'] = '';
+
+		$result = $this->registry->register( 'empty_logo', $args );
+
+		$this->assertArrayNotHasKey( 'logo_url', $result );
+	}
+
+	/**
+	 * @ticket 64791
+	 */
 	public function test_register_includes_plugin_data() {
 		$args           = self::$default_args;
 		$args['plugin'] = array( 'slug' => 'my-plugin' );

--- a/tests/phpunit/tests/connectors/wpConnectorsGetConnectorSettings.php
+++ b/tests/phpunit/tests/connectors/wpConnectorsGetConnectorSettings.php
@@ -117,94 +117,84 @@ class Tests_Connectors_WpConnectorsGetConnectorSettings extends WP_UnitTestCase 
 	}
 
 	/**
-	 * @ticket 64730
+	 * @ticket 64791
 	 */
 	public function test_filter_can_add_new_connector() {
-		add_filter(
-			'wp_connectors_settings',
-			static function ( $connectors ) {
-				$connectors['my_email_service'] = array(
-					'name'           => 'My Email Service',
-					'description'    => 'Send transactional emails.',
-					'type'           => 'email_service',
-					'authentication' => array( 'method' => 'none' ),
-				);
-				return $connectors;
-			}
-		);
+		$callback = static function ( $connectors ) {
+			$connectors['my_email_service'] = array(
+				'name'           => 'My Email Service',
+				'description'    => 'Send transactional emails.',
+				'type'           => 'email_service',
+				'authentication' => array( 'method' => 'none' ),
+			);
+			return $connectors;
+		};
+		add_filter( 'wp_connectors_settings', $callback );
 
 		$connectors = _wp_connectors_get_connector_settings();
+		remove_filter( 'wp_connectors_settings', $callback );
 
 		$this->assertArrayHasKey( 'my_email_service', $connectors );
 		$this->assertSame( 'My Email Service', $connectors['my_email_service']['name'] );
 		$this->assertSame( 'email_service', $connectors['my_email_service']['type'] );
 		$this->assertSame( 'none', $connectors['my_email_service']['authentication']['method'] );
-
-		remove_all_filters( 'wp_connectors_settings' );
 	}
 
 	/**
-	 * @ticket 64730
+	 * @ticket 64791
 	 */
 	public function test_filter_can_modify_existing_connector() {
-		add_filter(
-			'wp_connectors_settings',
-			static function ( $connectors ) {
-				$connectors['google']['description'] = 'Custom description for Google.';
-				return $connectors;
-			}
-		);
+		$callback = static function ( $connectors ) {
+			$connectors['google']['description'] = 'Custom description for Google.';
+			return $connectors;
+		};
+		add_filter( 'wp_connectors_settings', $callback );
 
 		$connectors = _wp_connectors_get_connector_settings();
+		remove_filter( 'wp_connectors_settings', $callback );
 
 		$this->assertSame( 'Custom description for Google.', $connectors['google']['description'] );
-
-		remove_all_filters( 'wp_connectors_settings' );
 	}
 
 	/**
-	 * @ticket 64730
+	 * @ticket 64791
 	 */
 	public function test_filter_can_remove_connector() {
-		add_filter(
-			'wp_connectors_settings',
-			static function ( $connectors ) {
-				unset( $connectors['openai'] );
-				return $connectors;
-			}
-		);
+		$callback = static function ( $connectors ) {
+			unset( $connectors['openai'] );
+			return $connectors;
+		};
+		add_filter( 'wp_connectors_settings', $callback );
 
 		$connectors = _wp_connectors_get_connector_settings();
+		remove_filter( 'wp_connectors_settings', $callback );
 
 		$this->assertArrayNotHasKey( 'openai', $connectors );
 		// Other connectors remain.
 		$this->assertArrayHasKey( 'google', $connectors );
 		$this->assertArrayHasKey( 'anthropic', $connectors );
-
-		remove_all_filters( 'wp_connectors_settings' );
 	}
 
 	/**
-	 * @ticket 64730
+	 * @ticket 64791
 	 */
 	public function test_filter_added_api_key_connector_gets_setting_name() {
-		add_filter(
-			'wp_connectors_settings',
-			static function ( $connectors ) {
-				$connectors['custom_ai'] = array(
-					'name'           => 'Custom AI',
-					'description'    => 'A custom AI provider.',
-					'type'           => 'ai_provider',
-					'authentication' => array(
-						'method'          => 'api_key',
-						'credentials_url' => 'https://example.com/keys',
-					),
-				);
-				return $connectors;
-			}
-		);
+		$callback = static function ( $connectors ) {
+			$connectors['custom_ai'] = array(
+				'name'           => 'Custom AI',
+				'description'    => 'A custom AI provider.',
+				'type'           => 'ai_provider',
+				'authentication' => array(
+					'method'          => 'api_key',
+					'credentials_url' => 'https://example.com/keys',
+				),
+			);
+			return $connectors;
+		};
+		add_filter( 'wp_connectors_settings', $callback );
 
 		$connectors = _wp_connectors_get_connector_settings();
+		remove_filter( 'wp_connectors_settings', $callback );
 
 		$this->assertArrayHasKey( 'custom_ai', $connectors );
 		$this->assertSame(
@@ -212,31 +202,28 @@ class Tests_Connectors_WpConnectorsGetConnectorSettings extends WP_UnitTestCase 
 			$connectors['custom_ai']['authentication']['setting_name'],
 			'Connectors added via the filter with api_key auth should receive a setting_name automatically.'
 		);
-
-		remove_all_filters( 'wp_connectors_settings' );
 	}
 
 	/**
-	 * @ticket 64730
+	 * @ticket 64791
 	 */
 	public function test_filter_added_non_ai_api_key_connector_does_not_get_setting_name() {
-		add_filter(
-			'wp_connectors_settings',
-			static function ( $connectors ) {
-				$connectors['my_crm'] = array(
-					'name'           => 'My CRM',
-					'description'    => 'CRM integration.',
-					'type'           => 'crm',
-					'authentication' => array(
-						'method'          => 'api_key',
-						'credentials_url' => 'https://example.com/crm-keys',
-					),
-				);
-				return $connectors;
-			}
-		);
+		$callback = static function ( $connectors ) {
+			$connectors['my_crm'] = array(
+				'name'           => 'My CRM',
+				'description'    => 'CRM integration.',
+				'type'           => 'crm',
+				'authentication' => array(
+					'method'          => 'api_key',
+					'credentials_url' => 'https://example.com/crm-keys',
+				),
+			);
+			return $connectors;
+		};
+		add_filter( 'wp_connectors_settings', $callback );
 
 		$connectors = _wp_connectors_get_connector_settings();
+		remove_filter( 'wp_connectors_settings', $callback );
 
 		$this->assertArrayHasKey( 'my_crm', $connectors );
 		$this->assertArrayNotHasKey(
@@ -244,31 +231,26 @@ class Tests_Connectors_WpConnectorsGetConnectorSettings extends WP_UnitTestCase 
 			$connectors['my_crm']['authentication'],
 			'Non-AI connectors should not receive an auto-generated setting_name.'
 		);
-
-		remove_all_filters( 'wp_connectors_settings' );
 	}
 
 	/**
-	 * @ticket 64730
+	 * @ticket 64791
 	 */
 	public function test_filter_receives_all_default_connectors() {
 		$received = null;
 
-		add_filter(
-			'wp_connectors_settings',
-			static function ( $connectors ) use ( &$received ) {
-				$received = $connectors;
-				return $connectors;
-			}
-		);
+		$callback = static function ( $connectors ) use ( &$received ) {
+			$received = $connectors;
+			return $connectors;
+		};
+		add_filter( 'wp_connectors_settings', $callback );
 
 		_wp_connectors_get_connector_settings();
+		remove_filter( 'wp_connectors_settings', $callback );
 
 		$this->assertArrayHasKey( 'google', $received );
 		$this->assertArrayHasKey( 'openai', $received );
 		$this->assertArrayHasKey( 'anthropic', $received );
 		$this->assertArrayHasKey( 'mock_connectors_test', $received );
-
-		remove_all_filters( 'wp_connectors_settings' );
 	}
 }

--- a/tests/phpunit/tests/connectors/wpConnectorsGetConnectorSettings.php
+++ b/tests/phpunit/tests/connectors/wpConnectorsGetConnectorSettings.php
@@ -117,102 +117,14 @@ class Tests_Connectors_WpConnectorsGetConnectorSettings extends WP_UnitTestCase 
 	}
 
 	/**
-	 * @ticket 64791
+	 * @ticket 64730
 	 */
-	public function test_filter_can_add_new_connector() {
-		$callback = static function ( $connectors ) {
-			$connectors['my_email_service'] = array(
-				'name'           => 'My Email Service',
-				'description'    => 'Send transactional emails.',
-				'type'           => 'email_service',
-				'authentication' => array( 'method' => 'none' ),
-			);
-			return $connectors;
-		};
-		add_filter( 'wp_connectors_settings', $callback );
-
+	public function test_connectors_are_sorted_alphabetically() {
 		$connectors = _wp_connectors_get_connector_settings();
-		remove_filter( 'wp_connectors_settings', $callback );
+		$keys       = array_keys( $connectors );
+		$sorted     = $keys;
+		sort( $sorted );
 
-		$this->assertArrayHasKey( 'my_email_service', $connectors );
-		$this->assertSame( 'My Email Service', $connectors['my_email_service']['name'] );
-		$this->assertSame( 'email_service', $connectors['my_email_service']['type'] );
-		$this->assertSame( 'none', $connectors['my_email_service']['authentication']['method'] );
-	}
-
-	/**
-	 * @ticket 64791
-	 */
-	public function test_filter_can_modify_existing_connector() {
-		$callback = static function ( $connectors ) {
-			$connectors['google']['description'] = 'Custom description for Google.';
-			return $connectors;
-		};
-		add_filter( 'wp_connectors_settings', $callback );
-
-		$connectors = _wp_connectors_get_connector_settings();
-		remove_filter( 'wp_connectors_settings', $callback );
-
-		$this->assertSame( 'Custom description for Google.', $connectors['google']['description'] );
-	}
-
-	/**
-	 * @ticket 64791
-	 */
-	public function test_filter_can_remove_connector() {
-		$callback = static function ( $connectors ) {
-			unset( $connectors['openai'] );
-			return $connectors;
-		};
-		add_filter( 'wp_connectors_settings', $callback );
-
-		$connectors = _wp_connectors_get_connector_settings();
-		remove_filter( 'wp_connectors_settings', $callback );
-
-		$this->assertArrayNotHasKey( 'openai', $connectors );
-		// Other connectors remain.
-		$this->assertArrayHasKey( 'google', $connectors );
-		$this->assertArrayHasKey( 'anthropic', $connectors );
-	}
-
-	/**
-	 * @ticket 64791
-	 */
-	public function test_filter_receives_all_default_connectors_with_setting_name() {
-		$received = null;
-
-		$callback = static function ( $connectors ) use ( &$received ) {
-			$received = $connectors;
-			return $connectors;
-		};
-		add_filter( 'wp_connectors_settings', $callback );
-
-		_wp_connectors_get_connector_settings();
-		remove_filter( 'wp_connectors_settings', $callback );
-
-		$this->assertArrayHasKey( 'google', $received );
-		$this->assertArrayHasKey( 'openai', $received );
-		$this->assertArrayHasKey( 'anthropic', $received );
-		$this->assertArrayHasKey( 'mock_connectors_test', $received );
-
-		// The filter receives fully populated data, including setting_name for API-key connectors.
-		$this->assertSame( 'connectors_ai_openai_api_key', $received['openai']['authentication']['setting_name'] );
-		$this->assertSame( 'connectors_ai_anthropic_api_key', $received['anthropic']['authentication']['setting_name'] );
-		$this->assertSame( 'connectors_ai_google_api_key', $received['google']['authentication']['setting_name'] );
-	}
-
-	/**
-	 * @ticket 64791
-	 */
-	public function test_filter_can_return_empty_array() {
-		$callback = static function () {
-			return array();
-		};
-		add_filter( 'wp_connectors_settings', $callback );
-
-		$connectors = _wp_connectors_get_connector_settings();
-		remove_filter( 'wp_connectors_settings', $callback );
-
-		$this->assertSame( array(), $connectors );
+		$this->assertSame( $sorted, $keys, 'Connectors should be sorted alphabetically by ID.' );
 	}
 }

--- a/tests/phpunit/tests/connectors/wpConnectorsGetConnectorSettings.php
+++ b/tests/phpunit/tests/connectors/wpConnectorsGetConnectorSettings.php
@@ -115,4 +115,160 @@ class Tests_Connectors_WpConnectorsGetConnectorSettings extends WP_UnitTestCase 
 		$this->assertNull( $mock['authentication']['credentials_url'] );
 		$this->assertSame( 'connectors_ai_mock_connectors_test_api_key', $mock['authentication']['setting_name'] );
 	}
+
+	/**
+	 * @ticket 64730
+	 */
+	public function test_filter_can_add_new_connector() {
+		add_filter(
+			'wp_connectors_settings',
+			static function ( $connectors ) {
+				$connectors['my_email_service'] = array(
+					'name'           => 'My Email Service',
+					'description'    => 'Send transactional emails.',
+					'type'           => 'email_service',
+					'authentication' => array( 'method' => 'none' ),
+				);
+				return $connectors;
+			}
+		);
+
+		$connectors = _wp_connectors_get_connector_settings();
+
+		$this->assertArrayHasKey( 'my_email_service', $connectors );
+		$this->assertSame( 'My Email Service', $connectors['my_email_service']['name'] );
+		$this->assertSame( 'email_service', $connectors['my_email_service']['type'] );
+		$this->assertSame( 'none', $connectors['my_email_service']['authentication']['method'] );
+
+		remove_all_filters( 'wp_connectors_settings' );
+	}
+
+	/**
+	 * @ticket 64730
+	 */
+	public function test_filter_can_modify_existing_connector() {
+		add_filter(
+			'wp_connectors_settings',
+			static function ( $connectors ) {
+				$connectors['google']['description'] = 'Custom description for Google.';
+				return $connectors;
+			}
+		);
+
+		$connectors = _wp_connectors_get_connector_settings();
+
+		$this->assertSame( 'Custom description for Google.', $connectors['google']['description'] );
+
+		remove_all_filters( 'wp_connectors_settings' );
+	}
+
+	/**
+	 * @ticket 64730
+	 */
+	public function test_filter_can_remove_connector() {
+		add_filter(
+			'wp_connectors_settings',
+			static function ( $connectors ) {
+				unset( $connectors['openai'] );
+				return $connectors;
+			}
+		);
+
+		$connectors = _wp_connectors_get_connector_settings();
+
+		$this->assertArrayNotHasKey( 'openai', $connectors );
+		// Other connectors remain.
+		$this->assertArrayHasKey( 'google', $connectors );
+		$this->assertArrayHasKey( 'anthropic', $connectors );
+
+		remove_all_filters( 'wp_connectors_settings' );
+	}
+
+	/**
+	 * @ticket 64730
+	 */
+	public function test_filter_added_api_key_connector_gets_setting_name() {
+		add_filter(
+			'wp_connectors_settings',
+			static function ( $connectors ) {
+				$connectors['custom_ai'] = array(
+					'name'           => 'Custom AI',
+					'description'    => 'A custom AI provider.',
+					'type'           => 'ai_provider',
+					'authentication' => array(
+						'method'          => 'api_key',
+						'credentials_url' => 'https://example.com/keys',
+					),
+				);
+				return $connectors;
+			}
+		);
+
+		$connectors = _wp_connectors_get_connector_settings();
+
+		$this->assertArrayHasKey( 'custom_ai', $connectors );
+		$this->assertSame(
+			'connectors_ai_custom_ai_api_key',
+			$connectors['custom_ai']['authentication']['setting_name'],
+			'Connectors added via the filter with api_key auth should receive a setting_name automatically.'
+		);
+
+		remove_all_filters( 'wp_connectors_settings' );
+	}
+
+	/**
+	 * @ticket 64730
+	 */
+	public function test_filter_added_non_ai_api_key_connector_does_not_get_setting_name() {
+		add_filter(
+			'wp_connectors_settings',
+			static function ( $connectors ) {
+				$connectors['my_crm'] = array(
+					'name'           => 'My CRM',
+					'description'    => 'CRM integration.',
+					'type'           => 'crm',
+					'authentication' => array(
+						'method'          => 'api_key',
+						'credentials_url' => 'https://example.com/crm-keys',
+					),
+				);
+				return $connectors;
+			}
+		);
+
+		$connectors = _wp_connectors_get_connector_settings();
+
+		$this->assertArrayHasKey( 'my_crm', $connectors );
+		$this->assertArrayNotHasKey(
+			'setting_name',
+			$connectors['my_crm']['authentication'],
+			'Non-AI connectors should not receive an auto-generated setting_name.'
+		);
+
+		remove_all_filters( 'wp_connectors_settings' );
+	}
+
+	/**
+	 * @ticket 64730
+	 */
+	public function test_filter_receives_all_default_connectors() {
+		$received = null;
+
+		add_filter(
+			'wp_connectors_settings',
+			static function ( $connectors ) use ( &$received ) {
+				$received = $connectors;
+				return $connectors;
+			}
+		);
+
+		_wp_connectors_get_connector_settings();
+
+		$this->assertArrayHasKey( 'google', $received );
+		$this->assertArrayHasKey( 'openai', $received );
+		$this->assertArrayHasKey( 'anthropic', $received );
+		$this->assertArrayHasKey( 'mock_connectors_test', $received );
+
+		remove_all_filters( 'wp_connectors_settings' );
+	}
 }

--- a/tests/phpunit/tests/connectors/wpConnectorsGetConnectorSettings.php
+++ b/tests/phpunit/tests/connectors/wpConnectorsGetConnectorSettings.php
@@ -200,4 +200,19 @@ class Tests_Connectors_WpConnectorsGetConnectorSettings extends WP_UnitTestCase 
 		$this->assertSame( 'connectors_ai_anthropic_api_key', $received['anthropic']['authentication']['setting_name'] );
 		$this->assertSame( 'connectors_ai_google_api_key', $received['google']['authentication']['setting_name'] );
 	}
+
+	/**
+	 * @ticket 64791
+	 */
+	public function test_filter_can_return_empty_array() {
+		$callback = static function () {
+			return array();
+		};
+		add_filter( 'wp_connectors_settings', $callback );
+
+		$connectors = _wp_connectors_get_connector_settings();
+		remove_filter( 'wp_connectors_settings', $callback );
+
+		$this->assertSame( array(), $connectors );
+	}
 }

--- a/tests/phpunit/tests/connectors/wpConnectorsGetConnectorSettings.php
+++ b/tests/phpunit/tests/connectors/wpConnectorsGetConnectorSettings.php
@@ -178,65 +178,7 @@ class Tests_Connectors_WpConnectorsGetConnectorSettings extends WP_UnitTestCase 
 	/**
 	 * @ticket 64791
 	 */
-	public function test_filter_added_api_key_connector_gets_setting_name() {
-		$callback = static function ( $connectors ) {
-			$connectors['custom_ai'] = array(
-				'name'           => 'Custom AI',
-				'description'    => 'A custom AI provider.',
-				'type'           => 'ai_provider',
-				'authentication' => array(
-					'method'          => 'api_key',
-					'credentials_url' => 'https://example.com/keys',
-				),
-			);
-			return $connectors;
-		};
-		add_filter( 'wp_connectors_settings', $callback );
-
-		$connectors = _wp_connectors_get_connector_settings();
-		remove_filter( 'wp_connectors_settings', $callback );
-
-		$this->assertArrayHasKey( 'custom_ai', $connectors );
-		$this->assertSame(
-			'connectors_ai_custom_ai_api_key',
-			$connectors['custom_ai']['authentication']['setting_name'],
-			'Connectors added via the filter with api_key auth should receive a setting_name automatically.'
-		);
-	}
-
-	/**
-	 * @ticket 64791
-	 */
-	public function test_filter_added_non_ai_api_key_connector_does_not_get_setting_name() {
-		$callback = static function ( $connectors ) {
-			$connectors['my_crm'] = array(
-				'name'           => 'My CRM',
-				'description'    => 'CRM integration.',
-				'type'           => 'crm',
-				'authentication' => array(
-					'method'          => 'api_key',
-					'credentials_url' => 'https://example.com/crm-keys',
-				),
-			);
-			return $connectors;
-		};
-		add_filter( 'wp_connectors_settings', $callback );
-
-		$connectors = _wp_connectors_get_connector_settings();
-		remove_filter( 'wp_connectors_settings', $callback );
-
-		$this->assertArrayHasKey( 'my_crm', $connectors );
-		$this->assertArrayNotHasKey(
-			'setting_name',
-			$connectors['my_crm']['authentication'],
-			'Non-AI connectors should not receive an auto-generated setting_name.'
-		);
-	}
-
-	/**
-	 * @ticket 64791
-	 */
-	public function test_filter_receives_all_default_connectors() {
+	public function test_filter_receives_all_default_connectors_with_setting_name() {
 		$received = null;
 
 		$callback = static function ( $connectors ) use ( &$received ) {
@@ -252,5 +194,10 @@ class Tests_Connectors_WpConnectorsGetConnectorSettings extends WP_UnitTestCase 
 		$this->assertArrayHasKey( 'openai', $received );
 		$this->assertArrayHasKey( 'anthropic', $received );
 		$this->assertArrayHasKey( 'mock_connectors_test', $received );
+
+		// The filter receives fully populated data, including setting_name for API-key connectors.
+		$this->assertSame( 'connectors_ai_openai_api_key', $received['openai']['authentication']['setting_name'] );
+		$this->assertSame( 'connectors_ai_anthropic_api_key', $received['anthropic']['authentication']['setting_name'] );
+		$this->assertSame( 'connectors_ai_google_api_key', $received['google']['authentication']['setting_name'] );
 	}
 }

--- a/tests/phpunit/tests/connectors/wpConnectorsResolveAiProviderLogoUrl.php
+++ b/tests/phpunit/tests/connectors/wpConnectorsResolveAiProviderLogoUrl.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * Tests for _wp_connectors_resolve_ai_provider_logo_url().
+ *
+ * @group connectors
+ * @covers ::_wp_connectors_resolve_ai_provider_logo_url
+ */
+class Tests_Connectors_WpConnectorsResolveAiProviderLogoUrl extends WP_UnitTestCase {
+
+	/**
+	 * Files to clean up after each test.
+	 *
+	 * @var string[]
+	 */
+	private array $created_files = array();
+
+	/**
+	 * Directories to clean up after each test.
+	 *
+	 * @var string[]
+	 */
+	private array $created_dirs = array();
+
+	/**
+	 * Clean up any files and directories created during the test.
+	 */
+	public function tear_down() {
+		foreach ( $this->created_files as $file ) {
+			if ( is_file( $file ) ) {
+				unlink( $file );
+			}
+		}
+		foreach ( array_reverse( $this->created_dirs ) as $dir ) {
+			if ( is_dir( $dir ) ) {
+				rmdir( $dir );
+			}
+		}
+		parent::tear_down();
+	}
+
+	/**
+	 * Creates a temporary file and tracks it for cleanup.
+	 *
+	 * @param string $path File path.
+	 */
+	private function create_file( string $path ): void {
+		$dir = dirname( $path );
+		if ( ! is_dir( $dir ) ) {
+			wp_mkdir_p( $dir );
+			$this->created_dirs[] = $dir;
+		}
+		file_put_contents( $path, '<svg></svg>' );
+		$this->created_files[] = $path;
+	}
+
+	/**
+	 * @ticket 64791
+	 */
+	public function test_returns_null_when_path_is_empty() {
+		$this->assertNull( _wp_connectors_resolve_ai_provider_logo_url( '' ) );
+	}
+
+	/**
+	 * @ticket 64791
+	 */
+	public function test_resolves_plugin_dir_path_to_url() {
+		$logo_path = WP_PLUGIN_DIR . '/my-plugin/logo.svg';
+		$this->create_file( $logo_path );
+
+		$result = _wp_connectors_resolve_ai_provider_logo_url( $logo_path );
+
+		$this->assertSame( site_url( '/wp-content/plugins/my-plugin/logo.svg' ), $result );
+	}
+
+	/**
+	 * @ticket 64791
+	 */
+	public function test_resolves_mu_plugin_dir_path_to_url() {
+		$logo_path = WPMU_PLUGIN_DIR . '/my-mu-plugin/logo.svg';
+		$this->create_file( $logo_path );
+
+		$result = _wp_connectors_resolve_ai_provider_logo_url( $logo_path );
+
+		$this->assertSame( site_url( '/wp-content/mu-plugins/my-mu-plugin/logo.svg' ), $result );
+	}
+
+	/**
+	 * @ticket 64791
+	 */
+	public function test_returns_null_when_file_does_not_exist() {
+		$this->assertNull(
+			_wp_connectors_resolve_ai_provider_logo_url( WP_PLUGIN_DIR . '/nonexistent/logo.svg' )
+		);
+	}
+
+	/**
+	 * @ticket 64791
+	 * @expectedIncorrectUsage _wp_connectors_resolve_ai_provider_logo_url
+	 */
+	public function test_returns_null_and_triggers_doing_it_wrong_for_path_outside_plugin_dirs() {
+		$tmp_file = tempnam( sys_get_temp_dir(), 'logo_' );
+		file_put_contents( $tmp_file, '<svg></svg>' );
+		$this->created_files[] = $tmp_file;
+
+		$this->assertNull( _wp_connectors_resolve_ai_provider_logo_url( $tmp_file ) );
+	}
+}

--- a/tests/phpunit/tests/connectors/wpRegisterConnector.php
+++ b/tests/phpunit/tests/connectors/wpRegisterConnector.php
@@ -1,77 +1,13 @@
 <?php
 /**
- * Tests for wp_register_connector() and companion functions.
+ * Tests for connector registration companion functions.
  *
  * @group connectors
- * @covers ::wp_register_connector
  * @covers ::wp_is_connector_registered
  * @covers ::wp_get_connector
  * @covers ::wp_get_connectors
  */
 class Tests_Connectors_WpRegisterConnector extends WP_UnitTestCase {
-
-	/**
-	 * Default valid connector args for testing.
-	 *
-	 * @var array
-	 */
-	private static $default_args = array();
-
-	/**
-	 * Set up before class.
-	 */
-	public static function set_up_before_class() {
-		parent::set_up_before_class();
-
-		self::$default_args = array(
-			'name'           => 'Test Connector',
-			'description'    => 'A test connector.',
-			'type'           => 'ai_provider',
-			'authentication' => array(
-				'method'          => 'api_key',
-				'credentials_url' => 'https://example.com/keys',
-			),
-		);
-	}
-
-	/**
-	 * Helper to simulate the wp_connectors_init action for registration.
-	 *
-	 * @param callable $callback The registration callback to run.
-	 */
-	private function simulate_doing_wp_connectors_init_action( callable $callback ): void {
-		global $wp_current_filter;
-		$wp_current_filter[] = 'wp_connectors_init';
-		$callback();
-		array_pop( $wp_current_filter );
-	}
-
-	/**
-	 * @ticket 64791
-	 */
-	public function test_register_fails_outside_action() {
-		$this->setExpectedIncorrectUsage( 'wp_register_connector' );
-
-		$result = wp_register_connector( 'outside_action', self::$default_args );
-
-		$this->assertNull( $result );
-	}
-
-	/**
-	 * @ticket 64791
-	 */
-	public function test_register_succeeds_during_action() {
-		$result = null;
-
-		$this->simulate_doing_wp_connectors_init_action(
-			function () use ( &$result ) {
-				$result = wp_register_connector( 'during_action', self::$default_args );
-			}
-		);
-
-		$this->assertIsArray( $result );
-		$this->assertSame( 'Test Connector', $result['name'] );
-	}
 
 	/**
 	 * @ticket 64791

--- a/tests/phpunit/tests/connectors/wpRegisterConnector.php
+++ b/tests/phpunit/tests/connectors/wpRegisterConnector.php
@@ -4,8 +4,7 @@
  *
  * @group connectors
  * @covers ::wp_register_connector
- * @covers ::wp_unregister_connector
- * @covers ::wp_has_connector
+ * @covers ::wp_is_connector_registered
  * @covers ::wp_get_connector
  * @covers ::wp_get_connectors
  */
@@ -77,18 +76,18 @@ class Tests_Connectors_WpRegisterConnector extends WP_UnitTestCase {
 	/**
 	 * @ticket 64791
 	 */
-	public function test_has_connector_returns_true_for_default() {
+	public function test_is_connector_registered_returns_true_for_default() {
 		// Default connectors are registered via wp_connectors_init.
-		$this->assertTrue( wp_has_connector( 'openai' ) );
-		$this->assertTrue( wp_has_connector( 'google' ) );
-		$this->assertTrue( wp_has_connector( 'anthropic' ) );
+		$this->assertTrue( wp_is_connector_registered( 'openai' ) );
+		$this->assertTrue( wp_is_connector_registered( 'google' ) );
+		$this->assertTrue( wp_is_connector_registered( 'anthropic' ) );
 	}
 
 	/**
 	 * @ticket 64791
 	 */
-	public function test_has_connector_returns_false_for_unregistered() {
-		$this->assertFalse( wp_has_connector( 'nonexistent_provider' ) );
+	public function test_is_connector_registered_returns_false_for_unregistered() {
+		$this->assertFalse( wp_is_connector_registered( 'nonexistent_provider' ) );
 	}
 
 	/**
@@ -124,34 +123,5 @@ class Tests_Connectors_WpRegisterConnector extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'openai', $connectors );
 		$this->assertArrayHasKey( 'google', $connectors );
 		$this->assertArrayHasKey( 'anthropic', $connectors );
-	}
-
-	/**
-	 * @ticket 64791
-	 */
-	public function test_unregister_removes_connector() {
-		$this->simulate_doing_wp_connectors_init_action(
-			function () {
-				wp_register_connector( 'to_remove', self::$default_args );
-			}
-		);
-
-		$this->assertTrue( wp_has_connector( 'to_remove' ) );
-
-		$result = wp_unregister_connector( 'to_remove' );
-
-		$this->assertIsArray( $result );
-		$this->assertFalse( wp_has_connector( 'to_remove' ) );
-	}
-
-	/**
-	 * @ticket 64791
-	 */
-	public function test_unregister_returns_null_for_nonexistent() {
-		$this->setExpectedIncorrectUsage( 'WP_Connector_Registry::unregister' );
-
-		$result = wp_unregister_connector( 'nonexistent' );
-
-		$this->assertNull( $result );
 	}
 }

--- a/tests/phpunit/tests/connectors/wpRegisterConnector.php
+++ b/tests/phpunit/tests/connectors/wpRegisterConnector.php
@@ -1,0 +1,157 @@
+<?php
+/**
+ * Tests for wp_register_connector() and companion functions.
+ *
+ * @group connectors
+ * @covers ::wp_register_connector
+ * @covers ::wp_unregister_connector
+ * @covers ::wp_has_connector
+ * @covers ::wp_get_connector
+ * @covers ::wp_get_connectors
+ */
+class Tests_Connectors_WpRegisterConnector extends WP_UnitTestCase {
+
+	/**
+	 * Default valid connector args for testing.
+	 *
+	 * @var array
+	 */
+	private static $default_args = array();
+
+	/**
+	 * Set up before class.
+	 */
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+
+		self::$default_args = array(
+			'name'           => 'Test Connector',
+			'description'    => 'A test connector.',
+			'type'           => 'ai_provider',
+			'authentication' => array(
+				'method'          => 'api_key',
+				'credentials_url' => 'https://example.com/keys',
+			),
+		);
+	}
+
+	/**
+	 * Helper to simulate the wp_connectors_init action for registration.
+	 *
+	 * @param callable $callback The registration callback to run.
+	 */
+	private function simulate_doing_wp_connectors_init_action( callable $callback ): void {
+		global $wp_current_filter;
+		$wp_current_filter[] = 'wp_connectors_init';
+		$callback();
+		array_pop( $wp_current_filter );
+	}
+
+	/**
+	 * @ticket 64791
+	 */
+	public function test_register_fails_outside_action() {
+		$this->setExpectedIncorrectUsage( 'wp_register_connector' );
+
+		$result = wp_register_connector( 'outside_action', self::$default_args );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * @ticket 64791
+	 */
+	public function test_register_succeeds_during_action() {
+		$result = null;
+
+		$this->simulate_doing_wp_connectors_init_action(
+			function () use ( &$result ) {
+				$result = wp_register_connector( 'during_action', self::$default_args );
+			}
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'Test Connector', $result['name'] );
+	}
+
+	/**
+	 * @ticket 64791
+	 */
+	public function test_has_connector_returns_true_for_default() {
+		// Default connectors are registered via wp_connectors_init.
+		$this->assertTrue( wp_has_connector( 'openai' ) );
+		$this->assertTrue( wp_has_connector( 'google' ) );
+		$this->assertTrue( wp_has_connector( 'anthropic' ) );
+	}
+
+	/**
+	 * @ticket 64791
+	 */
+	public function test_has_connector_returns_false_for_unregistered() {
+		$this->assertFalse( wp_has_connector( 'nonexistent_provider' ) );
+	}
+
+	/**
+	 * @ticket 64791
+	 */
+	public function test_get_connector_returns_data_for_default() {
+		$connector = wp_get_connector( 'openai' );
+
+		$this->assertIsArray( $connector );
+		$this->assertSame( 'OpenAI', $connector['name'] );
+		$this->assertSame( 'ai_provider', $connector['type'] );
+		$this->assertSame( 'api_key', $connector['authentication']['method'] );
+		$this->assertSame( 'connectors_ai_openai_api_key', $connector['authentication']['setting_name'] );
+	}
+
+	/**
+	 * @ticket 64791
+	 */
+	public function test_get_connector_returns_null_for_unregistered() {
+		$this->setExpectedIncorrectUsage( 'WP_Connector_Registry::get_registered' );
+
+		$result = wp_get_connector( 'nonexistent_provider' );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * @ticket 64791
+	 */
+	public function test_get_connectors_returns_all_defaults() {
+		$connectors = wp_get_connectors();
+
+		$this->assertArrayHasKey( 'openai', $connectors );
+		$this->assertArrayHasKey( 'google', $connectors );
+		$this->assertArrayHasKey( 'anthropic', $connectors );
+	}
+
+	/**
+	 * @ticket 64791
+	 */
+	public function test_unregister_removes_connector() {
+		$this->simulate_doing_wp_connectors_init_action(
+			function () {
+				wp_register_connector( 'to_remove', self::$default_args );
+			}
+		);
+
+		$this->assertTrue( wp_has_connector( 'to_remove' ) );
+
+		$result = wp_unregister_connector( 'to_remove' );
+
+		$this->assertIsArray( $result );
+		$this->assertFalse( wp_has_connector( 'to_remove' ) );
+	}
+
+	/**
+	 * @ticket 64791
+	 */
+	public function test_unregister_returns_null_for_nonexistent() {
+		$this->setExpectedIncorrectUsage( 'WP_Connector_Registry::unregister' );
+
+		$result = wp_unregister_connector( 'nonexistent' );
+
+		$this->assertNull( $result );
+	}
+}

--- a/tests/phpunit/tests/rest-api/rest-settings-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-settings-controller.php
@@ -120,10 +120,6 @@ class WP_Test_REST_Settings_Controller extends WP_Test_REST_Controller_Testcase 
 			'default_comment_status',
 			'site_icon', // Registered in wp-includes/blocks/site-logo.php
 			'wp_enable_real_time_collaboration',
-			// Connectors API keys are registered in _wp_register_default_connector_settings() in wp-includes/connectors.php.
-			'connectors_ai_anthropic_api_key',
-			'connectors_ai_google_api_key',
-			'connectors_ai_openai_api_key',
 		);
 
 		if ( ! is_multisite() ) {

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -11066,24 +11066,6 @@ mockedApiResponse.Schema = {
                         "PATCH"
                     ],
                     "args": {
-                        "connectors_ai_anthropic_api_key": {
-                            "title": "Anthropic API Key",
-                            "description": "API key for the Anthropic AI provider.",
-                            "type": "string",
-                            "required": false
-                        },
-                        "connectors_ai_google_api_key": {
-                            "title": "Google API Key",
-                            "description": "API key for the Google AI provider.",
-                            "type": "string",
-                            "required": false
-                        },
-                        "connectors_ai_openai_api_key": {
-                            "title": "OpenAI API Key",
-                            "description": "API key for the OpenAI AI provider.",
-                            "type": "string",
-                            "required": false
-                        },
                         "title": {
                             "title": "Title",
                             "description": "Site title.",
@@ -14762,9 +14744,6 @@ mockedApiResponse.CommentModel = {
 };
 
 mockedApiResponse.settings = {
-    "connectors_ai_anthropic_api_key": "",
-    "connectors_ai_google_api_key": "",
-    "connectors_ai_openai_api_key": "",
     "title": "Test Blog",
     "description": "",
     "url": "http://example.org",


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/64791

## Summary

Introduces `WP_Connector_Registry` class and a `wp_connectors_init` action hook so plugins can register their own connectors alongside the built-in defaults (Anthropic, Google, OpenAI).

### Key changes

- **`WP_Connector_Registry`** — A `final` singleton class managing connector registration and lookup, with validation for IDs, required fields, and authentication methods.
- **`wp_connectors_init` action** — Fired during `init` after built-in connectors are registered. Passes the registry instance so plugins call `$registry->register()` directly, which structurally enforces correct timing.
- **`_wp_connectors_init()`** — Private function that creates the registry, merges hardcoded defaults with AI Client registry data (provider plugins take precedence), registers them, then fires the action.
- **Public read-only functions** — `wp_is_connector_registered()`, `wp_get_connector()`, `wp_get_connectors()` for querying the registry after initialization.
- **Timing guards** — `set_instance()` rejects calls after `init` completes. Registration is only possible during `wp_connectors_init`.
- **PHPStan typing** — Multi-line `Connector` type definition with full shape including `setting_name` and `logo_url`.
- **Logo URL support** — Connectors can include an optional `logo_url` field. The `_wp_connectors_resolve_ai_provider_logo_url()` function resolves absolute file paths from plugin directories into URLs. During initialization, logo paths are automatically extracted from AI Client provider metadata.

### Registration example

```php
add_action( 'wp_connectors_init', function ( WP_Connector_Registry $registry ) {
    $registry->register(
        'my_custom_ai',
        array(
            'name'           => __( 'My Custom AI', 'my-plugin' ),
            'description'    => __( 'Custom AI provider integration.', 'my-plugin' ),
            'type'           => 'ai_provider',
            'logo_url'       => plugins_url( 'assets/logo.svg', __FILE__ ),
            'authentication' => array(
                'method'          => 'api_key',
                'credentials_url' => 'https://example.com/api-keys',
            ),
        )
    );
} );
```

### Design decisions

- **No `wp_register_connector()` wrapper** — Plugins use `$registry->register()` directly via the action callback, making misuse structurally difficult (per @felixarntz's feedback).
- **No `wp_unregister_connector()` wrapper** — The `unregister()` method exists on the class for internal use, but is not exposed as a public API to discourage unregistration.
- **Defaults are unhookable** — Built-in connectors are registered before the action fires, so they cannot be removed via `remove_action`.

## Test plan

- [x] `npm run test:php -- --group connectors` passes (49 tests, 154 assertions)
- [x] PHPCS lint passes on all changed files
- [x] PHPStan reports no errors on connector source files
- [ ] Verify a plugin can register a custom connector via the `wp_connectors_init` action
- [ ] Verify calling `$registry->register()` outside the action triggers `_doing_it_wrong`
- [ ] Verify `WP_Connector_Registry::set_instance()` after `init` triggers `_doing_it_wrong`
- [ ] Verify default connectors (openai, google, anthropic) are always present
- [ ] Verify `logo_url` is included in connector data when provided by AI Client metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)