### PR TITLE
Remove unminified `.min` files.

### DIFF
--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -281,11 +281,11 @@ function wp_default_packages_scripts( $scripts ) {
 	 *     'annotations.js' => array('dependencies' => array(...), 'version' => '...'),
 	 *     'api-fetch.js' => array(...
 	 */
-	$assets_file = ABSPATH . WPINC . "/assets/script-loader-packages{$suffix}.php";
+	$assets_file = ABSPATH . WPINC . '/assets/script-loader-packages.php';
 	$assets      = file_exists( $assets_file ) ? include $assets_file : array();
 
 	foreach ( $assets as $file_name => $package_data ) {
-		$basename = str_replace( $suffix . '.js', '', basename( $file_name ) );
+		$basename = str_replace( '.js', '', basename( $file_name ) );
 		$handle   = 'wp-' . $basename;
 		$path     = "/wp-includes/js/dist/{$basename}{$suffix}.js";
 

--- a/src/wp-includes/script-modules.php
+++ b/src/wp-includes/script-modules.php
@@ -149,11 +149,11 @@ function wp_default_script_modules() {
 	/*
 	 * Expects multidimensional array like:
 	 *
-	 *     'interactivity/index.min.js' => array('dependencies' => array(…), 'version' => '…'),
-	 *     'interactivity-router/index.min.js' => array('dependencies' => array(…), 'version' => '…'),
-	 *     'block-library/navigation/view.min.js' => …
+	 *     'interactivity/index.js' => array('dependencies' => array(…), 'version' => '…'),
+	 *     'interactivity-router/index.js' => array('dependencies' => array(…), 'version' => '…'),
+	 *     'block-library/navigation/view.js' => …
 	 */
-	$assets_file = ABSPATH . WPINC . "/assets/script-modules-packages{$suffix}.php";
+	$assets_file = ABSPATH . WPINC . '/assets/script-modules-packages.php';
 	$assets      = file_exists( $assets_file ) ? include $assets_file : array();
 
 	foreach ( $assets as $file_name => $script_module_data ) {
@@ -192,8 +192,10 @@ function wp_default_script_modules() {
 
 		// VIPS files are always minified — the non-minified versions are not
 		// shipped because they are ~10MB of inlined WASM with no debugging value.
-		if ( str_starts_with( $file_name, 'vips/' ) && ! str_contains( $file_name, '.min.' ) ) {
+		if ( str_starts_with( $file_name, 'vips/' ) ) {
 			$file_name = str_replace( '.js', '.min.js', $file_name );
+		} elseif ( '' !== $suffix ) {
+			$file_name = str_replace( '.js', $suffix . '.js', $file_name );
 		}
 
 		$path        = includes_url( "js/dist/script-modules/{$file_name}" );

--- a/tools/gutenberg/copy.js
+++ b/tools/gutenberg/copy.js
@@ -406,7 +406,7 @@ function generateScriptModulesPackages() {
 		'<?php return ' +
 		json2php.make( {
 			linebreak: '\n',
-			indent: '  ',
+			indent: '\t',
 			shortArraySyntax: false,
 		} )( assets ) +
 		';';
@@ -474,7 +474,7 @@ function generateScriptLoaderPackages() {
 		'<?php return ' +
 		json2php.make( {
 			linebreak: '\n',
-			indent: '  ',
+			indent: '\t',
 			shortArraySyntax: false,
 		} )( assets ) +
 		';';
@@ -628,7 +628,7 @@ function generateBlocksJson() {
 		'<?php return ' +
 		json2php.make( {
 			linebreak: '\n',
-			indent: '  ',
+			indent: '\t',
 			shortArraySyntax: false,
 		} )( blocks ) +
 		';';

--- a/tools/gutenberg/copy.js
+++ b/tools/gutenberg/copy.js
@@ -351,14 +351,13 @@ function copyBlockAssets( config ) {
 }
 
 /**
- * Generate script-modules-packages.min.php from individual asset files.
+ * Generate script-modules-packages.php from individual asset files.
  * Reads all view.min.asset.php files from modules/block-library and combines them
  * into a single PHP file.
  */
 function generateScriptModulesPackages() {
 	const modulesDir = path.join( gutenbergBuildDir, 'modules' );
-	const assetsMin = {};
-	const assetsRegular = {};
+	const assets = {};
 
 	/**
 	 * Recursively process directory to find .asset.php files.
@@ -384,16 +383,13 @@ function generateScriptModulesPackages() {
 				const normalizedPath = relativePath
 					.split( path.sep )
 					.join( '/' );
-				const jsPathMin = normalizedPath.replace(
-					/\.asset\.php$/,
-					'.js'
-				);
-				const jsPathRegular = jsPathMin.replace( /\.min\.js$/, '.js' );
+				const jsPath = normalizedPath
+					.replace( /\.asset\.php$/, '.js' )
+					.replace( /\.min\.js$/, '.js' );
 
 				try {
 					const assetData = readReturnedValueFromPHPFile( fullPath );
-					assetsMin[ jsPathMin ] = assetData;
-					assetsRegular[ jsPathRegular ] = assetData;
+					assets[ jsPath ] = assetData;
 				} catch ( error ) {
 					console.error(
 						`   ⚠️  Error reading ${ relativePath }:`,
@@ -406,52 +402,35 @@ function generateScriptModulesPackages() {
 
 	processDirectory( modulesDir, modulesDir );
 
-	// Generate both minified and non-minified PHP files using json2php.
-	const phpContentMin =
+	const phpContent =
 		'<?php return ' +
 		json2php.make( {
 			linebreak: '\n',
 			indent: '  ',
 			shortArraySyntax: false,
-		} )( assetsMin ) +
+		} )( assets ) +
 		';';
 
-	const phpContentRegular =
-		'<?php return ' +
-		json2php.make( {
-			linebreak: '\n',
-			indent: '  ',
-			shortArraySyntax: false,
-		} )( assetsRegular ) +
-		';';
-
-	const outputPathMin = path.join(
-		wpIncludesDir,
-		'assets/script-modules-packages.min.php'
-	);
-	const outputPathRegular = path.join(
+	const outputPath = path.join(
 		wpIncludesDir,
 		'assets/script-modules-packages.php'
 	);
 
-	fs.mkdirSync( path.dirname( outputPathMin ), { recursive: true } );
-	fs.writeFileSync( outputPathMin, phpContentMin );
-	fs.writeFileSync( outputPathRegular, phpContentRegular );
+	fs.mkdirSync( path.dirname( outputPath ), { recursive: true } );
+	fs.writeFileSync( outputPath, phpContent );
 
 	console.log(
-		`   ✅ Generated with ${ Object.keys( assetsMin ).length } modules`
+		`   ✅ Generated with ${ Object.keys( assets ).length } modules`
 	);
 }
 
 /**
- * Generate script-loader-packages.php and script-loader-packages.min.php from individual asset files.
- * Reads all .min.asset.php files from scripts/ and combines them into PHP files for script registration.
- * Generates both minified and non-minified versions.
+ * Generate script-loader-packages.php from individual asset files.
+ * Reads all .min.asset.php files from scripts/ and combines them into a PHP file for script registration.
  */
 function generateScriptLoaderPackages() {
 	const scriptsDir = path.join( gutenbergBuildDir, 'scripts' );
-	const assetsMin = {};
-	const assetsRegular = {};
+	const assets = {};
 
 	if ( ! fs.existsSync( scriptsDir ) ) {
 		console.log( '   ⚠️  Scripts directory not found' );
@@ -482,12 +461,7 @@ function generateScriptLoaderPackages() {
 				assetData.dependencies = [];
 			}
 
-			// Create entries for both minified and non-minified versions.
-			const jsPathMin = `${ entry.name }.min.js`;
-			const jsPathRegular = `${ entry.name }.js`;
-
-			assetsMin[ jsPathMin ] = assetData;
-			assetsRegular[ jsPathRegular ] = assetData;
+			assets[ `${ entry.name }.js` ] = assetData;
 		} catch ( error ) {
 			console.error(
 				`   ⚠️  Error reading ${ entry.name }/index.min.asset.php:`,
@@ -496,40 +470,25 @@ function generateScriptLoaderPackages() {
 		}
 	}
 
-	// Generate both minified and non-minified PHP files using json2php.
-	const phpContentMin =
+	const phpContent =
 		'<?php return ' +
 		json2php.make( {
 			linebreak: '\n',
 			indent: '  ',
 			shortArraySyntax: false,
-		} )( assetsMin ) +
+		} )( assets ) +
 		';';
 
-	const phpContentRegular =
-		'<?php return ' +
-		json2php.make( {
-			linebreak: '\n',
-			indent: '  ',
-			shortArraySyntax: false,
-		} )( assetsRegular ) +
-		';';
-
-	const outputPathMin = path.join(
-		wpIncludesDir,
-		'assets/script-loader-packages.min.php'
-	);
-	const outputPathRegular = path.join(
+	const outputPath = path.join(
 		wpIncludesDir,
 		'assets/script-loader-packages.php'
 	);
 
-	fs.mkdirSync( path.dirname( outputPathMin ), { recursive: true } );
-	fs.writeFileSync( outputPathMin, phpContentMin );
-	fs.writeFileSync( outputPathRegular, phpContentRegular );
+	fs.mkdirSync( path.dirname( outputPath ), { recursive: true } );
+	fs.writeFileSync( outputPath, phpContent );
 
 	console.log(
-		`   ✅ Generated with ${ Object.keys( assetsMin ).length } packages`
+		`   ✅ Generated with ${ Object.keys( assets ).length } packages`
 	);
 }
 

--- a/tools/gutenberg/copy.js
+++ b/tools/gutenberg/copy.js
@@ -352,8 +352,8 @@ function copyBlockAssets( config ) {
 
 /**
  * Generate script-modules-packages.php from individual asset files.
- * Reads all view.min.asset.php files from modules/block-library and combines them
- * into a single PHP file.
+ * Recursively scans the Gutenberg modules/ directory for *.min.asset.php files
+ * and combines their contents into a single PHP file.
  */
 function generateScriptModulesPackages() {
 	const modulesDir = path.join( gutenbergBuildDir, 'modules' );


### PR DESCRIPTION
This removes the `script-loader-packages.min.php` and `script-modules-packages.min.php` files.

They were not being minified and an unminified vesion of the file is more human readable. The unminified file is roughly 10KB larger, which seems like a reasonable tradeoff.

<!-- Insert a description of your changes here -->

Trac ticket: Core-64909.

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Sonnet 4.6
Used for: A detailed prompt was given to Claude to work through the changes required. The results were reviewed by me and adjustments were made.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
