### PR TITLE
Ensure the schema URL is changed from relative to absolute in `theme.json`

### DIFF
--- a/tools/gutenberg/copy-gutenberg-build.js
+++ b/tools/gutenberg/copy-gutenberg-build.js
@@ -98,6 +98,7 @@ const COPY_CONFIG = {
 			{ from: 'theme.json', to: 'theme.json' },
 			{ from: 'theme-i18n.json', to: 'theme-i18n.json' },
 		],
+		transform: true,
 	},
 
 	// Specific files to copy to wp-includes/$destination


### PR DESCRIPTION
It seems that the schema URL is not being transformed during the build process currently. This fixes that.

Trac ticket: Core-64393

## Use of AI Tools

None.

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
