### PR TITLE
Administration: Replace pure white body background on Font Library and Connectors pages

### DIFF
--- a/src/wp-includes/build/pages/font-library/page-wp-admin.php
+++ b/src/wp-includes/build/pages/font-library/page-wp-admin.php
@@ -226,7 +226,7 @@ function wp_font_library_wp_admin_render_page() {
 			overflow-y: auto;
 		}
 		body {
-			background: #fff;
+			background: #f0f0f1;
 		}
 
 		/* Reset wp-admin padding */

--- a/src/wp-includes/build/pages/options-connectors/page-wp-admin.php
+++ b/src/wp-includes/build/pages/options-connectors/page-wp-admin.php
@@ -226,7 +226,7 @@ function wp_options_connectors_wp_admin_render_page() {
 			overflow-y: auto;
 		}
 		body {
-			background: #fff;
+			background: #f0f0f1;
 		}
 
 		/* Reset wp-admin padding */


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65100

## Summary

Ticket [#65100](https://core.trac.wordpress.org/ticket/65100) reports several accessibility issues in the admin Font Library, and in comment #5 [@afercia](https://profiles.wordpress.org/afercia/) noted that the new Connectors page at `wp-admin/options-connectors.php` (introduced in 7.0) uses the same pattern and shares those issues — including a **pure white body background** that is inconsistent with the rest of core admin and against documented accessibility/UX best practice ("Never use full white", comment #5).

Both `page-wp-admin.php` wrapper files add this inline style:

```css
body {
    background: #fff;
}
```

This causes the white content cards (`.components-item`) to blend into the body background and is inconsistent with every other core admin screen, which use `#f0f0f1` (defined in `src/wp-admin/css/common.css`, line 225).

This PR changes that override to `#f0f0f1` on both pages so they match the rest of the core admin UI and give the white cards visible contrast with their surroundings — directly addressing the background-color concern from comments #5 and #6 on the ticket.

## Files changed

- `src/wp-includes/build/pages/font-library/page-wp-admin.php`
- `src/wp-includes/build/pages/options-connectors/page-wp-admin.php`

Both are single-line changes: `background: #fff;` → `background: #f0f0f1;`.

## Not in scope for this PR

The other accessibility items from the ticket are rendered by the Gutenberg `@wordpress/admin-ui` `Page`/`Header` component (compiled into `src/wp-includes/build/routes/**`), so the fix has to land in Gutenberg and will sync down on the next package update:

- **H1 vs H2 heading level** — already fixed upstream in [WordPress/gutenberg#77482](https://github.com/WordPress/gutenberg/pull/77482).
- **Inappropriate `<header>` landmark on the page title block** — comment #4; tracked in [WordPress/gutenberg#77481](https://github.com/WordPress/gutenberg/issues/77481).
- **ARIA landmarks nesting on the Connectors page** — comment #5; same Gutenberg component.

Once those Gutenberg fixes land and the build sync regenerates these files, the `background: #f0f0f1;` value in this PR is consistent with the plan in comment #6 (latest Gutenberg uses a near-white, not pure white).

## Test plan

- [ ] Load `wp-admin/options-connectors.php` (Settings → Connectors) and confirm the body background matches the rest of wp-admin (`#f0f0f1`) and the connector cards visually stand out.
- [ ] Load `wp-admin/font-library.php` (Appearance → Fonts) and confirm the same.
- [ ] Confirm no visual regression elsewhere on those two screens.
- [ ] Compare side-by-side with `wp-admin/options-general.php` to confirm consistency.

Props joedolson, afercia, hbhalodia, wildworks.
