### PR TITLE
Tests: Use assertSame() in WP_AI_Client_Prompt_Builder tests.

### DIFF
--- a/tests/phpunit/tests/ai-client/wpAiClientPromptBuilder.php
+++ b/tests/phpunit/tests/ai-client/wpAiClientPromptBuilder.php
@@ -188,7 +188,7 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 		$request_options = $this->get_wrapped_prompt_builder_property_value( $builder, 'requestOptions' );
 
 		$this->assertInstanceOf( RequestOptions::class, $request_options );
-		$this->assertEquals( 30, $request_options->getTimeout() );
+		$this->assertSame( 30.0, $request_options->getTimeout() );
 	}
 
 	/**
@@ -210,7 +210,7 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 		$request_options = $this->get_wrapped_prompt_builder_property_value( $builder, 'requestOptions' );
 
 		$this->assertInstanceOf( RequestOptions::class, $request_options );
-		$this->assertEquals( 45, $request_options->getTimeout() );
+		$this->assertSame( 45.0, $request_options->getTimeout() );
 	}
 
 	/**
@@ -401,7 +401,7 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 
 		$this->assertCount( 1, $messages );
 		$this->assertInstanceOf( Message::class, $messages[0] );
-		$this->assertEquals( 'Hello, world!', $messages[0]->getParts()[0]->getText() );
+		$this->assertSame( 'Hello, world!', $messages[0]->getParts()[0]->getText() );
 	}
 
 	/**
@@ -418,7 +418,7 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 
 		$this->assertCount( 1, $messages );
 		$this->assertInstanceOf( Message::class, $messages[0] );
-		$this->assertEquals( 'Test message', $messages[0]->getParts()[0]->getText() );
+		$this->assertSame( 'Test message', $messages[0]->getParts()[0]->getText() );
 	}
 
 	/**
@@ -479,7 +479,7 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 
 		$this->assertCount( 1, $messages );
 		$this->assertInstanceOf( Message::class, $messages[0] );
-		$this->assertEquals( 'Hello from array', $messages[0]->getParts()[0]->getText() );
+		$this->assertSame( 'Hello from array', $messages[0]->getParts()[0]->getText() );
 	}
 
 	/**
@@ -497,7 +497,7 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 		$messages = $this->get_wrapped_prompt_builder_property_value( $builder, 'messages' );
 
 		$this->assertCount( 1, $messages );
-		$this->assertEquals( 'Some text', $messages[0]->getParts()[0]->getText() );
+		$this->assertSame( 'Some text', $messages[0]->getParts()[0]->getText() );
 	}
 
 	/**
@@ -515,8 +515,8 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 		$this->assertCount( 1, $messages );
 		$parts = $messages[0]->getParts();
 		$this->assertCount( 2, $parts );
-		$this->assertEquals( 'Initial text', $parts[0]->getText() );
-		$this->assertEquals( ' Additional text', $parts[1]->getText() );
+		$this->assertSame( 'Initial text', $parts[0]->getText() );
+		$this->assertSame( ' Additional text', $parts[1]->getText() );
 	}
 
 	/**
@@ -537,8 +537,8 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 		$this->assertCount( 1, $messages );
 		$file = $messages[0]->getParts()[0]->getFile();
 		$this->assertInstanceOf( File::class, $file );
-		$this->assertEquals( 'data:image/png;base64,' . $base64, $file->getDataUri() );
-		$this->assertEquals( 'image/png', $file->getMimeType() );
+		$this->assertSame( 'data:image/png;base64,' . $base64, $file->getDataUri() );
+		$this->assertSame( 'image/png', $file->getMimeType() );
 	}
 
 	/**
@@ -558,8 +558,8 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 		$this->assertCount( 1, $messages );
 		$file = $messages[0]->getParts()[0]->getFile();
 		$this->assertInstanceOf( File::class, $file );
-		$this->assertEquals( 'https://example.com/image.jpg', $file->getUrl() );
-		$this->assertEquals( 'image/jpeg', $file->getMimeType() );
+		$this->assertSame( 'https://example.com/image.jpg', $file->getUrl() );
+		$this->assertSame( 'image/jpeg', $file->getMimeType() );
 	}
 
 	/**
@@ -580,7 +580,7 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 		$this->assertCount( 1, $messages );
 		$file = $messages[0]->getParts()[0]->getFile();
 		$this->assertInstanceOf( File::class, $file );
-		$this->assertEquals( 'image/jpeg', $file->getMimeType() );
+		$this->assertSame( 'image/jpeg', $file->getMimeType() );
 	}
 
 	/**
@@ -600,8 +600,8 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 		$this->assertCount( 1, $messages );
 		$file = $messages[0]->getParts()[0]->getFile();
 		$this->assertInstanceOf( File::class, $file );
-		$this->assertEquals( 'https://example.com/audio.mp3', $file->getUrl() );
-		$this->assertEquals( 'audio/mpeg', $file->getMimeType() );
+		$this->assertSame( 'https://example.com/audio.mp3', $file->getUrl() );
+		$this->assertSame( 'audio/mpeg', $file->getMimeType() );
 	}
 
 	/**
@@ -644,9 +644,9 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 		$this->assertCount( 1, $messages );
 		$parts = $messages[0]->getParts();
 		$this->assertCount( 3, $parts );
-		$this->assertEquals( 'Part 1', $parts[0]->getText() );
-		$this->assertEquals( 'Part 2', $parts[1]->getText() );
-		$this->assertEquals( 'Part 3', $parts[2]->getText() );
+		$this->assertSame( 'Part 1', $parts[0]->getText() );
+		$this->assertSame( 'Part 2', $parts[1]->getText() );
+		$this->assertSame( 'Part 3', $parts[2]->getText() );
 	}
 
 	/**
@@ -670,9 +670,9 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 		$messages = $this->get_wrapped_prompt_builder_property_value( $builder, 'messages' );
 
 		$this->assertCount( 3, $messages );
-		$this->assertEquals( 'User 1', $messages[0]->getParts()[0]->getText() );
-		$this->assertEquals( 'Model 1', $messages[1]->getParts()[0]->getText() );
-		$this->assertEquals( 'User 2', $messages[2]->getParts()[0]->getText() );
+		$this->assertSame( 'User 1', $messages[0]->getParts()[0]->getText() );
+		$this->assertSame( 'Model 1', $messages[1]->getParts()[0]->getText() );
+		$this->assertSame( 'User 2', $messages[2]->getParts()[0]->getText() );
 	}
 
 	/**
@@ -710,9 +710,9 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 		$this->assertInstanceOf( Message::class, $messages[0] );
 		$parts = $messages[0]->getParts();
 		$this->assertCount( 3, $parts );
-		$this->assertEquals( 'Part 1', $parts[0]->getText() );
-		$this->assertEquals( 'Part 2', $parts[1]->getText() );
-		$this->assertEquals( 'Part 3', $parts[2]->getText() );
+		$this->assertSame( 'Part 1', $parts[0]->getText() );
+		$this->assertSame( 'Part 2', $parts[1]->getText() );
+		$this->assertSame( 'Part 3', $parts[2]->getText() );
 	}
 
 	/**
@@ -735,9 +735,9 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 		$this->assertCount( 1, $messages );
 		$parts = $messages[0]->getParts();
 		$this->assertCount( 3, $parts );
-		$this->assertEquals( 'String part', $parts[0]->getText() );
-		$this->assertEquals( 'Part 1', $parts[1]->getText() );
-		$this->assertEquals( 'Part 2', $parts[2]->getText() );
+		$this->assertSame( 'String part', $parts[0]->getText() );
+		$this->assertSame( 'Part 1', $parts[1]->getText() );
+		$this->assertSame( 'Part 2', $parts[2]->getText() );
 	}
 
 	/**
@@ -775,13 +775,13 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 		/** @var ModelConfig $config */
 		$config = $this->get_wrapped_prompt_builder_property_value( $builder, 'modelConfig' );
 
-		$this->assertEquals( 'Be helpful', $config->getSystemInstruction() );
-		$this->assertEquals( 500, $config->getMaxTokens() );
-		$this->assertEquals( 0.8, $config->getTemperature() );
-		$this->assertEquals( 0.95, $config->getTopP() );
-		$this->assertEquals( 50, $config->getTopK() );
-		$this->assertEquals( 2, $config->getCandidateCount() );
-		$this->assertEquals( 'application/json', $config->getOutputMimeType() );
+		$this->assertSame( 'Be helpful', $config->getSystemInstruction() );
+		$this->assertSame( 500, $config->getMaxTokens() );
+		$this->assertSame( 0.8, $config->getTemperature() );
+		$this->assertSame( 0.95, $config->getTopP() );
+		$this->assertSame( 50, $config->getTopK() );
+		$this->assertSame( 2, $config->getCandidateCount() );
+		$this->assertSame( 'application/json', $config->getOutputMimeType() );
 	}
 
 	/**
@@ -1001,11 +1001,11 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 		/** @var ModelConfig $merged_config */
 		$merged_config = $this->get_wrapped_prompt_builder_property_value( $builder, 'modelConfig' );
 
-		$this->assertEquals( 'Builder instruction', $merged_config->getSystemInstruction() );
-		$this->assertEquals( 500, $merged_config->getMaxTokens() );
-		$this->assertEquals( 0.5, $merged_config->getTemperature() );
-		$this->assertEquals( 0.9, $merged_config->getTopP() );
-		$this->assertEquals( 40, $merged_config->getTopK() );
+		$this->assertSame( 'Builder instruction', $merged_config->getSystemInstruction() );
+		$this->assertSame( 500, $merged_config->getMaxTokens() );
+		$this->assertSame( 0.5, $merged_config->getTemperature() );
+		$this->assertSame( 0.9, $merged_config->getTopP() );
+		$this->assertSame( 40, $merged_config->getTopK() );
 	}
 
 	/**
@@ -1028,22 +1028,22 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 
 		$this->assertArrayHasKey( 'stopSequences', $custom_options );
 		$this->assertIsArray( $custom_options['stopSequences'] );
-		$this->assertEquals( array( 'CONFIG_STOP' ), $custom_options['stopSequences'] );
+		$this->assertSame( array( 'CONFIG_STOP' ), $custom_options['stopSequences'] );
 		$this->assertArrayHasKey( 'otherOption', $custom_options );
-		$this->assertEquals( 'value', $custom_options['otherOption'] );
+		$this->assertSame( 'value', $custom_options['otherOption'] );
 
 		$builder->using_stop_sequences( 'STOP' );
 
 		/** @var ModelConfig $merged_config */
 		$merged_config = $this->get_wrapped_prompt_builder_property_value( $builder, 'modelConfig' );
 
-		$this->assertEquals( array( 'STOP' ), $merged_config->getStopSequences() );
+		$this->assertSame( array( 'STOP' ), $merged_config->getStopSequences() );
 
 		$custom_options = $merged_config->getCustomOptions();
 		$this->assertArrayHasKey( 'stopSequences', $custom_options );
-		$this->assertEquals( array( 'CONFIG_STOP' ), $custom_options['stopSequences'] );
+		$this->assertSame( array( 'CONFIG_STOP' ), $custom_options['stopSequences'] );
 		$this->assertArrayHasKey( 'otherOption', $custom_options );
-		$this->assertEquals( 'value', $custom_options['otherOption'] );
+		$this->assertSame( 'value', $custom_options['otherOption'] );
 	}
 
 	/**
@@ -1058,7 +1058,7 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 		$this->assertSame( $builder, $result );
 
 		$actual_provider = $this->get_wrapped_prompt_builder_property_value( $builder, 'providerIdOrClassName' );
-		$this->assertEquals( 'test-provider', $actual_provider );
+		$this->assertSame( 'test-provider', $actual_provider );
 	}
 
 	/**
@@ -1075,7 +1075,7 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 		/** @var ModelConfig $config */
 		$config = $this->get_wrapped_prompt_builder_property_value( $builder, 'modelConfig' );
 
-		$this->assertEquals( 'You are a helpful assistant.', $config->getSystemInstruction() );
+		$this->assertSame( 'You are a helpful assistant.', $config->getSystemInstruction() );
 	}
 
 	/**
@@ -1092,7 +1092,7 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 		/** @var ModelConfig $config */
 		$config = $this->get_wrapped_prompt_builder_property_value( $builder, 'modelConfig' );
 
-		$this->assertEquals( 1000, $config->getMaxTokens() );
+		$this->assertSame( 1000, $config->getMaxTokens() );
 	}
 
 	/**
@@ -1109,7 +1109,7 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 		/** @var ModelConfig $config */
 		$config = $this->get_wrapped_prompt_builder_property_value( $builder, 'modelConfig' );
 
-		$this->assertEquals( 0.7, $config->getTemperature() );
+		$this->assertSame( 0.7, $config->getTemperature() );
 	}
 
 	/**
@@ -1126,7 +1126,7 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 		/** @var ModelConfig $config */
 		$config = $this->get_wrapped_prompt_builder_property_value( $builder, 'modelConfig' );
 
-		$this->assertEquals( 0.9, $config->getTopP() );
+		$this->assertSame( 0.9, $config->getTopP() );
 	}
 
 	/**
@@ -1143,7 +1143,7 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 		/** @var ModelConfig $config */
 		$config = $this->get_wrapped_prompt_builder_property_value( $builder, 'modelConfig' );
 
-		$this->assertEquals( 40, $config->getTopK() );
+		$this->assertSame( 40, $config->getTopK() );
 	}
 
 	/**
@@ -1160,7 +1160,7 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 		/** @var ModelConfig $config */
 		$config = $this->get_wrapped_prompt_builder_property_value( $builder, 'modelConfig' );
 
-		$this->assertEquals( array( 'STOP', 'END', '###' ), $config->getStopSequences() );
+		$this->assertSame( array( 'STOP', 'END', '###' ), $config->getStopSequences() );
 	}
 
 	/**
@@ -1177,7 +1177,7 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 		/** @var ModelConfig $config */
 		$config = $this->get_wrapped_prompt_builder_property_value( $builder, 'modelConfig' );
 
-		$this->assertEquals( 3, $config->getCandidateCount() );
+		$this->assertSame( 3, $config->getCandidateCount() );
 	}
 
 	/**
@@ -1194,7 +1194,7 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 		/** @var ModelConfig $config */
 		$config = $this->get_wrapped_prompt_builder_property_value( $builder, 'modelConfig' );
 
-		$this->assertEquals( 'application/json', $config->getOutputMimeType() );
+		$this->assertSame( 'application/json', $config->getOutputMimeType() );
 	}
 
 	/**
@@ -1218,7 +1218,7 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 		/** @var ModelConfig $config */
 		$config = $this->get_wrapped_prompt_builder_property_value( $builder, 'modelConfig' );
 
-		$this->assertEquals( $schema, $config->getOutputSchema() );
+		$this->assertSame( $schema, $config->getOutputSchema() );
 	}
 
 	/**
@@ -1258,7 +1258,7 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 		/** @var ModelConfig $config */
 		$config = $this->get_wrapped_prompt_builder_property_value( $builder, 'modelConfig' );
 
-		$this->assertEquals( 'application/json', $config->getOutputMimeType() );
+		$this->assertSame( 'application/json', $config->getOutputMimeType() );
 	}
 
 	/**
@@ -1276,8 +1276,8 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 		/** @var ModelConfig $config */
 		$config = $this->get_wrapped_prompt_builder_property_value( $builder, 'modelConfig' );
 
-		$this->assertEquals( 'application/json', $config->getOutputMimeType() );
-		$this->assertEquals( $schema, $config->getOutputSchema() );
+		$this->assertSame( 'application/json', $config->getOutputMimeType() );
+		$this->assertSame( $schema, $config->getOutputSchema() );
 	}
 
 	/**
@@ -1824,14 +1824,14 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 		$texts = $builder->generate_texts( 3 );
 
 		$this->assertCount( 3, $texts );
-		$this->assertEquals( 'Text 1', $texts[0] );
-		$this->assertEquals( 'Text 2', $texts[1] );
-		$this->assertEquals( 'Text 3', $texts[2] );
+		$this->assertSame( 'Text 1', $texts[0] );
+		$this->assertSame( 'Text 2', $texts[1] );
+		$this->assertSame( 'Text 3', $texts[2] );
 
 		/** @var ModelConfig $config */
 		$config = $this->get_wrapped_prompt_builder_property_value( $builder, 'modelConfig' );
 
-		$this->assertEquals( 3, $config->getCandidateCount() );
+		$this->assertSame( 3, $config->getCandidateCount() );
 	}
 
 	/**
@@ -2255,7 +2255,7 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 		/** @var ModelConfig $config */
 		$config = $this->get_wrapped_prompt_builder_property_value( $builder, 'modelConfig' );
 
-		$this->assertEquals( '16:9', $config->getOutputMediaAspectRatio() );
+		$this->assertSame( '16:9', $config->getOutputMediaAspectRatio() );
 	}
 
 	/**
@@ -2272,7 +2272,7 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 		/** @var ModelConfig $config */
 		$config = $this->get_wrapped_prompt_builder_property_value( $builder, 'modelConfig' );
 
-		$this->assertEquals( 'alloy', $config->getOutputSpeechVoice() );
+		$this->assertSame( 'alloy', $config->getOutputSpeechVoice() );
 	}
 
 	/**
@@ -2290,8 +2290,8 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 
 		$this->assertNotNull( $declarations );
 		$this->assertCount( 1, $declarations );
-		$this->assertEquals( 'wpab__wpaiclienttests__simple', $declarations[0]->getName() );
-		$this->assertEquals( 'A simple test ability with no parameters.', $declarations[0]->getDescription() );
+		$this->assertSame( 'wpab__wpaiclienttests__simple', $declarations[0]->getName() );
+		$this->assertSame( 'A simple test ability with no parameters.', $declarations[0]->getDescription() );
 	}
 
 	/**
@@ -2311,8 +2311,8 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 
 		$this->assertNotNull( $declarations );
 		$this->assertCount( 1, $declarations );
-		$this->assertEquals( 'wpab__wpaiclienttests__with-params', $declarations[0]->getName() );
-		$this->assertEquals( 'A test ability that accepts parameters.', $declarations[0]->getDescription() );
+		$this->assertSame( 'wpab__wpaiclienttests__with-params', $declarations[0]->getName() );
+		$this->assertSame( 'A test ability that accepts parameters.', $declarations[0]->getDescription() );
 
 		$params = $declarations[0]->getParameters();
 		$this->assertNotNull( $params );
@@ -2339,9 +2339,9 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 
 		$this->assertNotNull( $declarations );
 		$this->assertCount( 3, $declarations );
-		$this->assertEquals( 'wpab__wpaiclienttests__simple', $declarations[0]->getName() );
-		$this->assertEquals( 'wpab__wpaiclienttests__with-params', $declarations[1]->getName() );
-		$this->assertEquals( 'wpab__wpaiclienttests__returns-error', $declarations[2]->getName() );
+		$this->assertSame( 'wpab__wpaiclienttests__simple', $declarations[0]->getName() );
+		$this->assertSame( 'wpab__wpaiclienttests__with-params', $declarations[1]->getName() );
+		$this->assertSame( 'wpab__wpaiclienttests__returns-error', $declarations[2]->getName() );
 	}
 
 	/**
@@ -2367,8 +2367,8 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 
 		$this->assertNotNull( $declarations );
 		$this->assertCount( 2, $declarations );
-		$this->assertEquals( 'wpab__wpaiclienttests__simple', $declarations[0]->getName() );
-		$this->assertEquals( 'wpab__wpaiclienttests__with-params', $declarations[1]->getName() );
+		$this->assertSame( 'wpab__wpaiclienttests__simple', $declarations[0]->getName() );
+		$this->assertSame( 'wpab__wpaiclienttests__with-params', $declarations[1]->getName() );
 	}
 
 	/**
@@ -2407,8 +2407,8 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 
 		$this->assertNotNull( $declarations );
 		$this->assertCount( 2, $declarations );
-		$this->assertEquals( 'wpab__wpaiclienttests__simple', $declarations[0]->getName() );
-		$this->assertEquals( 'wpab__wpaiclienttests__with-params', $declarations[1]->getName() );
+		$this->assertSame( 'wpab__wpaiclienttests__simple', $declarations[0]->getName() );
+		$this->assertSame( 'wpab__wpaiclienttests__with-params', $declarations[1]->getName() );
 	}
 
 	/**
@@ -2426,7 +2426,7 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 
 		$this->assertNotNull( $declarations );
 		$this->assertCount( 1, $declarations );
-		$this->assertEquals( 'wpab__wpaiclienttests__hyphen-test', $declarations[0]->getName() );
+		$this->assertSame( 'wpab__wpaiclienttests__hyphen-test', $declarations[0]->getName() );
 	}
 
 	/**
@@ -2448,13 +2448,13 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 
 		$this->assertNotNull( $declarations );
 		$this->assertCount( 1, $declarations );
-		$this->assertEquals( 'wpab__wpaiclienttests__simple', $declarations[0]->getName() );
+		$this->assertSame( 'wpab__wpaiclienttests__simple', $declarations[0]->getName() );
 
 		/** @var ModelConfig $config */
 		$config = $this->get_wrapped_prompt_builder_property_value( $builder, 'modelConfig' );
 
-		$this->assertEquals( 'You are a helpful assistant', $config->getSystemInstruction() );
-		$this->assertEquals( 500, $config->getMaxTokens() );
+		$this->assertSame( 'You are a helpful assistant', $config->getSystemInstruction() );
+		$this->assertSame( 500, $config->getMaxTokens() );
 	}
 
 	/**


### PR DESCRIPTION
Migrates `assertEquals()` to `assertSame()` in `tests/phpunit/tests/ai-client/wpAiClientPromptBuilder.php`.

All 78 `assertEquals()` calls compare scalar values (strings, ints, floats, or string arrays), so strict `===` comparison is appropriate. Two assertions comparing timeout values were updated to use float literals (`30.0`, `45.0`) to match the actual return type of `getTimeout()`.                                                                              

172 tests, 439 assertions — all passing.


See https://core.trac.wordpress.org/ticket/64324