### PR TITLE
Build: Exclude non-minified VIPS files from grunt module copy

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -627,7 +627,13 @@ module.exports = function(grunt) {
 				files: [ {
 					expand: true,
 					cwd: 'gutenberg/build/modules',
-					src: [ '**/*', '!**/*.map' ],
+					src: [
+						'**/*',
+						'!**/*.map',
+						// Skip non-minified VIPS files — they are ~16MB of inlined WASM
+						// with no debugging value over the minified versions.
+						'!vips/!(*.min).js',
+					],
 					dest: WORKING_DIR + 'wp-includes/js/dist/script-modules/',
 				} ],
 			},


### PR DESCRIPTION
## Summary

Adds exclusion for non-minified VIPS files in the `gutenberg-modules` grunt copy task.

### Why

The VIPS worker files are ~16 MB of inlined WASM data where minification has negligible effect — `worker.js` and `worker.min.js` are nearly identical in size. This filter was already present in `tools/gutenberg/copy.js` (lines 213-220) but was missing from the Gruntfile grunt copy task that performs the actual module copy during `grunt build:gutenberg`.

### Size impact

| | Before | After | Saved |
|--|--------|-------|-------|
| `wp-includes/js/dist/script-modules/vips/` | ~32 MB (worker.js + worker.min.js) | ~16 MB (worker.min.js only) | **~16 MB** |

### Related PRs for further size reduction (in Gutenberg)

- https://github.com/WordPress/gutenberg/pull/76615 — Skip non-minified vips worker build (**saves ~32 MB from Gutenberg build output**)
- https://github.com/WordPress/gutenberg/pull/76639 — Remove unused JXL WASM module (**saves 3.1 MB from worker.min.js**, 16.1 → 13.1 MB)

## Test plan

- [ ] Run `npx grunt build:gutenberg` — verify `build/wp-includes/js/dist/script-modules/vips/` contains `worker.min.js` but NOT `worker.js`
- [ ] Run PHP tests: `vendor/bin/phpunit tests/phpunit/tests/script-modules/wpScriptModules.php`


Trac ticket: https://core.trac.wordpress.org/ticket/64884

---

## Commit message

```
Build: Exclude non-minified VIPS files from grunt module copy.

Add an exclusion for non-minified VIPS files to match the existing filter in `tools/gutenberg/copy.js`. This prevents the ~16 MB `worker.js` from being copied alongside the identically-sized `worker.min.js`, saving ~16 MB from the build output.

Props adamsilverstein, zieladam, desrosj.
Fixes #64884.
```