### PR TITLE
Only include files for active, stable routes

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -603,7 +603,7 @@ module.exports = function(grunt) {
 				src: 'vendor/composer/ca-bundle/res/cacert.pem',
 				dest: SOURCE_DIR + 'wp-includes/certificates/ca-bundle.crt'
 			},
-			// Gutenberg PHP infrastructure files (pages.php, constants.php, pages/).
+			// Gutenberg PHP infrastructure files (routes.php, pages.php, constants.php, pages/).
 			'gutenberg-php': {
 				options: {
 					process: function( content ) {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -629,31 +629,13 @@ module.exports = function(grunt) {
 			 * While the registry file does not contain any experimental routes, the `gutenberg/build/routes` directory
 			 * includes the files for all registered routes. Only the files related to the routes specified in the
 			 * registry should be included in the WordPress build.
+			 *
+			 * The `src` list is populated at task runtime by `routes:setup`, which reads the registry after
+			 * `gutenberg:download` has run. See the `routes:setup` task registration for implementation details.
 			 */
-			routes: ( function() {
-				var registryContent = fs.readFileSync( 'gutenberg/build/routes/registry.php', 'utf8' );
-				var routeNames = [];
-				var namePattern = /'name'\s*=>\s*'([^']+)'/g;
-				var match;
-				while ( ( match = namePattern.exec( registryContent ) ) !== null ) {
-					routeNames.push( match[ 1 ] );
-				}
-				return {
-					files: [ {
-						expand: true,
-						cwd: 'gutenberg/build',
-						src: [ 'routes.php', 'routes/registry.php' ].concat(
-							routeNames.flatMap( function( name ) {
-								return [
-									'routes/' + name + '/**/*.php',
-									'routes/' + name + '/**/*.js',
-								];
-							} )
-						),
-						dest: WORKING_DIR + 'wp-includes/build/',
-					} ],
-				};
-			} )(),
+			routes: {
+				files: [],
+			},
 			'gutenberg-js': {
 				files: [ {
 					expand: true,
@@ -2080,8 +2062,38 @@ module.exports = function(grunt) {
 			} );
 	} );
 
+	grunt.registerTask( 'routes:setup', 'Reads the routes registry and configures the copy:routes task.', function() {
+		var registryPath = 'gutenberg/build/routes/registry.php';
+		if ( ! fs.existsSync( registryPath ) ) {
+			grunt.fatal(
+				'Route registry not found at ' + registryPath + '. Run `grunt gutenberg:download` first.'
+			);
+		}
+		var registryContent = fs.readFileSync( registryPath, 'utf8' );
+		var routeNames = [];
+		var namePattern = /'name'\s*=>\s*'([^']+)'/g;
+		var match;
+		while ( ( match = namePattern.exec( registryContent ) ) !== null ) {
+			routeNames.push( match[ 1 ] );
+		}
+		grunt.config( [ 'copy', 'routes', 'files' ], [ {
+			expand: true,
+			cwd: 'gutenberg/build',
+			src: [ 'routes/registry.php' ].concat(
+				routeNames.flatMap( function( name ) {
+					return [
+						'routes/' + name + '/**/*.php',
+						'routes/' + name + '/**/*.js',
+					];
+				} )
+			),
+			dest: WORKING_DIR + 'wp-includes/build/',
+		} ] );
+	} );
+
 	grunt.registerTask( 'build:gutenberg', [
 		'copy:gutenberg-php',
+		'routes:setup',
 		'copy:routes',
 		'copy:gutenberg-js',
 		'gutenberg:copy',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -634,7 +634,10 @@ module.exports = function(grunt) {
 			 * `gutenberg:download` has run. See the `routes:setup` task registration for implementation details.
 			 */
 			routes: {
-				files: [],
+				expand: true,
+				cwd: 'gutenberg/build',
+				src: [],
+				dest: WORKING_DIR + 'wp-includes/build/',
 			},
 			'gutenberg-js': {
 				files: [ {
@@ -2076,19 +2079,14 @@ module.exports = function(grunt) {
 		while ( ( match = namePattern.exec( registryContent ) ) !== null ) {
 			routeNames.push( match[ 1 ] );
 		}
-		grunt.config( [ 'copy', 'routes', 'files' ], [ {
-			expand: true,
-			cwd: 'gutenberg/build',
-			src: [ 'routes/registry.php' ].concat(
-				routeNames.flatMap( function( name ) {
-					return [
-						'routes/' + name + '/**/*.php',
-						'routes/' + name + '/**/*.js',
-					];
-				} )
-			),
-			dest: WORKING_DIR + 'wp-includes/build/',
-		} ] );
+		grunt.config( [ 'copy', 'routes', 'src' ], [ 'routes/registry.php' ].concat(
+			routeNames.flatMap( function( name ) {
+				return [
+					'routes/' + name + '/**/*.php',
+					'routes/' + name + '/**/*.js',
+				];
+			} )
+		) );
 	} );
 
 	grunt.registerTask( 'build:gutenberg', [

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -616,6 +616,7 @@ module.exports = function(grunt) {
 					expand: true,
 					cwd: 'gutenberg/build',
 					src: [
+						'routes.php',
 						'pages.php',
 						'constants.php',
 						'pages/**/*.php',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -601,7 +601,7 @@ module.exports = function(grunt) {
 				src: 'vendor/composer/ca-bundle/res/cacert.pem',
 				dest: SOURCE_DIR + 'wp-includes/certificates/ca-bundle.crt'
 			},
-			// Gutenberg PHP infrastructure files (routes.php, pages.php, constants.php, pages/, routes/).
+			// Gutenberg PHP infrastructure files (pages.php, constants.php, pages/).
 			'gutenberg-php': {
 				options: {
 					process: function( content ) {
@@ -616,22 +616,50 @@ module.exports = function(grunt) {
 					expand: true,
 					cwd: 'gutenberg/build',
 					src: [
-						'routes.php',
 						'pages.php',
 						'constants.php',
 						'pages/**/*.php',
-						'routes/**/*.php',
 					],
 					dest: WORKING_DIR + 'wp-includes/build/',
 				} ],
 			},
+			/*
+			 * Only copy files relevant to the routes specified in the registry file.
+			 *
+			 * While the registry file does not contain any experimental routes, the `gutenberg/build/routes` directory
+			 * includes the files for all registered routes. Only the files related to the routes specified in the
+			 * registry should be included in the WordPress build.
+			 */
+			routes: ( function() {
+				var registryContent = fs.readFileSync( 'gutenberg/build/routes/registry.php', 'utf8' );
+				var routeNames = [];
+				var namePattern = /'name'\s*=>\s*'([^']+)'/g;
+				var match;
+				while ( ( match = namePattern.exec( registryContent ) ) !== null ) {
+					routeNames.push( match[ 1 ] );
+				}
+				return {
+					files: [ {
+						expand: true,
+						cwd: 'gutenberg/build',
+						src: [ 'routes.php', 'routes/registry.php' ].concat(
+							routeNames.flatMap( function( name ) {
+								return [
+									'routes/' + name + '/**/*.php',
+									'routes/' + name + '/**/*.js',
+								];
+							} )
+						),
+						dest: WORKING_DIR + 'wp-includes/build/',
+					} ],
+				};
+			} )(),
 			'gutenberg-js': {
 				files: [ {
 					expand: true,
 					cwd: 'gutenberg/build',
 					src: [
 						'pages/**/*.js',
-						'routes/**/*.js',
 					],
 					dest: WORKING_DIR + 'wp-includes/build/',
 				} ],
@@ -2054,6 +2082,7 @@ module.exports = function(grunt) {
 
 	grunt.registerTask( 'build:gutenberg', [
 		'copy:gutenberg-php',
+		'copy:routes',
 		'copy:gutenberg-js',
 		'gutenberg:copy',
 		'copy:gutenberg-modules',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2067,16 +2067,18 @@ module.exports = function(grunt) {
 	} );
 
 	grunt.registerTask( 'routes:setup', 'Reads the routes registry and configures the copy:routes task.', function() {
-		var registryPath = 'gutenberg/build/routes/registry.php';
-		if ( ! fs.existsSync( registryPath ) ) {
+		const registryPath = 'gutenberg/build/routes/registry.php';
+		let registryContent;
+		try {
+			registryContent = fs.readFileSync( registryPath, 'utf8' );
+		} catch ( e ) {
 			grunt.fatal(
 				'Route registry not found at ' + registryPath + '. Run `grunt gutenberg:download` first.'
 			);
 		}
-		var registryContent = fs.readFileSync( registryPath, 'utf8' );
-		var routeNames = [];
-		var namePattern = /'name'\s*=>\s*'([^']+)'/g;
-		var match;
+		const namePattern = /'name'\s*=>\s*'([^']+)'/g;
+		const routeNames = [];
+		let match;
 		while ( ( match = namePattern.exec( registryContent ) ) !== null ) {
 			routeNames.push( match[ 1 ] );
 		}
@@ -2086,6 +2088,15 @@ module.exports = function(grunt) {
 				'No route names found in ' + registryPath + '. The format of the file may have changed.'
 			);
 		}
+
+		const validName = /^[A-Za-z0-9_-]+$/;
+		routeNames.forEach( function( name ) {
+			if ( ! validName.test( name ) ) {
+				grunt.fatal(
+					'Invalid route name \'' + name + '\' in ' + registryPath + '. Expected only letters, digits, hyphens, and underscores.'
+				);
+			}
+		} );
 
 		grunt.config( [ 'copy', 'routes', 'src' ], [ 'routes/registry.php' ].concat(
 			routeNames.flatMap( function( name ) {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2080,6 +2080,13 @@ module.exports = function(grunt) {
 		while ( ( match = namePattern.exec( registryContent ) ) !== null ) {
 			routeNames.push( match[ 1 ] );
 		}
+
+		if ( routeNames.length === 0 ) {
+			grunt.fatal(
+				'No route names found in ' + registryPath + '. The format of the file may have changed.'
+			);
+		}
+
 		grunt.config( [ 'copy', 'routes', 'src' ], [ 'routes/registry.php' ].concat(
 			routeNames.flatMap( function( name ) {
 				return [


### PR DESCRIPTION
The built `gutenberg` asset currently includes the files for all routes in the Gutenberg plugin, even experimental and inactive ones. However, the `registry.php` file only references the routes that should be bundled in Core correctly.

This collects all of the `grunt copy` logic related to routes into a new `copy:routes` task and adjusts the `src` list to only include files related to the routes specified in the `registry.php` file to avoid unintentionally including files that were not meant to be considered stable.

Trac ticket: Core-64393.

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Sonnet 4.6
Used for: Created the initial first draft of the PR based a description of the problem and desired outcome.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
