### PR TITLE
Add unit tests for wp_make_theme_file_tree() in wp-admin/includes/mis…

### DIFF
--- a/tests/phpunit/tests/admin/includes/misc/wpMakeThemeFileTree.php
+++ b/tests/phpunit/tests/admin/includes/misc/wpMakeThemeFileTree.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Tests for the wp_make_theme_file_tree() function.
+ *
+ * @group admin
+ * @group admin-includes
+ * @covers ::wp_make_theme_file_tree
+ */
+class Tests_wp_make_theme_file_tree extends WP_UnitTestCase {
+
+	/**
+	 * Tests wp_make_theme_file_tree() with various file structures.
+	 *
+	 * @ticket 65175
+	 * @dataProvider data_wp_make_theme_file_tree
+	 *
+	 * @param array $allowed_files The list of theme files.
+	 * @param array $expected      The expected tree structure.
+	 */
+	public function test_wp_make_theme_file_tree( $allowed_files, $expected ) {
+		$this->assertSame( $expected, wp_make_theme_file_tree( $allowed_files ) );
+	}
+
+	/**
+	 * Data provider for test_wp_make_theme_file_tree.
+	 *
+	 * @return array<string, array{
+	 *     allowed_files: array<string, string>,
+	 *     expected:      array<string, string|array>,
+	 * }>
+	 */
+	public function data_wp_make_theme_file_tree(): array {
+		return array(
+			'empty_list'          => array(
+				'allowed_files' => array(),
+				'expected'      => array(),
+			),
+			'flat_list'           => array(
+				'allowed_files' => array(
+					'style.css' => '/path/to/theme/style.css',
+					'index.php' => '/path/to/theme/index.php',
+				),
+				'expected'      => array(
+					'style.css' => 'style.css',
+					'index.php' => 'index.php',
+				),
+			),
+			'nested_list'         => array(
+				'allowed_files' => array(
+					'style.css'       => '/path/to/theme/style.css',
+					'inc/header.php'  => '/path/to/theme/inc/header.php',
+					'inc/footer.php'  => '/path/to/theme/inc/footer.php',
+					'templates/a.php' => '/path/to/theme/templates/a.php',
+				),
+				'expected'      => array(
+					'style.css' => 'style.css',
+					'inc'       => array(
+						'header.php' => 'inc/header.php',
+						'footer.php' => 'inc/footer.php',
+					),
+					'templates' => array(
+						'a.php' => 'templates/a.php',
+					),
+				),
+			),
+			'deeply_nested_list'  => array(
+				'allowed_files' => array(
+					'a/b/c/d.php' => '/path/to/theme/a/b/c/d.php',
+				),
+				'expected'      => array(
+					'a' => array(
+						'b' => array(
+							'c' => array(
+								'd.php' => 'a/b/c/d.php',
+							),
+						),
+					),
+				),
+			),
+			'mixed_nesting'       => array(
+				'allowed_files' => array(
+					'index.php'       => '/path/to/theme/index.php',
+					'inc/header.php'  => '/path/to/theme/inc/header.php',
+					'inc/utils/a.php' => '/path/to/theme/inc/utils/a.php',
+				),
+				'expected'      => array(
+					'index.php' => 'index.php',
+					'inc'       => array(
+						'header.php' => 'inc/header.php',
+						'utils'      => array(
+							'a.php' => 'inc/utils/a.php',
+						),
+					),
+				),
+			),
+		);
+	}
+}

--- a/tests/phpunit/tests/admin/includes/misc/wpMakeThemeFileTree.php
+++ b/tests/phpunit/tests/admin/includes/misc/wpMakeThemeFileTree.php
@@ -31,11 +31,11 @@ class Tests_wp_make_theme_file_tree extends WP_UnitTestCase {
 	 */
 	public function data_wp_make_theme_file_tree(): array {
 		return array(
-			'empty_list'          => array(
+			'empty_list'         => array(
 				'allowed_files' => array(),
 				'expected'      => array(),
 			),
-			'flat_list'           => array(
+			'flat_list'          => array(
 				'allowed_files' => array(
 					'style.css' => '/path/to/theme/style.css',
 					'index.php' => '/path/to/theme/index.php',
@@ -45,7 +45,7 @@ class Tests_wp_make_theme_file_tree extends WP_UnitTestCase {
 					'index.php' => 'index.php',
 				),
 			),
-			'nested_list'         => array(
+			'nested_list'        => array(
 				'allowed_files' => array(
 					'style.css'       => '/path/to/theme/style.css',
 					'inc/header.php'  => '/path/to/theme/inc/header.php',
@@ -63,7 +63,7 @@ class Tests_wp_make_theme_file_tree extends WP_UnitTestCase {
 					),
 				),
 			),
-			'deeply_nested_list'  => array(
+			'deeply_nested_list' => array(
 				'allowed_files' => array(
 					'a/b/c/d.php' => '/path/to/theme/a/b/c/d.php',
 				),
@@ -77,7 +77,7 @@ class Tests_wp_make_theme_file_tree extends WP_UnitTestCase {
 					),
 				),
 			),
-			'mixed_nesting'       => array(
+			'mixed_nesting'      => array(
 				'allowed_files' => array(
 					'index.php'       => '/path/to/theme/index.php',
 					'inc/header.php'  => '/path/to/theme/inc/header.php',


### PR DESCRIPTION
…c.php

**Description**:
This PR adds unit tests for the `wp_make_theme_file_tree()` function in `wp-admin/includes/misc.php`. These tests ensure that the function correctly converts a flat list of theme file paths into a hierarchical tree structure, which is used for the file list in the theme editor.

The tests cover:
- Empty input list.
- Flat list of files (no directories).
- Nested list with single-level directories.
- Deeply nested directories.
- Mixed nesting levels.

Trac ticket: https://core.trac.wordpress.org/ticket/65175

**AI Disclosure**:
- AI assistance: Yes
- Tool(s): Junie (JetBrains)
- Model(s): gemini-3-flash-preview
- Used for: Code analysis, test implementation, and workflow management.
