### PR TITLE
Add aspect ratio for YouTube shorts iframe

### DIFF
--- a/src/wp-includes/css/wp-embed-template.css
+++ b/src/wp-includes/css/wp-embed-template.css
@@ -314,6 +314,11 @@ p.wp-embed-share-description {
 	cursor: text;
 }
 
+.wp-block-embed__wrapper iframe[src*="youtube.com/shorts"] {
+    aspect-ratio: 9 / 16;
+    height: auto;
+}
+
 textarea.wp-embed-share-input {
 	height: 72px;
 }


### PR DESCRIPTION
YouTube Shorts embeds are displayed with an incorrect aspect ratio on mobile devices, causing the iframe to overflow its container and break the layout.

This PR adds a targeted CSS rule to ensure Shorts (vertical videos) maintain a proper 9:16 aspect ratio, allowing them to scale correctly within responsive layouts.

Ticket: https://core.trac.wordpress.org/ticket/65067