### PR TITLE
REST API: Support nested _fields in revisions controller

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-revisions-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-revisions-controller.php
@@ -639,35 +639,46 @@ class WP_REST_Revisions_Controller extends WP_REST_Controller {
 			$data['slug'] = $post->post_name;
 		}
 
-		if ( in_array( 'guid', $fields, true ) ) {
-			$data['guid'] = array(
-				/** This filter is documented in wp-includes/post-template.php */
-				'rendered' => apply_filters( 'get_the_guid', $post->guid, $post->ID ),
-				'raw'      => $post->guid,
-			);
+		if ( rest_is_field_included( 'guid', $fields ) ) {
+			$data['guid'] = array();
+		}
+		if ( rest_is_field_included( 'guid.rendered', $fields ) ) {
+			/** This filter is documented in wp-includes/post-template.php */
+			$data['guid']['rendered'] = apply_filters( 'get_the_guid', $post->guid, $post->ID );
+		}
+		if ( rest_is_field_included( 'guid.raw', $fields ) ) {
+			$data['guid']['raw'] = $post->guid;
 		}
 
-		if ( in_array( 'title', $fields, true ) ) {
-			$data['title'] = array(
-				'raw'      => $post->post_title,
-				'rendered' => get_the_title( $post->ID ),
-			);
+		if ( rest_is_field_included( 'title', $fields ) ) {
+			$data['title'] = array();
+		}
+		if ( rest_is_field_included( 'title.raw', $fields ) ) {
+			$data['title']['raw'] = $post->post_title;
+		}
+		if ( rest_is_field_included( 'title.rendered', $fields ) ) {
+			$data['title']['rendered'] = get_the_title( $post->ID );
 		}
 
-		if ( in_array( 'content', $fields, true ) ) {
-
-			$data['content'] = array(
-				'raw'      => $post->post_content,
-				/** This filter is documented in wp-includes/post-template.php */
-				'rendered' => apply_filters( 'the_content', $post->post_content ),
-			);
+		if ( rest_is_field_included( 'content', $fields ) ) {
+			$data['content'] = array();
+		}
+		if ( rest_is_field_included( 'content.raw', $fields ) ) {
+			$data['content']['raw'] = $post->post_content;
+		}
+		if ( rest_is_field_included( 'content.rendered', $fields ) ) {
+			/** This filter is documented in wp-includes/post-template.php */
+			$data['content']['rendered'] = apply_filters( 'the_content', $post->post_content );
 		}
 
-		if ( in_array( 'excerpt', $fields, true ) ) {
-			$data['excerpt'] = array(
-				'raw'      => $post->post_excerpt,
-				'rendered' => $this->prepare_excerpt_response( $post->post_excerpt, $post ),
-			);
+		if ( rest_is_field_included( 'excerpt', $fields ) ) {
+			$data['excerpt'] = array();
+		}
+		if ( rest_is_field_included( 'excerpt.raw', $fields ) ) {
+			$data['excerpt']['raw'] = $post->post_excerpt;
+		}
+		if ( rest_is_field_included( 'excerpt.rendered', $fields ) ) {
+			$data['excerpt']['rendered'] = $this->prepare_excerpt_response( $post->post_excerpt, $post );
 		}
 
 		if ( rest_is_field_included( 'meta', $fields ) ) {


### PR DESCRIPTION
https://core.trac.wordpress.org/ticket/64844

Use `rest_is_field_included()` instead of `in_array()` for `content`, `title`, `excerpt`, and `guid` fields in `WP_REST_Revisions_Controller`. This lets clients request specific sub-fields (e.g. `_fields=content.raw`) and skip expensive `the_content` rendering.

The [REST API `_fields` documentation](https://developer.wordpress.org/rest-api/using-the-rest-api/global-parameters/#_fields) states that nested fields are supported using dot notation. However, the revisions controller uses `in_array()` which doesn't match nested keys like `content.raw`.

Several other controllers already use `rest_is_field_included()` for `raw`/`rendered` sub-fields:

- [`WP_REST_Posts_Controller`](https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php#L1976-L2005) — `title.raw`, `title.rendered`, `content.raw`, `content.rendered`
- [`WP_REST_Templates_Controller`](https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php#L708-L744) — `content.raw`, `title.raw`, `title.rendered`
- [`WP_REST_Menu_Items_Controller`](https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-includes/rest-api/endpoints/class-wp-rest-menu-items-controller.php#L522-L526) — `title.raw`, `title.rendered`
- [`WP_REST_Global_Styles_Controller`](https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-includes/rest-api/endpoints/class-wp-rest-global-styles-controller.php#L331-L334) — `title.raw`, `title.rendered`
- [`WP_REST_Themes_Controller`](https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php#L286-L290) — generic `{field}.raw`, `{field}.rendered`

Related Gutenberg PR: https://github.com/WordPress/gutenberg/pull/76347