### PR TITLE
REST API: Restore global $post in WP_REST_Posts_Controller::prepare_item_for_response()

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -1886,12 +1886,16 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		// Restores the more descriptive, specific name for use within this method.
 		$post = $item;
 
+		$previous_post   = isset( $GLOBALS['post'] ) ? $GLOBALS['post'] : null;
 		$GLOBALS['post'] = $post;
 
 		setup_postdata( $post );
 
 		// Don't prepare the response body for HEAD requests.
 		if ( $request->is_method( 'HEAD' ) ) {
+			$GLOBALS['post'] = $previous_post;
+			wp_reset_postdata();
+
 			/** This filter is documented in wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php */
 			return apply_filters( "rest_prepare_{$this->post_type}", new WP_REST_Response( array() ), $post, $request );
 		}
@@ -2207,6 +2211,9 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		 * @param WP_Post          $post     Post object.
 		 * @param WP_REST_Request  $request  Request object.
 		 */
+		$GLOBALS['post'] = $previous_post;
+		wp_reset_postdata();
+
 		return apply_filters( "rest_prepare_{$this->post_type}", $response, $post, $request );
 	}
 

--- a/tests/phpunit/tests/rest-api/rest-posts-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-posts-controller.php
@@ -2805,6 +2805,73 @@ Shankle pork chop prosciutto ribeye ham hock pastrami. T-bone shank brisket baco
 		$this->assertTrue( array_is_list( $data['class_list'] ), 'Expected class_list to be a list.' );
 	}
 
+	/**
+	 * @ticket 43502
+	 *
+	 * @covers WP_REST_Posts_Controller::prepare_item_for_response
+	 */
+	public function test_prepare_item_for_response_restores_global_post() {
+		$post_1 = self::factory()->post->create_and_get();
+		$post_2 = self::factory()->post->create_and_get();
+
+		// Set up a known global $post state.
+		$GLOBALS['post'] = $post_1;
+		setup_postdata( $post_1 );
+
+		$endpoint = new WP_REST_Posts_Controller( 'post' );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/posts/' . $post_2->ID );
+		$endpoint->prepare_item_for_response( $post_2, $request );
+
+		$this->assertSame(
+			$post_1->ID,
+			$GLOBALS['post']->ID,
+			'Global $post should be restored after prepare_item_for_response().'
+		);
+	}
+
+	/**
+	 * @ticket 43502
+	 *
+	 * @covers WP_REST_Posts_Controller::prepare_item_for_response
+	 */
+	public function test_prepare_item_for_response_restores_null_global_post() {
+		unset( $GLOBALS['post'] );
+
+		$post = self::factory()->post->create_and_get();
+
+		$endpoint = new WP_REST_Posts_Controller( 'post' );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/posts/' . $post->ID );
+		$endpoint->prepare_item_for_response( $post, $request );
+
+		$this->assertNull(
+			$GLOBALS['post'],
+			'Global $post should be restored to null when it was not set before prepare_item_for_response().'
+		);
+	}
+
+	/**
+	 * @ticket 43502
+	 *
+	 * @covers WP_REST_Posts_Controller::prepare_item_for_response
+	 */
+	public function test_prepare_item_for_response_restores_global_post_on_head_request() {
+		$post_1 = self::factory()->post->create_and_get();
+		$post_2 = self::factory()->post->create_and_get();
+
+		$GLOBALS['post'] = $post_1;
+		setup_postdata( $post_1 );
+
+		$endpoint = new WP_REST_Posts_Controller( 'post' );
+		$request  = new WP_REST_Request( 'HEAD', '/wp/v2/posts/' . $post_2->ID );
+		$endpoint->prepare_item_for_response( $post_2, $request );
+
+		$this->assertSame(
+			$post_1->ID,
+			$GLOBALS['post']->ID,
+			'Global $post should be restored after a HEAD request to prepare_item_for_response().'
+		);
+	}
+
 	public function test_create_item() {
 		wp_set_current_user( self::$editor_id );
 


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/43502

`prepare_item_for_response()` overwrote `$GLOBALS['post']` and called `setup_postdata()` without restoring the previous state. Anything running after a REST request that re-used the controller (block rendering, `the_content` filters, etc.) saw the wrong global post.

This PR captures the previous global before mutation and restores it on every return path, including the early HEAD-request return.

Tests cover:
- Restoration when a global post is already set
- Restoration to `null` when no global post was set
- Restoration on the HEAD-method early-return branch

Complements GH-1165 and GH-11455.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**