### PR TITLE
chore: fix hook registration type mismatches

### DIFF
--- a/src/wp-admin/includes/admin-filters.php
+++ b/src/wp-admin/includes/admin-filters.php
@@ -85,7 +85,7 @@ add_filter( 'wp_refresh_nonces', 'wp_refresh_heartbeat_nonces' );
 
 add_filter( 'heartbeat_settings', 'wp_heartbeat_set_suspension' );
 
-add_action( 'use_block_editor_for_post_type', '_disable_block_editor_for_navigation_post_type', 10, 2 );
+add_filter( 'use_block_editor_for_post_type', '_disable_block_editor_for_navigation_post_type', 10, 2 );
 add_action( 'edit_form_after_title', '_disable_content_editor_for_navigation_post_type' );
 add_action( 'edit_form_after_editor', '_enable_content_editor_for_navigation_post_type' );
 

--- a/src/wp-admin/includes/admin-filters.php
+++ b/src/wp-admin/includes/admin-filters.php
@@ -53,7 +53,7 @@ add_filter( 'nav_menu_meta_box_object', '_wp_nav_menu_meta_box_object' );
 
 // Prerendering.
 if ( ! is_customize_preview() ) {
-	add_filter( 'admin_print_styles', 'wp_resource_hints', 1 );
+	add_action( 'admin_print_styles', 'wp_resource_hints', 1 );
 }
 
 add_action( 'admin_print_scripts', 'print_emoji_detection_script' );

--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -385,7 +385,7 @@ if (
 
 // Login actions.
 add_action( 'login_head', 'wp_robots', 1 );
-add_filter( 'login_head', 'wp_resource_hints', 8 );
+add_action( 'login_head', 'wp_resource_hints', 8 );
 add_action( 'login_head', 'wp_print_head_scripts', 9 );
 add_action( 'login_head', 'print_admin_styles', 9 );
 add_action( 'login_head', 'wp_site_icon', 99 );


### PR DESCRIPTION
## Summary

Fixes 3 cases where hooks are registered with the wrong function — `add_action()` used on a filter or `add_filter()` used on an action. Functionally equivalent (since `add_action()` calls `add_filter()` internally), but semantically incorrect.

### `add_filter()` → `add_action()` (hook is fired via `do_action()`):
- `admin_print_styles` in `wp-admin/includes/admin-filters.php`
- `login_head` in `wp-includes/default-filters.php`

### `add_action()` → `add_filter()` (hook is fired via `apply_filters()`):
- `use_block_editor_for_post_type` in `wp-admin/includes/admin-filters.php`

A 4th mismatch (`get_block_type_variations` using `add_action()` on a filter) originates in the Gutenberg repo and is tracked separately: https://github.com/WordPress/gutenberg/issues/76296

For detailed investigation notes, see: https://github.com/apermo/wordpress-develop/milestone/4

Trac ticket: https://core.trac.wordpress.org/ticket/64828

## Use of AI Tools

Research (systematic cross-referencing of all `add_action`/`add_filter` registrations against their `do_action`/`apply_filters` call sites) and code were produced by Claude Code (claude-sonnet-4-6). The contributor reviewed the findings, verified each fix, and approved the final implementation.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**