### PR TITLE
REST API: Allow null origin in templates schema

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
@@ -1094,7 +1094,7 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 				),
 				'origin'          => array(
 					'description' => __( 'Source of a customized template' ),
-					'type'        => 'string',
+					'type'        => array( 'string', 'null' ),
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'readonly'    => true,
 				),

--- a/tests/phpunit/tests/rest-api/wpRestTemplatesController.php
+++ b/tests/phpunit/tests/rest-api/wpRestTemplatesController.php
@@ -1022,6 +1022,38 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 		$this->assertArrayHasKey( 'plugin', $properties );
 	}
 
+	/**
+	 * @ticket 64168
+	 * @covers WP_REST_Templates_Controller::get_item_schema
+	 */
+	public function test_get_item_schema_origin_allows_null() {
+		$request    = new WP_REST_Request( 'OPTIONS', '/wp/v2/templates' );
+		$response   = rest_get_server()->dispatch( $request );
+		$data       = $response->get_data();
+		$properties = $data['schema']['properties'];
+
+		$this->assertArrayHasKey( 'origin', $properties );
+		$this->assertSame(
+			array( 'string', 'null' ),
+			$properties['origin']['type'],
+			'The origin property type should allow string and null.'
+		);
+	}
+
+
+	/**
+	 * @ticket 64168
+	 * @covers WP_REST_Templates_Controller::prepare_item_for_response
+	 */
+	public function test_get_item_with_theme_template_returns_null_origin() {
+		wp_set_current_user( self::$admin_id );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/templates/default//my_template' );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertNull( $data['origin'], 'Theme template origin should be null.' );
+	}
+
 	protected function find_and_normalize_template_by_id( $templates, $id ) {
 		foreach ( $templates as $template ) {
 			if ( $template['id'] === $id ) {


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/64168

`WP_REST_Templates_Controller::prepare_item_for_response()` can return:
- `origin: null` for templates that do not come from a customizer/theme/plugin source

The schema previously declared `origin` as `string`, so responses with `origin: null` failed schema validation under strict-mode REST clients.

This PR widens the schema to match runtime behavior:
- `origin` becomes `[ string, null ]`

Tests cover:
- The `origin` schema accepts `null`
- A theme template returns `null` for `origin` against the new schema

*(Note: `modified` returning `null` was separately resolved in trunk in [62941] / #65728).*

Complements GH-10441.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
