### PR TITLE
I18N: Use _x() with verb context for translatable 'Reply' strings

### DIFF
--- a/src/js/_enqueues/admin/edit-comments.js
+++ b/src/js/_enqueues/admin/edit-comments.js
@@ -14,7 +14,7 @@ var getCount, updateCount, updateCountText, updatePending, updateApproved,
 	updateHtmlTitle, updateDashboardText, updateInModerationText, adminTitle = document.title,
 	isDashboard = $('#dashboard_right_now').length,
 	titleDiv, titleRegEx,
-	__ = wp.i18n.__;
+	__ = wp.i18n.__, _x = wp.i18n._x;
 
 	/**
 	 * Extracts a number from the content of a jQuery element.
@@ -370,7 +370,8 @@ window.setCommentsList = function() {
 
 		} else {
 			if ( settings.data.id == replyID )
-				replyButton.text( __( 'Reply' ) );
+				/* translators: Comment reply button text. */
+				replyButton.text( _x( 'Reply', 'verb' ) );
 
 			c.find( '.row-actions span.view' ).removeClass( 'hidden' ).end()
 				.find( 'div.comment_status' ).html( '1' );
@@ -1012,7 +1013,8 @@ window.commentReply = {
 			if ( c.hasClass('unapproved') ) {
 				replyButton.text( __( 'Approve and Reply' ) );
 			} else {
-				replyButton.text( __( 'Reply' ) );
+				/* translators: Comment reply button text. */
+				replyButton.text( _x( 'Reply', 'verb' ) );
 			}
 
 			$('#replyrow').fadeIn(300, function(){ $(this).show(); });

--- a/src/wp-admin/includes/class-wp-comments-list-table.php
+++ b/src/wp-admin/includes/class-wp-comments-list-table.php
@@ -875,7 +875,8 @@ class WP_Comments_List_Table extends WP_List_Table {
 				'replyto',
 				'vim-r comment-inline',
 				esc_attr__( 'Reply to this comment' ),
-				__( 'Reply' )
+				/* translators: Comment reply button text. */
+				_x( 'Reply', 'verb' )
 			);
 		}
 

--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -772,7 +772,8 @@ function _wp_dashboard_recent_comments_row( &$comment, $show_date = true ) {
 			$comment->comment_ID,
 			$comment->comment_post_ID,
 			esc_attr__( 'Reply to this comment' ),
-			__( 'Reply' )
+			/* translators: Comment reply button text. */
+			_x( 'Reply', 'verb' )
 		);
 
 		$actions['spam'] = sprintf(

--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -1756,7 +1756,8 @@ function get_comment_reply_link( $args = array(), $comment = null, $post = null 
 	$defaults = array(
 		'add_below'          => 'comment',
 		'respond_id'         => 'respond',
-		'reply_text'         => __( 'Reply' ),
+		/* translators: Comment reply button text. */
+		'reply_text'         => _x( 'Reply', 'verb' ),
 		/* translators: Comment reply button text. %s: Comment author name. */
 		'reply_to_text'      => __( 'Reply to %s' ),
 		'login_text'         => __( 'Log in to Reply' ),


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->

## Summary

Fixes the ambiguous translation of the string `'Reply'` used as a button/link label in comments UI. In some languages (e.g., German), "Reply" as a noun and as an imperative verb translate differently. Without a translator context, GlotPress cannot distinguish between uses, leading to mistranslations.

Replaces all `__( 'Reply' )` occurrences with `_x( 'Reply', 'verb' )` and adds `/* translators: */` docblock comments, consistent with the existing pattern used for `_x( 'Spam', 'verb' )` in the same codebase.

## Changes

- **`src/wp-admin/includes/dashboard.php`** — Use `_x()` for Reply button in dashboard comment actions.
- **`src/wp-admin/includes/class-wp-comments-list-table.php`** — Use `_x()` for Reply button in comments list table row actions.
- **`src/wp-includes/comment-template.php`** — Use `_x()` for default `reply_text` in `get_comment_reply_link()`.
- **`src/js/_enqueues/admin/edit-comments.js`** — Expose `wp.i18n._x` alongside `wp.i18n.__`, and use `_x()` for both Reply button text assignments.

## Testing

1. Verify the comments admin screens (`/wp-admin/edit-comments.php`) still show "Reply" buttons correctly.
2. Verify the comment reply link renders correctly on the front end.
3. Verify the dashboard Recent Comments widget still shows a "Reply" action link.
4. Optionally: confirm the new `verb` context appears in GlotPress under the `wp/dev` project strings for `'Reply'`.

---

Trac ticket: https://core.trac.wordpress.org/ticket/64984

---

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

AI assistance: Yes
Tool(s): GitHub Copilot
Model(s): Claude Sonnet 4.6
Used for: Identifying all affected locations, implementing the `_x()` replacements, and drafting this PR description; changes were reviewed before submission.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
