### PR TITLE
Make RTC opt-in / off-by-default

### DIFF
--- a/src/wp-admin/includes/schema.php
+++ b/src/wp-admin/includes/schema.php
@@ -409,163 +409,163 @@ function populate_options( array $options = array() ) {
 	}
 
 	$defaults = array(
-		'siteurl'                           => $guessurl,
-		'home'                              => $guessurl,
-		'blogname'                          => __( 'My Site' ),
-		'blogdescription'                   => '',
-		'users_can_register'                => 0,
-		'admin_email'                       => 'you@example.com',
+		'siteurl'                         => $guessurl,
+		'home'                            => $guessurl,
+		'blogname'                        => __( 'My Site' ),
+		'blogdescription'                 => '',
+		'users_can_register'              => 0,
+		'admin_email'                     => 'you@example.com',
 		/* translators: Default start of the week. 0 = Sunday, 1 = Monday. */
-		'start_of_week'                     => _x( '1', 'start of week' ),
-		'use_balanceTags'                   => 0,
-		'use_smilies'                       => 1,
-		'require_name_email'                => 1,
-		'comments_notify'                   => 1,
-		'posts_per_rss'                     => 10,
-		'rss_use_excerpt'                   => 0,
-		'mailserver_url'                    => 'mail.example.com',
-		'mailserver_login'                  => 'login@example.com',
-		'mailserver_pass'                   => '',
-		'mailserver_port'                   => 110,
-		'default_category'                  => 1,
-		'default_comment_status'            => 'open',
-		'default_ping_status'               => 'open',
-		'default_pingback_flag'             => 1,
-		'posts_per_page'                    => 10,
+		'start_of_week'                   => _x( '1', 'start of week' ),
+		'use_balanceTags'                 => 0,
+		'use_smilies'                     => 1,
+		'require_name_email'              => 1,
+		'comments_notify'                 => 1,
+		'posts_per_rss'                   => 10,
+		'rss_use_excerpt'                 => 0,
+		'mailserver_url'                  => 'mail.example.com',
+		'mailserver_login'                => 'login@example.com',
+		'mailserver_pass'                 => '',
+		'mailserver_port'                 => 110,
+		'default_category'                => 1,
+		'default_comment_status'          => 'open',
+		'default_ping_status'             => 'open',
+		'default_pingback_flag'           => 1,
+		'posts_per_page'                  => 10,
 		/* translators: Default date format, see https://www.php.net/manual/datetime.format.php */
-		'date_format'                       => __( 'F j, Y' ),
+		'date_format'                     => __( 'F j, Y' ),
 		/* translators: Default time format, see https://www.php.net/manual/datetime.format.php */
-		'time_format'                       => __( 'g:i a' ),
+		'time_format'                     => __( 'g:i a' ),
 		/* translators: Links last updated date format, see https://www.php.net/manual/datetime.format.php */
-		'links_updated_date_format'         => __( 'F j, Y g:i a' ),
-		'comment_moderation'                => 0,
-		'moderation_notify'                 => 1,
-		'permalink_structure'               => '',
-		'rewrite_rules'                     => '',
-		'hack_file'                         => 0,
-		'blog_charset'                      => 'UTF-8',
-		'moderation_keys'                   => '',
-		'active_plugins'                    => array(),
-		'category_base'                     => '',
-		'ping_sites'                        => 'https://rpc.pingomatic.com/',
-		'comment_max_links'                 => 2,
-		'gmt_offset'                        => $gmt_offset,
+		'links_updated_date_format'       => __( 'F j, Y g:i a' ),
+		'comment_moderation'              => 0,
+		'moderation_notify'               => 1,
+		'permalink_structure'             => '',
+		'rewrite_rules'                   => '',
+		'hack_file'                       => 0,
+		'blog_charset'                    => 'UTF-8',
+		'moderation_keys'                 => '',
+		'active_plugins'                  => array(),
+		'category_base'                   => '',
+		'ping_sites'                      => 'https://rpc.pingomatic.com/',
+		'comment_max_links'               => 2,
+		'gmt_offset'                      => $gmt_offset,
 
 		// 1.5.0
-		'default_email_category'            => 1,
-		'recently_edited'                   => '',
-		'template'                          => $template,
-		'stylesheet'                        => $stylesheet,
-		'comment_registration'              => 0,
-		'html_type'                         => 'text/html',
+		'default_email_category'          => 1,
+		'recently_edited'                 => '',
+		'template'                        => $template,
+		'stylesheet'                      => $stylesheet,
+		'comment_registration'            => 0,
+		'html_type'                       => 'text/html',
 
 		// 1.5.1
-		'use_trackback'                     => 0,
+		'use_trackback'                   => 0,
 
 		// 2.0.0
-		'default_role'                      => 'subscriber',
-		'db_version'                        => $wp_db_version,
+		'default_role'                    => 'subscriber',
+		'db_version'                      => $wp_db_version,
 
 		// 2.0.1
-		'uploads_use_yearmonth_folders'     => 1,
-		'upload_path'                       => '',
+		'uploads_use_yearmonth_folders'   => 1,
+		'upload_path'                     => '',
 
 		// 2.1.0
-		'blog_public'                       => '1',
-		'default_link_category'             => 2,
-		'show_on_front'                     => 'posts',
+		'blog_public'                     => '1',
+		'default_link_category'           => 2,
+		'show_on_front'                   => 'posts',
 
 		// 2.2.0
-		'tag_base'                          => '',
+		'tag_base'                        => '',
 
 		// 2.5.0
-		'show_avatars'                      => '1',
-		'avatar_rating'                     => 'G',
-		'upload_url_path'                   => '',
-		'thumbnail_size_w'                  => 150,
-		'thumbnail_size_h'                  => 150,
-		'thumbnail_crop'                    => 1,
-		'medium_size_w'                     => 300,
-		'medium_size_h'                     => 300,
+		'show_avatars'                    => '1',
+		'avatar_rating'                   => 'G',
+		'upload_url_path'                 => '',
+		'thumbnail_size_w'                => 150,
+		'thumbnail_size_h'                => 150,
+		'thumbnail_crop'                  => 1,
+		'medium_size_w'                   => 300,
+		'medium_size_h'                   => 300,
 
 		// 2.6.0
-		'avatar_default'                    => 'mystery',
+		'avatar_default'                  => 'mystery',
 
 		// 2.7.0
-		'large_size_w'                      => 1024,
-		'large_size_h'                      => 1024,
-		'image_default_link_type'           => 'none',
-		'image_default_size'                => '',
-		'image_default_align'               => '',
-		'close_comments_for_old_posts'      => 0,
-		'close_comments_days_old'           => 14,
-		'thread_comments'                   => 1,
-		'thread_comments_depth'             => 5,
-		'page_comments'                     => 0,
-		'comments_per_page'                 => 50,
-		'default_comments_page'             => 'newest',
-		'comment_order'                     => 'asc',
-		'sticky_posts'                      => array(),
-		'widget_categories'                 => array(),
-		'widget_text'                       => array(),
-		'widget_rss'                        => array(),
-		'uninstall_plugins'                 => array(),
+		'large_size_w'                    => 1024,
+		'large_size_h'                    => 1024,
+		'image_default_link_type'         => 'none',
+		'image_default_size'              => '',
+		'image_default_align'             => '',
+		'close_comments_for_old_posts'    => 0,
+		'close_comments_days_old'         => 14,
+		'thread_comments'                 => 1,
+		'thread_comments_depth'           => 5,
+		'page_comments'                   => 0,
+		'comments_per_page'               => 50,
+		'default_comments_page'           => 'newest',
+		'comment_order'                   => 'asc',
+		'sticky_posts'                    => array(),
+		'widget_categories'               => array(),
+		'widget_text'                     => array(),
+		'widget_rss'                      => array(),
+		'uninstall_plugins'               => array(),
 
 		// 2.8.0
-		'timezone_string'                   => $timezone_string,
+		'timezone_string'                 => $timezone_string,
 
 		// 3.0.0
-		'page_for_posts'                    => 0,
-		'page_on_front'                     => 0,
+		'page_for_posts'                  => 0,
+		'page_on_front'                   => 0,
 
 		// 3.1.0
-		'default_post_format'               => 0,
+		'default_post_format'             => 0,
 
 		// 3.5.0
-		'link_manager_enabled'              => 0,
+		'link_manager_enabled'            => 0,
 
 		// 4.3.0
-		'finished_splitting_shared_terms'   => 1,
-		'site_icon'                         => 0,
+		'finished_splitting_shared_terms' => 1,
+		'site_icon'                       => 0,
 
 		// 4.4.0
-		'medium_large_size_w'               => 768,
-		'medium_large_size_h'               => 0,
+		'medium_large_size_w'             => 768,
+		'medium_large_size_h'             => 0,
 
 		// 4.9.6
-		'wp_page_for_privacy_policy'        => 0,
+		'wp_page_for_privacy_policy'      => 0,
 
 		// 4.9.8
-		'show_comments_cookies_opt_in'      => 1,
+		'show_comments_cookies_opt_in'    => 1,
 
 		// 5.3.0
-		'admin_email_lifespan'              => ( time() + 6 * MONTH_IN_SECONDS ),
+		'admin_email_lifespan'            => ( time() + 6 * MONTH_IN_SECONDS ),
 
 		// 5.5.0
-		'disallowed_keys'                   => '',
-		'comment_previously_approved'       => 1,
-		'auto_plugin_theme_update_emails'   => array(),
+		'disallowed_keys'                 => '',
+		'comment_previously_approved'     => 1,
+		'auto_plugin_theme_update_emails' => array(),
 
 		// 5.6.0
-		'auto_update_core_dev'              => 'enabled',
-		'auto_update_core_minor'            => 'enabled',
+		'auto_update_core_dev'            => 'enabled',
+		'auto_update_core_minor'          => 'enabled',
 		/*
 		 * Default to enabled for new installs.
 		 * See https://core.trac.wordpress.org/ticket/51742.
 		 */
-		'auto_update_core_major'            => 'enabled',
+		'auto_update_core_major'          => 'enabled',
 
 		// 5.8.0
-		'wp_force_deactivated_plugins'      => array(),
+		'wp_force_deactivated_plugins'    => array(),
 
 		// 6.4.0
-		'wp_attachment_pages_enabled'       => 0,
+		'wp_attachment_pages_enabled'     => 0,
 
 		// 6.9.0
-		'wp_notes_notify'                   => 1,
+		'wp_notes_notify'                 => 1,
 
 		// 7.0.0
-		'wp_enable_real_time_collaboration' => 1,
+		'wp_collaboration_enabled'        => 0,
 	);
 
 	// 3.3.0

--- a/src/wp-admin/options-writing.php
+++ b/src/wp-admin/options-writing.php
@@ -112,8 +112,10 @@ unset( $post_formats['standard'] );
 <tr>
 <th scope="row"><?php _e( 'Collaboration' ); ?></th>
 <td>
-	<input name="wp_collaboration_enabled" type="checkbox" id="wp_collaboration_enabled" value="1" <?php checked( '1', wp_is_collaboration_enabled() ); ?> />
-	<label for="wp_collaboration_enabled"><?php _e( 'Enable real-time collaboration' ); ?></label>
+	<label for="wp_collaboration_enabled">
+		<input name="wp_collaboration_enabled" type="checkbox" id="wp_collaboration_enabled" value="1" <?php checked( '1', wp_is_collaboration_enabled() ); ?> />
+		<?php _e( 'Enable real-time collaboration' ); ?>
+	</label>
 </td>
 </tr>
 <?php

--- a/src/wp-admin/options-writing.php
+++ b/src/wp-admin/options-writing.php
@@ -113,7 +113,7 @@ unset( $post_formats['standard'] );
 <th scope="row"><?php _e( 'Collaboration' ); ?></th>
 <td>
 	<label for="wp_collaboration_enabled">
-		<input name="wp_collaboration_enabled" type="checkbox" id="wp_collaboration_enabled" value="1" <?php checked( '1', wp_is_collaboration_enabled() ); ?> />
+		<input name="wp_collaboration_enabled" type="checkbox" id="wp_collaboration_enabled" value="1" <?php checked( '1', (bool) get_option( 'wp_collaboration_enabled' ) ); ?> />
 		<?php _e( 'Enable real-time collaboration' ); ?>
 	</label>
 </td>

--- a/src/wp-admin/options-writing.php
+++ b/src/wp-admin/options-writing.php
@@ -110,10 +110,10 @@ unset( $post_formats['standard'] );
 </td>
 </tr>
 <tr>
-<th scope="row"><label for="wp_enable_real_time_collaboration"><?php _e( 'Collaboration' ); ?></label></th>
+<th scope="row"><?php _e( 'Collaboration' ); ?></th>
 <td>
-	<input name="wp_enable_real_time_collaboration" type="checkbox" id="wp_enable_real_time_collaboration" value="1" <?php checked( '1', get_option( 'wp_enable_real_time_collaboration' ) ); ?> />
-	<label for="wp_enable_real_time_collaboration"><?php _e( 'Enable real-time collaboration' ); ?></label>
+	<input name="wp_collaboration_enabled" type="checkbox" id="wp_collaboration_enabled" value="1" <?php checked( '1', wp_is_collaboration_enabled() ); ?> />
+	<label for="wp_collaboration_enabled"><?php _e( 'Enable real-time collaboration' ); ?></label>
 </td>
 </tr>
 <?php

--- a/src/wp-admin/options.php
+++ b/src/wp-admin/options.php
@@ -153,7 +153,7 @@ $allowed_options            = array(
 		'default_email_category',
 		'default_link_category',
 		'default_post_format',
-		'wp_enable_real_time_collaboration',
+		'wp_collaboration_enabled',
 	),
 );
 $allowed_options['misc']    = array();

--- a/src/wp-includes/collaboration.php
+++ b/src/wp-includes/collaboration.php
@@ -7,6 +7,17 @@
  */
 
 /**
+ * Checks whether real-time collaboration is enabled.
+ *
+ * @since 7.0.0
+ *
+ * @return bool True if real-time collaboration is enabled, false otherwise.
+ */
+function wp_is_collaboration_enabled() {
+	return (bool) get_option( 'wp_collaboration_enabled' );
+}
+
+/**
  * Injects the real-time collaboration setting into a global variable.
  *
  * @since 7.0.0
@@ -18,7 +29,7 @@
 function wp_collaboration_inject_setting() {
 	global $pagenow;
 
-	if ( ! get_option( 'wp_enable_real_time_collaboration' ) ) {
+	if ( ! wp_is_collaboration_enabled() ) {
 		return;
 	}
 

--- a/src/wp-includes/collaboration.php
+++ b/src/wp-includes/collaboration.php
@@ -7,17 +7,6 @@
  */
 
 /**
- * Checks whether real-time collaboration is enabled.
- *
- * @since 7.0.0
- *
- * @return bool True if real-time collaboration is enabled, false otherwise.
- */
-function wp_is_collaboration_enabled() {
-	return (bool) get_option( 'wp_collaboration_enabled' );
-}
-
-/**
  * Injects the real-time collaboration setting into a global variable.
  *
  * @since 7.0.0
@@ -29,7 +18,7 @@ function wp_is_collaboration_enabled() {
 function wp_collaboration_inject_setting() {
 	global $pagenow;
 
-	if ( ! wp_is_collaboration_enabled() ) {
+	if ( ! (bool) get_option( 'wp_collaboration_enabled' ) ) {
 		return;
 	}
 

--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -485,9 +485,8 @@ add_action( 'wp_head', 'wp_post_preview_js', 1 );
 // Timezone.
 add_filter( 'pre_option_gmt_offset', 'wp_timezone_override_offset' );
 
-// If the upgrade hasn't run yet, set some default options.
-add_filter( 'default_option_link_manager_enabled', '__return_true' ); // Assume link manager is used.
-add_filter( 'default_option_wp_collaboration_enabled', '__return_false' ); // Disable real-time collaboration by default.
+// If the upgrade hasn't run yet, assume link manager is used.
+add_filter( 'default_option_link_manager_enabled', '__return_true' );
 
 // This option no longer exists; tell plugins we always support auto-embedding.
 add_filter( 'pre_option_embed_autourls', '__return_true' );

--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -487,7 +487,7 @@ add_filter( 'pre_option_gmt_offset', 'wp_timezone_override_offset' );
 
 // If the upgrade hasn't run yet, set some default options.
 add_filter( 'default_option_link_manager_enabled', '__return_true' ); // Assume link manager is used.
-add_filter( 'default_option_wp_enable_real_time_collaboration', '__return_true' ); // Enable real-time collaboration.
+add_filter( 'default_option_wp_collaboration_enabled', '__return_false' ); // Disable real-time collaboration by default.
 
 // This option no longer exists; tell plugins we always support auto-embedding.
 add_filter( 'pre_option_embed_autourls', '__return_true' );

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -2887,12 +2887,12 @@ function register_initial_settings() {
 
 	register_setting(
 		'writing',
-		'wp_enable_real_time_collaboration',
+		'wp_collaboration_enabled',
 		array(
 			'type'              => 'boolean',
 			'description'       => __( 'Enable Real-Time Collaboration' ),
 			'sanitize_callback' => 'rest_sanitize_boolean',
-			'default'           => true,
+			'default'           => false,
 			'show_in_rest'      => true,
 		)
 	);

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -657,7 +657,7 @@ function create_initial_post_types() {
 		)
 	);
 
-	if ( get_option( 'wp_enable_real_time_collaboration' ) ) {
+	if ( wp_is_collaboration_enabled() ) {
 		register_post_type(
 			'wp_sync_storage',
 			array(
@@ -8672,7 +8672,7 @@ function wp_create_initial_post_meta() {
 		)
 	);
 
-	if ( get_option( 'wp_enable_real_time_collaboration' ) ) {
+	if ( wp_is_collaboration_enabled() ) {
 		register_meta(
 			'post',
 			'_crdt_document',

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -657,7 +657,7 @@ function create_initial_post_types() {
 		)
 	);
 
-	if ( wp_is_collaboration_enabled() ) {
+	if ( (bool) get_option( 'wp_collaboration_enabled' ) ) {
 		register_post_type(
 			'wp_sync_storage',
 			array(
@@ -8672,7 +8672,7 @@ function wp_create_initial_post_meta() {
 		)
 	);
 
-	if ( wp_is_collaboration_enabled() ) {
+	if ( (bool) get_option( 'wp_collaboration_enabled' ) ) {
 		register_meta(
 			'post',
 			'_crdt_document',

--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -430,7 +430,7 @@ function create_initial_rest_routes() {
 	$icons_controller->register_routes();
 
 	// Collaboration.
-	if ( wp_is_collaboration_enabled() ) {
+	if ( (bool) get_option( 'wp_collaboration_enabled' ) ) {
 		$sync_storage = new WP_Sync_Post_Meta_Storage();
 		$sync_server  = new WP_HTTP_Polling_Sync_Server( $sync_storage );
 		$sync_server->register_routes();

--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -430,7 +430,7 @@ function create_initial_rest_routes() {
 	$icons_controller->register_routes();
 
 	// Collaboration.
-	if ( get_option( 'wp_enable_real_time_collaboration' ) ) {
+	if ( wp_is_collaboration_enabled() ) {
 		$sync_storage = new WP_Sync_Post_Meta_Storage();
 		$sync_server  = new WP_HTTP_Polling_Sync_Server( $sync_storage );
 		$sync_server->register_routes();

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php
@@ -254,7 +254,7 @@ class WP_REST_Autosaves_Controller extends WP_REST_Revisions_Controller {
 		 *   the saved post. This diff is then applied to the in-memory CRDT
 		 *   document, which can lead to duplicate inserts or deletions.
 		 */
-		$is_collaboration_enabled = get_option( 'wp_enable_real_time_collaboration' );
+		$is_collaboration_enabled = wp_is_collaboration_enabled();
 
 		if ( $is_draft && (int) $post->post_author === $user_id && ! $post_lock && ! $is_collaboration_enabled ) {
 			/*

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php
@@ -254,7 +254,7 @@ class WP_REST_Autosaves_Controller extends WP_REST_Revisions_Controller {
 		 *   the saved post. This diff is then applied to the in-memory CRDT
 		 *   document, which can lead to duplicate inserts or deletions.
 		 */
-		$is_collaboration_enabled = wp_is_collaboration_enabled();
+		$is_collaboration_enabled = (bool) get_option( 'wp_collaboration_enabled' );
 
 		if ( $is_draft && (int) $post->post_author === $user_id && ! $post_lock && ! $is_collaboration_enabled ) {
 			/*

--- a/tests/phpunit/tests/rest-api/rest-autosaves-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-autosaves-controller.php
@@ -570,7 +570,7 @@ class WP_Test_REST_Autosaves_Controller extends WP_Test_REST_Post_Type_Controlle
 	}
 
 	public function test_rest_autosave_draft_post_same_author() {
-		add_filter( 'pre_option_wp_enable_real_time_collaboration', '__return_zero' ); // Zero as false doesn't work for pre-flight options.
+		add_filter( 'pre_option_wp_collaboration_enabled', '__return_zero' ); // Zero as false doesn't work for pre-flight options.
 
 		wp_set_current_user( self::$editor_id );
 
@@ -746,7 +746,7 @@ class WP_Test_REST_Autosaves_Controller extends WP_Test_REST_Post_Type_Controlle
 	}
 
 	public function test_update_item_draft_page_with_parent() {
-		add_filter( 'pre_option_wp_enable_real_time_collaboration', '__return_zero' ); // Zero as false doesn't work for pre-flight options.
+		add_filter( 'pre_option_wp_collaboration_enabled', '__return_zero' ); // Zero as false doesn't work for pre-flight options.
 
 		wp_set_current_user( self::$editor_id );
 		$request = new WP_REST_Request( 'POST', '/wp/v2/pages/' . self::$child_draft_page_id . '/autosaves' );
@@ -930,7 +930,7 @@ class WP_Test_REST_Autosaves_Controller extends WP_Test_REST_Post_Type_Controlle
 	 * same author should create a revision instead of updating the post directly.
 	 */
 	public function test_rest_autosave_draft_post_same_author_with_rtc() {
-		add_filter( 'pre_option_wp_enable_real_time_collaboration', '__return_true' );
+		add_filter( 'pre_option_wp_collaboration_enabled', '__return_true' );
 
 		wp_set_current_user( self::$editor_id );
 
@@ -976,7 +976,7 @@ class WP_Test_REST_Autosaves_Controller extends WP_Test_REST_Post_Type_Controlle
 	 * a parent should create a revision instead of updating the page directly.
 	 */
 	public function test_update_item_draft_page_with_parent_with_rtc() {
-		add_filter( 'pre_option_wp_enable_real_time_collaboration', '__return_true' );
+		add_filter( 'pre_option_wp_collaboration_enabled', '__return_true' );
 
 		wp_set_current_user( self::$editor_id );
 		$request = new WP_REST_Request( 'POST', '/wp/v2/pages/' . self::$child_draft_page_id . '/autosaves' );

--- a/tests/phpunit/tests/rest-api/rest-settings-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-settings-controller.php
@@ -119,7 +119,7 @@ class WP_Test_REST_Settings_Controller extends WP_Test_REST_Controller_Testcase 
 			'default_ping_status',
 			'default_comment_status',
 			'site_icon', // Registered in wp-includes/blocks/site-logo.php
-			'wp_enable_real_time_collaboration',
+			'wp_collaboration_enabled',
 		);
 
 		if ( ! is_multisite() ) {

--- a/tests/phpunit/tests/rest-api/rest-sync-server.php
+++ b/tests/phpunit/tests/rest-api/rest-sync-server.php
@@ -17,11 +17,15 @@ class WP_Test_REST_Sync_Server extends WP_Test_REST_Controller_Testcase {
 		self::$editor_id     = $factory->user->create( array( 'role' => 'editor' ) );
 		self::$subscriber_id = $factory->user->create( array( 'role' => 'subscriber' ) );
 		self::$post_id       = $factory->post->create( array( 'post_author' => self::$editor_id ) );
+
+		// Enable option in setUpBeforeClass to ensure REST routes are registered.
+		update_option( 'wp_collaboration_enabled', 1 );
 	}
 
 	public static function wpTearDownAfterClass() {
 		self::delete_user( self::$editor_id );
 		self::delete_user( self::$subscriber_id );
+		delete_option( 'wp_collaboration_enabled' );
 		wp_delete_post( self::$post_id, true );
 	}
 
@@ -29,7 +33,7 @@ class WP_Test_REST_Sync_Server extends WP_Test_REST_Controller_Testcase {
 		parent::set_up();
 
 		// Enable option for tests.
-		add_filter( 'pre_option_wp_enable_real_time_collaboration', '__return_true' );
+		update_option( 'wp_collaboration_enabled', 1 );
 
 		// Reset storage post ID cache to ensure clean state after transaction rollback.
 		$reflection = new ReflectionProperty( 'WP_Sync_Post_Meta_Storage', 'storage_post_ids' );
@@ -108,17 +112,14 @@ class WP_Test_REST_Sync_Server extends WP_Test_REST_Controller_Testcase {
 	public function test_register_routes_with_default_option() {
 		global $wp_rest_server;
 
-		// Remove the pre_option filter added in ::set_up() so get_option() uses its default logic.
-		remove_filter( 'pre_option_wp_enable_real_time_collaboration', '__return_true' );
-
 		// Ensure the option is not in the database.
-		delete_option( 'wp_enable_real_time_collaboration' );
+		delete_option( 'wp_collaboration_enabled' );
 
 		// Reset the REST server so routes are re-registered from scratch.
 		$wp_rest_server = null;
 
 		$routes = rest_get_server()->get_routes();
-		$this->assertArrayHasKey( '/wp-sync/v1/updates', $routes );
+		$this->assertArrayNotHasKey( '/wp-sync/v1/updates', $routes );
 	}
 
 	/**

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -20,8 +20,7 @@ mockedApiResponse.Schema = {
         "wp/v2",
         "wp-site-health/v1",
         "wp-block-editor/v1",
-        "wp-abilities/v1",
-        "wp-sync/v1"
+        "wp-abilities/v1"
     ],
     "authentication": {
         "application-passwords": {
@@ -12773,114 +12772,6 @@ mockedApiResponse.Schema = {
                     }
                 }
             ]
-        },
-        "/wp-sync/v1": {
-            "namespace": "wp-sync/v1",
-            "methods": [
-                "GET"
-            ],
-            "endpoints": [
-                {
-                    "methods": [
-                        "GET"
-                    ],
-                    "args": {
-                        "namespace": {
-                            "default": "wp-sync/v1",
-                            "required": false
-                        },
-                        "context": {
-                            "default": "view",
-                            "required": false
-                        }
-                    }
-                }
-            ],
-            "_links": {
-                "self": [
-                    {
-                        "href": "http://example.org/index.php?rest_route=/wp-sync/v1"
-                    }
-                ]
-            }
-        },
-        "/wp-sync/v1/updates": {
-            "namespace": "wp-sync/v1",
-            "methods": [
-                "POST"
-            ],
-            "endpoints": [
-                {
-                    "methods": [
-                        "POST"
-                    ],
-                    "args": {
-                        "rooms": {
-                            "items": {
-                                "properties": {
-                                    "after": {
-                                        "minimum": 0,
-                                        "required": true,
-                                        "type": "integer"
-                                    },
-                                    "awareness": {
-                                        "required": true,
-                                        "type": [
-                                            "object",
-                                            "null"
-                                        ]
-                                    },
-                                    "client_id": {
-                                        "minimum": 1,
-                                        "required": true,
-                                        "type": "integer"
-                                    },
-                                    "room": {
-                                        "required": true,
-                                        "type": "string",
-                                        "pattern": "^[^/]+/[^/:]+(?::\\S+)?$"
-                                    },
-                                    "updates": {
-                                        "items": {
-                                            "properties": {
-                                                "data": {
-                                                    "type": "string",
-                                                    "required": true
-                                                },
-                                                "type": {
-                                                    "type": "string",
-                                                    "required": true,
-                                                    "enum": [
-                                                        "compaction",
-                                                        "sync_step1",
-                                                        "sync_step2",
-                                                        "update"
-                                                    ]
-                                                }
-                                            },
-                                            "required": true,
-                                            "type": "object"
-                                        },
-                                        "minItems": 0,
-                                        "required": true,
-                                        "type": "array"
-                                    }
-                                },
-                                "type": "object"
-                            },
-                            "type": "array",
-                            "required": true
-                        }
-                    }
-                }
-            ],
-            "_links": {
-                "self": [
-                    {
-                        "href": "http://example.org/index.php?rest_route=/wp-sync/v1/updates"
-                    }
-                ]
-            }
         }
     },
     "image_sizes": {
@@ -14776,7 +14667,7 @@ mockedApiResponse.settings = {
     "use_smilies": true,
     "default_category": 1,
     "default_post_format": "0",
-    "wp_collaboration_enabled": true,
+    "wp_collaboration_enabled": false,
     "posts_per_page": 10,
     "show_on_front": "posts",
     "page_on_front": 0,

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -11160,7 +11160,7 @@ mockedApiResponse.Schema = {
                             "type": "string",
                             "required": false
                         },
-                        "wp_enable_real_time_collaboration": {
+                        "wp_collaboration_enabled": {
                             "title": "",
                             "description": "Enable Real-Time Collaboration",
                             "type": "boolean",
@@ -14776,7 +14776,7 @@ mockedApiResponse.settings = {
     "use_smilies": true,
     "default_category": 1,
     "default_post_format": "0",
-    "wp_enable_real_time_collaboration": true,
+    "wp_collaboration_enabled": true,
     "posts_per_page": 10,
     "show_on_front": "posts",
     "page_on_front": 0,


### PR DESCRIPTION
Per the [comment in Core Slack](https://wordpress.slack.com/archives/C07NVJ51X6K/p1773850504196589), we are moving the real-time collaboration feature to opt-in / off-by-default for 7.0 RC 1. Thank you to everyone who provided feedback during the testing period.

Note that we are intentionally changing the option name so that it will be off-by-default for everyone, including those that installed a beta release where the feature was on-by-default.

Trac ticket: https://core.trac.wordpress.org/ticket/64845

