### PR TITLE
Multisite: Fix My Sites admin bar menu for large networks.

### DIFF
--- a/src/js/_enqueues/lib/admin-bar.js
+++ b/src/js/_enqueues/lib/admin-bar.js
@@ -108,6 +108,61 @@
 		if ( adminBarLogout ) {
 			adminBarLogout.addEventListener( 'click', emptySessionStorage );
 		}
+
+		/*
+		 * My Sites fly-out positioning.
+		 *
+		 * When the My Sites dropdown is scrollable (overflow-y: auto), the nested
+		 * fly-out submenus (Dashboard, New Post, etc.) are clipped by the scroll
+		 * container. The CSS switches them to position: fixed, and this JS computes
+		 * their coordinates from getBoundingClientRect() so they appear next to
+		 * the hovered site. The fly-out is clamped so it never extends below the
+		 * viewport.
+		 *
+		 * @since 7.0.0
+		 * @see https://core.trac.wordpress.org/ticket/15317
+		 */
+		var mySitesWrapper = document.querySelector( '#wp-admin-bar-my-sites > .ab-sub-wrapper' );
+
+		if ( mySitesWrapper ) {
+			mySitesWrapper.addEventListener( 'mouseover', function( e ) {
+				var li  = getClosest( e.target, '.menupop' );
+
+				if ( ! li || li.id === 'wp-admin-bar-my-sites' ) {
+					return;
+				}
+
+				var sub = li.querySelector( ':scope > .ab-sub-wrapper' );
+
+				if ( ! sub ) {
+					return;
+				}
+
+				var rect = li.getBoundingClientRect();
+				var top  = rect.top;
+				var isRTL = ( document.documentElement.dir === 'rtl' );
+
+				// Measure the fly-out to keep it inside the viewport.
+				sub.style.visibility = 'hidden';
+				sub.style.display    = 'block';
+				var subHeight = sub.offsetHeight;
+				var subWidth  = sub.offsetWidth;
+				sub.style.removeProperty( 'visibility' );
+				sub.style.removeProperty( 'display' );
+
+				if ( top + subHeight > window.innerHeight ) {
+					top = Math.max( 0, window.innerHeight - subHeight );
+				}
+
+				li.style.setProperty( '--msf-top', top + 'px' );
+
+				if ( isRTL ) {
+					li.style.setProperty( '--msf-left', Math.max( 0, rect.left - subWidth ) + 'px' );
+				} else {
+					li.style.setProperty( '--msf-left', rect.right + 'px' );
+				}
+			} );
+		}
 	} );
 
 	/**

--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -675,18 +675,30 @@ function wp_admin_bar_my_sites_menu( $wp_admin_bar ) {
 	 *
 	 * @param bool $show_site_icons Whether site icons should be shown in the toolbar. Default true.
 	 */
-	$show_site_icons = apply_filters( 'wp_admin_bar_show_site_icons', true );
+	$blogs           = (array) $wp_admin_bar->user->blogs;
+	$show_site_icons = apply_filters( 'wp_admin_bar_show_site_icons', count( $blogs ) <= 20 );
 
-	foreach ( (array) $wp_admin_bar->user->blogs as $blog ) {
-		switch_to_blog( $blog->userblog_id );
+	foreach ( $blogs as $blog ) {
+		$blog_id  = (int) $blog->userblog_id;
+		$siteurl  = untrailingslashit( $blog->siteurl );
+		$adminurl = $siteurl . '/wp-admin';
+		$homeurl  = esc_url( set_url_scheme( 'http://' . $blog->domain . $blog->path ) );
 
-		if ( true === $show_site_icons && has_site_icon() ) {
-			$blavatar = sprintf(
-				'<img class="blavatar" src="%s" srcset="%s 2x" alt="" width="16" height="16"%s />',
-				esc_url( get_site_icon_url( 16 ) ),
-				esc_url( get_site_icon_url( 32 ) ),
-				( wp_lazy_loading_enabled( 'img', 'site_icon_in_toolbar' ) ? ' loading="lazy"' : '' )
-			);
+		if ( $show_site_icons ) {
+			switch_to_blog( $blog_id );
+
+			if ( has_site_icon() ) {
+				$blavatar = sprintf(
+					'<img class="blavatar" src="%s" srcset="%s 2x" alt="" width="16" height="16"%s />',
+					esc_url( get_site_icon_url( 16 ) ),
+					esc_url( get_site_icon_url( 32 ) ),
+					( wp_lazy_loading_enabled( 'img', 'site_icon_in_toolbar' ) ? ' loading="lazy"' : '' )
+				);
+			} else {
+				$blavatar = '<div class="blavatar"></div>';
+			}
+
+			restore_current_blog();
 		} else {
 			$blavatar = '<div class="blavatar"></div>';
 		}
@@ -694,72 +706,55 @@ function wp_admin_bar_my_sites_menu( $wp_admin_bar ) {
 		$blogname = $blog->blogname;
 
 		if ( ! $blogname ) {
-			$blogname = preg_replace( '#^(https?://)?(www\.)?#', '', get_home_url() );
+			$blogname = preg_replace( '#^(https?://)?(www\.)?#', '', $siteurl );
 		}
 
-		$menu_id = 'blog-' . $blog->userblog_id;
+		$menu_id = 'blog-' . $blog_id;
 
-		if ( current_user_can( 'read' ) ) {
-			$wp_admin_bar->add_node(
-				array(
-					'parent' => 'my-sites-list',
-					'id'     => $menu_id,
-					'title'  => $blavatar . $blogname,
-					'href'   => admin_url(),
-				)
-			);
+		$wp_admin_bar->add_node(
+			array(
+				'parent' => 'my-sites-list',
+				'id'     => $menu_id,
+				'title'  => $blavatar . esc_html( $blogname ),
+				'href'   => $adminurl,
+			)
+		);
 
-			$wp_admin_bar->add_node(
-				array(
-					'parent' => $menu_id,
-					'id'     => $menu_id . '-d',
-					'title'  => __( 'Dashboard' ),
-					'href'   => admin_url(),
-				)
-			);
-		} else {
-			$wp_admin_bar->add_node(
-				array(
-					'parent' => 'my-sites-list',
-					'id'     => $menu_id,
-					'title'  => $blavatar . $blogname,
-					'href'   => home_url(),
-				)
-			);
-		}
+		$wp_admin_bar->add_node(
+			array(
+				'parent' => $menu_id,
+				'id'     => $menu_id . '-d',
+				'title'  => __( 'Dashboard' ),
+				'href'   => $adminurl,
+			)
+		);
 
-		if ( current_user_can( get_post_type_object( 'post' )->cap->create_posts ) ) {
-			$wp_admin_bar->add_node(
-				array(
-					'parent' => $menu_id,
-					'id'     => $menu_id . '-n',
-					'title'  => get_post_type_object( 'post' )->labels->new_item,
-					'href'   => admin_url( 'post-new.php' ),
-				)
-			);
-		}
+		$wp_admin_bar->add_node(
+			array(
+				'parent' => $menu_id,
+				'id'     => $menu_id . '-n',
+				'title'  => __( 'New Post' ),
+				'href'   => $adminurl . '/post-new.php',
+			)
+		);
 
-		if ( current_user_can( 'edit_posts' ) ) {
-			$wp_admin_bar->add_node(
-				array(
-					'parent' => $menu_id,
-					'id'     => $menu_id . '-c',
-					'title'  => __( 'Manage Comments' ),
-					'href'   => admin_url( 'edit-comments.php' ),
-				)
-			);
-		}
+		$wp_admin_bar->add_node(
+			array(
+				'parent' => $menu_id,
+				'id'     => $menu_id . '-c',
+				'title'  => __( 'Manage Comments' ),
+				'href'   => $adminurl . '/edit-comments.php',
+			)
+		);
 
 		$wp_admin_bar->add_node(
 			array(
 				'parent' => $menu_id,
 				'id'     => $menu_id . '-v',
 				'title'  => __( 'Visit Site' ),
-				'href'   => home_url( '/' ),
+				'href'   => $homeurl,
 			)
 		);
-
-		restore_current_blog();
 	}
 }
 

--- a/src/wp-includes/css/admin-bar.css
+++ b/src/wp-includes/css/admin-bar.css
@@ -763,6 +763,32 @@ html:lang(he-il) .rtl #wpadminbar * {
 	box-shadow: 0 0 2px 2px rgba(0, 0, 0, 0.6);
 }
 
+/*
+ * My Sites scrollable dropdown.
+ *
+ * When the site list exceeds the viewport height, allow the menu to scroll.
+ * Fly-out submenus use position: fixed to escape the scroll container's
+ * overflow clipping. Coordinates are set via CSS custom properties from JS.
+ *
+ * @since 7.0.0
+ * @see https://core.trac.wordpress.org/ticket/15317
+ */
+@media screen and (min-width: 783px) {
+	#wpadminbar .ab-top-menu > li#wp-admin-bar-my-sites > .ab-sub-wrapper {
+		max-height: calc(100vh - var(--wp-admin--admin-bar--height, 32px));
+		overflow-y: auto;
+	}
+
+	/* Fly-out submenus: fixed position to escape the scroll container. */
+	#wpadminbar #wp-admin-bar-my-sites .ab-sub-wrapper .menupop > .ab-sub-wrapper {
+		position: fixed !important;
+		margin-left: 0 !important;
+		margin-top: 0 !important;
+		top: var(--msf-top, 0);
+		left: var(--msf-left, 0);
+	}
+}
+
 @media screen and (max-width: 782px) {
 	html {
 		--wp-admin--admin-bar--height: 46px;

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -1080,6 +1080,57 @@ function get_blogs_of_user( $user_id, $all = false ) {
 		return $sites;
 	}
 
+	/*
+	 * Super admins have implicit access to all sites on the network,
+	 * but only have explicit `_capabilities` meta rows for sites they
+	 * were individually added to. Use get_sites() so they see every site.
+	 *
+	 * @since 7.0.0
+	 */
+	if ( is_super_admin( $user_id ) ) {
+		$args = array(
+			'orderby' => 'path',
+			'number'  => 0, // All sites.
+		);
+		if ( ! $all ) {
+			$args['archived'] = 0;
+			$args['spam']     = 0;
+			$args['deleted']  = 0;
+			$args['mature']   = 0;
+		}
+
+		$_sites = get_sites( $args );
+
+		$_site_ids = array_map(
+			function ( $s ) {
+				return (int) $s->id;
+			},
+			$_sites
+		);
+
+		$_site_options = _batch_get_site_options( $_site_ids, array( 'blogname', 'siteurl' ) );
+
+		$sites = array();
+		foreach ( $_sites as $site ) {
+			$id           = (int) $site->id;
+			$sites[ $id ] = (object) array(
+				'userblog_id' => $id,
+				'blogname'    => isset( $_site_options[ $id ]['blogname'] ) ? $_site_options[ $id ]['blogname'] : '',
+				'domain'      => $site->domain,
+				'path'        => $site->path,
+				'site_id'     => (int) $site->network_id,
+				'siteurl'     => isset( $_site_options[ $id ]['siteurl'] ) ? $_site_options[ $id ]['siteurl'] : '',
+				'archived'    => $site->archived,
+				'mature'      => $site->mature,
+				'spam'        => $site->spam,
+				'deleted'     => $site->deleted,
+			);
+		}
+
+		/** This filter is documented in wp-includes/user.php */
+		return apply_filters( 'get_blogs_of_user', $sites, $user_id, $all );
+	}
+
 	$site_ids = array();
 
 	if ( isset( $keys[ $wpdb->base_prefix . 'capabilities' ] ) && defined( 'MULTISITE' ) ) {
@@ -1119,14 +1170,36 @@ function get_blogs_of_user( $user_id, $all = false ) {
 
 		$_sites = get_sites( $args );
 
+		/*
+		 * Batch-fetch blogname and siteurl for all sites in a single query.
+		 *
+		 * Accessing $site->blogname or $site->siteurl on a WP_Site object
+		 * triggers WP_Site::get_details(), which calls switch_to_blog()
+		 * internally for each site. On large networks this is expensive.
+		 *
+		 * Instead, build a UNION ALL query across per-site options tables
+		 * to fetch both values for all sites at once.
+		 *
+		 * @since 7.0.0
+		 */
+		$_site_ids = array_map(
+			function ( $s ) {
+				return (int) $s->id;
+			},
+			$_sites
+		);
+
+		$_site_options = _batch_get_site_options( $_site_ids, array( 'blogname', 'siteurl' ) );
+
 		foreach ( $_sites as $site ) {
-			$sites[ $site->id ] = (object) array(
-				'userblog_id' => $site->id,
-				'blogname'    => $site->blogname,
+			$id           = (int) $site->id;
+			$sites[ $id ] = (object) array(
+				'userblog_id' => $id,
+				'blogname'    => isset( $_site_options[ $id ]['blogname'] ) ? $_site_options[ $id ]['blogname'] : '',
 				'domain'      => $site->domain,
 				'path'        => $site->path,
 				'site_id'     => $site->network_id,
-				'siteurl'     => $site->siteurl,
+				'siteurl'     => isset( $_site_options[ $id ]['siteurl'] ) ? $_site_options[ $id ]['siteurl'] : '',
 				'archived'    => $site->archived,
 				'mature'      => $site->mature,
 				'spam'        => $site->spam,
@@ -1146,6 +1219,57 @@ function get_blogs_of_user( $user_id, $all = false ) {
 	 *                          those flagged for deletion, archived, or marked as spam.
 	 */
 	return apply_filters( 'get_blogs_of_user', $sites, $user_id, $all );
+}
+
+/**
+ * Batch-fetch option values for multiple sites in a single SQL query.
+ *
+ * Uses $wpdb->get_blog_prefix() (a pure function with no side effects) to
+ * build a UNION ALL query across per-site options tables. This avoids the
+ * hidden switch_to_blog() calls triggered by WP_Site::get_details() when
+ * accessing magic properties like blogname or siteurl.
+ *
+ * @since 7.0.0
+ * @access private
+ *
+ * @global wpdb $wpdb WordPress database abstraction object.
+ *
+ * @param int[]    $site_ids     Array of site IDs.
+ * @param string[] $option_names Array of option names to fetch.
+ * @return array<int, array<string, string>> Keyed by site ID, then option name.
+ */
+function _batch_get_site_options( array $site_ids, array $option_names ) {
+	if ( empty( $site_ids ) || empty( $option_names ) ) {
+		return array();
+	}
+
+	global $wpdb;
+
+	$name_placeholders = implode( ',', array_fill( 0, count( $option_names ), '%s' ) );
+
+	$union_parts = array();
+	foreach ( $site_ids as $site_id ) {
+		$site_id = (int) $site_id;
+		$prefix  = $wpdb->get_blog_prefix( $site_id );
+		$table   = $prefix . 'options';
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name from $wpdb->get_blog_prefix().
+		$union_parts[] = $wpdb->prepare(
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $table and $name_placeholders are safe.
+			"SELECT %d AS blog_id, option_name, option_value FROM {$table} WHERE option_name IN ({$name_placeholders})",
+			array_merge( array( $site_id ), $option_names )
+		);
+	}
+
+	// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- each part is prepared above.
+	$rows = $wpdb->get_results( implode( ' UNION ALL ', $union_parts ) );
+
+	$options = array();
+	foreach ( $rows as $row ) {
+		$options[ (int) $row->blog_id ][ $row->option_name ] = $row->option_value;
+	}
+
+	return $options;
 }
 
 /**


### PR DESCRIPTION


# Multisite: Fix My Sites admin bar menu for large networks

**Trac ticket:** [#15317](https://core.trac.wordpress.org/ticket/15317) (open since 2010)
**Based on:** Learnings from the [my-sites-fix](https://github.com/soderlind/my-sites-fix) proof-of-concept plugin and the [Super Admin All Sites Menu](https://github.com/soderlind/super-admin-all-sites-menu) plugin.

---

## The problem

The "My Sites" dropdown in the WordPress admin bar has three long-standing issues on multisite networks:

1. **Super admins only see sites they are explicitly added to.** `get_blogs_of_user()` discovers sites by scanning user meta keys ending in `_capabilities`. A super admin has implicit access to *all* sites but only has explicit capability rows for sites they were individually added to — so the menu is missing most sites.

2. **The dropdown can't scroll past the viewport.** When the site list is longer than the browser window, items below the fold are simply unreachable. There is no `max-height` or `overflow` on the submenu wrapper. This is the original bug reported in #15317.

3. **`switch_to_blog()` is called for every site.** Both `wp_admin_bar_my_sites_menu()` and `get_blogs_of_user()` call `switch_to_blog()` per site — the former explicitly in a loop, the latter implicitly via `WP_Site::get_details()` when accessing `$site->blogname` and `$site->siteurl`. On a network with hundreds of sites this is a significant performance hit.

## What this patch changes

### Files changed

| File | Summary |
|---|---|
| user.php | Super admin branch in `get_blogs_of_user()`; batch option fetch; new `_batch_get_site_options()` helper |
| admin-bar.php | Rewrite per-site loop in `wp_admin_bar_my_sites_menu()` |
| admin-bar.css | Scrollable dropdown + fixed-position fly-outs |
| admin-bar.js | Fly-out positioning with viewport clamping |

### Fix 1 — Show all network sites for super admins

In `get_blogs_of_user()`, when `is_super_admin( $user_id )` is true, the function now calls `get_sites()` (ordered by path, excluding archived/spam/deleted/mature) instead of scanning `_capabilities` meta keys. This ensures the admin bar and the My Sites admin page show every site on the network.

### Fix 2 — Make the dropdown scrollable

A new `@media screen and (min-width: 783px)` block in admin-bar.css adds:

```css
#wpadminbar .ab-top-menu > li#wp-admin-bar-my-sites > .ab-sub-wrapper {
    max-height: calc(100vh - var(--wp-admin--admin-bar--height, 32px));
    overflow-y: auto;
}
```

This makes the My Sites submenu scrollable when it exceeds the viewport height. The mobile menu (below 783px) is unaffected.

**Caveat:** `overflow-y: auto` clips the nested fly-out submenus (Dashboard, New Post, etc.) that normally position themselves with `margin-left: 100%`. The fix switches those fly-outs to `position: fixed` and computes their coordinates in JavaScript using `getBoundingClientRect()`. The JS also clamps the fly-out's top position so it never extends below the viewport, and supports RTL layouts by positioning to the left of the parent item when `document.documentElement.dir === 'rtl'`.

### Fix 3 — Eliminate `switch_to_blog()` overhead

**In the admin bar menu loop:** `wp_admin_bar_my_sites_menu()` no longer calls `switch_to_blog()` per site. URLs are computed directly from the blog object properties (`$blog->siteurl`, `$blog->domain`, `$blog->path`). Per-site `current_user_can()` checks are removed — these were guarding convenience links (Dashboard, New Post, Manage Comments) whose target pages enforce their own permissions.

`switch_to_blog()` is still called when site icons are enabled, since `has_site_icon()` and `get_site_icon_url()` require switched context. To mitigate the cost, the `wp_admin_bar_show_site_icons` filter now defaults to `false` for networks with more than 20 sites (previously it defaulted to `true` unconditionally). The filter remains available for plugins to override.

**In `get_blogs_of_user()`:** The magic property accesses `$site->blogname` and `$site->siteurl` on `WP_Site` objects triggered `WP_Site::get_details()`, which internally calls `switch_to_blog()` for each site. This is replaced by a new private helper function `_batch_get_site_options()` that builds a single `UNION ALL` query across per-site `wp_N_options` tables to fetch `blogname` and `siteurl` for all sites at once. Table names are derived from `$wpdb->get_blog_prefix()` (a pure function with no side effects), and option names are passed through `$wpdb->prepare()`.

## Backward compatibility notes

- The `pre_get_blogs_of_user` filter (since 4.6.0) continues to work and can override the super admin behavior.
- The `get_blogs_of_user` filter continues to fire on the result.
- The `wp_admin_bar_show_site_icons` filter (since 6.0.0) still controls site icon visibility; the only change is the default value now considers site count.
- The `myblogs_blog_actions` filter in my-sites.php is **not** affected — that page's render loop still uses `switch_to_blog()` to preserve backward compatibility for plugins relying on switched context.
- The `_batch_get_site_options()` function is marked `@access private` and is not intended for external use.

## Testing

1. **Multisite with < 15 sites:** Dropdown should not scroll unless needed; fly-outs appear correctly.
2. **Multisite with > 25 sites:** All sites reachable via scroll; fly-outs clamp within viewport.
3. **Super admin vs regular user:** Super admin sees all network sites; regular user sees only their sites.
4. **Performance:** Verify no `switch_to_blog()` calls during menu render (except when site icons are enabled for ≤ 20 sites). Check via Query Monitor or `$GLOBALS['_wp_switched_stack']`.
5. **RTL:** Fly-out submenus should appear to the left of the parent item.
6. **Mobile:** Menu unchanged below 783px viewport width.
7. **No-JS fallback:** Scroll works (CSS-only); fly-out positioning falls back to `top: 0; left: 0`.

Trac ticket: https://core.trac.wordpress.org/ticket/15317

## Use of AI Tools

GitHub Copilot + Opus 4.6 was used to review this fix

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
