### PR TITLE
Administration: Display serialized option values read-only instead of a placeholder

### DIFF
--- a/src/wp-admin/network/site-settings.php
+++ b/src/wp-admin/network/site-settings.php
@@ -132,62 +132,64 @@ if ( ! empty( $messages ) ) {
 			)
 		);
 
+		$ltr_fields = array(
+			'siteurl',
+			'home',
+			'admin_email',
+			'new_admin_email',
+			'mailserver_url',
+			'mailserver_login',
+			'mailserver_pass',
+			'ping_sites',
+			'permalink_structure',
+			'category_base',
+			'tag_base',
+			'upload_path',
+			'upload_url_path',
+		);
+
 		foreach ( $options as $option ) {
 			if ( 'default_role' === $option->option_name ) {
 				$editblog_default_role = $option->option_value;
 			}
 
-			$disabled = false;
-			$class    = 'all-options';
+			$value         = $option->option_value;
+			$disabled      = false;
+			$is_serialized = false;
 
-			if ( is_serialized( $option->option_value ) ) {
-				if ( is_serialized_string( $option->option_value ) ) {
-					$option->option_value = esc_html( maybe_unserialize( $option->option_value ) );
+			if ( is_serialized( $value ) ) {
+				if ( is_serialized_string( $value ) ) {
+					$value = maybe_unserialize( $value );
 				} else {
-					$option->option_value = 'SERIALIZED DATA';
-					$disabled             = true;
-					$class                = 'all-options disabled';
+					// Other serialized values (arrays, objects) are shown raw, read-only, inside a collapsible <details>.
+					$disabled      = true;
+					$is_serialized = true;
 				}
 			}
 
-			$ltr_fields = array(
-				'siteurl',
-				'home',
-				'admin_email',
-				'new_admin_email',
-				'mailserver_url',
-				'mailserver_login',
-				'mailserver_pass',
-				'ping_sites',
-				'permalink_structure',
-				'category_base',
-				'tag_base',
-				'upload_path',
-				'upload_url_path',
-			);
-			if ( in_array( $option->option_name, $ltr_fields, true ) ) {
-				$class .= ' ltr';
-			}
-
-			if ( str_contains( $option->option_value, "\n" ) ) {
-				?>
-				<tr class="form-field">
-					<th scope="row"><label for="<?php echo esc_attr( $option->option_name ); ?>" class="code"><?php echo esc_html( $option->option_name ); ?></label></th>
-					<td><textarea class="<?php echo $class; ?>" rows="5" cols="40" name="option[<?php echo esc_attr( $option->option_name ); ?>]" id="<?php echo esc_attr( $option->option_name ); ?>"<?php disabled( $disabled ); ?>><?php echo esc_textarea( $option->option_value ); ?></textarea></td>
-				</tr>
-				<?php
-			} else {
-				?>
-				<tr class="form-field">
-					<th scope="row"><label for="<?php echo esc_attr( $option->option_name ); ?>" class="code"><?php echo esc_html( $option->option_name ); ?></label></th>
-					<?php if ( $is_main_site && in_array( $option->option_name, array( 'siteurl', 'home' ), true ) ) { ?>
-					<td><code><?php echo esc_html( $option->option_value ); ?></code></td>
-					<?php } else { ?>
-					<td><input class="<?php echo $class; ?>" name="option[<?php echo esc_attr( $option->option_name ); ?>]" type="text" id="<?php echo esc_attr( $option->option_name ); ?>" value="<?php echo esc_attr( $option->option_value ); ?>" size="40" <?php disabled( $disabled ); ?> /></td>
-					<?php } ?>
-				</tr>
-				<?php
-			}
+			$class  = 'all-options' . ( $disabled ? ' disabled' : '' );
+			$class .= in_array( $option->option_name, $ltr_fields, true ) ? ' ltr' : '';
+			$name   = esc_attr( $option->option_name );
+			$label  = esc_html( $option->option_name );
+			?>
+			<tr class="form-field">
+				<th scope="row"><label for="<?php echo $name; ?>" class="code"><?php echo $label; ?></label></th>
+				<?php if ( $is_serialized ) : ?>
+				<td>
+					<details class="<?php echo $class; ?>">
+						<summary><?php esc_html_e( 'Serialized data' ); ?></summary>
+						<textarea class="<?php echo $class; ?>" rows="5" cols="40" id="<?php echo $name; ?>" readonly="readonly"><?php echo esc_textarea( $value ); ?></textarea>
+					</details>
+				</td>
+				<?php elseif ( str_contains( $value, "\n" ) ) : ?>
+				<td><textarea class="<?php echo $class; ?>" rows="5" cols="40" name="option[<?php echo $name; ?>]" id="<?php echo $name; ?>"<?php disabled( $disabled ); ?>><?php echo esc_textarea( $value ); ?></textarea></td>
+				<?php elseif ( $is_main_site && in_array( $option->option_name, array( 'siteurl', 'home' ), true ) ) : ?>
+				<td><code><?php echo esc_html( $value ); ?></code></td>
+				<?php else : ?>
+				<td><input class="<?php echo $class; ?>" name="option[<?php echo $name; ?>]" type="text" id="<?php echo $name; ?>" value="<?php echo esc_attr( $value ); ?>" size="40" <?php disabled( $disabled ); ?> /></td>
+				<?php endif; ?>
+			</tr>
+			<?php
 		} // End foreach.
 
 		/**

--- a/src/wp-admin/options.php
+++ b/src/wp-admin/options.php
@@ -399,56 +399,57 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 $options = $wpdb->get_results( "SELECT * FROM $wpdb->options ORDER BY option_name" );
 
 foreach ( (array) $options as $option ) :
-	$disabled = false;
-
 	if ( '' === $option->option_name ) {
 		continue;
 	}
 
-	if ( 'home' === $option->option_name && defined( 'WP_HOME' ) ) {
+	$value         = $option->option_value;
+	$disabled      = false;
+	$is_serialized = false;
+
+	if ( ( 'home' === $option->option_name && defined( 'WP_HOME' ) )
+		|| ( 'siteurl' === $option->option_name && defined( 'WP_SITEURL' ) )
+	) {
 		$disabled = true;
 	}
 
-	if ( 'siteurl' === $option->option_name && defined( 'WP_SITEURL' ) ) {
-		$disabled = true;
-	}
-
-	if ( is_serialized( $option->option_value ) ) {
-		if ( is_serialized_string( $option->option_value ) ) {
-			// This is a serialized string, so we should display it.
-			$value               = maybe_unserialize( $option->option_value );
+	if ( is_serialized( $value ) ) {
+		if ( is_serialized_string( $value ) ) {
+			// Serialized strings can be safely displayed and edited as their unserialized form.
+			$value               = maybe_unserialize( $value );
 			$options_to_update[] = $option->option_name;
 		} else {
-			$value    = 'SERIALIZED DATA';
-			$disabled = true;
+			// Other serialized values (arrays, objects) are shown raw, read-only, inside a collapsible <details>.
+			$disabled      = true;
+			$is_serialized = true;
 		}
 	} elseif ( str_starts_with( $option->option_name, 'connectors_' )
 		&& str_ends_with( $option->option_name, '_api_key' )
 	) {
 		// Mask connector API keys and prevent updates from this screen.
-		$value    = _wp_connectors_mask_api_key( $option->option_value );
+		$value    = _wp_connectors_mask_api_key( $value );
 		$disabled = true;
 	} else {
-		$value               = $option->option_value;
 		$options_to_update[] = $option->option_name;
 	}
 
-	$class = 'all-options';
-
-	if ( $disabled ) {
-		$class .= ' disabled';
-	}
-
-	$name = esc_attr( $option->option_name );
+	$class = 'all-options' . ( $disabled ? ' disabled' : '' );
+	$name  = esc_attr( $option->option_name );
 	?>
 <tr>
 	<th scope="row"><label for="<?php echo $name; ?>"><?php echo esc_html( $option->option_name ); ?></label></th>
-<td>
-	<?php if ( str_contains( $value, "\n" ) ) : ?>
-		<textarea class="<?php echo $class; ?>" name="<?php echo $name; ?>" id="<?php echo $name; ?>" cols="30" rows="5"><?php echo esc_textarea( $value ); ?></textarea>
+	<td>
+	<?php if ( $is_serialized ) : ?>
+		<details class="<?php echo $class; ?>">
+			<summary><?php esc_html_e( 'Serialized data' ); ?></summary>
+			<textarea class="<?php echo $class; ?>" id="<?php echo $name; ?>" cols="30" rows="5" readonly="readonly"><?php echo esc_textarea( $value ); ?></textarea>
+		</details>
+	<?php elseif ( str_contains( $value, "\n" ) ) : ?>
+		<textarea class="<?php echo $class; ?>" name="<?php echo $name; ?>" id="<?php echo $name; ?>" cols="30" rows="5"<?php disabled( $disabled, true ); ?>><?php echo esc_textarea( $value ); ?></textarea>
 	<?php else : ?>
 		<input class="regular-text <?php echo $class; ?>" type="text" name="<?php echo $name; ?>" id="<?php echo $name; ?>" value="<?php echo esc_attr( $value ); ?>"<?php disabled( $disabled, true ); ?> />
-	<?php endif; ?></td>
+	<?php endif; ?>
+	</td>
 </tr>
 <?php endforeach; ?>
 </table>


### PR DESCRIPTION
Fixes https://core.trac.wordpress.org/ticket/64581

## Summary
Replaces the hard-coded `SERIALIZED DATA` placeholder in `wp-admin/options.php` and `wp-admin/network/site-settings.php` with the **raw serialized value** rendered read-only inside a native `<details>`/`<summary>` element. The value remains non-editable and is excluded from form submission, so it cannot be accidentally corrupted on save.

This is an alternative implementation to #10853 based on the [feedback](https://github.com/WordPress/wordpress-develop/pull/10853#discussion_r2540732413) left there:

- **No JavaScript.** Uses the native `<details>` disclosure widget instead of a custom JS toggle.
- **Raw serialized value, not `print_r()`.** Preserves the exact stored value so it can be safely copied / inspected without lossy reformatting.
- **`readonly` textarea + `name` attribute omitted** so the value cannot round-trip back into the database via the form.
- Translatable string `__( 'Serialized data' )` replaces the hard-coded English placeholder.

The same pattern is applied to the network site settings screen, which had the identical placeholder issue.

## Incidental cleanup in the touched code

* **`options.php`**: hoists `$value = $option->option_value` out of per-branch assignments, collapses the `disabled`-class logic into a ternary, merges the `home`/`siteurl` `WP_HOME`/`WP_SITEURL` checks.
* **`site-settings.php`**: hoists the `\$ltr_fields` list out of the per-row loop, consolidates four duplicated `<tr>` blocks into a single row with inline branches, and **removes a double-escape** on serialized-string values — `esc_html()` was applied at assignment and then again at output through `esc_textarea`/`esc_attr`, corrupting any unserialized string containing `<`, `>`, or `&`.

## Test plan
- [x] On Single Site, visit `/wp-admin/options.php`. Any option whose value is a serialized array/object now renders as a `▸ Serialized data` toggle; expanding it shows the raw `a:N:{…}` payload in a disabled textarea.
- [x] Submit the form and confirm the serialized option's value is unchanged in the DB (it must not be present in `$_POST`).
- [x] Serialized-string options (e.g. some legacy single-string serialized values) still render as their unserialized text in a normal input/textarea, and special characters (`<`, `>`, `&`) display correctly without double-escaping.
- [x] On Multisite, edit a site via Network → Sites → Settings and verify the same behaviour for serialized values there.
- [x] Visual regression on `home`/`siteurl` rows when `WP_HOME`/`WP_SITEURL` constants are defined — they remain disabled inputs.

<img width="1274" height="816" alt="image" src="https://github.com/user-attachments/assets/350953c5-47b8-493c-8a2b-6ee8bebba2f9" />

<img width="1386" height="796" alt="image" src="https://github.com/user-attachments/assets/720fe836-39d1-45bd-bb38-43edda83b2a8" />

<img width="1330" height="782" alt="image" src="https://github.com/user-attachments/assets/ae3ab193-7223-4059-a359-4154d6862514" />
