### PR TITLE
WIP: Charset:  New unicode email functions

### DIFF
--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -28,6 +28,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( '-1' );
 }
 
+global $wpdb;
+
 // Strip, trim, kses, special chars for string saves.
 foreach ( array( 'pre_term_name', 'pre_comment_author_name', 'pre_link_name', 'pre_link_target', 'pre_link_rel', 'pre_user_display_name', 'pre_user_first_name', 'pre_user_last_name', 'pre_user_nickname' ) as $filter ) {
 	add_filter( $filter, 'sanitize_text_field' );
@@ -272,6 +274,10 @@ add_filter( 'the_guid', 'esc_url' );
 
 // Email filters.
 add_filter( 'wp_mail', 'wp_staticize_emoji_for_email' );
+if ( is_utf8_charset() && 'utf8mb4' === $wpdb->charset ) {
+	add_filter( 'is_email', 'is_unicode_email', 8, 3 );
+	add_filter( 'sanitize_email', 'sanitize_unicode_email', 8, 3 );
+}
 
 // Robots filters.
 add_filter( 'wp_robots', 'wp_robots_noindex' );

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -3624,6 +3624,28 @@ function is_email( $email, $deprecated = false ) {
 	return apply_filters( 'is_email', $email, $email, null );
 }
 
+$u = new Uri\WhatWg\Url('blar');
+$u->getAsciiHost()
+
+function is_unicode_email_filter( $ignored_filtered_email, $originally_provided_email, $ignored_message ) {
+	remove_filter( 'is_email', 'is_unicode_email_filter' );
+	$result = is_unicode_email( $originally_provided_email );
+	add_filter( 'is_email', 'is_unicode_email_filter', 8, 3 );
+
+	return $result;
+}
+
+function is_unicode_email( $email ) {
+	$email = WP_Email_Address::from_string( $email );
+	if ( null === $email ) {
+		return apply_filters( 'is_email', false, $email, 'non_parsable_email' );
+	}
+
+	...
+
+	return apply_filters( 'is_email', $email, $email, null );
+}
+
 /**
  * Converts to ASCII from email subjects.
  *


### PR DESCRIPTION
Trac ticket: Core-31922

Scaffolding an idea to progressively enhance WordPress for allowing non-US-ASCII (“Unicode”) email addresses.