### PR TITLE
Docs: add missing hook cross-reference comments

### DIFF
--- a/src/wp-admin/admin.php
+++ b/src/wp-admin/admin.php
@@ -395,17 +395,22 @@ if ( isset( $plugin_page ) ) {
 	 */
 	if ( 'page' === $typenow ) {
 		if ( 'post-new.php' === $pagenow ) {
+			/** This action is documented in wp-admin/admin.php */
 			do_action( 'load-page-new.php' ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
 		} elseif ( 'post.php' === $pagenow ) {
+			/** This action is documented in wp-admin/admin.php */
 			do_action( 'load-page.php' ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
 		}
 	} elseif ( 'edit-tags.php' === $pagenow ) {
 		if ( 'category' === $taxnow ) {
+			/** This action is documented in wp-admin/admin.php */
 			do_action( 'load-categories.php' ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
 		} elseif ( 'link_category' === $taxnow ) {
+			/** This action is documented in wp-admin/admin.php */
 			do_action( 'load-edit-link-categories.php' ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
 		}
 	} elseif ( 'term.php' === $pagenow ) {
+		/** This action is documented in wp-admin/admin.php */
 		do_action( 'load-edit-tags.php' ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
 	}
 }

--- a/src/wp-includes/block-editor.php
+++ b/src/wp-includes/block-editor.php
@@ -338,6 +338,7 @@ function _wp_get_iframed_editor_assets() {
 	 * front-end assets for the content.
 	 */
 	add_filter( 'should_load_block_editor_scripts_and_styles', '__return_false' );
+	/** This action is documented in wp-includes/script-loader.php */
 	do_action( 'enqueue_block_assets' );
 	remove_filter( 'should_load_block_editor_scripts_and_styles', '__return_false' );
 

--- a/src/wp-includes/deprecated.php
+++ b/src/wp-includes/deprecated.php
@@ -150,6 +150,7 @@ function previous_post($format='%', $previous='previous post: ', $title='yes', $
 
 	$string = '<a href="'.get_permalink($post->ID).'">'.$previous;
 	if ( 'yes' == $title )
+		/** This filter is documented in wp-includes/post-template.php */
 		$string .= apply_filters('the_title', $post->post_title, $post->ID);
 	$string .= '</a>';
 	$format = str_replace('%', $string, $format);
@@ -185,6 +186,7 @@ function next_post($format='%', $next='next post: ', $title='yes', $in_same_cat=
 
 	$string = '<a href="'.get_permalink($post->ID).'">'.$next;
 	if ( 'yes' == $title )
+		/** This filter is documented in wp-includes/post-template.php */
 		$string .= apply_filters('the_title', $post->post_title, $post->ID);
 	$string .= '</a>';
 	$format = str_replace('%', $string, $format);
@@ -2702,6 +2704,7 @@ function get_boundary_post_rel_link($title = '%title', $in_same_cat = false, $ex
 
 	$title = str_replace('%title', $post->post_title, $title);
 	$title = str_replace('%date', $date, $title);
+	/** This filter is documented in wp-includes/post-template.php */
 	$title = apply_filters('the_title', $title, $post->ID);
 
 	$link = $start ? "<link rel='start' title='" : "<link rel='end' title='";
@@ -2779,6 +2782,7 @@ function get_parent_post_rel_link( $title = '%title' ) {
 
 	$title = str_replace('%title', $post->post_title, $title);
 	$title = str_replace('%date', $date, $title);
+	/** This filter is documented in wp-includes/post-template.php */
 	$title = apply_filters('the_title', $title, $post->ID);
 
 	$link = "<link rel='up' title='";

--- a/src/wp-includes/deprecated.php
+++ b/src/wp-includes/deprecated.php
@@ -1062,6 +1062,7 @@ function get_links_list($order = 'name') {
 			// Handle each category.
 
 			// Display the category name.
+			/** This filter is documented in wp-includes/bookmark-template.php */
 			echo '  <li id="linkcat-' . $cat->term_id . '" class="linkcat"><h2>' . apply_filters('link_category', $cat->name ) . "</h2>\n\t<ul>\n";
 			// Call get_links() with all the appropriate params.
 			get_links($cat->term_id, '<li>', "</li>", "\n", true, 'name', false);


### PR DESCRIPTION
## Summary

Adds 11 missing "This filter/action is documented in …" cross-reference comments for hook calls that have a canonical PHPDoc block elsewhere but were missing the xref:

- **`the_title`** (×4 in `wp-includes/deprecated.php`) → canonical PHPDoc in `wp-includes/post-template.php`
- **`link_category`** (×1 in `wp-includes/deprecated.php`) → canonical PHPDoc in `wp-includes/bookmark-template.php`
- **`enqueue_block_assets`** (×1 in `wp-includes/block-editor.php`) → canonical PHPDoc in `wp-includes/script-loader.php`
- **Legacy `load-*.php` actions** (×5 in `wp-admin/admin.php`) → canonical PHPDoc for `load-{$pagenow}` in the same file

For detailed investigation notes, see: https://github.com/apermo/wordpress-develop/milestone/5

Trac ticket: https://core.trac.wordpress.org/ticket/64224

## Use of AI Tools

Research (cross-reference audit across all hook call sites in core) and code were produced by Claude Code (claude-sonnet-4-6). The contributor reviewed the findings, verified each fix, and approved the final implementation.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**