### PR TITLE
Toolbar: Fix dashicon color for mobile devices

### DIFF
--- a/src/wp-admin/css/colors/_admin.scss
+++ b/src/wp-admin/css/colors/_admin.scss
@@ -475,13 +475,13 @@ ul#adminmenu > li.current > a.current:after {
 #wpadminbar .quicklinks li a:focus .blavatar,
 #wpadminbar .quicklinks .ab-sub-wrapper .menupop.hover > a .blavatar,
 #wpadminbar .menupop .menupop > .ab-item:hover:before,
-#wpadminbar.mobile .quicklinks .ab-icon:before,
-#wpadminbar.mobile .quicklinks .ab-item:before {
+#wpadminbar.mobile .quicklinks .hover .ab-icon:before,
+#wpadminbar.mobile .quicklinks .hover .ab-item:before {
 	color: variables.$menu-submenu-focus-text;
 }
 
-#wpadminbar.mobile .quicklinks .hover .ab-icon:before,
-#wpadminbar.mobile .quicklinks .hover .ab-item:before {
+#wpadminbar.mobile .quicklinks .ab-icon:before,
+#wpadminbar.mobile .quicklinks .ab-item:before {
 	color: variables.$menu-icon;
 }
 


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65140

## Screenshots

| Scheme | Before | After |
|--------|--------|--------|
| Default | <img width="374" height="228" alt="image" src="https://github.com/user-attachments/assets/9215cd72-1145-4929-8f0d-e29a6a2103ee" />| <img width="378" height="234" alt="image" src="https://github.com/user-attachments/assets/410687e9-bc2e-4edc-866b-ecfbee453c63" />|
| Fresh | <img width="382" height="226" alt="image" src="https://github.com/user-attachments/assets/0247914f-c9eb-4bde-899c-af4d9b48c295" />| Same |
| Light | <img width="385" height="236" alt="image" src="https://github.com/user-attachments/assets/6b5a41b8-7284-43e5-b2ac-69945af8ade3" />| <img width="380" height="237" alt="image" src="https://github.com/user-attachments/assets/f10736c0-4da4-4442-b28f-008f57bb4249" />| 
| Blue | <img width="384" height="239" alt="image" src="https://github.com/user-attachments/assets/14cf9535-2c1e-4bbc-8112-8e03042c5e14" />| <img width="379" height="231" alt="image" src="https://github.com/user-attachments/assets/ead0f97b-9345-4755-8ff0-404cc519bb20" />|
| Coffee | <img width="386" height="234" alt="image" src="https://github.com/user-attachments/assets/65cf4294-cfd3-484d-8cb0-0fea10799ac0" />| <img width="376" height="230" alt="image" src="https://github.com/user-attachments/assets/049ca19a-d9de-4a84-b75a-ec02d162ace8" />|
| Ectplasm | <img width="379" height="233" alt="image" src="https://github.com/user-attachments/assets/b1531c68-0cea-4d7e-8a5a-ab95e54c1059" />| <img width="387" height="237" alt="image" src="https://github.com/user-attachments/assets/dfb5eea2-af3a-4a8d-9de3-a389e0e9ee6d" />| 
| Midnight | <img width="383" height="237" alt="image" src="https://github.com/user-attachments/assets/8ffe032f-d61b-4dc8-8aa1-90393c6067bf" />| <img width="383" height="233" alt="image" src="https://github.com/user-attachments/assets/82cf6a6a-db80-4fec-9981-0c833143d38b" />| 
| Ocean | <img width="386" height="233" alt="image" src="https://github.com/user-attachments/assets/0d448f73-5b56-431e-b8b6-6a0024bbf646" />| <img width="380" height="231" alt="image" src="https://github.com/user-attachments/assets/70b8c9be-9578-4c69-ae39-74646222b6b8" />| 
| Sunrise | <img width="383" height="237" alt="image" src="https://github.com/user-attachments/assets/a02bac9d-6f11-47de-ae3a-c769dc9f77ff" />| <img width="374" height="231" alt="image" src="https://github.com/user-attachments/assets/da734680-e609-4bc9-9cc7-057650fce0fe" />| 

## Use of AI Tools

AI assistance: Yes