### PR TITLE
Fix: [Admin reskin] Add Plugins search field border is not OK on small screen

### DIFF
--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -1380,6 +1380,12 @@ th.action-links {
 	}
 }
 
+@media only screen and (max-width: 1250px) {
+	.wp-filter:has(.plugin-install-search) .search-form {
+		margin: 11px 0;
+	}
+}
+
 @media only screen and (max-width: 1120px) {
 	.filter-drawer {
 		border-bottom: 1px solid #f0f0f1;


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/64809

- Target specific search form only when we have search results for the screen size.
- Else we are already having a margin of 11px.
- If we do not target specific when we have search results, it leads to extra spacing when there are no search results. So it goes to single line on specifc screen size without search results.

## Use of AI Tools

- None

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

## Screenshsots

1. With fix and search results
<img width="1440" height="718" alt="Screenshot 2026-03-06 at 12 05 19 PM" src="https://github.com/user-attachments/assets/354d6b37-aa0d-48db-bd9f-f68bf8e9402b" />

3. With fix and search results above 1250px.
<img width="1440" height="718" alt="Screenshot 2026-03-06 at 12 05 29 PM" src="https://github.com/user-attachments/assets/7e1597bc-1513-4282-996b-42a1bdf728b9" />
---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
