### PR TITLE
Dashboard: Fix Activity widget text overflow. Fixes #64827

### DIFF
--- a/src/wp-admin/css/dashboard.css
+++ b/src/wp-admin/css/dashboard.css
@@ -895,6 +895,19 @@ body #dashboard-widgets .postbox form .submit {
 
 /* Dashboard activity widget */
 
+#dashboard_activity ul li,
+#dashboard_activity ul li a {
+    overflow-wrap: break-word; 
+    word-wrap: break-word;      
+    word-break: break-word;     
+}
+
+#dashboard_activity ul li a {
+    display: inline-block;
+    max-width: 100%;
+    vertical-align: top;
+}
+
 #dashboard_activity .comment-meta span.approve:before {
 	content: "\f227";
 	content: "\f227" / '';


### PR DESCRIPTION
Prevents long text in the Dashboard Activity widget from overflowing its container.

This adjusts the widget CSS so long, unbroken strings wrap correctly in activity items and links.

Testing:
1. Open the Dashboard Activity widget.
2. Check an item with long unbroken text.
3. Confirm the text wraps instead of overflowing.

Trac ticket: https://core.trac.wordpress.org/ticket/64827