### PR TITLE
Add missing JavaScript files during `build` scripts

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -612,6 +612,16 @@ module.exports = function(grunt) {
 					dest: WORKING_DIR + 'wp-includes/build/',
 				} ],
 			},
+			'gutenberg-js': {
+				files: [ {
+					expand: true,
+					cwd: 'gutenberg/build',
+					src: [
+						'routes/**/*.js',
+					],
+					dest: WORKING_DIR + 'wp-includes/build/',
+				} ],
+			},
 			'gutenberg-modules': {
 				files: [ {
 					expand: true,

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -617,6 +617,7 @@ module.exports = function(grunt) {
 					expand: true,
 					cwd: 'gutenberg/build',
 					src: [
+						'pages/**/*.js',
 						'routes/**/*.js',
 					],
 					dest: WORKING_DIR + 'wp-includes/build/',
@@ -2051,6 +2052,7 @@ module.exports = function(grunt) {
 
 	grunt.registerTask( 'build:gutenberg', [
 		'copy:gutenberg-php',
+		'copy:gutenberg-js',
 		'gutenberg:copy',
 		'copy:gutenberg-modules',
 		'copy:gutenberg-styles',


### PR DESCRIPTION
This adjusts the Gutenberg-related `grunt copy` configurations to also copy over the `.js` files in the `gutenberg/build/pages` and `gutenberg/build/routes` directories.

Trac ticket: Core-64393.

## Use of AI Tools

Claude was used to confirm that this was causing the differences.
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
