### PR TITLE
Templates: Add `date` field

### DIFF
--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -595,6 +595,7 @@ function _remove_theme_attribute_from_template_part_block( &$block ) {
  *
  * @since 5.9.0
  * @since 6.3.0 Added `modified` property to template objects.
+ * @since 7.1.0 Added `date` property to template objects.
  * @access private
  *
  * @param array  $template_file Theme file.
@@ -617,6 +618,7 @@ function _build_block_template_result_from_file( $template_file, $template_type 
 	$template->has_theme_file = true;
 	$template->is_custom      = true;
 	$template->modified       = null;
+	$template->date           = null;
 
 	if ( 'wp_template' === $template_type ) {
 		$registered_template = WP_Block_Templates_Registry::get_instance()->get_by_slug( $template_file['slug'] );
@@ -867,6 +869,7 @@ function _build_block_template_object_from_post_object( $post, $terms = array(),
 	$template->is_custom      = empty( $meta['is_wp_suggestion'] );
 	$template->author         = $post->post_author;
 	$template->modified       = $post->post_modified;
+	$template->date           = $post->post_date;
 
 	if ( 'wp_template' === $post->post_type && $has_theme_file && isset( $template_file['postTypes'] ) ) {
 		$template->post_types = $template_file['postTypes'];

--- a/src/wp-includes/class-wp-block-template.php
+++ b/src/wp-includes/class-wp-block-template.php
@@ -162,4 +162,12 @@ class WP_Block_Template {
 	 * @var string|null
 	 */
 	public $modified;
+
+	/**
+	 * Date.
+	 *
+	 * @since 7.1.0
+	 * @var string|null
+	 */
+	public $date;
 }

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
@@ -667,6 +667,7 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 	 * @since 5.8.0
 	 * @since 5.9.0 Renamed `$template` to `$item` to match parent class for PHP 8 named parameter support.
 	 * @since 6.3.0 Added `modified` property to the response.
+	 * @since 7.1.0 Added `date` property to the response.
 	 *
 	 * @param WP_Block_Template $item    Template instance.
 	 * @param WP_REST_Request   $request Request object.
@@ -776,6 +777,10 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 
 		if ( rest_is_field_included( 'modified', $fields ) ) {
 			$data['modified'] = mysql_to_rfc3339( $template->modified );
+		}
+
+		if ( rest_is_field_included( 'date', $fields ) ) {
+			$data['date'] = mysql_to_rfc3339( $template->date );
 		}
 
 		if ( rest_is_field_included( 'author_text', $fields ) ) {
@@ -1171,6 +1176,13 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 						'site',
 						'user',
 					),
+				),
+				'date'        => array(
+					'description' => __( "The date the template was published, in the site's timezone." ),
+					'type'        => array( 'string', 'null' ),
+					'format'      => 'date-time',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
 				),
 			),
 		);

--- a/tests/phpunit/tests/rest-api/wpRestTemplateAutosavesController.php
+++ b/tests/phpunit/tests/rest-api/wpRestTemplateAutosavesController.php
@@ -682,6 +682,7 @@ class Tests_REST_wpRestTemplateAutosavesController extends WP_Test_REST_Controll
 		$this->assertArrayHasKey( 'has_theme_file', $properties, 'has_theme_file key should exist in properties.' );
 		$this->assertArrayHasKey( 'author', $properties, 'author key should exist in properties.' );
 		$this->assertArrayHasKey( 'modified', $properties, 'modified key should exist in properties.' );
+		$this->assertArrayHasKey( 'date', $properties, 'date key should exist in properties.' );
 		$this->assertArrayHasKey( 'parent', $properties, 'Parent key should exist in properties.' );
 		$this->assertArrayHasKey( 'author_text', $properties, 'author_text key should exist in properties.' );
 		$this->assertArrayHasKey( 'original_source', $properties, 'original_source key should exist in properties.' );
@@ -700,13 +701,13 @@ class Tests_REST_wpRestTemplateAutosavesController extends WP_Test_REST_Controll
 			'templates'      => array(
 				'templates',
 				self::TEST_THEME . '//' . self::TEMPLATE_NAME,
-				19,
+				20,
 				array( 'is_custom', 'plugin' ),
 			),
 			'template parts' => array(
 				'template-parts',
 				self::TEST_THEME . '//' . self::TEMPLATE_PART_NAME,
-				18,
+				19,
 				array( 'area' ),
 			),
 		);

--- a/tests/phpunit/tests/rest-api/wpRestTemplateRevisionsController.php
+++ b/tests/phpunit/tests/rest-api/wpRestTemplateRevisionsController.php
@@ -928,6 +928,7 @@ class Tests_REST_wpRestTemplateRevisionsController extends WP_Test_REST_Controll
 		$this->assertArrayHasKey( 'has_theme_file', $properties, 'has_theme_file key should exist in properties.' );
 		$this->assertArrayHasKey( 'author', $properties, 'author key should exist in properties.' );
 		$this->assertArrayHasKey( 'modified', $properties, 'modified key should exist in properties.' );
+		$this->assertArrayHasKey( 'date', $properties, 'date key should exist in properties.' );
 		$this->assertArrayHasKey( 'parent', $properties, 'Parent key should exist in properties.' );
 		$this->assertArrayHasKey( 'author_text', $properties, 'author_text key should exist in properties.' );
 		$this->assertArrayHasKey( 'original_source', $properties, 'original_source key should exist in properties.' );
@@ -947,13 +948,13 @@ class Tests_REST_wpRestTemplateRevisionsController extends WP_Test_REST_Controll
 			'templates'      => array(
 				'templates',
 				self::TEST_THEME . '//' . self::TEMPLATE_NAME,
-				19,
+				20,
 				array( 'is_custom', 'plugin' ),
 			),
 			'template parts' => array(
 				'template-parts',
 				self::TEST_THEME . '//' . self::TEMPLATE_PART_NAME,
-				18,
+				19,
 				array( 'area' ),
 			),
 		);

--- a/tests/phpunit/tests/rest-api/wpRestTemplatesController.php
+++ b/tests/phpunit/tests/rest-api/wpRestTemplatesController.php
@@ -168,6 +168,7 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 				'is_custom'       => true,
 				'author'          => 0,
 				'modified'        => mysql_to_rfc3339( self::$template_post->post_modified ),
+				'date'            => mysql_to_rfc3339( self::$template_post->post_date ),
 				'author_text'     => 'Test Blog',
 				'original_source' => 'site',
 			),
@@ -247,6 +248,7 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 				'is_custom'       => true,
 				'author'          => 0,
 				'modified'        => mysql_to_rfc3339( self::$template_post->post_modified ),
+				'date'            => mysql_to_rfc3339( self::$template_post->post_date ),
 				'author_text'     => 'Test Blog',
 				'original_source' => 'site',
 			),
@@ -304,6 +306,7 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 				'is_custom'       => true,
 				'author'          => 0,
 				'modified'        => mysql_to_rfc3339( self::$template_post->post_modified ),
+				'date'            => mysql_to_rfc3339( self::$template_post->post_date ),
 				'author_text'     => 'Test Blog',
 				'original_source' => 'site',
 			),
@@ -355,6 +358,7 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 				'is_custom'       => true,
 				'author'          => 0,
 				'modified'        => mysql_to_rfc3339( self::$template_post->post_modified ),
+				'date'            => mysql_to_rfc3339( self::$template_post->post_date ),
 				'author_text'     => 'Test Blog',
 				'original_source' => 'site',
 			),
@@ -404,6 +408,7 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 				'is_custom'       => true,
 				'author'          => 0,
 				'modified'        => mysql_to_rfc3339( self::$template_post->post_modified ),
+				'date'            => mysql_to_rfc3339( self::$template_post->post_date ),
 				'author_text'     => 'Test Blog',
 				'original_source' => 'site',
 			),
@@ -469,6 +474,7 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 				'modified'        => mysql_to_rfc3339( $post->post_modified ),
 				'author_text'     => $author_name,
 				'original_source' => 'user',
+				'date'            => mysql_to_rfc3339( $post->post_date ),
 			),
 			$data
 		);
@@ -673,6 +679,7 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 		$modified = get_post( $data['wp_id'] )->post_modified;
+		$date     = get_post( $data['wp_id'] )->post_date;
 		unset( $data['_links'] );
 		unset( $data['wp_id'] );
 
@@ -699,6 +706,7 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 				'is_custom'       => true,
 				'author'          => self::$admin_id,
 				'modified'        => mysql_to_rfc3339( $modified ),
+				'date'            => mysql_to_rfc3339( $date ),
 				'author_text'     => $author_name,
 				'original_source' => 'user',
 			),
@@ -725,6 +733,7 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 		$modified = get_post( $data['wp_id'] )->post_modified;
+		$date     = get_post( $data['wp_id'] )->post_date;
 		unset( $data['_links'] );
 		unset( $data['wp_id'] );
 
@@ -751,6 +760,7 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 				'is_custom'       => false,
 				'author'          => self::$admin_id,
 				'modified'        => mysql_to_rfc3339( $modified ),
+				'date'            => mysql_to_rfc3339( $date ),
 				'author_text'     => $author_name,
 				'original_source' => 'user',
 			),
@@ -781,6 +791,7 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 		$modified = get_post( $data['wp_id'] )->post_modified;
+		$date     = get_post( $data['wp_id'] )->post_date;
 		unset( $data['_links'] );
 		unset( $data['wp_id'] );
 
@@ -807,6 +818,7 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 				'is_custom'       => true,
 				'author'          => self::$admin_id,
 				'modified'        => mysql_to_rfc3339( $modified ),
+				'date'            => mysql_to_rfc3339( $date ),
 				'author_text'     => $author_name,
 				'original_source' => 'user',
 			),
@@ -967,7 +979,7 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 		$response   = rest_get_server()->dispatch( $request );
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
-		$this->assertCount( 18, $properties );
+		$this->assertCount( 19, $properties );
 		$this->assertArrayHasKey( 'id', $properties );
 		$this->assertArrayHasKey( 'description', $properties );
 		$this->assertArrayHasKey( 'slug', $properties );
@@ -984,6 +996,7 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 		$this->assertArrayHasKey( 'is_custom', $properties );
 		$this->assertArrayHasKey( 'author', $properties );
 		$this->assertArrayHasKey( 'modified', $properties );
+		$this->assertArrayHasKey( 'date', $properties );
 		$this->assertArrayHasKey( 'author_text', $properties );
 		$this->assertArrayHasKey( 'original_source', $properties );
 		$this->assertArrayHasKey( 'plugin', $properties );
@@ -1020,7 +1033,9 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 		$response                    = rest_get_server()->dispatch( $request );
 		$data                        = $response->get_data();
 		$modified                    = get_post( $data['wp_id'] )->post_modified;
+		$date                        = get_post( $data['wp_id'] )->post_date;
 		$expected['modified']        = mysql_to_rfc3339( $modified );
+		$expected['date']            = mysql_to_rfc3339( $date );
 		$expected['author_text']     = get_user_by( 'id', self::$admin_id )->get( 'display_name' );
 		$expected['original_source'] = 'user';
 


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->

Backports: https://github.com/WordPress/gutenberg/pull/77134

Trac ticket: https://core.trac.wordpress.org/ticket/65049


This PR adds the `date` field in templates and template parts. This will help with the simplification of revisions handling for these post types, as there is a lot of scattered code around that working around the fact that they expose only the `modified` date.

## Testing Instructions
1. `date` field should be returned through REST API
2. everything should work exactly as before - especially the templates/template parts flows since the change affects only them.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
