### PR TITLE
Backport real-time collaboration peer limits from Gutenberg #75381

### DIFF
--- a/src/wp-includes/collaboration/class-wp-http-polling-sync-server.php
+++ b/src/wp-includes/collaboration/class-wp-http-polling-sync-server.php
@@ -38,6 +38,23 @@ class WP_HTTP_Polling_Sync_Server {
 	const COMPACTION_THRESHOLD = 50;
 
 	/**
+	 * Default maximum number of peers allowed in a single room.
+	 *
+	 * @since 7.0.0
+	 * @var int
+	 */
+	const DEFAULT_MAX_PEERS_PER_ROOM = 2;
+
+	/**
+	 * Default maximum number of simultaneous clients (tabs) a single
+	 * user may have in one room.
+	 *
+	 * @since 7.0.0
+	 * @var int
+	 */
+	const DEFAULT_MAX_CLIENTS_PER_USER = 2;
+
+	/**
 	 * Sync update type: compaction.
 	 *
 	 * @since 7.0.0
@@ -185,8 +202,9 @@ class WP_HTTP_Polling_Sync_Server {
 		$wp_user_id = get_current_user_id();
 
 		foreach ( $rooms as $room ) {
-			$client_id = $room['client_id'];
-			$room      = $room['room'];
+			$client_id      = $room['client_id'];
+			$room_awareness = $room['awareness'];
+			$room           = $room['room'];
 
 			// Check that the client_id is not already owned by another user.
 			$existing_awareness = $this->storage->get_awareness_state( $room );
@@ -217,6 +235,54 @@ class WP_HTTP_Polling_Sync_Server {
 					),
 					array( 'status' => rest_authorization_required_code() )
 				);
+			}
+
+			// Enforce peer limit for single-entity rooms when the client
+			// is actively connecting (not sending a disconnect signal).
+			if ( null !== $object_id && null !== $room_awareness ) {
+				$is_client_tracked      = false;
+				$same_user_client_count = 0;
+				$other_user_ids         = array();
+				$current_time           = time();
+
+				foreach ( $existing_awareness as $entry ) {
+					if ( $current_time - $entry['updated_at'] >= self::AWARENESS_TIMEOUT ) {
+						continue;
+					}
+
+					if ( ! isset( $entry['wp_user_id'] ) ) {
+						continue;
+					}
+
+					if ( $wp_user_id === $entry['wp_user_id'] ) {
+						if ( $client_id === $entry['client_id'] ) {
+							$is_client_tracked = true;
+						} else {
+							++$same_user_client_count;
+						}
+					} else {
+						$other_user_ids[ $entry['wp_user_id'] ] = true;
+					}
+				}
+
+				// Limit the number of tabs a single user can open for this post.
+				if ( ! $is_client_tracked && $same_user_client_count >= $this->get_max_clients_per_user() ) {
+					return new WP_Error(
+						'rest_too_many_requests',
+						__( 'You have reached the maximum number of tabs for this post.' ),
+						array( 'status' => 429 )
+					);
+				}
+
+				// Limit the total number of unique users in the room.
+				$is_user_tracked = $is_client_tracked || $same_user_client_count > 0;
+				if ( ! $is_user_tracked && count( $other_user_ids ) >= $this->get_max_peers_per_room() ) {
+					return new WP_Error(
+						'rest_too_many_requests',
+						__( 'This post has reached its maximum number of simultaneous editors.' ),
+						array( 'status' => 429 )
+					);
+				}
 			}
 		}
 
@@ -375,6 +441,45 @@ class WP_HTTP_Polling_Sync_Server {
 		}
 
 		return $response;
+	}
+
+	/**
+	 * Returns the maximum number of peers allowed per room.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @return int Maximum peers per room.
+	 */
+	private function get_max_peers_per_room(): int {
+		/**
+		 * Filters the maximum number of concurrent peers allowed in a
+		 * single real-time collaboration room.
+		 *
+		 * @since 7.0.0
+		 *
+		 * @param int $max_peers Default maximum peers per room.
+		 */
+		return (int) apply_filters( 'real_time_collaboration_max_peers_per_room', self::DEFAULT_MAX_PEERS_PER_ROOM );
+	}
+
+	/**
+	 * Returns the maximum number of simultaneous clients (tabs) a single
+	 * user may have in one room.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @return int Maximum clients per user per room.
+	 */
+	private function get_max_clients_per_user(): int {
+		/**
+		 * Filters the maximum number of simultaneous clients (tabs) a
+		 * single user may have in a real-time collaboration room.
+		 *
+		 * @since 7.0.0
+		 *
+		 * @param int $max_clients Default maximum clients per user per room.
+		 */
+		return (int) apply_filters( 'real_time_collaboration_max_clients_per_user', self::DEFAULT_MAX_CLIENTS_PER_USER );
 	}
 
 	/**

--- a/tests/phpunit/tests/rest-api/rest-sync-server.php
+++ b/tests/phpunit/tests/rest-api/rest-sync-server.php
@@ -50,7 +50,7 @@ class WP_Test_REST_Sync_Server extends WP_Test_REST_Controller_Testcase {
 	 * @return array Room request data.
 	 */
 	private function build_room( $room, $client_id = 1, $cursor = 0, $awareness = array(), $updates = array() ) {
-		if ( empty( $awareness ) ) {
+		if ( array() === $awareness ) {
 			$awareness = array( 'user' => 'test' );
 		}
 

--- a/tests/phpunit/tests/rest-api/rest-sync-server.php
+++ b/tests/phpunit/tests/rest-api/rest-sync-server.php
@@ -829,6 +829,273 @@ class WP_Test_REST_Sync_Server extends WP_Test_REST_Controller_Testcase {
 		$this->assertSame( $room2, $data['rooms'][1]['room'] );
 	}
 
+	/*
+	 * Peer limit tests.
+	 */
+
+	public function test_sync_peer_limit_rejects_new_user_when_room_full() {
+		$room = $this->get_post_room();
+
+		// User 1 (editor) connects with client 1.
+		wp_set_current_user( self::$editor_id );
+		$this->dispatch_sync(
+			array(
+				$this->build_room( $room, 1, 0, array( 'name' => 'Editor 1' ) ),
+			)
+		);
+
+		// User 2 connects with client 2.
+		$editor_id_2 = self::factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $editor_id_2 );
+		$this->dispatch_sync(
+			array(
+				$this->build_room( $room, 2, 0, array( 'name' => 'Editor 2' ) ),
+			)
+		);
+
+		// User 3 tries to connect — should be rejected (default limit is 2).
+		$editor_id_3 = self::factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $editor_id_3 );
+		$response = $this->dispatch_sync(
+			array(
+				$this->build_room( $room, 3, 0, array( 'name' => 'Editor 3' ) ),
+			)
+		);
+
+		$this->assertErrorResponse( 'rest_too_many_requests', $response, 429 );
+	}
+
+	public function test_sync_peer_limit_allows_existing_tracked_client() {
+		$room = $this->get_post_room();
+
+		// User 1 connects with client 1.
+		wp_set_current_user( self::$editor_id );
+		$this->dispatch_sync(
+			array(
+				$this->build_room( $room, 1, 0, array( 'name' => 'Editor 1' ) ),
+			)
+		);
+
+		// User 2 connects with client 2.
+		$editor_id_2 = self::factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $editor_id_2 );
+		$this->dispatch_sync(
+			array(
+				$this->build_room( $room, 2, 0, array( 'name' => 'Editor 2' ) ),
+			)
+		);
+
+		// User 1 polls again — should succeed since they're already tracked.
+		wp_set_current_user( self::$editor_id );
+		$response = $this->dispatch_sync(
+			array(
+				$this->build_room( $room, 1, 0, array( 'name' => 'Editor 1' ) ),
+			)
+		);
+
+		$this->assertSame( 200, $response->get_status() );
+	}
+
+	public function test_sync_peer_limit_allows_same_user_multiple_tabs() {
+		$room = $this->get_post_room();
+
+		// User 1 connects with client 1.
+		wp_set_current_user( self::$editor_id );
+		$this->dispatch_sync(
+			array(
+				$this->build_room( $room, 1, 0, array( 'name' => 'Editor tab 1' ) ),
+			)
+		);
+
+		// User 2 connects with client 2.
+		$editor_id_2 = self::factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $editor_id_2 );
+		$this->dispatch_sync(
+			array(
+				$this->build_room( $room, 2, 0, array( 'name' => 'Editor 2' ) ),
+			)
+		);
+
+		// User 1 opens second tab (client 3) — should succeed because same user
+		// doesn't count as additional peer.
+		wp_set_current_user( self::$editor_id );
+		$response = $this->dispatch_sync(
+			array(
+				$this->build_room( $room, 3, 0, array( 'name' => 'Editor tab 2' ) ),
+			)
+		);
+
+		$this->assertSame( 200, $response->get_status() );
+	}
+
+	public function test_sync_per_user_client_limit_rejects_excess_tabs() {
+		$room = $this->get_post_room();
+
+		wp_set_current_user( self::$editor_id );
+
+		// Open client 1.
+		$this->dispatch_sync(
+			array(
+				$this->build_room( $room, 1, 0, array( 'name' => 'Tab 1' ) ),
+			)
+		);
+
+		// Open client 2.
+		$this->dispatch_sync(
+			array(
+				$this->build_room( $room, 2, 0, array( 'name' => 'Tab 2' ) ),
+			)
+		);
+
+		// Open client 3 — should be rejected (default per-user limit is 2).
+		$response = $this->dispatch_sync(
+			array(
+				$this->build_room( $room, 3, 0, array( 'name' => 'Tab 3' ) ),
+			)
+		);
+
+		$this->assertErrorResponse( 'rest_too_many_requests', $response, 429 );
+	}
+
+	public function test_sync_peer_limit_filter_is_respected() {
+		$room = $this->get_post_room();
+
+		// Increase peer limit to 3.
+		add_filter(
+			'real_time_collaboration_max_peers_per_room',
+			function () {
+				return 3;
+			}
+		);
+
+		// Connect 3 different users.
+		wp_set_current_user( self::$editor_id );
+		$this->dispatch_sync(
+			array(
+				$this->build_room( $room, 1, 0, array( 'name' => 'Editor 1' ) ),
+			)
+		);
+
+		$editor_id_2 = self::factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $editor_id_2 );
+		$this->dispatch_sync(
+			array(
+				$this->build_room( $room, 2, 0, array( 'name' => 'Editor 2' ) ),
+			)
+		);
+
+		$editor_id_3 = self::factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $editor_id_3 );
+		$response = $this->dispatch_sync(
+			array(
+				$this->build_room( $room, 3, 0, array( 'name' => 'Editor 3' ) ),
+			)
+		);
+
+		// Third user should be allowed since limit is now 3.
+		$this->assertSame( 200, $response->get_status() );
+	}
+
+	public function test_sync_client_limit_filter_is_respected() {
+		$room = $this->get_post_room();
+
+		// Increase per-user client limit to 3.
+		add_filter(
+			'real_time_collaboration_max_clients_per_user',
+			function () {
+				return 3;
+			}
+		);
+
+		wp_set_current_user( self::$editor_id );
+
+		// Open 3 tabs.
+		$this->dispatch_sync(
+			array(
+				$this->build_room( $room, 1, 0, array( 'name' => 'Tab 1' ) ),
+			)
+		);
+		$this->dispatch_sync(
+			array(
+				$this->build_room( $room, 2, 0, array( 'name' => 'Tab 2' ) ),
+			)
+		);
+		$response = $this->dispatch_sync(
+			array(
+				$this->build_room( $room, 3, 0, array( 'name' => 'Tab 3' ) ),
+			)
+		);
+
+		// Third tab should be allowed since limit is now 3.
+		$this->assertSame( 200, $response->get_status() );
+	}
+
+	public function test_sync_peer_limit_not_enforced_for_disconnect() {
+		$room = $this->get_post_room();
+
+		// Fill the room with 2 users.
+		wp_set_current_user( self::$editor_id );
+		$this->dispatch_sync(
+			array(
+				$this->build_room( $room, 1, 0, array( 'name' => 'Editor 1' ) ),
+			)
+		);
+
+		$editor_id_2 = self::factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $editor_id_2 );
+		$this->dispatch_sync(
+			array(
+				$this->build_room( $room, 2, 0, array( 'name' => 'Editor 2' ) ),
+			)
+		);
+
+		// User 3 sends null awareness (disconnect signal) — should not be rejected.
+		$editor_id_3 = self::factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $editor_id_3 );
+		$response = $this->dispatch_sync(
+			array(
+				$this->build_room( $room, 3, 0, null ),
+			)
+		);
+
+		$this->assertSame( 200, $response->get_status() );
+	}
+
+	public function test_sync_peer_limit_not_enforced_for_collection_rooms() {
+		// Collection rooms (no object ID) should not have peer limits.
+		$room = 'postType/post';
+
+		// Connect 3 different users to a collection room.
+		wp_set_current_user( self::$editor_id );
+		$this->dispatch_sync(
+			array(
+				$this->build_room( $room, 1, 0, array( 'name' => 'Editor 1' ) ),
+			)
+		);
+
+		$editor_id_2 = self::factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $editor_id_2 );
+		$this->dispatch_sync(
+			array(
+				$this->build_room( $room, 2, 0, array( 'name' => 'Editor 2' ) ),
+			)
+		);
+
+		$editor_id_3 = self::factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $editor_id_3 );
+		$response = $this->dispatch_sync(
+			array(
+				$this->build_room( $room, 3, 0, array( 'name' => 'Editor 3' ) ),
+			)
+		);
+
+		$this->assertSame( 200, $response->get_status() );
+	}
+
+	/*
+	 * Multiple rooms tests.
+	 */
+
 	public function test_sync_rooms_are_isolated() {
 		wp_set_current_user( self::$editor_id );
 

--- a/tests/phpunit/tests/rest-api/rest-sync-server.php
+++ b/tests/phpunit/tests/rest-api/rest-sync-server.php
@@ -530,6 +530,14 @@ class WP_Test_REST_Sync_Server extends WP_Test_REST_Controller_Testcase {
 	public function test_sync_total_updates_increments() {
 		wp_set_current_user( self::$editor_id );
 
+		// Raise per-user client limit so 4 clients from one user are allowed.
+		add_filter(
+			'real_time_collaboration_max_clients_per_user',
+			function () {
+				return 10;
+			}
+		);
+
 		$room   = $this->get_post_room();
 		$update = array(
 			'type' => 'update',
@@ -650,6 +658,14 @@ class WP_Test_REST_Sync_Server extends WP_Test_REST_Controller_Testcase {
 
 	public function test_sync_stale_compaction_succeeds_when_newer_compaction_exists() {
 		wp_set_current_user( self::$editor_id );
+
+		// Raise per-user client limit so 4 clients from one user are allowed.
+		add_filter(
+			'real_time_collaboration_max_clients_per_user',
+			function () {
+				return 10;
+			}
+		);
 
 		$room   = $this->get_post_room();
 		$update = array(


### PR DESCRIPTION
## Description

Backport of Gutenberg PR #75381: Add per-room and per-user limits to enforce concurrent peer capacity during real-time collaboration. When a room reaches capacity (default: 2 peers), new users receive HTTP 429. Users can open multiple tabs up to a per-user limit (default: 2).

Two new filters allow customization:
- `real_time_collaboration_max_peers_per_room` 
- `real_time_collaboration_max_clients_per_user`

Includes comprehensive test coverage for capacity enforcement, filter overrides, and edge cases.

**Note:** Client-side polling manager changes ship via Gutenberg `@wordpress/sync` package updates. This backport covers PHP server-side only.

Fixes #11120

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/
-->