### PR TITLE
Add unit tests for got_url_rewrite() in src/wp-admin/includes/misc.php

### DIFF
--- a/tests/phpunit/tests/admin/includes/misc/gotUrlRewrite.php
+++ b/tests/phpunit/tests/admin/includes/misc/gotUrlRewrite.php
@@ -1,0 +1,121 @@
+<?php
+
+/**
+ * Tests for the got_url_rewrite() function.
+ *
+ * @group admin
+ * @group rewrite
+ *
+ * @covers ::got_url_rewrite
+ */
+class Tests_got_url_rewrite extends WP_UnitTestCase {
+
+	/**
+	 * Tests that got_url_rewrite() correctly detects URL rewrite support based on server and filters.
+	 *
+	 * @ticket 65135
+	 *
+	 * @dataProvider data_got_url_rewrite
+	 *
+	 * @param bool $expected     The expected result from got_url_rewrite().
+	 * @param bool $mod_rewrite  Whether mod_rewrite is reported as supported.
+	 * @param bool $is_nginx     Value for the $is_nginx global.
+	 * @param bool $is_caddy     Value for the $is_caddy global.
+	 * @param bool $iis7_perm    Whether IIS7 supports permalinks (simulated).
+	 * @param bool|null $filter_val Optional value for the 'got_url_rewrite' filter.
+	 */
+	public function test_got_url_rewrite( $expected, $mod_rewrite, $is_nginx, $is_caddy, $iis7_perm, $filter_val = null ) {
+		global $is_nginx, $is_caddy;
+
+		// Backup globals.
+		$prev_nginx = $is_nginx;
+		$prev_caddy = $is_caddy;
+
+		$is_nginx = $is_nginx;
+		$is_caddy = $is_caddy;
+
+		// Mock got_mod_rewrite and iis7_supports_permalinks via filters if possible.
+		// However, got_url_rewrite calls got_mod_rewrite() which calls apache_mod_loaded.
+		// We can use the 'got_rewrite' filter to control got_mod_rewrite()'s output.
+		add_filter( 'got_rewrite', $mod_rewrite ? '__return_true' : '__return_false' );
+
+		// iis7_supports_permalinks() uses iis7_rewrite_rule_exists() which checks files.
+		// For simplicity, if we are on a non-IIS environment, it returns false.
+		// If we need to test IIS path, we might need more complex mocking or just rely on the final filter.
+
+		if ( null !== $filter_val ) {
+			add_filter( 'got_url_rewrite', $filter_val ? '__return_true' : '__return_false' );
+		}
+
+		$this->assertSame( $expected, got_url_rewrite() );
+
+		// Cleanup.
+		remove_filter( 'got_rewrite', $mod_rewrite ? '__return_true' : '__return_false' );
+		if ( null !== $filter_val ) {
+			remove_filter( 'got_url_rewrite', $filter_val ? '__return_true' : '__return_false' );
+		}
+		$is_nginx = $prev_nginx;
+		$is_caddy = $prev_caddy;
+	}
+
+	/**
+	 * Data provider for test_got_url_rewrite.
+	 *
+	 * @return array[] {
+	 *     @type bool      $expected    The expected result.
+	 *     @type bool      $mod_rewrite Whether mod_rewrite is supported.
+	 *     @type bool      $is_nginx    Whether server is nginx.
+	 *     @type bool      $is_caddy    Whether server is Caddy.
+	 *     @type bool      $iis7_perm   Whether IIS7 supports permalinks.
+	 *     @type bool|null $filter_val  Optional filter value.
+	 * }
+	 */
+	public function data_got_url_rewrite() {
+		return array(
+			'All false' => array(
+				'expected'    => false,
+				'mod_rewrite' => false,
+				'is_nginx'    => false,
+				'is_caddy'    => false,
+				'iis7_perm'   => false,
+			),
+			'Apache mod_rewrite supported' => array(
+				'expected'    => true,
+				'mod_rewrite' => true,
+				'is_nginx'    => false,
+				'is_caddy'    => false,
+				'iis7_perm'   => false,
+			),
+			'Nginx supported' => array(
+				'expected'    => true,
+				'mod_rewrite' => false,
+				'is_nginx'    => true,
+				'is_caddy'    => false,
+				'iis7_perm'   => false,
+			),
+			'Caddy supported' => array(
+				'expected'    => true,
+				'mod_rewrite' => false,
+				'is_nginx'    => false,
+				'is_caddy'    => true,
+				'iis7_perm'   => false,
+			),
+			'Filter overrides to true' => array(
+				'expected'    => true,
+				'mod_rewrite' => false,
+				'is_nginx'    => false,
+				'is_caddy'    => false,
+				'iis7_perm'   => false,
+				'filter_val'  => true,
+			),
+			'Filter overrides to false' => array(
+				'expected'    => false,
+				'mod_rewrite' => true,
+				'is_nginx'    => true,
+				'is_caddy'    => true,
+				'iis7_perm'   => true,
+				'filter_val'  => false,
+			),
+		);
+	}
+}

--- a/tests/phpunit/tests/admin/includes/misc/gotUrlRewrite.php
+++ b/tests/phpunit/tests/admin/includes/misc/gotUrlRewrite.php
@@ -99,7 +99,7 @@ class Tests_got_url_rewrite extends WP_UnitTestCase {
   *     filter_val?: bool|null,
   * }>
   */
-	public function data_got_url_rewrite() {
+	public function data_got_url_rewrite(): array {
 		return array(
 			'All false'                    => array(
 				'expected'    => false,

--- a/tests/phpunit/tests/admin/includes/misc/gotUrlRewrite.php
+++ b/tests/phpunit/tests/admin/includes/misc/gotUrlRewrite.php
@@ -78,7 +78,7 @@ class Tests_got_url_rewrite extends WP_UnitTestCase {
 		}
 	}
 
- /**
+  /**
   * Data provider for test_got_url_rewrite.
   *
   * @return array[] {

--- a/tests/phpunit/tests/admin/includes/misc/gotUrlRewrite.php
+++ b/tests/phpunit/tests/admin/includes/misc/gotUrlRewrite.php
@@ -12,15 +12,13 @@ class Tests_got_url_rewrite extends WP_UnitTestCase {
 
 	/**
 	 * Saved value of the $is_nginx global.
-	 * @var bool
 	 */
-	private $prev_nginx;
+	private bool $prev_nginx;
 
 	/**
 	 * Saved value of the $is_caddy global.
-	 * @var bool
 	 */
-	private $prev_caddy;
+	private bool $prev_caddy;
 
 	public function set_up() {
 		parent::set_up();
@@ -75,22 +73,12 @@ class Tests_got_url_rewrite extends WP_UnitTestCase {
 		remove_filter( 'got_rewrite', $mod_rewrite ? '__return_true' : '__return_false' );
 		if ( null !== $filter_val ) {
 			remove_filter( 'got_url_rewrite', $filter_val ? '__return_true' : '__return_false' );
-		}
 	}
 
   /**
   * Data provider for test_got_url_rewrite.
   *
-  * @return array[] {
-  *     @type bool      $expected    The expected result.
-  *     @type bool      $mod_rewrite Whether mod_rewrite is supported.
-  *     @type bool      $is_nginx    Whether server is nginx.
-  *     @type bool      $is_caddy    Whether server is Caddy.
-  *     @type bool      $iis7_perm   Whether IIS7 supports permalinks.
-  *     @type bool|null $filter_val  Optional filter value.
-  * }
-  *
-  * @phpstan-return array<string, array{
+  * @return array<string, array{
   *     expected:    bool,
   *     mod_rewrite: bool,
   *     is_nginx:    bool,

--- a/tests/phpunit/tests/admin/includes/misc/gotUrlRewrite.php
+++ b/tests/phpunit/tests/admin/includes/misc/gotUrlRewrite.php
@@ -11,6 +11,32 @@
 class Tests_got_url_rewrite extends WP_UnitTestCase {
 
 	/**
+	 * Saved value of the $is_nginx global.
+	 * @var bool
+	 */
+	private $prev_nginx;
+
+	/**
+	 * Saved value of the $is_caddy global.
+	 * @var bool
+	 */
+	private $prev_caddy;
+
+	public function set_up() {
+		parent::set_up();
+		global $is_nginx, $is_caddy;
+		$this->prev_nginx = $is_nginx;
+		$this->prev_caddy = $is_caddy;
+	}
+
+	public function tear_down() {
+		global $is_nginx, $is_caddy;
+		$is_nginx = $this->prev_nginx;
+		$is_caddy = $this->prev_caddy;
+		parent::tear_down();
+	}
+
+	/**
 	 * Tests that got_url_rewrite() correctly detects URL rewrite support based on server and filters.
 	 *
 	 * @ticket 65135
@@ -19,20 +45,16 @@ class Tests_got_url_rewrite extends WP_UnitTestCase {
 	 *
 	 * @param bool $expected     The expected result from got_url_rewrite().
 	 * @param bool $mod_rewrite  Whether mod_rewrite is reported as supported.
-	 * @param bool $is_nginx     Value for the $is_nginx global.
-	 * @param bool $is_caddy     Value for the $is_caddy global.
+	 * @param bool $is_nginx_val Value for the $is_nginx global.
+	 * @param bool $is_caddy_val Value for the $is_caddy global.
 	 * @param bool $iis7_perm    Whether IIS7 supports permalinks (simulated).
 	 * @param bool|null $filter_val Optional value for the 'got_url_rewrite' filter.
 	 */
-	public function test_got_url_rewrite( $expected, $mod_rewrite, $is_nginx, $is_caddy, $iis7_perm, $filter_val = null ) {
+	public function test_got_url_rewrite( $expected, $mod_rewrite, $is_nginx_val, $is_caddy_val, $iis7_perm, $filter_val = null ) {
 		global $is_nginx, $is_caddy;
 
-		// Backup globals.
-		$prev_nginx = $is_nginx;
-		$prev_caddy = $is_caddy;
-
-		$is_nginx = $is_nginx;
-		$is_caddy = $is_caddy;
+		$is_nginx = $is_nginx_val;
+		$is_caddy = $is_caddy_val;
 
 		// Mock got_mod_rewrite and iis7_supports_permalinks via filters if possible.
 		// However, got_url_rewrite calls got_mod_rewrite() which calls apache_mod_loaded.
@@ -54,25 +76,32 @@ class Tests_got_url_rewrite extends WP_UnitTestCase {
 		if ( null !== $filter_val ) {
 			remove_filter( 'got_url_rewrite', $filter_val ? '__return_true' : '__return_false' );
 		}
-		$is_nginx = $prev_nginx;
-		$is_caddy = $prev_caddy;
 	}
 
-	/**
-	 * Data provider for test_got_url_rewrite.
-	 *
-	 * @return array[] {
-	 *     @type bool      $expected    The expected result.
-	 *     @type bool      $mod_rewrite Whether mod_rewrite is supported.
-	 *     @type bool      $is_nginx    Whether server is nginx.
-	 *     @type bool      $is_caddy    Whether server is Caddy.
-	 *     @type bool      $iis7_perm   Whether IIS7 supports permalinks.
-	 *     @type bool|null $filter_val  Optional filter value.
-	 * }
-	 */
+ /**
+  * Data provider for test_got_url_rewrite.
+  *
+  * @return array[] {
+  *     @type bool      $expected    The expected result.
+  *     @type bool      $mod_rewrite Whether mod_rewrite is supported.
+  *     @type bool      $is_nginx    Whether server is nginx.
+  *     @type bool      $is_caddy    Whether server is Caddy.
+  *     @type bool      $iis7_perm   Whether IIS7 supports permalinks.
+  *     @type bool|null $filter_val  Optional filter value.
+  * }
+  *
+  * @phpstan-return array<string, array{
+  *     expected:    bool,
+  *     mod_rewrite: bool,
+  *     is_nginx:    bool,
+  *     is_caddy:    bool,
+  *     iis7_perm:   bool,
+  *     filter_val?: bool|null,
+  * }>
+  */
 	public function data_got_url_rewrite() {
 		return array(
-			'All false' => array(
+			'All false'                    => array(
 				'expected'    => false,
 				'mod_rewrite' => false,
 				'is_nginx'    => false,
@@ -86,21 +115,21 @@ class Tests_got_url_rewrite extends WP_UnitTestCase {
 				'is_caddy'    => false,
 				'iis7_perm'   => false,
 			),
-			'Nginx supported' => array(
+			'Nginx supported'              => array(
 				'expected'    => true,
 				'mod_rewrite' => false,
 				'is_nginx'    => true,
 				'is_caddy'    => false,
 				'iis7_perm'   => false,
 			),
-			'Caddy supported' => array(
+			'Caddy supported'              => array(
 				'expected'    => true,
 				'mod_rewrite' => false,
 				'is_nginx'    => false,
 				'is_caddy'    => true,
 				'iis7_perm'   => false,
 			),
-			'Filter overrides to true' => array(
+			'Filter overrides to true'     => array(
 				'expected'    => true,
 				'mod_rewrite' => false,
 				'is_nginx'    => false,
@@ -108,7 +137,7 @@ class Tests_got_url_rewrite extends WP_UnitTestCase {
 				'iis7_perm'   => false,
 				'filter_val'  => true,
 			),
-			'Filter overrides to false' => array(
+			'Filter overrides to false'    => array(
 				'expected'    => false,
 				'mod_rewrite' => true,
 				'is_nginx'    => true,


### PR DESCRIPTION
Reference: https://core.trac.wordpress.org/ticket/65135
This PR adds comprehensive unit tests for the `got_url_rewrite()` function in `src/wp-admin/includes/misc.php`.
The tests verify detection across different server environments:
- Apache (via `got_mod_rewrite`)
- Nginx (via `$is_nginx` global)
- Caddy (via `$is_caddy` global)
- Overriding via the `got_url_rewrite` filter.

Trac ticket: https://core.trac.wordpress.org/ticket/65135

## Use of AI Tools
AI assistance: Yes
Tool(s): Junie (JetBrains)
Model(s): gemini-3-flash-preview
Used for: Test structure generation, global variable mocking strategy, and dataProvider implementation.