### PR TITLE
Set the default value of `wp_enable_real_time_collaboration` to `true`.

### DIFF
--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -2892,7 +2892,7 @@ function register_initial_settings() {
 			'type'              => 'boolean',
 			'description'       => __( 'Enable Real-Time Collaboration' ),
 			'sanitize_callback' => 'rest_sanitize_boolean',
-			'default'           => false,
+			'default'           => true,
 			'show_in_rest'      => true,
 		)
 	);

--- a/tests/phpunit/tests/rest-api/rest-sync-server.php
+++ b/tests/phpunit/tests/rest-api/rest-sync-server.php
@@ -97,6 +97,30 @@ class WP_Test_REST_Sync_Server extends WP_Test_REST_Controller_Testcase {
 	}
 
 	/**
+	 * Verifies the sync route is registered when relying on the option's default
+	 * value (option not stored in the database).
+	 *
+	 * This covers the upgrade scenario where a site has never explicitly saved
+	 * the collaboration setting.
+	 *
+	 * @ticket 64814
+	 */
+	public function test_register_routes_with_default_option() {
+		// Remove the pre_option filter added in set_up() so get_option() uses its default logic.
+		remove_filter( 'pre_option_wp_enable_real_time_collaboration', '__return_true' );
+
+		// Ensure the option is not in the database.
+		delete_option( 'wp_enable_real_time_collaboration' );
+
+		// Reset the REST server so routes are re-registered from scratch.
+		global $wp_rest_server;
+		$wp_rest_server = null;
+
+		$routes = rest_get_server()->get_routes();
+		$this->assertArrayHasKey( '/wp-sync/v1/updates', $routes );
+	}
+
+	/**
 	 * @doesNotPerformAssertions
 	 */
 	public function test_context_param() {


### PR DESCRIPTION
Sets the default value of `wp_enable_real_time_collaboration` to `true` during setting registration, to match the intended default as set in PR 11161: https://github.com/WordPress/wordpress-develop/pull/11161

This aligns with how it's configured in `default-filters.php` and `populate_options()`.

Core-64814
<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/64814

## Use of AI Tools
Claude reviewed the phpunit test.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
