### PR TITLE
Docs: fix path typos in hook cross-references

### DIFF
--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -1953,7 +1953,7 @@ function _unzip_file_pclzip( $file, $to, $needed_dirs = array() ) {
 		}
 	}
 
-	/** This filter is documented in src/wp-admin/includes/file.php */
+	/** This filter is documented in wp-admin/includes/file.php */
 	$pre = apply_filters( 'pre_unzip_file', null, $file, $to, $needed_dirs, $required_space );
 
 	if ( null !== $pre ) {
@@ -1980,7 +1980,7 @@ function _unzip_file_pclzip( $file, $to, $needed_dirs = array() ) {
 		}
 	}
 
-	/** This action is documented in src/wp-admin/includes/file.php */
+	/** This filter is documented in wp-admin/includes/file.php */
 	$result = apply_filters( 'unzip_file', true, $file, $to, $needed_dirs, $required_space );
 
 	unset( $needed_dirs );

--- a/src/wp-includes/class-wp-customize-widgets.php
+++ b/src/wp-includes/class-wp-customize-widgets.php
@@ -897,7 +897,7 @@ final class WP_Customize_Widgets {
 			wp_enqueue_script( 'wp-customize-widgets' );
 			wp_enqueue_style( 'wp-customize-widgets' );
 
-			/** This action is documented in edit-form-blocks.php */
+			/** This action is documented in wp-admin/edit-form-blocks.php */
 			do_action( 'enqueue_block_editor_assets' );
 		}
 	}

--- a/src/wp-includes/deprecated.php
+++ b/src/wp-includes/deprecated.php
@@ -4790,7 +4790,7 @@ function wp_img_tag_add_loading_attr( $image, $context ) {
 		return $image;
 	}
 
-	/** This filter is documented in wp-admin/includes/media.php */
+	/** This filter is documented in wp-includes/media.php */
 	$value = apply_filters( 'wp_img_tag_add_loading_attr', $value, $image, $context );
 
 	if ( $value ) {

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php
@@ -436,7 +436,7 @@ class WP_REST_Autosaves_Controller extends WP_REST_Revisions_Controller {
 			$new_autosave['ID']          = $old_autosave->ID;
 			$new_autosave['post_author'] = $user_id;
 
-			/** This filter is documented in wp-admin/post.php */
+			/** This action is documented in wp-admin/includes/post.php */
 			do_action( 'wp_creating_autosave', $new_autosave );
 
 			// wp_update_post() expects escaped array.

--- a/src/wp-includes/widgets.php
+++ b/src/wp-includes/widgets.php
@@ -711,11 +711,11 @@ function dynamic_sidebar( $index = 1 ) {
 
 	$sidebars_widgets = wp_get_sidebars_widgets();
 	if ( empty( $wp_registered_sidebars[ $index ] ) || empty( $sidebars_widgets[ $index ] ) || ! is_array( $sidebars_widgets[ $index ] ) ) {
-		/** This action is documented in wp-includes/widget.php */
+		/** This action is documented in wp-includes/widgets.php */
 		do_action( 'dynamic_sidebar_before', $index, false );
-		/** This action is documented in wp-includes/widget.php */
+		/** This action is documented in wp-includes/widgets.php */
 		do_action( 'dynamic_sidebar_after', $index, false );
-		/** This filter is documented in wp-includes/widget.php */
+		/** This filter is documented in wp-includes/widgets.php */
 		return apply_filters( 'dynamic_sidebar_has_widgets', false, $index );
 	}
 


### PR DESCRIPTION
## Summary

Fixes 8 broken "This filter/action is documented in …" cross-reference comments where the referenced file path contains a typo or incorrect prefix:

- `wp-includes/widget.php` → `wp-includes/widgets.php` (missing 's') — 3 xrefs
- `edit-form-blocks.php` → `wp-admin/edit-form-blocks.php` (missing prefix) — 1 xref
- `wp-admin/post.php` → `wp-admin/includes/post.php` (missing `includes/`) — 1 xref
- `src/wp-admin/includes/file.php` → `wp-admin/includes/file.php` (spurious `src/`) — 2 xrefs
- `wp-admin/includes/media.php` → `wp-includes/media.php` (wrong path) — 1 xref

Also corrects two hook type labels (`filter` → `action` for `wp_creating_autosave`, `action` → `filter` for `unzip_file`).

For detailed investigation notes, see: https://github.com/apermo/wordpress-develop/milestone/2

Trac ticket: https://core.trac.wordpress.org/ticket/64224

## Use of AI Tools

Research (cross-reference audit using custom PHPStan rules and PHP scripts) and code were produced by Claude Code (claude-sonnet-4-6). The contributor reviewed the findings, verified each fix, and approved the final implementation.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**