### PR TITLE
Rewrite: Skip verbose page rules when permalink structure has a disambiguating stub

### DIFF
--- a/src/wp-includes/class-wp-rewrite.php
+++ b/src/wp-includes/class-wp-rewrite.php
@@ -1938,11 +1938,13 @@ class WP_Rewrite {
 		$this->use_trailing_slashes = str_ends_with( $this->permalink_structure, '/' );
 
 		// Enable generic rules for pages if permalink structure doesn't begin with a wildcard.
-		if ( preg_match( '/^[^%]*%(?:postname|category|tag|author)%/', $this->permalink_structure ) ) {
-			$this->use_verbose_page_rules = true;
-		} else {
-			$this->use_verbose_page_rules = false;
+		$clean_structure = str_replace( '/' . $this->index, '', $this->permalink_structure );
+
+		if ( is_multisite() && ! is_subdomain_install() && is_main_site() ) {
+			$clean_structure = preg_replace( '/^\/\w+/', '', $clean_structure, 1 );
 		}
+
+		$this->use_verbose_page_rules = (bool) preg_match( '#^/?%(?:postname|category|tag|author)%#', $clean_structure );
 	}
 
 	/**

--- a/tests/phpunit/tests/rewrite.php
+++ b/tests/phpunit/tests/rewrite.php
@@ -504,4 +504,20 @@ class Tests_Rewrite extends WP_UnitTestCase {
 		$this->assertIsArray( $rewrite_rules );
 		$this->assertNotEmpty( $rewrite_rules );
 	}
+
+	public function test_verbose_page_rules_enabled_without_stub() {
+		global $wp_rewrite;
+
+		$structures_expecting_true = array(
+			'/%postname%/',
+			'/%category%/%postname%/',
+			'/%tag%/%postname%/',
+			'/%author%/%postname%/',
+		);
+
+		foreach ( $structures_expecting_true as $structure ) {
+			$this->set_permalink_structure( $structure );
+			$this->assertTrue( $wp_rewrite->use_verbose_page_rules, "Expected true for: $structure" );
+		}
+	}
 }

--- a/tests/phpunit/tests/rewrite.php
+++ b/tests/phpunit/tests/rewrite.php
@@ -520,4 +520,23 @@ class Tests_Rewrite extends WP_UnitTestCase {
 			$this->assertTrue( $wp_rewrite->use_verbose_page_rules, "Expected true for: $structure" );
 		}
 	}
+
+	public function test_verbose_page_rules_disabled_with_stub() {
+		global $wp_rewrite;
+
+		$structures_expecting_false = array(
+			'/news/%postname%/',
+			'/blog/%postname%/',
+			'/news-and-events/%postname%/',
+			'/articles/%category%/%postname%/',
+			'/%year%/%monthnum%/%postname%/',
+			'/%year%/%postname%/',
+			'/archives/%post_id%',
+		);
+
+		foreach ( $structures_expecting_false as $structure ) {
+			$this->set_permalink_structure( $structure );
+			$this->assertFalse( $wp_rewrite->use_verbose_page_rules, "Expected false for: $structure" );
+		}
+	}
 }

--- a/tests/phpunit/tests/rewrite.php
+++ b/tests/phpunit/tests/rewrite.php
@@ -505,6 +505,10 @@ class Tests_Rewrite extends WP_UnitTestCase {
 		$this->assertNotEmpty( $rewrite_rules );
 	}
 
+	/**
+	 *
+	 * @ticket 9824
+	 */
 	public function test_verbose_page_rules_enabled_without_stub() {
 		global $wp_rewrite;
 
@@ -521,6 +525,10 @@ class Tests_Rewrite extends WP_UnitTestCase {
 		}
 	}
 
+	/**
+	 *
+	 * @ticket 9824
+	 */
 	public function test_verbose_page_rules_disabled_with_stub() {
 		global $wp_rewrite;
 


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/9824

When a permalink structure like `/news-and-events/%postname%/` is used, the existing regex incorrectly sets `use_verbose_page_rules` to true. The regex `^[^%]*%(?:postname|category|tag|author)%` matches any non-% characters before the tag, including literal path stubs. This causes pages and paginated archive URLs to resolve incorrectly, because rewrite rule ordering and the extra get_page_by_path() disambiguation check are applied when they aren't needed.

This PR fixes that by using a tighter regex `(^/?%(?:postname|category|tag|author)%)` that only matches when the ambiguous tag is the very first path component. When a literal stub like /news/ precedes the tag, verbose page rules are correctly skipped.

Props mdawaffe for the original Trac patch.

#### Testing

Run tests by - 

```
npm run test:php -- --filter=Tests_Rewrite
```

#### Use of AI Tools

For creating and testing the regex
