### PR TITLE
Build/Tools: Update PHPCompatibilityWP to 3.0.0-alpha2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,9 @@
 		"composer/ca-bundle": "1.5.10",
 		"squizlabs/php_codesniffer": "3.13.5",
 		"wp-coding-standards/wpcs": "~3.3.0",
-		"phpcompatibility/phpcompatibility-wp": "~2.1.3",
+		"phpcompatibility/phpcompatibility-wp": "3.0.0-alpha2",
+		"phpcompatibility/php-compatibility": "10.0.0-alpha2",
+		"phpcompatibility/phpcompatibility-paragonie": "2.0.0-alpha2",
 		"phpstan/phpstan": "2.1.39",
 		"yoast/phpunit-polyfills": "^1.1.0"
 	},

--- a/phpcompat.xml.dist
+++ b/phpcompat.xml.dist
@@ -115,11 +115,42 @@
 	</rule>
 
 	<!--
-		Excluded while waiting for PHPCompatibility v10.
-		See <https://github.com/PHPCompatibility/PHPCompatibility/issues/1481>.
+		The #[\SensitiveParameter] attribute is used intentionally.
+		It is silently ignored on PHP < 8.0 and active on 8.0+.
+		See https://core.trac.wordpress.org/ticket/57304.
 	-->
-	<rule ref="PHPCompatibility.FunctionDeclarations.NewClosure.ThisFoundInStatic">
-		<exclude-pattern>/src/wp-includes/script-loader\.php$</exclude-pattern>
+	<rule ref="PHPCompatibility.Attributes.NewAttributes.PHPNativeAttributeFound">
+		<exclude-pattern>*</exclude-pattern>
+	</rule>
+
+	<!-- Third-party library: SimplePie. -->
+	<rule ref="PHPCompatibility.FunctionUse.RemovedFunctions.strftimeDeprecated">
+		<exclude-pattern>/SimplePie/src/Item\.php$</exclude-pattern>
+	</rule>
+	<rule ref="PHPCompatibility.FunctionDeclarations.RemovedCallingDestructAfterConstructorExit.Found">
+		<exclude-pattern>/SimplePie/src/SimplePie\.php$</exclude-pattern>
+	</rule>
+	<rule ref="PHPCompatibility.FunctionUse.RemovedFunctions.curl_closeDeprecated">
+		<exclude-pattern>/SimplePie/src/File\.php$</exclude-pattern>
+	</rule>
+	<rule ref="PHPCompatibility.FunctionUse.RemovedFunctions.xml_parser_freeDeprecated">
+		<exclude-pattern>/SimplePie/src/Parser\.php$</exclude-pattern>
+		<exclude-pattern>/SimplePie/src/SimplePie\.php$</exclude-pattern>
+	</rule>
+
+	<!-- Third-party library: getID3. -->
+	<rule ref="PHPCompatibility.FunctionUse.RemovedFunctions.libxml_disable_entity_loaderDeprecated">
+		<exclude-pattern>/ID3/getid3\.lib\.php$</exclude-pattern>
+	</rule>
+
+	<!-- Third-party library: Snoopy (not maintained anymore and deprecated since WP 3.0). -->
+	<rule ref="PHPCompatibility.FunctionUse.RemovedFunctions.socket_set_timeoutDeprecated">
+		<exclude-pattern>/class-snoopy\.php$</exclude-pattern>
+	</rule>
+
+	<!-- Third-party library: Nyholm/Psr7. -->
+	<rule ref="PHPCompatibility.ParameterValues.RemovedTriggerErrorLevel.Deprecated">
+		<exclude-pattern>/php-ai-client/third-party/Nyholm/Psr7/StreamTrait\.php$</exclude-pattern>
 	</rule>
 
 </ruleset>

--- a/phpcompat.xml.dist
+++ b/phpcompat.xml.dist
@@ -79,20 +79,20 @@
 	<rule ref="PHPCompatibility.IniDirectives.RemovedIniDirectives.safe_modeDeprecatedRemoved">
 		<exclude-pattern>/ID3/getid3\.php$</exclude-pattern>
 	</rule>
-	<rule ref="PHPCompatibility.IniDirectives.RemovedIniDirectives.mbstring_func_overloadDeprecated">
+	<rule ref="PHPCompatibility.IniDirectives.RemovedIniDirectives.mbstring_func_overloadDeprecatedRemoved">
 		<exclude-pattern>/ID3/getid3\.php$</exclude-pattern>
 		<exclude-pattern>/PHPMailer/PHPMailer\.php$</exclude-pattern>
 	</rule>
-	<rule ref="PHPCompatibility.FunctionUse.RemovedFunctions.get_magic_quotes_runtimeDeprecated">
+	<rule ref="PHPCompatibility.FunctionUse.RemovedFunctions.get_magic_quotes_runtimeDeprecatedRemoved">
 		<exclude-pattern>/ID3/getid3\.php$</exclude-pattern>
 	</rule>
-	<rule ref="PHPCompatibility.FunctionUse.RemovedFunctions.get_magic_quotes_gpcDeprecated">
+	<rule ref="PHPCompatibility.FunctionUse.RemovedFunctions.get_magic_quotes_gpcDeprecatedRemoved">
 		<exclude-pattern>/ID3/getid3\.php$</exclude-pattern>
 	</rule>
 	<rule ref="PHPCompatibility.Lists.AssignmentOrder.Affected">
 		<exclude-pattern>/ID3/module.audio-video.quicktime\.php$</exclude-pattern>
 	</rule>
-	<rule ref="PHPCompatibility.Constants.RemovedConstants.intl_idna_variant_2003Deprecated">
+	<rule ref="PHPCompatibility.Constants.RemovedConstants.intl_idna_variant_2003DeprecatedRemoved">
 		<exclude-pattern>/PHPMailer/PHPMailer\.php$</exclude-pattern>
 	</rule>
 	<rule ref="PHPCompatibility.ParameterValues.NewIDNVariantDefault.NotSet">

--- a/phpcompat.xml.dist
+++ b/phpcompat.xml.dist
@@ -115,6 +115,15 @@
 	</rule>
 
 	<!--
+		Temporarily excluded while waiting for #53465.
+		The default value of the $flags parameter for htmlspecialchars(), htmlentities(),
+		html_entity_decode(), and htmlspecialchars_decode() changed in PHP 8.1.
+	-->
+	<rule ref="PHPCompatibility.ParameterValues.NewHTMLEntitiesFlagsDefault.NotSet">
+		<exclude-pattern>*</exclude-pattern>
+	</rule>
+
+	<!--
 		The #[\SensitiveParameter] attribute is used intentionally.
 		It is silently ignored on PHP < 8.0 and active on 8.0+.
 		See https://core.trac.wordpress.org/ticket/57304.

--- a/src/wp-admin/includes/export.php
+++ b/src/wp-admin/includes/export.php
@@ -246,7 +246,7 @@ function export_wp( $args = array() ) {
 		$str = (string) $str;
 
 		if ( ! wp_is_valid_utf8( $str ) ) {
-			$str = utf8_encode( $str );
+			$str = utf8_encode( $str ); // phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.utf8_encodeDeprecated -- See #55603.
 		}
 		// $str = ent2ncr(esc_html($str));
 		$str = '<![CDATA[' . str_replace( ']]>', ']]]]><![CDATA[>', $str ) . ']]>';

--- a/src/wp-admin/includes/image-edit.php
+++ b/src/wp-admin/includes/image-edit.php
@@ -393,7 +393,7 @@ function wp_stream_image( $image, $mime_type, $attachment_id ) {
 			case 'image/avif':
 				if ( function_exists( 'imageavif' ) ) {
 					header( 'Content-Type: image/avif' );
-					return imageavif( $image, null, 90 );
+					return imageavif( $image, null, 90 ); // phpcs:ignore PHPCompatibility.FunctionUse.NewFunctions.imageavifFound -- Wrapped in function_exists().
 				}
 				return false;
 			default:
@@ -502,7 +502,7 @@ function wp_save_image_file( $filename, $image, $mime_type, $post_id ) {
 				return false;
 			case 'image/avif':
 				if ( function_exists( 'imageavif' ) ) {
-					return imageavif( $image, $filename );
+					return imageavif( $image, $filename ); // phpcs:ignore PHPCompatibility.FunctionUse.NewFunctions.imageavifFound -- Wrapped in function_exists().
 				}
 				return false;
 			default:
@@ -546,7 +546,7 @@ function _rotate_image_resource( $img, $angle ) {
 
 		if ( is_gd_image( $rotated ) ) {
 			if ( PHP_VERSION_ID < 80000 ) { // imagedestroy() has no effect as of PHP 8.0.
-				imagedestroy( $img );
+				imagedestroy( $img ); // phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.imagedestroyDeprecated -- Called inside a PHP version guard.
 			}
 
 			$img = $rotated;
@@ -584,7 +584,7 @@ function _flip_image_resource( $img, $horz, $vert ) {
 
 		if ( imagecopyresampled( $dst, $img, 0, 0, $sx, $sy, $w, $h, $sw, $sh ) ) {
 			if ( PHP_VERSION_ID < 80000 ) { // imagedestroy() has no effect as of PHP 8.0.
-				imagedestroy( $img );
+				imagedestroy( $img ); // phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.imagedestroyDeprecated -- Called inside a PHP version guard.
 			}
 
 			$img = $dst;
@@ -613,7 +613,7 @@ function _crop_image_resource( $img, $x, $y, $w, $h ) {
 	if ( is_gd_image( $dst ) ) {
 		if ( imagecopy( $dst, $img, 0, 0, $x, $y, $w, $h ) ) {
 			if ( PHP_VERSION_ID < 80000 ) { // imagedestroy() has no effect as of PHP 8.0.
-				imagedestroy( $img );
+				imagedestroy( $img ); // phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.imagedestroyDeprecated -- Called inside a PHP version guard.
 			}
 
 			$img = $dst;

--- a/src/wp-admin/includes/image.php
+++ b/src/wp-admin/includes/image.php
@@ -1049,13 +1049,13 @@ function wp_read_image_metadata( $file ) {
 
 	foreach ( array( 'title', 'caption', 'credit', 'copyright', 'camera', 'iso' ) as $key ) {
 		if ( $meta[ $key ] && ! wp_is_valid_utf8( $meta[ $key ] ) ) {
-			$meta[ $key ] = utf8_encode( $meta[ $key ] );
+			$meta[ $key ] = utf8_encode( $meta[ $key ] ); // phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.utf8_encodeDeprecated -- See #55603.
 		}
 	}
 
 	foreach ( $meta['keywords'] as $key => $keyword ) {
 		if ( ! wp_is_valid_utf8( $keyword ) ) {
-			$meta['keywords'][ $key ] = utf8_encode( $keyword );
+			$meta['keywords'][ $key ] = utf8_encode( $keyword ); // phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.utf8_encodeDeprecated -- See #55603.
 		}
 	}
 

--- a/src/wp-admin/link-parse-opml.php
+++ b/src/wp-admin/link-parse-opml.php
@@ -98,7 +98,7 @@ if ( ! xml_parse( $xml_parser, $opml, true ) ) {
 
 if ( PHP_VERSION_ID < 80000 ) { // xml_parser_free() has no effect as of PHP 8.0.
 	// Free up memory used by the XML parser.
-	xml_parser_free( $xml_parser );
+	xml_parser_free( $xml_parser ); // phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.xml_parser_freeDeprecated -- Called inside a PHP version guard.
 }
 
 unset( $xml_parser );

--- a/src/wp-includes/IXR/class-IXR-message.php
+++ b/src/wp-includes/IXR/class-IXR-message.php
@@ -120,7 +120,7 @@ class IXR_Message
 
             if (!xml_parse($this->_parser, $part, $final)) {
                 if (PHP_VERSION_ID < 80000) { // xml_parser_free() has no effect as of PHP 8.0.
-                    xml_parser_free($this->_parser);
+                    xml_parser_free($this->_parser); // phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.xml_parser_freeDeprecated -- Called inside a PHP version guard.
                 }
 
                 unset($this->_parser);
@@ -133,7 +133,7 @@ class IXR_Message
         } while (true);
 
         if (PHP_VERSION_ID < 80000) { // xml_parser_free() has no effect as of PHP 8.0.
-            xml_parser_free($this->_parser);
+            xml_parser_free($this->_parser); // phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.xml_parser_freeDeprecated -- Called inside a PHP version guard.
         }
 
         unset($this->_parser);

--- a/src/wp-includes/atomlib.php
+++ b/src/wp-includes/atomlib.php
@@ -185,7 +185,7 @@ class AtomParser {
         fclose($fp);
 
         if (PHP_VERSION_ID < 80000) { // xml_parser_free() has no effect as of PHP 8.0.
-            xml_parser_free($parser);
+            xml_parser_free($parser); // phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.xml_parser_freeDeprecated -- Called inside a PHP version guard.
         }
 
         unset($parser);

--- a/src/wp-includes/class-wp-http-curl.php
+++ b/src/wp-includes/class-wp-http-curl.php
@@ -243,7 +243,7 @@ class WP_Http_Curl {
 
 			if ( $curl_error ) {
 				if ( PHP_VERSION_ID < 80000 ) { // curl_close() has no effect as of PHP 8.0.
-					curl_close( $handle );
+					curl_close( $handle ); // phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.curl_closeDeprecated -- Called inside a PHP version guard.
 				}
 
 				return new WP_Error( 'http_request_failed', $curl_error );
@@ -251,14 +251,14 @@ class WP_Http_Curl {
 
 			if ( in_array( curl_getinfo( $handle, CURLINFO_HTTP_CODE ), array( 301, 302 ), true ) ) {
 				if ( PHP_VERSION_ID < 80000 ) { // curl_close() has no effect as of PHP 8.0.
-					curl_close( $handle );
+					curl_close( $handle ); // phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.curl_closeDeprecated -- Called inside a PHP version guard.
 				}
 
 				return new WP_Error( 'http_request_failed', __( 'Too many redirects.' ) );
 			}
 
 			if ( PHP_VERSION_ID < 80000 ) { // curl_close() has no effect as of PHP 8.0.
-				curl_close( $handle );
+				curl_close( $handle ); // phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.curl_closeDeprecated -- Called inside a PHP version guard.
 			}
 
 			return array(
@@ -290,7 +290,7 @@ class WP_Http_Curl {
 				if ( ! $this->max_body_length || $this->max_body_length !== $bytes_written_total ) {
 					if ( $parsed_args['stream'] ) {
 						if ( PHP_VERSION_ID < 80000 ) { // curl_close() has no effect as of PHP 8.0.
-							curl_close( $handle );
+							curl_close( $handle ); // phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.curl_closeDeprecated -- Called inside a PHP version guard.
 						}
 
 						fclose( $this->stream_handle );
@@ -298,7 +298,7 @@ class WP_Http_Curl {
 						return new WP_Error( 'http_request_failed', __( 'Failed to write request to temporary file.' ) );
 					} else {
 						if ( PHP_VERSION_ID < 80000 ) { // curl_close() has no effect as of PHP 8.0.
-							curl_close( $handle );
+							curl_close( $handle ); // phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.curl_closeDeprecated -- Called inside a PHP version guard.
 						}
 
 						return new WP_Error( 'http_request_failed', curl_error( $handle ) );
@@ -309,7 +309,7 @@ class WP_Http_Curl {
 
 				if ( $curl_error ) {
 					if ( PHP_VERSION_ID < 80000 ) { // curl_close() has no effect as of PHP 8.0.
-						curl_close( $handle );
+						curl_close( $handle ); // phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.curl_closeDeprecated -- Called inside a PHP version guard.
 					}
 
 					return new WP_Error( 'http_request_failed', $curl_error );
@@ -318,7 +318,7 @@ class WP_Http_Curl {
 
 			if ( in_array( curl_getinfo( $handle, CURLINFO_HTTP_CODE ), array( 301, 302 ), true ) ) {
 				if ( PHP_VERSION_ID < 80000 ) { // curl_close() has no effect as of PHP 8.0.
-					curl_close( $handle );
+					curl_close( $handle ); // phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.curl_closeDeprecated -- Called inside a PHP version guard.
 				}
 
 				return new WP_Error( 'http_request_failed', __( 'Too many redirects.' ) );
@@ -326,7 +326,7 @@ class WP_Http_Curl {
 		}
 
 		if ( PHP_VERSION_ID < 80000 ) { // curl_close() has no effect as of PHP 8.0.
-			curl_close( $handle );
+			curl_close( $handle ); // phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.curl_closeDeprecated -- Called inside a PHP version guard.
 		}
 
 		if ( $parsed_args['stream'] ) {

--- a/src/wp-includes/class-wp-image-editor-gd.php
+++ b/src/wp-includes/class-wp-image-editor-gd.php
@@ -25,7 +25,7 @@ class WP_Image_Editor_GD extends WP_Image_Editor {
 		if ( $this->image ) {
 			if ( PHP_VERSION_ID < 80000 ) { // imagedestroy() has no effect as of PHP 8.0.
 				// We don't need the original in memory anymore.
-				imagedestroy( $this->image );
+				imagedestroy( $this->image ); // phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.imagedestroyDeprecated -- Called inside a PHP version guard.
 			}
 		}
 	}
@@ -113,7 +113,7 @@ class WP_Image_Editor_GD extends WP_Image_Editor {
 		} elseif (
 			function_exists( 'imagecreatefromavif' ) && ( 'image/avif' === wp_get_image_mime( $this->file ) )
 		) {
-			$this->image = @imagecreatefromavif( $this->file );
+			$this->image = @imagecreatefromavif( $this->file ); // phpcs:ignore PHPCompatibility.FunctionUse.NewFunctions.imagecreatefromavifFound -- Wrapped in function_exists().
 		} else {
 			$this->image = @imagecreatefromstring( $file_contents );
 		}
@@ -191,7 +191,7 @@ class WP_Image_Editor_GD extends WP_Image_Editor {
 
 		if ( is_gd_image( $resized ) ) {
 			if ( PHP_VERSION_ID < 80000 ) { // imagedestroy() has no effect as of PHP 8.0.
-				imagedestroy( $this->image );
+				imagedestroy( $this->image ); // phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.imagedestroyDeprecated -- Called inside a PHP version guard.
 			}
 
 			$this->image = $resized;
@@ -332,7 +332,7 @@ class WP_Image_Editor_GD extends WP_Image_Editor {
 			$saved = $this->_save( $resized );
 
 			if ( PHP_VERSION_ID < 80000 ) { // imagedestroy() has no effect as of PHP 8.0.
-				imagedestroy( $resized );
+				imagedestroy( $resized ); // phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.imagedestroyDeprecated -- Called inside a PHP version guard.
 			}
 		}
 
@@ -392,7 +392,7 @@ class WP_Image_Editor_GD extends WP_Image_Editor {
 
 		if ( is_gd_image( $dst ) ) {
 			if ( PHP_VERSION_ID < 80000 ) { // imagedestroy() has no effect as of PHP 8.0.
-				imagedestroy( $this->image );
+				imagedestroy( $this->image ); // phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.imagedestroyDeprecated -- Called inside a PHP version guard.
 			}
 
 			$this->image = $dst;
@@ -423,7 +423,7 @@ class WP_Image_Editor_GD extends WP_Image_Editor {
 				imagesavealpha( $rotated, true );
 
 				if ( PHP_VERSION_ID < 80000 ) { // imagedestroy() has no effect as of PHP 8.0.
-					imagedestroy( $this->image );
+					imagedestroy( $this->image ); // phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.imagedestroyDeprecated -- Called inside a PHP version guard.
 				}
 
 				$this->image = $rotated;
@@ -458,7 +458,7 @@ class WP_Image_Editor_GD extends WP_Image_Editor {
 
 			if ( imagecopyresampled( $dst, $this->image, 0, 0, $sx, $sy, $w, $h, $sw, $sh ) ) {
 				if ( PHP_VERSION_ID < 80000 ) { // imagedestroy() has no effect as of PHP 8.0.
-					imagedestroy( $this->image );
+					imagedestroy( $this->image ); // phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.imagedestroyDeprecated -- Called inside a PHP version guard.
 				}
 
 				$this->image = $dst;
@@ -617,7 +617,7 @@ class WP_Image_Editor_GD extends WP_Image_Editor {
 			if ( 'image/webp' === $this->mime_type && defined( 'IMG_WEBP_LOSSLESS' ) ) {
 				$webp_info = wp_get_webp_info( $this->file );
 				if ( ! empty( $webp_info['type'] ) && 'lossless' === $webp_info['type'] ) {
-					$quality = IMG_WEBP_LOSSLESS;
+					$quality = IMG_WEBP_LOSSLESS; // phpcs:ignore PHPCompatibility.Constants.NewConstants.img_webp_losslessFound -- Wrapped in defined().
 					parent::set_quality( $quality, $dims );
 				}
 			}
@@ -658,7 +658,7 @@ class WP_Image_Editor_GD extends WP_Image_Editor {
 			case 'image/avif':
 				if ( function_exists( 'imageavif' ) ) {
 					header( 'Content-Type: image/avif' );
-					return imageavif( $this->image, null, $this->get_quality() );
+					return imageavif( $this->image, null, $this->get_quality() ); // phpcs:ignore PHPCompatibility.FunctionUse.NewFunctions.imageavifFound -- Wrapped in function_exists().
 				}
 				// Fall back to JPEG.
 			default:

--- a/src/wp-includes/class-wp-oembed.php
+++ b/src/wp-includes/class-wp-oembed.php
@@ -621,7 +621,7 @@ class WP_oEmbed {
 			 * This function has been deprecated in PHP 8.0 because in libxml 2.9.0, external entity loading
 			 * is disabled by default, so this function is no longer needed to protect against XXE attacks.
 			 */
-			$loader = libxml_disable_entity_loader( true );
+			$loader = libxml_disable_entity_loader( true ); // phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.libxml_disable_entity_loaderDeprecated -- Called inside a PHP version guard.
 		}
 
 		$errors = libxml_use_internal_errors( true );

--- a/src/wp-includes/feed.php
+++ b/src/wp-includes/feed.php
@@ -601,7 +601,7 @@ function prep_atom_text_construct( $data ) {
 	$code = xml_get_error_code( $parser );
 
 	if ( PHP_VERSION_ID < 80000 ) { // xml_parser_free() has no effect as of PHP 8.0.
-		xml_parser_free( $parser );
+		xml_parser_free( $parser ); // phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.xml_parser_freeDeprecated -- Called inside a PHP version guard.
 	}
 
 	unset( $parser );

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -3185,7 +3185,7 @@ function wp_check_filetype_and_ext( $file, $filename, $mimes = null ) {
 		$real_mime = finfo_file( $finfo, $file );
 
 		if ( PHP_VERSION_ID < 80100 ) { // finfo_close() has no effect as of PHP 8.1.
-			finfo_close( $finfo );
+			finfo_close( $finfo ); // phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.finfo_closeDeprecated -- Called inside a PHP version guard.
 		}
 
 		$google_docs_types = array(
@@ -3417,7 +3417,7 @@ function wp_get_image_mime( $file ) {
 					$mime_type = finfo_file( $fileinfo, $file );
 
 					if ( PHP_VERSION_ID < 80100 ) { // finfo_close() has no effect as of PHP 8.1.
-						finfo_close( $fileinfo );
+						finfo_close( $fileinfo ); // phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.finfo_closeDeprecated -- Called inside a PHP version guard.
 					}
 
 					if ( wp_is_heic_image_mime_type( $mime_type ) ) {
@@ -7690,7 +7690,7 @@ function mbstring_binary_safe_encoding( $reset = false ) {
 
 	if ( is_null( $overloaded ) ) {
 		if ( function_exists( 'mb_internal_encoding' )
-			&& ( (int) ini_get( 'mbstring.func_overload' ) & 2 ) // phpcs:ignore PHPCompatibility.IniDirectives.RemovedIniDirectives.mbstring_func_overloadDeprecated
+			&& ( (int) ini_get( 'mbstring.func_overload' ) & 2 ) // phpcs:ignore PHPCompatibility.IniDirectives.RemovedIniDirectives.mbstring_func_overloadDeprecatedRemoved
 		) {
 			$overloaded = true;
 		} else {

--- a/src/wp-includes/pomo/po.php
+++ b/src/wp-includes/pomo/po.php
@@ -21,7 +21,7 @@ if ( ! defined( 'PO_MAX_LINE_LEN' ) ) {
  * which still use the old MacOS standalone `\r` as a line ending.
  * This fix should be revisited when PHP 9.0 is in alpha/beta.
  */
-@ini_set( 'auto_detect_line_endings', 1 ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+@ini_set( 'auto_detect_line_endings', 1 ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, PHPCompatibility.IniDirectives.RemovedIniDirectives.auto_detect_line_endingsDeprecated -- See comment above.
 
 /**
  * Routines for working with PO files

--- a/src/wp-includes/pomo/streams.php
+++ b/src/wp-includes/pomo/streams.php
@@ -21,7 +21,7 @@ if ( ! class_exists( 'POMO_Reader', false ) ) :
 		 */
 		public function __construct() {
 			if ( function_exists( 'mb_substr' )
-				&& ( (int) ini_get( 'mbstring.func_overload' ) & 2 ) // phpcs:ignore PHPCompatibility.IniDirectives.RemovedIniDirectives.mbstring_func_overloadDeprecated
+				&& ( (int) ini_get( 'mbstring.func_overload' ) & 2 ) // phpcs:ignore PHPCompatibility.IniDirectives.RemovedIniDirectives.mbstring_func_overloadDeprecatedRemoved
 			) {
 				$this->is_overloaded = true;
 			} else {

--- a/src/wp-includes/rss.php
+++ b/src/wp-includes/rss.php
@@ -94,7 +94,7 @@ class MagpieRSS {
 		}
 
 		if ( PHP_VERSION_ID < 80000 ) { // xml_parser_free() has no effect as of PHP 8.0.
-			xml_parser_free( $this->parser );
+			xml_parser_free( $this->parser ); // phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.xml_parser_freeDeprecated -- Called inside a PHP version guard.
 		}
 
 		unset( $this->parser );


### PR DESCRIPTION
This PR updates the PHPCompatibilityWP Composer dependency from ~2.1.3 to 3.0.0-alpha2 (which includes PHPCompatibility 10.0.0-alpha2) and addresses the new violations surfaced by the updated sniffs.

Changes are split into separate commits for easier review:

1. **Update PHPCompatibilityWP to 3.0.0-alpha2**: `composer.json` changes with explicit version pins for `phpcompatibility/php-compatibility-wp`, `phpcompatibility/php-compatibility` and `phpcompatibility/phpcompatibility-paragonie`.
2. **Update `phpcompat.xml.dist` error codes**: PHPCompatibility v10 adds removal data for functions/constants/directives removed in PHP 8+, changing their error codes from `*Deprecated` to `*DeprecatedRemoved`. Update the existing exclusion rules to match.
3. **Update `phpcompat.xml.dist` exclusions**: Add file-level exclusions for third-party bundled libraries (SimplePie, getID3, Snoopy, PHP AI Client) following the approach used in https://core.trac.wordpress.org/ticket/63168#comment:16. Also add a rule-level exclusion for the intentional use of `#[\SensitiveParameter]` (https://core.trac.wordpress.org/ticket/57304) and remove the workaround for PHPCompatibility#1481.
4. **Update inline `phpcs:ignore` annotations**: Add or update annotations in WordPress Core files for version-guarded deprecated function calls and `function_exists`/`defined`-guarded new function usage.
5. **TEMP: Temporarily exclude violations tracked in separate tickets**: This is a temporary commit to allow the PHP compatibility scan to pass. It excludes `NewHTMLEntitiesFlagsDefault.NotSet` (waiting for https://core.trac.wordpress.org/ticket/53465) and adds `phpcs:ignore` annotations for `utf8_encode` (https://core.trac.wordpress.org/ticket/55603). This commit should not be merged as-is; the plan is to wait for a decision on https://core.trac.wordpress.org/ticket/53465 and https://core.trac.wordpress.org/ticket/55603 before updating PHPCompatibilityWP.

Trac ticket: https://core.trac.wordpress.org/ticket/64634

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**