### PR TITLE
Media: Update post mime type when image format is converted during upload

### DIFF
--- a/src/wp-admin/includes/image.php
+++ b/src/wp-admin/includes/image.php
@@ -209,6 +209,20 @@ function _wp_image_meta_replace_original( $saved_data, $original_file, $image_me
 	// Update the attached file meta.
 	update_attached_file( $attachment_id, $new_file );
 
+	// Update the post mime type if the image was converted to a different format.
+	if ( ! empty( $saved_data['mime-type'] ) ) {
+		$post = get_post( $attachment_id );
+
+		if ( $post && $post->post_mime_type !== $saved_data['mime-type'] ) {
+			wp_update_post(
+				array(
+					'ID'             => $attachment_id,
+					'post_mime_type' => $saved_data['mime-type'],
+				)
+			);
+		}
+	}
+
 	// Width and height of the new image.
 	$image_meta['width']  = $saved_data['width'];
 	$image_meta['height'] = $saved_data['height'];

--- a/src/wp-includes/rest-api/class-wp-rest-server.php
+++ b/src/wp-includes/rest-api/class-wp-rest-server.php
@@ -1383,8 +1383,10 @@ class WP_REST_Server {
 			$input_formats  = array( 'image/jpeg', 'image/png', 'image/gif', 'image/webp', 'image/avif', 'image/heic' );
 			$output_formats = array();
 			foreach ( $input_formats as $mime_type ) {
-				/** This filter is documented in wp-includes/media.php */
-				$output_formats = apply_filters( 'image_editor_output_format', $output_formats, '', $mime_type );
+				$output_format = wp_get_image_editor_output_format( '', $mime_type );
+				if ( ! empty( $output_format[ $mime_type ] ) && $output_format[ $mime_type ] !== $mime_type ) {
+					$output_formats[ $mime_type ] = $output_format[ $mime_type ];
+				}
 			}
 			$available['image_output_formats'] = (object) $output_formats;
 


### PR DESCRIPTION
## Summary

- Updates `_wp_image_meta_replace_original()` to also update the attachment's `post_mime_type` when the image is converted to a different format (e.g., HEIC to JPEG). Previously, the actual files on disk were correctly converted but the post's mime type remained unchanged.
- Fixes the REST API index to use `wp_get_image_editor_output_format()` when building `image_output_formats`, so the default HEIC-to-JPEG mapping is properly exposed to client-side media processing.

## Trac ticket

https://core.trac.wordpress.org/ticket/XXXXX (to be created)

## Test plan

- [ ] Upload a HEIC file via the media library (not using client-side media processing in the block editor) on a server with HEIC support (e.g., Imagick with HEIC support)
- [ ] Verify the attachment's mime type is `image/jpeg` after upload, not `image/heic`
- [ ] Verify the generated sub-sizes are JPEG files
- [ ] Verify the REST API index (`/wp-json/`) includes `image/heic: image/jpeg` in `image_output_formats` when client-side media processing is enabled
- [ ] Upload a regular JPEG/PNG to confirm no regressions in the normal upload flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)