### PR TITLE
HTML API: Normalize TITLE content generation.

### DIFF
--- a/src/wp-admin/admin-header.php
+++ b/src/wp-admin/admin-header.php
@@ -92,7 +92,7 @@ wp_user_settings();
 
 _wp_admin_html_begin();
 ?>
-<title><?php echo esc_html( $admin_title ); ?></title>
+<title><?php echo wp_html_title( $admin_title ); ?></title>
 <?php
 
 wp_enqueue_style( 'colors' );

--- a/src/wp-admin/customize.php
+++ b/src/wp-admin/customize.php
@@ -157,7 +157,7 @@ if ( wp_use_widgets_block_editor() ) {
 $admin_title = sprintf( $wp_customize->get_document_title_template(), __( 'Loading&hellip;' ) );
 
 ?>
-<title><?php echo esc_html( $admin_title ); ?></title>
+<title><?php echo wp_html_title( $admin_title ); ?></title>
 
 <script>
 var ajaxurl = <?php echo wp_json_encode( admin_url( 'admin-ajax.php', 'relative' ), JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ); ?>,

--- a/src/wp-admin/includes/media.php
+++ b/src/wp-admin/includes/media.php
@@ -555,7 +555,7 @@ function wp_iframe( $content_func, ...$args ) {
 
 	_wp_admin_html_begin();
 	?>
-	<title><?php bloginfo( 'name' ); ?> &rsaquo; <?php _e( 'Uploads' ); ?> &#8212; <?php _e( 'WordPress' ); ?></title>
+	<title><?php echo wp_html_title( bloginfo( 'name' ) . ' &rsaquo; ' . __( 'Uploads' ) . ' &#8212; ' . __( 'WordPress' ) ); ?></title>
 	<?php
 
 	wp_enqueue_style( 'colors' );

--- a/src/wp-admin/includes/privacy-tools.php
+++ b/src/wp-admin/includes/privacy-tools.php
@@ -460,7 +460,7 @@ function wp_privacy_generate_personal_data_export_file( $request_id ) {
 	fwrite( $file, '.return-to-top { text-align: right; }' );
 	fwrite( $file, '</style>' );
 	fwrite( $file, '<title>' );
-	fwrite( $file, esc_html( $title ) );
+	fwrite( $file, wp_html_title( $title ) );
 	fwrite( $file, '</title>' );
 	fwrite( $file, "</head>\n" );
 	fwrite( $file, "<body>\n" );

--- a/src/wp-admin/includes/template.php
+++ b/src/wp-admin/includes/template.php
@@ -2139,7 +2139,7 @@ function iframe_header( $title = '', $deprecated = false ) {
 	header( 'Content-Type: ' . get_option( 'html_type' ) . '; charset=' . get_option( 'blog_charset' ) );
 	_wp_admin_html_begin();
 	?>
-<title><?php bloginfo( 'name' ); ?> &rsaquo; <?php echo $title; ?> &#8212; <?php _e( 'WordPress' ); ?></title>
+<title><?php wp_html_title( bloginfo( 'name' ) . " &rsaquo; {$title} &#8212; " . __( 'WordPress' ) ); ?></title>
 	<?php
 	wp_enqueue_style( 'colors' );
 	?>

--- a/src/wp-admin/install.php
+++ b/src/wp-admin/install.php
@@ -69,7 +69,7 @@ function display_header( $body_classes = '' ) {
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 	<meta name="robots" content="noindex,nofollow" />
-	<title><?php _e( 'WordPress &rsaquo; Installation' ); ?></title>
+	<title><?php wp_html_title( __( 'WordPress &rsaquo; Installation' ) ); ?></title>
 	<?php wp_admin_css( 'install', true ); ?>
 </head>
 <body class="wp-core-ui admin-color-modern<?php echo $body_classes; ?>">

--- a/src/wp-admin/maint/repair.php
+++ b/src/wp-admin/maint/repair.php
@@ -17,7 +17,7 @@ header( 'Content-Type: text/html; charset=utf-8' );
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 	<meta name="robots" content="noindex,nofollow" />
-	<title><?php _e( 'WordPress &rsaquo; Database Repair' ); ?></title>
+	<title><?php wp_html_title( __( 'WordPress &rsaquo; Database Repair' ) ); ?></title>
 	<?php wp_admin_css( 'install', true ); ?>
 </head>
 <body class="wp-core-ui admin-color-modern">

--- a/src/wp-admin/setup-config.php
+++ b/src/wp-admin/setup-config.php
@@ -109,7 +109,7 @@ function setup_config_display_header( $body_classes = array() ) {
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 	<meta name="robots" content="noindex,nofollow" />
-	<title><?php _e( 'WordPress &rsaquo; Setup Configuration File' ); ?></title>
+	<title><?php wp_html_title( __( 'WordPress &rsaquo; Setup Configuration File' ) ); ?></title>
 	<?php wp_admin_css( 'install', true ); ?>
 </head>
 <body class="<?php echo implode( ' ', $body_classes ); ?>">

--- a/src/wp-admin/upgrade.php
+++ b/src/wp-admin/upgrade.php
@@ -77,7 +77,7 @@ header( 'Content-Type: ' . get_option( 'html_type' ) . '; charset=' . get_option
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 	<meta http-equiv="Content-Type" content="<?php bloginfo( 'html_type' ); ?>; charset=<?php echo get_option( 'blog_charset' ); ?>" />
 	<meta name="robots" content="noindex,nofollow" />
-	<title><?php _e( 'WordPress &rsaquo; Update' ); ?></title>
+	<title><?php wp_html_title( __( 'WordPress &rsaquo; Update' ) ); ?></title>
 	<?php wp_admin_css( 'install', true ); ?>
 </head>
 <body class="wp-core-ui admin-color-modern">

--- a/src/wp-content/themes/twentyeleven/header.php
+++ b/src/wp-content/themes/twentyeleven/header.php
@@ -32,7 +32,7 @@ if ( $site_description && ( is_home() || is_front_page() ) ) {
 	// Add a page number if necessary:
 if ( ( $paged >= 2 || $page >= 2 ) && ! is_404() ) {
 	/* translators: %s: Page number. */
-	echo esc_html( ' | ' . sprintf( __( 'Page %s', 'twentyeleven' ), max( $paged, $page ) ) );
+	echo wp_html_title( ' | ' . sprintf( __( 'Page %s', 'twentyeleven' ), max( $paged, $page ) ) );
 }
 
 ?>

--- a/src/wp-content/themes/twentyfourteen/header.php
+++ b/src/wp-content/themes/twentyfourteen/header.php
@@ -13,7 +13,7 @@
 <head>
 	<meta charset="<?php bloginfo( 'charset' ); ?>">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<title><?php wp_title( '|', true, 'right' ); ?></title>
+	<title><?php wp_html_title( wp_title( '|', true, 'right' ) ); ?></title>
 	<link rel="profile" href="https://gmpg.org/xfn/11">
 	<link rel="pingback" href="<?php echo esc_url( get_bloginfo( 'pingback_url' ) ); ?>">
 	<?php wp_head(); ?>

--- a/src/wp-content/themes/twentyten/header.php
+++ b/src/wp-content/themes/twentyten/header.php
@@ -33,7 +33,7 @@ if ( $site_description && ( is_home() || is_front_page() ) ) {
 	// Add a page number if necessary:
 if ( ( $paged >= 2 || $page >= 2 ) && ! is_404() ) {
 	/* translators: %s: Page number. */
-	echo esc_html( ' | ' . sprintf( __( 'Page %s', 'twentyten' ), max( $paged, $page ) ) );
+	echo wp_html_title( ' | ' . sprintf( __( 'Page %s', 'twentyten' ), max( $paged, $page ) ) );
 }
 
 ?>

--- a/src/wp-content/themes/twentythirteen/header.php
+++ b/src/wp-content/themes/twentythirteen/header.php
@@ -13,7 +13,7 @@
 <head>
 	<meta charset="<?php bloginfo( 'charset' ); ?>">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<title><?php wp_title( '|', true, 'right' ); ?></title>
+	<title><?php wp_html_title( wp_title( '|', true, 'right' ) ); ?></title>
 	<link rel="profile" href="https://gmpg.org/xfn/11">
 	<link rel="pingback" href="<?php echo esc_url( get_bloginfo( 'pingback_url' ) ); ?>">
 	<?php wp_head(); ?>

--- a/src/wp-content/themes/twentytwelve/header.php
+++ b/src/wp-content/themes/twentytwelve/header.php
@@ -13,7 +13,7 @@
 <head>
 <meta charset="<?php bloginfo( 'charset' ); ?>" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<title><?php wp_title( '|', true, 'right' ); ?></title>
+<title><?php wp_html_title( wp_title( '|', true, 'right' ) ); ?></title>
 <link rel="profile" href="https://gmpg.org/xfn/11" />
 <link rel="pingback" href="<?php echo esc_url( get_bloginfo( 'pingback_url' ) ); ?>">
 <?php wp_head(); ?>

--- a/src/wp-includes/block-template.php
+++ b/src/wp-includes/block-template.php
@@ -230,7 +230,7 @@ function resolve_block_template( $template_type, $template_hierarchy, $fallback_
  * @see _wp_render_title_tag()
  */
 function _block_template_render_title_tag() {
-	echo '<title>' . wp_get_document_title() . '</title>' . "\n";
+	echo '<title>' . wp_html_title( wp_get_document_title() ) . '</title>' . "\n";
 }
 
 /**

--- a/src/wp-includes/build/pages/font-library/page.php
+++ b/src/wp-includes/build/pages/font-library/page.php
@@ -229,7 +229,7 @@ function wp_font_library_render_page() {
 	<head>
 		<meta charset="<?php bloginfo( 'charset' ); ?>">
 		<meta name="viewport" content="width=device-width, initial-scale=1">
-		<title><?php echo esc_html( get_admin_page_title() ); ?></title>
+		<title><?php echo wp_html_title( get_admin_page_title() ); ?></title>
 		<style>
 			html {
 				background: #f1f1f1;

--- a/src/wp-includes/build/pages/options-connectors/page.php
+++ b/src/wp-includes/build/pages/options-connectors/page.php
@@ -229,7 +229,7 @@ function wp_options_connectors_render_page() {
 	<head>
 		<meta charset="<?php bloginfo( 'charset' ); ?>">
 		<meta name="viewport" content="width=device-width, initial-scale=1">
-		<title><?php echo esc_html( get_admin_page_title() ); ?></title>
+		<title><?php echo wp_html_title( get_admin_page_title() ); ?></title>
 		<style>
 			html {
 				background: #f1f1f1;

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -2207,6 +2207,96 @@ function sanitize_key( $key ) {
 }
 
 /**
+ * Transforms rich-text markup into HTML title element content.
+ *
+ * HTML’s TITLE element contains no inner markup, only plaintext content
+ * with the possibility of containing character references. Any characters
+ * which would normally be interpreted as HTML syntax, apart from character
+ * references, is interpreted as plaintext, other than a closing TITLE tag.
+ *
+ * This function takes HTML markup as input, such as a rich-text version of
+ * a post’s title (since post titles in a theme may render as HTML), and
+ * produces a plaintext string safe and suitable for rendering into the
+ * TITLE element on an HTML page.
+ *
+ * This is not to be used when generating XML outputs.
+ *
+ * Example:
+ *
+ *     echo '<title>' . wp_html_title( $post->post_content ) . '</title>';
+ *
+ *     // Non-text content is removed.
+ *     'Thank goodness!' === wp_html_title( 'Thank <em>good<!-- but not great -->ness</em>!' );
+ *
+ *     // The content is treated as HTML, and encoded appropriately.
+ *     $title = '&lt;IMG loading="lazy"> & friends are neat tags.'
+ *     '&lt;IMG loading=&quot;lazy&quot;&gt; &amp; friends are neat tags.' === wp_html_title( $title );
+ *
+ * @todo Use the HTML Processor and skip over hidden or aria-hidden content, invisible content, etc…
+ *
+ * @since {WP_VERSION}
+ *
+ * @param string $rich_title_markup Should be rendered in an HTML TITLE element.
+ * @return string Plaintext value of input with appropriate characters encoded
+ *                which is safe for printing into an HTML TITLE element.
+ */
+function wp_html_title( $rich_title_markup ): string {
+	if ( ! is_string( $rich_title_markup ) && ! method_exists( $rich_title_markup, '__toString' ) ) {
+		_doing_it_wrong(
+			__FUNCTION__,
+			'Must pass a string or stringable value.',
+			'{WP_VERSION}'
+		);
+
+		return '';
+	}
+
+	// Speedup: If there are no HTML syntax characters then it’s safe to use directly.
+	if ( strlen( $rich_title_markup ) === strcspn( $rich_title_markup, '"&\'<>' ) ) {
+		return $rich_title_markup;
+	}
+
+	/*
+	 * This next section parses the title as HTML, extracts the text nodes,
+	 * and then re-encodes the text as a single HTML text node. This is a
+	 * bit convoluted, but it normalizes a number of ways post titles can
+	 * come in mixed forms.
+	 *
+	 * Notably, the type of a post title in WordPress is rich HTML. When
+	 * printed inside a typical theme layout, titles often contain inline
+	 * formatting like EM and CODE elements. However, the type of the HTML
+	 * TITLE element is parsed character data, meaning plaintext with
+	 * decoded character references.
+	 *
+	 * If `The <em>real</em> "deal".` were written inside that TITLE, then a
+	 * browser would display the `<em>` and `</em>` tags verbatim as text
+	 * instead of italicising the `real` between them.
+	 *
+	 * This is therefore why the roundtrip through the parser/printer is
+	 * relevant. First the plaintext content is extracted, then it is safely
+	 * encoded to avoid being later treated incorrectly as syntax.
+	 *
+	 *       Input: `The <em>real</em> "deal".`
+	 *        Text: `The real "deal".`
+	 *     Encoded: `The real &quot;deal&quot;.`
+	 */
+
+	$title     = '';
+	$processor = new WP_HTML_Tag_Processor( $rich_title_markup );
+	while ( $processor->next_token() ) {
+		if ( '#text' === $processor->get_token_name() ) {
+			$title .= $processor->get_modifiable_text();
+		}
+	}
+
+	$processor = new WP_HTML_Tag_Processor( ' ' );
+	$processor->next_token();
+	$processor->set_modifiable_text( $title );
+
+	return $processor->get_updated_html();
+}
+
+/**
  * Sanitizes a string into a slug, which can be used in URLs or HTML attributes.
  *
  * By default, converts accent characters to ASCII characters and further

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -3933,7 +3933,7 @@ function _default_wp_die_handler( $message, $title = '', $args = array() ) {
 			wp_robots();
 		}
 		?>
-	<title><?php echo $title; ?></title>
+	<title><?php echo wp_html_title( $title ); ?></title>
 	<style>
 		html {
 			background: #f1f1f1;

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -1312,7 +1312,7 @@ function _wp_render_title_tag() {
 		return;
 	}
 
-	echo '<title>' . wp_get_document_title() . '</title>' . "\n";
+	echo '<title>' . wp_html_title( wp_get_document_title() ) . '</title>' . "\n";
 }
 
 /**

--- a/src/wp-includes/theme-compat/header-embed.php
+++ b/src/wp-includes/theme-compat/header-embed.php
@@ -18,7 +18,7 @@ if ( ! headers_sent() ) {
 <!DOCTYPE html>
 <html <?php language_attributes(); ?> class="no-js">
 <head>
-	<title><?php echo wp_get_document_title(); ?></title>
+	<title><?php echo wp_html_title( wp_get_document_title() ); ?></title>
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<?php
 	/**

--- a/src/wp-includes/theme-compat/header.php
+++ b/src/wp-includes/theme-compat/header.php
@@ -21,7 +21,7 @@ _deprecated_file(
 <link rel="profile" href="https://gmpg.org/xfn/11" />
 <meta http-equiv="Content-Type" content="<?php bloginfo( 'html_type' ); ?>; charset=<?php bloginfo( 'charset' ); ?>" />
 
-<title><?php echo wp_get_document_title(); ?></title>
+<title><?php echo wp_html_title( wp_get_document_title() ); ?></title>
 
 <link rel="stylesheet" href="<?php bloginfo( 'stylesheet_url' ); ?>" media="screen" />
 <link rel="pingback" href="<?php bloginfo( 'pingback_url' ); ?>" />

--- a/src/wp-login.php
+++ b/src/wp-login.php
@@ -94,7 +94,7 @@ function login_header( $title = null, $message = '', $wp_error = null ) {
 	<html <?php language_attributes(); ?>>
 	<head>
 	<meta http-equiv="Content-Type" content="<?php bloginfo( 'html_type' ); ?>; charset=<?php bloginfo( 'charset' ); ?>" />
-	<title><?php echo $login_title; ?></title>
+	<title><?php echo wp_html_title( $login_title ); ?></title>
 	<?php
 
 	wp_enqueue_style( 'login' );

--- a/tests/phpunit/tests/general/wpGetDocumentTitle.php
+++ b/tests/phpunit/tests/general/wpGetDocumentTitle.php
@@ -72,7 +72,7 @@ class Tests_General_wpGetDocumentTitle extends WP_UnitTestCase {
 
 		update_option( 'blogdescription', 'A blog description' );
 
-		$this->expectOutputString( sprintf( "<title>%s &#8211; %s</title>\n", $this->blog_name, get_option( 'blogdescription' ) ) );
+		$this->expectOutputString( sprintf( "<title>%s — %s</title>\n", $this->blog_name, get_option( 'blogdescription' ) ) );
 		_wp_render_title_tag();
 	}
 


### PR DESCRIPTION
The HTML TITLE element behaves differently than other elements because it contains no content other than parsed character data; in other words, everything until the closing TITLE tag is treated as plaintext, while character references are decoded.

WordPress post titles, however, are nominally rich text and may contain markup which will be rendered when displayed inside a theme; just not when found insdie the TITLE element itself.

This patch introduces a new semantically-named function to transform rich HTML for rendering into the TITLE element and replaces existing uses of `esc_html()` and `_e()` to parse the input HTML, remove anything that isn’t text, and then normalize the escaping of syntax characters.