### PR TITLE
Ensure vendor scripts are present before `uglify`.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1837,6 +1837,7 @@ module.exports = function(grunt) {
 		'clean:js',
 		'build:webpack',
 		'copy:js',
+		'copy-vendor-scripts',
 		'file_append',
 		'uglify:all',
 		'concat:tinymce',
@@ -2133,7 +2134,6 @@ module.exports = function(grunt) {
 				'build:css',
 				'build:codemirror',
 				'build:gutenberg',
-				'copy-vendor-scripts',
 				'build:certificates'
 			] );
 		} else {
@@ -2145,7 +2145,6 @@ module.exports = function(grunt) {
 				'build:css',
 				'build:codemirror',
 				'build:gutenberg',
-				'copy-vendor-scripts',
 				'replace:source-maps',
 				'verify:build'
 			] );


### PR DESCRIPTION
This fixes a bug where the `moment.js` file is not present before the `uglify:all` Grunt task runs by moving the `copy-vendor-scripts` into the `build:js` task _before `uglify:all`.

The Moment.js files need to be present in the working directory before `uglify` because the built `moment.min.js` file includes `sourceMappingURL`s that need to be removed. See r48075 for Moment.js and r44740 for the `jquery.form.min.js` file.

Trac ticket: Core-65006.

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Sonnet 4.6
Used for: Comparing the current behavior to before the recent build script changes to determine what was different.