### PR TITLE
Build Tools: Replace deprecated browserslist --update-db command

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2221,7 +2221,7 @@ module.exports = function(grunt) {
 
 	grunt.registerTask( 'browserslist:update', 'Update the local database of browser supports', function() {
 		grunt.log.writeln( `Updating browsers list` );
-		spawn( 'npx', [ 'browserslist@latest', '--update-db' ], {
+		spawn( 'npx', [ 'update-browserslist-db@latest' ], {
 			cwd: __dirname,
 			stdio: 'inherit',
 		} );


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->
This patch replaces the deprecated `--update-db` command in the `browserslist:update` Grunt task with `update-browserslist-db@latest`.

Tested by running `npx grunt browserslist:update`, which executed successfully.

Trac ticket: https://core.trac.wordpress.org/ticket/64900

## Use of AI Tools
AI assistance: Yes
Tool(s): ChatGPT
Model(s): GPT-5.3
Used for: Testing the patch and understanding why it exists  

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
