### PR TITLE
#64066 Add unit tests: Moderate speculation eagerness when caches det…

### DIFF
--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -2447,6 +2447,7 @@ class WP_Site_Health {
 		$description  = '<p>' . __( 'Page cache enhances the speed and performance of your site by saving and serving static pages instead of calling for a page every time a user visits.' ) . '</p>';
 		$description .= '<p>' . __( 'Page cache is detected by looking for an active page cache plugin as well as making three requests to the homepage and looking for one or more of the following HTTP client caching response headers:' ) . '</p>';
 		$description .= '<code>' . implode( '</code>, <code>', array_keys( $this->get_page_cache_headers() ) ) . '.</code>';
+		$description .= '<p>' . $this->get_speculative_loading_cache_description() . '</p>';
 
 		$result = array(
 			'badge'       => array(
@@ -2580,8 +2581,9 @@ class WP_Site_Health {
 			),
 			'label'       => __( 'A persistent object cache is being used' ),
 			'description' => sprintf(
-				'<p>%s</p>',
-				__( 'A persistent object cache makes your site&#8217;s database more efficient, resulting in faster load times because WordPress can retrieve your site&#8217;s content and settings much more quickly.' )
+				'<p>%s</p><p>%s</p>',
+				__( 'A persistent object cache makes your site&#8217;s database more efficient, resulting in faster load times because WordPress can retrieve your site&#8217;s content and settings much more quickly.' ),
+				$this->get_speculative_loading_cache_description()
 			),
 			'actions'     => sprintf(
 				'<p><a href="%s" target="_blank">%s<span class="screen-reader-text"> %s</span><span aria-hidden="true" class="dashicons dashicons-external"></span></a></p>',
@@ -2645,6 +2647,32 @@ class WP_Site_Health {
 		);
 
 		return $result;
+	}
+
+	/**
+	 * Gets the description of speculative loading used in the page cache and persistent object cache tests.
+	 *
+	 * @since 6.9.0
+	 *
+	 * @see self::get_test_persistent_object_cache()
+	 * @see self::get_test_page_cache()
+	 * @see wp_get_speculation_rules_configuration()
+	 *
+	 * @return string Description.
+	 */
+	private function get_speculative_loading_cache_description() {
+		return sprintf(
+			/* translators: 1: Link to the Speculative Loading dev note. 2: Additional link attributes. 3: Accessibility text. */
+			__( 'When a page cache is detected and a persistent object cache is enabled, <a href="%1$s" %2$s>Speculative Loading%3$s</a> will accelerate cross-site navigations by using a default <code>eagerness</code> of <code>moderate</code> instead of <code>conservative</code>.' ),
+			/* translators: Localized Speculative Loading dev note, if one exists. */
+			esc_url( __( 'https://make.wordpress.org/core/2025/03/06/speculative-loading-in-6-8/' ) ),
+			'target="_blank"',
+			sprintf(
+				'<span class="screen-reader-text"> %s</span><span aria-hidden="true" class="dashicons dashicons-external"></span>',
+				/* translators: Hidden accessibility text. */
+				__( '(opens in a new tab)' )
+			)
+		);
 	}
 
 	/**
@@ -3603,9 +3631,10 @@ class WP_Site_Health {
 	 * @return WP_Error|array {
 	 *     Page cache detection details or else error information.
 	 *
-	 *     @type bool    $advanced_cache_present        Whether a page cache plugin is present.
-	 *     @type array[] $page_caching_response_headers Sets of client caching headers for the responses.
-	 *     @type float[] $response_timing               Response timings.
+	 *     @type bool     $advanced_cache_present        Whether a page cache plugin is present.
+	 *     @type array[]  $page_caching_response_headers Sets of client caching headers for the responses.
+	 *     @type float[]  $response_timing               Response timings.
+	 *     @type string[] $caching_response_headers      List of response headers detected which indicate page caching.
 	 * }
 	 */
 	private function check_for_page_caching() {
@@ -3628,6 +3657,7 @@ class WP_Site_Health {
 		$page_caching_response_headers = array();
 		$response_timing               = array();
 
+		$all_seen_headers = array();
 		for ( $i = 1; $i <= 3; $i++ ) {
 			$start_time    = microtime( true );
 			$http_response = wp_remote_get( home_url( '/' ), compact( 'sslverify', 'headers' ) );
@@ -3653,6 +3683,7 @@ class WP_Site_Health {
 				$header_values = (array) $header_values;
 				if ( empty( $callback ) || ( is_callable( $callback ) && count( array_filter( $header_values, $callback ) ) > 0 ) ) {
 					$response_headers[ $header ] = $header_values;
+					$all_seen_headers[]          = $header;
 				}
 			}
 
@@ -3660,7 +3691,7 @@ class WP_Site_Health {
 			$response_timing[]               = ( $end_time - $start_time ) * 1000;
 		}
 
-		return array(
+		$result = array(
 			'advanced_cache_present'        => (
 				file_exists( WP_CONTENT_DIR . '/advanced-cache.php' )
 				&&
@@ -3671,7 +3702,17 @@ class WP_Site_Health {
 			),
 			'page_caching_response_headers' => $page_caching_response_headers,
 			'response_timing'               => $response_timing,
+			'caching_response_headers'      => array_unique( $all_seen_headers ),
 		);
+
+		/*
+		 * Store the results in a non-expiring (autoloaded) transient so that Speculative Loading can use this to change
+		 * the default mode from conservative to moderate when page caching is enabled.
+		 * See wp_get_speculation_rules_configuration().
+		 */
+		set_transient( 'health_check_page_cache_detail', $result );
+
+		return $result;
 	}
 
 	/**

--- a/src/wp-includes/speculative-loading.php
+++ b/src/wp-includes/speculative-loading.php
@@ -61,6 +61,28 @@ function wp_get_speculation_rules_configuration(): ?array {
 	// Sanitize the configuration and replace 'auto' with current defaults.
 	$default_mode      = 'prefetch';
 	$default_eagerness = 'conservative';
+
+	// Default to moderate eagerness on production when page caching is detected and a persistent object cache is used.
+	if ( 'production' === wp_get_environment_type() && wp_using_ext_object_cache() ) {
+		$page_cache_detail = get_transient( 'health_check_page_cache_detail' );
+		if (
+			is_array( $page_cache_detail ) &&
+			(
+				(
+					isset( $page_cache_detail['advanced_cache_present'] ) &&
+					$page_cache_detail['advanced_cache_present']
+				) ||
+				(
+					isset( $page_cache_detail['caching_response_headers'] ) &&
+					is_array( $page_cache_detail['caching_response_headers'] ) &&
+					count( $page_cache_detail['caching_response_headers'] ) > 0
+				)
+			)
+		) {
+			$default_eagerness = 'moderate';
+		}
+	}
+
 	if ( ! is_array( $config ) ) {
 		return array(
 			'mode'      => $default_mode,

--- a/tests/phpunit/includes/abstract-testcase.php
+++ b/tests/phpunit/includes/abstract-testcase.php
@@ -135,6 +135,14 @@ abstract class WP_UnitTestCase_Base extends PHPUnit_Adapter_TestCase {
 			if ( $wp_rewrite->permalink_structure ) {
 				$this->set_permalink_structure( '' );
 			}
+
+			/*
+			 * Site Health stores page cache probe results in this transient. When a persistent object cache is used
+			 * (common in CI), it would otherwise change the default resolved eagerness for unrelated tests.
+			 *
+			 * @ticket 64066
+			 */
+			delete_transient( 'health_check_page_cache_detail' );
 		}
 
 		$this->start_transaction();

--- a/tests/phpunit/tests/admin/wpSiteHealth.php
+++ b/tests/phpunit/tests/admin/wpSiteHealth.php
@@ -707,4 +707,80 @@ class Tests_Admin_wpSiteHealth extends WP_UnitTestCase {
 			$this->assertStringContainsString( __( 'Enabling this cache can significantly improve the performance of your site.' ), $result['description'] );
 		}
 	}
+
+	/**
+	 * @ticket 64066
+	 *
+	 * @covers ::check_for_page_caching
+	 */
+	public function test_check_for_page_caching_stores_health_check_page_cache_detail_transient() {
+		delete_transient( 'health_check_page_cache_detail' );
+
+		$pre_http_response = function () {
+			return array(
+				'headers'  => array( 'age' => '100' ),
+				'response' => array(
+					'code'    => 200,
+					'message' => 'OK',
+				),
+			);
+		};
+		add_filter( 'pre_http_request', $pre_http_response, 10 );
+
+		$this->instance->get_test_page_cache();
+
+		$detail = get_transient( 'health_check_page_cache_detail' );
+
+		remove_filter( 'pre_http_request', $pre_http_response, 10 );
+
+		$this->assertIsArray( $detail );
+		$this->assertArrayHasKey( 'caching_response_headers', $detail );
+		$this->assertContains( 'age', $detail['caching_response_headers'] );
+	}
+
+	/**
+	 * @ticket 64066
+	 *
+	 * @covers ::get_test_page_cache
+	 */
+	public function test_get_test_page_cache_description_includes_speculative_loading_note() {
+		delete_transient( 'health_check_page_cache_detail' );
+
+		$pre_http_response = function () {
+			return array(
+				'headers'  => array( 'age' => '100' ),
+				'response' => array(
+					'code'    => 200,
+					'message' => 'OK',
+				),
+			);
+		};
+		add_filter( 'pre_http_request', $pre_http_response, 10 );
+
+		$result = $this->instance->get_test_page_cache();
+
+		remove_filter( 'pre_http_request', $pre_http_response, 10 );
+
+		$this->assertStringContainsString( 'Speculative Loading', $result['description'] );
+		$this->assertStringContainsString( 'moderate', $result['description'] );
+		$this->assertStringContainsString( 'conservative', $result['description'] );
+	}
+
+	/**
+	 * @ticket 64066
+	 *
+	 * @covers ::get_test_persistent_object_cache
+	 */
+	public function test_get_test_persistent_object_cache_includes_speculative_loading_note_when_ext_object_cache_enabled() {
+		$initial = wp_using_ext_object_cache();
+		wp_using_ext_object_cache( true );
+
+		$result = $this->instance->get_test_persistent_object_cache();
+
+		wp_using_ext_object_cache( $initial );
+
+		$this->assertStringContainsString( 'Speculative Loading', $result['description'] );
+		$this->assertStringContainsString( 'moderate', $result['description'] );
+		$this->assertStringContainsString( 'conservative', $result['description'] );
+	}
 }

--- a/tests/phpunit/tests/speculative-loading/wpGetSpeculationRulesConfiguration.php
+++ b/tests/phpunit/tests/speculative-loading/wpGetSpeculationRulesConfiguration.php
@@ -19,19 +19,31 @@ class Tests_Speculative_Loading_wpGetSpeculationRulesConfiguration extends WP_Un
 	 */
 	private $initial_using_ext_object_cache;
 
+	/**
+	 * getenv( 'WP_ENVIRONMENT_TYPE' ) at the start of the test, for restoration in tear_down().
+	 *
+	 * @var string|false
+	 */
+	private $wp_environment_type_env_before_test;
+
 	public function set_up() {
 		parent::set_up();
 
-		$this->initial_using_ext_object_cache = wp_using_ext_object_cache();
+		$this->initial_using_ext_object_cache     = wp_using_ext_object_cache();
+		$this->wp_environment_type_env_before_test = getenv( 'WP_ENVIRONMENT_TYPE' );
 
 		update_option( 'permalink_structure', '/%year%/%monthnum%/%day%/%postname%/' );
 	}
 
 	public function tear_down() {
 		wp_using_ext_object_cache( $this->initial_using_ext_object_cache );
-		delete_transient( 'health_check_page_cache_detail' );
-		// Reset for following tests: wp_get_environment_type() keeps a static when WP_RUN_CORE_TESTS is defined.
-		putenv( 'WP_ENVIRONMENT_TYPE=production' );
+
+		if ( false !== $this->wp_environment_type_env_before_test && '' !== $this->wp_environment_type_env_before_test ) {
+			putenv( 'WP_ENVIRONMENT_TYPE=' . $this->wp_environment_type_env_before_test );
+		} else {
+			putenv( 'WP_ENVIRONMENT_TYPE' );
+		}
+
 		parent::tear_down();
 	}
 

--- a/tests/phpunit/tests/speculative-loading/wpGetSpeculationRulesConfiguration.php
+++ b/tests/phpunit/tests/speculative-loading/wpGetSpeculationRulesConfiguration.php
@@ -12,10 +12,27 @@
  */
 class Tests_Speculative_Loading_wpGetSpeculationRulesConfiguration extends WP_UnitTestCase {
 
+	/**
+	 * Whether an external object cache was in use before each test.
+	 *
+	 * @var bool
+	 */
+	private $initial_using_ext_object_cache;
+
 	public function set_up() {
 		parent::set_up();
 
+		$this->initial_using_ext_object_cache = wp_using_ext_object_cache();
+
 		update_option( 'permalink_structure', '/%year%/%monthnum%/%day%/%postname%/' );
+	}
+
+	public function tear_down() {
+		wp_using_ext_object_cache( $this->initial_using_ext_object_cache );
+		delete_transient( 'health_check_page_cache_detail' );
+		// Reset for following tests: wp_get_environment_type() keeps a static when WP_RUN_CORE_TESTS is defined.
+		putenv( 'WP_ENVIRONMENT_TYPE=production' );
+		parent::tear_down();
 	}
 
 	/**
@@ -262,6 +279,186 @@ class Tests_Speculative_Loading_wpGetSpeculationRulesConfiguration extends WP_Un
 					'eagerness' => 'conservative',
 				),
 			),
+		);
+	}
+
+	/**
+	 * @ticket 64066
+	 */
+	public function test_wp_get_speculation_rules_configuration_uses_moderate_eagerness_when_production_persistent_object_cache_and_advanced_cache_detected() {
+		putenv( 'WP_ENVIRONMENT_TYPE=production' );
+		wp_using_ext_object_cache( true );
+		set_transient(
+			'health_check_page_cache_detail',
+			array(
+				'advanced_cache_present'        => true,
+				'page_caching_response_headers' => array(),
+				'response_timing'               => array(),
+				'caching_response_headers'      => array(),
+			)
+		);
+
+		$config = wp_get_speculation_rules_configuration();
+
+		$this->assertSame(
+			array(
+				'mode'      => 'prefetch',
+				'eagerness' => 'moderate',
+			),
+			$config
+		);
+	}
+
+	/**
+	 * @ticket 64066
+	 */
+	public function test_wp_get_speculation_rules_configuration_uses_moderate_eagerness_when_production_persistent_object_cache_and_caching_headers_detected() {
+		putenv( 'WP_ENVIRONMENT_TYPE=production' );
+		wp_using_ext_object_cache( true );
+		set_transient(
+			'health_check_page_cache_detail',
+			array(
+				'advanced_cache_present'        => false,
+				'page_caching_response_headers' => array(),
+				'response_timing'               => array(),
+				'caching_response_headers'      => array( 'age' ),
+			)
+		);
+
+		$config = wp_get_speculation_rules_configuration();
+
+		$this->assertSame(
+			array(
+				'mode'      => 'prefetch',
+				'eagerness' => 'moderate',
+			),
+			$config
+		);
+	}
+
+	/**
+	 * @ticket 64066
+	 */
+	public function test_wp_get_speculation_rules_configuration_remains_conservative_on_staging_even_with_caches_detected() {
+		putenv( 'WP_ENVIRONMENT_TYPE=staging' );
+		wp_using_ext_object_cache( true );
+		set_transient(
+			'health_check_page_cache_detail',
+			array(
+				'advanced_cache_present'        => true,
+				'page_caching_response_headers' => array(),
+				'response_timing'               => array(),
+				'caching_response_headers'      => array(),
+			)
+		);
+
+		$config = wp_get_speculation_rules_configuration();
+
+		$this->assertSame(
+			array(
+				'mode'      => 'prefetch',
+				'eagerness' => 'conservative',
+			),
+			$config
+		);
+	}
+
+	/**
+	 * @ticket 64066
+	 */
+	public function test_wp_get_speculation_rules_configuration_remains_conservative_in_non_production_even_with_caches_detected() {
+		putenv( 'WP_ENVIRONMENT_TYPE=development' );
+		wp_using_ext_object_cache( true );
+		set_transient(
+			'health_check_page_cache_detail',
+			array(
+				'advanced_cache_present'        => true,
+				'page_caching_response_headers' => array(),
+				'response_timing'               => array(),
+				'caching_response_headers'      => array(),
+			)
+		);
+
+		$config = wp_get_speculation_rules_configuration();
+
+		$this->assertSame(
+			array(
+				'mode'      => 'prefetch',
+				'eagerness' => 'conservative',
+			),
+			$config
+		);
+	}
+
+	/**
+	 * @ticket 64066
+	 */
+	public function test_wp_get_speculation_rules_configuration_remains_conservative_without_persistent_object_cache() {
+		putenv( 'WP_ENVIRONMENT_TYPE=production' );
+		wp_using_ext_object_cache( false );
+		set_transient(
+			'health_check_page_cache_detail',
+			array(
+				'advanced_cache_present'        => true,
+				'page_caching_response_headers' => array(),
+				'response_timing'               => array(),
+				'caching_response_headers'      => array(),
+			)
+		);
+
+		$config = wp_get_speculation_rules_configuration();
+
+		$this->assertSame(
+			array(
+				'mode'      => 'prefetch',
+				'eagerness' => 'conservative',
+			),
+			$config
+		);
+	}
+
+	/**
+	 * @ticket 64066
+	 */
+	public function test_wp_get_speculation_rules_configuration_remains_conservative_when_no_health_check_page_cache_detail() {
+		putenv( 'WP_ENVIRONMENT_TYPE=production' );
+		wp_using_ext_object_cache( true );
+
+		$config = wp_get_speculation_rules_configuration();
+
+		$this->assertSame(
+			array(
+				'mode'      => 'prefetch',
+				'eagerness' => 'conservative',
+			),
+			$config
+		);
+	}
+
+	/**
+	 * @ticket 64066
+	 */
+	public function test_wp_get_speculation_rules_configuration_remains_conservative_when_page_cache_detail_has_no_signals() {
+		putenv( 'WP_ENVIRONMENT_TYPE=production' );
+		wp_using_ext_object_cache( true );
+		set_transient(
+			'health_check_page_cache_detail',
+			array(
+				'advanced_cache_present'        => false,
+				'page_caching_response_headers' => array(),
+				'response_timing'               => array(),
+				'caching_response_headers'      => array(),
+			)
+		);
+
+		$config = wp_get_speculation_rules_configuration();
+
+		$this->assertSame(
+			array(
+				'mode'      => 'prefetch',
+				'eagerness' => 'conservative',
+			),
+			$config
 		);
 	}
 }


### PR DESCRIPTION
- In production, when a persistent object cache is in use and Site Health has detected page caching (via `advanced-cache.php` / `WP_CACHE` or caching response headers), `wp_get_speculation_rules_configuration()` now resolves `eagerness` `auto` to **moderate** instead of **conservative**.
- `WP_Site_Health::check_for_page_caching()` stores its raw detection result in the `health_check_page_cache_detail` transient (including a `caching_response_headers` list) so speculative loading can read it.
- Page cache and persistent object cache Site Health descriptions include a short note linking to the Speculative Loading dev note and explaining the moderate vs conservative default.
- PHPUnit coverage: `wpGetSpeculationRulesConfiguration` (production/staging/development, object cache, transient shapes) and `wpSiteHealth` (transient populated, descriptions mention speculative loading).

Trac ticket: https://core.trac.wordpress.org/ticket/64066