### PR TITLE
RTC: Define WP_ALLOW_COLLABORATION in wp_is_collaboration_allowed()

### DIFF
--- a/src/wp-admin/options-writing.php
+++ b/src/wp-admin/options-writing.php
@@ -112,15 +112,15 @@ unset( $post_formats['standard'] );
 <tr>
 <th scope="row"><?php _e( 'Collaboration' ); ?></th>
 <td>
-	<?php if ( defined( 'WP_ALLOW_COLLABORATION' ) && false === WP_ALLOW_COLLABORATION ) : ?>
-		<div class="notice notice-warning inline">
-			<p><?php _e( '<strong>Note:</strong> Real-time collaboration has been disabled.' ); ?></p>
-		</div>
-	<?php else : ?>
+	<?php if ( wp_is_collaboration_allowed() ) : ?>
 		<label for="wp_collaboration_enabled">
 			<input name="wp_collaboration_enabled" type="checkbox" id="wp_collaboration_enabled" value="1" <?php checked( '1', (bool) get_option( 'wp_collaboration_enabled' ) ); ?> />
 			<?php _e( 'Enable real-time collaboration' ); ?>
 		</label>
+	<?php else : ?>
+		<div class="notice notice-warning inline">
+			<p><?php _e( '<strong>Note:</strong> Real-time collaboration has been disabled.' ); ?></p>
+		</div>
 	<?php endif; ?>
 </td>
 </tr>

--- a/src/wp-admin/options-writing.php
+++ b/src/wp-admin/options-writing.php
@@ -115,7 +115,7 @@ unset( $post_formats['standard'] );
 	<?php if ( wp_is_collaboration_allowed() ) : ?>
 		<label for="wp_collaboration_enabled">
 			<input name="wp_collaboration_enabled" type="checkbox" id="wp_collaboration_enabled" value="1" <?php checked( '1', (bool) get_option( 'wp_collaboration_enabled' ) ); ?> />
-			<?php _e( 'Enable real-time collaboration' ); ?>
+			<?php _e( "Enable early access to real-time collaboration. Real-time collaboration may affect your website's performance." ); ?>
 		</label>
 	<?php else : ?>
 		<div class="notice notice-warning inline">

--- a/src/wp-includes/collaboration.php
+++ b/src/wp-includes/collaboration.php
@@ -19,7 +19,7 @@
  */
 function wp_is_collaboration_enabled() {
 	return (
-		wp_is_collaboration_allowed() && 
+		wp_is_collaboration_allowed() &&
 		(bool) get_option( 'wp_collaboration_enabled' )
 	);
 }

--- a/src/wp-includes/collaboration.php
+++ b/src/wp-includes/collaboration.php
@@ -18,11 +18,41 @@
  * @return bool Whether real-time collaboration is enabled.
  */
 function wp_is_collaboration_enabled() {
-	if ( ! defined( 'WP_ALLOW_COLLABORATION' ) || ! WP_ALLOW_COLLABORATION ) {
-		return false;
+	return (
+		wp_is_collaboration_allowed() && 
+		(bool) get_option( 'wp_collaboration_enabled' )
+	);
+}
+
+/**
+ * Determines whether real-time collaboration is allowed.
+ *
+ * If the WP_ALLOW_COLLABORATION constant is false,
+ * collaboration is not allowed and cannot be enabled.
+ * The constant defaults to true, unless the WP_ALLOW_COLLABORATION
+ * environment variable is set to string "false".
+ *
+ * @since 7.0.0
+ *
+ * @return bool Whether real-time collaboration is enabled.
+ */
+function wp_is_collaboration_allowed() {
+	if ( ! defined( 'WP_ALLOW_COLLABORATION' ) ) {
+		$env_value = getenv( 'WP_ALLOW_COLLABORATION' );
+		if ( false === $env_value ) {
+			// Environment variable is not defined, default to allowing collaboration.
+			define( 'WP_ALLOW_COLLABORATION', true );
+		} else {
+			/*
+			 * Environment variable is defined, let's confirm it is actually set to
+			 * "true" as it may still have a string value "false" – the preceeding
+			 * `if` branch only tests for the boolean `false`.
+			 */
+			define( 'WP_ALLOW_COLLABORATION', 'true' === $env_value );
+		}
 	}
 
-	return (bool) get_option( 'wp_collaboration_enabled' );
+	return WP_ALLOW_COLLABORATION;
 }
 
 /**

--- a/src/wp-includes/default-constants.php
+++ b/src/wp-includes/default-constants.php
@@ -398,26 +398,6 @@ function wp_functionality_constants() {
 	if ( ! defined( 'WP_CRON_LOCK_TIMEOUT' ) ) {
 		define( 'WP_CRON_LOCK_TIMEOUT', MINUTE_IN_SECONDS );
 	}
-
-	/**
-	 * Whether real time collaboration is permitted to be enabled.
-	 *
-	 * @since 7.0.0
-	 */
-	if ( ! defined( 'WP_ALLOW_COLLABORATION' ) ) {
-		$env_value = getenv( 'WP_ALLOW_COLLABORATION' );
-		if ( false === $env_value ) {
-			// Environment variable is not defined, default to allowing collaboration.
-			define( 'WP_ALLOW_COLLABORATION', true );
-		} else {
-			/*
-			 * Environment variable is defined, let's confirm it is actually set to
-			 * "true" as it may still have a string value "false" – the preceeding
-			 * `if` branch only tests for the boolean `false`.
-			 */
-			define( 'WP_ALLOW_COLLABORATION', 'true' === $env_value );
-		}
-	}
 }
 
 /**


### PR DESCRIPTION
https://github.com/WordPress/wordpress-develop/pull/11311 introduced the `WP_ALLOW_COLLABORATION` constant to help hosts disable RTC at the platform level. The constant was defined in `wp_functionality_constants()`, which runs in wp-settings.php after collaboration.php is loaded. That created a boot-order edge case where `wp_is_collaboration_enabled()` could be called before the constant existed – for instance via SHORTINIT.

This PR moves the constant definition into a new `wp_is_collaboration_allowed()` function in collaboration.php. The function checks the constant, and if it's missing, defines it on the spot from the environment variable (defaulting to true). `wp_is_collaboration_enabled()` now delegates to wp_is_collaboration_allowed() for the constant check, and the admin UI calls wp_is_collaboration_allowed() directly to decide whether to show the checkbox or a "disabled" notice.

Trac ticket: [core.trac.wordpress.org/ticket/64904](https://core.trac.wordpress.org/ticket/64904)