### PR TITLE
Command Palette: Fix macOs label for sites unable to determine UA via PHP

### DIFF
--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -961,18 +961,6 @@ function wp_admin_bar_command_palette_menu( WP_Admin_Bar $wp_admin_bar ): void {
 		/* translators: Hidden accessibility text. */
 		__( 'Open command palette' ),
 	);
-	$wp_admin_bar->add_node(
-		array(
-			'id'    => 'command-palette',
-			'title' => $title,
-			'href'  => '#',
-			'meta'  => array(
-				'class'   => 'hide-if-no-js',
-				'onclick' => 'wp.data.dispatch( "core/commands" ).open(); return false;',
-			),
-		)
-	);
-
 	/*
 	 * The script is added as an inline script to avoid an additional dependency.
 	 *
@@ -1001,7 +989,17 @@ function wp_admin_bar_command_palette_menu( WP_Admin_Bar $wp_admin_bar ): void {
 		})
 	JS;
 	$script .= '(' . wp_json_encode( $shortcut_labels ) . ');';
-	wp_add_inline_script( 'admin-bar', $script );
+	$wp_admin_bar->add_node(
+		array(
+			'id'    => 'command-palette',
+			'title' => $title,
+			'href'  => '#',
+			'meta'  => array(
+				'class'   => 'hide-if-no-js',
+				'onclick' => 'wp.data.dispatch( "core/commands" ).open(); return false;',
+			),
+		)
+	);
 }
 
 /**

--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -962,7 +962,7 @@ function wp_admin_bar_command_palette_menu( WP_Admin_Bar $wp_admin_bar ): void {
 		__( 'Open command palette' ),
 	);
 	/*
-	 * Detect Apple OS via JavaScript for users behind a CDN blocking the UA header.
+	 * Detect Apple OS via JavaScript for sites behind a CDN blocking the UA header.
 	 *
 	 * Running the script as the admin bar is rendered avoids a flash of incorrect content
 	 * for users with Apple OS when the UA header is blocked. It also prevents the need for

--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -969,16 +969,16 @@ function wp_admin_bar_command_palette_menu( WP_Admin_Bar $wp_admin_bar ): void {
 	 * wp-i18n to be loaded as a dependency.
 	 */
 	$function = <<<'JS'
-		( shortcutLabels ) => {
+		( appleOSLabel ) => {
 			if ( navigator.platform.startsWith("Mac") || navigator.platform === "iPhone" || navigator.platform === "iPad" ) {
-				document.querySelector( '#wp-admin-bar-command-palette .ab-label kbd' ).textContent = shortcutLabels.appleOS;
+				document.querySelector( '#wp-admin-bar-command-palette .ab-label kbd' ).textContent = appleOSLabel;
 			}
 		}
 	JS;
 	$script   = sprintf(
 		'( %s )( %s );',
 		$function,
-		wp_json_encode( $shortcut_labels, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES )
+		wp_json_encode( $shortcut_labels['appleOS'], JSON_HEX_TAG | JSON_UNESCAPED_SLASHES )
 	);
 	$script  .= "\n//# sourceURL=wp_admin_bar_command_palette_menu";
 	$wp_admin_bar->add_node(

--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -984,9 +984,10 @@ function wp_admin_bar_command_palette_menu( WP_Admin_Bar $wp_admin_bar ): void {
 	 */
 	$script  = <<<JS
 		(( shortCutLabels ) => {
+			let userAgent = '';
 			// Assigning agent may error if the HTTP header is blocked at the browser level.
 			try {
-				const userAgent = navigator.userAgent;
+				userAgent = navigator.userAgent;
 			} catch (error) {
 				// Make no change to the default shortcut label.
 				return;

--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -982,7 +982,7 @@ function wp_admin_bar_command_palette_menu( WP_Admin_Bar $wp_admin_bar ): void {
 	 * on the front-end, the script would be loaded but remain unused on the front-end of
 	 * a website.
 	 */
-	$script  = <<<JS
+	$script  = <<<'JS'
 		(( shortCutLabels ) => {
 			let userAgent = '';
 			// Assigning agent may error if the HTTP header is blocked at the browser level.
@@ -999,7 +999,7 @@ function wp_admin_bar_command_palette_menu( WP_Admin_Bar $wp_admin_bar ): void {
 				commandPaletteNode.textContent = shortcutLabel;
 			}
 		})
-JS;
+	JS;
 	$script .= '(' . wp_json_encode( $shortcut_labels ) . ');';
 	wp_add_inline_script( 'admin-bar', $script );
 }

--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -969,16 +969,16 @@ function wp_admin_bar_command_palette_menu( WP_Admin_Bar $wp_admin_bar ): void {
 	 * wp-i18n to be loaded as a dependency as it is most likely not included on the front
 	 * end of a site.
 	 */
-	$script  = <<<'JS'
-		(( shortcutLabels ) => {
+	$function = <<<'JS'
+		( shortcutLabels ) => {
 			const isAppleOS = navigator.platform.startsWith("Mac") || navigator.platform === "iPhone" || navigator.platform === "iPad";
 			if ( ! isAppleOS ) {
 				return;
 			}
 			document.querySelector( '#wp-admin-bar-command-palette .ab-label kbd' ).textContent = shortcutLabels.appleOS;
-		})
+		}
 	JS;
-	$script .= '(' . wp_json_encode( $shortcut_labels, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ) . ');';
+	$script   = sprintf( '( %s )( %s );', $function, wp_json_encode( $shortcut_labels, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ) );
 	$script .= "\n//# sourceURL=wp_admin_bar_command_palette_menu";
 	$wp_admin_bar->add_node(
 		array(

--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -953,7 +953,8 @@ function wp_admin_bar_command_palette_menu( WP_Admin_Bar $wp_admin_bar ): void {
 		'appleOS' => _x( '⌘K', 'keyboard shortcut to open the command palette' ),
 		'default' => _x( 'Ctrl+K', 'keyboard shortcut to open the command palette' ),
 	);
-	$is_apple_os     = (bool) preg_match( '/Macintosh|Mac OS X|Mac_PowerPC/i', $_SERVER['HTTP_USER_AGENT'] ?? '' );
+	$apple_pattern   = 'Macintosh|Mac OS X|Mac_PowerPC';
+	$is_apple_os     = (bool) preg_match( "/{$apple_pattern}/i", $_SERVER['HTTP_USER_AGENT'] ?? '' );
 	$shortcut_label  = $is_apple_os ? $shortcut_labels['appleOS'] : $shortcut_labels['default'];
 	$title           = sprintf(
 		'<span class="ab-icon" aria-hidden="true"></span><span class="ab-label"><kbd>%s</kbd><span class="screen-reader-text"> %s</span></span>',
@@ -969,15 +970,16 @@ function wp_admin_bar_command_palette_menu( WP_Admin_Bar $wp_admin_bar ): void {
 	 * wp-i18n to be loaded as a dependency.
 	 */
 	$function = <<<'JS'
-		( appleOSLabel ) => {
-			if ( navigator.platform.startsWith("Mac") || navigator.platform === "iPhone" || navigator.platform === "iPad" ) {
+		( applePattern, appleOSLabel ) => {
+			if ( ( new RegExp( applePattern ) ).test( navigator.userAgent ) ) {
 				document.querySelector( '#wp-admin-bar-command-palette .ab-label kbd' ).textContent = appleOSLabel;
 			}
 		}
 	JS;
 	$script   = sprintf(
-		'( %s )( %s );',
+		'( %s )( %s, %s );',
 		$function,
+		wp_json_encode( $apple_pattern, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ),
 		wp_json_encode( $shortcut_labels['appleOS'], JSON_HEX_TAG | JSON_UNESCAPED_SLASHES )
 	);
 	$script  .= "\n//# sourceURL=" . rawurlencode( __FUNCTION__ );

--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -980,7 +980,7 @@ function wp_admin_bar_command_palette_menu( WP_Admin_Bar $wp_admin_bar ): void {
 		$function,
 		wp_json_encode( $shortcut_labels['appleOS'], JSON_HEX_TAG | JSON_UNESCAPED_SLASHES )
 	);
-	$script  .= "\n//# sourceURL=" . esc_url_raw( __FUNCTION__ );
+	$script  .= "\n//# sourceURL=" . rawurlencode( __FUNCTION__ );
 	$wp_admin_bar->add_node(
 		array(
 			'id'    => 'command-palette',

--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -988,7 +988,7 @@ function wp_admin_bar_command_palette_menu( WP_Admin_Bar $wp_admin_bar ): void {
 			'meta'  => array(
 				'class'   => 'hide-if-no-js',
 				'onclick' => 'wp.data.dispatch( "core/commands" ).open(); return false;',
-				'html'    => '<script>' . $script . '</script>',
+				'html'    => "<script>{$script}</script>",
 			),
 		)
 	);

--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -962,33 +962,24 @@ function wp_admin_bar_command_palette_menu( WP_Admin_Bar $wp_admin_bar ): void {
 		__( 'Open command palette' ),
 	);
 	/*
-	 * The script is added as an inline script to avoid an additional dependency.
+	 * Detect Apple OS via JavaScript for users behind a CDN blocking the UA header.
 	 *
-	 * Adding the code within the admin-bar script would require the wp-i18n script to be loaded
-	 * as a dependency. While this is widely available in the admin, the wp-i18n script is not
-	 * commonly required on the front end of the site. As the command palette is not available
-	 * on the front-end, the script would be loaded but remain unused on the front-end of
-	 * a website.
+	 * Running the script as the admin bar is rendered avoids a flash of incorrect content
+	 * for users with Apple OS when the UA header is blocked. It also prevents the need for
+	 * wp-i18n to be loaded as a dependency as it is most likely not included on the front
+	 * end of a site.
 	 */
 	$script  = <<<'JS'
 		(( shortcutLabels ) => {
-			let userAgent = '';
-			// Assigning agent may error if the HTTP header is blocked at the browser level.
-			try {
-				userAgent = navigator.userAgent;
-			} catch (error) {
-				// Make no change to the default shortcut label.
+			const isAppleOS = navigator.platform.startsWith("Mac") || navigator.platform === "iPhone" || navigator.platform === "iPad";
+			if ( ! isAppleOS ) {
 				return;
 			}
-			const isAppleOS = /Macintosh|Mac OS X|Mac_PowerPC/i.test( userAgent );
-			const shortcutLabel = isAppleOS ? shortcutLabels.appleOS : shortcutLabels.default;
-			const commandPaletteNode = document.querySelector( '#wp-admin-bar-command-palette .ab-label kbd' );
-			if ( commandPaletteNode ) {
-				commandPaletteNode.textContent = shortcutLabel;
-			}
+			document.querySelector( '#wp-admin-bar-command-palette .ab-label kbd' ).textContent = shortcutLabels.appleOS;
 		})
 	JS;
-	$script .= '(' . wp_json_encode( $shortcut_labels ) . ');';
+	$script .= '(' . wp_json_encode( $shortcut_labels, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ) . ');';
+	$script .= "\n//# sourceURL=wp_admin_bar_command_palette_menu";
 	$wp_admin_bar->add_node(
 		array(
 			'id'    => 'command-palette',
@@ -997,6 +988,7 @@ function wp_admin_bar_command_palette_menu( WP_Admin_Bar $wp_admin_bar ): void {
 			'meta'  => array(
 				'class'   => 'hide-if-no-js',
 				'onclick' => 'wp.data.dispatch( "core/commands" ).open(); return false;',
+				'html'    => '<script>' . $script . '</script>',
 			),
 		)
 	);

--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -989,7 +989,7 @@ function wp_admin_bar_command_palette_menu( WP_Admin_Bar $wp_admin_bar ): void {
 			'meta'  => array(
 				'class'   => 'hide-if-no-js',
 				'onclick' => 'wp.data.dispatch( "core/commands" ).open(); return false;',
-				'html'    => "<script>{$script}</script>",
+				'html'    => wp_get_inline_script_tag( $script ),
 			),
 		)
 	);

--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -973,6 +973,15 @@ function wp_admin_bar_command_palette_menu( WP_Admin_Bar $wp_admin_bar ): void {
 		)
 	);
 
+	/*
+	 * The script is added as an inline script to avoid an additional dependency.
+	 *
+	 * Adding the code within the admin-bar script would require the wp-i18n script to be loaded
+	 * as a dependency. While this is widely available in the admin, the wp-i18n script is not
+	 * commonly required on the front end of the site. As the command palette is not available
+	 * on the front-end, the script would be loaded but remain unused on the front-end of
+	 * a website.
+	 */
 	$script  = <<<JS
 		(( shortCutLabels ) => {
 			// Assigning agent may error if the HTTP header is blocked at the browser level.

--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -983,7 +983,7 @@ function wp_admin_bar_command_palette_menu( WP_Admin_Bar $wp_admin_bar ): void {
 	 * a website.
 	 */
 	$script  = <<<'JS'
-		(( shortCutLabels ) => {
+		(( shortcutLabels ) => {
 			let userAgent = '';
 			// Assigning agent may error if the HTTP header is blocked at the browser level.
 			try {
@@ -993,7 +993,7 @@ function wp_admin_bar_command_palette_menu( WP_Admin_Bar $wp_admin_bar ): void {
 				return;
 			}
 			const isAppleOS = /Macintosh|Mac OS X|Mac_PowerPC/i.test( userAgent );
-			const shortcutLabel = isAppleOS ? shortCutLabels.appleOS : shortCutLabels.default;
+			const shortcutLabel = isAppleOS ? shortcutLabels.appleOS : shortcutLabels.default;
 			const commandPaletteNode = document.querySelector( '#wp-admin-bar-command-palette .ab-label kbd' );
 			if ( commandPaletteNode ) {
 				commandPaletteNode.textContent = shortcutLabel;

--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -979,7 +979,7 @@ function wp_admin_bar_command_palette_menu( WP_Admin_Bar $wp_admin_bar ): void {
 		}
 	JS;
 	$script   = sprintf( '( %s )( %s );', $function, wp_json_encode( $shortcut_labels, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ) );
-	$script .= "\n//# sourceURL=wp_admin_bar_command_palette_menu";
+	$script  .= "\n//# sourceURL=wp_admin_bar_command_palette_menu";
 	$wp_admin_bar->add_node(
 		array(
 			'id'    => 'command-palette',

--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -975,10 +975,9 @@ function wp_admin_bar_command_palette_menu( WP_Admin_Bar $wp_admin_bar ): void {
 
 	$script  = <<<JS
 		(( shortCutLabels ) => {
-			let userAgent = '';
 			// Assigning agent may error if the HTTP header is blocked at the browser level.
 			try {
-				userAgent = navigator.userAgent;
+				const userAgent = navigator.userAgent;
 			} catch (error) {
 				// Make no change to the default shortcut label.
 				return;

--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -971,11 +971,9 @@ function wp_admin_bar_command_palette_menu( WP_Admin_Bar $wp_admin_bar ): void {
 	 */
 	$function = <<<'JS'
 		( shortcutLabels ) => {
-			const isAppleOS = navigator.platform.startsWith("Mac") || navigator.platform === "iPhone" || navigator.platform === "iPad";
-			if ( ! isAppleOS ) {
-				return;
+			if ( navigator.platform.startsWith("Mac") || navigator.platform === "iPhone" || navigator.platform === "iPad" ) {
+				document.querySelector( '#wp-admin-bar-command-palette .ab-label kbd' ).textContent = shortcutLabels.appleOS;
 			}
-			document.querySelector( '#wp-admin-bar-command-palette .ab-label kbd' ).textContent = shortcutLabels.appleOS;
 		}
 	JS;
 	$script   = sprintf( '( %s )( %s );', $function, wp_json_encode( $shortcut_labels, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ) );

--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -966,8 +966,7 @@ function wp_admin_bar_command_palette_menu( WP_Admin_Bar $wp_admin_bar ): void {
 	 *
 	 * Running the script as the admin bar is rendered avoids a flash of incorrect content
 	 * for users with Apple OS when the UA header is blocked. It also prevents the need for
-	 * wp-i18n to be loaded as a dependency as it is most likely not included on the front
-	 * end of a site.
+	 * wp-i18n to be loaded as a dependency.
 	 */
 	$function = <<<'JS'
 		( shortcutLabels ) => {

--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -980,7 +980,7 @@ function wp_admin_bar_command_palette_menu( WP_Admin_Bar $wp_admin_bar ): void {
 		$function,
 		wp_json_encode( $shortcut_labels['appleOS'], JSON_HEX_TAG | JSON_UNESCAPED_SLASHES )
 	);
-	$script  .= "\n//# sourceURL=wp_admin_bar_command_palette_menu";
+	$script  .= "\n//# sourceURL=" . esc_url_raw( __FUNCTION__ );
 	$wp_admin_bar->add_node(
 		array(
 			'id'    => 'command-palette',

--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -949,11 +949,13 @@ function wp_admin_bar_command_palette_menu( WP_Admin_Bar $wp_admin_bar ): void {
 		return;
 	}
 
-	$is_apple_os    = (bool) preg_match( '/Macintosh|Mac OS X|Mac_PowerPC/i', $_SERVER['HTTP_USER_AGENT'] ?? '' );
-	$shortcut_label = $is_apple_os
-		? _x( '⌘K', 'keyboard shortcut to open the command palette' )
-		: _x( 'Ctrl+K', 'keyboard shortcut to open the command palette' );
-	$title          = sprintf(
+	$shortcut_labels = array(
+		'appleOS' => _x( '⌘K', 'keyboard shortcut to open the command palette' ),
+		'default' => _x( 'Ctrl+K', 'keyboard shortcut to open the command palette' ),
+	);
+	$is_apple_os     = (bool) preg_match( '/Macintosh|Mac OS X|Mac_PowerPC/i', $_SERVER['HTTP_USER_AGENT'] ?? '' );
+	$shortcut_label  = $is_apple_os ? $shortcut_labels['appleOS'] : $shortcut_labels['default'];
+	$title           = sprintf(
 		'<span class="ab-icon" aria-hidden="true"></span><span class="ab-label"><kbd>%s</kbd><span class="screen-reader-text"> %s</span></span>',
 		$shortcut_label,
 		/* translators: Hidden accessibility text. */
@@ -970,6 +972,27 @@ function wp_admin_bar_command_palette_menu( WP_Admin_Bar $wp_admin_bar ): void {
 			),
 		)
 	);
+
+	$script  = <<<JS
+		(( shortCutLabels ) => {
+			let userAgent = '';
+			// Assigning agent may error if the HTTP header is blocked at the browser level.
+			try {
+				userAgent = navigator.userAgent;
+			} catch (error) {
+				// Make no change to the default shortcut label.
+				return;
+			}
+			const isAppleOS = /Macintosh|Mac OS X|Mac_PowerPC/i.test( userAgent );
+			const shortcutLabel = isAppleOS ? shortCutLabels.appleOS : shortCutLabels.default;
+			const commandPaletteNode = document.querySelector( '#wp-admin-bar-command-palette .ab-label kbd' );
+			if ( commandPaletteNode ) {
+				commandPaletteNode.textContent = shortcutLabel;
+			}
+		})
+JS;
+	$script .= '(' . wp_json_encode( $shortcut_labels ) . ');';
+	wp_add_inline_script( 'admin-bar', $script );
 }
 
 /**

--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -975,7 +975,11 @@ function wp_admin_bar_command_palette_menu( WP_Admin_Bar $wp_admin_bar ): void {
 			}
 		}
 	JS;
-	$script   = sprintf( '( %s )( %s );', $function, wp_json_encode( $shortcut_labels, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ) );
+	$script   = sprintf(
+		'( %s )( %s );',
+		$function,
+		wp_json_encode( $shortcut_labels, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES )
+	);
 	$script  .= "\n//# sourceURL=wp_admin_bar_command_palette_menu";
 	$wp_admin_bar->add_node(
 		array(


### PR DESCRIPTION
Adds a JavaScript check of the User-Agent for displaying the text in the admin bar.

On sites served over a CDN is it relatively common for the CDN to strip the `User-Agent` HTTP header, on macOS systems this causes the incorrect label to be displayed.

See https://github.com/WordPress/gutenberg/issues/77636
Closes Core-65121


## Testing Instructions
1. Buy a macOS computer/use BrowserStack on macOS.
2. In your `wp-config.php` file, add the code `$_SERVER['HTTP_USER_AGENT'] = '';` to emulate a site behind a CDN stripping the header
3. Visit `/wp-admin`
4. Ensure the label is correct on this branch.
5. Ensure the label is incorrect on trunk
6. Remove the code added to the wp-config file to avoid confusion later.

Trac ticket: https://core.trac.wordpress.org/ticket/65121

## Use of AI Tools

N/A