### PR TITLE
wp_trim_words - ensure word separation around br tags

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -4052,6 +4052,7 @@ function wp_trim_words( $text, $num_words = 55, $more = null ) {
 	}
 
 	$original_text = $text;
+	$text          = preg_replace( '/<br\b[^>]*\/?>/i', ' ', $text );
 	$text          = wp_strip_all_tags( $text );
 	$num_words     = (int) $num_words;
 

--- a/tests/phpunit/tests/formatting/wpTrimExcerpt.php
+++ b/tests/phpunit/tests/formatting/wpTrimExcerpt.php
@@ -223,4 +223,22 @@ class Tests_Formatting_wpTrimExcerpt extends WP_UnitTestCase {
 		// Assert that the filter callback was not restored after running 'the_content'.
 		$this->assertFalse( has_filter( 'the_content', 'do_blocks' ) );
 	}
+
+	/**
+	 * Generated excerpts should treat `<br>` as word separators so stripping HTML does not join words.
+	 */
+	public function test_wp_trim_excerpt_replaces_line_break_tags_with_spaces_in_generated_excerpt() {
+		$post = self::factory()->post->create(
+			array(
+				'post_content' =>
+					'<!-- wp:paragraph --><p>Line one<br>line two line three</p><!-- /wp:paragraph -->' .
+					'<!-- wp:verse --><pre class="wp-block-verse">First line<br>second line<br>third line</pre><!-- /wp:verse -->',
+			)
+		);
+
+		$this->assertSame(
+			'Line one line two line three First line second line third line',
+			wp_trim_excerpt( '', $post )
+		);
+	}
 }

--- a/tests/phpunit/tests/formatting/wpTrimWords.php
+++ b/tests/phpunit/tests/formatting/wpTrimWords.php
@@ -87,4 +87,15 @@ class Tests_Formatting_wpTrimWords extends WP_UnitTestCase {
 		$this->assertSame( '', wp_trim_words( $this->long_text, null, '' ) );
 		$this->assertSame( 'Lorem ipsum dolor', wp_trim_words( $this->long_text, '3', '' ) );
 	}
+
+	/**
+	 * Ensures `<br>` is treated as a word boundary before tags are stripped, including with attributes.
+	 */
+	public function test_line_break_tags_become_word_separators_before_stripping_tags() {
+		$text = 'one<br>two<br/>three<br />four<BR>five<br class="a">six<br style="clear: both" data-x="y" />seven';
+		$this->assertSame(
+			'one two three four five six seven',
+			wp_trim_words( $text, 99, '' )
+		);
+	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->
Ensures words around br tags are not concatenated together during wp_trim_words by replacing br tags with a space. This is done just before all tags are stripped and will ensure the words are actually separated when the $words_array is generated.

These br tags are common in the core block editor as they can appear in paragraph blocks (shft+enter for spacing), verse blocks, and likely more. For content written in forms similar to that of poetry or song lyrics, excerpts generated from the content stick words together. e.g. "Line one<br>line two" becomes "line oneline two" - this PR aims to resolve this problem at the source in trim words.

Trac ticket: https://core.trac.wordpress.org/ticket/64944

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->
AI assistance: Yes
Tool(s): Cursor
Model(s): Composer 2
Used for: assistance with initial code investigation, assistance with generating regex pattern, initial test suggestions, and general writing directed by me. Placement of and suggested fix made by me, test reviewed and edited by me.
---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**


## Testing

* Run this branch on WP Playground.
* Create a new post using a paragraph of verse block. For the verse block, standard "enter" to add new lines will repro the issue. For the paragraph block, "shft + enter" to create new lines within the block.
    * You can verify the br tags are separating the lines in these blocks by toggling the code editor setting. 
* Do not create a custom excerpt.
* Publish the post.
* Run get_the_excerpt for the post.
* Verify that there are no spaces between the last words of one line and first words of the next. (on trunk, there will be words joined together as described in the examples).