### PR TITLE
Fix for wrong locale code in the admin for core/get-site-info` ability

### DIFF
--- a/src/wp-includes/abilities.php
+++ b/src/wp-includes/abilities.php
@@ -111,7 +111,11 @@ function wp_register_core_abilities(): void {
 
 				$result = array();
 				foreach ( $requested_fields as $field ) {
-					$result[ $field ] = get_bloginfo( $field );
+					if ( 'language' === $field ) {
+						$result[ $field ] = str_replace( '_', '-', get_option( 'WPLANG' ) ?: 'en_US' );
+					} else {
+						$result[ $field ] = get_bloginfo( $field );
+					}
 				}
 
 				return $result;

--- a/src/wp-includes/abilities.php
+++ b/src/wp-includes/abilities.php
@@ -112,7 +112,8 @@ function wp_register_core_abilities(): void {
 				$result = array();
 				foreach ( $requested_fields as $field ) {
 					if ( 'language' === $field ) {
-						$result[ $field ] = str_replace( '_', '-', get_option( 'WPLANG' ) ?: 'en_US' );
+						$wplang = get_option( 'WPLANG' );
+						$result[ $field ] = str_replace( '_', '-', $wplang ? $wplang : 'en_US' );
 					} else {
 						$result[ $field ] = get_bloginfo( $field );
 					}


### PR DESCRIPTION
Ticket: 64977
Link: https://core.trac.wordpress.org/ticket/64977

The core/get-site-info ability should return the site locale, but currently returns the user locale in admin due to using get_bloginfo(), which relies on determine_locale().

This can vary based on context (admin, login, request params, JSON requests), making it unreliable for getting the actual site locale.

The site's language is stored directly as the WPLANG option. Reading it bypasses all the context-dependent filtering:

if ( 'language' === $field ) {
$result[ $field ] = str_replace( '', '-', get_option( 'WPLANG' ) ?: 'en_US' );
}
get_option('WPLANG') returns the raw DB value — no context influence
The ?: 'en_US' handles the default English case where WPLANG is an empty string
str_replace('', '-', ...) preserves the existing BCP 47 formatting (e.g. en-US, pt-BR)

Multisite Behavior
In multisite, get_option() already scopes to the current site (it internally routes through get_blog_option()), so no special handling is needed. Each site in the network correctly returns its own configured language. If you ever needed the network-level language, that would be get_network_option(null, 'WPLANG'), but that's not appropriate for core/get-site-info.