### PR TITLE
Comment: Add $limit_by_depth argument to get_comment_reply_link() to control reply link visibility at max depth

### DIFF
--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -1725,6 +1725,7 @@ function comments_popup_link( $zero = false, $one = false, $more = false, $css_c
  *
  * @since 2.7.0
  * @since 4.4.0 Added the ability for `$comment` to also accept a WP_Comment object.
+ * @since 4.9.0 Added the `$limit_by_depth` argument, whether to hide the link at the max depth and below.
  *
  * @param array          $args {
  *     Optional. Override default arguments.
@@ -1746,6 +1747,7 @@ function comments_popup_link( $zero = false, $one = false, $more = false, $css_c
  *                                      of the 'thread_comments_depth' option set in Settings > Discussion. Default 0.
  *     @type string $before             The text or HTML to add before the reply link. Default empty.
  *     @type string $after              The text or HTML to add after the reply link. Default empty.
+ *     @type bool   $limit_by_depth    Hide the link at the max depth and below. Default true.
  * }
  * @param int|WP_Comment $comment Optional. Comment being replied to. Default current comment.
  * @param int|WP_Post    $post    Optional. Post ID or WP_Post object the comment is going to be displayed on.
@@ -1765,6 +1767,7 @@ function get_comment_reply_link( $args = array(), $comment = null, $post = null 
 		'before'             => '',
 		'after'              => '',
 		'show_reply_to_text' => false,
+		'limit_by_depth'     => true,
 	);
 
 	$args = wp_parse_args( $args, $defaults );
@@ -1772,7 +1775,11 @@ function get_comment_reply_link( $args = array(), $comment = null, $post = null 
 	$args['max_depth'] = (int) $args['max_depth'];
 	$args['depth']     = (int) $args['depth'];
 
-	if ( 0 === $args['depth'] || $args['max_depth'] <= $args['depth'] ) {
+	if ( 0 === $args['depth'] ) {
+		return null;
+	}
+
+	if ( $args['limit_by_depth'] && $args['max_depth'] <= $args['depth'] ) {
 		return null;
 	}
 

--- a/tests/phpunit/tests/comment/getCommentReplyLink.php
+++ b/tests/phpunit/tests/comment/getCommentReplyLink.php
@@ -95,7 +95,7 @@ class Tests_Comment_GetCommentReplyLink extends WP_UnitTestCase {
 		$post_id    = self::factory()->post->create();
 		$comment_id = self::factory()->comment->create(
 			array(
-				'comment_post_ID' => $post_id,
+				'comment_post_ID'  => $post_id,
 				'comment_approved' => '1',
 			)
 		);
@@ -116,7 +116,7 @@ class Tests_Comment_GetCommentReplyLink extends WP_UnitTestCase {
 		$post_id    = self::factory()->post->create();
 		$comment_id = self::factory()->comment->create(
 			array(
-				'comment_post_ID' => $post_id,
+				'comment_post_ID'  => $post_id,
 				'comment_approved' => '1',
 			)
 		);
@@ -137,7 +137,7 @@ class Tests_Comment_GetCommentReplyLink extends WP_UnitTestCase {
 		$post_id    = self::factory()->post->create( array( 'comment_status' => 'closed' ) );
 		$comment_id = self::factory()->comment->create(
 			array(
-				'comment_post_ID' => $post_id,
+				'comment_post_ID'  => $post_id,
 				'comment_approved' => '1',
 			)
 		);

--- a/tests/phpunit/tests/comment/getCommentReplyLink.php
+++ b/tests/phpunit/tests/comment/getCommentReplyLink.php
@@ -87,4 +87,66 @@ class Tests_Comment_GetCommentReplyLink extends WP_UnitTestCase {
 
 		$this->assertNull( $actual );
 	}
+
+	/**
+	 * @ticket 38925
+	 */
+	public function test_should_return_reply_link_when_limit_by_depth_is_false_and_max_depth_less_than_depth() {
+		$post_id    = self::factory()->post->create();
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID' => $post_id,
+				'comment_approved' => '1',
+			)
+		);
+
+		$args = array(
+			'depth'          => 5,
+			'max_depth'      => 4,
+			'limit_by_depth' => false,
+		);
+
+		$this->assertStringContainsString( 'replytocom', get_comment_reply_link( $args, $comment_id ) );
+	}
+
+	/**
+	 * @ticket 38925
+	 */
+	public function test_should_return_reply_link_when_limit_by_depth_is_true_and_depth_less_than_max_depth() {
+		$post_id    = self::factory()->post->create();
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID' => $post_id,
+				'comment_approved' => '1',
+			)
+		);
+
+		$args = array(
+			'depth'          => 4,
+			'max_depth'      => 5,
+			'limit_by_depth' => true,
+		);
+
+		$this->assertStringContainsString( 'replytocom', get_comment_reply_link( $args, $comment_id ) );
+	}
+
+	/**
+	 * @ticket 38925
+	 */
+	public function test_should_return_false_on_post_with_closed_comment_status() {
+		$post_id    = self::factory()->post->create( array( 'comment_status' => 'closed' ) );
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID' => $post_id,
+				'comment_approved' => '1',
+			)
+		);
+
+		$args = array(
+			'depth'     => 4,
+			'max_depth' => 5,
+		);
+
+		$this->assertFalse( get_comment_reply_link( $args, $comment_id ) );
+	}
 }


### PR DESCRIPTION
Ticket: https://core.trac.wordpress.org/ticket/38925