### PR TITLE
Connectors: Register Akismet Anti-Spam as a default connector

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"url": "https://develop.svn.wordpress.org/trunk"
 	},
 	"gutenberg": {
-		"sha": "0d133bf7e7437d65d68a06551f3d613a7d8e4361",
+		"sha": "6230e952d12131bd2d0aecff2f2a912ff2b976c1",
 		"ghcrRepo": "WordPress/gutenberg/gutenberg-wp-develop-build"
 	},
 	"engines": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"url": "https://develop.svn.wordpress.org/trunk"
 	},
 	"gutenberg": {
-		"sha": "6230e952d12131bd2d0aecff2f2a912ff2b976c1",
+		"sha": "0d133bf7e7437d65d68a06551f3d613a7d8e4361",
 		"ghcrRepo": "WordPress/gutenberg/gutenberg-wp-develop-build"
 	},
 	"engines": {

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -218,7 +218,7 @@ function _wp_connectors_init(): void {
 			'description'    => __( 'Protect your site from spam.' ),
 			'type'           => 'spam_filtering',
 			'plugin'         => array(
-				'slug' => 'akismet',
+				'file' => 'akismet/akismet.php',
 			),
 			'authentication' => array(
 				'method'          => 'api_key',

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -210,6 +210,25 @@ function _wp_connectors_init(): void {
 		_wp_connectors_register_default_ai_providers( $registry );
 	}
 
+	// Non-AI default connectors.
+	$registry->register(
+		'akismet',
+		array(
+			'name'           => __( 'Akismet Anti-Spam' ),
+			'description'    => __( 'Protect your site from spam.' ),
+			'type'           => 'spam_filtering',
+			'plugin'         => array(
+				'slug' => 'akismet',
+			),
+			'authentication' => array(
+				'method'          => 'api_key',
+				'credentials_url' => 'https://akismet.com/get/',
+				'setting_name'    => 'wordpress_api_key',
+				'constant_name'   => 'WPCOM_API_KEY',
+			),
+		)
+	);
+
 	/**
 	 * Fires when the connector registry is ready for plugins to register connectors.
 	 *

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -214,7 +214,7 @@ function _wp_connectors_init(): void {
 	$registry->register(
 		'akismet',
 		array(
-			'name'           => __( 'Akismet Anti-Spam' ),
+			'name'           => __( 'Akismet Anti-spam' ),
 			'description'    => __( 'Protect your site from spam.' ),
 			'type'           => 'spam_filtering',
 			'plugin'         => array(

--- a/tests/phpunit/tests/connectors/wpConnectorsGetConnectorSettings.php
+++ b/tests/phpunit/tests/connectors/wpConnectorsGetConnectorSettings.php
@@ -37,8 +37,9 @@ class Tests_Connectors_WpGetConnectors extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'google', $connectors );
 		$this->assertArrayHasKey( 'openai', $connectors );
 		$this->assertArrayHasKey( 'anthropic', $connectors );
+		$this->assertArrayHasKey( 'akismet', $connectors );
 		$this->assertArrayHasKey( 'mock-connectors-test', $connectors );
-		$this->assertCount( 4, $connectors );
+		$this->assertCount( 5, $connectors );
 	}
 
 	/**
@@ -56,7 +57,7 @@ class Tests_Connectors_WpGetConnectors extends WP_UnitTestCase {
 			$this->assertArrayHasKey( 'description', $connector_data, "Connector '{$connector_id}' is missing 'description'." );
 			$this->assertIsString( $connector_data['description'], "Connector '{$connector_id}' description should be a string." );
 			$this->assertArrayHasKey( 'type', $connector_data, "Connector '{$connector_id}' is missing 'type'." );
-			$this->assertContains( $connector_data['type'], array( 'ai_provider' ), "Connector '{$connector_id}' has unexpected type '{$connector_data['type']}'." );
+			$this->assertContains( $connector_data['type'], array( 'ai_provider', 'spam_filtering' ), "Connector '{$connector_id}' has unexpected type '{$connector_data['type']}'." );
 			$this->assertArrayHasKey( 'authentication', $connector_data, "Connector '{$connector_id}' is missing 'authentication'." );
 			$this->assertIsArray( $connector_data['authentication'], "Connector '{$connector_id}' authentication should be an array." );
 			$this->assertArrayHasKey( 'method', $connector_data['authentication'], "Connector '{$connector_id}' authentication is missing 'method'." );
@@ -79,11 +80,16 @@ class Tests_Connectors_WpGetConnectors extends WP_UnitTestCase {
 			++$api_key_count;
 
 			$this->assertArrayHasKey( 'setting_name', $connector_data['authentication'], "Connector '{$connector_id}' authentication is missing 'setting_name'." );
-			$this->assertSame(
-				'connectors_ai_' . str_replace( '-', '_', $connector_id ) . '_api_key',
-				$connector_data['authentication']['setting_name'] ?? null,
-				"Connector '{$connector_id}' setting_name does not match expected format."
-			);
+
+			// AI providers use the connectors_ai_{id}_api_key convention.
+			// Non-AI connectors may use custom setting names.
+			if ( 'ai_provider' === $connector_data['type'] ) {
+				$this->assertSame(
+					'connectors_ai_' . str_replace( '-', '_', $connector_id ) . '_api_key',
+					$connector_data['authentication']['setting_name'] ?? null,
+					"Connector '{$connector_id}' setting_name does not match expected format."
+				);
+			}
 		}
 
 		$this->assertGreaterThan( 0, $api_key_count, 'At least one connector should use api_key authentication.' );

--- a/tests/phpunit/tests/rest-api/rest-settings-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-settings-controller.php
@@ -119,6 +119,7 @@ class WP_Test_REST_Settings_Controller extends WP_Test_REST_Controller_Testcase 
 			'default_ping_status',
 			'default_comment_status',
 			'site_icon', // Registered in wp-includes/blocks/site-logo.php
+			'wordpress_api_key', // Registered by Akismet connector.
 			'wp_collaboration_enabled',
 		);
 

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -11012,7 +11012,7 @@ mockedApiResponse.Schema = {
                     ],
                     "args": {
                         "wordpress_api_key": {
-                            "title": "Akismet Anti-spam API key",
+                            "title": "Akismet Anti-spam API Key",
                             "description": "API key for the Akismet Anti-spam connector.",
                             "type": "string",
                             "required": false

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -11013,7 +11013,7 @@ mockedApiResponse.Schema = {
                     "args": {
                         "wordpress_api_key": {
                             "title": "Akismet Anti-Spam API Key",
-                            "description": "API key for the Akismet Anti-Spam connector.",
+                            "description": "API key for the Akismet Anti-spam connector.",
                             "type": "string",
                             "required": false
                         },

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -11011,6 +11011,12 @@ mockedApiResponse.Schema = {
                         "PATCH"
                     ],
                     "args": {
+                        "wordpress_api_key": {
+                            "title": "Akismet Anti-Spam API Key",
+                            "description": "API key for the Akismet Anti-Spam connector.",
+                            "type": "string",
+                            "required": false
+                        },
                         "title": {
                             "title": "Title",
                             "description": "Site title.",
@@ -14544,6 +14550,7 @@ mockedApiResponse.CommentModel = {
 };
 
 mockedApiResponse.settings = {
+    "wordpress_api_key": "",
     "title": "Test Blog",
     "description": "",
     "url": "http://example.org",

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -11012,7 +11012,7 @@ mockedApiResponse.Schema = {
                     ],
                     "args": {
                         "wordpress_api_key": {
-                            "title": "Akismet Anti-Spam API Key",
+                            "title": "Akismet Anti-spam API key",
                             "description": "API key for the Akismet Anti-spam connector.",
                             "type": "string",
                             "required": false


### PR DESCRIPTION
## Summary
Akismet comes with core but the connectors screen was not showing akismet even if akismet was on the file system. This PR fixes the issue.
Register Akismet Anti-Spam as a built-in non-AI connector with `spam_filtering` type.

- Uses the existing `wordpress_api_key` WordPress option for API key storage
- Checks the `WPCOM_API_KEY` PHP constant

Ticket: https://core.trac.wordpress.org/ticket/65012

## Testing
Verify the akismet connector works as expected:
- Test the default activation flow.
- Delete Akismet and test the installation flow. Set an Akismet key verify it shows as connected, on the connectors and on the Akismet own settings page.
- Set a key on Akismet settings page verify it is reflected on the connectors screen.
- Set a key using wp-config define( 'WPCOM_API_KEY', 'your-key' ); verify the connectors reflect the key was set on wp-config.


See also: https://github.com/WordPress/gutenberg/pull/76828