### PR TITLE
Code Quality: Simplify tag url assignment in `wp_generate_tag_cloud()`.

### DIFF
--- a/src/wp-includes/category-template.php
+++ b/src/wp-includes/category-template.php
@@ -976,7 +976,7 @@ function wp_generate_tag_cloud( $tags, $args = '' ) {
 
 		$tags_data[] = array(
 			'id'              => $tag_id,
-			'url'             => ( '#' !== $tag->link ) ? $tag->link : '#',
+			'url'             => $tag->link,
 			'role'            => ( '#' !== $tag->link ) ? '' : ' role="button"',
 			'name'            => $tag->name,
 			'formatted_count' => $formatted_count,


### PR DESCRIPTION
The `url` value is `$tag->link` unless `'#' === $tag->link`, then its `#`.  Which is the same as  `$tag->link`.
So we can simplify it and always use `$tag->link`.

Trac ticket: https://core.trac.wordpress.org/ticket/64898

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
