### PR TITLE
Application Passwords: Allow HTTP loopback redirect URLs

### DIFF
--- a/src/wp-admin/includes/user.php
+++ b/src/wp-admin/includes/user.php
@@ -700,7 +700,10 @@ function wp_is_authorize_application_password_request_valid( $request, $user ) {
 }
 
 /**
- * Validates the redirect URL protocol scheme. The protocol can be anything except `http` and `javascript`.
+ * Validates the redirect URL protocol scheme.
+ *
+ * The `http` scheme is allowed for loopback addresses (localhost, 127.0.0.1, [::1])
+ * and local environments. The `javascript` and `data` protocols are always rejected.
  *
  * @since 6.3.2
  *
@@ -745,7 +748,14 @@ function wp_is_authorize_application_redirect_url_valid( $url ) {
 		);
 	}
 
-	if ( 'http' === $scheme && ! $is_local ) {
+	// Allow insecure HTTP connections to locally hosted applications.
+	$is_loopback = in_array(
+		strtolower( $host ),
+		array( 'localhost', '127.0.0.1', '[::1]' ),
+		true
+	);
+
+	if ( 'http' === $scheme && ! $is_local && ! $is_loopback ) {
 		return new WP_Error(
 			'invalid_redirect_scheme',
 			__( 'The URL must be served over a secure connection.' )

--- a/src/wp-admin/includes/user.php
+++ b/src/wp-admin/includes/user.php
@@ -702,7 +702,7 @@ function wp_is_authorize_application_password_request_valid( $request, $user ) {
 /**
  * Validates the redirect URL protocol scheme.
  *
- * The `http` scheme is allowed for loopback addresses (localhost, 127.0.0.1, [::1])
+ * The `http` scheme is allowed for loopback IP addresses (127.0.0.1, [::1])
  * and local environments. The `javascript` and `data` protocols are always rejected.
  *
  * @since 6.3.2
@@ -751,7 +751,7 @@ function wp_is_authorize_application_redirect_url_valid( $url ) {
 	// Allow insecure HTTP connections to locally hosted applications.
 	$is_loopback = in_array(
 		strtolower( $host ),
-		array( 'localhost', '127.0.0.1', '[::1]' ),
+		array( '127.0.0.1', '[::1]' ),
 		true
 	);
 

--- a/tests/phpunit/tests/admin/Admin_Includes_User_WpIsAuthorizeApplicationPasswordRequestValid_Test.php
+++ b/tests/phpunit/tests/admin/Admin_Includes_User_WpIsAuthorizeApplicationPasswordRequestValid_Test.php
@@ -83,7 +83,7 @@ class Admin_Includes_User_WpIsAuthorizeApplicationPasswordRequestValid_Test exte
 			);
 
 			$datasets[ $environment_type . ' and a "http" loopback "success_url"' ] = array(
-				'request'             => array( 'success_url' => 'http://localhost:8080/callback' ),
+				'request'             => array( 'success_url' => 'http://127.0.0.1:8080/callback' ),
 				'expected_error_code' => '',
 				'env'                 => $environment_type,
 			);

--- a/tests/phpunit/tests/admin/Admin_Includes_User_WpIsAuthorizeApplicationPasswordRequestValid_Test.php
+++ b/tests/phpunit/tests/admin/Admin_Includes_User_WpIsAuthorizeApplicationPasswordRequestValid_Test.php
@@ -81,6 +81,18 @@ class Admin_Includes_User_WpIsAuthorizeApplicationPasswordRequestValid_Test exte
 				'expected_error_code' => 'local' === $environment_type ? '' : 'invalid_redirect_scheme',
 				'env'                 => $environment_type,
 			);
+
+			$datasets[ $environment_type . ' and a "http" loopback "success_url"' ] = array(
+				'request'             => array( 'success_url' => 'http://localhost:8080/callback' ),
+				'expected_error_code' => '',
+				'env'                 => $environment_type,
+			);
+
+			$datasets[ $environment_type . ' and a "http" loopback "reject_url"' ] = array(
+				'request'             => array( 'reject_url' => 'http://127.0.0.1/callback' ),
+				'expected_error_code' => '',
+				'env'                 => $environment_type,
+			);
 		}
 
 		return $datasets;

--- a/tests/phpunit/tests/admin/Admin_Includes_User_WpIsAuthorizeApplicationRedirectUrlValid_Test.php
+++ b/tests/phpunit/tests/admin/Admin_Includes_User_WpIsAuthorizeApplicationRedirectUrlValid_Test.php
@@ -1,0 +1,204 @@
+<?php
+
+/**
+ * @group admin
+ * @group user
+ *
+ * @covers ::wp_is_authorize_application_redirect_url_valid
+ */
+class Admin_Includes_User_WpIsAuthorizeApplicationRedirectUrlValid_Test extends WP_UnitTestCase {
+
+	/**
+	 * Test redirect URL validation for application password authorization.
+	 *
+	 * @ticket 57809
+	 *
+	 * @dataProvider data_wp_is_authorize_application_redirect_url_valid
+	 *
+	 * @param string $url                 The redirect URL to validate.
+	 * @param string $expected_error_code The expected error code, empty if no error is expected.
+	 * @param string $env                 The environment type. Defaults to 'production'.
+	 */
+	public function test_wp_is_authorize_application_redirect_url_valid( $url, $expected_error_code, $env = 'production' ) {
+		putenv( "WP_ENVIRONMENT_TYPE=$env" );
+
+		$actual = wp_is_authorize_application_redirect_url_valid( $url );
+
+		putenv( 'WP_ENVIRONMENT_TYPE' );
+
+		if ( $expected_error_code ) {
+			$this->assertWPError( $actual, 'A WP_Error object is expected.' );
+			$this->assertSame( $expected_error_code, $actual->get_error_code(), 'Unexpected error code.' );
+		} else {
+			$this->assertTrue( $actual, 'The URL should be considered valid.' );
+		}
+	}
+
+	/**
+	 * Data provider for test_wp_is_authorize_application_redirect_url_valid.
+	 *
+	 * @return array[]
+	 */
+	public function data_wp_is_authorize_application_redirect_url_valid() {
+		$environment_types = array( 'local', 'development', 'staging', 'production' );
+
+		$datasets = array();
+		foreach ( $environment_types as $environment_type ) {
+			// Empty URL should always be valid.
+			$datasets[ $environment_type . ' and an empty URL' ] = array(
+				'url'                 => '',
+				'expected_error_code' => '',
+				'env'                 => $environment_type,
+			);
+
+			// HTTPS URLs should always be valid.
+			$datasets[ $environment_type . ' and a "https" scheme URL' ] = array(
+				'url'                 => 'https://example.org',
+				'expected_error_code' => '',
+				'env'                 => $environment_type,
+			);
+
+			$datasets[ $environment_type . ' and a "https" scheme URL with path' ] = array(
+				'url'                 => 'https://example.org/callback',
+				'expected_error_code' => '',
+				'env'                 => $environment_type,
+			);
+
+			// Custom app schemes should always be valid.
+			$datasets[ $environment_type . ' and a custom app scheme URL' ] = array(
+				'url'                 => 'wordpress://callback',
+				'expected_error_code' => '',
+				'env'                 => $environment_type,
+			);
+
+			$datasets[ $environment_type . ' and another custom app scheme URL' ] = array(
+				'url'                 => 'myapp://auth/callback',
+				'expected_error_code' => '',
+				'env'                 => $environment_type,
+			);
+
+			// Invalid protocols should always be rejected.
+			$datasets[ $environment_type . ' and a "javascript" scheme URL' ] = array(
+				'url'                 => 'javascript://example.org/%0Aalert(1)',
+				'expected_error_code' => 'invalid_redirect_url_format',
+				'env'                 => $environment_type,
+			);
+
+			$datasets[ $environment_type . ' and a "data" scheme URL' ] = array(
+				'url'                 => 'data://text/html,test',
+				'expected_error_code' => 'invalid_redirect_url_format',
+				'env'                 => $environment_type,
+			);
+
+			// Invalid URL formats should always be rejected.
+			$datasets[ $environment_type . ' and a URL without a valid scheme' ] = array(
+				'url'                 => 'not-a-url',
+				'expected_error_code' => 'invalid_redirect_url_format',
+				'env'                 => $environment_type,
+			);
+
+			$datasets[ $environment_type . ' and a URL with an empty host' ] = array(
+				'url'                 => 'http://',
+				'expected_error_code' => 'invalid_redirect_url_format',
+				'env'                 => $environment_type,
+			);
+
+			// HTTP + loopback hosts should be valid in all environments.
+			$datasets[ $environment_type . ' and a "http" scheme URL with localhost' ] = array(
+				'url'                 => 'http://localhost/callback',
+				'expected_error_code' => '',
+				'env'                 => $environment_type,
+			);
+
+			$datasets[ $environment_type . ' and a "http" scheme URL with 127.0.0.1' ] = array(
+				'url'                 => 'http://127.0.0.1/callback',
+				'expected_error_code' => '',
+				'env'                 => $environment_type,
+			);
+
+			$datasets[ $environment_type . ' and a "http" scheme URL with IPv6 loopback' ] = array(
+				'url'                 => 'http://[::1]/callback',
+				'expected_error_code' => '',
+				'env'                 => $environment_type,
+			);
+
+			// HTTP + loopback hosts with ports should be valid in all environments.
+			$datasets[ $environment_type . ' and a "http" scheme URL with localhost and port' ] = array(
+				'url'                 => 'http://localhost:8080/callback',
+				'expected_error_code' => '',
+				'env'                 => $environment_type,
+			);
+
+			$datasets[ $environment_type . ' and a "http" scheme URL with 127.0.0.1 and port' ] = array(
+				'url'                 => 'http://127.0.0.1:3000/callback',
+				'expected_error_code' => '',
+				'env'                 => $environment_type,
+			);
+
+			$datasets[ $environment_type . ' and a "http" scheme URL with IPv6 loopback and port' ] = array(
+				'url'                 => 'http://[::1]:8080/callback',
+				'expected_error_code' => '',
+				'env'                 => $environment_type,
+			);
+
+			// Case insensitivity for loopback hostnames.
+			$datasets[ $environment_type . ' and a "http" scheme URL with uppercase LOCALHOST' ] = array(
+				'url'                 => 'http://LOCALHOST/callback',
+				'expected_error_code' => '',
+				'env'                 => $environment_type,
+			);
+
+			$datasets[ $environment_type . ' and a "http" scheme URL with mixed case Localhost' ] = array(
+				'url'                 => 'http://Localhost/callback',
+				'expected_error_code' => '',
+				'env'                 => $environment_type,
+			);
+
+			// HTTP + non-loopback host should only be valid in local environments.
+			$datasets[ $environment_type . ' and a "http" scheme URL with a non-loopback host' ] = array(
+				'url'                 => 'http://example.org',
+				'expected_error_code' => 'local' === $environment_type ? '' : 'invalid_redirect_scheme',
+				'env'                 => $environment_type,
+			);
+
+			$datasets[ $environment_type . ' and a "http" scheme URL with a non-loopback host and path' ] = array(
+				'url'                 => 'http://example.org/callback',
+				'expected_error_code' => 'local' === $environment_type ? '' : 'invalid_redirect_scheme',
+				'env'                 => $environment_type,
+			);
+
+			// Boundary cases: addresses NOT treated as loopback.
+			$datasets[ $environment_type . ' and a "http" scheme URL with 127.0.0.2' ] = array(
+				'url'                 => 'http://127.0.0.2/callback',
+				'expected_error_code' => 'local' === $environment_type ? '' : 'invalid_redirect_scheme',
+				'env'                 => $environment_type,
+			);
+
+			$datasets[ $environment_type . ' and a "http" scheme URL with expanded IPv6 loopback' ] = array(
+				'url'                 => 'http://[0:0:0:0:0:0:0:1]/callback',
+				'expected_error_code' => 'local' === $environment_type ? '' : 'invalid_redirect_scheme',
+				'env'                 => $environment_type,
+			);
+
+			$datasets[ $environment_type . ' and a "http" scheme URL with localhost.localdomain' ] = array(
+				'url'                 => 'http://localhost.localdomain/callback',
+				'expected_error_code' => 'local' === $environment_type ? '' : 'invalid_redirect_scheme',
+				'env'                 => $environment_type,
+			);
+
+			$datasets[ $environment_type . ' and a "http" scheme URL with localhost as subdomain' ] = array(
+				'url'                 => 'http://localhost.example.org/callback',
+				'expected_error_code' => 'local' === $environment_type ? '' : 'invalid_redirect_scheme',
+				'env'                 => $environment_type,
+			);
+
+			$datasets[ $environment_type . ' and a "http" scheme URL with localhost as suffix' ] = array(
+				'url'                 => 'http://examplelocalhost.org/callback',
+				'expected_error_code' => 'local' === $environment_type ? '' : 'invalid_redirect_scheme',
+				'env'                 => $environment_type,
+			);
+		}
+
+		return $datasets;
+	}
+}

--- a/tests/phpunit/tests/admin/Admin_Includes_User_WpIsAuthorizeApplicationRedirectUrlValid_Test.php
+++ b/tests/phpunit/tests/admin/Admin_Includes_User_WpIsAuthorizeApplicationRedirectUrlValid_Test.php
@@ -103,13 +103,7 @@ class Admin_Includes_User_WpIsAuthorizeApplicationRedirectUrlValid_Test extends 
 				'env'                 => $environment_type,
 			);
 
-			// HTTP + loopback hosts should be valid in all environments.
-			$datasets[ $environment_type . ' and a "http" scheme URL with localhost' ] = array(
-				'url'                 => 'http://localhost/callback',
-				'expected_error_code' => '',
-				'env'                 => $environment_type,
-			);
-
+			// HTTP + loopback IP addresses should be valid in all environments.
 			$datasets[ $environment_type . ' and a "http" scheme URL with 127.0.0.1' ] = array(
 				'url'                 => 'http://127.0.0.1/callback',
 				'expected_error_code' => '',
@@ -122,13 +116,7 @@ class Admin_Includes_User_WpIsAuthorizeApplicationRedirectUrlValid_Test extends 
 				'env'                 => $environment_type,
 			);
 
-			// HTTP + loopback hosts with ports should be valid in all environments.
-			$datasets[ $environment_type . ' and a "http" scheme URL with localhost and port' ] = array(
-				'url'                 => 'http://localhost:8080/callback',
-				'expected_error_code' => '',
-				'env'                 => $environment_type,
-			);
-
+			// HTTP + loopback IP addresses with ports should be valid in all environments.
 			$datasets[ $environment_type . ' and a "http" scheme URL with 127.0.0.1 and port' ] = array(
 				'url'                 => 'http://127.0.0.1:3000/callback',
 				'expected_error_code' => '',
@@ -137,19 +125,6 @@ class Admin_Includes_User_WpIsAuthorizeApplicationRedirectUrlValid_Test extends 
 
 			$datasets[ $environment_type . ' and a "http" scheme URL with IPv6 loopback and port' ] = array(
 				'url'                 => 'http://[::1]:8080/callback',
-				'expected_error_code' => '',
-				'env'                 => $environment_type,
-			);
-
-			// Case insensitivity for loopback hostnames.
-			$datasets[ $environment_type . ' and a "http" scheme URL with uppercase LOCALHOST' ] = array(
-				'url'                 => 'http://LOCALHOST/callback',
-				'expected_error_code' => '',
-				'env'                 => $environment_type,
-			);
-
-			$datasets[ $environment_type . ' and a "http" scheme URL with mixed case Localhost' ] = array(
-				'url'                 => 'http://Localhost/callback',
 				'expected_error_code' => '',
 				'env'                 => $environment_type,
 			);
@@ -167,7 +142,13 @@ class Admin_Includes_User_WpIsAuthorizeApplicationRedirectUrlValid_Test extends 
 				'env'                 => $environment_type,
 			);
 
-			// Boundary cases: addresses NOT treated as loopback.
+			// Boundary cases: hostnames and addresses NOT treated as loopback.
+			$datasets[ $environment_type . ' and a "http" scheme URL with localhost' ] = array(
+				'url'                 => 'http://localhost/callback',
+				'expected_error_code' => 'local' === $environment_type ? '' : 'invalid_redirect_scheme',
+				'env'                 => $environment_type,
+			);
+
 			$datasets[ $environment_type . ' and a "http" scheme URL with 127.0.0.2' ] = array(
 				'url'                 => 'http://127.0.0.2/callback',
 				'expected_error_code' => 'local' === $environment_type ? '' : 'invalid_redirect_scheme',


### PR DESCRIPTION
This change allows HTTP redirect URLs for loopback addresses (`127.0.0.1`, `[::1]`) in `wp_is_authorize_application_redirect_url_valid()`, regardless of environment type. This aligns with [RFC 8252 7.3](https://datatracker.ietf.org/doc/html/rfc8252#section-7.3).

It's worth noting that [section 8.3](https://datatracker.ietf.org/doc/html/rfc8252#section-8.3) of the RFC recommends against allowing `localhost` as a loopback redirect, since it may be susceptible to firewall interception and DNS resolution poisoning.

Trac ticket: https://core.trac.wordpress.org/ticket/57809
## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Opus 4.6
Used for: Initial creation of new tests.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
