### PR TITLE
Admin: Automatically enqueue postbox scripts for custom meta boxes

### DIFF
--- a/src/js/_enqueues/admin/postbox.js
+++ b/src/js/_enqueues/admin/postbox.js
@@ -657,4 +657,14 @@
 		pbhide : false
 	};
 
+	/*
+	 * @since 7.0.0
+	 * @see https://core.trac.wordpress.org/ticket/17704
+	 */
+	$( function() {
+		if ( typeof window.pagenow !== 'undefined' && ! postboxes.page && $( '.postbox' ).length ) {
+			postboxes.add_postbox_toggles( window.pagenow );
+		}
+	} );
+
 }(jQuery));

--- a/src/wp-admin/includes/class-wp-screen.php
+++ b/src/wp-admin/includes/class-wp-screen.php
@@ -1001,6 +1001,14 @@ final class WP_Screen {
 
 		$show_screen = ! empty( $wp_meta_boxes[ $this->id ] ) || $columns || $this->get_option( 'per_page' );
 
+		/*
+		 * @since 7.0.0
+		 * @see https://core.trac.wordpress.org/ticket/17704
+		 */
+		if ( ! empty( $wp_meta_boxes[ $this->id ] ) ) {
+			wp_enqueue_script( 'postbox' );
+		}
+
 		$this->_screen_settings = '';
 
 		if ( 'post' === $this->base ) {

--- a/tests/phpunit/tests/admin/includesScreen.php
+++ b/tests/phpunit/tests/admin/includesScreen.php
@@ -649,4 +649,20 @@ class Tests_Admin_IncludesScreen extends WP_UnitTestCase {
 		remove_meta_box( 'testbox-17704', $screen, 'advanced' );
 		wp_dequeue_script( 'postbox' );
 	}
+
+	public function test_show_screen_options_does_not_enqueue_postbox_script_when_no_meta_boxes() {
+		global $wp_meta_boxes;
+
+		set_current_screen( 'options-general.php' );
+		$screen = get_current_screen();
+
+		unset( $wp_meta_boxes[ $screen->id ] );
+
+		$screen->show_screen_options();
+
+		$this->assertFalse(
+			wp_script_is( 'postbox', 'enqueued' ),
+			'The postbox script should not be enqueued when no meta boxes are registered for the screen.'
+		);
+	}
 }

--- a/tests/phpunit/tests/admin/includesScreen.php
+++ b/tests/phpunit/tests/admin/includesScreen.php
@@ -631,6 +631,9 @@ class Tests_Admin_IncludesScreen extends WP_UnitTestCase {
 		$this->assertSame( $expected, $screen->is_block_editor );
 	}
 
+	/**
+	 * @ticket 17704
+	 */
 	public function test_show_screen_options_enqueues_postbox_script_when_meta_boxes_exist() {
 		global $wp_meta_boxes;
 
@@ -650,6 +653,9 @@ class Tests_Admin_IncludesScreen extends WP_UnitTestCase {
 		wp_dequeue_script( 'postbox' );
 	}
 
+	/**
+	 * @ticket 17704
+	 */
 	public function test_show_screen_options_does_not_enqueue_postbox_script_when_no_meta_boxes() {
 		global $wp_meta_boxes;
 

--- a/tests/phpunit/tests/admin/includesScreen.php
+++ b/tests/phpunit/tests/admin/includesScreen.php
@@ -630,4 +630,23 @@ class Tests_Admin_IncludesScreen extends WP_UnitTestCase {
 
 		$this->assertSame( $expected, $screen->is_block_editor );
 	}
+
+	public function test_show_screen_options_enqueues_postbox_script_when_meta_boxes_exist() {
+		global $wp_meta_boxes;
+
+		set_current_screen( 'tools.php' );
+		$screen = get_current_screen();
+
+		add_meta_box( 'testbox-17704', 'Test Meta Box', '__return_false', $screen );
+
+		$screen->show_screen_options();
+
+		$this->assertTrue(
+			wp_script_is( 'postbox', 'enqueued' ),
+			'The postbox script should be enqueued when meta boxes are registered for the screen.'
+		);
+
+		remove_meta_box( 'testbox-17704', $screen, 'advanced' );
+		wp_dequeue_script( 'postbox' );
+	}
 }


### PR DESCRIPTION

Trac ticket: https://core.trac.wordpress.org/ticket/17704


This PR resolves trac ticket #17704 by ensuring that the `postbox` script is automatically enqueued and initialized on custom admin pages that utilize `add_meta_box()`.

Previously, custom admin screens rendering meta boxes would lack drag-and-drop, collapse/expand toggle, and Screen Options functionality unless the plugin author manually enqueued the `postbox` script and initialized `postboxes.add_postbox_toggles()`.

### Testing 

Run the tests using - 

```
npm run test:php -- --filter=Tests_Admin_IncludesScreen
```

