### PR TITLE
Tests: Add missing @covers tags and refactor invalid block name tests to use a data provider

### DIFF
--- a/tests/phpunit/tests/blocks/wpBlockTypeRegistry.php
+++ b/tests/phpunit/tests/blocks/wpBlockTypeRegistry.php
@@ -7,6 +7,8 @@
  * @since 5.0.0
  *
  * @group blocks
+ *
+ * @covers WP_Block_Type_Registry
  */
 class Tests_Blocks_wpBlockTypeRegistry extends WP_UnitTestCase {
 
@@ -41,51 +43,30 @@ class Tests_Blocks_wpBlockTypeRegistry extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Should reject numbers
+	 * Should reject invalid block names.
 	 *
 	 * @ticket 45097
 	 *
+	 * @dataProvider data_invalid_block_names
 	 * @expectedIncorrectUsage WP_Block_Type_Registry::register
 	 */
-	public function test_invalid_non_string_names() {
-		$result = $this->registry->register( 1, array() );
+	public function test_invalid_block_names( $name ) {
+		$result = $this->registry->register( $name, array() );
 		$this->assertFalse( $result );
 	}
 
 	/**
-	 * Should reject blocks without a namespace
+	 * Data provider for test_invalid_block_names().
 	 *
-	 * @ticket 45097
-	 *
-	 * @expectedIncorrectUsage WP_Block_Type_Registry::register
+	 * @return array<string, array{ 0: mixed }>
 	 */
-	public function test_invalid_names_without_namespace() {
-		$result = $this->registry->register( 'paragraph', array() );
-		$this->assertFalse( $result );
-	}
-
-	/**
-	 * Should reject blocks with invalid characters
-	 *
-	 * @ticket 45097
-	 *
-	 * @expectedIncorrectUsage WP_Block_Type_Registry::register
-	 */
-	public function test_invalid_characters() {
-		$result = $this->registry->register( 'still/_doing_it_wrong', array() );
-		$this->assertFalse( $result );
-	}
-
-	/**
-	 * Should reject blocks with uppercase characters
-	 *
-	 * @ticket 45097
-	 *
-	 * @expectedIncorrectUsage WP_Block_Type_Registry::register
-	 */
-	public function test_uppercase_characters() {
-		$result = $this->registry->register( 'Core/Paragraph', array() );
-		$this->assertFalse( $result );
+	public function data_invalid_block_names(): array {
+		return array(
+			'non-string name'      => array( 1 ),
+			'no namespace'         => array( 'paragraph' ),
+			'invalid characters'   => array( 'still/_doing_it_wrong' ),
+			'uppercase characters' => array( 'Core/Paragraph' ),
+		);
 	}
 
 	/**

--- a/tests/phpunit/tests/rewrite/addRewriteEndpoint.php
+++ b/tests/phpunit/tests/rewrite/addRewriteEndpoint.php
@@ -2,6 +2,8 @@
 
 /**
  * @group rewrite
+ *
+ * @covers ::add_rewrite_endpoint
  */
 class Tests_Rewrite_AddRewriteEndpoint extends WP_UnitTestCase {
 	private $qvs;

--- a/tests/phpunit/tests/rewrite/addRewriteRule.php
+++ b/tests/phpunit/tests/rewrite/addRewriteRule.php
@@ -2,6 +2,8 @@
 
 /**
  * @group rewrite
+ *
+ * @covers ::add_rewrite_rule
  */
 class Tests_Rewrite_AddRewriteRule extends WP_UnitTestCase {
 


### PR DESCRIPTION
## What

This PR makes two types of test improvements across three test files. 

---
### 1. Add missing `@covers` annotations

Adds `@covers` tags to test classes that were missing them, as part of the ongoing effort in #64225:

  | File | Annotation added |                                                                                                                                                         
  |---|---|
  | `tests/phpunit/tests/rewrite/addRewriteRule.php` | `@covers ::add_rewrite_rule` |                                                                                                 
  | `tests/phpunit/tests/rewrite/addRewriteEndpoint.php` | `@covers ::add_rewrite_endpoint` |
  | `tests/phpunit/tests/blocks/wpBlockTypeRegistry.php` | `@covers WP_Block_Type_Registry` |                                                                                         

Both `add_rewrite_rule()` and `add_rewrite_endpoint()` are defined in `src/wp-includes/rewrite.php`.
                                                                                     
Without `@covers`, PHPUnit cannot correctly attribute code coverage to the functions under test, which leads to inaccurate coverage reports on Codecov.

---

### 2. Refactor repeated invalid block name tests to use a data provider

In `Tests_Blocks_wpBlockTypeRegistry`, four separate test methods were structurally identical — each registered one invalid block name and asserted `false`:

- `test_invalid_non_string_names()`
- `test_invalid_names_without_namespace()`
- `test_invalid_characters()`                                                                         
- `test_uppercase_characters()`

These have been consolidated into a single `test_invalid_block_names()` method backed by a `data_invalid_block_names()` data provider with named cases, following the same pattern used in recently updated tests across the suite.

**Before:** 4 methods × ~9 lines each = ~36 lines

**After:** 1 method + 1 data provider = ~21 lines

Named data sets also make PHPUnit failure output more readable — instead of `test_invalid_characters` you see `test_invalid_block_names with data set "invalid characters"`, which is clearer at a glance.

---
## Testing      
```
Ran all three affected test classes locally:                                                                              

npm run test:php -- --filter "Tests_Rewrite_AddRewriteRule|Tests_Rewrite_AddRewriteEndpoint|Tests_Blocks_wpBlockTypeRegistry"                                                       
                                                                                                                             
OK (20 tests, 42 assertions)
```

All passing. The data provider runs each case as its own PHPUnit test, so the assertion count is unchanged.                                                                                                      

---                                                                                                   
## Trac         

See https://core.trac.wordpress.org/ticket/64225

_This is my first contribution to WordPress core. I've enabled "Allow and access to secrets by maintainers". Happy to adjust anything based on review feedback._ 