### PR TITLE
Move `wp_load_classic_theme_block_styles_on_demand()` from the `init` action to `wp_default_styles`

### DIFF
--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -607,7 +607,7 @@ add_action( 'admin_enqueue_scripts', 'wp_enqueue_view_transitions_admin_css' );
 add_action( 'enqueue_block_assets', 'wp_enqueue_classic_theme_styles' );
 add_action( 'enqueue_block_assets', 'wp_enqueue_registered_block_scripts_and_styles' );
 add_action( 'enqueue_block_assets', 'enqueue_block_styles_assets', 30 );
-add_action( 'init', 'wp_load_classic_theme_block_styles_on_demand', 8 ); // Must happen before register_core_block_style_handles() at priority 9.
+add_action( 'wp_default_styles', 'wp_load_classic_theme_block_styles_on_demand', 0 ); // Must happen before wp_default_styles() and register_core_block_style_handles().
 /*
  * `wp_enqueue_registered_block_scripts_and_styles` is bound to both
  * `enqueue_block_editor_assets` and `enqueue_block_assets` hooks

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -3678,10 +3678,11 @@ function wp_remove_surrounding_empty_script_tags( $contents ) {
  * the filters are added to cause {@see wp_should_load_separate_core_block_assets()} to return true.
  *
  * @since 6.9.0
+ * @since 7.0.0 This is now invoked at the `wp_default_styles` action with priority 0 instead of at `init` with priority 8.
  *
  * @see _add_default_theme_supports()
  */
-function wp_load_classic_theme_block_styles_on_demand() {
+function wp_load_classic_theme_block_styles_on_demand(): void {
 	// This is not relevant to block themes, as they are opted in to loading separate styles on demand via _add_default_theme_supports().
 	if ( wp_is_block_theme() ) {
 		return;

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -3674,6 +3674,9 @@ function wp_remove_surrounding_empty_script_tags( $contents ) {
 /**
  * Adds hooks to load block styles on demand in classic themes.
  *
+ * This function must be called before {@see wp_default_styles()} and {@see register_core_block_style_handles()} so that
+ * the filters are added to cause {@see wp_should_load_separate_core_block_assets()} to return true.
+ *
  * @since 6.9.0
  *
  * @see _add_default_theme_supports()

--- a/tests/phpunit/tests/template.php
+++ b/tests/phpunit/tests/template.php
@@ -1963,6 +1963,10 @@ class Tests_Template extends WP_UnitTestCase {
 		// `_print_emoji_detection_script()` assumes `wp-includes/js/wp-emoji-loader.js` is present:
 		self::touch( ABSPATH . WPINC . '/js/wp-emoji-loader.js' );
 
+		if ( $set_up ) {
+			$set_up();
+		}
+
 		switch_theme( 'default' );
 		global $wp_styles;
 		$wp_styles = null;
@@ -2000,10 +2004,6 @@ class Tests_Template extends WP_UnitTestCase {
 				wp_enqueue_style( 'custom-block-styles', 'https://example.com/custom-block-styles.css', array(), null );
 			}
 		);
-
-		if ( $set_up ) {
-			$set_up();
-		}
 
 		wp_load_classic_theme_block_styles_on_demand();
 


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/64846

The `wp_load_classic_theme_block_styles_on_demand()` function was added to run at `init` action with priority 8 in r61008. This turns out to be too late since styles can be registered earlier. Registering a style earlier causes `wp_default_styles()` to be called, which registers the `wp-block-library` style. When a classic theme is active, before `wp_load_classic_theme_block_styles_on_demand()` is run, the `wp_should_load_block_assets_on_demand()` function will return `false`. This results in the combined block library stylesheet being incorrectly registered:

https://github.com/WordPress/wordpress-develop/blob/2bb252ae83bc78852c0d2e11749d640ac8b6bc8a/src/wp-includes/script-loader.php#L1819-L1823

The point of `wp_load_classic_theme_block_styles_on_demand()` is to opt-in to loading separate block styles on demand, but at the point it runs it is already too late since the combined `wp-block-library` has already been registered.

If the `init` priority of `wp_load_classic_theme_block_styles_on_demand()` is changed to `-1` then this fixes the problem, but this is not the ideal solution since a theme/plugin could always register a style earlier during the `init` action (e.g. `PHP_INT_MIN`). Note that the `init` action is the earliest point to register a style safely since `_wp_scripts_maybe_doing_it_wrong()` will issue a warning otherwise. Nevertheless, the better solution would be to not use the `init` action at all, but rather to use the `wp_default_styles` action (with a low priority) so that we'll be better guaranteed that the filters will have been added.

The issue can be reproduced with the following example plugin:

```php
<?php
/**
 * Plugin Name: Register test style at early init.
 * Plugin URI: https://core.trac.wordpress.org/ticket/64846
 */

add_action(
	'init',
	function () {
		wp_register_style( 'test-early-init', false );
		wp_add_inline_style( 'test-early-init', '/* With a classic theme active, make sure wp-block-library is common.css and not style.css */' );
		wp_enqueue_style( 'test-early-init' );
	},
	0
);
```

### Before ❌

```html
<link rel='stylesheet' id='wp-block-library-css' href='http://localhost:8000/wp-includes/css/dist/block-library/style.css?ver=7.0-beta4-61919-src' media='all' />

<style id="wp-block-accordion-inline-css">
.wp-block-accordion {
  box-sizing: border-box;
}
/*# sourceURL=http://localhost:8000/wp-includes/blocks/accordion/style.css */
</style>
```

### After ✅

```html
<style id="wp-block-library-inline-css">
/**
 * Colors
 */
...

/*# sourceURL=/wp-includes/css/dist/block-library/common.css */
</style>
<style id="wp-block-archives-inline-css">
.wp-block-archives {
  box-sizing: border-box;
}

.wp-block-archives-dropdown label {
  display: block;
}
/*# sourceURL=http://localhost:8000/wp-includes/blocks/archives/style.css */
</style>
```

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

None 🧠 

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
