### PR TITLE
Metabox: Fix focus outline being cut off for the collapse and move buttons

### DIFF
--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -3340,7 +3340,7 @@ img {
 .postbox .handle-order-higher:focus,
 .postbox .handle-order-lower:focus,
 .postbox .handlediv:focus {
-	box-shadow: 0 0 0 var(--wp-admin-border-width-focus, 1.5px) var(--wp-admin-theme-color);
+	box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus, 1.5px) var(--wp-admin-theme-color);
 	border-radius: 50%;
 	/* Only visible in Windows High Contrast mode */
 	outline: 2px solid transparent;


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65060

## Before

<img width="877" height="172" alt="image" src="https://github.com/user-attachments/assets/5494912b-0528-4f44-832f-f515d26d4e60" />


## After
<img width="874" height="164" alt="image" src="https://github.com/user-attachments/assets/aeae1e66-21ce-4d4a-9480-5bad32ebb994" />


## Use of AI Tools

None