### PR TITLE
Admin bar: Command palette button retains focus styles after closing

### DIFF
--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -966,7 +966,7 @@ function wp_admin_bar_command_palette_menu( WP_Admin_Bar $wp_admin_bar ): void {
 			'href'  => '#',
 			'meta'  => array(
 				'class'   => 'hide-if-no-js',
-				'onclick' => 'wp.data.dispatch( "core/commands" ).open(); return false;',
+				'onclick' => 'wp.data.dispatch( "core/commands" ).open(); event.currentTarget.blur(); return false; ',
 			),
 		)
 	);


### PR DESCRIPTION
Core trac : https://core.trac.wordpress.org/ticket/64859
-----
## Test
https://github.com/user-attachments/assets/975ff778-8db1-4899-9cfe-da26657b6129

