### PR TITLE
Prevent exception when constructing `WP_AI_Client_Prompt_Builder` when invalid timeout is provided by filter

### DIFF
--- a/src/wp-includes/ai-client.php
+++ b/src/wp-includes/ai-client.php
@@ -57,6 +57,6 @@ function wp_supports_ai(): bool {
  *                                                                                                   conversations. Default null.
  * @return WP_AI_Client_Prompt_Builder The prompt builder instance.
  */
-function wp_ai_client_prompt( $prompt = null ) {
+function wp_ai_client_prompt( $prompt = null ): WP_AI_Client_Prompt_Builder {
 	return new WP_AI_Client_Prompt_Builder( AiClient::defaultRegistry(), $prompt );
 }

--- a/src/wp-includes/ai-client.php
+++ b/src/wp-includes/ai-client.php
@@ -8,6 +8,8 @@
  */
 
 use WordPress\AiClient\AiClient;
+use WordPress\AiClient\Messages\DTO\Message;
+use WordPress\AiClient\Messages\DTO\MessagePart;
 
 /**
  * Returns whether AI features are supported in the current environment.

--- a/src/wp-includes/ai-client/adapters/class-wp-ai-client-cache.php
+++ b/src/wp-includes/ai-client/adapters/class-wp-ai-client-cache.php
@@ -104,7 +104,7 @@ class WP_AI_Client_Cache implements CacheInterface {
 	 * @param mixed            $default_value Default value to return for keys that do not exist.
 	 * @return array<string, mixed> A list of key => value pairs.
 	 */
-	public function getMultiple( $keys, $default_value = null ) {
+	public function getMultiple( $keys, $default_value = null ): array {
 		/**
 		 * Keys array.
 		 *

--- a/src/wp-includes/ai-client/adapters/class-wp-ai-client-http-client.php
+++ b/src/wp-includes/ai-client/adapters/class-wp-ai-client-http-client.php
@@ -32,17 +32,15 @@ class WP_AI_Client_HTTP_Client implements ClientInterface, ClientWithOptionsInte
 	 * Response factory instance.
 	 *
 	 * @since 7.0.0
-	 * @var ResponseFactoryInterface
 	 */
-	private $response_factory;
+	private ResponseFactoryInterface $response_factory;
 
 	/**
 	 * Stream factory instance.
 	 *
 	 * @since 7.0.0
-	 * @var StreamFactoryInterface
 	 */
-	private $stream_factory;
+	private StreamFactoryInterface $stream_factory;
 
 	/**
 	 * Constructor.

--- a/src/wp-includes/ai-client/class-wp-ai-client-prompt-builder.php
+++ b/src/wp-includes/ai-client/class-wp-ai-client-prompt-builder.php
@@ -190,14 +190,22 @@ class WP_AI_Client_Prompt_Builder {
 			$this->error   = $this->exception_to_wp_error( $e );
 		}
 
+		$default_timeout = 30;
+
 		/**
 		 * Filters the default request timeout in seconds for AI Client HTTP requests.
 		 *
 		 * @since 7.0.0
 		 *
-		 * @param int $default_timeout The default timeout in seconds.
+		 * @param float $default_timeout The default timeout in seconds.
 		 */
-		$default_timeout = (int) apply_filters( 'wp_ai_client_default_request_timeout', 30 );
+		$timeout = apply_filters( 'wp_ai_client_default_request_timeout', $default_timeout );
+		if ( is_numeric( $timeout ) ) {
+			$timeout = (float) $timeout;
+			if ( $timeout >= 0 ) {
+				$default_timeout = $timeout;
+			}
+		}
 
 		$this->builder->usingRequestOptions(
 			RequestOptions::fromArray(

--- a/src/wp-includes/ai-client/class-wp-ai-client-prompt-builder.php
+++ b/src/wp-includes/ai-client/class-wp-ai-client-prompt-builder.php
@@ -197,20 +197,17 @@ class WP_AI_Client_Prompt_Builder {
 		 *
 		 * @since 7.0.0
 		 *
-		 * @param float|null $default_timeout The default timeout in seconds, or null to disable the timeout.
-		 *                                    If not null, must be greater than or equal to zero.
+		 * @param float $default_timeout The default timeout in seconds.
 		 */
 		$timeout = apply_filters( 'wp_ai_client_default_request_timeout', $default_timeout );
 		if ( is_numeric( $timeout ) && (float) $timeout >= 0.0 ) {
 			$default_timeout = (float) $timeout;
-		} elseif ( null === $timeout ) {
-			$default_timeout = null;
 		} else {
 			_doing_it_wrong(
 				__METHOD__,
 				sprintf(
 					/* translators: %s: wp_ai_client_default_request_timeout */
-					__( 'The %s filter must return a non-negative number or null.' ),
+					__( 'The %s filter must return a non-negative number.' ),
 					'<code>wp_ai_client_default_request_timeout</code>'
 				),
 				'7.0.0'

--- a/src/wp-includes/ai-client/class-wp-ai-client-prompt-builder.php
+++ b/src/wp-includes/ai-client/class-wp-ai-client-prompt-builder.php
@@ -197,14 +197,24 @@ class WP_AI_Client_Prompt_Builder {
 		 *
 		 * @since 7.0.0
 		 *
-		 * @param float $default_timeout The default timeout in seconds. Must be greater than or equal to zero.
+		 * @param float|null $default_timeout The default timeout in seconds, or null to disable the timeout.
+		 *                                    If not null, must be greater than or equal to zero.
 		 */
 		$timeout = apply_filters( 'wp_ai_client_default_request_timeout', $default_timeout );
-		if ( is_numeric( $timeout ) ) {
-			$timeout = (float) $timeout;
-			if ( $timeout >= 0.0 ) {
-				$default_timeout = $timeout;
-			}
+		if ( is_numeric( $timeout ) && (float) $timeout >= 0.0 ) {
+			$default_timeout = (float) $timeout;
+		} elseif ( null === $timeout ) {
+			$default_timeout = null;
+		} else {
+			_doing_it_wrong(
+				__METHOD__,
+				sprintf(
+					/* translators: %s: wp_ai_client_default_request_timeout */
+					__( 'The %s filter must return a non-negative number or null.' ),
+					'<code>wp_ai_client_default_request_timeout</code>'
+				),
+				'7.0.0'
+			);
 		}
 
 		$this->builder->usingRequestOptions(

--- a/src/wp-includes/ai-client/class-wp-ai-client-prompt-builder.php
+++ b/src/wp-includes/ai-client/class-wp-ai-client-prompt-builder.php
@@ -199,9 +199,9 @@ class WP_AI_Client_Prompt_Builder {
 		 *
 		 * @param float $default_timeout The default timeout in seconds.
 		 */
-		$timeout = apply_filters( 'wp_ai_client_default_request_timeout', $default_timeout );
-		if ( is_numeric( $timeout ) && (float) $timeout >= 0.0 ) {
-			$default_timeout = (float) $timeout;
+		$filtered_default_timeout = apply_filters( 'wp_ai_client_default_request_timeout', $default_timeout );
+		if ( is_numeric( $filtered_default_timeout ) && (float) $filtered_default_timeout >= 0.0 ) {
+			$default_timeout = (float) $filtered_default_timeout;
 		} else {
 			_doing_it_wrong(
 				__METHOD__,

--- a/src/wp-includes/ai-client/class-wp-ai-client-prompt-builder.php
+++ b/src/wp-includes/ai-client/class-wp-ai-client-prompt-builder.php
@@ -190,19 +190,19 @@ class WP_AI_Client_Prompt_Builder {
 			$this->error   = $this->exception_to_wp_error( $e );
 		}
 
-		$default_timeout = 30;
+		$default_timeout = 30.0;
 
 		/**
 		 * Filters the default request timeout in seconds for AI Client HTTP requests.
 		 *
 		 * @since 7.0.0
 		 *
-		 * @param float $default_timeout The default timeout in seconds.
+		 * @param float $default_timeout The default timeout in seconds. Must be greater than or equal to zero.
 		 */
 		$timeout = apply_filters( 'wp_ai_client_default_request_timeout', $default_timeout );
 		if ( is_numeric( $timeout ) ) {
 			$timeout = (float) $timeout;
-			if ( $timeout >= 0 ) {
+			if ( $timeout >= 0.0 ) {
 				$default_timeout = $timeout;
 			}
 		}

--- a/tests/phpunit/tests/ai-client/wpAiClientPromptBuilder.php
+++ b/tests/phpunit/tests/ai-client/wpAiClientPromptBuilder.php
@@ -192,11 +192,11 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that the constructor allows overriding the default request timeout.
+	 * Test that the constructor allows overriding the default request timeout with a higher value.
 	 *
 	 * @ticket 64591
 	 */
-	public function test_constructor_allows_overriding_request_timeout() {
+	public function test_constructor_allows_overriding_request_timeout_with_higher_value() {
 		add_filter(
 			'wp_ai_client_default_request_timeout',
 			static function () {
@@ -211,6 +211,66 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 
 		$this->assertInstanceOf( RequestOptions::class, $request_options );
 		$this->assertEquals( 45, $request_options->getTimeout() );
+	}
+
+	/**
+	 * Test that the constructor allows overriding the default request timeout with null.
+	 *
+	 * @ticket 65094
+	 */
+	public function test_constructor_allows_overriding_request_timeout_with_null() {
+		add_filter( 'wp_ai_client_default_request_timeout', '__return_null' );
+
+		$builder = new WP_AI_Client_Prompt_Builder( AiClient::defaultRegistry() );
+
+		/** @var RequestOptions $request_options */
+		$request_options = $this->get_wrapped_prompt_builder_property_value( $builder, 'requestOptions' );
+
+		$this->assertInstanceOf( RequestOptions::class, $request_options );
+		$this->assertNull( $request_options->getTimeout() );
+	}
+
+	/**
+	 * Test that the constructor disallows overriding the default request timeout with a invalid value.
+	 *
+	 * @ticket 65094
+	 *
+	 * @expectedIncorrectUsage WP_AI_Client_Prompt_Builder::__construct
+	 */
+	public function test_constructor_disallows_overriding_with_negative_request_timeout() {
+		add_filter(
+			'wp_ai_client_default_request_timeout',
+			static function () {
+				return -1;
+			}
+		);
+
+		$builder = new WP_AI_Client_Prompt_Builder( AiClient::defaultRegistry() );
+
+		/** @var RequestOptions $request_options */
+		$request_options = $this->get_wrapped_prompt_builder_property_value( $builder, 'requestOptions' );
+
+		$this->assertInstanceOf( RequestOptions::class, $request_options );
+		$this->assertEquals( 30, $request_options->getTimeout() );
+	}
+
+	/**
+	 * Test that the constructor disallows overriding the default request timeout with a invalid value.
+	 *
+	 * @ticket 65094
+	 *
+	 * @expectedIncorrectUsage WP_AI_Client_Prompt_Builder::__construct
+	 */
+	public function test_constructor_disallows_overriding_with_bad_request_timeout_type() {
+		add_filter( 'wp_ai_client_default_request_timeout', '__return_empty_array' );
+
+		$builder = new WP_AI_Client_Prompt_Builder( AiClient::defaultRegistry() );
+
+		/** @var RequestOptions $request_options */
+		$request_options = $this->get_wrapped_prompt_builder_property_value( $builder, 'requestOptions' );
+
+		$this->assertInstanceOf( RequestOptions::class, $request_options );
+		$this->assertEquals( 30, $request_options->getTimeout() );
 	}
 
 	/**

--- a/tests/phpunit/tests/ai-client/wpAiClientPromptBuilder.php
+++ b/tests/phpunit/tests/ai-client/wpAiClientPromptBuilder.php
@@ -232,7 +232,7 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that the constructor disallows overriding the default request timeout with a invalid value.
+	 * Test that the constructor disallows overriding the default request timeout with an invalid value.
 	 *
 	 * @ticket 65094
 	 *
@@ -256,7 +256,7 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that the constructor disallows overriding the default request timeout with a invalid value.
+	 * Test that the constructor disallows overriding the default request timeout with an invalid value.
 	 *
 	 * @ticket 65094
 	 *

--- a/tests/phpunit/tests/ai-client/wpAiClientPromptBuilder.php
+++ b/tests/phpunit/tests/ai-client/wpAiClientPromptBuilder.php
@@ -236,13 +236,17 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 	 *
 	 * @ticket 65094
 	 *
+	 * @dataProvider data_invalid_request_timeouts
+	 *
 	 * @expectedIncorrectUsage WP_AI_Client_Prompt_Builder::__construct
+	 *
+	 * @param mixed $timeout The invalid timeout value returned by the filter.
 	 */
-	public function test_constructor_disallows_overriding_with_negative_request_timeout() {
+	public function test_constructor_disallows_overriding_with_invalid_request_timeout( $timeout ) {
 		add_filter(
 			'wp_ai_client_default_request_timeout',
-			static function () {
-				return -1;
+			static function () use ( $timeout ) {
+				return $timeout;
 			}
 		);
 
@@ -256,22 +260,15 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that the constructor disallows overriding the default request timeout with an invalid value.
+	 * Data provider for test_constructor_disallows_overriding_with_invalid_request_timeout().
 	 *
-	 * @ticket 65094
-	 *
-	 * @expectedIncorrectUsage WP_AI_Client_Prompt_Builder::__construct
+	 * @return array<string, array{0: mixed}>
 	 */
-	public function test_constructor_disallows_overriding_with_bad_request_timeout_type() {
-		add_filter( 'wp_ai_client_default_request_timeout', '__return_empty_array' );
-
-		$builder = new WP_AI_Client_Prompt_Builder( AiClient::defaultRegistry() );
-
-		/** @var RequestOptions $request_options */
-		$request_options = $this->get_wrapped_prompt_builder_property_value( $builder, 'requestOptions' );
-
-		$this->assertInstanceOf( RequestOptions::class, $request_options );
-		$this->assertEquals( 30, $request_options->getTimeout() );
+	public function data_invalid_request_timeouts(): array {
+		return array(
+			'negative number' => array( -1 ),
+			'array'           => array( array() ),
+		);
 	}
 
 	/**

--- a/tests/phpunit/tests/ai-client/wpAiClientPromptBuilder.php
+++ b/tests/phpunit/tests/ai-client/wpAiClientPromptBuilder.php
@@ -215,23 +215,6 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that the constructor allows overriding the default request timeout with null.
-	 *
-	 * @ticket 65094
-	 */
-	public function test_constructor_allows_overriding_request_timeout_with_null() {
-		add_filter( 'wp_ai_client_default_request_timeout', '__return_null' );
-
-		$builder = new WP_AI_Client_Prompt_Builder( AiClient::defaultRegistry() );
-
-		/** @var RequestOptions $request_options */
-		$request_options = $this->get_wrapped_prompt_builder_property_value( $builder, 'requestOptions' );
-
-		$this->assertInstanceOf( RequestOptions::class, $request_options );
-		$this->assertNull( $request_options->getTimeout() );
-	}
-
-	/**
 	 * Test that the constructor disallows overriding the default request timeout with an invalid value.
 	 *
 	 * @ticket 65094
@@ -256,7 +239,7 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 		$request_options = $this->get_wrapped_prompt_builder_property_value( $builder, 'requestOptions' );
 
 		$this->assertInstanceOf( RequestOptions::class, $request_options );
-		$this->assertSame( 30, $request_options->getTimeout() );
+		$this->assertSame( 30.0, $request_options->getTimeout() );
 	}
 
 	/**
@@ -268,6 +251,7 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 		return array(
 			'negative number' => array( -1 ),
 			'array'           => array( array() ),
+			'null'            => array( null ),
 		);
 	}
 

--- a/tests/phpunit/tests/ai-client/wpAiClientPromptBuilder.php
+++ b/tests/phpunit/tests/ai-client/wpAiClientPromptBuilder.php
@@ -195,12 +195,13 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 	 * Test that the constructor allows overriding the default request timeout with a higher value.
 	 *
 	 * @ticket 64591
+	 * @ticket 65094
 	 */
 	public function test_constructor_allows_overriding_request_timeout_with_higher_value() {
 		add_filter(
 			'wp_ai_client_default_request_timeout',
 			static function () {
-				return 45;
+				return 45.5;
 			}
 		);
 
@@ -210,7 +211,7 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 		$request_options = $this->get_wrapped_prompt_builder_property_value( $builder, 'requestOptions' );
 
 		$this->assertInstanceOf( RequestOptions::class, $request_options );
-		$this->assertEquals( 45, $request_options->getTimeout() );
+		$this->assertEquals( 45.5, $request_options->getTimeout() );
 	}
 
 	/**

--- a/tests/phpunit/tests/ai-client/wpAiClientPromptBuilder.php
+++ b/tests/phpunit/tests/ai-client/wpAiClientPromptBuilder.php
@@ -192,16 +192,21 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that the constructor allows overriding the default request timeout with a higher value.
+	 * Test that the constructor allows overriding the default request timeout with a valid value.
 	 *
 	 * @ticket 64591
 	 * @ticket 65094
+	 *
+	 * @dataProvider data_valid_request_timeout_overrides
+	 *
+	 * @param mixed $input    The timeout value returned by the filter.
+	 * @param float $expected The expected timeout stored on the request options.
 	 */
-	public function test_constructor_allows_overriding_request_timeout_with_higher_value() {
+	public function test_constructor_allows_overriding_request_timeout_with_valid_timeout( $input, float $expected ) {
 		add_filter(
 			'wp_ai_client_default_request_timeout',
-			static function () {
-				return 45.5;
+			static function () use ( $input ) {
+				return $input;
 			}
 		);
 
@@ -211,7 +216,22 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 		$request_options = $this->get_wrapped_prompt_builder_property_value( $builder, 'requestOptions' );
 
 		$this->assertInstanceOf( RequestOptions::class, $request_options );
-		$this->assertSame( 45.5, $request_options->getTimeout() );
+		$this->assertSame( $expected, $request_options->getTimeout() );
+	}
+
+	/**
+	 * Data provider for {@see self::test_constructor_allows_overriding_request_timeout_with_valid_timeout()}.
+	 *
+	 * @return array<string, array{0: mixed, 1: float}>
+	 */
+	public function data_valid_request_timeout_overrides(): array {
+		return array(
+			'float'    => array( 45.5, 45.5 ),
+			'integer'  => array( 67, 67.0 ),
+			'string'   => array( '20', 20.0 ),
+			'infinity' => array( INF, INF ),
+			'zero'     => array( 0.0, 0.0 ),
+		);
 	}
 
 	/**
@@ -243,7 +263,7 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Data provider for test_constructor_disallows_overriding_with_invalid_request_timeout().
+	 * Data provider for {@see self::test_constructor_disallows_overriding_with_invalid_request_timeout()}.
 	 *
 	 * @return array<string, array{0: mixed}>
 	 */


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65094

The primary change here is in `WP_AI_Client_Prompt_Builder::__construct()` to check that the return value of the `wp_ai_client_default_request_timeout` filter is in fact a non-negative `float`. ~It also newly allows the value `null`.~ Otherwise, the filtered value is discarded in favor of using the original default of 30, and a `_doing_it_wrong()` is issued. Without this check, a fatal error would ensue due to an exception being thrown by `\WordPress\AiClient\Providers\Http\DTO\RequestOptions::validateTimeout()`.

In addition to this change, static analysis issues were resolved:

* Use `float` instead of `int` for the `wp_ai_client_default_request_timeout`.
* Adding missing PHP imports for `Message` and `MessagePart` for the PHPDoc for `wp_ai_client_prompt()`.
* Adding PHP type hints for the return values of `wp_ai_client_prompt()` and `\WP_AI_Client_Cache::getMultiple()`.
* Use native property type hints in `WP_AI_Client_HTTP_Client`.

The following PHPStan level 10 issues are resolved:

1. `src/wp-includes/ai-client.php`: Parameter $prompt of function wp_ai_client_prompt() has invalid type Message.
2. `src/wp-includes/ai-client.php`: Parameter $prompt of function wp_ai_client_prompt() has invalid type MessagePart.
3. `src/wp-includes/ai-client/class-wp-ai-client-prompt-builder.php`: Cannot cast mixed to int.


## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 4.7
Used for: Research

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
