### PR TITLE
Plugins: Hide search form on Favorites tab

### DIFF
--- a/src/wp-admin/includes/class-wp-plugin-install-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugin-install-list-table.php
@@ -331,6 +331,8 @@ class WP_Plugin_Install_List_Table extends WP_List_Table {
 
 	/**
 	 * Overrides parent views so we can use the filter bar display.
+	 * 
+	 * @global string $tab The current tab.
 	 */
 	public function views() {
 		global $tab;

--- a/src/wp-admin/includes/class-wp-plugin-install-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugin-install-list-table.php
@@ -333,6 +333,8 @@ class WP_Plugin_Install_List_Table extends WP_List_Table {
 	 * Overrides parent views so we can use the filter bar display.
 	 */
 	public function views() {
+		global $tab;
+
 		$views = $this->get_views();
 
 		/** This filter is documented in wp-admin/includes/class-wp-list-table.php */
@@ -358,7 +360,11 @@ class WP_Plugin_Install_List_Table extends WP_List_Table {
 		?>
 	</ul>
 
-		<?php install_search_form(); ?>
+		<?php
+		if ( 'favorites' !== $tab ) {
+			install_search_form();
+		}
+		?>
 </div>
 		<?php
 	}

--- a/src/wp-admin/includes/class-wp-plugin-install-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugin-install-list-table.php
@@ -331,7 +331,7 @@ class WP_Plugin_Install_List_Table extends WP_List_Table {
 
 	/**
 	 * Overrides parent views so we can use the filter bar display.
-	 * 
+	 *
 	 * @global string $tab The current tab.
 	 */
 	public function views() {


### PR DESCRIPTION
The plugin search form should not be displayed on the Favorites tab where it is not applicable. This change prevents the search form from rendering when viewing favorite plugins, reducing UI confusion and aligning with expected behavior.

Fixes #65026

Ticket track -https://core.trac.wordpress.org/ticket/65026 

Go to Plugins → Add New

Click Favorites tab

1. Verify search form is hidden
Click Featured tab

2. Verify search form is visible
Click Popular tab

3.Verify search form is visible
Click Recommended tab

4.Verify search form is visible