### PR TITLE
Code Quality: Remove unused `$hooked_blocks` variable in `get_all_registered()`

### DIFF
--- a/src/wp-includes/class-wp-block-patterns-registry.php
+++ b/src/wp-includes/class-wp-block-patterns-registry.php
@@ -227,10 +227,9 @@ final class WP_Block_Patterns_Registry {
 	 *                 and per style.
 	 */
 	public function get_all_registered( $outside_init_only = false ) {
-		$patterns      = $outside_init_only
+		$patterns = $outside_init_only
 				? $this->registered_patterns_outside_init
 				: $this->registered_patterns;
-		$hooked_blocks = get_hooked_blocks();
 
 		foreach ( $patterns as $index => $pattern ) {
 			$content                       = $this->get_content( $pattern['name'], $outside_init_only );


### PR DESCRIPTION
The unused variable `$hooked_blocks` in `WP_Block_Patterns_Registry->get_all_registered()` has been removed.

Introduced in: https://core.trac.wordpress.org/changeset/56805/trunk/src/wp-includes/class-wp-block-patterns-registry.php
Unused since: https://core.trac.wordpress.org/changeset/59101/trunk/src/wp-includes/class-wp-block-patterns-registry.php

Trac ticket: https://core.trac.wordpress.org/ticket/64898

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
