### PR TITLE
Feature #64990: Add filtering support to `wp_get_abilities()` via `$args` array

### DIFF
--- a/src/wp-includes/abilities-api.php
+++ b/src/wp-includes/abilities-api.php
@@ -405,8 +405,8 @@ function wp_get_ability( string $name ): ?WP_Ability {
  *
  * 1. Declarative filters (`category`, `namespace`, `meta`) — per-item, AND logic between
  *    arg types, OR logic within multi-value `category` arrays.
- * 2. `match_callback` — per-item, caller-scoped. Return true to include, false to exclude.
- * 3. `wp_get_abilities_match` filter — per-item, ecosystem-scoped. Plugins can enforce
+ * 2. `item_include_callback` — per-item, caller-scoped. Return true to include, false to exclude.
+ * 3. `wp_get_abilities_item_include` filter — per-item, ecosystem-scoped. Plugins can enforce
  *    universal inclusion rules regardless of what the caller passed.
  * 4. `result_callback` — on the full matched array, caller-scoped. Sort, slice, or reshape.
  * 5. `wp_get_abilities_result` filter — on the full array, ecosystem-scoped.
@@ -439,7 +439,7 @@ function wp_get_ability( string $name ): ?WP_Ability {
  *
  *     // Caller-scoped per-item callback.
  *     $abilities = wp_get_abilities( array(
- *         'match_callback' => function ( WP_Ability $ability ) {
+ *         'item_include_callback' => function ( WP_Ability $ability ) {
  *             return current_user_can( 'manage_options' );
  *         },
  *     ) );
@@ -452,6 +452,12 @@ function wp_get_ability( string $name ): ?WP_Ability {
  *         },
  *     ) );
  *
+ * The pipeline always runs, even when called with no arguments. This ensures that the
+ * `wp_get_abilities_item_include` and `wp_get_abilities_result` filters always fire,
+ * giving plugins a reliable place to enforce universal inclusion or shaping rules.
+ * For raw, unfiltered registry data that bypasses the filter pipeline entirely, use
+ * {@see WP_Abilities_Registry::get_all_registered()} directly.
+ *
  * @since 6.9.0
  * @since 7.1.0 Added the `$args` parameter for filtering support.
  *
@@ -460,21 +466,21 @@ function wp_get_ability( string $name ): ?WP_Ability {
  * @param array $args {
  *     Optional. Arguments to filter the returned abilities. Default empty array (returns all).
  *
- *     @type string|string[] $category        Filter by category slug. A single string or an array of
- *                                            slugs — abilities matching any of the given slugs are
- *                                            included (OR logic within this arg type).
- *     @type string          $namespace       Filter by ability namespace prefix. Pass the namespace
- *                                            without a trailing slash, e.g. `'woocommerce'` matches
- *                                            `'woocommerce/create-order'`.
- *     @type array           $meta            Filter by meta key/value pairs. All conditions must
- *                                            match (AND logic). Supports nested arrays for structured
- *                                            meta, e.g. `array( 'mcp' => array( 'public' => true ) )`.
- *     @type callable        $match_callback  Optional. A callback invoked per ability after declarative
- *                                            filters. Receives a WP_Ability instance, returns bool.
- *                                            Return true to include, false to exclude.
- *     @type callable        $result_callback Optional. A callback invoked once on the full matched
- *                                            array. Receives WP_Ability[], must return WP_Ability[].
- *                                            Use for sorting, slicing, or reshaping the result.
+ *     @type string|string[] $category              Filter by category slug. A single string or an array of
+ *                                                  slugs — abilities matching any of the given slugs are
+ *                                                  included (OR logic within this arg type).
+ *     @type string          $namespace             Filter by ability namespace prefix. Pass the namespace
+ *                                                  without a trailing slash, e.g. `'woocommerce'` matches
+ *                                                  `'woocommerce/create-order'`.
+ *     @type array           $meta                  Filter by meta key/value pairs. All conditions must
+ *                                                  match (AND logic). Supports nested arrays for structured
+ *                                                  meta, e.g. `array( 'mcp' => array( 'public' => true ) )`.
+ *     @type callable        $item_include_callback Optional. A callback invoked per ability after declarative
+ *                                                  filters. Receives a WP_Ability instance, returns bool.
+ *                                                  Return true to include, false to exclude.
+ *     @type callable        $result_callback       Optional. A callback invoked once on the full matched
+ *                                                  array. Receives WP_Ability[], must return WP_Ability[].
+ *                                                  Use for sorting, slicing, or reshaping the result.
  * }
  * @return WP_Ability[] An array of registered WP_Ability instances matching the given args.
  *                      Returns an empty array if no abilities are registered, the registry is
@@ -488,16 +494,11 @@ function wp_get_abilities( array $args = array() ): array {
 
 	$abilities = $registry->get_all_registered();
 
-	// Bail early when no filtering is requested.
-	if ( empty( $args ) ) {
-		return $abilities;
-	}
-
-	$category        = isset( $args['category'] ) ? (array) $args['category'] : array();
-	$namespace       = isset( $args['namespace'] ) && is_string( $args['namespace'] ) ? rtrim( $args['namespace'], '/' ) . '/' : '';
-	$meta            = isset( $args['meta'] ) && is_array( $args['meta'] ) ? $args['meta'] : array();
-	$match_callback  = isset( $args['match_callback'] ) && is_callable( $args['match_callback'] ) ? $args['match_callback'] : null;
-	$result_callback = isset( $args['result_callback'] ) && is_callable( $args['result_callback'] ) ? $args['result_callback'] : null;
+	$category              = isset( $args['category'] ) ? (array) $args['category'] : array();
+	$namespace             = isset( $args['namespace'] ) && is_string( $args['namespace'] ) ? rtrim( $args['namespace'], '/' ) . '/' : '';
+	$meta                  = isset( $args['meta'] ) && is_array( $args['meta'] ) ? $args['meta'] : array();
+	$item_include_callback = isset( $args['item_include_callback'] ) && is_callable( $args['item_include_callback'] ) ? $args['item_include_callback'] : null;
+	$result_callback       = isset( $args['result_callback'] ) && is_callable( $args['result_callback'] ) ? $args['result_callback'] : null;
 
 	$matched = array();
 
@@ -519,14 +520,14 @@ function wp_get_abilities( array $args = array() ): array {
 
 		// Step 2: Caller-scoped per-item callback.
 		$include = true;
-		if ( null !== $match_callback ) {
-			$include = (bool) call_user_func( $match_callback, $ability );
+		if ( null !== $item_include_callback ) {
+			$include = (bool) call_user_func( $item_include_callback, $ability );
 		}
 
 		/**
 		 * Filters whether an individual ability should be included in the result set.
 		 *
-		 * Fires after the declarative filters and the caller-scoped match_callback.
+		 * Fires after the declarative filters and the caller-scoped item_include_callback.
 		 * Plugins can use this to enforce universal inclusion rules regardless of
 		 * what the caller passed in $args.
 		 *
@@ -536,7 +537,7 @@ function wp_get_abilities( array $args = array() ): array {
 		 * @param WP_Ability $ability The ability instance being evaluated.
 		 * @param array      $args    The full $args array passed to wp_get_abilities().
 		 */
-		$include = (bool) apply_filters( 'wp_get_abilities_match', $include, $ability, $args );
+		$include = (bool) apply_filters( 'wp_get_abilities_item_include', $include, $ability, $args );
 
 		if ( $include ) {
 			$matched[] = $ability;

--- a/src/wp-includes/abilities-api.php
+++ b/src/wp-includes/abilities-api.php
@@ -396,33 +396,201 @@ function wp_get_ability( string $name ): ?WP_Ability {
 }
 
 /**
- * Retrieves all registered abilities.
+ * Retrieves registered abilities, optionally filtered by the given arguments.
  *
- * Returns an array of all ability instances currently registered in the system.
- * Use this for discovery, debugging, or building administrative interfaces.
+ * When called without arguments, returns all registered abilities. When called
+ * with an $args array, returns only abilities that match every specified condition.
  *
- * Example:
+ * Filtering pipeline (executed in order):
  *
- *     // Prints information about all available abilities.
+ * 1. Declarative filters (`category`, `namespace`, `meta`) — per-item, AND logic between
+ *    arg types, OR logic within multi-value `category` arrays.
+ * 2. `match_callback` — per-item, caller-scoped. Return true to include, false to exclude.
+ * 3. `wp_get_abilities_match` filter — per-item, ecosystem-scoped. Plugins can enforce
+ *    universal inclusion rules regardless of what the caller passed.
+ * 4. `result_callback` — on the full matched array, caller-scoped. Sort, slice, or reshape.
+ * 5. `wp_get_abilities_result` filter — on the full array, ecosystem-scoped.
+ *
+ * Steps 1–3 run inside a single loop over the registry — no extra iteration.
+ *
+ * Examples:
+ *
+ *     // All abilities (unchanged behaviour).
  *     $abilities = wp_get_abilities();
- *     foreach ( $abilities as $ability ) {
- *         echo $ability->get_label() . ': ' . $ability->get_description() . "\n";
- *     }
+ *
+ *     // Filter by category.
+ *     $abilities = wp_get_abilities( array( 'category' => 'content' ) );
+ *
+ *     // Filter by multiple categories (OR logic).
+ *     $abilities = wp_get_abilities( array( 'category' => array( 'content', 'settings' ) ) );
+ *
+ *     // Filter by namespace.
+ *     $abilities = wp_get_abilities( array( 'namespace' => 'woocommerce' ) );
+ *
+ *     // Filter by meta.
+ *     $abilities = wp_get_abilities( array( 'meta' => array( 'show_in_rest' => true ) ) );
+ *
+ *     // Combine filters (AND logic between arg types).
+ *     $abilities = wp_get_abilities( array(
+ *         'category'  => 'content',
+ *         'namespace' => 'core',
+ *         'meta'      => array( 'show_in_rest' => true ),
+ *     ) );
+ *
+ *     // Caller-scoped per-item callback.
+ *     $abilities = wp_get_abilities( array(
+ *         'match_callback' => function ( WP_Ability $ability ) {
+ *             return current_user_can( 'manage_options' );
+ *         },
+ *     ) );
+ *
+ *     // Caller-scoped result callback (sort + paginate).
+ *     $abilities = wp_get_abilities( array(
+ *         'result_callback' => function ( array $abilities ) {
+ *             usort( $abilities, fn( $a, $b ) => strcasecmp( $a->get_label(), $b->get_label() ) );
+ *             return array_slice( $abilities, 0, 10 );
+ *         },
+ *     ) );
  *
  * @since 6.9.0
+ * @since 7.1.0 Added the `$args` parameter for filtering support.
  *
  * @see WP_Abilities_Registry::get_all_registered()
  *
- * @return WP_Ability[] An array of registered WP_Ability instances. Returns an empty
- *                     array if no abilities are registered or if the registry is unavailable.
+ * @param array $args {
+ *     Optional. Arguments to filter the returned abilities. Default empty array (returns all).
+ *
+ *     @type string|string[] $category        Filter by category slug. A single string or an array of
+ *                                            slugs — abilities matching any of the given slugs are
+ *                                            included (OR logic within this arg type).
+ *     @type string          $namespace       Filter by ability namespace prefix. Pass the namespace
+ *                                            without a trailing slash, e.g. `'woocommerce'` matches
+ *                                            `'woocommerce/create-order'`.
+ *     @type array           $meta            Filter by meta key/value pairs. All conditions must
+ *                                            match (AND logic). Supports nested arrays for structured
+ *                                            meta, e.g. `array( 'mcp' => array( 'public' => true ) )`.
+ *     @type callable        $match_callback  Optional. A callback invoked per ability after declarative
+ *                                            filters. Receives a WP_Ability instance, returns bool.
+ *                                            Return true to include, false to exclude.
+ *     @type callable        $result_callback Optional. A callback invoked once on the full matched
+ *                                            array. Receives WP_Ability[], must return WP_Ability[].
+ *                                            Use for sorting, slicing, or reshaping the result.
+ * }
+ * @return WP_Ability[] An array of registered WP_Ability instances matching the given args.
+ *                      Returns an empty array if no abilities are registered, the registry is
+ *                      unavailable, or no abilities match the given args.
  */
-function wp_get_abilities(): array {
+function wp_get_abilities( array $args = array() ): array {
 	$registry = WP_Abilities_Registry::get_instance();
 	if ( null === $registry ) {
 		return array();
 	}
 
-	return $registry->get_all_registered();
+	$abilities = $registry->get_all_registered();
+
+	// Bail early when no filtering is requested.
+	if ( empty( $args ) ) {
+		return $abilities;
+	}
+
+	$category        = isset( $args['category'] ) ? (array) $args['category'] : array();
+	$namespace       = isset( $args['namespace'] ) && is_string( $args['namespace'] ) ? rtrim( $args['namespace'], '/' ) . '/' : '';
+	$meta            = isset( $args['meta'] ) && is_array( $args['meta'] ) ? $args['meta'] : array();
+	$match_callback  = isset( $args['match_callback'] ) && is_callable( $args['match_callback'] ) ? $args['match_callback'] : null;
+	$result_callback = isset( $args['result_callback'] ) && is_callable( $args['result_callback'] ) ? $args['result_callback'] : null;
+
+	$matched = array();
+
+	foreach ( $abilities as $ability ) {
+		// Step 1a: Filter by category (OR logic within the arg).
+		if ( ! empty( $category ) && ! in_array( $ability->get_category(), $category, true ) ) {
+			continue;
+		}
+
+		// Step 1b: Filter by namespace prefix.
+		if ( '' !== $namespace && ! str_starts_with( $ability->get_name(), $namespace ) ) {
+			continue;
+		}
+
+		// Step 1c: Filter by meta key/value pairs (AND logic, supports nested arrays).
+		if ( ! empty( $meta ) && ! wp_get_abilities_match_meta( $ability->get_meta(), $meta ) ) {
+			continue;
+		}
+
+		// Step 2: Caller-scoped per-item callback.
+		$include = true;
+		if ( null !== $match_callback ) {
+			$include = (bool) call_user_func( $match_callback, $ability );
+		}
+
+		/**
+		 * Filters whether an individual ability should be included in the result set.
+		 *
+		 * Fires after the declarative filters and the caller-scoped match_callback.
+		 * Plugins can use this to enforce universal inclusion rules regardless of
+		 * what the caller passed in $args.
+		 *
+		 * @since 7.1.0
+		 *
+		 * @param bool       $include Whether to include the ability. Default true (after declarative filters pass).
+		 * @param WP_Ability $ability The ability instance being evaluated.
+		 * @param array      $args    The full $args array passed to wp_get_abilities().
+		 */
+		$include = (bool) apply_filters( 'wp_get_abilities_match', $include, $ability, $args );
+
+		if ( $include ) {
+			$matched[] = $ability;
+		}
+	}
+
+	// Step 4: Caller-scoped result callback.
+	if ( null !== $result_callback ) {
+		$matched = (array) call_user_func( $result_callback, $matched );
+	}
+
+	/**
+	 * Filters the full list of matched abilities after all per-item filtering is complete.
+	 *
+	 * Fires after the caller-scoped result_callback. Plugins can use this to sort,
+	 * paginate, or reshape the final result set universally.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param WP_Ability[] $matched The matched abilities after all filtering.
+	 * @param array        $args    The full $args array passed to wp_get_abilities().
+	 */
+	return (array) apply_filters( 'wp_get_abilities_result', $matched, $args );
+}
+
+/**
+ * Checks whether an ability's meta array matches a set of required key/value conditions.
+ *
+ * All conditions must match (AND logic). Supports nested arrays for structured meta,
+ * e.g. `array( 'mcp' => array( 'public' => true ) )`.
+ *
+ * @since 7.1.0
+ * @access private
+ *
+ * @param array $meta       The ability's meta array.
+ * @param array $conditions The required key/value conditions to match against.
+ * @return bool True if all conditions match, false otherwise.
+ */
+function wp_get_abilities_match_meta( array $meta, array $conditions ): bool {
+	foreach ( $conditions as $key => $value ) {
+		if ( ! array_key_exists( $key, $meta ) ) {
+			return false;
+		}
+
+		if ( is_array( $value ) ) {
+			if ( ! is_array( $meta[ $key ] ) || ! wp_get_abilities_match_meta( $meta[ $key ], $value ) ) {
+				return false;
+			}
+		} elseif ( $meta[ $key ] !== $value ) {
+			return false;
+		}
+	}
+
+	return true;
 }
 
 /**

--- a/src/wp-includes/abilities-api.php
+++ b/src/wp-includes/abilities-api.php
@@ -513,7 +513,7 @@ function wp_get_abilities( array $args = array() ): array {
 		}
 
 		// Step 1c: Filter by meta key/value pairs (AND logic, supports nested arrays).
-		if ( ! empty( $meta ) && ! wp_get_abilities_match_meta( $ability->get_meta(), $meta ) ) {
+		if ( ! empty( $meta ) && ! _wp_get_abilities_match_meta( $ability->get_meta(), $meta ) ) {
 			continue;
 		}
 
@@ -575,14 +575,14 @@ function wp_get_abilities( array $args = array() ): array {
  * @param array $conditions The required key/value conditions to match against.
  * @return bool True if all conditions match, false otherwise.
  */
-function wp_get_abilities_match_meta( array $meta, array $conditions ): bool {
+function _wp_get_abilities_match_meta( array $meta, array $conditions ): bool {
 	foreach ( $conditions as $key => $value ) {
 		if ( ! array_key_exists( $key, $meta ) ) {
 			return false;
 		}
 
 		if ( is_array( $value ) ) {
-			if ( ! is_array( $meta[ $key ] ) || ! wp_get_abilities_match_meta( $meta[ $key ], $value ) ) {
+			if ( ! is_array( $meta[ $key ] ) || ! _wp_get_abilities_match_meta( $meta[ $key ], $value ) ) {
 				return false;
 			}
 		} elseif ( $meta[ $key ] !== $value ) {

--- a/src/wp-includes/abilities-api.php
+++ b/src/wp-includes/abilities-api.php
@@ -482,9 +482,10 @@ function wp_get_ability( string $name ): ?WP_Ability {
  *                                                  array. Receives WP_Ability[], must return WP_Ability[].
  *                                                  Use for sorting, slicing, or reshaping the result.
  * }
- * @return WP_Ability[] An array of registered WP_Ability instances matching the given args.
- *                      Returns an empty array if no abilities are registered, the registry is
- *                      unavailable, or no abilities match the given args.
+ * @return WP_Ability[] An array of registered WP_Ability instances matching the given args,
+ *                      keyed by ability name. Returns an empty array if no abilities are
+ *                      registered, the registry is unavailable, or no abilities match the
+ *                      given args.
  */
 function wp_get_abilities( array $args = array() ): array {
 	$registry = WP_Abilities_Registry::get_instance();
@@ -502,7 +503,7 @@ function wp_get_abilities( array $args = array() ): array {
 
 	$matched = array();
 
-	foreach ( $abilities as $ability ) {
+	foreach ( $abilities as $name => $ability ) {
 		// Step 1a: Filter by category (OR logic within the arg).
 		if ( ! empty( $category ) && ! in_array( $ability->get_category(), $category, true ) ) {
 			continue;
@@ -540,7 +541,7 @@ function wp_get_abilities( array $args = array() ): array {
 		$include = (bool) apply_filters( 'wp_get_abilities_item_include', $include, $ability, $args );
 
 		if ( $include ) {
-			$matched[] = $ability;
+			$matched[ $name ] = $ability;
 		}
 	}
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-abilities-v1-list-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-abilities-v1-list-controller.php
@@ -86,25 +86,19 @@ class WP_REST_Abilities_V1_List_Controller extends WP_REST_Controller {
 	 * @return WP_REST_Response Response object on success.
 	 */
 	public function get_items( $request ) {
-		$abilities = array_filter(
-			wp_get_abilities(),
-			static function ( $ability ) {
-				return $ability->get_meta_item( 'show_in_rest' );
-			}
+		$query_args = array(
+			'meta' => array( 'show_in_rest' => true ),
 		);
 
-		// Filter by ability category if specified.
-		$category = $request['category'];
-		if ( ! empty( $category ) ) {
-			$abilities = array_filter(
-				$abilities,
-				static function ( $ability ) use ( $category ) {
-					return $ability->get_category() === $category;
-				}
-			);
-			// Reset array keys after filtering.
-			$abilities = array_values( $abilities );
+		if ( ! empty( $request['category'] ) ) {
+			$query_args['category'] = $request['category'];
 		}
+
+		if ( ! empty( $request['namespace'] ) ) {
+			$query_args['namespace'] = $request['namespace'];
+		}
+
+		$abilities = wp_get_abilities( $query_args );
 
 		$page     = $request['page'];
 		$per_page = $request['per_page'];
@@ -432,8 +426,14 @@ class WP_REST_Abilities_V1_List_Controller extends WP_REST_Controller {
 				'minimum'     => 1,
 				'maximum'     => 100,
 			),
-			'category' => array(
+			'category'  => array(
 				'description'       => __( 'Limit results to abilities in specific ability category.' ),
+				'type'              => 'string',
+				'sanitize_callback' => 'sanitize_key',
+				'validate_callback' => 'rest_validate_request_arg',
+			),
+			'namespace' => array(
+				'description'       => __( 'Limit results to abilities in a specific namespace.' ),
 				'type'              => 'string',
 				'sanitize_callback' => 'sanitize_key',
 				'validate_callback' => 'rest_validate_request_arg',

--- a/tests/phpunit/tests/abilities-api/wpGetAbilities.php
+++ b/tests/phpunit/tests/abilities-api/wpGetAbilities.php
@@ -461,7 +461,7 @@ class Tests_Abilities_API_WpGetAbilities extends WP_UnitTestCase {
 		$this->register_test_ability( 'test/ability-one' );
 		$this->register_test_ability( 'test/ability-two' );
 
-		$filter = static function ( bool $include, WP_Ability $ability ): bool {
+		$filter = static function ( bool $should_include, WP_Ability $ability ): bool {
 			return 'test/ability-two' !== $ability->get_name();
 		};
 
@@ -495,7 +495,7 @@ class Tests_Abilities_API_WpGetAbilities extends WP_UnitTestCase {
 		$query_args       = array( 'namespace' => 'test' );
 
 		$filter = static function (
-			bool $include,
+			bool $should_include,
 			WP_Ability $ability,
 			array $args
 		) use (
@@ -504,7 +504,7 @@ class Tests_Abilities_API_WpGetAbilities extends WP_UnitTestCase {
 		): bool {
 			$received_ability = $ability;
 			$received_args    = $args;
-			return $include;
+			return $should_include;
 		};
 
 		add_filter( 'wp_get_abilities_match', $filter, 10, 3 );

--- a/tests/phpunit/tests/abilities-api/wpGetAbilities.php
+++ b/tests/phpunit/tests/abilities-api/wpGetAbilities.php
@@ -612,7 +612,10 @@ class Tests_Abilities_API_WpGetAbilities extends WP_UnitTestCase {
 		$filter = static function (
 			array $abilities,
 			array $args
-		) use ( &$received_abilities, &$received_args ): array {
+		) use (
+			&$received_abilities,
+			&$received_args
+		): array {
 			$received_abilities = $abilities;
 			$received_args      = $args;
 			return $abilities;

--- a/tests/phpunit/tests/abilities-api/wpGetAbilities.php
+++ b/tests/phpunit/tests/abilities-api/wpGetAbilities.php
@@ -1,0 +1,685 @@
+<?php declare( strict_types=1 );
+
+/**
+ * Tests for the filtering support added to wp_get_abilities().
+ *
+ * @covers wp_get_abilities
+ *
+ * @group abilities-api
+ */
+class Tests_Abilities_API_WpGetAbilities extends WP_UnitTestCase {
+
+	/**
+	 * Test ability names registered during a test, used for teardown cleanup.
+	 *
+	 * @var string[]
+	 */
+	private $registered_ability_names = array();
+
+	/**
+	 * Set up before each test.
+	 */
+	public function set_up(): void {
+		global $wp_current_filter;
+
+		parent::set_up();
+
+		$wp_current_filter[] = 'wp_abilities_api_categories_init';
+		wp_register_ability_category(
+			'math',
+			array(
+				'label'       => 'Math',
+				'description' => 'Mathematical operations.',
+			)
+		);
+		wp_register_ability_category(
+			'text',
+			array(
+				'label'       => 'Text',
+				'description' => 'Text operations.',
+			)
+		);
+	}
+
+	/**
+	 * Tear down after each test.
+	 */
+	public function tear_down(): void {
+		foreach ( $this->registered_ability_names as $name ) {
+			wp_unregister_ability( $name );
+		}
+
+		$this->registered_ability_names = array();
+
+		wp_unregister_ability_category( 'math' );
+		wp_unregister_ability_category( 'text' );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Simulates the `wp_abilities_api_init` action.
+	 */
+	private function simulate_wp_abilities_init(): void {
+		global $wp_current_filter;
+
+		$wp_current_filter[] = 'wp_abilities_api_init';
+	}
+
+	/**
+	 * Registers a test ability and tracks its name for teardown.
+	 *
+	 * @param string  $name      The ability name.
+	 * @param array   $overrides Optional args to merge into the defaults.
+	 * @return WP_Ability|null The registered ability, or null on failure.
+	 */
+	private function register_test_ability( string $name, array $overrides = array() ): ?WP_Ability {
+		$args = array_merge(
+			array(
+				'label'               => 'Test Ability',
+				'description'         => 'A test ability.',
+				'category'            => 'math',
+				'input_schema'        => array(
+					'type'       => 'object',
+					'properties' => array(),
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(),
+				),
+				'execute_callback'    => static function (): array {
+					return array();
+				},
+				'permission_callback' => static function (): bool {
+					return true;
+				},
+				'meta'                => array(),
+			),
+			$overrides
+		);
+
+		$ability = wp_register_ability( $name, $args );
+
+		if ( null !== $ability ) {
+			$this->registered_ability_names[] = $name;
+		}
+
+		return $ability;
+	}
+
+	// -------------------------------------------------------------------------
+	// Category filter
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Tests filtering by a single category string.
+	 *
+	 * @ticket 64990
+	 */
+	public function test_filter_by_single_category(): void {
+		$this->simulate_wp_abilities_init();
+
+		$this->register_test_ability( 'test/math-add', array( 'category' => 'math' ) );
+		$this->register_test_ability( 'test/text-upper', array( 'category' => 'text' ) );
+
+		$result = wp_get_abilities( array( 'category' => 'math' ) );
+		$names  = array_map(
+			static function ( WP_Ability $a ) {
+				return $a->get_name();
+			},
+			$result
+		);
+
+		$this->assertContains( 'test/math-add', $names );
+		$this->assertNotContains( 'test/text-upper', $names );
+	}
+
+	/**
+	 * Tests that passing an array of categories uses OR logic.
+	 *
+	 * @ticket 64990
+	 */
+	public function test_filter_by_category_array_uses_or_logic(): void {
+		$this->simulate_wp_abilities_init();
+
+		$this->register_test_ability( 'test/math-add', array( 'category' => 'math' ) );
+		$this->register_test_ability( 'test/text-upper', array( 'category' => 'text' ) );
+
+		$result = wp_get_abilities( array( 'category' => array( 'math', 'text' ) ) );
+		$names  = array_map(
+			static function ( WP_Ability $a ) {
+				return $a->get_name();
+			},
+			$result
+		);
+
+		$this->assertContains( 'test/math-add', $names );
+		$this->assertContains( 'test/text-upper', $names );
+	}
+
+	/**
+	 * Tests that filtering by a non-existent category returns an empty array.
+	 *
+	 * @ticket 64990
+	 */
+	public function test_filter_by_nonexistent_category_returns_empty(): void {
+		$this->simulate_wp_abilities_init();
+
+		$this->register_test_ability( 'test/math-add', array( 'category' => 'math' ) );
+
+		$result = wp_get_abilities( array( 'category' => 'nonexistent' ) );
+
+		$this->assertSame( array(), $result );
+	}
+
+	// -------------------------------------------------------------------------
+	// Namespace filter
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Tests filtering by namespace prefix.
+	 *
+	 * @ticket 64990
+	 */
+	public function test_filter_by_namespace(): void {
+		$this->simulate_wp_abilities_init();
+
+		$this->register_test_ability( 'test/ability-one' );
+		$this->register_test_ability( 'other/ability-two', array( 'category' => 'text' ) );
+
+		$result = wp_get_abilities( array( 'namespace' => 'test' ) );
+		$names  = array_map(
+			static function ( WP_Ability $a ) {
+				return $a->get_name();
+			},
+			$result
+		);
+
+		$this->assertContains( 'test/ability-one', $names );
+		$this->assertNotContains( 'other/ability-two', $names );
+	}
+
+	/**
+	 * Tests that a namespace with a trailing slash produces the same result as one without.
+	 *
+	 * @ticket 64990
+	 */
+	public function test_filter_by_namespace_trailing_slash_is_normalized(): void {
+		$this->simulate_wp_abilities_init();
+
+		$this->register_test_ability( 'test/ability-one' );
+
+		$get_names           = static function ( array $abilities ): array {
+			return array_map(
+				static function ( WP_Ability $a ) {
+					return $a->get_name();
+				},
+				$abilities
+			);
+		};
+		$names_without_slash = $get_names( wp_get_abilities( array( 'namespace' => 'test' ) ) );
+		$names_with_slash    = $get_names( wp_get_abilities( array( 'namespace' => 'test/' ) ) );
+
+		$this->assertSame( $names_without_slash, $names_with_slash );
+	}
+
+	/**
+	 * Tests that a non-matching namespace returns an empty array.
+	 *
+	 * @ticket 64990
+	 */
+	public function test_filter_by_nonexistent_namespace_returns_empty(): void {
+		$this->simulate_wp_abilities_init();
+
+		$this->register_test_ability( 'test/ability-one' );
+
+		$result = wp_get_abilities( array( 'namespace' => 'nonexistent' ) );
+
+		$this->assertSame( array(), $result );
+	}
+
+	// -------------------------------------------------------------------------
+	// Meta filter
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Tests filtering by a single meta key/value pair.
+	 *
+	 * @ticket 64990
+	 */
+	public function test_filter_by_meta_single_key(): void {
+		$this->simulate_wp_abilities_init();
+
+		$this->register_test_ability(
+			'test/ability-rest',
+			array( 'meta' => array( 'show_in_rest' => true ) )
+		);
+		$this->register_test_ability(
+			'test/ability-no-rest',
+			array( 'meta' => array( 'show_in_rest' => false ) )
+		);
+
+		$result = wp_get_abilities( array( 'meta' => array( 'show_in_rest' => true ) ) );
+		$names  = array_map(
+			static function ( WP_Ability $a ) {
+				return $a->get_name();
+			},
+			$result
+		);
+
+		$this->assertContains( 'test/ability-rest', $names );
+		$this->assertNotContains( 'test/ability-no-rest', $names );
+	}
+
+	/**
+	 * Tests that multiple meta conditions use AND logic.
+	 *
+	 * @ticket 64990
+	 */
+	public function test_filter_by_meta_multiple_keys_uses_and_logic(): void {
+		$this->simulate_wp_abilities_init();
+
+		$this->register_test_ability(
+			'test/ability-both',
+			array( 'meta' => array( 'show_in_rest' => true, 'public' => true ) )
+		);
+		$this->register_test_ability(
+			'test/ability-one-key',
+			array( 'meta' => array( 'show_in_rest' => true, 'public' => false ) )
+		);
+
+		$result = wp_get_abilities(
+			array( 'meta' => array( 'show_in_rest' => true, 'public' => true ) )
+		);
+		$names  = array_map(
+			static function ( WP_Ability $a ) {
+				return $a->get_name();
+			},
+			$result
+		);
+
+		$this->assertContains( 'test/ability-both', $names );
+		$this->assertNotContains( 'test/ability-one-key', $names );
+	}
+
+	/**
+	 * Tests filtering by nested meta arrays.
+	 *
+	 * @ticket 64990
+	 */
+	public function test_filter_by_nested_meta(): void {
+		$this->simulate_wp_abilities_init();
+
+		$this->register_test_ability(
+			'test/ability-public-mcp',
+			array( 'meta' => array( 'mcp' => array( 'public' => true ) ) )
+		);
+		$this->register_test_ability(
+			'test/ability-private-mcp',
+			array( 'meta' => array( 'mcp' => array( 'public' => false ) ) )
+		);
+
+		$result = wp_get_abilities( array( 'meta' => array( 'mcp' => array( 'public' => true ) ) ) );
+		$names  = array_map(
+			static function ( WP_Ability $a ) {
+				return $a->get_name();
+			},
+			$result
+		);
+
+		$this->assertContains( 'test/ability-public-mcp', $names );
+		$this->assertNotContains( 'test/ability-private-mcp', $names );
+	}
+
+	/**
+	 * Tests that an ability without the required meta key is excluded.
+	 *
+	 * @ticket 64990
+	 */
+	public function test_filter_by_missing_meta_key_excludes_ability(): void {
+		$this->simulate_wp_abilities_init();
+
+		$this->register_test_ability( 'test/ability-no-meta', array( 'meta' => array() ) );
+
+		$result = wp_get_abilities( array( 'meta' => array( 'show_in_rest' => true ) ) );
+		$names  = array_map(
+			static function ( WP_Ability $a ) {
+				return $a->get_name();
+			},
+			$result
+		);
+
+		$this->assertNotContains( 'test/ability-no-meta', $names );
+	}
+
+	// -------------------------------------------------------------------------
+	// match_callback
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Tests that match_callback can include or exclude abilities per item.
+	 *
+	 * @ticket 64990
+	 */
+	public function test_match_callback_filters_per_item(): void {
+		$this->simulate_wp_abilities_init();
+
+		$this->register_test_ability( 'test/ability-alpha' );
+		$this->register_test_ability( 'test/ability-beta' );
+
+		$result = wp_get_abilities(
+			array(
+				'match_callback' => static function ( WP_Ability $ability ): bool {
+					return 'test/ability-alpha' === $ability->get_name();
+				},
+			)
+		);
+		$names  = array_map(
+			static function ( WP_Ability $a ) {
+				return $a->get_name();
+			},
+			$result
+		);
+
+		$this->assertContains( 'test/ability-alpha', $names );
+		$this->assertNotContains( 'test/ability-beta', $names );
+	}
+
+	/**
+	 * Tests that match_callback returning false for all abilities yields an empty result.
+	 *
+	 * @ticket 64990
+	 */
+	public function test_match_callback_returning_false_yields_empty_result(): void {
+		$this->simulate_wp_abilities_init();
+
+		$this->register_test_ability( 'test/ability-one' );
+
+		$result = wp_get_abilities(
+			array(
+				'match_callback' => static function ( WP_Ability $ability ): bool {
+					return false;
+				},
+			)
+		);
+
+		$this->assertSame( array(), $result );
+	}
+
+	/**
+	 * Tests that match_callback receives a WP_Ability instance.
+	 *
+	 * @ticket 64990
+	 */
+	public function test_match_callback_receives_ability_instance(): void {
+		$this->simulate_wp_abilities_init();
+
+		$this->register_test_ability( 'test/ability-one' );
+
+		$received = null;
+		wp_get_abilities(
+			array(
+				'namespace'      => 'test',
+				'match_callback' => static function ( WP_Ability $ability ) use ( &$received ): bool {
+					$received = $ability;
+					return true;
+				},
+			)
+		);
+
+		$this->assertInstanceOf( WP_Ability::class, $received );
+		$this->assertSame( 'test/ability-one', $received->get_name() );
+	}
+
+	// -------------------------------------------------------------------------
+	// wp_get_abilities_match filter hook
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Tests that wp_get_abilities_match filter can exclude an ability.
+	 *
+	 * @ticket 64990
+	 */
+	public function test_wp_get_abilities_match_filter_can_exclude_ability(): void {
+		$this->simulate_wp_abilities_init();
+
+		$this->register_test_ability( 'test/ability-one' );
+		$this->register_test_ability( 'test/ability-two' );
+
+		$filter = static function ( bool $include, WP_Ability $ability ): bool {
+			return 'test/ability-two' !== $ability->get_name();
+		};
+
+		add_filter( 'wp_get_abilities_match', $filter, 10, 2 );
+		$result = wp_get_abilities( array( 'namespace' => 'test' ) );
+		remove_filter( 'wp_get_abilities_match', $filter, 10 );
+
+		$names = array_map(
+			static function ( WP_Ability $a ) {
+				return $a->get_name();
+			},
+			$result
+		);
+
+		$this->assertContains( 'test/ability-one', $names );
+		$this->assertNotContains( 'test/ability-two', $names );
+	}
+
+	/**
+	 * Tests that wp_get_abilities_match filter receives the ability and original args.
+	 *
+	 * @ticket 64990
+	 */
+	public function test_wp_get_abilities_match_filter_receives_ability_and_args(): void {
+		$this->simulate_wp_abilities_init();
+
+		$this->register_test_ability( 'test/ability-one' );
+
+		$received_ability = null;
+		$received_args    = null;
+		$query_args       = array( 'namespace' => 'test' );
+
+		$filter = static function (
+			bool $include,
+			WP_Ability $ability,
+			array $args
+		) use ( &$received_ability, &$received_args ): bool {
+			$received_ability = $ability;
+			$received_args    = $args;
+			return $include;
+		};
+
+		add_filter( 'wp_get_abilities_match', $filter, 10, 3 );
+		wp_get_abilities( $query_args );
+		remove_filter( 'wp_get_abilities_match', $filter, 10 );
+
+		$this->assertInstanceOf( WP_Ability::class, $received_ability );
+		$this->assertSame( $query_args, $received_args );
+	}
+
+	// -------------------------------------------------------------------------
+	// result_callback
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Tests that result_callback receives the full array of matched abilities.
+	 *
+	 * @ticket 64990
+	 */
+	public function test_result_callback_receives_matched_abilities(): void {
+		$this->simulate_wp_abilities_init();
+
+		$this->register_test_ability( 'test/ability-one' );
+		$this->register_test_ability( 'test/ability-two' );
+
+		$received = null;
+		wp_get_abilities(
+			array(
+				'namespace'       => 'test',
+				'result_callback' => static function ( array $abilities ) use ( &$received ): array {
+					$received = $abilities;
+					return $abilities;
+				},
+			)
+		);
+
+		$this->assertIsArray( $received );
+		$this->assertCount( 2, $received );
+		$this->assertContainsOnlyInstancesOf( WP_Ability::class, $received );
+	}
+
+	/**
+	 * Tests that result_callback can reshape the result array.
+	 *
+	 * @ticket 64990
+	 */
+	public function test_result_callback_can_reshape_result(): void {
+		$this->simulate_wp_abilities_init();
+
+		$this->register_test_ability( 'test/ability-one' );
+		$this->register_test_ability( 'test/ability-two' );
+
+		$result = wp_get_abilities(
+			array(
+				'namespace'       => 'test',
+				'result_callback' => static function ( array $abilities ): array {
+					return array_slice( $abilities, 0, 1 );
+				},
+			)
+		);
+
+		$this->assertCount( 1, $result );
+	}
+
+	// -------------------------------------------------------------------------
+	// wp_get_abilities_result filter hook
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Tests that wp_get_abilities_result filter can reshape the final result.
+	 *
+	 * @ticket 64990
+	 */
+	public function test_wp_get_abilities_result_filter_can_reshape_result(): void {
+		$this->simulate_wp_abilities_init();
+
+		$this->register_test_ability( 'test/ability-one' );
+		$this->register_test_ability( 'test/ability-two' );
+
+		$filter = static function ( array $abilities ): array {
+			return array_slice( $abilities, 0, 1 );
+		};
+
+		add_filter( 'wp_get_abilities_result', $filter );
+		$result = wp_get_abilities( array( 'namespace' => 'test' ) );
+		remove_filter( 'wp_get_abilities_result', $filter );
+
+		$this->assertCount( 1, $result );
+	}
+
+	/**
+	 * Tests that wp_get_abilities_result filter receives the matched abilities and original args.
+	 *
+	 * @ticket 64990
+	 */
+	public function test_wp_get_abilities_result_filter_receives_abilities_and_args(): void {
+		$this->simulate_wp_abilities_init();
+
+		$this->register_test_ability( 'test/ability-one' );
+
+		$received_abilities = null;
+		$received_args      = null;
+		$query_args         = array( 'namespace' => 'test' );
+
+		$filter = static function (
+			array $abilities,
+			array $args
+		) use ( &$received_abilities, &$received_args ): array {
+			$received_abilities = $abilities;
+			$received_args      = $args;
+			return $abilities;
+		};
+
+		add_filter( 'wp_get_abilities_result', $filter, 10, 2 );
+		wp_get_abilities( $query_args );
+		remove_filter( 'wp_get_abilities_result', $filter, 10 );
+
+		$this->assertIsArray( $received_abilities );
+		$this->assertSame( $query_args, $received_args );
+	}
+
+	// -------------------------------------------------------------------------
+	// Combined filters
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Tests that category and meta filters are combined with AND logic between them.
+	 *
+	 * @ticket 64990
+	 */
+	public function test_combined_category_and_meta_filters(): void {
+		$this->simulate_wp_abilities_init();
+
+		$this->register_test_ability(
+			'test/math-rest',
+			array( 'category' => 'math', 'meta' => array( 'show_in_rest' => true ) )
+		);
+		$this->register_test_ability(
+			'test/math-no-rest',
+			array( 'category' => 'math', 'meta' => array( 'show_in_rest' => false ) )
+		);
+		$this->register_test_ability(
+			'test/text-rest',
+			array( 'category' => 'text', 'meta' => array( 'show_in_rest' => true ) )
+		);
+
+		$result = wp_get_abilities(
+			array(
+				'category' => 'math',
+				'meta'     => array( 'show_in_rest' => true ),
+			)
+		);
+		$names  = array_map(
+			static function ( WP_Ability $a ) {
+				return $a->get_name();
+			},
+			$result
+		);
+
+		$this->assertContains( 'test/math-rest', $names );
+		$this->assertNotContains( 'test/math-no-rest', $names );
+		$this->assertNotContains( 'test/text-rest', $names );
+	}
+
+	/**
+	 * Tests that namespace and match_callback filters are applied together.
+	 *
+	 * @ticket 64990
+	 */
+	public function test_combined_namespace_and_match_callback_filters(): void {
+		$this->simulate_wp_abilities_init();
+
+		$this->register_test_ability( 'test/ability-alpha' );
+		$this->register_test_ability( 'test/ability-beta' );
+		$this->register_test_ability( 'other/ability-gamma', array( 'category' => 'text' ) );
+
+		$result = wp_get_abilities(
+			array(
+				'namespace'      => 'test',
+				'match_callback' => static function ( WP_Ability $ability ): bool {
+					return 'test/ability-alpha' === $ability->get_name();
+				},
+			)
+		);
+		$names  = array_map(
+			static function ( WP_Ability $a ) {
+				return $a->get_name();
+			},
+			$result
+		);
+
+		$this->assertContains( 'test/ability-alpha', $names );
+		$this->assertNotContains( 'test/ability-beta', $names );
+		$this->assertNotContains( 'other/ability-gamma', $names );
+	}
+}

--- a/tests/phpunit/tests/abilities-api/wpGetAbilities.php
+++ b/tests/phpunit/tests/abilities-api/wpGetAbilities.php
@@ -281,15 +281,30 @@ class Tests_Abilities_API_WpGetAbilities extends WP_UnitTestCase {
 
 		$this->register_test_ability(
 			'test/ability-both',
-			array( 'meta' => array( 'show_in_rest' => true, 'public' => true ) )
+			array(
+				'meta' => array(
+					'show_in_rest' => true,
+					'public'       => true,
+				),
+			)
 		);
 		$this->register_test_ability(
 			'test/ability-one-key',
-			array( 'meta' => array( 'show_in_rest' => true, 'public' => false ) )
+			array(
+				'meta' => array(
+					'show_in_rest' => true,
+					'public'       => false,
+				),
+			)
 		);
 
 		$result = wp_get_abilities(
-			array( 'meta' => array( 'show_in_rest' => true, 'public' => true ) )
+			array(
+				'meta' => array(
+					'show_in_rest' => true,
+					'public'       => true,
+				),
+			)
 		);
 		$names  = array_map(
 			static function ( WP_Ability $a ) {
@@ -483,7 +498,10 @@ class Tests_Abilities_API_WpGetAbilities extends WP_UnitTestCase {
 			bool $include,
 			WP_Ability $ability,
 			array $args
-		) use ( &$received_ability, &$received_args ): bool {
+		) use (
+			&$received_ability,
+			&$received_args
+		): bool {
 			$received_ability = $ability;
 			$received_args    = $args;
 			return $include;
@@ -622,15 +640,24 @@ class Tests_Abilities_API_WpGetAbilities extends WP_UnitTestCase {
 
 		$this->register_test_ability(
 			'test/math-rest',
-			array( 'category' => 'math', 'meta' => array( 'show_in_rest' => true ) )
+			array(
+				'category' => 'math',
+				'meta'     => array( 'show_in_rest' => true ),
+			)
 		);
 		$this->register_test_ability(
 			'test/math-no-rest',
-			array( 'category' => 'math', 'meta' => array( 'show_in_rest' => false ) )
+			array(
+				'category' => 'math',
+				'meta'     => array( 'show_in_rest' => false ),
+			)
 		);
 		$this->register_test_ability(
 			'test/text-rest',
-			array( 'category' => 'text', 'meta' => array( 'show_in_rest' => true ) )
+			array(
+				'category' => 'text',
+				'meta'     => array( 'show_in_rest' => true ),
+			)
 		);
 
 		$result = wp_get_abilities(

--- a/tests/phpunit/tests/abilities-api/wpGetAbilities.php
+++ b/tests/phpunit/tests/abilities-api/wpGetAbilities.php
@@ -368,15 +368,15 @@ class Tests_Abilities_API_WpGetAbilities extends WP_UnitTestCase {
 	}
 
 	// -------------------------------------------------------------------------
-	// match_callback
+	// item_include_callback
 	// -------------------------------------------------------------------------
 
 	/**
-	 * Tests that match_callback can include or exclude abilities per item.
+	 * Tests that item_include_callback can include or exclude abilities per item.
 	 *
 	 * @ticket 64990
 	 */
-	public function test_match_callback_filters_per_item(): void {
+	public function test_item_include_callback_filters_per_item(): void {
 		$this->simulate_wp_abilities_init();
 
 		$this->register_test_ability( 'test/ability-alpha' );
@@ -384,7 +384,7 @@ class Tests_Abilities_API_WpGetAbilities extends WP_UnitTestCase {
 
 		$result = wp_get_abilities(
 			array(
-				'match_callback' => static function ( WP_Ability $ability ): bool {
+				'item_include_callback' => static function ( WP_Ability $ability ): bool {
 					return 'test/ability-alpha' === $ability->get_name();
 				},
 			)
@@ -401,18 +401,18 @@ class Tests_Abilities_API_WpGetAbilities extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that match_callback returning false for all abilities yields an empty result.
+	 * Tests that item_include_callback returning false for all abilities yields an empty result.
 	 *
 	 * @ticket 64990
 	 */
-	public function test_match_callback_returning_false_yields_empty_result(): void {
+	public function test_item_include_callback_returning_false_yields_empty_result(): void {
 		$this->simulate_wp_abilities_init();
 
 		$this->register_test_ability( 'test/ability-one' );
 
 		$result = wp_get_abilities(
 			array(
-				'match_callback' => static function ( WP_Ability $ability ): bool {
+				'item_include_callback' => static function ( WP_Ability $ability ): bool {
 					return false;
 				},
 			)
@@ -422,11 +422,11 @@ class Tests_Abilities_API_WpGetAbilities extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that match_callback receives a WP_Ability instance.
+	 * Tests that item_include_callback receives a WP_Ability instance.
 	 *
 	 * @ticket 64990
 	 */
-	public function test_match_callback_receives_ability_instance(): void {
+	public function test_item_include_callback_receives_ability_instance(): void {
 		$this->simulate_wp_abilities_init();
 
 		$this->register_test_ability( 'test/ability-one' );
@@ -434,8 +434,8 @@ class Tests_Abilities_API_WpGetAbilities extends WP_UnitTestCase {
 		$received = null;
 		wp_get_abilities(
 			array(
-				'namespace'      => 'test',
-				'match_callback' => static function ( WP_Ability $ability ) use ( &$received ): bool {
+				'namespace'             => 'test',
+				'item_include_callback' => static function ( WP_Ability $ability ) use ( &$received ): bool {
 					$received = $ability;
 					return true;
 				},
@@ -447,15 +447,15 @@ class Tests_Abilities_API_WpGetAbilities extends WP_UnitTestCase {
 	}
 
 	// -------------------------------------------------------------------------
-	// wp_get_abilities_match filter hook
+	// wp_get_abilities_item_include filter hook
 	// -------------------------------------------------------------------------
 
 	/**
-	 * Tests that wp_get_abilities_match filter can exclude an ability.
+	 * Tests that wp_get_abilities_item_include filter can exclude an ability.
 	 *
 	 * @ticket 64990
 	 */
-	public function test_wp_get_abilities_match_filter_can_exclude_ability(): void {
+	public function test_wp_get_abilities_item_include_filter_can_exclude_ability(): void {
 		$this->simulate_wp_abilities_init();
 
 		$this->register_test_ability( 'test/ability-one' );
@@ -465,9 +465,9 @@ class Tests_Abilities_API_WpGetAbilities extends WP_UnitTestCase {
 			return 'test/ability-two' !== $ability->get_name();
 		};
 
-		add_filter( 'wp_get_abilities_match', $filter, 10, 2 );
+		add_filter( 'wp_get_abilities_item_include', $filter, 10, 2 );
 		$result = wp_get_abilities( array( 'namespace' => 'test' ) );
-		remove_filter( 'wp_get_abilities_match', $filter, 10 );
+		remove_filter( 'wp_get_abilities_item_include', $filter, 10 );
 
 		$names = array_map(
 			static function ( WP_Ability $a ) {
@@ -481,11 +481,11 @@ class Tests_Abilities_API_WpGetAbilities extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that wp_get_abilities_match filter receives the ability and original args.
+	 * Tests that wp_get_abilities_item_include filter receives the ability and original args.
 	 *
 	 * @ticket 64990
 	 */
-	public function test_wp_get_abilities_match_filter_receives_ability_and_args(): void {
+	public function test_wp_get_abilities_item_include_filter_receives_ability_and_args(): void {
 		$this->simulate_wp_abilities_init();
 
 		$this->register_test_ability( 'test/ability-one' );
@@ -507,9 +507,9 @@ class Tests_Abilities_API_WpGetAbilities extends WP_UnitTestCase {
 			return $should_include;
 		};
 
-		add_filter( 'wp_get_abilities_match', $filter, 10, 3 );
+		add_filter( 'wp_get_abilities_item_include', $filter, 10, 3 );
 		wp_get_abilities( $query_args );
-		remove_filter( 'wp_get_abilities_match', $filter, 10 );
+		remove_filter( 'wp_get_abilities_item_include', $filter, 10 );
 
 		$this->assertInstanceOf( WP_Ability::class, $received_ability );
 		$this->assertSame( $query_args, $received_args );
@@ -630,6 +630,78 @@ class Tests_Abilities_API_WpGetAbilities extends WP_UnitTestCase {
 	}
 
 	// -------------------------------------------------------------------------
+	// Filters fire on no-arg calls
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Tests that the wp_get_abilities_item_include filter fires when wp_get_abilities()
+	 * is called with no arguments.
+	 *
+	 * The most common call path (no args) is also the path security and visibility
+	 * plugins most need to participate in, so the filter must run there.
+	 *
+	 * @ticket 64990
+	 */
+	public function test_wp_get_abilities_item_include_filter_fires_with_no_args(): void {
+		$this->simulate_wp_abilities_init();
+
+		$this->register_test_ability( 'test/ability-one' );
+		$this->register_test_ability( 'test/ability-two' );
+
+		$received_names = array();
+
+		$filter = static function ( bool $should_include, WP_Ability $ability ) use ( &$received_names ): bool {
+			$received_names[] = $ability->get_name();
+			return $should_include;
+		};
+
+		add_filter( 'wp_get_abilities_item_include', $filter, 10, 2 );
+		wp_get_abilities();
+		remove_filter( 'wp_get_abilities_item_include', $filter, 10 );
+
+		$this->assertContains( 'test/ability-one', $received_names );
+		$this->assertContains( 'test/ability-two', $received_names );
+	}
+
+	/**
+	 * Tests that the wp_get_abilities_result filter fires when wp_get_abilities()
+	 * is called with no arguments.
+	 *
+	 * @ticket 64990
+	 */
+	public function test_wp_get_abilities_result_filter_fires_with_no_args(): void {
+		$this->simulate_wp_abilities_init();
+
+		$this->register_test_ability( 'test/ability-one' );
+
+		$call_count         = 0;
+		$received_abilities = null;
+		$received_args      = null;
+
+		$filter = static function (
+			array $abilities,
+			array $args
+		) use (
+			&$call_count,
+			&$received_abilities,
+			&$received_args
+		): array {
+			++$call_count;
+			$received_abilities = $abilities;
+			$received_args      = $args;
+			return $abilities;
+		};
+
+		add_filter( 'wp_get_abilities_result', $filter, 10, 2 );
+		wp_get_abilities();
+		remove_filter( 'wp_get_abilities_result', $filter, 10 );
+
+		$this->assertSame( 1, $call_count );
+		$this->assertIsArray( $received_abilities );
+		$this->assertSame( array(), $received_args );
+	}
+
+	// -------------------------------------------------------------------------
 	// Combined filters
 	// -------------------------------------------------------------------------
 
@@ -682,11 +754,11 @@ class Tests_Abilities_API_WpGetAbilities extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that namespace and match_callback filters are applied together.
+	 * Tests that namespace and item_include_callback filters are applied together.
 	 *
 	 * @ticket 64990
 	 */
-	public function test_combined_namespace_and_match_callback_filters(): void {
+	public function test_combined_namespace_and_item_include_callback_filters(): void {
 		$this->simulate_wp_abilities_init();
 
 		$this->register_test_ability( 'test/ability-alpha' );
@@ -695,8 +767,8 @@ class Tests_Abilities_API_WpGetAbilities extends WP_UnitTestCase {
 
 		$result = wp_get_abilities(
 			array(
-				'namespace'      => 'test',
-				'match_callback' => static function ( WP_Ability $ability ): bool {
+				'namespace'             => 'test',
+				'item_include_callback' => static function ( WP_Ability $ability ): bool {
 					return 'test/ability-alpha' === $ability->get_name();
 				},
 			)

--- a/tests/phpunit/tests/rest-api/wpRestAbilitiesV1ListController.php
+++ b/tests/phpunit/tests/rest-api/wpRestAbilitiesV1ListController.php
@@ -778,6 +778,59 @@ class Tests_REST_API_WpRestAbilitiesV1ListController extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test filtering abilities by namespace.
+	 *
+	 * @ticket 64990
+	 */
+	public function test_filter_by_namespace(): void {
+		$request = new WP_REST_Request( 'GET', '/wp-abilities/v1/abilities' );
+		$request->set_param( 'namespace', 'test' );
+		$request->set_param( 'per_page', 100 );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$names = wp_list_pluck( $response->get_data(), 'name' );
+
+		$this->assertNotEmpty( $names, 'Expected at least one ability in the test namespace.' );
+		foreach ( $names as $name ) {
+			$this->assertStringStartsWith( 'test/', $name );
+		}
+	}
+
+	/**
+	 * Test filtering by non-existent namespace returns empty results.
+	 *
+	 * @ticket 64990
+	 */
+	public function test_filter_by_nonexistent_namespace(): void {
+		$request = new WP_REST_Request( 'GET', '/wp-abilities/v1/abilities' );
+		$request->set_param( 'namespace', 'nonexistent' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertEmpty( $response->get_data() );
+	}
+
+	/**
+	 * Test that filtering by namespace still excludes abilities without show_in_rest.
+	 *
+	 * The 'test/not-show-in-rest' fixture matches the 'test' namespace but is
+	 * registered without `show_in_rest => true`, so it must remain excluded.
+	 *
+	 * @ticket 64990
+	 */
+	public function test_filter_by_namespace_still_respects_show_in_rest(): void {
+		$request = new WP_REST_Request( 'GET', '/wp-abilities/v1/abilities' );
+		$request->set_param( 'namespace', 'test' );
+		$request->set_param( 'per_page', 100 );
+		$response = $this->server->dispatch( $request );
+
+		$names = wp_list_pluck( $response->get_data(), 'name' );
+		$this->assertNotContains( 'test/not-show-in-rest', $names );
+	}
+
+	/**
 	 * Test that WordPress-internal schema keywords are stripped from ability schemas in REST response.
 	 *
 	 * @ticket 65035

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -12582,6 +12582,11 @@ mockedApiResponse.Schema = {
                             "description": "Limit results to abilities in specific ability category.",
                             "type": "string",
                             "required": false
+                        },
+                        "namespace": {
+                            "description": "Limit results to abilities in a specific namespace.",
+                            "type": "string",
+                            "required": false
                         }
                     }
                 }


### PR DESCRIPTION
Core Trac Ticket: https://core.trac.wordpress.org/ticket/64990

**Problem**
wp_get_abilities() accepts no arguments and always returns the full registry. Callers who need a subset — by category, namespace, meta properties, or any combination — must retrieve all abilities and filter manually. As the number of registered abilities grows across core, plugins, and themes, several consumers have independently built ad-hoc filtering to work around this gap:

The MCP Adapter checks meta.mcp.public and meta.show_in_rest with its own array_filter pass
WooCommerce (v10.3+) introduced a woocommerce_mcp_include_ability filter that performs namespace-prefix matching (str_starts_with( $ability_id, 'woocommerce/' ))
The REST API controller already supports ?category filtering, but implements it with its own post-retrieval array_filter rather than delegating to wp_get_abilities()
This duplication signals a missing primitive. Each consumer reimplements the same patterns with slightly different semantics and no shared hook point for ecosystem-level participation.

**Root Cause**
wp_get_abilities() was shipped in 6.9 without filtering support. The REST API controller added its own array_filter logic for show_in_rest and category filtering instead of a shared primitive, creating a mismatch between what the PHP and REST APIs support. There was no per-item or result-level hook for plugins to participate in ability filtering without monkey-patching call sites.

**Solution**
Extends wp_get_abilities() to accept an optional $args array, following the established WordPress convention of array-based arguments (get_posts(), get_terms()). When called without arguments, behaviour is completely unchanged — no BC break.

