### PR TITLE
Backport compaction processing fix that can cause user YDocs to diverge

### DIFF
--- a/src/wp-includes/collaboration/class-wp-http-polling-sync-server.php
+++ b/src/wp-includes/collaboration/class-wp-http-polling-sync-server.php
@@ -499,12 +499,12 @@ class WP_HTTP_Polling_Sync_Server {
 				}
 
 				/*
-				* A newer compaction already advanced the cursor, but we
-				* can not safely drop an update. The incoming bytes still encode
-				* operations other clients may not have seen, so store them as a
-				* regular update. Y.applyUpdateV2 merges state-as-update blobs
-				* idempotently, so overlap with the existing compaction is safe.
-				*/
+				 * A newer compaction already advanced the cursor, but we
+				 * can not safely drop an update. The incoming bytes still encode
+				 * operations other clients may not have seen, so store them as a
+				 * regular update. Y.applyUpdateV2 merges state-as-update blobs
+				 * idempotently, so overlap with the existing compaction is safe.
+				 */
 				return $this->add_update( $room, $client_id, self::UPDATE_TYPE_UPDATE, $data );
 
 			case self::UPDATE_TYPE_SYNC_STEP1:

--- a/src/wp-includes/collaboration/class-wp-http-polling-sync-server.php
+++ b/src/wp-includes/collaboration/class-wp-http-polling-sync-server.php
@@ -498,9 +498,14 @@ class WP_HTTP_Polling_Sync_Server {
 					return $this->add_update( $room, $client_id, $type, $data );
 				}
 
-				// Reaching this point means there's a newer compaction, so we can
-				// silently ignore this one.
-				return true;
+				/*
+				* A newer compaction already advanced the cursor, but we
+				* can not safely drop an update. The incoming bytes still encode
+				* operations other clients may not have seen, so store them as a
+				* regular update. Y.applyUpdateV2 merges state-as-update blobs
+				* idempotently, so overlap with the existing compaction is safe.
+				*/
+				return $this->add_update( $room, $client_id, self::UPDATE_TYPE_UPDATE, $data );
 
 			case self::UPDATE_TYPE_SYNC_STEP1:
 			case self::UPDATE_TYPE_SYNC_STEP2:

--- a/tests/phpunit/tests/rest-api/rest-sync-server.php
+++ b/tests/phpunit/tests/rest-api/rest-sync-server.php
@@ -936,7 +936,7 @@ class WP_Test_REST_Sync_Server extends WP_Test_REST_Controller_Testcase {
 		$this->assertFalse( $data['rooms'][0]['should_compact'] );
 	}
 
-	public function test_sync_stale_compaction_succeeds_when_newer_compaction_exists() {
+	public function test_sync_stale_compaction_is_stored_as_update_when_newer_compaction_exists() {
 		wp_set_current_user( self::$editor_id );
 
 		$room   = $this->get_post_room();
@@ -962,13 +962,16 @@ class WP_Test_REST_Sync_Server extends WP_Test_REST_Controller_Testcase {
 
 		$this->dispatch_sync(
 			array(
-				$this->build_room( $room, 2, $end_cursor, array( 'user' => 'c2' ), array( $compaction ) ),
+				$this->build_room( $room, 2, $end_cursor, array( 'user' => 'c2' ), array( $compaction ) )
 			)
 		);
 
-		// Client 3 sends a stale compaction at cursor 0. The server should find
-		// client 2's compaction in the updates after cursor 0 and silently discard
-		// this one.
+		// Client 3 sends a stale compaction at cursor 0 (mirroring two offline
+		// clients that reconnect from the same baseline cursor). The server
+		// cannot run remove_updates_before_cursor because client 2 has already
+		// advanced the frontier, but the bytes must still be stored as a
+		// regular update so client 3's operations can propagate to other
+		// clients via Yjs state-as-update merging.
 		$stale_compaction = array(
 			'type' => 'compaction',
 			'data' => 'c3RhbGU=',
@@ -981,16 +984,29 @@ class WP_Test_REST_Sync_Server extends WP_Test_REST_Controller_Testcase {
 
 		$this->assertSame( 200, $response->get_status() );
 
-		// Verify the newer compaction is preserved and the stale one was not stored.
-		$response    = $this->dispatch_sync(
+		// Verify the newer compaction is preserved AND the stale compaction's
+		// bytes were persisted (now as type=update so subsequent compactions
+		// don't trip the has_newer_compaction check).
+		$response = $this->dispatch_sync(
 			array(
 				$this->build_room( $room, 4, 0, array( 'user' => 'c4' ) ),
 			)
 		);
-		$update_data = wp_list_pluck( $response->get_data()['rooms'][0]['updates'], 'data' );
+		$updates  = $response->get_data()['rooms'][0]['updates'];
 
+		$update_data = wp_list_pluck( $updates, 'data' );
 		$this->assertContains( 'Y29tcGFjdGVk', $update_data, 'The newer compaction should be preserved.' );
-		$this->assertNotContains( 'c3RhbGU=', $update_data, 'The stale compaction should not be stored.' );
+		$this->assertContains( 'c3RhbGU=', $update_data, 'The stale compaction bytes should be stored so client 3\'s operations propagate.' );
+
+		$stale_entry = null;
+		foreach ( $updates as $entry ) {
+			if ( 'c3RhbGU=' === $entry['data'] ) {
+				$stale_entry = $entry;
+				break;
+			}
+		}
+		$this->assertNotNull( $stale_entry, 'The stale compaction entry should be present in the room.' );
+		$this->assertSame( 'update', $stale_entry['type'], 'The stale compaction should be stored as type=update, not type=compaction.' );
 	}
 
 	/*

--- a/tests/phpunit/tests/rest-api/rest-sync-server.php
+++ b/tests/phpunit/tests/rest-api/rest-sync-server.php
@@ -966,12 +966,14 @@ class WP_Test_REST_Sync_Server extends WP_Test_REST_Controller_Testcase {
 			)
 		);
 
-		// Client 3 sends a stale compaction at cursor 0 (mirroring two offline
-		// clients that reconnect from the same baseline cursor). The server
-		// cannot run remove_updates_before_cursor because client 2 has already
-		// advanced the frontier, but the bytes must still be stored as a
-		// regular update so client 3's operations can propagate to other
-		// clients via Yjs state-as-update merging.
+		/*
+		 * Client 3 sends a stale compaction at cursor 0 (mirroring two offline
+		 * clients that reconnect from the same baseline cursor). The server
+		 * cannot run remove_updates_before_cursor because client 2 has already
+		 * advanced the frontier, but the bytes must still be stored as a
+		 * regular update so client 3's operations can propagate to other
+		 * clients via Yjs state-as-update merging.
+		 */
 		$stale_compaction = array(
 			'type' => 'compaction',
 			'data' => 'c3RhbGU=',
@@ -984,9 +986,11 @@ class WP_Test_REST_Sync_Server extends WP_Test_REST_Controller_Testcase {
 
 		$this->assertSame( 200, $response->get_status() );
 
-		// Verify the newer compaction is preserved AND the stale compaction's
-		// bytes were persisted (now as type=update so subsequent compactions
-		// don't trip the has_newer_compaction check).
+		/*
+		 * Verify the newer compaction is preserved AND the stale compaction's
+		 * bytes were persisted (now as type=update so subsequent compactions
+		 * don't trip the has_newer_compaction check).
+		 */
 		$response = $this->dispatch_sync(
 			array(
 				$this->build_room( $room, 4, 0, array( 'user' => 'c4' ) ),

--- a/tests/phpunit/tests/rest-api/rest-sync-server.php
+++ b/tests/phpunit/tests/rest-api/rest-sync-server.php
@@ -962,7 +962,7 @@ class WP_Test_REST_Sync_Server extends WP_Test_REST_Controller_Testcase {
 
 		$this->dispatch_sync(
 			array(
-				$this->build_room( $room, 2, $end_cursor, array( 'user' => 'c2' ), array( $compaction ) )
+				$this->build_room( $room, 2, $end_cursor, array( 'user' => 'c2' ), array( $compaction ) ),
 			)
 		);
 


### PR DESCRIPTION
Backport https://github.com/WordPress/gutenberg/pull/77980 to core. This PR fixes an issue that can happen when two offline users reconnect to the same document:

https://github.com/user-attachments/assets/75570ca2-ca9f-4e04-81ae-7093be3b7f24

When two users edit the same post offline and reconnect at roughly the same time, the second reconnecter's changes silently disappear from the server. Their local state still shows their changes, but no other client ever sees it, and the server-side document is the first reconnecter's state. Because of this, the second user is stuck in a non-convergent local `YDoc`.

The root cause is in `process_sync_update()`'s compaction handling. On reconnection, both clients push with the same cursor (the last position they saw before disconnecting). The server applies the first one and then sees `has_newer_compaction=true` for the second, and drops the second compaction. Because the polling provider resets its queue to a single compaction when updates are present on every poll failure, the second user to reconnect has their local changes dropped and becomes divergent.

We'll also want to merge these same changes into the [RTC Table PR](https://github.com/WordPress/wordpress-develop/pull/11599) or any other RTC table PRs that are finalized.

Trac ticket: https://core.trac.wordpress.org/ticket/64622

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude
Model(s): Opus 4.7
Used for: Diagnosing the silent-drop branch, drafting the fix.