### PR TITLE
Update cache invalidation to account for changes to post meta

### DIFF
--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -2883,6 +2883,11 @@ class WP_Query {
 				wp_cache_get_last_changed( 'posts' ),
 			);
 
+			// If this query has been filterd to include post meta table, then also include post meta last changed as part of the cache salt.
+			if ( str_contains( $comments_request, $wpdb->postmeta ) ) {
+				$last_changed[] = wp_cache_get_last_changed( 'post_meta' );
+			}
+
 			$cache_key   = "comment_feed:$key";
 			$comment_ids = wp_cache_get_salted( $cache_key, 'comment-queries', $last_changed );
 			if ( false === $comment_ids ) {
@@ -3248,6 +3253,11 @@ class WP_Query {
 		$last_changed = (array) wp_cache_get_last_changed( 'posts' );
 		if ( ! empty( $this->tax_query->queries ) ) {
 			$last_changed[] = wp_cache_get_last_changed( 'terms' );
+		}
+
+		// If meta query is present or postmeta is referenced in the request, salt cache key.
+		if ( ! empty( $this->meta_query->queries ) || str_contains( $this->request, $wpdb->postmeta ) ) {
+			$last_changed[] = wp_cache_get_last_changed( 'post_meta' );
 		}
 
 		if ( $query_vars['cache_results'] && $id_query_is_cacheable ) {

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -2880,7 +2880,7 @@ class WP_Query {
 			$key          = md5( $comments_request );
 			$last_changed = array(
 				wp_cache_get_last_changed( 'comment' ),
-				wp_cache_get_last_changed( 'posts' ),
+				wp_cache_get_last_changed( 'post-queries' ),
 			);
 
 			// If this query has been filterd to include post meta table, then also include post meta last changed as part of the cache salt.
@@ -3250,7 +3250,7 @@ class WP_Query {
 			$id_query_is_cacheable = false;
 		}
 
-		$last_changed = (array) wp_cache_get_last_changed( 'posts' );
+		$last_changed = (array) wp_cache_get_last_changed( 'post-queries' );
 		if ( ! empty( $this->tax_query->queries ) ) {
 			$last_changed[] = wp_cache_get_last_changed( 'terms' );
 		}

--- a/src/wp-includes/class-wp-user-query.php
+++ b/src/wp-includes/class-wp-user-query.php
@@ -1092,7 +1092,7 @@ class WP_User_Query {
 				switch_to_blog( $blog_id );
 			}
 
-			$last_changed[] = wp_cache_get_last_changed( 'posts' );
+			$last_changed[] = wp_cache_get_last_changed( 'post-queries' );
 
 			if ( $switch ) {
 				restore_current_blog();

--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -122,9 +122,9 @@ foreach ( array( 'user_register', 'deleted_user' ) as $action ) {
 }
 
 // Post meta.
-add_action( 'added_post_meta', 'wp_cache_set_posts_last_changed' );
-add_action( 'updated_post_meta', 'wp_cache_set_posts_last_changed' );
-add_action( 'deleted_post_meta', 'wp_cache_set_posts_last_changed' );
+add_action( 'added_post_meta', 'wp_cache_set_post_meta_last_changed' );
+add_action( 'updated_post_meta', 'wp_cache_set_post_meta_last_changed' );
+add_action( 'deleted_post_meta', 'wp_cache_set_post_meta_last_changed' );
 
 // User meta.
 add_action( 'added_user_meta', 'wp_cache_set_users_last_changed' );

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -2079,7 +2079,12 @@ function wp_get_archives( $args = '' ) {
 
 	$output = '';
 
-	$last_changed = wp_cache_get_last_changed( 'posts' );
+	$last_changed = (array) wp_cache_get_last_changed( 'posts' );
+
+	// If this query has been filtered to include post meta table, then also include post meta last changed as part of the cache salt.
+	if ( str_contains( $join, $wpdb->postmeta ) ) {
+		$last_changed[] = wp_cache_get_last_changed( 'post_meta' );
+	}
 
 	$limit = $parsed_args['limit'];
 

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -2079,7 +2079,7 @@ function wp_get_archives( $args = '' ) {
 
 	$output = '';
 
-	$last_changed = (array) wp_cache_get_last_changed( 'posts' );
+	$last_changed = (array) wp_cache_get_last_changed( 'post-queries' );
 
 	// If this query has been filtered to include post meta table, then also include post meta last changed as part of the cache salt.
 	if ( str_contains( $join, $wpdb->postmeta ) ) {

--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -2017,6 +2017,10 @@ function get_adjacent_post( $in_same_term = false, $excluded_terms = '', $previo
 	if ( $in_same_term || ! empty( $excluded_terms ) ) {
 		$last_changed[] = wp_cache_get_last_changed( 'terms' );
 	}
+	// If this query has been filtered to include post meta table, then also include post meta last changed as part of the cache salt.
+	if ( str_contains( $query, $wpdb->postmeta ) ) {
+		$last_changed[] = wp_cache_get_last_changed( 'post_meta' );
+	}
 	$cache_key = "adjacent_post:$key";
 
 	$result = wp_cache_get_salted( $cache_key, 'post-queries', $last_changed );

--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -2013,7 +2013,7 @@ function get_adjacent_post( $in_same_term = false, $excluded_terms = '', $previo
 
 	$query        = "SELECT p.ID FROM $wpdb->posts AS p $join $where $sort";
 	$key          = md5( $query );
-	$last_changed = (array) wp_cache_get_last_changed( 'posts' );
+	$last_changed = (array) wp_cache_get_last_changed( 'post-queries' );
 	if ( $in_same_term || ! empty( $excluded_terms ) ) {
 		$last_changed[] = wp_cache_get_last_changed( 'terms' );
 	}

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -8451,6 +8451,15 @@ function wp_cache_set_posts_last_changed() {
 }
 
 /**
+ * Sets the last changed time for the 'posts' cache group.
+ *
+ * @since 7.0.0
+ */
+function wp_cache_set_post_meta_last_changed() {
+	wp_cache_set_last_changed( 'post_meta' );
+}
+
+/**
  * Gets all available post MIME types for a given post type.
  *
  * @since 2.5.0

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -6190,7 +6190,7 @@ function get_page( $page, $output = OBJECT, $filter = 'raw' ) {
 function get_page_by_path( $page_path, $output = OBJECT, $post_type = 'page' ) {
 	global $wpdb;
 
-	$last_changed = wp_cache_get_last_changed( 'posts' );
+	$last_changed = wp_cache_get_last_changed( 'post-queries' );
 
 	$hash      = md5( $page_path . serialize( $post_type ) );
 	$cache_key = "get_page_by_path:$hash";
@@ -8448,6 +8448,7 @@ function wp_add_trashed_suffix_to_post_name_for_post( $post ) {
  */
 function wp_cache_set_posts_last_changed() {
 	wp_cache_set_last_changed( 'posts' );
+	wp_cache_set_last_changed( 'post-queries' );
 }
 
 /**
@@ -8456,6 +8457,7 @@ function wp_cache_set_posts_last_changed() {
  * @since 7.0.0
  */
 function wp_cache_set_post_meta_last_changed() {
+    wp_cache_set_last_changed( 'posts' );
 	wp_cache_set_last_changed( 'post_meta' );
 }
 

--- a/src/wp-includes/query.php
+++ b/src/wp-includes/query.php
@@ -1155,7 +1155,7 @@ function _find_post_by_old_slug( $post_type ) {
 
 	$key          = md5( $query );
 	$last_changed = array(
-		wp_cache_get_last_changed( 'posts' ),
+		wp_cache_get_last_changed( 'post-queries' ),
 		wp_cache_get_last_changed( 'post_meta' ),
 	);
 	$cache_key    = "find_post_by_old_slug:$key";
@@ -1201,7 +1201,7 @@ function _find_post_by_old_date( $post_type ) {
 		$query        = $wpdb->prepare( "SELECT post_id FROM $wpdb->postmeta AS pm_date, $wpdb->posts WHERE ID = post_id AND post_type = %s AND meta_key = '_wp_old_date' AND post_name = %s" . $date_query, $post_type, get_query_var( 'name' ) );
 		$key          = md5( $query );
 		$last_changed = array(
-			wp_cache_get_last_changed( 'posts' ),
+			wp_cache_get_last_changed( 'post-queries' ),
 			wp_cache_get_last_changed( 'post_meta' ),
 		);
 		$cache_key    = "find_post_by_old_date:$key";

--- a/src/wp-includes/query.php
+++ b/src/wp-includes/query.php
@@ -1154,7 +1154,10 @@ function _find_post_by_old_slug( $post_type ) {
 	}
 
 	$key          = md5( $query );
-	$last_changed = wp_cache_get_last_changed( 'posts' );
+	$last_changed = array(
+		wp_cache_get_last_changed( 'posts' ),
+		wp_cache_get_last_changed( 'post_meta' ),
+	);
 	$cache_key    = "find_post_by_old_slug:$key";
 	$cache        = wp_cache_get_salted( $cache_key, 'post-queries', $last_changed );
 	if ( false !== $cache ) {
@@ -1197,7 +1200,10 @@ function _find_post_by_old_date( $post_type ) {
 	if ( $date_query ) {
 		$query        = $wpdb->prepare( "SELECT post_id FROM $wpdb->postmeta AS pm_date, $wpdb->posts WHERE ID = post_id AND post_type = %s AND meta_key = '_wp_old_date' AND post_name = %s" . $date_query, $post_type, get_query_var( 'name' ) );
 		$key          = md5( $query );
-		$last_changed = wp_cache_get_last_changed( 'posts' );
+		$last_changed = array(
+			wp_cache_get_last_changed( 'posts' ),
+			wp_cache_get_last_changed( 'post_meta' ),
+		);
 		$cache_key    = "find_post_by_old_date:$key";
 		$cache        = wp_cache_get_salted( $cache_key, 'post-queries', $last_changed );
 		if ( false !== $cache ) {

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -622,7 +622,7 @@ function count_user_posts( $userid, $post_type = 'post', $public_only = false ) 
 	$where = get_posts_by_author_sql( $post_type, true, $userid, $public_only );
 	$query = "SELECT COUNT(*) FROM $wpdb->posts $where";
 
-	$last_changed = wp_cache_get_last_changed( 'posts' );
+	$last_changed = wp_cache_get_last_changed( 'post-queries' );
 	$cache_key    = 'count_user_posts:' . md5( $query );
 	$count        = wp_cache_get_salted( $cache_key, 'post-queries', $last_changed );
 	if ( false === $count ) {
@@ -695,7 +695,7 @@ function count_many_users_posts( $users, $post_type = 'post', $public_only = fal
 	$where       = get_posts_by_author_sql( $post_type, true, null, $public_only );
 	$query       = "SELECT post_author, COUNT(*) FROM $wpdb->posts $where AND post_author IN ($userlist) GROUP BY post_author";
 	$cache_key   = 'count_many_users_posts:' . md5( $query );
-	$cache_salts = array( wp_cache_get_last_changed( 'posts' ), wp_cache_get_last_changed( 'users' ) );
+	$cache_salts = array( wp_cache_get_last_changed( 'post-queries' ), wp_cache_get_last_changed( 'users' ) );
 	$count       = wp_cache_get_salted( $cache_key, 'post-queries', $cache_salts );
 
 	if ( false === $count ) {


### PR DESCRIPTION
- Introduced `wp_cache_set_post_meta_last_changed` to manage the 'post_meta' cache group.
- Updated relevant functions and queries to include 'post_meta' in cache invalidation logic where applicable.
- Ensured proper salting of cache keys when post meta data is involved in queries.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/64696

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
