### PR TITLE
Fix: Passwords: trim() asymmetry between wp_hash_password() and wp_check_password() introduced in 6.8

### DIFF
--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -2855,7 +2855,7 @@ if ( ! function_exists( 'wp_check_password' ) ) :
 			$check = false;
 		} elseif ( str_starts_with( $hash, '$wp' ) ) {
 			// Check the password using the current prefixed hash.
-			$password_to_verify = base64_encode( hash_hmac( 'sha384', $password, 'wp-sha384', true ) );
+			$password_to_verify = base64_encode( hash_hmac( 'sha384', trim( $password ), 'wp-sha384', true ) );
 			$check              = password_verify( $password_to_verify, substr( $hash, 3 ) );
 		} elseif ( str_starts_with( $hash, '$P$' ) ) {
 			// Check the password using phpass.

--- a/tests/phpunit/tests/auth.php
+++ b/tests/phpunit/tests/auth.php
@@ -189,6 +189,17 @@ class Tests_Auth extends WP_UnitTestCase {
 		$this->assertTrue( wp_check_password( $expected_password, wp_hash_password( $password_with_whitespace ) ) );
 	}
 
+	/**
+	 * Ensures wp_check_password() trims symmetrically with wp_hash_password() when both
+	 * receive the same whitespace-padded password.
+	 *
+	 * @ticket 65144
+	 * @dataProvider data_passwords_with_whitespace
+	 */
+	public function test_wp_check_password_trims_password_to_match_wp_hash_password( $password_with_whitespace ) {
+		$this->assertTrue( wp_check_password( $password_with_whitespace, wp_hash_password( $password_with_whitespace ) ) );
+	}
+
 	public function data_passwords_with_whitespace() {
 		return array(
 			'leading whitespace'  => array( ' pass with leading whitespace', 'pass with leading whitespace' ),


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/65144

- Update function, `wp_check_password`, to include the `trim()` while checking the password created using `wp_hash_password`.

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->
- None

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
