### PR TITLE
Query: Set `is_singular` in the `get_posts()`front page backstop

### DIFF
--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -2041,6 +2041,7 @@ class WP_Query {
 
 		if ( $this->is_home && ( empty( $this->query ) || 'true' === $query_vars['preview'] ) && ( 'page' === get_option( 'show_on_front' ) ) && get_option( 'page_on_front' ) ) {
 			$this->is_page         = true;
+			$this->is_singular     = true;
 			$this->is_home         = false;
 			$query_vars['page_id'] = get_option( 'page_on_front' );
 		}

--- a/tests/phpunit/tests/query/conditionals.php
+++ b/tests/phpunit/tests/query/conditionals.php
@@ -72,6 +72,48 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 		delete_option( 'page_for_posts' );
 	}
 
+	/**
+	 * The get_posts() backstop should set is_singular when promoting a home
+	 * query to a static front page query. Without is_singular, the SQL
+	 * defaults to post_type = 'post' and returns zero results.
+	 *
+	 * @ticket 65072
+	 *
+	 * @covers WP_Query::get_posts
+	 */
+	public function test_page_on_front_backstop_sets_is_singular_with_extra_query_vars() {
+		$page_on_front = self::factory()->post->create(
+			array(
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+			)
+		);
+		update_option( 'show_on_front', 'page' );
+		update_option( 'page_on_front', $page_on_front );
+
+		// Register an extra public query var so that the parse_query() static
+		// front page detection (array_diff check) fails, forcing the
+		// get_posts() backstop to fire.
+		add_filter(
+			'query_vars',
+			static function ( $vars ) {
+				$vars[] = 'custom_extra_var';
+				return $vars;
+			}
+		);
+
+		$this->go_to( '/?custom_extra_var=1&preview=true' );
+
+		$this->assertQueryTrue( 'is_front_page', 'is_page', 'is_singular', 'is_preview' );
+
+		// The query should find the front page, not return zero results.
+		$this->assertCount( 1, $GLOBALS['wp_query']->posts );
+		$this->assertEquals( $page_on_front, $GLOBALS['wp_query']->posts[0]->ID );
+
+		update_option( 'show_on_front', 'posts' );
+		delete_option( 'page_on_front' );
+	}
+
 	public function test_404() {
 		$this->go_to( '/notapage' );
 		$this->assertQueryTrue( 'is_404' );


### PR DESCRIPTION
The static front page backstop in `WP_Query::get_posts()` sets `is_page = true` and `is_home = false`, but did not update `is_singular`. This caused the query to generate incorrect SQL — using `post_type = 'post'` instead of `post_type = 'page'` — and return zero results.

The equivalent check in `parse_query()` correctly maintains the invariant by recalculating `is_singular` at line 1135. The `get_posts()` backstop now does the same.

The backstop fires when `parse_query()` fails to detect the static front page because `$this->query` contains unexpected public query vars (anything not in the allowlist of `preview`, `page`, `paged`, `cpage`). This can happen when a plugin registers a query var that collides with a parameter WordPress core uses in preview URLs.

Trac ticket: https://core.trac.wordpress.org/ticket/65072

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
AI assistance: Yes
Tool(s): Claude
Model(s): Claude Opus 4.6
Used for: Investigation, implementation, review and test; final implementation and tests were also reviewed and tested by myself


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
