### PR TITLE
Taxonomy: Ensure `_pad_term_counts()` handles post types safely.

### DIFF
--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -4065,8 +4065,20 @@ function _pad_term_counts( &$terms, $taxonomy ) {
 
 	// Get the object and term IDs and stick them in a lookup table.
 	$tax_obj      = get_taxonomy( $taxonomy );
-	$object_types = esc_sql( $tax_obj->object_type );
-	$results      = $wpdb->get_results( "SELECT object_id, term_taxonomy_id FROM $wpdb->term_relationships INNER JOIN $wpdb->posts ON object_id = ID WHERE term_taxonomy_id IN (" . implode( ',', array_keys( $term_ids ) ) . ") AND post_type IN ('" . implode( "', '", $object_types ) . "') AND post_status = 'publish'" );
+	$object_types = (array) $tax_obj->object_type;
+
+	//Filter invalid post types for consistency with _update_post_term_count().
+	$object_types = array_filter( $object_types, 'post_type_exists' );
+	if ( empty( $object_types ) ) {
+		return;
+	}
+
+	$results = $wpdb->get_results(
+		$wpdb->prepare(
+			"SELECT object_id, term_taxonomy_id FROM $wpdb->term_relationships INNER JOIN $wpdb->posts ON object_id = ID WHERE term_taxonomy_id IN (" . implode( ',', array_fill( 0, count( $term_ids ), '%d' ) ) . ') AND post_type IN (' . implode( ',', array_fill( 0, count( $object_types ), '%s' ) ) . ") AND post_status = 'publish'",
+			array_merge( array_keys( $term_ids ), $object_types )
+		)
+	);
 
 	foreach ( $results as $row ) {
 		$id = $term_ids[ $row->term_taxonomy_id ];

--- a/tests/phpunit/tests/taxonomy.php
+++ b/tests/phpunit/tests/taxonomy.php
@@ -1124,4 +1124,66 @@ class Tests_Taxonomy extends WP_UnitTestCase {
 		$this->assertContains( $tax1, $taxonomies );
 		$this->assertContains( $tax2, $taxonomies );
 	}
+
+	/**
+	 * @ticket 65055
+	 * Filter invalid post types before SQL query
+	 */
+	public function test_pad_term_counts_with_invalid_post_types() {
+		register_taxonomy( 'invalid_tax', array( 'non_existent_type' ), array( 'hierarchical' => true ) );
+
+		$parent = self::factory()->term->create( array( 'taxonomy' => 'invalid_tax' ) );
+		self::factory()->term->create(
+			array(
+				'taxonomy' => 'invalid_tax',
+				'parent'   => $parent,
+			)
+		);
+
+		_get_term_hierarchy( 'invalid_tax' );
+
+		$terms = get_terms(
+			array(
+				'taxonomy'   => 'invalid_tax',
+				'hide_empty' => false,
+			)
+		);
+
+		_pad_term_counts( $terms, 'invalid_tax' );
+
+		$this->assertEquals( 0, $terms[0]->count );
+	}
+
+	/**
+	 * @ticket 65055
+	 */
+	public function test_pad_term_counts_with_standard_post_types() {
+		register_post_type( 'book' );
+		register_taxonomy( 'genre', array( 'book' ), array( 'hierarchical' => true ) );
+
+		$parent = self::factory()->term->create( array( 'taxonomy' => 'genre' ) );
+		$child  = self::factory()->term->create(
+			array(
+				'taxonomy' => 'genre',
+				'parent'   => $parent,
+			)
+		);
+
+		_get_term_hierarchy( 'genre' );
+
+		$post_id = self::factory()->post->create( array( 'post_type' => 'book' ) );
+		wp_set_object_terms( $post_id, $child, 'genre' );
+
+		$terms = get_terms(
+			array(
+				'taxonomy'   => 'genre',
+				'hide_empty' => false,
+			)
+		);
+
+		_pad_term_counts( $terms, 'genre' );
+
+		$parent_term = wp_list_filter( $terms, array( 'term_id' => $parent ) );
+		$this->assertEquals( 1, current( $parent_term )->count, 'Parent terms should include post counts from their child terms' );
+	}
 }


### PR DESCRIPTION
This commit updates `_pad_term_counts()` to use `$wpdb->prepare()` for all database queries, improving security and consistency. Additionally, it introduces a filter using `post_type_exists()` to ensure that only registered post types are queried, aligning the behavior with `_update_post_term_count()`.Includes comprehensive unit tests to verify the logic and prevent regressions.Fixes #65055.See #11542.

Description
This PR builds upon the work by @rajeshcp in #11542. It implements the $wpdb->prepare() fix for #65055 and adds comprehensive unit tests to ensure the logic is robust.

While drafting the unit tests, I identified a scenario where _pad_term_counts() could query non-existent post types (see test_pad_term_counts_with_invalid_post_types). Following @abcd95's suggestion, I've aligned the logic with _update_post_term_count() by filtering via post_type_exists().

Key Changes:

Security: Refactored direct SQL string interpolation to use $wpdb->prepare() to prevent potential SQL injection and ensure standard database interaction.

Consistency: Integrated array_filter( $object_types, 'post_type_exists' ) before the query execution. This aligns _pad_term_counts() with the logic found in _update_post_term_count(), preventing queries from running against invalid or ghost post types that may still exist in the taxonomy's object_type array.

Robustness: Added an early exit if no valid post types remain after filtering, saving unnecessary database calls.

Unit Testing: Introduced comprehensive test cases in Tests_Taxonomy  (including a specific test for invalid post types) to ensure the logic works as expected and to prevent future regressions.

I have verified these changes with a zero-dependency local test script, confirming that the SQL arguments are correctly filtered and parameterized compared to the unpatched version.

Trac ticket: https://core.trac.wordpress.org/ticket/65055

Use of AI Tools
AI assistance: Yes
Tool(s): Gemini
Model(s): Gemini 3 Flash
Used for: Brainstorming the zero-dependency test script to isolate the core logic during local verification; assisting in drafting the technical description and PR documentation based on my local test results. All code changes and logic were manually implemented and verified by me.

This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.