### PR TITLE
Connectors: Respect custom setting_name in connector registration

### DIFF
--- a/src/wp-includes/class-wp-connector-registry.php
+++ b/src/wp-includes/class-wp-connector-registry.php
@@ -192,7 +192,11 @@ final class WP_Connector_Registry {
 			if ( ! empty( $args['authentication']['credentials_url'] ) && is_string( $args['authentication']['credentials_url'] ) ) {
 				$connector['authentication']['credentials_url'] = $args['authentication']['credentials_url'];
 			}
-			$connector['authentication']['setting_name'] = 'connectors_ai_' . str_replace( '-', '_', $id ) . '_api_key';
+			if ( ! empty( $args['authentication']['setting_name'] ) && is_string( $args['authentication']['setting_name'] ) ) {
+				$connector['authentication']['setting_name'] = $args['authentication']['setting_name'];
+			} else {
+				$connector['authentication']['setting_name'] = 'connectors_ai_' . str_replace( '-', '_', $id ) . '_api_key';
+			}
 		}
 
 		if ( ! empty( $args['plugin'] ) && is_array( $args['plugin'] ) ) {


### PR DESCRIPTION
## Summary

- `WP_Connector_Registry::register()` always auto-generates the `setting_name` for `api_key` connectors, ignoring any caller-provided value in `$args['authentication']['setting_name']`
- This prevents connectors from using existing WordPress options as their API key storage
- The fix checks for a non-empty `setting_name` in the provided args before falling back to the auto-generated name

Trac ticket: https://core.trac.wordpress.org/ticket/64957

## Test plan

- Register a connector with a custom `setting_name` and verify it is preserved in the registry output
- Verify existing connectors without a custom `setting_name` still get the auto-generated value