### PR TITLE
Themes: Prevent null deprecation in previous_posts().

### DIFF
--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -2649,7 +2649,8 @@ function get_previous_posts_page_link() {
  * @return string|null The previous posts page link if `$display = false`.
  */
 function previous_posts( $display = true ) {
-	$output = esc_url( get_previous_posts_page_link() );
+	$link   = get_previous_posts_page_link();
+	$output = $link ? esc_url( $link ) : '';
 
 	if ( $display ) {
 		echo $output;

--- a/tests/phpunit/tests/link/previousPosts.php
+++ b/tests/phpunit/tests/link/previousPosts.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * Tests the `previous_posts()` function.
+ *
+ * @since 7.0.0
+ *
+ * @group link
+ *
+ * @covers ::previous_posts
+ */
+class Tests_Link_PreviousPosts extends WP_UnitTestCase {
+
+	/**
+	 * The absence of a deprecation notice on PHP 8.1+ also shows that the issue is resolved.
+	 *
+	 * @ticket 64864
+	 */
+	public function test_should_return_empty_string_on_singular() {
+		$post_id = self::factory()->post->create();
+		$this->go_to( get_permalink( $post_id ) );
+
+		$this->assertSame( '', previous_posts( false ) );
+	}
+}


### PR DESCRIPTION
This adds a null guard to `previous_posts()`, matching the existing pattern used in `next_posts()`

Without this check, calling `previous_posts()` on a singular view can pass `null` to `esc_url()`, which in turn triggers an `ltrim()` deprecation notice on PHP 8.1 and newer

Props `@dd32`
Fixes #64864

Trac ticket: https://core.trac.wordpress.org/ticket/64864