### PR TITLE
Avoid copying CSS files twice - Option 2

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -668,7 +668,12 @@ module.exports = function(grunt) {
 				files: [ {
 					expand: true,
 					cwd: 'gutenberg/build/styles',
-					src: [ '**/*', '!**/*.map' ],
+					src: [
+						'**/*',
+						'!**/*.map',
+						// Per-block CSS is copied to wp-includes/blocks/ by tools/gutenberg/copy.js.
+						'!block-library/*/**',
+					],
 					dest: WORKING_DIR + 'wp-includes/css/dist/',
 				} ],
 			},


### PR DESCRIPTION
This removes duplicate block library-related CSS files in favor of moving all files to `wp-includes/css/dist/block-library/*`.

Trac ticket: Core-64933

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude
Model(s): Sonnet 4.6
Used for: Creating the initial PR based on a description of the problem.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
