### PR TITLE
Add support for `IMG` tags with `fetchpriority=low` or `fetchpriority=auto`

### DIFF
--- a/src/wp-includes/block-supports/block-visibility.php
+++ b/src/wp-includes/block-supports/block-visibility.php
@@ -140,15 +140,17 @@ function wp_render_block_visibility_support( $block_content, $block ) {
 			if ( $processor->next_tag() ) {
 				$processor->add_class( implode( ' ', $class_names ) );
 			}
+			$block_content = $processor->get_updated_html();
 
 			/*
 			 * Set all IMG tags to be `fetchpriority=auto` so that wp_get_loading_optimization_attributes() won't add
-			 * `fetchpriority=high` or increment the media count to affect whether subsequent IMG tags get `loading=lazy`.
+			 * `fetchpriority=high` or increment the media count to effect whether subsequent IMG tags get `loading=lazy`.
 			 */
-			while ( $processor->next_tag( 'IMG' ) ) {
-				$processor->set_attribute( 'fetchpriority', 'auto' );
+			$img_processor = new WP_HTML_Tag_Processor( $block_content );
+			while ( $img_processor->next_tag( 'IMG' ) ) {
+				$img_processor->set_attribute( 'fetchpriority', 'auto' );
 			}
-			$block_content = $processor->get_updated_html();
+			$block_content = $img_processor->get_updated_html();
 		}
 	}
 

--- a/src/wp-includes/block-supports/block-visibility.php
+++ b/src/wp-includes/block-supports/block-visibility.php
@@ -143,7 +143,7 @@ function wp_render_block_visibility_support( $block_content, $block ) {
 
 			/*
 			 * Set all IMG tags to be `fetchpriority=auto` so that wp_get_loading_optimization_attributes() won't add
-			 * `fetchpriority=high` or increment the media count to effect whether subsequent IMG tags get `loading=lazy`.
+			 * `fetchpriority=high` or increment the media count to affect whether subsequent IMG tags get `loading=lazy`.
 			 */
 			while ( $processor->next_tag( 'IMG' ) ) {
 				$processor->set_attribute( 'fetchpriority', 'auto' );

--- a/src/wp-includes/block-supports/block-visibility.php
+++ b/src/wp-includes/block-supports/block-visibility.php
@@ -142,7 +142,7 @@ function wp_render_block_visibility_support( $block_content, $block ) {
 
 				/*
 				 * Set all IMG tags to be `fetchpriority=auto` so that wp_get_loading_optimization_attributes() won't add
-				 * `fetchpriority=high` or increment the media count to effect whether subsequent IMG tags get `loading=lazy`.
+				 * `fetchpriority=high` or increment the media count to affect whether subsequent IMG tags get `loading=lazy`.
 				 */
 				do {
 					if ( 'IMG' === $processor->get_tag() ) {

--- a/src/wp-includes/block-supports/block-visibility.php
+++ b/src/wp-includes/block-supports/block-visibility.php
@@ -139,18 +139,18 @@ function wp_render_block_visibility_support( $block_content, $block ) {
 			$processor = new WP_HTML_Tag_Processor( $block_content );
 			if ( $processor->next_tag() ) {
 				$processor->add_class( implode( ' ', $class_names ) );
-			}
-			$block_content = $processor->get_updated_html();
 
-			/*
-			 * Set all IMG tags to be `fetchpriority=auto` so that wp_get_loading_optimization_attributes() won't add
-			 * `fetchpriority=high` or increment the media count to effect whether subsequent IMG tags get `loading=lazy`.
-			 */
-			$img_processor = new WP_HTML_Tag_Processor( $block_content );
-			while ( $img_processor->next_tag( 'IMG' ) ) {
-				$img_processor->set_attribute( 'fetchpriority', 'auto' );
+				/*
+				 * Set all IMG tags to be `fetchpriority=auto` so that wp_get_loading_optimization_attributes() won't add
+				 * `fetchpriority=high` or increment the media count to effect whether subsequent IMG tags get `loading=lazy`.
+				 */
+				do {
+					if ( 'IMG' === $processor->get_tag() ) {
+						$processor->set_attribute( 'fetchpriority', 'auto' );
+					}
+				} while ( $processor->next_tag() );
+				$block_content = $processor->get_updated_html();
 			}
-			$block_content = $img_processor->get_updated_html();
 		}
 	}
 

--- a/src/wp-includes/block-supports/block-visibility.php
+++ b/src/wp-includes/block-supports/block-visibility.php
@@ -139,8 +139,16 @@ function wp_render_block_visibility_support( $block_content, $block ) {
 			$processor = new WP_HTML_Tag_Processor( $block_content );
 			if ( $processor->next_tag() ) {
 				$processor->add_class( implode( ' ', $class_names ) );
-				$block_content = $processor->get_updated_html();
 			}
+
+			/*
+			 * Set all IMG tags to be `fetchpriority=auto` so that wp_get_loading_optimization_attributes() won't add
+			 * `fetchpriority=high` or increment the media count to effect whether subsequent IMG tags get `loading=lazy`.
+			 */
+			while ( $processor->next_tag( 'IMG' ) ) {
+				$processor->set_attribute( 'fetchpriority', 'auto' );
+			}
+			$block_content = $processor->get_updated_html();
 		}
 	}
 

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -881,6 +881,8 @@ class WP_HTML_Tag_Processor {
 	 *     @type string|null $tag_closers  "visit" or "skip": whether to stop on tag closers, e.g. </div>.
 	 * }
 	 * @return bool Whether a tag was matched.
+	 *
+	 * @phpstan-impure
 	 */
 	public function next_tag( $query = null ): bool {
 		$this->parse_query( $query );

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -6321,7 +6321,7 @@ function wp_maybe_add_fetchpriority_high_attr( $loading_attrs, $tag_name, $attr 
  * @access private
  *
  * @param bool $value Optional. Used to change the static variable. Default null.
- * @return bool Returns true if high-priority element was marked already, otherwise false.
+ * @return bool Returns true if the high-priority element was not already marked.
  */
 function wp_high_priority_element_flag( $value = null ) {
 	static $high_priority_element = true;

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -6111,7 +6111,7 @@ function wp_get_loading_optimization_attributes( $tag_name, $attr, $context ) {
 		 * they must not get `fetchpriority=low` because they may in fact be displayed in the current viewport. So as
 		 * a signal to indicate that an IMG may be in the viewport, `fetchpriority=auto` is added. This has the effect
 		 * here of preventing the media count from being increased, so that images hidden with block visibility do not
-		 * effect whether a following IMG gets `loading=lazy`. In particular, `loading=lazy` should still be omitted
+		 * affect whether a following IMG gets `loading=lazy`. In particular, `loading=lazy` should still be omitted
 		 * on an IMG following any number of initial IMGs with `fetchpriority=auto` since those initial images may not
 		 * be displayed.
 		 */

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -6260,12 +6260,13 @@ function wp_increase_content_media_count( $amount = 1 ) {
  * Determines whether to add `fetchpriority='high'` to loading attributes.
  *
  * @since 6.3.0
+ * @since 7.0.0 Support is added for IMG tags with `fetchpriority='low'` and `fetchpriority='auto'`.
  * @access private
  *
- * @param array  $loading_attrs Array of the loading optimization attributes for the element.
- * @param string $tag_name      The tag name.
- * @param array  $attr          Array of the attributes for the element.
- * @return array Updated loading optimization attributes for the element.
+ * @param array<string, string> $loading_attrs Array of the loading optimization attributes for the element.
+ * @param string                $tag_name      The tag name.
+ * @param array<string, mixed>  $attr          Array of the attributes for the element.
+ * @return array<string, string> Updated loading optimization attributes for the element.
  */
 function wp_maybe_add_fetchpriority_high_attr( $loading_attrs, $tag_name, $attr ) {
 	// For now, adding `fetchpriority="high"` is only supported for images.
@@ -6273,12 +6274,15 @@ function wp_maybe_add_fetchpriority_high_attr( $loading_attrs, $tag_name, $attr 
 		return $loading_attrs;
 	}
 
-	if ( isset( $attr['fetchpriority'] ) ) {
+	$existing_fetchpriority = $attr['fetchpriority'] ?? null;
+	if ( 'high' === $existing_fetchpriority || 'low' === $existing_fetchpriority ) {
 		/*
-		 * While any `fetchpriority` value could be set in `$loading_attrs`,
-		 * for consistency we only do it for `fetchpriority="high"` since that
-		 * is the only possible value that WordPress core would apply on its
-		 * own.
+		 * When an IMG has been explicitly marked with `fetchpriority=high`, then honor that this is the element that
+		 * should have the priority. In contrast, the Navigation block may add `fetchpriority=low` to an IMG which
+		 * appears in the Navigation Overlay; such images should never be considered candidates for
+		 * `fetchpriority=high`. Lastly, block visibility may add `fetchpriority=auto` to an IMG when the block is
+		 * conditionally displayed based on viewport size. Such an image is considered an LCP element candidate if it
+		 * exceeds the threshold for the minimum number of square pixels.
 		 */
 		if ( 'high' === $attr['fetchpriority'] ) {
 			$loading_attrs['fetchpriority'] = 'high';
@@ -6307,7 +6311,9 @@ function wp_maybe_add_fetchpriority_high_attr( $loading_attrs, $tag_name, $attr 
 	$wp_min_priority_img_pixels = apply_filters( 'wp_min_priority_img_pixels', 50000 );
 
 	if ( $wp_min_priority_img_pixels <= $attr['width'] * $attr['height'] ) {
-		$loading_attrs['fetchpriority'] = 'high';
+		if ( 'auto' !== $existing_fetchpriority ) {
+			$loading_attrs['fetchpriority'] = 'high';
+		}
 		wp_high_priority_element_flag( false );
 	}
 

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -6095,9 +6095,9 @@ function wp_get_loading_optimization_attributes( $tag_name, $attr, $context ) {
 		}
 	} elseif ( $is_low_fetchpriority ) {
 		/*
-		 * An IMG with fetchpriority=low is not initially displayed, as it may be a hidden in the Navigation Overlay,
-		 * or it may be occluded in a non-initial carousel slide. Such images must not be lazy-loaded since the browser
-		 * has no heuristic to know when to start loading them prior the user needing to see them.
+		 * An IMG with fetchpriority=low is not initially displayed; it may be hidden in the Navigation Overlay,
+		 * or it may be occluded in a non-initial carousel slide. Such images must not be lazy-loaded because the browser
+		 * has no heuristic to know when to start loading them before the user needs to see them.
 		 */
 		$maybe_in_viewport = false;
 	}

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -6115,7 +6115,6 @@ function wp_get_loading_optimization_attributes( $tag_name, $attr, $context ) {
 		 * on an IMG following any number of initial IMGs with `fetchpriority=auto` since those initial images may not
 		 * be displayed.
 		 */
-		$maybe_in_viewport = true;
 
 		// Preserve fetchpriority=auto.
 		$loading_attrs['fetchpriority'] = 'auto';
@@ -6195,16 +6194,20 @@ function wp_get_loading_optimization_attributes( $tag_name, $attr, $context ) {
 	/*
 	 * If flag was set based on contextual logic above, increase the content
 	 * media count, either unconditionally, or based on whether the image size
-	 * is larger than the threshold.
+	 * is larger than the threshold. This does not apply when the IMG has
+	 * fetchpriority=auto because it may be conditionally displayed by viewport
+	 * size.
 	 */
-	if ( $increase_count ) {
-		wp_increase_content_media_count();
-	} elseif ( $maybe_increase_count ) {
-		/** This filter is documented in wp-includes/media.php */
-		$wp_min_priority_img_pixels = apply_filters( 'wp_min_priority_img_pixels', 50000 );
-
-		if ( $wp_min_priority_img_pixels <= $attr['width'] * $attr['height'] ) {
+	if ( 'auto' !== $existing_fetchpriority ) {
+		if ( $increase_count ) {
 			wp_increase_content_media_count();
+		} elseif ( $maybe_increase_count ) {
+			/** This filter is documented in wp-includes/media.php */
+			$wp_min_priority_img_pixels = apply_filters( 'wp_min_priority_img_pixels', 50000 );
+
+			if ( $wp_min_priority_img_pixels <= $attr['width'] * $attr['height'] ) {
+				wp_increase_content_media_count();
+			}
 		}
 	}
 

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -6323,7 +6323,7 @@ function wp_maybe_add_fetchpriority_high_attr( $loading_attrs, $tag_name, $attr 
  * @param bool $value Optional. Used to change the static variable. Default null.
  * @return bool Returns true if the high-priority element was not already marked.
  */
-function wp_high_priority_element_flag( $value = null ) {
+function wp_high_priority_element_flag( $value = null ): bool {
 	static $high_priority_element = true;
 
 	if ( is_bool( $value ) ) {

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -6291,7 +6291,7 @@ function wp_maybe_add_fetchpriority_high_attr( $loading_attrs, $tag_name, $attr 
 	}
 
 	$existing_fetchpriority = $attr['fetchpriority'] ?? null;
-	if ( 'high' === $existing_fetchpriority || 'low' === $existing_fetchpriority ) {
+	if ( null !== $existing_fetchpriority && 'auto' !== $existing_fetchpriority ) {
 		/*
 		 * When an IMG has been explicitly marked with `fetchpriority=high`, then honor that this is the element that
 		 * should have the priority. In contrast, the Navigation block may add `fetchpriority=low` to an IMG which
@@ -6300,7 +6300,7 @@ function wp_maybe_add_fetchpriority_high_attr( $loading_attrs, $tag_name, $attr 
 		 * conditionally displayed based on viewport size. Such an image is considered an LCP element candidate if it
 		 * exceeds the threshold for the minimum number of square pixels.
 		 */
-		if ( 'high' === $attr['fetchpriority'] ) {
+		if ( 'high' === $existing_fetchpriority ) {
 			$loading_attrs['fetchpriority'] = 'high';
 			wp_high_priority_element_flag( false );
 		}

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -5967,7 +5967,7 @@ function wp_get_webp_info( $filename ) {
  * both attributes are present with those values.
  *
  * @since 6.3.0
- * @since 7.0.0 Support `fetchpriority=low` so that `loading=lazy` is not added and the media count is not increased.
+ * @since 7.0.0 Support `fetchpriority=low` and `fetchpriority=auto` so that `loading=lazy` is not added and the media count is not increased.
  *
  * @global WP_Query $wp_query WordPress Query object.
  *

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -5967,6 +5967,7 @@ function wp_get_webp_info( $filename ) {
  * both attributes are present with those values.
  *
  * @since 6.3.0
+ * @since 7.0.0 Support `fetchpriority=low` so that `loading=lazy` is not added and the media count is not increased.
  *
  * @global WP_Query $wp_query WordPress Query object.
  *
@@ -6067,7 +6068,9 @@ function wp_get_loading_optimization_attributes( $tag_name, $attr, $context ) {
 	}
 
 	// Logic to handle a `fetchpriority` attribute that is already provided.
-	if ( isset( $attr['fetchpriority'] ) && 'high' === $attr['fetchpriority'] ) {
+	$existing_fetchpriority = ( $attr['fetchpriority'] ?? null );
+	$is_low_fetchpriority   = ( 'low' === $existing_fetchpriority );
+	if ( 'high' === $existing_fetchpriority ) {
 		/*
 		 * If the image was already determined to not be in the viewport (e.g.
 		 * from an already provided `loading` attribute), trigger a warning.
@@ -6090,6 +6093,13 @@ function wp_get_loading_optimization_attributes( $tag_name, $attr, $context ) {
 		} else {
 			$maybe_in_viewport = true;
 		}
+	} elseif ( $is_low_fetchpriority ) {
+		/*
+		 * An IMG with fetchpriority=low is not initially displayed, as it may be a hidden in the Navigation Overlay,
+		 * or it may be occluded in a non-initial carousel slide. Such images must not be lazy-loaded since the browser
+		 * has no heuristic to know when to start loading them prior the user needing to see them.
+		 */
+		$maybe_in_viewport = false;
 	}
 
 	if ( null === $maybe_in_viewport ) {
@@ -6140,7 +6150,7 @@ function wp_get_loading_optimization_attributes( $tag_name, $attr, $context ) {
 			 * does not include any loop.
 			 */
 			&& did_action( 'get_header' ) && ! did_action( 'get_footer' )
-			) {
+		) {
 			$maybe_in_viewport    = true;
 			$maybe_increase_count = true;
 		}
@@ -6149,16 +6159,23 @@ function wp_get_loading_optimization_attributes( $tag_name, $attr, $context ) {
 	/*
 	 * If the element is in the viewport (`true`), potentially add
 	 * `fetchpriority` with a value of "high". Otherwise, i.e. if the element
-	 * is not not in the viewport (`false`) or it is unknown (`null`), add
-	 * `loading` with a value of "lazy".
+	 * is not in the viewport (`false`) or it is unknown (`null`), add
+	 * `loading` with a value of "lazy" if the element is not already being
+	 * de-prioritized with `fetchpriority=low` due to occlusion in
+	 * Navigation Overlay, non-initial carousel slides, or a collapsed Details block.
 	 */
 	if ( $maybe_in_viewport ) {
 		$loading_attrs = wp_maybe_add_fetchpriority_high_attr( $loading_attrs, $tag_name, $attr );
-	} else {
+	} elseif ( ! $is_low_fetchpriority ) {
 		// Only add `loading="lazy"` if the feature is enabled.
 		if ( wp_lazy_loading_enabled( $tag_name, $context ) ) {
 			$loading_attrs['loading'] = 'lazy';
 		}
+	}
+
+	// Preserve fetchpriorit=low.
+	if ( $is_low_fetchpriority ) {
+		$loading_attrs['fetchpriority'] = 'low';
 	}
 
 	/*

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -6173,7 +6173,7 @@ function wp_get_loading_optimization_attributes( $tag_name, $attr, $context ) {
 		}
 	}
 
-	// Preserve fetchpriorit=low.
+	// Preserve fetchpriority=low.
 	if ( $is_low_fetchpriority ) {
 		$loading_attrs['fetchpriority'] = 'low';
 	}

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -6100,6 +6100,9 @@ function wp_get_loading_optimization_attributes( $tag_name, $attr, $context ) {
 		 * has no heuristic to know when to start loading them before the user needs to see them.
 		 */
 		$maybe_in_viewport = false;
+
+		// Preserve fetchpriority=low.
+		$loading_attrs['fetchpriority'] = 'low';
 	}
 
 	if ( null === $maybe_in_viewport ) {
@@ -6171,11 +6174,6 @@ function wp_get_loading_optimization_attributes( $tag_name, $attr, $context ) {
 		if ( wp_lazy_loading_enabled( $tag_name, $context ) ) {
 			$loading_attrs['loading'] = 'lazy';
 		}
-	}
-
-	// Preserve fetchpriority=low.
-	if ( $is_low_fetchpriority ) {
-		$loading_attrs['fetchpriority'] = 'low';
 	}
 
 	/*

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -6103,6 +6103,22 @@ function wp_get_loading_optimization_attributes( $tag_name, $attr, $context ) {
 
 		// Preserve fetchpriority=low.
 		$loading_attrs['fetchpriority'] = 'low';
+	} elseif ( 'auto' === $existing_fetchpriority ) {
+		/*
+		 * When a block's visibility support identifies that the block is conditionally displayed based on the viewport
+		 * size, then it adds `fetchpriority=auto` to the block's IMG tags. These images must not be fetched with high
+		 * priority because they could be erroneously loaded in viewports which do not even display them. Contrarily,
+		 * they must not get `fetchpriority=low` because they may in fact be displayed in the current viewport. So as
+		 * a signal to indicate that an IMG may be in the viewport, `fetchpriority=auto` is added. This has the effect
+		 * here of preventing the media count from being increased, so that images hidden with block visibility do not
+		 * effect whether a following IMG gets `loading=lazy`. In particular, `loading=lazy` should still be omitted
+		 * on an IMG following any number of initial IMGs with `fetchpriority=auto` since those initial images may not
+		 * be displayed.
+		 */
+		$maybe_in_viewport = true;
+
+		// Preserve fetchpriority=auto.
+		$loading_attrs['fetchpriority'] = 'auto';
 	}
 
 	if ( null === $maybe_in_viewport ) {

--- a/tests/phpunit/tests/block-supports/block-visibility.php
+++ b/tests/phpunit/tests/block-supports/block-visibility.php
@@ -93,7 +93,7 @@ class Tests_Block_Supports_Block_Visibility extends WP_UnitTestCase {
 			array( 'visibility' => false )
 		);
 
-		$block_content = '<p>This is a test block.</p>';
+		$block_content = '<div>Test content <img src="https://example.com/image.jpg" width="1000" height="1000" alt=""></div>';
 		$block         = array(
 			'blockName' => 'test/visibility-block',
 			'attrs'     => array(
@@ -122,7 +122,7 @@ class Tests_Block_Supports_Block_Visibility extends WP_UnitTestCase {
 			'attrs'     => array(),
 		);
 
-		$block_content = '<div>Test content</div>';
+		$block_content = '<div>Test content <img src="https://example.com/image.jpg" width="1000" height="1000" alt=""></div>';
 		$result        = wp_render_block_visibility_support( $block_content, $block );
 
 		$this->assertSame( $block_content, $result, 'Block content should remain unchanged when no visibility attribute is present.' );
@@ -150,7 +150,7 @@ class Tests_Block_Supports_Block_Visibility extends WP_UnitTestCase {
 			),
 		);
 
-		$block_content = '<div>Test content</div>';
+		$block_content = '<div>Test content <img src="https://example.com/image.jpg" width="1000" height="1000" alt=""></div>';
 		$result        = wp_render_block_visibility_support( $block_content, $block );
 
 		$this->assertStringContainsString( 'wp-block-hidden-mobile', $result, 'Block should have the visibility class for the mobile breakpoint.' );
@@ -186,10 +186,15 @@ class Tests_Block_Supports_Block_Visibility extends WP_UnitTestCase {
 			),
 		);
 
-		$block_content = '<div class="existing-class">Test content</div>';
+		$block_content = '<div class="existing-class">Test content <img src="https://example.com/image.jpg" width="1000" height="1000" alt=""></div>';
 		$result        = wp_render_block_visibility_support( $block_content, $block );
 
-		$this->assertStringContainsString( 'class="existing-class wp-block-hidden-tablet"', $result, 'Block should have the existing class and the visibility class for the tablet breakpoint in the class attribute.' );
+		$this->assertEqualHTML(
+			'<div class="existing-class wp-block-hidden-tablet">Test content <img fetchpriority="auto" src="https://example.com/image.jpg" width="1000" height="1000" alt=""></div>',
+			$result,
+			'<body>',
+			'Block should have the existing class and the visibility class for the tablet breakpoint in the class attribute.'
+		);
 
 		$actual_stylesheet = wp_style_engine_get_stylesheet_from_context( 'block-supports', array( 'prettify' => false ) );
 
@@ -222,10 +227,15 @@ class Tests_Block_Supports_Block_Visibility extends WP_UnitTestCase {
 			),
 		);
 
-		$block_content = '<div>Test content</div>';
+		$block_content = '<div class="existing-class">Test content <img src="https://example.com/image.jpg" width="1000" height="1000" alt=""></div>';
 		$result        = wp_render_block_visibility_support( $block_content, $block );
 
-		$this->assertStringContainsString( 'class="wp-block-hidden-desktop"', $result, 'Block should have the visibility class for the desktop breakpoint in the class attribute.' );
+		$this->assertEqualHTML(
+			'<div class="existing-class wp-block-hidden-desktop">Test content <img fetchpriority="auto" src="https://example.com/image.jpg" width="1000" height="1000" alt=""></div>',
+			$result,
+			'<body>',
+			'Block should have the visibility class for the desktop breakpoint in the class attribute.'
+		);
 
 		$actual_stylesheet = wp_style_engine_get_stylesheet_from_context( 'block-supports', array( 'prettify' => false ) );
 
@@ -279,10 +289,11 @@ class Tests_Block_Supports_Block_Visibility extends WP_UnitTestCase {
 		);
 	}
 
-	/*
+	/**
 	 * @ticket 64414
+	 * @ticket 64823
 	 */
-	public function test_block_visibility_support_generated_css_with_all_viewport_sizes_visible() {
+	public function test_block_visibility_support_generated_css_with_all_viewport_sizes_visible(): void {
 		$this->register_visibility_block_with_support(
 			'test/viewport-all-visible',
 			array( 'visibility' => true )
@@ -303,16 +314,17 @@ class Tests_Block_Supports_Block_Visibility extends WP_UnitTestCase {
 			),
 		);
 
-		$block_content = '<div>Test content</div>';
+		$block_content = '<div>Test content <img src="https://example.com/image.jpg" width="1000" height="1000" alt=""></div>';
 		$result        = wp_render_block_visibility_support( $block_content, $block );
 
 		$this->assertSame( $block_content, $result, 'Block content should remain unchanged when all breakpoints are visible.' );
 	}
 
-	/*
+	/**
 	 * @ticket 64414
+	 * @ticket 64823
 	 */
-	public function test_block_visibility_support_generated_css_with_all_viewport_sizes_hidden() {
+	public function test_block_visibility_support_generated_css_with_all_viewport_sizes_hidden(): void {
 		$this->register_visibility_block_with_support(
 			'test/viewport-all-hidden',
 			array( 'visibility' => true )
@@ -333,10 +345,15 @@ class Tests_Block_Supports_Block_Visibility extends WP_UnitTestCase {
 			),
 		);
 
-		$block_content = '<div>Test content</div>';
+		$block_content = '<div>Test content <img src="https://example.com/image.jpg" width="1000" height="1000" alt=""></div>';
 		$result        = wp_render_block_visibility_support( $block_content, $block );
 
-		$this->assertSame( '<div class="wp-block-hidden-desktop wp-block-hidden-mobile wp-block-hidden-tablet">Test content</div>', $result, 'Block content should have the visibility classes for all viewport sizes in the class attribute.' );
+		$this->assertEqualHTML(
+			'<div class="wp-block-hidden-desktop wp-block-hidden-mobile wp-block-hidden-tablet">Test content <img fetchpriority="auto" src="https://example.com/image.jpg" width="1000" height="1000" alt=""></div>',
+			$result,
+			'<body>',
+			'Block content should have the visibility classes for all viewport sizes in the class attribute, and an IMG should get fetchpriority=auto.'
+		);
 	}
 
 	/*
@@ -357,7 +374,7 @@ class Tests_Block_Supports_Block_Visibility extends WP_UnitTestCase {
 			),
 		);
 
-		$block_content = '<div>Test content</div>';
+		$block_content = '<div>Test content <img src="https://example.com/image.jpg" width="1000" height="1000" alt=""></div>';
 		$result        = wp_render_block_visibility_support( $block_content, $block );
 
 		$this->assertSame( $block_content, $result, 'Block content should remain unchanged when blockVisibility is an empty array.' );
@@ -387,7 +404,7 @@ class Tests_Block_Supports_Block_Visibility extends WP_UnitTestCase {
 			),
 		);
 
-		$block_content = '<div>Test content</div>';
+		$block_content = '<div>Test content <img src="https://example.com/image.jpg" width="1000" height="1000" alt=""></div>';
 		$result        = wp_render_block_visibility_support( $block_content, $block );
 
 		$this->assertStringContainsString(

--- a/tests/phpunit/tests/block-supports/block-visibility.php
+++ b/tests/phpunit/tests/block-supports/block-visibility.php
@@ -11,18 +11,18 @@
  * @covers ::wp_render_block_visibility_support
  */
 class Tests_Block_Supports_Block_Visibility extends WP_UnitTestCase {
-	/**
-	 * @var string|null
-	 */
-	private $test_block_name;
 
-	public function set_up() {
+	private ?string $test_block_name;
+
+	public function set_up(): void {
 		parent::set_up();
 		$this->test_block_name = null;
 	}
 
-	public function tear_down() {
-		unregister_block_type( $this->test_block_name );
+	public function tear_down(): void {
+		if ( $this->test_block_name ) {
+			unregister_block_type( $this->test_block_name );
+		}
 		$this->test_block_name = null;
 		parent::tear_down();
 	}
@@ -30,12 +30,10 @@ class Tests_Block_Supports_Block_Visibility extends WP_UnitTestCase {
 	/**
 	 * Registers a new block for testing block visibility support.
 	 *
-	 * @param string $block_name Name for the test block.
-	 * @param array  $supports   Array defining block support configuration.
-	 *
-	 * @return WP_Block_Type The block type for the newly registered test block.
+	 * @param string              $block_name Name for the test block.
+	 * @param array<string, bool> $supports   Array defining block support configuration.
 	 */
-	private function register_visibility_block_with_support( $block_name, $supports = array() ) {
+	private function register_visibility_block_with_support( string $block_name, array $supports = array() ): void {
 		$this->test_block_name = $block_name;
 		register_block_type(
 			$this->test_block_name,
@@ -51,7 +49,7 @@ class Tests_Block_Supports_Block_Visibility extends WP_UnitTestCase {
 		);
 		$registry = WP_Block_Type_Registry::get_instance();
 
-		return $registry->get_registered( $this->test_block_name );
+		$registry->get_registered( $this->test_block_name );
 	}
 
 	/**
@@ -60,7 +58,7 @@ class Tests_Block_Supports_Block_Visibility extends WP_UnitTestCase {
 	 *
 	 * @ticket 64061
 	 */
-	public function test_block_visibility_support_hides_block_when_visibility_false() {
+	public function test_block_visibility_support_hides_block_when_visibility_false(): void {
 		$this->register_visibility_block_with_support(
 			'test/visibility-block',
 			array( 'visibility' => true )
@@ -87,7 +85,7 @@ class Tests_Block_Supports_Block_Visibility extends WP_UnitTestCase {
 	 *
 	 * @ticket 64061
 	 */
-	public function test_block_visibility_support_shows_block_when_support_not_opted_in() {
+	public function test_block_visibility_support_shows_block_when_support_not_opted_in(): void {
 		$this->register_visibility_block_with_support(
 			'test/visibility-block',
 			array( 'visibility' => false )
@@ -108,10 +106,10 @@ class Tests_Block_Supports_Block_Visibility extends WP_UnitTestCase {
 		$this->assertSame( $block_content, $result, 'Block content should remain unchanged when blockVisibility support is not opted in.' );
 	}
 
-	/*
+	/**
 	 * @ticket 64414
 	 */
-	public function test_block_visibility_support_no_visibility_attribute() {
+	public function test_block_visibility_support_no_visibility_attribute(): void {
 		$this->register_visibility_block_with_support(
 			'test/block-visibility-none',
 			array( 'visibility' => true )
@@ -128,10 +126,10 @@ class Tests_Block_Supports_Block_Visibility extends WP_UnitTestCase {
 		$this->assertSame( $block_content, $result, 'Block content should remain unchanged when no visibility attribute is present.' );
 	}
 
-	/*
+	/**
 	 * @ticket 64414
 	 */
-	public function test_block_visibility_support_generated_css_with_mobile_viewport_size() {
+	public function test_block_visibility_support_generated_css_with_mobile_viewport_size(): void {
 		$this->register_visibility_block_with_support(
 			'test/viewport-mobile',
 			array( 'visibility' => true )
@@ -164,10 +162,10 @@ class Tests_Block_Supports_Block_Visibility extends WP_UnitTestCase {
 		);
 	}
 
-	/*
+	/**
 	 * @ticket 64414
 	 */
-	public function test_block_visibility_support_generated_css_with_tablet_viewport_size() {
+	public function test_block_visibility_support_generated_css_with_tablet_viewport_size(): void {
 		$this->register_visibility_block_with_support(
 			'test/viewport-tablet',
 			array( 'visibility' => true )
@@ -205,10 +203,10 @@ class Tests_Block_Supports_Block_Visibility extends WP_UnitTestCase {
 		);
 	}
 
-	/*
+	/**
 	 * @ticket 64414
 	 */
-	public function test_block_visibility_support_generated_css_with_desktop_breakpoint() {
+	public function test_block_visibility_support_generated_css_with_desktop_breakpoint(): void {
 		$this->register_visibility_block_with_support(
 			'test/viewport-desktop',
 			array( 'visibility' => true )
@@ -250,7 +248,7 @@ class Tests_Block_Supports_Block_Visibility extends WP_UnitTestCase {
 	 * @ticket 64414
 	 * @ticket 64823
 	 */
-	public function test_block_visibility_support_generated_css_with_two_viewport_sizes() {
+	public function test_block_visibility_support_generated_css_with_two_viewport_sizes(): void {
 		$this->register_visibility_block_with_support(
 			'test/viewport-two',
 			array( 'visibility' => true )
@@ -356,10 +354,10 @@ class Tests_Block_Supports_Block_Visibility extends WP_UnitTestCase {
 		);
 	}
 
-	/*
+	/**
 	 * @ticket 64414
 	 */
-	public function test_block_visibility_support_generated_css_with_empty_object() {
+	public function test_block_visibility_support_generated_css_with_empty_object(): void {
 		$this->register_visibility_block_with_support(
 			'test/viewport-empty',
 			array( 'visibility' => true )
@@ -380,10 +378,10 @@ class Tests_Block_Supports_Block_Visibility extends WP_UnitTestCase {
 		$this->assertSame( $block_content, $result, 'Block content should remain unchanged when blockVisibility is an empty array.' );
 	}
 
-	/*
+	/**
 	 * @ticket 64414
 	 */
-	public function test_block_visibility_support_generated_css_with_unknown_viewport_sizes_ignored() {
+	public function test_block_visibility_support_generated_css_with_unknown_viewport_sizes_ignored(): void {
 		$this->register_visibility_block_with_support(
 			'test/viewport-unknown-viewport-sizes',
 			array( 'visibility' => true )
@@ -414,10 +412,10 @@ class Tests_Block_Supports_Block_Visibility extends WP_UnitTestCase {
 		);
 	}
 
-	/*
+	/**
 	 * @ticket 64414
 	 */
-	public function test_block_visibility_support_generated_css_with_empty_content() {
+	public function test_block_visibility_support_generated_css_with_empty_content(): void {
 		$this->register_visibility_block_with_support(
 			'test/viewport-empty-content',
 			array( 'visibility' => true )

--- a/tests/phpunit/tests/block-supports/block-visibility.php
+++ b/tests/phpunit/tests/block-supports/block-visibility.php
@@ -236,8 +236,9 @@ class Tests_Block_Supports_Block_Visibility extends WP_UnitTestCase {
 		);
 	}
 
-	/*
+	/**
 	 * @ticket 64414
+	 * @ticket 64823
 	 */
 	public function test_block_visibility_support_generated_css_with_two_viewport_sizes() {
 		$this->register_visibility_block_with_support(
@@ -259,13 +260,14 @@ class Tests_Block_Supports_Block_Visibility extends WP_UnitTestCase {
 			),
 		);
 
-		$block_content = '<div>Test content</div>';
+		$block_content = '<div>Test content <img src="https://example.com/image.jpg" width="1000" height="1000" alt=""></div>';
 		$result        = wp_render_block_visibility_support( $block_content, $block );
 
-		$this->assertStringContainsString(
-			'class="wp-block-hidden-desktop wp-block-hidden-mobile"',
+		$this->assertEqualHTML(
+			'<div class="wp-block-hidden-desktop wp-block-hidden-mobile">Test content <img fetchpriority="auto" src="https://example.com/image.jpg" width="1000" height="1000" alt=""></div>',
 			$result,
-			'Block should have both visibility classes in the class attribute'
+			'<body>',
+			'Block should have both visibility classes in the class attribute, and the IMG should have fetchpriority=auto.'
 		);
 
 		$actual_stylesheet = wp_style_engine_get_stylesheet_from_context( 'block-supports', array( 'prettify' => false ) );

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -4552,7 +4552,7 @@ EOF;
 					'fetchpriority' => 'high',
 				),
 				wp_get_loading_optimization_attributes( 'img', $attr, $context ),
-				"Expected first image to not be lazy-loaded. First large image gets high fetchpriority."
+				'Expected first image to not be lazy-loaded. First large image gets high fetchpriority.'
 			);
 
 			$this->assert_fetchpriority_low_loading_attrs( $attr, $context );

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -4607,7 +4607,7 @@ EOF;
 	/**
 	 * Tests that wp_get_loading_optimization_attributes() returns the expected loading attribute value.
 	 *
-	 * This test is the same as {@see self::wp_get_loading_optimization_attributes()} except that the IMG which
+	 * This test is the same as {@see self::test_wp_get_loading_optimization_attributes()} except that the IMG which
 	 * previously got `fetchpriority=high` now initially has `fetchpriority=auto`. This causes the initial lazy-loaded
 	 * image to be bumped down one.
 	 *

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -6086,52 +6086,83 @@ EOF;
 	 *
 	 * @dataProvider data_wp_maybe_add_fetchpriority_high_attr
 	 */
-	public function test_wp_maybe_add_fetchpriority_high_attr( $loading_attrs, $tag_name, $attr, $expected_fetchpriority ) {
+	public function test_wp_maybe_add_fetchpriority_high_attr( array $loading_attrs, string $tag_name, array $attr, ?string $expected_fetchpriority, bool $expected_high_priority_element_flag ): void {
 		$loading_attrs = wp_maybe_add_fetchpriority_high_attr( $loading_attrs, $tag_name, $attr );
 
-		if ( $expected_fetchpriority ) {
+		if ( null !== $expected_fetchpriority ) {
 			$this->assertArrayHasKey( 'fetchpriority', $loading_attrs, 'fetchpriority attribute should be present' );
 			$this->assertSame( $expected_fetchpriority, $loading_attrs['fetchpriority'], 'fetchpriority attribute has incorrect value' );
 		} else {
 			$this->assertArrayNotHasKey( 'fetchpriority', $loading_attrs, 'fetchpriority attribute should not be present' );
 		}
+		$this->assertSame( $expected_high_priority_element_flag, wp_high_priority_element_flag() );
 	}
 
 	/**
 	 * Data provider.
 	 *
-	 * @return array[]
+	 * @return array<string, array{
+	 *     0: array<string, string>,
+	 *     1: string,
+	 *     2: array<string, string>,
+	 *     3: string|null,
+	 *     5: bool,
+	 * }}>
 	 */
-	public function data_wp_maybe_add_fetchpriority_high_attr() {
+	public function data_wp_maybe_add_fetchpriority_high_attr(): array {
 		return array(
-			'small image'                   => array(
+			'small image'                         => array(
 				array(),
 				'img',
 				$this->get_insufficient_width_height_for_high_priority(),
-				false,
+				null,
+				true,
 			),
-			'large image'                   => array(
+			'small image with fetchpriority=auto' => array(
+				array(),
+				'img',
+				array_merge(
+					$this->get_insufficient_width_height_for_high_priority(),
+					array( 'fetchpriority' => 'auto' )
+				),
+				null,
+				true,
+			),
+			'large image'                         => array(
 				array(),
 				'img',
 				$this->get_width_height_for_high_priority(),
 				'high',
+				false,
 			),
-			'image with loading=lazy'       => array(
+			'large image with fetchpriority=auto' => array(
+				array(),
+				'img',
+				array_merge(
+					$this->get_width_height_for_high_priority(),
+					array( 'fetchpriority' => 'auto' )
+				),
+				null,
+				false,
+			),
+			'image with loading=lazy'             => array(
 				array(
 					'loading'  => 'lazy',
 					'decoding' => 'async',
 				),
 				'img',
 				$this->get_width_height_for_high_priority(),
-				false,
+				null,
+				true,
 			),
-			'image with loading=eager'      => array(
+			'image with loading=eager'            => array(
 				array( 'loading' => 'eager' ),
 				'img',
 				$this->get_width_height_for_high_priority(),
 				'high',
+				false,
 			),
-			'image with fetchpriority=high' => array(
+			'image with fetchpriority=high'       => array(
 				array(),
 				'img',
 				array_merge(
@@ -6139,21 +6170,24 @@ EOF;
 					array( 'fetchpriority' => 'high' )
 				),
 				'high',
+				false,
 			),
-			'image with fetchpriority=low'  => array(
+			'image with fetchpriority=low'        => array(
 				array(),
 				'img',
 				array_merge(
 					$this->get_insufficient_width_height_for_high_priority(),
 					array( 'fetchpriority' => 'low' )
 				),
-				false,
+				null,
+				true,
 			),
-			'non-image element'             => array(
+			'non-image element'                   => array(
 				array(),
 				'video',
 				$this->get_width_height_for_high_priority(),
-				false,
+				null,
+				true,
 			),
 		);
 	}

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -6232,10 +6232,10 @@ EOF;
 	 * @return array<string, array{
 	 *     0: array<string, string>,
 	 *     1: string,
-	 *     2: array<string, string>,
+	 *     2: array<string, mixed>,
 	 *     3: string|null,
-	 *     5: bool,
-	 * }}>
+	 *     4: bool,
+	 * }>
 	 */
 	public function data_wp_maybe_add_fetchpriority_high_attr(): array {
 		return array(
@@ -7227,9 +7227,9 @@ EOF;
 	/**
 	 * Returns an array with dimension attribute values eligible for a high priority image.
 	 *
-	 * @return array Associative array with 'width' and 'height' keys.
+	 * @return array{ width: int, height: int } Associative array with 'width' and 'height' keys.
 	 */
-	private function get_width_height_for_high_priority() {
+	private function get_width_height_for_high_priority(): array {
 		/*
 		 * The product of width * height must be >50000 to qualify for high priority image.
 		 * 300 * 200 = 60000
@@ -7243,9 +7243,9 @@ EOF;
 	/**
 	 * Returns an array with dimension attribute values ineligible for a high priority image.
 	 *
-	 * @return array Associative array with 'width' and 'height' keys.
+	 * @return array{ width: int, height: int } Associative array with 'width' and 'height' keys.
 	 */
-	private function get_insufficient_width_height_for_high_priority() {
+	private function get_insufficient_width_height_for_high_priority(): array {
 		/*
 		 * The product of width * height must be >50000 to qualify for high priority image.
 		 * 200 * 100 = 20000

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -4513,6 +4513,8 @@ EOF;
 			wp_get_loading_optimization_attributes( 'img', $attr, 'wp_get_attachment_image' )
 		);
 
+		$this->assert_fetchpriority_low_loading_attrs( $attr, 'wp_get_attachment_image' );
+
 		// Return 'lazy' if not in the loop or the main query.
 		$this->assertSameSetsWithIndex(
 			array(
@@ -4527,6 +4529,8 @@ EOF;
 		while ( have_posts() ) {
 			the_post();
 
+			$this->assert_fetchpriority_low_loading_attrs( $attr, $context );
+
 			// Return 'lazy' if in the loop but not in the main query.
 			$this->assertSameSetsWithIndex(
 				array(
@@ -4539,6 +4543,8 @@ EOF;
 			// Set as main query.
 			$this->set_main_query( $query );
 
+			$this->assert_fetchpriority_low_loading_attrs( $attr, $context );
+
 			// First three element are not lazy loaded. However, first image is loaded with fetchpriority high.
 			$this->assertSameSetsWithIndex(
 				array(
@@ -4548,6 +4554,9 @@ EOF;
 				wp_get_loading_optimization_attributes( 'img', $attr, $context ),
 				"Expected first image to not be lazy-loaded. First large image get's high fetchpriority."
 			);
+
+			$this->assert_fetchpriority_low_loading_attrs( $attr, $context );
+
 			$this->assertSameSetsWithIndex(
 				array(
 					'decoding' => 'async',
@@ -4555,6 +4564,9 @@ EOF;
 				wp_get_loading_optimization_attributes( 'img', $attr, $context ),
 				'Expected second image to not be lazy-loaded.'
 			);
+
+			$this->assert_fetchpriority_low_loading_attrs( $attr, $context );
+
 			$this->assertSameSetsWithIndex(
 				array(
 					'decoding' => 'async',
@@ -4562,6 +4574,8 @@ EOF;
 				wp_get_loading_optimization_attributes( 'img', $attr, $context ),
 				'Expected third image to not be lazy-loaded.'
 			);
+
+			$this->assert_fetchpriority_low_loading_attrs( $attr, $context );
 
 			// Return 'lazy' if in the loop and in the main query for any subsequent elements.
 			$this->assertSameSetsWithIndex(
@@ -4572,6 +4586,8 @@ EOF;
 				wp_get_loading_optimization_attributes( 'img', $attr, $context )
 			);
 
+			$this->assert_fetchpriority_low_loading_attrs( $attr, $context );
+
 			// Yes, for all subsequent elements.
 			$this->assertSameSetsWithIndex(
 				array(
@@ -4580,6 +4596,8 @@ EOF;
 				),
 				wp_get_loading_optimization_attributes( 'img', $attr, $context )
 			);
+
+			$this->assert_fetchpriority_low_loading_attrs( $attr, $context );
 		}
 	}
 
@@ -4606,12 +4624,17 @@ EOF;
 			'The "loading" attribute should be "lazy" when not in the loop or the main query.'
 		);
 
+		$this->assert_fetchpriority_low_loading_attrs( $attr, $context );
+
 		$query = $this->get_new_wp_query_for_published_post();
 
 		// Set as main query.
 		$this->set_main_query( $query );
 
 		while ( have_posts() ) {
+
+			$this->assert_fetchpriority_low_loading_attrs( $attr, $context );
+
 			the_post();
 
 			$this->assertSameSetsWithIndex(
@@ -4656,8 +4679,12 @@ EOF;
 			'The "loading" attribute should be "lazy" before the main query loop.'
 		);
 
+		$this->assert_fetchpriority_low_loading_attrs( $attr, $context );
+
 		while ( have_posts() ) {
 			the_post();
+
+			$this->assert_fetchpriority_low_loading_attrs( $attr, $context );
 
 			$this->assertSameSetsWithIndex(
 				array(
@@ -4740,6 +4767,8 @@ EOF;
 			wp_get_loading_optimization_attributes( 'img', $attr, $context ),
 			'Images in the header context should get lazy-loaded after the wp_loading_optimization_force_header_contexts filter.'
 		);
+
+		$this->assert_fetchpriority_low_loading_attrs( $attr, $context );
 	}
 
 	/**
@@ -4769,6 +4798,8 @@ EOF;
 				return $contexts;
 			}
 		);
+
+		$this->assert_fetchpriority_low_loading_attrs( $attr, 'something_completely_arbitrary' );
 
 		$this->assertSameSetsWithIndex(
 			array(
@@ -4809,6 +4840,8 @@ EOF;
 			),
 			wp_get_loading_optimization_attributes( 'img', $attr, $context )
 		);
+
+		$this->assert_fetchpriority_low_loading_attrs( $attr, $context );
 	}
 
 	/**
@@ -4840,6 +4873,8 @@ EOF;
 			),
 			wp_get_loading_optimization_attributes( 'img', $attr, $context )
 		);
+
+		$this->assert_fetchpriority_low_loading_attrs( $attr, $context );
 	}
 
 	/**
@@ -4862,6 +4897,8 @@ EOF;
 		do_action( 'get_header' );
 
 		$attr = $this->get_width_height_for_high_priority();
+
+		$this->assert_fetchpriority_low_loading_attrs( $attr, $context );
 
 		// First image is loaded with high fetchpriority.
 		$this->assertSameSetsWithIndex(
@@ -6309,6 +6346,24 @@ EOF;
 		);
 	}
 
+	/**
+	 * Asserts that loading attributes for IMG with fetchpriority=low.
+	 *
+	 * It must not get lazy-loaded or increase the counter since they may be in the Navigation Overlay.
+	 */
+	protected function assert_fetchpriority_low_loading_attrs( array $attr, string $context ): void {
+		$this->assertSameSetsWithIndex(
+			array(
+				'fetchpriority' => 'low',
+				'decoding'      => 'async',
+			),
+			wp_get_loading_optimization_attributes(
+				'img',
+				array_merge( $attr, array( 'fetchpriority' => 'low' ) ),
+				$context
+			)
+		);
+	}
 
 	/**
 	 * Test WebP lossless quality is handled correctly.

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -3916,7 +3916,10 @@ EOF;
 		$this->assertFalse( wp_get_loading_attr_default( 'template_part_' . WP_TEMPLATE_PART_AREA_HEADER ), 'Images in the footer block template part should not be lazy-loaded.' );
 	}
 
-	public function data_wp_get_loading_attr_default() {
+	/**
+	 * @return array<int, array{ 0: string }>
+	 */
+	public function data_wp_get_loading_attr_default(): array {
 		return array(
 			array( 'the_content' ),
 			array( 'the_post_thumbnail' ),
@@ -4481,7 +4484,7 @@ EOF;
 	}
 
 	/**
-	 * Tests that wp_get_loading_attr_default() returns the expected loading attribute value.
+	 * Tests that wp_get_loading_optimization_attributes() returns the expected loading attribute value.
 	 *
 	 * @ticket 53675
 	 * @ticket 56930
@@ -4494,7 +4497,7 @@ EOF;
 	 *
 	 * @param string $context
 	 */
-	public function test_wp_get_loading_optimization_attributes( $context ) {
+	public function test_wp_get_loading_optimization_attributes( string $context ): void {
 		$attr = $this->get_width_height_for_high_priority();
 
 		// Return 'lazy' by default.
@@ -4582,6 +4585,131 @@ EOF;
 				array(
 					'decoding' => 'async',
 					'loading'  => 'lazy',
+				),
+				wp_get_loading_optimization_attributes( 'img', $attr, $context )
+			);
+
+			$this->assert_fetchpriority_low_loading_attrs( $attr, $context );
+
+			// Yes, for all subsequent elements.
+			$this->assertSameSetsWithIndex(
+				array(
+					'decoding' => 'async',
+					'loading'  => 'lazy',
+				),
+				wp_get_loading_optimization_attributes( 'img', $attr, $context )
+			);
+
+			$this->assert_fetchpriority_low_loading_attrs( $attr, $context );
+		}
+	}
+
+	/**
+	 * Tests that wp_get_loading_optimization_attributes() returns the expected loading attribute value.
+	 *
+	 * This test is the same as {@see self::wp_get_loading_optimization_attributes()} except that the IMG which
+	 * previously got `fetchpriority=high` now initially has `fetchpriority=auto`. This causes the initial lazy-loaded
+	 * image to be bumped down one.
+	 *
+	 * @ticket 64823
+	 *
+	 * @covers ::wp_get_loading_optimization_attributes
+	 *
+	 * @dataProvider data_wp_get_loading_attr_default
+	 *
+	 * @param string $context
+	 */
+	public function test_wp_get_loading_optimization_attributes_with_fetchpriority_auto_for_lcp_candidate( string $context ): void {
+		$attr = $this->get_width_height_for_high_priority();
+
+		// Return 'lazy' by default.
+		$this->assertSameSetsWithIndex(
+			array(
+				'decoding' => 'async',
+				'loading'  => 'lazy',
+			),
+			wp_get_loading_optimization_attributes( 'img', $attr, 'test' )
+		);
+		$this->assertSameSetsWithIndex(
+			array(
+				'decoding' => 'async',
+				'loading'  => 'lazy',
+			),
+			wp_get_loading_optimization_attributes( 'img', $attr, 'wp_get_attachment_image' )
+		);
+
+		$this->assert_fetchpriority_low_loading_attrs( $attr, 'wp_get_attachment_image' );
+
+		// Return 'lazy' if not in the loop or the main query.
+		$this->assertSameSetsWithIndex(
+			array(
+				'decoding' => 'async',
+				'loading'  => 'lazy',
+			),
+			wp_get_loading_optimization_attributes( 'img', $attr, $context )
+		);
+
+		$query = $this->get_new_wp_query_for_published_post();
+
+		while ( have_posts() ) {
+			the_post();
+
+			$this->assert_fetchpriority_low_loading_attrs( $attr, $context );
+
+			// Return 'lazy' if in the loop but not in the main query.
+			$this->assertSameSetsWithIndex(
+				array(
+					'decoding' => 'async',
+					'loading'  => 'lazy',
+				),
+				wp_get_loading_optimization_attributes( 'img', $attr, $context )
+			);
+
+			// Set as main query.
+			$this->set_main_query( $query );
+
+			$this->assert_fetchpriority_low_loading_attrs( $attr, $context );
+
+			// First three element are not lazy loaded. However, first image initially has `fetchpriority=auto` which marks it as a possible LCP element.
+			$this->assertSameSetsWithIndex(
+				array(
+					'decoding'      => 'async',
+					'fetchpriority' => 'auto',
+				),
+				wp_get_loading_optimization_attributes(
+					'img',
+					array_merge( $attr, array( 'fetchpriority' => 'auto' ) ),
+					$context
+				),
+				'Expected first image to not be lazy-loaded.'
+			);
+
+			$this->assert_fetchpriority_low_loading_attrs( $attr, $context );
+
+			$this->assertSameSetsWithIndex(
+				array(
+					'decoding' => 'async',
+				),
+				wp_get_loading_optimization_attributes( 'img', $attr, $context ),
+				'Expected second image to not be lazy-loaded.'
+			);
+
+			$this->assert_fetchpriority_low_loading_attrs( $attr, $context );
+
+			$this->assertSameSetsWithIndex(
+				array(
+					'decoding' => 'async',
+				),
+				wp_get_loading_optimization_attributes( 'img', $attr, $context ),
+				'Expected third image to not be lazy-loaded.'
+			);
+
+			$this->assert_fetchpriority_low_loading_attrs( $attr, $context );
+
+			// This is the 4th subsequent image, and it still is not lazy-loaded because the first had fetchpriority=auto and so it may have been hidden with block visibility.
+			$this->assertSameSetsWithIndex(
+				array(
+					'decoding' => 'async',
 				),
 				wp_get_loading_optimization_attributes( 'img', $attr, $context )
 			);

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -6350,6 +6350,9 @@ EOF;
 	 * Asserts that loading attributes for IMG with fetchpriority=low.
 	 *
 	 * It must not get lazy-loaded or increase the counter since they may be in the Navigation Overlay.
+	 *
+	 * @param array<string, string> $attr
+	 * @param string                $context
 	 */
 	protected function assert_fetchpriority_low_loading_attrs( array $attr, string $context ): void {
 		$this->assertSameSetsWithIndex(

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -4552,7 +4552,7 @@ EOF;
 					'fetchpriority' => 'high',
 				),
 				wp_get_loading_optimization_attributes( 'img', $attr, $context ),
-				"Expected first image to not be lazy-loaded. First large image get's high fetchpriority."
+				"Expected first image to not be lazy-loaded. First large image gets high fetchpriority."
 			);
 
 			$this->assert_fetchpriority_low_loading_attrs( $attr, $context );

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -6513,8 +6513,8 @@ EOF;
 	 *
 	 * It must not get lazy-loaded or increase the counter since they may be in the Navigation Overlay.
 	 *
-	 * @param array<string, string> $attr
-	 * @param string                $context
+	 * @param array<string, mixed> $attr
+	 * @param string               $context
 	 */
 	protected function assert_fetchpriority_low_loading_attrs( array $attr, string $context ): void {
 		$this->assertSameSetsWithIndex(

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -4601,6 +4601,20 @@ EOF;
 			);
 
 			$this->assert_fetchpriority_low_loading_attrs( $attr, $context );
+
+			$this->assertSameSetsWithIndex(
+				array(
+					'decoding'      => 'async',
+					'fetchpriority' => 'auto',
+					'loading'       => 'lazy',
+				),
+				wp_get_loading_optimization_attributes(
+					'img',
+					array_merge( $attr, array( 'fetchpriority' => 'auto' ) ),
+					$context
+				),
+				'Expected a fetchpriority=auto IMG appearing after the media count threshold to still be lazy-loaded.'
+			);
 		}
 	}
 

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -4738,7 +4738,7 @@ EOF;
 					array_merge( $attr, array( 'fetchpriority' => 'auto' ) ),
 					$context
 				),
-				'Expected a fetchpriority=auto IMG appearing after the media count threshold to till be lazy-loaded.'
+				'Expected a fetchpriority=auto IMG appearing after the media count threshold to still be lazy-loaded.'
 			);
 		}
 	}

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -4921,7 +4921,7 @@ EOF;
 
 		add_filter(
 			'wp_loading_optimization_force_header_contexts',
-			function ( $context ) {
+			function ( $contexts ) {
 				$contexts['something_completely_arbitrary'] = true;
 				return $contexts;
 			}

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -4726,6 +4726,20 @@ EOF;
 			);
 
 			$this->assert_fetchpriority_low_loading_attrs( $attr, $context );
+
+			$this->assertSameSetsWithIndex(
+				array(
+					'decoding'      => 'async',
+					'fetchpriority' => 'auto',
+					'loading'       => 'lazy',
+				),
+				wp_get_loading_optimization_attributes(
+					'img',
+					array_merge( $attr, array( 'fetchpriority' => 'auto' ) ),
+					$context
+				),
+				'Expected a fetchpriority=auto IMG appearing after the media count threshold to till be lazy-loaded.'
+			);
 		}
 	}
 


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/64823

## Ensure `IMG` with `fetchpriority=low` does not get lazy-loaded, increase media count, or interfere with assigning `fetchpriority=high`

With https://github.com/WordPress/gutenberg/pull/76208 checked out and there are 5 large images added to a Navigation Overlay and 5 large images in the post content, given the following script being run in the console:

```js
Array.from(document.querySelectorAll(".wp-site-blocks img")).map((img) => {
  return {
    insideNavOverlay: !!img.closest(".wp-block-navigation__overlay-container"),
    loading: img.loading,
    fetchPriority: img.fetchPriority,
  };
});
```

<details><summary>Before ❌</summary>

```json
[
    {
        "insideNavOverlay": true,
        "loading": "auto",
        "fetchPriority": "low"
    },
    {
        "insideNavOverlay": true,
        "loading": "auto",
        "fetchPriority": "low"
    },
    {
        "insideNavOverlay": true,
        "loading": "auto",
        "fetchPriority": "low"
    },
    {
        "insideNavOverlay": true,
        "loading": "auto",
        "fetchPriority": "low"
    },
    {
        "insideNavOverlay": true,
        "loading": "auto",
        "fetchPriority": "low"
    },
    {
        "insideNavOverlay": false,
        "loading": "lazy",
        "fetchPriority": "auto"
    },
    {
        "insideNavOverlay": false,
        "loading": "lazy",
        "fetchPriority": "auto"
    },
    {
        "insideNavOverlay": false,
        "loading": "lazy",
        "fetchPriority": "auto"
    },
    {
        "insideNavOverlay": false,
        "loading": "lazy",
        "fetchPriority": "auto"
    },
    {
        "insideNavOverlay": false,
        "loading": "lazy",
        "fetchPriority": "auto"
    }
]
```

</details> 

<details><summary>After ✅</summary>

```json
[
    {
        "insideNavOverlay": true,
        "loading": "auto",
        "fetchPriority": "low"
    },
    {
        "insideNavOverlay": true,
        "loading": "auto",
        "fetchPriority": "low"
    },
    {
        "insideNavOverlay": true,
        "loading": "auto",
        "fetchPriority": "low"
    },
    {
        "insideNavOverlay": true,
        "loading": "auto",
        "fetchPriority": "low"
    },
    {
        "insideNavOverlay": true,
        "loading": "auto",
        "fetchPriority": "low"
    },
    {
        "insideNavOverlay": false,
        "loading": "auto",
        "fetchPriority": "high"
    },
    {
        "insideNavOverlay": false,
        "loading": "auto",
        "fetchPriority": "auto"
    },
    {
        "insideNavOverlay": false,
        "loading": "auto",
        "fetchPriority": "auto"
    },
    {
        "insideNavOverlay": false,
        "loading": "lazy",
        "fetchPriority": "auto"
    },
    {
        "insideNavOverlay": false,
        "loading": "lazy",
        "fetchPriority": "auto"
    }
]
```

</details> 

The diff shows the changes to the first three images in the content (outside of the navigation overlay):

```diff
--- before.json	2026-03-06 15:32:18
+++ after.json	2026-03-06 15:32:27
@@ -26,17 +26,17 @@
     },
     {
         "insideNavOverlay": false,
-        "loading": "lazy",
-        "fetchPriority": "auto"
+        "loading": "auto",
+        "fetchPriority": "high"
     },
     {
         "insideNavOverlay": false,
-        "loading": "lazy",
+        "loading": "auto",
         "fetchPriority": "auto"
     },
     {
         "insideNavOverlay": false,
-        "loading": "lazy",
+        "loading": "auto",
         "fetchPriority": "auto"
     },
     {
```

Fixes:

1. Preserve `fetchpriority=high` being assigned to the first large image outside of the Navigation Overlay.
2. Prevent adding `loading=lazy` on the first three images in the content.

## Add support for `fetchpriority=auto`

This also improves handling of `IMG` tags with `fetchpriority=auto`, as is proposed solution to prevent viewport-conditional Image blocks from getting `fetchpriority=high` applied. See:

- https://github.com/WordPress/gutenberg/pull/76302

(This wordpress-develop PR is a backport PR for that Gutenberg PR.)

Nevertheless, that PR alone does exclude images with `fetchpriority=auto` from contributing to the overall media count. This means you can have 3 images which are conditionally displayed in mobile, tablet, and desktop, respectively, and then the fourth image is rendered with `loading=lazy` when in reality it is only the second image actually displayed.

<details><summary>Example Post Content</summary>

```html
<!-- wp:image {"id":38,"sizeSlug":"large","linkDestination":"none","metadata":{"blockVisibility":{"viewport":{"desktop":false,"tablet":false}},"name":"Mobile image"}} -->
<figure class="wp-block-image size-large"><img src="http://localhost:8000/wp-content/uploads/2025/11/Bison_bison_Wichita_Mountain_Oklahoma-1024x741.jpg" alt="Mobile" class="wp-image-38"/></figure>
<!-- /wp:image -->

<!-- wp:image {"id":37,"sizeSlug":"large","linkDestination":"none","metadata":{"blockVisibility":{"viewport":{"desktop":false,"mobile":false}},"name":"Tablet image"}} -->
<figure class="wp-block-image size-large"><img src="http://localhost:8000/wp-content/uploads/2025/11/Bison_with_its_young-2560w-1024x683.jpg" alt="Tablet" class="wp-image-37"/></figure>
<!-- /wp:image -->

<!-- wp:image {"id":36,"sizeSlug":"large","linkDestination":"none","metadata":{"blockVisibility":{"viewport":{"tablet":false,"mobile":false}},"name":"Desktop image"}} -->
<figure class="wp-block-image size-large"><img src="http://localhost:8000/wp-content/uploads/2025/11/American_bison_k5680-1-1024x668.jpg" alt="Desktop" class="wp-image-36"/></figure>
<!-- /wp:image -->

<!-- wp:image {"id":430,"sizeSlug":"large","linkDestination":"none"} -->
<figure class="wp-block-image size-large"><img src="http://localhost:8000/wp-content/uploads/2026/03/PXL_20260125_215136959-1024x771.jpg" alt="" class="wp-image-430"/></figure>
<!-- /wp:image -->
```

</details> 

<details><summary>Before ❌</summary>

```html
<div
  class="entry-content alignfull wp-block-post-content has-global-padding is-layout-constrained wp-block-post-content-is-layout-constrained"
>
  <figure
    class="wp-block-image size-large wp-block-hidden-desktop wp-block-hidden-tablet"
  >
    <img
      decoding="async"
      width="1024"
      height="741"
      fetchpriority="auto"
      src="http://localhost:8000/wp-content/uploads/2025/11/Bison_bison_Wichita_Mountain_Oklahoma-1024x741.jpg"
      alt="Mobile"
      class="wp-image-38"
      srcset="
        http://localhost:8000/wp-content/uploads/2025/11/Bison_bison_Wichita_Mountain_Oklahoma-1024x741.jpg  1024w,
        http://localhost:8000/wp-content/uploads/2025/11/Bison_bison_Wichita_Mountain_Oklahoma-300x217.jpg    300w,
        http://localhost:8000/wp-content/uploads/2025/11/Bison_bison_Wichita_Mountain_Oklahoma-768x556.jpg    768w,
        http://localhost:8000/wp-content/uploads/2025/11/Bison_bison_Wichita_Mountain_Oklahoma-1536x1112.jpg 1536w,
        http://localhost:8000/wp-content/uploads/2025/11/Bison_bison_Wichita_Mountain_Oklahoma-2048x1483.jpg 2048w
      "
      sizes="(max-width: 1024px) 100vw, 1024px"
    />
  </figure>

  <figure
    class="wp-block-image size-large wp-block-hidden-desktop wp-block-hidden-mobile"
  >
    <img
      decoding="async"
      width="1024"
      height="683"
      fetchpriority="auto"
      src="http://localhost:8000/wp-content/uploads/2025/11/Bison_with_its_young-2560w-1024x683.jpg"
      alt="Tablet"
      class="wp-image-37"
      srcset="
        http://localhost:8000/wp-content/uploads/2025/11/Bison_with_its_young-2560w-1024x683.jpg  1024w,
        http://localhost:8000/wp-content/uploads/2025/11/Bison_with_its_young-2560w-300x200.jpg    300w,
        http://localhost:8000/wp-content/uploads/2025/11/Bison_with_its_young-2560w-768x512.jpg    768w,
        http://localhost:8000/wp-content/uploads/2025/11/Bison_with_its_young-2560w-1536x1025.jpg 1536w,
        http://localhost:8000/wp-content/uploads/2025/11/Bison_with_its_young-2560w-2048x1366.jpg 2048w
      "
      sizes="(max-width: 1024px) 100vw, 1024px"
    />
  </figure>

  <figure
    class="wp-block-image size-large wp-block-hidden-mobile wp-block-hidden-tablet"
  >
    <img
      decoding="async"
      width="1024"
      height="668"
      fetchpriority="auto"
      src="http://localhost:8000/wp-content/uploads/2025/11/American_bison_k5680-1-1024x668.jpg"
      alt="Desktop"
      class="wp-image-36"
      srcset="
        http://localhost:8000/wp-content/uploads/2025/11/American_bison_k5680-1-1024x668.jpg  1024w,
        http://localhost:8000/wp-content/uploads/2025/11/American_bison_k5680-1-300x196.jpg    300w,
        http://localhost:8000/wp-content/uploads/2025/11/American_bison_k5680-1-768x501.jpg    768w,
        http://localhost:8000/wp-content/uploads/2025/11/American_bison_k5680-1-1536x1002.jpg 1536w,
        http://localhost:8000/wp-content/uploads/2025/11/American_bison_k5680-1-2048x1336.jpg 2048w
      "
      sizes="(max-width: 1024px) 100vw, 1024px"
    />
  </figure>

  <figure class="wp-block-image size-large">
    <img
      loading="lazy"
      decoding="async"
      width="1024"
      height="771"
      src="http://localhost:8000/wp-content/uploads/2026/03/PXL_20260125_215136959-1024x771.jpg"
      alt=""
      class="wp-image-430"
      srcset="
        http://localhost:8000/wp-content/uploads/2026/03/PXL_20260125_215136959-1024x771.jpg  1024w,
        http://localhost:8000/wp-content/uploads/2026/03/PXL_20260125_215136959-300x226.jpg    300w,
        http://localhost:8000/wp-content/uploads/2026/03/PXL_20260125_215136959-768x578.jpg    768w,
        http://localhost:8000/wp-content/uploads/2026/03/PXL_20260125_215136959-1536x1157.jpg 1536w,
        http://localhost:8000/wp-content/uploads/2026/03/PXL_20260125_215136959-2048x1542.jpg 2048w
      "
      sizes="auto, (max-width: 1024px) 100vw, 1024px"
    />
  </figure>
</div>
```

</details> 

<details><summary>After ✅</summary>

```html
<div
  class="entry-content alignfull wp-block-post-content has-global-padding is-layout-constrained wp-block-post-content-is-layout-constrained"
>
  <figure
    class="wp-block-image size-large wp-block-hidden-desktop wp-block-hidden-tablet"
  >
    <img
      decoding="async"
      width="1024"
      height="741"
      fetchpriority="auto"
      src="http://localhost:8000/wp-content/uploads/2025/11/Bison_bison_Wichita_Mountain_Oklahoma-1024x741.jpg"
      alt="Mobile"
      class="wp-image-38"
      srcset="
        http://localhost:8000/wp-content/uploads/2025/11/Bison_bison_Wichita_Mountain_Oklahoma-1024x741.jpg  1024w,
        http://localhost:8000/wp-content/uploads/2025/11/Bison_bison_Wichita_Mountain_Oklahoma-300x217.jpg    300w,
        http://localhost:8000/wp-content/uploads/2025/11/Bison_bison_Wichita_Mountain_Oklahoma-768x556.jpg    768w,
        http://localhost:8000/wp-content/uploads/2025/11/Bison_bison_Wichita_Mountain_Oklahoma-1536x1112.jpg 1536w,
        http://localhost:8000/wp-content/uploads/2025/11/Bison_bison_Wichita_Mountain_Oklahoma-2048x1483.jpg 2048w
      "
      sizes="(max-width: 1024px) 100vw, 1024px"
    />
  </figure>

  <figure
    class="wp-block-image size-large wp-block-hidden-desktop wp-block-hidden-mobile"
  >
    <img
      decoding="async"
      width="1024"
      height="683"
      fetchpriority="auto"
      src="http://localhost:8000/wp-content/uploads/2025/11/Bison_with_its_young-2560w-1024x683.jpg"
      alt="Tablet"
      class="wp-image-37"
      srcset="
        http://localhost:8000/wp-content/uploads/2025/11/Bison_with_its_young-2560w-1024x683.jpg  1024w,
        http://localhost:8000/wp-content/uploads/2025/11/Bison_with_its_young-2560w-300x200.jpg    300w,
        http://localhost:8000/wp-content/uploads/2025/11/Bison_with_its_young-2560w-768x512.jpg    768w,
        http://localhost:8000/wp-content/uploads/2025/11/Bison_with_its_young-2560w-1536x1025.jpg 1536w,
        http://localhost:8000/wp-content/uploads/2025/11/Bison_with_its_young-2560w-2048x1366.jpg 2048w
      "
      sizes="(max-width: 1024px) 100vw, 1024px"
    />
  </figure>

  <figure
    class="wp-block-image size-large wp-block-hidden-mobile wp-block-hidden-tablet"
  >
    <img
      decoding="async"
      width="1024"
      height="668"
      fetchpriority="auto"
      src="http://localhost:8000/wp-content/uploads/2025/11/American_bison_k5680-1-1024x668.jpg"
      alt="Desktop"
      class="wp-image-36"
      srcset="
        http://localhost:8000/wp-content/uploads/2025/11/American_bison_k5680-1-1024x668.jpg  1024w,
        http://localhost:8000/wp-content/uploads/2025/11/American_bison_k5680-1-300x196.jpg    300w,
        http://localhost:8000/wp-content/uploads/2025/11/American_bison_k5680-1-768x501.jpg    768w,
        http://localhost:8000/wp-content/uploads/2025/11/American_bison_k5680-1-1536x1002.jpg 1536w,
        http://localhost:8000/wp-content/uploads/2025/11/American_bison_k5680-1-2048x1336.jpg 2048w
      "
      sizes="(max-width: 1024px) 100vw, 1024px"
    />
  </figure>

  <figure class="wp-block-image size-large">
    <img
      decoding="async"
      width="1024"
      height="771"
      src="http://localhost:8000/wp-content/uploads/2026/03/PXL_20260125_215136959-1024x771.jpg"
      alt=""
      class="wp-image-430"
      srcset="
        http://localhost:8000/wp-content/uploads/2026/03/PXL_20260125_215136959-1024x771.jpg  1024w,
        http://localhost:8000/wp-content/uploads/2026/03/PXL_20260125_215136959-300x226.jpg    300w,
        http://localhost:8000/wp-content/uploads/2026/03/PXL_20260125_215136959-768x578.jpg    768w,
        http://localhost:8000/wp-content/uploads/2026/03/PXL_20260125_215136959-1536x1157.jpg 1536w,
        http://localhost:8000/wp-content/uploads/2026/03/PXL_20260125_215136959-2048x1542.jpg 2048w
      "
      sizes="(max-width: 1024px) 100vw, 1024px"
    />
  </figure>
</div>
```

</details> 

```diff
--- before.html	2026-03-08 19:17:32
+++ after.html	2026-03-08 19:18:07
@@ -69,7 +69,6 @@
 
   <figure class="wp-block-image size-large">
     <img
-      loading="lazy"
       decoding="async"
       width="1024"
       height="771"
@@ -83,7 +82,7 @@
         http://localhost:8000/wp-content/uploads/2026/03/PXL_20260125_215136959-1536x1157.jpg 1536w,
         http://localhost:8000/wp-content/uploads/2026/03/PXL_20260125_215136959-2048x1542.jpg 2048w
       "
-      sizes="auto, (max-width: 1024px) 100vw, 1024px"
+      sizes="(max-width: 1024px) 100vw, 1024px"
     />
   </figure>
 </div>
```

## Use of AI Tools

* None for authoring
* Copilot for review

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
