### PR TITLE
Use flex for radio layout

### DIFF
--- a/src/wp-admin/css/forms.css
+++ b/src/wp-admin/css/forms.css
@@ -214,6 +214,8 @@ input[type="radio"]:checked::before {
 	height: 0.5rem; /* 8px */
 	margin: auto;
 	background-color: #fff;
+	/* Only visible in Windows High Contrast mode */
+	outline: 4px solid transparent;
 }
 
 @-moz-document url-prefix() {

--- a/src/wp-admin/css/forms.css
+++ b/src/wp-admin/css/forms.css
@@ -174,6 +174,8 @@ input[type="radio"] {
 	display: inline-flex;
 	border-radius: 50%;
 	margin-right: 0.25rem;
+	align-items: center;
+	justify-content: center;
 }
 
 input[type="checkbox"]:checked::before,

--- a/src/wp-admin/css/forms.css
+++ b/src/wp-admin/css/forms.css
@@ -171,10 +171,9 @@ td > input[type="checkbox"],
 }
 
 input[type="radio"] {
+	display: inline-flex;
 	border-radius: 50%;
 	margin-right: 0.25rem;
-	/* 10px not sure if still necessary, comes from the MP6 redesign in r26072 */
-	line-height: 0.71428571;
 }
 
 input[type="checkbox"]:checked::before,
@@ -211,10 +210,8 @@ input[type="radio"]:checked::before {
 	border-radius: 50%;
 	width: 0.5rem; /* 8px */
 	height: 0.5rem; /* 8px */
-	margin: 0.1875rem; /* 3px */
+	margin: auto;
 	background-color: #fff;
-	/* 16px not sure if still necessary, comes from the MP6 redesign in r26072 */
-	line-height: 1.14285714;
 }
 
 @-moz-document url-prefix() {
@@ -955,13 +952,6 @@ ul#add-to-blog-users {
 .form-table td fieldset p,
 .form-table td fieldset li {
 	line-height: 1.4;
-}
-
-.form-table input.tog,
-.form-table input[type="radio"] {
-	margin-top: -4px;
-	margin-right: 4px;
-	float: none;
 }
 
 .form-table .pre {

--- a/src/wp-admin/includes/misc.php
+++ b/src/wp-admin/includes/misc.php
@@ -1032,7 +1032,7 @@ function admin_color_scheme_picker( $user_id ) {
 
 			?>
 			<div class="color-option <?php echo ( $color === $current_color ) ? 'selected' : ''; ?>">
-				<input name="admin_color" id="admin_color_<?php echo esc_attr( $color ); ?>" type="radio" value="<?php echo esc_attr( $color ); ?>" class="tog" <?php checked( $color, $current_color ); ?> />
+				<input name="admin_color" id="admin_color_<?php echo esc_attr( $color ); ?>" type="radio" value="<?php echo esc_attr( $color ); ?>" <?php checked( $color, $current_color ); ?> />
 				<input type="hidden" class="css_url" value="<?php echo esc_url( $color_info->url ); ?>" />
 				<input type="hidden" class="icon_colors" value="<?php echo esc_attr( wp_json_encode( array( 'icons' => $color_info->icon_colors ) ) ); ?>" />
 				<label for="admin_color_<?php echo esc_attr( $color ); ?>"><?php echo esc_html( $color_info->name ); ?></label>

--- a/src/wp-admin/options-reading.php
+++ b/src/wp-admin/options-reading.php
@@ -90,12 +90,12 @@ else :
 <td id="front-static-pages"><fieldset>
 	<legend class="screen-reader-text"><span><?php echo $your_homepage_displays_title; ?></span></legend>
 	<p><label>
-		<input name="show_on_front" type="radio" value="posts" class="tog" <?php checked( 'posts', get_option( 'show_on_front' ) ); ?> />
+		<input name="show_on_front" type="radio" value="posts" <?php checked( 'posts', get_option( 'show_on_front' ) ); ?> />
 		<?php _e( 'Your latest posts' ); ?>
 	</label>
 	</p>
 	<p><label>
-		<input name="show_on_front" type="radio" value="page" class="tog" <?php checked( 'page', get_option( 'show_on_front' ) ); ?> />
+		<input name="show_on_front" type="radio" value="page" <?php checked( 'page', get_option( 'show_on_front' ) ); ?> />
 		<?php
 		printf(
 			/* translators: %s: URL to Pages screen. */


### PR DESCRIPTION
This PR extends the patch by @siliconforks to remove some additional CSS.

The class `.tog` is used only on the adim theme color switching and in the selector to set the front page between a page or a post. Removing these styles appears to have no impact. The line-height also appears to now be irrelevant.

Some additional cross-browser testing would probably be beneficial.

Trac ticket: https://core.trac.wordpress.org/ticket/64816

## Use of AI Tools

None

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
