### PR TITLE
Administration: Fix post edit screen content overflow caused by unconditional metabox padding.

### DIFF
--- a/src/wp-admin/css/edit.css
+++ b/src/wp-admin/css/edit.css
@@ -5,7 +5,6 @@
 
 #poststuff #post-body {
 	padding: 0;
-	margin: 0 -4px;
 }
 
 #poststuff .postbox-container {
@@ -174,12 +173,9 @@ body.post-type-wp_navigation .inline-edit-status {
 
 /* Post Screen */
 
-.metabox-holder .postbox-container .meta-box-sortables {
-	padding: 4px;
-}
-
 /* Only highlight drop zones when dragging and only in the 2 columns layout. */
 .is-dragging-metaboxes .metabox-holder .postbox-container .meta-box-sortables {
+	padding: 4px;
 	border-radius: 8px;
 	background: rgb(var(--wp-admin-theme-color--rgb), 0.04);
 	/*


### PR DESCRIPTION
`padding: 4px` was added to `.meta-box-sortables` to give drag-and-drop drop zones a small inset for the new rounded corners. To counteract it, a `margin: 0 -4px` was added to `#poststuff #post-body` which caused content to overflow its container on the post Add/Edit screen.

As padding is needed during dragging, so moved it inside the existing `.is-dragging-metaboxes` selector and removed the compensating negative margin.

<img width="1449" height="939" alt="Screenshot 2026-04-03 at 5 09 46 PM" src="https://github.com/user-attachments/assets/471c793b-772e-439c-ad79-0fc5dcc420a1" />

Trac ticket: [#65018](https://core.trac.wordpress.org/ticket/65018)



## Use of AI Tools

AI assistance: Yes
Tool(s): GitHub Copilot
Model(s): Gemini, Claude
Used for: Checking for potential edge cases, drafting the PR description, and assisting with local code review. The final implementation and testing were written and executed manually by me.

---

**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**

