### PR TITLE
Fixes #64825: Twenty Seventeen: Stop passing get_the_ID() to twentyseventeen_edit_link(), simplify docblock. 

### DIFF
--- a/src/wp-content/themes/twentyseventeen/inc/template-tags.php
+++ b/src/wp-content/themes/twentyseventeen/inc/template-tags.php
@@ -110,12 +110,7 @@ endif;
 
 if ( ! function_exists( 'twentyseventeen_edit_link' ) ) :
 	/**
-	 * Returns an accessibility-friendly link to edit a post or page.
-	 *
-	 * This also gives a little context about what exactly we're editing
-	 * (post or page?) so that users understand a bit more where they are in terms
-	 * of the template hierarchy and their content. Helpful when/if the single-page
-	 * layout with multiple posts/pages shown gets confusing.
+	 * Displays an accessibility-friendly edit link for the current post in the loop.
 	 */
 	function twentyseventeen_edit_link() {
 		edit_post_link(

--- a/src/wp-content/themes/twentyseventeen/inc/template-tags.php
+++ b/src/wp-content/themes/twentyseventeen/inc/template-tags.php
@@ -110,7 +110,7 @@ endif;
 
 if ( ! function_exists( 'twentyseventeen_edit_link' ) ) :
 	/**
-	 * Displays an accessibility-friendly edit link for the current post in the loop.
+	 * Displays an accessibility-friendly link to edit a post or page.
 	 */
 	function twentyseventeen_edit_link() {
 		edit_post_link(

--- a/src/wp-content/themes/twentyseventeen/template-parts/page/content-front-page-panels.php
+++ b/src/wp-content/themes/twentyseventeen/template-parts/page/content-front-page-panels.php
@@ -33,7 +33,7 @@ global $twentyseventeencounter;
 			<header class="entry-header">
 				<?php the_title( '<h2 class="entry-title">', '</h2>' ); ?>
 
-				<?php twentyseventeen_edit_link( get_the_ID() ); ?>
+				<?php twentyseventeen_edit_link(); ?>
 
 			</header><!-- .entry-header -->
 

--- a/src/wp-content/themes/twentyseventeen/template-parts/page/content-front-page.php
+++ b/src/wp-content/themes/twentyseventeen/template-parts/page/content-front-page.php
@@ -30,7 +30,7 @@
 			<header class="entry-header">
 				<?php the_title( '<h2 class="entry-title">', '</h2>' ); ?>
 
-				<?php twentyseventeen_edit_link( get_the_ID() ); ?>
+				<?php twentyseventeen_edit_link(); ?>
 
 			</header><!-- .entry-header -->
 

--- a/src/wp-content/themes/twentyseventeen/template-parts/page/content-page.php
+++ b/src/wp-content/themes/twentyseventeen/template-parts/page/content-page.php
@@ -15,7 +15,7 @@
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
 	<header class="entry-header">
 		<?php the_title( '<h1 class="entry-title">', '</h1>' ); ?>
-		<?php twentyseventeen_edit_link( get_the_ID() ); ?>
+		<?php twentyseventeen_edit_link(); ?>
 	</header><!-- .entry-header -->
 	<div class="entry-content">
 		<?php


### PR DESCRIPTION
Stop passing get_the_ID() to twentyseventeen_edit_link() 

Trac ticket: https://core.trac.wordpress.org/ticket/64825

