### PR TITLE
Add unit tests for wp_color_scheme_settings() in wp-admin/includes/mi…

### DIFF
--- a/tests/phpunit/tests/admin/includes/misc/wpColorSchemeSettings.php
+++ b/tests/phpunit/tests/admin/includes/misc/wpColorSchemeSettings.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * Test wp_color_scheme_settings().
+ *
+ * @group admin
+ * @group misc
+ */
+class Tests_wp_color_scheme_settings extends WP_UnitTestCase {
+
+	/**
+	 * Original $_wp_admin_css_colors global.
+	 *
+	 * @var array
+	 */
+	private $orig_wp_admin_css_colors;
+
+	public function set_up() {
+		parent::set_up();
+		global $_wp_admin_css_colors;
+		$this->orig_wp_admin_css_colors = $_wp_admin_css_colors;
+	}
+
+	public function tear_down() {
+		global $_wp_admin_css_colors;
+		$_wp_admin_css_colors = $this->orig_wp_admin_css_colors;
+		parent::tear_down();
+	}
+
+	/**
+	 * Test wp_color_scheme_settings() with a valid color scheme.
+	 */
+	public function test_wp_color_scheme_settings_valid_scheme() {
+		global $_wp_admin_css_colors;
+
+		$user_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user_id );
+		update_user_option( $user_id, 'admin_color', 'blue' );
+
+		$_wp_admin_css_colors = array(
+			'blue' => (object) array(
+				'icon_colors' => array(
+					'base'    => '#e5f8ff',
+					'focus'   => '#fff',
+					'current' => '#fff',
+				),
+			),
+		);
+
+		ob_start();
+		wp_color_scheme_settings();
+		$output = ob_get_clean();
+
+		$expected = array(
+			'icons' => array(
+				'base'    => '#e5f8ff',
+				'focus'   => '#fff',
+				'current' => '#fff',
+			),
+		);
+
+		$this->assertStringContainsString( 'var _wpColorScheme = ' . wp_json_encode( $expected ), $output );
+	}
+
+	/**
+	 * Test wp_color_scheme_settings() with an invalid color scheme (fallback to modern).
+	 */
+	public function test_wp_color_scheme_settings_invalid_scheme_fallback_to_modern() {
+		global $_wp_admin_css_colors;
+
+		$user_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user_id );
+		update_user_option( $user_id, 'admin_color', 'non-existent' );
+
+		$_wp_admin_css_colors = array(
+			'modern' => (object) array(
+				'icon_colors' => array(
+					'base'    => '#f0f0f1',
+					'focus'   => '#fff',
+					'current' => '#fff',
+				),
+			),
+		);
+
+		ob_start();
+		wp_color_scheme_settings();
+		$output = ob_get_clean();
+
+		$expected = array(
+			'icons' => array(
+				'base'    => '#f0f0f1',
+				'focus'   => '#fff',
+				'current' => '#fff',
+			),
+		);
+
+		$this->assertStringContainsString( 'var _wpColorScheme = ' . wp_json_encode( $expected ), $output );
+	}
+
+	/**
+	 * Test wp_color_scheme_settings() with no icon colors defined (fallback to defaults).
+	 */
+	public function test_wp_color_scheme_settings_no_icon_colors_fallback() {
+		global $_wp_admin_css_colors;
+
+		$user_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user_id );
+		update_user_option( $user_id, 'admin_color', 'empty-scheme' );
+
+		$_wp_admin_css_colors = array(
+			'empty-scheme' => (object) array(),
+			'modern'       => (object) array(),
+		);
+
+		ob_start();
+		wp_color_scheme_settings();
+		$output = ob_get_clean();
+
+		$expected = array(
+			'icons' => array(
+				'base'    => '#a7aaad',
+				'focus'   => '#72aee6',
+				'current' => '#fff',
+			),
+		);
+
+		$this->assertStringContainsString( 'var _wpColorScheme = ' . wp_json_encode( $expected ), $output );
+	}
+}


### PR DESCRIPTION
…sc.php
**Description**:
This PR adds unit tests for the `wp_color_scheme_settings()` function in `wp-admin/includes/misc.php`. These tests ensure that the function correctly outputs the JavaScript configuration for admin color schemes, including appropriate icon color fallbacks when schemes are missing or partially defined.

The tests cover:
- Successful output of icon colors for a valid user-selected color scheme.
- Correct fallback to the "modern" color scheme when an invalid scheme is set in user options.
- Default icon color fallback when neither the current nor the "modern" scheme has defined icon colors.

Trac ticket: https://core.trac.wordpress.org/ticket/65185

**AI Disclosure**:
- AI assistance: Yes
- Tool(s): Junie (JetBrains)
- Model(s): gemini-3-flash-preview
- Used for: Code analysis, test implementation, and workflow management.