### PR TITLE
Admin reskin: Fix vertical alignment of pagination input in list tables.

### DIFF
--- a/src/wp-admin/css/list-tables.css
+++ b/src/wp-admin/css/list-tables.css
@@ -682,6 +682,7 @@ th.sorted a span {
 }
 
 .tablenav-pages .current-page {
+	vertical-align: top;
 	margin: 0 2px 0 0;
 	font-size: 13px;
 	text-align: center;


### PR DESCRIPTION
The page number input in `WP_List_Table` pagination was vertically misaligned with the navigation buttons due to different baseline positions.

The fix adds `vertical-align: top` to `.current-page`, which aligns the input flush with the buttons without side effects on the bottom pagination row (which has no input field).

Before:
<img width="334" height="90" alt="image" src="https://github.com/user-attachments/assets/50db2c6a-ce81-483b-9d24-fa0f7d926ac6" />

After:
<img width="335" height="90" alt="image" src="https://github.com/user-attachments/assets/8157c203-5bae-4f3c-b87b-28ef94a5a473" />


For additional context, other approaches explored and discarded:
- `display: flex` + `align-items: center` on the pagination containers fixed alignment but changed horizontal spacing and affected the bottom pagination row.
- `vertical-align: middle` on buttons and text elements fixed the top row but shifted the bottom pagination which was already aligned.

Trac ticket: https://core.trac.wordpress.org/ticket/64975

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 4.6
Used for: Measuring computed styles in the browser and code reviewing. Final fix validated and reviewed by me.