### PR TITLE
Formatting: Add excerpt_allowed_tags filter to preserve HTML tags in wp_trim_excerpt()

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -3944,8 +3944,9 @@ function human_time_diff( $from, $to = 0 ) {
  *
  * Returns a maximum of 55 words with an ellipsis appended if necessary.
  *
- * The 55-word limit can be modified by plugins/themes using the {@see 'excerpt_length'} filter
- * The ' [&hellip;]' string can be modified by plugins/themes using the {@see 'excerpt_more'} filter
+ * The 55-word limit can be modified by plugins/themes using the {@see 'excerpt_length'} filter.
+ * The ' [&hellip;]' string can be modified by plugins/themes using the {@see 'excerpt_more'} filter.
+ * Allowed HTML tags can be specified using the {@see 'excerpt_allowed_tags'} filter.
  *
  * @since 1.5.0
  * @since 5.2.0 Added the `$post` parameter.

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -3951,6 +3951,7 @@ function human_time_diff( $from, $to = 0 ) {
  * @since 1.5.0
  * @since 5.2.0 Added the `$post` parameter.
  * @since 6.3.0 Removes footnotes markup from the excerpt content.
+ * @since 7.1.0 Added support for preserving allowed HTML tags via the `excerpt_allowed_tags` filter.
  *
  * @param string             $text Optional. The excerpt. If set to empty, an excerpt is generated.
  * @param WP_Post|object|int $post Optional. WP_Post instance or Post ID/object. Default null.

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -4117,7 +4117,6 @@ function wp_trim_excerpt( $text = '', $post = null ) {
 		} else {
 			$text = wp_trim_words( $text, $excerpt_length, $excerpt_more );
 		}
-
 	}
 
 	/**

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -4017,7 +4017,104 @@ function wp_trim_excerpt( $text = '', $post = null ) {
 		 * @param string $more_string The string shown within the more link.
 		 */
 		$excerpt_more = apply_filters( 'excerpt_more', ' ' . '[&hellip;]' );
-		$text         = wp_trim_words( $text, $excerpt_length, $excerpt_more );
+
+		/**
+		 * Filters the HTML tags allowed in an auto-generated post excerpt.
+		 *
+		 * @since 7.0.0
+		 *
+		 * @param string $allowed_tags Allowed HTML tags. Default empty string (strip all tags).
+		 */
+		$excerpt_allowed_tags = apply_filters( 'excerpt_allowed_tags', '' );
+
+		if ( '' !== $excerpt_allowed_tags ) {
+			$text_to_trim = strip_tags( $text, $excerpt_allowed_tags );
+
+			$plain_text = wp_strip_all_tags( $text_to_trim );
+
+			if ( str_starts_with( wp_get_word_count_type(), 'characters' ) && preg_match( '/^utf\-?8$/i', get_option( 'blog_charset' ) ) ) {
+				$plain_text = trim( preg_replace( "/[\n\r\t ]+/", ' ', $plain_text ), ' ' );
+				preg_match_all( '/./u', $plain_text, $chars );
+				$needs_trim = count( $chars[0] ) > $excerpt_length;
+
+				if ( $needs_trim ) {
+					$char_count = 0;
+					$cut_pos    = strlen( $text_to_trim );
+					$remaining  = $text_to_trim;
+					$offset     = 0;
+
+					while ( '' !== $remaining ) {
+						if ( '<' === $remaining[0] ) {
+							$tag_end = strpos( $remaining, '>' );
+							if ( false === $tag_end ) {
+								break;
+							}
+							$offset   += $tag_end + 1;
+							$remaining = substr( $remaining, $tag_end + 1 );
+							continue;
+						}
+
+						if ( preg_match( '/^./us', $remaining, $m ) ) {
+							++$char_count;
+							if ( $char_count > $excerpt_length ) {
+								$cut_pos = $offset;
+								break;
+							}
+							$offset   += strlen( $m[0] );
+							$remaining = substr( $remaining, strlen( $m[0] ) );
+						} else {
+							break;
+						}
+					}
+
+					$text = force_balance_tags( substr( $text_to_trim, 0, $cut_pos ) ) . $excerpt_more;
+				} else {
+					$text = $text_to_trim;
+				}
+			} else {
+				$words = preg_split( "/[\n\r\t ]+/", $plain_text, $excerpt_length + 1, PREG_SPLIT_NO_EMPTY );
+
+				if ( count( $words ) > $excerpt_length ) {
+					$word_count = 0;
+					$cut_pos    = strlen( $text_to_trim );
+					$remaining  = $text_to_trim;
+					$offset     = 0;
+
+					while ( '' !== $remaining ) {
+						if ( '<' === $remaining[0] ) {
+							$tag_end = strpos( $remaining, '>' );
+							if ( false === $tag_end ) {
+								break;
+							}
+							$offset   += $tag_end + 1;
+							$remaining = substr( $remaining, $tag_end + 1 );
+							continue;
+						}
+
+						if ( preg_match( '/^(\S+)/', $remaining, $m ) ) {
+							++$word_count;
+							if ( $word_count > $excerpt_length ) {
+								$cut_pos = $offset;
+								break;
+							}
+							$offset   += strlen( $m[0] );
+							$remaining = substr( $remaining, strlen( $m[0] ) );
+						} elseif ( preg_match( '/^(\s+)/', $remaining, $m ) ) {
+							$offset   += strlen( $m[0] );
+							$remaining = substr( $remaining, strlen( $m[0] ) );
+						} else {
+							break;
+						}
+					}
+
+					$text = force_balance_tags( substr( $text_to_trim, 0, $cut_pos ) ) . $excerpt_more;
+				} else {
+					$text = $text_to_trim;
+				}
+			}
+		} else {
+			$text = wp_trim_words( $text, $excerpt_length, $excerpt_more );
+		}
 
 	}
 

--- a/tests/phpunit/tests/formatting/wpTrimExcerpt.php
+++ b/tests/phpunit/tests/formatting/wpTrimExcerpt.php
@@ -223,4 +223,21 @@ class Tests_Formatting_wpTrimExcerpt extends WP_UnitTestCase {
 		// Assert that the filter callback was not restored after running 'the_content'.
 		$this->assertFalse( has_filter( 'the_content', 'do_blocks' ) );
 	}
+
+	/**
+	 * Tests that by default all HTML is stripped from the excerpt.
+	 *
+	 * @ticket 12084
+	 */
+	public function test_excerpt_allowed_tags_default_strips_all_html() {
+		$post = self::factory()->post->create(
+			array(
+				'post_content' => '<p>Hello <strong>world</strong>.</p>',
+			)
+		);
+
+		$excerpt = wp_trim_excerpt( '', $post );
+
+		$this->assertStringNotContainsString( '<', $excerpt, 'Default excerpt should contain no HTML tags.' );
+	}
 }

--- a/tests/phpunit/tests/formatting/wpTrimExcerpt.php
+++ b/tests/phpunit/tests/formatting/wpTrimExcerpt.php
@@ -269,4 +269,36 @@ class Tests_Formatting_wpTrimExcerpt extends WP_UnitTestCase {
 		$this->assertStringNotContainsString( '<p>', $excerpt, 'Disallowed tag should be stripped.' );
 		$this->assertStringContainsString( 'Hello', $excerpt, 'Inner text of stripped tags should be kept.' );
 	}
+
+	/**
+	 * Tests that tags are balanced after truncation when allowed tags are set.
+	 *
+	 * @ticket 12084
+	 */
+	public function test_excerpt_allowed_tags_balances_tags_after_truncation() {
+		$long_content = '<strong>' . implode( ' ', range( 1, 60 ) ) . '</strong>';
+
+		$post = self::factory()->post->create(
+			array(
+				'post_content' => $long_content,
+			)
+		);
+
+		add_filter(
+			'excerpt_allowed_tags',
+			static function () {
+				return '<strong>';
+			}
+		);
+
+		$excerpt = wp_trim_excerpt( '', $post );
+
+		remove_all_filters( 'excerpt_allowed_tags' );
+
+		$this->assertSame(
+			substr_count( $excerpt, '<strong>' ),
+			substr_count( $excerpt, '</strong>' ),
+			'Tags should be balanced after truncation.'
+		);
+	}
 }

--- a/tests/phpunit/tests/formatting/wpTrimExcerpt.php
+++ b/tests/phpunit/tests/formatting/wpTrimExcerpt.php
@@ -240,4 +240,33 @@ class Tests_Formatting_wpTrimExcerpt extends WP_UnitTestCase {
 
 		$this->assertStringNotContainsString( '<', $excerpt, 'Default excerpt should contain no HTML tags.' );
 	}
+
+	/**
+	 * Tests that the excerpt_allowed_tags filter preserves specified tags
+	 * and strips disallowed ones while keeping their inner text.
+	 *
+	 * @ticket 12084
+	 */
+	public function test_excerpt_allowed_tags_preserves_specified_tags() {
+		$post = self::factory()->post->create(
+			array(
+				'post_content' => '<p>Hello <strong>bold</strong> and <em>italic</em> text.</p>',
+			)
+		);
+
+		add_filter(
+			'excerpt_allowed_tags',
+			static function () {
+				return '<strong><em>';
+			}
+		);
+
+		$excerpt = wp_trim_excerpt( '', $post );
+
+		remove_all_filters( 'excerpt_allowed_tags' );
+
+		$this->assertStringContainsString( '<strong>bold</strong>', $excerpt, 'Allowed tag should be preserved.' );
+		$this->assertStringNotContainsString( '<p>', $excerpt, 'Disallowed tag should be stripped.' );
+		$this->assertStringContainsString( 'Hello', $excerpt, 'Inner text of stripped tags should be kept.' );
+	}
 }


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/12084

`wp_trim_excerpt()` has always stripped all HTML from auto-generated excerpts unconditionally, via `wp_trim_words()` → `wp_strip_all_tags()`. There was no hook to preserve any markup, making it impossible for themes and plugins to retain semantic HTML (e.g., `<strong>`, `<em>`, `<a>`) in excerpts without replacing the entire `wp_trim_excerpt` function.


This PR introduces a new `excerpt_allowed_tags` filter in `wp_trim_excerpt()` that defaults to an empty string (fully backward compat). When a non-empty allowed-tags string is supplied, a new HTML-aware trimming path is
taken instead of the `wp_trim_words()` path.


#### Usage

```php
add_filter( 'excerpt_allowed_tags', function () {
    return '<strong><em><a>';
} );
```

#### Testing

You can run and check the tests using - 

```
npm run test:php -- --filter=Tests_Formatting_wpTrimExcerpt 
```
