### PR TITLE
Metabox container alignment classic editor

### DIFF
--- a/src/wp-admin/css/edit.css
+++ b/src/wp-admin/css/edit.css
@@ -173,10 +173,6 @@ body.post-type-wp_navigation .inline-edit-status {
 
 /* Post Screen */
 
-.metabox-holder .postbox-container .meta-box-sortables {
-	padding: 4px;
-}
-
 /* Only highlight drop zones when dragging and only in the 2 columns layout. */
 .is-dragging-metaboxes .metabox-holder .postbox-container .meta-box-sortables {
 	border-radius: 8px;

--- a/src/wp-admin/css/edit.css
+++ b/src/wp-admin/css/edit.css
@@ -5,7 +5,7 @@
 
 #poststuff #post-body {
 	padding: 0;
-	margin: 0 -4px;
+	margin: 0;
 }
 
 #poststuff .postbox-container {

--- a/src/wp-admin/css/edit.css
+++ b/src/wp-admin/css/edit.css
@@ -5,7 +5,6 @@
 
 #poststuff #post-body {
 	padding: 0;
-	margin: 0;
 }
 
 #poststuff .postbox-container {


### PR DESCRIPTION


[@TobiasBg](https://profiles.wordpress.org/tobiasbg/) has suggested to remove negative -4px margin on #poststuff #post-body that pulling post-body to left. This margin is not required.[ Here](https://core.trac.wordpress.org/ticket/65141?replyto=8#comment:8)

This margin was added in changeset for admin reskin  https://core.trac.wordpress.org/changeset/61646

Trac ticket: https://core.trac.wordpress.org/ticket/65141

