### PR TITLE
Avoid copying block-library CSS files twice - Option 1

### DIFF
--- a/src/wp-includes/blocks/index.php
+++ b/src/wp-includes/blocks/index.php
@@ -39,10 +39,11 @@ function register_core_block_style_handles() {
 		return;
 	}
 
-	$blocks_url   = includes_url( 'blocks/' );
-	$suffix       = wp_scripts_get_suffix();
-	$wp_styles    = wp_styles();
-	$style_fields = array(
+	$block_css_path = ABSPATH . WPINC . '/css/dist/block-library/';
+	$blocks_url     = includes_url( 'css/dist/block-library/' );
+	$suffix         = wp_scripts_get_suffix();
+	$wp_styles      = wp_styles();
+	$style_fields   = array(
 		'style'       => 'style',
 		'editorStyle' => 'editor',
 	);
@@ -79,14 +80,14 @@ function register_core_block_style_handles() {
 	}
 
 	if ( ! $files ) {
-		$files = glob( wp_normalize_path( BLOCKS_PATH . '**/**.css' ) );
+		$files = glob( wp_normalize_path( $block_css_path . '**/**.css' ) );
 
-		// Normalize BLOCKS_PATH prior to substitution for Windows environments.
-		$normalized_blocks_path = wp_normalize_path( BLOCKS_PATH );
+		// Normalize path prior to substitution for Windows environments.
+		$normalized_block_css_path = wp_normalize_path( $block_css_path );
 
 		$files = array_map(
-			static function ( $file ) use ( $normalized_blocks_path ) {
-				return str_replace( $normalized_blocks_path, '', $file );
+			static function ( $file ) use ( $normalized_block_css_path ) {
+				return str_replace( $normalized_block_css_path, '', $file );
 			},
 			$files
 		);
@@ -103,9 +104,9 @@ function register_core_block_style_handles() {
 		}
 	}
 
-	$register_style = static function ( $name, $filename, $style_handle ) use ( $blocks_url, $suffix, $wp_styles, $files ) {
+	$register_style = static function ( $name, $filename, $style_handle ) use ( $block_css_path, $blocks_url, $suffix, $wp_styles, $files ) {
 		$style_path = "{$name}/{$filename}{$suffix}.css";
-		$path       = wp_normalize_path( BLOCKS_PATH . $style_path );
+		$path       = wp_normalize_path( $block_css_path . $style_path );
 
 		if ( ! in_array( $style_path, $files, true ) ) {
 			$wp_styles->add(

--- a/tools/gutenberg/copy.js
+++ b/tools/gutenberg/copy.js
@@ -60,14 +60,12 @@ const COPY_CONFIG = {
 				// Block library blocks.
 				name: 'block-library',
 				scripts: 'scripts/block-library',
-				styles: 'styles/block-library',
 				php: 'scripts/block-library',
 			},
 			{
 				// Widget blocks.
 				name: 'widgets',
 				scripts: 'scripts/widgets/blocks',
-				styles: 'styles/widgets',
 				php: 'scripts/widgets/blocks',
 			},
 		],
@@ -141,7 +139,6 @@ function copyBlockAssets( config ) {
 
 	for ( const source of config.sources ) {
 		const scriptsSrc = path.join( gutenbergBuildDir, source.scripts );
-		const stylesSrc = path.join( gutenbergBuildDir, source.styles );
 		const phpSrc = path.join( gutenbergBuildDir, source.php );
 
 		if ( ! fs.existsSync( scriptsSrc ) ) {
@@ -176,27 +173,13 @@ function copyBlockAssets( config ) {
 					blockDest,
 					{
 						recursive: true,
-						// Skip PHP, copied from build in steps 3 & 4.
+						// Skip PHP, copied from build in steps 2 & 3.
 						filter: f => ! f.endsWith( '.php' ),
 					}
 				);
 			}
 
-			// 2. Copy styles (if they exist in per-block directory)
-			const blockStylesSrc = path.join( stylesSrc, blockName );
-			if ( fs.existsSync( blockStylesSrc ) ) {
-				const cssFiles = fs
-					.readdirSync( blockStylesSrc )
-					.filter( ( file ) => file.endsWith( '.css' ) );
-				for ( const cssFile of cssFiles ) {
-					fs.copyFileSync(
-						path.join( blockStylesSrc, cssFile ),
-						path.join( blockDest, cssFile )
-					);
-				}
-			}
-
-			// 3. Copy PHP from build
+			// 2. Copy PHP from build
 			const blockPhpSrc = path.join( phpSrc, `${ blockName }.php` );
 			const phpDest = path.join(
 				wpIncludesDir,


### PR DESCRIPTION
This removes duplicate block library-related CSS files in favor of the same location as WP 6.9: `wp-includes/blocks`.

Trac ticket: Core-64933

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude
Model(s): Sonnet 4.6
Used for: Creating the initial PR based on a description of the problem.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
