### PR TITLE
Cleanup: remove unused variable `$network_exists` in `populate_network()` function

### DIFF
--- a/src/wp-admin/includes/schema.php
+++ b/src/wp-admin/includes/schema.php
@@ -1033,7 +1033,6 @@ function populate_network( $network_id = 1, $domain = '', $email = '', $site_nam
 	}
 
 	// Check for network collision.
-	$network_exists = false;
 	if ( is_multisite() ) {
 		if ( get_network( $network_id ) ) {
 			$errors->add( 'siteid_exists', __( 'The network already exists.' ) );


### PR DESCRIPTION
This pull request makes a minor change to the `populate_network` function in `src/wp-admin/includes/schema.php`. The unused `$network_exists` variable has been removed to clean up the code.

Trac ticket: https://core.trac.wordpress.org/ticket/64851

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
