### PR TITLE
Add unit tests for wp_admin_viewport_meta() in wp-admin/includes/misc…

### DIFF
--- a/tests/phpunit/tests/admin/includes/misc/wpAdminViewportMeta.php
+++ b/tests/phpunit/tests/admin/includes/misc/wpAdminViewportMeta.php
@@ -21,7 +21,7 @@ class Tests_wp_admin_viewport_meta extends WP_UnitTestCase {
 		if ( null !== $filter_value ) {
 			add_filter(
 				'admin_viewport_meta',
-				function() use ( $filter_value ) {
+				function () use ( $filter_value ) {
 					return $filter_value;
 				}
 			);

--- a/tests/phpunit/tests/admin/includes/misc/wpAdminViewportMeta.php
+++ b/tests/phpunit/tests/admin/includes/misc/wpAdminViewportMeta.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Test wp_admin_viewport_meta().
+ *
+ * @group admin
+ * @group misc
+ */
+class Tests_wp_admin_viewport_meta extends WP_UnitTestCase {
+
+	/**
+	 * Test wp_admin_viewport_meta() output.
+	 *
+	 * @dataProvider data_wp_admin_viewport_meta
+	 *
+	 * @param string|null $filter_value The value to return from the filter, or null if no filter.
+	 * @param string      $expected     The expected output string.
+	 *
+	 * @return void
+	 */
+	public function test_wp_admin_viewport_meta( $filter_value, $expected ) {
+		if ( null !== $filter_value ) {
+			add_filter(
+				'admin_viewport_meta',
+				function() use ( $filter_value ) {
+					return $filter_value;
+				}
+			);
+		}
+
+		$this->expectOutputString( $expected );
+		wp_admin_viewport_meta();
+	}
+
+	/**
+	 * Data provider for test_wp_admin_viewport_meta.
+	 *
+	 * @return array<string, array{
+	 *     filter_value: string|null,
+	 *     expected:     string,
+	 * }>
+	 */
+	public function data_wp_admin_viewport_meta(): array {
+		return array(
+			'default_value'          => array(
+				'filter_value' => null,
+				'expected'     => '<meta name="viewport" content="width=device-width,initial-scale=1.0">',
+			),
+			'custom_filtered_value'  => array(
+				'filter_value' => 'width=device-width,initial-scale=2.0',
+				'expected'     => '<meta name="viewport" content="width=device-width,initial-scale=2.0">',
+			),
+			'empty_filtered_value'   => array(
+				'filter_value' => '',
+				'expected'     => '',
+			),
+			'escaped_filtered_value' => array(
+				'filter_value' => 'width=device-width; content="><script>alert(1)</script>',
+				'expected'     => '<meta name="viewport" content="' . esc_attr( 'width=device-width; content="><script>alert(1)</script>' ) . '">',
+			),
+		);
+	}
+}

--- a/tests/phpunit/tests/admin/includes/misc/wpAdminViewportMeta.php
+++ b/tests/phpunit/tests/admin/includes/misc/wpAdminViewportMeta.php
@@ -4,11 +4,15 @@
  *
  * @group admin
  * @group misc
+ *
+ * @covers ::wp_admin_viewport_meta
  */
 class Tests_wp_admin_viewport_meta extends WP_UnitTestCase {
 
 	/**
 	 * Test wp_admin_viewport_meta() output.
+	 *
+	 * @ticket 65187
 	 *
 	 * @dataProvider data_wp_admin_viewport_meta
 	 *


### PR DESCRIPTION
….php
**Description**:
This PR adds unit tests for the `wp_admin_viewport_meta()` function in `wp-admin/includes/misc.php`. These tests ensure that the function correctly outputs the viewport meta tag, handles the `admin_viewport_meta` filter, and properly escapes the content attribute.

The tests cover:
- Default viewport meta output.
- Custom viewport meta via the `admin_viewport_meta` filter.
- Ensuring no output is generated when the filtered value is empty.
- Security verification of attribute escaping in the output.

Trac ticket: https://core.trac.wordpress.org/ticket/65187

**AI Disclosure**:
- AI assistance: Yes
- Tool(s): Junie (JetBrains)
- Model(s): gemini-3-flash-preview
- Used for: Code analysis, test implementation, and workflow management.
