### PR TITLE
Code Quality: Remove unused variable in `edit_term_link()`

### DIFF
--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -1144,7 +1144,6 @@ function edit_term_link( $link = '', $before = '', $after = '', $term = null, $d
 		return null;
 	}
 
-	$tax = get_taxonomy( $term->taxonomy );
 	if ( ! current_user_can( 'edit_term', $term->term_id ) ) {
 		return null;
 	}


### PR DESCRIPTION
This pull request makes a minor change to the `edit_term_link` function in `link-template.php`, removing an unused variable assignment. This helps clean up the code without affecting functionality.

Trac ticket: https://core.trac.wordpress.org/ticket/64881

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
