### PR TITLE
Add unit tests for wp_doc_link_parse() in wp-admin/includes/misc.php

### DIFF
--- a/tests/phpunit/tests/admin/includes/misc/wpDocLinkParse.php
+++ b/tests/phpunit/tests/admin/includes/misc/wpDocLinkParse.php
@@ -90,7 +90,7 @@ class Tests_wp_doc_link_parse extends WP_UnitTestCase {
 	 * @ticket 65182
 	 */
 	public function test_wp_doc_link_parse_filter() {
-		$filter = function( $ignore ) {
+		$filter = function ( $ignore ) {
 			$ignore[] = 'wp_remote_get';
 			return $ignore;
 		};

--- a/tests/phpunit/tests/admin/includes/misc/wpDocLinkParse.php
+++ b/tests/phpunit/tests/admin/includes/misc/wpDocLinkParse.php
@@ -31,7 +31,7 @@ class Tests_wp_doc_link_parse extends WP_UnitTestCase {
 	 */
 	public function data_wp_doc_link_parse(): array {
 		return array(
-			'empty string'                    => array(
+			'empty string'              => array(
 				'content'  => '',
 				'expected' => array(),
 			),

--- a/tests/phpunit/tests/admin/includes/misc/wpDocLinkParse.php
+++ b/tests/phpunit/tests/admin/includes/misc/wpDocLinkParse.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Test wp_doc_link_parse().
+ *
+ * @group admin
+ *
+ * @covers ::wp_doc_link_parse
+ */
+class Tests_wp_doc_link_parse extends WP_UnitTestCase {
+
+	/**
+	 * Tests wp_doc_link_parse() with various PHP content.
+	 *
+	 * @dataProvider data_wp_doc_link_parse
+	 * @ticket 65182
+	 *
+	 * @param string $content  The PHP content to parse.
+	 * @param array  $expected The expected array of function names.
+	 */
+	public function test_wp_doc_link_parse( $content, $expected ) {
+		$this->assertSame( $expected, wp_doc_link_parse( $content ) );
+	}
+
+	/**
+	 * Data provider for test_wp_doc_link_parse.
+	 *
+	 * @return array<string, array{
+	 *     content:  string,
+	 *     expected: string[],
+	 * }>
+	 */
+	public function data_wp_doc_link_parse(): array {
+		return array(
+			'empty string'                    => array(
+				'content'  => '',
+				'expected' => array(),
+			),
+			'null (invalid type)'             => array(
+				'content'  => null,
+				'expected' => array(),
+			),
+			'simple function call'            => array(
+				'content'  => '<?php get_header(); ?>',
+				'expected' => array( 'get_header' ),
+			),
+			'multiple unique functions'       => array(
+				'content'  => '<?php get_header(); wp_footer(); ?>',
+				'expected' => array( 'get_header', 'wp_footer' ),
+			),
+			'duplicate functions'             => array(
+				'content'  => '<?php _e("test"); _e("again"); ?>',
+				'expected' => array( '_e' ),
+			),
+			'sorted output'                   => array(
+				'content'  => '<?php zeta(); alpha(); ?>',
+				'expected' => array( 'alpha', 'zeta' ),
+			),
+			'local function definition'       => array(
+				'content'  => '<?php function my_local_func() {} my_local_func(); ?>',
+				'expected' => array(),
+			),
+			'class method call'               => array(
+				'content'  => '<?php $obj->my_method(); ?>',
+				'expected' => array(),
+			),
+			'static class method call'        => array(
+				'content'  => '<?php MyClass::my_static_method(); ?>',
+				'expected' => array( 'my_static_method' ), // token_get_all handles :: differently.
+			),
+			'mixed content'                   => array(
+				'content'  => '<?php
+					function local_f() {}
+					local_f();
+					wp_remote_get();
+					$o->method();
+					esc_html( "test" );
+				?>',
+				'expected' => array( 'esc_html', 'wp_remote_get' ),
+			),
+			'function call with space'        => array(
+				'content'  => '<?php is_array ( $val ); ?>',
+				'expected' => array( 'is_array' ),
+			),
+		);
+	}
+
+	/**
+	 * Tests the documentation_ignore_functions filter.
+	 *
+	 * @ticket 65182
+	 */
+	public function test_wp_doc_link_parse_filter() {
+		$filter = function( $ignore ) {
+			$ignore[] = 'wp_remote_get';
+			return $ignore;
+		};
+
+		add_filter( 'documentation_ignore_functions', $filter );
+		$result = wp_doc_link_parse( '<?php wp_remote_get(); esc_html(); ?>' );
+		remove_filter( 'documentation_ignore_functions', $filter );
+
+		$this->assertSame( array( 'esc_html' ), $result );
+	}
+}

--- a/tests/phpunit/tests/admin/includes/misc/wpDocLinkParse.php
+++ b/tests/phpunit/tests/admin/includes/misc/wpDocLinkParse.php
@@ -35,39 +35,39 @@ class Tests_wp_doc_link_parse extends WP_UnitTestCase {
 				'content'  => '',
 				'expected' => array(),
 			),
-			'null (invalid type)'             => array(
+			'null (invalid type)'       => array(
 				'content'  => null,
 				'expected' => array(),
 			),
-			'simple function call'            => array(
+			'simple function call'      => array(
 				'content'  => '<?php get_header(); ?>',
 				'expected' => array( 'get_header' ),
 			),
-			'multiple unique functions'       => array(
+			'multiple unique functions' => array(
 				'content'  => '<?php get_header(); wp_footer(); ?>',
 				'expected' => array( 'get_header', 'wp_footer' ),
 			),
-			'duplicate functions'             => array(
+			'duplicate functions'       => array(
 				'content'  => '<?php _e("test"); _e("again"); ?>',
 				'expected' => array( '_e' ),
 			),
-			'sorted output'                   => array(
+			'sorted output'             => array(
 				'content'  => '<?php zeta(); alpha(); ?>',
 				'expected' => array( 'alpha', 'zeta' ),
 			),
-			'local function definition'       => array(
+			'local function definition' => array(
 				'content'  => '<?php function my_local_func() {} my_local_func(); ?>',
 				'expected' => array(),
 			),
-			'class method call'               => array(
+			'class method call'         => array(
 				'content'  => '<?php $obj->my_method(); ?>',
 				'expected' => array(),
 			),
-			'static class method call'        => array(
+			'static class method call'  => array(
 				'content'  => '<?php MyClass::my_static_method(); ?>',
 				'expected' => array( 'my_static_method' ), // token_get_all handles :: differently.
 			),
-			'mixed content'                   => array(
+			'mixed content'             => array(
 				'content'  => '<?php
 					function local_f() {}
 					local_f();
@@ -77,7 +77,7 @@ class Tests_wp_doc_link_parse extends WP_UnitTestCase {
 				?>',
 				'expected' => array( 'esc_html', 'wp_remote_get' ),
 			),
-			'function call with space'        => array(
+			'function call with space'  => array(
 				'content'  => '<?php is_array ( $val ); ?>',
 				'expected' => array( 'is_array' ),
 			),


### PR DESCRIPTION

**Description**:
This PR adds unit tests for the `wp_doc_link_parse()` function in `wp-admin/includes/misc.php`. These tests ensure that the function correctly parses PHP content to identify function calls while correctly ignoring local function definitions and class method calls.

The tests cover:
- Empty and invalid inputs.
- Simple and multiple function calls.
- Duplicate and sorted function names.
- Ignoring local function definitions and object methods.
- Correct handling of static class methods.
- Verification of the `documentation_ignore_functions` filter.

Trac ticket: https://core.trac.wordpress.org/ticket/65182

**AI Disclosure**:
- AI assistance: Yes
- Tool(s): Junie (JetBrains)
- Model(s): gemini-3-flash-preview
- Used for: Code analysis, test implementation, and workflow management.