### PR TITLE
Docs: update hook xrefs for relocated hooks

### DIFF
--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -2382,7 +2382,7 @@ function wp_ajax_save_widget() {
 	 */
 	do_action( 'widgets.php' ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
 
-	/** This action is documented in wp-admin/widgets.php */
+	/** This action is documented in wp-admin/widgets-form.php */
 	do_action( 'sidebar_admin_setup' );
 
 	$id_base      = wp_unslash( $_POST['id_base'] );
@@ -2410,7 +2410,7 @@ function wp_ajax_save_widget() {
 			'delete_widget'      => '1',
 		);
 
-		/** This action is documented in wp-admin/widgets.php */
+		/** This action is documented in wp-admin/widgets-form.php */
 		do_action( 'delete_widget', $widget_id, $sidebar_id, $id_base );
 
 	} elseif ( $settings && preg_match( '/__i__|%i%/', key( $settings ) ) ) {
@@ -2486,7 +2486,7 @@ function wp_ajax_delete_inactive_widgets() {
 	do_action( 'load-widgets.php' ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
 	/** This action is documented in wp-admin/includes/ajax-actions.php */
 	do_action( 'widgets.php' ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
-	/** This action is documented in wp-admin/widgets.php */
+	/** This action is documented in wp-admin/widgets-form.php */
 	do_action( 'sidebar_admin_setup' );
 
 	$sidebars_widgets = wp_get_sidebars_widgets();

--- a/src/wp-admin/includes/ms.php
+++ b/src/wp-admin/includes/ms.php
@@ -97,7 +97,7 @@ function wpmu_delete_blog( $blog_id, $drop = false ) {
 	if ( $drop ) {
 		wp_delete_site( $blog_id );
 	} else {
-		/** This action is documented in wp-includes/ms-blogs.php */
+		/** This action is documented in wp-includes/ms-site.php */
 		do_action_deprecated( 'delete_blog', array( $blog_id, false ), '5.1.0' );
 
 		$users = get_users(
@@ -116,7 +116,7 @@ function wpmu_delete_blog( $blog_id, $drop = false ) {
 
 		update_blog_status( $blog_id, 'deleted', 1 );
 
-		/** This action is documented in wp-includes/ms-blogs.php */
+		/** This action is documented in wp-includes/ms-site.php */
 		do_action_deprecated( 'deleted_blog', array( $blog_id, false ), '5.1.0' );
 	}
 

--- a/src/wp-includes/class-wp-customize-widgets.php
+++ b/src/wp-includes/class-wp-customize-widgets.php
@@ -338,7 +338,7 @@ final class WP_Customize_Widgets {
 		/** This action is documented in wp-admin/includes/ajax-actions.php */
 		do_action( 'widgets.php' ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
 
-		/** This action is documented in wp-admin/widgets.php */
+		/** This action is documented in wp-admin/widgets-form.php */
 		do_action( 'sidebar_admin_setup' );
 	}
 
@@ -1722,7 +1722,7 @@ final class WP_Customize_Widgets {
 		/** This action is documented in wp-admin/includes/ajax-actions.php */
 		do_action( 'widgets.php' ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
 
-		/** This action is documented in wp-admin/widgets.php */
+		/** This action is documented in wp-admin/widgets-form.php */
 		do_action( 'sidebar_admin_setup' );
 
 		$widget_id = $this->get_post_value( 'widget-id' );

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -3469,21 +3469,21 @@ class WP_Query {
 		}
 
 		if ( ! empty( $this->posts ) && $this->is_comment_feed && $this->is_singular ) {
-			/** This filter is documented in wp-includes/query.php */
+			/** This filter is documented in wp-includes/class-wp-query.php */
 			$cjoin = apply_filters_ref_array( 'comment_feed_join', array( '', &$this ) );
 
-			/** This filter is documented in wp-includes/query.php */
+			/** This filter is documented in wp-includes/class-wp-query.php */
 			$cwhere = apply_filters_ref_array( 'comment_feed_where', array( "WHERE comment_post_ID = '{$this->posts[0]->ID}' AND comment_approved = '1'", &$this ) );
 
-			/** This filter is documented in wp-includes/query.php */
+			/** This filter is documented in wp-includes/class-wp-query.php */
 			$cgroupby = apply_filters_ref_array( 'comment_feed_groupby', array( '', &$this ) );
 			$cgroupby = ( ! empty( $cgroupby ) ) ? 'GROUP BY ' . $cgroupby : '';
 
-			/** This filter is documented in wp-includes/query.php */
+			/** This filter is documented in wp-includes/class-wp-query.php */
 			$corderby = apply_filters_ref_array( 'comment_feed_orderby', array( 'comment_date_gmt DESC', &$this ) );
 			$corderby = ( ! empty( $corderby ) ) ? 'ORDER BY ' . $corderby : '';
 
-			/** This filter is documented in wp-includes/query.php */
+			/** This filter is documented in wp-includes/class-wp-query.php */
 			$climits = apply_filters_ref_array( 'comment_feed_limits', array( 'LIMIT ' . get_option( 'posts_per_rss' ), &$this ) );
 
 			$comments_request = "SELECT {$wpdb->comments}.comment_ID FROM {$wpdb->comments} $cjoin $cwhere $cgroupby $corderby $climits";

--- a/src/wp-includes/class-wp-text-diff-renderer-table.php
+++ b/src/wp-includes/class-wp-text-diff-renderer-table.php
@@ -235,7 +235,7 @@ class WP_Text_Diff_Renderer_Table extends Text_Diff_Renderer {
 			if ( $encode ) {
 				$processed_line = htmlspecialchars( $line );
 
-				/** This filter is documented in wp-includes/wp-diff.php */
+				/** This filter is documented in wp-includes/class-wp-text-diff-renderer-table.php */
 				$line = apply_filters( 'process_text_diff_html', $processed_line, $line, 'deleted' );
 			}
 			if ( $this->_show_split_view ) {
@@ -260,7 +260,7 @@ class WP_Text_Diff_Renderer_Table extends Text_Diff_Renderer {
 			if ( $encode ) {
 				$processed_line = htmlspecialchars( $line );
 
-				/** This filter is documented in wp-includes/wp-diff.php */
+				/** This filter is documented in wp-includes/class-wp-text-diff-renderer-table.php */
 				$line = apply_filters( 'process_text_diff_html', $processed_line, $line, 'unchanged' );
 			}
 			if ( $this->_show_split_view ) {

--- a/src/wp-includes/comment.php
+++ b/src/wp-includes/comment.php
@@ -807,7 +807,7 @@ function wp_allow_comment( $commentdata, $wp_error = false ) {
 	);
 
 	if ( $is_flood ) {
-		/** This filter is documented in wp-includes/comment-template.php */
+		/** This filter is documented in wp-includes/comment.php */
 		$comment_flood_message = apply_filters( 'comment_flood_message', __( 'You are posting comments too quickly. Slow down.' ) );
 
 		return new WP_Error( 'comment_flood', $comment_flood_message, 429 );

--- a/src/wp-includes/ms-load.php
+++ b/src/wp-includes/ms-load.php
@@ -383,7 +383,7 @@ function ms_load_current_site_and_network( $domain, $path, $subdomain = false ) 
 
 	// No network has been found, bail.
 	if ( empty( $current_site ) ) {
-		/** This action is documented in wp-includes/ms-settings.php */
+		/** This action is documented in wp-includes/ms-load.php */
 		do_action( 'ms_network_not_found', $domain, $path );
 
 		return false;

--- a/src/wp-includes/rest-api/class-wp-rest-server.php
+++ b/src/wp-includes/rest-api/class-wp-rest-server.php
@@ -1388,11 +1388,11 @@ class WP_REST_Server {
 			}
 			$available['image_output_formats'] = (object) $output_formats;
 
-			/** This filter is documented in wp-includes/class-wp-image-editor-imagick.php */
+			/** This filter is documented in wp-includes/class-wp-image-editor-gd.php */
 			$available['jpeg_interlaced'] = (bool) apply_filters( 'image_save_progressive', false, 'image/jpeg' );
-			/** This filter is documented in wp-includes/class-wp-image-editor-imagick.php */
+			/** This filter is documented in wp-includes/class-wp-image-editor-gd.php */
 			$available['png_interlaced'] = (bool) apply_filters( 'image_save_progressive', false, 'image/png' );
-			/** This filter is documented in wp-includes/class-wp-image-editor-imagick.php */
+			/** This filter is documented in wp-includes/class-wp-image-editor-gd.php */
 			$available['gif_interlaced'] = (bool) apply_filters( 'image_save_progressive', false, 'image/gif' );
 		}
 

--- a/src/wp-includes/rest-api/class-wp-rest-server.php
+++ b/src/wp-includes/rest-api/class-wp-rest-server.php
@@ -1383,7 +1383,7 @@ class WP_REST_Server {
 			$input_formats  = array( 'image/jpeg', 'image/png', 'image/gif', 'image/webp', 'image/avif', 'image/heic' );
 			$output_formats = array();
 			foreach ( $input_formats as $mime_type ) {
-				/** This filter is documented in wp-includes/class-wp-image-editor.php */
+				/** This filter is documented in wp-includes/media.php */
 				$output_formats = apply_filters( 'image_editor_output_format', $output_formats, '', $mime_type );
 			}
 			$available['image_output_formats'] = (object) $output_formats;


### PR DESCRIPTION
## Summary

Fixes 17 broken "This filter/action is documented in …" cross-reference comments where the hook was moved to a different file but the cross-reference was not updated:

- `wp-admin/widgets.php` → `wp-admin/widgets-form.php` (`sidebar_admin_setup`, `delete_widget`) — 5 xrefs
- `wp-includes/query.php` → `wp-includes/class-wp-query.php` (`comment_feed_*` filters) — 5 xrefs
- `wp-includes/wp-diff.php` → `wp-includes/class-wp-text-diff-renderer-table.php` (`process_text_diff_html`) — 2 xrefs
- `wp-includes/comment-template.php` → `wp-includes/comment.php` (`comment_flood_message`) — 1 xref
- `wp-includes/ms-settings.php` → `wp-includes/ms-load.php` (`ms_network_not_found`) — 1 xref
- `wp-includes/ms-blogs.php` → `wp-includes/ms-site.php` (`delete_blog`, `deleted_blog`) — 2 xrefs
- `wp-includes/class-wp-image-editor-imagick.php` → `wp-includes/class-wp-image-editor-gd.php` (`image_save_progressive`) — 3 xrefs (core only; 3 additional in bundled Gutenberg)
- `wp-includes/class-wp-image-editor.php` → `wp-includes/media.php` (`image_editor_output_format`) — 1 xref

For detailed investigation notes, see: https://github.com/apermo/wordpress-develop/milestone/2

Trac ticket: https://core.trac.wordpress.org/ticket/64224

## Use of AI Tools

Research (cross-reference audit using custom PHPStan rules and PHP scripts) and code were produced by Claude Code (claude-sonnet-4-6). The contributor reviewed the findings, verified each fix, and approved the final implementation.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**