### PR TITLE
Update plugin/theme upload box to remove overlapping text

### DIFF
--- a/src/wp-admin/css/themes.css
+++ b/src/wp-admin/css/themes.css
@@ -1136,24 +1136,23 @@ body.folded .theme-browser ~ .theme-overlay .theme-wrap {
 .upload-theme .wp-upload-form,
 .upload-plugin .wp-upload-form {
 	position: relative;
-	margin: 30px auto;
+	margin: 30px;
 	display: inline-flex;
 	justify-content: space-between;
 	align-items: center;
+	border: 1px solid #c3c4c7;
+	background: #f6f7f7;
 }
 
 .upload-theme .wp-upload-form input[type="file"],
 .upload-plugin .wp-upload-form input[type="file"] {
-	background: #f6f7f7;
-    border: 1px solid #c3c4c7;
+	background: transparent;
     margin: 0;
-    padding: 30px 128px 30px 30px;
+    padding: 30px 0 30px 30px;
 }
 
-.upload-plugin .wp-upload-form input[type=submit],
-.upload-theme .wp-upload-form input[type=submit] {
-	position: absolute;
-	right: 30px;
+.wp-upload-form input[type="submit"].button {
+	margin-right: 30px;
 }
 
 .upload-theme .install-help,
@@ -2071,19 +2070,12 @@ body.full-overlay-active {
 	.upload-plugin .wp-upload-form,
 	.upload-theme .wp-upload-form {
 		width: 100%;
+		box-sizing: border-box;
 	}
 
 	.upload-plugin .wp-upload-form input[type=file],
 	.upload-theme .wp-upload-form input[type=file] {
-		padding: 30px 30px 80px;
+		padding: 30px 0 30px 30px;
 		width: 100%;
-	}
-
-	:is(.upload-theme, .upload-plugin) .wp-upload-form input[type="submit"].button {
-		right: unset;
-		left: 50%;
-		transform: translateX(-50%) !important;
-    	top: calc( 1.4em + 42px ); /* Line height of control + gap + top padding. */
-		margin: 10px 0 0;
 	}
 }


### PR DESCRIPTION
This is an alternate approach to https://github.com/WordPress/wordpress-develop/pull/11216 by @PANawkar

While it reduces the dropzone from the original commit, it still maintains a significantly larger and easier dropzone than existed previously.

Another alternative would be to simply give the button a non-transparent background, so that it covered the file upload hint. That's already truncated, so covering part of it is not necessarily a significant loss; the big problem right now is that with a transparent background, the text overlaps and becomes difficult to read.

Trac ticket:https://core.trac.wordpress.org/ticket/64832

## Use of AI Tools

None

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
