### PR TITLE
Follow up fixes to r62282

### DIFF
--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -971,7 +971,7 @@ function wp_admin_bar_command_palette_menu( WP_Admin_Bar $wp_admin_bar ): void {
 	 */
 	$function = <<<'JS'
 		( applePattern, appleOSLabel ) => {
-			if ( ( new RegExp( applePattern ) ).test( navigator.userAgent ) ) {
+			if ( ( new RegExp( applePattern, 'i' ) ).test( navigator.userAgent ) ) {
 				document.querySelector( '#wp-admin-bar-command-palette .ab-label kbd' ).textContent = appleOSLabel;
 			}
 		}

--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -971,8 +971,12 @@ function wp_admin_bar_command_palette_menu( WP_Admin_Bar $wp_admin_bar ): void {
 	 */
 	$function = <<<'JS'
 		( applePattern, appleOSLabel ) => {
-			if ( ( new RegExp( applePattern, 'i' ) ).test( navigator.userAgent ) ) {
-				document.querySelector( '#wp-admin-bar-command-palette .ab-label kbd' ).textContent = appleOSLabel;
+			if ( ! ( new RegExp( applePattern, 'i' ) ).test( navigator.userAgent ) ) {
+				return;
+			}
+			const kbd = document.querySelector( '#wp-admin-bar-command-palette .ab-label kbd' );
+			if ( kbd ) {
+				kbd.textContent = appleOSLabel;
 			}
 		}
 	JS;


### PR DESCRIPTION
Follow up to r62282.

- Adds the case-insensitive flag to the matching JavaScript Regex.
- Guards against a `TypeError` if the admin bar element has been moved or manipulated in some way.

Trac ticket: Core-65121.

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude
Model(s): Opus 4.7
Used for: Used Claude to analyze the previous changeset to try and find potential issues. Validated them before fixing here in the PR.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
