### PR TITLE
Administration: Fix spinner misalignment with 40px buttons

### DIFF
--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -961,7 +961,6 @@ a#remove-post-thumbnail:hover,
 
 #publishing-action .spinner {
 	float: none;
-	margin-top: 5px;
 }
 
 #misc-publishing-actions {
@@ -2460,7 +2459,7 @@ h1.nav-tab-wrapper, /* Back-compat for pre-4.4 */
 	filter: alpha(opacity=70);
 	width: 20px;
 	height: 20px;
-	margin: 4px 10px 0;
+	margin: 10px 10px 0; /* Vertically center 20px spinner in 40px button height: ( 40 - 20 ) / 2 */
 }
 
 .spinner.is-active,

--- a/src/wp-admin/css/edit.css
+++ b/src/wp-admin/css/edit.css
@@ -1535,7 +1535,7 @@ p.popular-tags a {
 
 #addtag .spinner {
 	float: none;
-	vertical-align: top;
+	vertical-align: middle;
 }
 
 #edittag {

--- a/src/wp-admin/css/media.css
+++ b/src/wp-admin/css/media.css
@@ -302,6 +302,7 @@
 	float: none;
 	left: 105px;
 	position: absolute;
+	top: 10px; /* Vertically center 20px spinner in 40px input: ( 40 - 20 ) / 2 */
 }
 
 .find-box-search,

--- a/src/wp-admin/css/nav-menus.css
+++ b/src/wp-admin/css/nav-menus.css
@@ -487,7 +487,7 @@ input.bulk-select-switcher:focus + .bulk-select-button-label {
 
 .quick-search-wrap .spinner {
 	float: none;
-	margin: -3px -10px 0 0;
+	margin: 10px -10px 0 0;
 }
 
 .nav-menus-php .list-wrap {

--- a/src/wp-admin/css/widgets.css
+++ b/src/wp-admin/css/widgets.css
@@ -500,18 +500,17 @@ div#widgets-right .closed .widgets-sortables {
 	margin-bottom: 0;
 }
 
-.sidebar-name .spinner,
-.remove-inactive-widgets .spinner {
-	float: none;
-	position: relative;
-	top: -2px;
-	margin: -5px 5px;
-}
-
 .sidebar-name .spinner {
+	float: none;
 	position: absolute;
 	top: 18px;
 	right: 30px;
+	margin: -5px 5px;
+}
+
+.remove-inactive-widgets .spinner {
+	float: none;
+	margin: 10px 5px 0;
 }
 
 /* Dragging a widget over a closed sidebar */


### PR DESCRIPTION
Vertically centers the 20px spinner relative to the 40px button height introduced by the new admin design system. Formula: (40 - 20) / 2 = 10px.

- Base .spinner: margin-top 4px → 10px
- #publishing-action .spinner: remove stale 5px margin-top override
- #addtag .spinner: vertical-align top → middle
- .quick-search-wrap .spinner: margin-top -3px → 10px
- .find-box-search .spinner: add explicit top: 10px for absolute position
- widgets.css: split shared rule, update .remove-inactive-widgets margin

Fixes: https://core.trac.wordpress.org/ticket/65131

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
