### PR TITLE
Connectors: Type-agnostic registry with explicit key configuration

### DIFF
--- a/src/wp-includes/class-wp-connector-registry.php
+++ b/src/wp-includes/class-wp-connector-registry.php
@@ -35,7 +35,9 @@
  *     authentication: array{
  *         method: 'api_key'|'none',
  *         credentials_url?: non-empty-string,
- *         setting_name?: non-empty-string
+ *         setting_name?: non-empty-string,
+ *         constant_name?: non-empty-string,
+ *         env_var_name?: non-empty-string
  *     },
  *     plugin?: array{
  *         slug: non-empty-string
@@ -95,6 +97,10 @@ final class WP_Connector_Registry {
 	 *
 	 *         @type string $method          Required. The authentication method: 'api_key' or 'none'.
 	 *         @type string $credentials_url Optional. URL where users can obtain API credentials.
+	 *         @type string $constant_name   Optional. PHP constant name for the API key
+	 *                                       (e.g., 'WPCOM_API_KEY'). Defaults to '{UPPER_ID}_API_KEY'.
+	 *         @type string $env_var_name    Optional. Environment variable name for the API key.
+	 *                                       Defaults to '{UPPER_ID}_API_KEY'.
 	 *     }
 	 *     @type array  $plugin         {
 	 *         Optional. Plugin data for install/activate UI.
@@ -196,6 +202,12 @@ final class WP_Connector_Registry {
 				$connector['authentication']['setting_name'] = $args['authentication']['setting_name'];
 			} else {
 				$connector['authentication']['setting_name'] = 'connectors_ai_' . str_replace( '-', '_', $id ) . '_api_key';
+			}
+			if ( ! empty( $args['authentication']['constant_name'] ) && is_string( $args['authentication']['constant_name'] ) ) {
+				$connector['authentication']['constant_name'] = $args['authentication']['constant_name'];
+			}
+			if ( ! empty( $args['authentication']['env_var_name'] ) && is_string( $args['authentication']['env_var_name'] ) ) {
+				$connector['authentication']['env_var_name'] = $args['authentication']['env_var_name'];
 			}
 		}
 

--- a/src/wp-includes/class-wp-connector-registry.php
+++ b/src/wp-includes/class-wp-connector-registry.php
@@ -201,7 +201,16 @@ final class WP_Connector_Registry {
 			if ( ! empty( $args['authentication']['setting_name'] ) && is_string( $args['authentication']['setting_name'] ) ) {
 				$connector['authentication']['setting_name'] = $args['authentication']['setting_name'];
 			} else {
-				$connector['authentication']['setting_name'] = 'connectors_ai_' . str_replace( '-', '_', $id ) . '_api_key';
+				$sanitized_id = str_replace( '-', '_', $id );
+				$type         = $connector['type'] ?? '';
+				if ( 'ai_provider' === $type ) {
+					$type_prefix = 'ai_';
+				} elseif ( '' !== $type ) {
+					$type_prefix = str_replace( '-', '_', $type ) . '_';
+				} else {
+					$type_prefix = '';
+				}
+				$connector['authentication']['setting_name'] = "connectors_{$type_prefix}{$sanitized_id}_api_key";
 			}
 			if ( ! empty( $args['authentication']['constant_name'] ) && is_string( $args['authentication']['constant_name'] ) ) {
 				$connector['authentication']['constant_name'] = $args['authentication']['constant_name'];

--- a/src/wp-includes/class-wp-connector-registry.php
+++ b/src/wp-includes/class-wp-connector-registry.php
@@ -97,10 +97,12 @@ final class WP_Connector_Registry {
 	 *
 	 *         @type string $method          Required. The authentication method: 'api_key' or 'none'.
 	 *         @type string $credentials_url Optional. URL where users can obtain API credentials.
+	 *         @type string $setting_name    Optional. Custom option name for the API key.
+	 *                                       Defaults to 'connectors_{type}_{id}_api_key'.
 	 *         @type string $constant_name   Optional. PHP constant name for the API key
-	 *                                       (e.g., 'WPCOM_API_KEY'). Defaults to '{UPPER_ID}_API_KEY'.
+	 *                                       (e.g., 'WPCOM_API_KEY'). Only checked when provided.
 	 *         @type string $env_var_name    Optional. Environment variable name for the API key.
-	 *                                       Defaults to '{UPPER_ID}_API_KEY'.
+	 *                                       Only checked when provided.
 	 *     }
 	 *     @type array  $plugin         {
 	 *         Optional. Plugin data for install/activate UI.
@@ -201,16 +203,11 @@ final class WP_Connector_Registry {
 			if ( ! empty( $args['authentication']['setting_name'] ) && is_string( $args['authentication']['setting_name'] ) ) {
 				$connector['authentication']['setting_name'] = $args['authentication']['setting_name'];
 			} else {
-				$sanitized_id = str_replace( '-', '_', $id );
-				$type         = $connector['type'] ?? '';
-				if ( 'ai_provider' === $type ) {
-					$type_prefix = 'ai_';
-				} elseif ( '' !== $type ) {
-					$type_prefix = str_replace( '-', '_', $type ) . '_';
-				} else {
-					$type_prefix = '';
-				}
-				$connector['authentication']['setting_name'] = "connectors_{$type_prefix}{$sanitized_id}_api_key";
+				$sanitized_id   = str_replace( '-', '_', $id );
+				$sanitized_type = str_replace( '-', '_', $connector['type'] ?? '' );
+				$connector['authentication']['setting_name'] = '' !== $sanitized_type
+					? "connectors_{$sanitized_type}_{$sanitized_id}_api_key"
+					: "connectors_{$sanitized_id}_api_key";
 			}
 			if ( ! empty( $args['authentication']['constant_name'] ) && is_string( $args['authentication']['constant_name'] ) ) {
 				$connector['authentication']['constant_name'] = $args['authentication']['constant_name'];

--- a/src/wp-includes/class-wp-connector-registry.php
+++ b/src/wp-includes/class-wp-connector-registry.php
@@ -31,7 +31,7 @@
  *     name: non-empty-string,
  *     description: non-empty-string,
  *     logo_url?: non-empty-string,
- *     type: 'ai_provider',
+ *     type: non-empty-string,
  *     authentication: array{
  *         method: 'api_key'|'none',
  *         credentials_url?: non-empty-string,
@@ -67,18 +67,6 @@ final class WP_Connector_Registry {
 	/**
 	 * Registers a new connector.
 	 *
-	 * Validates the provided arguments and stores the connector in the registry.
-	 * For connectors with `api_key` authentication, a `setting_name` is automatically
-	 * generated using the pattern `connectors_ai_{$id}_api_key`, with hyphens in the ID
-	 * normalized to underscores (e.g., connector ID `openai` produces
-	 * `connectors_ai_openai_api_key`, and `azure-openai` produces
-	 * `connectors_ai_azure_openai_api_key`). This setting name is used for the Settings
-	 * API registration and REST API exposure.
-	 *
-	 * Registering a connector with an ID that is already registered will trigger a
-	 * `_doing_it_wrong()` notice and return `null`. To override an existing connector,
-	 * call `unregister()` first.
-	 *
 	 * @since 7.0.0
 	 *
 	 * @see WP_Connector_Registry::unregister()
@@ -91,7 +79,7 @@ final class WP_Connector_Registry {
 	 *     @type string $name           Required. The connector's display name.
 	 *     @type string $description    Optional. The connector's description. Default empty string.
 	 *     @type string $logo_url       Optional. URL to the connector's logo image.
-	 *     @type string $type           Required. The connector type. Currently, only 'ai_provider' is supported.
+	 *     @type string $type           Required. The connector type, e.g. 'ai_provider' or 'spam_filtering'.
 	 *     @type array  $authentication {
 	 *         Required. Authentication configuration.
 	 *
@@ -203,11 +191,7 @@ final class WP_Connector_Registry {
 			if ( ! empty( $args['authentication']['setting_name'] ) && is_string( $args['authentication']['setting_name'] ) ) {
 				$connector['authentication']['setting_name'] = $args['authentication']['setting_name'];
 			} else {
-				$sanitized_id   = str_replace( '-', '_', $id );
-				$sanitized_type = str_replace( '-', '_', $connector['type'] ?? '' );
-				$connector['authentication']['setting_name'] = '' !== $sanitized_type
-					? "connectors_{$sanitized_type}_{$sanitized_id}_api_key"
-					: "connectors_{$sanitized_id}_api_key";
+				$connector['authentication']['setting_name'] = str_replace( '-', '_', "connectors_{$connector['type']}_{$id}_api_key" );
 			}
 			if ( ! empty( $args['authentication']['constant_name'] ) && is_string( $args['authentication']['constant_name'] ) ) {
 				$connector['authentication']['constant_name'] = $args['authentication']['constant_name'];

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -259,6 +259,9 @@ function _wp_connectors_register_default_ai_providers( WP_Connector_Registry $re
 			'authentication' => array(
 				'method'          => 'api_key',
 				'credentials_url' => 'https://platform.claude.com/settings/keys',
+				'setting_name'    => 'connectors_ai_anthropic_api_key',
+				'constant_name'   => 'ANTHROPIC_API_KEY',
+				'env_var_name'    => 'ANTHROPIC_API_KEY',
 			),
 		),
 		'google'    => array(
@@ -271,6 +274,9 @@ function _wp_connectors_register_default_ai_providers( WP_Connector_Registry $re
 			'authentication' => array(
 				'method'          => 'api_key',
 				'credentials_url' => 'https://aistudio.google.com/api-keys',
+				'setting_name'    => 'connectors_ai_google_api_key',
+				'constant_name'   => 'GOOGLE_API_KEY',
+				'env_var_name'    => 'GOOGLE_API_KEY',
 			),
 		),
 		'openai'    => array(
@@ -283,6 +289,9 @@ function _wp_connectors_register_default_ai_providers( WP_Connector_Registry $re
 			'authentication' => array(
 				'method'          => 'api_key',
 				'credentials_url' => 'https://platform.openai.com/api-keys',
+				'setting_name'    => 'connectors_ai_openai_api_key',
+				'constant_name'   => 'OPENAI_API_KEY',
+				'env_var_name'    => 'OPENAI_API_KEY',
 			),
 		),
 	);
@@ -331,6 +340,16 @@ function _wp_connectors_register_default_ai_providers( WP_Connector_Registry $re
 				$defaults[ $connector_id ]['authentication']['credentials_url'] = $authentication['credentials_url'];
 			}
 		} else {
+			// Generate explicit key names for third-party AI providers.
+			if ( $is_api_key ) {
+				$sanitized_id    = str_replace( '-', '_', $connector_id );
+				$constant_case   = strtoupper( preg_replace( '/([a-z])([A-Z])/', '$1_$2', $sanitized_id ) );
+
+				$authentication['setting_name']  = "connectors_ai_{$sanitized_id}_api_key";
+				$authentication['constant_name'] = "{$constant_case}_API_KEY";
+				$authentication['env_var_name']  = "{$constant_case}_API_KEY";
+			}
+
 			$defaults[ $connector_id ] = array(
 				'name'           => $name ? $name : ucwords( $connector_id ),
 				'description'    => $description ? $description : '',
@@ -368,42 +387,33 @@ function _wp_connectors_mask_api_key( string $key ): string {
  * Determines the source of an API key for a given connector.
  *
  * Checks in order: environment variable, PHP constant, database.
- * By default, derives the env var / constant name from the connector ID
- * using the same convention as the WP AI Client ProviderRegistry
- * (e.g., 'openai' → 'OPENAI_API_KEY'). Connectors may override these
- * names via `env_var_name` and `constant_name` in their authentication config.
+ * Environment variable and PHP constant are only checked when explicitly
+ * provided in the connector's authentication config.
  *
  * @since 7.0.0
  * @access private
  *
- * @param string $connector_id      The connector ID (e.g., 'openai', 'akismet').
- * @param string $setting_name      The option name for the API key (e.g., 'connectors_ai_openai_api_key').
- * @param string $env_var_override  Optional. Custom environment variable name. Default empty string.
- * @param string $constant_override Optional. Custom PHP constant name (e.g., 'WPCOM_API_KEY'). Default empty string.
+ * @param string $setting_name  The option name for the API key (e.g., 'connectors_ai_openai_api_key').
+ * @param string $env_var_name  Optional. Environment variable name. Only checked when non-empty.
+ * @param string $constant_name Optional. PHP constant name. Only checked when non-empty.
  * @return string The key source: 'env', 'constant', 'database', or 'none'.
  */
-function _wp_connectors_get_api_key_source( string $connector_id, string $setting_name, string $env_var_override = '', string $constant_override = '' ): string {
-	// Derive default name from connector ID in CONSTANT_CASE.
-	// e.g., 'openai' -> 'OPENAI_API_KEY', 'anthropic' -> 'ANTHROPIC_API_KEY'.
-	$constant_case_id = strtoupper(
-		preg_replace( '/([a-z])([A-Z])/', '$1_$2', str_replace( '-', '_', $connector_id ) )
-	);
-	$default_name     = "{$constant_case_id}_API_KEY";
-
-	$env_var_name  = '' !== $env_var_override ? $env_var_override : $default_name;
-	$constant_name = '' !== $constant_override ? $constant_override : $default_name;
-
-	// Check environment variable first.
-	$env_value = getenv( $env_var_name );
-	if ( false !== $env_value && '' !== $env_value ) {
-		return 'env';
+function _wp_connectors_get_api_key_source( string $setting_name, string $env_var_name = '', string $constant_name = '' ): string {
+	// Check environment variable (only if explicitly configured).
+	if ( '' !== $env_var_name ) {
+		$env_value = getenv( $env_var_name );
+		if ( false !== $env_value && '' !== $env_value ) {
+			return 'env';
+		}
 	}
 
-	// Check PHP constant.
-	if ( defined( $constant_name ) ) {
-		$const_value = constant( $constant_name );
-		if ( is_string( $const_value ) && '' !== $const_value ) {
-			return 'constant';
+	// Check PHP constant (only if explicitly configured).
+	if ( '' !== $constant_name ) {
+		if ( defined( $constant_name ) ) {
+			$const_value = constant( $constant_name );
+			if ( is_string( $const_value ) && '' !== $const_value ) {
+				return 'constant';
+			}
 		}
 	}
 
@@ -586,7 +596,6 @@ function _wp_connectors_pass_default_keys_to_ai_client(): void {
 
 			// Skip if the key is already provided via env var or constant.
 			$key_source = _wp_connectors_get_api_key_source(
-				$connector_id,
 				$auth['setting_name'],
 				$auth['env_var_name'] ?? '',
 				$auth['constant_name'] ?? ''
@@ -642,7 +651,6 @@ function _wp_connectors_get_connector_script_module_data( array $data ): array {
 			$auth_out['settingName']    = $auth['setting_name'] ?? '';
 			$auth_out['credentialsUrl'] = $auth['credentials_url'] ?? null;
 			$auth_out['keySource']      = _wp_connectors_get_api_key_source(
-				$connector_id,
 				$auth['setting_name'] ?? '',
 				$auth['env_var_name'] ?? '',
 				$auth['constant_name'] ?? ''

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -51,6 +51,8 @@ function wp_is_connector_registered( string $id ): bool {
  *         @type string $method          The authentication method: 'api_key' or 'none'.
  *         @type string $credentials_url Optional. URL where users can obtain API credentials.
  *         @type string $setting_name    Optional. The setting name for the API key.
+ *         @type string $constant_name   Optional. PHP constant name for the API key.
+ *         @type string $env_var_name    Optional. Environment variable name for the API key.
  *     }
  *     @type array  $plugin         {
  *         Optional. Plugin data for install/activate UI.
@@ -66,7 +68,9 @@ function wp_is_connector_registered( string $id ): bool {
  *     authentication: array{
  *         method: 'api_key'|'none',
  *         credentials_url?: non-empty-string,
- *         setting_name?: non-empty-string
+ *         setting_name?: non-empty-string,
+ *         constant_name?: non-empty-string,
+ *         env_var_name?: non-empty-string
  *     },
  *     plugin?: array{
  *         slug: non-empty-string
@@ -106,6 +110,8 @@ function wp_get_connector( string $id ): ?array {
  *             @type string $method          The authentication method: 'api_key' or 'none'.
  *             @type string $credentials_url Optional. URL where users can obtain API credentials.
  *             @type string $setting_name    Optional. The setting name for the API key.
+ *             @type string $constant_name   Optional. PHP constant name for the API key.
+ *             @type string $env_var_name    Optional. Environment variable name for the API key.
  *         }
  *         @type array       $plugin         {
  *             Optional. Plugin data for install/activate UI.
@@ -122,7 +128,9 @@ function wp_get_connector( string $id ): ?array {
  *     authentication: array{
  *         method: 'api_key'|'none',
  *         credentials_url?: non-empty-string,
- *         setting_name?: non-empty-string
+ *         setting_name?: non-empty-string,
+ *         constant_name?: non-empty-string,
+ *         env_var_name?: non-empty-string
  *     },
  *     plugin?: array{
  *         slug: non-empty-string
@@ -357,25 +365,33 @@ function _wp_connectors_mask_api_key( string $key ): string {
 }
 
 /**
- * Determines the source of an API key for a given provider.
+ * Determines the source of an API key for a given connector.
  *
  * Checks in order: environment variable, PHP constant, database.
- * Uses the same naming convention as the WP AI Client ProviderRegistry.
+ * By default, derives the env var / constant name from the connector ID
+ * using the same convention as the WP AI Client ProviderRegistry
+ * (e.g., 'openai' → 'OPENAI_API_KEY'). Connectors may override these
+ * names via `env_var_name` and `constant_name` in their authentication config.
  *
  * @since 7.0.0
  * @access private
  *
- * @param string $provider_id  The provider ID (e.g., 'openai', 'anthropic', 'google').
- * @param string $setting_name The option name for the API key (e.g., 'connectors_ai_openai_api_key').
+ * @param string $connector_id      The connector ID (e.g., 'openai', 'akismet').
+ * @param string $setting_name      The option name for the API key (e.g., 'connectors_ai_openai_api_key').
+ * @param string $env_var_override  Optional. Custom environment variable name. Default empty string.
+ * @param string $constant_override Optional. Custom PHP constant name (e.g., 'WPCOM_API_KEY'). Default empty string.
  * @return string The key source: 'env', 'constant', 'database', or 'none'.
  */
-function _wp_connectors_get_api_key_source( string $provider_id, string $setting_name ): string {
-	// Convert provider ID to CONSTANT_CASE for env var name.
-	// e.g., 'openai' -> 'OPENAI', 'anthropic' -> 'ANTHROPIC'.
+function _wp_connectors_get_api_key_source( string $connector_id, string $setting_name, string $env_var_override = '', string $constant_override = '' ): string {
+	// Derive default name from connector ID in CONSTANT_CASE.
+	// e.g., 'openai' -> 'OPENAI_API_KEY', 'anthropic' -> 'ANTHROPIC_API_KEY'.
 	$constant_case_id = strtoupper(
-		preg_replace( '/([a-z])([A-Z])/', '$1_$2', str_replace( '-', '_', $provider_id ) )
+		preg_replace( '/([a-z])([A-Z])/', '$1_$2', str_replace( '-', '_', $connector_id ) )
 	);
-	$env_var_name     = "{$constant_case_id}_API_KEY";
+	$default_name     = "{$constant_case_id}_API_KEY";
+
+	$env_var_name  = '' !== $env_var_override ? $env_var_override : $default_name;
+	$constant_name = '' !== $constant_override ? $constant_override : $default_name;
 
 	// Check environment variable first.
 	$env_value = getenv( $env_var_name );
@@ -384,8 +400,8 @@ function _wp_connectors_get_api_key_source( string $provider_id, string $setting
 	}
 
 	// Check PHP constant.
-	if ( defined( $env_var_name ) ) {
-		$const_value = constant( $env_var_name );
+	if ( defined( $constant_name ) ) {
+		$const_value = constant( $constant_name );
 		if ( is_string( $const_value ) && '' !== $const_value ) {
 			return 'constant';
 		}
@@ -569,7 +585,12 @@ function _wp_connectors_pass_default_keys_to_ai_client(): void {
 			}
 
 			// Skip if the key is already provided via env var or constant.
-			$key_source = _wp_connectors_get_api_key_source( $connector_id, $auth['setting_name'] );
+			$key_source = _wp_connectors_get_api_key_source(
+				$connector_id,
+				$auth['setting_name'],
+				$auth['env_var_name'] ?? '',
+				$auth['constant_name'] ?? ''
+			);
 			if ( 'env' === $key_source || 'constant' === $key_source ) {
 				continue;
 			}
@@ -620,7 +641,12 @@ function _wp_connectors_get_connector_script_module_data( array $data ): array {
 		if ( 'api_key' === $auth['method'] ) {
 			$auth_out['settingName']    = $auth['setting_name'] ?? '';
 			$auth_out['credentialsUrl'] = $auth['credentials_url'] ?? null;
-			$auth_out['keySource']      = _wp_connectors_get_api_key_source( $connector_id, $auth['setting_name'] ?? '' );
+			$auth_out['keySource']      = _wp_connectors_get_api_key_source(
+				$connector_id,
+				$auth['setting_name'] ?? '',
+				$auth['env_var_name'] ?? '',
+				$auth['constant_name'] ?? ''
+			);
 			try {
 				$auth_out['isConnected'] = $registry->hasProvider( $connector_id ) && $registry->isProviderConfigured( $connector_id );
 			} catch ( Exception $e ) {

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -43,7 +43,7 @@ function wp_is_connector_registered( string $id ): bool {
  *     @type string $name           The connector's display name.
  *     @type string $description    The connector's description.
  *     @type string $logo_url       Optional. URL to the connector's logo image.
- *     @type string $type           The connector type. Currently, only 'ai_provider' is supported.
+ *     @type string $type           The connector type, e.g. 'ai_provider' or 'spam_filtering'.
  *     @type array  $authentication {
  *         Authentication configuration. When method is 'api_key', includes
  *         credentials_url and setting_name. When 'none', only method is present.
@@ -64,7 +64,7 @@ function wp_is_connector_registered( string $id ): bool {
  *     name: non-empty-string,
  *     description: non-empty-string,
  *     logo_url?: non-empty-string,
- *     type: 'ai_provider',
+ *     type: non-empty-string,
  *     authentication: array{
  *         method: 'api_key'|'none',
  *         credentials_url?: non-empty-string,
@@ -102,7 +102,7 @@ function wp_get_connector( string $id ): ?array {
  *         @type string      $name           The connector's display name.
  *         @type string      $description    The connector's description.
  *         @type string      $logo_url       Optional. URL to the connector's logo image.
- *         @type string      $type           The connector type. Currently, only 'ai_provider' is supported.
+ *         @type string      $type           The connector type, e.g. 'ai_provider' or 'spam_filtering'.
  *         @type array       $authentication {
  *             Authentication configuration. When method is 'api_key', includes
  *             credentials_url and setting_name. When 'none', only method is present.
@@ -124,7 +124,7 @@ function wp_get_connector( string $id ): ?array {
  *     name: non-empty-string,
  *     description: non-empty-string,
  *     logo_url?: non-empty-string,
- *     type: 'ai_provider',
+ *     type: non-empty-string,
  *     authentication: array{
  *         method: 'api_key'|'none',
  *         credentials_url?: non-empty-string,
@@ -496,7 +496,7 @@ function _wp_connectors_rest_settings_dispatch( WP_REST_Response $response, WP_R
 
 	foreach ( wp_get_connectors() as $connector_id => $connector_data ) {
 		$auth = $connector_data['authentication'];
-		if ( 'ai_provider' !== $connector_data['type'] || 'api_key' !== $auth['method'] || empty( $auth['setting_name'] ) ) {
+		if ( 'api_key' !== $auth['method'] || empty( $auth['setting_name'] ) ) {
 			continue;
 		}
 
@@ -507,8 +507,9 @@ function _wp_connectors_rest_settings_dispatch( WP_REST_Response $response, WP_R
 
 		$value = $data[ $setting_name ];
 
-		// On update, validate the key before masking.
-		if ( $is_update && is_string( $value ) && '' !== $value ) {
+		// On update, validate AI provider keys before masking.
+		// Non-AI connectors accept keys as-is; the service plugin handles its own validation.
+		if ( $is_update && is_string( $value ) && '' !== $value && 'ai_provider' === $connector_data['type'] ) {
 			if ( true !== _wp_connectors_is_ai_api_key_valid( $value, $connector_id ) ) {
 				update_option( $setting_name, '' );
 				$data[ $setting_name ] = '';
@@ -534,16 +535,22 @@ add_filter( 'rest_post_dispatch', '_wp_connectors_rest_settings_dispatch', 10, 3
  * @access private
  */
 function _wp_register_default_connector_settings(): void {
-	$ai_registry = AiClient::defaultRegistry();
+	$ai_registry       = AiClient::defaultRegistry();
+	$existing_settings = get_registered_settings();
 
 	foreach ( wp_get_connectors() as $connector_id => $connector_data ) {
 		$auth = $connector_data['authentication'];
-		if ( 'ai_provider' !== $connector_data['type'] || 'api_key' !== $auth['method'] || empty( $auth['setting_name'] ) ) {
+		if ( 'api_key' !== $auth['method'] || empty( $auth['setting_name'] ) ) {
 			continue;
 		}
 
-		// Skip registering the setting if the provider is not in the registry.
-		if ( ! $ai_registry->hasProvider( $connector_id ) ) {
+		// For AI providers, skip if the provider is not in the AI Client registry.
+		if ( 'ai_provider' === $connector_data['type'] && ! $ai_registry->hasProvider( $connector_id ) ) {
+			continue;
+		}
+
+		// Skip if the setting is already registered (e.g. by the connector's plugin).
+		if ( isset( $existing_settings[ $auth['setting_name'] ] ) ) {
 			continue;
 		}
 
@@ -553,13 +560,13 @@ function _wp_register_default_connector_settings(): void {
 			array(
 				'type'              => 'string',
 				'label'             => sprintf(
-					/* translators: %s: AI provider name. */
+					/* translators: %s: Connector name. */
 					__( '%s API Key' ),
 					$connector_data['name']
 				),
 				'description'       => sprintf(
-					/* translators: %s: AI provider name. */
-					__( 'API key for the %s AI provider.' ),
+					/* translators: %s: Connector name. */
+					__( 'API key for %s.' ),
 					$connector_data['name']
 				),
 				'default'           => '',
@@ -655,10 +662,16 @@ function _wp_connectors_get_connector_script_module_data( array $data ): array {
 				$auth['env_var_name'] ?? '',
 				$auth['constant_name'] ?? ''
 			);
-			try {
-				$auth_out['isConnected'] = $registry->hasProvider( $connector_id ) && $registry->isProviderConfigured( $connector_id );
-			} catch ( Exception $e ) {
-				$auth_out['isConnected'] = false;
+
+			if ( 'ai_provider' === $connector_data['type'] ) {
+				try {
+					$auth_out['isConnected'] = $registry->hasProvider( $connector_id ) && $registry->isProviderConfigured( $connector_id );
+				} catch ( Exception $e ) {
+					$auth_out['isConnected'] = false;
+				}
+			} else {
+				// For non-AI connectors, consider connected if a key exists from any source.
+				$auth_out['isConnected'] = 'none' !== $auth_out['keySource'];
 			}
 		}
 
@@ -679,7 +692,9 @@ function _wp_connectors_get_connector_script_module_data( array $data ): array {
 
 			$connector_out['plugin'] = array(
 				'slug'        => $plugin_slug,
-				'isInstalled' => $is_installed,
+				'pluginFile'  => $is_installed
+					? ( str_ends_with( $plugin_file, '.php' ) ? substr( $plugin_file, 0, -4 ) : $plugin_file )
+					: null,
 				'isActivated' => $is_activated,
 			);
 		}

--- a/tests/phpunit/includes/wp-ai-client-mock-provider-trait.php
+++ b/tests/phpunit/includes/wp-ai-client-mock-provider-trait.php
@@ -172,6 +172,7 @@ trait WP_AI_Client_Mock_Provider_Trait {
 					'authentication' => array(
 						'method'          => 'api_key',
 						'credentials_url' => null,
+						'setting_name'    => 'connectors_ai_mock_connectors_test_api_key',
 					),
 				)
 			);

--- a/tests/phpunit/tests/connectors/wpConnectorRegistry.php
+++ b/tests/phpunit/tests/connectors/wpConnectorRegistry.php
@@ -62,7 +62,10 @@ class Tests_Connectors_WpConnectorRegistry extends WP_UnitTestCase {
 	 * @ticket 64791
 	 */
 	public function test_register_generates_setting_name_for_api_key() {
-		$result = $this->registry->register( 'myai', self::$default_args );
+		$args = self::$default_args;
+		unset( $args['authentication']['setting_name'] );
+
+		$result = $this->registry->register( 'myai', $args );
 
 		$this->assertSame( 'connectors_ai_provider_myai_api_key', $result['authentication']['setting_name'] );
 	}
@@ -71,7 +74,10 @@ class Tests_Connectors_WpConnectorRegistry extends WP_UnitTestCase {
 	 * @ticket 64861
 	 */
 	public function test_register_generates_setting_name_normalizes_hyphens() {
-		$result = $this->registry->register( 'my-ai', self::$default_args );
+		$args = self::$default_args;
+		unset( $args['authentication']['setting_name'] );
+
+		$result = $this->registry->register( 'my-ai', $args );
 
 		$this->assertSame( 'connectors_ai_provider_my_ai_api_key', $result['authentication']['setting_name'] );
 	}

--- a/tests/phpunit/tests/connectors/wpConnectorRegistry.php
+++ b/tests/phpunit/tests/connectors/wpConnectorRegistry.php
@@ -38,6 +38,7 @@ class Tests_Connectors_WpConnectorRegistry extends WP_UnitTestCase {
 			'authentication' => array(
 				'method'          => 'api_key',
 				'credentials_url' => 'https://example.com/keys',
+				'setting_name'    => 'connectors_ai_test_provider_api_key',
 			),
 		);
 	}
@@ -63,7 +64,7 @@ class Tests_Connectors_WpConnectorRegistry extends WP_UnitTestCase {
 	public function test_register_generates_setting_name_for_api_key() {
 		$result = $this->registry->register( 'myai', self::$default_args );
 
-		$this->assertSame( 'connectors_ai_myai_api_key', $result['authentication']['setting_name'] );
+		$this->assertSame( 'connectors_ai_provider_myai_api_key', $result['authentication']['setting_name'] );
 	}
 
 	/**
@@ -72,7 +73,7 @@ class Tests_Connectors_WpConnectorRegistry extends WP_UnitTestCase {
 	public function test_register_generates_setting_name_normalizes_hyphens() {
 		$result = $this->registry->register( 'my-ai', self::$default_args );
 
-		$this->assertSame( 'connectors_ai_my_ai_api_key', $result['authentication']['setting_name'] );
+		$this->assertSame( 'connectors_ai_provider_my_ai_api_key', $result['authentication']['setting_name'] );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Makes the connectors system support arbitrary connector types (not just `ai_provider`), while keeping AI-specific behavior where needed.

**Registry & types**
- PHPStan `type` field widened from `'ai_provider'` to `non-empty-string`
- Default `setting_name` uses `connectors_{type}_{id}_api_key` pattern
- Built-in AI connectors pass explicit `setting_name`, `constant_name`, and `env_var_name`
- `constant_name` and `env_var_name` are truly optional — only checked when provided

**REST dispatch**
- Masks API keys for all connector types (not just AI)
- Validates keys on update only for AI providers; non-AI connectors skip validation

**Settings registration**
- Registers settings for all connector types with `api_key` auth
- Skips settings already registered by the connector's own plugin
- AI provider registry check scoped to `ai_provider` type only

**Script module data**
- Type-aware `isConnected`: AI providers check the AI Client registry; others check key presence
- Adds `pluginFile` field to plugin data
- `method_exists()` guards on AI provider metadata methods

## Test plan

- [ ] Verify existing connector unit tests pass
- [ ] Confirm AI provider connectors still validate keys on save
- [ ] Confirm non-AI connectors can register and have keys masked in REST