### PR TITLE
Change Icon Library asset location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,7 @@ wp-tests-config.php
 /src/wp-includes/css/*-rtl.css
 /src/wp-includes/blocks/*
 !/src/wp-includes/blocks/index.php
-/src/wp-includes/icons
+/src/wp-includes/images/icon-library
 /src/wp-includes/build
 /src/wp-includes/theme.json
 /packagehash.txt

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -705,7 +705,7 @@ module.exports = function(grunt) {
 							// resolve correctly relative to wp-includes/images/icon-library/.
 							.replace(
 								/'filePath' => 'library\//g,
-								"'filePath' => '"
+								'\'filePath\' => \''
 							);
 					}
 				},

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -55,6 +55,8 @@ module.exports = function(grunt) {
 			'wp-includes/css/dist',
 			'wp-includes/blocks/**/*',
 			'!wp-includes/blocks/index.php',
+			'wp-includes/images/icon-library',
+			// Old location kept temporarily to ensure they are cleaned up.
 			'wp-includes/icons',
 		],
 
@@ -682,31 +684,35 @@ module.exports = function(grunt) {
 					},
 				],
 			},
-			'gutenberg-icons': {
+			'icon-library-images': {
+				files: [ {
+					expand: true,
+					cwd: 'gutenberg/packages/icons/src/library',
+					src: '*.svg',
+					dest: WORKING_DIR + 'wp-includes/images/icon-library',
+				} ],
+			},
+			'icon-library-manifest': {
 				options: {
-					process: function( content, srcpath ) {
-						// Remove the 'gutenberg' text domain from _x() calls in manifest.php.
-						if ( path.basename( srcpath ) === 'manifest.php' ) {
-							return content.replace(
+					process: function( content ) {
+						return content
+							// Remove the 'gutenberg' text domain from _x() calls.
+							.replace(
 								/_x\(\s*([^,]+),\s*([^,]+),\s*['"]gutenberg['"]\s*\)/g,
 								'_x( $1, $2 )'
+							)
+							// Strip the 'library/' prefix from filePath values so they
+							// resolve correctly relative to wp-includes/images/icon-library/.
+							.replace(
+								/'filePath' => 'library\//g,
+								"'filePath' => '"
 							);
-						}
-						return content;
 					}
 				},
-				files: [
-					{
-						src: 'gutenberg/packages/icons/src/manifest.php',
-						dest: WORKING_DIR + 'wp-includes/icons/manifest.php',
-					},
-					{
-						expand: true,
-						cwd: 'gutenberg/packages/icons/src/library',
-						src: '*.svg',
-						dest: WORKING_DIR + 'wp-includes/icons/library/',
-					},
-				],
+				files: [ {
+					src: 'gutenberg/packages/icons/src/manifest.php',
+					dest: WORKING_DIR + 'wp-includes/assets/icon-library-manifest.php',
+				} ],
 			},
 		},
 		sass: {
@@ -2059,12 +2065,13 @@ module.exports = function(grunt) {
 		'copy:gutenberg-modules',
 		'copy:gutenberg-styles',
 		'copy:gutenberg-theme-json',
-		'copy:gutenberg-icons',
+		'copy:icon-library-images',
+		'copy:icon-library-manifest',
 	] );
 
 	grunt.registerTask( 'build', function() {
 		var done = this.async();
-		
+
 		grunt.util.spawn( {
 			grunt: true,
 			args: [ 'clean', '--dev' ],

--- a/src/wp-includes/class-wp-icons-registry.php
+++ b/src/wp-includes/class-wp-icons-registry.php
@@ -41,8 +41,8 @@ class WP_Icons_Registry {
 	 * registry is loaded with those icons listed in the manifest.
 	 */
 	protected function __construct() {
-		$icons_directory = __DIR__ . '/icons/';
-		$manifest_path   = $icons_directory . 'manifest.php';
+		$icons_directory = __DIR__ . '/images/icon-library/';
+		$manifest_path   = __DIR__ . '/assets/icon-library-manifest.php';
 
 		if ( ! is_readable( $manifest_path ) ) {
 			wp_trigger_error(

--- a/src/wp-includes/class-wp-icons-registry.php
+++ b/src/wp-includes/class-wp-icons-registry.php
@@ -42,7 +42,6 @@ class WP_Icons_Registry {
 	 */
 	protected function __construct() {
 		$icons_directory = __DIR__ . '/icons/';
-		$icons_directory = trailingslashit( $icons_directory );
 		$manifest_path   = $icons_directory . 'manifest.php';
 
 		if ( ! is_readable( $manifest_path ) ) {

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-icons-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-icons-controller.php
@@ -11,8 +11,8 @@
 /**
  * Controller which provides a REST endpoint for the editor to read registered
  * icons. For the time being, only core icons are available, which are defined
- * in a single manifest file (wp-includes/icons/manifest.php). Icons are
- * comprised of their SVG source, a name and a translatable label.
+ * in a single manifest file (wp-includes/assets/icon-library-manifest.php).
+ * Icons are comprised of their SVG source, a name and a translatable label.
  *
  * @since 7.0.0
  *


### PR DESCRIPTION
The Icon Library image files are images, so they should live in the `wp-includes/images/` directory.

This updates the build script to:
- copy the icon library SVG files to `wp-includes/images/icon-library` instead of `wp-includes/icons`
- Moves the `manifest.php` file to the `wp-includes/assets/` directory.
- Gives the `manifest.php` file a more specific name: `icon-library-manifest.php`
- Remove `gutenberg-` from the corresponding `grunt copy` tasks.
- Removes an unnecessary `trailingslashit()` call in the icon registry class.

Trac ticket: Core-64393

## Use of AI Tools

AI assistance: Yes
Tools: GitHub Copilot
Used for code review on the PR.
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
