### PR TITLE
Twenty Seventeen: Add a parameter to `twentyseventeen_edit_link()`

### DIFF
--- a/src/wp-content/themes/twentyseventeen/inc/template-tags.php
+++ b/src/wp-content/themes/twentyseventeen/inc/template-tags.php
@@ -110,22 +110,20 @@ endif;
 
 if ( ! function_exists( 'twentyseventeen_edit_link' ) ) :
 	/**
-	 * Returns an accessibility-friendly link to edit a post or page.
+	 * Displays an accessibility-friendly link to edit a post or page.
 	 *
-	 * This also gives a little context about what exactly we're editing
-	 * (post or page?) so that users understand a bit more where they are in terms
-	 * of the template hierarchy and their content. Helpful when/if the single-page
-	 * layout with multiple posts/pages shown gets confusing.
+	 * @param int $post_id Post ID. Default 0.
 	 */
-	function twentyseventeen_edit_link() {
+	function twentyseventeen_edit_link( $post_id = 0 ) {
 		edit_post_link(
 			sprintf(
 				/* translators: %s: Post title. Only visible to screen readers. */
 				__( 'Edit<span class="screen-reader-text"> "%s"</span>', 'twentyseventeen' ),
-				get_the_title()
+				get_the_title( $post_id )
 			),
 			'<span class="edit-link">',
-			'</span>'
+			'</span>',
+			$post_id
 		);
 	}
 endif;

--- a/src/wp-content/themes/twentyseventeen/inc/template-tags.php
+++ b/src/wp-content/themes/twentyseventeen/inc/template-tags.php
@@ -112,6 +112,9 @@ if ( ! function_exists( 'twentyseventeen_edit_link' ) ) :
 	/**
 	 * Displays an accessibility-friendly link to edit a post or page.
 	 *
+	 * @since Twenty Seventeen 1.0
+	 * @since Twenty Seventeen 4.1 Added `$post_id` parameter.
+	 *
 	 * @param int $post_id Post ID. Default 0.
 	 */
 	function twentyseventeen_edit_link( $post_id = 0 ) {


### PR DESCRIPTION
Adds a `$post_id` parameter to `twentyseventeen_edit_link()` and updates documentation.

[Trac 64825](https://core.trac.wordpress.org/ticket/64825)

Use of AI Tools: none

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
