### PR TITLE
Admin & Customizer: Fix type casting for version string and aria-pressed attribute

### DIFF
--- a/src/wp-admin/admin-header.php
+++ b/src/wp-admin/admin-header.php
@@ -195,7 +195,6 @@ $version_without_tag     = strtok( get_bloginfo( 'version' ), '-' );
 $version_components      = explode( '.', $version_without_tag );
 $version_class           = 'version-' . implode( '-', $version_components );
 $admin_body_class       .= ' ' . $version_class;
-
 $branch_version_components = array_slice( $version_components, 0, 2 );
 if ( '0' === array_last( $branch_version_components ) ) {
 	array_pop( $branch_version_components );

--- a/src/wp-admin/admin-header.php
+++ b/src/wp-admin/admin-header.php
@@ -191,7 +191,7 @@ if ( $current_screen->taxonomy ) {
 	$admin_body_class .= ' taxonomy-' . $current_screen->taxonomy;
 }
 
-$admin_body_class .= ' branch-' . str_replace( array( '.', ',' ), '-', (string) get_bloginfo( 'version' ) );
+$admin_body_class .= ' branch-' . str_replace( array( '.', ',' ), '-', (string) ( (float)  get_bloginfo( 'version' ) ) );
 $admin_body_class .= ' version-' . str_replace( '.', '-', preg_replace( '/^([.0-9]+).*/', '$1', get_bloginfo( 'version' ) ) );
 $admin_body_class .= ' admin-color-' . sanitize_html_class( get_user_option( 'admin_color' ), 'modern' );
 $admin_body_class .= ' locale-' . sanitize_html_class( strtolower( str_replace( '_', '-', get_user_locale() ) ) );

--- a/src/wp-admin/admin-header.php
+++ b/src/wp-admin/admin-header.php
@@ -191,8 +191,17 @@ if ( $current_screen->taxonomy ) {
 	$admin_body_class .= ' taxonomy-' . $current_screen->taxonomy;
 }
 
-$admin_body_class .= ' branch-' . str_replace( array( '.', ',' ), '-', (string) ( (float) get_bloginfo( 'version' ) ) );
-$admin_body_class .= ' version-' . str_replace( '.', '-', preg_replace( '/^([.0-9]+).*/', '$1', get_bloginfo( 'version' ) ) );
+$version_without_tag     = strtok( get_bloginfo( 'version' ), '-' );
+$version_components      = explode( '.', $version_without_tag );
+$version_class           = 'version-' . implode( '-', $version_components );
+$admin_body_class       .= ' ' . $version_class;
+
+$branch_version_components = array_slice( $version_components, 0, 2 );
+if ( '0' === array_last( $branch_version_components ) ) {
+	array_pop( $branch_version_components );
+}
+$branch_class      = 'branch-' . implode( '-', $branch_version_components );
+$admin_body_class .= ' ' . $branch_class;
 $admin_body_class .= ' admin-color-' . sanitize_html_class( get_user_option( 'admin_color' ), 'modern' );
 $admin_body_class .= ' locale-' . sanitize_html_class( strtolower( str_replace( '_', '-', get_user_locale() ) ) );
 

--- a/src/wp-admin/admin-header.php
+++ b/src/wp-admin/admin-header.php
@@ -191,7 +191,7 @@ if ( $current_screen->taxonomy ) {
 	$admin_body_class .= ' taxonomy-' . $current_screen->taxonomy;
 }
 
-$admin_body_class .= ' branch-' . str_replace( array( '.', ',' ), '-', (float) get_bloginfo( 'version' ) );
+$admin_body_class .= ' branch-' . str_replace( array( '.', ',' ), '-', (string) get_bloginfo( 'version' ) );
 $admin_body_class .= ' version-' . str_replace( '.', '-', preg_replace( '/^([.0-9]+).*/', '$1', get_bloginfo( 'version' ) ) );
 $admin_body_class .= ' admin-color-' . sanitize_html_class( get_user_option( 'admin_color' ), 'modern' );
 $admin_body_class .= ' locale-' . sanitize_html_class( strtolower( str_replace( '_', '-', get_user_locale() ) ) );

--- a/src/wp-admin/admin-header.php
+++ b/src/wp-admin/admin-header.php
@@ -191,7 +191,7 @@ if ( $current_screen->taxonomy ) {
 	$admin_body_class .= ' taxonomy-' . $current_screen->taxonomy;
 }
 
-$admin_body_class .= ' branch-' . str_replace( array( '.', ',' ), '-', (string) ( (float)  get_bloginfo( 'version' ) ) );
+$admin_body_class .= ' branch-' . str_replace( array( '.', ',' ), '-', (string) ( (float) get_bloginfo( 'version' ) ) );
 $admin_body_class .= ' version-' . str_replace( '.', '-', preg_replace( '/^([.0-9]+).*/', '$1', get_bloginfo( 'version' ) ) );
 $admin_body_class .= ' admin-color-' . sanitize_html_class( get_user_option( 'admin_color' ), 'modern' );
 $admin_body_class .= ' locale-' . sanitize_html_class( strtolower( str_replace( '_', '-', get_user_locale() ) ) );

--- a/src/wp-admin/customize.php
+++ b/src/wp-admin/customize.php
@@ -288,7 +288,7 @@ do_action( 'customize_controls_head' );
 							$class .= ' active';
 						}
 						?>
-						<button type="button" class="<?php echo esc_attr( $class ); ?>" aria-pressed="<?php echo esc_attr( (string) $active ); ?>" data-device="<?php echo esc_attr( $device ); ?>">
+						<button type="button" class="<?php echo esc_attr( $class ); ?>" aria-pressed="<?php echo esc_attr( $active ? 'true' : 'false' ); ?>" data-device="<?php echo esc_attr( $device ); ?>">
 							<span class="screen-reader-text"><?php echo esc_html( $settings['label'] ); ?></span>
 						</button>
 					<?php endforeach; ?>

--- a/src/wp-admin/customize.php
+++ b/src/wp-admin/customize.php
@@ -288,7 +288,7 @@ do_action( 'customize_controls_head' );
 							$class .= ' active';
 						}
 						?>
-						<button type="button" class="<?php echo esc_attr( $class ); ?>" aria-pressed="<?php echo esc_attr( $active ); ?>" data-device="<?php echo esc_attr( $device ); ?>">
+						<button type="button" class="<?php echo esc_attr( $class ); ?>" aria-pressed="<?php echo esc_attr( (string) $active ); ?>" data-device="<?php echo esc_attr( $device ); ?>">
 							<span class="screen-reader-text"><?php echo esc_html( $settings['label'] ); ?></span>
 						</button>
 					<?php endforeach; ?>


### PR DESCRIPTION
## Description
Fixes type casting issues found by PHPStan:

- **admin-header.php**: Change `(float)` to `(string)` cast for version to preserve full format (e.g., "7.0-beta3")
- **customize.php**: Add `(string)` cast for `$active` in `aria-pressed` attribute

## Trac Ticket
https://core.trac.wordpress.org/ticket/64238

## Testing
1. Admin body class shows full version (e.g., `branch-7-0-beta3`)
2. Customizer device buttons have proper `aria-pressed` string values