### PR TITLE
Admin Reskin: Add more margin below the plugin card header

### DIFF
--- a/src/wp-admin/css/list-tables.css
+++ b/src/wp-admin/css/list-tables.css
@@ -1608,7 +1608,7 @@ div.action-links,
 }
 
 .plugin-card h3 {
-	margin: 0 12px 12px 0;
+	margin: 0 12px 16px 0;
 	font-size: 18px;
 	line-height: 1.3;
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

## Use of AI Tools

None

## Screenshots

In the following screenshots, the locale and screen size are intentionally set so that the install button and text are close together to make the difference clear.

### Before

<img width="1255" height="534" alt="image" src="https://github.com/user-attachments/assets/a5c504b4-5483-4bef-9970-dc73f99bb371" />

### After

<img width="1258" height="547" alt="image" src="https://github.com/user-attachments/assets/a52796ae-a3d2-42f5-8be5-bf549c6cf43f" />
