### PR TITLE
Media: Guard against false return from wp_get_attachment_image_src() for PHP 8.5

### DIFF
--- a/src/wp-includes/embed.php
+++ b/src/wp-includes/embed.php
@@ -739,10 +739,12 @@ function get_oembed_response_data_rich( $data, $post, $width, $height ) {
 	}
 
 	if ( $thumbnail_id ) {
-		list( $thumbnail_url, $thumbnail_width, $thumbnail_height ) = wp_get_attachment_image_src( $thumbnail_id, array( $width, 0 ) );
-		$data['thumbnail_url']                                      = $thumbnail_url;
-		$data['thumbnail_width']                                    = $thumbnail_width;
-		$data['thumbnail_height']                                   = $thumbnail_height;
+		$thumbnail_src = wp_get_attachment_image_src( $thumbnail_id, array( $width, 0 ) );
+		if ( is_array( $thumbnail_src ) ) {
+			$data['thumbnail_url']    = $thumbnail_src[0];
+			$data['thumbnail_width']  = $thumbnail_src[1];
+			$data['thumbnail_height'] = $thumbnail_src[2];
+		}
 	}
 
 	return $data;

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -988,7 +988,8 @@ function wp_get_attachment_image_src( $attachment_id, $size = 'thumbnail', $icon
 
 				$src_file = $icon_dir . '/' . wp_basename( $src );
 
-				list( $width, $height ) = wp_getimagesize( $src_file );
+				$width  = 0;
+				$height = 0;
 
 				$ext = strtolower( substr( $src_file, -4 ) );
 
@@ -997,7 +998,11 @@ function wp_get_attachment_image_src( $attachment_id, $size = 'thumbnail', $icon
 					$width  = 48;
 					$height = 64;
 				} else {
-					list( $width, $height ) = wp_getimagesize( $src_file );
+					$imagesize = wp_getimagesize( $src_file );
+					if ( is_array( $imagesize ) ) {
+						$width  = $imagesize[0];
+						$height = $imagesize[1];
+					}
 				}
 			}
 		}
@@ -3230,10 +3235,22 @@ function wp_playlist_shortcode( $attr ) {
 		if ( $atts['images'] ) {
 			$thumb_id = get_post_thumbnail_id( $attachment->ID );
 			if ( ! empty( $thumb_id ) ) {
-				list( $src, $width, $height ) = wp_get_attachment_image_src( $thumb_id, 'full' );
-				$track['image']               = compact( 'src', 'width', 'height' );
-				list( $src, $width, $height ) = wp_get_attachment_image_src( $thumb_id, 'thumbnail' );
-				$track['thumb']               = compact( 'src', 'width', 'height' );
+				$image_src = wp_get_attachment_image_src( $thumb_id, 'full' );
+				if ( is_array( $image_src ) ) {
+					$track['image'] = array(
+						'src'    => $image_src[0],
+						'width'  => $image_src[1],
+						'height' => $image_src[2],
+					);
+				}
+				$thumb_src = wp_get_attachment_image_src( $thumb_id, 'thumbnail' );
+				if ( is_array( $thumb_src ) ) {
+					$track['thumb'] = array(
+						'src'    => $thumb_src[0],
+						'width'  => $thumb_src[1],
+						'height' => $thumb_src[2],
+					);
+				}
 			} else {
 				$src            = wp_mime_type_icon( $attachment->ID, '.svg' );
 				$width          = 48;
@@ -4711,10 +4728,22 @@ function wp_prepare_attachment_for_js( $attachment ) {
 
 		$id = get_post_thumbnail_id( $attachment->ID );
 		if ( ! empty( $id ) ) {
-			list( $src, $width, $height ) = wp_get_attachment_image_src( $id, 'full' );
-			$response['image']            = compact( 'src', 'width', 'height' );
-			list( $src, $width, $height ) = wp_get_attachment_image_src( $id, 'thumbnail' );
-			$response['thumb']            = compact( 'src', 'width', 'height' );
+			$image_src = wp_get_attachment_image_src( $id, 'full' );
+			if ( is_array( $image_src ) ) {
+				$response['image'] = array(
+					'src'    => $image_src[0],
+					'width'  => $image_src[1],
+					'height' => $image_src[2],
+				);
+			}
+			$thumb_src = wp_get_attachment_image_src( $id, 'thumbnail' );
+			if ( is_array( $thumb_src ) ) {
+				$response['thumb'] = array(
+					'src'    => $thumb_src[0],
+					'width'  => $thumb_src[1],
+					'height' => $thumb_src[2],
+				);
+			}
 		} else {
 			$src               = wp_mime_type_icon( $attachment->ID, '.svg' );
 			$width             = 48;

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -7283,6 +7283,35 @@ EOF;
 			'height' => 100,
 		);
 	}
+
+	/**
+	 * @ticket 64742
+	 */
+	public function test_wp_get_attachment_image_src_returns_false_for_invalid_attachment() {
+		$result = wp_get_attachment_image_src( 99999, 'thumbnail' );
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * @ticket 64742
+	 */
+	public function test_wp_prepare_attachment_for_js_with_invalid_thumbnail_does_not_warn() {
+		$attachment_id = self::factory()->attachment->create_object(
+			DIR_TESTDATA . '/uploads/test-image.jpg',
+			0,
+			array(
+				'post_mime_type' => 'audio/mpeg',
+				'post_type'     => 'attachment',
+			)
+		);
+
+		// Set _thumbnail_id to a non-existent attachment ID.
+		update_post_meta( $attachment_id, '_thumbnail_id', 99999 );
+
+		$result = wp_prepare_attachment_for_js( $attachment_id );
+
+		$this->assertIsArray( $result );
+	}
 }
 
 /**

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -7301,7 +7301,7 @@ EOF;
 			0,
 			array(
 				'post_mime_type' => 'audio/mpeg',
-				'post_type'     => 'attachment',
+				'post_type'      => 'attachment',
 			)
 		);
 

--- a/tests/phpunit/tests/oembed/getResponseData.php
+++ b/tests/phpunit/tests/oembed/getResponseData.php
@@ -289,4 +289,21 @@ class Tests_oEmbed_Response_Data extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'thumbnail_height', $data );
 		$this->assertLessThanOrEqual( 400, $data['thumbnail_width'] );
 	}
+
+	/**
+	 * @ticket 64742
+	 */
+	public function test_get_oembed_response_data_with_invalid_thumbnail_does_not_warn() {
+		$post = self::factory()->post->create_and_get();
+
+		// Set _thumbnail_id to a non-existent attachment ID.
+		update_post_meta( $post->ID, '_thumbnail_id', 99999 );
+
+		$data = get_oembed_response_data( $post, 400 );
+
+		$this->assertIsArray( $data );
+		$this->assertArrayNotHasKey( 'thumbnail_url', $data );
+		$this->assertArrayNotHasKey( 'thumbnail_width', $data );
+		$this->assertArrayNotHasKey( 'thumbnail_height', $data );
+	}
 }


### PR DESCRIPTION
## Summary

- Fixes PHP 8.5 warning when `list()` is used to destructure `false` returned by `wp_get_attachment_image_src()`
- Adds `is_array()` guards in `embed.php` (`get_oembed_response_data_rich`), and `media.php` (`wp_get_attachment_image_src`, `wp_playlist_shortcode`, `wp_prepare_attachment_for_js`)
- Adds unit tests for invalid thumbnail scenarios

## Trac Ticket

https://core.trac.wordpress.org/ticket/64742

## Test Plan

- [x] PHPUnit tests pass (430 tests in Media + oEmbed suites)
- [x] Manual test: set `_thumbnail_id` to a non-existent ID, visit oEmbed endpoint — no warnings, no null thumbnail keys