### PR TITLE
[no review][no merge] Register Akismet Anti-Spam as a connector.

### DIFF
--- a/src/wp-includes/class-wp-connector-registry.php
+++ b/src/wp-includes/class-wp-connector-registry.php
@@ -71,8 +71,8 @@ final class WP_Connector_Registry {
 	 * For connectors with `api_key` authentication, a `setting_name` can be provided
 	 * explicitly. If omitted, one is automatically generated using the pattern
 	 * `connectors_{$type}_{$id}_api_key`, with hyphens in the type and ID normalized
-	 * to underscores (e.g., connector type `spam_filtering` with ID `my_plugin` produces
-	 * `connectors_spam_filtering_my_plugin_api_key`). This setting name is used for the
+	 * to underscores (e.g., connector type `spam_filtering` with ID `akismet` produces
+	 * `connectors_spam_filtering_akismet_api_key`). This setting name is used for the
 	 * Settings API registration and REST API exposure.
 	 *
 	 * Registering a connector with an ID that is already registered will trigger a
@@ -110,7 +110,7 @@ final class WP_Connector_Registry {
 	 *         Optional. Plugin data for install/activate UI.
 	 *
 	 *         @type string $file The plugin's main file path relative to the plugins
-	 *                            directory (e.g. 'my-plugin/my-plugin.php' or 'hello.php').
+	 *                            directory (e.g. 'akismet/akismet.php' or 'hello.php').
 	 *     }
 	 * }
 	 * @return array|null The registered connector data on success, null on failure.

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -59,7 +59,7 @@ function wp_is_connector_registered( string $id ): bool {
  *         Optional. Plugin data for install/activate UI.
  *
  *         @type string $file The plugin's main file path relative to the plugins
- *                            directory (e.g. 'my-plugin/my-plugin.php' or 'hello.php').
+ *                            directory (e.g. 'akismet/akismet.php' or 'hello.php').
  *     }
  * }
  * @phpstan-return ?array{
@@ -120,7 +120,7 @@ function wp_get_connector( string $id ): ?array {
  *             Optional. Plugin data for install/activate UI.
  *
  *             @type string $file The plugin's main file path relative to the plugins
- *                                directory (e.g. 'my-plugin/my-plugin.php' or 'hello.php').
+ *                                directory (e.g. 'akismet/akismet.php' or 'hello.php').
  *         }
  *     }
  * }
@@ -209,6 +209,25 @@ function _wp_connectors_init(): void {
 	if ( wp_supports_ai() ) {
 		_wp_connectors_register_default_ai_providers( $registry );
 	}
+
+	// Non-AI default connectors.
+	$registry->register(
+		'akismet',
+		array(
+			'name'           => __( 'Akismet Anti-spam' ),
+			'description'    => __( 'Protect your site from spam.' ),
+			'type'           => 'spam_filtering',
+			'plugin'         => array(
+				'file' => 'akismet/akismet.php',
+			),
+			'authentication' => array(
+				'method'          => 'api_key',
+				'credentials_url' => 'https://akismet.com/get/',
+				'setting_name'    => 'wordpress_api_key',
+				'constant_name'   => 'WPCOM_API_KEY',
+			),
+		)
+	);
 
 	/**
 	 * Fires when the connector registry is ready for plugins to register connectors.
@@ -398,9 +417,9 @@ function _wp_connectors_mask_api_key( string $key ): string {
  * @since 7.0.0
  * @access private
  *
- * @param string $setting_name  The option name for the API key (e.g., 'connectors_spam_filtering_my_plugin_api_key').
- * @param string $env_var_name  Optional. Environment variable name to check (e.g., 'MY_PLUGIN_API_KEY').
- * @param string $constant_name Optional. PHP constant name to check (e.g., 'MY_PLUGIN_API_KEY').
+ * @param string $setting_name  The option name for the API key (e.g., 'connectors_spam_filtering_akismet_api_key').
+ * @param string $env_var_name  Optional. Environment variable name to check (e.g., 'AKISMET_API_KEY').
+ * @param string $constant_name Optional. PHP constant name to check (e.g., 'AKISMET_API_KEY').
  * @return string The key source: 'env', 'constant', 'database', or 'none'.
  */
 function _wp_connectors_get_api_key_source( string $setting_name, string $env_var_name = '', string $constant_name = '' ): string {

--- a/tests/phpunit/tests/connectors/wpConnectorsGetConnectorSettings.php
+++ b/tests/phpunit/tests/connectors/wpConnectorsGetConnectorSettings.php
@@ -37,8 +37,9 @@ class Tests_Connectors_WpGetConnectors extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'google', $connectors );
 		$this->assertArrayHasKey( 'openai', $connectors );
 		$this->assertArrayHasKey( 'anthropic', $connectors );
+		$this->assertArrayHasKey( 'akismet', $connectors );
 		$this->assertArrayHasKey( 'mock-connectors-test', $connectors );
-		$this->assertCount( 4, $connectors );
+		$this->assertCount( 5, $connectors );
 	}
 
 	/**
@@ -56,7 +57,7 @@ class Tests_Connectors_WpGetConnectors extends WP_UnitTestCase {
 			$this->assertArrayHasKey( 'description', $connector_data, "Connector '{$connector_id}' is missing 'description'." );
 			$this->assertIsString( $connector_data['description'], "Connector '{$connector_id}' description should be a string." );
 			$this->assertArrayHasKey( 'type', $connector_data, "Connector '{$connector_id}' is missing 'type'." );
-			$this->assertContains( $connector_data['type'], array( 'ai_provider' ), "Connector '{$connector_id}' has unexpected type '{$connector_data['type']}'." );
+			$this->assertContains( $connector_data['type'], array( 'ai_provider', 'spam_filtering' ), "Connector '{$connector_id}' has unexpected type '{$connector_data['type']}'." );
 			$this->assertArrayHasKey( 'authentication', $connector_data, "Connector '{$connector_id}' is missing 'authentication'." );
 			$this->assertIsArray( $connector_data['authentication'], "Connector '{$connector_id}' authentication should be an array." );
 			$this->assertArrayHasKey( 'method', $connector_data['authentication'], "Connector '{$connector_id}' authentication is missing 'method'." );
@@ -79,11 +80,16 @@ class Tests_Connectors_WpGetConnectors extends WP_UnitTestCase {
 			++$api_key_count;
 
 			$this->assertArrayHasKey( 'setting_name', $connector_data['authentication'], "Connector '{$connector_id}' authentication is missing 'setting_name'." );
-			$this->assertSame(
-				'connectors_ai_' . str_replace( '-', '_', $connector_id ) . '_api_key',
-				$connector_data['authentication']['setting_name'] ?? null,
-				"Connector '{$connector_id}' setting_name does not match expected format."
-			);
+
+			// AI providers use the connectors_ai_{id}_api_key convention.
+			// Non-AI connectors may use custom setting names.
+			if ( 'ai_provider' === $connector_data['type'] ) {
+				$this->assertSame(
+					'connectors_ai_' . str_replace( '-', '_', $connector_id ) . '_api_key',
+					$connector_data['authentication']['setting_name'] ?? null,
+					"Connector '{$connector_id}' setting_name does not match expected format."
+				);
+			}
 		}
 
 		$this->assertGreaterThan( 0, $api_key_count, 'At least one connector should use api_key authentication.' );

--- a/tests/phpunit/tests/rest-api/rest-settings-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-settings-controller.php
@@ -119,6 +119,7 @@ class WP_Test_REST_Settings_Controller extends WP_Test_REST_Controller_Testcase 
 			'default_ping_status',
 			'default_comment_status',
 			'site_icon', // Registered in wp-includes/blocks/site-logo.php
+			'wordpress_api_key', // Registered by Akismet connector.
 			'wp_collaboration_enabled',
 		);
 

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -11011,6 +11011,12 @@ mockedApiResponse.Schema = {
                         "PATCH"
                     ],
                     "args": {
+                        "wordpress_api_key": {
+                            "title": "Akismet Anti-spam API Key",
+                            "description": "API key for the Akismet Anti-spam connector.",
+                            "type": "string",
+                            "required": false
+                        },
                         "title": {
                             "title": "Title",
                             "description": "Site title.",
@@ -14544,6 +14550,7 @@ mockedApiResponse.CommentModel = {
 };
 
 mockedApiResponse.settings = {
+    "wordpress_api_key": "",
     "title": "Test Blog",
     "description": "",
     "url": "http://example.org",


### PR DESCRIPTION
This is just to be able to demo the behavior before the revert of Akismet connector on playground, and share in the discussion issue https://core.trac.wordpress.org/ticket/65012 not something to review or merge.