### PR TITLE
Removed extra padding CSS added for meta-box-sortables to fix alignment issue with classic editor

### DIFF
--- a/src/wp-admin/css/edit.css
+++ b/src/wp-admin/css/edit.css
@@ -173,10 +173,6 @@ body.post-type-wp_navigation .inline-edit-status {
 
 /* Post Screen */
 
-.metabox-holder .postbox-container .meta-box-sortables {
-	padding: 4px;
-}
-
 /* Only highlight drop zones when dragging and only in the 2 columns layout. */
 .is-dragging-metaboxes .metabox-holder .postbox-container .meta-box-sortables {
 	border-radius: 8px;


### PR DESCRIPTION
This PR fixes alignment issue for meta-box-sortables with the editor.
In this PR I've remove extra 4px padding added to metabox container.

Trac ticket: https://core.trac.wordpress.org/ticket/65141

