### PR TITLE
Admin: Avoid using `HTTP_HOST` to build admin URLs.

### DIFF
--- a/src/wp-admin/includes/class-wp-list-table.php
+++ b/src/wp-admin/includes/class-wp-list-table.php
@@ -1040,9 +1040,7 @@ class WP_List_Table {
 		$current              = $this->get_pagenum();
 		$removable_query_args = wp_removable_query_args();
 
-		$current_url = set_url_scheme( 'http://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'] );
-
-		$current_url = remove_query_arg( $removable_query_args, $current_url );
+		$current_url = remove_query_arg( $removable_query_args );
 
 		$page_links = array();
 

--- a/src/wp-admin/includes/class-wp-list-table.php
+++ b/src/wp-admin/includes/class-wp-list-table.php
@@ -1392,8 +1392,7 @@ class WP_List_Table {
 	public function print_column_headers( $with_id = true ) {
 		list( $columns, $hidden, $sortable, $primary ) = $this->get_column_info();
 
-		$current_url = set_url_scheme( 'http://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'] );
-		$current_url = remove_query_arg( 'paged', $current_url );
+		$current_url = remove_query_arg( 'paged' );
 
 		// When users click on a column header to sort by other columns.
 		if ( isset( $_GET['orderby'] ) ) {

--- a/src/wp-admin/includes/misc.php
+++ b/src/wp-admin/includes/misc.php
@@ -1406,7 +1406,11 @@ function wp_admin_canonical_url() {
 	}
 
 	// Ensure we're using an absolute URL.
-	$current_url  = set_url_scheme( 'http://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'] );
+	// Build the canonical URL using the configured admin URL to avoid issues
+	// with reverse proxies that expose a different host via HTTP_HOST.
+	$path         = parse_url( $_SERVER['REQUEST_URI'], PHP_URL_PATH );
+	$query        = parse_url( $_SERVER['REQUEST_URI'], PHP_URL_QUERY );
+	$current_url  = admin_url( ltrim( $path, '/' ) . ( $query ? '?' . $query : '' ) );
 	$filtered_url = remove_query_arg( $removable_query_args, $current_url );
 
 	/**

--- a/tests/phpunit/tests/admin/wpListTable.php
+++ b/tests/phpunit/tests/admin/wpListTable.php
@@ -623,4 +623,22 @@ class Tests_Admin_WpListTable extends WP_UnitTestCase {
 			'Pagination links should not contain the raw HTTP_HOST value.'
 		);
 	}
+
+	public function test_print_column_headers_should_not_use_http_host_for_urls() {
+		$fake_host     = 'internal.proxy.example.local';
+		$original_host = $_SERVER['HTTP_HOST'] ?? '';
+
+		$_SERVER['HTTP_HOST']   = $fake_host;
+		$_SERVER['REQUEST_URI'] = '/wp-admin/edit.php?post_type=post';
+
+		$actual = get_echo( array( $this->list_table, 'print_column_headers' ) );
+
+		$_SERVER['HTTP_HOST'] = $original_host;
+
+		$this->assertStringNotContainsString(
+			$fake_host,
+			$actual,
+			'Column header links should not contain the raw HTTP_HOST value.'
+		);
+	}
 }

--- a/tests/phpunit/tests/admin/wpListTable.php
+++ b/tests/phpunit/tests/admin/wpListTable.php
@@ -592,4 +592,35 @@ class Tests_Admin_WpListTable extends WP_UnitTestCase {
 
 		$this->assertStringContainsString( $expected_html, $actual );
 	}
+
+	public function test_pagination_should_not_use_http_host_for_urls() {
+		$fake_host     = 'internal.proxy.example.local';
+		$original_host = $_SERVER['HTTP_HOST'] ?? '';
+
+		$_SERVER['HTTP_HOST']   = $fake_host;
+		$_SERVER['REQUEST_URI'] = '/wp-admin/edit.php?post_type=post';
+
+		$pagination_args = new ReflectionProperty( $this->list_table, '_pagination_args' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$pagination_args->setAccessible( true );
+		}
+		$pagination_args->setValue(
+			$this->list_table,
+			array(
+				'total_items' => 100,
+				'total_pages' => 5,
+				'per_page'    => 20,
+			)
+		);
+
+		$actual = get_echo( array( $this->list_table, 'pagination' ), array( 'top' ) );
+
+		$_SERVER['HTTP_HOST'] = $original_host;
+
+		$this->assertStringNotContainsString(
+			$fake_host,
+			$actual,
+			'Pagination links should not contain the raw HTTP_HOST value.'
+		);
+	}
 }

--- a/tests/phpunit/tests/admin/wpListTable.php
+++ b/tests/phpunit/tests/admin/wpListTable.php
@@ -593,6 +593,9 @@ class Tests_Admin_WpListTable extends WP_UnitTestCase {
 		$this->assertStringContainsString( $expected_html, $actual );
 	}
 
+	/**
+	 * @ticket 16858
+	 */
 	public function test_pagination_should_not_use_http_host_for_urls() {
 		$fake_host     = 'internal.proxy.example.local';
 		$original_host = $_SERVER['HTTP_HOST'] ?? '';
@@ -624,6 +627,10 @@ class Tests_Admin_WpListTable extends WP_UnitTestCase {
 		);
 	}
 
+
+	/**
+	 * @ticket 16858
+	 */
 	public function test_print_column_headers_should_not_use_http_host_for_urls() {
 		$fake_host     = 'internal.proxy.example.local';
 		$original_host = $_SERVER['HTTP_HOST'] ?? '';


### PR DESCRIPTION

Trac ticket: https://core.trac.wordpress.org/ticket/16858

WordPress admin constructz the "current URL" by manually concatenating `$_SERVER['HTTP_HOST']` with `$_SERVER['REQUEST_URI']` these places:

- `WP_List_Table::pagination()` — pagination navigation links
- `WP_List_Table::print_column_headers()` — column sort links
- `wp_admin_canonical_url()` — the admin canonical `<link>` tag

When WordPress runs behind a reverse proxy, `HTTP_HOST` reflects the internal backend hostname, not
the public-facing WordPress URL, causing these links to point to the wrong host.


### Testing 

Run tests by - 

```
npm run test:php -- --filter=Tests_Admin_WpListTable
```


### Use of AI Tools

AI assistance: Yes
Tool(s): ChatGPT
Model(s): GPT-5.1
Used for: Unit tests review


---

Props dd32
