### PR TITLE
Fix: Revision REST schema remove `protected`

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-revisions-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-revisions-controller.php
@@ -820,10 +820,16 @@ class WP_REST_Revisions_Controller extends WP_REST_Controller {
 
 		if ( ! empty( $parent_schema['properties']['content'] ) ) {
 			$schema['properties']['content'] = $parent_schema['properties']['content'];
+
+			// Revisions do not support password protection.
+			unset( $schema['properties']['content']['properties']['protected'] );
 		}
 
 		if ( ! empty( $parent_schema['properties']['excerpt'] ) ) {
 			$schema['properties']['excerpt'] = $parent_schema['properties']['excerpt'];
+
+			// Revisions do not support password protection.
+			unset( $schema['properties']['excerpt']['properties']['protected'] );
 		}
 
 		if ( ! empty( $parent_schema['properties']['guid'] ) ) {

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-revisions-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-revisions-controller.php
@@ -822,14 +822,18 @@ class WP_REST_Revisions_Controller extends WP_REST_Controller {
 			$schema['properties']['content'] = $parent_schema['properties']['content'];
 
 			// Revisions do not support password protection.
-			unset( $schema['properties']['content']['properties']['protected'] );
+			if ( isset( $schema['properties']['content']['properties']['protected'] ) ) {
+				unset( $schema['properties']['content']['properties']['protected'] );
+			}
 		}
 
 		if ( ! empty( $parent_schema['properties']['excerpt'] ) ) {
 			$schema['properties']['excerpt'] = $parent_schema['properties']['excerpt'];
 
 			// Revisions do not support password protection.
-			unset( $schema['properties']['excerpt']['properties']['protected'] );
+			if ( isset( $schema['properties']['excerpt']['properties']['protected'] ) ) {
+				unset( $schema['properties']['excerpt']['properties']['protected'] );
+			}
 		}
 
 		if ( ! empty( $parent_schema['properties']['guid'] ) ) {

--- a/tests/phpunit/tests/rest-api/rest-revisions-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-revisions-controller.php
@@ -691,6 +691,86 @@ class WP_Test_REST_Revisions_Controller extends WP_Test_REST_Controller_Testcase
 	}
 
 	/**
+	 * Test that the 'protected' property is not included in the revision schema's content.
+	 *
+	 * Verifies the fix for the issue where revision schema incorrectly included
+	 * 'protected' properties that don't actually exist in revision responses.
+	 *
+	 * @ticket 53417
+	 */
+	public function test_revision_schema_content_does_not_have_protected() {
+		$request    = new WP_REST_Request( 'OPTIONS', '/wp/v2/posts/' . self::$post_id . '/revisions' );
+		$response   = rest_get_server()->dispatch( $request );
+		$data       = $response->get_data();
+		$properties = $data['schema']['properties'];
+
+		$this->assertArrayHasKey( 'content', $properties );
+		$this->assertArrayHasKey( 'properties', $properties['content'] );
+		$this->assertArrayNotHasKey(
+			'protected',
+			$properties['content']['properties'],
+			'The "protected" property should not be present in revision content schema'
+		);
+
+		$this->assertArrayHasKey( 'raw', $properties['content']['properties'] );
+		$this->assertArrayHasKey( 'rendered', $properties['content']['properties'] );
+		$this->assertArrayHasKey( 'block_version', $properties['content']['properties'] );
+	}
+
+	/**
+	 * Test that the 'protected' property is not included in the revision schema's excerpt.
+	 *
+	 * Verifies the fix for the issue where revision schema incorrectly included
+	 * 'protected' properties that don't actually exist in revision responses.
+	 *
+	 * @ticket 53417
+	 */
+	public function test_revision_schema_excerpt_does_not_have_protected() {
+		$request    = new WP_REST_Request( 'OPTIONS', '/wp/v2/posts/' . self::$post_id . '/revisions' );
+		$response   = rest_get_server()->dispatch( $request );
+		$data       = $response->get_data();
+		$properties = $data['schema']['properties'];
+
+		$this->assertArrayHasKey( 'excerpt', $properties );
+		$this->assertArrayHasKey( 'properties', $properties['excerpt'] );
+		$this->assertArrayNotHasKey(
+			'protected',
+			$properties['excerpt']['properties'],
+			'The "protected" property should not be present in revision excerpt schema'
+		);
+
+		$this->assertArrayHasKey( 'raw', $properties['excerpt']['properties'] );
+		$this->assertArrayHasKey( 'rendered', $properties['excerpt']['properties'] );
+	}
+
+	/**
+	 * Test that revision response data does not include the 'protected' property in excerpt.
+	 *
+	 * Verifies that actual revision responses don't include the 'protected' property,
+	 * matching the corrected schema.
+	 *
+	 * @ticket 53417
+	 */
+	public function test_revision_response_excerpt_does_not_include_protected() {
+		wp_set_current_user( self::$editor_id );
+
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/posts/' . self::$post_id . '/revisions/' . $this->revision_id1 );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+
+		$this->assertArrayHasKey( 'excerpt', $data );
+		$this->assertArrayNotHasKey(
+			'protected',
+			$data['excerpt'],
+			'The "protected" property should not be present in revision excerpt response'
+		);
+
+		$this->assertArrayHasKey( 'rendered', $data['excerpt'] );
+	}
+
+	/**
 	 * Test the pagination header of the last page.
 	 *
 	 * @dataProvider data_readable_http_methods


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/53417

The schema provided by the REST API endpoints for revisions at `wp/v2/posts/{id}/revisions` and `wp/v2/pages/{id}/revisions` incorrectly states that `content.protected` and `excerpt.protected` properties exist. Revisions do not inherently support password protection in their response payloads, as they belong to the parent post.

This PR fixes the issue by removing the `protected` property from the revision schema for both the `content` and `excerpt` fields within `WP_REST_Revisions_Controller::get_item_schema()`. 

### Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

AI assistance: Yes
Tool(s): Github Copilot (Claude 4.6 Sonnet, Gemini 3.1 Pro)
Used for: Discussing the implementation approach and refining the PHPUnit tests for schema validation. Final code and tests were reviewed and verified locally by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
