### PR TITLE
Permalinks: Ignore malformed post type query arrays

### DIFF
--- a/src/wp-includes/class-wp.php
+++ b/src/wp-includes/class-wp.php
@@ -382,7 +382,10 @@ class WP {
 					unset( $this->query_vars['post_type'] );
 				}
 			} else {
-				$this->query_vars['post_type'] = array_intersect( $this->query_vars['post_type'], $queryable_post_types );
+				$this->query_vars['post_type'] = array_intersect(
+					array_filter( $this->query_vars['post_type'], 'is_scalar' ),
+					$queryable_post_types
+				);
 			}
 		}
 

--- a/tests/phpunit/tests/wp/parseRequest.php
+++ b/tests/phpunit/tests/wp/parseRequest.php
@@ -56,4 +56,70 @@ class Tests_WP_ParseRequest extends WP_UnitTestCase {
 		$this->wp->parse_request();
 		$this->assertSame( '', $this->wp->request );
 	}
+
+	/**
+	 * @ticket 65123
+	 */
+	public function test_parse_request_ignores_non_scalar_post_type_values_from_get() {
+		$original_get     = $_GET;
+		$original_post    = $_POST;
+		$original_request = $_SERVER['REQUEST_URI'] ?? null;
+		$original_self    = $_SERVER['PHP_SELF'] ?? null;
+
+		$_GET['post_type']      = array( array( 'page' ), 'post' );
+		$_SERVER['REQUEST_URI'] = '/?post_type[][]=page&post_type[]=post';
+		$_SERVER['PHP_SELF']    = '/index.php';
+
+		$this->wp->parse_request();
+
+		$this->assertSame( array( 'post' ), array_values( $this->wp->query_vars['post_type'] ) );
+
+		$_GET  = $original_get;
+		$_POST = $original_post;
+
+		if ( null === $original_request ) {
+			unset( $_SERVER['REQUEST_URI'] );
+		} else {
+			$_SERVER['REQUEST_URI'] = $original_request;
+		}
+
+		if ( null === $original_self ) {
+			unset( $_SERVER['PHP_SELF'] );
+		} else {
+			$_SERVER['PHP_SELF'] = $original_self;
+		}
+	}
+
+	/**
+	 * @ticket 65123
+	 */
+	public function test_parse_request_ignores_non_scalar_post_type_values_from_post() {
+		$original_get     = $_GET;
+		$original_post    = $_POST;
+		$original_request = $_SERVER['REQUEST_URI'] ?? null;
+		$original_self    = $_SERVER['PHP_SELF'] ?? null;
+
+		$_POST['post_type']     = array( array( 'page' ), 'post' );
+		$_SERVER['REQUEST_URI'] = '/';
+		$_SERVER['PHP_SELF']    = '/index.php';
+
+		$this->wp->parse_request();
+
+		$this->assertSame( array( 'post' ), array_values( $this->wp->query_vars['post_type'] ) );
+
+		$_GET  = $original_get;
+		$_POST = $original_post;
+
+		if ( null === $original_request ) {
+			unset( $_SERVER['REQUEST_URI'] );
+		} else {
+			$_SERVER['REQUEST_URI'] = $original_request;
+		}
+
+		if ( null === $original_self ) {
+			unset( $_SERVER['PHP_SELF'] );
+		} else {
+			$_SERVER['PHP_SELF'] = $original_self;
+		}
+	}
 }

--- a/tests/phpunit/tests/wp/parseRequest.php
+++ b/tests/phpunit/tests/wp/parseRequest.php
@@ -59,67 +59,49 @@ class Tests_WP_ParseRequest extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 65123
+	 * @dataProvider data_parse_request_ignores_non_scalar_post_type_values
 	 */
-	public function test_parse_request_ignores_non_scalar_post_type_values_from_get() {
+	public function test_parse_request_ignores_non_scalar_post_type_values( $request_method, $request_uri ) {
 		$original_get     = $_GET;
 		$original_post    = $_POST;
 		$original_request = $_SERVER['REQUEST_URI'] ?? null;
 		$original_self    = $_SERVER['PHP_SELF'] ?? null;
 
-		$_GET['post_type']      = array( array( 'page' ), 'post' );
-		$_SERVER['REQUEST_URI'] = '/?post_type[][]=page&post_type[]=post';
-		$_SERVER['PHP_SELF']    = '/index.php';
-
-		$this->wp->parse_request();
-
-		$this->assertSame( array( 'post' ), array_values( $this->wp->query_vars['post_type'] ) );
-
-		$_GET  = $original_get;
-		$_POST = $original_post;
-
-		if ( null === $original_request ) {
-			unset( $_SERVER['REQUEST_URI'] );
+		if ( 'GET' === $request_method ) {
+			$_GET['post_type'] = array( array( 'page' ), 'post' );
 		} else {
-			$_SERVER['REQUEST_URI'] = $original_request;
+			$_POST['post_type'] = array( array( 'page' ), 'post' );
 		}
 
-		if ( null === $original_self ) {
-			unset( $_SERVER['PHP_SELF'] );
-		} else {
-			$_SERVER['PHP_SELF'] = $original_self;
+		$_SERVER['REQUEST_URI'] = $request_uri;
+		$_SERVER['PHP_SELF']    = '/index.php';
+
+		try {
+			$this->wp->parse_request();
+
+			$this->assertSame( array( 'post' ), array_values( $this->wp->query_vars['post_type'] ) );
+		} finally {
+			$_GET  = $original_get;
+			$_POST = $original_post;
+
+			if ( null === $original_request ) {
+				unset( $_SERVER['REQUEST_URI'] );
+			} else {
+				$_SERVER['REQUEST_URI'] = $original_request;
+			}
+
+			if ( null === $original_self ) {
+				unset( $_SERVER['PHP_SELF'] );
+			} else {
+				$_SERVER['PHP_SELF'] = $original_self;
+			}
 		}
 	}
 
-	/**
-	 * @ticket 65123
-	 */
-	public function test_parse_request_ignores_non_scalar_post_type_values_from_post() {
-		$original_get     = $_GET;
-		$original_post    = $_POST;
-		$original_request = $_SERVER['REQUEST_URI'] ?? null;
-		$original_self    = $_SERVER['PHP_SELF'] ?? null;
-
-		$_POST['post_type']     = array( array( 'page' ), 'post' );
-		$_SERVER['REQUEST_URI'] = '/';
-		$_SERVER['PHP_SELF']    = '/index.php';
-
-		$this->wp->parse_request();
-
-		$this->assertSame( array( 'post' ), array_values( $this->wp->query_vars['post_type'] ) );
-
-		$_GET  = $original_get;
-		$_POST = $original_post;
-
-		if ( null === $original_request ) {
-			unset( $_SERVER['REQUEST_URI'] );
-		} else {
-			$_SERVER['REQUEST_URI'] = $original_request;
-		}
-
-		if ( null === $original_self ) {
-			unset( $_SERVER['PHP_SELF'] );
-		} else {
-			$_SERVER['PHP_SELF'] = $original_self;
-		}
+	public function data_parse_request_ignores_non_scalar_post_type_values() {
+		return array(
+			'get'  => array( 'GET', '/?post_type[][]=page&post_type[]=post' ),
+			'post' => array( 'POST', '/' ),
+		);
 	}
 }


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65123

## Summary
This ignores non-scalar values when sanitizing `post_type` query vars in `WP::parse_request()`, preventing malformed array input from surfacing PHP warnings during front-end requests.

## Testing Instructions
1. Request `/?post_type[][]=page&post_type[]=post` on a local site with `WP_DEBUG_DISPLAY` enabled.
2. Confirm no warning is emitted before the page output.
3. Run `npm run test:php -- --filter Tests_WP_ParseRequest`.
