### PR TITLE
REST API: Fix object/array validation for JSON strings in GET requests (#64926)

### DIFF
--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -1845,7 +1845,7 @@ function rest_find_matching_pattern_property_schema( $property, $args ) {
  * @since 5.6.0
  *
  * @param string $param The parameter name.
- * @param array $error  The error details.
+ * @param array  $error  The error details.
  * @return WP_Error
  */
 function rest_format_combining_operation_error( $param, $error ) {
@@ -2182,6 +2182,7 @@ function rest_get_allowed_schema_keywords() {
  * @return true|WP_Error
  */
 function rest_validate_value_from_schema( $value, $args, $param = '' ) {
+
 	if ( isset( $args['anyOf'] ) ) {
 		$matching_schema = rest_find_any_matching_schema( $value, $args, $param );
 		if ( is_wp_error( $matching_schema ) ) {
@@ -2243,9 +2244,32 @@ function rest_validate_value_from_schema( $value, $args, $param = '' ) {
 			$is_valid = rest_validate_boolean_value_from_schema( $value, $param );
 			break;
 		case 'object':
+			/*
+			 * A JSON-encoded string (e.g. from a GET query parameter) should be
+			 * decoded before validation, mirroring what parse_json_params() does
+			 * for application/json request bodies.
+			 */
+			if ( is_string( $value ) ) {
+				$decoded = json_decode( $value, true );
+				if ( null !== $decoded && JSON_ERROR_NONE === json_last_error() ) {
+					$value = $decoded;
+				}
+			}
 			$is_valid = rest_validate_object_value_from_schema( $value, $args, $param );
 			break;
 		case 'array':
+			/*
+			 * A JSON-encoded string (e.g. ?ids=[1,2,3]) should be decoded before
+			 * validation. This takes priority over the comma-separated-value
+			 * fallback in rest_is_array() / wp_parse_list(), which cannot
+			 * preserve value types.
+			 */
+			if ( is_string( $value ) && str_starts_with( ltrim( $value ), '[' ) ) {
+				$decoded = json_decode( $value, true );
+				if ( is_array( $decoded ) && JSON_ERROR_NONE === json_last_error() ) {
+					$value = $decoded;
+				}
+			}
 			$is_valid = rest_validate_array_value_from_schema( $value, $args, $param );
 			break;
 		case 'number':
@@ -2780,6 +2804,7 @@ function rest_validate_integer_value_from_schema( $value, $args, $param ) {
  * @return mixed|WP_Error The sanitized value or a WP_Error instance if the value cannot be safely sanitized.
  */
 function rest_sanitize_value_from_schema( $value, $args, $param = '' ) {
+
 	if ( isset( $args['anyOf'] ) ) {
 		$matching_schema = rest_find_any_matching_schema( $value, $args, $param );
 		if ( is_wp_error( $matching_schema ) ) {
@@ -2833,6 +2858,19 @@ function rest_sanitize_value_from_schema( $value, $args, $param = '' ) {
 	}
 
 	if ( 'array' === $args['type'] ) {
+		/*
+		 * A JSON-encoded string (e.g. ?ids=[1,2,3]) should be decoded before
+		 * sanitization. This takes priority over the comma-separated-value
+		 * fallback in rest_sanitize_array() / wp_parse_list(), which cannot
+		 * preserve value types.
+		 */
+		if ( is_string( $value ) && str_starts_with( ltrim( $value ), '[' ) ) {
+			$decoded = json_decode( $value, true );
+			if ( is_array( $decoded ) && JSON_ERROR_NONE === json_last_error() ) {
+				$value = $decoded;
+			}
+		}
+
 		$value = rest_sanitize_array( $value );
 
 		if ( ! empty( $args['items'] ) ) {
@@ -2850,6 +2888,18 @@ function rest_sanitize_value_from_schema( $value, $args, $param = '' ) {
 	}
 
 	if ( 'object' === $args['type'] ) {
+		/*
+		 * A JSON-encoded string (e.g. from a GET query parameter) should be
+		 * decoded before sanitization, mirroring what parse_json_params() does
+		 * for application/json request bodies.
+		 */
+		if ( is_string( $value ) ) {
+			$decoded = json_decode( $value, true );
+			if ( null !== $decoded && JSON_ERROR_NONE === json_last_error() ) {
+				$value = $decoded;
+			}
+		}
+
 		$value = rest_sanitize_object( $value );
 
 		foreach ( $value as $property => $v ) {

--- a/tests/phpunit/tests/rest-api.php
+++ b/tests/phpunit/tests/rest-api.php
@@ -2583,4 +2583,94 @@ class Tests_REST_API extends WP_UnitTestCase {
 			throw $e; // Re-throw to satisfy expectException
 		}
 	}
+
+
+	/**
+	 * @ticket 64926
+	 * REST API: GET requests fail object/array schema validation
+	 * when params are JSON-serialized strings.
+	 * Test that rest_validate_value_from_schema correctly decodes and validates a JSON string for array types.
+	 */
+	public function test_validate_json_string_array() {
+		$schema = array(
+			'type'  => 'array',
+			'items' => array( 'type' => 'integer' ),
+		);
+
+		$value    = '[1, 2, 3]';
+		$is_valid = rest_validate_value_from_schema( $value, $schema, 'test_param' );
+
+		$this->assertTrue( $is_valid, 'The JSON array string should be correctly decoded and validated.' );
+	}
+
+	/**
+	 * @ticket 64926
+	 * Test that rest_validate_value_from_schema correctly decodes and validates a JSON string for object types.
+	 */
+	public function test_validate_json_string_object() {
+		$schema = array(
+			'type'       => 'object',
+			'properties' => array(
+				'id'   => array( 'type' => 'integer' ),
+				'name' => array( 'type' => 'string' ),
+			),
+		);
+
+		$value    = '{"id": 123, "name": "Gemini"}';
+		$is_valid = rest_validate_value_from_schema( $value, $schema, 'test_param' );
+
+		$this->assertTrue( $is_valid, 'The JSON object string should be correctly decoded and validated.' );
+	}
+
+	/**
+	 * @ticket 64926
+	 * Test that rest_sanitize_value_from_schema correctly decodes and sanitizes a JSON array string.
+	 */
+	public function test_sanitize_json_string_array() {
+		$schema = array(
+			'type'  => 'array',
+			'items' => array( 'type' => 'integer' ),
+		);
+
+		$value     = '[10, "20", 30]';
+		$sanitized = rest_sanitize_value_from_schema( $value, $schema, 'test_param' );
+
+		$this->assertIsArray( $sanitized );
+		$this->assertSame( array( 10, 20, 30 ), $sanitized );
+	}
+
+	/**
+	 * @ticket 64926
+	 * Test that rest_sanitize_value_from_schema correctly decodes and sanitizes a JSON object string.
+	 */
+	public function test_sanitize_json_string_object() {
+		$schema = array(
+			'type'       => 'object',
+			'properties' => array(
+				'active' => array( 'type' => 'boolean' ),
+			),
+		);
+
+		$value     = '{"active": "true"}';
+		$sanitized = rest_sanitize_value_from_schema( $value, $schema, 'test_param' );
+
+		$this->assertIsArray( $sanitized );
+		$this->assertTrue( $sanitized['active'] );
+	}
+
+	/**
+	 * @ticket 64926
+	 * Test that invalid JSON strings fall back to the original validation logic.
+	 */
+	public function test_validate_invalid_json_falls_back() {
+		$schema = array(
+			'type' => 'array',
+		);
+
+		$value = '1,2,3';
+
+		$is_valid = rest_validate_value_from_schema( $value, $schema, 'test_param' );
+
+		$this->assertNotWPError( $is_valid );
+	}
 }


### PR DESCRIPTION
Description
Trac Ticket: https://core.trac.wordpress.org/ticket/64926

This PR addresses #64926, where REST API GET requests fail validation when parameters defined as object or array are passed as JSON-encoded strings (e.g., via JSON.stringify).

The Problem
Currently, rest_validate_value_from_schema() receives these parameters as raw strings from $_GET. Since the schema expects an object or array, it triggers a rest_invalid_type error (400 Bad Request) before any sanitization or decoding can occur. While POST requests handle this via parse_json_params(), no equivalent coercion exists for query-string parameters.

The Fix
This PR introduces JSON coercion in both rest_validate_value_from_schema() and rest_sanitize_value_from_schema().

If the schema expects a structured type but receives a string, it attempts to json_decode().

Uses json_last_error() === JSON_ERROR_NONE to ensure only valid JSON is coerced, maintaining safety for regular strings.

Supports multi-type schemas (e.g., ['string', 'object']).

No changes to function signatures, ensuring backward compatibility.

How to Test
Register a test endpoint with an object type parameter:

PHP
register_rest_route( 'my-test/v1', '/schema-test', array(
    'methods' => 'GET',
    'callback' => function( $request ) {
        return array( 'success' => true, 'data' => $request->get_param( 'config' ) );
    },
    'args' => array(
        'config' => array( 'type' => 'object' ),
    ),
) );
Test Case A: Valid JSON Object

URL: /wp-json/my-test/v1/schema-test?config={"id":123,"name":"Gemini"}

Expected Result: {"success":true,"data":{"id":123,"name":"Gemini"}} (Integers preserved).

Test Case B: Empty Object

URL: /wp-json/my-test/v1/schema-test?config={}

Expected Result: {"success":true,"data":[]} (PHP decodes empty JSON object as array).

Test Case C: Invalid JSON (Safety Check)

URL: /wp-json/my-test/v1/schema-test?config={id:123}

Expected Result: 400 Bad Request (Correctly rejected because it's not valid JSON and doesn't match type object).

Screenshots/Logs
Tested in a local WordPress development environment.

Before Patch: Returns rest_invalid_type error for all JSON string inputs in GET.

After Patch: Successfully decodes and validates structured data while maintaining strictness for invalid JSON.

Types of changes
[x] Bug fix (non-breaking change which fixes an issue)

[ ] New feature (non-breaking change which adds functionality)

[ ] Performance improvement