### PR TITLE
Feat: Add application passwords expiry

### DIFF
--- a/src/js/_enqueues/admin/application-passwords.js
+++ b/src/js/_enqueues/admin/application-passwords.js
@@ -64,6 +64,7 @@
 			$newAppPassButton.removeProp( 'aria-disabled' ).removeClass( 'disabled' );
 		} ).done( function( response ) {
 			$newAppPassField.val( '' );
+			$newAppPassExpiresField.val( '' );
 			$newAppPassButton.prop( 'disabled', false );
 
 			$newAppPassForm.after( tmplNewAppPass( {
@@ -87,6 +88,85 @@
 			 */
 			wp.hooks.doAction( 'wp_application_passwords_created_password', response, request );
 		} ).fail( handleErrorResponse );
+	});
+
+	/**
+	 * Handles the inline editing of an application password expiration date.
+	 * * @since 7.1.0
+	 */
+	$appPassTbody.on( 'click', '.edit-expires', function( e ) {
+		e.preventDefault();
+
+		var $button = $( this ),
+			$tr = $button.closest( 'tr' ),
+			uuid = $tr.data( 'uuid' ),
+			currentExpires = $tr.data( 'expires' ),
+			$td = $button.closest( 'td' );
+
+		if ( $td.find( '.edit-expires-form' ).length ) {
+			return;
+		}
+
+		var $form = $( '<div class="edit-expires-form"></div>' );
+		var $input = $( '<input type="date" class="edit-expires-input" />' );
+
+		if ( currentExpires ) {
+		    $input.val( currentExpires.split( 'T' )[0] );
+		}
+
+		var $buttonContainer = $( '<div class="edit-expires-button-group"></div>' );
+		var $saveBtn = $( '<button type="button" class="button button-small button-primary">' + wp.i18n.__( 'Save' ) + '</button>' );
+		var $cancelBtn = $( '<button type="button" class="button button-small">' + wp.i18n.__( 'Cancel' ) + '</button>' );
+
+		$buttonContainer.append( $saveBtn ).append( $cancelBtn );
+		$form.append( $input ).append( $buttonContainer );
+
+		$td.append( $form );
+		$button.hide();
+		$input.trigger( 'focus' );
+
+		// Close form on Escape key.
+		$input.on( 'keydown', function( e ) {
+			if ( 27 === e.which ) {
+				$cancelBtn.trigger( 'click' );
+			}
+			if ( 13 === e.which ) {
+				e.preventDefault();
+				$saveBtn.trigger( 'click' );
+			}
+		});
+
+		$cancelBtn.on( 'click', function() {
+			$form.remove();
+			$button.show().trigger( 'focus' );
+		} );
+
+		$saveBtn.on( 'click', function() {
+			var newExpires = $input.val();
+			var expiresDate = newExpires ? new Date( newExpires ) : null;
+			var requestData = {
+				expires: ( expiresDate && ! isNaN( expiresDate.getTime() ) ) ? expiresDate.toISOString() : null
+			};
+
+			clearNotices();
+			$saveBtn.prop( 'disabled', true );
+			$cancelBtn.prop( 'disabled', true );
+
+			wp.apiRequest( {
+				path: '/wp/v2/users/' + userId + '/application-passwords/' + uuid + '?_locale=user',
+				method: 'PUT',
+				data: JSON.stringify( requestData ),
+				contentType: 'application/json'
+			} ).always( function() {
+				$saveBtn.prop( 'disabled', false );
+				$cancelBtn.prop( 'disabled', false );
+			} ).done( function( response ) {
+				var $newRow = $( tmplAppPassRow( response ) );
+				$tr.replaceWith( $newRow );
+				$newRow.find( '.edit-expires' ).trigger( 'focus' );
+				addNotice( wp.i18n.__( 'Application password expiration updated.' ), 'success' );
+			} ).fail( handleErrorResponse );
+		} );
 	} );
 
 	$appPassTbody.on( 'click', '.delete', function( e ) {

--- a/src/js/_enqueues/admin/application-passwords.js
+++ b/src/js/_enqueues/admin/application-passwords.js
@@ -5,7 +5,8 @@
 ( function( $ ) {
 	var $appPassSection = $( '#application-passwords-section' ),
 		$newAppPassForm = $appPassSection.find( '.create-application-password' ),
-		$newAppPassField = $newAppPassForm.find( '.input' ),
+		$newAppPassField = $newAppPassForm.find( '#new_application_password_name' ),
+		$newAppPassExpiresField = $newAppPassForm.find( '#new_application_password_expires' ),
 		$newAppPassButton = $newAppPassForm.find( '.button' ),
 		$appPassTwrapper = $appPassSection.find( '.application-passwords-list-table-wrapper' ),
 		$appPassTbody = $appPassSection.find( 'tbody' ),
@@ -35,6 +36,15 @@
 		var request = {
 			name: name
 		};
+
+		var expires = $newAppPassExpiresField.val();
+		if ( expires ) {
+		    var expiresDate = new Date( expires );
+
+		    if ( ! isNaN( expiresDate.getTime() ) ) {
+		        request.expires = expiresDate.toISOString();
+		    }
+		}
 
 		/**
 		 * Filters the request data used to create a new Application Password.

--- a/src/wp-admin/css/forms.css
+++ b/src/wp-admin/css/forms.css
@@ -1077,6 +1077,28 @@ table.form-table td .updated p {
 	max-width: 20em;
 }
 
+.edit-expires-form {
+	margin-top: 8px;
+	width: 100%;
+}
+
+.edit-expires-input {
+	display: block;
+	width: 100%;
+	max-width: 150px;
+	margin-bottom: 5px;
+}
+
+.edit-expires-button-group {
+	display: flex;
+	gap: 4px;
+	justify-content: flex-start;
+}
+
+.column-expires {
+	vertical-align: top;
+}
+
 .auth-app-card.card {
 	max-width: 768px;
 }

--- a/src/wp-admin/includes/class-wp-application-passwords-list-table.php
+++ b/src/wp-admin/includes/class-wp-application-passwords-list-table.php
@@ -29,6 +29,7 @@ class WP_Application_Passwords_List_Table extends WP_List_Table {
 			'created'   => __( 'Created' ),
 			'last_used' => __( 'Last Used' ),
 			'last_ip'   => __( 'Last IP' ),
+			'expires'   => __( 'Expires' ),
 			'revoke'    => __( 'Revoke' ),
 		);
 	}
@@ -99,6 +100,35 @@ class WP_Application_Passwords_List_Table extends WP_List_Table {
 		} else {
 			echo $item['last_ip'];
 		}
+	}
+
+	/**
+	 * Handles the expires column output.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param array $item The current application password item.
+	 */
+	public function column_expires( $item ) {
+		if ( empty( $item['expires'] ) ) {
+			echo '&mdash;';
+		} else {
+			$date = date_i18n( __( 'F j, Y' ), $item['expires'] );
+			if ( time() > $item['expires'] ) {
+				printf(
+					'%s',
+					/* translators: %s: Expiration date for the Application Password. */
+					sprintf( __( 'Expired on %s' ), $date )
+				);
+			} else {
+				echo $date;
+			}
+		}
+		printf(
+			'<br><button type="button" class="button-link edit-expires" aria-label="%s">%s</button>',
+			esc_attr__( 'Edit Application Password Expiration Date' ),
+			esc_html__( 'Edit Expiry' )
+		);
 	}
 
 	/**
@@ -229,6 +259,25 @@ class WP_Application_Passwords_List_Table extends WP_List_Table {
 					break;
 				case 'last_ip':
 					echo "{{ data.last_ip || '—' }}";
+					break;
+				case 'expires':
+					?>
+					<# if ( data.expires ) { #>
+						<# var isExpired = new Date().getTime() > new Date( data.expires ).getTime(); #>
+						<# var formattedDate = wp.date.dateI18n( <?php echo wp_json_encode( __( 'F j, Y' ) ); ?>, data.expires ); #>
+						<# if ( isExpired ) { #>
+							<?php
+							/* translators: %s: Expiration date for the Application Password. */
+							printf( esc_html__( 'Expired on %s' ), '{{ formattedDate }}' );
+							?>
+						<# } else { #>
+							{{ formattedDate }}
+						<# } #>
+					<# } else { #>
+						—
+					<# } #>
+					<br><button type="button" class="button-link edit-expires" aria-label="<?php esc_attr_e( 'Edit Expiration Date' ); ?>"><?php esc_html_e( 'Edit Expiry' ); ?></button>
+					<?php
 					break;
 				case 'revoke':
 					printf(

--- a/src/wp-admin/user-edit.php
+++ b/src/wp-admin/user-edit.php
@@ -837,6 +837,12 @@ switch ( $action ) {
 											<p class="description" id="new_application_password_name_desc"><?php _e( 'Required to create an Application Password, but not to update the user.' ); ?></p>
 										</div>
 
+										<div class="form-field">
+											<label for="new_application_password_expires"><?php _e( 'Expires on' ); ?></label>
+											<input type="date" id="new_application_password_expires" name="new_application_password_expires" class="input ltr" />
+											<p class="description"><?php _e( 'Optional. Set an expiration date for this password.' ); ?></p>
+										</div>
+
 										<?php
 										/**
 										 * Fires in the create Application Passwords form.

--- a/src/wp-includes/class-wp-application-passwords.php
+++ b/src/wp-includes/class-wp-application-passwords.php
@@ -106,6 +106,7 @@ class WP_Application_Passwords {
 			'created'   => time(),
 			'last_used' => null,
 			'last_ip'   => null,
+			'expires'   => isset( $args['expires'] ) ? (int) $args['expires'] : null,
 		);
 
 		$passwords   = static::get_user_application_passwords( $user_id );
@@ -281,6 +282,14 @@ class WP_Application_Passwords {
 			}
 
 			$save = false;
+
+			if ( array_key_exists( 'expires', $update ) ) {
+				$expires = null === $update['expires'] ? null : (int) $update['expires'];
+				if ( ! array_key_exists( 'expires', $item ) || $item['expires'] !== $expires ) {
+					$item['expires'] = $expires;
+					$save            = true;
+				}
+			}
 
 			if ( ! empty( $update['name'] ) && $item['name'] !== $update['name'] ) {
 				$item['name'] = $update['name'];

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-application-passwords-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-application-passwords-controller.php
@@ -583,6 +583,11 @@ class WP_REST_Application_Passwords_Controller extends WP_REST_Controller {
 			$prepared->app_id = $request['app_id'];
 		}
 
+		$prepared->expires = null;
+		if ( isset( $request['expires'] ) && null !== $request['expires'] ) {
+			$prepared->expires = rest_parse_date( $request['expires'] );
+		}
+
 		/**
 		 * Filters an application password before it is inserted via the REST API.
 		 *
@@ -619,6 +624,7 @@ class WP_REST_Application_Passwords_Controller extends WP_REST_Controller {
 			'created'   => gmdate( 'Y-m-d\TH:i:s', $item['created'] ),
 			'last_used' => $item['last_used'] ? gmdate( 'Y-m-d\TH:i:s', $item['last_used'] ) : null,
 			'last_ip'   => $item['last_ip'] ? $item['last_ip'] : null,
+			'expires'   => ! empty( $item['expires'] ) ? gmdate( 'Y-m-d\TH:i:s', $item['expires'] ) : null,
 		);
 
 		if ( isset( $item['new_password'] ) ) {
@@ -848,6 +854,12 @@ class WP_REST_Application_Passwords_Controller extends WP_REST_Controller {
 					'format'      => 'ip',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
+				),
+				'expires'   => array(
+					'description' => __( 'The GMT date the application password expires.' ),
+					'type'        => array( 'string', 'null' ),
+					'format'      => 'date-time',
+					'context'     => array( 'view', 'edit' ),
 				),
 			),
 		);

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -463,6 +463,13 @@ function wp_authenticate_application_password(
 
 		$error = new WP_Error();
 
+		if ( ! empty( $item['expires'] ) && time() > $item['expires'] ) {
+			$error->add(
+				'application_password_expired',
+				__( 'The provided application password has expired.' )
+			);
+		}
+
 		/**
 		 * Fires when an application password has been successfully checked as valid.
 		 *

--- a/tests/e2e/specs/profile/applications-passwords.test.js
+++ b/tests/e2e/specs/profile/applications-passwords.test.js
@@ -40,6 +40,56 @@ test.describe( 'Manage applications passwords', () => {
 		);
 	} );
 
+	test('should correctly create a new application password with expiration', async ( {
+		page,
+		applicationPasswords
+	} ) => {
+		const expiresDate = new Date();
+		expiresDate.setDate( expiresDate.getDate() + 7 );
+		const expiresString = expiresDate.toISOString().split( 'T' )[ 0 ];
+
+		await applicationPasswords.create( TEST_APPLICATION_NAME, expiresString );
+
+		const [ app ] = await applicationPasswords.get();
+		expect( app['name'] ).toBe( TEST_APPLICATION_NAME );
+		expect( app['expires'] ).not.toBeNull();
+		expect( app['expires'].startsWith( expiresString ) ).toBe( true );
+
+		const successMessage = page.getByRole( 'alert' );
+		await expect( successMessage ).toHaveClass( /notice-success/ );
+	} );
+
+	test('should correctly update an application password expiration date', async ( {
+		page,
+		applicationPasswords
+	} ) => {
+		await applicationPasswords.create();
+
+		const [ app ] = await applicationPasswords.get();
+		expect( app['expires'] ).toBeNull();
+
+		const editButton = page.getByRole( 'button', { name: 'Edit Expiration Date' } );
+		await expect( editButton ).toBeVisible();
+		await editButton.click();
+
+		const expiresInput = page.locator( '.edit-expires-input' );
+		await expect( expiresInput ).toBeVisible();
+
+		const expiresDate = new Date();
+		expiresDate.setDate( expiresDate.getDate() + 10 );
+		const expiresString = expiresDate.toISOString().split( 'T' )[ 0 ];
+		await expiresInput.fill( expiresString );
+
+		const saveButton = page.getByRole( 'button', { name: 'Save' } );
+		await saveButton.click();
+
+		await expect( page.getByRole( 'alert' ) ).toContainText( 'Application password expiration updated.' );
+
+		const [ updatedApp ] = await applicationPasswords.get();
+		expect( updatedApp['expires'] ).not.toBeNull();
+		expect( updatedApp['expires'].startsWith( expiresString ) ).toBe( true );
+	} );
+
 	test( 'should correctly revoke a single application password', async ( {
 		page,
 		applicationPasswords
@@ -94,12 +144,18 @@ class ApplicationPasswords {
 		this.admin = admin;
 	}
 
-	async create(applicationName = TEST_APPLICATION_NAME) {
+	async create(applicationName = TEST_APPLICATION_NAME, expires = null) {
 		await this.admin.visitAdminPage( '/profile.php' );
 
 		const newPasswordField = this.page.getByRole( 'textbox', { name: 'New Application Password Name' } );
 		await expect( newPasswordField ).toBeVisible();
 		await newPasswordField.fill( applicationName );
+
+		if ( expires ) {
+			const newPasswordExpiresField = this.page.getByLabel( 'Expires on' );
+			await expect( newPasswordExpiresField ).toBeVisible();
+			await newPasswordExpiresField.fill( expires );
+		}
 
 		await this.page.getByRole( 'button', { name: 'Add Application Password' } ).click();
 		await expect( this.page.getByRole( 'alert' ) ).toBeVisible();

--- a/tests/phpunit/tests/auth.php
+++ b/tests/phpunit/tests/auth.php
@@ -1768,6 +1768,26 @@ class Tests_Auth extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 53995
+	 */
+	public function test_authenticate_application_password_expired() {
+		add_filter( 'application_password_is_api_request', '__return_true' );
+		add_filter( 'wp_is_application_passwords_available', '__return_true' );
+
+		list( $password ) = WP_Application_Passwords::create_new_application_password(
+			self::$user_id,
+			array(
+				'name'    => 'phpunit',
+				'expires' => time() - DAY_IN_SECONDS,
+			)
+		);
+
+		$error = wp_authenticate_application_password( null, self::$_user->user_login, $password );
+		$this->assertWPError( $error );
+		$this->assertSame( 'application_password_expired', $error->get_error_code() );
+	}
+
+	/**
 	 * @ticket 51939
 	 */
 	public function test_authenticate_application_password_returns_null_if_not_in_use() {

--- a/tests/phpunit/tests/rest-api/application-passwords.php
+++ b/tests/phpunit/tests/rest-api/application-passwords.php
@@ -95,7 +95,7 @@ class Test_WP_Application_Passwords extends WP_UnitTestCase {
 
 		$this->assertNotEmpty( $new_password );
 		$this->assertSame(
-			array( 'uuid', 'app_id', 'name', 'password', 'created', 'last_used', 'last_ip' ),
+			array( 'uuid', 'app_id', 'name', 'password', 'created', 'last_used', 'last_ip', 'expires' ),
 			array_keys( $new_item )
 		);
 		$this->assertSame( $args['name'], $new_item['name'] );
@@ -106,9 +106,15 @@ class Test_WP_Application_Passwords extends WP_UnitTestCase {
 			'should create new password when no passwords exists' => array(
 				'args' => array( 'name' => 'test3' ),
 			),
-			'should create new password when name is unique'      => array(
+			'should create new password when name is unique' => array(
 				'args'  => array( 'name' => 'test3' ),
 				'names' => array( 'test1', 'test2' ),
+			),
+			'should create new password with expiration' => array(
+				'args' => array(
+					'name'    => 'test_expire',
+					'expires' => time() + DAY_IN_SECONDS,
+				),
 			),
 		);
 	}
@@ -154,7 +160,7 @@ class Test_WP_Application_Passwords extends WP_UnitTestCase {
 		// Check updated only given values.
 		$updated_item = WP_Application_Passwords::get_user_application_password( self::$user_id, $uuid );
 		foreach ( $updated_item as $key => $update_value ) {
-			$expected_value = $update[ $key ] ?? $original_item[ $key ];
+			$expected_value = array_key_exists( $key, $update ) ? $update[ $key ] : $original_item[ $key ];
 			$this->assertSame( $expected_value, $update_value );
 		}
 	}
@@ -185,6 +191,17 @@ class Test_WP_Application_Passwords extends WP_UnitTestCase {
 			'should update name'                     => array(
 				'update'   => array( 'name' => 'Test Updated' ),
 				'existing' => array( 'name' => 'Test' ),
+			),
+			'should update expires'                  => array(
+				'update'   => array( 'expires' => time() + DAY_IN_SECONDS ),
+				'existing' => array( 'name' => 'Test' ),
+			),
+			'should clear expires'                   => array(
+				'update'   => array( 'expires' => null ),
+				'existing' => array(
+					'name'    => 'Test',
+					'expires' => time() + DAY_IN_SECONDS,
+				),
 			),
 		);
 	}

--- a/tests/phpunit/tests/rest-api/rest-application-passwords-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-application-passwords-controller.php
@@ -906,6 +906,7 @@ class WP_Test_REST_Application_Passwords_Controller extends WP_Test_REST_Control
 		$this->assertArrayHasKey( 'created', $response );
 		$this->assertArrayHasKey( 'last_used', $response );
 		$this->assertArrayHasKey( 'last_ip', $response );
+		$this->assertArrayHasKey( 'expires', $response );
 
 		$this->assertSame( $item['uuid'], $response['uuid'] );
 		$this->assertSame( $item['app_id'], $response['app_id'] );
@@ -922,6 +923,12 @@ class WP_Test_REST_Application_Passwords_Controller extends WP_Test_REST_Control
 			$this->assertSame( $item['last_ip'], $response['last_ip'] );
 		} else {
 			$this->assertNull( $response['last_ip'] );
+		}
+
+		if ( ! empty( $item['expires'] ) ) {
+			$this->assertSame( gmdate( 'Y-m-d\TH:i:s', $item['expires'] ), $response['expires'] );
+		} else {
+			$this->assertNull( $response['expires'] );
 		}
 
 		if ( $password ) {
@@ -947,7 +954,8 @@ class WP_Test_REST_Application_Passwords_Controller extends WP_Test_REST_Control
 		$this->assertArrayHasKey( 'created', $properties );
 		$this->assertArrayHasKey( 'last_used', $properties );
 		$this->assertArrayHasKey( 'last_ip', $properties );
-		$this->assertCount( 7, $properties );
+		$this->assertArrayHasKey( 'expires', $properties );
+		$this->assertCount( 8, $properties );
 	}
 
 	/**

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -10200,6 +10200,15 @@ mockedApiResponse.Schema = {
                             "minLength": 1,
                             "pattern": ".*\\S.*",
                             "required": true
+                        },
+                        "expires": {
+                            "description": "The GMT date the application password expires.",
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "format": "date-time",
+                            "required": false
                         }
                     }
                 },
@@ -10294,6 +10303,15 @@ mockedApiResponse.Schema = {
                             "type": "string",
                             "minLength": 1,
                             "pattern": ".*\\S.*",
+                            "required": false
+                        },
+                        "expires": {
+                            "description": "The GMT date the application password expires.",
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "format": "date-time",
                             "required": false
                         }
                     }


### PR DESCRIPTION

This PR introduces the ability to set and manage expiration dates for Application Passwords in WordPress. Currently, application passwords are permanent until revoked; this change enhances security by allowing users to define a "Time to Live" (TTL) for specific credentials.

**Key Changes:**
- **User Interface:** Added an "Expires on" date picker to the "Add New Application Password" form.
- **Management:** Added an "Expires" column to the Application Passwords list table.
- **Inline Editing:** Implemented AJAX-powered inline editing for expiration dates directly from the list table, including "Save" and "Cancel" functionality.
- **REST API:** Updated the `application-passwords` controller to support the `expires` field for both creation and updates.
- **Authentication:** Updated `wp_authenticate_application_password` to validate the expiration timestamp. If a password has expired, authentication will fail with an `application_password_expired` error.
- **Tests:** Added e2e tests and unit tests to cover creation with expiration, inline editing of expiration dates, and ensuring expired passwords display correctly.

https://github.com/user-attachments/assets/e6d6fd2e-7c2e-47ad-8613-8281419ca6cc

Trac ticket: https://core.trac.wordpress.org/ticket/53995

### Use of AI Tools

AI assistance: Yes
Tool(s): Gemini/Antigravity
Model(s): Gemini 3 Flash, Gemini 3.1 Pro
Used for: Troubleshooting E2E test failures and drafting the PR description based on provided code diffs.

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
