### PR TITLE
Missing escaping in title tag #65076

### DIFF
--- a/src/wp-login.php
+++ b/src/wp-login.php
@@ -94,7 +94,7 @@ function login_header( $title = null, $message = '', $wp_error = null ) {
 	<html <?php language_attributes(); ?>>
 	<head>
 	<meta http-equiv="Content-Type" content="<?php bloginfo( 'html_type' ); ?>; charset=<?php bloginfo( 'charset' ); ?>" />
-	<title><?php echo $login_title; ?></title>
+	<title><?php echo esc_html( $login_title ); ?></title>
 	<?php
 
 	wp_enqueue_style( 'login' );


### PR DESCRIPTION

**Missing escaping in `<title>` tag** 
- **File:** [src/wp-login.php](src/wp-login.php#L97)
- **Line:** 97
- **Problem:** `<title>` tag outputs `$login_title` without escaping. Special characters could break HTML structure.
- **Severity:** Security best practice
- **Current Code:**
  ```php
  <title><?php echo $login_title; ?></title>
  ```
- **Fix:**
  ```php
  <title><?php echo esc_html( $login_title ); ?></title>
  ```

Trac ticket: https://core.trac.wordpress.org/ticket/65076#ticket

