### PR TITLE
Connectors: Remove redundant helper and inline sorting where needed

### DIFF
--- a/src/wp-includes/class-wp-connector-registry.php
+++ b/src/wp-includes/class-wp-connector-registry.php
@@ -214,7 +214,7 @@ final class WP_Connector_Registry {
 	 *
 	 *         @type string      $name           The connector's display name.
 	 *         @type string      $description    The connector's description.
-	 *         @type string|null $logo_url        Optional. URL to the connector's logo image.
+	 *         @type string|null $logo_url       Optional. URL to the connector's logo image.
 	 *         @type string      $type           The connector type. Currently, only 'ai_provider' is supported.
 	 *         @type array       $plugin         Optional. Plugin data for install/activate UI.
 	 *             @type string $slug       The WordPress.org plugin slug.

--- a/src/wp-includes/class-wp-connector-registry.php
+++ b/src/wp-includes/class-wp-connector-registry.php
@@ -206,7 +206,28 @@ final class WP_Connector_Registry {
 	 *
 	 * @see wp_get_connectors()
 	 *
-	 * @return array<string, array> The array of registered connectors keyed by connector ID.
+	 * @return array {
+	 *     Connector settings keyed by connector ID.
+	 *
+	 *     @type array ...$0 {
+	 *         Data for a single connector.
+	 *
+	 *         @type string $name           The connector's display name.
+	 *         @type string $description    The connector's description.
+	 *         @type string $type           The connector type. Currently, only 'ai_provider' is supported.
+	 *         @type array  $plugin         Optional. Plugin data for install/activate UI.
+	 *             @type string $slug       The WordPress.org plugin slug.
+	 *         }
+	 *         @type array  $authentication {
+	 *             Authentication configuration. When method is 'api_key', includes
+	 *             credentials_url and setting_name. When 'none', only method is present.
+	 *
+	 *             @type string      $method          The authentication method: 'api_key' or 'none'.
+	 *             @type string|null $credentials_url Optional. URL where users can obtain API credentials.
+	 *             @type string      $setting_name    Optional. The setting name for the API key.
+	 *         }
+	 *     }
+	 * }
 	 * @phpstan-return array<string, Connector>
 	 */
 	public function get_all_registered(): array {

--- a/src/wp-includes/class-wp-connector-registry.php
+++ b/src/wp-includes/class-wp-connector-registry.php
@@ -216,7 +216,9 @@ final class WP_Connector_Registry {
 	 *         @type string      $description    The connector's description.
 	 *         @type string|null $logo_url       Optional. URL to the connector's logo image.
 	 *         @type string      $type           The connector type. Currently, only 'ai_provider' is supported.
-	 *         @type array       $plugin         Optional. Plugin data for install/activate UI.
+	 *         @type array       $plugin         {
+	 *             Optional. Plugin data for install/activate UI.
+	 *
 	 *             @type string $slug       The WordPress.org plugin slug.
 	 *         }
 	 *         @type array  $authentication {

--- a/src/wp-includes/class-wp-connector-registry.php
+++ b/src/wp-includes/class-wp-connector-registry.php
@@ -18,11 +18,11 @@
  * @phpstan-type Connector array{
  *     name: string,
  *     description: string,
- *     logo_url?: string|null,
+ *     logo_url?: string,
  *     type: string,
  *     authentication: array{
  *         method: string,
- *         credentials_url?: string|null,
+ *         credentials_url?: string,
  *         setting_name?: string
  *     },
  *     plugin?: array{
@@ -62,13 +62,13 @@ final class WP_Connector_Registry {
 	 *
 	 *     @type string $name           Required. The connector's display name.
 	 *     @type string $description    Optional. The connector's description. Default empty string.
-	 *     @type string|null $logo_url  Optional. URL to the connector's logo image. Default null.
+	 *     @type string $logo_url       Optional. URL to the connector's logo image.
 	 *     @type string $type           Required. The connector type. Currently, only 'ai_provider' is supported.
 	 *     @type array  $authentication {
 	 *         Required. Authentication configuration.
 	 *
-	 *         @type string      $method          Required. The authentication method: 'api_key' or 'none'.
-	 *         @type string|null $credentials_url Optional. URL where users can obtain API credentials.
+	 *         @type string $method          Required. The authentication method: 'api_key' or 'none'.
+	 *         @type string $credentials_url Optional. URL where users can obtain API credentials.
 	 *     }
 	 *     @type array  $plugin {
 	 *         Optional. Plugin data for install/activate UI.
@@ -158,8 +158,10 @@ final class WP_Connector_Registry {
 		}
 
 		if ( 'api_key' === $args['authentication']['method'] ) {
-			$connector['authentication']['credentials_url'] = $args['authentication']['credentials_url'] ?? null;
-			$connector['authentication']['setting_name']    = "connectors_ai_{$id}_api_key";
+			if ( ! empty( $args['authentication']['credentials_url'] ) && is_string( $args['authentication']['credentials_url'] ) ) {
+				$connector['authentication']['credentials_url'] = $args['authentication']['credentials_url'];
+			}
+			$connector['authentication']['setting_name'] = "connectors_ai_{$id}_api_key";
 		}
 
 		if ( ! empty( $args['plugin'] ) && is_array( $args['plugin'] ) ) {
@@ -212,11 +214,11 @@ final class WP_Connector_Registry {
 	 *     @type array ...$0 {
 	 *         Data for a single connector.
 	 *
-	 *         @type string      $name           The connector's display name.
-	 *         @type string      $description    The connector's description.
-	 *         @type string|null $logo_url       Optional. URL to the connector's logo image.
-	 *         @type string      $type           The connector type. Currently, only 'ai_provider' is supported.
-	 *         @type array       $plugin         {
+	 *         @type string $name           The connector's display name.
+	 *         @type string $description    The connector's description.
+	 *         @type string $logo_url       Optional. URL to the connector's logo image.
+	 *         @type string $type           The connector type. Currently, only 'ai_provider' is supported.
+	 *         @type array  $plugin         {
 	 *             Optional. Plugin data for install/activate UI.
 	 *
 	 *             @type string $slug       The WordPress.org plugin slug.
@@ -225,9 +227,9 @@ final class WP_Connector_Registry {
 	 *             Authentication configuration. When method is 'api_key', includes
 	 *             credentials_url and setting_name. When 'none', only method is present.
 	 *
-	 *             @type string      $method          The authentication method: 'api_key' or 'none'.
-	 *             @type string|null $credentials_url Optional. URL where users can obtain API credentials.
-	 *             @type string      $setting_name    Optional. The setting name for the API key.
+	 *             @type string $method          The authentication method: 'api_key' or 'none'.
+	 *             @type string $credentials_url Optional. URL where users can obtain API credentials.
+	 *             @type string $setting_name    Optional. The setting name for the API key.
 	 *         }
 	 *     }
 	 * }

--- a/src/wp-includes/class-wp-connector-registry.php
+++ b/src/wp-includes/class-wp-connector-registry.php
@@ -70,7 +70,7 @@ final class WP_Connector_Registry {
 	 *         @type string $method          Required. The authentication method: 'api_key' or 'none'.
 	 *         @type string $credentials_url Optional. URL where users can obtain API credentials.
 	 *     }
-	 *     @type array  $plugin {
+	 *     @type array  $plugin         {
 	 *         Optional. Plugin data for install/activate UI.
 	 *
 	 *         @type string $slug The WordPress.org plugin slug.
@@ -208,31 +208,8 @@ final class WP_Connector_Registry {
 	 *
 	 * @see wp_get_connectors()
 	 *
-	 * @return array {
-	 *     Connector settings keyed by connector ID.
+	 * @return array Connector settings keyed by connector ID.
 	 *
-	 *     @type array ...$0 {
-	 *         Data for a single connector.
-	 *
-	 *         @type string $name           The connector's display name.
-	 *         @type string $description    The connector's description.
-	 *         @type string $logo_url       Optional. URL to the connector's logo image.
-	 *         @type string $type           The connector type. Currently, only 'ai_provider' is supported.
-	 *         @type array  $plugin         {
-	 *             Optional. Plugin data for install/activate UI.
-	 *
-	 *             @type string $slug       The WordPress.org plugin slug.
-	 *         }
-	 *         @type array  $authentication {
-	 *             Authentication configuration. When method is 'api_key', includes
-	 *             credentials_url and setting_name. When 'none', only method is present.
-	 *
-	 *             @type string $method          The authentication method: 'api_key' or 'none'.
-	 *             @type string $credentials_url Optional. URL where users can obtain API credentials.
-	 *             @type string $setting_name    Optional. The setting name for the API key.
-	 *         }
-	 *     }
-	 * }
 	 * @phpstan-return array<string, Connector>
 	 */
 	public function get_all_registered(): array {

--- a/src/wp-includes/class-wp-connector-registry.php
+++ b/src/wp-includes/class-wp-connector-registry.php
@@ -212,10 +212,11 @@ final class WP_Connector_Registry {
 	 *     @type array ...$0 {
 	 *         Data for a single connector.
 	 *
-	 *         @type string $name           The connector's display name.
-	 *         @type string $description    The connector's description.
-	 *         @type string $type           The connector type. Currently, only 'ai_provider' is supported.
-	 *         @type array  $plugin         Optional. Plugin data for install/activate UI.
+	 *         @type string      $name           The connector's display name.
+	 *         @type string      $description    The connector's description.
+	 *         @type string|null $logo_url        Optional. URL to the connector's logo image.
+	 *         @type string      $type           The connector type. Currently, only 'ai_provider' is supported.
+	 *         @type array       $plugin         Optional. Plugin data for install/activate UI.
 	 *             @type string $slug       The WordPress.org plugin slug.
 	 *         }
 	 *         @type array  $authentication {

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -38,6 +38,20 @@ function wp_is_connector_registered( string $id ): bool {
  *
  * @param string $id The connector identifier.
  * @return array|null The registered connector data, or null if not registered.
+ * @phpstan-return ?array{
+ *     name: string,
+ *     description: string,
+ *     logo_url?: string|null,
+ *     type: string,
+ *     authentication: array{
+ *         method: string,
+ *         credentials_url?: string|null,
+ *         setting_name?: string
+ *     },
+ *     plugin?: array{
+ *         slug: string
+ *     }
+ * }
  */
 function wp_get_connector( string $id ): ?array {
 	$registry = WP_Connector_Registry::get_instance();
@@ -55,8 +69,6 @@ function wp_get_connector( string $id ): ?array {
  *
  * @see WP_Connector_Registry::get_all_registered()
  *
- * @phpstan-import-type Connector from WP_Connector_Registry
- *
  * @return array {
  *     Connector settings keyed by connector ID.
  *
@@ -65,7 +77,7 @@ function wp_get_connector( string $id ): ?array {
  *
  *         @type string      $name           The connector's display name.
  *         @type string      $description    The connector's description.
- *         @type string|null $logo_url        Optional. URL to the connector's logo image.
+ *         @type string|null $logo_url       Optional. URL to the connector's logo image.
  *         @type string      $type           The connector type. Currently, only 'ai_provider' is supported.
  *         @type array       $plugin         Optional. Plugin data for install/activate UI.
  *             @type string $slug       The WordPress.org plugin slug.
@@ -80,7 +92,20 @@ function wp_get_connector( string $id ): ?array {
  *         }
  *     }
  * }
- * @phpstan-return array<string, Connector>
+ * @phpstan-return array<string, array{
+ *     name: string,
+ *     description: string,
+ *     logo_url?: string|null,
+ *     type: string,
+ *     authentication: array{
+ *         method: string,
+ *         credentials_url?: string|null,
+ *         setting_name?: string
+ *     },
+ *     plugin?: array{
+ *         slug: string
+ *     }
+ * }>
  */
 function wp_get_connectors(): array {
 	$registry = WP_Connector_Registry::get_instance();

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -63,10 +63,11 @@ function wp_get_connector( string $id ): ?array {
  *     @type array ...$0 {
  *         Data for a single connector.
  *
- *         @type string $name           The connector's display name.
- *         @type string $description    The connector's description.
- *         @type string $type           The connector type. Currently, only 'ai_provider' is supported.
- *         @type array  $plugin         Optional. Plugin data for install/activate UI.
+ *         @type string      $name           The connector's display name.
+ *         @type string      $description    The connector's description.
+ *         @type string|null $logo_url        Optional. URL to the connector's logo image.
+ *         @type string      $type           The connector type. Currently, only 'ai_provider' is supported.
+ *         @type array       $plugin         Optional. Plugin data for install/activate UI.
  *             @type string $slug       The WordPress.org plugin slug.
  *         }
  *         @type array  $authentication {

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -39,17 +39,17 @@ function wp_is_connector_registered( string $id ): bool {
  * @param string $id The connector identifier.
  * @return array|null The registered connector data, or null if not registered.
  * @phpstan-return ?array{
- *     name: string,
- *     description: string,
- *     logo_url?: string|null,
- *     type: string,
+ *     name: non-empty-string,
+ *     description: non-empty-string,
+ *     logo_url?: non-empty-string|null,
+ *     type: 'ai_provider',
  *     authentication: array{
- *         method: string,
- *         credentials_url?: string|null,
- *         setting_name?: string
+ *         method: 'api_key'|'none',
+ *         credentials_url?: non-empty-string|null,
+ *         setting_name?: non-empty-string
  *     },
  *     plugin?: array{
- *         slug: string
+ *         slug: non-empty-string
  *     }
  * }
  */
@@ -79,8 +79,10 @@ function wp_get_connector( string $id ): ?array {
  *         @type string      $description    The connector's description.
  *         @type string|null $logo_url       Optional. URL to the connector's logo image.
  *         @type string      $type           The connector type. Currently, only 'ai_provider' is supported.
- *         @type array       $plugin         Optional. Plugin data for install/activate UI.
- *             @type string $slug       The WordPress.org plugin slug.
+ *         @type array       $plugin {
+ *             Optional. Plugin data for install/activate UI.
+ *
+ *             @type string $slug The WordPress.org plugin slug.
  *         }
  *         @type array  $authentication {
  *             Authentication configuration. When method is 'api_key', includes

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -44,11 +44,6 @@ function wp_is_connector_registered( string $id ): bool {
  *     @type string $description    The connector's description.
  *     @type string $logo_url       Optional. URL to the connector's logo image.
  *     @type string $type           The connector type. Currently, only 'ai_provider' is supported.
- *     @type array  $plugin {
- *         Optional. Plugin data for install/activate UI.
- *
- *         @type string $slug The WordPress.org plugin slug.
- *     }
  *     @type array  $authentication {
  *         Authentication configuration. When method is 'api_key', includes
  *         credentials_url and setting_name. When 'none', only method is present.
@@ -56,6 +51,11 @@ function wp_is_connector_registered( string $id ): bool {
  *         @type string $method          The authentication method: 'api_key' or 'none'.
  *         @type string $credentials_url Optional. URL where users can obtain API credentials.
  *         @type string $setting_name    Optional. The setting name for the API key.
+ *     }
+ *     @type array  $plugin         {
+ *         Optional. Plugin data for install/activate UI.
+ *
+ *         @type string $slug The WordPress.org plugin slug.
  *     }
  * }
  * @phpstan-return ?array{
@@ -99,11 +99,6 @@ function wp_get_connector( string $id ): ?array {
  *         @type string      $description    The connector's description.
  *         @type string      $logo_url       Optional. URL to the connector's logo image.
  *         @type string      $type           The connector type. Currently, only 'ai_provider' is supported.
- *         @type array       $plugin {
- *             Optional. Plugin data for install/activate UI.
- *
- *             @type string $slug The WordPress.org plugin slug.
- *         }
  *         @type array       $authentication {
  *             Authentication configuration. When method is 'api_key', includes
  *             credentials_url and setting_name. When 'none', only method is present.
@@ -111,6 +106,11 @@ function wp_get_connector( string $id ): ?array {
  *             @type string $method          The authentication method: 'api_key' or 'none'.
  *             @type string $credentials_url Optional. URL where users can obtain API credentials.
  *             @type string $setting_name    Optional. The setting name for the API key.
+ *         }
+ *         @type array       $plugin         {
+ *             Optional. Plugin data for install/activate UI.
+ *
+ *             @type string $slug The WordPress.org plugin slug.
  *         }
  *     }
  * }

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -37,15 +37,35 @@ function wp_is_connector_registered( string $id ): bool {
  * @see WP_Connector_Registry::get_registered()
  *
  * @param string $id The connector identifier.
- * @return array|null The registered connector data, or null if not registered.
+ * @return array|null {
+ *     Connector data, or null if not registered.
+ *
+ *     @type string $name           The connector's display name.
+ *     @type string $description    The connector's description.
+ *     @type string $logo_url       Optional. URL to the connector's logo image.
+ *     @type string $type           The connector type. Currently, only 'ai_provider' is supported.
+ *     @type array  $plugin {
+ *         Optional. Plugin data for install/activate UI.
+ *
+ *         @type string $slug The WordPress.org plugin slug.
+ *     }
+ *     @type array  $authentication {
+ *         Authentication configuration. When method is 'api_key', includes
+ *         credentials_url and setting_name. When 'none', only method is present.
+ *
+ *         @type string $method          The authentication method: 'api_key' or 'none'.
+ *         @type string $credentials_url Optional. URL where users can obtain API credentials.
+ *         @type string $setting_name    Optional. The setting name for the API key.
+ *     }
+ * }
  * @phpstan-return ?array{
  *     name: non-empty-string,
  *     description: non-empty-string,
- *     logo_url?: non-empty-string|null,
+ *     logo_url?: non-empty-string,
  *     type: 'ai_provider',
  *     authentication: array{
  *         method: 'api_key'|'none',
- *         credentials_url?: non-empty-string|null,
+ *         credentials_url?: non-empty-string,
  *         setting_name?: non-empty-string
  *     },
  *     plugin?: array{
@@ -77,35 +97,35 @@ function wp_get_connector( string $id ): ?array {
  *
  *         @type string      $name           The connector's display name.
  *         @type string      $description    The connector's description.
- *         @type string|null $logo_url       Optional. URL to the connector's logo image.
+ *         @type string      $logo_url       Optional. URL to the connector's logo image.
  *         @type string      $type           The connector type. Currently, only 'ai_provider' is supported.
  *         @type array       $plugin {
  *             Optional. Plugin data for install/activate UI.
  *
  *             @type string $slug The WordPress.org plugin slug.
  *         }
- *         @type array  $authentication {
+ *         @type array       $authentication {
  *             Authentication configuration. When method is 'api_key', includes
  *             credentials_url and setting_name. When 'none', only method is present.
  *
- *             @type string      $method          The authentication method: 'api_key' or 'none'.
- *             @type string|null $credentials_url Optional. URL where users can obtain API credentials.
- *             @type string      $setting_name    Optional. The setting name for the API key.
+ *             @type string $method          The authentication method: 'api_key' or 'none'.
+ *             @type string $credentials_url Optional. URL where users can obtain API credentials.
+ *             @type string $setting_name    Optional. The setting name for the API key.
  *         }
  *     }
  * }
  * @phpstan-return array<string, array{
- *     name: string,
- *     description: string,
- *     logo_url?: string|null,
- *     type: string,
+ *     name: non-empty-string,
+ *     description: non-empty-string,
+ *     logo_url?: non-empty-string,
+ *     type: 'ai_provider',
  *     authentication: array{
- *         method: string,
- *         credentials_url?: string|null,
- *         setting_name?: string
+ *         method: 'api_key'|'none',
+ *         credentials_url?: non-empty-string,
+ *         setting_name?: non-empty-string
  *     },
  *     plugin?: array{
- *         slug: string
+ *         slug: non-empty-string
  *     }
  * }>
  */

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -512,7 +512,8 @@ add_action( 'init', '_wp_connectors_pass_default_keys_to_ai_client', 20 );
  * @access private
  *
  * @param array $data Existing script module data.
- * @return array Script module data with connectors added.
+ * @param array<string, mixed> $data Existing script module data.
+ * @return array<string, mixed> Script module data with connectors added.
  */
 function _wp_connectors_get_connector_script_module_data( array $data ): array {
 	$connectors = array();

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -55,6 +55,8 @@ function wp_get_connector( string $id ): ?array {
  *
  * @see WP_Connector_Registry::get_all_registered()
  *
+ * @phpstan-import-type Connector from WP_Connector_Registry
+ *
  * @return array {
  *     Connector settings keyed by connector ID.
  *
@@ -77,6 +79,7 @@ function wp_get_connector( string $id ): ?array {
  *         }
  *     }
  * }
+ * @phpstan-return array<string, Connector>
  */
 function wp_get_connectors(): array {
 	$registry = WP_Connector_Registry::get_instance();

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -55,7 +55,28 @@ function wp_get_connector( string $id ): ?array {
  *
  * @see WP_Connector_Registry::get_all_registered()
  *
- * @return array[] An array of registered connectors keyed by connector ID.
+ * @return array {
+ *     Connector settings keyed by connector ID.
+ *
+ *     @type array ...$0 {
+ *         Data for a single connector.
+ *
+ *         @type string $name           The connector's display name.
+ *         @type string $description    The connector's description.
+ *         @type string $type           The connector type. Currently, only 'ai_provider' is supported.
+ *         @type array  $plugin         Optional. Plugin data for install/activate UI.
+ *             @type string $slug       The WordPress.org plugin slug.
+ *         }
+ *         @type array  $authentication {
+ *             Authentication configuration. When method is 'api_key', includes
+ *             credentials_url and setting_name. When 'none', only method is present.
+ *
+ *             @type string      $method          The authentication method: 'api_key' or 'none'.
+ *             @type string|null $credentials_url Optional. URL where users can obtain API credentials.
+ *             @type string      $setting_name    Optional. The setting name for the API key.
+ *         }
+ *     }
+ * }
  */
 function wp_get_connectors(): array {
 	$registry = WP_Connector_Registry::get_instance();
@@ -325,41 +346,6 @@ function _wp_connectors_get_real_api_key( string $option_name, callable $mask_ca
 }
 
 /**
- * Gets the registered connector settings.
- *
- * @since 7.0.0
- * @access private
- *
- * @return array {
- *     Connector settings keyed by connector ID.
- *
- *     @type array ...$0 {
- *         Data for a single connector.
- *
- *         @type string $name           The connector's display name.
- *         @type string $description    The connector's description.
- *         @type string $type           The connector type. Currently, only 'ai_provider' is supported.
- *         @type array  $plugin         Optional. Plugin data for install/activate UI.
- *             @type string $slug       The WordPress.org plugin slug.
- *         }
- *         @type array  $authentication {
- *             Authentication configuration. When method is 'api_key', includes
- *             credentials_url and setting_name. When 'none', only method is present.
- *
- *             @type string      $method          The authentication method: 'api_key' or 'none'.
- *             @type string|null $credentials_url Optional. URL where users can obtain API credentials.
- *             @type string      $setting_name    Optional. The setting name for the API key.
- *         }
- *     }
- * }
- */
-function _wp_connectors_get_connector_settings(): array {
-	$connectors = wp_get_connectors();
-	ksort( $connectors );
-	return $connectors;
-}
-
-/**
  * Validates connector API keys in the REST response when explicitly requested.
  *
  * Runs on `rest_post_dispatch` for `/wp/v2/settings` requests that include connector
@@ -396,7 +382,7 @@ function _wp_connectors_validate_keys_in_rest( WP_REST_Response $response, WP_RE
 		return $response;
 	}
 
-	foreach ( _wp_connectors_get_connector_settings() as $connector_id => $connector_data ) {
+	foreach ( wp_get_connectors() as $connector_id => $connector_data ) {
 		$auth = $connector_data['authentication'];
 		if ( 'ai_provider' !== $connector_data['type'] || 'api_key' !== $auth['method'] || empty( $auth['setting_name'] ) ) {
 			continue;
@@ -431,7 +417,7 @@ add_filter( 'rest_post_dispatch', '_wp_connectors_validate_keys_in_rest', 10, 3 
 function _wp_register_default_connector_settings(): void {
 	$ai_registry = AiClient::defaultRegistry();
 
-	foreach ( _wp_connectors_get_connector_settings() as $connector_id => $connector_data ) {
+	foreach ( wp_get_connectors() as $connector_id => $connector_data ) {
 		$auth = $connector_data['authentication'];
 		if ( 'ai_provider' !== $connector_data['type'] || 'api_key' !== $auth['method'] || empty( $auth['setting_name'] ) ) {
 			continue;
@@ -485,7 +471,7 @@ add_action( 'init', '_wp_register_default_connector_settings', 20 );
 function _wp_connectors_pass_default_keys_to_ai_client(): void {
 	try {
 		$ai_registry = AiClient::defaultRegistry();
-		foreach ( _wp_connectors_get_connector_settings() as $connector_id => $connector_data ) {
+		foreach ( wp_get_connectors() as $connector_id => $connector_data ) {
 			if ( 'ai_provider' !== $connector_data['type'] ) {
 				continue;
 			}
@@ -526,7 +512,7 @@ add_action( 'init', '_wp_connectors_pass_default_keys_to_ai_client', 20 );
  */
 function _wp_connectors_get_connector_script_module_data( array $data ): array {
 	$connectors = array();
-	foreach ( _wp_connectors_get_connector_settings() as $connector_id => $connector_data ) {
+	foreach ( wp_get_connectors() as $connector_id => $connector_data ) {
 		$auth     = $connector_data['authentication'];
 		$auth_out = array( 'method' => $auth['method'] );
 
@@ -548,6 +534,7 @@ function _wp_connectors_get_connector_script_module_data( array $data ): array {
 
 		$connectors[ $connector_id ] = $connector_out;
 	}
+	ksort( $connectors );
 	$data['connectors'] = $connectors;
 	return $data;
 }

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -536,7 +536,6 @@ add_action( 'init', '_wp_connectors_pass_default_keys_to_ai_client', 20 );
  * @since 7.0.0
  * @access private
  *
- * @param array $data Existing script module data.
  * @param array<string, mixed> $data Existing script module data.
  * @return array<string, mixed> Script module data with connectors added.
  */

--- a/tests/phpunit/tests/connectors/wpGetConnectors.php
+++ b/tests/phpunit/tests/connectors/wpGetConnectors.php
@@ -15,7 +15,7 @@ class Tests_Connectors_WpGetConnectors extends WP_UnitTestCase {
 	/**
 	 * Registers the mock provider once before any tests in this class run.
 	 */
-	public static function set_up_before_class() {
+	public static function set_up_before_class(): void {
 		parent::set_up_before_class();
 		self::register_mock_connectors_provider();
 	}
@@ -23,7 +23,7 @@ class Tests_Connectors_WpGetConnectors extends WP_UnitTestCase {
 	/**
 	 * Unregisters the mock provider setting added by `init`.
 	 */
-	public static function tear_down_after_class() {
+	public static function tear_down_after_class(): void {
 		self::unregister_mock_connector_setting();
 		parent::tear_down_after_class();
 	}
@@ -31,7 +31,7 @@ class Tests_Connectors_WpGetConnectors extends WP_UnitTestCase {
 	/**
 	 * @ticket 64730
 	 */
-	public function test_returns_expected_connector_keys() {
+	public function test_returns_expected_connector_keys(): void {
 		$connectors = wp_get_connectors();
 
 		$this->assertArrayHasKey( 'google', $connectors );
@@ -44,7 +44,7 @@ class Tests_Connectors_WpGetConnectors extends WP_UnitTestCase {
 	/**
 	 * @ticket 64730
 	 */
-	public function test_each_connector_has_required_fields() {
+	public function test_each_connector_has_required_fields(): void {
 		$connectors = wp_get_connectors();
 
 		$this->assertNotEmpty( $connectors, 'Connector settings should not be empty.' );
@@ -67,7 +67,7 @@ class Tests_Connectors_WpGetConnectors extends WP_UnitTestCase {
 	/**
 	 * @ticket 64730
 	 */
-	public function test_api_key_connectors_have_setting_name_and_credentials_url() {
+	public function test_api_key_connectors_have_setting_name_and_credentials_url(): void {
 		$connectors    = wp_get_connectors();
 		$api_key_count = 0;
 
@@ -81,7 +81,7 @@ class Tests_Connectors_WpGetConnectors extends WP_UnitTestCase {
 			$this->assertArrayHasKey( 'setting_name', $connector_data['authentication'], "Connector '{$connector_id}' authentication is missing 'setting_name'." );
 			$this->assertSame(
 				"connectors_ai_{$connector_id}_api_key",
-				$connector_data['authentication']['setting_name'],
+				$connector_data['authentication']['setting_name'] ?? null,
 				"Connector '{$connector_id}' setting_name does not match expected format."
 			);
 			$this->assertArrayHasKey( 'credentials_url', $connector_data['authentication'], "Connector '{$connector_id}' authentication is missing 'credentials_url'." );
@@ -93,7 +93,7 @@ class Tests_Connectors_WpGetConnectors extends WP_UnitTestCase {
 	/**
 	 * @ticket 64730
 	 */
-	public function test_featured_provider_names_match_expected() {
+	public function test_featured_provider_names_match_expected(): void {
 		$connectors = wp_get_connectors();
 
 		$this->assertSame( 'Google', $connectors['google']['name'] );
@@ -104,7 +104,7 @@ class Tests_Connectors_WpGetConnectors extends WP_UnitTestCase {
 	/**
 	 * @ticket 64730
 	 */
-	public function test_includes_registered_provider_from_registry() {
+	public function test_includes_registered_provider_from_registry(): void {
 		$connectors = wp_get_connectors();
 		$mock       = $connectors['mock_connectors_test'];
 
@@ -112,7 +112,7 @@ class Tests_Connectors_WpGetConnectors extends WP_UnitTestCase {
 		$this->assertSame( '', $mock['description'] );
 		$this->assertSame( 'ai_provider', $mock['type'] );
 		$this->assertSame( 'api_key', $mock['authentication']['method'] );
-		$this->assertNull( $mock['authentication']['credentials_url'] );
-		$this->assertSame( 'connectors_ai_mock_connectors_test_api_key', $mock['authentication']['setting_name'] );
+		$this->assertNull( $mock['authentication']['credentials_url'] ?? null );
+		$this->assertSame( 'connectors_ai_mock_connectors_test_api_key', $mock['authentication']['setting_name'] ?? null );
 	}
 }

--- a/tests/phpunit/tests/connectors/wpGetConnectors.php
+++ b/tests/phpunit/tests/connectors/wpGetConnectors.php
@@ -3,12 +3,12 @@
 require_once dirname( __DIR__, 2 ) . '/includes/wp-ai-client-mock-provider-trait.php';
 
 /**
- * Tests for _wp_connectors_get_connector_settings().
+ * Tests for wp_get_connectors().
  *
  * @group connectors
- * @covers ::_wp_connectors_get_connector_settings
+ * @covers ::wp_get_connectors
  */
-class Tests_Connectors_WpConnectorsGetConnectorSettings extends WP_UnitTestCase {
+class Tests_Connectors_WpGetConnectors extends WP_UnitTestCase {
 
 	use WP_AI_Client_Mock_Provider_Trait;
 
@@ -32,7 +32,7 @@ class Tests_Connectors_WpConnectorsGetConnectorSettings extends WP_UnitTestCase 
 	 * @ticket 64730
 	 */
 	public function test_returns_expected_connector_keys() {
-		$connectors = _wp_connectors_get_connector_settings();
+		$connectors = wp_get_connectors();
 
 		$this->assertArrayHasKey( 'google', $connectors );
 		$this->assertArrayHasKey( 'openai', $connectors );
@@ -45,7 +45,7 @@ class Tests_Connectors_WpConnectorsGetConnectorSettings extends WP_UnitTestCase 
 	 * @ticket 64730
 	 */
 	public function test_each_connector_has_required_fields() {
-		$connectors = _wp_connectors_get_connector_settings();
+		$connectors = wp_get_connectors();
 
 		$this->assertNotEmpty( $connectors, 'Connector settings should not be empty.' );
 
@@ -68,7 +68,7 @@ class Tests_Connectors_WpConnectorsGetConnectorSettings extends WP_UnitTestCase 
 	 * @ticket 64730
 	 */
 	public function test_api_key_connectors_have_setting_name_and_credentials_url() {
-		$connectors    = _wp_connectors_get_connector_settings();
+		$connectors    = wp_get_connectors();
 		$api_key_count = 0;
 
 		foreach ( $connectors as $connector_id => $connector_data ) {
@@ -94,7 +94,7 @@ class Tests_Connectors_WpConnectorsGetConnectorSettings extends WP_UnitTestCase 
 	 * @ticket 64730
 	 */
 	public function test_featured_provider_names_match_expected() {
-		$connectors = _wp_connectors_get_connector_settings();
+		$connectors = wp_get_connectors();
 
 		$this->assertSame( 'Google', $connectors['google']['name'] );
 		$this->assertSame( 'OpenAI', $connectors['openai']['name'] );
@@ -105,7 +105,7 @@ class Tests_Connectors_WpConnectorsGetConnectorSettings extends WP_UnitTestCase 
 	 * @ticket 64730
 	 */
 	public function test_includes_registered_provider_from_registry() {
-		$connectors = _wp_connectors_get_connector_settings();
+		$connectors = wp_get_connectors();
 		$mock       = $connectors['mock_connectors_test'];
 
 		$this->assertSame( 'Mock Connectors Test', $mock['name'] );
@@ -114,17 +114,5 @@ class Tests_Connectors_WpConnectorsGetConnectorSettings extends WP_UnitTestCase 
 		$this->assertSame( 'api_key', $mock['authentication']['method'] );
 		$this->assertNull( $mock['authentication']['credentials_url'] );
 		$this->assertSame( 'connectors_ai_mock_connectors_test_api_key', $mock['authentication']['setting_name'] );
-	}
-
-	/**
-	 * @ticket 64730
-	 */
-	public function test_connectors_are_sorted_alphabetically() {
-		$connectors = _wp_connectors_get_connector_settings();
-		$keys       = array_keys( $connectors );
-		$sorted     = $keys;
-		sort( $sorted );
-
-		$this->assertSame( $sorted, $keys, 'Connectors should be sorted alphabetically by ID.' );
 	}
 }

--- a/tests/phpunit/tests/connectors/wpGetConnectors.php
+++ b/tests/phpunit/tests/connectors/wpGetConnectors.php
@@ -84,7 +84,6 @@ class Tests_Connectors_WpGetConnectors extends WP_UnitTestCase {
 				$connector_data['authentication']['setting_name'] ?? null,
 				"Connector '{$connector_id}' setting_name does not match expected format."
 			);
-			$this->assertArrayHasKey( 'credentials_url', $connector_data['authentication'], "Connector '{$connector_id}' authentication is missing 'credentials_url'." );
 		}
 
 		$this->assertGreaterThan( 0, $api_key_count, 'At least one connector should use api_key authentication.' );


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/64791

Follow-up for https://github.com/WordPress/wordpress-develop/pull/11175#issuecomment-4040455470 (https://core.trac.wordpress.org/changeset/61943).

## Summary

- Removes the private `_wp_connectors_get_connector_settings()` wrapper, which only called `wp_get_connectors()` and applied `ksort()`. Callers now use `wp_get_connectors()` directly, with the sort applied in `_wp_connectors_get_connector_script_module_data()` — the only place where ordering matters.
- Expands the WordPress-style `@return` array shape for both `wp_get_connector()` and `wp_get_connectors()`, documenting all fields including `logo_url`, `authentication`, and `plugin`.
- Adds `@phpstan-return` inline array shapes to `wp_get_connector()` and `wp_get_connectors()` using `non-empty-string` and literal union types (`'ai_provider'`, `'api_key'|'none'`) for improved static analysis. Note: `@phpstan-import-type` is not used due to a [known PHPStan limitation](https://github.com/phpstan/phpstan/issues/9164).
- Makes `logo_url` and `credentials_url` truly optional (no longer stored as `null` when absent), consistent with how optional fields are handled elsewhere in `register()`.
- Simplifies `get_all_registered()` `@return` to a one-liner, avoiding a duplicate shape on an internal method; `@phpstan-return array<string, Connector>` covers static analysis.
- Renames the test class from `wpConnectorsGetConnectorSettings` to `wpGetConnectors`, targeting `wp_get_connectors()` directly.

## Test plan

- [ ] Run `npm run test:php -- --filter=connectors` and confirm all 53 tests pass.
- [ ] Run `npm run env:composer -- lint -- src/wp-includes/connectors.php src/wp-includes/class-wp-connector-registry.php` and confirm no PHPCS violations.
- [ ] Run `npm run typecheck:php` and confirm no new PHPStan errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)