### PR TITLE
Media: Remove IMG from crossorigin attribute injection

### DIFF
--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -6558,14 +6558,7 @@ function wp_add_crossorigin_attributes( string $html ): string {
 	// See https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin.
 	$cross_origin_tag_attributes = array(
 		'AUDIO'  => array( 'src' => false ),
-		'IMG'    => array(
-			'src'    => false,
-			'srcset' => true,
-		),
-		'LINK'   => array(
-			'href'        => false,
-			'imagesrcset' => true,
-		),
+		'LINK'   => array( 'href' => false ),
 		'SCRIPT' => array( 'src' => false ),
 		'VIDEO'  => array(
 			'src'    => false,

--- a/tests/phpunit/tests/media/wpCrossOriginIsolation.php
+++ b/tests/phpunit/tests/media/wpCrossOriginIsolation.php
@@ -237,4 +237,233 @@ class Tests_Media_wpCrossOriginIsolation extends WP_UnitTestCase {
 
 		$this->assertStringNotContainsString( 'crossorigin="anonymous"', $output );
 	}
+
+	/**
+	 * Images with srcset should also not get crossorigin="anonymous".
+	 *
+	 * @ticket 64766
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_output_buffer_does_not_add_crossorigin_to_images_with_srcset() {
+		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36';
+
+		ob_start();
+
+		wp_start_cross_origin_isolation_output_buffer();
+		echo '<img src="https://external.example.com/image.jpg" srcset="https://external.example.com/image-2x.jpg 2x" />';
+
+		ob_end_flush();
+		$output = ob_get_clean();
+
+		$this->assertStringNotContainsString( 'crossorigin="anonymous"', $output );
+	}
+
+	/**
+	 * Audio elements with cross-origin sources should get crossorigin="anonymous".
+	 *
+	 * @ticket 64766
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_output_buffer_adds_crossorigin_to_audio() {
+		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36';
+
+		ob_start();
+
+		wp_start_cross_origin_isolation_output_buffer();
+		echo '<audio src="https://external.example.com/audio.mp3"></audio>';
+
+		ob_end_flush();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'crossorigin="anonymous"', $output );
+	}
+
+	/**
+	 * Video elements with cross-origin sources should get crossorigin="anonymous".
+	 *
+	 * @ticket 64766
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_output_buffer_adds_crossorigin_to_video() {
+		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36';
+
+		ob_start();
+
+		wp_start_cross_origin_isolation_output_buffer();
+		echo '<video src="https://external.example.com/video.mp4"></video>';
+
+		ob_end_flush();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'crossorigin="anonymous"', $output );
+	}
+
+	/**
+	 * Link elements with cross-origin href should get crossorigin="anonymous".
+	 *
+	 * @ticket 64766
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_output_buffer_adds_crossorigin_to_link() {
+		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36';
+
+		ob_start();
+
+		wp_start_cross_origin_isolation_output_buffer();
+		echo '<link rel="stylesheet" href="https://external.example.com/style.css" />';
+
+		ob_end_flush();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'crossorigin="anonymous"', $output );
+	}
+
+	/**
+	 * Link elements with imagesrcset should no longer trigger crossorigin="anonymous"
+	 * since imagesrcset handling was removed along with IMG.
+	 *
+	 * @ticket 64766
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_output_buffer_does_not_add_crossorigin_to_link_with_imagesrcset_only() {
+		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36';
+
+		ob_start();
+
+		wp_start_cross_origin_isolation_output_buffer();
+		echo '<link rel="preload" as="image" imagesrcset="https://external.example.com/image.jpg 1x" href="/local-fallback.jpg" />';
+
+		ob_end_flush();
+		$output = ob_get_clean();
+
+		$this->assertStringNotContainsString( 'crossorigin="anonymous"', $output, 'Link elements should not get crossorigin based on imagesrcset alone.' );
+	}
+
+	/**
+	 * Same-origin URLs should not get crossorigin="anonymous".
+	 *
+	 * @ticket 64766
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_output_buffer_does_not_add_crossorigin_to_same_origin_script() {
+		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36';
+
+		ob_start();
+
+		wp_start_cross_origin_isolation_output_buffer();
+		echo '<script src="' . site_url( '/wp-includes/js/wp-embed.min.js' ) . '"></script>';
+
+		ob_end_flush();
+		$output = ob_get_clean();
+
+		$this->assertStringNotContainsString( 'crossorigin="anonymous"', $output, 'Same-origin scripts should not get crossorigin attribute.' );
+	}
+
+	/**
+	 * Relative URLs should not get crossorigin="anonymous".
+	 *
+	 * @ticket 64766
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_output_buffer_does_not_add_crossorigin_to_relative_urls() {
+		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36';
+
+		ob_start();
+
+		wp_start_cross_origin_isolation_output_buffer();
+		echo '<script src="/wp-includes/js/wp-embed.min.js"></script>';
+
+		ob_end_flush();
+		$output = ob_get_clean();
+
+		$this->assertStringNotContainsString( 'crossorigin="anonymous"', $output, 'Relative URLs should not get crossorigin attribute.' );
+	}
+
+	/**
+	 * Elements that already have a crossorigin attribute should not be modified.
+	 *
+	 * @ticket 64766
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_output_buffer_does_not_override_existing_crossorigin() {
+		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36';
+
+		ob_start();
+
+		wp_start_cross_origin_isolation_output_buffer();
+		echo '<script src="https://external.example.com/script.js" crossorigin="use-credentials"></script>';
+
+		ob_end_flush();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'crossorigin="use-credentials"', $output, 'Existing crossorigin attribute should not be overridden.' );
+		$this->assertStringNotContainsString( 'crossorigin="anonymous"', $output );
+	}
+
+	/**
+	 * Source elements inside video/audio with cross-origin src should add
+	 * crossorigin to the parent element.
+	 *
+	 * @ticket 64766
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_output_buffer_adds_crossorigin_to_video_with_source() {
+		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36';
+
+		ob_start();
+
+		wp_start_cross_origin_isolation_output_buffer();
+		echo '<video><source src="https://external.example.com/video.mp4" type="video/mp4" /></video>';
+
+		ob_end_flush();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'crossorigin="anonymous"', $output );
+	}
+
+	/**
+	 * Multiple tags in the same output should each be handled correctly.
+	 *
+	 * @ticket 64766
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_output_buffer_handles_mixed_tags() {
+		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36';
+
+		ob_start();
+
+		wp_start_cross_origin_isolation_output_buffer();
+		echo '<img src="https://external.example.com/image.jpg" />';
+		echo '<script src="https://external.example.com/script.js"></script>';
+		echo '<audio src="https://external.example.com/audio.mp3"></audio>';
+
+		ob_end_flush();
+		$output = ob_get_clean();
+
+		// IMG should NOT have crossorigin.
+		$this->assertStringContainsString( '<img src="https://external.example.com/image.jpg" />', $output, 'IMG should not be modified.' );
+
+		// Script and audio should have crossorigin.
+		$this->assertSame( 2, substr_count( $output, 'crossorigin="anonymous"' ), 'Script and audio should both get crossorigin, but not img.' );
+	}
 }

--- a/tests/phpunit/tests/media/wpCrossOriginIsolation.php
+++ b/tests/phpunit/tests/media/wpCrossOriginIsolation.php
@@ -202,12 +202,39 @@ class Tests_Media_wpCrossOriginIsolation extends WP_UnitTestCase {
 		ob_start();
 
 		wp_start_cross_origin_isolation_output_buffer();
-		echo '<img src="https://external.example.com/image.jpg" />';
+		echo '<script src="https://external.example.com/script.js"></script>';
 
 		// Flush the inner buffer to trigger the callback, sending processed output to the outer buffer.
 		ob_end_flush();
 		$output = ob_get_clean();
 
 		$this->assertStringContainsString( 'crossorigin="anonymous"', $output );
+	}
+
+	/**
+	 * Images should not get crossorigin="anonymous" because under
+	 * Document-Isolation-Policy: isolate-and-credentialless, the credentialless
+	 * mode handles image loading without CORS headers. Adding the attribute
+	 * would break external images that don't serve CORS headers.
+	 *
+	 * @ticket 64766
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_output_buffer_does_not_add_crossorigin_to_images() {
+		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36';
+
+		// Start an outer buffer to capture the callback-processed output.
+		ob_start();
+
+		wp_start_cross_origin_isolation_output_buffer();
+		echo '<img src="https://external.example.com/image.jpg" />';
+
+		// Flush the inner buffer to trigger the callback, sending processed output to the outer buffer.
+		ob_end_flush();
+		$output = ob_get_clean();
+
+		$this->assertStringNotContainsString( 'crossorigin="anonymous"', $output );
 	}
 }

--- a/tests/phpunit/tests/media/wpCrossOriginIsolation.php
+++ b/tests/phpunit/tests/media/wpCrossOriginIsolation.php
@@ -282,13 +282,34 @@ class Tests_Media_wpCrossOriginIsolation extends WP_UnitTestCase {
 			'link with cross-origin imagesrcset only' => array(
 				'<link rel="preload" as="image" imagesrcset="https://external.example.com/image.jpg 1x" href="/local-fallback.jpg" />',
 			),
-			'same-origin script'                      => array(
-				'<script src="http://example.org/wp-includes/js/wp-embed.min.js"></script>',
-			),
 			'relative URL script'                     => array(
 				'<script src="/wp-includes/js/wp-embed.min.js"></script>',
 			),
 		);
+	}
+
+	/**
+	 * Same-origin URLs should not get crossorigin="anonymous".
+	 *
+	 * Uses site_url() at runtime since the test domain varies by CI config.
+	 *
+	 * @ticket 64766
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_output_buffer_does_not_add_crossorigin_to_same_origin() {
+		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36';
+
+		ob_start();
+
+		wp_start_cross_origin_isolation_output_buffer();
+		echo '<script src="' . site_url( '/wp-includes/js/wp-embed.min.js' ) . '"></script>';
+
+		ob_end_flush();
+		$output = ob_get_clean();
+
+		$this->assertStringNotContainsString( 'crossorigin="anonymous"', $output );
 	}
 
 	/**

--- a/tests/phpunit/tests/media/wpCrossOriginIsolation.php
+++ b/tests/phpunit/tests/media/wpCrossOriginIsolation.php
@@ -273,19 +273,19 @@ class Tests_Media_wpCrossOriginIsolation extends WP_UnitTestCase {
 	 */
 	public function data_elements_that_should_not_get_crossorigin() {
 		return array(
-			'cross-origin img'                       => array(
+			'cross-origin img'                        => array(
 				'<img src="https://external.example.com/image.jpg" />',
 			),
-			'cross-origin img with srcset'           => array(
+			'cross-origin img with srcset'            => array(
 				'<img src="https://external.example.com/image.jpg" srcset="https://external.example.com/image-2x.jpg 2x" />',
 			),
 			'link with cross-origin imagesrcset only' => array(
 				'<link rel="preload" as="image" imagesrcset="https://external.example.com/image.jpg 1x" href="/local-fallback.jpg" />',
 			),
-			'same-origin script'                     => array(
+			'same-origin script'                      => array(
 				'<script src="http://example.org/wp-includes/js/wp-embed.min.js"></script>',
 			),
-			'relative URL script'                    => array(
+			'relative URL script'                     => array(
 				'<script src="/wp-includes/js/wp-embed.min.js"></script>',
 			),
 		);

--- a/tests/phpunit/tests/media/wpCrossOriginIsolation.php
+++ b/tests/phpunit/tests/media/wpCrossOriginIsolation.php
@@ -186,25 +186,25 @@ class Tests_Media_wpCrossOriginIsolation extends WP_UnitTestCase {
 	}
 
 	/**
-	 * This test must run in a separate process because the output buffer
-	 * callback sends HTTP headers via header(), which would fail in the
-	 * main PHPUnit process where output has already started.
+	 * Verifies that cross-origin elements get crossorigin="anonymous" added.
 	 *
 	 * @ticket 64766
 	 *
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
+	 *
+	 * @dataProvider data_elements_that_should_get_crossorigin
+	 *
+	 * @param string $html HTML input to process.
 	 */
-	public function test_output_buffer_adds_crossorigin_attributes() {
+	public function test_output_buffer_adds_crossorigin( $html ) {
 		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36';
 
-		// Start an outer buffer to capture the callback-processed output.
 		ob_start();
 
 		wp_start_cross_origin_isolation_output_buffer();
-		echo '<script src="https://external.example.com/script.js"></script>';
+		echo $html;
 
-		// Flush the inner buffer to trigger the callback, sending processed output to the outer buffer.
 		ob_end_flush();
 		$output = ob_get_clean();
 
@@ -212,26 +212,54 @@ class Tests_Media_wpCrossOriginIsolation extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Images should not get crossorigin="anonymous" because under
-	 * Document-Isolation-Policy: isolate-and-credentialless, the credentialless
-	 * mode handles image loading without CORS headers. Adding the attribute
-	 * would break external images that don't serve CORS headers.
+	 * Data provider for elements that should receive crossorigin="anonymous".
+	 *
+	 * @return array[]
+	 */
+	public function data_elements_that_should_get_crossorigin() {
+		return array(
+			'cross-origin script'              => array(
+				'<script src="https://external.example.com/script.js"></script>',
+			),
+			'cross-origin audio'               => array(
+				'<audio src="https://external.example.com/audio.mp3"></audio>',
+			),
+			'cross-origin video'               => array(
+				'<video src="https://external.example.com/video.mp4"></video>',
+			),
+			'cross-origin link stylesheet'     => array(
+				'<link rel="stylesheet" href="https://external.example.com/style.css" />',
+			),
+			'cross-origin source inside video' => array(
+				'<video><source src="https://external.example.com/video.mp4" type="video/mp4" /></video>',
+			),
+		);
+	}
+
+	/**
+	 * Verifies that certain elements do not get crossorigin="anonymous" added.
+	 *
+	 * Images are excluded because under Document-Isolation-Policy:
+	 * isolate-and-credentialless, the browser handles cross-origin images
+	 * in credentialless mode without needing explicit CORS headers.
 	 *
 	 * @ticket 64766
 	 *
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
+	 *
+	 * @dataProvider data_elements_that_should_not_get_crossorigin
+	 *
+	 * @param string $html HTML input to process.
 	 */
-	public function test_output_buffer_does_not_add_crossorigin_to_images() {
+	public function test_output_buffer_does_not_add_crossorigin( $html ) {
 		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36';
 
-		// Start an outer buffer to capture the callback-processed output.
 		ob_start();
 
 		wp_start_cross_origin_isolation_output_buffer();
-		echo '<img src="https://external.example.com/image.jpg" />';
+		echo $html;
 
-		// Flush the inner buffer to trigger the callback, sending processed output to the outer buffer.
 		ob_end_flush();
 		$output = ob_get_clean();
 
@@ -239,158 +267,28 @@ class Tests_Media_wpCrossOriginIsolation extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Images with srcset should also not get crossorigin="anonymous".
+	 * Data provider for elements that should not receive crossorigin="anonymous".
 	 *
-	 * @ticket 64766
-	 *
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
+	 * @return array[]
 	 */
-	public function test_output_buffer_does_not_add_crossorigin_to_images_with_srcset() {
-		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36';
-
-		ob_start();
-
-		wp_start_cross_origin_isolation_output_buffer();
-		echo '<img src="https://external.example.com/image.jpg" srcset="https://external.example.com/image-2x.jpg 2x" />';
-
-		ob_end_flush();
-		$output = ob_get_clean();
-
-		$this->assertStringNotContainsString( 'crossorigin="anonymous"', $output );
-	}
-
-	/**
-	 * Audio elements with cross-origin sources should get crossorigin="anonymous".
-	 *
-	 * @ticket 64766
-	 *
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 */
-	public function test_output_buffer_adds_crossorigin_to_audio() {
-		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36';
-
-		ob_start();
-
-		wp_start_cross_origin_isolation_output_buffer();
-		echo '<audio src="https://external.example.com/audio.mp3"></audio>';
-
-		ob_end_flush();
-		$output = ob_get_clean();
-
-		$this->assertStringContainsString( 'crossorigin="anonymous"', $output );
-	}
-
-	/**
-	 * Video elements with cross-origin sources should get crossorigin="anonymous".
-	 *
-	 * @ticket 64766
-	 *
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 */
-	public function test_output_buffer_adds_crossorigin_to_video() {
-		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36';
-
-		ob_start();
-
-		wp_start_cross_origin_isolation_output_buffer();
-		echo '<video src="https://external.example.com/video.mp4"></video>';
-
-		ob_end_flush();
-		$output = ob_get_clean();
-
-		$this->assertStringContainsString( 'crossorigin="anonymous"', $output );
-	}
-
-	/**
-	 * Link elements with cross-origin href should get crossorigin="anonymous".
-	 *
-	 * @ticket 64766
-	 *
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 */
-	public function test_output_buffer_adds_crossorigin_to_link() {
-		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36';
-
-		ob_start();
-
-		wp_start_cross_origin_isolation_output_buffer();
-		echo '<link rel="stylesheet" href="https://external.example.com/style.css" />';
-
-		ob_end_flush();
-		$output = ob_get_clean();
-
-		$this->assertStringContainsString( 'crossorigin="anonymous"', $output );
-	}
-
-	/**
-	 * Link elements with imagesrcset should no longer trigger crossorigin="anonymous"
-	 * since imagesrcset handling was removed along with IMG.
-	 *
-	 * @ticket 64766
-	 *
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 */
-	public function test_output_buffer_does_not_add_crossorigin_to_link_with_imagesrcset_only() {
-		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36';
-
-		ob_start();
-
-		wp_start_cross_origin_isolation_output_buffer();
-		echo '<link rel="preload" as="image" imagesrcset="https://external.example.com/image.jpg 1x" href="/local-fallback.jpg" />';
-
-		ob_end_flush();
-		$output = ob_get_clean();
-
-		$this->assertStringNotContainsString( 'crossorigin="anonymous"', $output, 'Link elements should not get crossorigin based on imagesrcset alone.' );
-	}
-
-	/**
-	 * Same-origin URLs should not get crossorigin="anonymous".
-	 *
-	 * @ticket 64766
-	 *
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 */
-	public function test_output_buffer_does_not_add_crossorigin_to_same_origin_script() {
-		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36';
-
-		ob_start();
-
-		wp_start_cross_origin_isolation_output_buffer();
-		echo '<script src="' . site_url( '/wp-includes/js/wp-embed.min.js' ) . '"></script>';
-
-		ob_end_flush();
-		$output = ob_get_clean();
-
-		$this->assertStringNotContainsString( 'crossorigin="anonymous"', $output, 'Same-origin scripts should not get crossorigin attribute.' );
-	}
-
-	/**
-	 * Relative URLs should not get crossorigin="anonymous".
-	 *
-	 * @ticket 64766
-	 *
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 */
-	public function test_output_buffer_does_not_add_crossorigin_to_relative_urls() {
-		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36';
-
-		ob_start();
-
-		wp_start_cross_origin_isolation_output_buffer();
-		echo '<script src="/wp-includes/js/wp-embed.min.js"></script>';
-
-		ob_end_flush();
-		$output = ob_get_clean();
-
-		$this->assertStringNotContainsString( 'crossorigin="anonymous"', $output, 'Relative URLs should not get crossorigin attribute.' );
+	public function data_elements_that_should_not_get_crossorigin() {
+		return array(
+			'cross-origin img'                       => array(
+				'<img src="https://external.example.com/image.jpg" />',
+			),
+			'cross-origin img with srcset'           => array(
+				'<img src="https://external.example.com/image.jpg" srcset="https://external.example.com/image-2x.jpg 2x" />',
+			),
+			'link with cross-origin imagesrcset only' => array(
+				'<link rel="preload" as="image" imagesrcset="https://external.example.com/image.jpg 1x" href="/local-fallback.jpg" />',
+			),
+			'same-origin script'                     => array(
+				'<script src="http://example.org/wp-includes/js/wp-embed.min.js"></script>',
+			),
+			'relative URL script'                    => array(
+				'<script src="/wp-includes/js/wp-embed.min.js"></script>',
+			),
+		);
 	}
 
 	/**
@@ -414,29 +312,6 @@ class Tests_Media_wpCrossOriginIsolation extends WP_UnitTestCase {
 
 		$this->assertStringContainsString( 'crossorigin="use-credentials"', $output, 'Existing crossorigin attribute should not be overridden.' );
 		$this->assertStringNotContainsString( 'crossorigin="anonymous"', $output );
-	}
-
-	/**
-	 * Source elements inside video/audio with cross-origin src should add
-	 * crossorigin to the parent element.
-	 *
-	 * @ticket 64766
-	 *
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 */
-	public function test_output_buffer_adds_crossorigin_to_video_with_source() {
-		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36';
-
-		ob_start();
-
-		wp_start_cross_origin_isolation_output_buffer();
-		echo '<video><source src="https://external.example.com/video.mp4" type="video/mp4" /></video>';
-
-		ob_end_flush();
-		$output = ob_get_clean();
-
-		$this->assertStringContainsString( 'crossorigin="anonymous"', $output );
 	}
 
 	/**


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/64886

Related Gutenberg issue: https://github.com/WordPress/gutenberg/issues/76476

## Description

Removes `IMG` from the list of elements that receive `crossorigin="anonymous"` in `wp_add_crossorigin_attributes()`. Also removes the related `imagesrcset` handling from `LINK` elements.

Under `Document-Isolation-Policy: isolate-and-credentialless` (introduced in r61844), the browser's credentialless mode already handles cross-origin image loading without requiring CORS headers on the remote server. Explicitly adding `crossorigin="anonymous"` to `<img>` elements overrides this behavior and forces a CORS preflight — breaking images from servers that don't include `Access-Control-Allow-Origin` in their response headers.

This causes image previews to break in the block editor sidebar when an image block references an external URL (e.g. `https://placehold.jp/1024x768.jpg`).

Related Gutenberg PR: https://github.com/WordPress/gutenberg/pull/76618

## Changes

- Remove `IMG` entry from `$cross_origin_tag_attributes` in `wp_add_crossorigin_attributes()`
- Remove `imagesrcset` from `LINK` entry (used for `<link>` preload tags for images — same issue)
- Update existing test to use `<script>` instead of `<img>` for the positive case
- Add new test asserting `<img>` does NOT get `crossorigin="anonymous"`

## Testing

1. Open block editor in Chromium 137+
2. Add an Image block → "Insert from URL" → `https://placehold.jp/1024x768.jpg`
3. Sidebar preview should render correctly (no CORS error)
4. Verify `Document-Isolation-Policy: isolate-and-credentialless` header is still sent
5. Drag an image from desktop onto the editor — client-side media processing still works

---

## Commit message

```
Media: Remove `IMG` from crossorigin attribute injection.

Under `Document-Isolation-Policy: isolate-and-credentialless`, the browser's credentialless mode already handles cross-origin image loading without requiring CORS headers. Explicitly adding `crossorigin="anonymous"` to `<img>` elements overrides this behavior and forces a CORS preflight request, breaking images from servers that don't include `Access-Control-Allow-Origin` in their response headers.

This also removes the related `imagesrcset` handling from `LINK` elements, which had the same issue for `<link>` preload tags for images.

See related Gutenberg issue: https://github.com/WordPress/gutenberg/issues/76476.

Follow-up to [61844], [61846].

Props adamsilverstein, swissspidy.
Fixes #64886.
```