### PR TITLE
fix: clarify error message for request authentication in connector

### DIFF
--- a/src/wp-includes/php-ai-client/src/Providers/Http/Traits/WithRequestAuthenticationTrait.php
+++ b/src/wp-includes/php-ai-client/src/Providers/Http/Traits/WithRequestAuthenticationTrait.php
@@ -33,7 +33,7 @@ trait WithRequestAuthenticationTrait
     public function getRequestAuthentication(): RequestAuthenticationInterface
     {
         if ($this->requestAuthentication === null) {
-            throw new RuntimeException('RequestAuthenticationInterface instance not set. ' . 'Make sure you use the AiClient class for all requests.');
+            throw new RuntimeException('Image generation isn’t available because it hasn’t been set up yet. Please add an API key for an image-generation provider in Connectors, then try again.');
         }
         return $this->requestAuthentication;
     }


### PR DESCRIPTION
This pull request updates the error message thrown when request authentication is not set in the image generation client. The new message is more user-friendly and provides clear instructions for resolving the issue.

Trac ticket: https://core.trac.wordpress.org/ticket/64917

Error handling improvement:

* Updated the exception message in `WithRequestAuthenticationTrait.php` to clearly inform users that image generation requires setup and instruct them to add an API key for an image-generation provider in Connectors.