### PR TITLE
Add action hooks to media modal

### DIFF
--- a/src/js/media/views/attachment/details.js
+++ b/src/js/media/views/attachment/details.js
@@ -272,6 +272,63 @@ Details = Attachment.extend(/** @lends wp.media.view.Attachment.Details.prototyp
 			var el = wp.media.view.MediaDetails.prepareSrc( elem );
 			new window.MediaElementPlayer( el, wp.media.mixin.mejsSettings );
 		} );
+
+		this.renderFieldControls();
+	},
+
+	/**
+	 * Fires the `media.view.attachment.renderFieldAfter` action for each
+	 * rendered field, allowing plugins to append controls adjacent to fields
+	 * without relying on brittle DOM manipulation.
+	 *
+	 * Called automatically at the end of {@see wp.media.view.Attachment.Details#render}.
+	 *
+	 * @since x.x.x
+	 *
+	 * @fires media.view.attachment.renderFieldAfter
+	 *
+	 * @return {void}
+	 */
+	renderFieldControls: function() {
+		var view = this,
+			attachment = this.model,
+			fields = [ 'alt', 'title', 'caption', 'description', 'artist', 'album', 'url' ];
+
+		_.each( fields, function( field ) {
+			var $setting = view.$( '[data-setting="' + field + '"]' );
+
+			if ( ! $setting.length ) {
+				return;
+			}
+
+			/**
+			 * Fires after a field is rendered in the Attachment Details panel.
+			 *
+			 * Allows plugins to append additional controls (e.g. buttons) directly
+			 * inside the `.setting` container for a specific attachment field.
+			 *
+			 * The action fires for every field key that is present in the rendered
+			 * template. Fields currently emitted: `alt`, `title`, `caption`,
+			 * `description`, `artist`, `album`, `url`.
+			 *
+			 * @since x.x.x
+			 *
+			 * @param {jQuery}  $setting              The `.setting` container element.
+			 * @param {Object}  context               Context object.
+			 * @param {string}  context.field         Field key, e.g. `'alt'`, `'caption'`.
+			 * @param {wp.media.model.Attachment} context.attachment  Attachment model.
+			 * @param {wp.media.view.Attachment.Details} context.view  This view instance.
+			 */
+			wp.hooks.doAction(
+				'media.view.attachment.renderFieldAfter',
+				$setting,
+				{
+					field: field,
+					attachment: attachment,
+					view: view,
+				}
+			);
+		} );
 	}
 });
 


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65086

## Use of AI Tools
AI assistance: Yes
Tool(s): Claude code
Model(s): opus 4.6
Used for: used for documentation and code review.

## Example plugin integration

```
// my-ai-plugin/js/generate-alt-text.js
wp.hooks.addAction(
	'media.view.attachment.renderFieldAfter',
	'my-ai-plugin/generate-alt-text',
	function( $setting, context ) {
		// Only inject beside the alt text field.
		if ( 'alt' !== context.field ) {
			return;
		}

		// Avoid double-injection on repeated renders.
		if ( $setting.find( '.my-ai-generate-alt' ).length ) {
			return;
		}

		var $button = $( '<button>', {
			type:  'button',
			class: 'button button-small my-ai-generate-alt',
			text:  wp.i18n.__( 'Generate', 'my-ai-plugin' ),
		} );

		$button.on( 'click', function() {
			var attachment = context.attachment;
			var $textarea  = $setting.find( 'textarea' );

			$button.prop( 'disabled', true ).text( wp.i18n.__( 'Generating…', 'my-ai-plugin' ) );

			wp.apiFetch( {
				path: '/my-ai-plugin/v1/generate-alt',
				method: 'POST',
				data: { attachment_id: attachment.get( 'id' ) },
			} ).then( function( response ) {
				// Update the Backbone model — triggers save via existing event binding.
				attachment.set( 'alt', response.alt_text );
				$textarea.val( response.alt_text ).trigger( 'change' );
			} ).catch( function() {
				// Surface error accessibly.
				wp.a11y.speak( wp.i18n.__( 'Could not generate alt text.', 'my-ai-plugin' ) );
			} ).finally( function() {
				$button.prop( 'disabled', false ).text( wp.i18n.__( 'Generate', 'my-ai-plugin' ) );
			} );
		} );

		$setting.append( $button );
	}
);

// Edit media screen
add_filter( 'attachment_fields_to_edit', function( $fields, $post ) {
    $fields['my_ai_generate_alt'] = array(
        'label'         => '',
        'input'         => 'html',
        'html'          => '<button type="button" class="button my-ai-generate-alt" data-id="' . esc_attr( $post->ID ) . '">'
                            . esc_html__( 'Generate Alt Text', 'my-ai-plugin' )
                            . '</button>',
        'show_in_edit'  => true,
        'show_in_modal' => false, // keep it out of the modal's compat meta
    );
    return $fields;
}, 10, 2 );


```
