### PR TITLE
Mail: Wrap phpmailer_init hook in try-catch to log initialization failures

### DIFF
--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -612,19 +612,20 @@ if ( ! function_exists( 'wp_mail' ) ) :
 			}
 		}
 
-		/**
-		 * Fires after PHPMailer is initialized.
-		 *
-		 * @since 2.2.0
-		 *
-		 * @param PHPMailer $phpmailer The PHPMailer instance (passed by reference).
-		 */
-		do_action_ref_array( 'phpmailer_init', array( &$phpmailer ) );
-
-		$mail_data = compact( 'to', 'subject', 'message', 'headers', 'attachments', 'embeds' );
-
-		// Send!
 		try {
+			/**
+			 * Fires after PHPMailer is initialized.
+			 *
+			 * @since 2.2.0
+			 *
+			 * @param PHPMailer $phpmailer The PHPMailer instance (passed by reference).
+			 */
+			do_action_ref_array( 'phpmailer_init', array( &$phpmailer ) );
+
+			$mail_data = compact( 'to', 'subject', 'message', 'headers', 'attachments', 'embeds' );
+
+			// Send!
+		
 			$send = $phpmailer->send();
 
 			/**


### PR DESCRIPTION
This PR wraps the phpmailer_init hook (do_action_ref_array( 'phpmailer_init', array( &$phpmailer ) )) in a try-catch block within wp_mail() to ensure that exceptions during mail initialization are properly caught and logged.

Currently, if an exception occurs during the execution of the phpmailer_init hook, it may fail silently or without sufficient logging, making it difficult to identify the root cause of mail delivery issues.

In real-world scenarios, failures can occur due to issues such as:

File permission errors (e.g., inaccessible files in wp-content/uploads)
Invalid attachments or embedded resources
Third-party hook implementations throwing exceptions

These failures can result in generic errors like "wp_mail failed" without exposing the underlying cause.

Solution:
Wrapped the phpmailer_init hook execution in a try-catch block
Ensured that any thrown exceptions are properly captured
Allows meaningful error messages to be logged for debugging purposes

Trac ticket: [#64940](https://core.trac.wordpress.org/ticket/64940)

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
