### PR TITLE
Formatting: Add capital Eszett (ẞ → SS) to remove_accents() for German locale

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -1600,7 +1600,7 @@ function utf8_uri_encode( $utf8_string, $length = 0, $encode_ascii_characters = 
  * @since 5.7.0 Added locale support for `de_AT`.
  * @since 6.0.0 Added the `$locale` parameter.
  * @since 6.1.0 Added Unicode NFC encoding normalization support.
- * @since 7.1.0 Added capital Eszett (U+1E9E) support for German locales.
+ * @since TBD   Added capital Eszett (U+1E9E) support for German locales.
  *
  * @param string $text   Text that might have accent characters.
  * @param string $locale Optional. The locale to use for accent removal. Some character

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -1566,6 +1566,7 @@ function utf8_uri_encode( $utf8_string, $length = 0, $encode_ascii_characters = 
  * | U+00F6   | ö     | oe          | Latin small letter o with diaeresis     |
  * | U+00DC   | Ü     | Ue          | Latin capital letter U with diaeresis   |
  * | U+00FC   | ü     | ue          | Latin small letter u with diaeresis     |
+ * | U+1E9E   | ẞ     | SS          | Latin capital letter sharp s            |
  * | U+00DF   | ß     | ss          | Latin small letter sharp s              |
  *
  * Danish (`da_DK`) locale:
@@ -1599,6 +1600,7 @@ function utf8_uri_encode( $utf8_string, $length = 0, $encode_ascii_characters = 
  * @since 5.7.0 Added locale support for `de_AT`.
  * @since 6.0.0 Added the `$locale` parameter.
  * @since 6.1.0 Added Unicode NFC encoding normalization support.
+ * @since 7.1.0 Added capital Eszett (U+1E9E) support for German locales.
  *
  * @param string $text   Text that might have accent characters.
  * @param string $locale Optional. The locale to use for accent removal. Some character

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -1972,6 +1972,7 @@ function remove_accents( $text, $locale = '' ) {
 			$chars['ö'] = 'oe';
 			$chars['Ü'] = 'Ue';
 			$chars['ü'] = 'ue';
+			$chars['ẞ'] = 'SS';
 			$chars['ß'] = 'ss';
 		} elseif ( 'da_DK' === $locale ) {
 			$chars['Æ'] = 'Ae';

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -1600,7 +1600,7 @@ function utf8_uri_encode( $utf8_string, $length = 0, $encode_ascii_characters = 
  * @since 5.7.0 Added locale support for `de_AT`.
  * @since 6.0.0 Added the `$locale` parameter.
  * @since 6.1.0 Added Unicode NFC encoding normalization support.
- * @since TBD   Added capital Eszett (U+1E9E) support for German locales.
+ * @since 7.0.0 Added capital Eszett (U+1E9E) support for German locales.
  *
  * @param string $text   Text that might have accent characters.
  * @param string $locale Optional. The locale to use for accent removal. Some character

--- a/tests/phpunit/tests/formatting/removeAccents.php
+++ b/tests/phpunit/tests/formatting/removeAccents.php
@@ -109,6 +109,16 @@ class Tests_Formatting_RemoveAccents extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 64821
+	 */
+	public function test_remove_accents_germanic_capital_eszett() {
+		// U+1E9E LATIN CAPITAL LETTER SHARP S, standardized in German orthography in 2017 (DIN 5008).
+		$this->assertSame( 'SS', remove_accents( 'ẞ', 'de_DE' ) );
+		// Verify it works in context alongside the lowercase variant.
+		$this->assertSame( 'SSstrasse', remove_accents( 'ẞstraße', 'de_DE' ) );
+	}
+
+	/**
 	 * @ticket 23907
 	 */
 	public function test_remove_danish_accents() {


### PR DESCRIPTION
Adds `ẞ` (U+1E9E, LATIN CAPITAL LETTER SHARP S) → `SS` to the German locale block in `remove_accents()`, directly after the existing `ß` → `ss` entry.

The uppercase ß was officially standardized in German orthography in 2017 (DIN 5008 revision). This is an edge case — ẞ appears almost exclusively in all-caps contexts such as street names and official documents — but it is included for completeness and consistency: every other character in the German locale block has both its upper and lowercase form mapped.

Without this fix, `ẞ` falls through without a mapping and is returned unchanged, leading to URL-encoded characters in slugs:

```php
remove_accents( 'STRAẞE', 'de_DE' );
// Before: STRAẞE  (ẞ unchanged)
// After:  STRASSE
```

Trac ticket: https://core.trac.wordpress.org/ticket/64821

## Use of AI Tools

This patch was developed with the assistance of Claude Code (Anthropic). The change, test case, and Trac ticket were reviewed and approved by the contributor before submission.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**