### PR TITLE
Update comment bubbles' color in hover state

### DIFF
--- a/src/wp-admin/css/list-tables.css
+++ b/src/wp-admin/css/list-tables.css
@@ -79,14 +79,14 @@
 .column-response a.post-com-count-approved:focus .comment-count-approved,
 .column-comments a.post-com-count-approved:hover .comment-count-approved,
 .column-comments a.post-com-count-approved:focus .comment-count-approved {
-	background: #2271b1;
+	background: #3858e9;
 }
 
 .column-response a.post-com-count-approved:hover:after,
 .column-response a.post-com-count-approved:focus:after,
 .column-comments a.post-com-count-approved:hover:after,
 .column-comments a.post-com-count-approved:focus:after {
-	border-top-color: #2271b1;
+	border-top-color: #3858e9;
 }
 
 /* @todo: consider to use a single rule for these counters and the admin menu counters. */


### PR DESCRIPTION
<!--

<!-- Insert a description of your changes here -->
I used `#3858e9` to set the colors instead of `var(--wp-admin-theme-color)`.  This acts as `<a>` in that they don't change color, no matter the chosen admin color scheme.
If it needs to use the variable instead, let me know, and I will update accordingly.

Trac ticket: https://core.trac.wordpress.org/ticket/64829#ticket

## Use of AI Tools
None

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
