### PR TITLE
Options: Return default value when option data cannot be unserialized #59588

### DIFF
--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -240,6 +240,22 @@ function get_option( $option, $default_value = false ) {
 		$value = untrailingslashit( $value );
 	}
 
+	$raw_value = $value;
+	$value     = maybe_unserialize( $value );
+
+	/*
+	 * If the stored value was serialized but could not be unserialized, `maybe_unserialize()`
+	 * returns `false`. In that case, return the default value to avoid incorrectly returning
+	 * `false` instead of the caller's expected default.
+	 *
+	 * Note: `b:0;` is the valid serialization of boolean `false`. When properly unserialized
+	 * it returns `false`, which is correct and should not be treated as a failure.
+	 */
+	if ( false === $value && is_serialized( $raw_value ) && 'b:0;' !== trim( $raw_value ) ) {
+		/** This filter is documented in wp-includes/option.php */
+		return apply_filters( "default_option_{$option}", $default_value, $option, $passed_default );
+	}
+
 	/**
 	 * Filters the value of an existing option.
 	 *
@@ -253,7 +269,7 @@ function get_option( $option, $default_value = false ) {
 	 *                       unserialized prior to being returned.
 	 * @param string $option Option name.
 	 */
-	return apply_filters( "option_{$option}", maybe_unserialize( $value ), $option );
+	return apply_filters( "option_{$option}", $value, $option );
 }
 
 /**

--- a/tests/phpunit/tests/option/option.php
+++ b/tests/phpunit/tests/option/option.php
@@ -162,6 +162,75 @@ class Tests_Option_Option extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that get_option() returns the default value when stored data is corrupted/unserializable.
+	 *
+	 * @ticket 59588
+	 *
+	 * @covers ::get_option
+	 */
+	public function test_get_option_returns_default_when_unserialize_fails() {
+		global $wpdb;
+
+		// Insert a corrupted serialized value directly into the DB.
+		$option_name = 'test_corrupted_option_59588';
+		$wpdb->insert(
+			$wpdb->options,
+			array(
+				'option_name'  => $option_name,
+				'option_value' => 'a:2:{i:0;s:3:"foo";', // Truncated/corrupted serialized array.
+				'autoload'     => 'yes',
+			)
+		);
+		// Clear alloptions cache so get_option() reads from DB.
+		wp_cache_delete( 'alloptions', 'options' );
+		wp_cache_delete( $option_name, 'options' );
+
+		$default = array( 'default_key' => 'default_value' );
+		$result  = get_option( $option_name, $default );
+
+		// Cleanup.
+		$wpdb->delete( $wpdb->options, array( 'option_name' => $option_name ) );
+		wp_cache_delete( 'alloptions', 'options' );
+		wp_cache_delete( $option_name, 'options' );
+
+		$this->assertSame( $default, $result, 'get_option() should return the default value when stored data cannot be unserialized.' );
+	}
+
+	/**
+	 * Tests that get_option() correctly returns false when the stored value is a serialized boolean false.
+	 *
+	 * @ticket 59588
+	 *
+	 * @covers ::get_option
+	 */
+	public function test_get_option_returns_false_for_serialized_false_value() {
+		global $wpdb;
+
+		// Insert the serialization of boolean false (`b:0;`) directly into the DB.
+		$option_name = 'test_serialized_false_59588';
+		$wpdb->insert(
+			$wpdb->options,
+			array(
+				'option_name'  => $option_name,
+				'option_value' => 'b:0;',
+				'autoload'     => 'yes',
+			)
+		);
+		// Clear alloptions cache so get_option() reads from DB.
+		wp_cache_delete( 'alloptions', 'options' );
+		wp_cache_delete( $option_name, 'options' );
+
+		$result = get_option( $option_name, 'should-not-be-returned' );
+
+		// Cleanup.
+		$wpdb->delete( $wpdb->options, array( 'option_name' => $option_name ) );
+		wp_cache_delete( 'alloptions', 'options' );
+		wp_cache_delete( $option_name, 'options' );
+
+		$this->assertFalse( $result, 'get_option() should return false when the stored value is a serialized boolean false.' );
+	}
+
+	/**
 	 * @ticket 23289
 	 *
 	 * @dataProvider data_bad_option_names


### PR DESCRIPTION
  ## Problem                                                                                                                                                                                                       
                                                                                                                                                                                                                   
  When an option exists in the DB with corrupted/truncated serialized data,                                                                                                                                        
  `@unserialize()` returns `false`, which `get_option()` passes back to the                                                                                                                                        
  caller instead of the provided `$default_value`.
                                                                                                                                                                                                                   
  ## Solution                             
                                                                                                                                                                                                                   
  After calling `maybe_unserialize()`, detect a failed unserialization:                                                                                                                                            
  stored value is serialized + result is `false` + value is not `b:0;`                                                                                                                                             
  (the valid serialization of boolean `false`). In that case, fall back to                                                                                                                                         
  `$default_value` via the `default_option_{$option}` filter.                                                                                                                                                      
                                              
  ## Tests                                                                                                                                                                                                         
                  
  Two new cases in `tests/phpunit/tests/option/option.php`:                                                                                                                                                        
  - Corrupted serialized data → default value is returned.
  - `b:0;` stored value → `false` is correctly returned, not the default.                                                                                                                                          
                                              
  Trac: https://core.trac.wordpress.org/ticket/59588
                                                               