### PR TITLE
Fix #65024: Add item_draft_saved label to make 'Draft saved.' message…

### DIFF
--- a/src/wp-includes/class-wp-post-type.php
+++ b/src/wp-includes/class-wp-post-type.php
@@ -1015,6 +1015,7 @@ final class WP_Post_Type {
 			'item_trashed'             => array( __( 'Post trashed.' ), __( 'Page trashed.' ) ),
 			'item_scheduled'           => array( __( 'Post scheduled.' ), __( 'Page scheduled.' ) ),
 			'item_updated'             => array( __( 'Post updated.' ), __( 'Page updated.' ) ),
+			'item_draft_saved'         => array( __( 'Draft saved.' ), __( 'Draft saved.' ) ),
 			'item_link'                => array(
 				_x( 'Post Link', 'navigation link block title' ),
 				_x( 'Page Link', 'navigation link block title' ),

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -323,6 +323,7 @@ function create_initial_post_types() {
 				'item_reverted_to_draft'   => __( 'Pattern reverted to draft.' ),
 				'item_scheduled'           => __( 'Pattern scheduled.' ),
 				'item_updated'             => __( 'Pattern updated.' ),
+				'item_draft_saved'         => __( 'Pattern draft saved.' ),
 			),
 			'public'                => false,
 			'_builtin'              => true, /* internal use only. don't use this when registering your own post type. */
@@ -2143,6 +2144,8 @@ function _post_type_meta_capabilities( $capabilities = null ) {
  * - `item_scheduled` - Label used when an item is scheduled for publishing. Default is 'Post scheduled.' /
  *                    'Page scheduled.'
  * - `item_updated` - Label used when an item is updated. Default is 'Post updated.' / 'Page updated.'
+ * - `item_draft_saved` - Label used when a draft is saved. Default is 'Draft saved.' for both
+ *                      non-hierarchical and hierarchical post types.
  * - `item_link` - Title for a navigation link block variation. Default is 'Post Link' / 'Page Link'.
  * - `item_link_description` - Description for a navigation link block variation. Default is 'A link to a post.' /
  *                             'A link to a page.'
@@ -2167,6 +2170,7 @@ function _post_type_meta_capabilities( $capabilities = null ) {
  * @since 6.4.0 Changed default values for the `add_new` label to include the type of content.
  *              This matches `add_new_item` and provides more context for better accessibility.
  * @since 6.6.0 Added the `template_name` label.
+ * @since 7.1.0 Added the `item_draft_saved` label.
  * @since 6.7.0 Restored pre-6.4.0 defaults for the `add_new` label and updated documentation.
  *              Updated core usage to reference `add_new_item`.
  *


### PR DESCRIPTION
Core Trac Ticket: https://core.trac.wordpress.org/ticket/65024

**Problem**
The "Draft saved." message that appears in the block editor snackbar notification when saving a post in draft status cannot be modified by plugins or themes. Unlike other editor save messages (e.g. "Post published.", "Post updated.", "Post trashed."), there is no WordPress filter or hook that exposes this string.

**Root Cause**
All other save notification messages in the block editor are sourced from postType.labels — PHP-defined post type label objects that are exposed via the REST API and filterable using the post_type_labels_{post_type} hook. However, the "Draft saved." message is hardcoded directly in JavaScript (wp-includes/js/dist/editor.js) inside the getNotificationArgumentsForSaveSuccess() function, bypassing the label system entirely and making it impossible to override.

**Solution**
This PR handles the PHP side of the fix by adding a new item_draft_saved label to the post type labels system, following the same pattern as existing labels like item_updated, item_published, and item_trashed:

class-wp-post-type.php: Added item_draft_saved to WP_Post_Type::get_default_labels() with a default value of 'Draft saved.' for both hierarchical and non-hierarchical post types.
post.php: Added a contextual 'Pattern draft saved.' label for the wp_block post type (which already defines its own full set of custom labels), and updated the get_post_type_labels() docblock to document the new label.
Since the REST API post types controller already exposes the full $post_type->labels object, the new label flows to the JavaScript side automatically with no REST API changes needed.

The corresponding JS change — replacing the hardcoded __("Draft saved.") with postType2.labels.item_draft_saved in packages/editor/src/store/utils/notice-builder.js — needs to be made in a separate Gutenberg PR, as wp-includes/js/dist/editor.js is a compiled build artifact synced from the Gutenberg monorepo.

Once both the PHP (this PR) and the Gutenberg JS change land, plugins will be able to filter the message using the existing hook:


add_filter( 'post_type_labels_post', function( $labels ) {
    $labels->item_draft_saved = 'Your custom message.';
    return $labels;
} );