### PR TITLE
Block Hooks: Fix bug with RTC

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1196,6 +1196,7 @@ function apply_block_hooks_to_content( $content, $context = null, $callback = 'i
  * of the block that corresponds to the post type are handled correctly.
  *
  * @since 6.8.0
+ * @since 7.0.0 Added the `$ignored_hooked_blocks_at_root` parameter.
  * @access private
  *
  * @param string       $content  Serialized content.
@@ -1205,9 +1206,17 @@ function apply_block_hooks_to_content( $content, $context = null, $callback = 'i
  * @param callable     $callback A function that will be called for each block to generate
  *                               the markup for a given list of blocks that are hooked to it.
  *                               Default: 'insert_hooked_blocks'.
+ * @param array|null   $ignored_hooked_blocks_at_root A reference to an array that will be populated
+ *                               with the ignored hooked blocks at the root level.
+ *                               Default: `null`.
  * @return string The serialized markup.
  */
-function apply_block_hooks_to_content_from_post_object( $content, $post = null, $callback = 'insert_hooked_blocks' ) {
+function apply_block_hooks_to_content_from_post_object(
+	$content,
+	$post = null,
+	$callback = 'insert_hooked_blocks',
+	&$ignored_hooked_blocks_at_root = null
+) {
 	// Default to the current post if no context is provided.
 	if ( null === $post ) {
 		$post = get_post();
@@ -1286,6 +1295,16 @@ function apply_block_hooks_to_content_from_post_object( $content, $post = null, 
 	add_filter( 'hooked_block_types', $suppress_blocks_from_insertion_before_and_after_wrapper_block, PHP_INT_MAX, 3 );
 	$content = apply_block_hooks_to_content( $content, $post, $callback );
 	remove_filter( 'hooked_block_types', $suppress_blocks_from_insertion_before_and_after_wrapper_block, PHP_INT_MAX );
+
+	if ( null !== $ignored_hooked_blocks_at_root ) {
+		// Check wrapper block's metadata for ignored hooked blocks at the root level, and populate the reference parameter if needed.
+		$wrapper_block_markup = extract_serialized_parent_block( $content );
+		$wrapper_block        = parse_blocks( $wrapper_block_markup )[0];
+
+		if ( ! empty( $wrapper_block['attrs']['metadata']['ignoredHookedBlocks'] ) ) {
+			$ignored_hooked_blocks_at_root = $wrapper_block['attrs']['metadata']['ignoredHookedBlocks'];
+		}
+	}
 
 	// Finally, we need to remove the temporary wrapper block.
 	$content = remove_serialized_parent_block( $content );
@@ -1449,6 +1468,7 @@ function insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata( &$parsed_a
  *
  * @since 6.6.0
  * @since 6.8.0 Support non-`wp_navigation` post types.
+ * @since 7.0.0 Set `_wp_ignored_hooked_blocks` meta in the response for blocks hooked at the root level.
  *
  * @param WP_REST_Response $response The response object.
  * @param WP_Post          $post     Post object.
@@ -1459,11 +1479,17 @@ function insert_hooked_blocks_into_rest_response( $response, $post ) {
 		return $response;
 	}
 
+	$ignored_hooked_blocks_at_root    = array();
 	$response->data['content']['raw'] = apply_block_hooks_to_content_from_post_object(
 		$response->data['content']['raw'],
 		$post,
-		'insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata'
+		'insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata',
+		$ignored_hooked_blocks_at_root
 	);
+
+	if ( ! empty( $ignored_hooked_blocks_at_root ) ) {
+		$response->data['meta']['_wp_ignored_hooked_blocks'] = wp_json_encode( $ignored_hooked_blocks_at_root );
+	}
 
 	// If the rendered content was previously empty, we leave it like that.
 	if ( empty( $response->data['content']['rendered'] ) ) {

--- a/tests/phpunit/tests/blocks/applyBlockHooksToContentFromPostObject.php
+++ b/tests/phpunit/tests/blocks/applyBlockHooksToContentFromPostObject.php
@@ -131,20 +131,58 @@ class Tests_Blocks_ApplyBlockHooksToContentFromPostObject extends WP_UnitTestCas
 	}
 
 	/**
+	 * @ticket 65008
+	 */
+	public function test_apply_block_hooks_to_content_from_post_object_sets_ignored_hooked_blocks() {
+		$ignored_hooked_blocks_at_root = array();
+
+		$expected = '<!-- wp:tests/hooked-block-first-child /-->' .
+			'<!-- wp:heading {"level":1,"metadata":{"ignoredHookedBlocks":["tests/hooked-block"]}} -->' .
+			'<h1>Hello World!</h1>' .
+			'<!-- /wp:heading -->' .
+			'<!-- wp:tests/hooked-block /-->';
+		$actual   = apply_block_hooks_to_content_from_post_object(
+			self::$post->post_content,
+			self::$post,
+			'insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata',
+			$ignored_hooked_blocks_at_root
+		);
+		$this->assertSame( $expected, $actual, "Markup wasn't updated correctly." );
+		$this->assertSame(
+			array( 'tests/hooked-block-first-child' ),
+			$ignored_hooked_blocks_at_root,
+			"Hooked block added at 'first_child' position wasn't added to ignoredHookedBlocks metadata."
+		);
+	}
+
+	/**
 	 * @ticket 62716
+	 * @ticket 65008
 	 */
 	public function test_apply_block_hooks_to_content_from_post_object_respects_ignored_hooked_blocks_post_meta() {
-		$expected = self::$post_with_ignored_hooked_block->post_content . '<!-- wp:tests/hooked-block /-->';
+		$ignored_hooked_blocks_at_root = array();
+
+		$expected = '<!-- wp:heading {"level":1,"metadata":{"ignoredHookedBlocks":["tests/hooked-block"]}} -->' .
+			'<h1>Hello World!</h1>' .
+			'<!-- /wp:heading -->' .
+			'<!-- wp:tests/hooked-block /-->';
 		$actual   = apply_block_hooks_to_content_from_post_object(
 			self::$post_with_ignored_hooked_block->post_content,
 			self::$post_with_ignored_hooked_block,
-			'insert_hooked_blocks'
+			'insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata',
+			$ignored_hooked_blocks_at_root
 		);
 		$this->assertSame( $expected, $actual );
+		$this->assertSame(
+			array( 'tests/hooked-block-first-child' ),
+			$ignored_hooked_blocks_at_root,
+			"Pre-existing ignored hooked block at root level wasn't reflected in metadata."
+		);
 	}
 
 	/**
 	 * @ticket 63287
+	 * @ticket 65008
 	 */
 	public function test_apply_block_hooks_to_content_from_post_object_does_not_insert_hooked_block_before_container_block() {
 		$filter = function ( $hooked_block_types, $relative_position, $anchor_block_type ) {
@@ -155,31 +193,50 @@ class Tests_Blocks_ApplyBlockHooksToContentFromPostObject extends WP_UnitTestCas
 			return $hooked_block_types;
 		};
 
+		$ignored_hooked_blocks_at_root = array();
+
 		$expected = '<!-- wp:tests/hooked-block-first-child /-->' .
-			self::$post->post_content .
+			'<!-- wp:heading {"level":1,"metadata":{"ignoredHookedBlocks":["tests/hooked-block"]}} -->' .
+			'<h1>Hello World!</h1>' .
+			'<!-- /wp:heading -->' .
 			'<!-- wp:tests/hooked-block /-->';
 
 		add_filter( 'hooked_block_types', $filter, 10, 3 );
 		$actual = apply_block_hooks_to_content_from_post_object(
 			self::$post->post_content,
 			self::$post,
-			'insert_hooked_blocks'
+			'insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata',
+			$ignored_hooked_blocks_at_root
 		);
 		remove_filter( 'hooked_block_types', $filter, 10 );
 
-		$this->assertSame( $expected, $actual );
+		$this->assertSame( $expected, $actual, "Hooked block added before 'core/post-content' block shouldn't be inserted." );
+		$this->assertSame(
+			array( 'tests/hooked-block-first-child' ),
+			$ignored_hooked_blocks_at_root,
+			"ignoredHookedBlocks metadata wasn't set correctly."
+		);
 	}
 
 	/**
 	 * @ticket 62716
+	 * @ticket 65008
 	 */
 	public function test_apply_block_hooks_to_content_from_post_object_inserts_hooked_block_if_content_contains_no_blocks() {
+		$ignored_hooked_blocks_at_root = array();
+
 		$expected = '<!-- wp:tests/hooked-block-first-child /-->' . self::$post_with_non_block_content->post_content;
 		$actual   = apply_block_hooks_to_content_from_post_object(
 			self::$post_with_non_block_content->post_content,
 			self::$post_with_non_block_content,
-			'insert_hooked_blocks'
+			'insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata',
+			$ignored_hooked_blocks_at_root
 		);
-		$this->assertSame( $expected, $actual );
+		$this->assertSame( $expected, $actual, "Markup wasn't updated correctly." );
+		$this->assertSame(
+			array( 'tests/hooked-block-first-child' ),
+			$ignored_hooked_blocks_at_root,
+			"Hooked block added at 'first_child' position wasn't added to ignoredHookedBlocks metadata."
+		);
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/76176.

Trac ticket: https://core.trac.wordpress.org/ticket/65008

See https://github.com/WordPress/gutenberg/pull/76895#issuecomment-4162625780 and https://github.com/WordPress/gutenberg/pull/76895#issuecomment-4163602210 for more details.

## Testing Instructions

_tl;dr:_ Verify that https://github.com/WordPress/gutenberg/issues/76176 is fixed.

## TODO

- [x] This needs more work, mostly in terms of performance: It adds another full traversal of a given post's block tree, which we should be able to avoid by more cleverly extracting information that's readily available from an earlier traversal, but it will require rethinking some interfaces.
- [x] Test coverage for the new argument and behavior of `apply_block_hooks_to_content_from_post_object`.

I also need to double-check if it has any other unwanted side effects (unit test coverage should help with that).

## Use of AI Tools

“Autocomplete”-level assistance when updating unit tests (e.g. for assertion failure  messages).

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
