### PR TITLE
Posts: Introduce post_title_child_separator filter (#39106)

### DIFF
--- a/src/wp-admin/includes/class-wp-posts-list-table.php
+++ b/src/wp-admin/includes/class-wp-posts-list-table.php
@@ -1137,7 +1137,21 @@ class WP_Posts_List_Table extends WP_List_Table {
 			echo '<div class="locked-info"><span class="locked-avatar">' . $locked_avatar . '</span> <span class="locked-text">' . $locked_text . "</span></div>\n";
 		}
 
-		$pad = str_repeat( '&#8212; ', $this->current_level );
+		/**
+		 * Filters the hierarchy separator for a post title in the posts list table.
+		 *
+		 * The separator is output once per hierarchical level before the post title
+		 * (it is repeated based on the current depth in the tree).
+		 *
+		 * @since 7.1.0
+		 *
+		 * @param string  $separator The hierarchy separator. Default em dash with a trailing space (`&#8212; `).
+		 * @param int     $level     Current hierarchical depth for this row.
+		 * @param WP_Post $post      Current post object.
+		 */
+		$separator = apply_filters( 'post_title_child_separator', '&#8212; ', $this->current_level, $post );
+		$pad       = str_repeat( $separator, $this->current_level );
+
 		echo '<strong>';
 
 		$title = _draft_or_post_title();

--- a/tests/phpunit/tests/admin/wpPostsListTable.php
+++ b/tests/phpunit/tests/admin/wpPostsListTable.php
@@ -330,4 +330,48 @@ class Tests_Admin_wpPostsListTable extends WP_UnitTestCase {
 
 		$this->assertSame( $expected, $actual );
 	}
+
+	/**
+	 * @ticket 39106
+	 *
+	 * @covers WP_Posts_List_Table::column_title
+	 */
+	public function test_post_title_child_separator_filter_changes_title_pad() {
+		add_filter(
+			'post_title_child_separator',
+			static function () {
+				return '-- ';
+			}
+		);
+
+		$child = self::$children[1][1];
+
+		$this->table->set_hierarchical_display( true );
+
+		ob_start();
+		$this->table->single_row( $child, 2 );
+		$output = ob_get_clean();
+
+		remove_all_filters( 'post_title_child_separator' );
+
+		// Level 2 => separator repeated twice before the title.
+		$this->assertStringContainsString( '-- -- ', $output, 'Filtered separator should repeat per hierarchy level.' );
+	}
+
+	/**
+	 * @ticket 39106
+	 *
+	 * @covers WP_Posts_List_Table::column_title
+	 */
+	public function test_post_title_child_separator_default_pad_unchanged() {
+		$child = self::$children[1][1];
+
+		$this->table->set_hierarchical_display( true );
+
+		ob_start();
+		$this->table->single_row( $child, 1 );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( '&#8212; ', $output, 'Default hierarchy separator should remain the em dash.' );
+	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

## Summary

`WP_Posts_List_Table::column_title()` built the hierarchical indent with a hardcoded em dash string repeated per level. This adds a filter — **`post_title_child_separator`** — so the **per-level** separator can be changed while preserving default output (`&#8212; `) when the filter is not used.

Props **rebasaurus**, **mayankmajeji**, and **seanchayes** for earlier patches and discussion on the ticket.

## Testing

- `phpunit` (filtered): `post_title_child_separator` in `tests/phpunit/tests/admin/wpPostsListTable.php`

Trac ticket: https://core.trac.wordpress.org/ticket/39106

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

AI assistance: Yes  
Tool(s): Cursor (AI-assisted editor)  
Used for: Implementation and PHPUnit coverage; I reviewed the result and ran tests locally before opening this PR.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**