### PR TITLE
Bundled Themes: Prevent Twenty Fourteen from hiding featured tag during REST requests

### DIFF
--- a/src/wp-content/themes/twentyfourteen/inc/featured-content.php
+++ b/src/wp-content/themes/twentyfourteen/inc/featured-content.php
@@ -288,7 +288,7 @@ class Featured_Content {
 	public static function hide_featured_term( $terms, $taxonomies, $args ) {
 
 		// This filter is only appropriate on the front end.
-		if ( is_admin() ) {
+		if ( is_admin() || ( function_exists( 'wp_is_serving_rest_request' ) && wp_is_serving_rest_request() ) ) {
 			return $terms;
 		}
 
@@ -335,7 +335,7 @@ class Featured_Content {
 	public static function hide_the_featured_term( $terms, $id, $taxonomy ) {
 
 		// This filter is only appropriate on the front end.
-		if ( is_admin() ) {
+		if ( is_admin() || ( function_exists( 'wp_is_serving_rest_request' ) && wp_is_serving_rest_request() ) ) {
 			return $terms;
 		}
 


### PR DESCRIPTION
## Summary

- Fixes the "featured" tag being stripped from posts when saved in the block editor with Twenty Fourteen theme
- Added `wp_is_serving_rest_request()` check alongside `is_admin()` in both `hide_featured_term()` and `hide_the_featured_term()` methods
- Uses `function_exists()` guard for backward compatibility with WordPress < 6.5

## Trac Ticket

https://core.trac.wordpress.org/ticket/64882

## Test Plan

1. Activate Twenty Fourteen theme
2. Go to Appearance → Customize → Featured Content, set tag to "featured", enable "Hide tag"
3. Create a post with the "featured" tag
4. Open the post in block editor — the tag should be visible
5. Save the post — the "featured" tag should be preserved
6. Visit `/wp-json/wp/v2/posts/{id}` — tags array should include the featured tag ID