### PR TITLE
Connectors: Add is_active callback support to plugin registration

### DIFF
--- a/src/wp-includes/class-wp-connector-registry.php
+++ b/src/wp-includes/class-wp-connector-registry.php
@@ -40,7 +40,8 @@
  *         env_var_name?: non-empty-string
  *     },
  *     plugin?: array{
- *         file: non-empty-string
+ *         file: non-empty-string,
+ *         is_active?: callable(): bool
  *     }
  * }
  */
@@ -111,6 +112,8 @@ final class WP_Connector_Registry {
 	 *
 	 *         @type string $file The plugin's main file path relative to the plugins
 	 *                            directory (e.g. 'my-plugin/my-plugin.php' or 'hello.php').
+	 *         @type callable $is_active Optional callback to determine whether the plugin
+	 *                                   is active. Receives no arguments and must return bool.
 	 *     }
 	 * }
 	 * @return array|null The registered connector data on success, null on failure.
@@ -245,6 +248,20 @@ final class WP_Connector_Registry {
 
 		if ( ! empty( $args['plugin'] ) && is_array( $args['plugin'] ) && ! empty( $args['plugin']['file'] ) ) {
 			$connector['plugin'] = array( 'file' => $args['plugin']['file'] );
+
+			if ( isset( $args['plugin']['is_active'] ) ) {
+				if ( ! is_callable( $args['plugin']['is_active'] ) ) {
+					_doing_it_wrong(
+						__METHOD__,
+						/* translators: %s: Connector ID. */
+						sprintf( __( 'Connector "%s" plugin is_active must be callable.' ), esc_html( $id ) ),
+						'7.0.0'
+					);
+					return null;
+				}
+
+				$connector['plugin']['is_active'] = $args['plugin']['is_active'];
+			}
 		}
 
 		$this->registered_connectors[ $id ] = $connector;

--- a/src/wp-includes/class-wp-connector-registry.php
+++ b/src/wp-includes/class-wp-connector-registry.php
@@ -110,8 +110,9 @@ final class WP_Connector_Registry {
 	 *     @type array  $plugin         {
 	 *         Optional. Plugin data for install/activate UI.
 	 *
-	 *         @type string   $file      The plugin's main file path relative to the plugins
-	 *                                   directory (e.g. 'my-plugin/my-plugin.php' or 'hello.php').
+	 *         @type string   $file      Optional. The plugin's main file path relative to the
+	 *                                   plugins directory (e.g. 'my-plugin/my-plugin.php' or
+	 *                                   'hello.php').
 	 *         @type callable $is_active Optional callback to determine whether the plugin
 	 *                                   is active. Receives no arguments and must return bool.
 	 *                                   Defaults to `__return_true`.
@@ -247,8 +248,12 @@ final class WP_Connector_Registry {
 			}
 		}
 
-		if ( ! empty( $args['plugin'] ) && is_array( $args['plugin'] ) && ! empty( $args['plugin']['file'] ) ) {
-			$connector['plugin'] = array( 'file' => $args['plugin']['file'] );
+		$connector['plugin'] = array();
+
+		if ( ! empty( $args['plugin'] ) && is_array( $args['plugin'] ) ) {
+			if ( ! empty( $args['plugin']['file'] ) ) {
+				$connector['plugin']['file'] = $args['plugin']['file'];
+			}
 
 			if ( isset( $args['plugin']['is_active'] ) ) {
 				if ( ! is_callable( $args['plugin']['is_active'] ) ) {
@@ -262,9 +267,11 @@ final class WP_Connector_Registry {
 				}
 
 				$connector['plugin']['is_active'] = $args['plugin']['is_active'];
-			} else {
-				$connector['plugin']['is_active'] = '__return_true';
 			}
+		}
+
+		if ( ! isset( $connector['plugin']['is_active'] ) ) {
+			$connector['plugin']['is_active'] = '__return_true';
 		}
 
 		$this->registered_connectors[ $id ] = $connector;

--- a/src/wp-includes/class-wp-connector-registry.php
+++ b/src/wp-includes/class-wp-connector-registry.php
@@ -114,6 +114,7 @@ final class WP_Connector_Registry {
 	 *                                   directory (e.g. 'my-plugin/my-plugin.php' or 'hello.php').
 	 *         @type callable $is_active Optional callback to determine whether the plugin
 	 *                                   is active. Receives no arguments and must return bool.
+	 *                                   Defaults to `__return_true`.
 	 *     }
 	 * }
 	 * @return array|null The registered connector data on success, null on failure.
@@ -261,6 +262,8 @@ final class WP_Connector_Registry {
 				}
 
 				$connector['plugin']['is_active'] = $args['plugin']['is_active'];
+			} else {
+				$connector['plugin']['is_active'] = '__return_true';
 			}
 		}
 

--- a/src/wp-includes/class-wp-connector-registry.php
+++ b/src/wp-includes/class-wp-connector-registry.php
@@ -110,8 +110,8 @@ final class WP_Connector_Registry {
 	 *     @type array  $plugin         {
 	 *         Optional. Plugin data for install/activate UI.
 	 *
-	 *         @type string $file The plugin's main file path relative to the plugins
-	 *                            directory (e.g. 'my-plugin/my-plugin.php' or 'hello.php').
+	 *         @type string $file        The plugin's main file path relative to the plugins
+	 *                                   directory (e.g. 'my-plugin/my-plugin.php' or 'hello.php').
 	 *         @type callable $is_active Optional callback to determine whether the plugin
 	 *                                   is active. Receives no arguments and must return bool.
 	 *     }

--- a/src/wp-includes/class-wp-connector-registry.php
+++ b/src/wp-includes/class-wp-connector-registry.php
@@ -110,7 +110,7 @@ final class WP_Connector_Registry {
 	 *     @type array  $plugin         {
 	 *         Optional. Plugin data for install/activate UI.
 	 *
-	 *         @type string $file        The plugin's main file path relative to the plugins
+	 *         @type string   $file      The plugin's main file path relative to the plugins
 	 *                                   directory (e.g. 'my-plugin/my-plugin.php' or 'hello.php').
 	 *         @type callable $is_active Optional callback to determine whether the plugin
 	 *                                   is active. Receives no arguments and must return bool.

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -638,10 +638,6 @@ add_action( 'init', '_wp_connectors_pass_default_keys_to_ai_client', 20 );
 function _wp_connectors_get_connector_script_module_data( array $data ): array {
 	$registry = AiClient::defaultRegistry();
 
-	if ( ! function_exists( 'is_plugin_active' ) ) {
-		require_once ABSPATH . 'wp-admin/includes/plugin.php';
-	}
-
 	$connectors = array();
 	foreach ( wp_get_connectors() as $connector_id => $connector_data ) {
 		$auth     = $connector_data['authentication'];
@@ -674,17 +670,7 @@ function _wp_connectors_get_connector_script_module_data( array $data ): array {
 
 		if ( ! empty( $connector_data['plugin']['file'] ) ) {
 			$file         = $connector_data['plugin']['file'];
-			$is_installed = false;
-			$is_activated = false;
-
-			if ( ! empty( $connector_data['plugin']['is_active'] ) && is_callable( $connector_data['plugin']['is_active'] ) ) {
-				$is_activated = (bool) call_user_func( $connector_data['plugin']['is_active'] );
-			}
-
-			if ( ! $is_activated ) {
-				$is_activated = is_plugin_active( $file );
-			}
-
+			$is_activated = (bool) call_user_func( $connector_data['plugin']['is_active'] );
 			$is_installed = $is_activated || file_exists( WP_PLUGIN_DIR . '/' . $file );
 
 			$connector_out['plugin'] = array(

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -674,8 +674,22 @@ function _wp_connectors_get_connector_script_module_data( array $data ): array {
 
 		if ( ! empty( $connector_data['plugin']['file'] ) ) {
 			$file         = $connector_data['plugin']['file'];
-			$is_installed = file_exists( wp_normalize_path( WP_PLUGIN_DIR . '/' . $file ) );
-			$is_activated = $is_installed && is_plugin_active( $file );
+			$is_installed = false;
+			$is_activated = false;
+
+			if ( ! empty( $connector_data['plugin']['is_active'] ) && is_callable( $connector_data['plugin']['is_active'] ) ) {
+				$is_activated = (bool) call_user_func( $connector_data['plugin']['is_active'] );
+			}
+
+			if ( ! $is_activated ) {
+				$is_activated = is_plugin_active( $file );
+			}
+
+			if ( $is_activated ) {
+				$is_installed = true;
+			} else {
+				$is_installed = file_exists( WP_PLUGIN_DIR . '/' . $file );
+			}
 
 			$connector_out['plugin'] = array(
 				'file'        => $file,

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -685,11 +685,7 @@ function _wp_connectors_get_connector_script_module_data( array $data ): array {
 				$is_activated = is_plugin_active( $file );
 			}
 
-			if ( $is_activated ) {
-				$is_installed = true;
-			} else {
-				$is_installed = file_exists( WP_PLUGIN_DIR . '/' . $file );
-			}
+			$is_installed = $is_activated || file_exists( WP_PLUGIN_DIR . '/' . $file );
 
 			$connector_out['plugin'] = array(
 				'file'        => $file,

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -367,6 +367,17 @@ function _wp_connectors_register_default_ai_providers( WP_Connector_Registry $re
 				}
 			}
 		}
+
+		if ( ! isset( $args['plugin']['is_active'] ) ) {
+			$args['plugin']['is_active'] = static function () use ( $ai_registry, $id ): bool {
+				try {
+					return $ai_registry->hasProvider( $id );
+				} catch ( Exception $e ) {
+					return false;
+				}
+			};
+		}
+
 		$registry->register( $id, $args );
 	}
 }
@@ -671,7 +682,7 @@ function _wp_connectors_get_connector_script_module_data( array $data ): array {
 		if ( ! empty( $connector_data['plugin']['file'] ) ) {
 			$file         = $connector_data['plugin']['file'];
 			$is_activated = (bool) call_user_func( $connector_data['plugin']['is_active'] );
-			$is_installed = $is_activated || file_exists( WP_PLUGIN_DIR . '/' . $file );
+			$is_installed = $is_activated || file_exists( wp_normalize_path( WP_PLUGIN_DIR . '/' . $file ) );
 
 			$connector_out['plugin'] = array(
 				'file'        => $file,

--- a/tests/phpunit/tests/connectors/wpConnectorRegistry.php
+++ b/tests/phpunit/tests/connectors/wpConnectorRegistry.php
@@ -353,10 +353,12 @@ class Tests_Connectors_WpConnectorRegistry extends WP_UnitTestCase {
 	/**
 	 * @ticket 64791
 	 */
-	public function test_register_omits_plugin_when_not_provided() {
+	public function test_register_defaults_plugin_when_not_provided() {
 		$result = $this->registry->register( 'no-plugin', self::$default_args );
 
-		$this->assertArrayNotHasKey( 'plugin', $result );
+		$this->assertArrayHasKey( 'plugin', $result );
+		$this->assertArrayNotHasKey( 'file', $result['plugin'] );
+		$this->assertSame( '__return_true', $result['plugin']['is_active'] );
 	}
 
 	/**

--- a/tests/phpunit/tests/connectors/wpConnectorRegistry.php
+++ b/tests/phpunit/tests/connectors/wpConnectorRegistry.php
@@ -299,7 +299,55 @@ class Tests_Connectors_WpConnectorRegistry extends WP_UnitTestCase {
 		$result = $this->registry->register( 'with-plugin', $args );
 
 		$this->assertArrayHasKey( 'plugin', $result );
-		$this->assertSame( array( 'file' => 'my-plugin/my-plugin.php' ), $result['plugin'] );
+		$this->assertSame( 'my-plugin/my-plugin.php', $result['plugin']['file'] );
+	}
+
+	/**
+	 * @ticket 65020
+	 */
+	public function test_register_stores_plugin_is_active_callback() {
+		$args           = self::$default_args;
+		$args['plugin'] = array(
+			'file'      => 'my-plugin/my-plugin.php',
+			'is_active' => '__return_true',
+		);
+
+		$result = $this->registry->register( 'with-callback', $args );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'is_active', $result['plugin'] );
+		$this->assertIsCallable( $result['plugin']['is_active'] );
+	}
+
+	/**
+	 * @ticket 65020
+	 */
+	public function test_register_rejects_non_callable_plugin_is_active() {
+		$this->setExpectedIncorrectUsage( 'WP_Connector_Registry::register' );
+
+		$args           = self::$default_args;
+		$args['plugin'] = array(
+			'file'      => 'my-plugin/my-plugin.php',
+			'is_active' => 'not_a_real_function_name',
+		);
+
+		$result = $this->registry->register( 'bad-callback', $args );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * @ticket 65020
+	 */
+	public function test_register_defaults_plugin_is_active_to_return_true() {
+		$args           = self::$default_args;
+		$args['plugin'] = array( 'file' => 'my-plugin/my-plugin.php' );
+
+		$result = $this->registry->register( 'default-callback', $args );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'is_active', $result['plugin'] );
+		$this->assertSame( '__return_true', $result['plugin']['is_active'] );
 	}
 
 	/**


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

Backport of wordpress/gutenberg#76994.  Adds an optional `is_active` callable to the `plugin` definition when
registering a connector via `WP_Connector_Registry::register()`. 

The Connectors screen previously resolved a connector's active/installed status by checking `is_plugin_active()` and `file_exists()` against `WP_PLUGIN_DIR` only. Plugins installed as must-use plugins — or loaded from non-standard paths could not be detected this way, causing their connectors to disappear from the screen even though the plugin was in use.

Trac ticket: https://core.trac.wordpress.org/ticket/65020

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
