### PR TITLE
Docs: Fix malformed nested DocBlock types for wp_register_ability()

### DIFF
--- a/src/wp-includes/abilities-api.php
+++ b/src/wp-includes/abilities-api.php
@@ -251,23 +251,16 @@ declare( strict_types = 1 );
  *     @type array<string, mixed> $output_schema       Optional. JSON Schema definition for the ability's output.
  *                                                     Describes the structure of successful return values from
  *                                                     `execute_callback`. Used for documentation and validation.
- *     @type array<string, mixed> $meta                {
- *         Optional. Additional metadata for the ability.
- *
- *         @type array<string, bool|null> $annotations  {
- *             Optional. Semantic annotations describing the ability's behavioral characteristics.
- *             These annotations are hints for tooling and documentation.
- *
- *             @type bool|null $readonly    Optional. If true, the ability does not modify its environment.
- *             @type bool|null $destructive Optional. If true, the ability may perform destructive updates to its environment.
- *                                          If false, the ability performs only additive updates.
- *             @type bool|null $idempotent  Optional. If true, calling the ability repeatedly with the same arguments
- *                                          will have no additional effect on its environment.
- *         }
- *         @type bool                     $show_in_rest Optional. Whether to expose this ability in the REST API.
- *                                                      When true, the ability can be invoked via HTTP requests.
- *                                                      Default false.
- *     }
+ *     @type array<string, mixed> $meta                Optional. Additional metadata for the ability.
+ *     @type array<string, bool|null> $annotations     Optional. Semantic annotations describing the ability's behavioral
+ *                                                     characteristics. These annotations are hints for tooling and documentation.
+ *     @type bool|null            $readonly            Optional. If true, the ability does not modify its environment.
+ *     @type bool|null            $destructive         Optional. If true, the ability may perform destructive updates to its
+ *                                                     environment. If false, the ability performs only additive updates.
+ *     @type bool|null            $idempotent          Optional. If true, calling the ability repeatedly with the same arguments
+ *                                                     will have no additional effect on its environment.
+ *     @type bool                 $show_in_rest        Optional. Whether to expose this ability in the REST API. When true,
+ *                                                     the ability can be invoked via HTTP requests. Default false.
  *     @type string               $ability_class       Optional. Fully-qualified custom class name to instantiate
  *                                                     instead of the default `WP_Ability` class. The custom class
  *                                                     must extend `WP_Ability`. Useful for advanced customization


### PR DESCRIPTION
Related GitHub issue: https://github.com/WordPress/Documentation-Issue-Tracker/issues/2244

No corresponding Core Trac ticket exists for this documentation issue.
