### PR TITLE
General: Introduce wp_get_branch_version() helper to extract major.minor version safely.

### DIFF
--- a/src/wp-admin/admin-header.php
+++ b/src/wp-admin/admin-header.php
@@ -191,7 +191,11 @@ if ( $current_screen->taxonomy ) {
 	$admin_body_class .= ' taxonomy-' . $current_screen->taxonomy;
 }
 
-$admin_body_class .= ' branch-' . str_replace( '.', '-', preg_replace( '/\.0$/', '', wp_get_branch_version() ) );
+$major_version     = wp_get_wp_version( 'major' );
+$admin_body_class .= ' branch-' . str_replace( '.', '-', $major_version );
+if ( str_ends_with( $major_version, '.0' ) ) {
+	$admin_body_class .= ' branch-' . (int) $major_version;
+}
 $admin_body_class .= ' version-' . str_replace( '.', '-', preg_replace( '/^([.0-9]+).*/', '$1', get_bloginfo( 'version' ) ) );
 $admin_body_class .= ' admin-color-' . sanitize_html_class( get_user_option( 'admin_color' ), 'modern' );
 $admin_body_class .= ' locale-' . sanitize_html_class( strtolower( str_replace( '_', '-', get_user_locale() ) ) );

--- a/src/wp-admin/admin-header.php
+++ b/src/wp-admin/admin-header.php
@@ -191,7 +191,7 @@ if ( $current_screen->taxonomy ) {
 	$admin_body_class .= ' taxonomy-' . $current_screen->taxonomy;
 }
 
-$admin_body_class .= ' branch-' . str_replace( array( '.', ',' ), '-', (float) get_bloginfo( 'version' ) );
+$admin_body_class .= ' branch-' . str_replace( '.', '-', preg_replace( '/\.0$/', '', wp_get_branch_version() ) );
 $admin_body_class .= ' version-' . str_replace( '.', '-', preg_replace( '/^([.0-9]+).*/', '$1', get_bloginfo( 'version' ) ) );
 $admin_body_class .= ' admin-color-' . sanitize_html_class( get_user_option( 'admin_color' ), 'modern' );
 $admin_body_class .= ' locale-' . sanitize_html_class( strtolower( str_replace( '_', '-', get_user_locale() ) ) );

--- a/src/wp-admin/includes/class-core-upgrader.php
+++ b/src/wp-admin/includes/class-core-upgrader.php
@@ -279,8 +279,8 @@ class Core_Upgrader extends WP_Upgrader {
 	public static function should_update_to_version( $offered_ver ) {
 		require ABSPATH . WPINC . '/version.php'; // $wp_version; // x.y.z
 
-		$current_branch = implode( '.', array_slice( preg_split( '/[.-]/', $wp_version ), 0, 2 ) ); // x.y
-		$new_branch     = implode( '.', array_slice( preg_split( '/[.-]/', $offered_ver ), 0, 2 ) ); // x.y
+		$current_branch = wp_get_branch_version( $wp_version ); // x.y
+		$new_branch     = wp_get_branch_version( $offered_ver ); // x.y
 
 		$current_is_development_version = (bool) strpos( $wp_version, '-' );
 

--- a/src/wp-admin/includes/class-wp-site-health-auto-updates.php
+++ b/src/wp-admin/includes/class-wp-site-health-auto-updates.php
@@ -352,8 +352,16 @@ class WP_Site_Health_Auto_Updates {
 		$dev       = ( str_contains( $wp_version, '-' ) );
 		// Get the last stable version's files and test against that.
 		if ( ! $checksums && $dev ) {
-			$parts     = preg_split( '/[.-]/', $wp_version, 3 );
-			$prev_ver  = $parts[0] . '.' . max( 0, (int) ( $parts[1] ?? 0 ) - 1 );
+			$parts = explode( '.', wp_get_branch_version( $wp_version ) );
+			$major = (int) $parts[0];
+			$minor = (int) $parts[1];
+
+			if ( $minor > 0 ) {
+				$prev_ver = $major . '.' . ( $minor - 1 );
+			} else {
+				$prev_ver = ( $major - 1 ) . '.9';
+			}
+
 			$checksums = get_core_checksums( $prev_ver, 'en_US' );
 		}
 

--- a/src/wp-admin/includes/class-wp-site-health-auto-updates.php
+++ b/src/wp-admin/includes/class-wp-site-health-auto-updates.php
@@ -352,7 +352,9 @@ class WP_Site_Health_Auto_Updates {
 		$dev       = ( str_contains( $wp_version, '-' ) );
 		// Get the last stable version's files and test against that.
 		if ( ! $checksums && $dev ) {
-			$checksums = get_core_checksums( (float) $wp_version - 0.1, 'en_US' );
+			$parts     = preg_split( '/[.-]/', $wp_version, 3 );
+			$prev_ver  = $parts[0] . '.' . max( 0, (int) ( $parts[1] ?? 0 ) - 1 );
+			$checksums = get_core_checksums( $prev_ver, 'en_US' );
 		}
 
 		// There aren't always checksums for development releases, so just skip the test if we still can't find any.

--- a/src/wp-admin/includes/plugin-install.php
+++ b/src/wp-admin/includes/plugin-install.php
@@ -113,7 +113,7 @@ function plugins_api( $action, $args = array() ) {
 	}
 
 	if ( ! isset( $args->wp_version ) ) {
-		$args->wp_version = wp_get_branch_version(); // x.y
+		$args->wp_version = wp_get_wp_version( 'major' ); // x.y
 	}
 
 	/**

--- a/src/wp-admin/includes/plugin-install.php
+++ b/src/wp-admin/includes/plugin-install.php
@@ -113,7 +113,7 @@ function plugins_api( $action, $args = array() ) {
 	}
 
 	if ( ! isset( $args->wp_version ) ) {
-		$args->wp_version = substr( wp_get_wp_version(), 0, 3 ); // x.y
+		$args->wp_version = wp_get_branch_version(); // x.y
 	}
 
 	/**

--- a/src/wp-admin/includes/theme.php
+++ b/src/wp-admin/includes/theme.php
@@ -504,7 +504,7 @@ function themes_api( $action, $args = array() ) {
 	}
 
 	if ( ! isset( $args->wp_version ) ) {
-		$args->wp_version = wp_get_branch_version(); // x.y
+		$args->wp_version = wp_get_wp_version( 'major' ); // x.y
 	}
 
 	/**

--- a/src/wp-admin/includes/theme.php
+++ b/src/wp-admin/includes/theme.php
@@ -504,7 +504,7 @@ function themes_api( $action, $args = array() ) {
 	}
 
 	if ( ! isset( $args->wp_version ) ) {
-		$args->wp_version = substr( wp_get_wp_version(), 0, 3 ); // x.y
+		$args->wp_version = wp_get_branch_version(); // x.y
 	}
 
 	/**

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -1553,7 +1553,7 @@ function wp_generate_block_templates_export_file() {
 	$theme_json_raw = $tree->get_data();
 	// If a version is defined, add a schema.
 	if ( $theme_json_raw['version'] ) {
-		$theme_json_version = 'wp/' . substr( $wp_version, 0, 3 );
+		$theme_json_version = 'wp/' . wp_get_branch_version( $wp_version );
 		$schema             = array( '$schema' => 'https://schemas.wp.org/' . $theme_json_version . '/theme.json' );
 		$theme_json_raw     = array_merge( $schema, $theme_json_raw );
 	}

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -8979,6 +8979,28 @@ function wp_get_wp_version() {
 }
 
 /**
+ * Returns the major.minor "branch" version for a given WordPress version string.
+ *
+ * Extracts the first two version components (major and minor) from a WordPress
+ * version string, stripping any patch level and pre-release suffix.
+ *
+ * @since 7.1.0
+ *
+ * @param string $version Optional. A WordPress version string. Defaults to the
+ *                        current WordPress version from wp_get_wp_version().
+ * @return string The branch version string in "major.minor" format (e.g. "6.9").
+ */
+function wp_get_branch_version( $version = '' ) {
+	if ( '' === $version ) {
+		$version = wp_get_wp_version();
+	}
+
+	$parts = preg_split( '/[.-]/', $version, 3 );
+
+	return $parts[0] . '.' . ( $parts[1] ?? '0' );
+}
+
+/**
  * Checks compatibility with the current WordPress version.
  *
  * @since 5.2.0

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -8987,9 +8987,7 @@ function wp_get_wp_version( $part = 'full' ) {
 
 	if ( 'major' === $part ) {
 		return wp_get_branch_version( $wp_version );
-	}
-
-	if ( 'minor' === $part ) {
+	} elseif ( 'minor' === $part ) {
 		$parts = preg_split( '/[.-]/', $wp_version, 4 );
 		return $parts[0] . '.' . ( $parts[1] ?? '0' ) . '.' . ( $parts[2] ?? '0' );
 	}

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -8958,37 +8958,56 @@ function clean_dirsize_cache( $path ) {
 }
 
 /**
- * Returns the current WordPress version.
+ * Returns the WordPress version string in the requested format.
  *
- * Returns an unmodified value of `$wp_version`. Some plugins modify the global
- * in an attempt to improve security through obscurity. This practice can cause
- * errors in WordPress, so the ability to get an unmodified version is needed.
+ * Returns an unmodified value of `$wp_version` by default. Some plugins modify
+ * the global in an attempt to improve security through obscurity. This practice
+ * can cause errors in WordPress, so the ability to get an unmodified version is
+ * needed.
+ *
+ * WordPress version numbering: x.y is the "major" release (e.g. 7.0, 6.9),
+ * x.y.z is the "minor" release (e.g. 7.0.1). See
+ * https://make.wordpress.org/core/handbook/about/release-cycle/version-numbering/
  *
  * @since 6.7.0
+ * @since 7.1.0 Added the `$part` parameter to support 'major' and 'minor' formats.
  *
- * @return string The current WordPress version.
+ * @param string $part Optional. The version part to return. Accepts 'major' for the
+ *                     x.y version (e.g. '6.9'), 'minor' for the x.y.z version
+ *                     (e.g. '6.9.1'), or 'full' for the complete version string
+ *                     (e.g. '7.0-beta3-61849'). Default 'full'.
+ * @return string The WordPress version string in the requested format.
  */
-function wp_get_wp_version() {
+function wp_get_wp_version( $part = 'full' ) {
 	static $wp_version;
 
 	if ( ! isset( $wp_version ) ) {
 		require ABSPATH . WPINC . '/version.php';
 	}
 
+	if ( 'major' === $part ) {
+		return wp_get_branch_version( $wp_version );
+	}
+
+	if ( 'minor' === $part ) {
+		$parts = preg_split( '/[.-]/', $wp_version, 4 );
+		return $parts[0] . '.' . ( $parts[1] ?? '0' ) . '.' . ( $parts[2] ?? '0' );
+	}
+
 	return $wp_version;
 }
 
 /**
- * Returns the major.minor "branch" version for a given WordPress version string.
+ * Extracts the major version (x.y) from a WordPress version string.
  *
- * Extracts the first two version components (major and minor) from a WordPress
- * version string, stripping any patch level and pre-release suffix.
+ * WordPress version numbering: x.y is the "major" release (e.g. 7.0, 6.9).
+ * This function strips the minor release number and any pre-release suffix.
  *
  * @since 7.1.0
  *
  * @param string $version Optional. A WordPress version string. Defaults to the
  *                        current WordPress version from wp_get_wp_version().
- * @return string The branch version string in "major.minor" format (e.g. "6.9").
+ * @return string The major version string in "x.y" format (e.g. "7.0").
  */
 function wp_get_branch_version( $version = '' ) {
 	if ( '' === $version ) {

--- a/tests/phpunit/tests/functions/wpGetBranchVersion.php
+++ b/tests/phpunit/tests/functions/wpGetBranchVersion.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * Tests for wp_get_branch_version() and wp_get_wp_version() $part parameter.
+ *
+ * @group functions
+ *
+ * @covers ::wp_get_branch_version
+ * @covers ::wp_get_wp_version
+ */
+class Tests_Functions_WpGetBranchVersion extends WP_UnitTestCase {
+
+	/**
+	 * Tests extracting the major (x.y) version from a WordPress version string.
+	 *
+	 * @dataProvider data_major_version
+	 *
+	 * @ticket 64830
+	 *
+	 * @param string $version  The input version string.
+	 * @param string $expected The expected major version string.
+	 */
+	public function test_major_version( $version, $expected ) {
+		$this->assertSame( $expected, wp_get_branch_version( $version ) );
+	}
+
+	/**
+	 * Data provider for major version extraction.
+	 *
+	 * @return array[]
+	 */
+	public function data_major_version() {
+		return array(
+			'major ending with 0 and no minor'             => array( '7.0', '7.0' ),
+			'minor number zero'                            => array( '7.0.0', '7.0' ),
+			'minor with a major that ends in zero'         => array( '7.0.1', '7.0' ),
+			'double digit minor with trailing zero'        => array( '7.0.10', '7.0' ),
+			'double digit first part of major having zero' => array( '10.0.0', '10.0' ),
+			'triple digit major'                           => array( '100.1.0', '100.1' ),
+			'typical release'                              => array( '6.9', '6.9' ),
+			'typical minor release'                        => array( '6.9.1', '6.9' ),
+			'alpha suffix'                                 => array( '7.0-alpha-61215', '7.0' ),
+			'beta suffix'                                  => array( '7.0-beta3-61849', '7.0' ),
+			'RC suffix'                                    => array( '7.0-RC1', '7.0' ),
+			'src suffix'                                   => array( '7.0-alpha-61215-src', '7.0' ),
+			'single component'                             => array( '7', '7.0' ),
+		);
+	}
+
+	/**
+	 * Tests that wp_get_wp_version( 'major' ) returns the expected major version.
+	 *
+	 * @ticket 64830
+	 */
+	public function test_wp_get_wp_version_major() {
+		$expected = wp_get_branch_version( wp_get_wp_version() );
+		$this->assertSame( $expected, wp_get_wp_version( 'major' ) );
+	}
+
+	/**
+	 * Tests that wp_get_wp_version( 'minor' ) returns the expected minor version.
+	 *
+	 * @ticket 64830
+	 */
+	public function test_wp_get_wp_version_minor() {
+		$full    = wp_get_wp_version();
+		$parts   = preg_split( '/[.-]/', $full, 4 );
+		$expected = $parts[0] . '.' . ( $parts[1] ?? '0' ) . '.' . ( $parts[2] ?? '0' );
+		$this->assertSame( $expected, wp_get_wp_version( 'minor' ) );
+	}
+
+	/**
+	 * Tests that wp_get_wp_version() with no argument still returns the full version.
+	 *
+	 * @ticket 64830
+	 */
+	public function test_wp_get_wp_version_full_default() {
+		$this->assertSame( $GLOBALS['wp_version'], wp_get_wp_version() );
+	}
+
+	/**
+	 * Tests that wp_get_wp_version( 'full' ) returns the full version.
+	 *
+	 * @ticket 64830
+	 */
+	public function test_wp_get_wp_version_full_explicit() {
+		$this->assertSame( $GLOBALS['wp_version'], wp_get_wp_version( 'full' ) );
+	}
+
+	/**
+	 * Tests that wp_get_branch_version() with no argument returns the current major version.
+	 *
+	 * @ticket 64830
+	 */
+	public function test_wp_get_branch_version_defaults_to_current() {
+		$this->assertSame( wp_get_wp_version( 'major' ), wp_get_branch_version() );
+	}
+}

--- a/tests/phpunit/tests/functions/wpGetBranchVersion.php
+++ b/tests/phpunit/tests/functions/wpGetBranchVersion.php
@@ -63,8 +63,8 @@ class Tests_Functions_WpGetBranchVersion extends WP_UnitTestCase {
 	 * @ticket 64830
 	 */
 	public function test_wp_get_wp_version_minor() {
-		$full    = wp_get_wp_version();
-		$parts   = preg_split( '/[.-]/', $full, 4 );
+		$full     = wp_get_wp_version();
+		$parts    = preg_split( '/[.-]/', $full, 4 );
 		$expected = $parts[0] . '.' . ( $parts[1] ?? '0' ) . '.' . ( $parts[2] ?? '0' );
 		$this->assertSame( $expected, wp_get_wp_version( 'minor' ) );
 	}


### PR DESCRIPTION
This introduces a new helper function `wp_get_branch_version()` for extracting the WordPress branch version (major.minor) from a version string.

Currently, several different approaches are used across core to determine the branch version, including:

- `(float)` casting of `get_bloginfo( 'version' )`
- `substr( $ver, 0, 3 )`
- `explode( '.' )` based parsing
- `preg_split()` in `class-core-upgrader.php`

Some of these approaches are fragile or incorrect:

- `(float)` casting can produce incorrect values due to floating-point precision issues.
- `substr( $ver, 0, 3 )` breaks for versions >= 10.
- Multiple inconsistent approaches make maintenance harder.

This patch introduces `wp_get_branch_version()` using a string-based approach:


```php
function wp_get_branch_version( $version = '' ) {
    if ( '' === $version ) {
        $version = wp_get_wp_version();
    }

    $parts = preg_split( '/[.-]/', $version, 3 );

    return $parts[0] . '.' . ( $parts[1] ?? '0' );
}
```

Trac ticket: https://core.trac.wordpress.org/ticket/64830