### PR TITLE
Add link to WP Repo in Theme Preview screen

### DIFF
--- a/src/wp-admin/css/themes.css
+++ b/src/wp-admin/css/themes.css
@@ -1966,6 +1966,11 @@ body.full-overlay-active {
 	max-width: 100%;
 }
 
+.install-theme-info .theme-url {
+	display: block;
+	margin: 15px 0 0;
+}
+
 .theme-install-overlay .wp-full-overlay-header .button {
 	float: right;
 	margin: 3px 10px 0 0; /* Vertically center 40px button in 45px header */

--- a/src/wp-admin/theme-install.php
+++ b/src/wp-admin/theme-install.php
@@ -595,6 +595,10 @@ if ( $tab ) {
 
 						<div class="theme-description">{{{ data.description }}}</div>
 					</div>
+
+					<a class="theme-url" href="<?php echo esc_url( __( 'https://wordpress.org/themes/' ) ); ?>/{{ data.id }}" target="_blank">
+						<?php _e( 'WordPress.org Theme Page »' ); ?>
+					</a>
 				</div>
 			</div>
 			<div class="wp-full-overlay-footer">

--- a/src/wp-admin/theme-install.php
+++ b/src/wp-admin/theme-install.php
@@ -596,7 +596,7 @@ if ( $tab ) {
 						<div class="theme-description">{{{ data.description }}}</div>
 					</div>
 
-					<a class="theme-url" href="<?php echo esc_url( __( 'https://wordpress.org/themes/' ) ); ?>/{{ data.id }}/" target="_blank">
+					<a class="theme-url" href="<?php echo esc_url( __( 'https://wordpress.org/themes/' ) ); ?>{{ data.id }}/" target="_blank">
 						<?php _e( 'WordPress.org Theme Page &#187;' ); ?>
 					</a>
 				</div>

--- a/src/wp-admin/theme-install.php
+++ b/src/wp-admin/theme-install.php
@@ -596,7 +596,7 @@ if ( $tab ) {
 						<div class="theme-description">{{{ data.description }}}</div>
 					</div>
 
-					<a class="theme-url" href="<?php echo esc_url( __( 'https://wordpress.org/themes/' ) ); ?>/{{ data.id }}" target="_blank">
+					<a class="theme-url" href="<?php echo esc_url( __( 'https://wordpress.org/themes/' ) ); ?>/{{ data.id }}/" target="_blank">
 						<?php _e( 'WordPress.org Theme Page &#187;' ); ?>
 					</a>
 				</div>

--- a/src/wp-admin/theme-install.php
+++ b/src/wp-admin/theme-install.php
@@ -597,7 +597,7 @@ if ( $tab ) {
 					</div>
 
 					<a class="theme-url" href="<?php echo esc_url( __( 'https://wordpress.org/themes/' ) ); ?>/{{ data.id }}" target="_blank">
-						<?php _e( 'WordPress.org Theme Page »' ); ?>
+						<?php _e( 'WordPress.org Theme Page &#187;' ); ?>
 					</a>
 				</div>
 			</div>

--- a/src/wp-admin/theme-install.php
+++ b/src/wp-admin/theme-install.php
@@ -596,7 +596,7 @@ if ( $tab ) {
 						<div class="theme-description">{{{ data.description }}}</div>
 					</div>
 
-					<a class="theme-url" href="<?php echo esc_url( __( 'https://wordpress.org/themes/' ) ); ?>{{ data.id }}/" target="_blank">
+					<a class="theme-url" href="<?php echo esc_url( __( 'https://wordpress.org/themes/' ) ); ?>{{ data.id }}/">
 						<?php _e( 'WordPress.org Theme Page &#187;' ); ?>
 					</a>
 				</div>


### PR DESCRIPTION
While searching for a theme at page `wp-admin/theme-install.php` you can click Details & Preview and a live preview opens.
Sometimes you want to learn more about the theme. This PR adds a link to the theme page in the WP Repo.

What's possible for plugins (View Details / WordPress.org Plugin Page ») should also be possible for themes.

Note: you can also reach the WP Repo via the ratings link, but that one does not link to the main theme page.

Trac ticket: [#64905](https://core.trac.wordpress.org/ticket/64905)


![Theme Preview](https://github.com/user-attachments/assets/fce36940-f8f4-46a8-9f1a-b03ecf0d86b9)
