### PR TITLE
RTC: Fix stuck "Join" link in post list when RTC lock expires

### DIFF
--- a/src/wp-admin/css/list-tables.css
+++ b/src/wp-admin/css/list-tables.css
@@ -639,6 +639,18 @@ tr.wp-locked .row-actions .trash {
 	display: block;
 }
 
+.join-action-text {
+	display: none;
+}
+
+.wp-collaborative-editing .edit-action-text {
+	display: none;
+}
+
+.wp-collaborative-editing .join-action-text {
+	display: inline;
+}
+
 #menu-locations-wrap .widefat {
 	width: 60%;
 }

--- a/src/wp-admin/includes/class-wp-posts-list-table.php
+++ b/src/wp-admin/includes/class-wp-posts-list-table.php
@@ -1493,6 +1493,12 @@ class WP_Posts_List_Table extends WP_List_Table {
 		if ( $can_edit_post && 'trash' !== $post->post_status ) {
 			$is_rtc_enabled = (bool) get_option( 'wp_collaboration_enabled' );
 
+			/*
+			 * When RTC is enabled, both "Edit" and "Join" labels are rendered.
+			 * The visible label is toggled by CSS based on the row's
+			 * `wp-collaborative-editing` class, which is added or removed by
+			 * inline-edit-post.js in response to heartbeat ticks.
+			 */
 			if ( $is_rtc_enabled ) {
 				$actions['edit'] = sprintf(
 					'<a href="%1$s">'

--- a/src/wp-admin/includes/class-wp-posts-list-table.php
+++ b/src/wp-admin/includes/class-wp-posts-list-table.php
@@ -1495,14 +1495,14 @@ class WP_Posts_List_Table extends WP_List_Table {
 
 			if ( $is_rtc_enabled ) {
 				$link_text = sprintf(
-					'<span class="edit-action-text">%s<span class="screen-reader-text"> %s</span></span><span class="join-action-text">%s<span class="screen-reader-text"> %s</span></span>',
+					'<span class="edit-action-text"><span aria-hidden="true">%s</span><span class="screen-reader-text">%s</span></span><span class="join-action-text"><span aria-hidden="true">%s</span><span class="screen-reader-text">%s</span></span>',
 					__( 'Edit' ),
 					/* translators: %s: Post title. */
-					sprintf( __( '&#8220;%s&#8221;' ), $title ),
+					sprintf( __( 'Edit &#8220;%s&#8221;' ), $title ),
 					/* translators: Action link text for a singular post in the post list. Can be any type of post. */
 					_x( 'Join', 'post list' ),
 					/* translators: %s: Post title. */
-					sprintf( __( 'editing &#8220;%s&#8221;' ), $title )
+					sprintf( __( 'Join editing &#8220;%s&#8221;', 'post list' ), $title )
 				);
 
 				$actions['edit'] = sprintf(

--- a/src/wp-admin/includes/class-wp-posts-list-table.php
+++ b/src/wp-admin/includes/class-wp-posts-list-table.php
@@ -1494,22 +1494,25 @@ class WP_Posts_List_Table extends WP_List_Table {
 			$is_rtc_enabled = (bool) get_option( 'wp_collaboration_enabled' );
 
 			if ( $is_rtc_enabled ) {
-				$link_text  = '<span class="edit-action-text">';
-				$link_text .= '<span aria-hidden="true">' . __( 'Edit' ) . '</span>';
-				/* translators: %s: Post title. */
-				$link_text .= '<span class="screen-reader-text">' . sprintf( __( 'Edit &#8220;%s&#8221;' ), $title ) . '</span>';
-				$link_text .= '</span>';
-				$link_text .= '<span class="join-action-text">';
-				/* translators: Action link text for a singular post in the post list. Can be any type of post. */
-				$link_text .= '<span aria-hidden="true">' . _x( 'Join', 'post list' ) . '</span>';
-				/* translators: %s: Post title. */
-				$link_text .= '<span class="screen-reader-text">' . sprintf( __( 'Join editing &#8220;%s&#8221;', 'post list' ), $title ) . '</span>';
-				$link_text .= '</span>';
-
 				$actions['edit'] = sprintf(
-					'<a href="%s">%s</a>',
+					'<a href="%1$s">'
+					.   '<span class="edit-action-text">'
+					.     '<span aria-hidden="true">%2$s</span>'
+					.     '<span class="screen-reader-text">%3$s</span>'
+					.   '</span>'
+					.   '<span class="join-action-text">'
+					.     '<span aria-hidden="true">%4$s</span>'
+					.     '<span class="screen-reader-text">%5$s</span>'
+					.   '</span>'
+					. '</a>',
 					get_edit_post_link( $post->ID ),
-					$link_text
+					__( 'Edit' ),
+					/* translators: %s: Post title. */
+					sprintf( __( 'Edit &#8220;%s&#8221;' ), $title ),
+					/* translators: Action link text for a singular post in the post list. Can be any type of post. */
+					_x( 'Join', 'post list' ),
+					/* translators: %s: Post title. */
+					sprintf( __( 'Join editing &#8220;%s&#8221;', 'post list' ), $title )
 				);
 			} else {
 				$actions['edit'] = sprintf(

--- a/src/wp-admin/includes/class-wp-posts-list-table.php
+++ b/src/wp-admin/includes/class-wp-posts-list-table.php
@@ -1495,22 +1495,30 @@ class WP_Posts_List_Table extends WP_List_Table {
 
 			if ( $is_rtc_enabled ) {
 				$link_text = sprintf(
-					'<span class="edit-action-text">%s</span><span class="join-action-text">%s</span>',
+					'<span class="edit-action-text">%s<span class="screen-reader-text"> %s</span></span><span class="join-action-text">%s<span class="screen-reader-text"> %s</span></span>',
 					__( 'Edit' ),
+					/* translators: %s: Post title. */
+					sprintf( __( '&#8220;%s&#8221;' ), $title ),
 					/* translators: Action link text for a singular post in the post list. Can be any type of post. */
-					_x( 'Join', 'post list' )
+					_x( 'Join', 'post list' ),
+					/* translators: %s: Post title. */
+					sprintf( __( 'editing &#8220;%s&#8221;' ), $title )
+				);
+
+				$actions['edit'] = sprintf(
+					'<a href="%s">%s</a>',
+					get_edit_post_link( $post->ID ),
+					$link_text
 				);
 			} else {
-				$link_text = __( 'Edit' );
+				$actions['edit'] = sprintf(
+					'<a href="%s" aria-label="%s">%s</a>',
+					get_edit_post_link( $post->ID ),
+					/* translators: %s: Post title. */
+					esc_attr( sprintf( __( 'Edit &#8220;%s&#8221;' ), $title ) ),
+					__( 'Edit' )
+				);
 			}
-
-			$actions['edit'] = sprintf(
-				'<a href="%s" aria-label="%s">%s</a>',
-				get_edit_post_link( $post->ID ),
-				/* translators: %s: Post title. */
-				esc_attr( sprintf( __( 'Edit &#8220;%s&#8221;' ), $title ) ),
-				$link_text
-			);
 
 			/**
 			 * Filters whether Quick Edit should be enabled for the given post type.

--- a/src/wp-admin/includes/class-wp-posts-list-table.php
+++ b/src/wp-admin/includes/class-wp-posts-list-table.php
@@ -1502,14 +1502,14 @@ class WP_Posts_List_Table extends WP_List_Table {
 			if ( $is_rtc_enabled ) {
 				$actions['edit'] = sprintf(
 					'<a href="%1$s">'
-					.   '<span class="edit-action-text">'
-					.     '<span aria-hidden="true">%2$s</span>'
-					.     '<span class="screen-reader-text">%3$s</span>'
-					.   '</span>'
-					.   '<span class="join-action-text">'
-					.     '<span aria-hidden="true">%4$s</span>'
-					.     '<span class="screen-reader-text">%5$s</span>'
-					.   '</span>'
+					. '<span class="edit-action-text">'
+					. '<span aria-hidden="true">%2$s</span>'
+					. '<span class="screen-reader-text">%3$s</span>'
+					. '</span>'
+					. '<span class="join-action-text">'
+					. '<span aria-hidden="true">%4$s</span>'
+					. '<span class="screen-reader-text">%5$s</span>'
+					. '</span>'
 					. '</a>',
 					get_edit_post_link( $post->ID ),
 					__( 'Edit' ),

--- a/src/wp-admin/includes/class-wp-posts-list-table.php
+++ b/src/wp-admin/includes/class-wp-posts-list-table.php
@@ -1494,16 +1494,17 @@ class WP_Posts_List_Table extends WP_List_Table {
 			$is_rtc_enabled = (bool) get_option( 'wp_collaboration_enabled' );
 
 			if ( $is_rtc_enabled ) {
-				$link_text = sprintf(
-					'<span class="edit-action-text"><span aria-hidden="true">%s</span><span class="screen-reader-text">%s</span></span><span class="join-action-text"><span aria-hidden="true">%s</span><span class="screen-reader-text">%s</span></span>',
-					__( 'Edit' ),
-					/* translators: %s: Post title. */
-					sprintf( __( 'Edit &#8220;%s&#8221;' ), $title ),
-					/* translators: Action link text for a singular post in the post list. Can be any type of post. */
-					_x( 'Join', 'post list' ),
-					/* translators: %s: Post title. */
-					sprintf( __( 'Join editing &#8220;%s&#8221;', 'post list' ), $title )
-				);
+				$link_text  = '<span class="edit-action-text">';
+				$link_text .= '<span aria-hidden="true">' . __( 'Edit' ) . '</span>';
+				/* translators: %s: Post title. */
+				$link_text .= '<span class="screen-reader-text">' . sprintf( __( 'Edit &#8220;%s&#8221;' ), $title ) . '</span>';
+				$link_text .= '</span>';
+				$link_text .= '<span class="join-action-text">';
+				/* translators: Action link text for a singular post in the post list. Can be any type of post. */
+				$link_text .= '<span aria-hidden="true">' . _x( 'Join', 'post list' ) . '</span>';
+				/* translators: %s: Post title. */
+				$link_text .= '<span class="screen-reader-text">' . sprintf( __( 'Join editing &#8220;%s&#8221;', 'post list' ), $title ) . '</span>';
+				$link_text .= '</span>';
 
 				$actions['edit'] = sprintf(
 					'<a href="%s">%s</a>',

--- a/src/wp-admin/includes/class-wp-posts-list-table.php
+++ b/src/wp-admin/includes/class-wp-posts-list-table.php
@@ -1491,23 +1491,25 @@ class WP_Posts_List_Table extends WP_List_Table {
 		$title            = _draft_or_post_title();
 
 		if ( $can_edit_post && 'trash' !== $post->post_status ) {
-			$is_rtc_locked = get_option( 'wp_collaboration_enabled' ) && wp_check_post_lock( $post->ID );
+			$is_rtc_enabled = (bool) get_option( 'wp_collaboration_enabled' );
+
+			if ( $is_rtc_enabled ) {
+				$link_text = sprintf(
+					'<span class="edit-action-text">%s</span><span class="join-action-text">%s</span>',
+					__( 'Edit' ),
+					/* translators: Action link text for a singular post in the post list. Can be any type of post. */
+					_x( 'Join', 'post list' )
+				);
+			} else {
+				$link_text = __( 'Edit' );
+			}
 
 			$actions['edit'] = sprintf(
 				'<a href="%s" aria-label="%s">%s</a>',
 				get_edit_post_link( $post->ID ),
-				esc_attr(
-					sprintf(
-						$is_rtc_locked
-							/* translators: %s: Post title. */
-							? __( 'Join editing &#8220;%s&#8221;', 'post list' )
-							/* translators: %s: Post title. */
-							: __( 'Edit &#8220;%s&#8221;' ),
-						$title
-					)
-				),
-				/* translators: Action link text for a singular post in the post list. Can be any type of post. */
-				$is_rtc_locked ? _x( 'Join', 'post list' ) : __( 'Edit' )
+				/* translators: %s: Post title. */
+				esc_attr( sprintf( __( 'Edit &#8220;%s&#8221;' ), $title ) ),
+				$link_text
 			);
 
 			/**


### PR DESCRIPTION
When RTC is enabled, the "Join" action link on the post list gets stuck after the post lock expires. The heartbeat correctly clears the lock status text and CSS class, but the link text was rendered server-side at page load and never updated back to "Edit".

PR #11234 which removed post lock, conditionally rendered "Join" or "Edit" based on `wp_check_post_lock()` at page load. The heartbeat JS updates the lock class and status text but has no code to swap the action link.

**Fix:** Always render both "Edit" and "Join" as separate `<span>` elements and toggle visibility via CSS using the `.wp-collaborative-editing` class the heartbeat already manages. Also replaces `aria-label` with `screen-reader-text` spans so the accessible name stays in sync with the visible text across lock state changes.

Trac ticket: https://core.trac.wordpress.org/ticket/64622
Related #11234 