### PR TITLE
Missing escaping for XML error message  #65047

### DIFF
--- a/src/wp-trackback.php
+++ b/src/wp-trackback.php
@@ -34,7 +34,7 @@ function trackback_response( $error = 0, $error_message = '' ) {
 		echo '<?xml version="1.0" encoding="utf-8"?' . ">\n";
 		echo "<response>\n";
 		echo "<error>1</error>\n";
-		echo "<message>" . esc_html ( $error_message ) . "</message>\n";
+		echo "<message>" . esc_xml( $error_message ) . "</message>\n";
 		echo '</response>';
 		die();
 	} else {

--- a/src/wp-trackback.php
+++ b/src/wp-trackback.php
@@ -34,7 +34,7 @@ function trackback_response( $error = 0, $error_message = '' ) {
 		echo '<?xml version="1.0" encoding="utf-8"?' . ">\n";
 		echo "<response>\n";
 		echo "<error>1</error>\n";
-		echo "<message>" . wp_kses_post( $error_message ) . "</message>\n";
+		echo "<message>" . esc_html ( $error_message ) . "</message>\n";
 		echo '</response>';
 		die();
 	} else {

--- a/src/wp-trackback.php
+++ b/src/wp-trackback.php
@@ -34,7 +34,7 @@ function trackback_response( $error = 0, $error_message = '' ) {
 		echo '<?xml version="1.0" encoding="utf-8"?' . ">\n";
 		echo "<response>\n";
 		echo "<error>1</error>\n";
-		echo "<message>" . esc_xml( $error_message ) . "</message>\n";
+		echo '<message>' . esc_xml( $error_message ) . "</message>\n";
 		echo '</response>';
 		die();
 	} else {

--- a/src/wp-trackback.php
+++ b/src/wp-trackback.php
@@ -34,7 +34,7 @@ function trackback_response( $error = 0, $error_message = '' ) {
 		echo '<?xml version="1.0" encoding="utf-8"?' . ">\n";
 		echo "<response>\n";
 		echo "<error>1</error>\n";
-		echo "<message>$error_message</message>\n";
+		echo "<message>" . wp_kses_post( $error_message ) . "</message>\n";
 		echo '</response>';
 		die();
 	} else {


### PR DESCRIPTION
Add escaping [src/wp-trackback.php](src/wp-trackback.php#L37)

if ( $error ) {

echo '<?xml version="1.0" encoding="utf-8"?' . ">\n";
echo "<response>\n";
echo "<error>1</error>\n";
echo "<message>" . esc_html ( $error_message ) . "</message>\n";
echo '</response>';

}

Trac ticket: https://core.trac.wordpress.org/ticket/65047#ticket

