### PR TITLE
Fix #23197: Conditionally define WP_INSTALLING in wp-activate.php so site plugins load on user-only activations

### DIFF
--- a/src/wp-activate.php
+++ b/src/wp-activate.php
@@ -6,7 +6,9 @@
  * @package WordPress
  */
 
-define( 'WP_INSTALLING', true );
+if ( isset( $_GET['new_blog'] ) ) {
+	define( 'WP_INSTALLING', true );
+}
 
 /** Sets up the WordPress Environment. */
 require __DIR__ . '/wp-load.php';

--- a/src/wp-includes/ms-functions.php
+++ b/src/wp-includes/ms-functions.php
@@ -968,9 +968,9 @@ function wpmu_signup_blog_notification(
 
 	// Send email with activation link.
 	if ( ! is_subdomain_install() || get_current_network_id() !== 1 ) {
-		$activate_url = network_site_url( "wp-activate.php?key=$key" );
+		$activate_url = network_site_url( "wp-activate.php?key=$key&new_blog=1" );
 	} else {
-		$activate_url = "http://{$domain}{$path}wp-activate.php?key=$key"; // @todo Use *_url() API.
+		$activate_url = "http://{$domain}{$path}wp-activate.php?key=$key&new_blog=1"; // @todo Use *_url() API.
 	}
 
 	$activate_url = esc_url( $activate_url );


### PR DESCRIPTION
Core Trac: https://core.trac.wordpress.org/ticket/23197

**Problem**
On a WordPress Multisite installation, visiting wp-activate.php does not load site-level plugins. This means plugins cannot hook into the activation process, making it impossible to run custom code on user or site activation. Only network-activated (must-use) plugins are available, which is an unreasonable workaround for plugin developers.

This also affects non-multisite installs where visiting wp-activate.php directly (e.g. via bots or exploits) causes PHP errors because the theme loads without plugins, breaking any theme code that depends on a plugin.

**Root Cause**
wp-activate.php unconditionally defines WP_INSTALLING = true before WordPress loads. This constant is checked inside wp_get_active_and_valid_plugins() in load.php, which returns an empty array when it is set — meaning site plugins are never loaded.

WP_INSTALLING exists in wp-activate.php for a valid reason: when a new blog is being activated on a subdomain that doesn't yet exist in wp_blogs, ms-settings.php uses it during bootstrap to load the main site's settings instead of the (non-existent) new site's settings — preventing a crash.

However, this is only necessary for new blog activations. User-only activations (no new blog/subdomain being created) have no such requirement, yet WP_INSTALLING is set for both cases unconditionally.

This creates a chicken-and-egg problem: WP_INSTALLING must be defined before WordPress loads, but you can only determine the activation type (new blog vs user-only) after WordPress loads by querying the signups table.

Notably, wp_get_active_and_valid_themes() already has a wp-activate.php exception that allows themes to load — but plugins have no equivalent exception, creating an inconsistency.

**Solution**
The activation type is encoded directly in the activation URL using a new_blog=1 query parameter, since the notification functions already know the activation type when generating the email.

src/wp-includes/ms-functions.php — wpmu_signup_blog_notification():
Appends &new_blog=1 to the activation URL in both URL construction paths (subdirectory and subdomain installs). wpmu_signup_user_notification() is intentionally left unchanged — user-only activation emails carry no new_blog parameter.

src/wp-activate.php:
Replaces the unconditional define( 'WP_INSTALLING', true ) with a conditional check:


if ( isset( $_GET['new_blog'] ) ) {
    define( 'WP_INSTALLING', true );
}
This means:

New blog activations (?key=xxx&new_blog=1) → WP_INSTALLING is set → ms-settings.php bootstraps correctly for the new subdomain → consistent with previous behaviour
User-only activations (?key=xxx) → WP_INSTALLING is not set → site plugins load normally → bug fixed
Non-multisite visits → WP_INSTALLING is not set → plugins load, then immediate redirect → errors fixed

