### PR TITLE
Language dropdown shows old hover/focus color on setup screen

### DIFF
--- a/src/wp-admin/css/install.css
+++ b/src/wp-admin/css/install.css
@@ -340,7 +340,7 @@ body.language-chooser {
 
 .language-chooser select option:hover,
 .language-chooser select option:focus {
-	color: #0a4b78;
+	color: var(--wp-admin-theme-color-darker-20);
 }
 
 .language-chooser .step {


### PR DESCRIPTION
Ticket: https://core.trac.wordpress.org/ticket/64961
