### PR TITLE
Add unit tests for iis7_rewrite_rule_exists() in src/wp-admin/include…

### DIFF
--- a/src/wp-admin/includes/misc.php
+++ b/src/wp-admin/includes/misc.php
@@ -833,7 +833,6 @@ function iis7_rewrite_rule_exists( $filename ) {
 	}
 
 	$doc = new DOMDocument();
-
 	if ( $doc->load( $filename ) === false ) {
 		return false;
 	}

--- a/tests/phpunit/tests/admin/includes/misc/iis7RewriteRuleExists.php
+++ b/tests/phpunit/tests/admin/includes/misc/iis7RewriteRuleExists.php
@@ -66,23 +66,23 @@ class Tests_iis7_rewrite_rule_exists extends WP_UnitTestCase {
 				'expected' => true,
 				'content'  => '<configuration><system.webServer><rewrite><rules><rule name="wordpress-rules" /></rules></rewrite></system.webServer></configuration>',
 			),
-			'Rule with name "wordpress" exists'               => array(
+			'Rule with name "wordpress" exists' => array(
 				'expected' => true,
 				'content'  => '<configuration><system.webServer><rewrite><rules><rule name="wordpress" /></rules></rewrite></system.webServer></configuration>',
 			),
-			'Rule with name "WordPress" exists'               => array(
+			'Rule with name "WordPress" exists' => array(
 				'expected' => true,
 				'content'  => '<configuration><system.webServer><rewrite><rules><rule name="WordPress" /></rules></rewrite></system.webServer></configuration>',
 			),
-			'Rule does not exist'                             => array(
+			'Rule does not exist'               => array(
 				'expected' => false,
 				'content'  => '<configuration><system.webServer><rewrite><rules><rule name="other-rule" /></rules></rewrite></system.webServer></configuration>',
 			),
-			'Empty configuration'                             => array(
+			'Empty configuration'               => array(
 				'expected' => false,
 				'content'  => '<configuration />',
 			),
-			'Invalid XML'                                     => array(
+			'Invalid XML'                       => array(
 				'expected' => false,
 				'content'  => 'Not XML',
 			),

--- a/tests/phpunit/tests/admin/includes/misc/iis7RewriteRuleExists.php
+++ b/tests/phpunit/tests/admin/includes/misc/iis7RewriteRuleExists.php
@@ -47,7 +47,8 @@ class Tests_iis7_rewrite_rule_exists extends WP_UnitTestCase {
 	public function test_iis7_rewrite_rule_exists( $expected, $content ) {
 		if ( 'Not XML' === $content ) {
 			file_put_contents( $this->temp_file, $content );
-			$this->assertSame( $expected, iis7_rewrite_rule_exists( $this->temp_file ) );
+			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+			$this->assertSame( $expected, @iis7_rewrite_rule_exists( $this->temp_file ) );
 		} else {
 			file_put_contents( $this->temp_file, $content );
 			$this->assertSame( $expected, iis7_rewrite_rule_exists( $this->temp_file ) );

--- a/tests/phpunit/tests/admin/includes/misc/iis7RewriteRuleExists.php
+++ b/tests/phpunit/tests/admin/includes/misc/iis7RewriteRuleExists.php
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ * Tests for the iis7_rewrite_rule_exists() function.
+ *
+ * @group admin
+ *
+ * @covers ::iis7_rewrite_rule_exists
+ */
+class Tests_iis7_rewrite_rule_exists extends WP_UnitTestCase {
+
+	/**
+	 * Path to the temporary file.
+	 *
+	 * @var string
+	 */
+	private $temp_file;
+
+	public function set_up() {
+		parent::set_up();
+
+		require_once ABSPATH . 'wp-admin/includes/misc.php';
+
+		$this->temp_file = wp_tempnam( 'web.config' );
+	}
+
+	public function tear_down() {
+		if ( file_exists( $this->temp_file ) ) {
+			unlink( $this->temp_file );
+		}
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Tests that iis7_rewrite_rule_exists() correctly identifies the existence of rules.
+	 *
+	 * @ticket 65148
+	 *
+	 * @dataProvider data_iis7_rewrite_rule_exists
+	 *
+	 * @phpstan-return array<string, array{expected: bool, content: string}>
+	 *
+	 * @param bool   $expected Whether the rule is expected to exist.
+	 * @param string $content  The XML content of the file.
+	 */
+	public function test_iis7_rewrite_rule_exists( $expected, $content ) {
+		if ( 'Not XML' === $content ) {
+			@file_put_contents( $this->temp_file, $content );
+			$this->assertSame( $expected, @iis7_rewrite_rule_exists( $this->temp_file ) );
+		} else {
+			file_put_contents( $this->temp_file, $content );
+			$this->assertSame( $expected, iis7_rewrite_rule_exists( $this->temp_file ) );
+		}
+	}
+
+	/**
+	 * Data provider for test_iis7_rewrite_rule_exists.
+	 *
+	 * @return array<string, array{expected: bool, content: string}>
+	 */
+	public function data_iis7_rewrite_rule_exists() {
+		return array(
+			'Rule with name "wordpress" exists' => array(
+				'expected' => true,
+				'content'  => '<configuration><system.webServer><rewrite><rules><rule name="wordpress" /></rules></rewrite></system.webServer></configuration>',
+			),
+			'Rule with name "WordPress" exists' => array(
+				'expected' => true,
+				'content'  => '<configuration><system.webServer><rewrite><rules><rule name="WordPress" /></rules></rewrite></system.webServer></configuration>',
+			),
+			'Rule with name starting with "wordpress" exists' => array(
+				'expected' => true,
+				'content'  => '<configuration><system.webServer><rewrite><rules><rule name="wordpress-rules" /></rules></rewrite></system.webServer></configuration>',
+			),
+			'Rule does not exist' => array(
+				'expected' => false,
+				'content'  => '<configuration><system.webServer><rewrite><rules><rule name="other-rule" /></rules></rewrite></system.webServer></configuration>',
+			),
+			'Empty configuration' => array(
+				'expected' => false,
+				'content'  => '<configuration />',
+			),
+			'Invalid XML' => array(
+				'expected' => false,
+				'content'  => 'Not XML',
+			),
+		);
+	}
+
+	/**
+	 * Tests that iis7_rewrite_rule_exists() returns false if the file does not exist.
+	 *
+	 * @ticket 65148
+	 */
+	public function test_iis7_rewrite_rule_exists_non_existent_file() {
+		$this->assertFalse( iis7_rewrite_rule_exists( '/non/existent/file' ) );
+	}
+}

--- a/tests/phpunit/tests/admin/includes/misc/iis7RewriteRuleExists.php
+++ b/tests/phpunit/tests/admin/includes/misc/iis7RewriteRuleExists.php
@@ -59,7 +59,7 @@ class Tests_iis7_rewrite_rule_exists extends WP_UnitTestCase {
 	 *
 	 * @return array<string, array{expected: bool, content: string}>
 	 */
-	public function data_iis7_rewrite_rule_exists() {
+	public function data_iis7_rewrite_rule_exists(): array {
 		return array(
 			'Rule with name "wordpress" exists' => array(
 				'expected' => true,

--- a/tests/phpunit/tests/admin/includes/misc/iis7RewriteRuleExists.php
+++ b/tests/phpunit/tests/admin/includes/misc/iis7RewriteRuleExists.php
@@ -46,8 +46,8 @@ class Tests_iis7_rewrite_rule_exists extends WP_UnitTestCase {
 	 */
 	public function test_iis7_rewrite_rule_exists( $expected, $content ) {
 		if ( 'Not XML' === $content ) {
-			@file_put_contents( $this->temp_file, $content );
-			$this->assertSame( $expected, @iis7_rewrite_rule_exists( $this->temp_file ) );
+			file_put_contents( $this->temp_file, $content );
+			$this->assertSame( $expected, iis7_rewrite_rule_exists( $this->temp_file ) );
 		} else {
 			file_put_contents( $this->temp_file, $content );
 			$this->assertSame( $expected, iis7_rewrite_rule_exists( $this->temp_file ) );
@@ -61,11 +61,11 @@ class Tests_iis7_rewrite_rule_exists extends WP_UnitTestCase {
 	 */
 	public function data_iis7_rewrite_rule_exists(): array {
 		return array(
-			'Rule with name "wordpress" exists' => array(
+			'Rule with name "wordpress" exists'               => array(
 				'expected' => true,
 				'content'  => '<configuration><system.webServer><rewrite><rules><rule name="wordpress" /></rules></rewrite></system.webServer></configuration>',
 			),
-			'Rule with name "WordPress" exists' => array(
+			'Rule with name "WordPress" exists'               => array(
 				'expected' => true,
 				'content'  => '<configuration><system.webServer><rewrite><rules><rule name="WordPress" /></rules></rewrite></system.webServer></configuration>',
 			),
@@ -73,15 +73,15 @@ class Tests_iis7_rewrite_rule_exists extends WP_UnitTestCase {
 				'expected' => true,
 				'content'  => '<configuration><system.webServer><rewrite><rules><rule name="wordpress-rules" /></rules></rewrite></system.webServer></configuration>',
 			),
-			'Rule does not exist' => array(
+			'Rule does not exist'                             => array(
 				'expected' => false,
 				'content'  => '<configuration><system.webServer><rewrite><rules><rule name="other-rule" /></rules></rewrite></system.webServer></configuration>',
 			),
-			'Empty configuration' => array(
+			'Empty configuration'                             => array(
 				'expected' => false,
 				'content'  => '<configuration />',
 			),
-			'Invalid XML' => array(
+			'Invalid XML'                                     => array(
 				'expected' => false,
 				'content'  => 'Not XML',
 			),

--- a/tests/phpunit/tests/admin/includes/misc/iis7RewriteRuleExists.php
+++ b/tests/phpunit/tests/admin/includes/misc/iis7RewriteRuleExists.php
@@ -61,6 +61,10 @@ class Tests_iis7_rewrite_rule_exists extends WP_UnitTestCase {
 	 */
 	public function data_iis7_rewrite_rule_exists(): array {
 		return array(
+			'Rule with name starting with "wordpress" exists' => array(
+				'expected' => true,
+				'content'  => '<configuration><system.webServer><rewrite><rules><rule name="wordpress-rules" /></rules></rewrite></system.webServer></configuration>',
+			),
 			'Rule with name "wordpress" exists'               => array(
 				'expected' => true,
 				'content'  => '<configuration><system.webServer><rewrite><rules><rule name="wordpress" /></rules></rewrite></system.webServer></configuration>',
@@ -68,10 +72,6 @@ class Tests_iis7_rewrite_rule_exists extends WP_UnitTestCase {
 			'Rule with name "WordPress" exists'               => array(
 				'expected' => true,
 				'content'  => '<configuration><system.webServer><rewrite><rules><rule name="WordPress" /></rules></rewrite></system.webServer></configuration>',
-			),
-			'Rule with name starting with "wordpress" exists' => array(
-				'expected' => true,
-				'content'  => '<configuration><system.webServer><rewrite><rules><rule name="wordpress-rules" /></rules></rewrite></system.webServer></configuration>',
 			),
 			'Rule does not exist'                             => array(
 				'expected' => false,


### PR DESCRIPTION
…s/misc.php
This PR adds comprehensive unit tests for the `iis7_rewrite_rule_exists()` function in `src/wp-admin/includes/misc.php`.

The tests cover:
- Detection of rewrite rules with names "wordpress" and "WordPress".
- Detection of rules with names starting with "wordpress".
- Correct handling of files where the rule does not exist.
- Handling of empty XML configuration and invalid XML content.
- Handling of non-existent files (returns `false`).

Trac ticket: https://core.trac.wordpress.org/ticket/65148

## Use of AI Tools
AI assistance: Yes
Tool(s): Junie (JetBrains)
Model(s): gemini-3-flash-preview
Used for: Test structure generation, dataProvider implementation, and local environment verification. All tests were verified against WordPress core standards and run in the local Docker environment.
