### PR TITLE
AI Client: pass event dispatcher to Prompt Builder

### DIFF
--- a/src/wp-includes/ai-client.php
+++ b/src/wp-includes/ai-client.php
@@ -30,5 +30,5 @@ use WordPress\AiClient\AiClient;
  * @return WP_AI_Client_Prompt_Builder The prompt builder instance.
  */
 function wp_ai_client_prompt( $prompt = null ) {
-	return new WP_AI_Client_Prompt_Builder( AiClient::defaultRegistry(), $prompt );
+	return new WP_AI_Client_Prompt_Builder( AiClient::defaultRegistry(), $prompt, AiClient::getEventDispatcher() );
 }

--- a/src/wp-includes/ai-client/class-wp-ai-client-prompt-builder.php
+++ b/src/wp-includes/ai-client/class-wp-ai-client-prompt-builder.php
@@ -23,6 +23,7 @@ use WordPress\AiClient\Results\DTO\GenerativeAiResult;
 use WordPress\AiClient\Tools\DTO\FunctionDeclaration;
 use WordPress\AiClient\Tools\DTO\FunctionResponse;
 use WordPress\AiClient\Tools\DTO\WebSearch;
+use WordPress\AiClientDependencies\Psr\EventDispatcher\EventDispatcherInterface;
 
 /**
  * Fluent builder for constructing AI prompts, returning WP_Error on failure.
@@ -173,12 +174,13 @@ class WP_AI_Client_Prompt_Builder {
 	 *                                                                                                    message array shape, or a list of
 	 *                                                                                                    parts or messages for multi-turn
 	 *                                                                                                    conversations. Default null.
+	 * @param EventDispatcherInterface|null                                                          $event_dispatcher Optional. Event dispatcher for prompt lifecycle events.
 	 */
-	public function __construct( ProviderRegistry $registry, $prompt = null ) {
+	public function __construct( ProviderRegistry $registry, $prompt = null, ?EventDispatcherInterface $event_dispatcher = null ) {
 		try {
-			$this->builder = new PromptBuilder( $registry, $prompt );
+			$this->builder = new PromptBuilder( $registry, $prompt, $event_dispatcher );
 		} catch ( Exception $e ) {
-			$this->builder = new PromptBuilder( $registry );
+			$this->builder = new PromptBuilder( $registry, null, $event_dispatcher );
 			$this->error   = new WP_Error(
 				'prompt_builder_error',
 				$e->getMessage(),

--- a/tests/phpunit/tests/ai-client/wpAiClientPromptBuilder.php
+++ b/tests/phpunit/tests/ai-client/wpAiClientPromptBuilder.php
@@ -34,6 +34,7 @@ use WordPress\AiClient\Results\Enums\FinishReasonEnum;
 use WordPress\AiClient\Builders\PromptBuilder;
 use WordPress\AiClient\Tools\DTO\FunctionDeclaration;
 use WordPress\AiClient\Tools\DTO\FunctionResponse;
+use WordPress\AiClientDependencies\Psr\EventDispatcher\EventDispatcherInterface;
 
 require_once dirname( __DIR__, 2 ) . '/includes/wp-ai-client-mock-model-creation-trait.php';
 require_once dirname( __DIR__, 2 ) . '/includes/wp-ai-client-test-abilities-trait.php';
@@ -1403,6 +1404,45 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 
 		$this->assertWPError( $result );
 		$this->assertSame( 'prompt_builder_error', $result->get_error_code() );
+	}
+
+	/**
+	 * Tests that wp_ai_client_prompt() passes the AI client event dispatcher to the wrapped prompt builder.
+	 *
+	 * @ticket 64938
+	 */
+	public function test_wp_ai_client_prompt_passes_event_dispatcher() {
+		$original_event_dispatcher = AiClient::getEventDispatcher();
+		$event_dispatcher          = new WP_AI_Client_Event_Dispatcher();
+
+		AiClient::setEventDispatcher( $event_dispatcher );
+
+		try {
+			$builder = wp_ai_client_prompt( 'Test prompt' );
+
+			$this->assertSame(
+				$event_dispatcher,
+				$this->get_wrapped_prompt_builder_property_value( $builder, 'eventDispatcher' )
+			);
+		} finally {
+			AiClient::setEventDispatcher( $original_event_dispatcher );
+		}
+	}
+
+	/**
+	 * Tests that the prompt builder constructor forwards an event dispatcher to the wrapped SDK prompt builder.
+	 *
+	 * @ticket 64938
+	 */
+	public function test_constructor_passes_event_dispatcher() {
+		$event_dispatcher = $this->createMock( EventDispatcherInterface::class );
+
+		$builder = new WP_AI_Client_Prompt_Builder( AiClient::defaultRegistry(), 'Test prompt', $event_dispatcher );
+
+		$this->assertSame(
+			$event_dispatcher,
+			$this->get_wrapped_prompt_builder_property_value( $builder, 'eventDispatcher' )
+		);
 	}
 
 	/**


### PR DESCRIPTION




This patch fixes AI Client event dispatching so lifecycle actions fire as intended.

### What was fixed

- The helper function now passes the configured global event dispatcher into the prompt builder.
- The WordPress prompt builder now accepts an optional event dispatcher and forwards it to the underlying SDK prompt builder.
- Constructor fallback behavior was updated so the dispatcher is still preserved if prompt parsing throws and the fallback builder instance is created.

### Files changed

- ai-client.php
- class-wp-ai-client-prompt-builder.php


### Tests added

- Added regression test verifying helper-level wiring of dispatcher:
  - wpAiClientPromptBuilder.php
- Added regression test verifying constructor-level forwarding of dispatcher:
  - wpAiClientPromptBuilder.php


Trac ticket: https://core.trac.wordpress.org/ticket/64938

## Use of AI Tools

AI assistance: Yes
Tool(s): GitHub Copilot
Model(s): Opus 4.6
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
