### PR TITLE
Fixed: Admin reskin: Vertical alignment of list pagination is off

### DIFF
--- a/src/wp-admin/css/list-tables.css
+++ b/src/wp-admin/css/list-tables.css
@@ -681,6 +681,11 @@ th.sorted a span {
 	cursor: pointer;
 }
 
+.tablenav-pages .paging-input {
+	position: relative;
+	top: -1px;
+}
+
 .tablenav-pages .current-page {
 	margin: 0 2px 0 0;
 	font-size: 13px;


### PR DESCRIPTION
Ticket: https://core.trac.wordpress.org/ticket/64975

## Summary
This PR addresses the issue where the pagination elements in WP_List_Tables are vertically misaligned. The update ensures consistent alignment across pagination controls for better visual consistency.

## Problem
The pagination UI in WP_List_Tables has inconsistent vertical alignment between page numbers, input field, and navigation buttons. This results in a slightly uneven and unpolished appearance in the admin interface.

## Solution

- Adjusted CSS styles to properly align pagination elements.
- Ensured consistent spacing and alignment pagination controls.

## Screenshot
<img width="1506" height="471" alt="image" src="https://github.com/user-attachments/assets/40830892-2f3b-44c0-955a-ba151c961317" />
