### PR TITLE
Query: Prevent fatal TypeError when taxonomy query var is an array

### DIFF
--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -1189,7 +1189,7 @@ class WP_Query {
 					'field'    => 'slug',
 				);
 
-				if ( ! empty( $t->rewrite['hierarchical'] ) ) {
+				if ( is_string( $query_vars[ $t->query_var ] ) && ! empty( $t->rewrite['hierarchical'] ) ) {
 					$query_vars[ $t->query_var ] = wp_basename( $query_vars[ $t->query_var ] );
 				}
 

--- a/tests/phpunit/tests/query/parseQuery.php
+++ b/tests/phpunit/tests/query/parseQuery.php
@@ -233,4 +233,33 @@ class Tests_Query_ParseQuery extends WP_UnitTestCase {
 
 		$this->assertEmpty( $q->query_vars['attachment_id'] );
 	}
+
+	/**
+	 * Ensure an array value for a hierarchical taxonomy query var
+	 * does not cause a fatal TypeError in wp_basename().
+	 *
+	 * @ticket 64870
+	 */
+	public function test_parse_query_hierarchical_taxonomy_query_var_array() {
+		register_taxonomy(
+			'wptests_tax',
+			'post',
+			array(
+				'query_var' => 'wptests_tax',
+				'rewrite'   => array( 'hierarchical' => true ),
+				'public'    => true,
+			)
+		);
+
+		$q = new WP_Query(
+			array(
+				'wptests_tax' => array( 'term-a', 'term-b' ),
+			)
+		);
+
+		// The query should complete without a fatal TypeError.
+		$this->assertIsArray( $q->posts );
+
+		unregister_taxonomy( 'wptests_tax' );
+	}
 }


### PR DESCRIPTION
When a URL contains array-style GET parameters for a hierarchical taxonomy (e.g. `?product_cat[]=clothing` or `?category_name[]=foo`), `wp_basename()` receives an array instead of a string. This causes a fatal `TypeError` on PHP 8+ because `urlencode()` inside `wp_basename()` only accepts strings.

## Changes
- Added `is_string()` check before calling `wp_basename()` on the taxonomy query var value in `WP_Query::parse_tax_query()`.
- The existing `is_array()` check on the next line already handles array values correctly, so this change only prevents the fatal crash without altering query behavior.
- Added a unit test to verify the query completes without a `TypeError` when a hierarchical taxonomy query var is passed as an array.

Trac ticket: https://core.trac.wordpress.org/ticket/64870
Props patricedefago.
Fixes #64870.