### PR TITLE
Feat: Plugins: Display plugin slug/identifier in Installed Plugins columns after name

### DIFF
--- a/src/wp-admin/includes/class-wp-plugins-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugins-list-table.php
@@ -60,6 +60,26 @@ class WP_Plugins_List_Table extends WP_List_Table {
 		$this->show_autoupdates = wp_is_auto_update_enabled_for_type( 'plugin' )
 			&& current_user_can( 'update_plugins' )
 			&& ( ! is_multisite() || $this->screen->in_admin( 'network' ) );
+
+		add_filter( 'default_hidden_columns', array( $this, 'get_default_hidden_columns' ), 10, 2 );
+	}
+
+	/**
+	 * Returns the list of columns hidden by default.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param string[]  $hidden Array of IDs of columns hidden by default.
+	 * @param WP_Screen $screen WP_Screen object of the current screen.
+	 *
+	 * @return string[] Array of IDs of columns hidden by default.
+	 */
+	public function get_default_hidden_columns( array $hidden, WP_Screen $screen ) {
+		if ( $this->screen->id === $screen->id ) {
+			$hidden[] = 'slug';
+		}
+
+		return $hidden;
 	}
 
 	/**
@@ -469,6 +489,7 @@ class WP_Plugins_List_Table extends WP_List_Table {
 		$columns = array(
 			'cb'          => ! in_array( $status, array( 'mustuse', 'dropins' ), true ) ? '<input type="checkbox" />' : '',
 			'name'        => __( 'Plugin' ),
+			'slug'        => __( 'Slug' ),
 			'description' => __( 'Description' ),
 		);
 
@@ -1175,6 +1196,9 @@ class WP_Plugins_List_Table extends WP_List_Table {
 					echo $this->row_actions( $actions, true );
 					echo '</td>';
 					break;
+				case 'slug':
+					echo "<td class='column-slug{$extra_classes}'>" . esc_html( $plugin_file ) . "</td>";
+					break;
 				case 'description':
 					$classes = 'column-description desc';
 
@@ -1199,9 +1223,6 @@ class WP_Plugins_List_Table extends WP_List_Table {
 						/* translators: %s: Plugin author name. */
 						$plugin_meta[] = sprintf( __( 'By %s' ), $author );
 					}
-
-					/* translators: %s: Plugin slug. */
-					$plugin_meta[] = sprintf( __( 'Slug: %s' ), esc_html( $plugin_slug ) );
 
 					// Details link using API info, if available.
 					if ( isset( $plugin_data['slug'] ) && current_user_can( 'install_plugins' ) ) {

--- a/src/wp-admin/includes/class-wp-plugins-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugins-list-table.php
@@ -1197,7 +1197,7 @@ class WP_Plugins_List_Table extends WP_List_Table {
 					echo '</td>';
 					break;
 				case 'slug':
-					echo "<td class='column-slug{$extra_classes}'>" . esc_html( $plugin_file ) . "</td>";
+					echo "<td class='column-slug{$extra_classes}'>$plugin_file</td>";
 					break;
 				case 'description':
 					$classes = 'column-description desc';

--- a/src/wp-admin/includes/class-wp-plugins-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugins-list-table.php
@@ -1200,6 +1200,9 @@ class WP_Plugins_List_Table extends WP_List_Table {
 						$plugin_meta[] = sprintf( __( 'By %s' ), $author );
 					}
 
+					/* translators: %s: Plugin slug. */
+					$plugin_meta[] = sprintf( __( 'Slug: %s' ), esc_html( $plugin_slug ) );
+
 					// Details link using API info, if available.
 					if ( isset( $plugin_data['slug'] ) && current_user_can( 'install_plugins' ) ) {
 						$plugin_meta[] = sprintf(


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/65145

- Used `$plugin_slug` already available to display in plugin meta after the author as `Slug: <plugin-slug>`.


## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/047c2823-37f7-4081-b44c-97f76ee6aae7



## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->
- None


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**

