### PR TITLE
Settings API: Add ID attributes to section title headings.

### DIFF
--- a/src/wp-admin/includes/template.php
+++ b/src/wp-admin/includes/template.php
@@ -1780,7 +1780,7 @@ function do_settings_sections( $page ) {
 		}
 
 		if ( $section['title'] ) {
-			echo "<h2>{$section['title']}</h2>\n";
+			echo '<h2 id="' . esc_attr( $section['id'] ) . '">' . $section['title'] . "</h2>\n";
 		}
 
 		if ( $section['callback'] ) {

--- a/src/wp-admin/includes/template.php
+++ b/src/wp-admin/includes/template.php
@@ -1780,7 +1780,7 @@ function do_settings_sections( $page ) {
 		}
 
 		if ( $section['title'] ) {
-			echo '<h2 id="' . esc_attr( $section['id'] ) . '">' . $section['title'] . "</h2>\n";
+			echo '<h2 id="wp_section_' . esc_attr( $section['id'] ) . '">' . $section['title'] . "</h2>\n";
 		}
 
 		if ( $section['callback'] ) {

--- a/src/wp-admin/includes/template.php
+++ b/src/wp-admin/includes/template.php
@@ -1780,7 +1780,8 @@ function do_settings_sections( $page ) {
 		}
 
 		if ( $section['title'] ) {
-			echo '<h2 id="wp_section_' . esc_attr( $section['id'] ) . '">' . $section['title'] . "</h2>\n";
+			$unique_id = wp_unique_id( 'wp-settings-section-' . $section['id'] . '-' );
+			echo '<h2 id="' . esc_attr( $unique_id ) . '">' . $section['title'] . "</h2>\n";
 		}
 
 		if ( $section['callback'] ) {

--- a/src/wp-admin/options-discussion.php
+++ b/src/wp-admin/options-discussion.php
@@ -211,7 +211,7 @@ printf(
 <?php do_settings_fields( 'discussion', 'default' ); ?>
 </table>
 
-<h2 id="avatars" class="title"><?php _e( 'Avatars' ); ?></h2>
+<h2 id="wp-settings-section-avatars" class="title"><?php _e( 'Avatars' ); ?></h2>
 
 <p><?php _e( 'An avatar is an image that can be associated with a user across multiple websites. In this area, you can choose to display avatars of users who interact with the site.' ); ?></p>
 

--- a/src/wp-admin/options-discussion.php
+++ b/src/wp-admin/options-discussion.php
@@ -211,7 +211,7 @@ printf(
 <?php do_settings_fields( 'discussion', 'default' ); ?>
 </table>
 
-<h2 class="title"><?php _e( 'Avatars' ); ?></h2>
+<h2 id="avatars" class="title"><?php _e( 'Avatars' ); ?></h2>
 
 <p><?php _e( 'An avatar is an image that can be associated with a user across multiple websites. In this area, you can choose to display avatars of users who interact with the site.' ); ?></p>
 

--- a/src/wp-admin/options-media.php
+++ b/src/wp-admin/options-media.php
@@ -52,7 +52,7 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 <form action="options.php" method="post">
 <?php settings_fields( 'media' ); ?>
 
-<h2 class="title"><?php _e( 'Image sizes' ); ?></h2>
+<h2 id="image-sizes" class="title"><?php _e( 'Image sizes' ); ?></h2>
 <p><?php _e( 'The sizes listed below determine the maximum dimensions in pixels to use when adding an image to the Media Library.' ); ?></p>
 
 <table class="form-table" role="presentation">
@@ -104,14 +104,14 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
  */
 if ( isset( $GLOBALS['wp_settings']['media']['embeds'] ) ) :
 	?>
-<h2 class="title"><?php _e( 'Embeds' ); ?></h2>
+<h2 id="embeds" class="title"><?php _e( 'Embeds' ); ?></h2>
 <table class="form-table" role="presentation">
 	<?php do_settings_fields( 'media', 'embeds' ); ?>
 </table>
 <?php endif; ?>
 
 <?php if ( ! is_multisite() ) : ?>
-<h2 class="title"><?php _e( 'Uploading Files' ); ?></h2>
+<h2 id="uploading-files" class="title"><?php _e( 'Uploading Files' ); ?></h2>
 <table class="form-table" role="presentation">
 	<?php
 	/*

--- a/src/wp-admin/options-media.php
+++ b/src/wp-admin/options-media.php
@@ -52,7 +52,7 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 <form action="options.php" method="post">
 <?php settings_fields( 'media' ); ?>
 
-<h2 id="image-sizes" class="title"><?php _e( 'Image sizes' ); ?></h2>
+<h2 id="wp-settings-section-image-sizes" class="title"><?php _e( 'Image sizes' ); ?></h2>
 <p><?php _e( 'The sizes listed below determine the maximum dimensions in pixels to use when adding an image to the Media Library.' ); ?></p>
 
 <table class="form-table" role="presentation">
@@ -104,14 +104,14 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
  */
 if ( isset( $GLOBALS['wp_settings']['media']['embeds'] ) ) :
 	?>
-<h2 id="embeds" class="title"><?php _e( 'Embeds' ); ?></h2>
+<h2 id="wp-settings-section-embeds" class="title"><?php _e( 'Embeds' ); ?></h2>
 <table class="form-table" role="presentation">
 	<?php do_settings_fields( 'media', 'embeds' ); ?>
 </table>
 <?php endif; ?>
 
 <?php if ( ! is_multisite() ) : ?>
-<h2 id="uploading-files" class="title"><?php _e( 'Uploading Files' ); ?></h2>
+<h2 id="wp-settings-section-uploading-files" class="title"><?php _e( 'Uploading Files' ); ?></h2>
 <table class="form-table" role="presentation">
 	<?php
 	/*

--- a/src/wp-admin/options-permalink.php
+++ b/src/wp-admin/options-permalink.php
@@ -314,7 +314,7 @@ $tag_removed = __( '%s removed from permalink structure' );
 /* translators: %s: Permalink structure tag. */
 $tag_already_used = __( '%s (already used in permalink structure)' );
 ?>
-<h2 id="common-settings" class="title"><?php _e( 'Common Settings' ); ?></h2>
+<h2 id="wp-settings-section-common-settings" class="title"><?php _e( 'Common Settings' ); ?></h2>
 <p>
 <?php
 printf(
@@ -405,7 +405,7 @@ printf(
 </tbody>
 </table>
 
-<h2 id="optional" class="title"><?php _e( 'Optional' ); ?></h2>
+<h2 id="wp-settings-section-optional" class="title"><?php _e( 'Optional' ); ?></h2>
 <p class="permalink-structure-optional-description">
 <?php
 printf(

--- a/src/wp-admin/options-permalink.php
+++ b/src/wp-admin/options-permalink.php
@@ -314,7 +314,7 @@ $tag_removed = __( '%s removed from permalink structure' );
 /* translators: %s: Permalink structure tag. */
 $tag_already_used = __( '%s (already used in permalink structure)' );
 ?>
-<h2 class="title"><?php _e( 'Common Settings' ); ?></h2>
+<h2 id="common-settings" class="title"><?php _e( 'Common Settings' ); ?></h2>
 <p>
 <?php
 printf(
@@ -405,7 +405,7 @@ printf(
 </tbody>
 </table>
 
-<h2 class="title"><?php _e( 'Optional' ); ?></h2>
+<h2 id="optional" class="title"><?php _e( 'Optional' ); ?></h2>
 <p class="permalink-structure-optional-description">
 <?php
 printf(

--- a/src/wp-admin/options-writing.php
+++ b/src/wp-admin/options-writing.php
@@ -141,7 +141,7 @@ do_settings_fields( 'writing', 'remote_publishing' ); // A deprecated section.
 /** This filter is documented in wp-admin/options.php */
 if ( apply_filters( 'enable_post_by_email_configuration', true ) ) {
 	?>
-<h2 id="post-via-email" class="title"><?php _e( 'Post via email' ); ?></h2>
+<h2 id="wp-settings-section-post-via-email" class="title"><?php _e( 'Post via email' ); ?></h2>
 <p>
 	<?php
 	printf(
@@ -212,7 +212,7 @@ if ( apply_filters( 'enable_post_by_email_configuration', true ) ) {
  */
 if ( apply_filters( 'enable_update_services_configuration', true ) ) {
 	?>
-<h2 id="update-services" class="title"><?php _e( 'Update Services' ); ?></h2>
+<h2 id="wp-settings-section-update-services" class="title"><?php _e( 'Update Services' ); ?></h2>
 
 	<?php if ( '1' === get_option( 'blog_public' ) ) : ?>
 

--- a/src/wp-admin/options-writing.php
+++ b/src/wp-admin/options-writing.php
@@ -141,7 +141,7 @@ do_settings_fields( 'writing', 'remote_publishing' ); // A deprecated section.
 /** This filter is documented in wp-admin/options.php */
 if ( apply_filters( 'enable_post_by_email_configuration', true ) ) {
 	?>
-<h2 class="title"><?php _e( 'Post via email' ); ?></h2>
+<h2 id="post-via-email" class="title"><?php _e( 'Post via email' ); ?></h2>
 <p>
 	<?php
 	printf(
@@ -212,7 +212,7 @@ if ( apply_filters( 'enable_post_by_email_configuration', true ) ) {
  */
 if ( apply_filters( 'enable_update_services_configuration', true ) ) {
 	?>
-<h2 class="title"><?php _e( 'Update Services' ); ?></h2>
+<h2 id="update-services" class="title"><?php _e( 'Update Services' ); ?></h2>
 
 	<?php if ( '1' === get_option( 'blog_public' ) ) : ?>
 


### PR DESCRIPTION
Ticket Details: https://core.trac.wordpress.org/ticket/65027

The main motivation for doing that is to allow hash navigation via URL. We could easily in the documentation have links such as wp-admin/options-discussion.php#avatars, which I think it is a huge benefit if we're talking long forms. 