### PR TITLE
Fix: Misleading error message on user screen actions, if no role has been selected

### DIFF
--- a/src/js/_enqueues/admin/common.js
+++ b/src/js/_enqueues/admin/common.js
@@ -1350,9 +1350,15 @@ $( function() {
 		event.stopPropagation();
 		$( 'html, body' ).animate( { scrollTop: 0 } );
 
+		var noSelectionMessages = {
+			'changeit': __( 'Please select a role to change.' ),
+			'bulk_action': __( 'Please select a bulk action to perform.' )
+		};
+
 		var errorMessage = value !== '-1' ?
 			__( 'Please select at least one item to perform this action on.' ) :
-			__( 'Please select a bulk action to perform.' );
+			noSelectionMessages[ submitterName ] || noSelectionMessages['bulk_action'];
+
 		addAdminNotice( {
 			id: value !== '-1' ? 'no-items-selected' : 'no-bulk-action-selected',
 			type: 'error',

--- a/src/js/_enqueues/admin/common.js
+++ b/src/js/_enqueues/admin/common.js
@@ -1357,7 +1357,7 @@ $( function() {
 
 		var errorMessage = value !== '-1' ?
 			__( 'Please select at least one item to perform this action on.' ) :
-			noSelectionMessages[ submitterName ] || noSelectionMessages['bulk_action'];
+			noSelectionMessages[ submitterName ] || noSelectionMessages.bulk_action;
 
 		addAdminNotice( {
 			id: value !== '-1' ? 'no-items-selected' : 'no-bulk-action-selected',

--- a/src/js/_enqueues/admin/common.js
+++ b/src/js/_enqueues/admin/common.js
@@ -1351,8 +1351,8 @@ $( function() {
 		$( 'html, body' ).animate( { scrollTop: 0 } );
 
 		var noSelectionMessages = {
-			'changeit': __( 'Please select a role to change.' ),
-			'bulk_action': __( 'Please select a bulk action to perform.' )
+			'bulk_action': __( 'Please select a bulk action to perform.' ),
+			'changeit': __( 'Please select a role to change.' )
 		};
 
 		var errorMessage = value !== '-1' ?


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/65160

## Description

- Update the message on `users.php` list when a role change action is performed without selecting any role, which says `Please select a bulk action to perform.`, instead added `Please select a role to change.` so that users does not mislead the information.

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->
- None

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
