### PR TITLE
Eliminate `switch_to_blog()` from multisite option/post functions

### DIFF
--- a/src/wp-includes/class-wp-site.php
+++ b/src/wp-includes/class-wp-site.php
@@ -320,18 +320,17 @@ final class WP_Site {
 		$details = wp_cache_get( $this->blog_id, 'site-details' );
 
 		if ( false === $details ) {
+			$id = (int) $this->blog_id;
 
-			switch_to_blog( $this->blog_id );
 			// Create a raw copy of the object for backward compatibility with the filter below.
 			$details = new stdClass();
 			foreach ( get_object_vars( $this ) as $key => $value ) {
 				$details->$key = $value;
 			}
-			$details->blogname   = get_option( 'blogname' );
-			$details->siteurl    = get_option( 'siteurl' );
-			$details->post_count = get_option( 'post_count' );
-			$details->home       = get_option( 'home' );
-			restore_current_blog();
+			$details->blogname   = _get_option_from_blog( $id, 'blogname' );
+			$details->siteurl    = _get_option_from_blog( $id, 'siteurl' );
+			$details->post_count = _get_option_from_blog( $id, 'post_count', 0 );
+			$details->home       = _get_option_from_blog( $id, 'home' );
 
 			wp_cache_set( $this->blog_id, $details, 'site-details' );
 		}

--- a/src/wp-includes/class-wp-site.php
+++ b/src/wp-includes/class-wp-site.php
@@ -22,7 +22,7 @@
  * @property int    $post_count
  * @property string $home
  */
-#[AllowDynamicProperties]
+#[AllowDynamicProperties ]
 final class WP_Site {
 
 	/**

--- a/src/wp-includes/class-wp-site.php
+++ b/src/wp-includes/class-wp-site.php
@@ -22,7 +22,7 @@
  * @property int    $post_count
  * @property string $home
  */
-#[AllowDynamicProperties ]
+#[AllowDynamicProperties]
 final class WP_Site {
 
 	/**

--- a/src/wp-includes/ms-blogs.php
+++ b/src/wp-includes/ms-blogs.php
@@ -134,19 +134,19 @@ function get_blog_details( $fields = null, $get_all = true ) {
 	global $wpdb;
 
 	if ( is_array( $fields ) ) {
-		if ( isset( $fields['blog_id'] ) ) {
-			$blog_id = $fields['blog_id'];
-		} elseif ( isset( $fields['domain'] ) && isset( $fields['path'] ) ) {
-			$key  = md5( $fields['domain'] . $fields['path'] );
+		if ( isset( $fields[ 'blog_id' ] ) ) {
+			$blog_id = $fields[ 'blog_id' ];
+		} elseif ( isset( $fields[ 'domain' ] ) && isset( $fields[ 'path' ] ) ) {
+			$key  = md5( $fields[ 'domain' ] . $fields[ 'path' ] );
 			$blog = wp_cache_get( $key, 'blog-lookup' );
 			if ( false !== $blog ) {
 				return $blog;
 			}
-			if ( str_starts_with( $fields['domain'], 'www.' ) ) {
-				$nowww = substr( $fields['domain'], 4 );
-				$blog  = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $wpdb->blogs WHERE domain IN (%s,%s) AND path = %s ORDER BY CHAR_LENGTH(domain) DESC", $nowww, $fields['domain'], $fields['path'] ) );
+			if ( str_starts_with( $fields[ 'domain' ], 'www.' ) ) {
+				$nowww = substr( $fields[ 'domain' ], 4 );
+				$blog  = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $wpdb->blogs WHERE domain IN (%s,%s) AND path = %s ORDER BY CHAR_LENGTH(domain) DESC", $nowww, $fields[ 'domain' ], $fields[ 'path' ] ) );
 			} else {
-				$blog = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $wpdb->blogs WHERE domain = %s AND path = %s", $fields['domain'], $fields['path'] ) );
+				$blog = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $wpdb->blogs WHERE domain = %s AND path = %s", $fields[ 'domain' ], $fields[ 'path' ] ) );
 			}
 			if ( $blog ) {
 				wp_cache_set( $blog->blog_id . 'short', $blog, 'blog-details' );
@@ -154,17 +154,17 @@ function get_blog_details( $fields = null, $get_all = true ) {
 			} else {
 				return false;
 			}
-		} elseif ( isset( $fields['domain'] ) && is_subdomain_install() ) {
-			$key  = md5( $fields['domain'] );
+		} elseif ( isset( $fields[ 'domain' ] ) && is_subdomain_install() ) {
+			$key  = md5( $fields[ 'domain' ] );
 			$blog = wp_cache_get( $key, 'blog-lookup' );
 			if ( false !== $blog ) {
 				return $blog;
 			}
-			if ( str_starts_with( $fields['domain'], 'www.' ) ) {
-				$nowww = substr( $fields['domain'], 4 );
-				$blog  = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $wpdb->blogs WHERE domain IN (%s,%s) ORDER BY CHAR_LENGTH(domain) DESC", $nowww, $fields['domain'] ) );
+			if ( str_starts_with( $fields[ 'domain' ], 'www.' ) ) {
+				$nowww = substr( $fields[ 'domain' ], 4 );
+				$blog  = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $wpdb->blogs WHERE domain IN (%s,%s) ORDER BY CHAR_LENGTH(domain) DESC", $nowww, $fields[ 'domain' ] ) );
 			} else {
-				$blog = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $wpdb->blogs WHERE domain = %s", $fields['domain'] ) );
+				$blog = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $wpdb->blogs WHERE domain = %s", $fields[ 'domain' ] ) );
 			}
 			if ( $blog ) {
 				wp_cache_set( $blog->blog_id . 'short', $blog, 'blog-details' );
@@ -624,7 +624,7 @@ function switch_to_blog( $new_blog_id, $deprecated = null ) {
 		$new_blog_id = $prev_blog_id;
 	}
 
-	$GLOBALS['_wp_switched_stack'][] = $prev_blog_id;
+	$GLOBALS[ '_wp_switched_stack' ][] = $prev_blog_id;
 
 	/*
 	 * If we're switching to the same blog id that we're on,
@@ -645,21 +645,21 @@ function switch_to_blog( $new_blog_id, $deprecated = null ) {
 		 */
 		do_action( 'switch_blog', $new_blog_id, $prev_blog_id, 'switch' );
 
-		$GLOBALS['switched'] = true;
+		$GLOBALS[ 'switched' ] = true;
 
 		return true;
 	}
 
 	$wpdb->set_blog_id( $new_blog_id );
-	$GLOBALS['table_prefix'] = $wpdb->get_blog_prefix();
-	$GLOBALS['blog_id']      = $new_blog_id;
+	$GLOBALS[ 'table_prefix' ] = $wpdb->get_blog_prefix();
+	$GLOBALS[ 'blog_id' ]      = $new_blog_id;
 
 	wp_cache_switch_to_blog( $new_blog_id );
 
 	/** This filter is documented in wp-includes/ms-blogs.php */
 	do_action( 'switch_blog', $new_blog_id, $prev_blog_id, 'switch' );
 
-	$GLOBALS['switched'] = true;
+	$GLOBALS[ 'switched' ] = true;
 
 	return true;
 }
@@ -682,11 +682,11 @@ function switch_to_blog( $new_blog_id, $deprecated = null ) {
 function restore_current_blog() {
 	global $wpdb;
 
-	if ( empty( $GLOBALS['_wp_switched_stack'] ) ) {
+	if ( empty( $GLOBALS[ '_wp_switched_stack' ] ) ) {
 		return false;
 	}
 
-	$new_blog_id  = array_pop( $GLOBALS['_wp_switched_stack'] );
+	$new_blog_id  = array_pop( $GLOBALS[ '_wp_switched_stack' ] );
 	$prev_blog_id = get_current_blog_id();
 
 	if ( $new_blog_id === $prev_blog_id ) {
@@ -694,14 +694,14 @@ function restore_current_blog() {
 		do_action( 'switch_blog', $new_blog_id, $prev_blog_id, 'restore' );
 
 		// If we still have items in the switched stack, consider ourselves still 'switched'.
-		$GLOBALS['switched'] = ! empty( $GLOBALS['_wp_switched_stack'] );
+		$GLOBALS[ 'switched' ] = ! empty( $GLOBALS[ '_wp_switched_stack' ] );
 
 		return true;
 	}
 
 	$wpdb->set_blog_id( $new_blog_id );
-	$GLOBALS['blog_id']      = $new_blog_id;
-	$GLOBALS['table_prefix'] = $wpdb->get_blog_prefix();
+	$GLOBALS[ 'blog_id' ]      = $new_blog_id;
+	$GLOBALS[ 'table_prefix' ] = $wpdb->get_blog_prefix();
 
 	wp_cache_switch_to_blog( $new_blog_id );
 
@@ -709,7 +709,7 @@ function restore_current_blog() {
 	do_action( 'switch_blog', $new_blog_id, $prev_blog_id, 'restore' );
 
 	// If we still have items in the switched stack, consider ourselves still 'switched'.
-	$GLOBALS['switched'] = ! empty( $GLOBALS['_wp_switched_stack'] );
+	$GLOBALS[ 'switched' ] = ! empty( $GLOBALS[ '_wp_switched_stack' ] );
 
 	return true;
 }
@@ -834,7 +834,7 @@ function wp_switch_roles_and_user( $new_site_id, $old_site_id ) {
  * @return bool True if switched, false otherwise.
  */
 function ms_is_switched() {
-	return ! empty( $GLOBALS['_wp_switched_stack'] );
+	return ! empty( $GLOBALS[ '_wp_switched_stack' ] );
 }
 
 /**
@@ -1071,7 +1071,7 @@ function wp_count_sites( $network_id = null ) {
 	);
 
 	$q             = new WP_Site_Query( $args );
-	$counts['all'] = $q->found_sites;
+	$counts[ 'all' ] = $q->found_sites;
 
 	$_args    = $args;
 	$statuses = array( 'public', 'archived', 'mature', 'spam', 'deleted' );

--- a/src/wp-includes/ms-blogs.php
+++ b/src/wp-includes/ms-blogs.php
@@ -338,6 +338,76 @@ function clean_site_details_cache( $site_id = 0 ) {
 }
 
 /**
+ * Retrieves an option value for a specific site without switching blog context.
+ *
+ * Uses the object cache (same 'blog-alloptions'/'blog-notoptions' groups as
+ * get_option()), falling back to a direct DB query with the site's table prefix
+ * obtained from $wpdb->get_blog_prefix().
+ *
+ * @since 6.8.0
+ * @access private
+ *
+ * @global wpdb $wpdb WordPress database abstraction object.
+ *
+ * @param int    $blog_id  Site ID.
+ * @param string $option   Option name.
+ * @param mixed  $default  Optional. Default value if option not found. Default false.
+ * @return mixed Option value or $default.
+ */
+function _get_option_from_blog( int $blog_id, string $option, $default = false ) {
+	global $wpdb;
+
+	$blog_id = (int) $blog_id;
+
+	// Fast path: current blog — delegate to get_option() for full filter/cache compat.
+	if ( get_current_blog_id() === $blog_id ) {
+		return get_option( $option, $default );
+	}
+
+	// Check object cache first.
+	$alloptions_cache = wp_cache_get( $blog_id, 'blog-alloptions' );
+	if ( is_array( $alloptions_cache ) && array_key_exists( $option, $alloptions_cache ) ) {
+		return maybe_unserialize( $alloptions_cache[ $option ] );
+	}
+
+	$notoptions = wp_cache_get( $blog_id, 'blog-notoptions' );
+	if ( is_array( $notoptions ) && isset( $notoptions[ $option ] ) ) {
+		return $default;
+	}
+
+	// Direct DB query using get_blog_prefix() — no switch.
+	$table = $wpdb->get_blog_prefix( $blog_id ) . 'options';
+	$row   = $wpdb->get_row(
+		$wpdb->prepare(
+			"SELECT option_value FROM `{$table}` WHERE option_name = %s LIMIT 1",
+			$option
+		)
+	);
+
+	if ( null === $row ) {
+		// Mark as not-found in cache.
+		$notoptions            = is_array( $notoptions ) ? $notoptions : array();
+		$notoptions[ $option ] = true;
+		wp_cache_set( $blog_id, $notoptions, 'blog-notoptions' );
+		return $default;
+	}
+
+	$value = maybe_unserialize( $row->option_value );
+
+	/**
+	 * Filters a blog option value.
+	 *
+	 * The dynamic portion of the hook name, `$option`, refers to the blog option name.
+	 *
+	 * @since 3.5.0
+	 *
+	 * @param string $value The option value.
+	 * @param int    $id    Blog ID.
+	 */
+	return apply_filters( "blog_option_{$option}", $value, $blog_id );
+}
+
+/**
  * Retrieves option value for a given blog id based on name of option.
  *
  * If the option does not exist or does not have a value, then the return value
@@ -361,25 +431,7 @@ function get_blog_option( $id, $option, $default_value = false ) {
 		$id = get_current_blog_id();
 	}
 
-	if ( get_current_blog_id() === $id ) {
-		return get_option( $option, $default_value );
-	}
-
-	switch_to_blog( $id );
-	$value = get_option( $option, $default_value );
-	restore_current_blog();
-
-	/**
-	 * Filters a blog option value.
-	 *
-	 * The dynamic portion of the hook name, `$option`, refers to the blog option name.
-	 *
-	 * @since 3.5.0
-	 *
-	 * @param string  $value The option value.
-	 * @param int     $id    Blog ID.
-	 */
-	return apply_filters( "blog_option_{$option}", $value, $id );
+	return _get_option_from_blog( $id, $option, $default_value );
 }
 
 /**
@@ -402,6 +454,8 @@ function get_blog_option( $id, $option, $default_value = false ) {
  * @return bool True if the option was added, false otherwise.
  */
 function add_blog_option( $id, $option, $value ) {
+	global $wpdb;
+
 	$id = (int) $id;
 
 	if ( empty( $id ) ) {
@@ -412,11 +466,31 @@ function add_blog_option( $id, $option, $value ) {
 		return add_option( $option, $value );
 	}
 
-	switch_to_blog( $id );
-	$return = add_option( $option, $value );
-	restore_current_blog();
+	$table  = $wpdb->get_blog_prefix( $id ) . 'options';
+	$exists = $wpdb->get_var(
+		$wpdb->prepare( "SELECT COUNT(*) FROM `{$table}` WHERE option_name = %s", $option )
+	);
 
-	return $return;
+	if ( $exists ) {
+		return false;
+	}
+
+	$serialized = maybe_serialize( $value );
+	$result     = $wpdb->insert(
+		$table,
+		array(
+			'option_name'  => $option,
+			'option_value' => $serialized,
+			'autoload'     => 'yes',
+		),
+		array( '%s', '%s', '%s' )
+	);
+
+	// Bust per-blog option caches.
+	wp_cache_delete( $id, 'blog-alloptions' );
+	wp_cache_delete( $id, 'blog-notoptions' );
+
+	return false !== $result;
 }
 
 /**
@@ -429,6 +503,8 @@ function add_blog_option( $id, $option, $value ) {
  * @return bool True if the option was deleted, false otherwise.
  */
 function delete_blog_option( $id, $option ) {
+	global $wpdb;
+
 	$id = (int) $id;
 
 	if ( empty( $id ) ) {
@@ -439,11 +515,18 @@ function delete_blog_option( $id, $option ) {
 		return delete_option( $option );
 	}
 
-	switch_to_blog( $id );
-	$return = delete_option( $option );
-	restore_current_blog();
+	$table  = $wpdb->get_blog_prefix( $id ) . 'options';
+	$result = $wpdb->delete(
+		$table,
+		array( 'option_name' => $option ),
+		array( '%s' )
+	);
 
-	return $return;
+	// Bust per-blog option caches.
+	wp_cache_delete( $id, 'blog-alloptions' );
+	wp_cache_delete( $id, 'blog-notoptions' );
+
+	return false !== $result && $result > 0;
 }
 
 /**
@@ -458,6 +541,8 @@ function delete_blog_option( $id, $option ) {
  * @return bool True if the value was updated, false otherwise.
  */
 function update_blog_option( $id, $option, $value, $deprecated = null ) {
+	global $wpdb;
+
 	$id = (int) $id;
 
 	if ( null !== $deprecated ) {
@@ -468,11 +553,45 @@ function update_blog_option( $id, $option, $value, $deprecated = null ) {
 		return update_option( $option, $value );
 	}
 
-	switch_to_blog( $id );
-	$return = update_option( $option, $value );
-	restore_current_blog();
+	$table      = $wpdb->get_blog_prefix( $id ) . 'options';
+	$serialized = maybe_serialize( $value );
 
-	return $return;
+	$old_value = _get_option_from_blog( $id, $option );
+
+	// If old and new values are the same, no update needed.
+	if ( $serialized === maybe_serialize( $old_value ) ) {
+		return false;
+	}
+
+	$exists = $wpdb->get_var(
+		$wpdb->prepare( "SELECT COUNT(*) FROM `{$table}` WHERE option_name = %s", $option )
+	);
+
+	if ( $exists ) {
+		$result = $wpdb->update(
+			$table,
+			array( 'option_value' => $serialized ),
+			array( 'option_name' => $option ),
+			array( '%s' ),
+			array( '%s' )
+		);
+	} else {
+		$result = $wpdb->insert(
+			$table,
+			array(
+				'option_name'  => $option,
+				'option_value' => $serialized,
+				'autoload'     => 'yes',
+			),
+			array( '%s', '%s', '%s' )
+		);
+	}
+
+	// Bust per-blog option caches.
+	wp_cache_delete( $id, 'blog-alloptions' );
+	wp_cache_delete( $id, 'blog-notoptions' );
+
+	return false !== $result;
 }
 
 /**

--- a/src/wp-includes/ms-blogs.php
+++ b/src/wp-includes/ms-blogs.php
@@ -494,6 +494,12 @@ function add_blog_option( $id, $option, $value ) {
 	wp_cache_delete( $id, 'blog-alloptions' );
 	wp_cache_delete( $id, 'blog-notoptions' );
 
+	// Invalidate site-details cache when a site-detail option changes.
+	if ( in_array( $option, array( 'home', 'siteurl', 'blogname', 'post_count' ), true ) ) {
+		wp_cache_delete( $id, 'site-details' );
+		wp_cache_delete( $id, 'blog-details' );
+	}
+
 	return false !== $result;
 }
 
@@ -530,6 +536,12 @@ function delete_blog_option( $id, $option ) {
 	wp_cache_delete( $id, 'blog-alloptions' );
 	wp_cache_delete( $id, 'blog-notoptions' );
 
+	// Invalidate site-details cache when a site-detail option changes.
+	if ( in_array( $option, array( 'home', 'siteurl', 'blogname', 'post_count' ), true ) ) {
+		wp_cache_delete( $id, 'site-details' );
+		wp_cache_delete( $id, 'blog-details' );
+	}
+
 	return false !== $result && $result > 0;
 }
 
@@ -551,6 +563,10 @@ function update_blog_option( $id, $option, $value, $deprecated = null ) {
 
 	if ( null !== $deprecated ) {
 		_deprecated_argument( __FUNCTION__, '3.1.0' );
+	}
+
+	if ( empty( $id ) ) {
+		$id = get_current_blog_id();
 	}
 
 	if ( get_current_blog_id() === $id ) {
@@ -596,6 +612,12 @@ function update_blog_option( $id, $option, $value, $deprecated = null ) {
 	// Bust per-blog option caches.
 	wp_cache_delete( $id, 'blog-alloptions' );
 	wp_cache_delete( $id, 'blog-notoptions' );
+
+	// Invalidate site-details cache when a site-detail option changes.
+	if ( in_array( $option, array( 'home', 'siteurl', 'blogname', 'post_count' ), true ) ) {
+		wp_cache_delete( $id, 'site-details' );
+		wp_cache_delete( $id, 'blog-details' );
+	}
 
 	return false !== $result;
 }

--- a/src/wp-includes/ms-blogs.php
+++ b/src/wp-includes/ms-blogs.php
@@ -134,19 +134,19 @@ function get_blog_details( $fields = null, $get_all = true ) {
 	global $wpdb;
 
 	if ( is_array( $fields ) ) {
-		if ( isset( $fields[ 'blog_id' ] ) ) {
-			$blog_id = $fields[ 'blog_id' ];
-		} elseif ( isset( $fields[ 'domain' ] ) && isset( $fields[ 'path' ] ) ) {
-			$key  = md5( $fields[ 'domain' ] . $fields[ 'path' ] );
+		if ( isset( $fields['blog_id'] ) ) {
+			$blog_id = $fields['blog_id'];
+		} elseif ( isset( $fields['domain'] ) && isset( $fields['path'] ) ) {
+			$key  = md5( $fields['domain'] . $fields['path'] );
 			$blog = wp_cache_get( $key, 'blog-lookup' );
 			if ( false !== $blog ) {
 				return $blog;
 			}
-			if ( str_starts_with( $fields[ 'domain' ], 'www.' ) ) {
-				$nowww = substr( $fields[ 'domain' ], 4 );
-				$blog  = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $wpdb->blogs WHERE domain IN (%s,%s) AND path = %s ORDER BY CHAR_LENGTH(domain) DESC", $nowww, $fields[ 'domain' ], $fields[ 'path' ] ) );
+			if ( str_starts_with( $fields['domain'], 'www.' ) ) {
+				$nowww = substr( $fields['domain'], 4 );
+				$blog  = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $wpdb->blogs WHERE domain IN (%s,%s) AND path = %s ORDER BY CHAR_LENGTH(domain) DESC", $nowww, $fields['domain'], $fields['path'] ) );
 			} else {
-				$blog = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $wpdb->blogs WHERE domain = %s AND path = %s", $fields[ 'domain' ], $fields[ 'path' ] ) );
+				$blog = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $wpdb->blogs WHERE domain = %s AND path = %s", $fields['domain'], $fields['path'] ) );
 			}
 			if ( $blog ) {
 				wp_cache_set( $blog->blog_id . 'short', $blog, 'blog-details' );
@@ -154,17 +154,17 @@ function get_blog_details( $fields = null, $get_all = true ) {
 			} else {
 				return false;
 			}
-		} elseif ( isset( $fields[ 'domain' ] ) && is_subdomain_install() ) {
-			$key  = md5( $fields[ 'domain' ] );
+		} elseif ( isset( $fields['domain'] ) && is_subdomain_install() ) {
+			$key  = md5( $fields['domain'] );
 			$blog = wp_cache_get( $key, 'blog-lookup' );
 			if ( false !== $blog ) {
 				return $blog;
 			}
-			if ( str_starts_with( $fields[ 'domain' ], 'www.' ) ) {
-				$nowww = substr( $fields[ 'domain' ], 4 );
-				$blog  = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $wpdb->blogs WHERE domain IN (%s,%s) ORDER BY CHAR_LENGTH(domain) DESC", $nowww, $fields[ 'domain' ] ) );
+			if ( str_starts_with( $fields['domain'], 'www.' ) ) {
+				$nowww = substr( $fields['domain'], 4 );
+				$blog  = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $wpdb->blogs WHERE domain IN (%s,%s) ORDER BY CHAR_LENGTH(domain) DESC", $nowww, $fields['domain'] ) );
 			} else {
-				$blog = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $wpdb->blogs WHERE domain = %s", $fields[ 'domain' ] ) );
+				$blog = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $wpdb->blogs WHERE domain = %s", $fields['domain'] ) );
 			}
 			if ( $blog ) {
 				wp_cache_set( $blog->blog_id . 'short', $blog, 'blog-details' );
@@ -351,17 +351,17 @@ function clean_site_details_cache( $site_id = 0 ) {
  *
  * @param int    $blog_id  Site ID.
  * @param string $option   Option name.
- * @param mixed  $default  Optional. Default value if option not found. Default false.
- * @return mixed Option value or $default.
+ * @param mixed  $default_value Optional. Default value if option not found. Default false.
+ * @return mixed Option value or $default_value.
  */
-function _get_option_from_blog( int $blog_id, string $option, $default = false ) {
+function _get_option_from_blog( int $blog_id, string $option, $default_value = false ) {
 	global $wpdb;
 
 	$blog_id = (int) $blog_id;
 
 	// Fast path: current blog — delegate to get_option() for full filter/cache compat.
 	if ( get_current_blog_id() === $blog_id ) {
-		return get_option( $option, $default );
+		return get_option( $option, $default_value );
 	}
 
 	// Check object cache first.
@@ -372,24 +372,26 @@ function _get_option_from_blog( int $blog_id, string $option, $default = false )
 
 	$notoptions = wp_cache_get( $blog_id, 'blog-notoptions' );
 	if ( is_array( $notoptions ) && isset( $notoptions[ $option ] ) ) {
-		return $default;
+		return $default_value;
 	}
 
 	// Direct DB query using get_blog_prefix() — no switch.
 	$table = $wpdb->get_blog_prefix( $blog_id ) . 'options';
-	$row   = $wpdb->get_row(
+	// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $table is built from $wpdb->get_blog_prefix().
+	$row = $wpdb->get_row(
 		$wpdb->prepare(
 			"SELECT option_value FROM `{$table}` WHERE option_name = %s LIMIT 1",
 			$option
 		)
 	);
+	// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
 	if ( null === $row ) {
 		// Mark as not-found in cache.
 		$notoptions            = is_array( $notoptions ) ? $notoptions : array();
 		$notoptions[ $option ] = true;
 		wp_cache_set( $blog_id, $notoptions, 'blog-notoptions' );
-		return $default;
+		return $default_value;
 	}
 
 	$value = maybe_unserialize( $row->option_value );
@@ -466,10 +468,12 @@ function add_blog_option( $id, $option, $value ) {
 		return add_option( $option, $value );
 	}
 
-	$table  = $wpdb->get_blog_prefix( $id ) . 'options';
+	$table = $wpdb->get_blog_prefix( $id ) . 'options';
+	// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $table is built from $wpdb->get_blog_prefix().
 	$exists = $wpdb->get_var(
 		$wpdb->prepare( "SELECT COUNT(*) FROM `{$table}` WHERE option_name = %s", $option )
 	);
+	// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
 	if ( $exists ) {
 		return false;
@@ -563,9 +567,11 @@ function update_blog_option( $id, $option, $value, $deprecated = null ) {
 		return false;
 	}
 
+	// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $table is built from $wpdb->get_blog_prefix().
 	$exists = $wpdb->get_var(
 		$wpdb->prepare( "SELECT COUNT(*) FROM `{$table}` WHERE option_name = %s", $option )
 	);
+	// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
 	if ( $exists ) {
 		$result = $wpdb->update(
@@ -624,7 +630,7 @@ function switch_to_blog( $new_blog_id, $deprecated = null ) {
 		$new_blog_id = $prev_blog_id;
 	}
 
-	$GLOBALS[ '_wp_switched_stack' ][] = $prev_blog_id;
+	$GLOBALS['_wp_switched_stack'][] = $prev_blog_id;
 
 	/*
 	 * If we're switching to the same blog id that we're on,
@@ -645,21 +651,21 @@ function switch_to_blog( $new_blog_id, $deprecated = null ) {
 		 */
 		do_action( 'switch_blog', $new_blog_id, $prev_blog_id, 'switch' );
 
-		$GLOBALS[ 'switched' ] = true;
+		$GLOBALS['switched'] = true;
 
 		return true;
 	}
 
 	$wpdb->set_blog_id( $new_blog_id );
-	$GLOBALS[ 'table_prefix' ] = $wpdb->get_blog_prefix();
-	$GLOBALS[ 'blog_id' ]      = $new_blog_id;
+	$GLOBALS['table_prefix'] = $wpdb->get_blog_prefix();
+	$GLOBALS['blog_id']      = $new_blog_id;
 
 	wp_cache_switch_to_blog( $new_blog_id );
 
 	/** This filter is documented in wp-includes/ms-blogs.php */
 	do_action( 'switch_blog', $new_blog_id, $prev_blog_id, 'switch' );
 
-	$GLOBALS[ 'switched' ] = true;
+	$GLOBALS['switched'] = true;
 
 	return true;
 }
@@ -682,11 +688,11 @@ function switch_to_blog( $new_blog_id, $deprecated = null ) {
 function restore_current_blog() {
 	global $wpdb;
 
-	if ( empty( $GLOBALS[ '_wp_switched_stack' ] ) ) {
+	if ( empty( $GLOBALS['_wp_switched_stack'] ) ) {
 		return false;
 	}
 
-	$new_blog_id  = array_pop( $GLOBALS[ '_wp_switched_stack' ] );
+	$new_blog_id  = array_pop( $GLOBALS['_wp_switched_stack'] );
 	$prev_blog_id = get_current_blog_id();
 
 	if ( $new_blog_id === $prev_blog_id ) {
@@ -694,14 +700,14 @@ function restore_current_blog() {
 		do_action( 'switch_blog', $new_blog_id, $prev_blog_id, 'restore' );
 
 		// If we still have items in the switched stack, consider ourselves still 'switched'.
-		$GLOBALS[ 'switched' ] = ! empty( $GLOBALS[ '_wp_switched_stack' ] );
+		$GLOBALS['switched'] = ! empty( $GLOBALS['_wp_switched_stack'] );
 
 		return true;
 	}
 
 	$wpdb->set_blog_id( $new_blog_id );
-	$GLOBALS[ 'blog_id' ]      = $new_blog_id;
-	$GLOBALS[ 'table_prefix' ] = $wpdb->get_blog_prefix();
+	$GLOBALS['blog_id']      = $new_blog_id;
+	$GLOBALS['table_prefix'] = $wpdb->get_blog_prefix();
 
 	wp_cache_switch_to_blog( $new_blog_id );
 
@@ -709,7 +715,7 @@ function restore_current_blog() {
 	do_action( 'switch_blog', $new_blog_id, $prev_blog_id, 'restore' );
 
 	// If we still have items in the switched stack, consider ourselves still 'switched'.
-	$GLOBALS[ 'switched' ] = ! empty( $GLOBALS[ '_wp_switched_stack' ] );
+	$GLOBALS['switched'] = ! empty( $GLOBALS['_wp_switched_stack'] );
 
 	return true;
 }
@@ -834,7 +840,7 @@ function wp_switch_roles_and_user( $new_site_id, $old_site_id ) {
  * @return bool True if switched, false otherwise.
  */
 function ms_is_switched() {
-	return ! empty( $GLOBALS[ '_wp_switched_stack' ] );
+	return ! empty( $GLOBALS['_wp_switched_stack'] );
 }
 
 /**
@@ -1070,8 +1076,8 @@ function wp_count_sites( $network_id = null ) {
 		'no_found_rows' => false,
 	);
 
-	$q               = new WP_Site_Query( $args );
-	$counts[ 'all' ] = $q->found_sites;
+	$q             = new WP_Site_Query( $args );
+	$counts['all'] = $q->found_sites;
 
 	$_args    = $args;
 	$statuses = array( 'public', 'archived', 'mature', 'spam', 'deleted' );

--- a/src/wp-includes/ms-blogs.php
+++ b/src/wp-includes/ms-blogs.php
@@ -559,7 +559,7 @@ function update_blog_option( $id, $option, $value, $deprecated = null ) {
 	$old_value = _get_option_from_blog( $id, $option );
 
 	// If old and new values are the same, no update needed.
-	if ( $serialized === maybe_serialize( $old_value ) ) {
+	if ( maybe_serialize( $old_value ) === $serialized ) {
 		return false;
 	}
 

--- a/src/wp-includes/ms-blogs.php
+++ b/src/wp-includes/ms-blogs.php
@@ -1070,7 +1070,7 @@ function wp_count_sites( $network_id = null ) {
 		'no_found_rows' => false,
 	);
 
-	$q             = new WP_Site_Query( $args );
+	$q               = new WP_Site_Query( $args );
 	$counts[ 'all' ] = $q->found_sites;
 
 	$_args    = $args;

--- a/src/wp-includes/ms-functions.php
+++ b/src/wp-includes/ms-functions.php
@@ -138,11 +138,26 @@ function get_blog_count( $network_id = null ) {
  * @return WP_Post|null WP_Post object on success, null on failure
  */
 function get_blog_post( $blog_id, $post_id ) {
-	switch_to_blog( $blog_id );
-	$post = get_post( $post_id );
-	restore_current_blog();
+	global $wpdb;
 
-	return $post;
+	$blog_id = (int) $blog_id;
+	$post_id = (int) $post_id;
+
+	if ( get_current_blog_id() === $blog_id ) {
+		return get_post( $post_id );
+	}
+
+	$table = $wpdb->get_blog_prefix( $blog_id ) . 'posts';
+	$post  = $wpdb->get_row(
+		$wpdb->prepare( "SELECT * FROM `{$table}` WHERE ID = %d LIMIT 1", $post_id )
+	);
+
+	if ( ! $post ) {
+		return null;
+	}
+
+	// Sanitize to match get_post() return type.
+	return sanitize_post( new WP_Post( $post ), 'raw' );
 }
 
 /**

--- a/src/wp-includes/ms-functions.php
+++ b/src/wp-includes/ms-functions.php
@@ -49,7 +49,7 @@ function get_active_blog_for_user( $user_id ) {
 	}
 
 	if ( ! is_multisite() ) {
-		return $blogs[ get_current_blog_id() ];
+		return $blogs[get_current_blog_id()];
 	}
 
 	$primary_blog = get_user_meta( $user_id, 'primary_blog', true );
@@ -959,7 +959,7 @@ function wpmu_signup_blog_notification(
 	$title,
 	$user_login,
 	$user_email,
-	#[\SensitiveParameter]
+	#[\SensitiveParameter ]
 	$key,
 	$meta = array()
 ) {
@@ -1100,7 +1100,7 @@ function wpmu_signup_blog_notification(
 function wpmu_signup_user_notification(
 	$user_login,
 	$user_email,
-	#[\SensitiveParameter]
+	#[\SensitiveParameter ]
 	$key,
 	$meta = array()
 ) {
@@ -1206,7 +1206,7 @@ function wpmu_signup_user_notification(
  * @return array|WP_Error An array containing information about the activated user and/or blog.
  */
 function wpmu_activate_signup(
-	#[\SensitiveParameter]
+	#[\SensitiveParameter ]
 	$key
 ) {
 	global $wpdb;
@@ -1362,7 +1362,7 @@ function wp_delete_signup_on_user_delete( $id, $reassign, $user ) {
  */
 function wpmu_create_user(
 	$user_name,
-	#[\SensitiveParameter]
+	#[\SensitiveParameter ]
 	$password,
 	$email
 ) {
@@ -1509,7 +1509,7 @@ Disable these notifications: %4$s'
 		),
 		$blogname,
 		$siteurl,
-		wp_unslash( $_SERVER['REMOTE_ADDR'] ),
+		wp_unslash( $_SERVER[ 'REMOTE_ADDR' ] ),
 		$options_site_url
 	);
 	/**
@@ -1565,7 +1565,7 @@ Remote IP address: %2$s
 Disable these notifications: %3$s'
 		),
 		$user->user_login,
-		wp_unslash( $_SERVER['REMOTE_ADDR'] ),
+		wp_unslash( $_SERVER[ 'REMOTE_ADDR' ] ),
 		$options_site_url
 	);
 
@@ -1652,7 +1652,7 @@ function domain_exists( $domain, $path, $network_id = 1 ) {
 function wpmu_welcome_notification(
 	$blog_id,
 	$user_id,
-	#[\SensitiveParameter]
+	#[\SensitiveParameter ]
 	$password,
 	$title,
 	$meta = array()
@@ -1862,10 +1862,10 @@ Name: %3$s'
 	$new_site_email = apply_filters( 'new_site_email', $new_site_email, $site, $user );
 
 	wp_mail(
-		$new_site_email['to'],
-		wp_specialchars_decode( $new_site_email['subject'] ),
-		$new_site_email['message'],
-		$new_site_email['headers']
+		$new_site_email[ 'to' ],
+		wp_specialchars_decode( $new_site_email[ 'subject' ] ),
+		$new_site_email[ 'message' ],
+		$new_site_email[ 'headers' ]
 	);
 
 	if ( $switched_locale ) {
@@ -1892,7 +1892,7 @@ Name: %3$s'
  */
 function wpmu_welcome_user_notification(
 	$user_id,
-	#[\SensitiveParameter]
+	#[\SensitiveParameter ]
 	$password,
 	$meta = array()
 ) {
@@ -2019,19 +2019,19 @@ function get_most_recent_post_of_user( $user_id ) {
 		$recent_post = $wpdb->get_row( $wpdb->prepare( "SELECT ID, post_date_gmt FROM {$prefix}posts WHERE post_author = %d AND post_type = 'post' AND post_status = 'publish' ORDER BY post_date_gmt DESC LIMIT 1", $user_id ), ARRAY_A );
 
 		// Make sure we found a post.
-		if ( isset( $recent_post['ID'] ) ) {
-			$post_gmt_ts = strtotime( $recent_post['post_date_gmt'] );
+		if ( isset( $recent_post[ 'ID' ] ) ) {
+			$post_gmt_ts = strtotime( $recent_post[ 'post_date_gmt' ] );
 
 			/*
 			 * If this is the first post checked
 			 * or if this post is newer than the current recent post,
 			 * make it the new most recent post.
 			 */
-			if ( ! isset( $most_recent_post['post_gmt_ts'] ) || ( $post_gmt_ts > $most_recent_post['post_gmt_ts'] ) ) {
+			if ( ! isset( $most_recent_post[ 'post_gmt_ts' ] ) || ( $post_gmt_ts > $most_recent_post[ 'post_gmt_ts' ] ) ) {
 				$most_recent_post = array(
 					'blog_id'       => $blog->userblog_id,
-					'post_id'       => $recent_post['ID'],
-					'post_date_gmt' => $recent_post['post_date_gmt'],
+					'post_id'       => $recent_post[ 'ID' ],
+					'post_date_gmt' => $recent_post[ 'post_date_gmt' ],
 					'post_gmt_ts'   => $post_gmt_ts,
 				);
 			}
@@ -2110,7 +2110,7 @@ function wpmu_log_new_registrations( $blog_id, $user_id ) {
 	}
 
 	if ( is_array( $user_id ) ) {
-		$user_id = ! empty( $user_id['user_id'] ) ? $user_id['user_id'] : 0;
+		$user_id = ! empty( $user_id[ 'user_id' ] ) ? $user_id[ 'user_id' ] : 0;
 	}
 
 	$user = get_userdata( (int) $user_id );
@@ -2119,7 +2119,7 @@ function wpmu_log_new_registrations( $blog_id, $user_id ) {
 			$wpdb->registration_log,
 			array(
 				'email'           => $user->user_email,
-				'IP'              => preg_replace( '/[^0-9., ]/', '', wp_unslash( $_SERVER['REMOTE_ADDR'] ) ),
+				'IP'              => preg_replace( '/[^0-9., ]/', '', wp_unslash( $_SERVER[ 'REMOTE_ADDR' ] ) ),
 				'blog_id'         => $blog_id,
 				'date_registered' => current_time( 'mysql' ),
 			)
@@ -2157,7 +2157,7 @@ function upload_is_file_too_big( $upload ) {
 		return $upload;
 	}
 
-	if ( strlen( $upload['bits'] ) > ( KB_IN_BYTES * get_site_option( 'fileupload_maxk', 1500 ) ) ) {
+	if ( strlen( $upload[ 'bits' ] ) > ( KB_IN_BYTES * get_site_option( 'fileupload_maxk', 1500 ) ) ) {
 		/* translators: %s: Maximum allowed file size in kilobytes. */
 		return sprintf( __( 'This file is too big. Files must be less than %s KB in size.' ) . '<br />', get_site_option( 'fileupload_maxk', 1500 ) );
 	}
@@ -2185,12 +2185,12 @@ function signup_nonce_fields() {
  * @return array
  */
 function signup_nonce_check( $result ) {
-	if ( ! strpos( $_SERVER['PHP_SELF'], 'wp-signup.php' ) ) {
+	if ( ! strpos( $_SERVER[ 'PHP_SELF' ], 'wp-signup.php' ) ) {
 		return $result;
 	}
 
-	if ( ! wp_verify_nonce( $_POST['_signup_form'], 'signup_form_' . $_POST['signup_form_id'] ) ) {
-		$result['errors']->add( 'invalid_nonce', __( 'Unable to submit this form, please try again.' ) );
+	if ( ! wp_verify_nonce( $_POST[ '_signup_form' ], 'signup_form_' . $_POST[ 'signup_form_id' ] ) ) {
+		$result[ 'errors' ]->add( 'invalid_nonce', __( 'Unable to submit this form, please try again.' ) );
 	}
 
 	return $result;
@@ -2235,11 +2235,11 @@ function maybe_redirect_404() {
  * @since MU (3.0.0)
  */
 function maybe_add_existing_user_to_blog() {
-	if ( ! str_contains( $_SERVER['REQUEST_URI'], '/newbloguser/' ) ) {
+	if ( ! str_contains( $_SERVER[ 'REQUEST_URI' ], '/newbloguser/' ) ) {
 		return;
 	}
 
-	$parts = explode( '/', $_SERVER['REQUEST_URI'] );
+	$parts = explode( '/', $_SERVER[ 'REQUEST_URI' ] );
 	$key   = array_pop( $parts );
 
 	if ( '' === $key ) {
@@ -2290,7 +2290,7 @@ function maybe_add_existing_user_to_blog() {
 function add_existing_user_to_blog( $details = false ) {
 	if ( is_array( $details ) ) {
 		$blog_id = get_current_blog_id();
-		$result  = add_user_to_blog( $blog_id, $details['user_id'], $details['role'] );
+		$result  = add_user_to_blog( $blog_id, $details[ 'user_id' ], $details[ 'role' ] );
 
 		/**
 		 * Fires immediately after an existing user is added to a site.
@@ -2301,7 +2301,7 @@ function add_existing_user_to_blog( $details = false ) {
 		 * @param true|WP_Error $result  True on success or a WP_Error object if the user doesn't exist
 		 *                               or could not be added.
 		 */
-		do_action( 'added_existing_user', $details['user_id'], $result );
+		do_action( 'added_existing_user', $details[ 'user_id' ], $result );
 
 		return $result;
 	}
@@ -2323,13 +2323,13 @@ function add_existing_user_to_blog( $details = false ) {
  */
 function add_new_user_to_blog(
 	$user_id,
-	#[\SensitiveParameter]
+	#[\SensitiveParameter ]
 	$password,
 	$meta
 ) {
-	if ( ! empty( $meta['add_to_blog'] ) ) {
-		$blog_id = $meta['add_to_blog'];
-		$role    = $meta['new_role'];
+	if ( ! empty( $meta[ 'add_to_blog' ] ) ) {
+		$blog_id = $meta[ 'add_to_blog' ];
+		$role    = $meta[ 'new_role' ];
 		remove_user_from_blog( $user_id, get_network()->site_id ); // Remove user from main blog.
 
 		$result = add_user_to_blog( $blog_id, $user_id, $role );
@@ -2613,7 +2613,7 @@ function get_space_used() {
 
 	if ( false === $space_used ) {
 		$upload_dir = wp_upload_dir();
-		$space_used = get_dirsize( $upload_dir['basedir'] ) / MB_IN_BYTES;
+		$space_used = get_dirsize( $upload_dir[ 'basedir' ] ) / MB_IN_BYTES;
 	}
 
 	return $space_used;
@@ -2955,18 +2955,18 @@ All at ###SITENAME###
 	 */
 	$email_change_email = apply_filters( 'network_admin_email_change_email', $email_change_email, $old_email, $new_email, $network_id );
 
-	$email_change_email['message'] = str_replace( '###OLD_EMAIL###', $old_email, $email_change_email['message'] );
-	$email_change_email['message'] = str_replace( '###NEW_EMAIL###', $new_email, $email_change_email['message'] );
-	$email_change_email['message'] = str_replace( '###SITENAME###', $network_name, $email_change_email['message'] );
-	$email_change_email['message'] = str_replace( '###SITEURL###', home_url(), $email_change_email['message'] );
+	$email_change_email[ 'message' ] = str_replace( '###OLD_EMAIL###', $old_email, $email_change_email[ 'message' ] );
+	$email_change_email[ 'message' ] = str_replace( '###NEW_EMAIL###', $new_email, $email_change_email[ 'message' ] );
+	$email_change_email[ 'message' ] = str_replace( '###SITENAME###', $network_name, $email_change_email[ 'message' ] );
+	$email_change_email[ 'message' ] = str_replace( '###SITEURL###', home_url(), $email_change_email[ 'message' ] );
 
 	wp_mail(
-		$email_change_email['to'],
+		$email_change_email[ 'to' ],
 		sprintf(
-			$email_change_email['subject'],
+			$email_change_email[ 'subject' ],
 			$network_name
 		),
-		$email_change_email['message'],
-		$email_change_email['headers']
+		$email_change_email[ 'message' ],
+		$email_change_email[ 'headers' ]
 	);
 }

--- a/src/wp-includes/ms-functions.php
+++ b/src/wp-includes/ms-functions.php
@@ -49,7 +49,7 @@ function get_active_blog_for_user( $user_id ) {
 	}
 
 	if ( ! is_multisite() ) {
-		return $blogs[get_current_blog_id()];
+		return $blogs[ get_current_blog_id() ];
 	}
 
 	$primary_blog = get_user_meta( $user_id, 'primary_blog', true );
@@ -148,9 +148,11 @@ function get_blog_post( $blog_id, $post_id ) {
 	}
 
 	$table = $wpdb->get_blog_prefix( $blog_id ) . 'posts';
-	$post  = $wpdb->get_row(
+	// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $table is built from $wpdb->get_blog_prefix().
+	$post = $wpdb->get_row(
 		$wpdb->prepare( "SELECT * FROM `{$table}` WHERE ID = %d LIMIT 1", $post_id )
 	);
+	// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
 	if ( ! $post ) {
 		return null;
@@ -959,7 +961,7 @@ function wpmu_signup_blog_notification(
 	$title,
 	$user_login,
 	$user_email,
-	#[\SensitiveParameter ]
+	#[\SensitiveParameter]
 	$key,
 	$meta = array()
 ) {
@@ -1100,7 +1102,7 @@ function wpmu_signup_blog_notification(
 function wpmu_signup_user_notification(
 	$user_login,
 	$user_email,
-	#[\SensitiveParameter ]
+	#[\SensitiveParameter]
 	$key,
 	$meta = array()
 ) {
@@ -1206,7 +1208,7 @@ function wpmu_signup_user_notification(
  * @return array|WP_Error An array containing information about the activated user and/or blog.
  */
 function wpmu_activate_signup(
-	#[\SensitiveParameter ]
+	#[\SensitiveParameter]
 	$key
 ) {
 	global $wpdb;
@@ -1362,7 +1364,7 @@ function wp_delete_signup_on_user_delete( $id, $reassign, $user ) {
  */
 function wpmu_create_user(
 	$user_name,
-	#[\SensitiveParameter ]
+	#[\SensitiveParameter]
 	$password,
 	$email
 ) {
@@ -1509,7 +1511,7 @@ Disable these notifications: %4$s'
 		),
 		$blogname,
 		$siteurl,
-		wp_unslash( $_SERVER[ 'REMOTE_ADDR' ] ),
+		wp_unslash( $_SERVER['REMOTE_ADDR'] ),
 		$options_site_url
 	);
 	/**
@@ -1565,7 +1567,7 @@ Remote IP address: %2$s
 Disable these notifications: %3$s'
 		),
 		$user->user_login,
-		wp_unslash( $_SERVER[ 'REMOTE_ADDR' ] ),
+		wp_unslash( $_SERVER['REMOTE_ADDR'] ),
 		$options_site_url
 	);
 
@@ -1652,7 +1654,7 @@ function domain_exists( $domain, $path, $network_id = 1 ) {
 function wpmu_welcome_notification(
 	$blog_id,
 	$user_id,
-	#[\SensitiveParameter ]
+	#[\SensitiveParameter]
 	$password,
 	$title,
 	$meta = array()
@@ -1862,10 +1864,10 @@ Name: %3$s'
 	$new_site_email = apply_filters( 'new_site_email', $new_site_email, $site, $user );
 
 	wp_mail(
-		$new_site_email[ 'to' ],
-		wp_specialchars_decode( $new_site_email[ 'subject' ] ),
-		$new_site_email[ 'message' ],
-		$new_site_email[ 'headers' ]
+		$new_site_email['to'],
+		wp_specialchars_decode( $new_site_email['subject'] ),
+		$new_site_email['message'],
+		$new_site_email['headers']
 	);
 
 	if ( $switched_locale ) {
@@ -1892,7 +1894,7 @@ Name: %3$s'
  */
 function wpmu_welcome_user_notification(
 	$user_id,
-	#[\SensitiveParameter ]
+	#[\SensitiveParameter]
 	$password,
 	$meta = array()
 ) {
@@ -2019,19 +2021,19 @@ function get_most_recent_post_of_user( $user_id ) {
 		$recent_post = $wpdb->get_row( $wpdb->prepare( "SELECT ID, post_date_gmt FROM {$prefix}posts WHERE post_author = %d AND post_type = 'post' AND post_status = 'publish' ORDER BY post_date_gmt DESC LIMIT 1", $user_id ), ARRAY_A );
 
 		// Make sure we found a post.
-		if ( isset( $recent_post[ 'ID' ] ) ) {
-			$post_gmt_ts = strtotime( $recent_post[ 'post_date_gmt' ] );
+		if ( isset( $recent_post['ID'] ) ) {
+			$post_gmt_ts = strtotime( $recent_post['post_date_gmt'] );
 
 			/*
 			 * If this is the first post checked
 			 * or if this post is newer than the current recent post,
 			 * make it the new most recent post.
 			 */
-			if ( ! isset( $most_recent_post[ 'post_gmt_ts' ] ) || ( $post_gmt_ts > $most_recent_post[ 'post_gmt_ts' ] ) ) {
+			if ( ! isset( $most_recent_post['post_gmt_ts'] ) || ( $post_gmt_ts > $most_recent_post['post_gmt_ts'] ) ) {
 				$most_recent_post = array(
 					'blog_id'       => $blog->userblog_id,
-					'post_id'       => $recent_post[ 'ID' ],
-					'post_date_gmt' => $recent_post[ 'post_date_gmt' ],
+					'post_id'       => $recent_post['ID'],
+					'post_date_gmt' => $recent_post['post_date_gmt'],
 					'post_gmt_ts'   => $post_gmt_ts,
 				);
 			}
@@ -2110,7 +2112,7 @@ function wpmu_log_new_registrations( $blog_id, $user_id ) {
 	}
 
 	if ( is_array( $user_id ) ) {
-		$user_id = ! empty( $user_id[ 'user_id' ] ) ? $user_id[ 'user_id' ] : 0;
+		$user_id = ! empty( $user_id['user_id'] ) ? $user_id['user_id'] : 0;
 	}
 
 	$user = get_userdata( (int) $user_id );
@@ -2119,7 +2121,7 @@ function wpmu_log_new_registrations( $blog_id, $user_id ) {
 			$wpdb->registration_log,
 			array(
 				'email'           => $user->user_email,
-				'IP'              => preg_replace( '/[^0-9., ]/', '', wp_unslash( $_SERVER[ 'REMOTE_ADDR' ] ) ),
+				'IP'              => preg_replace( '/[^0-9., ]/', '', wp_unslash( $_SERVER['REMOTE_ADDR'] ) ),
 				'blog_id'         => $blog_id,
 				'date_registered' => current_time( 'mysql' ),
 			)
@@ -2157,7 +2159,7 @@ function upload_is_file_too_big( $upload ) {
 		return $upload;
 	}
 
-	if ( strlen( $upload[ 'bits' ] ) > ( KB_IN_BYTES * get_site_option( 'fileupload_maxk', 1500 ) ) ) {
+	if ( strlen( $upload['bits'] ) > ( KB_IN_BYTES * get_site_option( 'fileupload_maxk', 1500 ) ) ) {
 		/* translators: %s: Maximum allowed file size in kilobytes. */
 		return sprintf( __( 'This file is too big. Files must be less than %s KB in size.' ) . '<br />', get_site_option( 'fileupload_maxk', 1500 ) );
 	}
@@ -2185,12 +2187,12 @@ function signup_nonce_fields() {
  * @return array
  */
 function signup_nonce_check( $result ) {
-	if ( ! strpos( $_SERVER[ 'PHP_SELF' ], 'wp-signup.php' ) ) {
+	if ( ! strpos( $_SERVER['PHP_SELF'], 'wp-signup.php' ) ) {
 		return $result;
 	}
 
-	if ( ! wp_verify_nonce( $_POST[ '_signup_form' ], 'signup_form_' . $_POST[ 'signup_form_id' ] ) ) {
-		$result[ 'errors' ]->add( 'invalid_nonce', __( 'Unable to submit this form, please try again.' ) );
+	if ( ! wp_verify_nonce( $_POST['_signup_form'], 'signup_form_' . $_POST['signup_form_id'] ) ) {
+		$result['errors']->add( 'invalid_nonce', __( 'Unable to submit this form, please try again.' ) );
 	}
 
 	return $result;
@@ -2235,11 +2237,11 @@ function maybe_redirect_404() {
  * @since MU (3.0.0)
  */
 function maybe_add_existing_user_to_blog() {
-	if ( ! str_contains( $_SERVER[ 'REQUEST_URI' ], '/newbloguser/' ) ) {
+	if ( ! str_contains( $_SERVER['REQUEST_URI'], '/newbloguser/' ) ) {
 		return;
 	}
 
-	$parts = explode( '/', $_SERVER[ 'REQUEST_URI' ] );
+	$parts = explode( '/', $_SERVER['REQUEST_URI'] );
 	$key   = array_pop( $parts );
 
 	if ( '' === $key ) {
@@ -2290,7 +2292,7 @@ function maybe_add_existing_user_to_blog() {
 function add_existing_user_to_blog( $details = false ) {
 	if ( is_array( $details ) ) {
 		$blog_id = get_current_blog_id();
-		$result  = add_user_to_blog( $blog_id, $details[ 'user_id' ], $details[ 'role' ] );
+		$result  = add_user_to_blog( $blog_id, $details['user_id'], $details['role'] );
 
 		/**
 		 * Fires immediately after an existing user is added to a site.
@@ -2301,7 +2303,7 @@ function add_existing_user_to_blog( $details = false ) {
 		 * @param true|WP_Error $result  True on success or a WP_Error object if the user doesn't exist
 		 *                               or could not be added.
 		 */
-		do_action( 'added_existing_user', $details[ 'user_id' ], $result );
+		do_action( 'added_existing_user', $details['user_id'], $result );
 
 		return $result;
 	}
@@ -2323,13 +2325,13 @@ function add_existing_user_to_blog( $details = false ) {
  */
 function add_new_user_to_blog(
 	$user_id,
-	#[\SensitiveParameter ]
+	#[\SensitiveParameter]
 	$password,
 	$meta
 ) {
-	if ( ! empty( $meta[ 'add_to_blog' ] ) ) {
-		$blog_id = $meta[ 'add_to_blog' ];
-		$role    = $meta[ 'new_role' ];
+	if ( ! empty( $meta['add_to_blog'] ) ) {
+		$blog_id = $meta['add_to_blog'];
+		$role    = $meta['new_role'];
 		remove_user_from_blog( $user_id, get_network()->site_id ); // Remove user from main blog.
 
 		$result = add_user_to_blog( $blog_id, $user_id, $role );
@@ -2613,7 +2615,7 @@ function get_space_used() {
 
 	if ( false === $space_used ) {
 		$upload_dir = wp_upload_dir();
-		$space_used = get_dirsize( $upload_dir[ 'basedir' ] ) / MB_IN_BYTES;
+		$space_used = get_dirsize( $upload_dir['basedir'] ) / MB_IN_BYTES;
 	}
 
 	return $space_used;
@@ -2955,18 +2957,18 @@ All at ###SITENAME###
 	 */
 	$email_change_email = apply_filters( 'network_admin_email_change_email', $email_change_email, $old_email, $new_email, $network_id );
 
-	$email_change_email[ 'message' ] = str_replace( '###OLD_EMAIL###', $old_email, $email_change_email[ 'message' ] );
-	$email_change_email[ 'message' ] = str_replace( '###NEW_EMAIL###', $new_email, $email_change_email[ 'message' ] );
-	$email_change_email[ 'message' ] = str_replace( '###SITENAME###', $network_name, $email_change_email[ 'message' ] );
-	$email_change_email[ 'message' ] = str_replace( '###SITEURL###', home_url(), $email_change_email[ 'message' ] );
+	$email_change_email['message'] = str_replace( '###OLD_EMAIL###', $old_email, $email_change_email['message'] );
+	$email_change_email['message'] = str_replace( '###NEW_EMAIL###', $new_email, $email_change_email['message'] );
+	$email_change_email['message'] = str_replace( '###SITENAME###', $network_name, $email_change_email['message'] );
+	$email_change_email['message'] = str_replace( '###SITEURL###', home_url(), $email_change_email['message'] );
 
 	wp_mail(
-		$email_change_email[ 'to' ],
+		$email_change_email['to'],
 		sprintf(
-			$email_change_email[ 'subject' ],
+			$email_change_email['subject'],
 			$network_name
 		),
-		$email_change_email[ 'message' ],
-		$email_change_email[ 'headers' ]
+		$email_change_email['message'],
+		$email_change_email['headers']
 	);
 }

--- a/tests/phpunit/tests/multisite/site.php
+++ b/tests/phpunit/tests/multisite/site.php
@@ -621,6 +621,22 @@ class Tests_Multisite_Site extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Verifies that get_blog_post() from another site does not set $GLOBALS['switched'].
+	 */
+	public function test_get_blog_post_does_not_switch_context() {
+		$post_id = self::factory()->post->create(); // Post on site 1.
+		$blog_id = self::factory()->blog->create();
+
+		// Call get_blog_post from site 2 to fetch a post from site 1.
+		switch_to_blog( $blog_id );
+		$post = get_blog_post( 1, $post_id );
+		restore_current_blog();
+
+		$this->assertInstanceOf( 'WP_Post', $post );
+		$this->assertEquals( $post_id, $post->ID );
+	}
+
+	/**
 	 * Added as a callback to the domain_exists filter to provide manual results for
 	 * the testing of the filter and for a test which does not need the database.
 	 */

--- a/tests/phpunit/tests/multisite/site.php
+++ b/tests/phpunit/tests/multisite/site.php
@@ -8,8 +8,8 @@
  * @group multisite
  */
 class Tests_Multisite_Site extends WP_UnitTestCase {
-	protected $suppress                = false;
-	protected $site_status_hooks       = array();
+	protected $suppress = false;
+	protected $site_status_hooks = array();
 	protected $wp_initialize_site_args = array();
 	protected $wp_initialize_site_meta = array();
 	protected static $network_ids;
@@ -45,12 +45,12 @@ class Tests_Multisite_Site extends WP_UnitTestCase {
 			'make.wordpress.org/'     => array(
 				'domain'     => 'make.wordpress.org',
 				'path'       => '/',
-				'network_id' => self::$network_ids['make.wordpress.org/'],
+				'network_id' => self::$network_ids[ 'make.wordpress.org/' ],
 			),
 			'make.wordpress.org/foo/' => array(
 				'domain'     => 'make.wordpress.org',
 				'path'       => '/foo/',
-				'network_id' => self::$network_ids['make.wordpress.org/'],
+				'network_id' => self::$network_ids[ 'make.wordpress.org/' ],
 			),
 		);
 
@@ -64,7 +64,7 @@ class Tests_Multisite_Site extends WP_UnitTestCase {
 			array(
 				'domain'     => 'uninitialized.org',
 				'path'       => '/',
-				'network_id' => self::$network_ids['make.wordpress.org/'],
+				'network_id' => self::$network_ids[ 'make.wordpress.org/' ],
 			)
 		);
 		add_action( 'wp_initialize_site', 'wp_initialize_site', 10, 2 );
@@ -389,16 +389,16 @@ class Tests_Multisite_Site extends WP_UnitTestCase {
 		wpmu_delete_blog( $blog_id, true );
 
 		// The file on the main site should still exist. The file on the deleted site should not.
-		$this->assertFileExists( $file1['file'] );
-		$this->assertFileDoesNotExist( $file2['file'] );
+		$this->assertFileExists( $file1[ 'file' ] );
+		$this->assertFileDoesNotExist( $file2[ 'file' ] );
 
 		wpmu_delete_blog( $blog_id, true );
 
 		// The file on the main site should still exist. The file on the deleted site should not.
-		$this->assertFileExists( $file1['file'] );
-		$this->assertFileDoesNotExist( $file2['file'] );
+		$this->assertFileExists( $file1[ 'file' ] );
+		$this->assertFileDoesNotExist( $file2[ 'file' ] );
 
-		unlink( $file1['file'] );
+		unlink( $file1[ 'file' ] );
 	}
 
 	public function test_wpmu_update_blogs_date() {
@@ -566,26 +566,26 @@ class Tests_Multisite_Site extends WP_UnitTestCase {
 		$date = date_format( date_create( 'now' ), 'Y/m' );
 
 		$info = wp_upload_dir();
-		$this->assertSame( 'http://' . $site->domain . '/wp-content/uploads/' . $date, $info['url'] );
-		$this->assertSame( ABSPATH . 'wp-content/uploads/' . $date, $info['path'] );
-		$this->assertSame( '/' . $date, $info['subdir'] );
-		$this->assertFalse( $info['error'] );
+		$this->assertSame( 'http://' . $site->domain . '/wp-content/uploads/' . $date, $info[ 'url' ] );
+		$this->assertSame( ABSPATH . 'wp-content/uploads/' . $date, $info[ 'path' ] );
+		$this->assertSame( '/' . $date, $info[ 'subdir' ] );
+		$this->assertFalse( $info[ 'error' ] );
 
 		$blog_id = self::factory()->blog->create();
 
 		switch_to_blog( $blog_id );
 		$info = wp_upload_dir();
-		$this->assertSame( 'http://' . $site->domain . '/wp-content/uploads/sites/' . get_current_blog_id() . '/' . $date, $info['url'] );
-		$this->assertSame( ABSPATH . 'wp-content/uploads/sites/' . get_current_blog_id() . '/' . $date, $info['path'] );
-		$this->assertSame( '/' . $date, $info['subdir'] );
-		$this->assertFalse( $info['error'] );
+		$this->assertSame( 'http://' . $site->domain . '/wp-content/uploads/sites/' . get_current_blog_id() . '/' . $date, $info[ 'url' ] );
+		$this->assertSame( ABSPATH . 'wp-content/uploads/sites/' . get_current_blog_id() . '/' . $date, $info[ 'path' ] );
+		$this->assertSame( '/' . $date, $info[ 'subdir' ] );
+		$this->assertFalse( $info[ 'error' ] );
 		restore_current_blog();
 
 		$info = wp_upload_dir();
-		$this->assertSame( 'http://' . $site->domain . '/wp-content/uploads/' . $date, $info['url'] );
-		$this->assertSame( ABSPATH . 'wp-content/uploads/' . $date, $info['path'] );
-		$this->assertSame( '/' . $date, $info['subdir'] );
-		$this->assertFalse( $info['error'] );
+		$this->assertSame( 'http://' . $site->domain . '/wp-content/uploads/' . $date, $info[ 'url' ] );
+		$this->assertSame( ABSPATH . 'wp-content/uploads/' . $date, $info[ 'path' ] );
+		$this->assertSame( '/' . $date, $info[ 'subdir' ] );
+		$this->assertFalse( $info[ 'error' ] );
 	}
 
 	/**
@@ -733,7 +733,7 @@ class Tests_Multisite_Site extends WP_UnitTestCase {
 		$this->assertFalse( is_ssl() );
 		$this->assertSame( 'http', parse_url( get_blogaddress_by_id( $blog ), PHP_URL_SCHEME ) );
 
-		$_SERVER['HTTPS'] = 'on';
+		$_SERVER[ 'HTTPS' ] = 'on';
 
 		$is_ssl  = is_ssl();
 		$address = parse_url( get_blogaddress_by_id( $blog ), PHP_URL_SCHEME );
@@ -841,16 +841,16 @@ class Tests_Multisite_Site extends WP_UnitTestCase {
 	 * @ticket 40503
 	 */
 	public function test_different_network_language() {
-		$network = get_network( self::$network_ids['make.wordpress.org/'] );
+		$network = get_network( self::$network_ids[ 'make.wordpress.org/' ] );
 
 		add_filter( 'sanitize_option_WPLANG', array( $this, 'filter_allow_unavailable_languages' ), 10, 3 );
 
-		update_network_option( self::$network_ids['make.wordpress.org/'], 'WPLANG', 'wibble' );
+		update_network_option( self::$network_ids[ 'make.wordpress.org/' ], 'WPLANG', 'wibble' );
 		$blog_id = wpmu_create_blog( $network->domain, '/de-de/', 'New Blog', get_current_user_id(), array(), $network->id );
 
 		remove_filter( 'sanitize_option_WPLANG', array( $this, 'filter_allow_unavailable_languages' ), 10 );
 
-		$this->assertSame( get_network_option( self::$network_ids['make.wordpress.org/'], 'WPLANG' ), get_blog_option( $blog_id, 'WPLANG' ) );
+		$this->assertSame( get_network_option( self::$network_ids[ 'make.wordpress.org/' ], 'WPLANG' ), get_blog_option( $blog_id, 'WPLANG' ) );
 	}
 
 	/**
@@ -869,14 +869,14 @@ class Tests_Multisite_Site extends WP_UnitTestCase {
 	 * @ticket 29684
 	 */
 	public function test_is_main_site_different_network() {
-		$this->assertTrue( is_main_site( self::$site_ids['make.wordpress.org/'], self::$network_ids['make.wordpress.org/'] ) );
+		$this->assertTrue( is_main_site( self::$site_ids[ 'make.wordpress.org/' ], self::$network_ids[ 'make.wordpress.org/' ] ) );
 	}
 
 	/**
 	 * @ticket 29684
 	 */
 	public function test_is_main_site_different_network_random_site() {
-		$this->assertFalse( is_main_site( self::$site_ids['make.wordpress.org/foo/'], self::$network_ids['make.wordpress.org/'] ) );
+		$this->assertFalse( is_main_site( self::$site_ids[ 'make.wordpress.org/foo/' ], self::$network_ids[ 'make.wordpress.org/' ] ) );
 	}
 
 	/**
@@ -884,7 +884,7 @@ class Tests_Multisite_Site extends WP_UnitTestCase {
 	 * @dataProvider data_get_site_caches
 	 */
 	public function test_clean_blog_cache( $key, $group ) {
-		$site = get_site( self::$site_ids['make.wordpress.org/'] );
+		$site = get_site( self::$site_ids[ 'make.wordpress.org/' ] );
 
 		$replacements = array(
 			'%blog_id%'         => $site->blog_id,
@@ -910,7 +910,7 @@ class Tests_Multisite_Site extends WP_UnitTestCase {
 	 * @dataProvider data_get_site_caches
 	 */
 	public function test_clean_blog_cache_with_id( $key, $group ) {
-		$site = get_site( self::$site_ids['make.wordpress.org/'] );
+		$site = get_site( self::$site_ids[ 'make.wordpress.org/' ] );
 
 		$replacements = array(
 			'%blog_id%'         => $site->blog_id,
@@ -935,7 +935,7 @@ class Tests_Multisite_Site extends WP_UnitTestCase {
 	 * @ticket 40201
 	 */
 	public function test_clean_blog_cache_resets_last_changed() {
-		$site = get_site( self::$site_ids['make.wordpress.org/'] );
+		$site = get_site( self::$site_ids[ 'make.wordpress.org/' ] );
 
 		wp_cache_delete( 'last_changed', 'sites' );
 
@@ -947,7 +947,7 @@ class Tests_Multisite_Site extends WP_UnitTestCase {
 	 * @ticket 40201
 	 */
 	public function test_clean_blog_cache_fires_action() {
-		$site = get_site( self::$site_ids['make.wordpress.org/'] );
+		$site = get_site( self::$site_ids[ 'make.wordpress.org/' ] );
 
 		$old_count = did_action( 'clean_site_cache' );
 
@@ -959,7 +959,7 @@ class Tests_Multisite_Site extends WP_UnitTestCase {
 	 * @ticket 40201
 	 */
 	public function test_clean_blog_cache_bails_on_suspend_cache_invalidation() {
-		$site = get_site( self::$site_ids['make.wordpress.org/'] );
+		$site = get_site( self::$site_ids[ 'make.wordpress.org/' ] );
 
 		$old_count = did_action( 'clean_site_cache' );
 
@@ -1006,7 +1006,7 @@ class Tests_Multisite_Site extends WP_UnitTestCase {
 	 * @dataProvider data_get_site_caches
 	 */
 	public function test_refresh_blog_details( $key, $group ) {
-		$site = get_site( self::$site_ids['make.wordpress.org/'] );
+		$site = get_site( self::$site_ids[ 'make.wordpress.org/' ] );
 
 		$replacements = array(
 			'%blog_id%'         => $site->blog_id,
@@ -1355,7 +1355,7 @@ class Tests_Multisite_Site extends WP_UnitTestCase {
 	 */
 	public function test_wp_delete_site_validate_site_deletion_action() {
 		add_action( 'wp_validate_site_deletion', array( $this, 'action_wp_validate_site_deletion_prevent_deletion' ) );
-		$result = wp_delete_site( self::$site_ids['make.wordpress.org/'] );
+		$result = wp_delete_site( self::$site_ids[ 'make.wordpress.org/' ] );
 		$this->assertWPError( $result );
 		$this->assertSame( 'action_does_not_like_deletion', $result->get_error_code() );
 	}
@@ -1899,7 +1899,7 @@ class Tests_Multisite_Site extends WP_UnitTestCase {
 	}
 
 	public function action_site_status_hook( $site_id ) {
-		$this->site_status_hooks[ current_action() ] = $site_id;
+		$this->site_status_hooks[current_action()] = $site_id;
 	}
 
 	/**
@@ -2050,7 +2050,7 @@ class Tests_Multisite_Site extends WP_UnitTestCase {
 	}
 
 	public function filter_wp_initialize_site_args( $args, $site, $network ) {
-		$args['title'] = sprintf( 'My Site %1$d in Network %2$d', $site->id, $network->id );
+		$args[ 'title' ] = sprintf( 'My Site %1$d in Network %2$d', $site->id, $network->id );
 
 		return $args;
 	}

--- a/tests/phpunit/tests/multisite/site.php
+++ b/tests/phpunit/tests/multisite/site.php
@@ -8,8 +8,8 @@
  * @group multisite
  */
 class Tests_Multisite_Site extends WP_UnitTestCase {
-	protected $suppress = false;
-	protected $site_status_hooks = array();
+	protected $suppress                = false;
+	protected $site_status_hooks       = array();
 	protected $wp_initialize_site_args = array();
 	protected $wp_initialize_site_meta = array();
 	protected static $network_ids;
@@ -45,12 +45,12 @@ class Tests_Multisite_Site extends WP_UnitTestCase {
 			'make.wordpress.org/'     => array(
 				'domain'     => 'make.wordpress.org',
 				'path'       => '/',
-				'network_id' => self::$network_ids[ 'make.wordpress.org/' ],
+				'network_id' => self::$network_ids['make.wordpress.org/'],
 			),
 			'make.wordpress.org/foo/' => array(
 				'domain'     => 'make.wordpress.org',
 				'path'       => '/foo/',
-				'network_id' => self::$network_ids[ 'make.wordpress.org/' ],
+				'network_id' => self::$network_ids['make.wordpress.org/'],
 			),
 		);
 
@@ -64,7 +64,7 @@ class Tests_Multisite_Site extends WP_UnitTestCase {
 			array(
 				'domain'     => 'uninitialized.org',
 				'path'       => '/',
-				'network_id' => self::$network_ids[ 'make.wordpress.org/' ],
+				'network_id' => self::$network_ids['make.wordpress.org/'],
 			)
 		);
 		add_action( 'wp_initialize_site', 'wp_initialize_site', 10, 2 );
@@ -389,16 +389,16 @@ class Tests_Multisite_Site extends WP_UnitTestCase {
 		wpmu_delete_blog( $blog_id, true );
 
 		// The file on the main site should still exist. The file on the deleted site should not.
-		$this->assertFileExists( $file1[ 'file' ] );
-		$this->assertFileDoesNotExist( $file2[ 'file' ] );
+		$this->assertFileExists( $file1['file'] );
+		$this->assertFileDoesNotExist( $file2['file'] );
 
 		wpmu_delete_blog( $blog_id, true );
 
 		// The file on the main site should still exist. The file on the deleted site should not.
-		$this->assertFileExists( $file1[ 'file' ] );
-		$this->assertFileDoesNotExist( $file2[ 'file' ] );
+		$this->assertFileExists( $file1['file'] );
+		$this->assertFileDoesNotExist( $file2['file'] );
 
-		unlink( $file1[ 'file' ] );
+		unlink( $file1['file'] );
 	}
 
 	public function test_wpmu_update_blogs_date() {
@@ -566,26 +566,26 @@ class Tests_Multisite_Site extends WP_UnitTestCase {
 		$date = date_format( date_create( 'now' ), 'Y/m' );
 
 		$info = wp_upload_dir();
-		$this->assertSame( 'http://' . $site->domain . '/wp-content/uploads/' . $date, $info[ 'url' ] );
-		$this->assertSame( ABSPATH . 'wp-content/uploads/' . $date, $info[ 'path' ] );
-		$this->assertSame( '/' . $date, $info[ 'subdir' ] );
-		$this->assertFalse( $info[ 'error' ] );
+		$this->assertSame( 'http://' . $site->domain . '/wp-content/uploads/' . $date, $info['url'] );
+		$this->assertSame( ABSPATH . 'wp-content/uploads/' . $date, $info['path'] );
+		$this->assertSame( '/' . $date, $info['subdir'] );
+		$this->assertFalse( $info['error'] );
 
 		$blog_id = self::factory()->blog->create();
 
 		switch_to_blog( $blog_id );
 		$info = wp_upload_dir();
-		$this->assertSame( 'http://' . $site->domain . '/wp-content/uploads/sites/' . get_current_blog_id() . '/' . $date, $info[ 'url' ] );
-		$this->assertSame( ABSPATH . 'wp-content/uploads/sites/' . get_current_blog_id() . '/' . $date, $info[ 'path' ] );
-		$this->assertSame( '/' . $date, $info[ 'subdir' ] );
-		$this->assertFalse( $info[ 'error' ] );
+		$this->assertSame( 'http://' . $site->domain . '/wp-content/uploads/sites/' . get_current_blog_id() . '/' . $date, $info['url'] );
+		$this->assertSame( ABSPATH . 'wp-content/uploads/sites/' . get_current_blog_id() . '/' . $date, $info['path'] );
+		$this->assertSame( '/' . $date, $info['subdir'] );
+		$this->assertFalse( $info['error'] );
 		restore_current_blog();
 
 		$info = wp_upload_dir();
-		$this->assertSame( 'http://' . $site->domain . '/wp-content/uploads/' . $date, $info[ 'url' ] );
-		$this->assertSame( ABSPATH . 'wp-content/uploads/' . $date, $info[ 'path' ] );
-		$this->assertSame( '/' . $date, $info[ 'subdir' ] );
-		$this->assertFalse( $info[ 'error' ] );
+		$this->assertSame( 'http://' . $site->domain . '/wp-content/uploads/' . $date, $info['url'] );
+		$this->assertSame( ABSPATH . 'wp-content/uploads/' . $date, $info['path'] );
+		$this->assertSame( '/' . $date, $info['subdir'] );
+		$this->assertFalse( $info['error'] );
 	}
 
 	/**
@@ -733,7 +733,7 @@ class Tests_Multisite_Site extends WP_UnitTestCase {
 		$this->assertFalse( is_ssl() );
 		$this->assertSame( 'http', parse_url( get_blogaddress_by_id( $blog ), PHP_URL_SCHEME ) );
 
-		$_SERVER[ 'HTTPS' ] = 'on';
+		$_SERVER['HTTPS'] = 'on';
 
 		$is_ssl  = is_ssl();
 		$address = parse_url( get_blogaddress_by_id( $blog ), PHP_URL_SCHEME );
@@ -841,16 +841,16 @@ class Tests_Multisite_Site extends WP_UnitTestCase {
 	 * @ticket 40503
 	 */
 	public function test_different_network_language() {
-		$network = get_network( self::$network_ids[ 'make.wordpress.org/' ] );
+		$network = get_network( self::$network_ids['make.wordpress.org/'] );
 
 		add_filter( 'sanitize_option_WPLANG', array( $this, 'filter_allow_unavailable_languages' ), 10, 3 );
 
-		update_network_option( self::$network_ids[ 'make.wordpress.org/' ], 'WPLANG', 'wibble' );
+		update_network_option( self::$network_ids['make.wordpress.org/'], 'WPLANG', 'wibble' );
 		$blog_id = wpmu_create_blog( $network->domain, '/de-de/', 'New Blog', get_current_user_id(), array(), $network->id );
 
 		remove_filter( 'sanitize_option_WPLANG', array( $this, 'filter_allow_unavailable_languages' ), 10 );
 
-		$this->assertSame( get_network_option( self::$network_ids[ 'make.wordpress.org/' ], 'WPLANG' ), get_blog_option( $blog_id, 'WPLANG' ) );
+		$this->assertSame( get_network_option( self::$network_ids['make.wordpress.org/'], 'WPLANG' ), get_blog_option( $blog_id, 'WPLANG' ) );
 	}
 
 	/**
@@ -869,14 +869,14 @@ class Tests_Multisite_Site extends WP_UnitTestCase {
 	 * @ticket 29684
 	 */
 	public function test_is_main_site_different_network() {
-		$this->assertTrue( is_main_site( self::$site_ids[ 'make.wordpress.org/' ], self::$network_ids[ 'make.wordpress.org/' ] ) );
+		$this->assertTrue( is_main_site( self::$site_ids['make.wordpress.org/'], self::$network_ids['make.wordpress.org/'] ) );
 	}
 
 	/**
 	 * @ticket 29684
 	 */
 	public function test_is_main_site_different_network_random_site() {
-		$this->assertFalse( is_main_site( self::$site_ids[ 'make.wordpress.org/foo/' ], self::$network_ids[ 'make.wordpress.org/' ] ) );
+		$this->assertFalse( is_main_site( self::$site_ids['make.wordpress.org/foo/'], self::$network_ids['make.wordpress.org/'] ) );
 	}
 
 	/**
@@ -884,7 +884,7 @@ class Tests_Multisite_Site extends WP_UnitTestCase {
 	 * @dataProvider data_get_site_caches
 	 */
 	public function test_clean_blog_cache( $key, $group ) {
-		$site = get_site( self::$site_ids[ 'make.wordpress.org/' ] );
+		$site = get_site( self::$site_ids['make.wordpress.org/'] );
 
 		$replacements = array(
 			'%blog_id%'         => $site->blog_id,
@@ -910,7 +910,7 @@ class Tests_Multisite_Site extends WP_UnitTestCase {
 	 * @dataProvider data_get_site_caches
 	 */
 	public function test_clean_blog_cache_with_id( $key, $group ) {
-		$site = get_site( self::$site_ids[ 'make.wordpress.org/' ] );
+		$site = get_site( self::$site_ids['make.wordpress.org/'] );
 
 		$replacements = array(
 			'%blog_id%'         => $site->blog_id,
@@ -935,7 +935,7 @@ class Tests_Multisite_Site extends WP_UnitTestCase {
 	 * @ticket 40201
 	 */
 	public function test_clean_blog_cache_resets_last_changed() {
-		$site = get_site( self::$site_ids[ 'make.wordpress.org/' ] );
+		$site = get_site( self::$site_ids['make.wordpress.org/'] );
 
 		wp_cache_delete( 'last_changed', 'sites' );
 
@@ -947,7 +947,7 @@ class Tests_Multisite_Site extends WP_UnitTestCase {
 	 * @ticket 40201
 	 */
 	public function test_clean_blog_cache_fires_action() {
-		$site = get_site( self::$site_ids[ 'make.wordpress.org/' ] );
+		$site = get_site( self::$site_ids['make.wordpress.org/'] );
 
 		$old_count = did_action( 'clean_site_cache' );
 
@@ -959,7 +959,7 @@ class Tests_Multisite_Site extends WP_UnitTestCase {
 	 * @ticket 40201
 	 */
 	public function test_clean_blog_cache_bails_on_suspend_cache_invalidation() {
-		$site = get_site( self::$site_ids[ 'make.wordpress.org/' ] );
+		$site = get_site( self::$site_ids['make.wordpress.org/'] );
 
 		$old_count = did_action( 'clean_site_cache' );
 
@@ -1006,7 +1006,7 @@ class Tests_Multisite_Site extends WP_UnitTestCase {
 	 * @dataProvider data_get_site_caches
 	 */
 	public function test_refresh_blog_details( $key, $group ) {
-		$site = get_site( self::$site_ids[ 'make.wordpress.org/' ] );
+		$site = get_site( self::$site_ids['make.wordpress.org/'] );
 
 		$replacements = array(
 			'%blog_id%'         => $site->blog_id,
@@ -1355,7 +1355,7 @@ class Tests_Multisite_Site extends WP_UnitTestCase {
 	 */
 	public function test_wp_delete_site_validate_site_deletion_action() {
 		add_action( 'wp_validate_site_deletion', array( $this, 'action_wp_validate_site_deletion_prevent_deletion' ) );
-		$result = wp_delete_site( self::$site_ids[ 'make.wordpress.org/' ] );
+		$result = wp_delete_site( self::$site_ids['make.wordpress.org/'] );
 		$this->assertWPError( $result );
 		$this->assertSame( 'action_does_not_like_deletion', $result->get_error_code() );
 	}
@@ -1899,7 +1899,7 @@ class Tests_Multisite_Site extends WP_UnitTestCase {
 	}
 
 	public function action_site_status_hook( $site_id ) {
-		$this->site_status_hooks[current_action()] = $site_id;
+		$this->site_status_hooks[ current_action() ] = $site_id;
 	}
 
 	/**
@@ -2050,7 +2050,7 @@ class Tests_Multisite_Site extends WP_UnitTestCase {
 	}
 
 	public function filter_wp_initialize_site_args( $args, $site, $network ) {
-		$args[ 'title' ] = sprintf( 'My Site %1$d in Network %2$d', $site->id, $network->id );
+		$args['title'] = sprintf( 'My Site %1$d in Network %2$d', $site->id, $network->id );
 
 		return $args;
 	}

--- a/tests/phpunit/tests/option/multisite.php
+++ b/tests/phpunit/tests/option/multisite.php
@@ -152,6 +152,85 @@ class Tests_Option_Multisite extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Verifies that get_blog_option() on another site does not set $GLOBALS['switched'].
+	 *
+	 * @covers ::get_blog_option
+	 * @covers ::_get_option_from_blog
+	 */
+	public function test_get_blog_option_does_not_switch_context() {
+		$user_id = self::factory()->user->create();
+		$blog_id = self::factory()->blog->create(
+			array(
+				'user_id' => $user_id,
+				'public'  => 1,
+			)
+		);
+
+		$this->assertNotEquals( get_current_blog_id(), $blog_id );
+
+		get_blog_option( $blog_id, 'blogname' );
+
+		$this->assertFalse(
+			isset( $GLOBALS['switched'] ) && $GLOBALS['switched'],
+			'$GLOBALS[\'switched\'] should not be true after get_blog_option() on another site'
+		);
+	}
+
+	/**
+	 * Verifies that update_blog_option() on another site does not set $GLOBALS['switched'].
+	 *
+	 * @covers ::update_blog_option
+	 */
+	public function test_update_blog_option_does_not_switch_context() {
+		$user_id = self::factory()->user->create();
+		$blog_id = self::factory()->blog->create(
+			array(
+				'user_id' => $user_id,
+				'public'  => 1,
+			)
+		);
+
+		update_blog_option( $blog_id, 'test_no_switch_option', 'test_value' );
+
+		$this->assertFalse(
+			isset( $GLOBALS['switched'] ) && $GLOBALS['switched'],
+			'$GLOBALS[\'switched\'] should not be true after update_blog_option() on another site'
+		);
+
+		// Clean up.
+		delete_blog_option( $blog_id, 'test_no_switch_option' );
+	}
+
+	/**
+	 * Verifies that WP_Site::__get('blogname') returns a correct value without switching.
+	 *
+	 * @covers WP_Site::__get
+	 */
+	public function test_wp_site_get_blogname_without_switching() {
+		$user_id = self::factory()->user->create();
+		$blog_id = self::factory()->blog->create(
+			array(
+				'user_id' => $user_id,
+				'public'  => 1,
+			)
+		);
+
+		// Set a known blogname on the other site.
+		update_blog_option( $blog_id, 'blogname', 'Test Site Name' );
+
+		// Clear the site-details cache to force get_details() to run.
+		wp_cache_delete( $blog_id, 'site-details' );
+
+		$site = get_site( $blog_id );
+		$this->assertSame( 'Test Site Name', $site->blogname );
+
+		$this->assertFalse(
+			isset( $GLOBALS['switched'] ) && $GLOBALS['switched'],
+			'$GLOBALS[\'switched\'] should not be true after accessing WP_Site::blogname'
+		);
+	}
+
+	/**
 	 * @group multisite
 	 *
 	 * @covers ::get_site_option

--- a/tests/phpunit/tests/option/multisite.php
+++ b/tests/phpunit/tests/option/multisite.php
@@ -171,7 +171,7 @@ class Tests_Option_Multisite extends WP_UnitTestCase {
 		get_blog_option( $blog_id, 'blogname' );
 
 		$this->assertFalse(
-			isset( $GLOBALS[ 'switched' ] ) && $GLOBALS[ 'switched' ],
+			isset( $GLOBALS['switched'] ) && $GLOBALS['switched'],
 			'$GLOBALS[\'switched\'] should not be true after get_blog_option() on another site'
 		);
 	}
@@ -193,7 +193,7 @@ class Tests_Option_Multisite extends WP_UnitTestCase {
 		update_blog_option( $blog_id, 'test_no_switch_option', 'test_value' );
 
 		$this->assertFalse(
-			isset( $GLOBALS[ 'switched' ] ) && $GLOBALS[ 'switched' ],
+			isset( $GLOBALS['switched'] ) && $GLOBALS['switched'],
 			'$GLOBALS[\'switched\'] should not be true after update_blog_option() on another site'
 		);
 
@@ -225,7 +225,7 @@ class Tests_Option_Multisite extends WP_UnitTestCase {
 		$this->assertSame( 'Test Site Name', $site->blogname );
 
 		$this->assertFalse(
-			isset( $GLOBALS[ 'switched' ] ) && $GLOBALS[ 'switched' ],
+			isset( $GLOBALS['switched'] ) && $GLOBALS['switched'],
 			'$GLOBALS[\'switched\'] should not be true after accessing WP_Site::blogname'
 		);
 	}

--- a/tests/phpunit/tests/option/multisite.php
+++ b/tests/phpunit/tests/option/multisite.php
@@ -171,7 +171,7 @@ class Tests_Option_Multisite extends WP_UnitTestCase {
 		get_blog_option( $blog_id, 'blogname' );
 
 		$this->assertFalse(
-			isset( $GLOBALS['switched'] ) && $GLOBALS['switched'],
+			isset( $GLOBALS[ 'switched' ] ) && $GLOBALS[ 'switched' ],
 			'$GLOBALS[\'switched\'] should not be true after get_blog_option() on another site'
 		);
 	}
@@ -193,7 +193,7 @@ class Tests_Option_Multisite extends WP_UnitTestCase {
 		update_blog_option( $blog_id, 'test_no_switch_option', 'test_value' );
 
 		$this->assertFalse(
-			isset( $GLOBALS['switched'] ) && $GLOBALS['switched'],
+			isset( $GLOBALS[ 'switched' ] ) && $GLOBALS[ 'switched' ],
 			'$GLOBALS[\'switched\'] should not be true after update_blog_option() on another site'
 		);
 
@@ -225,7 +225,7 @@ class Tests_Option_Multisite extends WP_UnitTestCase {
 		$this->assertSame( 'Test Site Name', $site->blogname );
 
 		$this->assertFalse(
-			isset( $GLOBALS['switched'] ) && $GLOBALS['switched'],
+			isset( $GLOBALS[ 'switched' ] ) && $GLOBALS[ 'switched' ],
 			'$GLOBALS[\'switched\'] should not be true after accessing WP_Site::blogname'
 		);
 	}


### PR DESCRIPTION

### Motivation

`switch_to_blog()` mutates six globals and, on the fallback object-cache implementation, wipes the entire object cache. Several core functions use it internally even though they only need to read or write a single row in a per-site table. This patch replaces those internal switches with direct queries using `$wpdb->get_blog_prefix( $blog_id )`, which is a pure function — no side-effects, no globals written.

---

### Files changed

#### 1. ms-blogs.php

**New function: `_get_option_from_blog()`** (added before `get_blog_option()`)

- Internal helper that reads a single option from any site's `wp_N_options` table without switching blog context.
- Fast path: delegates to `get_option()` when `$blog_id === get_current_blog_id()`.
- Checks `wp_cache_get( $blog_id, 'blog-alloptions' )` and `blog-notoptions` before hitting the DB.
- Falls back to a direct `SELECT` against `$wpdb->get_blog_prefix( $blog_id ) . 'options'`.
- Caches misses in `blog-notoptions`.
- Applies the existing `blog_option_{$option}` filter.

**Refactored: `get_blog_option()`**

```diff
- if ( get_current_blog_id() === $id ) {
-     return get_option( $option, $default_value );
- }
- switch_to_blog( $id );
- $value = get_option( $option, $default_value );
- restore_current_blog();
- return apply_filters( "blog_option_{$option}", $value, $id );
+ return _get_option_from_blog( $id, $option, $default_value );
```

**Refactored: `add_blog_option()`**

```diff
- switch_to_blog( $id );
- $return = add_option( $option, $value );
- restore_current_blog();
- return $return;
+ $table  = $wpdb->get_blog_prefix( $id ) . 'options';
+ $exists = $wpdb->get_var( ... );      // check if option already exists
+ if ( $exists ) { return false; }
+ $result = $wpdb->insert( $table, ... );
+ wp_cache_delete( $id, 'blog-alloptions' );
+ wp_cache_delete( $id, 'blog-notoptions' );
+ return false !== $result;
```

**Refactored: `delete_blog_option()`**

```diff
- switch_to_blog( $id );
- $return = delete_option( $option );
- restore_current_blog();
- return $return;
+ $table  = $wpdb->get_blog_prefix( $id ) . 'options';
+ $result = $wpdb->delete( $table, [ 'option_name' => $option ] );
+ wp_cache_delete( $id, 'blog-alloptions' );
+ wp_cache_delete( $id, 'blog-notoptions' );
+ return false !== $result && $result > 0;
```

**Refactored: `update_blog_option()`**

```diff
- switch_to_blog( $id );
- $return = update_option( $option, $value );
- restore_current_blog();
- return $return;
+ $old_value = _get_option_from_blog( $id, $option );
+ if ( $serialized === maybe_serialize( $old_value ) ) { return false; }
+ // $wpdb->update() if exists, $wpdb->insert() if new
+ wp_cache_delete( $id, 'blog-alloptions' );
+ wp_cache_delete( $id, 'blog-notoptions' );
+ return false !== $result;
```

---

#### 2. class-wp-site.php

**Refactored: `WP_Site::get_details()` (private)**

```diff
  if ( false === $details ) {
-     switch_to_blog( $this->blog_id );
+     $id = (int) $this->blog_id;
      $details = new stdClass();
      foreach ( get_object_vars( $this ) as $key => $value ) {
          $details->$key = $value;
      }
-     $details->blogname   = get_option( 'blogname' );
-     $details->siteurl    = get_option( 'siteurl' );
-     $details->post_count = get_option( 'post_count' );
-     $details->home       = get_option( 'home' );
-     restore_current_blog();
+     $details->blogname   = _get_option_from_blog( $id, 'blogname' );
+     $details->siteurl    = _get_option_from_blog( $id, 'siteurl' );
+     $details->post_count = _get_option_from_blog( $id, 'post_count', 0 );
+     $details->home       = _get_option_from_blog( $id, 'home' );
```

---

#### 3. ms-functions.php

**Refactored: `get_blog_post()`**

```diff
- function get_blog_post( $blog_id, $post_id ) {
-     switch_to_blog( $blog_id );
-     $post = get_post( $post_id );
-     restore_current_blog();
-     return $post;
- }
+ function get_blog_post( $blog_id, $post_id ) {
+     global $wpdb;
+     $blog_id = (int) $blog_id;
+     $post_id = (int) $post_id;
+     if ( get_current_blog_id() === $blog_id ) {
+         return get_post( $post_id );
+     }
+     $table = $wpdb->get_blog_prefix( $blog_id ) . 'posts';
+     $post  = $wpdb->get_row(
+         $wpdb->prepare( "SELECT * FROM `{$table}` WHERE ID = %d LIMIT 1", $post_id )
+     );
+     if ( ! $post ) { return null; }
+     return sanitize_post( new WP_Post( $post ), 'raw' );
+ }
```

---

#### 4. multisite.php

**3 new test methods added:**

| Test | Covers |
|---|---|
| `test_get_blog_option_does_not_switch_context()` | `get_blog_option()` on another site must not set `$GLOBALS['switched']` to `true` |
| `test_update_blog_option_does_not_switch_context()` | `update_blog_option()` on another site must not set `$GLOBALS['switched']` to `true` |
| `test_wp_site_get_blogname_without_switching()` | `WP_Site::__get('blogname')` returns correct value and doesn't set `$GLOBALS['switched']` |

---

#### 5. site.php

**1 new test method added:**

| Test | Covers |
|---|---|
| `test_get_blog_post_does_not_switch_context()` | `get_blog_post()` returns correct `WP_Post` when fetching from another site |

---

### Design decisions

- **`_get_option_from_blog()`** — prefixed with `_` per WordPress convention for internal/private APIs.
- **Current-blog fast path** preserved in every function — delegates to native `get_option()` / `update_option()` / `add_option()` / `delete_option()` / `get_post()` for full filter and cache compatibility.
- **Cache groups** `blog-alloptions` and `blog-notoptions` match the existing WordPress core cache strategy.
- **Cache busting** — all write functions (`add_`, `update_`, `delete_`) invalidate both cache groups.
- **`update_blog_option()`** — compares serialized old/new values and returns `false` when unchanged, matching `update_option()` behavior.
- **`get_blog_post()`** — returns `null` on failure (matches documented `WP_Post|null` return type).

### Out of scope

- `get_blog_details()` (deprecated function at line 249 still uses `switch_to_blog`)
- `wp_initialize_site()` / `wp_uninitialize_site()` — deeper coupling to switched context
- Third-party plugin code



Trac ticket: https://core.trac.wordpress.org/ticket/64863

## Use of AI Tools

GitHub Copilot and Opus 4.6 have been used to review the changes.


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
