### PR TITLE
wp_register_custom_css_support: update PHP doc to clarify purpose

### DIFF
--- a/src/wp-includes/block-supports/custom-css.php
+++ b/src/wp-includes/block-supports/custom-css.php
@@ -125,7 +125,7 @@ function wp_register_custom_css_support( $block_type ) {
 }
 
 /**
- * Strips `style.css` attributes from all blocks in post content.
+ * Strips custom CSS (`style.css` in attributes) from all blocks in post content.
  *
  * Uses {@see WP_Block_Parser::next_token()} to scan block tokens and surgically
  * replace only the attribute JSON that changed — no parse_blocks() +


### PR DESCRIPTION
Follow up to:

- https://github.com/WordPress/wordpress-develop/pull/11347

Clarify the purpose of the `wp_register_custom_css_support` function.

See: https://core.trac.wordpress.org/ticket/64771#comment:65

"Removing styles.css" is technically correct, but the comment didn't explain the "why" in plain language.

Props to @audrasjb 

Trac ticket: https://core.trac.wordpress.org/ticket/64771

