### PR TITLE
Formatting: Skip readonly properties in `map_deep()` to prevent fatal errors on PHP 8.1+

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -5145,6 +5145,13 @@ function map_deep( $value, $callback ) {
 	} elseif ( is_object( $value ) ) {
 		$object_vars = get_object_vars( $value );
 		foreach ( $object_vars as $property_name => $property_value ) {
+			if ( PHP_VERSION_ID >= 80100 ) {
+				$reflection_property = new ReflectionProperty( $value, $property_name );
+				if ( $reflection_property->isReadOnly() ) {
+					continue;
+				}
+			}
+
 			$value->$property_name = map_deep( $property_value, $callback );
 		}
 	} else {


### PR DESCRIPTION

Trac ticket: https://core.trac.wordpress.org/ticket/60355

On PHP 8.1+, passing an object with `readonly` properties through `map_deep()` causes a fatal error because the function attempts to reassign every property after applying the callback.

This affects any code path that stores objects in metadata, since `update_metadata()` → `wp_unslash()` → `stripslashes_deep()` calls `map_deep()` internally.

This PR adds a `PHP_VERSION_ID >= 80100` guard inside `map_deep()` that uses `ReflectionProperty::isReadOnly()` to detect and skip readonly properties. 