### PR TITLE
Docs: Add missing @since note for wp_get_user_request()

### DIFF
--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -5098,6 +5098,7 @@ function wp_validate_user_request_key(
  * Returns the user request object for the specified request ID.
  *
  * @since 4.9.6
+ * @since 5.4.0 Renamed from wp_get_user_request_data() to wp_get_user_request().
  *
  * @param int $request_id The ID of the user request.
  * @return WP_User_Request|false


### PR DESCRIPTION
Adds the missing @since 5.4.0 description to the wp_get_user_request() DocBlock, noting that the function was renamed from wp_get_user_request_data().
Trac ticket: https://core.trac.wordpress.org/ticket/65132