### PR TITLE
Add example disclosure statement to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,6 +23,13 @@ Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->
 
 <!--
 You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
+
+Example disclosure:
+
+AI assistance: Yes
+Tool(s): GitHub Copilot, ChatGPT
+Model(s): GPT-5.1.
+Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
 -->
 
 ---

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -28,7 +28,7 @@ Example disclosure:
 
 AI assistance: Yes
 Tool(s): GitHub Copilot, ChatGPT
-Model(s): GPT-5.1.
+Model(s): GPT-5.1
 Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
 -->
 


### PR DESCRIPTION
This adds an example disclosure statement for the `Use of AI Tools` section in the pull request template.

By including a template, contributors are encouraged to leave a detailed disclosure and reminded of what details are important.

Of note, I have chosen to add the `Model(s)` line. I am going to suggest this be added to the example in the AI handbook.

Trac ticket: Core-64587.

## Use of AI Tools

AI assistance: None

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
