### PR TITLE
Charset: Support multibyte email addresses in `antispambot()`

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -2901,30 +2901,88 @@ function urldecode_deep( $value ) {
 }
 
 /**
- * Converts email addresses characters to HTML entities to block spam bots.
+ * Obscures email addresses in HTML to prevent spam bots from harvesting them.
+ *
+ * Typically this will randomly replace characters from the email address with
+ * HTML character references; however, when the hex encoding parameter is set,
+ * some characters will also be represented in their percent-encoded form.
+ *
+ * Because this function is randomized, the outputs for any given input may
+ * differ between calls. This helps diversify the ways the email addresses
+ * are obscured.
+ *
+ * When non-UTF-8 inputs are provided, any spans of invalid UTF-8 bytes will
+ * be passed through without any obfuscation.
+ *
+ * Example:
+ *
+ *     $email      = 'noreply@example.com';
+ *     $obscured   = antispambot( $email );
+ *     $obscured === 'nore&#112;&#108;y&#64;e&#120;ample.com';
+ *
+ *     // Hex-encoding also obscures characters with percent-encoding.
+ *     $obscured   = antispambot( $email, 1 );
+ *     $obscured === '%6e&#111;&#114;e%70l%79&#64;%65x%61mp&#108;&#101;%2e%63%6f&#109;';
+ *
+ *     // Non-UTF-8 characters are not obfuscated. "\xFC" is Latin1 "ü".
+ *     $obscured   = antispambot( "b\xFCcher@library.de" );
+ *     $obscured === 'b�cher&#64;li&#98;r&#97;r&#121;.&#100;&#101;';
+ *     $obscured === "b\xFCcher&#64;li&#98;r&#97;r&#121;.&#100;&#101;"
  *
  * @since 0.71
+ * @since 7.1.0 Masquerades multibyte characters.
  *
  * @param string $email_address Email address.
  * @param int    $hex_encoding  Optional. Set to 1 to enable hex encoding.
  * @return string Converted email address.
  */
 function antispambot( $email_address, $hex_encoding = 0 ) {
-	$email_no_spam_address = '';
+	$obfuscated     = '';
+	$at             = 0;
+	$end            = strlen( $email_address );
+	$invalid_length = 0;
 
-	for ( $i = 0, $len = strlen( $email_address ); $i < $len; $i++ ) {
-		$j = rand( 0, 1 + $hex_encoding );
-
-		if ( 0 === $j ) {
-			$email_no_spam_address .= '&#' . ord( $email_address[ $i ] ) . ';';
-		} elseif ( 1 === $j ) {
-			$email_no_spam_address .= $email_address[ $i ];
-		} elseif ( 2 === $j ) {
-			$email_no_spam_address .= '%' . zeroise( dechex( ord( $email_address[ $i ] ) ), 2 );
+	while ( $at < $end ) {
+		$was_at = $at;
+		if (
+			0 === _wp_scan_utf8( $email_address, $at, $invalid_length, null, 1 ) &&
+			0 === $invalid_length
+		) {
+			break;
 		}
+
+		$character_length = $at - $was_at;
+
+		if ( $character_length > 0 ) {
+			$character = substr( $email_address, $was_at, $character_length );
+
+			switch ( rand( 0, 1 + $hex_encoding ) ) {
+				case 0:
+					$code_point  = mb_ord( $character );
+					$obfuscated .= "&#{$code_point};";
+					break;
+
+				case 1:
+					$obfuscated .= $character;
+					break;
+
+				case 2:
+					for ( $i = 0; $i < $character_length; $i++ ) {
+						$hex_value   = bin2hex( $character[ $i ] );
+						$obfuscated .= "%{$hex_value}";
+					}
+					break;
+			}
+		}
+
+		if ( 0 !== $invalid_length ) {
+			$obfuscated .= substr( $email_address, $at, $invalid_length );
+		}
+
+		$at += $invalid_length;
 	}
 
-	return str_replace( '@', '&#64;', $email_no_spam_address );
+	return str_replace( '@', '&#64;', $obfuscated );
 }
 
 /**

--- a/tests/phpunit/tests/formatting/antispambot.php
+++ b/tests/phpunit/tests/formatting/antispambot.php
@@ -35,6 +35,8 @@ class Tests_Formatting_Antispambot extends WP_UnitTestCase {
 			'deep subdomain'       => array( 'kevin@many.subdomains.make.a.happy.man.edu' ),
 			'short address'        => array( 'a@b.co' ),
 			'weird but legal dots' => array( '..@example.com' ),
+			'umlauts'              => array( 'bücher@gmx.de' ),
+			'three-byte UTF-8'     => array( "\u{FFFD}@who.knows.com" ),
 		);
 	}
 
@@ -49,25 +51,41 @@ class Tests_Formatting_Antispambot extends WP_UnitTestCase {
 	 * @param string $provided The email address to obfuscate.
 	 */
 	public function test_antispambot_obfuscates( $provided ) {
-		// The only token should be the email address, so advance once and treat as a text node.
-		$obfuscated = antispambot( $provided );
-		$p          = new WP_HTML_Tag_Processor( $obfuscated );
-		$p->next_token();
-		$decoded = rawurldecode( $p->get_modifiable_text() );
+		$obfuscated = antispambot( $provided, 1 );
+		$processor  = new WP_HTML_Tag_Processor( $obfuscated );
 
-		$this->assertNotSame( $provided, $obfuscated, 'Should have produced an obfuscated representation.' );
-		$this->assertSame( $provided, $decoded, 'Should have decoded to the original email after restoring.' );
+		// The only token should be the email address, so advance once and treat as a text node.
+		$processor->next_token();
+		$decoded = rawurldecode( $processor->get_modifiable_text() );
+
+		$this->assertNotSame(
+			$provided,
+			$obfuscated,
+			'Should have produced an obfuscated representation.'
+		);
+
+		$this->assertSame(
+			$provided,
+			$decoded,
+			'Should have decoded to the original email after restoring.'
+		);
 	}
 
 	/**
 	 * Data provider.
 	 *
-	 * @return array[]
+	 * @return Generator
 	 */
 	public function data_antispambot_obfuscates() {
-		return array(
-			array( 'example@example.com' ),
-			array( '#@example.com' ),
+		$addresses = array(
+			'example@example.com',
+			'#@example.com',
+			'πετρος@example.com',
+			"\u{FFFD}@mad.mail.com",
 		);
+
+		foreach ( $addresses as $address ) {
+			yield $address => array( $address );
+		}
 	}
 }


### PR DESCRIPTION
Trac ticket: Core-31992

Updates `antispambot()` to prevent breaking with multibyte email addresses.

Need to split the `mb_ord()` polyfill into a separate ticket.