### PR TITLE
Hooks/filters parity for preview & update functionality

### DIFF
--- a/src/wp-includes/customize/class-wp-customize-nav-menu-item-setting.php
+++ b/src/wp-includes/customize/class-wp-customize-nav-menu-item-setting.php
@@ -471,7 +471,29 @@ class WP_Customize_Nav_Menu_Item_Setting extends WP_Customize_Setting {
 			add_filter( 'wp_get_nav_menu_items', array( __CLASS__, 'sort_wp_get_nav_menu_items' ), 1000, 3 );
 		}
 
-		// @todo Add get_post_metadata filters for plugins to add their data.
+		/**
+		 * Fires when the WP_Customize_Nav_Menu_Item_Setting::preview() method is called
+		 * for a specific nav menu item setting.
+		 *
+		 * The dynamic portion of the hook name, `$this->id`, refers to the setting ID.
+		 *
+		 * @since 7.1.0
+		 *
+		 * @param WP_Customize_Nav_Menu_Item_Setting $setting WP_Customize_Nav_Menu_Item_Setting instance.
+		 */
+		do_action( "customize_preview_{$this->id}", $this );
+
+		/**
+		 * Fires when the WP_Customize_Nav_Menu_Item_Setting::preview() method is called
+		 * for nav menu item settings.
+		 *
+		 * The dynamic portion of the hook name, `$this->type`, refers to the setting type.
+		 *
+		 * @since 7.1.0
+		 *
+		 * @param WP_Customize_Nav_Menu_Item_Setting $setting WP_Customize_Nav_Menu_Item_Setting instance.
+		 */
+		do_action( "customize_preview_{$this->type}", $this );
 
 		return true;
 	}
@@ -887,6 +909,18 @@ class WP_Customize_Nav_Menu_Item_Setting extends WP_Customize_Setting {
 				}
 			}
 		}
+
+		/**
+		 * Fires when the WP_Customize_Nav_Menu_Item_Setting::update() method is called.
+		 *
+		 * The dynamic portion of the hook name, `$this->type`, refers to the setting type.
+		 *
+		 * @since 7.1.0
+		 *
+		 * @param array|false                        $value   Value of the setting. False if the menu item is to be deleted.
+		 * @param WP_Customize_Nav_Menu_Item_Setting $setting WP_Customize_Nav_Menu_Item_Setting instance.
+		 */
+		do_action( "customize_update_{$this->type}", $value, $this );
 
 		return ( 'error' !== $this->update_status );
 	}

--- a/tests/phpunit/tests/customize/nav-menu-item-setting.php
+++ b/tests/phpunit/tests/customize/nav-menu-item-setting.php
@@ -844,6 +844,131 @@ class Test_WP_Customize_Nav_Menu_Item_Setting extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that preview() fires the customize_preview_{$id} and customize_preview_{$type} action hooks.
+	 *
+	 * @ticket 55051
+	 *
+	 * @covers WP_Customize_Nav_Menu_Item_Setting::preview
+	 */
+	public function test_preview_fires_action_hooks() {
+		do_action( 'customize_register', $this->wp_customize );
+
+		$menu_id = wp_create_nav_menu( 'Primary' );
+		$post_id = self::factory()->post->create( array( 'post_title' => 'Hello World' ) );
+		$item_id = wp_update_nav_menu_item(
+			$menu_id,
+			0,
+			array(
+				'menu-item-type'      => 'post_type',
+				'menu-item-object'    => 'post',
+				'menu-item-object-id' => $post_id,
+				'menu-item-title'     => 'Hello World',
+				'menu-item-status'    => 'publish',
+			)
+		);
+
+		$setting_id = "nav_menu_item[$item_id]";
+		$setting    = new WP_Customize_Nav_Menu_Item_Setting( $this->wp_customize, $setting_id );
+		$this->wp_customize->set_post_value(
+			$setting_id,
+			array(
+				'type'             => 'post_type',
+				'object'           => 'post',
+				'object_id'        => $post_id,
+				'title'            => 'Updated Title',
+				'status'           => 'publish',
+				'nav_menu_term_id' => $menu_id,
+			)
+		);
+
+		$preview_id_action_count   = 0;
+		$preview_type_action_count = 0;
+		$preview_id_setting        = null;
+		$preview_type_setting      = null;
+
+		add_action(
+			"customize_preview_{$setting_id}",
+			function ( $s ) use ( &$preview_id_action_count, &$preview_id_setting ) {
+				++$preview_id_action_count;
+				$preview_id_setting = $s;
+			}
+		);
+
+		add_action(
+			'customize_preview_nav_menu_item',
+			function ( $s ) use ( &$preview_type_action_count, &$preview_type_setting ) {
+				++$preview_type_action_count;
+				$preview_type_setting = $s;
+			}
+		);
+
+		$setting->preview();
+
+		$this->assertSame( 1, $preview_id_action_count, 'customize_preview_{$id} action was not fired exactly once.' );
+		$this->assertSame( $setting, $preview_id_setting, 'customize_preview_{$id} action did not receive the setting instance.' );
+		$this->assertSame( 1, $preview_type_action_count, 'customize_preview_{$type} action was not fired exactly once.' );
+		$this->assertSame( $setting, $preview_type_setting, 'customize_preview_{$type} action did not receive the setting instance.' );
+	}
+
+	/**
+	 * Tests that update() fires the customize_update_{$type} action hook.
+	 *
+	 * @ticket 55051
+	 *
+	 * @covers WP_Customize_Nav_Menu_Item_Setting::update
+	 */
+	public function test_update_fires_action_hook() {
+		do_action( 'customize_register', $this->wp_customize );
+
+		$menu_id = wp_create_nav_menu( 'Primary' );
+		$post_id = self::factory()->post->create( array( 'post_title' => 'Hello World' ) );
+		$item_id = wp_update_nav_menu_item(
+			$menu_id,
+			0,
+			array(
+				'menu-item-type'      => 'post_type',
+				'menu-item-object'    => 'post',
+				'menu-item-object-id' => $post_id,
+				'menu-item-title'     => 'Hello World',
+				'menu-item-status'    => 'publish',
+			)
+		);
+
+		$post_value = array(
+			'type'             => 'post_type',
+			'object'           => 'post',
+			'object_id'        => $post_id,
+			'title'            => 'Updated Title',
+			'status'           => 'publish',
+			'nav_menu_term_id' => $menu_id,
+		);
+		$setting_id = "nav_menu_item[$item_id]";
+		$setting    = new WP_Customize_Nav_Menu_Item_Setting( $this->wp_customize, $setting_id );
+		$this->wp_customize->set_post_value( $setting_id, $post_value );
+
+		$update_action_count   = 0;
+		$update_action_value   = null;
+		$update_action_setting = null;
+
+		add_action(
+			'customize_update_nav_menu_item',
+			function ( $value, $s ) use ( &$update_action_count, &$update_action_value, &$update_action_setting ) {
+				++$update_action_count;
+				$update_action_value   = $value;
+				$update_action_setting = $s;
+			},
+			10,
+			2
+		);
+
+		$setting->save();
+
+		$this->assertSame( 1, $update_action_count, 'customize_update_{$type} action was not fired exactly once.' );
+		$this->assertSame( $setting, $update_action_setting, 'customize_update_{$type} action did not receive the setting instance.' );
+		$this->assertIsArray( $update_action_value, 'customize_update_{$type} action did not receive the value as an array.' );
+	}
+
+	/**
 	 * @ticket 33665
 	 */
 	public function test_invalid_nav_menu_item() {


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->

Trac ticket: [https://core.trac.wordpress.org/ticket/55051](https://www.google.com/search?q=https://core.trac.wordpress.org/ticket/55051)

Here's a summary of what was changed:

[class-wp-customize-nav-menu-item-setting.php]

Removed the // @todo Add get_post_metadata filters for plugins to add their data. placeholder (line 474)
Added do_action( "customize_preview_{$this->id}", $this ) at line 484
Added do_action( "customize_preview_{$this->type}", $this ) at line 496 (both with full docblocks, @since 7.1.0)
Added do_action( "customize_update_{$this->type}", $value, $this ) at line 923 before the final return

[tests/phpunit/tests/customize/nav-menu-item-setting.php]

test_preview_fires_action_hooks() — asserts both customize_preview_{id} and customize_preview_nav_menu_item fire once with the correct setting instance
test_update_fires_action_hook() — asserts customize_update_nav_menu_item fires once with the value array and correct setting instance

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
