### PR TITLE
General: Add filter to WP_Posts_List_Table::get_table_classes(). Adds…

### DIFF
--- a/src/wp-admin/includes/class-wp-posts-list-table.php
+++ b/src/wp-admin/includes/class-wp-posts-list-table.php
@@ -640,12 +640,24 @@ class WP_Posts_List_Table extends WP_List_Table {
 
 		$mode_class = esc_attr( 'table-view-' . $mode );
 
-		return array(
-			'widefat',
-			'fixed',
-			'striped',
-			$mode_class,
-			is_post_type_hierarchical( $this->screen->post_type ) ? 'pages' : 'posts',
+		/**
+		 * Filters the CSS classes applied to the posts list table.
+		 *
+		 * @since 6.8.0
+		 *
+		 * @param string[] $classes   An array of CSS classes for the posts list table.
+		 * @param string   $post_type The post type slug.
+		 */
+		return apply_filters(
+			'post_list_table_classes',
+			array(
+				'widefat',
+				'fixed',
+				'striped',
+				$mode_class,
+				is_post_type_hierarchical( $this->screen->post_type ) ? 'pages' : 'posts',
+			),
+			$this->screen->post_type
 		);
 	}
 

--- a/tests/phpunit/tests/admin/wpPostsListTable.php
+++ b/tests/phpunit/tests/admin/wpPostsListTable.php
@@ -310,6 +310,74 @@ class Tests_Admin_wpPostsListTable extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 58824
+	 *
+	 * @covers WP_Posts_List_Table::get_table_classes
+	 */
+	public function test_get_table_classes_returns_default_classes() {
+		$method = new ReflectionMethod( $this->table, 'get_table_classes' );
+		$method->setAccessible( true );
+
+		$classes = $method->invoke( $this->table );
+
+		$this->assertContains( 'widefat', $classes );
+		$this->assertContains( 'fixed', $classes );
+		$this->assertContains( 'striped', $classes );
+		$this->assertContains( 'pages', $classes );
+	}
+
+	/**
+	 * @ticket 58824
+	 *
+	 * @covers WP_Posts_List_Table::get_table_classes
+	 */
+	public function test_get_table_classes_filter_modifies_classes() {
+		add_filter(
+			'post_list_table_classes',
+			static function ( $classes ) {
+				$classes[] = 'my-custom-class';
+				return $classes;
+			}
+		);
+
+		$method = new ReflectionMethod( $this->table, 'get_table_classes' );
+		$method->setAccessible( true );
+
+		$classes = $method->invoke( $this->table );
+
+		remove_all_filters( 'post_list_table_classes' );
+
+		$this->assertContains( 'my-custom-class', $classes );
+	}
+
+	/**
+	 * @ticket 58824
+	 *
+	 * @covers WP_Posts_List_Table::get_table_classes
+	 */
+	public function test_get_table_classes_filter_receives_post_type() {
+		$received_post_type = null;
+
+		add_filter(
+			'post_list_table_classes',
+			static function ( $classes, $post_type ) use ( &$received_post_type ) {
+				$received_post_type = $post_type;
+				return $classes;
+			},
+			10,
+			2
+		);
+
+		$method = new ReflectionMethod( $this->table, 'get_table_classes' );
+		$method->setAccessible( true );
+		$method->invoke( $this->table );
+
+		remove_all_filters( 'post_list_table_classes' );
+
+		$this->assertSame( 'page', $received_post_type );
+	}
+
+	/**
 	 * @ticket 42066
 	 *
 	 * @covers WP_Posts_List_Table::get_views

--- a/tests/phpunit/tests/admin/wpPostsListTable.php
+++ b/tests/phpunit/tests/admin/wpPostsListTable.php
@@ -316,7 +316,6 @@ class Tests_Admin_wpPostsListTable extends WP_UnitTestCase {
 	 */
 	public function test_get_table_classes_returns_default_classes() {
 		$method = new ReflectionMethod( $this->table, 'get_table_classes' );
-		$method->setAccessible( true );
 
 		$classes = $method->invoke( $this->table );
 
@@ -341,7 +340,6 @@ class Tests_Admin_wpPostsListTable extends WP_UnitTestCase {
 		);
 
 		$method = new ReflectionMethod( $this->table, 'get_table_classes' );
-		$method->setAccessible( true );
 
 		$classes = $method->invoke( $this->table );
 
@@ -369,7 +367,6 @@ class Tests_Admin_wpPostsListTable extends WP_UnitTestCase {
 		);
 
 		$method = new ReflectionMethod( $this->table, 'get_table_classes' );
-		$method->setAccessible( true );
 		$method->invoke( $this->table );
 
 		remove_all_filters( 'post_list_table_classes' );


### PR DESCRIPTION
Adds a `post_list_table_classes` filter to `WP_Posts_List_Table::get_table_classes()` so developers can modify the CSS classes applied to the posts list table in the admin.                                                                                                                                                
                                                                                                                                                                
Currently the classes are hardcoded with no way to customize them. This filter allows developers to add, remove, or modify classes — for example, adding post-type-specific classes.                           

Trac ticket: https://core.trac.wordpress.org/ticket/58824

<img width="1458" height="445" alt="image" src="https://github.com/user-attachments/assets/11efcd49-7f09-4d8c-b6de-b233b9f1e57a" />
