### PR TITLE
Connectors: Allow hyphens in connector IDs

### DIFF
--- a/src/wp-includes/class-wp-connector-registry.php
+++ b/src/wp-includes/class-wp-connector-registry.php
@@ -67,9 +67,11 @@ final class WP_Connector_Registry {
 	 *
 	 * Validates the provided arguments and stores the connector in the registry.
 	 * For connectors with `api_key` authentication, a `setting_name` is automatically
-	 * generated using the pattern `connectors_ai_{$id}_api_key` (e.g., connector ID
-	 * `openai` produces `connectors_ai_openai_api_key`). This setting name is used
-	 * for the Settings API registration and REST API exposure.
+	 * generated using the pattern `connectors_ai_{$id}_api_key`, with hyphens in the ID
+	 * normalized to underscores (e.g., connector ID `openai` produces
+	 * `connectors_ai_openai_api_key`, and `azure-openai` produces
+	 * `connectors_ai_azure_openai_api_key`). This setting name is used for the Settings
+	 * API registration and REST API exposure.
 	 *
 	 * Registering a connector with an ID that is already registered will trigger a
 	 * `_doing_it_wrong()` notice and return `null`. To override an existing connector,
@@ -80,7 +82,7 @@ final class WP_Connector_Registry {
 	 * @see WP_Connector_Registry::unregister()
 	 *
 	 * @param string $id   The unique connector identifier. Must match the pattern
-	 *                     `/^[a-z0-9_]+$/` (lowercase alphanumeric and underscores only).
+	 *                     `/^[a-z0-9-]+$/` (lowercase alphanumeric and hyphens only).
 	 * @param array  $args {
 	 *     An associative array of arguments for the connector.
 	 *
@@ -106,11 +108,11 @@ final class WP_Connector_Registry {
 	 * @phpstan-return Connector|null
 	 */
 	public function register( string $id, array $args ): ?array {
-		if ( ! preg_match( '/^[a-z0-9_]+$/', $id ) ) {
+		if ( ! preg_match( '/^[a-z0-9-]+$/', $id ) ) {
 			_doing_it_wrong(
 				__METHOD__,
 				__(
-					'Connector ID must contain only lowercase alphanumeric characters and underscores.'
+					'Connector ID must contain only lowercase alphanumeric characters and hyphens.'
 				),
 				'7.0.0'
 			);
@@ -185,7 +187,7 @@ final class WP_Connector_Registry {
 			if ( ! empty( $args['authentication']['credentials_url'] ) && is_string( $args['authentication']['credentials_url'] ) ) {
 				$connector['authentication']['credentials_url'] = $args['authentication']['credentials_url'];
 			}
-			$connector['authentication']['setting_name'] = "connectors_ai_{$id}_api_key";
+			$connector['authentication']['setting_name'] = 'connectors_ai_' . str_replace( '-', '_', $id ) . '_api_key';
 		}
 
 		if ( ! empty( $args['plugin'] ) && is_array( $args['plugin'] ) ) {

--- a/src/wp-includes/class-wp-connector-registry.php
+++ b/src/wp-includes/class-wp-connector-registry.php
@@ -108,11 +108,11 @@ final class WP_Connector_Registry {
 	 * @phpstan-return Connector|null
 	 */
 	public function register( string $id, array $args ): ?array {
-		if ( ! preg_match( '/^[a-z0-9-]+$/', $id ) ) {
+		if ( ! preg_match( '/^[a-z0-9_-]+$/', $id ) ) {
 			_doing_it_wrong(
 				__METHOD__,
 				__(
-					'Connector ID must contain only lowercase alphanumeric characters and hyphens.'
+					'Connector ID must contain only lowercase alphanumeric characters, hyphens, and underscores.'
 				),
 				'7.0.0'
 			);

--- a/src/wp-includes/class-wp-connector-registry.php
+++ b/src/wp-includes/class-wp-connector-registry.php
@@ -82,7 +82,7 @@ final class WP_Connector_Registry {
 	 * @see WP_Connector_Registry::unregister()
 	 *
 	 * @param string $id   The unique connector identifier. Must match the pattern
-	 *                     `/^[a-z0-9-]+$/` (lowercase alphanumeric and hyphens only).
+	 *                     `/^[a-z0-9_-]+$/` (lowercase alphanumeric, hyphens, and underscores only).
 	 * @param array  $args {
 	 *     An associative array of arguments for the connector.
 	 *

--- a/tests/phpunit/includes/wp-ai-client-mock-provider-trait.php
+++ b/tests/phpunit/includes/wp-ai-client-mock-provider-trait.php
@@ -96,7 +96,7 @@ class Mock_Connectors_Test_Provider extends AbstractProvider {
 	 */
 	protected static function createProviderMetadata(): ProviderMetadata {
 		return new ProviderMetadata(
-			'mock_connectors_test',
+			'mock-connectors-test',
 			'Mock Connectors Test',
 			ProviderTypeEnum::cloud(),
 			null,
@@ -156,15 +156,15 @@ trait WP_AI_Client_Mock_Provider_Trait {
 	 */
 	private static function register_mock_connectors_provider(): void {
 		$ai_registry = AiClient::defaultRegistry();
-		if ( ! $ai_registry->hasProvider( 'mock_connectors_test' ) ) {
+		if ( ! $ai_registry->hasProvider( 'mock-connectors-test' ) ) {
 			$ai_registry->registerProvider( Mock_Connectors_Test_Provider::class );
 		}
 
 		// Also register in the WP connector registry if not already present.
 		$connector_registry = WP_Connector_Registry::get_instance();
-		if ( null !== $connector_registry && ! $connector_registry->is_registered( 'mock_connectors_test' ) ) {
+		if ( null !== $connector_registry && ! $connector_registry->is_registered( 'mock-connectors-test' ) ) {
 			$connector_registry->register(
-				'mock_connectors_test',
+				'mock-connectors-test',
 				array(
 					'name'           => 'Mock Connectors Test',
 					'description'    => '',

--- a/tests/phpunit/tests/connectors/wpConnectorRegistry.php
+++ b/tests/phpunit/tests/connectors/wpConnectorRegistry.php
@@ -84,7 +84,7 @@ class Tests_Connectors_WpConnectorRegistry extends WP_UnitTestCase {
 			'type'           => 'ai_provider',
 			'authentication' => array( 'method' => 'none' ),
 		);
-		$result = $this->registry->register( 'noauth', $args );
+		$result = $this->registry->register( 'no-auth', $args );
 
 		$this->assertIsArray( $result );
 		$this->assertArrayNotHasKey( 'setting_name', $result['authentication'] );

--- a/tests/phpunit/tests/connectors/wpConnectorRegistry.php
+++ b/tests/phpunit/tests/connectors/wpConnectorRegistry.php
@@ -184,12 +184,10 @@ class Tests_Connectors_WpConnectorRegistry extends WP_UnitTestCase {
 	/**
 	 * @ticket 64861
 	 */
-	public function test_register_rejects_invalid_id_with_underscores() {
-		$this->setExpectedIncorrectUsage( 'WP_Connector_Registry::register' );
-
+	public function test_register_accepts_id_with_underscores() {
 		$result = $this->registry->register( 'my_provider', self::$default_args );
 
-		$this->assertNull( $result );
+		$this->assertIsArray( $result );
 	}
 
 	/**

--- a/tests/phpunit/tests/connectors/wpConnectorRegistry.php
+++ b/tests/phpunit/tests/connectors/wpConnectorRegistry.php
@@ -46,7 +46,7 @@ class Tests_Connectors_WpConnectorRegistry extends WP_UnitTestCase {
 	 * @ticket 64791
 	 */
 	public function test_register_returns_connector_data() {
-		$result = $this->registry->register( 'test_provider', self::$default_args );
+		$result = $this->registry->register( 'test-provider', self::$default_args );
 
 		$this->assertIsArray( $result );
 		$this->assertSame( 'Test Provider', $result['name'] );
@@ -61,7 +61,16 @@ class Tests_Connectors_WpConnectorRegistry extends WP_UnitTestCase {
 	 * @ticket 64791
 	 */
 	public function test_register_generates_setting_name_for_api_key() {
-		$result = $this->registry->register( 'my_ai', self::$default_args );
+		$result = $this->registry->register( 'myai', self::$default_args );
+
+		$this->assertSame( 'connectors_ai_myai_api_key', $result['authentication']['setting_name'] );
+	}
+
+	/**
+	 * @ticket 64861
+	 */
+	public function test_register_generates_setting_name_normalizes_hyphens() {
+		$result = $this->registry->register( 'my-ai', self::$default_args );
 
 		$this->assertSame( 'connectors_ai_my_ai_api_key', $result['authentication']['setting_name'] );
 	}
@@ -75,7 +84,7 @@ class Tests_Connectors_WpConnectorRegistry extends WP_UnitTestCase {
 			'type'           => 'ai_provider',
 			'authentication' => array( 'method' => 'none' ),
 		);
-		$result = $this->registry->register( 'no_auth', $args );
+		$result = $this->registry->register( 'noauth', $args );
 
 		$this->assertIsArray( $result );
 		$this->assertArrayNotHasKey( 'setting_name', $result['authentication'] );
@@ -91,7 +100,7 @@ class Tests_Connectors_WpConnectorRegistry extends WP_UnitTestCase {
 			'authentication' => array( 'method' => 'none' ),
 		);
 
-		$result = $this->registry->register( 'minimal', $args );
+		$result = $this->registry->register( 'minimal-provider', $args );
 
 		$this->assertSame( '', $result['description'] );
 	}
@@ -103,7 +112,7 @@ class Tests_Connectors_WpConnectorRegistry extends WP_UnitTestCase {
 		$args             = self::$default_args;
 		$args['logo_url'] = 'https://example.com/logo.png';
 
-		$result = $this->registry->register( 'with_logo', $args );
+		$result = $this->registry->register( 'with-logo', $args );
 
 		$this->assertArrayHasKey( 'logo_url', $result );
 		$this->assertSame( 'https://example.com/logo.png', $result['logo_url'] );
@@ -113,7 +122,7 @@ class Tests_Connectors_WpConnectorRegistry extends WP_UnitTestCase {
 	 * @ticket 64791
 	 */
 	public function test_register_omits_logo_url_when_not_provided() {
-		$result = $this->registry->register( 'no_logo', self::$default_args );
+		$result = $this->registry->register( 'no-logo', self::$default_args );
 
 		$this->assertArrayNotHasKey( 'logo_url', $result );
 	}
@@ -125,7 +134,7 @@ class Tests_Connectors_WpConnectorRegistry extends WP_UnitTestCase {
 		$args             = self::$default_args;
 		$args['logo_url'] = '';
 
-		$result = $this->registry->register( 'empty_logo', $args );
+		$result = $this->registry->register( 'empty-logo', $args );
 
 		$this->assertArrayNotHasKey( 'logo_url', $result );
 	}
@@ -137,7 +146,7 @@ class Tests_Connectors_WpConnectorRegistry extends WP_UnitTestCase {
 		$args           = self::$default_args;
 		$args['plugin'] = array( 'slug' => 'my-plugin' );
 
-		$result = $this->registry->register( 'with_plugin', $args );
+		$result = $this->registry->register( 'with-plugin', $args );
 
 		$this->assertArrayHasKey( 'plugin', $result );
 		$this->assertSame( array( 'slug' => 'my-plugin' ), $result['plugin'] );
@@ -147,7 +156,7 @@ class Tests_Connectors_WpConnectorRegistry extends WP_UnitTestCase {
 	 * @ticket 64791
 	 */
 	public function test_register_omits_plugin_when_not_provided() {
-		$result = $this->registry->register( 'no_plugin', self::$default_args );
+		$result = $this->registry->register( 'no-plugin', self::$default_args );
 
 		$this->assertArrayNotHasKey( 'plugin', $result );
 	}
@@ -164,12 +173,21 @@ class Tests_Connectors_WpConnectorRegistry extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @ticket 64791
+	 * @ticket 64861
 	 */
-	public function test_register_rejects_invalid_id_with_dashes() {
+	public function test_register_accepts_id_with_hyphens() {
+		$result = $this->registry->register( 'my-provider', self::$default_args );
+
+		$this->assertIsArray( $result );
+	}
+
+	/**
+	 * @ticket 64861
+	 */
+	public function test_register_rejects_invalid_id_with_underscores() {
 		$this->setExpectedIncorrectUsage( 'WP_Connector_Registry::register' );
 
-		$result = $this->registry->register( 'my-provider', self::$default_args );
+		$result = $this->registry->register( 'my_provider', self::$default_args );
 
 		$this->assertNull( $result );
 	}
@@ -191,8 +209,8 @@ class Tests_Connectors_WpConnectorRegistry extends WP_UnitTestCase {
 	public function test_register_rejects_duplicate_id() {
 		$this->setExpectedIncorrectUsage( 'WP_Connector_Registry::register' );
 
-		$this->registry->register( 'duplicate', self::$default_args );
-		$result = $this->registry->register( 'duplicate', self::$default_args );
+		$this->registry->register( 'test-duplicate', self::$default_args );
+		$result = $this->registry->register( 'test-duplicate', self::$default_args );
 
 		$this->assertNull( $result );
 	}
@@ -206,7 +224,7 @@ class Tests_Connectors_WpConnectorRegistry extends WP_UnitTestCase {
 		$args = self::$default_args;
 		unset( $args['name'] );
 
-		$result = $this->registry->register( 'no_name', $args );
+		$result = $this->registry->register( 'no-name', $args );
 
 		$this->assertNull( $result );
 	}
@@ -220,7 +238,7 @@ class Tests_Connectors_WpConnectorRegistry extends WP_UnitTestCase {
 		$args         = self::$default_args;
 		$args['name'] = '';
 
-		$result = $this->registry->register( 'empty_name', $args );
+		$result = $this->registry->register( 'empty-name', $args );
 
 		$this->assertNull( $result );
 	}
@@ -234,7 +252,7 @@ class Tests_Connectors_WpConnectorRegistry extends WP_UnitTestCase {
 		$args = self::$default_args;
 		unset( $args['type'] );
 
-		$result = $this->registry->register( 'no_type', $args );
+		$result = $this->registry->register( 'no-type', $args );
 
 		$this->assertNull( $result );
 	}
@@ -248,7 +266,7 @@ class Tests_Connectors_WpConnectorRegistry extends WP_UnitTestCase {
 		$args = self::$default_args;
 		unset( $args['authentication'] );
 
-		$result = $this->registry->register( 'no_auth', $args );
+		$result = $this->registry->register( 'no-auth', $args );
 
 		$this->assertNull( $result );
 	}
@@ -262,7 +280,7 @@ class Tests_Connectors_WpConnectorRegistry extends WP_UnitTestCase {
 		$args                             = self::$default_args;
 		$args['authentication']['method'] = 'oauth';
 
-		$result = $this->registry->register( 'bad_auth', $args );
+		$result = $this->registry->register( 'bad-auth', $args );
 
 		$this->assertNull( $result );
 	}
@@ -287,9 +305,9 @@ class Tests_Connectors_WpConnectorRegistry extends WP_UnitTestCase {
 	 * @ticket 64791
 	 */
 	public function test_get_registered_returns_connector_data() {
-		$this->registry->register( 'my_connector', self::$default_args );
+		$this->registry->register( 'my-connector', self::$default_args );
 
-		$result = $this->registry->get_registered( 'my_connector' );
+		$result = $this->registry->get_registered( 'my-connector' );
 
 		$this->assertIsArray( $result );
 		$this->assertSame( 'Test Provider', $result['name'] );
@@ -334,13 +352,13 @@ class Tests_Connectors_WpConnectorRegistry extends WP_UnitTestCase {
 	 * @ticket 64791
 	 */
 	public function test_unregister_removes_connector() {
-		$this->registry->register( 'to_remove', self::$default_args );
+		$this->registry->register( 'to-remove', self::$default_args );
 
-		$result = $this->registry->unregister( 'to_remove' );
+		$result = $this->registry->unregister( 'to-remove' );
 
 		$this->assertIsArray( $result );
 		$this->assertSame( 'Test Provider', $result['name'] );
-		$this->assertFalse( $this->registry->is_registered( 'to_remove' ) );
+		$this->assertFalse( $this->registry->is_registered( 'to-remove' ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/connectors/wpConnectorsGetConnectorSettings.php
+++ b/tests/phpunit/tests/connectors/wpConnectorsGetConnectorSettings.php
@@ -37,7 +37,7 @@ class Tests_Connectors_WpGetConnectors extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'google', $connectors );
 		$this->assertArrayHasKey( 'openai', $connectors );
 		$this->assertArrayHasKey( 'anthropic', $connectors );
-		$this->assertArrayHasKey( 'mock_connectors_test', $connectors );
+		$this->assertArrayHasKey( 'mock-connectors-test', $connectors );
 		$this->assertCount( 4, $connectors );
 	}
 
@@ -80,7 +80,7 @@ class Tests_Connectors_WpGetConnectors extends WP_UnitTestCase {
 
 			$this->assertArrayHasKey( 'setting_name', $connector_data['authentication'], "Connector '{$connector_id}' authentication is missing 'setting_name'." );
 			$this->assertSame(
-				"connectors_ai_{$connector_id}_api_key",
+				'connectors_ai_' . str_replace( '-', '_', $connector_id ) . '_api_key',
 				$connector_data['authentication']['setting_name'] ?? null,
 				"Connector '{$connector_id}' setting_name does not match expected format."
 			);
@@ -105,7 +105,7 @@ class Tests_Connectors_WpGetConnectors extends WP_UnitTestCase {
 	 */
 	public function test_includes_registered_provider_from_registry(): void {
 		$connectors = wp_get_connectors();
-		$mock       = $connectors['mock_connectors_test'];
+		$mock       = $connectors['mock-connectors-test'];
 
 		$this->assertSame( 'Mock Connectors Test', $mock['name'] );
 		$this->assertSame( '', $mock['description'] );

--- a/tests/phpunit/tests/connectors/wpConnectorsIsApiKeyValid.php
+++ b/tests/phpunit/tests/connectors/wpConnectorsIsApiKeyValid.php
@@ -49,7 +49,7 @@ class Tests_Connectors_WpConnectorsIsApiKeyValid extends WP_UnitTestCase {
 	public function test_configured_provider_returns_true() {
 		self::set_mock_provider_configured( true );
 
-		$result = _wp_connectors_is_ai_api_key_valid( 'test-key', 'mock_connectors_test' );
+		$result = _wp_connectors_is_ai_api_key_valid( 'test-key', 'mock-connectors-test' );
 
 		$this->assertTrue( $result );
 	}
@@ -62,7 +62,7 @@ class Tests_Connectors_WpConnectorsIsApiKeyValid extends WP_UnitTestCase {
 	public function test_unconfigured_provider_returns_false() {
 		self::set_mock_provider_configured( false );
 
-		$result = _wp_connectors_is_ai_api_key_valid( 'test-key', 'mock_connectors_test' );
+		$result = _wp_connectors_is_ai_api_key_valid( 'test-key', 'mock-connectors-test' );
 
 		$this->assertFalse( $result );
 	}


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/64861

## Summary

- Expands connector ID validation from `/^[a-z0-9_]+$/` to `/^[a-z0-9_-]+$/`, adding hyphen support alongside the existing underscore support. This aligns with WordPress.org plugin slug conventions (kebab-case).
- Hyphens in connector IDs are normalized to underscores when auto-generating `setting_name` (e.g. `azure-openai` → `connectors_ai_azure_openai_api_key`), consistent with how the WP AI Client library already builds env var names.
- Updates existing tests to use hyphen-based IDs and adds three new tests covering the hyphen acceptance, underscore acceptance, and hyphen-to-underscore normalization in setting names.

## Test plan

- [ ] Run `npm run test:php -- --filter=Tests_Connectors_WpConnectorRegistry` — all 31 tests pass.
- [ ] Register a third-party AI provider with a hyphenated ID (e.g. `azure-openai`) and confirm it appears on **Settings → Connectors** without a `_doing_it_wrong` notice.
- [ ] Confirm the generated option name is `connectors_ai_azure_openai_api_key` (underscores).

🤖 Generated with [Claude Code](https://claude.com/claude-code)