### PR TITLE
Date/Time: Fix swapped variable names and comments in get_weekstartend().

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -589,13 +589,13 @@ function get_weekstartend( $mysqlstring, $start_of_week = '' ) {
 	$my = substr( $mysqlstring, 0, 4 );
 
 	// MySQL string month.
-	$mm = substr( $mysqlstring, 8, 2 );
+	$mm = substr( $mysqlstring, 5, 2 );
 
 	// MySQL string day.
-	$md = substr( $mysqlstring, 5, 2 );
+	$md = substr( $mysqlstring, 8, 2 );
 
 	// The timestamp for MySQL string day.
-	$day = mktime( 0, 0, 0, $md, $mm, $my );
+	$day = mktime( 0, 0, 0, $mm, $md, $my );
 
 	// The day of the week from the timestamp.
 	$weekday = (int) gmdate( 'w', $day );

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -586,16 +586,16 @@ function human_readable_duration( $duration = '' ) {
  */
 function get_weekstartend( $mysqlstring, $start_of_week = '' ) {
 	// MySQL string year.
-	$my = substr( $mysqlstring, 0, 4 );
+	$mysql_year = substr( $mysqlstring, 0, 4 );
 
 	// MySQL string month.
-	$mm = substr( $mysqlstring, 5, 2 );
+	$mysql_month = substr( $mysqlstring, 5, 2 );
 
 	// MySQL string day.
-	$md = substr( $mysqlstring, 8, 2 );
+	$mysql_day = substr( $mysqlstring, 8, 2 );
 
 	// The timestamp for MySQL string day.
-	$day = mktime( 0, 0, 0, $mm, $md, $my );
+	$day = mktime( 0, 0, 0, $mysql_month, $mysql_day, $mysql_year );
 
 	// The day of the week from the timestamp.
 	$weekday = (int) gmdate( 'w', $day );


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65046

The variables `$mm` and `$md` had their substr() positions and inline                                            
  comments swapped — `$mm` was extracting the day digits (position 8)                                              
  while `$md` was extracting the month digits (position 5), contrary to                                            
  what the comments indicated.                                                                                     
                                                                                                                   
  The output was accidentally correct because the two mistakes cancelled                                           
  each other out in the mktime() call, but the misleading naming posed
  a future maintenance risk.                                                                                       
                  
  Corrects the substr() positions and mktime() argument order so that                                              
  variable names, comments, and logic are all consistent.

Fixes #65046
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

The variables `$mm` and `$md` had their substr() positions and inline                                            
  comments swapped — `$mm` was extracting the day digits (position 8)                                              
  while `$md` was extracting the month digits (position 5), contrary to                                            
  what the comments indicated.                                                                                     
                                                                                                                   
  The output was accidentally correct because the two mistakes cancelled                                           
  each other out in the mktime() call, but the misleading naming posed
  a future maintenance risk.                                                                                       
                  
  Corrects the substr() positions and mktime() argument order so that                                              
  variable names, comments, and logic are all consistent.

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
