### PR TITLE
RTC: Ensure a single canonical update log for collaborative edits.

### DIFF
--- a/src/wp-includes/collaboration/class-wp-sync-post-meta-storage.php
+++ b/src/wp-includes/collaboration/class-wp-sync-post-meta-storage.php
@@ -86,7 +86,7 @@ class WP_Sync_Post_Meta_Storage implements WP_Sync_Storage {
 		// Use direct database operation to avoid cache invalidation performed by
 		// post meta functions (`wp_cache_set_posts_last_changed()` and direct
 		// `wp_cache_delete()` calls).
-		$result = $wpdb->insert(
+		return (bool) $wpdb->insert(
 			$wpdb->postmeta,
 			array(
 				'post_id'    => $post_id,
@@ -95,13 +95,6 @@ class WP_Sync_Post_Meta_Storage implements WP_Sync_Storage {
 			),
 			array( '%d', '%s', '%s' )
 		);
-
-		if ( $result ) {
-			$room_hash                            = md5( $room );
-			self::$storage_post_ids[ $room_hash ] = $this->merge_duplicate_storage_posts( $room_hash, $post_id );
-		}
-
-		return (bool) $result;
 	}
 
 	/**
@@ -160,8 +153,7 @@ class WP_Sync_Post_Meta_Storage implements WP_Sync_Storage {
 	public function set_awareness_state( string $room, array $awareness ): bool {
 		global $wpdb;
 
-		$room_hash = md5( $room );
-		$post_id   = $this->get_storage_post_id( $room );
+		$post_id = $this->get_storage_post_id( $room );
 		if ( null === $post_id ) {
 			return false;
 		}
@@ -182,22 +174,16 @@ class WP_Sync_Post_Meta_Storage implements WP_Sync_Storage {
 		);
 
 		if ( $meta_id ) {
-			$result = $wpdb->update(
+			return (bool) $wpdb->update(
 				$wpdb->postmeta,
 				array( 'meta_value' => wp_json_encode( $awareness ) ),
 				array( 'meta_id' => $meta_id ),
 				array( '%s' ),
 				array( '%d' )
 			);
-
-			if ( false !== $result ) {
-				self::$storage_post_ids[ $room_hash ] = $this->merge_duplicate_storage_posts( $room_hash, $post_id );
-			}
-
-			return false !== $result;
 		}
 
-		$result = $wpdb->insert(
+		return (bool) $wpdb->insert(
 			$wpdb->postmeta,
 			array(
 				'post_id'    => $post_id,
@@ -206,12 +192,6 @@ class WP_Sync_Post_Meta_Storage implements WP_Sync_Storage {
 			),
 			array( '%d', '%s', '%s' )
 		);
-
-		if ( $result ) {
-			self::$storage_post_ids[ $room_hash ] = $this->merge_duplicate_storage_posts( $room_hash, $post_id );
-		}
-
-		return (bool) $result;
 	}
 
 	/**
@@ -400,33 +380,6 @@ class WP_Sync_Post_Meta_Storage implements WP_Sync_Storage {
 
 		clean_post_cache( $post_id );
 		return $post_id;
-	}
-
-	/**
-	 * Lists storage posts belonging to a room hash, including suffixed duplicates.
-	 *
-	 * @since 7.0.0
-	 *
-	 * @param string $room_hash MD5 hash of the room identifier.
-	 * @return array<int> Storage post IDs.
-	 */
-	private function get_storage_post_ids_for_room_hash( string $room_hash ): array {
-		global $wpdb;
-
-		$post_ids = $wpdb->get_col(
-			$wpdb->prepare(
-				"SELECT ID FROM {$wpdb->posts}
-				WHERE post_type = %s
-					AND post_status = 'publish'
-					AND ( post_name = %s OR post_name LIKE %s )
-				ORDER BY ID ASC",
-				self::POST_TYPE,
-				$room_hash,
-				$wpdb->esc_like( $room_hash . '-' ) . '%'
-			)
-		);
-
-		return array_map( 'intval', $post_ids );
 	}
 
 	/**

--- a/src/wp-includes/collaboration/class-wp-sync-post-meta-storage.php
+++ b/src/wp-includes/collaboration/class-wp-sync-post-meta-storage.php
@@ -86,7 +86,7 @@ class WP_Sync_Post_Meta_Storage implements WP_Sync_Storage {
 		// Use direct database operation to avoid cache invalidation performed by
 		// post meta functions (`wp_cache_set_posts_last_changed()` and direct
 		// `wp_cache_delete()` calls).
-		return (bool) $wpdb->insert(
+		$result = $wpdb->insert(
 			$wpdb->postmeta,
 			array(
 				'post_id'    => $post_id,
@@ -95,6 +95,13 @@ class WP_Sync_Post_Meta_Storage implements WP_Sync_Storage {
 			),
 			array( '%d', '%s', '%s' )
 		);
+
+		if ( $result ) {
+			$room_hash                            = md5( $room );
+			self::$storage_post_ids[ $room_hash ] = $this->merge_duplicate_storage_posts( $room_hash, $post_id );
+		}
+
+		return (bool) $result;
 	}
 
 	/**
@@ -153,7 +160,8 @@ class WP_Sync_Post_Meta_Storage implements WP_Sync_Storage {
 	public function set_awareness_state( string $room, array $awareness ): bool {
 		global $wpdb;
 
-		$post_id = $this->get_storage_post_id( $room );
+		$room_hash = md5( $room );
+		$post_id   = $this->get_storage_post_id( $room );
 		if ( null === $post_id ) {
 			return false;
 		}
@@ -174,16 +182,22 @@ class WP_Sync_Post_Meta_Storage implements WP_Sync_Storage {
 		);
 
 		if ( $meta_id ) {
-			return (bool) $wpdb->update(
+			$result = $wpdb->update(
 				$wpdb->postmeta,
 				array( 'meta_value' => wp_json_encode( $awareness ) ),
 				array( 'meta_id' => $meta_id ),
 				array( '%s' ),
 				array( '%d' )
 			);
+
+			if ( false !== $result ) {
+				self::$storage_post_ids[ $room_hash ] = $this->merge_duplicate_storage_posts( $room_hash, $post_id );
+			}
+
+			return false !== $result;
 		}
 
-		return (bool) $wpdb->insert(
+		$result = $wpdb->insert(
 			$wpdb->postmeta,
 			array(
 				'post_id'    => $post_id,
@@ -192,6 +206,12 @@ class WP_Sync_Post_Meta_Storage implements WP_Sync_Storage {
 			),
 			array( '%d', '%s', '%s' )
 		);
+
+		if ( $result ) {
+			self::$storage_post_ids[ $room_hash ] = $this->merge_duplicate_storage_posts( $room_hash, $post_id );
+		}
+
+		return (bool) $result;
 	}
 
 	/**
@@ -256,12 +276,153 @@ class WP_Sync_Post_Meta_Storage implements WP_Sync_Storage {
 			)
 		);
 
-		if ( is_int( $post_id ) ) {
-			self::$storage_post_ids[ $room_hash ] = $post_id;
-			return $post_id;
+		if ( is_int( $post_id ) && $post_id > 0 ) {
+			$canonical_post_id = $this->resolve_canonical_storage_post_id_after_insert( $room_hash, $post_id );
+			if ( null === $canonical_post_id ) {
+				return null;
+			}
+
+			self::$storage_post_ids[ $room_hash ] = $canonical_post_id;
+			return $canonical_post_id;
 		}
 
 		return null;
+	}
+
+	/**
+	 * Resolves the canonical room storage post after inserting a new post.
+	 *
+	 * Two concurrent first writers can both miss the lookup above and create
+	 * storage posts for the same room hash. Depending on the exact interleaving,
+	 * WordPress may create either a duplicate exact slug or a suffixed slug.
+	 * When this request receives a non-canonical post, redirect it to the
+	 * canonical storage before any sync or awareness data is written.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param string $room_hash        MD5 hash of the room identifier.
+	 * @param int    $inserted_post_id Post ID returned by wp_insert_post().
+	 * @return int|null Canonical storage post ID.
+	 */
+	private function resolve_canonical_storage_post_id_after_insert( string $room_hash, int $inserted_post_id ): ?int {
+		$canonical_post_id = $this->find_canonical_storage_post_id( $room_hash );
+		if ( null === $canonical_post_id ) {
+			$canonical_post_id = $this->promote_storage_post_to_canonical_slug( $room_hash, $inserted_post_id );
+		}
+
+		if ( null === $canonical_post_id ) {
+			wp_delete_post( $inserted_post_id, true );
+			return null;
+		}
+
+		if ( $inserted_post_id !== $canonical_post_id ) {
+			/*
+			 * This request just created a duplicate empty storage post because
+			 * another first writer won the exact-slug race. Delete only that
+			 * just-created empty post and write this request's data to canonical
+			 * storage.
+			 *
+			 * Do not merge or delete older duplicate storage posts here. A stale
+			 * request may already hold a duplicate post ID, and MySQL advisory
+			 * locks/raw transactions are not a reliable cross-server fence under
+			 * HyperDB or database proxies. Future historical repair should be
+			 * bounded and idempotent, or run out of band with primary-pinned
+			 * verification and a grace period before deleting duplicates.
+			 */
+			wp_delete_post( $inserted_post_id, true );
+		}
+
+		return $canonical_post_id;
+	}
+
+	/**
+	 * Finds the canonical storage post for a room hash.
+	 *
+	 * The canonical post is the oldest published storage post with the exact
+	 * room hash slug. Suffixed slugs are repair candidates, not canonical.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param string $room_hash MD5 hash of the room identifier.
+	 * @return int|null Canonical storage post ID.
+	 */
+	private function find_canonical_storage_post_id( string $room_hash ): ?int {
+		$post_id = get_posts(
+			array(
+				'post_type'      => self::POST_TYPE,
+				'posts_per_page' => 1,
+				'post_status'    => 'publish',
+				'name'           => $room_hash,
+				'fields'         => 'ids',
+				'orderby'        => 'ID',
+				'order'          => 'ASC',
+			)
+		);
+
+		return is_numeric( $post_id ) ? (int) $post_id : null;
+	}
+
+	/**
+	 * Promotes a storage post to the canonical room slug.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param string $room_hash MD5 hash of the room identifier.
+	 * @param int    $post_id   Post ID to promote.
+	 * @return int|null Promoted post ID on success.
+	 */
+	private function promote_storage_post_to_canonical_slug( string $room_hash, int $post_id ): ?int {
+		global $wpdb;
+
+		/*
+		 * @todo Could this be replaced by {@see wp_update_post()}? Could we experience
+		 *       a race with other posts having a different post type or post status?
+		 */
+		$result = $wpdb->update(
+			$wpdb->posts,
+			array( 'post_name' => $room_hash ),
+			array(
+				'ID'          => $post_id,
+				'post_type'   => self::POST_TYPE,
+				'post_status' => 'publish',
+			),
+			array( '%s' ),
+			array( '%d', '%s', '%s' )
+		);
+
+		if ( false === $result ) {
+			return null;
+		}
+
+		clean_post_cache( $post_id );
+		return $post_id;
+	}
+
+	/**
+	 * Lists storage posts belonging to a room hash, including suffixed duplicates.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param string $room_hash MD5 hash of the room identifier.
+	 * @return array<int> Storage post IDs.
+	 */
+	private function get_storage_post_ids_for_room_hash( string $room_hash ): array {
+		global $wpdb;
+
+		$post_ids = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT ID FROM {$wpdb->posts}
+				WHERE post_type = %s
+					AND post_status = 'publish'
+					AND ( post_name = %s OR post_name LIKE %s )
+				ORDER BY ID ASC",
+				self::POST_TYPE,
+				$room_hash,
+				$wpdb->esc_like( $room_hash . '-' ) . '%'
+			)
+		);
+
+		return array_map( 'intval', $post_ids );
 	}
 
 	/**

--- a/src/wp-includes/collaboration/class-wp-sync-post-meta-storage.php
+++ b/src/wp-includes/collaboration/class-wp-sync-post-meta-storage.php
@@ -347,7 +347,7 @@ class WP_Sync_Post_Meta_Storage implements WP_Sync_Storage {
 	 * @return int|null Canonical storage post ID.
 	 */
 	private function find_canonical_storage_post_id( string $room_hash ): ?int {
-		$post_id = get_posts(
+		$posts = get_posts(
 			array(
 				'post_type'      => self::POST_TYPE,
 				'posts_per_page' => 1,
@@ -359,7 +359,11 @@ class WP_Sync_Post_Meta_Storage implements WP_Sync_Storage {
 			)
 		);
 
-		return is_numeric( $post_id ) ? (int) $post_id : null;
+		if ( empty( $posts ) ) {
+			return null;
+		}
+
+		return $posts[0];
 	}
 
 	/**

--- a/tests/phpunit/tests/collaboration/wpSyncPostMetaStorage.php
+++ b/tests/phpunit/tests/collaboration/wpSyncPostMetaStorage.php
@@ -32,12 +32,42 @@ class Tests_Collaboration_WpSyncPostMetaStorage extends WP_UnitTestCase {
 		parent::set_up();
 		update_option( 'wp_collaboration_enabled', 1 );
 
-		// Reset storage post ID cache to ensure clean state after transaction rollback.
+		$this->reset_storage_post_id_cache();
+	}
+
+	/**
+	 * Resets the static room-to-storage-post cache.
+	 */
+	private function reset_storage_post_id_cache(): void {
 		$reflection = new ReflectionProperty( 'WP_Sync_Post_Meta_Storage', 'storage_post_ids' );
 		if ( PHP_VERSION_ID < 80100 ) {
 			$reflection->setAccessible( true );
 		}
 		$reflection->setValue( null, array() );
+	}
+
+	/**
+	 * Gets active storage posts that could be used as room storage lineages.
+	 *
+	 * @param string $room Room identifier.
+	 * @return array<int, object> Matching storage posts.
+	 */
+	private function get_storage_post_lineages( string $room ): array {
+		global $wpdb;
+
+		$room_hash = md5( $room );
+		return $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT ID, post_name FROM {$wpdb->posts}
+				WHERE post_type = %s
+					AND post_status = 'publish'
+					AND ( post_name = %s OR post_name LIKE %s )
+				ORDER BY ID ASC",
+				WP_Sync_Post_Meta_Storage::POST_TYPE,
+				$room_hash,
+				$wpdb->esc_like( $room_hash . '-' ) . '%'
+			)
+		);
 	}
 
 	/**
@@ -702,6 +732,154 @@ class Tests_Collaboration_WpSyncPostMetaStorage extends WP_UnitTestCase {
 			$concurrent_update['data'],
 			$update_data,
 			'Concurrent update should survive compaction.'
+		);
+	}
+
+	/**
+	 * @ticket 65138
+	 */
+	public function test_first_access_race_does_not_split_room_storage() {
+		$storage   = new WP_Sync_Post_Meta_Storage();
+		$room      = $this->get_room() . ':first-access-race';
+		$room_hash = md5( $room );
+		$update    = array(
+			'type' => 'update',
+			'data' => base64_encode( 'first-access-race' ),
+		);
+
+		$did_inject       = false;
+		$injected_post_id = 0;
+		$injector         = static function ( $data ) use ( &$did_inject, &$injected_post_id, $room_hash ) {
+			if (
+				$did_inject ||
+				! is_array( $data ) ||
+				( $data['post_type'] ?? null ) !== WP_Sync_Post_Meta_Storage::POST_TYPE ||
+				( $data['post_name'] ?? null ) !== $room_hash
+			) {
+				return $data;
+			}
+
+			$did_inject       = true;
+			$injected_post_id = wp_insert_post(
+				array(
+					'post_type'   => WP_Sync_Post_Meta_Storage::POST_TYPE,
+					'post_status' => 'publish',
+					'post_title'  => 'Sync Storage',
+					'post_name'   => $room_hash,
+				)
+			);
+
+			return $data;
+		};
+
+		add_filter( 'wp_insert_post_data', $injector, 10, 1 );
+		try {
+			$this->assertTrue( $storage->add_update( $room, $update ) );
+		} finally {
+			remove_filter( 'wp_insert_post_data', $injector, 10 );
+		}
+
+		$this->assertTrue( $did_inject, 'Expected first-access race injection to occur.' );
+		$this->assertIsInt( $injected_post_id, 'Expected injected storage post to be created.' );
+		$this->assertGreaterThan( 0, $injected_post_id, 'Expected injected storage post to be created.' );
+
+		$lineages = $this->get_storage_post_lineages( $room );
+		$this->assertCount( 1, $lineages, 'First-access race split room storage.' );
+		$this->assertSame(
+			$room_hash,
+			$lineages[0]->post_name,
+			'The surviving storage lineage must use the exact room hash slug.'
+		);
+
+		$this->reset_storage_post_id_cache();
+		$fresh_storage = new WP_Sync_Post_Meta_Storage();
+		$updates       = $fresh_storage->get_updates_after_cursor( $room, 0 );
+
+		$this->assertContains(
+			$update['data'],
+			wp_list_pluck( $updates, 'data' ),
+			'An acknowledged first-access update must be visible to a fresh storage instance.'
+		);
+	}
+
+	/**
+	 * @ticket 65138
+	 */
+	public function test_duplicate_storage_merge_preserves_exact_room_slug() {
+		global $wpdb;
+
+		$storage   = new WP_Sync_Post_Meta_Storage();
+		$room      = $this->get_room() . ':suffix-id-before-exact';
+		$room_hash = md5( $room );
+
+		$suffixed_post_id = wp_insert_post(
+			array(
+				'post_type'   => WP_Sync_Post_Meta_Storage::POST_TYPE,
+				'post_status' => 'publish',
+				'post_title'  => 'Sync Storage',
+				'post_name'   => $room_hash . '-2',
+			)
+		);
+		$this->assertIsInt( $suffixed_post_id );
+		$this->assertGreaterThan( 0, $suffixed_post_id );
+		$this->assertSame( $room_hash . '-2', get_post_field( 'post_name', $suffixed_post_id ) );
+
+		$suffixed_update = array(
+			'type' => 'update',
+			'data' => base64_encode( 'suffixed-lineage-update' ),
+		);
+		$this->assertNotFalse(
+			$wpdb->insert(
+				$wpdb->postmeta,
+				array(
+					'post_id'    => $suffixed_post_id,
+					'meta_key'   => WP_Sync_Post_Meta_Storage::SYNC_UPDATE_META_KEY,
+					'meta_value' => wp_json_encode( $suffixed_update ),
+				),
+				array( '%d', '%s', '%s' )
+			)
+		);
+
+		$exact_post_id = wp_insert_post(
+			array(
+				'post_type'   => WP_Sync_Post_Meta_Storage::POST_TYPE,
+				'post_status' => 'publish',
+				'post_title'  => 'Sync Storage',
+				'post_name'   => $room_hash,
+			)
+		);
+		$this->assertIsInt( $exact_post_id );
+		$this->assertGreaterThan( $suffixed_post_id, $exact_post_id );
+		$this->assertSame( $room_hash, get_post_field( 'post_name', $exact_post_id ) );
+
+		$exact_update = array(
+			'type' => 'update',
+			'data' => base64_encode( 'exact-lineage-update' ),
+		);
+		$this->assertTrue( $storage->add_update( $room, $exact_update ) );
+
+		$lineages = $this->get_storage_post_lineages( $room );
+		$this->assertCount( 1, $lineages, 'Duplicate storage lineages should be merged.' );
+		$this->assertSame(
+			$room_hash,
+			$lineages[0]->post_name,
+			'Merging must keep the exact room hash slug even when a suffixed duplicate has the lower post ID.'
+		);
+
+		$this->reset_storage_post_id_cache();
+		$fresh_storage = new WP_Sync_Post_Meta_Storage();
+		$updates       = $fresh_storage->get_updates_after_cursor( $room, 0 );
+		$update_data   = wp_list_pluck( $updates, 'data' );
+
+		$this->assertContains(
+			$suffixed_update['data'],
+			$update_data,
+			'Merged storage must preserve updates from the suffixed lineage.'
+		);
+		$this->assertContains(
+			$exact_update['data'],
+			$update_data,
+			'Merged storage must preserve updates from the exact lineage.'
 		);
 	}
 }


### PR DESCRIPTION
Trac ticket: Core-65138

Backport of https://github.com/WordPress/gutenberg/pull/77675

A race condition on opening an editor session allows for Core to create duplicate post meta for sync storage. This creates two copies of the document which the editors operate on independently, leading to a mismatch between the sessions.

In this patch, when such a duplicate storage row is detected, a canonical version of the post meta is chosen (the one with the lowest id viz. the oldest one) and the duplicate is merged into it.

This should ensure that all edit sessions for a given post use the same synchronized backing store.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
