### PR TITLE
Media: Fix strpos() check and file_get_contents() handling in wp_get_…

### DIFF
--- a/src/wp-admin/includes/image.php
+++ b/src/wp-admin/includes/image.php
@@ -1088,11 +1088,16 @@ function wp_read_image_metadata( $file ) {
 function wp_get_image_alttext( $file ) {
 	$alt_text     = '';
 	$img_contents = file_get_contents( $file );
+
+	if ( false === $img_contents ) {
+		return $alt_text;
+	}
+
 	// Find the start and end positions of the XMP metadata.
 	$xmp_start = strpos( $img_contents, '<x:xmpmeta' );
 	$xmp_end   = strpos( $img_contents, '</x:xmpmeta>' );
 
-	if ( ! $xmp_start || ! $xmp_end ) {
+	if ( false === $xmp_start || false === $xmp_end ) {
 		// No XMP metadata found.
 		return $alt_text;
 	}


### PR DESCRIPTION
Fixes https://core.trac.wordpress.org/ticket/64849#ticket

### Summary

The `wp_get_image_alttext()` function in `src/wp-admin/includes/image.php` checks for XMP metadata using `strpos()`, but the current implementation uses a loose comparison:

```php
if ( ! $xmp_start || ! $xmp_end ) {
    return $alt_text;
}