### PR TITLE
Adjust the WP_ALLOW_COLLABORATION check in writing options

### DIFF
--- a/src/wp-admin/options-writing.php
+++ b/src/wp-admin/options-writing.php
@@ -112,7 +112,7 @@ unset( $post_formats['standard'] );
 <tr>
 <th scope="row"><?php _e( 'Collaboration' ); ?></th>
 <td>
-	<?php if ( ! defined( 'WP_ALLOW_COLLABORATION' ) || true === WP_ALLOW_COLLABORATION ) : ?>
+	<?php if ( defined( 'WP_ALLOW_COLLABORATION' ) && false === WP_ALLOW_COLLABORATION ) : ?>
 		<div class="notice notice-warning inline">
 			<p><?php _e( '<strong>Note:</strong> Real-time collaboration has been disabled.' ); ?></p>
 		</div>


### PR DESCRIPTION
The `WP_ALLOW_COLLABORATION` constant was introduced in PR #11311 to support disabling RTC at the host level or at the wp-config.php level. A part of that PR was hiding the "Enable RTC" checkbox in the writing options when RTC is explicitly disallowed via the constant. In the process of reviewing the change and merging suggestions, I have used the wrong condition to hide that checkbox.

This PR makes the condition right.

Props to @tyxla for noticing!

## Testing instructions

* Set the WP_ALLOW_COLLABORATION constant to false, go to writing options, confirm the checkbox is replaced by a message "Real-time collaboration has been disabled".
* Set it to true, confirm the checkbox is there.
* Remove the constant, confirm the checkbox is there.

cc @ellatrix