### PR TITLE
Plugins: Don't skip the next priority's callbacks when a callback empties its bucket mid-iteration

### DIFF
--- a/src/wp-includes/class-wp-hook.php
+++ b/src/wp-includes/class-wp-hook.php
@@ -150,6 +150,16 @@ final class WP_Hook implements Iterator, ArrayAccess {
 				}
 			}
 
+			/*
+			 * If $current's bucket was emptied during iteration, the iterator now
+			 * sits on the first remaining priority greater than $current. The
+			 * trailing next() in ::apply_filters() would skip past it, so step
+			 * back one so that next() lands on it instead.
+			 */
+			if ( false !== current( $iteration ) && ! isset( $this->callbacks[ $current ] ) ) {
+				prev( $iteration );
+			}
+
 			// If we have a new priority that didn't exist, but ::apply_filters() or ::do_action() thinks it's the current priority...
 			if ( $new_priority === $this->current_priority[ $index ] && ! $priority_existed ) {
 				/*

--- a/tests/phpunit/tests/hooks/removeFilter.php
+++ b/tests/phpunit/tests/hooks/removeFilter.php
@@ -96,17 +96,18 @@ class Tests_Hooks_RemoveFilter extends WP_UnitTestCase {
 	 * @covers WP_Hook::apply_filters
 	 */
 	public function test_remove_filter_during_iteration_does_not_skip_next_priority() {
-		$hook  = new WP_Hook();
-		$fired = array();
+		$hook      = new WP_Hook();
+		$hook_name = __FUNCTION__;
+		$fired     = array();
 
 		$early = static function ( $value ) use ( &$fired ) {
 			$fired[] = 'early';
 			return $value;
 		};
 
-		$self_removing = static function ( $value ) use ( &$hook, &$self_removing, &$fired ) {
+		$self_removing = static function ( $value ) use ( &$hook, $hook_name, &$self_removing, &$fired ) {
 			$fired[] = 'self_removing';
-			$hook->remove_filter( __FUNCTION__, $self_removing, 10 );
+			$hook->remove_filter( $hook_name, $self_removing, 10 );
 			return $value;
 		};
 
@@ -115,9 +116,9 @@ class Tests_Hooks_RemoveFilter extends WP_UnitTestCase {
 			return $value;
 		};
 
-		$hook->add_filter( __FUNCTION__, $early, 5, 1 );
-		$hook->add_filter( __FUNCTION__, $self_removing, 10, 1 );
-		$hook->add_filter( __FUNCTION__, $later, 20, 1 );
+		$hook->add_filter( $hook_name, $early, 5, 1 );
+		$hook->add_filter( $hook_name, $self_removing, 10, 1 );
+		$hook->add_filter( $hook_name, $later, 20, 1 );
 
 		$hook->apply_filters( null, array( null ) );
 

--- a/tests/phpunit/tests/hooks/removeFilter.php
+++ b/tests/phpunit/tests/hooks/removeFilter.php
@@ -86,6 +86,44 @@ class Tests_Hooks_RemoveFilter extends WP_UnitTestCase {
 		$this->check_priority_exists( $hook, $priority + 1, 'Should priority of 3' );
 	}
 
+	/**
+	 * Removing the last callback at the currently iterating priority must not
+	 * cause the next remaining priority to be silently skipped.
+	 *
+	 * @ticket 65167
+	 *
+	 * @covers WP_Hook::remove_filter
+	 * @covers WP_Hook::apply_filters
+	 */
+	public function test_remove_filter_during_iteration_does_not_skip_next_priority() {
+		$hook  = new WP_Hook();
+		$fired = array();
+
+		$early = static function ( $value ) use ( &$fired ) {
+			$fired[] = 'early';
+			return $value;
+		};
+
+		$self_removing = static function ( $value ) use ( &$hook, &$self_removing, &$fired ) {
+			$fired[] = 'self_removing';
+			$hook->remove_filter( __FUNCTION__, $self_removing, 10 );
+			return $value;
+		};
+
+		$later = static function ( $value ) use ( &$fired ) {
+			$fired[] = 'later';
+			return $value;
+		};
+
+		$hook->add_filter( __FUNCTION__, $early, 5, 1 );
+		$hook->add_filter( __FUNCTION__, $self_removing, 10, 1 );
+		$hook->add_filter( __FUNCTION__, $later, 20, 1 );
+
+		$hook->apply_filters( null, array( null ) );
+
+		$this->assertSame( array( 'early', 'self_removing', 'later' ), $fired );
+	}
+
 	protected function check_priority_non_existent( $hook, $priority ) {
 		$priorities = $this->get_priorities( $hook );
 


### PR DESCRIPTION
When a callback running inside `apply_filters()` is the only one at its priority and removes itself (or another callback empties that bucket), `WP_Hook` silently skips the callbacks at the next remaining priority — but only when at least one earlier-priority callback has already run.

`WP_Hook::resort_active_iterations()` already has symmetric handling for the add path (a callback added at the current priority during iteration). The remove path was missing the equivalent fix; the trailing `next()` in `apply_filters()` overshoots the first remaining priority greater than `$current` and skips its callbacks.

This patch adds the symmetric counterpart: when `$current`'s bucket has been emptied during iteration, step the iterator back one so that `apply_filters()`'s trailing `next()` lands on the right priority.

A regression test is added to `tests/phpunit/tests/hooks/removeFilter.php`. It fails on trunk without the patch and passes with it.

Trac ticket: https://core.trac.wordpress.org/ticket/64653

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 4.7
Used for: Investigation of the bug, drafting the patch and the regression test, and writing this PR description. The diagnosis, patch shape, and tests were reviewed and edited by me before submission.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request.**