### PR TITLE
Docs: Fix parameter rendering for Abilities API functions

### DIFF
--- a/src/wp-includes/abilities-api.php
+++ b/src/wp-includes/abilities-api.php
@@ -225,11 +225,11 @@ declare( strict_types = 1 );
  * @see wp_register_ability_category()
  * @see wp_unregister_ability()
  *
- * @param string               $name The name of the ability. Must be a namespaced string containing
- *                                   a prefix, e.g., `my-plugin/my-ability`. Can only contain lowercase
- *                                   alphanumeric characters, dashes, and forward slashes.
- * @param array<string, mixed> $args {
- *     An associative array of arguments for configuring the ability.
+ * @param string $name The name of the ability. Must be a namespaced string containing
+ *                     a prefix, e.g., `my-plugin/my-ability`. Can only contain lowercase
+ *                     alphanumeric characters, dashes, and forward slashes.
+ * @param array  $args {
+ *      An associative array of arguments for configuring the ability.
  *
  *     @type string               $label               Required. The human-readable label for the ability.
  *     @type string               $description         Required. A detailed description of what the ability does
@@ -453,10 +453,10 @@ function wp_get_abilities(): array {
  * @see wp_register_ability()
  * @see wp_unregister_ability_category()
  *
- * @param string               $slug The unique slug for the ability category. Must contain only lowercase
- *                                   alphanumeric characters and dashes (e.g., 'data-export').
- * @param array<string, mixed> $args {
- *     An associative array of arguments for the ability category.
+ * @param string $slug The unique slug for the ability category. Must contain only lowercase
+ *                     alphanumeric characters and dashes (e.g., 'data-export').
+ * @param array  $args {
+ *      An associative array of arguments for the ability category.
  *
  *     @type string               $label       Required. The human-readable label for the ability category.
  *     @type string               $description Required. A description of what abilities in this category do.


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

This PR fixes rendering issues in the "Parameters" section for wp_register_ability() and wp_register_ability_category() on the Developer Hub. The issue is caused by a collision between modern PHP generic syntax (array<string, mixed>) and the legacy "hash notation" parser used by the DevHub theme. When these are combined, the parser fails to correctly identify the variable name, leading to malformed text being displayed on the site.

Trac ticket: https://core.trac.wordpress.org/ticket/65074

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
