### PR TITLE
I18N: Fix JIT translations for network-activated plugins in multisite

### DIFF
--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -498,6 +498,9 @@ wp_plugin_directory_constants();
  */
 $GLOBALS['wp_plugin_paths'] = array();
 
+// To make get_plugin_data() available for both network-activated and site-activated plugins, see #62244 and #64249.
+require_once ABSPATH . 'wp-admin/includes/plugin.php';
+
 // Load must-use plugins.
 foreach ( wp_get_mu_plugins() as $mu_plugin ) {
 	$_wp_plugin_file = $mu_plugin;
@@ -520,6 +523,17 @@ if ( is_multisite() ) {
 	foreach ( wp_get_active_network_plugins() as $network_plugin ) {
 		wp_register_plugin_realpath( $network_plugin );
 
+		$plugin_data = get_plugin_data( $network_plugin, false, false );
+
+		$textdomain = $plugin_data['TextDomain'];
+		if ( $textdomain ) {
+			if ( $plugin_data['DomainPath'] ) {
+				$GLOBALS['wp_textdomain_registry']->set_custom_path( $textdomain, dirname( $network_plugin ) . $plugin_data['DomainPath'] );
+			} else {
+				$GLOBALS['wp_textdomain_registry']->set_custom_path( $textdomain, dirname( $network_plugin ) );
+			}
+		}
+
 		$_wp_plugin_file = $network_plugin;
 		include_once $network_plugin;
 		$network_plugin = $_wp_plugin_file; // Avoid stomping of the $network_plugin variable in a plugin.
@@ -533,7 +547,7 @@ if ( is_multisite() ) {
 		 */
 		do_action( 'network_plugin_loaded', $network_plugin );
 	}
-	unset( $network_plugin, $_wp_plugin_file );
+	unset( $network_plugin, $_wp_plugin_file, $plugin_data, $textdomain );
 }
 
 /**
@@ -570,9 +584,6 @@ if ( ! is_multisite() && wp_is_fatal_error_handler_enabled() ) {
 	// Handle users requesting a recovery mode link and initiating recovery mode.
 	wp_recovery_mode()->initialize();
 }
-
-// To make get_plugin_data() available in a way that's compatible with plugins also loading this file, see #62244.
-require_once ABSPATH . 'wp-admin/includes/plugin.php';
 
 // Load active plugins.
 foreach ( wp_get_active_and_valid_plugins() as $plugin ) {


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->

## Problem

Since WordPress 6.7 ([59461](https://core.trac.wordpress.org/changeset/59461)), the just-in-time (JIT) translation loading mechanism registers text domains by reading each plugin's `Text Domain` and `Domain Path` headers during bootstrap. However, this registration only happened for site-level active plugins (`wp_get_active_and_valid_plugins()`), completely skipping network-activated plugins (`wp_get_active_network_plugins()`) in multisite installations.

As a result, PHP translation functions (`__()`, `_e()`, etc.) silently fell back to untranslated strings for all network-activated plugins — even when correct translation files were present — because `$wp_textdomain_registry` had no path registered for those domains and `_load_textdomain_just_in_time()` had nothing to work with.

> **Note:** JavaScript translations were unaffected as they use a separate mechanism.

## Changes

**`wp-settings.php`**

- Moves `require_once ABSPATH . 'wp-admin/includes/plugin.php'` earlier in the bootstrap — from just before the site plugins loop to just before the must-use plugins loop — making `get_plugin_data()` available for all plugin loading stages. Comment updated to reference both #62244 and #64249.
- Adds text domain registration inside the network-activated plugins loop, mirroring the logic already present in the site plugins loop: reads `TextDomain` and `DomainPath` headers via `get_plugin_data()` and calls `$wp_textdomain_registry->set_custom_path()` accordingly.
- Adds `$plugin_data` and `$textdomain` to the `unset()` at the end of the network plugins block, consistent with the site plugins loop.

## Backward Compatibility

- `get_plugin_data()` only reads the plugin file's comment header — no database calls, no side effects.
- `set_custom_path()` is idempotent. Plugins already calling `load_plugin_textdomain()` explicitly as a workaround will continue to work correctly.
- Moving the `require_once` earlier carries negligible risk — `plugin.php` was already hardened for early loading in #62244.

## References

- Trac ticket: https://core.trac.wordpress.org/ticket/64249
- Original JIT changeset: https://core.trac.wordpress.org/changeset/59461
- Related ticket: https://core.trac.wordpress.org/ticket/62244

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
