### PR TITLE
Code Quality: Replace is_integer() with is_int() for consistency

### DIFF
--- a/src/wp-admin/includes/class-pclzip.php
+++ b/src/wp-admin/includes/class-pclzip.php
@@ -296,7 +296,7 @@
       $v_size--;
 
       // ----- Look for first arg
-      if ((is_integer($v_arg_list[0])) && ($v_arg_list[0] > 77000)) {
+      if ((is_int($v_arg_list[0])) && ($v_arg_list[0] > 77000)) {
 
         // ----- Parse the options
         $v_result = $this->privParseOptions($v_arg_list, $v_size, $v_options,
@@ -479,7 +479,7 @@
       $v_size--;
 
       // ----- Look for first arg
-      if ((is_integer($v_arg_list[0])) && ($v_arg_list[0] > 77000)) {
+      if ((is_int($v_arg_list[0])) && ($v_arg_list[0] > 77000)) {
 
         // ----- Parse the options
         $v_result = $this->privParseOptions($v_arg_list, $v_size, $v_options,
@@ -732,7 +732,7 @@
       $v_arg_list = func_get_args();
 
       // ----- Look for first arg
-      if ((is_integer($v_arg_list[0])) && ($v_arg_list[0] > 77000)) {
+      if ((is_int($v_arg_list[0])) && ($v_arg_list[0] > 77000)) {
 
         // ----- Parse the options
         $v_result = $this->privParseOptions($v_arg_list, $v_size, $v_options,
@@ -893,7 +893,7 @@
       $v_size--;
 
       // ----- Look for first arg
-      if ((is_integer($v_arg_list[0])) && ($v_arg_list[0] > 77000)) {
+      if ((is_int($v_arg_list[0])) && ($v_arg_list[0] > 77000)) {
 
         // ----- Parse the options
         $v_result = $this->privParseOptions($v_arg_list, $v_size, $v_options,
@@ -1479,7 +1479,7 @@
 
           // ----- Check the value
           $v_value = $p_options_list[$i+1];
-          if ((!is_integer($v_value)) || ($v_value<0)) {
+          if ((!is_int($v_value)) || ($v_value<0)) {
             PclZip::privErrorLog(PCLZIP_ERR_INVALID_OPTION_VALUE, "Integer expected for option '".PclZipUtilOptionText($p_options_list[$i])."'");
             return PclZip::errorCode();
           }
@@ -1646,7 +1646,7 @@
               // ----- Parse items
               $v_work_list = explode(",", $p_options_list[$i+1]);
           }
-          else if (is_integer($p_options_list[$i+1])) {
+          else if (is_int($p_options_list[$i+1])) {
               $v_work_list[0] = $p_options_list[$i+1].'-'.$p_options_list[$i+1];
           }
           else if (is_array($p_options_list[$i+1])) {
@@ -1944,7 +1944,7 @@
         break;
 
         case PCLZIP_ATT_FILE_MTIME :
-          if (!is_integer($v_value)) {
+          if (!is_int($v_value)) {
             PclZip::privErrorLog(PCLZIP_ERR_INVALID_ATTRIBUTE_VALUE, "Invalid type ".gettype($v_value).". Integer expected for attribute '".PclZipUtilOptionText($v_key)."'");
             return PclZip::errorCode();
           }

--- a/src/wp-includes/IXR/class-IXR-value.php
+++ b/src/wp-includes/IXR/class-IXR-value.php
@@ -44,7 +44,7 @@ class IXR_Value {
         if ($this->data === true || $this->data === false) {
             return 'boolean';
         }
-        if (is_integer($this->data)) {
+        if (is_int($this->data)) {
             return 'int';
         }
         if (is_double($this->data)) {

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -5105,7 +5105,7 @@ function _wp_array_get( $input_array, $path, $default_value = null ) {
 		}
 
 		if ( is_string( $path_element )
-			|| is_integer( $path_element )
+			|| is_int( $path_element )
 			|| null === $path_element
 		) {
 			/*
@@ -5182,7 +5182,7 @@ function _wp_array_set( &$input_array, $path, $value = null ) {
 
 	foreach ( $path as $path_element ) {
 		if (
-			! is_string( $path_element ) && ! is_integer( $path_element ) &&
+			! is_string( $path_element ) && ! is_int( $path_element ) &&
 			! is_null( $path_element )
 		) {
 			return;


### PR DESCRIPTION
[is_integer()](https://www.php.net/manual/en/function.is-integer.php) is an alias for [is_int()](https://www.php.net/manual/en/function.is-int.php). While they function identically, the WordPress Coding Standards and modern PHP practices generally lean towards using the official function name rather than its alias to maintain consistency across the codebase.

There is also a proposal to deprecate `is_integer()` in PHP 8.6, [see RFC](https://wiki.php.net/rfc/deprecations_php_8_6#deprecate_is_integer)

I am proposing to replace all occurrences of `is_integer()` with `is_int()` throughout the WordPress Core. This is a non-breaking change as the functionality remains exactly the same.

Trac ticket: https://core.trac.wordpress.org/ticket/64913

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
