### PR TITLE
Fix installation testing workflow errors on PHP <= 7.3 with MySQL 8.4

### DIFF
--- a/.github/workflows/install-testing.yml
+++ b/.github/workflows/install-testing.yml
@@ -114,7 +114,7 @@ jobs:
           -e MYSQL_ROOT_PASSWORD="root"
           -e MYSQL_DATABASE="test_db"
           --entrypoint sh ${{ matrix.db-type }}:${{ matrix.db-version }}
-          -c "exec docker-entrypoint.sh mysqld${{ matrix.db-type == 'mysql' && contains( fromJSON('["5.4", "5.5", "5.6", "7.0", "7.1", "7.2", "7.3"]'), matrix.php ) && ( matrix.db-version == '8.4' && ' --authentication-policy=mysql_native_password' || ' --default-authentication-plugin=mysql_native_password' ) || '' }}"
+          -c "exec docker-entrypoint.sh mysqld${{ matrix.db-type == 'mysql' && contains( fromJSON('["5.4", "5.5", "5.6", "7.0", "7.1", "7.2", "7.3"]'), matrix.php ) && ( matrix.db-version == '8.4' && ' --mysql-native-password=ON --authentication-policy=mysql_native_password' || ' --default-authentication-plugin=mysql_native_password' ) || '' }}"
 
     steps:
       - name: Set up PHP ${{ matrix.php }}

--- a/.github/workflows/install-testing.yml
+++ b/.github/workflows/install-testing.yml
@@ -88,17 +88,13 @@ jobs:
           - db-version: '5.0'
           - db-version: '5.1'
           - db-version: '5.5'
-          # The PHP <= 7.3/MySQL 8.4 jobs currently fail due to mysql_native_password being disabled by default. See https://core.trac.wordpress.org/ticket/61218.
-          - php: '7.2'
-            db-version: '8.4'
-          - php: '7.3'
-            db-version: '8.4'
           # Only test the latest innovation release.
           - db-version: '9.0'
           - db-version: '9.1'
           - db-version: '9.2'
           - db-version: '9.3'
           - db-version: '9.4'
+          - db-version: '9.5'
           # MySQL 9.0+ will not work on PHP 7.2 & 7.3. See https://core.trac.wordpress.org/ticket/61218.
           - php: '7.2'
             db-version: '9.6'
@@ -118,7 +114,7 @@ jobs:
           -e MYSQL_ROOT_PASSWORD="root"
           -e MYSQL_DATABASE="test_db"
           --entrypoint sh ${{ matrix.db-type }}:${{ matrix.db-version }}
-          -c "exec docker-entrypoint.sh mysqld${{ matrix.db-type == 'mysql' && contains( fromJSON('["7.2", "7.3"]'), matrix.php ) && ' --default-authentication-plugin=mysql_native_password' || '' }}"
+          -c "exec docker-entrypoint.sh mysqld${{ matrix.db-type == 'mysql' && contains( fromJSON('["5.4", "5.5", "5.6", "7.0", "7.1", "7.2", "7.3"]'), matrix.php ) && ( matrix.db-version == '8.4' && ' --authentication-policy=mysql_native_password' || ' --default-authentication-plugin=mysql_native_password' ) || '' }}"
 
     steps:
       - name: Set up PHP ${{ matrix.php }}


### PR DESCRIPTION
This addresses installation test failures on older branches caused by authentication plugin changes in MySQL:
- In MySQL 8.0, the default authentication plugin was changed to `caching_sha2_password`, which did not exist on PHP <= 7.3. The previous behavior can be restored using `--default-authentication-plugin=mysql_native_password`.
- In MySQL 8.4, the name of the authentication plugin flag changed to `--authentication-policy`.
- In MySQL 9.0, `mysql_native_password` was removed entirely.

The last scenario is already guarded against through `exclude` statements. But the current conditional statement in the workflow:
- Does not account for PHP 7.1 and lower.
- Does not account for the difference in flag names between MySQL 8.4 and lower versions.

This adjusts the conditional statements to fully account for all scenarios.

A workaround for this was previously included in `trunk`, but has since been removed when PHP 7.3 was dropped earlier in the 7.0 release cycle. There is helpful history and details in r59277, which merged support for MySQL 8.4 in the local Docker environment. The [custom .conf file in particular has good inline documentation](https://core.trac.wordpress.org/browser/trunk/tools/local-env/mysql-old-php.conf?rev=59279).

Trac ticket: Core-64227.

## Use of AI Tools

Claude was used to collect research and generate the first draft of this PR.
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
