### PR TITLE
First pass at constant for forcing enable/disable of real time collab

### DIFF
--- a/src/wp-admin/options-writing.php
+++ b/src/wp-admin/options-writing.php
@@ -112,10 +112,18 @@ unset( $post_formats['standard'] );
 <tr>
 <th scope="row"><?php _e( 'Collaboration' ); ?></th>
 <td>
-	<label for="wp_collaboration_enabled">
-		<input name="wp_collaboration_enabled" type="checkbox" id="wp_collaboration_enabled" value="1" <?php checked( '1', (bool) get_option( 'wp_collaboration_enabled' ) ); ?> />
-		<?php _e( 'Enable real-time collaboration' ); ?>
-	</label>
+	<?php if ( defined ( 'FORCE_COLLABORATION_ENABLED' ) ) : ?>
+		<?php if ( TRUE === FORCE_COLLABORATION_ENABLED ) : ?>
+			<p class="notice notice-warning inline"><?php _e( '<strong>Note:</strong> The real-time collaboration feature preview is enabled.' ); ?></p>
+		<?php else : ?>
+			<p class="notice notice-warning inline"><?php _e( '<strong>Note:</strong> The real-time collaboration feature preview has been disabled.' ); ?></p>
+		<?php endif; ?>
+	<?php else : ?>
+		<label for="wp_collaboration_enabled">
+			<input name="wp_collaboration_enabled" type="checkbox" id="wp_collaboration_enabled" value="1" <?php checked( '1', (bool) get_option( 'wp_collaboration_enabled' ) ); ?> />
+			<?php _e( 'Enable real-time collaboration feature preview' ); ?>
+		</label>
+	<?php endif; ?>
 </td>
 </tr>
 <?php


### PR DESCRIPTION
This is the start at adding a constant for forcing enable/disable for real time collab.  Currently only includes UI changes

Trac ticket: https://core.trac.wordpress.org/ticket/64904

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): Claude
Model(s): Sonnet 4.6
Used for: Used to scaffold update that I then manually edited
-->

AI assistance: Yes
Tool(s): Claude
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
