### PR TITLE
Fix test that checks the EOL date for MySQL

### DIFF
--- a/tests/phpunit/tests/readme.php
+++ b/tests/phpunit/tests/readme.php
@@ -30,16 +30,21 @@ class Tests_Readme extends WP_UnitTestCase {
 	 */
 	public function test_readme_mysql_version() {
 		// This test is designed to only run on trunk.
-		$this->skipOnAutomatedBranches();
+		//      $this->skipOnAutomatedBranches();
 
 		$readme = file_get_contents( ABSPATH . 'readme.html' );
 
 		preg_match( '#Recommendations.*MySQL</a> version <strong>([0-9.]*)#s', $readme, $matches );
 
-		$response_body = $this->get_response_body( "https://dev.mysql.com/doc/relnotes/mysql/{$matches[1]}/en/" );
+		$response_body = json_decode( $this->get_response_body( 'https://endoflife.date/api/mysql.json' ) );
+		$eol_date      = '';
 
-		// Retrieve the date of the first GA release for the recommended branch.
-		preg_match( '#.*(\d{4}-\d{2}-\d{2}), General Availability#s', $response_body, $mysql_matches );
+		foreach ( $response_body as $version ) {
+			if ( $version->cycle === $matches[1] && false !== $version->eol ) {
+				$eol_date = $version->eol;
+				break;
+			}
+		}
 
 		/*
 		 * Per https://www.mysql.com/support/, Oracle actively supports MySQL releases for 5 years from GA release.
@@ -50,7 +55,7 @@ class Tests_Readme extends WP_UnitTestCase {
 		 *
 		 * TODO: Reduce this back to 5 years once MySQL 8.1 compatibility is achieved.
 		 */
-		$mysql_eol    = gmdate( 'Y-m-d', strtotime( $mysql_matches[1] . ' +8 years' ) );
+		$mysql_eol    = gmdate( 'Y-m-d', strtotime( $eol_date . ' +8 years' ) );
 		$current_date = gmdate( 'Y-m-d' );
 
 		$this->assertLessThan( $mysql_eol, $current_date, "readme.html's Recommended MySQL version is too old. Remember to update the WordPress.org Requirements page, too." );

--- a/tests/phpunit/tests/readme.php
+++ b/tests/phpunit/tests/readme.php
@@ -30,7 +30,7 @@ class Tests_Readme extends WP_UnitTestCase {
 	 */
 	public function test_readme_mysql_version() {
 		// This test is designed to only run on trunk.
-		//      $this->skipOnAutomatedBranches();
+	  	$this->skipOnAutomatedBranches();
 
 		$readme = file_get_contents( ABSPATH . 'readme.html' );
 


### PR DESCRIPTION
This fixes a failing tst that seems to be caused by the fact that MySQL changed the content on release pages.

Unfortunately, it does not seem like there is an official API available from MySQL itself. However, endoflife.date is an open source, MIT licensed, reasonably maintained project that does have an endpoint available.

Trac ticket: Core-64894.

## Use of AI Tools

AI Assistance: Yes
Tool(s): Claude Code
Model(s): Sonnet 4.6
Used for: Searching for possible APIs to use to replace parsing an HTML document.

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
