### PR TITLE
Users: Make user email comparison case-insensitive in wp_insert_user()/wp_update_user()

### DIFF
--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -2547,7 +2547,7 @@ function wp_insert_user( $userdata ) {
 	}
 
 	if ( $update ) {
-		if ( $user_email !== $old_user_data->user_email || $user_pass !== $old_user_data->user_pass ) {
+		if ( 0 !== strcasecmp( $user_email, $old_user_data->user_email ) || $user_pass !== $old_user_data->user_pass ) {
 			$data['user_activation_key'] = '';
 		}
 		$wpdb->update( $wpdb->users, $data, array( 'ID' => $user_id ) );
@@ -2763,7 +2763,7 @@ function wp_update_user( $userdata ) {
 		$send_password_change_email = apply_filters( 'send_password_change_email', true, $user, $userdata );
 	}
 
-	if ( isset( $userdata['user_email'] ) && $user['user_email'] !== $userdata['user_email'] ) {
+	if ( isset( $userdata['user_email'] ) && 0 !== strcasecmp( $user['user_email'], $userdata['user_email'] ) ) {
 		/**
 		 * Filters whether to send the email change email.
 		 *

--- a/tests/phpunit/tests/user.php
+++ b/tests/phpunit/tests/user.php
@@ -2874,4 +2874,105 @@ class Tests_User extends WP_UnitTestCase {
 		$this->assertSame( $updated_password, $args[0][0], 'Invalid password in wp_set_password action.' );
 		$this->assertSame( $user_id, $args[0][1], 'Invalid user ID in wp_set_password action.' );
 	}
+
+	/**
+	 * Changing only the case of an email should not trigger the email change notification.
+	 *
+	 * @ticket 52976
+	 * @covers ::wp_update_user
+	 */
+	public function test_case_only_email_change_does_not_trigger_email_change_notification() {
+		$user_id = self::factory()->user->create(
+			array(
+				'user_email' => 'testcase@example.com',
+			)
+		);
+
+		$email_change_fired = false;
+		$callback           = static function () use ( &$email_change_fired ) {
+			$email_change_fired = true;
+			return false;
+		};
+
+		add_filter( 'send_email_change_email', $callback );
+
+		wp_update_user(
+			array(
+				'ID'         => $user_id,
+				'user_email' => 'TestCase@Example.COM',
+			)
+		);
+
+		remove_filter( 'send_email_change_email', $callback );
+
+		$this->assertFalse( $email_change_fired, 'Email change notification should not fire for case-only email change.' );
+	}
+
+	/**
+	 * Changing to a genuinely different email should still trigger the notification.
+	 *
+	 * @ticket 52976
+	 * @covers ::wp_update_user
+	 */
+	public function test_real_email_change_triggers_email_change_notification() {
+		$user_id = self::factory()->user->create(
+			array(
+				'user_email' => 'original@example.com',
+			)
+		);
+
+		$email_change_fired = false;
+		$callback           = static function () use ( &$email_change_fired ) {
+			$email_change_fired = true;
+			return false;
+		};
+
+		add_filter( 'send_email_change_email', $callback );
+
+		wp_update_user(
+			array(
+				'ID'         => $user_id,
+				'user_email' => 'different@example.com',
+			)
+		);
+
+		remove_filter( 'send_email_change_email', $callback );
+
+		$this->assertTrue( $email_change_fired, 'Email change notification should fire for a genuinely different email.' );
+	}
+
+	/**
+	 * Changing only the case of an email should not clear the user_activation_key.
+	 *
+	 * Complements `test_changing_email_invalidates_password_reset_key()`, which covers the case
+	 * where a genuinely different email clears the key.
+	 *
+	 * @ticket 52976
+	 * @covers ::wp_insert_user
+	 */
+	public function test_case_only_email_change_does_not_clear_user_activation_key() {
+		global $wpdb;
+
+		$user_id = self::factory()->user->create(
+			array(
+				'user_email' => 'keytest@example.com',
+			)
+		);
+
+		$wpdb->update( $wpdb->users, array( 'user_activation_key' => 'key' ), array( 'ID' => $user_id ) );
+		clean_user_cache( $user_id );
+
+		$user = get_userdata( $user_id );
+		$this->assertSame( 'key', $user->user_activation_key, 'Precondition: activation key should be set.' );
+
+		wp_update_user(
+			array(
+				'ID'         => $user_id,
+				'user_email' => 'KeyTest@Example.COM',
+			)
+		);
+
+		$user = get_userdata( $user_id );
+		$this->assertSame( 'key', $user->user_activation_key, 'user_activation_key should not be cleared on case-only email change.' );
+	}
 }


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/52976

Email addresses are case-insensitive in their domain part (per RFC 5321) and treated as such by virtually all mail providers in the local part too. Previously, comparing `user_email` with `!==` could:

- Reset `user_activation_key` even when only the case of an email changed
- Trigger the email-change notification for a case-only "change"

This PR replaces those strict comparisons with `strcasecmp()`.

Tests cover:
- Case-only email change does not fire `send_email_change_email`
- Genuinely different email change still fires the notification
- Case-only email change does not clear `user_activation_key`

Complements GH-9196 with proper PHPUnit coverage. Narrower scope than GH-9196 (focused on `user.php` only); happy to expand to admin/multisite call sites in a follow-up if reviewers prefer one bundled change.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**