### PR TITLE
Registration: Reject usernames that contain "www."

### DIFF
--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -393,6 +393,9 @@ add_action( 'login_footer', 'wp_print_footer_scripts', 20 );
 add_action( 'login_init', 'send_frame_options_header', 10, 0 );
 add_action( 'login_init', 'wp_admin_headers' );
 
+// Registration
+add_filter( 'validate_username', 'wp_validate_username_spam', 10, 2 );
+
 // Feed generator tags.
 foreach ( array( 'rss2_head', 'commentsrss2_head', 'rss_head', 'rdf_header', 'atom_head', 'comments_atom_head', 'opml_head', 'app_head' ) as $action ) {
 	add_action( $action, 'the_generator' );

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -5095,6 +5095,22 @@ function wp_validate_user_request_key(
 }
 
 /**
+ * Reject usernames that can be used for spamming people.
+ *
+ * @param string $username Username to check.
+ * @return bool Whether username given is valid.
+ */
+function wp_validate_username_spam( $valid, $username ) {
+	//username begins with "www." or has " www." in it,
+	// which gets auto-linked by email clients
+	if ( strpos( ' ' . $username, ' www.' ) !== false ) {
+		return false;
+	}
+
+	return $valid;
+}
+
+/**
  * Returns the user request object for the specified request ID.
  *
  * @since 4.9.6

--- a/tests/phpunit/tests/user.php
+++ b/tests/phpunit/tests/user.php
@@ -1274,6 +1274,14 @@ class Tests_User extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 63085
+	 */
+	public function test_validate_username_spam() {
+		$this->assertFalse( validate_username( 'www.example.com - 1.2342 BTC' ) );
+		$this->assertFalse( validate_username( '1.23 BTC www.spammer.example.com' ) );
+	}
+
+	/**
 	 * @ticket 29880
 	 */
 	public function test_wp_insert_user_should_not_wipe_existing_password() {


### PR DESCRIPTION
Wordpress registration e-mails are used to send bitcoin spam to people - by using usernames with spaces like
> www.spammer.example.com - 1.2342 BTC

This patch filters out usernames that begin with "www." or contain " www." - such names are auto-linked by email clients and made clickable.

Documented occurences of that spamming problem:
- https://cweiske.de/tagebuch/wordpress-registration-spam.htm
- https://www.reddit.com/r/Wordpress/comments/1gyyhx7/spammed_with_100_fake_wordpress_login_emails_help/

Fixes #63085.

Trac ticket: https://core.trac.wordpress.org/ticket/63085

## Use of AI Tools

AI assistance: No

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
