### PR TITLE
I18N: Add translator context to "Notes" label in Link Manager to disambiguate from editor Notes feature

### DIFF
--- a/src/wp-admin/includes/meta-boxes.php
+++ b/src/wp-admin/includes/meta-boxes.php
@@ -1453,7 +1453,14 @@ function link_advanced_meta_box( $link ) {
 		<td><input name="link_rss" class="code" type="text" id="rss_uri" maxlength="255" value="<?php echo ( isset( $link->link_rss ) ? esc_attr( $link->link_rss ) : '' ); ?>" /></td>
 	</tr>
 	<tr>
-		<th scope="row"><label for="link_notes"><?php _e( 'Notes' ); ?></label></th>
+		<th scope="row">
+			<label for="link_notes">
+				<?php
+				/* translators: Label for the Notes textarea in the Link Manager edit screen. */
+				_ex( 'Notes', 'link manager notes field label' );
+				?>
+			</label>
+		</th>
 		<td><textarea name="link_notes" id="link_notes" rows="10"><?php echo $link->link_notes ?? ''; // textarea_escaped ?></textarea></td>
 	</tr>
 	<tr>


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->

## Summary

Fixes a translation ambiguity where the string `"Notes"` is used in two distinct UI contexts with different meanings, causing conflicts for translators (e.g. German requires "Anmerkungen" for the Link Manager field vs. "Notiz" for the editor collaborative Notes feature).

## Changes

- **`src/wp-admin/includes/meta-boxes.php`** — Replaced `_e( 'Notes' )` with `_ex( 'Notes', 'link manager notes field label' )` and added a `/* translators: */` comment on the Notes textarea label in the Link Manager edit screen.

## Why

WordPress 6.9 introduced a collaborative "Notes" feature in the block editor. Both it and the pre-existing Link Manager "Notes" field share the same bare translation string, making it impossible for translators to supply different translations for each context. Using `_ex()` with a context string resolves this ambiguity per [WordPress i18n best practices](https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/#disambiguation-by-context).

## Testing

No behavioral change — this is a translation context fix only. Verify by confirming the Link Manager edit screen still renders the "Notes" label correctly.

---

Trac ticket: https://core.trac.wordpress.org/ticket/64980

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
