### PR TITLE
65186 misc customizer mobile viewport meta

### DIFF
--- a/tests/phpunit/tests/admin/includes/misc/customizerMobileViewportMeta.php
+++ b/tests/phpunit/tests/admin/includes/misc/customizerMobileViewportMeta.php
@@ -15,6 +15,8 @@ class Tests_Customizer_Mobile_Viewport_Meta extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_customizer_mobile_viewport_meta
 	 *
+	 * @ticket 65186
+	 *
 	 * @param string $viewport_meta Original viewport meta.
 	 * @param string $expected      Expected viewport meta.
 	 */

--- a/tests/phpunit/tests/admin/includes/misc/customizerMobileViewportMeta.php
+++ b/tests/phpunit/tests/admin/includes/misc/customizerMobileViewportMeta.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * Tests for _customizer_mobile_viewport_meta().
+ *
+ * @group admin
+ * @group includes
+ *
+ * @covers ::_customizer_mobile_viewport_meta
+ */
+class Tests_Customizer_Mobile_Viewport_Meta extends WP_UnitTestCase {
+
+	/**
+	 * Tests _customizer_mobile_viewport_meta().
+	 *
+	 * @dataProvider data_customizer_mobile_viewport_meta
+	 *
+	 * @param string $viewport_meta Original viewport meta.
+	 * @param string $expected      Expected viewport meta.
+	 */
+	public function test_customizer_mobile_viewport_meta( $viewport_meta, $expected ) {
+		$this->assertSame( $expected, _customizer_mobile_viewport_meta( $viewport_meta ) );
+	}
+
+	/**
+	 * Data provider for test_customizer_mobile_viewport_meta.
+	 *
+	 * @return array<string, array{
+	 *     viewport_meta: string,
+	 *     expected:      string,
+	 * }>
+	 */
+	public function data_customizer_mobile_viewport_meta(): array {
+		return array(
+			'default'                       => array(
+				'viewport_meta' => 'width=device-width,initial-scale=1.0',
+				'expected'      => 'width=device-width,initial-scale=1.0,minimum-scale=0.5,maximum-scale=1.2',
+			),
+			'empty'                         => array(
+				'viewport_meta' => '',
+				'expected'      => ',minimum-scale=0.5,maximum-scale=1.2',
+			),
+			'with trailing comma'           => array(
+				'viewport_meta' => 'width=device-width,initial-scale=1.0,',
+				'expected'      => 'width=device-width,initial-scale=1.0,minimum-scale=0.5,maximum-scale=1.2',
+			),
+			'with multiple trailing commas' => array(
+				'viewport_meta' => 'width=device-width,initial-scale=1.0,,',
+				'expected'      => 'width=device-width,initial-scale=1.0,minimum-scale=0.5,maximum-scale=1.2',
+			),
+		);
+	}
+}


### PR DESCRIPTION
**Description**:
This PR adds unit tests for the `_customizer_mobile_viewport_meta()` function in `wp-admin/includes/misc.php`. These tests ensure that the function correctly appends Customizer-specific viewport settings (`minimum-scale=0.5,maximum-scale=1.2`) to an existing viewport meta string, while handling trailing commas and empty input.

The tests cover:
- Appending to a standard viewport string.
- Handling of empty input strings.
- Correct trimming of single and multiple trailing commas before appending.

Trac ticket: https://core.trac.wordpress.org/ticket/65186

**AI Disclosure**:
- AI assistance: Yes
- Tool(s): Junie (JetBrains)
- Model(s): gemini-3-flash-preview
- Used for: Code analysis, test implementation, and workflow management.
