### PR TITLE
Update php-ai-client to 1.3.1.

### DIFF
--- a/src/wp-includes/php-ai-client/src/AiClient.php
+++ b/src/wp-includes/php-ai-client/src/AiClient.php
@@ -84,7 +84,7 @@ class AiClient
     /**
      * @var string The version of the AI Client.
      */
-    public const VERSION = '1.3.0';
+    public const VERSION = '1.3.1';
     /**
      * @var ProviderRegistry|null The default provider registry instance.
      */

--- a/src/wp-includes/php-ai-client/src/Common/AbstractDataTransferObject.php
+++ b/src/wp-includes/php-ai-client/src/Common/AbstractDataTransferObject.php
@@ -112,11 +112,13 @@ abstract class AbstractDataTransferObject implements WithArrayTransformationInte
                     $data[$index] = $this->convertEmptyArraysToObjects($item, $schema['items']);
                 }
             }
-            // Handle oneOf schemas - just use the first one
-            if (isset($schema['oneOf']) && is_array($schema['oneOf'])) {
-                foreach ($schema['oneOf'] as $possibleSchema) {
-                    if (is_array($possibleSchema)) {
-                        return $this->convertEmptyArraysToObjects($data, $possibleSchema);
+            // Handle oneOf/anyOf schemas - just use the first one
+            foreach (['oneOf', 'anyOf'] as $keyword) {
+                if (isset($schema[$keyword]) && is_array($schema[$keyword])) {
+                    foreach ($schema[$keyword] as $possibleSchema) {
+                        if (is_array($possibleSchema)) {
+                            return $this->convertEmptyArraysToObjects($data, $possibleSchema);
+                        }
                     }
                 }
             }

--- a/src/wp-includes/php-ai-client/src/Providers/DTO/ProviderMetadata.php
+++ b/src/wp-includes/php-ai-client/src/Providers/DTO/ProviderMetadata.php
@@ -4,6 +4,7 @@ declare (strict_types=1);
 namespace WordPress\AiClient\Providers\DTO;
 
 use WordPress\AiClient\Common\AbstractDataTransferObject;
+use WordPress\AiClient\Common\Exception\InvalidArgumentException;
 use WordPress\AiClient\Providers\Enums\ProviderTypeEnum;
 use WordPress\AiClient\Providers\Http\Enums\RequestAuthenticationMethod;
 /**
@@ -79,9 +80,17 @@ class ProviderMetadata extends AbstractDataTransferObject
      * @param RequestAuthenticationMethod|null $authenticationMethod The authentication method.
      * @param string|null $description The provider's description.
      * @param string|null $logoPath The full path to the provider's logo image file.
+     * @throws InvalidArgumentException If the provider ID contains invalid characters.
      */
     public function __construct(string $id, string $name, ProviderTypeEnum $type, ?string $credentialsUrl = null, ?RequestAuthenticationMethod $authenticationMethod = null, ?string $description = null, ?string $logoPath = null)
     {
+        if (!preg_match('/^[a-z0-9\-_]+$/', $id)) {
+            throw new InvalidArgumentException(sprintf(
+                // phpcs:ignore Generic.Files.LineLength.TooLong
+                'Invalid provider ID "%s". Only lowercase alphanumeric characters, hyphens, and underscores are allowed.',
+                $id
+            ));
+        }
         $this->id = $id;
         $this->name = $name;
         $this->description = $description;

--- a/src/wp-includes/php-ai-client/src/Tools/DTO/FunctionCall.php
+++ b/src/wp-includes/php-ai-client/src/Tools/DTO/FunctionCall.php
@@ -93,7 +93,7 @@ class FunctionCall extends AbstractDataTransferObject
      */
     public static function getJsonSchema(): array
     {
-        return ['type' => 'object', 'properties' => [self::KEY_ID => ['type' => 'string', 'description' => 'Unique identifier for this function call.'], self::KEY_NAME => ['type' => 'string', 'description' => 'The name of the function to call.'], self::KEY_ARGS => ['type' => ['string', 'number', 'boolean', 'object', 'array', 'null'], 'description' => 'The arguments to pass to the function.']], 'oneOf' => [['required' => [self::KEY_ID]], ['required' => [self::KEY_NAME]]]];
+        return ['type' => 'object', 'properties' => [self::KEY_ID => ['type' => 'string', 'description' => 'Unique identifier for this function call.'], self::KEY_NAME => ['type' => 'string', 'description' => 'The name of the function to call.'], self::KEY_ARGS => ['type' => ['string', 'number', 'boolean', 'object', 'array', 'null'], 'description' => 'The arguments to pass to the function.']], 'anyOf' => [['required' => [self::KEY_ID]], ['required' => [self::KEY_NAME]]]];
     }
     /**
      * {@inheritDoc}

--- a/src/wp-includes/php-ai-client/src/Tools/DTO/FunctionResponse.php
+++ b/src/wp-includes/php-ai-client/src/Tools/DTO/FunctionResponse.php
@@ -13,7 +13,7 @@ use WordPress\AiClient\Common\Exception\InvalidArgumentException;
  *
  * @since 0.1.0
  *
- * @phpstan-type FunctionResponseArrayShape array{id: string, name: string, response: mixed}
+ * @phpstan-type FunctionResponseArrayShape array{id?: string, name?: string, response: mixed}
  *
  * @extends AbstractDataTransferObject<FunctionResponseArrayShape>
  */
@@ -23,13 +23,13 @@ class FunctionResponse extends AbstractDataTransferObject
     public const KEY_NAME = 'name';
     public const KEY_RESPONSE = 'response';
     /**
-     * @var string The ID of the function call this is responding to.
+     * @var string|null The ID of the function call this is responding to.
      */
-    private string $id;
+    private ?string $id;
     /**
-     * @var string The name of the function that was called.
+     * @var string|null The name of the function that was called.
      */
-    private string $name;
+    private ?string $name;
     /**
      * @var mixed The response data from the function.
      */
@@ -39,12 +39,16 @@ class FunctionResponse extends AbstractDataTransferObject
      *
      * @since 0.1.0
      *
-     * @param string $id The ID of the function call this is responding to.
-     * @param string $name The name of the function that was called.
+     * @param string|null $id The ID of the function call this is responding to.
+     * @param string|null $name The name of the function that was called.
      * @param mixed $response The response data from the function.
+     * @throws InvalidArgumentException If neither id nor name is provided.
      */
-    public function __construct(string $id, string $name, $response)
+    public function __construct(?string $id, ?string $name, $response)
     {
+        if ($id === null && $name === null) {
+            throw new InvalidArgumentException('At least one of id or name must be provided.');
+        }
         $this->id = $id;
         $this->name = $name;
         $this->response = $response;
@@ -89,7 +93,7 @@ class FunctionResponse extends AbstractDataTransferObject
      */
     public static function getJsonSchema(): array
     {
-        return ['type' => 'object', 'properties' => [self::KEY_ID => ['type' => 'string', 'description' => 'The ID of the function call this is responding to.'], self::KEY_NAME => ['type' => 'string', 'description' => 'The name of the function that was called.'], self::KEY_RESPONSE => ['type' => ['string', 'number', 'boolean', 'object', 'array', 'null'], 'description' => 'The response data from the function.']], 'oneOf' => [['required' => [self::KEY_RESPONSE, self::KEY_ID]], ['required' => [self::KEY_RESPONSE, self::KEY_NAME]]]];
+        return ['type' => 'object', 'properties' => [self::KEY_ID => ['type' => 'string', 'description' => 'The ID of the function call this is responding to.'], self::KEY_NAME => ['type' => 'string', 'description' => 'The name of the function that was called.'], self::KEY_RESPONSE => ['type' => ['string', 'number', 'boolean', 'object', 'array', 'null'], 'description' => 'The response data from the function.']], 'anyOf' => [['required' => [self::KEY_RESPONSE, self::KEY_ID]], ['required' => [self::KEY_RESPONSE, self::KEY_NAME]]]];
     }
     /**
      * {@inheritDoc}
@@ -100,7 +104,15 @@ class FunctionResponse extends AbstractDataTransferObject
      */
     public function toArray(): array
     {
-        return [self::KEY_ID => $this->id, self::KEY_NAME => $this->name, self::KEY_RESPONSE => $this->response];
+        $data = [];
+        if ($this->id !== null) {
+            $data[self::KEY_ID] = $this->id;
+        }
+        if ($this->name !== null) {
+            $data[self::KEY_NAME] = $this->name;
+        }
+        $data[self::KEY_RESPONSE] = $this->response;
+        return $data;
     }
     /**
      * {@inheritDoc}
@@ -110,10 +122,6 @@ class FunctionResponse extends AbstractDataTransferObject
     public static function fromArray(array $array): self
     {
         static::validateFromArrayData($array, [self::KEY_RESPONSE]);
-        // Validate that at least one of id or name is provided
-        if (!array_key_exists(self::KEY_ID, $array) && !array_key_exists(self::KEY_NAME, $array)) {
-            throw new InvalidArgumentException('At least one of id or name must be provided.');
-        }
         return new self($array[self::KEY_ID] ?? null, $array[self::KEY_NAME] ?? null, $array[self::KEY_RESPONSE]);
     }
 }


### PR DESCRIPTION
This PR updates `WordPress/php-ai-client` to version 1.3.1. See release: https://github.com/WordPress/php-ai-client/releases/tag/1.3.1

Trac ticket: https://core.trac.wordpress.org/ticket/64591

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
