### PR TITLE
fix: inconsistent button and select padding on Post listing, Media and all custom post type listing

### DIFF
--- a/src/wp-admin/css/forms.css
+++ b/src/wp-admin/css/forms.css
@@ -561,7 +561,7 @@ input[type="number"].tiny-text {
 	float: left;
 	margin-right: 6px;
 	max-width: 12.5rem;
-	padding: 0 24px 0 8px;
+	padding: 0 24px 0 12px;
 }
 
 .wp-core-ui .tablenav .button {


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/65152

## Use of AI Tools
NO

## Description 
In the Posts, media pages there is an inconsistency in the **_left padding_** between buttons (e.g., "Add Media File", "Add Post", "Apply", "Filter") and the select dropdowns (e.g., "Bulk Actions", "All Categories", "All dates").


## Screenshots

### Button Before 
`padding : 0 12px` i.e. padding-left will be `12px`

<img width="833" height="474" alt="buttons-before" src="https://github.com/user-attachments/assets/6d1f5a64-e39c-47b1-856e-62ad431e3f1b" />

### Select Before
 `padding: 0 24px 0 8px;`
<img width="833" height="474" alt="select-before" src="https://github.com/user-attachments/assets/24089299-f86c-4f62-8eb1-9bb71b3a043d" />
### Select After
 `padding: 0 24px 0 12px;`
<img width="833" height="474" alt="select-after" src="https://github.com/user-attachments/assets/b8dc9353-3eed-4b1e-8a36-7f9f8b9ebda3" />
   
## Expected Behavior
Both buttons and select dropdowns should have consistent left padding for better visual alignment.

## Actual Behavior
The select dropdown has `8px` left padding while buttons have `12px` left padding, causing text misalignment when these elements appear side by side.

## Proposed Solution
Update the left padding of the select dropdown in `/wp-admin/css/forms.css` from `8px` to `12px` to match the button padding.

## Tested:
WordPress: Playground and 7.0 RC-2 both
OS: Ubuntu 24.04
Browser: Version 146.0.7680.153 (Official Build) (64-bit)

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
