### PR TITLE
Fix: Correct formatting of locked text in posts list table

### DIFF
--- a/src/wp-admin/includes/class-wp-posts-list-table.php
+++ b/src/wp-admin/includes/class-wp-posts-list-table.php
@@ -1122,7 +1122,7 @@ class WP_Posts_List_Table extends WP_List_Table {
 				if ( get_option( 'wp_collaboration_enabled' ) ) {
 					$locked_avatar = '';
 					/* translators: Collaboration status message for a singular post in the post list. Can be any type of post. */
-					$locked_text   = esc_html_x( 'Currently being edited', 'post list' );
+					$locked_text = esc_html_x( 'Currently being edited', 'post list' );
 				} else {
 					$lock_holder   = get_userdata( $lock_holder );
 					$locked_avatar = get_avatar( $lock_holder->ID, 18 );


### PR DESCRIPTION
Ticket: https://core.trac.wordpress.org/ticket/65114

## Description
Correct the alignment of the $locked_text variable assignment in the column_title() method of WP_Posts_List_Table.

## Testing
Run PHPCS against `src/wp-admin/includes/class-wp-posts-list-table.php` and verify no coding standards errors are reported.