### PR TITLE
Embeds: Preserve site icon fallback URL

### DIFF
--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -978,7 +978,11 @@ function get_site_icon_url( $size = 512, $url = '', $blog_id = 0 ) {
 		} else {
 			$size_data = array( $size, $size );
 		}
-		$url = wp_get_attachment_image_url( $site_icon_id, $size_data );
+
+		$site_icon_url = wp_get_attachment_image_url( $site_icon_id, $size_data );
+		if ( $site_icon_url ) {
+			$url = $site_icon_url;
+		}
 	}
 
 	if ( $switched_blog ) {

--- a/tests/phpunit/tests/general/template.php
+++ b/tests/phpunit/tests/general/template.php
@@ -123,6 +123,20 @@ class Tests_General_Template extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 65098
+	 * @group site_icon
+	 * @covers ::get_site_icon_url
+	 */
+	public function test_get_site_icon_url_uses_fallback_when_site_icon_url_is_unavailable() {
+		update_option( 'site_icon', 999999 );
+
+		$this->assertSame(
+			'https://example.org/fallback.png',
+			get_site_icon_url( 32, 'https://example.org/fallback.png' )
+		);
+	}
+
+	/**
 	 * @group site_icon
 	 * @covers ::site_icon_url
 	 * @requires function imagejpeg


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65098

## Summary
When a site icon option is set but `wp_get_attachment_image_url()` cannot resolve a URL, the provided fallback URL should be preserved instead of being replaced with `false`.

## Testing Instructions
1. Set the `site_icon` option to an invalid attachment ID.
2. Call `get_site_icon_url( 32, "https://example.org/fallback.png" )`.
3. Confirm the fallback URL is returned.
4. Run `npm run test:php -- --filter test_get_site_icon_url`.
