### PR TITLE
Fix: add css to fix the overflowing password on the application password screen

### DIFF
--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -924,6 +924,10 @@ a#remove-post-thumbnail:hover,
     margin-left: 0.5rem;
 }
 
+.application-password-display strong {
+	overflow-wrap: break-word;
+}
+
 /*------------------------------------------------------------------------------
   3.0 - Actions
 ------------------------------------------------------------------------------*/


### PR DESCRIPTION
### Scenarios Observed:

    Text Does Not Overflow:
        When the application name (app_name parameter) contains paragraphs or spaces between words, the text is wrapped appropriately within the card area.
        Example URL:

    http://localhost:8889/wp-admin/authorize-application.php?app_name=Contrary+to+popular+belief%2C+Lorem+Ipsum+is+not+simply+random+text.+It+has+roots+in+a+piece+of+classical+Latin+literature+from+45+BC%2C+making+it+over+2000+years+old.+Richard+McClintock%2C+a+Latin+professor+at+Hampden-Sydney+College+in+Virginia%2C+looked+up+one+of+the+more+obscure+Latin+words%2C+consectetur%2C+from+a+Lorem+Ipsum+passage%2C+and+going+through+the+cites+of+the+word+in+classical+literature%2C+discovered+the+undoubtable+source.


### Text Overflows:

    When the application name (app_name parameter) contains continuous text without any spaces or breaks, the text exceeds the boundaries of the card area and breaks the layout.
    Example URL:

http://localhost:8889/wp-admin/authorize-application.php?app_name=asdflaksdklfjakldjfklajdfklasdkfjaklsdjjajknmmakalsjdkfjklajsdklfjaksdjfkasdjfkjsdfkaskdlfjaklsjdfklasjdfklajsdfkljakljsdklfjkljklajsdklfjklajsdfkljaklsdjfakljdfklajdfklasjdfklajsdfkljasdklfjaskldfjaslkdfjaskldjflaksjdfklasdjflkasjdflkajsdfasdkljfaklsjdfasjdfkaljsdfkladsf

Trac ticket: https://core.trac.wordpress.org/ticket/62064

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
![Clipboard - November 22, 2024 11_59 AM](https://github.com/user-attachments/assets/7bef940c-0314-4089-8324-90831189222a)
![Clipboard - November 22, 2024 11_56 AM](https://github.com/user-attachments/assets/eb476c66-71bf-4c48-ad2b-56fb80b74b4f)
![Clipboard - November 22, 2024 11_52 AM](https://github.com/user-attachments/assets/94624806-1b93-47da-a0a8-3b25117ff872)
