### PR TITLE
Exclude the `wp_sync_storage` post type from exports.

### DIFF
--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -687,6 +687,7 @@ function create_initial_post_types() {
 				'show_in_menu'       => false,
 				'show_in_rest'       => false,
 				'show_ui'            => false,
+				'can_export'         => false,
 				'supports'           => array( 'custom-fields' ),
 			)
 		);

--- a/tests/phpunit/tests/admin/exportWp.php
+++ b/tests/phpunit/tests/admin/exportWp.php
@@ -474,4 +474,41 @@ class Tests_Admin_ExportWp extends WP_UnitTestCase {
 		$this->assertNotFalse( $xml, 'Export should not fail with NULL term meta values' );
 		$this->assertGreaterThan( 0, count( $xml->channel->item ), 'Export should contain items' );
 	}
+
+	/**
+	 * Ensure that posts types with 'can_export' set to false are not included in the export.
+	 *
+	 * @ticket 64964
+	 */
+	public function test_export_does_not_include_excluded_post_types() {
+		register_post_type(
+			'wpexport_excluded',
+			array( 'can_export' => false )
+		);
+
+		$excluded_post_id = self::factory()->post->create(
+			array(
+				'post_title'  => 'Excluded Post Type',
+				'post_type'   => 'wpexport_excluded',
+				'post_status' => 'publish',
+			)
+		);
+
+		$xml = $this->get_the_export(
+			array(
+				'content' => 'all',
+			)
+		);
+
+		$found_post = false;
+		foreach ( $xml->channel->item as $item ) {
+			$wp_item = $item->children( 'wp', true );
+			if ( (int) $wp_item->post_id === $excluded_post_id ) {
+				$found_post = true;
+				break;
+			}
+		}
+
+		$this->assertFalse( $found_post, 'Posts of excluded post types should not be included in export' );
+	}
 }


### PR DESCRIPTION
Exclude the RTC post type from WordPress exports.

Trac ticket: https://core.trac.wordpress.org/ticket/64964

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
