### PR TITLE
Media: Hide fallback file URL on attachment edit screen

### DIFF
--- a/src/wp-admin/includes/media.php
+++ b/src/wp-admin/includes/media.php
@@ -3194,7 +3194,11 @@ function edit_form_image_editor( $post ) {
 
 		wp_maybe_generate_attachment_metadata( $post );
 
-		echo wp_audio_shortcode( array( 'src' => $att_url ) );
+		$preview = wp_audio_shortcode( array( 'src' => $att_url ) );
+
+		if ( ! str_contains( $preview, 'class="wp-embedded-audio"' ) ) :
+			echo $preview;
+		endif;
 
 	elseif ( $attachment_id && wp_attachment_is( 'video', $post ) ) :
 
@@ -3221,7 +3225,11 @@ function edit_form_image_editor( $post ) {
 			$attr['poster'] = wp_get_attachment_url( $thumb_id );
 		}
 
-		echo wp_video_shortcode( $attr );
+		$preview = wp_video_shortcode( $attr );
+
+		if ( ! str_contains( $preview, 'class="wp-embedded-video"' ) ) :
+			echo $preview;
+		endif;
 
 	elseif ( isset( $thumb_url[0] ) ) :
 		?>

--- a/tests/phpunit/tests/admin/includesMedia.php
+++ b/tests/phpunit/tests/admin/includesMedia.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * @group admin
+ */
+class Tests_Admin_IncludesMedia extends WP_UnitTestCase {
+	/**
+	 * The ID of an administrator user.
+	 *
+	 * @var int
+	 */
+	protected static $admin_id;
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		require_once ABSPATH . 'wp-admin/includes/media.php';
+
+		self::$admin_id = $factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+	}
+
+	public function set_up(): void {
+		parent::set_up();
+
+		wp_set_current_user( self::$admin_id );
+		set_current_screen( 'post.php' );
+	}
+
+	public function tear_down(): void {
+		unset( $_GET['image-editor'] );
+		parent::tear_down();
+	}
+
+	/**
+	 * @ticket 64929
+	 */
+	public function test_edit_form_image_editor_skips_fallback_link_for_non_previewable_video() {
+		$attachment_id = $this->create_upload_attachment_from_contents( 'sample.avi', 'RIFF0000AVI LIST' );
+		$post          = get_post( $attachment_id );
+
+		ob_start();
+		edit_form_image_editor( $post );
+		$markup = ob_get_clean();
+
+		$this->assertStringNotContainsString( 'wp-embedded-video', $markup );
+		$this->assertStringNotContainsString( wp_get_attachment_url( $attachment_id ), $markup );
+	}
+
+	/**
+	 * @ticket 64929
+	 */
+	public function test_edit_form_image_editor_keeps_preview_for_supported_video() {
+		$attachment_id = self::factory()->attachment->create_upload_object( DIR_TESTDATA . '/uploads/small-video.mp4' );
+		$post          = get_post( $attachment_id );
+
+		ob_start();
+		edit_form_image_editor( $post );
+		$markup = ob_get_clean();
+
+		$this->assertStringContainsString( '<video', $markup );
+		$this->assertStringNotContainsString( 'wp-embedded-video', $markup );
+	}
+
+	/**
+	 * Creates an uploaded attachment from raw file contents.
+	 *
+	 * @param string $filename The file name to use for the upload.
+	 * @param string $contents The file contents.
+	 * @return int Attachment ID.
+	 */
+	private function create_upload_attachment_from_contents( $filename, $contents ) {
+		$temp_file = trailingslashit( get_temp_dir() ) . wp_generate_password( 8, false ) . '-' . $filename;
+		file_put_contents( $temp_file, $contents );
+
+		$attachment_id = self::factory()->attachment->create_upload_object( $temp_file );
+
+		unlink( $temp_file );
+
+		$this->assertIsInt( $attachment_id );
+
+		return $attachment_id;
+	}
+}

--- a/tests/phpunit/tests/admin/includesMedia.php
+++ b/tests/phpunit/tests/admin/includesMedia.php
@@ -35,6 +35,8 @@ class Tests_Admin_IncludesMedia extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 64929
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
 	 */
 	public function test_edit_form_image_editor_skips_fallback_link_for_non_previewable_video() {
 		$attachment_id = $this->create_upload_attachment_from_contents( 'sample.avi', 'RIFF0000AVI LIST' );
@@ -50,6 +52,8 @@ class Tests_Admin_IncludesMedia extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 64929
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
 	 */
 	public function test_edit_form_image_editor_keeps_preview_for_supported_video() {
 		$attachment_id = self::factory()->attachment->create_upload_object( DIR_TESTDATA . '/uploads/small-video.mp4' );


### PR DESCRIPTION
## Summary
- Prevent the attachment edit screen from rendering the shortcode fallback file link for non-previewable audio/video files.
- Preserve normal previews for supported media types.

## Testing
- npm run test:php -- --filter Tests_Admin_IncludesMedia
- Reproduced locally with an uploaded .avi file on the media attachment edit screen

Trac ticket: https://core.trac.wordpress.org/ticket/64929
