### PR TITLE
Taxonomy: Fix WP_Term_Query cache miss for equivalent queries

### DIFF
--- a/src/wp-includes/class-wp-term-query.php
+++ b/src/wp-includes/class-wp-term-query.php
@@ -1177,6 +1177,11 @@ class WP_Term_Query {
 			'child_of' => (int) $args['child_of'],
 		);
 
+		// cache_domain is a caller-controlled key that intentionally separates cache
+		// entries for the same query. It must be included so that callers can opt into
+		// distinct cache buckets even when the SQL is identical.
+		$php_cache_args['cache_domain'] = $args['cache_domain'];
+
 		// pad_counts changes result values via _pad_term_counts() and also changes the
 		// shape of what is stored in the cache ({term_id, count} objects vs. term_ids).
 		$php_cache_args['pad_counts'] = (bool) $args['pad_counts'];

--- a/src/wp-includes/class-wp-term-query.php
+++ b/src/wp-includes/class-wp-term-query.php
@@ -1161,19 +1161,51 @@ class WP_Term_Query {
 	 */
 	protected function generate_cache_key( array $args, $sql ) {
 		global $wpdb;
-		// $args can be anything. Only use the args defined in defaults to compute the key.
-		$cache_args = wp_array_slice_assoc( $args, array_keys( $this->query_var_defaults ) );
-
-		unset( $cache_args['cache_results'], $cache_args['update_term_meta_cache'] );
-
-		if ( 'count' !== $args['fields'] && 'all_with_object_id' !== $args['fields'] ) {
-			$cache_args['fields'] = 'all';
-		}
 
 		// Replace wpdb placeholder in the SQL statement used by the cache key.
 		$sql = $wpdb->remove_placeholder_escape( $sql );
 
-		$key = md5( serialize( $cache_args ) . $sql );
+		/*
+		 * The SQL statement already captures everything that drives the database query
+		 * (taxonomy, orderby, hide_empty + hierarchical combos, LIMIT, JOINs, etc.).
+		 * Only include args that affect PHP-level post-processing of the query results,
+		 * since those are not reflected in the SQL.
+		 */
+
+		// child_of is filtered in PHP via _get_term_children(); it is not always in the SQL.
+		$php_cache_args = array(
+			'child_of' => (int) $args['child_of'],
+		);
+
+		// pad_counts changes result values via _pad_term_counts() and also changes the
+		// shape of what is stored in the cache ({term_id, count} objects vs. term_ids).
+		$php_cache_args['pad_counts'] = (bool) $args['pad_counts'];
+
+		/*
+		 * PHP empty-term pruning runs only when BOTH hierarchical and hide_empty are truthy
+		 * (see the `$hierarchical && $args['hide_empty']` check in get_terms()). The
+		 * individual values are irrelevant; only the combined boolean result matters.
+		 */
+		$php_cache_args['prune_empty_terms'] = (bool) ( $args['hierarchical'] && $args['hide_empty'] );
+
+		/*
+		 * When a query is hierarchical, SQL does not apply LIMIT/OFFSET (to avoid
+		 * cutting off branches). In that case PHP slices the result set afterward, so
+		 * the actual number and offset values must be part of the key.
+		 */
+		if ( $args['hierarchical'] && $args['number'] ) {
+			$php_cache_args['number'] = (int) $args['number'];
+			$php_cache_args['offset'] = (int) $args['offset'];
+		}
+
+		// fields determines the shape of data stored in, and read from, the cache.
+		if ( 'count' !== $args['fields'] && 'all_with_object_id' !== $args['fields'] ) {
+			$php_cache_args['fields'] = 'all';
+		} else {
+			$php_cache_args['fields'] = $args['fields'];
+		}
+
+		$key = md5( $sql . serialize( $php_cache_args ) );
 
 		return "get_terms:$key";
 	}

--- a/tests/phpunit/tests/term/query.php
+++ b/tests/phpunit/tests/term/query.php
@@ -1207,4 +1207,220 @@ class Tests_Term_Query extends WP_UnitTestCase {
 
 		$this->assertSame( ltrim( $q->request ), $q->request, 'The query has leading whitespace' );
 	}
+
+	/**
+	 * Queries producing equivalent SQL and identical PHP post-processing should share
+	 * a single cache entry regardless of how their input args are expressed.
+	 *
+	 * The motivating case: wp_dropdown_categories() passes `hierarchical=1, hide_empty=0`
+	 * to get_terms(), while wp_terms_checklist() passes `get='all'` which normalises to
+	 * `hierarchical=false, hide_empty=0`.  Both produce the same SQL and the same PHP
+	 * post-processing behaviour, so they should hit the same cache entry and avoid the
+	 * duplicate database query reported in ticket #64038.
+	 *
+	 * @ticket 64038
+	 * @group  cache
+	 *
+	 * @covers WP_Term_Query::generate_cache_key
+	 */
+	public function test_equivalent_queries_share_cache_entry() {
+		register_taxonomy( 'wptests_tax_1', 'post' );
+		self::factory()->term->create_many( 3, array( 'taxonomy' => 'wptests_tax_1' ) );
+
+		// First query: explicit hierarchical=1, hide_empty=0 (wp_dropdown_categories style).
+		$query1 = new WP_Term_Query(
+			array(
+				'taxonomy'     => 'wptests_tax_1',
+				'hide_empty'   => 0,
+				'hierarchical' => 1,
+				'fields'       => 'ids',
+			)
+		);
+
+		$terms1 = $query1->get_terms();
+
+		$num_queries_after_first = get_num_queries();
+
+		// Second query: get='all' (wp_terms_checklist style) – normalises to the same SQL
+		// and the same PHP post-processing path as the first query.
+		$query2 = new WP_Term_Query(
+			array(
+				'taxonomy' => 'wptests_tax_1',
+				'get'      => 'all',
+				'fields'   => 'ids',
+			)
+		);
+
+		$terms2 = $query2->get_terms();
+
+		$this->assertSame(
+			$num_queries_after_first,
+			get_num_queries(),
+			'A second equivalent term query should be served from cache without an extra database query.'
+		);
+
+		$this->assertSameSets(
+			$terms1,
+			$terms2,
+			'Both queries should return the same term IDs.'
+		);
+	}
+
+	/**
+	 * Two queries that produce the same SQL but differ in whether PHP empty-term pruning
+	 * applies (`hierarchical=true && hide_empty=true` vs. `hide_empty=false`) must NOT
+	 * share a cache entry, because the stored result sets may be different.
+	 *
+	 * @ticket 64038
+	 * @group  cache
+	 *
+	 * @covers WP_Term_Query::generate_cache_key
+	 */
+	public function test_queries_with_different_prune_empty_terms_get_separate_cache_entries() {
+		register_taxonomy( 'wptests_tax_1', 'post', array( 'hierarchical' => true ) );
+
+		$reflection = new ReflectionMethod( new WP_Term_Query(), 'generate_cache_key' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$reflection->setAccessible( true );
+		}
+
+		// Query A: hierarchical=true + hide_empty=true  ->  PHP pruning IS active.
+		$query_a = new WP_Term_Query();
+		$query_a->query(
+			array(
+				'taxonomy'     => 'wptests_tax_1',
+				'hierarchical' => true,
+				'hide_empty'   => true,
+				'fields'       => 'ids',
+			)
+		);
+
+		$key_a = $reflection->invoke( $query_a, $query_a->query_vars, $query_a->request );
+
+		// Query B: hide_empty=false  ->  PHP pruning is NOT active (hierarchical irrelevant).
+		$query_b = new WP_Term_Query();
+		$query_b->query(
+			array(
+				'taxonomy'     => 'wptests_tax_1',
+				'hierarchical' => false,
+				'hide_empty'   => false,
+				'fields'       => 'ids',
+			)
+		);
+
+		$key_b = $reflection->invoke( $query_b, $query_b->query_vars, $query_b->request );
+
+		$this->assertNotSame(
+			$key_a,
+			$key_b,
+			'Queries with different PHP empty-term pruning behaviour must have distinct cache keys.'
+		);
+	}
+
+	/**
+	 * Two queries with the same SQL but different child_of values must NOT share
+	 * a cache entry; child_of filtering is applied in PHP, not SQL.
+	 *
+	 * @ticket 64038
+	 * @group  cache
+	 *
+	 * @covers WP_Term_Query::generate_cache_key
+	 */
+	public function test_queries_with_different_child_of_get_separate_cache_entries() {
+		register_taxonomy( 'wptests_tax_1', 'post', array( 'hierarchical' => true ) );
+
+		$parent = self::factory()->term->create( array( 'taxonomy' => 'wptests_tax_1' ) );
+		self::factory()->term->create(
+			array(
+				'taxonomy' => 'wptests_tax_1',
+				'parent'   => $parent,
+			)
+		);
+
+		$reflection = new ReflectionMethod( new WP_Term_Query(), 'generate_cache_key' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$reflection->setAccessible( true );
+		}
+
+		// Query A: no child_of filter.
+		$query_a = new WP_Term_Query();
+		$query_a->query(
+			array(
+				'taxonomy'   => 'wptests_tax_1',
+				'hide_empty' => false,
+				'fields'     => 'ids',
+			)
+		);
+
+		$key_a = $reflection->invoke( $query_a, $query_a->query_vars, $query_a->request );
+
+		// Query B: child_of filtering.
+		$query_b = new WP_Term_Query();
+		$query_b->query(
+			array(
+				'taxonomy'   => 'wptests_tax_1',
+				'hide_empty' => false,
+				'child_of'   => $parent,
+				'fields'     => 'ids',
+			)
+		);
+
+		$key_b = $reflection->invoke( $query_b, $query_b->query_vars, $query_b->request );
+
+		$this->assertNotSame(
+			$key_a,
+			$key_b,
+			'Queries with different child_of values must have distinct cache keys.'
+		);
+	}
+
+	/**
+	 * Two queries with the same SQL but different pad_counts values must NOT share
+	 * a cache entry; pad_counts is applied in PHP and changes the cache data shape.
+	 *
+	 * @ticket 64038
+	 * @group  cache
+	 *
+	 * @covers WP_Term_Query::generate_cache_key
+	 */
+	public function test_queries_with_different_pad_counts_get_separate_cache_entries() {
+		register_taxonomy( 'wptests_tax_1', 'post', array( 'hierarchical' => true ) );
+
+		$reflection = new ReflectionMethod( new WP_Term_Query(), 'generate_cache_key' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$reflection->setAccessible( true );
+		}
+
+		$query_a = new WP_Term_Query();
+		$query_a->query(
+			array(
+				'taxonomy'     => 'wptests_tax_1',
+				'hide_empty'   => false,
+				'hierarchical' => false,
+				'pad_counts'   => false,
+				'fields'       => 'all',
+			)
+		);
+
+		$key_a = $reflection->invoke( $query_a, $query_a->query_vars, $query_a->request );
+
+		$query_b = new WP_Term_Query();
+		$query_b->query(
+			array(
+				'taxonomy'     => 'wptests_tax_1',
+				'hide_empty'   => false,
+				'hierarchical' => false,
+				'pad_counts'   => true,
+				'fields'       => 'all',
+			)
+		);
+
+		$key_b = $reflection->invoke( $query_b, $query_b->query_vars, $query_b->request );
+
+		$this->assertNotSame(
+			$key_a,
+			$key_b,
+			'Queries with different pad_counts values must have distinct cache keys.'
+		);
+	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->

## Summary

Fixes a duplicate database query that occurs on the Posts list table (and wherever `wp_dropdown_categories()` and `wp_terms_checklist()` are rendered on the same page) due to two semantically identical `get_terms()` calls producing different cache keys.

---

## Problem

`WP_Term_Query::generate_cache_key()` hashes the full set of sanitised query args together with the SQL:

```php
$key = md5( serialize( $cache_args ) . $sql );
```

`wp_dropdown_categories()` passes `hierarchical => 1` (int), while `wp_terms_checklist()` passes `get => 'all'` which `parse_query()` immediately normalises to `hierarchical => false` (bool). Both produce **identical SQL**, yet `serialize()` produces two different strings → two different cache keys → two identical DB queries on every page load.

---

## Solution

Replace the wide arg-serialisation approach with **SQL + only the args that drive PHP-level post-processing** (which is not captured by the SQL):

| Arg | Reason kept |
|---|---|
| `child_of` | `_get_term_children()` runs in PHP; not always reflected in SQL |
| `pad_counts` | `_pad_term_counts()` runs in PHP and changes the cached data shape |
| `prune_empty_terms` | Combined `(bool)($hierarchical && $hide_empty)` — only the conjunction determines PHP pruning |
| `number` / `offset` (hierarchical only) | No `LIMIT` in SQL for hierarchical queries; PHP slices with `array_slice()` |
| `fields` | Preserved from existing logic; determines cache value shape |

---

## Changes

- **`src/wp-includes/class-wp-term-query.php`** — Rewrites `generate_cache_key()` to key on SQL + a minimal set of PHP-post-processing args.
- **`tests/phpunit/tests/term/query.php`** — Adds four new `@ticket 64038` / `@group cache` test methods covering: shared cache entry for equivalent queries, and separate keys for differing `prune_empty_terms`, `child_of`, and `pad_counts`.

---

## Testing

```bash
vendor/bin/phpunit tests/phpunit/tests/term/query.php --filter cache
```

---

Trac ticket: https://core.trac.wordpress.org/ticket/64038

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

AI assistance: Yes
Tool(s): GitHub Copilot (Claude Sonnet 4.6)
Used for: The problem analysis, approach selection, implementation, and test cases were reviewed and verified by the human author before submission. All code changes have been manually checked for correctness against the WordPress codebase.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
