### PR TITLE
Upgrade/Install: Show and select translation updates on the Updates screen

### DIFF
--- a/src/wp-admin/includes/class-language-pack-upgrader.php
+++ b/src/wp-admin/includes/class-language-pack-upgrader.php
@@ -70,6 +70,10 @@ class Language_Pack_Upgrader extends WP_Upgrader {
 		foreach ( $language_updates as $key => $language_update ) {
 			$update = ! empty( $language_update->autoupdate );
 
+			if ( wp_is_translation_update_deferred( $language_update ) ) {
+				$update = false;
+			}
+
 			/**
 			 * Filters whether to asynchronously update translation for core, a plugin, or a theme.
 			 *

--- a/src/wp-admin/includes/class-language-pack-upgrader.php
+++ b/src/wp-admin/includes/class-language-pack-upgrader.php
@@ -67,10 +67,12 @@ class Language_Pack_Upgrader extends WP_Upgrader {
 			return;
 		}
 
+		$deferred_updates = wp_get_deferred_translation_updates( $language_updates );
+
 		foreach ( $language_updates as $key => $language_update ) {
 			$update = ! empty( $language_update->autoupdate );
 
-			if ( wp_is_translation_update_deferred( $language_update ) ) {
+			if ( $update && wp_is_translation_update_deferred( $language_update, $deferred_updates ) ) {
 				$update = false;
 			}
 

--- a/src/wp-admin/includes/class-wp-automatic-updater.php
+++ b/src/wp-admin/includes/class-wp-automatic-updater.php
@@ -229,6 +229,10 @@ class WP_Automatic_Updater {
 			}
 		} else {
 			$update = ! empty( $item->autoupdate );
+
+			if ( wp_is_translation_update_deferred( $item ) ) {
+				$update = false;
+			}
 		}
 
 		// If the `disable_autoupdate` flag is set, override any user-choice, but allow filters.

--- a/src/wp-admin/includes/class-wp-automatic-updater.php
+++ b/src/wp-admin/includes/class-wp-automatic-updater.php
@@ -230,7 +230,7 @@ class WP_Automatic_Updater {
 		} else {
 			$update = ! empty( $item->autoupdate );
 
-			if ( wp_is_translation_update_deferred( $item ) ) {
+			if ( $update && wp_is_translation_update_deferred( $item ) ) {
 				$update = false;
 			}
 		}

--- a/src/wp-admin/includes/update.php
+++ b/src/wp-admin/includes/update.php
@@ -642,6 +642,136 @@ function get_theme_updates() {
 }
 
 /**
+ * Gets the display name for a translation update.
+ *
+ * @since 6.7.0
+ *
+ * @param object $update Translation update object.
+ * @return string The translation update name.
+ */
+function wp_get_translation_update_name( $update ) {
+	$type = isset( $update->type ) ? $update->type : '';
+	$slug = isset( $update->slug ) ? $update->slug : '';
+
+	switch ( $type ) {
+		case 'core':
+			return 'WordPress'; // Not translated.
+
+		case 'theme':
+			$theme = wp_get_theme( $slug );
+			if ( $theme->exists() ) {
+				return $theme->get( 'Name' );
+			}
+			break;
+
+		case 'plugin':
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+
+			$plugin_names  = array();
+			$all_plugins   = get_plugins();
+			$plugin_update = get_site_transient( 'update_plugins' );
+
+			if ( is_object( $plugin_update ) ) {
+				$plugin_updates = array();
+
+				if ( ! empty( $plugin_update->response ) && is_array( $plugin_update->response ) ) {
+					$plugin_updates = array_merge( $plugin_updates, $plugin_update->response );
+				}
+
+				if ( ! empty( $plugin_update->no_update ) && is_array( $plugin_update->no_update ) ) {
+					$plugin_updates = array_merge( $plugin_updates, $plugin_update->no_update );
+				}
+
+				foreach ( $plugin_updates as $plugin_file => $plugin_data ) {
+					$plugin_data = (object) $plugin_data;
+
+					if ( ! empty( $plugin_data->slug ) && ! empty( $all_plugins[ $plugin_file ]['Name'] ) ) {
+						$plugin_names[ $plugin_data->slug ] = $all_plugins[ $plugin_file ]['Name'];
+					}
+				}
+			}
+
+			foreach ( $all_plugins as $plugin_file => $plugin_data ) {
+				$plugin_basename = dirname( $plugin_file );
+
+				if ( isset( $plugin_data['Name'] ) ) {
+					$plugin_names[ $plugin_file ]                     = $plugin_data['Name'];
+					$plugin_names[ basename( $plugin_file, '.php' ) ] = $plugin_data['Name'];
+
+					if ( '.' !== $plugin_basename ) {
+						$plugin_names[ $plugin_basename ] = $plugin_data['Name'];
+					}
+				}
+			}
+
+			if ( ! empty( $plugin_names[ $slug ] ) ) {
+				return $plugin_names[ $slug ];
+			}
+			break;
+	}
+
+	return $slug;
+}
+
+/**
+ * Gets the display language for a translation update.
+ *
+ * @since 6.7.0
+ *
+ * @param string $locale Translation update locale.
+ * @return string The translation update language.
+ */
+function wp_get_translation_update_language( $locale ) {
+	$translations = get_site_transient( 'available_translations' );
+
+	if ( is_array( $translations ) && ! empty( $translations[ $locale ]['native_name'] ) ) {
+		return sprintf(
+			/* translators: 1: Native language name, 2: Locale. */
+			__( '%1$s (%2$s)' ),
+			$translations[ $locale ]['native_name'],
+			$locale
+		);
+	}
+
+	return $locale;
+}
+
+/**
+ * Gets display data for available translation updates.
+ *
+ * @since 6.7.0
+ *
+ * @return array[] {
+ *     An array of translation update display data.
+ *
+ *     @type string $language      Translation update language.
+ *     @type string $language_code Translation update locale.
+ *     @type string $name          Translation update name.
+ *     @type string $slug          Translation update slug.
+ *     @type string $type          Translation update type.
+ *     @type string $version       Translation update version.
+ * }
+ */
+function wp_get_translation_update_data() {
+	$translation_updates = array();
+
+	foreach ( wp_get_translation_updates() as $update ) {
+		$language = isset( $update->language ) ? $update->language : '';
+
+		$translation_updates[] = array(
+			'language'      => wp_get_translation_update_language( $language ),
+			'language_code' => $language,
+			'name'          => wp_get_translation_update_name( $update ),
+			'slug'          => isset( $update->slug ) ? $update->slug : '',
+			'type'          => isset( $update->type ) ? $update->type : '',
+			'version'       => isset( $update->version ) ? $update->version : '',
+		);
+	}
+
+	return $translation_updates;
+}
+
+/**
  * Adds a callback to display update information for themes with updates available.
  *
  * @since 3.1.0

--- a/src/wp-admin/includes/update.php
+++ b/src/wp-admin/includes/update.php
@@ -642,14 +642,66 @@ function get_theme_updates() {
 }
 
 /**
+ * Gets plugin names for translation updates.
+ *
+ * @since 7.1.0
+ *
+ * @return string[] Plugin names keyed by plugin file, directory, basename, and slug.
+ */
+function wp_get_translation_update_plugin_names() {
+	require_once ABSPATH . 'wp-admin/includes/plugin.php';
+
+	$plugin_names  = array();
+	$all_plugins   = get_plugins();
+	$plugin_update = get_site_transient( 'update_plugins' );
+
+	if ( is_object( $plugin_update ) ) {
+		$plugin_updates = array();
+
+		if ( ! empty( $plugin_update->response ) && is_array( $plugin_update->response ) ) {
+			$plugin_updates = array_merge( $plugin_updates, $plugin_update->response );
+		}
+
+		if ( ! empty( $plugin_update->no_update ) && is_array( $plugin_update->no_update ) ) {
+			$plugin_updates = array_merge( $plugin_updates, $plugin_update->no_update );
+		}
+
+		foreach ( $plugin_updates as $plugin_file => $plugin_data ) {
+			$plugin_data = (object) $plugin_data;
+
+			if ( ! empty( $plugin_data->slug ) && ! empty( $all_plugins[ $plugin_file ]['Name'] ) ) {
+				$plugin_names[ $plugin_data->slug ] = $all_plugins[ $plugin_file ]['Name'];
+			}
+		}
+	}
+
+	foreach ( $all_plugins as $plugin_file => $plugin_data ) {
+		$plugin_basename = dirname( $plugin_file );
+
+		if ( isset( $plugin_data['Name'] ) ) {
+			$plugin_names[ $plugin_file ]                     = $plugin_data['Name'];
+			$plugin_names[ basename( $plugin_file, '.php' ) ] = $plugin_data['Name'];
+
+			if ( '.' !== $plugin_basename ) {
+				$plugin_names[ $plugin_basename ] = $plugin_data['Name'];
+			}
+		}
+	}
+
+	return $plugin_names;
+}
+
+/**
  * Gets the display name for a translation update.
  *
  * @since 7.1.0
  *
- * @param object $update Translation update object.
+ * @param object        $update       Translation update object.
+ * @param string[]|null $plugin_names Optional. Plugin names keyed by plugin file, directory,
+ *                                    basename, and slug. Default null.
  * @return string The translation update name.
  */
-function wp_get_translation_update_name( $update ) {
+function wp_get_translation_update_name( $update, $plugin_names = null ) {
 	$type = isset( $update->type ) ? $update->type : '';
 	$slug = isset( $update->slug ) ? $update->slug : '';
 
@@ -665,43 +717,8 @@ function wp_get_translation_update_name( $update ) {
 			break;
 
 		case 'plugin':
-			require_once ABSPATH . 'wp-admin/includes/plugin.php';
-
-			$plugin_names  = array();
-			$all_plugins   = get_plugins();
-			$plugin_update = get_site_transient( 'update_plugins' );
-
-			if ( is_object( $plugin_update ) ) {
-				$plugin_updates = array();
-
-				if ( ! empty( $plugin_update->response ) && is_array( $plugin_update->response ) ) {
-					$plugin_updates = array_merge( $plugin_updates, $plugin_update->response );
-				}
-
-				if ( ! empty( $plugin_update->no_update ) && is_array( $plugin_update->no_update ) ) {
-					$plugin_updates = array_merge( $plugin_updates, $plugin_update->no_update );
-				}
-
-				foreach ( $plugin_updates as $plugin_file => $plugin_data ) {
-					$plugin_data = (object) $plugin_data;
-
-					if ( ! empty( $plugin_data->slug ) && ! empty( $all_plugins[ $plugin_file ]['Name'] ) ) {
-						$plugin_names[ $plugin_data->slug ] = $all_plugins[ $plugin_file ]['Name'];
-					}
-				}
-			}
-
-			foreach ( $all_plugins as $plugin_file => $plugin_data ) {
-				$plugin_basename = dirname( $plugin_file );
-
-				if ( isset( $plugin_data['Name'] ) ) {
-					$plugin_names[ $plugin_file ]                     = $plugin_data['Name'];
-					$plugin_names[ basename( $plugin_file, '.php' ) ] = $plugin_data['Name'];
-
-					if ( '.' !== $plugin_basename ) {
-						$plugin_names[ $plugin_basename ] = $plugin_data['Name'];
-					}
-				}
+			if ( null === $plugin_names ) {
+				$plugin_names = wp_get_translation_update_plugin_names();
 			}
 
 			if ( ! empty( $plugin_names[ $slug ] ) ) {
@@ -758,12 +775,18 @@ function wp_get_translation_update_language( $locale ) {
 function wp_get_translation_update_data() {
 	$available_updates            = wp_get_translation_updates();
 	$deferred_translation_updates = wp_get_deferred_translation_updates( $available_updates );
+	$plugin_names                 = null;
 	$translation_updates          = array();
 
 	foreach ( $available_updates as $update ) {
 		$translation_update_id = wp_get_translation_update_id( $update );
 		$language              = isset( $update->language ) ? $update->language : '';
+		$type                  = isset( $update->type ) ? $update->type : '';
 		$deferred              = isset( $deferred_translation_updates[ $translation_update_id ] );
+
+		if ( 'plugin' === $type && null === $plugin_names ) {
+			$plugin_names = wp_get_translation_update_plugin_names();
+		}
 
 		$translation_updates[] = array(
 			'checked'       => ! $deferred,
@@ -771,9 +794,9 @@ function wp_get_translation_update_data() {
 			'id'            => $translation_update_id,
 			'language'      => wp_get_translation_update_language( $language ),
 			'language_code' => $language,
-			'name'          => wp_get_translation_update_name( $update ),
+			'name'          => wp_get_translation_update_name( $update, $plugin_names ),
 			'slug'          => isset( $update->slug ) ? $update->slug : '',
-			'type'          => isset( $update->type ) ? $update->type : '',
+			'type'          => $type,
 			'version'       => isset( $update->version ) ? $update->version : '',
 		);
 	}

--- a/src/wp-admin/includes/update.php
+++ b/src/wp-admin/includes/update.php
@@ -644,7 +644,7 @@ function get_theme_updates() {
 /**
  * Gets the display name for a translation update.
  *
- * @since 6.7.0
+ * @since 7.1.0
  *
  * @param object $update Translation update object.
  * @return string The translation update name.
@@ -716,7 +716,7 @@ function wp_get_translation_update_name( $update ) {
 /**
  * Gets the display language for a translation update.
  *
- * @since 6.7.0
+ * @since 7.1.0
  *
  * @param string $locale Translation update locale.
  * @return string The translation update language.
@@ -739,11 +739,14 @@ function wp_get_translation_update_language( $locale ) {
 /**
  * Gets display data for available translation updates.
  *
- * @since 6.7.0
+ * @since 7.1.0
  *
  * @return array[] {
  *     An array of translation update display data.
  *
+ *     @type bool   $checked       Whether the translation update is selected for installation.
+ *     @type bool   $deferred      Whether the translation update has been deferred.
+ *     @type string $id            Translation update identifier.
  *     @type string $language      Translation update language.
  *     @type string $language_code Translation update locale.
  *     @type string $name          Translation update name.
@@ -753,12 +756,19 @@ function wp_get_translation_update_language( $locale ) {
  * }
  */
 function wp_get_translation_update_data() {
-	$translation_updates = array();
+	$available_updates            = wp_get_translation_updates();
+	$deferred_translation_updates = wp_get_deferred_translation_updates( $available_updates );
+	$translation_updates          = array();
 
-	foreach ( wp_get_translation_updates() as $update ) {
-		$language = isset( $update->language ) ? $update->language : '';
+	foreach ( $available_updates as $update ) {
+		$translation_update_id = wp_get_translation_update_id( $update );
+		$language              = isset( $update->language ) ? $update->language : '';
+		$deferred              = isset( $deferred_translation_updates[ $translation_update_id ] );
 
 		$translation_updates[] = array(
+			'checked'       => ! $deferred,
+			'deferred'      => $deferred,
+			'id'            => $translation_update_id,
 			'language'      => wp_get_translation_update_language( $language ),
 			'language_code' => $language,
 			'name'          => wp_get_translation_update_name( $update ),

--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -813,8 +813,8 @@ function list_theme_updates() {
  * @since 3.7.0
  */
 function list_translation_updates() {
-	$updates = wp_get_translation_updates();
-	if ( ! $updates ) {
+	$translation_updates = wp_get_translation_update_data();
+	if ( ! $translation_updates ) {
 		if ( 'en_US' !== get_locale() ) {
 			echo '<h2>' . __( 'Translations' ) . '</h2>';
 			echo '<p>' . __( 'Your translations are all up to date.' ) . '</p>';
@@ -822,11 +822,35 @@ function list_translation_updates() {
 		return;
 	}
 
-	$form_action = 'update-core.php?action=do-translation-upgrade';
+	$form_action   = 'update-core.php?action=do-translation-upgrade';
+	$updates_count = count( $translation_updates );
 	?>
-	<h2><?php _e( 'Translations' ); ?></h2>
+	<h2>
+	<?php
+	printf(
+		'%s <span class="count">(%d)</span>',
+		__( 'Translations' ),
+		number_format_i18n( $updates_count )
+	);
+	?>
+	</h2>
 	<form method="post" action="<?php echo esc_url( $form_action ); ?>" name="upgrade-translations" class="upgrade">
-		<p><?php _e( 'New translations are available.' ); ?></p>
+		<p><?php _e( 'The following translation updates are available. Update Translations to install them.' ); ?></p>
+		<ul class="ul-disc">
+			<?php foreach ( $translation_updates as $translation_update ) : ?>
+				<li>
+					<strong><?php echo esc_html( $translation_update['name'] ); ?></strong>:
+					<?php
+					printf(
+						/* translators: 1: Language name or locale, 2: Version number. */
+						__( '%1$s translation is available for version %2$s.' ),
+						esc_html( $translation_update['language'] ),
+						esc_html( $translation_update['version'] )
+					);
+					?>
+				</li>
+			<?php endforeach; ?>
+		</ul>
 		<?php wp_nonce_field( 'upgrade-translations' ); ?>
 		<p><input class="button" type="submit" value="<?php esc_attr_e( 'Update Translations' ); ?>" name="upgrade" /></p>
 	</form>

--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -835,24 +835,66 @@ function list_translation_updates() {
 	?>
 	</h2>
 	<form method="post" action="<?php echo esc_url( $form_action ); ?>" name="upgrade-translations" class="upgrade">
-		<p><?php _e( 'The following translation updates are available. Update Translations to install them.' ); ?></p>
-		<ul class="ul-disc">
-			<?php foreach ( $translation_updates as $translation_update ) : ?>
-				<li>
-					<strong><?php echo esc_html( $translation_update['name'] ); ?></strong>:
-					<?php
-					printf(
-						/* translators: 1: Language name or locale, 2: Version number. */
-						__( '%1$s translation is available for version %2$s.' ),
-						esc_html( $translation_update['language'] ),
-						esc_html( $translation_update['version'] )
-					);
-					?>
-				</li>
-			<?php endforeach; ?>
-		</ul>
+		<p><?php _e( 'The following translation updates are available. Leave any translation updates unchecked if you want to install them later, then click &#8220;Update Translations&#8221;.' ); ?></p>
+		<p><?php _e( 'Translation updates you leave unchecked will remain available until you select them.' ); ?></p>
 		<?php wp_nonce_field( 'upgrade-translations' ); ?>
-		<p><input class="button" type="submit" value="<?php esc_attr_e( 'Update Translations' ); ?>" name="upgrade" /></p>
+		<p><input id="upgrade-translations" class="button" type="submit" value="<?php esc_attr_e( 'Update Translations' ); ?>" name="upgrade" /></p>
+		<table class="widefat updates-table" id="update-translations-table">
+			<thead>
+			<tr>
+				<td class="manage-column check-column"><input type="checkbox" id="translations-select-all" /></td>
+				<td class="manage-column"><label for="translations-select-all"><?php _e( 'Select All' ); ?></label></td>
+			</tr>
+			</thead>
+
+			<tbody class="plugins">
+			<?php foreach ( $translation_updates as $translation_update ) : ?>
+				<?php $checkbox_id = 'checkbox_' . md5( $translation_update['id'] ); ?>
+				<tr>
+					<td class="check-column">
+						<input type="hidden" name="translations[]" value="<?php echo esc_attr( $translation_update['id'] ); ?>" />
+						<input type="checkbox" name="checked[]" id="<?php echo esc_attr( $checkbox_id ); ?>" value="<?php echo esc_attr( $translation_update['id'] ); ?>" <?php checked( $translation_update['checked'] ); ?> />
+						<label for="<?php echo esc_attr( $checkbox_id ); ?>">
+							<span class="screen-reader-text">
+							<?php
+							printf(
+								/* translators: 1: Project name, 2: Language name or locale. */
+								esc_html__( 'Select the translation update for %1$s in %2$s' ),
+								esc_html( $translation_update['name'] ),
+								esc_html( $translation_update['language'] )
+							);
+							?>
+							</span>
+						</label>
+					</td>
+					<td class="plugin-title"><p>
+						<strong><?php echo esc_html( $translation_update['name'] ); ?></strong>
+						<?php
+						printf(
+							/* translators: 1: Language name or locale, 2: Version number. */
+							esc_html__( '%1$s translation is available for version %2$s.' ),
+							esc_html( $translation_update['language'] ),
+							esc_html( $translation_update['version'] )
+						);
+
+						if ( $translation_update['deferred'] ) {
+							echo ' ';
+							esc_html_e( 'This translation update will remain available until you select it.' );
+						}
+						?>
+					</p></td>
+				</tr>
+			<?php endforeach; ?>
+			</tbody>
+
+			<tfoot>
+			<tr>
+				<td class="manage-column check-column"><input type="checkbox" id="translations-select-all-2" /></td>
+				<td class="manage-column"><label for="translations-select-all-2"><?php _e( 'Select All' ); ?></label></td>
+			</tr>
+			</tfoot>
+		</table>
+		<p><input id="upgrade-translations-2" class="button" type="submit" value="<?php esc_attr_e( 'Update Translations' ); ?>" name="upgrade" /></p>
 	</form>
 	<?php
 }
@@ -1026,7 +1068,7 @@ $updates_howto  = '<p>' . __( '<strong>WordPress</strong> &mdash; Updating your 
 $updates_howto .= '<p>' . __( '<strong>Themes and Plugins</strong> &mdash; To update individual themes or plugins from this screen, use the checkboxes to make your selection, then <strong>click on the appropriate &#8220;Update&#8221; button</strong>. To update all of your themes or plugins at once, you can check the box at the top of the section to select all before clicking the update button.' ) . '</p>';
 
 if ( 'en_US' !== get_locale() ) {
-	$updates_howto .= '<p>' . __( '<strong>Translations</strong> &mdash; The files translating WordPress into your language are updated for you whenever any other updates occur. But if these files are out of date, you can <strong>click the &#8220;Update Translations&#8221;</strong> button.' ) . '</p>';
+	$updates_howto .= '<p>' . __( '<strong>Translations</strong> &mdash; Translation updates are selected for installation by default. Leave any translation updates unchecked if you want to install them later, then <strong>click the &#8220;Update Translations&#8221;</strong> button. Translation updates you leave unchecked will remain available until you select them.' ) . '</p>';
 }
 
 get_current_screen()->add_help_tab(
@@ -1114,6 +1156,15 @@ if ( 'upgrade-core' === $action ) {
 				);
 			}
 		}
+	}
+
+	if ( isset( $_GET['translation_updates'] ) && 'deferred' === $_GET['translation_updates'] ) {
+		wp_admin_notice(
+			__( 'The unchecked translation updates will remain available until you select them.' ),
+			array(
+				'type' => 'success',
+			)
+		);
 	}
 
 	$last_update_check = false;
@@ -1299,6 +1350,55 @@ if ( 'upgrade-core' === $action ) {
 
 	check_admin_referer( 'upgrade-translations' );
 
+	if ( empty( $_POST['translations'] ) ) {
+		wp_redirect( self_admin_url( 'update-core.php' ) );
+		exit;
+	}
+
+	$translation_updates = wp_get_translation_updates_by_id();
+
+	$translation_update_ids = array_unique(
+		array_map(
+			'sanitize_text_field',
+			wp_unslash( (array) $_POST['translations'] )
+		)
+	);
+
+	$translation_updates = array_intersect_key( $translation_updates, array_flip( $translation_update_ids ) );
+
+	if ( empty( $translation_updates ) ) {
+		wp_redirect( self_admin_url( 'update-core.php' ) );
+		exit;
+	}
+
+	$selected_translation_updates = array();
+
+	if ( ! empty( $_POST['checked'] ) ) {
+		$selected_translation_update_ids = array_unique(
+			array_map(
+				'sanitize_text_field',
+				wp_unslash( (array) $_POST['checked'] )
+			)
+		);
+
+		$selected_translation_updates = array_intersect_key( $translation_updates, array_flip( $selected_translation_update_ids ) );
+	}
+
+	$current_translation_updates   = wp_get_translation_updates_by_id();
+	$deferred_translation_updates  = array_intersect_key(
+		$current_translation_updates,
+		wp_get_deferred_translation_updates( $current_translation_updates )
+	);
+	$deferred_translation_updates  = array_diff_key( $deferred_translation_updates, $translation_updates );
+	$deferred_translation_updates += array_diff_key( $translation_updates, $selected_translation_updates );
+
+	wp_set_deferred_translation_updates( $deferred_translation_updates );
+
+	if ( empty( $selected_translation_updates ) ) {
+		wp_redirect( add_query_arg( 'translation_updates', 'deferred', self_admin_url( 'update-core.php' ) ) );
+		exit;
+	}
+
 	require_once ABSPATH . 'wp-admin/admin-header.php';
 	require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
 
@@ -1308,7 +1408,7 @@ if ( 'upgrade-core' === $action ) {
 	$context = WP_LANG_DIR;
 
 	$upgrader = new Language_Pack_Upgrader( new Language_Pack_Upgrader_Skin( compact( 'url', 'nonce', 'title', 'context' ) ) );
-	$result   = $upgrader->bulk_upgrade();
+	$result   = $upgrader->bulk_upgrade( array_values( $selected_translation_updates ) );
 
 	wp_localize_script(
 		'updates',

--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -1362,7 +1362,7 @@ if ( 'upgrade-core' === $action ) {
 		exit;
 	}
 
-	$translation_updates = wp_get_translation_updates_by_id();
+	$current_translation_updates = wp_get_translation_updates_by_id();
 
 	$translation_update_ids = array_unique(
 		array_map(
@@ -1371,7 +1371,7 @@ if ( 'upgrade-core' === $action ) {
 		)
 	);
 
-	$translation_updates = array_intersect_key( $translation_updates, array_flip( $translation_update_ids ) );
+	$translation_updates = array_intersect_key( $current_translation_updates, array_flip( $translation_update_ids ) );
 
 	if ( empty( $translation_updates ) ) {
 		wp_redirect( self_admin_url( 'update-core.php' ) );
@@ -1391,7 +1391,6 @@ if ( 'upgrade-core' === $action ) {
 		$selected_translation_updates = array_intersect_key( $translation_updates, array_flip( $selected_translation_update_ids ) );
 	}
 
-	$current_translation_updates   = wp_get_translation_updates_by_id();
 	$deferred_translation_updates  = array_intersect_key(
 		$current_translation_updates,
 		wp_get_deferred_translation_updates( $current_translation_updates )

--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -828,7 +828,7 @@ function list_translation_updates() {
 	<h2>
 	<?php
 	printf(
-		'%s <span class="count">(%d)</span>',
+		'%s <span class="count">(%s)</span>',
 		__( 'Translations' ),
 		number_format_i18n( $updates_count )
 	);

--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -1158,7 +1158,14 @@ if ( 'upgrade-core' === $action ) {
 		}
 	}
 
-	if ( isset( $_GET['translation_updates'] ) && 'deferred' === $_GET['translation_updates'] ) {
+	$translation_updates_status = isset( $_GET['translation_updates'] ) ? wp_unslash( $_GET['translation_updates'] ) : '';
+	if ( is_string( $translation_updates_status ) ) {
+		$translation_updates_status = sanitize_key( $translation_updates_status );
+	} else {
+		$translation_updates_status = '';
+	}
+
+	if ( 'deferred' === $translation_updates_status ) {
 		wp_admin_notice(
 			__( 'The unchecked translation updates will remain available until you select them.' ),
 			array(

--- a/src/wp-includes/update.php
+++ b/src/wp-includes/update.php
@@ -921,6 +921,144 @@ function wp_get_translation_updates() {
 }
 
 /**
+ * Gets a stable identifier for a translation update.
+ *
+ * @since 7.1.0
+ *
+ * @param array|object $update Translation update data.
+ * @return string Translation update identifier.
+ */
+function wp_get_translation_update_id( $update ) {
+	$update = (object) $update;
+
+	return md5(
+		wp_json_encode(
+			array(
+				'type'     => $update->type ?? '',
+				'slug'     => $update->slug ?? '',
+				'language' => $update->language ?? '',
+				'version'  => $update->version ?? '',
+			)
+		)
+	);
+}
+
+/**
+ * Gets translation updates keyed by their stable identifiers.
+ *
+ * @since 7.1.0
+ *
+ * @param object[]|null $updates Optional. Translation update objects. Default null.
+ * @return object[] Translation updates keyed by identifier.
+ */
+function wp_get_translation_updates_by_id( $updates = null ) {
+	if ( null === $updates ) {
+		$updates = wp_get_translation_updates();
+	}
+
+	$translation_updates = array();
+
+	foreach ( (array) $updates as $update ) {
+		$translation_updates[ wp_get_translation_update_id( $update ) ] = (object) $update;
+	}
+
+	return $translation_updates;
+}
+
+/**
+ * Gets deferred translation updates.
+ *
+ * Deferred translation updates remain available for later installation and are
+ * skipped by background translation updates until they are selected again.
+ *
+ * @since 7.1.0
+ *
+ * @param object[]|null $updates Optional. Translation update objects used to filter deferred updates
+ *                               to currently available updates. Default null.
+ * @return array[] Deferred translation updates keyed by identifier.
+ */
+function wp_get_deferred_translation_updates( $updates = null ) {
+	$stored_updates = get_site_option( 'deferred_translation_updates', array() );
+
+	if ( ! is_array( $stored_updates ) ) {
+		return array();
+	}
+
+	$deferred_updates = array();
+
+	foreach ( $stored_updates as $stored_update ) {
+		if ( ! is_array( $stored_update ) ) {
+			continue;
+		}
+
+		$stored_update = (object) array(
+			'type'     => $stored_update['type'] ?? '',
+			'slug'     => $stored_update['slug'] ?? '',
+			'language' => $stored_update['language'] ?? '',
+			'version'  => $stored_update['version'] ?? '',
+		);
+
+		$deferred_updates[ wp_get_translation_update_id( $stored_update ) ] = (array) $stored_update;
+	}
+
+	if ( null !== $updates ) {
+		$deferred_updates = array_intersect_key( $deferred_updates, wp_get_translation_updates_by_id( $updates ) );
+	}
+
+	return $deferred_updates;
+}
+
+/**
+ * Determines whether a translation update has been deferred.
+ *
+ * @since 7.1.0
+ *
+ * @param array|object $update           Translation update data.
+ * @param array[]|null $deferred_updates Optional. Deferred translation updates keyed by identifier.
+ *                                       Default null.
+ * @return bool Whether the translation update has been deferred.
+ */
+function wp_is_translation_update_deferred( $update, $deferred_updates = null ) {
+	if ( null === $deferred_updates ) {
+		$deferred_updates = wp_get_deferred_translation_updates();
+	}
+
+	return isset( $deferred_updates[ wp_get_translation_update_id( $update ) ] );
+}
+
+/**
+ * Stores deferred translation updates.
+ *
+ * @since 7.1.0
+ *
+ * @param object[]|array[] $updates Translation updates to defer.
+ * @return void
+ */
+function wp_set_deferred_translation_updates( $updates ) {
+	$deferred_updates = array();
+
+	foreach ( (array) $updates as $update ) {
+		$update = (object) $update;
+
+		$translation_update = array(
+			'type'     => $update->type ?? '',
+			'slug'     => $update->slug ?? '',
+			'language' => $update->language ?? '',
+			'version'  => $update->version ?? '',
+		);
+
+		$deferred_updates[ wp_get_translation_update_id( $translation_update ) ] = $translation_update;
+	}
+
+	if ( empty( $deferred_updates ) ) {
+		delete_site_option( 'deferred_translation_updates' );
+		return;
+	}
+
+	update_site_option( 'deferred_translation_updates', $deferred_updates );
+}
+
+/**
  * Collects counts and UI strings for available updates.
  *
  * @since 3.3.0

--- a/tests/phpunit/tests/admin/includesUpdate.php
+++ b/tests/phpunit/tests/admin/includesUpdate.php
@@ -9,6 +9,7 @@
  * @covers ::wp_get_translation_update_id
  * @covers ::wp_get_translation_update_language
  * @covers ::wp_get_translation_update_name
+ * @covers ::wp_get_translation_update_plugin_names
  * @covers ::wp_get_translation_updates_by_id
  * @covers ::wp_is_translation_update_deferred
  * @covers ::wp_set_deferred_translation_updates
@@ -28,8 +29,59 @@ class Tests_Admin_IncludesUpdate extends WP_UnitTestCase {
 		delete_site_transient( 'update_plugins' );
 		delete_site_transient( 'update_themes' );
 		remove_all_filters( 'all_plugins' );
+		remove_all_filters( 'pre_site_transient_update_plugins' );
 
 		parent::tear_down();
+	}
+
+	/**
+	 * @ticket 42281
+	 */
+	public function test_wp_get_translation_update_data_loads_plugin_names_once() {
+		$plugin_updates = array(
+			array(
+				'type'     => 'plugin',
+				'slug'     => 'custom-internationalized-plugin',
+				'language' => 'de_DE',
+				'version'  => '1.0.0',
+			),
+			array(
+				'type'     => 'plugin',
+				'slug'     => 'hello-dolly',
+				'language' => 'de_DE',
+				'version'  => '1.7.2',
+			),
+		);
+
+		set_site_transient(
+			'update_plugins',
+			(object) array(
+				'translations' => $plugin_updates,
+				'no_update'    => array(
+					'hello.php' => (object) array(
+						'slug' => 'hello-dolly',
+					),
+				),
+			)
+		);
+
+		$transient_reads = 0;
+
+		add_filter(
+			'pre_site_transient_update_plugins',
+			static function ( $value ) use ( &$transient_reads ) {
+				++$transient_reads;
+				return $value;
+			}
+		);
+
+		wp_get_translation_update_data();
+
+		$this->assertSame(
+			2,
+			$transient_reads,
+			'The plugin update transient should be read once for available updates and once for plugin names.'
+		);
 	}
 
 	/**

--- a/tests/phpunit/tests/admin/includesUpdate.php
+++ b/tests/phpunit/tests/admin/includesUpdate.php
@@ -1,0 +1,196 @@
+<?php
+
+/**
+ * @group admin
+ * @group upgrade
+ *
+ * @covers ::wp_get_translation_update_data
+ * @covers ::wp_get_translation_update_language
+ * @covers ::wp_get_translation_update_name
+ */
+class Tests_Admin_IncludesUpdate extends WP_UnitTestCase {
+	/**
+	 * Sets up shared fixtures.
+	 */
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		require_once ABSPATH . 'wp-admin/includes/update.php';
+	}
+
+	public function tear_down() {
+		delete_site_transient( 'available_translations' );
+		delete_site_transient( 'update_core' );
+		delete_site_transient( 'update_plugins' );
+		delete_site_transient( 'update_themes' );
+		remove_all_filters( 'all_plugins' );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * @ticket 42281
+	 */
+	public function test_wp_get_translation_update_data_returns_display_ready_translation_updates() {
+		set_site_transient(
+			'available_translations',
+			array(
+				'de_DE' => array(
+					'native_name' => 'Deutsch',
+				),
+			)
+		);
+
+		set_site_transient(
+			'update_core',
+			(object) array(
+				'translations' => array(
+					array(
+						'type'     => 'core',
+						'slug'     => 'default',
+						'language' => 'de_DE',
+						'version'  => '6.7-beta3',
+					),
+				),
+			)
+		);
+
+		set_site_transient(
+			'update_plugins',
+			(object) array(
+				'translations' => array(
+					array(
+						'type'     => 'plugin',
+						'slug'     => 'custom-internationalized-plugin',
+						'language' => 'de_DE',
+						'version'  => '1.0.0',
+					),
+				),
+			)
+		);
+
+		set_site_transient(
+			'update_themes',
+			(object) array(
+				'translations' => array(
+					array(
+						'type'     => 'theme',
+						'slug'     => 'custom-internationalized-theme',
+						'language' => 'de_DE',
+						'version'  => '1.0.0',
+					),
+				),
+			)
+		);
+
+		$this->assertSame(
+			array(
+				array(
+					'language'      => 'Deutsch (de_DE)',
+					'language_code' => 'de_DE',
+					'name'          => 'WordPress',
+					'slug'          => 'default',
+					'type'          => 'core',
+					'version'       => '6.7-beta3',
+				),
+				array(
+					'language'      => 'Deutsch (de_DE)',
+					'language_code' => 'de_DE',
+					'name'          => 'Custom Dummy Plugin',
+					'slug'          => 'custom-internationalized-plugin',
+					'type'          => 'plugin',
+					'version'       => '1.0.0',
+				),
+				array(
+					'language'      => 'Deutsch (de_DE)',
+					'language_code' => 'de_DE',
+					'name'          => 'Custom Internationalized Theme',
+					'slug'          => 'custom-internationalized-theme',
+					'type'          => 'theme',
+					'version'       => '1.0.0',
+				),
+			),
+			wp_get_translation_update_data()
+		);
+	}
+
+	/**
+	 * @ticket 42281
+	 */
+	public function test_wp_get_translation_update_data_falls_back_to_locale_and_slug() {
+		set_site_transient(
+			'update_plugins',
+			(object) array(
+				'translations' => array(
+					array(
+						'type'     => 'plugin',
+						'slug'     => 'missing-plugin',
+						'language' => 'it_IT',
+						'version'  => '2.0.0',
+					),
+				),
+			)
+		);
+
+		$this->assertSame(
+			array(
+				array(
+					'language'      => 'it_IT',
+					'language_code' => 'it_IT',
+					'name'          => 'missing-plugin',
+					'slug'          => 'missing-plugin',
+					'type'          => 'plugin',
+					'version'       => '2.0.0',
+				),
+			),
+			wp_get_translation_update_data()
+		);
+	}
+
+	/**
+	 * @ticket 42281
+	 */
+	public function test_wp_get_translation_update_data_matches_plugin_update_slug_to_plugin_file() {
+		add_filter(
+			'all_plugins',
+			static function () {
+				return array(
+					'hello.php' => array(
+						'Name' => 'Hello Dolly',
+					),
+				);
+			}
+		);
+
+		set_site_transient(
+			'update_plugins',
+			(object) array(
+				'translations' => array(
+					array(
+						'type'     => 'plugin',
+						'slug'     => 'hello-dolly',
+						'language' => 'de_DE',
+						'version'  => '1.7.2',
+					),
+				),
+				'no_update'    => array(
+					'hello.php' => (object) array(
+						'slug' => 'hello-dolly',
+					),
+				),
+			)
+		);
+
+		$this->assertSame(
+			array(
+				array(
+					'language'      => 'de_DE',
+					'language_code' => 'de_DE',
+					'name'          => 'Hello Dolly',
+					'slug'          => 'hello-dolly',
+					'type'          => 'plugin',
+					'version'       => '1.7.2',
+				),
+			),
+			wp_get_translation_update_data()
+		);
+	}
+}

--- a/tests/phpunit/tests/admin/includesUpdate.php
+++ b/tests/phpunit/tests/admin/includesUpdate.php
@@ -4,9 +4,14 @@
  * @group admin
  * @group upgrade
  *
+ * @covers ::wp_get_deferred_translation_updates
  * @covers ::wp_get_translation_update_data
+ * @covers ::wp_get_translation_update_id
  * @covers ::wp_get_translation_update_language
  * @covers ::wp_get_translation_update_name
+ * @covers ::wp_get_translation_updates_by_id
+ * @covers ::wp_is_translation_update_deferred
+ * @covers ::wp_set_deferred_translation_updates
  */
 class Tests_Admin_IncludesUpdate extends WP_UnitTestCase {
 	/**
@@ -17,6 +22,7 @@ class Tests_Admin_IncludesUpdate extends WP_UnitTestCase {
 	}
 
 	public function tear_down() {
+		delete_site_option( 'deferred_translation_updates' );
 		delete_site_transient( 'available_translations' );
 		delete_site_transient( 'update_core' );
 		delete_site_transient( 'update_plugins' );
@@ -30,6 +36,27 @@ class Tests_Admin_IncludesUpdate extends WP_UnitTestCase {
 	 * @ticket 42281
 	 */
 	public function test_wp_get_translation_update_data_returns_display_ready_translation_updates() {
+		$core_update = (object) array(
+			'type'     => 'core',
+			'slug'     => 'default',
+			'language' => 'de_DE',
+			'version'  => '6.7-beta3',
+		);
+
+		$plugin_update = (object) array(
+			'type'     => 'plugin',
+			'slug'     => 'custom-internationalized-plugin',
+			'language' => 'de_DE',
+			'version'  => '1.0.0',
+		);
+
+		$theme_update = (object) array(
+			'type'     => 'theme',
+			'slug'     => 'custom-internationalized-theme',
+			'language' => 'de_DE',
+			'version'  => '1.0.0',
+		);
+
 		set_site_transient(
 			'available_translations',
 			array(
@@ -43,12 +70,7 @@ class Tests_Admin_IncludesUpdate extends WP_UnitTestCase {
 			'update_core',
 			(object) array(
 				'translations' => array(
-					array(
-						'type'     => 'core',
-						'slug'     => 'default',
-						'language' => 'de_DE',
-						'version'  => '6.7-beta3',
-					),
+					(array) $core_update,
 				),
 			)
 		);
@@ -57,12 +79,7 @@ class Tests_Admin_IncludesUpdate extends WP_UnitTestCase {
 			'update_plugins',
 			(object) array(
 				'translations' => array(
-					array(
-						'type'     => 'plugin',
-						'slug'     => 'custom-internationalized-plugin',
-						'language' => 'de_DE',
-						'version'  => '1.0.0',
-					),
+					(array) $plugin_update,
 				),
 			)
 		);
@@ -71,12 +88,7 @@ class Tests_Admin_IncludesUpdate extends WP_UnitTestCase {
 			'update_themes',
 			(object) array(
 				'translations' => array(
-					array(
-						'type'     => 'theme',
-						'slug'     => 'custom-internationalized-theme',
-						'language' => 'de_DE',
-						'version'  => '1.0.0',
-					),
+					(array) $theme_update,
 				),
 			)
 		);
@@ -84,6 +96,9 @@ class Tests_Admin_IncludesUpdate extends WP_UnitTestCase {
 		$this->assertSame(
 			array(
 				array(
+					'checked'       => true,
+					'deferred'      => false,
+					'id'            => wp_get_translation_update_id( $core_update ),
 					'language'      => 'Deutsch (de_DE)',
 					'language_code' => 'de_DE',
 					'name'          => 'WordPress',
@@ -92,6 +107,9 @@ class Tests_Admin_IncludesUpdate extends WP_UnitTestCase {
 					'version'       => '6.7-beta3',
 				),
 				array(
+					'checked'       => true,
+					'deferred'      => false,
+					'id'            => wp_get_translation_update_id( $plugin_update ),
 					'language'      => 'Deutsch (de_DE)',
 					'language_code' => 'de_DE',
 					'name'          => 'Custom Dummy Plugin',
@@ -100,6 +118,9 @@ class Tests_Admin_IncludesUpdate extends WP_UnitTestCase {
 					'version'       => '1.0.0',
 				),
 				array(
+					'checked'       => true,
+					'deferred'      => false,
+					'id'            => wp_get_translation_update_id( $theme_update ),
 					'language'      => 'Deutsch (de_DE)',
 					'language_code' => 'de_DE',
 					'name'          => 'Custom Internationalized Theme',
@@ -116,16 +137,18 @@ class Tests_Admin_IncludesUpdate extends WP_UnitTestCase {
 	 * @ticket 42281
 	 */
 	public function test_wp_get_translation_update_data_falls_back_to_locale_and_slug() {
+		$plugin_update = (object) array(
+			'type'     => 'plugin',
+			'slug'     => 'missing-plugin',
+			'language' => 'it_IT',
+			'version'  => '2.0.0',
+		);
+
 		set_site_transient(
 			'update_plugins',
 			(object) array(
 				'translations' => array(
-					array(
-						'type'     => 'plugin',
-						'slug'     => 'missing-plugin',
-						'language' => 'it_IT',
-						'version'  => '2.0.0',
-					),
+					(array) $plugin_update,
 				),
 			)
 		);
@@ -133,6 +156,9 @@ class Tests_Admin_IncludesUpdate extends WP_UnitTestCase {
 		$this->assertSame(
 			array(
 				array(
+					'checked'       => true,
+					'deferred'      => false,
+					'id'            => wp_get_translation_update_id( $plugin_update ),
 					'language'      => 'it_IT',
 					'language_code' => 'it_IT',
 					'name'          => 'missing-plugin',
@@ -149,6 +175,13 @@ class Tests_Admin_IncludesUpdate extends WP_UnitTestCase {
 	 * @ticket 42281
 	 */
 	public function test_wp_get_translation_update_data_matches_plugin_update_slug_to_plugin_file() {
+		$plugin_update = (object) array(
+			'type'     => 'plugin',
+			'slug'     => 'hello-dolly',
+			'language' => 'de_DE',
+			'version'  => '1.7.2',
+		);
+
 		add_filter(
 			'all_plugins',
 			static function () {
@@ -164,12 +197,7 @@ class Tests_Admin_IncludesUpdate extends WP_UnitTestCase {
 			'update_plugins',
 			(object) array(
 				'translations' => array(
-					array(
-						'type'     => 'plugin',
-						'slug'     => 'hello-dolly',
-						'language' => 'de_DE',
-						'version'  => '1.7.2',
-					),
+					(array) $plugin_update,
 				),
 				'no_update'    => array(
 					'hello.php' => (object) array(
@@ -182,6 +210,9 @@ class Tests_Admin_IncludesUpdate extends WP_UnitTestCase {
 		$this->assertSame(
 			array(
 				array(
+					'checked'       => true,
+					'deferred'      => false,
+					'id'            => wp_get_translation_update_id( $plugin_update ),
 					'language'      => 'de_DE',
 					'language_code' => 'de_DE',
 					'name'          => 'Hello Dolly',
@@ -191,6 +222,110 @@ class Tests_Admin_IncludesUpdate extends WP_UnitTestCase {
 				),
 			),
 			wp_get_translation_update_data()
+		);
+	}
+
+	/**
+	 * @ticket 42281
+	 */
+	public function test_wp_get_translation_updates_by_id_keys_updates_by_identifier() {
+		$core_update = (object) array(
+			'type'     => 'core',
+			'slug'     => 'default',
+			'language' => 'de_DE',
+			'version'  => '6.7-beta3',
+		);
+
+		$this->assertSame(
+			array(
+				wp_get_translation_update_id( $core_update ) => $core_update,
+			),
+			wp_get_translation_updates_by_id( array( $core_update ) )
+		);
+	}
+
+	/**
+	 * @ticket 42281
+	 */
+	public function test_wp_get_translation_update_data_marks_deferred_translation_updates() {
+		$plugin_update = (object) array(
+			'type'     => 'plugin',
+			'slug'     => 'deferred-plugin',
+			'language' => 'de_DE',
+			'version'  => '1.0.0',
+		);
+
+		set_site_transient(
+			'update_plugins',
+			(object) array(
+				'translations' => array(
+					(array) $plugin_update,
+				),
+			)
+		);
+
+		wp_set_deferred_translation_updates( array( $plugin_update ) );
+
+		$this->assertSame(
+			array(
+				array(
+					'checked'       => false,
+					'deferred'      => true,
+					'id'            => wp_get_translation_update_id( $plugin_update ),
+					'language'      => 'de_DE',
+					'language_code' => 'de_DE',
+					'name'          => 'deferred-plugin',
+					'slug'          => 'deferred-plugin',
+					'type'          => 'plugin',
+					'version'       => '1.0.0',
+				),
+			),
+			wp_get_translation_update_data()
+		);
+	}
+
+	/**
+	 * @ticket 42281
+	 */
+	public function test_wp_get_deferred_translation_updates_filters_to_available_updates() {
+		$available_update = (object) array(
+			'type'     => 'plugin',
+			'slug'     => 'available-plugin',
+			'language' => 'de_DE',
+			'version'  => '1.0.0',
+		);
+
+		$stale_update = (object) array(
+			'type'     => 'plugin',
+			'slug'     => 'stale-plugin',
+			'language' => 'de_DE',
+			'version'  => '1.0.0',
+		);
+
+		wp_set_deferred_translation_updates( array( $available_update, $stale_update ) );
+
+		$this->assertSame(
+			array(
+				wp_get_translation_update_id( $available_update ) => array(
+					'type'     => 'plugin',
+					'slug'     => 'available-plugin',
+					'language' => 'de_DE',
+					'version'  => '1.0.0',
+				),
+			),
+			wp_get_deferred_translation_updates( array( $available_update ) )
+		);
+
+		$this->assertTrue( wp_is_translation_update_deferred( $available_update ) );
+		$this->assertFalse(
+			wp_is_translation_update_deferred(
+				(object) array(
+					'type'     => 'plugin',
+					'slug'     => 'different-plugin',
+					'language' => 'de_DE',
+					'version'  => '1.0.0',
+				)
+			)
 		);
 	}
 }

--- a/tests/phpunit/tests/admin/languagePackUpgrader.php
+++ b/tests/phpunit/tests/admin/languagePackUpgrader.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * @group admin
+ * @group upgrade
+ *
+ * @covers Language_Pack_Upgrader
+ */
+class Tests_Admin_LanguagePackUpgrader extends WP_UnitTestCase {
+	/**
+	 * Loads the class to be tested.
+	 */
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+
+		require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+	}
+
+	public function tear_down() {
+		delete_site_option( 'deferred_translation_updates' );
+		delete_site_transient( 'update_plugins' );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Tests that deferred translation updates are not passed to the bulk upgrader.
+	 *
+	 * @ticket 42281
+	 *
+	 * @covers Language_Pack_Upgrader::async_upgrade
+	 */
+	public function test_async_upgrade_should_skip_deferred_translation_updates() {
+		$deferred_update = (object) array(
+			'type'       => 'plugin',
+			'slug'       => 'deferred-plugin',
+			'language'   => 'de_DE',
+			'version'    => '1.0.0',
+			'autoupdate' => true,
+			'package'    => 'https://example.org/deferred-plugin-de_DE.zip',
+		);
+
+		set_site_transient(
+			'update_plugins',
+			(object) array(
+				'translations' => array( $deferred_update ),
+			)
+		);
+
+		wp_set_deferred_translation_updates( array( $deferred_update ) );
+
+		$async_update_results = array();
+		$bulk_upgrade_started = false;
+
+		add_filter( 'automatic_updates_is_vcs_checkout', '__return_false' );
+		add_filter(
+			'async_update_translation',
+			static function ( $update ) use ( &$async_update_results ) {
+				$async_update_results[] = $update;
+				return $update;
+			}
+		);
+		add_filter(
+			'request_filesystem_credentials',
+			static function () use ( &$bulk_upgrade_started ) {
+				$bulk_upgrade_started = true;
+				return false;
+			}
+		);
+
+		Language_Pack_Upgrader::async_upgrade();
+
+		$this->assertSame( array( false ), $async_update_results );
+		$this->assertFalse( $bulk_upgrade_started );
+	}
+}

--- a/tests/phpunit/tests/admin/wpAutomaticUpdater.php
+++ b/tests/phpunit/tests/admin/wpAutomaticUpdater.php
@@ -40,6 +40,41 @@ class Tests_Admin_WpAutomaticUpdater extends WP_UnitTestCase {
 		add_filter( 'pre_wp_mail', '__return_false' );
 	}
 
+	public function tear_down() {
+		delete_site_option( 'deferred_translation_updates' );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Tests that deferred translation updates are not automatically updated.
+	 *
+	 * @ticket 42281
+	 *
+	 * @covers WP_Automatic_Updater::should_update
+	 */
+	public function test_should_update_should_skip_deferred_translation_updates() {
+		$deferred_update = (object) array(
+			'type'       => 'plugin',
+			'slug'       => 'deferred-plugin',
+			'language'   => 'de_DE',
+			'version'    => '1.0.0',
+			'autoupdate' => true,
+		);
+
+		$available_update       = clone $deferred_update;
+		$available_update->slug = 'available-plugin';
+
+		wp_set_deferred_translation_updates( array( $deferred_update ) );
+
+		add_filter( 'request_filesystem_credentials', '__return_true' );
+		add_filter( 'automatic_updates_is_vcs_checkout', '__return_false' );
+		add_filter( 'automatic_updater_disabled', '__return_false' );
+
+		$this->assertFalse( self::$updater->should_update( 'translation', $deferred_update, WP_LANG_DIR ) );
+		$this->assertTrue( self::$updater->should_update( 'translation', $available_update, WP_LANG_DIR ) );
+	}
+
 	/**
 	 * Tests that `WP_Automatic_Updater::send_plugin_theme_email()` appends
 	 * plugin URLs.


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/42281

## Summary

`list_translation_updates()` currently renders only a generic translations notice and an `Update Translations` button. Unlike the WordPress core, plugin, and theme update sections, it does not resolve or display the specific translation updates that are pending, and it does not allow individual translation updates to be deferred for later installation.

This PR brings the translations section closer to the existing plugin and theme update UX by:

- listing the specific pending translation updates
- rendering them in a checkbox table that matches the existing updates UI
- allowing individual translation updates to be left unchecked and installed later
- persisting those unchecked translation updates as deferred so they remain available and are skipped by background translation updates until selected again

## Changes

- add translation update display helpers in `wp-admin/includes/update.php`
- add translation update identifiers and deferred-state helpers in `wp-includes/update.php`
- resolve translation update names for core, themes, and plugins
- map plugin translation slugs back to installed plugin files so WordPress.org-style slugs still display the correct plugin name
- replace the plain translations list on `update-core.php` with a checkbox table styled like the existing plugin/theme update tables
- persist unchecked translation updates in a site option and keep them visible for later installation
- pass only selected translation updates to `Language_Pack_Upgrader::bulk_upgrade()`
- skip deferred translation updates in `WP_Automatic_Updater::should_update()` and `Language_Pack_Upgrader::async_upgrade()`
- add PHPUnit coverage for translation update display/deferred data, identifier handling, and deferred background/async update behavior

## Test plan

- [x] `php -l src/wp-admin/includes/update.php`
- [x] `php -l src/wp-admin/update-core.php`
- [x] `php -l src/wp-includes/update.php`
- [x] `php -l src/wp-admin/includes/class-language-pack-upgrader.php`
- [x] `php -l src/wp-admin/includes/class-wp-automatic-updater.php`
- [x] `php -l tests/phpunit/tests/admin/includesUpdate.php`
- [x] `php -l tests/phpunit/tests/admin/languagePackUpgrader.php`
- [x] `php -l tests/phpunit/tests/admin/wpAutomaticUpdater.php`
- [x] `vendor/bin/phpcs --standard=phpcs.xml.dist src/wp-admin/includes/update.php src/wp-admin/update-core.php src/wp-includes/update.php src/wp-admin/includes/class-language-pack-upgrader.php src/wp-admin/includes/class-wp-automatic-updater.php tests/phpunit/tests/admin/includesUpdate.php tests/phpunit/tests/admin/languagePackUpgrader.php tests/phpunit/tests/admin/wpAutomaticUpdater.php`
- [x] `git diff --check`
- [x] `npm run build:dev`
- [x] Authenticated HTTP E2E validation against `https://wpcore.wp-studio.dev/wp-admin/update-core.php` using a temporary MU-plugin fixture and local language-pack ZIP fixtures:
- [x] verified the translations table rendered with `3` rows for `WordPress`, `Hello Dolly`, and `Twenty Twenty-Four`
- [x] verified all `3` translation rows were selected by default
- [x] submitted the form with only the core and theme translation updates selected
- [x] verified the upgrade screen completed with `2` successful translation updates
- [x] verified the remaining plugin translation update stayed available on the Updates screen and rendered unchecked
- [x] verified `deferred_translation_updates` persisted only the unchecked plugin translation update
- [x] verified `WP_Automatic_Updater::should_update( 'translation', ... )` returned `false` for the deferred plugin translation update and `true` for a non-deferred translation update
- [x] verified `Language_Pack_Upgrader::async_upgrade()` left the deferred translation update pending
- [x] Current-head WordPress Playground E2E verified all-select, clear-all, defer-all, persisted unchecked rows, and malformed query handling with controlled core/plugin/theme translation fixtures
- [x] Official GitHub Actions: Coding Standards, PHP Compatibility, PHPStan, build, both E2E variants, performance, and upgrade tests passed
- [x] Official PHPUnit matrix: 176 jobs passed and 3 were skipped by matrix conditions. One PHP 7.4/MySQL 8.0 multisite job reached the workflow's 20-minute limit after its PHPUnit, AJAX, `ms-files`, and Xdebug test commands had all passed.

Local PHPUnit execution was unavailable because this environment does not have the required WordPress test database/Docker runtime; the official GitHub Actions matrix provides the PHPUnit validation above.

## Use of AI Tools

AI assistance: Yes  
Tool(s): Codex  
Model(s): GPT-5-based Codex  
Used for: implementation, test scaffolding, server-side E2E validation orchestration, and PR drafting; outputs were reviewed and validated with syntax checks, PHPCS, `git diff --check`, and authenticated admin-page testing.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
