### PR TITLE
Site Health: Deduplicate VCS detection via WP_Automatic_Updater (#47428)

### DIFF
--- a/src/wp-admin/includes/class-wp-automatic-updater.php
+++ b/src/wp-admin/includes/class-wp-automatic-updater.php
@@ -107,24 +107,34 @@ class WP_Automatic_Updater {
 	}
 
 	/**
-	 * Checks for version control checkouts.
+	 * Discovers version control checkouts without applying filters.
 	 *
-	 * Checks for Subversion, Git, Mercurial, and Bazaar. It recursively looks up the
-	 * filesystem to the top of the drive, erring on the side of detecting a VCS
-	 * checkout somewhere.
+	 * Checks for Subversion, Git, Mercurial, and Bazaar. It walks up from each
+	 * relevant directory to the top of the drive, erring on the side of detecting
+	 * a VCS checkout somewhere.
 	 *
 	 * ABSPATH is always checked in addition to whatever `$context` is (which may be the
 	 * wp-content directory, for example). The underlying assumption is that if you are
 	 * using version control *anywhere*, then you should be making decisions for
 	 * how things get updated.
 	 *
-	 * @since 3.7.0
+	 * @since 7.1.0
 	 *
 	 * @param string $context The filesystem path to check, in addition to ABSPATH.
-	 * @return bool True if a VCS checkout was discovered at `$context` or ABSPATH,
-	 *              or anywhere higher. False otherwise.
+	 * @return array{
+	 *     checkout: bool,
+	 *     check_dir: string,
+	 *     vcs_dir: string
+	 * } {
+	 *     @type bool   $checkout  Whether a VCS checkout was discovered at `$context`
+	 *                             or ABSPATH, or anywhere higher.
+	 *     @type string $check_dir Directory where the VCS metadata directory was found.
+	 *                             Empty string when `$checkout` is false.
+	 *     @type string $vcs_dir   Version control metadata directory name (e.g. `.git`).
+	 *                             Empty string when `$checkout` is false.
+	 * }
 	 */
-	public function is_vcs_checkout( $context ) {
+	public function get_vcs_checkout_details( $context ) {
 		$context_dirs = array( untrailingslashit( $context ) );
 		if ( ABSPATH !== $context ) {
 			$context_dirs[] = untrailingslashit( ABSPATH );
@@ -149,20 +159,52 @@ class WP_Automatic_Updater {
 
 		$check_dirs = array_unique( $check_dirs );
 		$checkout   = false;
+		$check_dir  = '';
+		$vcs_dir    = '';
 
 		// Search all directories we've found for evidence of version control.
-		foreach ( $vcs_dirs as $vcs_dir ) {
-			foreach ( $check_dirs as $check_dir ) {
-				if ( ! $this->is_allowed_dir( $check_dir ) ) {
+		foreach ( $vcs_dirs as $vcs_dir_candidate ) {
+			foreach ( $check_dirs as $check_dir_candidate ) {
+				if ( ! $this->is_allowed_dir( $check_dir_candidate ) ) {
 					continue;
 				}
 
-				$checkout = is_dir( rtrim( $check_dir, '\\/' ) . "/$vcs_dir" );
+				$checkout = is_dir( rtrim( $check_dir_candidate, '\\/' ) . "/$vcs_dir_candidate" );
 				if ( $checkout ) {
+					$check_dir = $check_dir_candidate;
+					$vcs_dir   = $vcs_dir_candidate;
 					break 2;
 				}
 			}
 		}
+
+		return array(
+			'checkout'  => $checkout,
+			'check_dir' => $check_dir,
+			'vcs_dir'   => $vcs_dir,
+		);
+	}
+
+	/**
+	 * Checks for version control checkouts.
+	 *
+	 * Checks for Subversion, Git, Mercurial, and Bazaar. It recursively looks up the
+	 * filesystem to the top of the drive, erring on the side of detecting a VCS
+	 * checkout somewhere.
+	 *
+	 * ABSPATH is always checked in addition to whatever `$context` is (which may be the
+	 * wp-content directory, for example). The underlying assumption is that if you are
+	 * using version control *anywhere*, then you should be making decisions for
+	 * how things get updated.
+	 *
+	 * @since 3.7.0
+	 *
+	 * @param string $context The filesystem path to check, in addition to ABSPATH.
+	 * @return bool True if a VCS checkout was discovered at `$context` or ABSPATH,
+	 *              or anywhere higher. False otherwise.
+	 */
+	public function is_vcs_checkout( $context ) {
+		$details = $this->get_vcs_checkout_details( $context );
 
 		/**
 		 * Filters whether the automatic updater should consider a filesystem
@@ -175,7 +217,7 @@ class WP_Automatic_Updater {
 		 * @param string $context The filesystem context (a path) against which
 		 *                        filesystem status should be checked.
 		 */
-		return apply_filters( 'automatic_updates_is_vcs_checkout', $checkout, $context );
+		return apply_filters( 'automatic_updates_is_vcs_checkout', $details['checkout'], $context );
 	}
 
 	/**

--- a/src/wp-admin/includes/class-wp-site-health-auto-updates.php
+++ b/src/wp-admin/includes/class-wp-site-health-auto-updates.php
@@ -214,44 +214,20 @@ class WP_Site_Health_Auto_Updates {
 	 * @return array The test results.
 	 */
 	public function test_vcs_abspath() {
-		$context_dirs = array( ABSPATH );
-		$vcs_dirs     = array( '.svn', '.git', '.hg', '.bzr' );
-		$check_dirs   = array();
-
-		foreach ( $context_dirs as $context_dir ) {
-			// Walk up from $context_dir to the root.
-			do {
-				$check_dirs[] = $context_dir;
-
-				// Once we've hit '/' or 'C:\', we need to stop. dirname will keep returning the input here.
-				if ( dirname( $context_dir ) === $context_dir ) {
-					break;
-				}
-
-				// Continue one level at a time.
-			} while ( $context_dir = dirname( $context_dir ) );
+		if ( ! class_exists( 'WP_Automatic_Updater' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/class-wp-automatic-updater.php';
 		}
 
-		$check_dirs = array_unique( $check_dirs );
-		$updater    = new WP_Automatic_Updater();
-		$checkout   = false;
-
-		// Search all directories we've found for evidence of version control.
-		foreach ( $vcs_dirs as $vcs_dir ) {
-			foreach ( $check_dirs as $check_dir ) {
-				if ( ! $updater->is_allowed_dir( $check_dir ) ) {
-					continue;
-				}
-
-				$checkout = is_dir( rtrim( $check_dir, '\\/' ) . "/$vcs_dir" );
-				if ( $checkout ) {
-					break 2;
-				}
-			}
-		}
+		$updater   = new WP_Automatic_Updater();
+		$details   = $updater->get_vcs_checkout_details( ABSPATH );
+		$checkout  = $details['checkout'];
+		$check_dir = $details['check_dir'];
+		$vcs_dir   = $details['vcs_dir'];
 
 		/** This filter is documented in wp-admin/includes/class-wp-automatic-updater.php */
-		if ( $checkout && ! apply_filters( 'automatic_updates_is_vcs_checkout', true, ABSPATH ) ) {
+		$filtered = apply_filters( 'automatic_updates_is_vcs_checkout', $checkout, ABSPATH );
+
+		if ( $checkout && ! $filtered ) {
 			return array(
 				'description' => sprintf(
 					/* translators: 1: Folder name. 2: Version control directory. 3: Filter name. */

--- a/tests/phpunit/tests/admin/wpAutomaticUpdater.php
+++ b/tests/phpunit/tests/admin/wpAutomaticUpdater.php
@@ -733,4 +733,45 @@ class Tests_Admin_WpAutomaticUpdater extends WP_UnitTestCase {
 
 		$this->assertFalse( $updater_mock->is_vcs_checkout( get_temp_dir() ) );
 	}
+
+	/**
+	 * Tests that `WP_Automatic_Updater::get_vcs_checkout_details()` reports no checkout
+	 * when none of the checked directories are allowed.
+	 *
+	 * @ticket 47428
+	 *
+	 * @covers WP_Automatic_Updater::get_vcs_checkout_details
+	 */
+	public function test_get_vcs_checkout_details_should_report_no_checkout_when_no_directories_are_allowed() {
+		$updater_mock = $this->getMockBuilder( 'WP_Automatic_Updater' )
+			->setMethods( array( 'is_allowed_dir' ) )
+			->getMock();
+
+		$updater_mock->expects( $this->any() )->method( 'is_allowed_dir' )->willReturn( false );
+
+		$details = $updater_mock->get_vcs_checkout_details( get_temp_dir() );
+
+		$this->assertIsArray( $details );
+		$this->assertFalse( $details['checkout'] );
+		$this->assertSame( '', $details['check_dir'] );
+		$this->assertSame( '', $details['vcs_dir'] );
+	}
+
+	/**
+	 * Tests that `is_vcs_checkout()` applies the same filter input as a direct
+	 * `apply_filters()` call using raw discovery from `get_vcs_checkout_details()`.
+	 *
+	 * @ticket 47428
+	 *
+	 * @covers WP_Automatic_Updater::get_vcs_checkout_details
+	 * @covers WP_Automatic_Updater::is_vcs_checkout
+	 */
+	public function test_is_vcs_checkout_matches_filtered_get_vcs_checkout_details_checkout() {
+		$context = ABSPATH;
+
+		$details  = self::$updater->get_vcs_checkout_details( $context );
+		$expected = apply_filters( 'automatic_updates_is_vcs_checkout', $details['checkout'], $context );
+
+		$this->assertSame( $expected, self::$updater->is_vcs_checkout( $context ) );
+	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

## Summary

Removes duplicated VCS checkout detection between Site Health and the automatic updater by centralizing the filesystem walk and `.svn` / `.git` / `.hg` / `.bzr` checks.

### Changes

- Adds `WP_Automatic_Updater::get_vcs_checkout_details()` to return whether a VCS metadata directory was found, which ancestor path matched, and which marker (e.g. `.git`) was used—**before** the `automatic_updates_is_vcs_checkout` filter is applied.
- Refactors `WP_Automatic_Updater::is_vcs_checkout()` to call `get_vcs_checkout_details()` and then apply the filter to the raw boolean, preserving existing behavior.
- Updates `WP_Site_Health_Auto_Updates::test_vcs_abspath()` to use `get_vcs_checkout_details( ABSPATH )` for the user-facing messages and applies `automatic_updates_is_vcs_checkout` once with the raw discovery result (equivalent to the previous logic when a checkout was detected).
- Extends PHPUnit coverage in `tests/phpunit/tests/admin/wpAutomaticUpdater.php` for the new helper and consistency between raw discovery and the filtered `is_vcs_checkout()` result.

Trac ticket: https://core.trac.wordpress.org/ticket/47428



<!--
## Use of AI Tools
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**