### PR TITLE
Add metabox flag for RTC-compatible metaboxes

### DIFF
--- a/src/wp-admin/includes/post.php
+++ b/src/wp-admin/includes/post.php
@@ -2429,17 +2429,11 @@ function the_block_editor_meta_boxes() {
 					continue;
 				}
 
-				$meta_box_entry = array(
-					'id'    => $meta_box['id'],
-					'title' => $meta_box['title'],
+				$meta_boxes_per_location[ $location ][] = array(
+					'id'               => $meta_box['id'],
+					'title'            => $meta_box['title'],
+					'__rtc_compatible' => ! empty( $meta_box['args']['__rtc_compatible_meta_box'] ),
 				);
-
-				// Mark meta boxes compatible with real-time collaboration.
-				if ( ! empty( $meta_box['args']['__rtc_compatible_meta_box'] ) ) {
-					$meta_box_entry['__rtc_compatible'] = true;
-				}
-
-				$meta_boxes_per_location[ $location ][] = $meta_box_entry;
 			}
 		}
 	}

--- a/src/wp-admin/includes/post.php
+++ b/src/wp-admin/includes/post.php
@@ -2406,8 +2406,6 @@ function the_block_editor_meta_boxes() {
 	<?php
 
 	$meta_boxes_per_location = array();
-	$rtc_compatible_ids      = array();
-
 	foreach ( $locations as $location ) {
 		$meta_boxes_per_location[ $location ] = array();
 
@@ -2426,20 +2424,22 @@ function the_block_editor_meta_boxes() {
 					continue;
 				}
 
-				// Track meta boxes marked as compatible with real-time collaboration.
-				if ( isset( $meta_box['args']['__rtc_compatible_meta_box'] ) && $meta_box['args']['__rtc_compatible_meta_box'] ) {
-					$rtc_compatible_ids[] = $meta_box['id'];
-				}
-
 				// If a meta box is just here for back compat, don't show it in the block editor.
 				if ( isset( $meta_box['args']['__back_compat_meta_box'] ) && $meta_box['args']['__back_compat_meta_box'] ) {
 					continue;
 				}
 
-				$meta_boxes_per_location[ $location ][] = array(
+				$meta_box_entry = array(
 					'id'    => $meta_box['id'],
 					'title' => $meta_box['title'],
 				);
+
+				// Mark meta boxes compatible with real-time collaboration.
+				if ( ! empty( $meta_box['args']['__rtc_compatible_meta_box'] ) ) {
+					$meta_box_entry['__rtc_compatible'] = true;
+				}
+
+				$meta_boxes_per_location[ $location ][] = $meta_box_entry;
 			}
 		}
 	}
@@ -2464,30 +2464,6 @@ function the_block_editor_meta_boxes() {
 	 */
 	if ( wp_script_is( 'wp-edit-post', 'done' ) ) {
 		printf( "<script>\n%s\n</script>\n", trim( $script ) );
-	}
-
-	/*
-	 * If collaboration is enabled and any meta boxes are marked as RTC-compatible,
-	 * pass their IDs to the editor so it can determine which meta boxes are safe
-	 * to use alongside real-time collaboration.
-	 */
-	if ( wp_is_collaboration_enabled() && ! empty( $rtc_compatible_ids ) ) {
-		$rtc_script = 'window._wpLoadBlockEditor.then( function() {
-			wp.data.dispatch( \'core/edit-post\' ).setRtcCompatibleMetaBoxIds( '
-			. wp_json_encode( array_values( array_unique( $rtc_compatible_ids ) ) )
-			. ' );
-		} );';
-
-		wp_add_inline_script( 'wp-edit-post', $rtc_script );
-
-		/*
-		 * When `wp-edit-post` is output in the `<head>`, the inline script needs to be
-		 * manually printed. Otherwise, inline scripts for `wp-edit-post` will not be
-		 * printed again after this point.
-		 */
-		if ( wp_script_is( 'wp-edit-post', 'done' ) ) {
-			printf( "<script>\n%s\n</script>\n", trim( $rtc_script ) );
-		}
 	}
 
 	/*

--- a/src/wp-admin/includes/post.php
+++ b/src/wp-admin/includes/post.php
@@ -2406,6 +2406,8 @@ function the_block_editor_meta_boxes() {
 	<?php
 
 	$meta_boxes_per_location = array();
+	$rtc_compatible_ids      = array();
+
 	foreach ( $locations as $location ) {
 		$meta_boxes_per_location[ $location ] = array();
 
@@ -2422,6 +2424,11 @@ function the_block_editor_meta_boxes() {
 			foreach ( $meta_boxes as $meta_box ) {
 				if ( false === $meta_box || ! $meta_box['title'] ) {
 					continue;
+				}
+
+				// Track meta boxes marked as compatible with real-time collaboration.
+				if ( isset( $meta_box['args']['__rtc_compatible_meta_box'] ) && $meta_box['args']['__rtc_compatible_meta_box'] ) {
+					$rtc_compatible_ids[] = $meta_box['id'];
 				}
 
 				// If a meta box is just here for back compat, don't show it in the block editor.
@@ -2457,6 +2464,30 @@ function the_block_editor_meta_boxes() {
 	 */
 	if ( wp_script_is( 'wp-edit-post', 'done' ) ) {
 		printf( "<script>\n%s\n</script>\n", trim( $script ) );
+	}
+
+	/*
+	 * If collaboration is enabled and any meta boxes are marked as RTC-compatible,
+	 * pass their IDs to the editor so it can determine which meta boxes are safe
+	 * to use alongside real-time collaboration.
+	 */
+	if ( wp_is_collaboration_enabled() && ! empty( $rtc_compatible_ids ) ) {
+		$rtc_script = 'window._wpLoadBlockEditor.then( function() {
+			wp.data.dispatch( \'core/edit-post\' ).setRtcCompatibleMetaBoxIds( '
+			. wp_json_encode( array_values( array_unique( $rtc_compatible_ids ) ) )
+			. ' );
+		} );';
+
+		wp_add_inline_script( 'wp-edit-post', $rtc_script );
+
+		/*
+		 * When `wp-edit-post` is output in the `<head>`, the inline script needs to be
+		 * manually printed. Otherwise, inline scripts for `wp-edit-post` will not be
+		 * printed again after this point.
+		 */
+		if ( wp_script_is( 'wp-edit-post', 'done' ) ) {
+			printf( "<script>\n%s\n</script>\n", trim( $rtc_script ) );
+		}
 	}
 
 	/*


### PR DESCRIPTION
See Gutenberg change https://github.com/WordPress/gutenberg/pull/76939. Previously, the presence of any legacy meta box would unconditionally disable collaboration support with a modal:

<img width="575" height="335" alt="image" src="https://github.com/user-attachments/assets/38a6dc54-ac58-414e-83a4-04f858571abb" />

This PR adds a server-side `__rtc_compatible_meta_box` [compatibility flag for `add_meta_box()`](https://make.wordpress.org/core/2018/11/07/meta-box-compatibility-flags/), consistent with the existing `__back_compat_meta_box` and `__block_editor_compatible_meta_box` flags.

Some meta box plugins are safe to use alongside real-time collaboration, but there was no way to indicate this. The existing check meant that any meta box would force the editor into single-user lock mode.

This change gives plugin authors the ability to mark their meta boxes as compatible so collaboration stays enabled. Site administrators can also add the flag to third-party meta boxes via the existing `filter_block_editor_meta_boxes` PHP hook, without waiting for plugin authors to update.

---

Example code:

Plugin authors can mark their meta box as RTC-compatible directly:

```php
add_meta_box(
    'my-metabox-id',
    'My Meta Box',
    'my_metabox_render',
    'post',
    'normal',
    'default',
    array( '__rtc_compatible_meta_box' => true ) // <- The compatibility flag
);
```

Alternatively, plugin users can mark an existing third-party meta box as compatible using the `filter_block_editor_meta_boxes` hook:

```php
add_filter( 'filter_block_editor_meta_boxes', function ( $wp_meta_boxes ) {
    // Mark 'some-plugin-metabox' as RTC-compatible.
    foreach ( $wp_meta_boxes as $screen_id => $locations ) {
        foreach ( $locations as $location => $priorities ) {
            foreach ( $priorities as $priority => $boxes ) {
                if ( isset( $boxes['some-plugin-metabox'] ) ) {
                    $wp_meta_boxes[ $screen_id ][ $location ][ $priority ]['some-plugin-metabox']['args']['__rtc_compatible_meta_box'] = true;
                }
            }
        }
    }

    return $wp_meta_boxes;
} );
```

Trac ticket: https://core.trac.wordpress.org/ticket/64622

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude
Model(s): GPT-5.1
Used for: Implementation


