### PR TITLE
Avoid calling PHP directly in build process

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -79,6 +79,7 @@
 				"grunt-webpack": "7.0.1",
 				"install-changed": "1.1.0",
 				"json2php": "0.0.12",
+				"php-array-reader": "2.1.3",
 				"postcss": "8.5.8",
 				"prettier": "npm:wp-prettier@3.0.3",
 				"qunit": "~2.25.0",
@@ -26136,6 +26137,23 @@
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
 			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
 			"dev": true
+		},
+		"node_modules/php-array-reader": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/php-array-reader/-/php-array-reader-2.1.3.tgz",
+			"integrity": "sha512-FjgMmNfnbi76wsbzO/dWEeySt0WZpxv8q/7RH0XFPyNLxsfJSf97KKe/4Rgdmx/XRDGlbl8THU5ayKwGE3Xqrw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"php-parser": "^3.1.5"
+			}
+		},
+		"node_modules/php-parser": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/php-parser/-/php-parser-3.5.0.tgz",
+			"integrity": "sha512-EHdzSckQNP86jQRCEsMYhs+YzS4BfvfxnyhvzHVhVRoRUGEMFi8f3xKfuS9xdChBazZSyvb10SZbqhYQLGBcQg==",
+			"dev": true,
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/picocolors": {
 			"version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
 		"grunt-webpack": "7.0.1",
 		"install-changed": "1.1.0",
 		"json2php": "0.0.12",
+		"php-array-reader": "2.1.3",
 		"postcss": "8.5.8",
 		"prettier": "npm:wp-prettier@3.0.3",
 		"qunit": "~2.25.0",

--- a/tools/gutenberg/copy.js
+++ b/tools/gutenberg/copy.js
@@ -9,10 +9,10 @@
  * @package WordPress
  */
 
-const child_process = require( 'child_process' );
 const fs = require( 'fs' );
 const path = require( 'path' );
 const json2php = require( 'json2php' );
+const { fromString } = require( 'php-array-reader' );
 
 // Paths.
 const rootDir = path.resolve( __dirname, '../..' );
@@ -78,36 +78,14 @@ const COPY_CONFIG = {
  * Given a path to a PHP file which returns a single value, converts that
  * value into a native JavaScript value (limited by JSON serialization).
  *
- * @throws Error when PHP source file unable to be read, or PHP is unavailable.
+ * @throws Error when PHP source file unable to be read or parsed.
  *
  * @param {string} phpFilepath Absolute path of PHP file returning a single value.
  * @return {Object|Array} JavaScript representation of value from input file.
  */
 function readReturnedValueFromPHPFile( phpFilepath ) {
-	const results = child_process.spawnSync(
-		'php',
-		[ '-r', '$path = file_get_contents( "php://stdin" ); if ( ! is_file( $path ) ) { die( 1 ); } try { $data = require $path; } catch ( \\Throwable $e ) { die( 2 ); } $json = json_encode( $data ); if ( ! is_string( $json ) ) { die( 3 ); } echo $json;' ],
-		{
-			encoding: 'utf8',
-			input: phpFilepath,
-		}
-	);
-
-	switch ( results.status ) {
-		case 0:
-			return JSON.parse( results.stdout );
-
-		case 1:
-			throw new Error( `Could not read PHP source file: '${ phpFilepath }'` );
-
-		case 2:
-			throw new Error( `PHP source file did not return value when imported: '${ phpFilepath }'` );
-
-		case 3:
-			throw new Error( `Could not serialize PHP source value into JSON: '${ phpFilepath }'` );
-	}
-
-	throw new Error( `Unknown error while reading PHP source file: '${ phpFilepath }'` );
+	const content = fs.readFileSync( phpFilepath, 'utf8' );
+	return fromString( content );
 }
 
 /**


### PR DESCRIPTION
This removes the `php` command in the build script introduced in r61873.

Trac ticket: Core-64925

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Sonnet 4.6
Used for: Used to create the first draft of this PR.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
