### PR TITLE
RTC: Backport fix to prevent autosaves from losing content.

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php
@@ -253,7 +253,8 @@ class WP_REST_Autosaves_Controller extends WP_REST_Revisions_Controller {
 			(int) $post->post_author === $user_id &&
 			! $is_collaboration_enabled
 		);
-		$can_promote_auto_draft_post  = (
+
+		$can_promote_auto_draft_post = (
 			$is_auto_draft &&
 			$is_collaboration_enabled &&
 			current_user_can( 'edit_post', $post->ID )

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php
@@ -248,11 +248,20 @@ class WP_REST_Autosaves_Controller extends WP_REST_Revisions_Controller {
 		 * into a real draft post. If this doesn’t happen then the peers may continue to make edits
 		 * but the draft will be lost, as auto-drafts are not listed in post views.
 		 */
-		$should_update_parent_draft_post = (
+		$can_update_author_draft_post = (
 			$is_draft &&
 			(int) $post->post_author === $user_id &&
-			! $post_lock_is_active &&
-			( ! $is_collaboration_enabled || $is_auto_draft )
+			! $is_collaboration_enabled
+		);
+		$can_promote_auto_draft_post  = (
+			$is_auto_draft &&
+			$is_collaboration_enabled &&
+			current_user_can( 'edit_post', $post->ID )
+		);
+
+		$should_update_parent_draft_post = (
+			$can_promote_auto_draft_post ||
+			( ! $post_lock_is_active && $can_update_author_draft_post )
 		);
 
 		if ( $should_update_parent_draft_post ) {

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php
@@ -229,8 +229,9 @@ class WP_REST_Autosaves_Controller extends WP_REST_Revisions_Controller {
 			require_once ABSPATH . 'wp-admin/includes/post.php';
 		}
 
-		$post_lock = wp_check_post_lock( $post->ID );
-		$is_draft  = 'draft' === $post->post_status || 'auto-draft' === $post->post_status;
+		$post_lock     = wp_check_post_lock( $post->ID );
+		$is_auto_draft = 'auto-draft' === $post->post_status;
+		$is_draft      = 'draft' === $post->post_status || $is_auto_draft;
 
 		/*
 		 * In the context of real-time collaboration, all peers are effectively
@@ -256,10 +257,19 @@ class WP_REST_Autosaves_Controller extends WP_REST_Revisions_Controller {
 		 */
 		$is_collaboration_enabled = wp_is_collaboration_enabled();
 
-		if ( $is_draft && (int) $post->post_author === $user_id && ! $post_lock && ! $is_collaboration_enabled ) {
+		if (
+			$is_draft &&
+			(int) $post->post_author === $user_id &&
+			! $post_lock &&
+			( ! $is_collaboration_enabled || $is_auto_draft )
+		) {
 			/*
 			 * Draft posts for the same author: autosaving updates the post and does not create a revision.
 			 * Convert the post object to an array and add slashes, wp_update_post() expects escaped array.
+			 *
+			 * Auto-drafts must still be promoted to drafts when collaboration is enabled so that a new post
+			 * survives URL loss and appears in Drafts. Regular draft autosaves remain revisions under
+			 * collaboration to keep the saved post from diverging from the persisted CRDT document.
 			 */
 			$autosave_id = wp_update_post( wp_slash( (array) $prepared_post ), true );
 		} else {

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php
@@ -229,51 +229,35 @@ class WP_REST_Autosaves_Controller extends WP_REST_Revisions_Controller {
 			require_once ABSPATH . 'wp-admin/includes/post.php';
 		}
 
-		$post_lock     = wp_check_post_lock( $post->ID );
-		$is_auto_draft = 'auto-draft' === $post->post_status;
-		$is_draft      = 'draft' === $post->post_status || $is_auto_draft;
-
-		/*
-		 * In the context of real-time collaboration, all peers are effectively
-		 * authors and we don't want to vary behavior based on whether they are the
-		 * original author. Always target an autosave revision.
-		 *
-		 * This avoids the following issue when real-time collaboration is enabled:
-		 *
-		 * - Autosaves from the original author (if they have the post lock) will
-		 *   target the saved post.
-		 *
-		 * - Autosaves from other users are applied to a post revision.
-		 *
-		 * - If any user reloads a post, they load changes from the author's autosave.
-		 *
-		 * - The saved post has now diverged from the persisted CRDT document. The
-		 *   content (and/or title or excerpt) are now "ahead" of the persisted CRDT
-		 *   document.
-		 *
-		 * - When the persisted CRDT document is loaded, a diff is computed against
-		 *   the saved post. This diff is then applied to the in-memory CRDT
-		 *   document, which can lead to duplicate inserts or deletions.
-		 */
+		$post_lock_is_active      = wp_check_post_lock( $post->ID );
+		$is_auto_draft            = 'auto-draft' === $post->post_status;
+		$is_draft                 = 'draft' === $post->post_status || $is_auto_draft;
 		$is_collaboration_enabled = wp_is_collaboration_enabled();
 
-		if (
+		/*
+		 * When a post is still in draft form, updates from the author can directly update the post.
+		 * Other autosaves must be stored as per-user autosave revisions.
+		 *
+		 * When RTC is active, however, regular draft autosaves must not update the parent post directly.
+		 * Since all peers are sharing a persisted editing state (a shared CRDT), it’s important that
+		 * they all store updates in a revision. If edits were applied to the post, then upon the next
+		 * editor reload, it would appear as though the post had been updated externally, and those same
+		 * changes would be re-applied to the CRDT, duplicating the edits.
+		 *
+		 * The one caveat for RTC is that the first peer to store an edit must promote an auto-draft
+		 * into a real draft post. If this doesn’t happen then the peers may continue to make edits
+		 * but the draft will be lost, as auto-drafts are not listed in post views.
+		 */
+		$should_update_parent_draft_post = (
 			$is_draft &&
 			(int) $post->post_author === $user_id &&
-			! $post_lock &&
+			! $post_lock_is_active &&
 			( ! $is_collaboration_enabled || $is_auto_draft )
-		) {
-			/*
-			 * Draft posts for the same author: autosaving updates the post and does not create a revision.
-			 * Convert the post object to an array and add slashes, wp_update_post() expects escaped array.
-			 *
-			 * Auto-drafts must still be promoted to drafts when collaboration is enabled so that a new post
-			 * survives URL loss and appears in Drafts. Regular draft autosaves remain revisions under
-			 * collaboration to keep the saved post from diverging from the persisted CRDT document.
-			 */
+		);
+
+		if ( $should_update_parent_draft_post ) {
 			$autosave_id = wp_update_post( wp_slash( (array) $prepared_post ), true );
 		} else {
-			// Non-draft posts: create or update the post autosave. Pass the meta data.
 			$autosave_id = $this->create_post_autosave( (array) $prepared_post, (array) $request->get_param( 'meta' ) );
 		}
 

--- a/tests/phpunit/tests/collaboration/restAutosavesController.php
+++ b/tests/phpunit/tests/collaboration/restAutosavesController.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Tests for the collaboration autosaves REST controller override.
+ *
+ * @package gutenberg
+ * @subpackage Collaboration
+ *
+ * @group collaboration
+ * @group restapi
+ */
+class Tests_Collaboration_RestAutosavesController extends WP_UnitTestCase {
+
+	protected static int $author_id;
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$author_id = $factory->user->create( array( 'role' => 'author' ) );
+	}
+
+	public static function wpTearDownAfterClass() {
+		self::delete_user( self::$author_id );
+		delete_option( 'wp_collaboration_enabled' );
+	}
+
+	public function set_up() {
+		parent::set_up();
+		wp_set_current_user( self::$author_id );
+	}
+
+	/**
+	 * Creates an empty auto-draft post.
+	 *
+	 * @return int Post ID.
+	 */
+	private function create_auto_draft(): int {
+		return self::factory()->post->create(
+			array(
+				'post_author'  => self::$author_id,
+				'post_content' => '',
+				'post_status'  => 'auto-draft',
+				'post_title'   => 'Auto Draft',
+				'post_type'    => 'post',
+			)
+		);
+	}
+
+	/**
+	 * Dispatches an autosave request for a post.
+	 *
+	 * @param int    $post_id Post ID.
+	 * @param string $title   Autosaved post title.
+	 * @param string $content Autosaved post content.
+	 * @return WP_REST_Response Autosave response.
+	 */
+	private function dispatch_autosave( int $post_id, string $title, string $content ): WP_REST_Response {
+		$request = new WP_REST_Request( 'POST', "/wp/v2/posts/{$post_id}/autosaves" );
+		$request->set_param( 'title', $title );
+		$request->set_param( 'content', $content );
+		$request->set_param( 'status', 'draft' );
+
+		return rest_get_server()->dispatch( $request );
+	}
+
+	public function test_auto_draft_autosave_promotes_parent_post_when_collaboration_is_disabled() {
+		update_option( 'wp_collaboration_enabled', 0 );
+
+		$post_id = $this->create_auto_draft();
+		$title   = 'No RTC autosaved title';
+		$content = '<!-- wp:paragraph --><p>No RTC autosaved content</p><!-- /wp:paragraph -->';
+
+		$response = $this->dispatch_autosave( $post_id, $title, $content );
+
+		$this->assertSame( 200, $response->get_status() );
+		$post = get_post( $post_id );
+		$this->assertSame( 'draft', $post->post_status );
+		$this->assertSame( $title, $post->post_title );
+		$this->assertSame( $content, $post->post_content );
+	}
+
+	public function test_auto_draft_autosave_promotes_parent_post_when_collaboration_is_enabled() {
+		update_option( 'wp_collaboration_enabled', 1 );
+
+		$post_id = $this->create_auto_draft();
+		$title   = 'RTC autosaved title';
+		$content = '<!-- wp:paragraph --><p>RTC autosaved content</p><!-- /wp:paragraph -->';
+
+		$response = $this->dispatch_autosave( $post_id, $title, $content );
+
+		$this->assertSame( 200, $response->get_status() );
+		$post = get_post( $post_id );
+		$this->assertSame( 'draft', $post->post_status );
+		$this->assertSame( $title, $post->post_title );
+		$this->assertSame( $content, $post->post_content );
+	}
+}

--- a/tests/phpunit/tests/collaboration/restAutosavesController.php
+++ b/tests/phpunit/tests/collaboration/restAutosavesController.php
@@ -82,6 +82,9 @@ class Tests_Collaboration_RestAutosavesController extends WP_UnitTestCase {
 		return rest_get_server()->dispatch( $request );
 	}
 
+	/**
+	 * @ticket 65138
+	 */
 	public function test_auto_draft_autosave_promotes_parent_post_when_collaboration_is_disabled() {
 		update_option( 'wp_collaboration_enabled', 0 );
 
@@ -98,6 +101,9 @@ class Tests_Collaboration_RestAutosavesController extends WP_UnitTestCase {
 		$this->assertSame( $content, $post->post_content );
 	}
 
+	/**
+	 * @ticket 65138
+	 */
 	public function test_auto_draft_autosave_promotes_parent_post_when_collaboration_is_enabled() {
 		update_option( 'wp_collaboration_enabled', 1 );
 
@@ -114,6 +120,9 @@ class Tests_Collaboration_RestAutosavesController extends WP_UnitTestCase {
 		$this->assertSame( $content, $post->post_content );
 	}
 
+	/**
+	 * @ticket 65138
+	 */
 	public function test_collaborator_auto_draft_autosave_promotes_parent_post_when_collaboration_is_enabled() {
 		update_option( 'wp_collaboration_enabled', 1 );
 
@@ -131,6 +140,9 @@ class Tests_Collaboration_RestAutosavesController extends WP_UnitTestCase {
 		$this->assertSame( $content, $post->post_content );
 	}
 
+	/**
+	 * @ticket 65138
+	 */
 	public function test_draft_autosave_creates_revision_when_collaboration_is_enabled() {
 		update_option( 'wp_collaboration_enabled', 1 );
 

--- a/tests/phpunit/tests/collaboration/restAutosavesController.php
+++ b/tests/phpunit/tests/collaboration/restAutosavesController.php
@@ -2,7 +2,7 @@
 /**
  * Tests for the collaboration autosaves REST controller override.
  *
- * @package gutenberg
+ * @package WordPress
  * @subpackage Collaboration
  *
  * @group collaboration
@@ -11,13 +11,16 @@
 class Tests_Collaboration_RestAutosavesController extends WP_UnitTestCase {
 
 	protected static int $author_id;
+	protected static int $editor_id;
 
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
 		self::$author_id = $factory->user->create( array( 'role' => 'author' ) );
+		self::$editor_id = $factory->user->create( array( 'role' => 'editor' ) );
 	}
 
 	public static function wpTearDownAfterClass() {
 		self::delete_user( self::$author_id );
+		self::delete_user( self::$editor_id );
 		delete_option( 'wp_collaboration_enabled' );
 	}
 
@@ -38,6 +41,25 @@ class Tests_Collaboration_RestAutosavesController extends WP_UnitTestCase {
 				'post_content' => '',
 				'post_status'  => 'auto-draft',
 				'post_title'   => 'Auto Draft',
+				'post_type'    => 'post',
+			)
+		);
+	}
+
+	/**
+	 * Creates a draft post.
+	 *
+	 * @param string $title   Post title.
+	 * @param string $content Post content.
+	 * @return int Post ID.
+	 */
+	private function create_draft( string $title, string $content ): int {
+		return self::factory()->post->create(
+			array(
+				'post_author'  => self::$author_id,
+				'post_content' => $content,
+				'post_status'  => 'draft',
+				'post_title'   => $title,
 				'post_type'    => 'post',
 			)
 		);
@@ -90,5 +112,45 @@ class Tests_Collaboration_RestAutosavesController extends WP_UnitTestCase {
 		$this->assertSame( 'draft', $post->post_status );
 		$this->assertSame( $title, $post->post_title );
 		$this->assertSame( $content, $post->post_content );
+	}
+
+	public function test_collaborator_auto_draft_autosave_promotes_parent_post_when_collaboration_is_enabled() {
+		update_option( 'wp_collaboration_enabled', 1 );
+
+		$post_id = $this->create_auto_draft();
+		$title   = 'RTC collaborator autosaved title';
+		$content = '<!-- wp:paragraph --><p>RTC collaborator autosaved content</p><!-- /wp:paragraph -->';
+
+		wp_set_current_user( self::$editor_id );
+		$response = $this->dispatch_autosave( $post_id, $title, $content );
+
+		$this->assertSame( 200, $response->get_status() );
+		$post = get_post( $post_id );
+		$this->assertSame( 'draft', $post->post_status );
+		$this->assertSame( $title, $post->post_title );
+		$this->assertSame( $content, $post->post_content );
+	}
+
+	public function test_draft_autosave_creates_revision_when_collaboration_is_enabled() {
+		update_option( 'wp_collaboration_enabled', 1 );
+
+		$original_title   = 'Original RTC draft title';
+		$original_content = '<!-- wp:paragraph --><p>Original RTC draft content</p><!-- /wp:paragraph -->';
+		$post_id          = $this->create_draft( $original_title, $original_content );
+		$title            = 'RTC draft autosaved title';
+		$content          = '<!-- wp:paragraph --><p>RTC draft autosaved content</p><!-- /wp:paragraph -->';
+
+		$response = $this->dispatch_autosave( $post_id, $title, $content );
+
+		$this->assertSame( 200, $response->get_status() );
+		$post = get_post( $post_id );
+		$this->assertSame( 'draft', $post->post_status );
+		$this->assertSame( $original_title, $post->post_title );
+		$this->assertSame( $original_content, $post->post_content );
+
+		$autosave = wp_get_post_autosave( $post_id, self::$author_id );
+		$this->assertInstanceOf( WP_Post::class, $autosave );
+		$this->assertSame( $title, $autosave->post_title );
+		$this->assertSame( $content, $autosave->post_content );
 	}
 }


### PR DESCRIPTION
Trac ticket: Core-65138

This is a companion change to wordpress/gutenberg#77865.

An interaction with autosave can cause posts and revisions to get lost even when a single user is editing a post.