### PR TITLE
Fix user edit screen alignment for password toggle button

### DIFF
--- a/src/wp-admin/css/forms.css
+++ b/src/wp-admin/css/forms.css
@@ -1,4 +1,4 @@
-/* Include margin and padding in the width calculation of input and textarea. */
+/* Include margi and padding in the width calculation of input and textarea. */
 input,
 select,
 textarea,

--- a/src/wp-admin/css/forms.css
+++ b/src/wp-admin/css/forms.css
@@ -584,8 +584,8 @@ input[type="number"].tiny-text {
 }
 
 .button.wp-hide-pw.user-new-password-toggle > .dashicons {
-	line-height: normal;
-	vertical-align: baseline;
+	line-height: 1.9;
+	vertical-align: top;
 }
 
 .wp-cancel-pw .dashicons-no {

--- a/src/wp-admin/css/forms.css
+++ b/src/wp-admin/css/forms.css
@@ -584,7 +584,7 @@ input[type="number"].tiny-text {
 }
 
 .button.wp-hide-pw.user-new-password-toggle > .dashicons {
-	line-height: 1.9;
+	line-height: 1.85;
 	vertical-align: top;
 }
 

--- a/src/wp-admin/css/forms.css
+++ b/src/wp-admin/css/forms.css
@@ -1,4 +1,4 @@
-/* Include margi and padding in the width calculation of input and textarea. */
+/* Include margin and padding in the width calculation of input and textarea. */
 input,
 select,
 textarea,

--- a/src/wp-admin/css/forms.css
+++ b/src/wp-admin/css/forms.css
@@ -583,6 +583,11 @@ input[type="number"].tiny-text {
 	vertical-align: middle;
 }
 
+.button.wp-hide-pw.user-new-password-toggle > .dashicons {
+	line-height: normal;
+	vertical-align: baseline;
+}
+
 .wp-cancel-pw .dashicons-no {
 	display: none;
 }

--- a/src/wp-admin/user-edit.php
+++ b/src/wp-admin/user-edit.php
@@ -695,7 +695,7 @@ switch ( $action ) {
 											<input type="password" name="pass1" id="pass1" class="regular-text ltr" value="" autocomplete="new-password" spellcheck="false" data-pw="<?php echo esc_attr( wp_generate_password( 24 ) ); ?>" aria-describedby="pass-strength-result" />
 											<div style="display:none" id="pass-strength-result" aria-live="polite"></div>
 										</div>
-										<button type="button" class="button wp-hide-pw hide-if-no-js" data-toggle="0" aria-label="<?php esc_attr_e( 'Hide password' ); ?>">
+										<button type="button" class="button wp-hide-pw user-new-password-toggle hide-if-no-js" data-toggle="0" aria-label="<?php esc_attr_e( 'Hide password' ); ?>">
 											<span class="dashicons dashicons-hidden" aria-hidden="true"></span>
 											<span class="text"><?php _e( 'Hide' ); ?></span>
 										</button>

--- a/src/wp-admin/user-new.php
+++ b/src/wp-admin/user-new.php
@@ -603,7 +603,7 @@ if ( current_user_can( 'create_users' ) ) {
 					<input type="password" name="pass1" id="pass1" class="regular-text ltr" autocomplete="new-password" spellcheck="false" data-reveal="1" data-pw="<?php echo esc_attr( $initial_password ); ?>" aria-describedby="pass-strength-result" />
 					<div style="display:none" id="pass-strength-result" aria-live="polite"></div>
 				</div>
-				<button type="button" class="button wp-hide-pw hide-if-no-js" data-toggle="0" aria-label="<?php esc_attr_e( 'Hide password' ); ?>">
+				<button type="button" class="button wp-hide-pw user-new-password-toggle hide-if-no-js" data-toggle="0" aria-label="<?php esc_attr_e( 'Hide password' ); ?>">
 					<span class="dashicons dashicons-hidden" aria-hidden="true"></span>
 					<span class="text"><?php _e( 'Hide' ); ?></span>
 				</button>

--- a/src/wp-admin/user-new.php
+++ b/src/wp-admin/user-new.php
@@ -603,7 +603,7 @@ if ( current_user_can( 'create_users' ) ) {
 					<input type="password" name="pass1" id="pass1" class="regular-text ltr" autocomplete="new-password" spellcheck="false" data-reveal="1" data-pw="<?php echo esc_attr( $initial_password ); ?>" aria-describedby="pass-strength-result" />
 					<div style="display:none" id="pass-strength-result" aria-live="polite"></div>
 				</div>
-				<button type="button" class="button wp-hide-pw user-new-password-toggle hide-if-no-js" data-toggle="0" aria-label="<?php esc_attr_e( 'Hide password' ); ?>">
+				<button type="button" class="button wp-hide-pw hide-if-no-js" data-toggle="0" aria-label="<?php esc_attr_e( 'Hide password' ); ?>">
 					<span class="dashicons dashicons-hidden" aria-hidden="true"></span>
 					<span class="text"><?php _e( 'Hide' ); ?></span>
 				</button>


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65031

## Before:
<img width="604" height="197" alt="Screenshot 2026-04-07 at 6 52 41 PM" src="https://github.com/user-attachments/assets/bf64d192-2c23-4f27-a2b4-b150de8f29f4" />


## After:
<img width="587" height="190" alt="Screenshot 2026-04-07 at 6 57 27 PM" src="https://github.com/user-attachments/assets/a4e45e6f-e6d7-4545-a8be-68315130e8d9" />
