### PR TITLE
Fix #8592: Include private pages in parent dropdown for users with read_private_posts capability

### DIFF
--- a/src/wp-admin/includes/class-wp-posts-list-table.php
+++ b/src/wp-admin/includes/class-wp-posts-list-table.php
@@ -1885,6 +1885,10 @@ class WP_Posts_List_Table extends WP_List_Table {
 								'sort_column'       => 'menu_order, post_title',
 							);
 
+							if ( current_user_can( $post_type_object->cap->read_private_posts ) ) {
+								$dropdown_args['post_status'] = array( 'publish', 'private' );
+							}
+
 							if ( $bulk ) {
 								$dropdown_args['show_option_no_change'] = __( '&mdash; No Change &mdash;' );
 								$dropdown_args['id']                    = 'bulk_edit_post_parent';

--- a/src/wp-admin/includes/meta-boxes.php
+++ b/src/wp-admin/includes/meta-boxes.php
@@ -1012,6 +1012,11 @@ function page_attributes_meta_box( $post ) {
 			'echo'             => 0,
 		);
 
+		$post_type_object = get_post_type_object( $post->post_type );
+		if ( current_user_can( $post_type_object->cap->read_private_posts ) ) {
+			$dropdown_args['post_status'] = array( 'publish', 'private' );
+		}
+
 		/**
 		 * Filters the arguments used to generate a Pages drop-down element.
 		 *


### PR DESCRIPTION
Core Trac: https://core.trac.wordpress.org/ticket/8592

**Problem**
Private pages do not appear in the Parent dropdown of the Page Attributes metabox when editing a page, nor in the Parent dropdown within the Quick Edit row on the Pages list screen. This makes it impossible to create a hierarchy of private pages through the WordPress admin UI, forcing users to either use plugins or avoid private pages entirely when building hierarchical page structures.

**Root Cause**
Both the Page Attributes metabox (page_attributes_meta_box() in meta-boxes.php) and the Quick Edit dropdown (class-wp-posts-list-table.php) build their $dropdown_args without a post_status argument. This means they rely on get_pages() which defaults to post_status = 'publish' — private pages are never included.

The filters page_attributes_dropdown_pages_args and quick_edit_dropdown_pages_args were added in 3.3 to allow plugins to work around this, and get_pages() has supported multiple statuses since 3.2. However, core itself never used these capabilities to include private pages based on user permissions — the burden was left entirely on plugins.

**Solution**
Added a capability check in both locations before the existing filters are applied. When the current user has the read_private_posts capability for the post type (maps to read_private_pages for the built-in page post type), post_status is explicitly set to include both 'publish' and 'private' pages in the dropdown.

src/wp-admin/includes/meta-boxes.php — page_attributes_meta_box():


$post_type_object = get_post_type_object( $post->post_type );
if ( current_user_can( $post_type_object->cap->read_private_posts ) ) {
    $dropdown_args['post_status'] = array( 'publish', 'private' );
}
src/wp-admin/includes/class-wp-posts-list-table.php — Quick Edit dropdown:


if ( current_user_can( $post_type_object->cap->read_private_posts ) ) {
    $dropdown_args['post_status'] = array( 'publish', 'private' );
}
Using $post_type_object->cap->read_private_posts instead of the hardcoded 'read_private_pages' string ensures this works correctly for both the built-in page post type and any custom hierarchical post types.