### PR TITLE
Script Modules: add dns-prefetch resource hints support

### DIFF
--- a/src/wp-includes/class-wp-script-modules.php
+++ b/src/wp-includes/class-wp-script-modules.php
@@ -363,6 +363,8 @@ class WP_Script_Modules {
 		add_action( 'admin_print_footer_scripts', array( $this, 'print_script_module_data' ) );
 		add_action( 'wp_footer', array( $this, 'print_a11y_script_module_html' ), 20 );
 		add_action( 'admin_print_footer_scripts', array( $this, 'print_a11y_script_module_html' ), 20 );
+
+		add_filter( 'wp_resource_hints', array( $this, 'filter_resource_hints' ), 10, 2 );
 	}
 
 	/**
@@ -1022,5 +1024,48 @@ class WP_Script_Modules {
 			. '<div id="a11y-speak-assertive" class="a11y-speak-region" aria-live="assertive" aria-relevant="additions text" aria-atomic="true"></div>'
 			. '<div id="a11y-speak-polite" class="a11y-speak-region" aria-live="polite" aria-relevant="additions text" aria-atomic="true"></div>'
 			. '</div>';
+	}
+
+	/**
+	 * Filters resource hints to add DNS prefetch for external script module hosts.
+	 *
+	 * Hooks into the {@see 'wp_resource_hints'} filter to include DNS prefetch hints
+	 * for all external hosts used by enqueued script modules and their dependencies,
+	 * including dynamic dependencies which do not receive modulepreload hints.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param array  $urls          Array of resources and their attributes, or URLs to print
+	 *                              for resource hints.
+	 * @param string $relation_type The relation type the URLs are printed for.
+	 * @return array Filtered array of resource URLs.
+	 */
+	public function filter_resource_hints( array $urls, string $relation_type ): array {
+		if ( 'dns-prefetch' !== $relation_type ) {
+			return $urls;
+		}
+
+		// Collect all queued module IDs and all their dependencies (static and dynamic).
+		$all_ids = array_unique(
+			array_merge( $this->queue, array_keys( $this->get_dependencies( $this->queue ) ) )
+		);
+
+		foreach ( $all_ids as $id ) {
+			if ( ! isset( $this->registered[ $id ] ) ) {
+				continue;
+			}
+
+			$src    = $this->registered[ $id ]['src'];
+			$parsed = wp_parse_url( $src );
+
+			if (
+				! empty( $parsed['host'] ) &&
+				$parsed['host'] !== $_SERVER['SERVER_NAME']
+			) {
+				$urls[] = $src;
+			}
+		}
+
+		return $urls;
 	}
 }

--- a/tests/phpunit/tests/script-modules/wpScriptModulesResourceHints.php
+++ b/tests/phpunit/tests/script-modules/wpScriptModulesResourceHints.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * Unit tests covering WP_Script_Modules::filter_resource_hints().
+ *
+ * @package WordPress
+ * @subpackage Script Modules
+ *
+ * @since 7.1.0
+ *
+ * @group script-modules
+ * @ticket 62709
+ * @covers WP_Script_Modules::filter_resource_hints
+ */
+class Tests_Script_Modules_WpScriptModules_ResourceHints extends WP_UnitTestCase {
+
+	protected WP_Script_Modules $original_script_modules;
+	protected WP_Script_Modules $script_modules;
+
+	public function set_up() {
+		global $wp_script_modules;
+		parent::set_up();
+		$this->original_script_modules = $wp_script_modules;
+		$wp_script_modules             = null;
+		$this->script_modules          = wp_script_modules();
+	}
+
+	public function tear_down() {
+		global $wp_script_modules;
+		$wp_script_modules = $this->original_script_modules;
+		parent::tear_down();
+	}
+
+	/**
+	 * Tests that a DNS prefetch hint is added for an enqueued module with an external src.
+	 */
+	public function test_dns_prefetch_for_enqueued_script_module() {
+		$this->script_modules->enqueue( 'my-module', 'https://cdn.example.com/module.js' );
+
+		$hints = $this->script_modules->filter_resource_hints( array(), 'dns-prefetch' );
+		$hosts = array_map( fn( $url ) => wp_parse_url( $url, PHP_URL_HOST ), $hints );
+
+		$this->assertContains( 'cdn.example.com', $hosts );
+	}
+
+	/**
+	 * Tests that a DNS prefetch hint is added for a static external dependency.
+	 */
+	public function test_dns_prefetch_for_static_dependency() {
+		$this->script_modules->register( 'dep-module', 'https://cdn.example.com/dep.js' );
+		$this->script_modules->enqueue( 'my-module', '/local/module.js', array( 'dep-module' ) );
+
+		$hints = $this->script_modules->filter_resource_hints( array(), 'dns-prefetch' );
+		$hosts = array_map( fn( $url ) => wp_parse_url( $url, PHP_URL_HOST ), $hints );
+
+		$this->assertContains( 'cdn.example.com', $hosts );
+	}
+
+	/**
+	 * Tests that a DNS prefetch hint is added for a dynamic external dependency.
+	 *
+	 * Dynamic dependencies never receive modulepreload hints, so dns-prefetch is
+	 * particularly valuable for them.
+	 */
+	public function test_dns_prefetch_for_dynamic_dependency() {
+		$this->script_modules->register( 'dep-module', 'https://cdn.example.com/dep.js' );
+		$this->script_modules->enqueue(
+			'my-module',
+			'/local/module.js',
+			array( array( 'id' => 'dep-module', 'import' => 'dynamic' ) )
+		);
+
+		$hints = $this->script_modules->filter_resource_hints( array(), 'dns-prefetch' );
+		$hosts = array_map( fn( $url ) => wp_parse_url( $url, PHP_URL_HOST ), $hints );
+
+		$this->assertContains( 'cdn.example.com', $hosts );
+	}
+
+	/**
+	 * Tests that modules hosted on the same site are excluded from DNS prefetch hints.
+	 */
+	public function test_dns_prefetch_excludes_same_site_modules() {
+		$server_name = $_SERVER['SERVER_NAME'];
+		$this->script_modules->enqueue( 'local-module', "https://{$server_name}/module.js" );
+
+		$hints = $this->script_modules->filter_resource_hints( array(), 'dns-prefetch' );
+
+		$this->assertEmpty( $hints );
+	}
+
+	/**
+	 * Tests that modules with relative (root-relative) src paths are excluded from DNS prefetch hints.
+	 */
+	public function test_dns_prefetch_excludes_relative_src_modules() {
+		$this->script_modules->enqueue( 'local-module', '/wp-includes/js/my-module.js' );
+
+		$hints = $this->script_modules->filter_resource_hints( array(), 'dns-prefetch' );
+
+		$this->assertEmpty( $hints );
+	}
+
+	/**
+	 * Tests that registered-but-not-enqueued modules do not produce DNS prefetch hints.
+	 */
+	public function test_dns_prefetch_excludes_registered_only_modules() {
+		$this->script_modules->register( 'my-module', 'https://cdn.example.com/module.js' );
+		// Intentionally not enqueued.
+
+		$hints = $this->script_modules->filter_resource_hints( array(), 'dns-prefetch' );
+
+		$this->assertEmpty( $hints );
+	}
+
+	/**
+	 * Tests that non-dns-prefetch relation types are not modified.
+	 */
+	public function test_other_relation_types_are_not_modified() {
+		$this->script_modules->enqueue( 'my-module', 'https://cdn.example.com/module.js' );
+
+		$original = array( 'https://other.example.com' );
+
+		foreach ( array( 'preconnect', 'prefetch', 'prerender' ) as $relation_type ) {
+			$hints = $this->script_modules->filter_resource_hints( $original, $relation_type );
+			$this->assertSame( $original, $hints, "Relation type '{$relation_type}' should not be modified." );
+		}
+	}
+
+	/**
+	 * Tests that duplicate external hosts only produce a single DNS prefetch hint entry.
+	 */
+	public function test_dns_prefetch_deduplicates_hosts_via_wp_resource_hints() {
+		// Both modules share the same CDN host.
+		$this->script_modules->enqueue( 'module-a', 'https://cdn.example.com/module-a.js' );
+		$this->script_modules->enqueue( 'module-b', 'https://cdn.example.com/module-b.js' );
+
+		// filter_resource_hints itself may include both raw URLs; deduplication by host
+		// is handled by wp_resource_hints(). Verify via the full pipeline.
+		add_filter( 'wp_resource_hints', array( $this->script_modules, 'filter_resource_hints' ), 10, 2 );
+		$output = get_echo( 'wp_resource_hints' );
+		remove_filter( 'wp_resource_hints', array( $this->script_modules, 'filter_resource_hints' ) );
+
+		$this->assertSame(
+			1,
+			substr_count( $output, '//cdn.example.com' ),
+			'The same CDN host should only appear once in the output.'
+		);
+	}
+
+	/**
+	 * Tests that the filter_resource_hints method integrates correctly with wp_resource_hints().
+	 */
+	public function test_integration_with_wp_resource_hints() {
+		$this->script_modules->enqueue( 'my-module', 'https://cdn.example.com/module.js' );
+
+		add_filter( 'wp_resource_hints', array( $this->script_modules, 'filter_resource_hints' ), 10, 2 );
+		$output = get_echo( 'wp_resource_hints' );
+		remove_filter( 'wp_resource_hints', array( $this->script_modules, 'filter_resource_hints' ) );
+
+		$this->assertStringContainsString( "<link rel='dns-prefetch' href='//cdn.example.com' />", $output );
+	}
+}

--- a/tests/phpunit/tests/script-modules/wpScriptModulesResourceHints.php
+++ b/tests/phpunit/tests/script-modules/wpScriptModulesResourceHints.php
@@ -66,7 +66,12 @@ class Tests_Script_Modules_WpScriptModules_ResourceHints extends WP_UnitTestCase
 		$this->script_modules->enqueue(
 			'my-module',
 			'/local/module.js',
-			array( array( 'id' => 'dep-module', 'import' => 'dynamic' ) )
+			array(
+				array(
+					'id' => 'dep-module',
+					'import' => 'dynamic',
+				),
+			)
 		);
 
 		$hints = $this->script_modules->filter_resource_hints( array(), 'dns-prefetch' );

--- a/tests/phpunit/tests/script-modules/wpScriptModulesResourceHints.php
+++ b/tests/phpunit/tests/script-modules/wpScriptModulesResourceHints.php
@@ -68,7 +68,7 @@ class Tests_Script_Modules_WpScriptModules_ResourceHints extends WP_UnitTestCase
 			'/local/module.js',
 			array(
 				array(
-					'id' => 'dep-module',
+					'id'     => 'dep-module',
 					'import' => 'dynamic',
 				),
 			)


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->

## Description

[`wp_resource_hints()`](https://developer.wordpress.org/reference/functions/wp_resource_hints/) prints `<link rel="dns-prefetch">` tags for all external hosts used by enqueued scripts and styles, giving browsers an early signal to resolve DNS before requests are made. However, `WP_Script_Modules` was never wired into this system, so external hosts referenced by script modules received no DNS prefetch hints.

This PR addresses [#62709](https://core.trac.wordpress.org/ticket/62709) by adding a new public method `WP_Script_Modules::filter_resource_hints()`, registered on the `wp_resource_hints` filter inside `add_hooks()`. The method collects all enqueued module IDs and their full dependency tree — including **dynamic dependencies**, which never receive `modulepreload` hints and are therefore the clearest gap — parses each `src` for its host, filters out same-site hosts, and appends the external URLs to the `dns-prefetch` hints array. Deduplication by host is handled downstream by `wp_resource_hints()` itself, as it does for scripts and styles.

On classic themes, `wp_resource_hints` fires in `wp_head` at priority 2, while all module-related tags fire in `wp_footer`. This means even static dependency hosts will benefit from an early hint in the page `<head>` well before any module tag is processed.

## Changes

- **`src/wp-includes/class-wp-script-modules.php`**
  - Added `filter_resource_hints( array $urls, string $relation_type ): array` public method.
  - Registered the filter in `add_hooks()` via `wp_resource_hints`.

- **`tests/phpunit/tests/script-modules/wpScriptModulesResourceHints.php`** _(new file)_
  - 9 tests covering: enqueued modules, static dependencies, dynamic dependencies, same-site exclusion, relative-path exclusion, registered-only exclusion, non-dns-prefetch relation types left unmodified, host deduplication, and full `wp_resource_hints()` integration.

## How to test

1. Enqueue a script module with an external `src`, e.g.:
```php
wp_enqueue_script_module( 'my-module', 'https://cdn.example.com/module.js' );
```

2. View the page source and confirm a `<link rel="dns-prefetch" href="//cdn.example.com" />` tag appears in `<head>`.

3. Run the new unit tests:
```php
phpunit --filter Tests_Script_Modules_WpScriptModules_ResourceHints
```

---

Trac ticket: https://core.trac.wordpress.org/ticket/62709

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
