### PR TITLE
Media: Make client-side supported MIME types configurable

### DIFF
--- a/src/wp-admin/edit-form-blocks.php
+++ b/src/wp-admin/edit-form-blocks.php
@@ -98,6 +98,7 @@ $preload_paths = array(
 			'jpeg_interlaced',
 			'png_interlaced',
 			'gif_interlaced',
+			'client_side_supported_mime_types',
 			'name',
 			'site_icon',
 			'site_icon_url',

--- a/src/wp-admin/site-editor.php
+++ b/src/wp-admin/site-editor.php
@@ -224,6 +224,7 @@ $preload_paths = array(
 			'jpeg_interlaced',
 			'png_interlaced',
 			'gif_interlaced',
+			'client_side_supported_mime_types',
 			'name',
 			'site_icon',
 			'site_icon_url',

--- a/src/wp-includes/rest-api/class-wp-rest-server.php
+++ b/src/wp-includes/rest-api/class-wp-rest-server.php
@@ -1394,6 +1394,21 @@ class WP_REST_Server {
 			$available['png_interlaced'] = (bool) apply_filters( 'image_save_progressive', false, 'image/png' );
 			/** This filter is documented in wp-includes/class-wp-image-editor-gd.php */
 			$available['gif_interlaced'] = (bool) apply_filters( 'image_save_progressive', false, 'image/gif' );
+
+			/**
+			 * Filters the MIME types supported by client-side media processing.
+			 *
+			 * Allows plugins to add or remove MIME types from the list of formats
+			 * that can be processed client-side using WebAssembly-based vips.
+			 *
+			 * @since 7.0.0
+			 *
+			 * @param string[] $mime_types Array of MIME type strings.
+			 */
+			$available['client_side_supported_mime_types'] = apply_filters(
+				'client_side_supported_mime_types',
+				array( 'image/jpeg', 'image/png', 'image/gif', 'image/webp', 'image/avif' )
+			);
 		}
 
 		$response = new WP_REST_Response( $available );

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -12920,6 +12920,13 @@ mockedApiResponse.Schema = {
     "jpeg_interlaced": false,
     "png_interlaced": false,
     "gif_interlaced": false,
+    "client_side_supported_mime_types": [
+        "image/jpeg",
+        "image/png",
+        "image/gif",
+        "image/webp",
+        "image/avif"
+    ],
     "site_logo": 0,
     "site_icon": 0,
     "site_icon_url": ""


### PR DESCRIPTION
## Summary

Add a `client_side_supported_mime_types` filter and REST API index field so plugins can customize which image formats are processed client-side via WebAssembly-based vips.

- Adds `client_side_supported_mime_types` filter with default list: `image/jpeg`, `image/png`, `image/gif`, `image/webp`, `image/avif`
- Exposes the filtered value in the REST API root index response (for users with `upload_files` capability)
- Updates preload paths in both post editor and site editor to include the new field

## Changes

- `src/wp-includes/rest-api/class-wp-rest-server.php` — Add filter and REST index field
- `src/wp-admin/edit-form-blocks.php` — Add field to preload paths
- `src/wp-admin/site-editor.php` — Add field to preload paths
- `tests/qunit/fixtures/wp-api-generated.js` — Update test fixture

## Related

- Gutenberg PR: https://github.com/WordPress/gutenberg/pull/76549

Trac ticket: https://core.trac.wordpress.org/ticket/64876
