### PR TITLE
Post: Remove unused variable `$hidden_inputs`

### DIFF
--- a/src/wp-admin/includes/post.php
+++ b/src/wp-admin/includes/post.php
@@ -2564,7 +2564,6 @@ function the_block_editor_meta_box_post_form_hidden_fields( $post ) {
 	$classic_output = ob_get_clean();
 
 	$classic_elements = wp_html_split( $classic_output );
-	$hidden_inputs    = '';
 	foreach ( $classic_elements as $element ) {
 		if ( ! str_starts_with( $element, '<input ' ) ) {
 			continue;


### PR DESCRIPTION
This pull request makes a minor change to the `the_block_editor_meta_box_post_form_hidden_fields` function in `src/wp-admin/includes/post.php`. The change removes the unused `$hidden_inputs` variable, simplifying the code and reducing clutter.

Trac ticket: https://core.trac.wordpress.org/ticket/64871

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
