### PR TITLE
Fix error messages for invalid usernames to use consistent terminology

### DIFF
--- a/src/wp-admin/includes/user.php
+++ b/src/wp-admin/includes/user.php
@@ -188,7 +188,7 @@ function edit_user( $user_id = 0 ) {
 	}
 
 	if ( ! $update && isset( $_POST['user_login'] ) && ! validate_username( $_POST['user_login'] ) ) {
-		$errors->add( 'user_login', __( '<strong>Error:</strong> This username is invalid because it uses unallowed characters. Please enter a valid username.' ) );
+		$errors->add( 'user_login', __( '<strong>Error:</strong> This username is invalid because it uses disallowed characters. Please enter a valid username.' ) );
 	}
 
 	if ( ! $update && username_exists( $user->user_login ) ) {

--- a/src/wp-admin/includes/user.php
+++ b/src/wp-admin/includes/user.php
@@ -188,7 +188,7 @@ function edit_user( $user_id = 0 ) {
 	}
 
 	if ( ! $update && isset( $_POST['user_login'] ) && ! validate_username( $_POST['user_login'] ) ) {
-		$errors->add( 'user_login', __( '<strong>Error:</strong> This username is invalid because it uses illegal characters. Please enter a valid username.' ) );
+		$errors->add( 'user_login', __( '<strong>Error:</strong> This username is invalid because it uses unallowed characters. Please enter a valid username.' ) );
 	}
 
 	if ( ! $update && username_exists( $user->user_login ) ) {

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
@@ -1322,7 +1322,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 		if ( ! validate_username( $username ) ) {
 			return new WP_Error(
 				'rest_user_invalid_username',
-				__( 'This username is invalid because it uses unallowed characters. Please enter a valid username.' ),
+				__( 'This username is invalid because it uses disallowed characters. Please enter a valid username.' ),
 				array( 'status' => 400 )
 			);
 		}

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
@@ -1322,7 +1322,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 		if ( ! validate_username( $username ) ) {
 			return new WP_Error(
 				'rest_user_invalid_username',
-				__( 'This username is invalid because it uses illegal characters. Please enter a valid username.' ),
+				__( 'This username is invalid because it uses unallowed characters. Please enter a valid username.' ),
 				array( 'status' => 400 )
 			);
 		}

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -3544,7 +3544,7 @@ function register_new_user( $user_login, $user_email ) {
 	if ( '' === $sanitized_user_login ) {
 		$errors->add( 'empty_username', __( '<strong>Error:</strong> Please enter a username.' ) );
 	} elseif ( ! validate_username( $user_login ) ) {
-		$errors->add( 'invalid_username', __( '<strong>Error:</strong> This username is invalid because it uses illegal characters. Please enter a valid username.' ) );
+		$errors->add( 'invalid_username', __( '<strong>Error:</strong> This username is invalid because it uses unallowed characters. Please enter a valid username.' ) );
 		$sanitized_user_login = '';
 	} elseif ( username_exists( $sanitized_user_login ) ) {
 		$errors->add( 'username_exists', __( '<strong>Error:</strong> This username is already registered. Please choose another one.' ) );

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -3544,7 +3544,7 @@ function register_new_user( $user_login, $user_email ) {
 	if ( '' === $sanitized_user_login ) {
 		$errors->add( 'empty_username', __( '<strong>Error:</strong> Please enter a username.' ) );
 	} elseif ( ! validate_username( $user_login ) ) {
-		$errors->add( 'invalid_username', __( '<strong>Error:</strong> This username is invalid because it uses unallowed characters. Please enter a valid username.' ) );
+		$errors->add( 'invalid_username', __( '<strong>Error:</strong> This username is invalid because it uses disallowed characters. Please enter a valid username.' ) );
 		$sanitized_user_login = '';
 	} elseif ( username_exists( $sanitized_user_login ) ) {
 		$errors->add( 'username_exists', __( '<strong>Error:</strong> This username is already registered. Please choose another one.' ) );

--- a/tests/phpunit/tests/rest-api/rest-users-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-users-controller.php
@@ -1416,7 +1416,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 			$this->assertIsArray( $data['data']['params'] );
 			$errors = $data['data']['params'];
 			$this->assertIsString( $errors['username'] );
-			$this->assertSame( 'This username is invalid because it uses unallowed characters. Please enter a valid username.', $errors['username'] );
+			$this->assertSame( 'This username is invalid because it uses disallowed characters. Please enter a valid username.', $errors['username'] );
 		}
 	}
 

--- a/tests/phpunit/tests/rest-api/rest-users-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-users-controller.php
@@ -1416,7 +1416,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 			$this->assertIsArray( $data['data']['params'] );
 			$errors = $data['data']['params'];
 			$this->assertIsString( $errors['username'] );
-			$this->assertSame( 'This username is invalid because it uses illegal characters. Please enter a valid username.', $errors['username'] );
+			$this->assertSame( 'This username is invalid because it uses unallowed characters. Please enter a valid username.', $errors['username'] );
 		}
 	}
 


### PR DESCRIPTION
#### Trac ticket: https://core.trac.wordpress.org/ticket/65084

---

### Summary

This PR replaces the "illegal characters" with "disallowed characters" across all the occurences for consistency.
