### PR TITLE
Include block name context in _doing_it_wrong messages in WP_Block_Type_Registry::register()

### DIFF
--- a/src/wp-includes/class-wp-block-type-registry.php
+++ b/src/wp-includes/class-wp-block-type-registry.php
@@ -55,7 +55,8 @@ final class WP_Block_Type_Registry {
 		if ( ! is_string( $name ) ) {
 			_doing_it_wrong(
 				__METHOD__,
-				__( 'Block type names must be strings.' ),
+				/* translators: %s: The received block type name type. */
+				sprintf( __( 'Block type names must be strings, received %s.' ), gettype( $name ) ),
 				'5.0.0'
 			);
 			return false;
@@ -64,7 +65,8 @@ final class WP_Block_Type_Registry {
 		if ( preg_match( '/[A-Z]+/', $name ) ) {
 			_doing_it_wrong(
 				__METHOD__,
-				__( 'Block type names must not contain uppercase characters.' ),
+				/* translators: %s: Block name. */
+				sprintf( __( 'Block type names must not contain uppercase characters. "%s" was given.' ), $name ),
 				'5.0.0'
 			);
 			return false;
@@ -74,7 +76,8 @@ final class WP_Block_Type_Registry {
 		if ( ! preg_match( $name_matcher, $name ) ) {
 			_doing_it_wrong(
 				__METHOD__,
-				__( 'Block type names must contain a namespace prefix. Example: my-plugin/my-custom-block-type' ),
+				/* translators: %s: Block name. */
+				sprintf( __( 'Block type names must contain a namespace prefix. Example: my-plugin/my-custom-block-type. "%s" was given.' ), $name ),
 				'5.0.0'
 			);
 			return false;


### PR DESCRIPTION
WP_Block_Type_Registry::register() has four _doing_it_wrong() calls for invalid block names. Three of them don't say which name caused the error.

Example: you get "Block type names must not contain uppercase characters." with no way to tell which block it's about.
The fourth message ("Block type "%s" is already registered.") already includes the name. The other three should do the same to improve developper experience.

Trac ticket: https://core.trac.wordpress.org/ticket/65039

_Use of AI : I used AI to help write this PR description — my English isn't great._

Props benjgrolleau