### PR TITLE
Backport: Disable real-time collaboration when revisions are off

### DIFF
--- a/src/wp-admin/options-writing.php
+++ b/src/wp-admin/options-writing.php
@@ -112,15 +112,25 @@ unset( $post_formats['standard'] );
 <tr>
 <th scope="row"><?php _e( 'Collaboration' ); ?></th>
 <td>
-	<?php if ( wp_is_collaboration_allowed() ) : ?>
+	<?php if ( ! wp_is_collaboration_allowed() ) : ?>
+		<div class="notice notice-warning inline">
+			<p><?php _e( '<strong>Note:</strong> Real-time collaboration has been disabled.' ); ?></p>
+		</div>
+	<?php elseif ( ! wp_revisions_are_globally_supported() ) : ?>
+		<div class="notice notice-warning inline">
+			<p><?php _e( '<strong>Note:</strong> Real-time collaboration requires post revisions. Enable revisions in your site configuration to use collaboration.' ); ?></p>
+		</div>
+		<p>
+			<label for="wp_collaboration_enabled">
+				<input name="wp_collaboration_enabled_disabled" type="checkbox" id="wp_collaboration_enabled" disabled="disabled" <?php checked( '1', (bool) get_option( 'wp_collaboration_enabled' ) ); ?> />
+				<?php _e( "Enable early access to real-time collaboration. Real-time collaboration may affect your website's performance." ); ?>
+			</label>
+		</p>
+	<?php else : ?>
 		<label for="wp_collaboration_enabled">
 			<input name="wp_collaboration_enabled" type="checkbox" id="wp_collaboration_enabled" value="1" <?php checked( '1', (bool) get_option( 'wp_collaboration_enabled' ) ); ?> />
 			<?php _e( "Enable early access to real-time collaboration. Real-time collaboration may affect your website's performance." ); ?>
 		</label>
-	<?php else : ?>
-		<div class="notice notice-warning inline">
-			<p><?php _e( '<strong>Note:</strong> Real-time collaboration has been disabled.' ); ?></p>
-		</div>
 	<?php endif; ?>
 </td>
 </tr>

--- a/src/wp-includes/assets/script-loader-packages.php
+++ b/src/wp-includes/assets/script-loader-packages.php
@@ -519,7 +519,7 @@
 				'import' => 'static'
 			)
 		),
-		'version' => '63782008412a6163c9f0'
+		'version' => '802fb559fa0abfe26970'
 	),
 	'element.js' => array(
 		'dependencies' => array(
@@ -703,7 +703,7 @@
 			'wp-primitives',
 			'wp-private-apis'
 		),
-		'version' => '035813168e404aa30193'
+		'version' => '41ab6cb7d553434296c6'
 	),
 	'preferences-persistence.js' => array(
 		'dependencies' => array(

--- a/src/wp-includes/assets/script-loader-packages.php
+++ b/src/wp-includes/assets/script-loader-packages.php
@@ -519,7 +519,7 @@
 				'import' => 'static'
 			)
 		),
-		'version' => '802fb559fa0abfe26970'
+		'version' => '63782008412a6163c9f0'
 	),
 	'element.js' => array(
 		'dependencies' => array(
@@ -703,7 +703,7 @@
 			'wp-primitives',
 			'wp-private-apis'
 		),
-		'version' => '41ab6cb7d553434296c6'
+		'version' => '035813168e404aa30193'
 	),
 	'preferences-persistence.js' => array(
 		'dependencies' => array(

--- a/src/wp-includes/collaboration.php
+++ b/src/wp-includes/collaboration.php
@@ -12,6 +12,8 @@
  * If the WP_ALLOW_COLLABORATION constant is false,
  * collaboration is always disabled regardless of the database option.
  * Otherwise, falls back to the 'wp_collaboration_enabled' option.
+ * Collaboration is also disabled when post revisions are turned off
+ * site-wide (see {@see wp_revisions_are_globally_supported()}).
  *
  * @since 7.0.0
  *
@@ -20,7 +22,8 @@
 function wp_is_collaboration_enabled() {
 	return (
 		wp_is_collaboration_allowed() &&
-		(bool) get_option( 'wp_collaboration_enabled' )
+		(bool) get_option( 'wp_collaboration_enabled' ) &&
+		wp_revisions_are_globally_supported()
 	);
 }
 
@@ -53,6 +56,29 @@ function wp_is_collaboration_allowed() {
 	}
 
 	return WP_ALLOW_COLLABORATION;
+}
+
+/**
+ * Determines whether post revisions are enabled site-wide.
+ *
+ * When {@see WP_POST_REVISIONS} is false or 0, WordPress does not store
+ * revisions. Real-time collaboration depends on revision-related flows and
+ * must remain off in that configuration.
+ *
+ * @since 7.1.0
+ *
+ * @return bool Whether revisions are globally supported.
+ */
+function wp_revisions_are_globally_supported() {
+	if ( ! defined( 'WP_POST_REVISIONS' ) ) {
+		return true;
+	}
+
+	if ( false === WP_POST_REVISIONS ) {
+		return false;
+	}
+
+	return 0 !== (int) WP_POST_REVISIONS;
 }
 
 /**

--- a/src/wp-includes/collaboration.php
+++ b/src/wp-includes/collaboration.php
@@ -82,30 +82,6 @@ function wp_revisions_are_globally_supported() {
 }
 
 /**
- * Determines whether real-time collaboration is disabled for a post type.
- *
- * @since 7.1.0
- *
- * @param string $post_type Post type name.
- * @return bool Whether real-time collaboration is disabled for the post type.
- */
-function wp_is_post_type_collaboration_disabled( $post_type ) {
-	if ( ! post_type_exists( $post_type ) ) {
-		return true;
-	}
-
-	/**
-	 * Filters whether real-time collaboration is disabled for a post type.
-	 *
-	 * @since 7.1.0
-	 *
-	 * @param bool   $disabled  Whether real-time collaboration is disabled for the post type.
-	 * @param string $post_type Post type name.
-	 */
-	return (bool) apply_filters( 'wp_is_post_type_collaboration_disabled', false, $post_type );
-}
-
-/**
  * Injects the real-time collaboration setting into a global variable.
  *
  * @since 7.0.0
@@ -127,17 +103,9 @@ function wp_collaboration_inject_setting() {
 		$enabled = false;
 	}
 
-	$disabled_post_types = array_values(
-		array_filter(
-			get_post_types( array( 'show_in_rest' => true ) ),
-			'wp_is_post_type_collaboration_disabled'
-		)
-	);
-
 	wp_add_inline_script(
 		'wp-core-data',
-		'window._wpCollaborationEnabled = ' . wp_json_encode( $enabled ) . ';' .
-		'window._wpCollaborationDisabledPostTypes = ' . wp_json_encode( $disabled_post_types ) . ';',
+		'window._wpCollaborationEnabled = ' . wp_json_encode( $enabled ) . ';',
 		'after'
 	);
 }

--- a/src/wp-includes/collaboration.php
+++ b/src/wp-includes/collaboration.php
@@ -82,6 +82,30 @@ function wp_revisions_are_globally_supported() {
 }
 
 /**
+ * Determines whether real-time collaboration is disabled for a post type.
+ *
+ * @since 7.1.0
+ *
+ * @param string $post_type Post type name.
+ * @return bool Whether real-time collaboration is disabled for the post type.
+ */
+function wp_is_post_type_collaboration_disabled( $post_type ) {
+	if ( ! post_type_exists( $post_type ) ) {
+		return true;
+	}
+
+	/**
+	 * Filters whether real-time collaboration is disabled for a post type.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param bool   $disabled  Whether real-time collaboration is disabled for the post type.
+	 * @param string $post_type Post type name.
+	 */
+	return (bool) apply_filters( 'wp_is_post_type_collaboration_disabled', false, $post_type );
+}
+
+/**
  * Injects the real-time collaboration setting into a global variable.
  *
  * @since 7.0.0
@@ -103,9 +127,17 @@ function wp_collaboration_inject_setting() {
 		$enabled = false;
 	}
 
+	$disabled_post_types = array_values(
+		array_filter(
+			get_post_types( array( 'show_in_rest' => true ) ),
+			'wp_is_post_type_collaboration_disabled'
+		)
+	);
+
 	wp_add_inline_script(
 		'wp-core-data',
-		'window._wpCollaborationEnabled = ' . wp_json_encode( $enabled ) . ';',
+		'window._wpCollaborationEnabled = ' . wp_json_encode( $enabled ) . ';' .
+		'window._wpCollaborationDisabledPostTypes = ' . wp_json_encode( $disabled_post_types ) . ';',
 		'after'
 	);
 }

--- a/src/wp-includes/collaboration.php
+++ b/src/wp-includes/collaboration.php
@@ -65,7 +65,7 @@ function wp_is_collaboration_allowed() {
  * revisions. Real-time collaboration depends on revision-related flows and
  * must remain off in that configuration.
  *
- * @since 7.1.0
+ * @since 7.0.0
  *
  * @return bool Whether revisions are globally supported.
  */

--- a/tests/phpunit/tests/collaboration/wpRevisionsGloballySupported.php
+++ b/tests/phpunit/tests/collaboration/wpRevisionsGloballySupported.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Tests for revision-based gating of real-time collaboration.
+ *
+ * @package WordPress
+ * @subpackage Collaboration
+ *
+ * @group collaboration
+ *
+ * @covers ::wp_revisions_are_globally_supported
+ * @covers ::wp_is_collaboration_enabled
+ */
+class Tests_Collaboration_WpRevisionsGloballySupported extends WP_UnitTestCase {
+
+	/**
+	 * When WP_POST_REVISIONS is unset, revisions behave as enabled site-wide.
+	 *
+	 * @ticket 77499
+	 */
+	public function test_wp_revisions_are_globally_supported_defaults_to_true() {
+		$this->assertTrue( wp_revisions_are_globally_supported() );
+	}
+
+	/**
+	 * Collaboration follows global revision availability when the option is on.
+	 *
+	 * @ticket 77499
+	 */
+	public function test_wp_is_collaboration_enabled_true_when_option_enabled_and_revisions_supported() {
+		update_option( 'wp_collaboration_enabled', 1 );
+
+		$this->assertTrue( wp_revisions_are_globally_supported() );
+		$this->assertTrue( wp_is_collaboration_enabled() );
+	}
+}


### PR DESCRIPTION
## Summary

Backports [WordPress/gutenberg#77502](https://github.com/WordPress/gutenberg/pull/77502) for [Gutenberg issue #77499](https://github.com/WordPress/gutenberg/issues/77499).

### PHP

- Introduces `wp_revisions_are_globally_supported()` and gates `wp_is_collaboration_enabled()` so RTC stays off when `WP_POST_REVISIONS` disables revisions site-wide.
- **Settings -> Writing:** inline notice and disabled Collaboration checkbox when revisions are globally unavailable.

### JavaScript

Built bundles live under `src/wp-includes/js/` (gitignored). Rely on the usual Core sync workflow before merge so the built `editor` and `preferences` assets include the corresponding Gutenberg JavaScript changes.

### Tests

Adds PHPUnit coverage for `wp_revisions_are_globally_supported()` and the enabled gate under default test configuration.

---

See the Gutenberg PR description for manual testing steps (`WP_POST_REVISIONS`, Writing screen, editor preferences).

Made with [Cursor](https://cursor.com)
