### PR TITLE
Connectors: Make the API more flexible for custom connector types

### DIFF
--- a/src/wp-includes/class-wp-connector-registry.php
+++ b/src/wp-includes/class-wp-connector-registry.php
@@ -214,7 +214,7 @@ final class WP_Connector_Registry {
 				}
 				$connector['authentication']['setting_name'] = $args['authentication']['setting_name'];
 			} else {
-				$connector['authentication']['setting_name'] = 'connectors_' . str_replace( '-', '_', $args['type'] . '_' . $id ) . '_api_key';
+				$connector['authentication']['setting_name'] = str_replace( '-', '_', "connectors_{$connector['type']}_{$id}_api_key" );
 			}
 			if ( isset( $args['authentication']['constant_name'] ) ) {
 				if ( ! is_string( $args['authentication']['constant_name'] ) || '' === $args['authentication']['constant_name'] ) {

--- a/src/wp-includes/class-wp-connector-registry.php
+++ b/src/wp-includes/class-wp-connector-registry.php
@@ -68,10 +68,10 @@ final class WP_Connector_Registry {
 	 * Validates the provided arguments and stores the connector in the registry.
 	 * For connectors with `api_key` authentication, a `setting_name` can be provided
 	 * explicitly. If omitted, one is automatically generated using the pattern
-	 * `connectors_ai_{$id}_api_key`, with hyphens in the ID normalized to underscores
-	 * (e.g., connector ID `openai` produces `connectors_ai_openai_api_key`, and
-	 * `azure-openai` produces `connectors_ai_azure_openai_api_key`). This setting
-	 * name is used for the Settings API registration and REST API exposure.
+	 * `connectors_{$type}_{$id}_api_key`, with hyphens in the type and ID normalized
+	 * to underscores (e.g., connector type `ai_provider` with ID `openai` produces
+	 * `connectors_ai_provider_openai_api_key`). This setting name is used for the
+	 * Settings API registration and REST API exposure.
 	 *
 	 * Registering a connector with an ID that is already registered will trigger a
 	 * `_doing_it_wrong()` notice and return `null`. To override an existing connector,
@@ -96,7 +96,8 @@ final class WP_Connector_Registry {
 	 *         @type string $method          Required. The authentication method: 'api_key' or 'none'.
 	 *         @type string $credentials_url Optional. URL where users can obtain API credentials.
 	 *         @type string $setting_name    Optional. The setting name for the API key.
-	 *                                       When omitted, auto-generated as `connectors_ai_{$id}_api_key`.
+	 *                                       When omitted, auto-generated as
+	 *                                       `connectors_{$type}_{$id}_api_key`.
 	 *                                       Must be a non-empty string when provided.
 	 *     }
 	 *     @type array  $plugin         {
@@ -207,7 +208,10 @@ final class WP_Connector_Registry {
 				}
 				$connector['authentication']['setting_name'] = $args['authentication']['setting_name'];
 			} else {
-				$connector['authentication']['setting_name'] = 'connectors_ai_' . str_replace( '-', '_', $id ) . '_api_key';
+				$sanitized_type = str_replace( '-', '_', $args['type'] );
+				$sanitized_id   = str_replace( '-', '_', $id );
+
+				$connector['authentication']['setting_name'] = "connectors_{$sanitized_type}_{$sanitized_id}_api_key";
 			}
 		}
 

--- a/src/wp-includes/class-wp-connector-registry.php
+++ b/src/wp-includes/class-wp-connector-registry.php
@@ -214,10 +214,7 @@ final class WP_Connector_Registry {
 				}
 				$connector['authentication']['setting_name'] = $args['authentication']['setting_name'];
 			} else {
-				$sanitized_type = str_replace( '-', '_', $args['type'] );
-				$sanitized_id   = str_replace( '-', '_', $id );
-
-				$connector['authentication']['setting_name'] = "connectors_{$sanitized_type}_{$sanitized_id}_api_key";
+				$connector['authentication']['setting_name'] = 'connectors_' . str_replace( '-', '_', $args['type'] . '_' . $id ) . '_api_key';
 			}
 			if ( isset( $args['authentication']['constant_name'] ) ) {
 				if ( ! is_string( $args['authentication']['constant_name'] ) || '' === $args['authentication']['constant_name'] ) {

--- a/src/wp-includes/class-wp-connector-registry.php
+++ b/src/wp-includes/class-wp-connector-registry.php
@@ -71,8 +71,8 @@ final class WP_Connector_Registry {
 	 * For connectors with `api_key` authentication, a `setting_name` can be provided
 	 * explicitly. If omitted, one is automatically generated using the pattern
 	 * `connectors_{$type}_{$id}_api_key`, with hyphens in the type and ID normalized
-	 * to underscores (e.g., connector type `ai_provider` with ID `openai` produces
-	 * `connectors_ai_provider_openai_api_key`). This setting name is used for the
+	 * to underscores (e.g., connector type `spam_filtering` with ID `akismet` produces
+	 * `connectors_spam_filtering_akismet_api_key`). This setting name is used for the
 	 * Settings API registration and REST API exposure.
 	 *
 	 * Registering a connector with an ID that is already registered will trigger a

--- a/src/wp-includes/class-wp-connector-registry.php
+++ b/src/wp-includes/class-wp-connector-registry.php
@@ -35,7 +35,9 @@
  *     authentication: array{
  *         method: 'api_key'|'none',
  *         credentials_url?: non-empty-string,
- *         setting_name?: non-empty-string
+ *         setting_name?: non-empty-string,
+ *         constant_name?: non-empty-string,
+ *         env_var_name?: non-empty-string
  *     },
  *     plugin?: array{
  *         slug: non-empty-string
@@ -99,6 +101,10 @@ final class WP_Connector_Registry {
 	 *                                       When omitted, auto-generated as
 	 *                                       `connectors_{$type}_{$id}_api_key`.
 	 *                                       Must be a non-empty string when provided.
+	 *         @type string $constant_name   Optional. PHP constant name for the API key
+	 *                                       (e.g. 'OPENAI_API_KEY'). Only checked when provided.
+	 *         @type string $env_var_name    Optional. Environment variable name for the API key
+	 *                                       (e.g. 'OPENAI_API_KEY'). Only checked when provided.
 	 *     }
 	 *     @type array  $plugin         {
 	 *         Optional. Plugin data for install/activate UI.
@@ -212,6 +218,30 @@ final class WP_Connector_Registry {
 				$sanitized_id   = str_replace( '-', '_', $id );
 
 				$connector['authentication']['setting_name'] = "connectors_{$sanitized_type}_{$sanitized_id}_api_key";
+			}
+			if ( isset( $args['authentication']['constant_name'] ) ) {
+				if ( ! is_string( $args['authentication']['constant_name'] ) || '' === $args['authentication']['constant_name'] ) {
+					_doing_it_wrong(
+						__METHOD__,
+						/* translators: %s: Connector ID. */
+						sprintf( __( 'Connector "%s" authentication constant_name must be a non-empty string.' ), esc_html( $id ) ),
+						'7.0.0'
+					);
+					return null;
+				}
+				$connector['authentication']['constant_name'] = $args['authentication']['constant_name'];
+			}
+			if ( isset( $args['authentication']['env_var_name'] ) ) {
+				if ( ! is_string( $args['authentication']['env_var_name'] ) || '' === $args['authentication']['env_var_name'] ) {
+					_doing_it_wrong(
+						__METHOD__,
+						/* translators: %s: Connector ID. */
+						sprintf( __( 'Connector "%s" authentication env_var_name must be a non-empty string.' ), esc_html( $id ) ),
+						'7.0.0'
+					);
+					return null;
+				}
+				$connector['authentication']['env_var_name'] = $args['authentication']['env_var_name'];
 			}
 		}
 

--- a/src/wp-includes/class-wp-connector-registry.php
+++ b/src/wp-includes/class-wp-connector-registry.php
@@ -192,7 +192,16 @@ final class WP_Connector_Registry {
 			if ( ! empty( $args['authentication']['credentials_url'] ) && is_string( $args['authentication']['credentials_url'] ) ) {
 				$connector['authentication']['credentials_url'] = $args['authentication']['credentials_url'];
 			}
-			if ( ! empty( $args['authentication']['setting_name'] ) && is_string( $args['authentication']['setting_name'] ) ) {
+			if ( isset( $args['authentication']['setting_name'] ) ) {
+				if ( ! is_string( $args['authentication']['setting_name'] ) || '' === $args['authentication']['setting_name'] ) {
+					_doing_it_wrong(
+						__METHOD__,
+						/* translators: %s: Connector ID. */
+						sprintf( __( 'Connector "%s" authentication setting_name must be a non-empty string.' ), esc_html( $id ) ),
+						'7.0.0'
+					);
+					return null;
+				}
 				$connector['authentication']['setting_name'] = $args['authentication']['setting_name'];
 			} else {
 				$connector['authentication']['setting_name'] = 'connectors_ai_' . str_replace( '-', '_', $id ) . '_api_key';

--- a/src/wp-includes/class-wp-connector-registry.php
+++ b/src/wp-includes/class-wp-connector-registry.php
@@ -102,9 +102,9 @@ final class WP_Connector_Registry {
 	 *                                       `connectors_{$type}_{$id}_api_key`.
 	 *                                       Must be a non-empty string when provided.
 	 *         @type string $constant_name   Optional. PHP constant name for the API key
-	 *                                       (e.g. 'OPENAI_API_KEY'). Only checked when provided.
+	 *                                       (e.g. 'ANTHROPIC_API_KEY'). Only checked when provided.
 	 *         @type string $env_var_name    Optional. Environment variable name for the API key
-	 *                                       (e.g. 'OPENAI_API_KEY'). Only checked when provided.
+	 *                                       (e.g. 'ANTHROPIC_API_KEY'). Only checked when provided.
 	 *     }
 	 *     @type array  $plugin         {
 	 *         Optional. Plugin data for install/activate UI.

--- a/src/wp-includes/class-wp-connector-registry.php
+++ b/src/wp-includes/class-wp-connector-registry.php
@@ -31,7 +31,7 @@
  *     name: non-empty-string,
  *     description: non-empty-string,
  *     logo_url?: non-empty-string,
- *     type: 'ai_provider',
+ *     type: non-empty-string,
  *     authentication: array{
  *         method: 'api_key'|'none',
  *         credentials_url?: non-empty-string,
@@ -66,12 +66,12 @@ final class WP_Connector_Registry {
 	 * Registers a new connector.
 	 *
 	 * Validates the provided arguments and stores the connector in the registry.
-	 * For connectors with `api_key` authentication, a `setting_name` is automatically
-	 * generated using the pattern `connectors_ai_{$id}_api_key`, with hyphens in the ID
-	 * normalized to underscores (e.g., connector ID `openai` produces
-	 * `connectors_ai_openai_api_key`, and `azure-openai` produces
-	 * `connectors_ai_azure_openai_api_key`). This setting name is used for the Settings
-	 * API registration and REST API exposure.
+	 * For connectors with `api_key` authentication, a `setting_name` can be provided
+	 * explicitly. If omitted, one is automatically generated using the pattern
+	 * `connectors_ai_{$id}_api_key`, with hyphens in the ID normalized to underscores
+	 * (e.g., connector ID `openai` produces `connectors_ai_openai_api_key`, and
+	 * `azure-openai` produces `connectors_ai_azure_openai_api_key`). This setting
+	 * name is used for the Settings API registration and REST API exposure.
 	 *
 	 * Registering a connector with an ID that is already registered will trigger a
 	 * `_doing_it_wrong()` notice and return `null`. To override an existing connector,
@@ -89,12 +89,15 @@ final class WP_Connector_Registry {
 	 *     @type string $name           Required. The connector's display name.
 	 *     @type string $description    Optional. The connector's description. Default empty string.
 	 *     @type string $logo_url       Optional. URL to the connector's logo image.
-	 *     @type string $type           Required. The connector type. Currently, only 'ai_provider' is supported.
+	 *     @type string $type           Required. The connector type, e.g. 'ai_provider'.
 	 *     @type array  $authentication {
 	 *         Required. Authentication configuration.
 	 *
 	 *         @type string $method          Required. The authentication method: 'api_key' or 'none'.
 	 *         @type string $credentials_url Optional. URL where users can obtain API credentials.
+	 *         @type string $setting_name    Optional. The setting name for the API key.
+	 *                                       When omitted, auto-generated as `connectors_ai_{$id}_api_key`.
+	 *                                       Must be a non-empty string when provided.
 	 *     }
 	 *     @type array  $plugin         {
 	 *         Optional. Plugin data for install/activate UI.

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -394,9 +394,9 @@ function _wp_connectors_mask_api_key( string $key ): string {
  * @since 7.0.0
  * @access private
  *
- * @param string $setting_name  The option name for the API key (e.g., 'connectors_ai_anthropic_api_key').
- * @param string $env_var_name  Optional. Environment variable name to check (e.g., 'ANTHROPIC_API_KEY').
- * @param string $constant_name Optional. PHP constant name to check (e.g., 'ANTHROPIC_API_KEY').
+ * @param string $setting_name  The option name for the API key (e.g., 'connectors_spam_filtering_akismet_api_key').
+ * @param string $env_var_name  Optional. Environment variable name to check (e.g., 'AKISMET_API_KEY').
+ * @param string $constant_name Optional. PHP constant name to check (e.g., 'AKISMET_API_KEY').
  * @return string The key source: 'env', 'constant', 'database', or 'none'.
  */
 function _wp_connectors_get_api_key_source( string $setting_name, string $env_var_name = '', string $constant_name = '' ): string {

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -495,7 +495,7 @@ function _wp_connectors_rest_settings_dispatch( WP_REST_Response $response, WP_R
 
 	foreach ( wp_get_connectors() as $connector_id => $connector_data ) {
 		$auth = $connector_data['authentication'];
-		if ( 'ai_provider' !== $connector_data['type'] || 'api_key' !== $auth['method'] || empty( $auth['setting_name'] ) ) {
+		if ( 'api_key' !== $auth['method'] || empty( $auth['setting_name'] ) ) {
 			continue;
 		}
 
@@ -507,7 +507,8 @@ function _wp_connectors_rest_settings_dispatch( WP_REST_Response $response, WP_R
 		$value = $data[ $setting_name ];
 
 		// On update, validate the key before masking.
-		if ( $is_update && is_string( $value ) && '' !== $value ) {
+		// Validation is only available for AI providers via the AI Client registry.
+		if ( $is_update && is_string( $value ) && '' !== $value && 'ai_provider' === $connector_data['type'] ) {
 			if ( true !== _wp_connectors_is_ai_api_key_valid( $value, $connector_id ) ) {
 				update_option( $setting_name, '' );
 				$data[ $setting_name ] = '';
@@ -533,16 +534,22 @@ add_filter( 'rest_post_dispatch', '_wp_connectors_rest_settings_dispatch', 10, 3
  * @access private
  */
 function _wp_register_default_connector_settings(): void {
-	$ai_registry = AiClient::defaultRegistry();
+	$ai_registry         = AiClient::defaultRegistry();
+	$registered_settings = get_registered_settings();
 
 	foreach ( wp_get_connectors() as $connector_id => $connector_data ) {
 		$auth = $connector_data['authentication'];
-		if ( 'ai_provider' !== $connector_data['type'] || 'api_key' !== $auth['method'] || empty( $auth['setting_name'] ) ) {
+		if ( 'api_key' !== $auth['method'] || empty( $auth['setting_name'] ) ) {
 			continue;
 		}
 
-		// Skip registering the setting if the provider is not in the registry.
-		if ( ! $ai_registry->hasProvider( $connector_id ) ) {
+		// Skip if the setting is already registered (e.g. by an owning plugin).
+		if ( isset( $registered_settings[ $auth['setting_name'] ] ) ) {
+			continue;
+		}
+
+		// For AI providers, skip if the provider is not in the AI Client registry.
+		if ( 'ai_provider' === $connector_data['type'] && ! $ai_registry->hasProvider( $connector_id ) ) {
 			continue;
 		}
 
@@ -552,13 +559,13 @@ function _wp_register_default_connector_settings(): void {
 			array(
 				'type'              => 'string',
 				'label'             => sprintf(
-					/* translators: %s: AI provider name. */
+					/* translators: %s: Connector name. */
 					__( '%s API Key' ),
 					$connector_data['name']
 				),
 				'description'       => sprintf(
-					/* translators: %s: AI provider name. */
-					__( 'API key for the %s AI provider.' ),
+					/* translators: %s: Connector name. */
+					__( 'API key for the %s connector.' ),
 					$connector_data['name']
 				),
 				'default'           => '',
@@ -645,11 +652,17 @@ function _wp_connectors_get_connector_script_module_data( array $data ): array {
 		if ( 'api_key' === $auth['method'] ) {
 			$auth_out['settingName']    = $auth['setting_name'] ?? '';
 			$auth_out['credentialsUrl'] = $auth['credentials_url'] ?? null;
-			$auth_out['keySource']      = _wp_connectors_get_api_key_source( $auth['setting_name'] ?? '', $auth['env_var_name'] ?? '', $auth['constant_name'] ?? '' );
-			try {
-				$auth_out['isConnected'] = $registry->hasProvider( $connector_id ) && $registry->isProviderConfigured( $connector_id );
-			} catch ( Exception $e ) {
-				$auth_out['isConnected'] = false;
+			$key_source                 = _wp_connectors_get_api_key_source( $auth['setting_name'] ?? '', $auth['env_var_name'] ?? '', $auth['constant_name'] ?? '' );
+			$auth_out['keySource']      = $key_source;
+
+			if ( 'ai_provider' === $connector_data['type'] ) {
+				try {
+					$auth_out['isConnected'] = $registry->hasProvider( $connector_id ) && $registry->isProviderConfigured( $connector_id );
+				} catch ( Exception $e ) {
+					$auth_out['isConnected'] = false;
+				}
+			} else {
+				$auth_out['isConnected'] = 'none' !== $key_source;
 			}
 		}
 

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -394,9 +394,9 @@ function _wp_connectors_mask_api_key( string $key ): string {
  * @since 7.0.0
  * @access private
  *
- * @param string $setting_name  The option name for the API key (e.g., 'connectors_ai_openai_api_key').
- * @param string $env_var_name  Optional. Environment variable name to check (e.g., 'OPENAI_API_KEY').
- * @param string $constant_name Optional. PHP constant name to check (e.g., 'OPENAI_API_KEY').
+ * @param string $setting_name  The option name for the API key (e.g., 'connectors_ai_anthropic_api_key').
+ * @param string $env_var_name  Optional. Environment variable name to check (e.g., 'ANTHROPIC_API_KEY').
+ * @param string $constant_name Optional. PHP constant name to check (e.g., 'ANTHROPIC_API_KEY').
  * @return string The key source: 'env', 'constant', 'database', or 'none'.
  */
 function _wp_connectors_get_api_key_source( string $setting_name, string $env_var_name = '', string $constant_name = '' ): string {

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -342,7 +342,6 @@ function _wp_connectors_register_default_ai_providers( WP_Connector_Registry $re
 	}
 
 	// Register all default connectors directly on the registry.
-	// All AI providers use the {CONSTANT_CASE_ID}_API_KEY naming convention.
 	foreach ( $defaults as $id => $args ) {
 		if ( 'api_key' === ( $args['authentication']['method'] ?? '' ) ) {
 			$sanitized_id = str_replace( '-', '_', $id );
@@ -351,16 +350,17 @@ function _wp_connectors_register_default_ai_providers( WP_Connector_Registry $re
 				$args['authentication']['setting_name'] = "connectors_ai_{$sanitized_id}_api_key";
 			}
 
-			if ( ! isset( $args['authentication']['constant_name'] ) ) {
-				$constant_case = strtoupper( preg_replace( '/([a-z])([A-Z])/', '$1_$2', $sanitized_id ) );
+			// All AI providers use the {CONSTANT_CASE_ID}_API_KEY naming convention.
+			if ( ! isset( $args['authentication']['constant_name'] ) || ! isset( $args['authentication']['env_var_name'] ) ) {
+				$constant_case_key = strtoupper( preg_replace( '/([a-z])([A-Z])/', '$1_$2', $sanitized_id ) ) . '_API_KEY';
 
-				$args['authentication']['constant_name'] = "{$constant_case}_API_KEY";
-			}
+				if ( ! isset( $args['authentication']['constant_name'] ) ) {
+					$args['authentication']['constant_name'] = $constant_case_key;
+				}
 
-			if ( ! isset( $args['authentication']['env_var_name'] ) ) {
-				$constant_case = $constant_case ?? strtoupper( preg_replace( '/([a-z])([A-Z])/', '$1_$2', $sanitized_id ) );
-
-				$args['authentication']['env_var_name'] = "{$constant_case}_API_KEY";
+				if ( ! isset( $args['authentication']['env_var_name'] ) ) {
+					$args['authentication']['env_var_name'] = $constant_case_key;
+				}
 			}
 		}
 		$registry->register( $id, $args );

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -343,7 +343,7 @@ function _wp_connectors_register_default_ai_providers( WP_Connector_Registry $re
 
 	// Register all default connectors directly on the registry.
 	foreach ( $defaults as $id => $args ) {
-		if ( 'api_key' === ( $args['authentication']['method'] ?? '' ) ) {
+		if ( 'api_key' === $args['authentication']['method'] ) {
 			$sanitized_id = str_replace( '-', '_', $id );
 
 			if ( ! isset( $args['authentication']['setting_name'] ) ) {

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -334,7 +334,11 @@ function _wp_connectors_register_default_ai_providers( WP_Connector_Registry $re
 	}
 
 	// Register all default connectors directly on the registry.
+	// All AI providers use the connectors_ai_{$id}_api_key naming convention.
 	foreach ( $defaults as $id => $args ) {
+		if ( 'api_key' === ( $args['authentication']['method'] ?? '' ) && ! isset( $args['authentication']['setting_name'] ) ) {
+			$args['authentication']['setting_name'] = 'connectors_ai_' . str_replace( '-', '_', $id ) . '_api_key';
+		}
 		$registry->register( $id, $args );
 	}
 }

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -106,7 +106,8 @@ function wp_get_connector( string $id ): ?array {
  *         @type string      $type           The connector type, e.g. 'ai_provider'.
  *         @type array       $authentication {
  *             Authentication configuration. When method is 'api_key', includes
- *             credentials_url and setting_name. When 'none', only method is present.
+ *             credentials_url, setting_name, and optionally constant_name and
+ *             env_var_name. When 'none', only method is present.
  *
  *             @type string $method          The authentication method: 'api_key' or 'none'.
  *             @type string $credentials_url Optional. URL where users can obtain API credentials.
@@ -507,8 +508,8 @@ function _wp_connectors_rest_settings_dispatch( WP_REST_Response $response, WP_R
 
 		$value = $data[ $setting_name ];
 
-		// On update, validate the key before masking.
-		// Validation is only available for AI providers via the AI Client registry.
+		// On update, validate AI provider keys before masking.
+		// Non-AI connectors accept keys as-is; the service plugin handles its own validation.
 		if ( $is_update && is_string( $value ) && '' !== $value && 'ai_provider' === $connector_data['type'] ) {
 			if ( true !== _wp_connectors_is_ai_api_key_valid( $value, $connector_id ) ) {
 				update_option( $setting_name, '' );
@@ -684,7 +685,9 @@ function _wp_connectors_get_connector_script_module_data( array $data ): array {
 
 			$connector_out['plugin'] = array(
 				'slug'        => $plugin_slug,
-				'isInstalled' => $is_installed,
+				'pluginFile'  => $is_installed
+					? ( str_ends_with( $plugin_file, '.php' ) ? substr( $plugin_file, 0, -4 ) : $plugin_file )
+					: null,
 				'isActivated' => $is_activated,
 			);
 		}

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -46,7 +46,8 @@ function wp_is_connector_registered( string $id ): bool {
  *     @type string $type           The connector type, e.g. 'ai_provider'.
  *     @type array  $authentication {
  *         Authentication configuration. When method is 'api_key', includes
- *         credentials_url and setting_name. When 'none', only method is present.
+ *         credentials_url, setting_name, and optionally constant_name and
+ *         env_var_name. When 'none', only method is present.
  *
  *         @type string $method          The authentication method: 'api_key' or 'none'.
  *         @type string $credentials_url Optional. URL where users can obtain API credentials.
@@ -224,10 +225,10 @@ function _wp_connectors_init(): void {
 	 * Example — overriding metadata on an auto-discovered connector:
 	 *
 	 *     add_action( 'wp_connectors_init', function ( WP_Connector_Registry $registry ) {
-	 *         if ( $registry->is_registered( 'openai' ) ) {
-	 *             $connector = $registry->unregister( 'openai' );
-	 *             $connector['description'] = __( 'Custom description for OpenAI.', 'my-plugin' );
-	 *             $registry->register( 'openai', $connector );
+	 *         if ( $registry->is_registered( 'anthropic' ) ) {
+	 *             $connector = $registry->unregister( 'anthropic' );
+	 *             $connector['description'] = __( 'Custom description for Anthropic.', 'my-plugin' );
+	 *             $registry->register( 'anthropic', $connector );
 	 *         }
 	 *     } );
 	 *

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -51,6 +51,8 @@ function wp_is_connector_registered( string $id ): bool {
  *         @type string $method          The authentication method: 'api_key' or 'none'.
  *         @type string $credentials_url Optional. URL where users can obtain API credentials.
  *         @type string $setting_name    Optional. The setting name for the API key.
+ *         @type string $constant_name   Optional. PHP constant name for the API key.
+ *         @type string $env_var_name    Optional. Environment variable name for the API key.
  *     }
  *     @type array  $plugin         {
  *         Optional. Plugin data for install/activate UI.
@@ -66,7 +68,9 @@ function wp_is_connector_registered( string $id ): bool {
  *     authentication: array{
  *         method: 'api_key'|'none',
  *         credentials_url?: non-empty-string,
- *         setting_name?: non-empty-string
+ *         setting_name?: non-empty-string,
+ *         constant_name?: non-empty-string,
+ *         env_var_name?: non-empty-string
  *     },
  *     plugin?: array{
  *         slug: non-empty-string
@@ -106,6 +110,8 @@ function wp_get_connector( string $id ): ?array {
  *             @type string $method          The authentication method: 'api_key' or 'none'.
  *             @type string $credentials_url Optional. URL where users can obtain API credentials.
  *             @type string $setting_name    Optional. The setting name for the API key.
+ *             @type string $constant_name   Optional. PHP constant name for the API key.
+ *             @type string $env_var_name    Optional. Environment variable name for the API key.
  *         }
  *         @type array       $plugin         {
  *             Optional. Plugin data for install/activate UI.
@@ -122,7 +128,9 @@ function wp_get_connector( string $id ): ?array {
  *     authentication: array{
  *         method: 'api_key'|'none',
  *         credentials_url?: non-empty-string,
- *         setting_name?: non-empty-string
+ *         setting_name?: non-empty-string,
+ *         constant_name?: non-empty-string,
+ *         env_var_name?: non-empty-string
  *     },
  *     plugin?: array{
  *         slug: non-empty-string
@@ -334,10 +342,26 @@ function _wp_connectors_register_default_ai_providers( WP_Connector_Registry $re
 	}
 
 	// Register all default connectors directly on the registry.
-	// All AI providers use the connectors_ai_{$id}_api_key naming convention.
+	// All AI providers use the {CONSTANT_CASE_ID}_API_KEY naming convention.
 	foreach ( $defaults as $id => $args ) {
-		if ( 'api_key' === ( $args['authentication']['method'] ?? '' ) && ! isset( $args['authentication']['setting_name'] ) ) {
-			$args['authentication']['setting_name'] = 'connectors_ai_' . str_replace( '-', '_', $id ) . '_api_key';
+		if ( 'api_key' === ( $args['authentication']['method'] ?? '' ) ) {
+			$sanitized_id = str_replace( '-', '_', $id );
+
+			if ( ! isset( $args['authentication']['setting_name'] ) ) {
+				$args['authentication']['setting_name'] = "connectors_ai_{$sanitized_id}_api_key";
+			}
+
+			if ( ! isset( $args['authentication']['constant_name'] ) ) {
+				$constant_case = strtoupper( preg_replace( '/([a-z])([A-Z])/', '$1_$2', $sanitized_id ) );
+
+				$args['authentication']['constant_name'] = "{$constant_case}_API_KEY";
+			}
+
+			if ( ! isset( $args['authentication']['env_var_name'] ) ) {
+				$constant_case = $constant_case ?? strtoupper( preg_replace( '/([a-z])([A-Z])/', '$1_$2', $sanitized_id ) );
+
+				$args['authentication']['env_var_name'] = "{$constant_case}_API_KEY";
+			}
 		}
 		$registry->register( $id, $args );
 	}

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -43,7 +43,7 @@ function wp_is_connector_registered( string $id ): bool {
  *     @type string $name           The connector's display name.
  *     @type string $description    The connector's description.
  *     @type string $logo_url       Optional. URL to the connector's logo image.
- *     @type string $type           The connector type. Currently, only 'ai_provider' is supported.
+ *     @type string $type           The connector type, e.g. 'ai_provider'.
  *     @type array  $authentication {
  *         Authentication configuration. When method is 'api_key', includes
  *         credentials_url and setting_name. When 'none', only method is present.
@@ -62,7 +62,7 @@ function wp_is_connector_registered( string $id ): bool {
  *     name: non-empty-string,
  *     description: non-empty-string,
  *     logo_url?: non-empty-string,
- *     type: 'ai_provider',
+ *     type: non-empty-string,
  *     authentication: array{
  *         method: 'api_key'|'none',
  *         credentials_url?: non-empty-string,
@@ -98,7 +98,7 @@ function wp_get_connector( string $id ): ?array {
  *         @type string      $name           The connector's display name.
  *         @type string      $description    The connector's description.
  *         @type string      $logo_url       Optional. URL to the connector's logo image.
- *         @type string      $type           The connector type. Currently, only 'ai_provider' is supported.
+ *         @type string      $type           The connector type, e.g. 'ai_provider'.
  *         @type array       $authentication {
  *             Authentication configuration. When method is 'api_key', includes
  *             credentials_url and setting_name. When 'none', only method is present.
@@ -118,7 +118,7 @@ function wp_get_connector( string $id ): ?array {
  *     name: non-empty-string,
  *     description: non-empty-string,
  *     logo_url?: non-empty-string,
- *     type: 'ai_provider',
+ *     type: non-empty-string,
  *     authentication: array{
  *         method: 'api_key'|'none',
  *         credentials_url?: non-empty-string,

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -385,35 +385,32 @@ function _wp_connectors_mask_api_key( string $key ): string {
 }
 
 /**
- * Determines the source of an API key for a given provider.
+ * Determines the source of an API key for a given connector.
  *
  * Checks in order: environment variable, PHP constant, database.
- * Uses the same naming convention as the WP AI Client ProviderRegistry.
+ * Environment variable and constant are only checked when their
+ * respective names are provided.
  *
  * @since 7.0.0
  * @access private
  *
- * @param string $provider_id  The provider ID (e.g., 'openai', 'anthropic', 'google').
- * @param string $setting_name The option name for the API key (e.g., 'connectors_ai_openai_api_key').
+ * @param string $setting_name  The option name for the API key (e.g., 'connectors_ai_openai_api_key').
+ * @param string $env_var_name  Optional. Environment variable name to check (e.g., 'OPENAI_API_KEY').
+ * @param string $constant_name Optional. PHP constant name to check (e.g., 'OPENAI_API_KEY').
  * @return string The key source: 'env', 'constant', 'database', or 'none'.
  */
-function _wp_connectors_get_api_key_source( string $provider_id, string $setting_name ): string {
-	// Convert provider ID to CONSTANT_CASE for env var name.
-	// e.g., 'openai' -> 'OPENAI', 'anthropic' -> 'ANTHROPIC'.
-	$constant_case_id = strtoupper(
-		preg_replace( '/([a-z])([A-Z])/', '$1_$2', str_replace( '-', '_', $provider_id ) )
-	);
-	$env_var_name     = "{$constant_case_id}_API_KEY";
-
+function _wp_connectors_get_api_key_source( string $setting_name, string $env_var_name = '', string $constant_name = '' ): string {
 	// Check environment variable first.
-	$env_value = getenv( $env_var_name );
-	if ( false !== $env_value && '' !== $env_value ) {
-		return 'env';
+	if ( '' !== $env_var_name ) {
+		$env_value = getenv( $env_var_name );
+		if ( false !== $env_value && '' !== $env_value ) {
+			return 'env';
+		}
 	}
 
 	// Check PHP constant.
-	if ( defined( $env_var_name ) ) {
-		$const_value = constant( $env_var_name );
+	if ( '' !== $constant_name && defined( $constant_name ) ) {
+		$const_value = constant( $constant_name );
 		if ( is_string( $const_value ) && '' !== $const_value ) {
 			return 'constant';
 		}
@@ -597,7 +594,7 @@ function _wp_connectors_pass_default_keys_to_ai_client(): void {
 			}
 
 			// Skip if the key is already provided via env var or constant.
-			$key_source = _wp_connectors_get_api_key_source( $connector_id, $auth['setting_name'] );
+			$key_source = _wp_connectors_get_api_key_source( $auth['setting_name'], $auth['env_var_name'] ?? '', $auth['constant_name'] ?? '' );
 			if ( 'env' === $key_source || 'constant' === $key_source ) {
 				continue;
 			}
@@ -648,7 +645,7 @@ function _wp_connectors_get_connector_script_module_data( array $data ): array {
 		if ( 'api_key' === $auth['method'] ) {
 			$auth_out['settingName']    = $auth['setting_name'] ?? '';
 			$auth_out['credentialsUrl'] = $auth['credentials_url'] ?? null;
-			$auth_out['keySource']      = _wp_connectors_get_api_key_source( $connector_id, $auth['setting_name'] ?? '' );
+			$auth_out['keySource']      = _wp_connectors_get_api_key_source( $auth['setting_name'] ?? '', $auth['env_var_name'] ?? '', $auth['constant_name'] ?? '' );
 			try {
 				$auth_out['isConnected'] = $registry->hasProvider( $connector_id ) && $registry->isProviderConfigured( $connector_id );
 			} catch ( Exception $e ) {

--- a/tests/phpunit/includes/wp-ai-client-mock-provider-trait.php
+++ b/tests/phpunit/includes/wp-ai-client-mock-provider-trait.php
@@ -172,6 +172,7 @@ trait WP_AI_Client_Mock_Provider_Trait {
 					'authentication' => array(
 						'method'          => 'api_key',
 						'credentials_url' => null,
+						'setting_name'    => 'connectors_ai_mock_connectors_test_api_key',
 					),
 				)
 			);

--- a/tests/phpunit/tests/connectors/wpConnectorRegistry.php
+++ b/tests/phpunit/tests/connectors/wpConnectorRegistry.php
@@ -76,6 +76,46 @@ class Tests_Connectors_WpConnectorRegistry extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 64957
+	 */
+	public function test_register_uses_custom_setting_name_when_provided() {
+		$args                                       = self::$default_args;
+		$args['authentication']['setting_name']     = 'wordpress_api_key';
+
+		$result = $this->registry->register( 'custom-setting', $args );
+
+		$this->assertSame( 'wordpress_api_key', $result['authentication']['setting_name'] );
+	}
+
+	/**
+	 * @ticket 64957
+	 */
+	public function test_register_rejects_empty_setting_name() {
+		$this->setExpectedIncorrectUsage( 'WP_Connector_Registry::register' );
+
+		$args                                   = self::$default_args;
+		$args['authentication']['setting_name'] = '';
+
+		$result = $this->registry->register( 'empty-setting', $args );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * @ticket 64957
+	 */
+	public function test_register_rejects_non_string_setting_name() {
+		$this->setExpectedIncorrectUsage( 'WP_Connector_Registry::register' );
+
+		$args                                   = self::$default_args;
+		$args['authentication']['setting_name'] = 123;
+
+		$result = $this->registry->register( 'non-string-setting', $args );
+
+		$this->assertNull( $result );
+	}
+
+	/**
 	 * @ticket 64791
 	 */
 	public function test_register_no_setting_name_for_none_auth() {

--- a/tests/phpunit/tests/connectors/wpConnectorRegistry.php
+++ b/tests/phpunit/tests/connectors/wpConnectorRegistry.php
@@ -91,8 +91,8 @@ class Tests_Connectors_WpConnectorRegistry extends WP_UnitTestCase {
 	 * @ticket 64957
 	 */
 	public function test_register_uses_custom_setting_name_when_provided() {
-		$args                                       = self::$default_args;
-		$args['authentication']['setting_name']     = 'wordpress_api_key';
+		$args                                   = self::$default_args;
+		$args['authentication']['setting_name'] = 'wordpress_api_key';
 
 		$result = $this->registry->register( 'custom-setting', $args );
 
@@ -131,8 +131,8 @@ class Tests_Connectors_WpConnectorRegistry extends WP_UnitTestCase {
 	 * @ticket 64957
 	 */
 	public function test_register_stores_constant_name_when_provided() {
-		$args                                        = self::$default_args;
-		$args['authentication']['constant_name']     = 'MY_PROVIDER_API_KEY';
+		$args                                    = self::$default_args;
+		$args['authentication']['constant_name'] = 'MY_PROVIDER_API_KEY';
 
 		$result = $this->registry->register( 'my-provider', $args );
 
@@ -180,8 +180,8 @@ class Tests_Connectors_WpConnectorRegistry extends WP_UnitTestCase {
 	 * @ticket 64957
 	 */
 	public function test_register_stores_env_var_name_when_provided() {
-		$args                                       = self::$default_args;
-		$args['authentication']['env_var_name']     = 'MY_PROVIDER_API_KEY';
+		$args                                   = self::$default_args;
+		$args['authentication']['env_var_name'] = 'MY_PROVIDER_API_KEY';
 
 		$result = $this->registry->register( 'my-provider', $args );
 

--- a/tests/phpunit/tests/connectors/wpConnectorRegistry.php
+++ b/tests/phpunit/tests/connectors/wpConnectorRegistry.php
@@ -128,6 +128,104 @@ class Tests_Connectors_WpConnectorRegistry extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 64957
+	 */
+	public function test_register_stores_constant_name_when_provided() {
+		$args                                        = self::$default_args;
+		$args['authentication']['constant_name']     = 'MY_PROVIDER_API_KEY';
+
+		$result = $this->registry->register( 'my-provider', $args );
+
+		$this->assertSame( 'MY_PROVIDER_API_KEY', $result['authentication']['constant_name'] );
+	}
+
+	/**
+	 * @ticket 64957
+	 */
+	public function test_register_omits_constant_name_when_not_provided() {
+		$result = $this->registry->register( 'no-const', self::$default_args );
+
+		$this->assertArrayNotHasKey( 'constant_name', $result['authentication'] );
+	}
+
+	/**
+	 * @ticket 64957
+	 */
+	public function test_register_rejects_empty_constant_name() {
+		$this->setExpectedIncorrectUsage( 'WP_Connector_Registry::register' );
+
+		$args                                    = self::$default_args;
+		$args['authentication']['constant_name'] = '';
+
+		$result = $this->registry->register( 'empty-const', $args );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * @ticket 64957
+	 */
+	public function test_register_rejects_non_string_constant_name() {
+		$this->setExpectedIncorrectUsage( 'WP_Connector_Registry::register' );
+
+		$args                                    = self::$default_args;
+		$args['authentication']['constant_name'] = 123;
+
+		$result = $this->registry->register( 'bad-const', $args );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * @ticket 64957
+	 */
+	public function test_register_stores_env_var_name_when_provided() {
+		$args                                       = self::$default_args;
+		$args['authentication']['env_var_name']     = 'MY_PROVIDER_API_KEY';
+
+		$result = $this->registry->register( 'my-provider', $args );
+
+		$this->assertSame( 'MY_PROVIDER_API_KEY', $result['authentication']['env_var_name'] );
+	}
+
+	/**
+	 * @ticket 64957
+	 */
+	public function test_register_omits_env_var_name_when_not_provided() {
+		$result = $this->registry->register( 'no-env', self::$default_args );
+
+		$this->assertArrayNotHasKey( 'env_var_name', $result['authentication'] );
+	}
+
+	/**
+	 * @ticket 64957
+	 */
+	public function test_register_rejects_empty_env_var_name() {
+		$this->setExpectedIncorrectUsage( 'WP_Connector_Registry::register' );
+
+		$args                                   = self::$default_args;
+		$args['authentication']['env_var_name'] = '';
+
+		$result = $this->registry->register( 'empty-env', $args );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * @ticket 64957
+	 */
+	public function test_register_rejects_non_string_env_var_name() {
+		$this->setExpectedIncorrectUsage( 'WP_Connector_Registry::register' );
+
+		$args                                   = self::$default_args;
+		$args['authentication']['env_var_name'] = 123;
+
+		$result = $this->registry->register( 'bad-env', $args );
+
+		$this->assertNull( $result );
+	}
+
+	/**
 	 * @ticket 64791
 	 */
 	public function test_register_no_setting_name_for_none_auth() {

--- a/tests/phpunit/tests/connectors/wpConnectorRegistry.php
+++ b/tests/phpunit/tests/connectors/wpConnectorRegistry.php
@@ -32,9 +32,9 @@ class Tests_Connectors_WpConnectorRegistry extends WP_UnitTestCase {
 		$this->registry = new WP_Connector_Registry();
 
 		self::$default_args = array(
-			'name'           => 'Test Provider',
-			'description'    => 'A test AI provider.',
-			'type'           => 'ai_provider',
+			'name'           => 'Test Connector',
+			'description'    => 'A test connector.',
+			'type'           => 'test_type',
 			'authentication' => array(
 				'method'          => 'api_key',
 				'credentials_url' => 'https://example.com/keys',
@@ -49,12 +49,12 @@ class Tests_Connectors_WpConnectorRegistry extends WP_UnitTestCase {
 		$result = $this->registry->register( 'test-provider', self::$default_args );
 
 		$this->assertIsArray( $result );
-		$this->assertSame( 'Test Provider', $result['name'] );
-		$this->assertSame( 'A test AI provider.', $result['description'] );
-		$this->assertSame( 'ai_provider', $result['type'] );
+		$this->assertSame( 'Test Connector', $result['name'] );
+		$this->assertSame( 'A test connector.', $result['description'] );
+		$this->assertSame( 'test_type', $result['type'] );
 		$this->assertSame( 'api_key', $result['authentication']['method'] );
 		$this->assertSame( 'https://example.com/keys', $result['authentication']['credentials_url'] );
-		$this->assertSame( 'connectors_ai_provider_test_provider_api_key', $result['authentication']['setting_name'] );
+		$this->assertSame( 'connectors_test_type_test_provider_api_key', $result['authentication']['setting_name'] );
 	}
 
 	/**
@@ -63,7 +63,7 @@ class Tests_Connectors_WpConnectorRegistry extends WP_UnitTestCase {
 	public function test_register_generates_setting_name_for_api_key() {
 		$result = $this->registry->register( 'myai', self::$default_args );
 
-		$this->assertSame( 'connectors_ai_provider_myai_api_key', $result['authentication']['setting_name'] );
+		$this->assertSame( 'connectors_test_type_myai_api_key', $result['authentication']['setting_name'] );
 	}
 
 	/**
@@ -72,7 +72,7 @@ class Tests_Connectors_WpConnectorRegistry extends WP_UnitTestCase {
 	public function test_register_generates_setting_name_normalizes_hyphens() {
 		$result = $this->registry->register( 'my-ai', self::$default_args );
 
-		$this->assertSame( 'connectors_ai_provider_my_ai_api_key', $result['authentication']['setting_name'] );
+		$this->assertSame( 'connectors_test_type_my_ai_api_key', $result['authentication']['setting_name'] );
 	}
 
 	/**
@@ -80,11 +80,11 @@ class Tests_Connectors_WpConnectorRegistry extends WP_UnitTestCase {
 	 */
 	public function test_register_generates_setting_name_using_type_and_id() {
 		$args         = self::$default_args;
-		$args['type'] = 'spam_filtering';
+		$args['type'] = 'email_delivery';
 
-		$result = $this->registry->register( 'akismet', $args );
+		$result = $this->registry->register( 'sendgrid', $args );
 
-		$this->assertSame( 'connectors_spam_filtering_akismet_api_key', $result['authentication']['setting_name'] );
+		$this->assertSame( 'connectors_email_delivery_sendgrid_api_key', $result['authentication']['setting_name'] );
 	}
 
 	/**
@@ -230,8 +230,8 @@ class Tests_Connectors_WpConnectorRegistry extends WP_UnitTestCase {
 	 */
 	public function test_register_no_setting_name_for_none_auth() {
 		$args   = array(
-			'name'           => 'No Auth Provider',
-			'type'           => 'ai_provider',
+			'name'           => 'No Auth Connector',
+			'type'           => 'test_type',
 			'authentication' => array( 'method' => 'none' ),
 		);
 		$result = $this->registry->register( 'no-auth', $args );
@@ -246,7 +246,7 @@ class Tests_Connectors_WpConnectorRegistry extends WP_UnitTestCase {
 	public function test_register_defaults_description_to_empty_string() {
 		$args = array(
 			'name'           => 'Minimal',
-			'type'           => 'ai_provider',
+			'type'           => 'test_type',
 			'authentication' => array( 'method' => 'none' ),
 		);
 
@@ -458,7 +458,7 @@ class Tests_Connectors_WpConnectorRegistry extends WP_UnitTestCase {
 		$result = $this->registry->get_registered( 'my-connector' );
 
 		$this->assertIsArray( $result );
-		$this->assertSame( 'Test Provider', $result['name'] );
+		$this->assertSame( 'Test Connector', $result['name'] );
 	}
 
 	/**
@@ -505,7 +505,7 @@ class Tests_Connectors_WpConnectorRegistry extends WP_UnitTestCase {
 		$result = $this->registry->unregister( 'to-remove' );
 
 		$this->assertIsArray( $result );
-		$this->assertSame( 'Test Provider', $result['name'] );
+		$this->assertSame( 'Test Connector', $result['name'] );
 		$this->assertFalse( $this->registry->is_registered( 'to-remove' ) );
 	}
 
@@ -554,7 +554,9 @@ class Tests_Connectors_WpConnectorRegistry extends WP_UnitTestCase {
 	public function test_register_skips_when_ai_not_supported() {
 		add_filter( 'wp_supports_ai', '__return_false' );
 
-		$this->registry->register( 'first', self::$default_args );
+		$args         = self::$default_args;
+		$args['type'] = 'ai_provider';
+		$this->registry->register( 'first', $args );
 
 		$all = $this->registry->get_all_registered();
 		$this->assertCount( 0, $all );

--- a/tests/phpunit/tests/connectors/wpConnectorRegistry.php
+++ b/tests/phpunit/tests/connectors/wpConnectorRegistry.php
@@ -54,7 +54,7 @@ class Tests_Connectors_WpConnectorRegistry extends WP_UnitTestCase {
 		$this->assertSame( 'ai_provider', $result['type'] );
 		$this->assertSame( 'api_key', $result['authentication']['method'] );
 		$this->assertSame( 'https://example.com/keys', $result['authentication']['credentials_url'] );
-		$this->assertSame( 'connectors_ai_test_provider_api_key', $result['authentication']['setting_name'] );
+		$this->assertSame( 'connectors_ai_provider_test_provider_api_key', $result['authentication']['setting_name'] );
 	}
 
 	/**
@@ -63,7 +63,7 @@ class Tests_Connectors_WpConnectorRegistry extends WP_UnitTestCase {
 	public function test_register_generates_setting_name_for_api_key() {
 		$result = $this->registry->register( 'myai', self::$default_args );
 
-		$this->assertSame( 'connectors_ai_myai_api_key', $result['authentication']['setting_name'] );
+		$this->assertSame( 'connectors_ai_provider_myai_api_key', $result['authentication']['setting_name'] );
 	}
 
 	/**
@@ -72,7 +72,19 @@ class Tests_Connectors_WpConnectorRegistry extends WP_UnitTestCase {
 	public function test_register_generates_setting_name_normalizes_hyphens() {
 		$result = $this->registry->register( 'my-ai', self::$default_args );
 
-		$this->assertSame( 'connectors_ai_my_ai_api_key', $result['authentication']['setting_name'] );
+		$this->assertSame( 'connectors_ai_provider_my_ai_api_key', $result['authentication']['setting_name'] );
+	}
+
+	/**
+	 * @ticket 64957
+	 */
+	public function test_register_generates_setting_name_using_type_and_id() {
+		$args         = self::$default_args;
+		$args['type'] = 'spam_filtering';
+
+		$result = $this->registry->register( 'akismet', $args );
+
+		$this->assertSame( 'connectors_spam_filtering_akismet_api_key', $result['authentication']['setting_name'] );
 	}
 
 	/**

--- a/tests/phpunit/tests/connectors/wpConnectorsGetApiKeySource.php
+++ b/tests/phpunit/tests/connectors/wpConnectorsGetApiKeySource.php
@@ -26,9 +26,9 @@ class Tests_Connectors_WpConnectorsGetApiKeySource extends WP_UnitTestCase {
 
 		$result = _wp_connectors_get_api_key_source( $setting_name );
 
-		$this->assertSame( 'database', $result );
-
 		delete_option( $setting_name );
+
+		$this->assertSame( 'database', $result );
 	}
 
 	/**
@@ -40,9 +40,9 @@ class Tests_Connectors_WpConnectorsGetApiKeySource extends WP_UnitTestCase {
 
 		$result = _wp_connectors_get_api_key_source( 'connectors_ai_test_api_key', $env_var );
 
-		$this->assertSame( 'env', $result );
-
 		putenv( $env_var );
+
+		$this->assertSame( 'env', $result );
 	}
 
 	/**
@@ -75,10 +75,10 @@ class Tests_Connectors_WpConnectorsGetApiKeySource extends WP_UnitTestCase {
 
 		$result = _wp_connectors_get_api_key_source( $setting_name, $env_var, $constant_name );
 
-		$this->assertSame( 'env', $result );
-
 		putenv( $env_var );
 		delete_option( $setting_name );
+
+		$this->assertSame( 'env', $result );
 	}
 
 	/**
@@ -95,28 +95,28 @@ class Tests_Connectors_WpConnectorsGetApiKeySource extends WP_UnitTestCase {
 
 		$result = _wp_connectors_get_api_key_source( $setting_name, '', $constant_name );
 
-		$this->assertSame( 'constant', $result );
-
 		delete_option( $setting_name );
+
+		$this->assertSame( 'constant', $result );
 	}
 
 	/**
 	 * @ticket 64957
 	 */
 	public function test_skips_env_check_when_env_var_name_empty() {
-		$env_var = 'WP_TEST_SKIP_ENV_KEY';
-		putenv( "{$env_var}=sk-from-env" );
-
+		$env_var      = 'WP_TEST_SKIP_ENV_KEY';
 		$setting_name = 'connectors_ai_skip_env_api_key';
+
+		putenv( "{$env_var}=sk-from-env" );
 		update_option( $setting_name, 'sk-from-db' );
 
 		// Empty env_var_name means env is not checked, falls through to database.
 		$result = _wp_connectors_get_api_key_source( $setting_name, '', '' );
 
-		$this->assertSame( 'database', $result );
-
 		putenv( $env_var );
 		delete_option( $setting_name );
+
+		$this->assertSame( 'database', $result );
 	}
 
 	/**
@@ -124,18 +124,18 @@ class Tests_Connectors_WpConnectorsGetApiKeySource extends WP_UnitTestCase {
 	 */
 	public function test_skips_constant_check_when_constant_name_empty() {
 		$constant_name = 'WP_TEST_SKIP_CONST_KEY';
+		$setting_name  = 'connectors_ai_skip_const_api_key';
+
 		if ( ! defined( $constant_name ) ) {
 			define( $constant_name, 'sk-from-constant' );
 		}
-
-		$setting_name = 'connectors_ai_skip_const_api_key';
 		update_option( $setting_name, 'sk-from-db' );
 
 		// Empty constant_name means constant is not checked, falls through to database.
 		$result = _wp_connectors_get_api_key_source( $setting_name, '' );
 
-		$this->assertSame( 'database', $result );
-
 		delete_option( $setting_name );
+
+		$this->assertSame( 'database', $result );
 	}
 }

--- a/tests/phpunit/tests/connectors/wpConnectorsGetApiKeySource.php
+++ b/tests/phpunit/tests/connectors/wpConnectorsGetApiKeySource.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * Tests for _wp_connectors_get_api_key_source().
+ *
+ * @covers ::_wp_connectors_get_api_key_source
+ *
+ * @group connectors
+ */
+class Tests_Connectors_WpConnectorsGetApiKeySource extends WP_UnitTestCase {
+
+	/**
+	 * @ticket 64957
+	 */
+	public function test_returns_none_when_no_key_found() {
+		$result = _wp_connectors_get_api_key_source( 'connectors_ai_nonexistent_api_key' );
+
+		$this->assertSame( 'none', $result );
+	}
+
+	/**
+	 * @ticket 64957
+	 */
+	public function test_returns_database_when_option_set() {
+		$setting_name = 'connectors_ai_test_source_api_key';
+		update_option( $setting_name, 'sk-test-key-123' );
+
+		$result = _wp_connectors_get_api_key_source( $setting_name );
+
+		$this->assertSame( 'database', $result );
+
+		delete_option( $setting_name );
+	}
+
+	/**
+	 * @ticket 64957
+	 */
+	public function test_returns_env_when_env_var_set() {
+		$env_var = 'WP_TEST_CONNECTOR_API_KEY';
+		putenv( "{$env_var}=sk-from-env" );
+
+		$result = _wp_connectors_get_api_key_source( 'connectors_ai_test_api_key', $env_var );
+
+		$this->assertSame( 'env', $result );
+
+		putenv( $env_var );
+	}
+
+	/**
+	 * @ticket 64957
+	 */
+	public function test_returns_constant_when_constant_defined() {
+		$constant_name = 'WP_TEST_CONNECTOR_CONST_KEY';
+		if ( ! defined( $constant_name ) ) {
+			define( $constant_name, 'sk-from-constant' );
+		}
+
+		$result = _wp_connectors_get_api_key_source( 'connectors_ai_test_api_key', '', $constant_name );
+
+		$this->assertSame( 'constant', $result );
+	}
+
+	/**
+	 * @ticket 64957
+	 */
+	public function test_env_takes_priority_over_constant_and_database() {
+		$setting_name  = 'connectors_ai_priority_test_api_key';
+		$env_var       = 'WP_TEST_PRIORITY_ENV_KEY';
+		$constant_name = 'WP_TEST_PRIORITY_CONST_KEY';
+
+		update_option( $setting_name, 'sk-from-db' );
+		putenv( "{$env_var}=sk-from-env" );
+		if ( ! defined( $constant_name ) ) {
+			define( $constant_name, 'sk-from-constant' );
+		}
+
+		$result = _wp_connectors_get_api_key_source( $setting_name, $env_var, $constant_name );
+
+		$this->assertSame( 'env', $result );
+
+		putenv( $env_var );
+		delete_option( $setting_name );
+	}
+
+	/**
+	 * @ticket 64957
+	 */
+	public function test_constant_takes_priority_over_database() {
+		$setting_name  = 'connectors_ai_const_priority_api_key';
+		$constant_name = 'WP_TEST_CONST_PRIORITY_KEY';
+
+		update_option( $setting_name, 'sk-from-db' );
+		if ( ! defined( $constant_name ) ) {
+			define( $constant_name, 'sk-from-constant' );
+		}
+
+		$result = _wp_connectors_get_api_key_source( $setting_name, '', $constant_name );
+
+		$this->assertSame( 'constant', $result );
+
+		delete_option( $setting_name );
+	}
+
+	/**
+	 * @ticket 64957
+	 */
+	public function test_skips_env_check_when_env_var_name_empty() {
+		$env_var = 'WP_TEST_SKIP_ENV_KEY';
+		putenv( "{$env_var}=sk-from-env" );
+
+		$setting_name = 'connectors_ai_skip_env_api_key';
+		update_option( $setting_name, 'sk-from-db' );
+
+		// Empty env_var_name means env is not checked, falls through to database.
+		$result = _wp_connectors_get_api_key_source( $setting_name, '', '' );
+
+		$this->assertSame( 'database', $result );
+
+		putenv( $env_var );
+		delete_option( $setting_name );
+	}
+
+	/**
+	 * @ticket 64957
+	 */
+	public function test_skips_constant_check_when_constant_name_empty() {
+		$constant_name = 'WP_TEST_SKIP_CONST_KEY';
+		if ( ! defined( $constant_name ) ) {
+			define( $constant_name, 'sk-from-constant' );
+		}
+
+		$setting_name = 'connectors_ai_skip_const_api_key';
+		update_option( $setting_name, 'sk-from-db' );
+
+		// Empty constant_name means constant is not checked, falls through to database.
+		$result = _wp_connectors_get_api_key_source( $setting_name, '' );
+
+		$this->assertSame( 'database', $result );
+
+		delete_option( $setting_name );
+	}
+}


### PR DESCRIPTION
## Summary

- Validate `setting_name`, `constant_name`, and `env_var_name` in connector registration — reject invalid values with `_doing_it_wrong()` instead of silently falling back.
- Update PHPDoc to reflect current behavior — widen `type` from literal `'ai_provider'` to `non-empty-string`, document new authentication fields, use Anthropic and non-AI examples throughout.
- Change auto-generated `setting_name` pattern from `connectors_ai_{$id}_api_key` to `connectors_{$type}_{$id}_api_key` so it works for any connector type. Built-in AI providers infer their names using the existing `connectors_ai_{$id}_api_key` convention.
- Add `constant_name` and `env_var_name` as optional authentication fields, allowing connectors to declare explicit PHP constant and environment variable names for API key lookup. AI providers auto-generate these using the `{CONSTANT_CASE_ID}_API_KEY` convention.
- Refactor `_wp_connectors_get_api_key_source()` to accept explicit `env_var_name` and `constant_name` parameters instead of deriving them from the provider ID. Environment variable and constant checks are skipped when not provided.
- Generalize REST dispatch, settings registration, and script module data to work with all connector types, not just `ai_provider`. Settings registration skips already-registered settings. Non-AI connectors determine `isConnected` based on key source.

## Test plan

- [ ] Verify existing AI provider connectors retain their `connectors_ai_{id}_api_key` setting names
- [ ] Register a custom non-AI connector type and verify auto-generated setting name uses `connectors_{type}_{id}_api_key`
- [ ] Verify `constant_name` and `env_var_name` are stored when provided and omitted when not
- [ ] Verify invalid `setting_name`, `constant_name`, and `env_var_name` values trigger `_doing_it_wrong()`
- [ ] Verify API key masking works for non-AI connector types in REST responses
- [ ] Verify settings registration skips already-registered settings
- [ ] Run full connector test suite: `npm run test:php -- --filter=Tests_Connectors`

Trac ticket: https://core.trac.wordpress.org/ticket/64957
See also: https://github.com/WordPress/gutenberg/pull/76828

🤖 Generated with [Claude Code](https://claude.com/claude-code)