### PR TITLE
Style plugin name in inline update notices on the Plugins screen

### DIFF
--- a/src/wp-admin/includes/update.php
+++ b/src/wp-admin/includes/update.php
@@ -468,7 +468,7 @@ function wp_plugin_update_row( $file, $plugin_data ) {
 		'em'      => array(),
 		'strong'  => array(),
 	);
-	$plugin_display_name = '<strong>' . wp_kses( $plugin_data['Name'], $plugins_allowedtags )  . '</strong>';
+	$plugin_display_name = '<strong>' . wp_kses( $plugin_data['Name'], $plugins_allowedtags ) . '</strong>';
 
 	$plugin_name = strip_tags( $plugin_display_name );
 	$plugin_slug = $response->slug ?? $response->id;

--- a/src/wp-admin/includes/update.php
+++ b/src/wp-admin/includes/update.php
@@ -468,8 +468,9 @@ function wp_plugin_update_row( $file, $plugin_data ) {
 		'em'      => array(),
 		'strong'  => array(),
 	);
+	$plugin_display_name = '<strong>' . wp_kses( $plugin_data['Name'], $plugins_allowedtags )  . '</strong>';
 
-	$plugin_name = wp_kses( $plugin_data['Name'], $plugins_allowedtags );
+	$plugin_name = strip_tags( $plugin_display_name );
 	$plugin_slug = $response->slug ?? $response->id;
 
 	if ( isset( $response->slug ) ) {
@@ -524,41 +525,41 @@ function wp_plugin_update_row( $file, $plugin_data ) {
 			printf(
 				/* translators: 1: Plugin name, 2: Details URL, 3: Additional link attributes, 4: Version number. */
 				__( 'There is a new version of %1$s available. <a href="%2$s" %3$s>View version %4$s details</a>.' ),
-				$plugin_name,
+				$plugin_display_name,
 				esc_url( $details_url ),
 				sprintf(
 					'class="thickbox open-plugin-details-modal" aria-label="%s"',
 					/* translators: 1: Plugin name, 2: Version number. */
 					esc_attr( sprintf( __( 'View %1$s version %2$s details' ), $plugin_name, $response->new_version ) )
 				),
-				esc_attr( $response->new_version )
+				esc_html( $response->new_version )
 			);
 		} elseif ( empty( $response->package ) ) {
 			printf(
 				/* translators: 1: Plugin name, 2: Details URL, 3: Additional link attributes, 4: Version number. */
 				__( 'There is a new version of %1$s available. <a href="%2$s" %3$s>View version %4$s details</a>. <em>Automatic update is unavailable for this plugin.</em>' ),
-				$plugin_name,
+				$plugin_display_name,
 				esc_url( $details_url ),
 				sprintf(
 					'class="thickbox open-plugin-details-modal" aria-label="%s"',
 					/* translators: 1: Plugin name, 2: Version number. */
 					esc_attr( sprintf( __( 'View %1$s version %2$s details' ), $plugin_name, $response->new_version ) )
 				),
-				esc_attr( $response->new_version )
+				esc_html( $response->new_version )
 			);
 		} else {
 			if ( $compatible_php ) {
 				printf(
 					/* translators: 1: Plugin name, 2: Details URL, 3: Additional link attributes, 4: Version number, 5: Update URL, 6: Additional link attributes. */
 					__( 'There is a new version of %1$s available. <a href="%2$s" %3$s>View version %4$s details</a> or <a href="%5$s" %6$s>update now</a>.' ),
-					$plugin_name,
+					$plugin_display_name,
 					esc_url( $details_url ),
 					sprintf(
 						'class="thickbox open-plugin-details-modal" aria-label="%s"',
 						/* translators: 1: Plugin name, 2: Version number. */
 						esc_attr( sprintf( __( 'View %1$s version %2$s details' ), $plugin_name, $response->new_version ) )
 					),
-					esc_attr( $response->new_version ),
+					esc_html( $response->new_version ),
 					wp_nonce_url( self_admin_url( 'update.php?action=upgrade-plugin&plugin=' ) . $file, 'upgrade-plugin_' . $file ),
 					sprintf(
 						'class="update-link" aria-label="%s"',
@@ -570,14 +571,14 @@ function wp_plugin_update_row( $file, $plugin_data ) {
 				printf(
 					/* translators: 1: Plugin name, 2: Details URL, 3: Additional link attributes, 4: Version number 5: URL to Update PHP page. */
 					__( 'There is a new version of %1$s available, but it does not work with your version of PHP. <a href="%2$s" %3$s>View version %4$s details</a> or <a href="%5$s">learn more about updating PHP</a>.' ),
-					$plugin_name,
+					$plugin_display_name,
 					esc_url( $details_url ),
 					sprintf(
 						'class="thickbox open-plugin-details-modal" aria-label="%s"',
 						/* translators: 1: Plugin name, 2: Version number. */
 						esc_attr( sprintf( __( 'View %1$s version %2$s details' ), $plugin_name, $response->new_version ) )
 					),
-					esc_attr( $response->new_version ),
+					esc_html( $response->new_version ),
 					esc_url( wp_get_update_php_url() )
 				);
 				wp_update_php_annotation( '<br><em>', '</em>' );


### PR DESCRIPTION
- Adds `strong` tags in a new `$plugin_display_name` variable.
- Strips HTML from the `$plugin_name` variable before using it in the `aria-label`.
- Switches `esc_attr()` to `esc_html()` for the visible `new_version` text.

[Trac 64843](https://core.trac.wordpress.org/ticket/64843)

Use of AI Tools: none

<img width="1180" height="500" alt="Plugin rows, with and without updates available, activated and inactive" src="https://github.com/user-attachments/assets/cd0f39b3-8f91-413c-aeb5-056f62678a81" />

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
