### PR TITLE
Privacy: Fix vertical alignment of Copied text

### DIFF
--- a/src/wp-admin/css/color-picker.css
+++ b/src/wp-admin/css/color-picker.css
@@ -10,7 +10,7 @@
 
 /* Needs higher specificity to override `.wp-core-ui .button`. */
 .wp-picker-container .wp-color-result.button {
-	min-height: 30px;
+	min-height: 32px;
 	margin: 0 6px 6px 0;
 	padding: 0 0 0 30px;
 	font-size: 11px;
@@ -22,7 +22,7 @@
 	border-left: 1px solid #c3c4c7;
 	color: #50575e;
 	display: block;
-	line-height: 2.54545455; /* 28px */
+	line-height: 2.72727273; /* 30px */
 	padding: 0 6px;
 	text-align: center;
 }
@@ -76,8 +76,8 @@
 .wp-customizer .wp-picker-input-wrap .button.wp-picker-clear {
 	margin-left: 6px;
 	padding: 0 8px;
-	line-height: 2.54545455; /* 28px */
-	min-height: 30px;
+	line-height: 2.72727273; /* 30px */
+	min-height: 32px;
 }
 
 .wp-picker-container .iris-square-slider .ui-slider-handle:focus {
@@ -97,7 +97,7 @@
 	margin: 0;
 	padding: 0 5px;
 	vertical-align: top;
-	min-height: 30px;
+	min-height: 32px;
 }
 
 .wp-color-picker::-webkit-input-placeholder {

--- a/src/wp-admin/css/color-picker.css
+++ b/src/wp-admin/css/color-picker.css
@@ -10,7 +10,7 @@
 
 /* Needs higher specificity to override `.wp-core-ui .button`. */
 .wp-picker-container .wp-color-result.button {
-	min-height: 32px;
+	min-height: 30px;
 	margin: 0 6px 6px 0;
 	padding: 0 0 0 30px;
 	font-size: 11px;
@@ -22,7 +22,7 @@
 	border-left: 1px solid #c3c4c7;
 	color: #50575e;
 	display: block;
-	line-height: 2.72727273; /* 30px */
+	line-height: 2.54545455; /* 28px */
 	padding: 0 6px;
 	text-align: center;
 }
@@ -76,8 +76,8 @@
 .wp-customizer .wp-picker-input-wrap .button.wp-picker-clear {
 	margin-left: 6px;
 	padding: 0 8px;
-	line-height: 2.72727273; /* 30px */
-	min-height: 32px;
+	line-height: 2.54545455; /* 28px */
+	min-height: 30px;
 }
 
 .wp-picker-container .iris-square-slider .ui-slider-handle:focus {
@@ -97,7 +97,7 @@
 	margin: 0;
 	padding: 0 5px;
 	vertical-align: top;
-	min-height: 32px;
+	min-height: 30px;
 }
 
 .wp-color-picker::-webkit-input-placeholder {

--- a/src/wp-admin/css/edit.css
+++ b/src/wp-admin/css/edit.css
@@ -1002,7 +1002,7 @@ form#tags-filter {
 	display: none;
 	color: #007017;
 	padding-right: 1em;
-	padding-top: 6px;
+	vertical-align: middle;
 }
 
 .privacy-settings-accordion-actions .success.visible {

--- a/src/wp-admin/css/edit.css
+++ b/src/wp-admin/css/edit.css
@@ -995,14 +995,15 @@ form#tags-filter {
 
 .privacy-settings-accordion-actions {
 	text-align: right;
-	display: block;
+	display: flex;
+	justify-content: flex-end;
+	align-items: center;
 }
 
 .privacy-settings-accordion-actions .success {
-	display: none;
-	color: #007017;
-	padding-right: 1em;
-	vertical-align: middle;
+	 display: none;
+	 color: #007017;
+	 padding-right: 1em;
 }
 
 .privacy-settings-accordion-actions .success.visible {


### PR DESCRIPTION
 Trac ticket: https://core.trac.wordpress.org/ticket/65009

## Description
Fixes the vertical alignment of the Copied text that appears after clicking the Copy suggested policy text to clipboard button.

## Changes
- Removed padding-top: 6px
- Added vertical-align: middle

in src/wp-admin/css/edit.css

## Testing
1. Go to wp-admin/options-privacy.php
2. Click the Copy button next to any policy section
3. The Copied text should now be vertically aligned with the button