### PR TITLE
Docs: Add missing inline doc descriptions in wp-admin/includes/misc.php

### DIFF
--- a/src/wp-admin/includes/misc.php
+++ b/src/wp-admin/includes/misc.php
@@ -334,7 +334,7 @@ function iis7_save_url_rewrite_rules() {
  *
  * @since 1.5.0
  *
- * @param string $file
+ * @param string $file Path to the recently edited file. 
  */
 function update_recently_edited( $file ) {
 	$oldfiles = (array) get_option( 'recently_edited' );
@@ -563,8 +563,8 @@ function wp_print_plugin_file_tree( $tree, $label = '', $level = 2, $size = 1, $
  *
  * @since 2.1.0
  *
- * @param string $old_value
- * @param string $value
+ * @param string $old_value The old value of the option.
+ * @param string $value     The new value of the option.
  */
 function update_home_siteurl( $old_value, $value ) {
 	if ( wp_installing() ) {
@@ -608,7 +608,7 @@ function wp_reset_vars( $vars ) {
  *
  * @since 2.1.0
  *
- * @param string|WP_Error $message
+ * @param string|WP_Error $message The message to display, or a WP_Error object.
  */
 function show_message( $message ) {
 	if ( is_wp_error( $message ) ) {
@@ -980,8 +980,8 @@ function iis7_add_rewrite_rule( $filename, $rewrite_rule ) {
  *
  * @since 2.8.0
  *
- * @param DOMDocument $doc
- * @param string      $filename
+ * @param DOMDocument $doc      The DOMDocument object to save.
+ * @param string      $filename The file path to save the XML document to.
  */
 function saveDomDocument( $doc, $filename ) { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.FunctionNameInvalid
 	$config = $doc->saveXML();
@@ -1057,6 +1057,7 @@ function admin_color_scheme_picker( $user_id ) {
 }
 
 /**
+ * Outputs the JavaScript for the admin color scheme settings.
  *
  * @since 3.8.0
  *

--- a/src/wp-admin/includes/misc.php
+++ b/src/wp-admin/includes/misc.php
@@ -625,9 +625,11 @@ function show_message( $message ) {
 }
 
 /**
+ * Parses the PHP content and finds function calls to be used for documentation linking.
+ *
  * @since 2.8.0
  *
- * @param string $content
+ * @param string $content The PHP content to parse.
  * @return string[] Array of function names.
  */
 function wp_doc_link_parse( $content ) {


### PR DESCRIPTION
## Description

Add missing inline doc `@param` descriptions and function summary in `src/wp-admin/includes/misc.php`.

### Functions fixed:

- `update_recently_edited()` — missing `@param $file` description
- `update_home_siteurl()` — missing `@param $old_value` and `@param $value` descriptions
- `show_message()` — missing `@param $message` description
- `saveDomDocument()` — missing `@param $doc` and `@param $filename` descriptions
- `wp_color_scheme_settings()` — missing function summary description

## Changes

- No functional changes, documentation only.
- Follows the [WordPress Inline Documentation Standards](https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/).

## Trac Ticket

Fixes https://core.trac.wordpress.org/ticket/64920