### PR TITLE
Enhance `WP_REST_Posts_Controller` with writable `PreparedPost` and static analysis fixes

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -5777,6 +5777,8 @@ function sanitize_trackback_urls( $to_ping ) {
  *
  * @param string|array $value String or array of data to slash.
  * @return string|array Slashed `$value`, in the same type as supplied.
+ *
+ * @phpstan-return ( $value is string ? string : array )
  */
 function wp_slash( $value ) {
 	if ( is_array( $value ) ) {

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -1145,6 +1145,14 @@ function get_extended( $post ) {
  *                                 or 'display'. Default 'raw'.
  * @return WP_Post|array|null Type corresponding to $output on success or null on failure.
  *                            When $output is OBJECT, a `WP_Post` instance is returned.
+ *
+ * @phpstan-return (
+ *     $output is 'ARRAY_A' ? array<string, mixed>|null : (
+ *         $output is 'ARRAY_N' ? array<int, mixed>|null : (
+ *             WP_Post|null
+ *         )
+ *     )
+ * )
  */
 function get_post( $post = null, $output = OBJECT, $filter = 'raw' ) {
 	if ( empty( $post ) && isset( $GLOBALS['post'] ) ) {

--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -684,6 +684,8 @@ function rest_ensure_request( $request ) {
  * @return WP_REST_Response|WP_Error If response generated an error, WP_Error, if response
  *                                   is already an instance, WP_REST_Response, otherwise
  *                                   returns a new WP_REST_Response instance.
+ *
+ * @phpstan-return ( $response is WP_Error ? WP_Error : WP_REST_Response )
  */
 function rest_ensure_response( $response ) {
 	if ( is_wp_error( $response ) ) {

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
@@ -327,7 +327,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 
 		$name       = wp_basename( $file['file'] );
 		$name_parts = pathinfo( $name );
-		$name       = trim( substr( $name, 0, -( 1 + strlen( $name_parts['extension'] ) ) ) );
+		$name       = trim( substr( $name, 0, -( 1 + strlen( $name_parts['extension'] ?? '' ) ) ) );
 
 		$url  = $file['url'];
 		$type = $file['type'];
@@ -365,10 +365,12 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 		// If the title was not set, use the original filename.
 		if ( empty( $attachment->post_title ) && ! empty( $files['file']['name'] ) ) {
 			// Remove the file extension (after the last `.`)
-			$tmp_title = substr( $files['file']['name'], 0, strrpos( $files['file']['name'], '.' ) );
-
-			if ( ! empty( $tmp_title ) ) {
-				$attachment->post_title = $tmp_title;
+			$last_dot_location = strrpos( $files['file']['name'], '.' );
+			if ( false !== $last_dot_location ) {
+				$tmp_title = substr( $files['file']['name'], 0, $last_dot_location );
+				if ( ! empty( $tmp_title ) ) {
+					$attachment->post_title = $tmp_title;
+				}
 			}
 		}
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
@@ -355,6 +355,9 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 		}
 
 		$attachment = $this->prepare_item_for_database( $request );
+		if ( is_wp_error( $attachment ) ) {
+			return $attachment;
+		}
 
 		$attachment->post_mime_type = $type;
 		$attachment->guid           = $url;
@@ -377,10 +380,6 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 		// $post_parent is inherited from $attachment['post_parent'].
 		$id = wp_insert_attachment( wp_slash( (array) $attachment ), $file, 0, true, false );
 
-		if ( trim( $alt ) ) {
-			update_post_meta( $id, '_wp_attachment_image_alt', sanitize_text_field( $alt ) );
-		}
-
 		if ( is_wp_error( $id ) ) {
 			if ( 'db_update_error' === $id->get_error_code() ) {
 				$id->add_data( array( 'status' => 500 ) );
@@ -389,6 +388,10 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 			}
 
 			return $id;
+		}
+
+		if ( trim( $alt ) ) {
+			update_post_meta( $id, '_wp_attachment_image_alt', sanitize_text_field( $alt ) );
 		}
 
 		$attachment = get_post( $id );
@@ -766,7 +769,11 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 		$original_attachment_post = get_post( $attachment_id );
 
 		// Check request fields and assign default values.
-		$new_attachment_post                 = $this->prepare_item_for_database( $request );
+		$new_attachment_post = $this->prepare_item_for_database( $request );
+		if ( is_wp_error( $new_attachment_post ) ) {
+			return $new_attachment_post;
+		}
+
 		$new_attachment_post->post_mime_type = $saved['mime-type'];
 		$new_attachment_post->guid           = $uploads['url'] . "/$filename";
 
@@ -869,6 +876,9 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 	 */
 	protected function prepare_item_for_database( $request ) {
 		$prepared_attachment = parent::prepare_item_for_database( $request );
+		if ( is_wp_error( $prepared_attachment ) ) {
+			return $prepared_attachment;
+		}
 
 		// Attachment caption (post_excerpt internally).
 		if ( isset( $request['caption'] ) ) {

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
@@ -664,6 +664,13 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 		if ( ! file_exists( $image_file_to_edit ) ) {
 			$image_file_to_edit = _load_image_to_edit_path( $attachment_id );
 		}
+		if ( false === $image_file_to_edit ) {
+			return new WP_Error(
+				'rest_cannot_get_image_file_to_edit',
+				__( 'Unable to get image file.' ),
+				array( 'status' => 404 )
+			);
+		}
 
 		$image_editor = wp_get_image_editor( $image_file_to_edit );
 
@@ -861,7 +868,15 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 
 		wp_update_attachment_metadata( $new_attachment_id, $new_image_meta );
 
-		$response = $this->prepare_item_for_response( get_post( $new_attachment_id ), $request );
+		$new_attachment_post = get_post( $new_attachment_id );
+		if ( ! $new_attachment_post ) {
+			return new WP_Error(
+				'rest_post_invalid_id',
+				__( 'Invalid post ID.' ),
+				array( 'status' => 404 )
+			);
+		}
+		$response = $this->prepare_item_for_response( $new_attachment_post, $request );
 		$response->set_status( 201 );
 		$response->header( 'Location', rest_url( sprintf( '%s/%s/%s', $this->namespace, $this->rest_base, $new_attachment_id ) ) );
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php
@@ -14,6 +14,8 @@
  *
  * @see WP_REST_Revisions_Controller
  * @see WP_REST_Controller
+ *
+ * @phpstan-import-type PreparedPost from WP_REST_Posts_Controller
  */
 class WP_REST_Autosaves_Controller extends WP_REST_Revisions_Controller {
 
@@ -225,6 +227,9 @@ class WP_REST_Autosaves_Controller extends WP_REST_Revisions_Controller {
 			return $prepared_post;
 		}
 
+		/**
+		 * @var PreparedPost $prepared_post
+		 */
 		$prepared_post->ID = $post->ID;
 		$user_id           = get_current_user_id();
 
@@ -276,6 +281,13 @@ class WP_REST_Autosaves_Controller extends WP_REST_Revisions_Controller {
 		}
 
 		$autosave = get_post( $autosave_id );
+		if ( ! $autosave ) {
+			return new WP_Error(
+				'rest_post_invalid_id',
+				__( 'Invalid post ID.' ),
+				array( 'status' => 404 )
+			);
+		}
 		$request->set_param( 'context', 'edit' );
 
 		$response = $this->prepare_item_for_response( $autosave, $request );

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php
@@ -220,7 +220,11 @@ class WP_REST_Autosaves_Controller extends WP_REST_Revisions_Controller {
 			return $post;
 		}
 
-		$prepared_post     = $this->parent_controller->prepare_item_for_database( $request );
+		$prepared_post = $this->parent_controller->prepare_item_for_database( $request );
+		if ( is_wp_error( $prepared_post ) ) {
+			return $prepared_post;
+		}
+
 		$prepared_post->ID = $post->ID;
 		$user_id           = get_current_user_id();
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-menu-items-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-menu-items-controller.php
@@ -196,6 +196,13 @@ class WP_REST_Menu_Items_Controller extends WP_REST_Posts_Controller {
 		do_action( 'rest_after_insert_nav_menu_item', $nav_menu_item, $request, true );
 
 		$post = get_post( $nav_menu_item_id );
+		if ( ! $post ) {
+			return new WP_Error(
+				'rest_post_invalid_id',
+				__( 'Invalid post ID.' ),
+				array( 'status' => 404 )
+			);
+		}
 		wp_after_insert_post( $post, false, null );
 
 		$response = $this->prepare_item_for_response( $post, $request );

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -814,6 +814,13 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		}
 
 		$post = get_post( $post_id );
+		if ( ! $post ) {
+			return new WP_Error(
+				'rest_post_invalid_id',
+				__( 'Invalid post ID.' ),
+				array( 'status' => 404 )
+			);
+		}
 
 		/**
 		 * Fires after a single post is created or updated via the REST API.
@@ -870,7 +877,6 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			}
 		}
 
-		$post          = get_post( $post_id );
 		$fields_update = $this->update_additional_fields_for_object( $post, $request );
 
 		if ( is_wp_error( $fields_update ) ) {
@@ -901,6 +907,10 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		wp_after_insert_post( $post, false, null );
 
 		$response = $this->prepare_item_for_response( $post, $request );
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
 		$response = rest_ensure_response( $response );
 
 		$response->set_status( 201 );

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -714,6 +714,13 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		}
 
 		$post_type = get_post_type_object( $this->post_type );
+		if ( ! $post_type ) {
+			return new WP_Error(
+				'rest_post_invalid_type',
+				__( 'Invalid post type.' ),
+				array( 'status' => 400 )
+			);
+		}
 
 		if ( ! empty( $request['author'] ) && get_current_user_id() !== $request['author'] && ! current_user_can( $post_type->cap->edit_others_posts ) ) {
 			return new WP_Error(

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -1033,6 +1033,13 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		}
 
 		$post = get_post( $post_id );
+		if ( ! $post ) {
+			return new WP_Error(
+				'rest_post_invalid_id',
+				__( 'Invalid post ID.' ),
+				array( 'status' => 404 )
+			);
+		}
 
 		/** This action is documented in wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php */
 		do_action( "rest_insert_{$this->post_type}", $post, $request, false );
@@ -1073,7 +1080,6 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			}
 		}
 
-		$post          = get_post( $post_id );
 		$fields_update = $this->update_additional_fields_for_object( $post, $request );
 
 		if ( is_wp_error( $fields_update ) ) {

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -790,13 +790,16 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			 * `wp_unique_post_slug()` returns the same slug for 'draft' or 'pending' posts.
 			 *
 			 * To ensure that a unique slug is generated, pass the post data with the 'publish' status.
+			 *
+			 * Note that neither ID nor post_parent are guaranteed to be set in ::prepare_item_for_database(), so this
+			 * is the reason for the null coalescing operator.
 			 */
 			$prepared_post->post_name = wp_unique_post_slug(
 				$prepared_post->post_name,
-				$prepared_post->id,
+				$prepared_post->ID ?? 0,
 				'publish',
 				$prepared_post->post_type,
-				$prepared_post->post_parent
+				$prepared_post->post_parent ?? 0
 			);
 		}
 
@@ -999,15 +1002,17 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		 * `wp_unique_post_slug()` returns the same slug for 'draft' or 'pending' posts.
 		 *
 		 * To ensure that a unique slug is generated, pass the post data with the 'publish' status.
+		 *
+		 * Note that neither ID nor post_parent are guaranteed to be set in ::prepare_item_for_database(), so this
+		 * is the reason for the null coalescing operator.
 		 */
 		if ( ! empty( $post->post_name ) && in_array( $post_status, array( 'draft', 'pending' ), true ) ) {
-			$post_parent     = ! empty( $post->post_parent ) ? $post->post_parent : 0;
 			$post->post_name = wp_unique_post_slug(
 				$post->post_name,
-				$post->ID,
+				$post->ID ?? 0,
 				'publish',
 				$post->post_type,
-				$post_parent
+				$post->post_parent ?? 0
 			);
 		}
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -780,6 +780,10 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			return $prepared_post;
 		}
 
+		/*
+		 * This is also set in the ::prepare_item_for_database() method above, but since the return value is filterable,
+		 * there is no guarantee.
+		 */
 		$prepared_post->post_type = $this->post_type;
 
 		if ( ! empty( $prepared_post->post_name )

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -962,14 +962,12 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function update_item( $request ) {
-		$valid_check = $this->get_post( $request['id'] );
-		if ( is_wp_error( $valid_check ) ) {
-			return $valid_check;
+		$post_before = $this->get_post( $request['id'] );
+		if ( is_wp_error( $post_before ) ) {
+			return $post_before;
 		}
 
-		$post_before = get_post( $request['id'] );
-		$post        = $this->prepare_item_for_database( $request );
-
+		$post = $this->prepare_item_for_database( $request );
 		if ( is_wp_error( $post ) ) {
 			return $post;
 		}

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -32,7 +32,7 @@
  *     ping_status?: string,
  *     page_template?: null,
  *     meta_input?: array<string, string>,
- * }
+ * }&stdClass
  */
 class WP_REST_Posts_Controller extends WP_REST_Controller {
 	/**

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -13,6 +13,26 @@
  * @since 4.7.0
  *
  * @see WP_REST_Controller
+ *
+ * @phpstan-type PreparedPost object{
+ *     ID?: int,
+ *     post_title?: string,
+ *     post_content?: string,
+ *     post_excerpt?: string,
+ *     post_type: string,
+ *     post_status?: string,
+ *     post_date?: string|null,
+ *     post_date_gmt?: string|null,
+ *     edit_date?: true,
+ *     post_name?: string,
+ *     post_author?: int,
+ *     post_parent?: int,
+ *     menu_order?: int,
+ *     comment_status?: string,
+ *     ping_status?: string,
+ *     page_template?: null,
+ *     meta_input?: array<string, string>,
+ * }
  */
 class WP_REST_Posts_Controller extends WP_REST_Controller {
 	/**
@@ -1283,13 +1303,15 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 	 * @since 4.7.0
 	 *
 	 * @param WP_REST_Request $request Request object.
-	 * @return stdClass|WP_Error Post object or WP_Error.
+	 * @return object|WP_Error Post object or WP_Error.
+	 * @phpstan-return PreparedPost|WP_Error
 	 */
 	protected function prepare_item_for_database( $request ) {
 		$prepared_post  = new stdClass();
 		$current_status = '';
 
 		// Post ID.
+		$existing_post = null;
 		if ( isset( $request['id'] ) ) {
 			$existing_post = $this->get_post( $request['id'] );
 			if ( is_wp_error( $existing_post ) ) {
@@ -1330,15 +1352,22 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		}
 
 		// Post type.
-		if ( empty( $request['id'] ) ) {
+		if ( ! $existing_post ) {
 			// Creating new post, use default type for the controller.
 			$prepared_post->post_type = $this->post_type;
 		} else {
 			// Updating a post, use previous type.
-			$prepared_post->post_type = get_post_type( $request['id'] );
+			$prepared_post->post_type = $existing_post->post_type;
 		}
 
 		$post_type = get_post_type_object( $prepared_post->post_type );
+		if ( ! $post_type ) {
+			return new WP_Error(
+				'rest_post_invalid_type',
+				__( 'Invalid post type.' ),
+				array( 'status' => 400 )
+			);
+		}
 
 		// Post status.
 		if (
@@ -1357,7 +1386,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 
 		// Post date.
 		if ( ! empty( $schema['properties']['date'] ) && ! empty( $request['date'] ) ) {
-			$current_date = isset( $prepared_post->ID ) ? get_post( $prepared_post->ID )->post_date : false;
+			$current_date = $existing_post ? $existing_post->post_date : false;
 			$date_data    = rest_get_date_with_gmt( $request['date'] );
 
 			if ( ! empty( $date_data ) && $current_date !== $date_data[0] ) {
@@ -1365,7 +1394,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 				$prepared_post->edit_date                                        = true;
 			}
 		} elseif ( ! empty( $schema['properties']['date_gmt'] ) && ! empty( $request['date_gmt'] ) ) {
-			$current_date = isset( $prepared_post->ID ) ? get_post( $prepared_post->ID )->post_date_gmt : false;
+			$current_date = $existing_post ? $existing_post->post_date_gmt : false;
 			$date_data    = rest_get_date_with_gmt( $request['date_gmt'], true );
 
 			if ( ! empty( $date_data ) && $current_date !== $date_data[1] ) {
@@ -1423,7 +1452,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 					);
 				}
 
-				if ( ! empty( $prepared_post->ID ) && is_sticky( $prepared_post->ID ) ) {
+				if ( $existing_post && is_sticky( $existing_post->ID ) ) {
 					return new WP_Error(
 						'rest_invalid_field',
 						__( 'A sticky post can not be password protected.' ),
@@ -1434,7 +1463,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		}
 
 		if ( ! empty( $schema['properties']['sticky'] ) && ! empty( $request['sticky'] ) ) {
-			if ( ! empty( $prepared_post->ID ) && post_password_required( $prepared_post->ID ) ) {
+			if ( $existing_post && post_password_required( $prepared_post->ID ) ) {
 				return new WP_Error(
 					'rest_invalid_field',
 					__( 'A password protected post can not be set to sticky.' ),


### PR DESCRIPTION
This primarily is for fixing calls to `wp_unique_post_slug()` in `\WP_REST_Posts_Controller::create_item()` and `\WP_REST_Posts_Controller::update_item()`. However, as part of that I also looked at `WP_REST_Posts_Controller::prepare_item_for_database()` and all methods that called it to ensure that they also had their static analysis issues addressed. I don't intend to commit this entire PR as-is. Subsets would be committed at a time, ideally with tests to catch the holes identified by static analysis

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/64921

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
