### PR TITLE
Add transparent pseudo-element on active buttons for border in Windows High Contrast mode

### DIFF
--- a/src/wp-includes/css/buttons.css
+++ b/src/wp-includes/css/buttons.css
@@ -194,6 +194,7 @@ TABLE OF CONTENTS:
 	color: var(--wp-admin-theme-color-darker-20, #183ad6);
 	border-color: var(--wp-admin-theme-color, #3858e9);
 	box-shadow: inset 0 2px 6px -2px  var(--wp-admin-theme-color-darker-20);
+	position: relative;
 }
 
 .wp-core-ui .button.active:focus {
@@ -201,6 +202,19 @@ TABLE OF CONTENTS:
 	color: var(--wp-admin-theme-color-darker-20, #183ad6);
 	border-color: var(--wp-admin-theme-color-darker-20, #183ad6);
 	box-shadow: inset 0 2px 6px -2px  var(--wp-admin-theme-color-darker-20), 0 0 0 var(--wp-admin-border-width-focus, 1.5px) var(--wp-admin-theme-color, #3858e9);
+}
+
+/* Only visible in Windows High Contrast mode */
+.wp-core-ui .button.active:before {
+	content: "";
+	display: block;
+	position: absolute;
+	width: 100%;
+	height: 100%;
+	border: 1px solid transparent;
+	border-bottom-width: 3px;
+	left: 0;
+	box-sizing: border-box;
 }
 
 .wp-core-ui .button[disabled],

--- a/src/wp-includes/css/buttons.css
+++ b/src/wp-includes/css/buttons.css
@@ -210,9 +210,9 @@ TABLE OF CONTENTS:
 	display: block;
 	position: absolute;
 	width: 100%;
-	height: 100%;
-	border: 1px solid transparent;
-	border-bottom-width: 3px;
+	height: 0;
+	border-top: 3px solid transparent;
+	bottom: 0;
 	left: 0;
 	box-sizing: border-box;
 }


### PR DESCRIPTION
Adds a transparent pseudo-element on active buttons. In Windows High Contrast mode, this shows a thin border on three sides and a thicker border on the bottom. 

Using a pseudo-element reduces the chance of confusion with the focus outline, and it does not change the border (and button height) for other users.

[Trac 65153](https://core.trac.wordpress.org/ticket/65153)

## Screenshots

Screenshots using:
- Windows 11
- Aquatic contrast theme plus Dark mode
- Chrome 147.0.7727.102

### Permalinks options, showing focus outline on selected post name button

Before
<img width="640" height="220" alt="Before patch: Permalinks options, showing focus outline on post name" src="https://github.com/user-attachments/assets/0768bce1-1d71-4bc9-b322-4f561ddc5e9f" />

With patch (this also shows hover style on `post_id` button)
<img width="640" height="220" alt="With patch: Permalinks options, showing focus outline on post name and hover style on post ID" src="https://github.com/user-attachments/assets/7bc8783d-92b3-4a62-91a1-c8dbdcaf19a2" />

### Alignment options

The 'None' button is selected.

#### Selected None button has focus outline

Before
<img width="320" height="60" alt="Before patch: showing focus outline on selected button" src="https://github.com/user-attachments/assets/c95ee48e-e290-4863-8ca9-2a34210f4903" />

With patch 
<img width="320" height="60" alt="With patch: showing inner border and focus outline on selected button" src="https://github.com/user-attachments/assets/47fe849f-14c3-431b-ad0b-e5f942e484eb" />

#### Unselected Left button has focus outline

Before
<img width="320" height="60" alt="Before patch: showing focus outline on an unselected button" src="https://github.com/user-attachments/assets/84f3ade2-aafd-49f6-a914-b9dae098a4ee" />

With patch 
<img width="320" height="60" alt="With patch: showing inner border on selected button and focus outline on an unselected button" src="https://github.com/user-attachments/assets/c48d8cf2-22a7-496d-9372-24154a32591a" />

## Use of AI Tools

none

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
