### PR TITLE
Add border radius and overflow hidden to .postbox

### DIFF
--- a/src/wp-admin/css/edit.css
+++ b/src/wp-admin/css/edit.css
@@ -191,6 +191,8 @@ body.post-type-wp_navigation .inline-edit-status {
 	position: relative;
 	min-width: 255px;
 	border: 1px solid #c3c4c7;
+	border-radius: 8px;
+	overflow: hidden;
 	box-shadow: 0 1px 1px rgba(0, 0, 0, 0.04);
 	background: #fff;
 }


### PR DESCRIPTION

Trac ticket: https://core.trac.wordpress.org/ticket/65142
---

### Edit Media Screen (Save metabox)

| Before | After |
|--------|--------|
| <img width="610" height="972" alt="image" src="https://github.com/user-attachments/assets/1f0ee214-a474-46c9-9e24-68cd9a8b3f4d" /> | <img width="614" height="954" alt="image" src="https://github.com/user-attachments/assets/db611978-3cb6-41dd-910c-8d8f681974d9" /> | 

### Edit Post Screen

| Before |
|--------|
| <img width="2978" height="1588" alt="image" src="https://github.com/user-attachments/assets/d23e8ea8-6d9a-47b5-867a-d64bf38c1a73" /> |

| After |
|--------|
| <img width="1495" height="790" alt="image" src="https://github.com/user-attachments/assets/67ef30da-fba3-474b-85b0-02b9659dfbaf" /> | 

