### PR TITLE
 Administration: Fix vertical alignment of pagination in list tables

### DIFF
--- a/src/wp-admin/css/list-tables.css
+++ b/src/wp-admin/css/list-tables.css
@@ -708,10 +708,12 @@ th.sorted a span {
 	max-width: 98%;
 }
 
-.tablenav .tablenav-pages {
-	float: right;
-	margin: 0 0 9px;
-}
+  .tablenav .tablenav-pages {                                                                                                                                              
+      float: right;
+      margin: 0;
+      display: flex;
+      align-items: center;                                                                                                                                                 
+  }
 
 .tablenav .no-pages,
 .tablenav .one-page .pagination-links {


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/64975                                                                                                                
                                                           
  Fixes the vertical alignment issue in WP_List_Table pagination rows.                                                                                                     
  Changed `.tablenav-pages` margin from `0 0 9px` to `0` and added                                                                                                         
  `display: flex` + `align-items: center` for proper alignment.   
                                                                