### PR TITLE
Code Quality: Remove redundant variable assignment in author template

### DIFF
--- a/src/wp-includes/author-template.php
+++ b/src/wp-includes/author-template.php
@@ -489,8 +489,7 @@ function wp_list_authors( $args = '' ) {
 	 */
 	$query_args = apply_filters( 'wp_list_authors_args', $query_args, $parsed_args );
 
-	$authors     = get_users( $query_args );
-	$post_counts = array();
+	$authors = get_users( $query_args );
 
 	/**
 	 * Filters whether to short-circuit performing the query for author post counts.


### PR DESCRIPTION
We don't need to initialize `$post_counts` as an empty array, since it will be overwritten directly by the filter value in line 502

Trac ticket: https://core.trac.wordpress.org/ticket/64238

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
