### PR TITLE
Only copy `.js` files for scripts

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -641,7 +641,7 @@ module.exports = function(grunt) {
 					expand: true,
 					cwd: 'gutenberg/build/modules',
 					src: [
-						'**/*',
+						'**/*.js',
 						'!**/*.map',
 						// Skip non-minified VIPS files — they are ~16MB of inlined WASM
 						// with no debugging value over the minified versions.

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -641,7 +641,8 @@ module.exports = function(grunt) {
 					expand: true,
 					cwd: 'gutenberg/build/modules',
 					src: [
-						'**/*.js',
+						'**/*',
+						'!**/*.map',
 						// Skip non-minified VIPS files — they are ~16MB of inlined WASM
 						// with no debugging value over the minified versions.
 						'!vips/!(*.min).js',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -642,7 +642,6 @@ module.exports = function(grunt) {
 					cwd: 'gutenberg/build/modules',
 					src: [
 						'**/*.js',
-						'!**/*.map',
 						// Skip non-minified VIPS files — they are ~16MB of inlined WASM
 						// with no debugging value over the minified versions.
 						'!vips/!(*.min).js',

--- a/tools/gutenberg/copy.js
+++ b/tools/gutenberg/copy.js
@@ -595,7 +595,7 @@ async function main() {
 
 					for ( const file of packageFiles ) {
 						if (
-							/^index\.(js|min\.js|min\.asset\.php)$/.test( file )
+							/^index\.(js|min\.js)$/.test( file )
 						) {
 							const srcFile = path.join( src, file );
 							// Replace 'index.' with 'package-name.'.


### PR DESCRIPTION
The `*.min.asset.php` files in the `js/dist` directory should not be copied in the build step.

The contents of these files are already included in the built `wp-includes/assets/script-loader-packages.php` file.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->

Trac ticket: Core-64393.

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Sonnet 4.6
Used for: Used Claude to analyze the code base to confirm that the PHP files being removed had no use within `wordpress-develop`.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
