### PR TITLE
Media: The progress bar color is outdated

### DIFF
--- a/src/wp-includes/css/media-views.css
+++ b/src/wp-includes/css/media-views.css
@@ -1409,7 +1409,7 @@
 	height: 10px;
 	min-width: 20px;
 	width: 0;
-	background: #2271b1;
+	background: var(--wp-admin-theme-color, #3858e9);
 	border-radius: 10px;
 	transition: width 300ms;
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/65010

Updates the Site Icon uploader bar color to match the dynamic admin theme color instead of hardcoded color

### Screenshots

After :

<img width="400" height="250" alt="image" src="https://github.com/user-attachments/assets/3ceb2cc4-80f0-4da1-a4c2-0cda693eb8d2" />

<img width="400" height="250" alt="image" src="https://github.com/user-attachments/assets/167a0201-b4f5-46ac-a4d0-bde22d314b58" />

Before: 

<img width="400" height="250" alt="image" src="https://github.com/user-attachments/assets/879a5be7-7b04-4931-b159-8f7e39834c3a" />

<img width="400" height="250" alt="image" src="https://github.com/user-attachments/assets/920d112e-cc2b-47c6-bb0a-96571858ab2c" />


### Steps to verify
- Go to Settings > General > Choose a Site Icon
- Upload a new media
- Check the progress bar color
---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
