### PR TITLE
Tests: Add missing @covers tags for blocks, oembed, and rewrite tests

### DIFF
--- a/tests/phpunit/tests/blocks/render.php
+++ b/tests/phpunit/tests/blocks/render.php
@@ -7,6 +7,8 @@
  * @since 5.0.0
  *
  * @group blocks
+ *
+ * @covers ::do_blocks
  */
 class Tests_Blocks_Render extends WP_UnitTestCase {
 	/**

--- a/tests/phpunit/tests/blocks/renderReusable.php
+++ b/tests/phpunit/tests/blocks/renderReusable.php
@@ -7,6 +7,8 @@
  * @since 5.0.0
  *
  * @group blocks
+ *
+ * @covers WP_Block
  */
 class Tests_Blocks_RenderReusable extends WP_UnitTestCase {
 	/**

--- a/tests/phpunit/tests/blocks/wpBlockList.php
+++ b/tests/phpunit/tests/blocks/wpBlockList.php
@@ -7,6 +7,8 @@
  * @since 5.5.0
  *
  * @group blocks
+ *
+ * @covers WP_Block_List
  */
 class Tests_Blocks_wpBlockList extends WP_UnitTestCase {
 

--- a/tests/phpunit/tests/rewrite/numericSlugs.php
+++ b/tests/phpunit/tests/rewrite/numericSlugs.php
@@ -3,6 +3,8 @@
 /**
  * @group rewrite
  * @ticket 5305
+ *
+ * @covers ::url_to_postid
  */
 class Tests_Rewrite_NumericSlugs extends WP_UnitTestCase {
 	private $old_current_user;


### PR DESCRIPTION
## What

Adds missing `@covers` annotations to 10 test classes across the `blocks`, `oembed`, and `rewrite` groups, as part of the ongoing effort in #64225.

### blocks/

| File | Annotation added |
|---|---|
| `render.php` | `@covers ::do_blocks` |
| `renderReusable.php` | `@covers WP_Block` |
| `wpBlockParser.php` | `@covers WP_Block_Parser` |
| `wpBlockList.php` | `@covers WP_Block_List` | 
| `registerBlockTypeFromMetadataWithRegistry.php` | `@covers ::register_block_type_from_metadata` |

### oembed/ 

| File | Annotation added |
|---|---|
| `wpOembed.php` | `@covers WP_oEmbed` |
| `WpEmbed.php` | `@covers WP_Embed` |
| `postEmbedUrl.php` | `@covers ::get_post_embed_url` | 
 
### rewrite/ 

| File | Annotation added |
|---|---|
| `permastructs.php` | `@covers ::add_permastruct`, `@covers ::remove_permastruct` |
| `numericSlugs.php` | `@covers ::url_to_postid` |
 
## Why

Without `@covers`, PHPUnit cannot correctly attribute code coverage to the functions and classes under test. This leads to inaccurate coverage reports on Codecov, where a function may appear uncovered even when dedicated tests exist for it.

## Testing

Ran all 10 affected test classes locally:
 
 ```
npm run test:php -- --filter 
"Tests_Blocks_Render|Tests_Blocks_RenderReusable|Tests_Blocks_wpBlockParser| 
Tests_Blocks_wpBlockList|Tests_Blocks_RegisterBlockTypeFromMetadataWithRegistry| 
Tests_WP_oEmbed|Tests_WP_Embed|Tests_Post_Embed_URL|
Tests_Rewrite_Permastructs|Tests_Rewrite_NumericSlugs"

OK (234 tests, 330 assertions) 
```
## Trac

Follow-up to [62213], [62218], [62222].

Fixes https://core.trac.wordpress.org/ticket/64225