### PR TITLE
Clean `src` before building to remove abandoned files

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2063,9 +2063,17 @@ module.exports = function(grunt) {
 	] );
 
 	grunt.registerTask( 'build', function() {
+		grunt.util.spawn( {
+			grunt: true,
+			args: [ 'clean', '--dev' ],
+			opts: { stdio: 'inherit' }
+		}, function( buildError ) {
+			done( ! buildError );
+		} );
+
 		if ( grunt.option( 'dev' ) ) {
 			grunt.task.run( [
-				'gutenberg:verify',
+				'gutenberg:download',
 				'build:js',
 				'build:css',
 				'build:codemirror',
@@ -2075,7 +2083,7 @@ module.exports = function(grunt) {
 			] );
 		} else {
 			grunt.task.run( [
-				'gutenberg:verify',
+				'gutenberg:download',
 				'build:certificates',
 				'build:files',
 				'build:js',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2063,6 +2063,8 @@ module.exports = function(grunt) {
 	] );
 
 	grunt.registerTask( 'build', function() {
+		var done = this.async();
+		
 		grunt.util.spawn( {
 			grunt: true,
 			args: [ 'clean', '--dev' ],

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
 		"wicg-inert": "3.1.3"
 	},
 	"scripts": {
-		"postinstall": "npm run gutenberg:verify && npm run grunt clean -- --dev",
+		"postinstall": "npm run gutenberg:verify",
 		"build": "grunt build",
 		"build:dev": "grunt build --dev",
 		"build:gutenberg": "grunt build:gutenberg",

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
 		"wicg-inert": "3.1.3"
 	},
 	"scripts": {
-		"postinstall": "npm run grunt clean -- --dev && npm run gutenberg:verify",
+		"postinstall": "npm run gutenberg:download",
 		"build": "grunt build",
 		"build:dev": "grunt build --dev",
 		"build:gutenberg": "grunt build:gutenberg",

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
 		"wicg-inert": "3.1.3"
 	},
 	"scripts": {
-		"postinstall": "npm run gutenberg:download",
+		"postinstall": "npm run gutenberg:verify && npm run grunt clean -- --dev",
 		"build": "grunt build",
 		"build:dev": "grunt build --dev",
 		"build:gutenberg": "grunt build:gutenberg",

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
 		"wicg-inert": "3.1.3"
 	},
 	"scripts": {
-		"postinstall": "npm run gutenberg:verify",
+		"postinstall": "npm run grunt clean -- --dev && npm run gutenberg:verify",
 		"build": "grunt build",
 		"build:dev": "grunt build --dev",
 		"build:gutenberg": "grunt build:gutenberg",


### PR DESCRIPTION
This addresses an issue where files persist in the `src` directory of the build server checkout despite having been removed. Because the files are not under version control and there's no explicit delete command, they are not removed from `src` as expected.

Specific details about this issue can be found in [this comment](https://core.trac.wordpress.org/ticket/64393#comment:177).

Now that `grunt clean` has been updated to account for the new files and locations, it can be run before building to ensure a clean state (see dc203521db5c3dc49cf98ab9ab5354ef2835ef51).

This is a short-term solution that's meant to run once and be removed. The long-term solution is the work being done in #11064, which will re-add these files to version control, which solves this problem naturally through changes to the files themselves.

Trac ticket: Core-64393.

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
