### PR TITLE
REST API: Restore global post state in WP_REST_Posts_Controller.Ensur…

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -1886,12 +1886,16 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		// Restores the more descriptive, specific name for use within this method.
 		$post = $item;
 
+		$previous_post   = isset( $GLOBALS['post'] ) ? $GLOBALS['post'] : null;
 		$GLOBALS['post'] = $post;
 
 		setup_postdata( $post );
 
 		// Don't prepare the response body for HEAD requests.
 		if ( $request->is_method( 'HEAD' ) ) {
+			$GLOBALS['post'] = $previous_post;
+			wp_reset_postdata();
+
 			/** This filter is documented in wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php */
 			return apply_filters( "rest_prepare_{$this->post_type}", new WP_REST_Response( array() ), $post, $request );
 		}
@@ -2207,6 +2211,9 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		 * @param WP_Post          $post     Post object.
 		 * @param WP_REST_Request  $request  Request object.
 		 */
+		$GLOBALS['post'] = $previous_post;
+		wp_reset_postdata();
+
 		return apply_filters( "rest_prepare_{$this->post_type}", $response, $post, $request );
 	}
 

--- a/tests/phpunit/tests/rest-api/rest-posts-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-posts-controller.php
@@ -2805,6 +2805,50 @@ Shankle pork chop prosciutto ribeye ham hock pastrami. T-bone shank brisket baco
 		$this->assertTrue( array_is_list( $data['class_list'] ), 'Expected class_list to be a list.' );
 	}
 
+	/**
+	 * @ticket 43502
+	 *
+	 * @covers WP_REST_Posts_Controller::prepare_item_for_response
+	 */
+	public function test_prepare_item_for_response_restores_global_post() {
+		$post_1 = self::factory()->post->create_and_get();
+		$post_2 = self::factory()->post->create_and_get();
+
+		// Set up a known global $post state.
+		$GLOBALS['post'] = $post_1;
+		setup_postdata( $post_1 );
+
+		$endpoint = new WP_REST_Posts_Controller( 'post' );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/posts/' . $post_2->ID );
+		$endpoint->prepare_item_for_response( $post_2, $request );
+
+		$this->assertSame(
+			$post_1->ID,
+			$GLOBALS['post']->ID,
+			'Global $post should be restored after prepare_item_for_response().'
+		);
+	}
+
+	/**
+	 * @ticket 43502
+	 *
+	 * @covers WP_REST_Posts_Controller::prepare_item_for_response
+	 */
+	public function test_prepare_item_for_response_restores_null_global_post() {
+		unset( $GLOBALS['post'] );
+
+		$post = self::factory()->post->create_and_get();
+
+		$endpoint = new WP_REST_Posts_Controller( 'post' );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/posts/' . $post->ID );
+		$endpoint->prepare_item_for_response( $post, $request );
+
+		$this->assertNull(
+			$GLOBALS['post'],
+			'Global $post should be restored to null when it was not set before prepare_item_for_response().'
+		);
+	}
+
 	public function test_create_item() {
 		wp_set_current_user( self::$editor_id );
 


### PR DESCRIPTION
This PR addresses a long-standing issue in WP_REST_Posts_Controller::prepare_item_for_response() where the global $post object was not restored after calling setup_postdata().

When the REST API processes post data, it temporarily modifies the global $post state to ensure core functions (like get_the_content()) work correctly. However, failing to reset this state leads to "global context pollution," especially when the REST API is called internally during a custom WP_Query loop or other custom development contexts.

Changes included in this PR:

Manual State Backup: Saves the original $GLOBALS['post'] before modification.

Robust Restoration: Ensures the global $post is restored to its original state (including null) in both the main execution path and the early-return path for HEAD requests.

Comprehensive Unit Tests: 1. Verified that the global $post is restored to its previous object after the API call.
2. Verified that the global $post is restored to null if it wasn't set before the call.

Trac ticket: https://core.trac.wordpress.org/ticket/43502

Use of AI Tools
AI assistance: Yes
Tool(s): Gemini
Model(s): Gemini 3 Flash
Used for: Identifying the core architectural issue (global state pollution vs. wp_reset_postdata limitations) and drafting the technical explanation for the PR description. The final implementation was verified against the latest Trac patch (#43502.6.diff) and local PHPUnit tests.
