### PR TITLE
Administration: Fix misaligned icon in user profile password field in mobile layout

### DIFF
--- a/src/wp-admin/css/forms.css
+++ b/src/wp-admin/css/forms.css
@@ -583,9 +583,10 @@ input[type="number"].tiny-text {
 	vertical-align: middle;
 }
 
-.button.wp-hide-pw.user-new-password-toggle > .dashicons {
-	line-height: 1.85;
-	vertical-align: top;
+.button.wp-hide-pw.user-new-password-toggle {
+	display: inline-flex;
+	align-items: center;
+	column-gap: 4px;
 }
 
 .wp-cancel-pw .dashicons-no {


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65031

Approaches using `line-height` or `vertical-align` may be unstable. While I know that there are fewer use cases for core currently, I believe we should actively adopt flex layouts.

## Screenshots

| Before | After |
|--------|--------|
| <img width="543" height="152" alt="image" src="https://github.com/user-attachments/assets/3a3be7cc-e7fa-48d7-8133-801e89683aec" />| <img width="543" height="140" alt="image" src="https://github.com/user-attachments/assets/68a7ff86-bd04-4781-80c5-de6e4f053797" />|
| <img width="347" height="177" alt="image" src="https://github.com/user-attachments/assets/f928d6c1-90df-47e0-a28a-0f8490333f7d" /> | <img width="350" height="169" alt="image" src="https://github.com/user-attachments/assets/bd542977-4c03-49a4-86b2-fe344e8b37bd" />| 

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 4.7
Used for: Identifying the existing `.toggle-auto-update` Flexbox pattern in Core as a reference, and drafting the CSS replacement. Final implementation and visual verification were done by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
