### PR TITLE
Output without escaping for dynamic link text #65090

### DIFF
--- a/src/wp-login.php
+++ b/src/wp-login.php
@@ -231,7 +231,7 @@ function login_header( $title = null, $message = '', $wp_error = null ) {
 	$message = apply_filters( 'login_message', $message );
 
 	if ( ! empty( $message ) ) {
-		echo $message . "\n";
+		echo wp_kses_post( $message ) . "\n";
 	}
 
 	// In case a plugin uses $error rather than the $wp_errors object.


### PR DESCRIPTION


**File:** [src/wp-login.php](src/wp-login.php#L234)
- **Line:** 234
- **Problem:** `$message` output without escaping (filterable content)
- **Current Code:**
  ```php
  if ( ! empty( $message ) ) {
      echo $message . "\n";
  }
  ```
- **Context:** `$message` comes from `apply_filters( 'login_message', $message )` but could contain HTML or special chars
- **Fix:** Context-dependent, could be:
  ```php
  // If message is expected to have HTML:
  if ( ! empty( $message ) ) {
      echo wp_kses_post( $message ) . "\n";
  }
  // Or if plain text:
  if ( ! empty( $message ) ) {
      echo esc_html( $message ) . "\n";
  }
  ```

Trac ticket: https://core.trac.wordpress.org/ticket/65090#ticket

