### PR TITLE
Fix #53348: Add isset() checks and else fallback for checkemail in wp-login.php

### DIFF
--- a/src/wp-login.php
+++ b/src/wp-login.php
@@ -1214,7 +1214,7 @@ switch ( $action ) {
 		$redirect_to = admin_url();
 		$errors      = new WP_Error();
 
-		if ( 'confirm' === $_GET['checkemail'] ) {
+		if ( isset( $_GET['checkemail'] ) && 'confirm' === $_GET['checkemail'] ) {
 			$errors->add(
 				'confirm',
 				sprintf(
@@ -1224,7 +1224,7 @@ switch ( $action ) {
 				),
 				'message'
 			);
-		} elseif ( 'registered' === $_GET['checkemail'] ) {
+		} elseif ( isset( $_GET['checkemail'] ) && 'registered' === $_GET['checkemail'] ) {
 			$errors->add(
 				'registered',
 				sprintf(
@@ -1234,6 +1234,9 @@ switch ( $action ) {
 				),
 				'message'
 			);
+		} else {
+			wp_redirect( wp_login_url() );
+			exit;
 		}
 
 		/** This action is documented in wp-login.php */


### PR DESCRIPTION
Core Trac: https://core.trac.wordpress.org/ticket/53348

**Problem**

Visiting wp-login.php with certain query strings results in a blank page instead of the login form. The affected URLs are:

wp-login.php?action=checkemail
wp-login.php?checkemail=foo (any value other than confirm or registered)
Additionally, visiting wp-login.php?action=checkemail triggers two PHP notices:


Notice: Undefined index: checkemail in wp-login.php on line 1217
Notice: Undefined index: checkemail in wp-login.php on line 1227

**Root Cause**

In the checkemail switch case, $_GET['checkemail'] was accessed directly without an isset() check. When checkemail is not present in the query string (e.g. ?action=checkemail), PHP fires an "Undefined index" notice for both the if and elseif comparisons.

Furthermore, there was no else fallback for unexpected or missing checkemail values. When neither 'confirm' nor 'registered' matched, the code called login_header() and login_footer() with an empty $errors object — rendering a page with no content, no form, and no message.

**Solution**

Two targeted changes inside the checkemail switch case in [src/wp-login.php](vscode-webview://06h8mmh3l0rub6ucnbbpeqvqebdb26rk7krdfbk8ba35ibg73ftq/src/wp-login.php):

Added isset() guards before each $_GET['checkemail'] comparison to eliminate the PHP notices:

if ( isset( $_GET['checkemail'] ) && 'confirm' === $_GET['checkemail'] ) {

} elseif ( isset( $_GET['checkemail'] ) && 'registered' === $_GET['checkemail'] ) {
Added an else fallback that redirects to the login URL for all unexpected or missing checkemail values:

} else {
    wp_redirect( wp_login_url() );
    exit;
}
This is consistent with existing behaviour — when an unrecognised ?action= value is supplied, WordPress falls back to the login form (line 509–510). No user-supplied input is used in the redirect, so there is no open redirect vulnerability.


