### PR TITLE
Fix: Media Library insert from URL doesn't give a message when a URL check fails.

### DIFF
--- a/src/js/media/views/embed/url.js
+++ b/src/js/media/views/embed/url.js
@@ -79,7 +79,7 @@ EmbedUrl = View.extend(/** @lends wp.media.view.EmbedUrl.prototype */{
 	isValidUrlInput: function ( el ) {
 		var url = ( el.value || '' ).trim();
 		try {
-			var url = new URL( url );
+			url = new URL( url );
 			return [ 'http:', 'https:' ].includes(url.protocol);
 		} catch ( e ) {
 			return false;

--- a/src/js/media/views/embed/url.js
+++ b/src/js/media/views/embed/url.js
@@ -43,6 +43,8 @@ EmbedUrl = View.extend(/** @lends wp.media.view.EmbedUrl.prototype */{
 				this.model.trigger( 'change:url' );
 			}, this ), 500 );
 		}
+
+		this.updateUrl = _.debounce( this.updateUrl, 500 );
 	},
 	/**
 	 * @return {wp.media.view.EmbedUrl} Returns itself to allow chaining.
@@ -70,8 +72,22 @@ EmbedUrl = View.extend(/** @lends wp.media.view.EmbedUrl.prototype */{
 	url: function( event ) {
 		var $el = $( event.target );
 		var url = $el.val() || '';
+		var valid = this.isValidUrlInput( event.target );
+		this.updateUrl( url, valid );
+	},
 
-		if ( this.isValidUrlInput( event.target ) ) {
+	isValidUrlInput: function ( el ) {
+		var url = ( el.value || '' ).trim();
+		try {
+			var url = new URL( url );
+			return [ 'http:', 'https:' ].includes(url.protocol);
+		} catch ( e ) {
+			return false;
+		}
+	},
+
+	updateUrl: function ( url, valid ) {
+		if ( valid ) {
 			this.model.set( 'url', url.trim() );
 			this.$error.hide();
 		} else {
@@ -83,17 +99,6 @@ EmbedUrl = View.extend(/** @lends wp.media.view.EmbedUrl.prototype */{
 				this.$error.hide();
 			}
 		}
-	},
-
-	isValidUrlInput: function ( el ) {
-		var url = ( el.value || '' ).trim();
-
-		var isNativeValid = el.validity ? el.validity.valid : true;
-
-		var pattern = /^(https?:\/\/)([\w.-]+)+(:\d+)?(\/.*)?$/i;
-		var isRegexValid = pattern.test( url );
-
-		return isNativeValid && isRegexValid;
 	}
 });
 

--- a/src/js/media/views/embed/url.js
+++ b/src/js/media/views/embed/url.js
@@ -14,7 +14,7 @@ var View = wp.media.View,
  * @augments Backbone.View
  */
 EmbedUrl = View.extend(/** @lends wp.media.view.EmbedUrl.prototype */{
-	tagName:   'span',
+	tagName:	 'span',
 	className: 'embed-url',
 
 	events: {
@@ -28,7 +28,13 @@ EmbedUrl = View.extend(/** @lends wp.media.view.EmbedUrl.prototype */{
 		this.input = this.$input[0];
 
 		this.spinner = $('<span class="spinner" />')[0];
-		this.$el.append([ this.input, this.spinner ]);
+
+		this.error = $('<div class="notice notice-error embed-url-error"><p></p></div>')[0];
+
+		this.$error = $(this.error);
+		this.$error.hide();
+
+		this.$el.append([ this.input, this.spinner, this.error ]);
 
 		this.listenTo( this.model, 'change:url', this.render );
 
@@ -62,8 +68,32 @@ EmbedUrl = View.extend(/** @lends wp.media.view.EmbedUrl.prototype */{
 	},
 
 	url: function( event ) {
-		var url = event.target.value || '';
-		this.model.set( 'url', url.trim() );
+		var $el = $( event.target );
+		var url = $el.val() || '';
+
+		if ( this.isValidUrlInput( event.target ) ) {
+			this.model.set( 'url', url.trim() );
+			this.$error.hide();
+		} else {
+			if ( url.length > 0 ) {
+				this.model.set( 'url', '' );
+				this.$error.find( 'p' ).text( l10n.invalidUrl );
+				this.$error.show();
+			} else {
+				this.$error.hide();
+			}
+		}
+	},
+
+	isValidUrlInput: function ( el ) {
+		var url = ( el.value || '' ).trim();
+
+		var isNativeValid = el.validity ? el.validity.valid : true;
+
+		var pattern = /^(https?:\/\/)([\w.-]+)+(:\d+)?(\/.*)?$/i;
+		var isRegexValid = pattern.test( url );
+
+		return isNativeValid && isRegexValid;
 	}
 });
 

--- a/src/wp-includes/css/media-views.css
+++ b/src/wp-includes/css/media-views.css
@@ -2118,6 +2118,10 @@
 	right: 26px;
 }
 
+.media-frame .embed-url-error {
+	margin: 4px 0;
+}
+
 .media-frame .embed-loading .embed-url .spinner {
 	visibility: visible;
 }

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -5076,6 +5076,7 @@ function wp_enqueue_media( $args = array() ) {
 
 		// From URL.
 		'insertFromUrlTitle'          => __( 'Insert from URL' ),
+		'invalidUrl'                  => __( 'Please enter a valid URL.' ),
 
 		// Featured Images.
 		'setFeaturedImageTitle'       => $post_type_object->labels->featured_image,
@@ -6446,4 +6447,3 @@ function wp_get_image_editor_output_format( $filename, $mime_type ) {
 	 */
 	return apply_filters( 'image_editor_output_format', $output_format, $filename, $mime_type );
 }
-


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/41349

This PR addresses an issue in the Media Library where users received no feedback when entering an invalid URL in the "Insert from URL" field. Previously, the input would simply fail silently.

### Before

https://github.com/user-attachments/assets/204d7f0e-d82e-4eba-b716-716e14b1eb60

### After

https://github.com/user-attachments/assets/8b209dfc-64aa-472d-bb8e-295672ccbe91

## Use of AI Tools
AI assistance: Yes
Tool(s): Gemini 3 Flash
Used for: Summarizing the technical changes from the diff and formatting the Pull Request description.

Tool(s): Gemini 3 Flash, GitHub Copilot (Claude Sonnet 4.6, Haiku 4.5)
Used for: Initial debugging and code review; final technical summary and formatting of the Pull Request description.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
