### PR TITLE
[Admin reskin] Inconsistent hover vs focus styles on submenu items

### DIFF
--- a/src/wp-admin/css/admin-menu.css
+++ b/src/wp-admin/css/admin-menu.css
@@ -112,6 +112,7 @@
 .folded #adminmenu .wp-submenu-head:hover {
 	box-shadow: inset 4px 0 0 0 currentColor;
 	transition: box-shadow .1s linear;
+	border-radius: 0;
 }
 
 #adminmenu li.menu-top {


### PR DESCRIPTION
Core trac: https://core.trac.wordpress.org/ticket/64860

### Test
Before :
<img width="1129" height="540" alt="Screenshot 2026-03-16 at 10 23 43 AM" src="https://github.com/user-attachments/assets/ef218578-5358-4a27-98be-de8b28071280" />

After :
<img width="1081" height="554" alt="Screenshot 2026-03-16 at 10 27 03 AM" src="https://github.com/user-attachments/assets/b2fd16cb-4817-491a-98ec-c0e0c848ae10" />
