### PR TITLE
Toolbar: normalize admin bar title entities

### DIFF
--- a/src/wp-includes/class-wp-admin-bar.php
+++ b/src/wp-includes/class-wp-admin-bar.php
@@ -587,7 +587,7 @@ class WP_Admin_Bar {
 			}
 		}
 
-		echo ">{$arrow}{$node->title}";
+		echo '>' . $arrow . wp_kses_normalize_entities( $node->title );
 
 		if ( $has_link ) {
 			echo '</a>';

--- a/tests/phpunit/tests/adminbar.php
+++ b/tests/phpunit/tests/adminbar.php
@@ -268,6 +268,25 @@ class Tests_AdminBar extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 62545
+	 */
+	public function test_admin_bar_normalizes_title_entities_without_escaping_html() {
+		$admin_bar = new WP_Admin_Bar();
+		$admin_bar->add_node(
+			array(
+				'id'    => 'test-node',
+				'title' => '<span class="ab-icon" aria-hidden="true"></span>This & that',
+				'href'  => 'https://example.org',
+			)
+		);
+
+		$admin_bar_html = get_echo( array( $admin_bar, 'render' ) );
+
+		$this->assertStringContainsString( '<span class="ab-icon" aria-hidden="true"></span>This &amp; that', $admin_bar_html );
+		$this->assertStringNotContainsString( '&lt;span class=&quot;ab-icon&quot;', $admin_bar_html );
+	}
+
+	/**
 	 * Data provider for test_admin_bar_with_tabindex_meta().
 	 *
 	 * @return array {


### PR DESCRIPTION
## Summary
Normalize HTML entities when rendering admin bar node titles without escaping valid markup used by core and plugins.

## Problem
`WP_Admin_Bar::_render_item()` outputs `$node->title` directly. This means text like `This & that` is rendered with a literal `&` instead of a normalized `&amp;`, while broad escaping approaches would break existing admin bar titles that intentionally include HTML.

Trac ticket: https://core.trac.wordpress.org/ticket/62545

## Solution
Use `wp_kses_normalize_entities()` when rendering the admin bar title. This normalizes entities in text content while preserving valid embedded markup.

## Testing
Added a PHPUnit regression test covering an admin bar title that includes both HTML markup and an ampersand.

Verified in the configured local `wordpress-develop` environment with:
- `node ./tools/local-env/scripts/docker.js exec --user wp_php php ./vendor/bin/phpunit --filter test_admin_bar_normalizes_title_entities_without_escaping_html tests/phpunit/tests/adminbar.php`
- `node ./tools/local-env/scripts/docker.js exec --user wp_php php ./vendor/bin/phpunit tests/phpunit/tests/adminbar.php`
