### PR TITLE
Menus: Highlight CPT archive in nav on singular views (#38836)

### DIFF
--- a/src/wp-includes/nav-menu-template.php
+++ b/src/wp-includes/nav-menu-template.php
@@ -394,6 +394,13 @@ function _wp_menu_item_classes_by_context( &$menu_items ) {
 	$front_page_id          = (int) get_option( 'page_on_front' );
 	$privacy_policy_page_id = (int) get_option( 'wp_page_for_privacy_policy' );
 
+	$public_custom_post_types = get_post_types(
+		array(
+			'public'   => true,
+			'_builtin' => false,
+		)
+	);
+
 	foreach ( (array) $menu_items as $key => $menu_item ) {
 
 		$menu_items[ $key ]->current = false;
@@ -523,6 +530,15 @@ function _wp_menu_item_classes_by_context( &$menu_items ) {
 
 			if ( untrailingslashit( $item_url ) === home_url() ) {
 				$classes[] = 'menu-item-home';
+			}
+		}
+
+		// If a public custom post type single is being viewed, the archive menu item is a logical parent (#38836).
+		if ( is_singular( $public_custom_post_types ) ) {
+			$post_type = get_post_type();
+
+			if ( $post_type === $menu_item->object && 'post_type_archive' === $menu_item->type ) {
+				$classes[] = 'current_page_parent';
 			}
 		}
 

--- a/tests/phpunit/tests/post/nav-menu.php
+++ b/tests/phpunit/tests/post/nav-menu.php
@@ -1426,9 +1426,9 @@ class Tests_Post_Nav_Menu extends WP_UnitTestCase {
 			$this->menu_id,
 			0,
 			array(
-				'menu-item-type'      => 'post_type_archive',
-				'menu-item-object'    => 'cpt38836',
-				'menu-item-status'    => 'publish',
+				'menu-item-type'   => 'post_type_archive',
+				'menu-item-object' => 'cpt38836',
+				'menu-item-status' => 'publish',
 			)
 		);
 
@@ -1477,9 +1477,9 @@ class Tests_Post_Nav_Menu extends WP_UnitTestCase {
 			$this->menu_id,
 			0,
 			array(
-				'menu-item-type'      => 'post_type_archive',
-				'menu-item-object'    => 'cpt38836b',
-				'menu-item-status'    => 'publish',
+				'menu-item-type'   => 'post_type_archive',
+				'menu-item-object' => 'cpt38836b',
+				'menu-item-status' => 'publish',
 			)
 		);
 

--- a/tests/phpunit/tests/post/nav-menu.php
+++ b/tests/phpunit/tests/post/nav-menu.php
@@ -1392,4 +1392,103 @@ class Tests_Post_Nav_Menu extends WP_UnitTestCase {
 		$post = get_post( $menu_item_id );
 		$this->assertEqualsWithDelta( strtotime( gmdate( 'Y-m-d H:i:s' ) ), strtotime( $post->post_date ), 2, 'The dates should be equal' );
 	}
+
+	/**
+	 * Post type archive menu items should receive current_page_parent on public CPT single views.
+	 *
+	 * @ticket 38836
+	 */
+	public function test_post_type_archive_menu_item_gets_current_page_parent_on_public_cpt_single() {
+		$page_id = self::factory()->post->create(
+			array(
+				'post_type'  => 'page',
+				'post_title' => 'Test Page',
+			)
+		);
+
+		register_post_type(
+			'cpt38836',
+			array(
+				'public'      => true,
+				'has_archive' => true,
+			)
+		);
+
+		$cpt_id = self::factory()->post->create(
+			array(
+				'post_type'   => 'cpt38836',
+				'post_name'   => 'cpt-name',
+				'post_status' => 'publish',
+			)
+		);
+
+		wp_update_nav_menu_item(
+			$this->menu_id,
+			0,
+			array(
+				'menu-item-type'      => 'post_type_archive',
+				'menu-item-object'    => 'cpt38836',
+				'menu-item-status'    => 'publish',
+			)
+		);
+
+		wp_update_nav_menu_item(
+			$this->menu_id,
+			0,
+			array(
+				'menu-item-type'      => 'post_type',
+				'menu-item-object'    => 'page',
+				'menu-item-object-id' => $page_id,
+				'menu-item-status'    => 'publish',
+			)
+		);
+
+		$this->go_to( get_permalink( $cpt_id ) );
+
+		$menu_items = wp_get_nav_menu_items( $this->menu_id );
+		_wp_menu_item_classes_by_context( $menu_items );
+
+		$this->assertContains( 'current_page_parent', $menu_items[0]->classes, 'Archive item should be marked parent on CPT single.' );
+		$this->assertNotContains( 'current_page_parent', $menu_items[1]->classes, 'Unrelated page item should not get the class.' );
+	}
+
+	/**
+	 * Non-public CPT singles should not add current_page_parent to the archive menu item.
+	 *
+	 * @ticket 38836
+	 */
+	public function test_post_type_archive_menu_item_is_not_current_page_parent_for_non_public_cpt_single() {
+		register_post_type(
+			'cpt38836b',
+			array(
+				'has_archive' => true,
+			)
+		);
+
+		$cpt_id = self::factory()->post->create(
+			array(
+				'post_type'   => 'cpt38836b',
+				'post_name'   => 'cpt-name',
+				'post_status' => 'publish',
+			)
+		);
+
+		wp_update_nav_menu_item(
+			$this->menu_id,
+			0,
+			array(
+				'menu-item-type'      => 'post_type_archive',
+				'menu-item-object'    => 'cpt38836b',
+				'menu-item-status'    => 'publish',
+			)
+		);
+
+		$this->go_to( get_permalink( $cpt_id ) );
+
+		$menu_items = wp_get_nav_menu_items( $this->menu_id );
+		_wp_menu_item_classes_by_context( $menu_items );
+
+		$cpt_archive_classes = $menu_items[0]->classes;
+		$this->assertNotContains( 'current_page_parent', $cpt_archive_classes );
+	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

## Summary

When viewing a **singular** post of a **public, non–built-in** custom post type, the corresponding **post type archive** nav menu item did not receive the `current_page_parent` class, unlike the behavior users expect for “section” parents in menus.

This change:

- Precomputes public custom post types once in `_wp_menu_item_classes_by_context()`.
- On singular views of those types, adds `current_page_parent` to matching **`post_type_archive`** menu items (same post type in `object`).

Refreshes the approach from older patches on the ticket and adds PHPUnit coverage.

## Testing

`phpunit` (filtered): `Tests_Post_Nav_Menu` — all tests passed locally.

Trac ticket: https://core.trac.wordpress.org/ticket/38836

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

AI assistance: Yes  
Tool(s): Cursor (AI-assisted editor)  
Used for: Guidance on contribution workflow, patch review, test structure, and PR text; implementation was applied in the local checkout, run through PHPUnit (`Tests_Post_Nav_Menu`), and reviewed by me before opening this PR.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**