### PR TITLE
Nonce check order flaw in post-quickdraft-save

### DIFF
--- a/src/wp-admin/post.php
+++ b/src/wp-admin/post.php
@@ -72,13 +72,14 @@ if ( ! $sendback ||
 switch ( $action ) {
 	case 'post-quickdraft-save':
 		// Check nonce and capabilities.
-		$nonce     = $_REQUEST['_wpnonce'];
+		$nonce   = isset( $_REQUEST['_wpnonce'] ) ? $_REQUEST['_wpnonce'] : '';
+  		$post_id = absint( $_REQUEST['post_ID'] ?? 0 );
 		$error_msg = false;
 
 		// For output of the Quick Draft dashboard widget.
 		require_once ABSPATH . 'wp-admin/includes/dashboard.php';
 
-		if ( ! wp_verify_nonce( $nonce, 'add-post' ) ) {
+		if ( ! $post_id || ! wp_verify_nonce( $nonce, 'add-post' ) ) {
 			$error_msg = __( 'Unable to submit this form, please refresh and try again.' );
 		}
 
@@ -90,7 +91,14 @@ switch ( $action ) {
 			return wp_dashboard_quick_press( $error_msg );
 		}
 
-		$post = get_post( $_REQUEST['post_ID'] );
+		$post = get_post( $post_id );
+		if ( ! $post ) {
+			$error_msg = __( 'Unable to submit this form, please refresh and try again.' );
+		}
+
+		if ( $error_msg ) {
+			return wp_dashboard_quick_press( $error_msg );
+		}
 		check_admin_referer( 'add-' . $post->post_type );
 
 		$_POST['comment_status'] = get_default_comment_status( $post->post_type );


### PR DESCRIPTION
$_REQUEST['post_ID'] is used to load a post object before the referer is actually checked on line 93. A
  crafted request can cause a database lookup on an arbitrary post_ID before authorization. $_REQUEST['_wpnonce'] is
  also accessed without checking key existence.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/65052
Fixes #65052

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
