### PR TITLE
Abilities: Catch exceptions thrown by ability callbacks

### DIFF
--- a/src/wp-includes/abilities-api/class-wp-ability.php
+++ b/src/wp-includes/abilities-api/class-wp-ability.php
@@ -502,7 +502,7 @@ class WP_Ability {
 	 *
 	 * @param callable $callback The callable to invoke.
 	 * @param mixed    $input    Optional. The input data for the ability. Default `null`.
-	 * @return mixed The result of the callable execution.
+	 * @return mixed The result of the callable execution, or a `WP_Error` if the callback threw.
 	 */
 	protected function invoke_callback( callable $callback, $input = null ) {
 		$args = array();
@@ -510,7 +510,19 @@ class WP_Ability {
 			$args[] = $input;
 		}
 
-		return $callback( ...$args );
+		try {
+			return $callback( ...$args );
+		} catch ( Throwable $e ) {
+			return new WP_Error(
+				'ability_callback_exception',
+				sprintf(
+					/* translators: 1: Ability name, 2: Exception message. */
+					__( 'Ability "%1$s" callback threw an exception: %2$s' ),
+					esc_html( $this->name ),
+					esc_html( $e->getMessage() )
+				)
+			);
+		}
 	}
 
 	/**

--- a/tests/phpunit/tests/abilities-api/wpAbility.php
+++ b/tests/phpunit/tests/abilities-api/wpAbility.php
@@ -498,6 +498,54 @@ class Tests_Abilities_API_WpAbility extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that an exception thrown by the execute callback is converted to a WP_Error
+	 * instead of being propagated as an uncaught throwable.
+	 *
+	 * @ticket 65058
+	 */
+	public function test_execute_catches_callback_exception() {
+		$args = array_merge(
+			self::$test_ability_properties,
+			array(
+				'execute_callback' => static function (): int {
+					throw new RuntimeException( 'boom' );
+				},
+			)
+		);
+
+		$ability = new WP_Ability( self::$test_ability_name, $args );
+		$result  = $ability->execute();
+
+		$this->assertWPError( $result, 'Ability::execute() should return WP_Error when the callback throws.' );
+		$this->assertSame( 'ability_callback_exception', $result->get_error_code() );
+		$this->assertStringContainsString( 'boom', $result->get_error_message() );
+	}
+
+	/**
+	 * Tests that an exception thrown by the permission callback is converted to a WP_Error
+	 * instead of being propagated as an uncaught throwable.
+	 *
+	 * @ticket 65058
+	 */
+	public function test_check_permissions_catches_callback_exception() {
+		$args = array_merge(
+			self::$test_ability_properties,
+			array(
+				'permission_callback' => static function (): bool {
+					throw new RuntimeException( 'permission exploded' );
+				},
+			)
+		);
+
+		$ability = new WP_Ability( self::$test_ability_name, $args );
+		$result  = $ability->check_permissions();
+
+		$this->assertWPError( $result, 'Ability::check_permissions() should return WP_Error when the callback throws.' );
+		$this->assertSame( 'ability_callback_exception', $result->get_error_code() );
+		$this->assertStringContainsString( 'permission exploded', $result->get_error_message() );
+	}
+
+	/**
 	 * Tests that before_execute_ability action is fired with correct parameters.
 	 *
 	 * @ticket 64098


### PR DESCRIPTION
## Summary

When an ability's `execute_callback` or `permission_callback` throws an uncaught exception, it propagates through `WP_Ability::execute()` and the REST run controller, causing WordPress to render an HTML fatal error page with a 500 status instead of a JSON error response.

This was first reported via the Core AI feature plugin when an AI connector's HTTP request to a remote provider timed out after 30 seconds — the underlying client threw a `ServerException`, which surfaced to the browser as a full HTML page inside the REST response, breaking client-side error handling.

See https://github.com/WordPress/ai/issues/392 for the original report and root-cause analysis.

## Fix

`WP_Ability::invoke_callback()` now catches any `Throwable` raised by the callback and converts it to a `WP_Error` with code `ability_callback_exception`. Because `invoke_callback()` is shared between `do_execute()` and `check_permissions()`, both callback types are protected by a single change, and the existing `is_wp_error()` handling in `execute()` surfaces the error to the caller unchanged.

Trac ticket: https://core.trac.wordpress.org/ticket/65058

## Test plan

- [x] New unit test covers an `execute_callback` that throws — expects `WP_Error` with code `ability_callback_exception`.
- [x] New unit test covers a `permission_callback` that throws via `check_permissions()` directly — same code, same behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)