### PR TITLE
Update the pinned `gutenberg` hash

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"url": "https://develop.svn.wordpress.org/trunk"
 	},
 	"gutenberg": {
-		"ref": "f290e6cb50d66809787fe198ef1cbc222482f37d"
+		"ref": "9b8144036fa5faf75de43d4502ff9809fcf689ad"
 	},
 	"engines": {
 		"node": ">=20.10.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"url": "https://develop.svn.wordpress.org/trunk"
 	},
 	"gutenberg": {
-		"ref": "7b7fa2bc97a8029a302bd6511cf0d206b5953172"
+		"ref": "f290e6cb50d66809787fe198ef1cbc222482f37d"
 	},
 	"engines": {
 		"node": ">=20.10.0",


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

This updates the pinned `gutenberg` repository hash from https://github.com/WordPress/gutenberg/commit/7b7fa2bc97a8029a302bd6511cf0d206b5953172 to https://github.com/WordPress/gutenberg/commit/9b8144036fa5faf75de43d4502ff9809fcf689ad.

## Included Changes

The following changes are included in this update:

- Use V2 Yjs methods for HTTP Polling (https://github.com/WordPress/gutenberg/pull/76304)
- Plugin: Include Icons assets in ZIP (https://github.com/WordPress/gutenberg/pull/75866)
- Ensure consistent, repeatable build results when inlining WASM files via `wasmInlinePlugin`  (https://github.com/WordPress/gutenberg/pull/76113)
- Account `IS_WORDPRESS_CORE` is set. (https://github.com/WordPress/gutenberg/pull/76334)
- Block Visibility: Add `fetchpriority=auto` to `IMG` tags in blocks with conditional viewport visibility to prevent potential erroneous high loading priority (https://github.com/WordPress/gutenberg/pull/76302)

Trac ticket: Core-64595.

## Use of AI Tools

No use of AI.
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
