### PR TITLE
Rewrite: Respect rewrite[feeds] for CPTs when has_archive is false

### DIFF
--- a/src/wp-includes/class-wp-post-type.php
+++ b/src/wp-includes/class-wp-post-type.php
@@ -652,7 +652,7 @@ final class WP_Post_Type {
 			if ( ! isset( $args['rewrite']['pages'] ) ) {
 				$args['rewrite']['pages'] = true;
 			}
-			if ( ! isset( $args['rewrite']['feeds'] ) || ! $args['has_archive'] ) {
+			if ( ! isset( $args['rewrite']['feeds'] ) ) {
 				$args['rewrite']['feeds'] = (bool) $args['has_archive'];
 			}
 			if ( ! isset( $args['rewrite']['ep_mask'] ) ) {

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -1813,7 +1813,8 @@ function get_post_types( $args = array(), $output = 'names', $operator = 'and' )
  *         @type bool   $with_front Whether the permastruct should be prepended with WP_Rewrite::$front.
  *                                  Default true.
  *         @type bool   $feeds      Whether the feed permastruct should be built for this post type.
- *                                  Default is value of $has_archive.
+ *                                  Enables single post (comments) feed URLs regardless of $has_archive.
+ *                                  When not set, defaults to the value of $has_archive.
  *         @type bool   $pages      Whether the permastruct should provide for pagination. Default true.
  *         @type int    $ep_mask    Endpoint mask to assign. If not specified and permalink_epmask is set,
  *                                  inherits from $permalink_epmask. If not specified and permalink_epmask

--- a/tests/phpunit/tests/rewrite.php
+++ b/tests/phpunit/tests/rewrite.php
@@ -504,4 +504,116 @@ class Tests_Rewrite extends WP_UnitTestCase {
 		$this->assertIsArray( $rewrite_rules );
 		$this->assertNotEmpty( $rewrite_rules );
 	}
+
+	/**
+	 * @ticket 43746
+	 */
+	public function test_cpt_with_no_archive_and_explicit_feeds_true_generates_single_post_feed_rules() {
+		global $wp_rewrite;
+
+		register_post_type(
+			'cpt_43746_rules',
+			array(
+				'public'      => true,
+				'has_archive' => false,
+				'rewrite'     => array(
+					'slug'  => 'cpt-43746-rules',
+					'feeds' => true,
+				),
+			)
+		);
+
+		$wp_rewrite->flush_rules();
+		$rules = $wp_rewrite->rewrite_rules();
+
+		$feed_rule_found = false;
+		foreach ( array_keys( $rules ) as $pattern ) {
+			// Match direct single-post feed patterns.
+			if ( str_contains( $pattern, 'cpt-43746-rules/([^/]+)/' ) && str_contains( $pattern, 'feed' ) ) {
+				$feed_rule_found = true;
+				break;
+			}
+		}
+
+		_unregister_post_type( 'cpt_43746_rules' );
+		$wp_rewrite->flush_rules();
+
+		$this->assertTrue( $feed_rule_found, 'Feed rewrite rules should be generated for a CPT with has_archive=false and feeds=true' );
+	}
+
+	/**
+	 * @ticket 43746
+	 */
+	public function test_cpt_with_no_archive_and_feeds_false_does_not_generate_single_post_feed_rules() {
+		global $wp_rewrite;
+
+		register_post_type(
+			'cpt_43746_norules',
+			array(
+				'public'      => true,
+				'has_archive' => false,
+				'rewrite'     => array(
+					'slug'  => 'cpt-43746-norules',
+					'feeds' => false,
+				),
+			)
+		);
+
+		$wp_rewrite->flush_rules();
+		$rules = $wp_rewrite->rewrite_rules();
+
+		$feed_rule_found = false;
+		foreach ( array_keys( $rules ) as $pattern ) {
+			// Only look for direct single-post feed patterns.
+			if ( str_contains( $pattern, 'cpt-43746-norules/([^/]+)/' ) && str_contains( $pattern, 'feed' ) ) {
+				$feed_rule_found = true;
+				break;
+			}
+		}
+
+		_unregister_post_type( 'cpt_43746_norules' );
+		$wp_rewrite->flush_rules();
+
+		$this->assertFalse( $feed_rule_found, 'No feed rewrite rules should be generated for a CPT with has_archive=false and feeds=false' );
+	}
+
+	/**
+	 * @ticket 43746
+	 */
+	public function test_cpt_with_no_archive_and_explicit_feeds_true_does_not_generate_archive_feed_rules() {
+		global $wp_rewrite;
+
+		register_post_type(
+			'cpt_43746_noarch',
+			array(
+				'public'      => true,
+				'has_archive' => false,
+				'rewrite'     => array(
+					'slug'  => 'cpt-43746-noarch',
+					'feeds' => true,
+				),
+			)
+		);
+
+		$wp_rewrite->flush_rules();
+		$rules = $wp_rewrite->rewrite_rules();
+
+		$archive_feed_rule_found = false;
+		foreach ( $rules as $pattern => $query ) {
+			// Archive feed rules point directly to post_type=cpt_43746_noarch&feed= (no post slug segment).
+			if ( str_contains( $pattern, 'cpt-43746-noarch' )
+				&& str_contains( $pattern, 'feed' )
+				&& str_contains( $query, 'post_type=cpt_43746_noarch&feed=' )
+				&& ! str_contains( $query, 'cpt_43746_noarch=' )
+			) {
+				$archive_feed_rule_found = true;
+				break;
+			}
+		}
+
+		_unregister_post_type( 'cpt_43746_noarch' );
+		$wp_rewrite->flush_rules();
+
+		$this->assertFalse( $archive_feed_rule_found, 'Archive feed rewrite rules should NOT be generated when has_archive is false, even if feeds is true' );
+	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/43746


## Use of AI Tools
AI assistance: Yes  
Tool(s): Opencode
Model(s): Kimi K2.5
Used for: Drafting test skeletons and preparing the PR title.

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
