### PR TITLE
Script Loader: Defer single-page admin init until DOMContentLoaded (Trac #65103)

### DIFF
--- a/src/wp-includes/build/pages/font-library/page-wp-admin.php
+++ b/src/wp-includes/build/pages/font-library/page-wp-admin.php
@@ -163,11 +163,25 @@ function wp_font_library_wp_admin_enqueue_scripts( $hook_suffix ) {
 		 * Chrome, evaluating before wp.theme.privateApis is defined and throwing
 		 * "Cannot unlock an undefined object". See #65103.
 		 */
+		$init_js_function = <<<'JS'
+( mountId, routes ) => {
+	const run = async () => {
+		const mod = await import( "@wordpress/boot" );
+		mod.initSinglePage( { mountId, routes } );
+	};
+	if ( document.readyState === "loading" ) {
+		document.addEventListener( "DOMContentLoaded", run );
+	} else {
+		run();
+	}
+}
+JS;
 		wp_add_inline_script(
 			'font-library-wp-admin-prerequisites',
 			sprintf(
-				'(function(){var run=function(){import("@wordpress/boot").then(function(mod){mod.initSinglePage({mountId: "%s", routes: %s});});};if(document.readyState==="loading"){document.addEventListener("DOMContentLoaded",run);}else{run();}})();',
-				'font-library-wp-admin-app',
+				'( %s )( %s, %s );',
+				$init_js_function,
+				wp_json_encode( 'font-library-wp-admin-app', JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ),
 				wp_json_encode( $routes, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES )
 			)
 		);

--- a/src/wp-includes/build/pages/font-library/page-wp-admin.php
+++ b/src/wp-includes/build/pages/font-library/page-wp-admin.php
@@ -155,14 +155,13 @@ function wp_font_library_wp_admin_enqueue_scripts( $hook_suffix ) {
 
 		/*
 		 * Add inline script to initialize the app using initSinglePage (no menuItems).
-		 *
-		 * The call is deferred until DOMContentLoaded so that all classic script
-		 * dependencies of @wordpress/boot (wp-private-apis, wp-components, wp-theme,
-		 * etc.) have finished parsing and executing before the dynamic module import
-		 * resolves. Without this, a modulepreloaded @wordpress/boot can win the race
+		 * The dynamic import is deferred until DOMContentLoaded so that all classic
+		 * script dependencies of @wordpress/boot (wp-private-apis, wp-components,
+		 * wp-theme, etc.) have finished parsing and executing before the boot module
+		 * evaluates. Otherwise, a modulepreloaded @wordpress/boot can win the race
 		 * against the classic-script-printing pass on fast CDN-fronted hosts in
 		 * Chrome, evaluating before wp.theme.privateApis is defined and throwing
-		 * "Cannot unlock an undefined object". See Trac #65103.
+		 * "Cannot unlock an undefined object". See #65103.
 		 */
 		wp_add_inline_script(
 			'font-library-wp-admin-prerequisites',

--- a/src/wp-includes/build/pages/font-library/page-wp-admin.php
+++ b/src/wp-includes/build/pages/font-library/page-wp-admin.php
@@ -153,11 +153,21 @@ function wp_font_library_wp_admin_enqueue_scripts( $hook_suffix ) {
 		// 2. It initializes the boot module as an inline script.
 		wp_register_script( 'font-library-wp-admin-prerequisites', '', $asset['dependencies'], $asset['version'], true );
 
-		// Add inline script to initialize the app using initSinglePage (no menuItems)
+		/*
+		 * Add inline script to initialize the app using initSinglePage (no menuItems).
+		 *
+		 * The call is deferred until DOMContentLoaded so that all classic script
+		 * dependencies of @wordpress/boot (wp-private-apis, wp-components, wp-theme,
+		 * etc.) have finished parsing and executing before the dynamic module import
+		 * resolves. Without this, a modulepreloaded @wordpress/boot can win the race
+		 * against the classic-script-printing pass on fast CDN-fronted hosts in
+		 * Chrome, evaluating before wp.theme.privateApis is defined and throwing
+		 * "Cannot unlock an undefined object". See Trac #65103.
+		 */
 		wp_add_inline_script(
 			'font-library-wp-admin-prerequisites',
 			sprintf(
-				'import("@wordpress/boot").then(mod => mod.initSinglePage({mountId: "%s", routes: %s}));',
+				'(function(){var run=function(){import("@wordpress/boot").then(function(mod){mod.initSinglePage({mountId: "%s", routes: %s});});};if(document.readyState==="loading"){document.addEventListener("DOMContentLoaded",run);}else{run();}})();',
 				'font-library-wp-admin-app',
 				wp_json_encode( $routes, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES )
 			)

--- a/src/wp-includes/build/pages/font-library/page.php
+++ b/src/wp-includes/build/pages/font-library/page.php
@@ -169,16 +169,30 @@ function wp_font_library_render_page() {
 		 * Chrome, evaluating before wp.theme.privateApis is defined and throwing
 		 * "Cannot unlock an undefined object". See #65103.
 		 */
-		$init_modules = [];
+		$init_modules     = [];
+		$init_js_function = <<<'JS'
+( mountId, menuItems, routes, initModules, dashboardLink ) => {
+	const run = async () => {
+		const mod = await import( "@wordpress/boot" );
+		mod.init( { mountId, menuItems, routes, initModules, dashboardLink } );
+	};
+	if ( document.readyState === "loading" ) {
+		document.addEventListener( "DOMContentLoaded", run );
+	} else {
+		run();
+	}
+}
+JS;
 		wp_add_inline_script(
 			'font-library-prerequisites',
 			sprintf(
-				'(function(){var run=function(){import("@wordpress/boot").then(function(mod){mod.init({mountId: "%s", menuItems: %s, routes: %s, initModules: %s, dashboardLink: "%s"});});};if(document.readyState==="loading"){document.addEventListener("DOMContentLoaded",run);}else{run();}})();',
-				'font-library-app',
+				'( %s )( %s, %s, %s, %s, %s );',
+				$init_js_function,
+				wp_json_encode( 'font-library-app', JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ),
 				wp_json_encode( $menu_items, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ),
 				wp_json_encode( $routes, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ),
 				wp_json_encode( $init_modules, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ),
-				esc_url( admin_url( '/' ) )
+				wp_json_encode( admin_url( '/' ), JSON_HEX_TAG | JSON_UNESCAPED_SLASHES )
 			)
 		);
 

--- a/src/wp-includes/build/pages/font-library/page.php
+++ b/src/wp-includes/build/pages/font-library/page.php
@@ -159,12 +159,22 @@ function wp_font_library_render_page() {
 		// 2. It initializes the boot module as an inline script.
 		wp_register_script( 'font-library-prerequisites', '', $asset['dependencies'], $asset['version'], true );
 
-		// Add inline script to initialize the app
+		/*
+		 * Add inline script to initialize the app.
+		 *
+		 * The call is deferred until DOMContentLoaded so that all classic script
+		 * dependencies of @wordpress/boot (wp-private-apis, wp-components, wp-theme,
+		 * etc.) have finished parsing and executing before the dynamic module import
+		 * resolves. Without this, a modulepreloaded @wordpress/boot can win the race
+		 * against the classic-script-printing pass on fast CDN-fronted hosts in
+		 * Chrome, evaluating before wp.theme.privateApis is defined and throwing
+		 * "Cannot unlock an undefined object". See Trac #65103.
+		 */
 		$init_modules = [];
 		wp_add_inline_script(
 			'font-library-prerequisites',
 			sprintf(
-				'import("@wordpress/boot").then(mod => mod.init({mountId: "%s", menuItems: %s, routes: %s, initModules: %s, dashboardLink: "%s"}));',
+				'(function(){var run=function(){import("@wordpress/boot").then(function(mod){mod.init({mountId: "%s", menuItems: %s, routes: %s, initModules: %s, dashboardLink: "%s"});});};if(document.readyState==="loading"){document.addEventListener("DOMContentLoaded",run);}else{run();}})();',
 				'font-library-app',
 				wp_json_encode( $menu_items, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ),
 				wp_json_encode( $routes, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ),

--- a/src/wp-includes/build/pages/font-library/page.php
+++ b/src/wp-includes/build/pages/font-library/page.php
@@ -161,14 +161,13 @@ function wp_font_library_render_page() {
 
 		/*
 		 * Add inline script to initialize the app.
-		 *
-		 * The call is deferred until DOMContentLoaded so that all classic script
-		 * dependencies of @wordpress/boot (wp-private-apis, wp-components, wp-theme,
-		 * etc.) have finished parsing and executing before the dynamic module import
-		 * resolves. Without this, a modulepreloaded @wordpress/boot can win the race
+		 * The dynamic import is deferred until DOMContentLoaded so that all classic
+		 * script dependencies of @wordpress/boot (wp-private-apis, wp-components,
+		 * wp-theme, etc.) have finished parsing and executing before the boot module
+		 * evaluates. Otherwise, a modulepreloaded @wordpress/boot can win the race
 		 * against the classic-script-printing pass on fast CDN-fronted hosts in
 		 * Chrome, evaluating before wp.theme.privateApis is defined and throwing
-		 * "Cannot unlock an undefined object". See Trac #65103.
+		 * "Cannot unlock an undefined object". See #65103.
 		 */
 		$init_modules = [];
 		wp_add_inline_script(

--- a/src/wp-includes/build/pages/options-connectors/page-wp-admin.php
+++ b/src/wp-includes/build/pages/options-connectors/page-wp-admin.php
@@ -153,11 +153,21 @@ function wp_options_connectors_wp_admin_enqueue_scripts( $hook_suffix ) {
 		// 2. It initializes the boot module as an inline script.
 		wp_register_script( 'options-connectors-wp-admin-prerequisites', '', $asset['dependencies'], $asset['version'], true );
 
-		// Add inline script to initialize the app using initSinglePage (no menuItems)
+		/*
+		 * Add inline script to initialize the app using initSinglePage (no menuItems).
+		 *
+		 * The call is deferred until DOMContentLoaded so that all classic script
+		 * dependencies of @wordpress/boot (wp-private-apis, wp-components, wp-theme,
+		 * etc.) have finished parsing and executing before the dynamic module import
+		 * resolves. Without this, a modulepreloaded @wordpress/boot can win the race
+		 * against the classic-script-printing pass on fast CDN-fronted hosts in
+		 * Chrome, evaluating before wp.theme.privateApis is defined and throwing
+		 * "Cannot unlock an undefined object". See Trac #65103.
+		 */
 		wp_add_inline_script(
 			'options-connectors-wp-admin-prerequisites',
 			sprintf(
-				'import("@wordpress/boot").then(mod => mod.initSinglePage({mountId: "%s", routes: %s}));',
+				'(function(){var run=function(){import("@wordpress/boot").then(function(mod){mod.initSinglePage({mountId: "%s", routes: %s});});};if(document.readyState==="loading"){document.addEventListener("DOMContentLoaded",run);}else{run();}})();',
 				'options-connectors-wp-admin-app',
 				wp_json_encode( $routes, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES )
 			)

--- a/src/wp-includes/build/pages/options-connectors/page-wp-admin.php
+++ b/src/wp-includes/build/pages/options-connectors/page-wp-admin.php
@@ -163,11 +163,25 @@ function wp_options_connectors_wp_admin_enqueue_scripts( $hook_suffix ) {
 		 * Chrome, evaluating before wp.theme.privateApis is defined and throwing
 		 * "Cannot unlock an undefined object". See #65103.
 		 */
+		$init_js_function = <<<'JS'
+( mountId, routes ) => {
+	const run = async () => {
+		const mod = await import( "@wordpress/boot" );
+		mod.initSinglePage( { mountId, routes } );
+	};
+	if ( document.readyState === "loading" ) {
+		document.addEventListener( "DOMContentLoaded", run );
+	} else {
+		run();
+	}
+}
+JS;
 		wp_add_inline_script(
 			'options-connectors-wp-admin-prerequisites',
 			sprintf(
-				'(function(){var run=function(){import("@wordpress/boot").then(function(mod){mod.initSinglePage({mountId: "%s", routes: %s});});};if(document.readyState==="loading"){document.addEventListener("DOMContentLoaded",run);}else{run();}})();',
-				'options-connectors-wp-admin-app',
+				'( %s )( %s, %s );',
+				$init_js_function,
+				wp_json_encode( 'options-connectors-wp-admin-app', JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ),
 				wp_json_encode( $routes, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES )
 			)
 		);

--- a/src/wp-includes/build/pages/options-connectors/page-wp-admin.php
+++ b/src/wp-includes/build/pages/options-connectors/page-wp-admin.php
@@ -155,14 +155,13 @@ function wp_options_connectors_wp_admin_enqueue_scripts( $hook_suffix ) {
 
 		/*
 		 * Add inline script to initialize the app using initSinglePage (no menuItems).
-		 *
-		 * The call is deferred until DOMContentLoaded so that all classic script
-		 * dependencies of @wordpress/boot (wp-private-apis, wp-components, wp-theme,
-		 * etc.) have finished parsing and executing before the dynamic module import
-		 * resolves. Without this, a modulepreloaded @wordpress/boot can win the race
+		 * The dynamic import is deferred until DOMContentLoaded so that all classic
+		 * script dependencies of @wordpress/boot (wp-private-apis, wp-components,
+		 * wp-theme, etc.) have finished parsing and executing before the boot module
+		 * evaluates. Otherwise, a modulepreloaded @wordpress/boot can win the race
 		 * against the classic-script-printing pass on fast CDN-fronted hosts in
 		 * Chrome, evaluating before wp.theme.privateApis is defined and throwing
-		 * "Cannot unlock an undefined object". See Trac #65103.
+		 * "Cannot unlock an undefined object". See #65103.
 		 */
 		wp_add_inline_script(
 			'options-connectors-wp-admin-prerequisites',

--- a/src/wp-includes/build/pages/options-connectors/page.php
+++ b/src/wp-includes/build/pages/options-connectors/page.php
@@ -169,16 +169,30 @@ function wp_options_connectors_render_page() {
 		 * Chrome, evaluating before wp.theme.privateApis is defined and throwing
 		 * "Cannot unlock an undefined object". See #65103.
 		 */
-		$init_modules = [];
+		$init_modules     = [];
+		$init_js_function = <<<'JS'
+( mountId, menuItems, routes, initModules, dashboardLink ) => {
+	const run = async () => {
+		const mod = await import( "@wordpress/boot" );
+		mod.init( { mountId, menuItems, routes, initModules, dashboardLink } );
+	};
+	if ( document.readyState === "loading" ) {
+		document.addEventListener( "DOMContentLoaded", run );
+	} else {
+		run();
+	}
+}
+JS;
 		wp_add_inline_script(
 			'options-connectors-prerequisites',
 			sprintf(
-				'(function(){var run=function(){import("@wordpress/boot").then(function(mod){mod.init({mountId: "%s", menuItems: %s, routes: %s, initModules: %s, dashboardLink: "%s"});});};if(document.readyState==="loading"){document.addEventListener("DOMContentLoaded",run);}else{run();}})();',
-				'options-connectors-app',
+				'( %s )( %s, %s, %s, %s, %s );',
+				$init_js_function,
+				wp_json_encode( 'options-connectors-app', JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ),
 				wp_json_encode( $menu_items, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ),
 				wp_json_encode( $routes, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ),
 				wp_json_encode( $init_modules, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ),
-				esc_url( admin_url( '/' ) )
+				wp_json_encode( admin_url( '/' ), JSON_HEX_TAG | JSON_UNESCAPED_SLASHES )
 			)
 		);
 

--- a/src/wp-includes/build/pages/options-connectors/page.php
+++ b/src/wp-includes/build/pages/options-connectors/page.php
@@ -159,12 +159,22 @@ function wp_options_connectors_render_page() {
 		// 2. It initializes the boot module as an inline script.
 		wp_register_script( 'options-connectors-prerequisites', '', $asset['dependencies'], $asset['version'], true );
 
-		// Add inline script to initialize the app
+		/*
+		 * Add inline script to initialize the app.
+		 *
+		 * The call is deferred until DOMContentLoaded so that all classic script
+		 * dependencies of @wordpress/boot (wp-private-apis, wp-components, wp-theme,
+		 * etc.) have finished parsing and executing before the dynamic module import
+		 * resolves. Without this, a modulepreloaded @wordpress/boot can win the race
+		 * against the classic-script-printing pass on fast CDN-fronted hosts in
+		 * Chrome, evaluating before wp.theme.privateApis is defined and throwing
+		 * "Cannot unlock an undefined object". See Trac #65103.
+		 */
 		$init_modules = [];
 		wp_add_inline_script(
 			'options-connectors-prerequisites',
 			sprintf(
-				'import("@wordpress/boot").then(mod => mod.init({mountId: "%s", menuItems: %s, routes: %s, initModules: %s, dashboardLink: "%s"}));',
+				'(function(){var run=function(){import("@wordpress/boot").then(function(mod){mod.init({mountId: "%s", menuItems: %s, routes: %s, initModules: %s, dashboardLink: "%s"});});};if(document.readyState==="loading"){document.addEventListener("DOMContentLoaded",run);}else{run();}})();',
 				'options-connectors-app',
 				wp_json_encode( $menu_items, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ),
 				wp_json_encode( $routes, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ),

--- a/src/wp-includes/build/pages/options-connectors/page.php
+++ b/src/wp-includes/build/pages/options-connectors/page.php
@@ -161,14 +161,13 @@ function wp_options_connectors_render_page() {
 
 		/*
 		 * Add inline script to initialize the app.
-		 *
-		 * The call is deferred until DOMContentLoaded so that all classic script
-		 * dependencies of @wordpress/boot (wp-private-apis, wp-components, wp-theme,
-		 * etc.) have finished parsing and executing before the dynamic module import
-		 * resolves. Without this, a modulepreloaded @wordpress/boot can win the race
+		 * The dynamic import is deferred until DOMContentLoaded so that all classic
+		 * script dependencies of @wordpress/boot (wp-private-apis, wp-components,
+		 * wp-theme, etc.) have finished parsing and executing before the boot module
+		 * evaluates. Otherwise, a modulepreloaded @wordpress/boot can win the race
 		 * against the classic-script-printing pass on fast CDN-fronted hosts in
 		 * Chrome, evaluating before wp.theme.privateApis is defined and throwing
-		 * "Cannot unlock an undefined object". See Trac #65103.
+		 * "Cannot unlock an undefined object". See #65103.
 		 */
 		$init_modules = [];
 		wp_add_inline_script(


### PR DESCRIPTION
## Trac ticket

https://core.trac.wordpress.org/ticket/65103

## Summary

Fixes a race condition that prevents the Connectors (`/wp-admin/options-connectors.php`) and Font Library admin screens from mounting in Chrome on fast-CDN-fronted hosts (reproducible on WordPress VIP). The failure surfaces as an empty mount div plus `Uncaught Error: Cannot unlock an undefined object` in the console.

## Root cause

The four auto-generated files below register a `-prerequisites` classic-script handle with an empty `src` and attach an inline script that does a dynamic ESM import:

```php
wp_register_script( '…-prerequisites', '', $asset['dependencies'], $asset['version'], true );
wp_add_inline_script( '…-prerequisites',
    'import("@wordpress/boot").then(mod => mod.init({…}));'
);
```

Because the handle has no `src`, only the inline is printed, and it runs as a classic `<script>` the instant the HTML parser reaches it.

`@wordpress/boot` is `<link rel="modulepreload">`-ed in `<head>`. On a fast CDN the bundle is effectively free, so the dynamic import resolves and the module evaluates **before** the parser has reached the classic deps it relies on (`wp-private-apis`, `wp-components`, `wp-theme`).

At its top-level `@wordpress/boot` reads `window.wp.theme.privateApis`, which is still `undefined` at that point, so `unlock(undefined)` throws and `initSinglePage` / `init` never runs.

Only Chrome + fast CDN reliably loses the race; Firefox/Safari schedule module eval slightly later, and local dev is slow enough that the classic deps usually finish first.

## The fix (Option 1 from the ticket)

Wrap the dynamic import in `DOMContentLoaded`. The HTML spec guarantees `DOMContentLoaded` fires only after every parser-blocking classic `<script>` has executed, so `wp.theme.privateApis` (and the rest) are populated before `@wordpress/boot` evaluates. A `document.readyState === "loading"` guard preserves behavior when the inline is ever re-run after DOM ready (e.g. AJAX-injected contexts).

Before:

```js
import("@wordpress/boot").then(mod => mod.initSinglePage({mountId: "…", routes: [...]}));
```

After:

```js
(function(){
  var run = function(){
    import("@wordpress/boot").then(function(mod){
      mod.initSinglePage({mountId: "…", routes: [...]});
    });
  };
  if (document.readyState === "loading") {
    document.addEventListener("DOMContentLoaded", run);
  } else {
    run();
  }
})();
```

## Files changed

All four auto-generated files that share this pattern:

- `src/wp-includes/build/pages/options-connectors/page.php` (`init`)
- `src/wp-includes/build/pages/options-connectors/page-wp-admin.php` (`initSinglePage`)
- `src/wp-includes/build/pages/font-library/page.php` (`init`)
- `src/wp-includes/build/pages/font-library/page-wp-admin.php` (`initSinglePage`)

Each file's `wp_add_inline_script(…)` call is updated, plus an explanatory comment referencing Trac #65103. No registration logic, dependency lists, script module graph, or style registration is touched.

## Why not the other options from the ticket

- **Option 2** (emit the inline as a module script) would require a new `wp_add_inline_script_module()` API or a `script_loader_tag` filter — out of scope for a bugfix.
- **Option 3** (move `initSinglePage` into `loader.js`) would change the public module contract, require a coordinated Gutenberg-side change, and migrate every downstream consumer of the pattern.

## Follow-up note for committers

These files are marked "Auto-generated by build process. Do not edit this file manually." The generator lives in Gutenberg's build pipeline. A search of the local Gutenberg checkout finds no matching template string, so the `wordpress-develop` copies are effectively the current source of truth — but the Gutenberg-side template should receive the same change (or the next sync from Gutenberg will silently revert this). Happy to open a follow-up Gutenberg PR once this lands.

## Test plan

- [ ] Manual: on a CloudFront-fronted dev environment in Chrome (or with DevTools Network throttling set to simulate CDN on module responses only), load `/wp-admin/options-connectors.php` and the Font Library admin screen. Confirm the app mounts and "Cannot unlock an undefined object" is not logged.
- [ ] Manual: hard-reload several times to exercise the race window.
- [ ] Manual: repeat in Firefox and Safari to confirm no regression.
- [ ] Confirm `document.readyState` guard: visit the page, then in the console re-evaluate the inline body and verify `mod.init` / `mod.initSinglePage` is still called exactly once (behavior preserved for late-arriving scripts).

## Related

- Not a regression — the pattern worked everywhere the race was too tight to fire. Surfaces only in fast-CDN + Chrome setups.
- Connectors screen landed in 7.0; Font Library uses the same generator output.
- Any downstream consumer using the same `wp_register_script('-prerequisites', '', …)` + inline `import("@wordpress/boot")` pattern has the same bug.
