### PR TITLE
Fix RTL layout on Connectors admin screen

### DIFF
--- a/src/wp-admin/options-connectors.php
+++ b/src/wp-admin/options-connectors.php
@@ -33,19 +33,6 @@ $title = __( 'Connectors' );
 $parent_file  = 'options-general.php';
 $submenu_file = 'options-connectors.php';
 
-add_action(
-	'admin_head-options-connectors.php', // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
-	static function () {
-		?>
-		<style>
-			#wpcontent {
-				background-color: #fff;
-			}
-		</style>
-		<?php
-	}
-);
-
 require_once ABSPATH . 'wp-admin/admin-header.php';
 
 // Render the Connectors page.

--- a/src/wp-admin/options-connectors.php
+++ b/src/wp-admin/options-connectors.php
@@ -30,11 +30,41 @@ if ( ! class_exists( '\WordPress\AiClient\AiClient' ) || ! function_exists( 'wp_
 $title = __( 'Connectors' );
 
 // Set parent file for menu highlighting.
-$parent_file = 'options-general.php';
+$parent_file  = 'options-general.php';
+$submenu_file = 'options-connectors.php';
+
+add_action(
+	'admin_head-options-connectors.php', // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
+	static function () {
+		?>
+		<style>
+			#wpcontent {
+				background-color: #fff;
+			}
+		</style>
+		<?php
+	}
+);
 
 require_once ABSPATH . 'wp-admin/admin-header.php';
 
 // Render the Connectors page.
 wp_options_connectors_wp_admin_render_page();
+
+if ( is_rtl() ) {
+	?>
+	<style>
+		.rtl .admin-ui-page__header > div > div:first-child {
+			justify-content: start;
+		}
+
+		.rtl ul#adminmenu a.wp-has-current-submenu::after,
+		.rtl ul#adminmenu > li.current > a.current::after {
+			border-right-color: transparent;
+			border-left-color: #fff;
+		}
+	</style>
+	<?php
+}
 
 require_once ABSPATH . 'wp-admin/admin-footer.php';


### PR DESCRIPTION
Addresses two RTL issues on Settings → Connectors when the admin locale is RTL (e.g. Arabic, Hebrew, Central Kurdish):

• Page heading alignment  
The "Connectors" heading remained left-aligned in RTL. The page header used `justify-content: left`, which does not respect document direction. This patch adds an RTL override so the heading aligns to the inline-start edge (right in RTL).

• Admin menu current-item arrow  
The Connectors page injected `border-right-color: #fff` for the current menu item arrow, which is correct in LTR. In RTL, WordPress uses `border-left-color`, causing a duplicate arrow to appear. This patch removes the right border color and applies `border-left-color: #fff` for RTL so only the correct arrow is displayed.

Additionally sets `$submenu_file = 'options-connectors.php'` so the Settings → Connectors menu item highlights correctly.

Fixes https://core.trac.wordpress.org/ticket/64857