### PR TITLE
Post Types: Add 'at_a_glance' property and update dashboard widget logic. Fixes #45035.

### DIFF
--- a/src/wp-admin/css/dashboard.css
+++ b/src/wp-admin/css/dashboard.css
@@ -445,22 +445,8 @@
 #dashboard_right_now li a:before,
 #dashboard_right_now li > span:before { /* get only the first level span to exclude screen-reader-text in mu-storage */
 	padding: 0 5px 0 0;
-	/* generic icon for items added by CPTs ? */
-	content: "\f159";
-	content: "\f159" / '';
 }
 
-#dashboard_right_now .page-count a:before,
-#dashboard_right_now .page-count span:before {
-	content: "\f105";
-	content: "\f105" / '';
-}
-
-#dashboard_right_now .post-count a:before,
-#dashboard_right_now .post-count span:before {
-	content: "\f109";
-	content: "\f109" / '';
-}
 
 #dashboard_right_now .comment-count a:before {
 	content: "\f101";

--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -302,23 +302,42 @@ function wp_dashboard_right_now() {
 	<div class="main">
 	<ul>
 	<?php
-	// Posts and Pages.
-	foreach ( array( 'post', 'page' ) as $post_type ) {
-		$num_posts = wp_count_posts( $post_type );
+	// At a Glance Post Types.
+	foreach ( get_post_types( array( 'at_a_glance' => true ), 'objects' ) as $post_type_object ) {
+		$post_type          = $post_type_object->name;
+		$num_posts          = wp_count_posts( $post_type );
+		$num_post_published = intval( $num_posts->publish );
 
-		if ( $num_posts && $num_posts->publish ) {
-			if ( 'post' === $post_type ) {
-				/* translators: %s: Number of posts. */
-				$text = _n( '%s Published post', '%s Published posts', $num_posts->publish );
+		if ( $num_posts && $num_post_published ) {
+			if ( 1 === $num_post_published ) {
+				$post_label = $post_type_object->labels->singular_name;
 			} else {
-				/* translators: %s: Number of pages. */
-				$text = _n( '%s Published page', '%s Published pages', $num_posts->publish );
+				$post_label = $post_type_object->labels->name;
+			}
+			$text = number_format_i18n( $num_post_published ) . ' ' . $post_label;
+
+			$icon_class = '';
+
+			if ( str_starts_with( $post_type_object->menu_icon, 'dashicons-' ) ) {
+				$icon_class = $post_type_object->menu_icon;
+			} elseif ( str_starts_with( $post_type_object->menu_icon, 'data:image/svg+xml;base64,' ) ) {
+				printf(
+					'<style>
+#dashboard_right_now li.%1$s-count a:before,
+#dashboard_right_now li.%1$s-count > span:before {
+	content: url( \'%2$s\' );
+	height: auto;
+	width: 20px;
+}
+</style>',
+					$post_type,
+					$post_type_object->menu_icon
+				);
 			}
 
-			$text             = sprintf( $text, number_format_i18n( $num_posts->publish ) );
-			$post_type_object = get_post_type_object( $post_type );
+			$class_attr = $icon_class ? sprintf( ' class="%s"', $icon_class ) : '';
 
-			if ( $post_type_object && current_user_can( $post_type_object->cap->edit_posts ) ) {
+			if ( current_user_can( $post_type_object->cap->edit_posts ) ) {
 				$url = add_query_arg(
 					array(
 						'post_status' => 'publish',
@@ -326,9 +345,9 @@ function wp_dashboard_right_now() {
 					),
 					admin_url( 'edit.php' )
 				);
-				printf( '<li class="%1$s-count"><a href="%2$s">%3$s</a></li>', $post_type, esc_url( $url ), esc_html( $text ) );
+				printf( '<li class="%1$s-count"><a%3$s href="%2$s">%4$s</a></li>', $post_type, esc_url( $url ), $class_attr, esc_html( $text ) );
 			} else {
-				printf( '<li class="%1$s-count"><span>%2$s</span></li>', $post_type, $text );
+				printf( '<li class="%1$s-count"><span%3$s>%2$s</span></li>', $post_type, esc_html( $text ), $class_attr );
 			}
 		}
 	}

--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -317,10 +317,11 @@ function wp_dashboard_right_now() {
 			$text = number_format_i18n( $num_post_published ) . ' ' . $post_label;
 
 			$icon_class = '';
+			$menu_icon  = $post_type_object->menu_icon ?? 'dashicons-admin-post';
 
-			if ( str_starts_with( $post_type_object->menu_icon, 'dashicons-' ) ) {
-				$icon_class = $post_type_object->menu_icon;
-			} elseif ( str_starts_with( $post_type_object->menu_icon, 'data:image/svg+xml;base64,' ) ) {
+			if ( str_starts_with( $menu_icon, 'dashicons-' ) ) {
+				$icon_class = $menu_icon;
+			} elseif ( str_starts_with( $menu_icon, 'data:image/svg+xml;base64,' ) ) {
 				printf(
 					'<style>
 #dashboard_right_now li.%1$s-count a:before,
@@ -331,7 +332,7 @@ function wp_dashboard_right_now() {
 }
 </style>',
 					$post_type,
-					$post_type_object->menu_icon
+					$menu_icon
 				);
 			}
 

--- a/src/wp-includes/class-wp-post-type.php
+++ b/src/wp-includes/class-wp-post-type.php
@@ -608,11 +608,6 @@ final class WP_Post_Type {
 			$args['at_a_glance'] = (bool) $args['show_in_menu'];
 		}
 
-		// If not set, default to the post icon.
-		if ( null === $args['menu_icon'] ) {
-			$args['menu_icon'] = 'dashicons-admin-post';
-		}
-
 		// If not set, default to the setting for 'show_in_menu'.
 		if ( null === $args['show_in_admin_bar'] ) {
 			$args['show_in_admin_bar'] = (bool) $args['show_in_menu'];

--- a/src/wp-includes/class-wp-post-type.php
+++ b/src/wp-includes/class-wp-post-type.php
@@ -148,6 +148,16 @@ final class WP_Post_Type {
 	public $show_in_menu = null;
 
 	/**
+	 * Makes this post type visible in the At a Glance dashboard widget.
+	 *
+	 * Default is the value of $show_in_menu.
+	 *
+	 * @since 7.0.0
+	 * @var bool $at_a_glance
+	 */
+	public $at_a_glance = null;
+
+	/**
 	 * Makes this post type available for selection in navigation menus.
 	 *
 	 * Default is the value $public.
@@ -190,7 +200,7 @@ final class WP_Post_Type {
 	 * @since 4.6.0
 	 * @var string $menu_icon
 	 */
-	public $menu_icon = null;
+	public $menu_icon;
 
 	/**
 	 * The string to use to build the read, edit, and delete capabilities.
@@ -539,6 +549,7 @@ final class WP_Post_Type {
 			'show_in_admin_bar'               => null,
 			'menu_position'                   => null,
 			'menu_icon'                       => null,
+			'at_a_glance'                     => null,
 			'capability_type'                 => 'post',
 			'capabilities'                    => array(),
 			'map_meta_cap'                    => null,
@@ -590,6 +601,16 @@ final class WP_Post_Type {
 		// If not set, default to the setting for 'show_ui'.
 		if ( null === $args['show_in_menu'] || ! $args['show_ui'] ) {
 			$args['show_in_menu'] = $args['show_ui'];
+		}
+
+		// If not set, default to the setting for show_in_menu.
+		if ( null === $args['at_a_glance'] ) {
+			$args['at_a_glance'] = (bool) $args['show_in_menu'];
+		}
+
+		// If not set, default to the post icon.
+		if ( null === $args['menu_icon'] ) {
+			$args['menu_icon'] = 'dashicons-admin-post';
 		}
 
 		// If not set, default to the setting for 'show_in_menu'.

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -103,6 +103,7 @@ function create_initial_post_types() {
 			),
 			'public'                => true,
 			'show_ui'               => true,
+			'at_a_glance'           => false,
 			'_builtin'              => true, /* internal use only. don't use this when registering your own post type. */
 			'_edit_link'            => 'post.php?post=%d', /* internal use only. don't use this when registering your own post type. */
 			'capability_type'       => 'post',
@@ -1771,6 +1772,8 @@ function get_post_types( $args = array(), $output = 'names', $operator = 'and' )
  *                                                         of a Dashicons helper class to use a font icon, e.g.
  *                                                        'dashicons-chart-pie'. Pass 'none' to leave div.wp-menu-image empty
  *                                                         so an icon can be added via CSS. Defaults to use the posts icon.
+ *     @type bool         $at_a_glance                     Whether to display this post type in the 'At a Glance' dashboard widget.
+ *                                                         Default is value of $show_in_menu.
  *     @type string|array $capability_type                 The string to use to build the read, edit, and delete capabilities.
  *                                                         May be passed as an array to allow for alternative plurals when using
  *                                                         this argument as a base to construct the capabilities, e.g.

--- a/tests/phpunit/tests/post/types.php
+++ b/tests/phpunit/tests/post/types.php
@@ -676,4 +676,25 @@ class Tests_Post_Types extends WP_UnitTestCase {
 		);
 		$this->assertFalse( $post_type->embeddable, 'Post type should not be embeddable even though it is public' );
 	}
+
+	/**
+	 * @ticket 45035
+	 *
+	 * @covers ::register_post_type()
+	 */
+	public function test_register_post_type_at_a_glance_should_default_to_value_of_show_in_menu() {
+		/*
+		 * 'public'       Default is false
+		 * 'show_ui'      Default is null ('public')
+		 * 'show_in_menu' Default is null ('show_ui' > 'public')
+		 * 'at_a_glance'  Default is null ('show_in_menu' > 'show_ui' > 'public')
+		 */
+		$args = register_post_type( $this->post_type, array( 'public' => $public = false ) );
+		// Should fall back to 'show_in_menu'.
+		$this->assertSame( $args->show_in_menu, $args->at_a_glance );
+		// Should fall back to 'show_ui'.
+		$this->assertSame( $args->show_ui, $args->at_a_glance );
+		// Should fall back to 'public'.
+		$this->assertSame( $public, $args->at_a_glance );
+	}
 }


### PR DESCRIPTION
Refreshes #10647, resolving merge conflicts with trunk and addressing outstanding review feedback.

**Note on "Published" label:** Trunk changed the built-in labels to "Published post / Published page" [61555](https://core.trac.wordpress.org/changeset/61555). This PR uses `$post_type_object->labels->name` for CPTs, which does not include "Published". 

**Testing Instructions:**
1. Install the test plugin from this [gist](https://gist.github.com/SainathPoojary/4040c7617d860379a997c2b61e066d73):
   It registers three CPTs: `book` (dashicon, `at_a_glance=true`), `movie` (SVG icon, `at_a_glance=true`), and `secret_type`  (`at_a_glance=false`).
2. Publish some posts of each type.
3. Check **Dashboard → At a Glance**:
   - `Books` and `Movies` counts should appear with their icons 
   - `Secret Types` should NOT appear 
4. Verify built-in Posts and Pages still work correctly.

<img width="1208" height="638" alt="Screenshot 2026-04-03 at 1 24 48 PM" src="https://github.com/user-attachments/assets/e356eac9-b2b7-462d-87bc-71fba4ab3530" />



Trac ticket: https://core.trac.wordpress.org/ticket/45035

## Use of AI Tools

AI assistance: Yes
Tool(s): GitHub Copilot
Model(s): Gemini, Claude
Used for: Checking for potential edge cases, drafting the PR description, and assisting with local code review. The final implementation and testing were written and executed manually by me.

---

**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
