### PR TITLE
Code Quality: Unwrap sprintf() with one argument.

### DIFF
--- a/src/wp-admin/plugin-editor.php
+++ b/src/wp-admin/plugin-editor.php
@@ -164,7 +164,7 @@ $settings = array(
 );
 wp_enqueue_script( 'wp-theme-plugin-editor' );
 wp_add_inline_script( 'wp-theme-plugin-editor', sprintf( 'jQuery( function( $ ) { wp.themePluginEditor.init( $( "#template" ), %s ); } )', wp_json_encode( $settings, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ) ) );
-wp_add_inline_script( 'wp-theme-plugin-editor', sprintf( 'wp.themePluginEditor.themeOrPlugin = "plugin";' ) );
+wp_add_inline_script( 'wp-theme-plugin-editor', 'wp.themePluginEditor.themeOrPlugin = "plugin";' );
 
 require_once ABSPATH . 'wp-admin/admin-header.php';
 

--- a/src/wp-includes/class-wp-customize-widgets.php
+++ b/src/wp-includes/class-wp-customize-widgets.php
@@ -775,9 +775,7 @@ final class WP_Customize_Widgets {
 
 		if ( 1 === $registered_sidebar_count ) {
 			$no_areas_shown_message = html_entity_decode(
-				sprintf(
-					__( 'Your theme has 1 widget area, but this particular page does not display it.' )
-				),
+				__( 'Your theme has 1 widget area, but this particular page does not display it.' ),
 				ENT_QUOTES,
 				get_bloginfo( 'charset' )
 			);

--- a/src/wp-includes/class-wp-xmlrpc-server.php
+++ b/src/wp-includes/class-wp-xmlrpc-server.php
@@ -296,7 +296,7 @@ class wp_xmlrpc_server extends IXR_Server {
 		$password
 	) {
 		if ( ! $this->is_enabled ) {
-			$this->error = new IXR_Error( 405, sprintf( __( 'XML-RPC services are disabled on this site.' ) ) );
+			$this->error = new IXR_Error( 405, __( 'XML-RPC services are disabled on this site.' ) );
 			return false;
 		}
 


### PR DESCRIPTION
This pull request makes minor code cleanups across several files, removing unnecessary uses of the `sprintf` function when localizing or outputting static strings. These changes simplify the code and improve readability without affecting functionality.

Introduced in:

- https://core.trac.wordpress.org/changeset/21804/trunk/wp-includes/class-wp-xmlrpc-server.php
- https://core.trac.wordpress.org/changeset/40330/trunk/src/wp-includes/class-wp-customize-widgets.php
- https://core.trac.wordpress.org/changeset/41774/trunk/src/wp-admin/plugin-editor.php

Trac ticket: https://core.trac.wordpress.org/ticket/64898

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
