### PR TITLE
Connectors: Register Akismet as a default non-AI connector

### DIFF
--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -210,6 +210,27 @@ function _wp_connectors_init(): void {
 		_wp_connectors_register_default_ai_providers( $registry );
 	}
 
+	// Non-AI default connectors.
+	$registry->register(
+		'akismet',
+		array(
+			'name'           => __( 'Akismet Anti-spam' ),
+			'description'    => __( 'Protect your site from spam.' ),
+			'type'           => 'spam_filtering',
+			'plugin'         => array(
+				'file' => 'akismet/akismet.php',
+				// If the plugin is active, it will pass its its own is_active callback.
+				'is_active' => '__return_false',
+			),
+			'authentication' => array(
+				'method'          => 'api_key',
+				'credentials_url' => 'https://akismet.com/get/',
+				'setting_name'    => 'wordpress_api_key',
+				'constant_name'   => 'WPCOM_API_KEY',
+			),
+		)
+	);
+
 	/**
 	 * Fires when the connector registry is ready for plugins to register connectors.
 	 *

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -218,8 +218,8 @@ function _wp_connectors_init(): void {
 			'description'    => __( 'Protect your site from spam.' ),
 			'type'           => 'spam_filtering',
 			'plugin'         => array(
-				'file' => 'akismet/akismet.php',
-				'is_active' => function () {
+				'file'      => 'akismet/akismet.php',
+				'is_active' => static function () {
 					return defined( 'AKISMET_VERSION' );
 				},
 			),

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -219,8 +219,9 @@ function _wp_connectors_init(): void {
 			'type'           => 'spam_filtering',
 			'plugin'         => array(
 				'file' => 'akismet/akismet.php',
-				// If the plugin is active, it will pass its its own is_active callback.
-				'is_active' => '__return_false',
+				'is_active' => function () {
+					return defined( 'AKISMET_VERSION' );
+				},
 			),
 			'authentication' => array(
 				'method'          => 'api_key',

--- a/tests/phpunit/tests/connectors/wpConnectorsGetConnectorSettings.php
+++ b/tests/phpunit/tests/connectors/wpConnectorsGetConnectorSettings.php
@@ -37,8 +37,9 @@ class Tests_Connectors_WpGetConnectors extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'google', $connectors );
 		$this->assertArrayHasKey( 'openai', $connectors );
 		$this->assertArrayHasKey( 'anthropic', $connectors );
+		$this->assertArrayHasKey( 'akismet', $connectors );
 		$this->assertArrayHasKey( 'mock-connectors-test', $connectors );
-		$this->assertCount( 4, $connectors );
+		$this->assertCount( 5, $connectors );
 	}
 
 	/**
@@ -56,7 +57,7 @@ class Tests_Connectors_WpGetConnectors extends WP_UnitTestCase {
 			$this->assertArrayHasKey( 'description', $connector_data, "Connector '{$connector_id}' is missing 'description'." );
 			$this->assertIsString( $connector_data['description'], "Connector '{$connector_id}' description should be a string." );
 			$this->assertArrayHasKey( 'type', $connector_data, "Connector '{$connector_id}' is missing 'type'." );
-			$this->assertContains( $connector_data['type'], array( 'ai_provider' ), "Connector '{$connector_id}' has unexpected type '{$connector_data['type']}'." );
+			$this->assertContains( $connector_data['type'], array( 'ai_provider', 'spam_filtering' ), "Connector '{$connector_id}' has unexpected type '{$connector_data['type']}'." );
 			$this->assertArrayHasKey( 'authentication', $connector_data, "Connector '{$connector_id}' is missing 'authentication'." );
 			$this->assertIsArray( $connector_data['authentication'], "Connector '{$connector_id}' authentication should be an array." );
 			$this->assertArrayHasKey( 'method', $connector_data['authentication'], "Connector '{$connector_id}' authentication is missing 'method'." );
@@ -79,10 +80,16 @@ class Tests_Connectors_WpGetConnectors extends WP_UnitTestCase {
 			++$api_key_count;
 
 			$this->assertArrayHasKey( 'setting_name', $connector_data['authentication'], "Connector '{$connector_id}' authentication is missing 'setting_name'." );
+			$this->assertNotEmpty( $connector_data['authentication']['setting_name'], "Connector '{$connector_id}' setting_name should not be empty." );
+
+			if ( 'ai_provider' !== $connector_data['type'] ) {
+				continue;
+			}
+
 			$this->assertSame(
 				'connectors_ai_' . str_replace( '-', '_', $connector_id ) . '_api_key',
-				$connector_data['authentication']['setting_name'] ?? null,
-				"Connector '{$connector_id}' setting_name does not match expected format."
+				$connector_data['authentication']['setting_name'],
+				"Connector '{$connector_id}' setting_name does not match expected AI provider format."
 			);
 		}
 


### PR DESCRIPTION
## Summary

- Registers Akismet in the default connector registry as a `spam_filtering` type.
- Wires plugin metadata to `akismet/akismet.php` with an `is_active` callback.
- Reuses the existing `wordpress_api_key` option / `WPCOM_API_KEY` constant for API key authentication, and points users to `https://akismet.com/get/` for credentials.

Must be tested with akismet installed, as the connector only appears if akismet is installed, does not needs activation.

Ticket: https://core.trac.wordpress.org/ticket/65012

## Test plan

- [ ] With Akismet inactive, confirm the connector appears in the registry and reports `is_active` as `false`.
- [ ] With Akismet active and registering its own `is_active` callback, confirm the connector reports `is_active` as `true`.
- [ ] Verify the `wordpress_api_key` option and `WPCOM_API_KEY` constant are picked up as credentials.