### PR TITLE
Admin: Standardize mobile viewport heights for interactive elements

### DIFF
--- a/src/js/media/views/button/select-mode-toggle.js
+++ b/src/js/media/views/button/select-mode-toggle.js
@@ -40,7 +40,7 @@ SelectModeToggle = Button.extend(/** @lends wp.media.view.SelectModeToggle.proto
 
 	render: function() {
 		Button.prototype.render.apply( this, arguments );
-		this.$el.addClass( 'select-mode-toggle-button' );
+		this.$el.addClass( 'select-mode-toggle-button button-compact' );
 		return this;
 	},
 

--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -1417,6 +1417,17 @@ th.action-links {
 		padding: 0;
 		width: 50%;
 	}
+
+	.wp-filter .search-form input[type="search"] {
+		min-height: 40px;
+		padding: 0 12px;
+	}
+
+	.wp-filter .search-form select,
+	.wp-filter .filter-items select {
+		min-height: 40px;
+		padding: 0 24px 0 12px;
+	}
 }
 
 @media only screen and (max-width: 320px) {

--- a/src/wp-admin/css/forms.css
+++ b/src/wp-admin/css/forms.css
@@ -1798,6 +1798,7 @@ table.form-table td .updated p {
 	p.search-box input[type="search"],
 	p.search-box input[type="text"] {
 		min-height: 40px;
+		padding: 0 12px;
 	}
 
 	p.search-box input[type="submit"] {
@@ -1944,6 +1945,7 @@ table.form-table td .updated p {
 	.options-general-php input[type="text"].small-text {
 		max-width: 6.25em;
 		margin: 0;
+		min-height: 40px;
 	}
 
 	/* Privacy Policy settings screen */

--- a/src/wp-admin/css/forms.css
+++ b/src/wp-admin/css/forms.css
@@ -1801,7 +1801,7 @@ table.form-table td .updated p {
 		padding: 0 12px;
 	}
 
-	p.search-box input[type="submit"] {
+	p.search-box input[type="submit"].button {
 		margin-bottom: 10px;
 	}
 

--- a/src/wp-admin/css/forms.css
+++ b/src/wp-admin/css/forms.css
@@ -524,10 +524,6 @@ input[type="number"].tiny-text {
 	margin: 0 8px 0 0;
 }
 
-#delete_all {
-	margin-bottom: 0;
-}
-
 /* @since 5.7.0 secondary bulk action controls require JS. */
 .no-js label[for="bulk-action-selector-bottom"],
 .no-js select#bulk-action-selector-bottom,

--- a/src/wp-admin/css/forms.css
+++ b/src/wp-admin/css/forms.css
@@ -524,6 +524,10 @@ input[type="number"].tiny-text {
 	margin: 0 8px 0 0;
 }
 
+#delete_all {
+	margin-bottom: 0;
+}
+
 /* @since 5.7.0 secondary bulk action controls require JS. */
 .no-js label[for="bulk-action-selector-bottom"],
 .no-js select#bulk-action-selector-bottom,

--- a/src/wp-admin/css/list-tables.css
+++ b/src/wp-admin/css/list-tables.css
@@ -1541,6 +1541,7 @@ div.action-links,
 .plugin-action-buttons li .button {
 	min-height: 32px;
 	line-height: 2.30769231; /* 30px for 32px min-height */
+	font-size: 13px;
 	padding: 0 12px;
 }
 

--- a/src/wp-admin/css/list-tables.css
+++ b/src/wp-admin/css/list-tables.css
@@ -1537,14 +1537,6 @@ div.action-links,
 	margin: 0; /* Override existing margins */
 }
 
-/* Use compact size for space-constrained plugin cards */
-.plugin-action-buttons li .button {
-	min-height: 32px;
-	line-height: 2.30769231; /* 30px for 32px min-height */
-	font-size: 13px;
-	padding: 0 12px;
-}
-
 .plugin-card h3 {
 	margin: 0 12px 16px 0;
 	font-size: 18px;

--- a/src/wp-admin/css/media.css
+++ b/src/wp-admin/css/media.css
@@ -1413,6 +1413,21 @@ audio, video {
 		top: 46px;
 		right: 10px;
 	}
+
+	.media-frame.mode-grid .media-toolbar select {
+		min-height: 40px;
+		padding: 0 24px 0 12px;
+	}
+
+	.media-frame.mode-grid .media-toolbar input[type="search"] {
+		min-height: 40px;
+		padding: 0 12px;
+	}
+
+	.media-frame.mode-grid .media-toolbar .button {
+		min-height: 40px;
+		padding: 0 14px;
+	}
 }
 
 @media only screen and (max-width: 600px) {

--- a/src/wp-admin/css/media.css
+++ b/src/wp-admin/css/media.css
@@ -374,6 +374,10 @@
 	.find-box-inside {
 		bottom: 57px;
 	}
+
+	#delete_all {
+		margin-bottom: 0;
+	}
 }
 
 @media screen and (max-width: 660px) {

--- a/src/wp-admin/css/media.css
+++ b/src/wp-admin/css/media.css
@@ -1400,7 +1400,6 @@ audio, video {
 	.wp-filter p.search-box {
 		float: none;
 		width: 100%;
-		margin-bottom: 20px;
 		display: flex;
 		flex-wrap: nowrap;
 		column-gap: 0;
@@ -1426,6 +1425,10 @@ audio, video {
 	.media-frame.mode-grid .media-toolbar input[type="search"] {
 		min-height: 40px;
 		padding: 0 12px;
+	}
+
+	.wp-filter p.search-box {
+		margin-bottom: 0;
 	}
 }
 

--- a/src/wp-admin/css/media.css
+++ b/src/wp-admin/css/media.css
@@ -1423,11 +1423,6 @@ audio, video {
 		min-height: 40px;
 		padding: 0 12px;
 	}
-
-	.media-frame.mode-grid .media-toolbar .button {
-		min-height: 40px;
-		padding: 0 14px;
-	}
 }
 
 @media only screen and (max-width: 600px) {

--- a/src/wp-admin/css/themes.css
+++ b/src/wp-admin/css/themes.css
@@ -1965,6 +1965,8 @@ body.full-overlay-active {
 .theme-install-overlay .wp-full-overlay-header .button {
 	float: right;
 	margin: 7px 10px 0 0; /* Vertically center 32px button in 45px header */
+	min-height: 32px;
+	line-height: 2.30769231; /* 30px for 32px height with 13px font */
 }
 
 .theme-install-overlay .wp-full-overlay-sidebar {

--- a/src/wp-admin/css/themes.css
+++ b/src/wp-admin/css/themes.css
@@ -119,10 +119,6 @@ body.js .theme-browser.search-loading {
 .theme-browser .theme .theme-actions .button {
 	float: none;
 	margin-left: 3px;
-	min-height: 32px;
-	line-height: 2.30769231; /* 30px for 32px min-height */
-	font-size: 13px;
-	padding: 0 12px;
 }
 
 .theme-browser .theme .theme-actions .button.updated-message::before,

--- a/src/wp-admin/css/themes.css
+++ b/src/wp-admin/css/themes.css
@@ -121,6 +121,7 @@ body.js .theme-browser.search-loading {
 	margin-left: 3px;
 	min-height: 32px;
 	line-height: 2.30769231; /* 30px for 32px min-height */
+	font-size: 13px;
 	padding: 0 12px;
 }
 

--- a/src/wp-admin/includes/class-wp-media-list-table.php
+++ b/src/wp-admin/includes/class-wp-media-list-table.php
@@ -242,7 +242,7 @@ class WP_Media_List_Table extends WP_List_Table {
 			/** This action is documented in wp-admin/includes/class-wp-posts-list-table.php */
 			do_action( 'restrict_manage_posts', $this->screen->post_type, $which );
 
-			submit_button( __( 'Filter' ), 'button-compact', 'filter_action', false, array( 'id' => 'post-query-submit' ) );
+			submit_button( __( 'Filter' ), 'button-compact', 'filter_action', false );
 
 			if ( $this->is_trash && $this->has_items()
 				&& current_user_can( 'edit_others_posts' )

--- a/src/wp-admin/includes/class-wp-media-list-table.php
+++ b/src/wp-admin/includes/class-wp-media-list-table.php
@@ -242,7 +242,7 @@ class WP_Media_List_Table extends WP_List_Table {
 			/** This action is documented in wp-admin/includes/class-wp-posts-list-table.php */
 			do_action( 'restrict_manage_posts', $this->screen->post_type, $which );
 
-			submit_button( __( 'Filter' ), 'button-compact', 'filter_action', false );
+			submit_button( __( 'Filter' ), 'button-compact', 'filter_action', false, array( 'id' => 'post-query-submit' ) );
 
 			if ( $this->is_trash && $this->has_items()
 				&& current_user_can( 'edit_others_posts' )

--- a/src/wp-admin/includes/class-wp-media-list-table.php
+++ b/src/wp-admin/includes/class-wp-media-list-table.php
@@ -351,7 +351,7 @@ class WP_Media_List_Table extends WP_List_Table {
 					?>
 					</label>
 					<input type="search" id="media-search-input" class="search" name="s" value="<?php _admin_search_query(); ?>">
-					<input id="search-submit" type="submit" class="button" value="<?php esc_attr_e( 'Search Media' ); ?>">
+					<input id="search-submit" type="submit" class="button button-compact" value="<?php esc_attr_e( 'Search Media' ); ?>">
 				</p>
 			</div>
 		</div>

--- a/src/wp-admin/includes/class-wp-media-list-table.php
+++ b/src/wp-admin/includes/class-wp-media-list-table.php
@@ -247,7 +247,7 @@ class WP_Media_List_Table extends WP_List_Table {
 			if ( $this->is_trash && $this->has_items()
 				&& current_user_can( 'edit_others_posts' )
 			) {
-				submit_button( __( 'Empty Trash' ), 'apply', 'delete_all', false );
+				submit_button( __( 'Empty Trash' ), 'apply button-compact', 'delete_all', false );
 			}
 			?>
 		</div>

--- a/src/wp-admin/includes/plugin-install.php
+++ b/src/wp-admin/includes/plugin-install.php
@@ -940,7 +940,7 @@ function wp_get_plugin_action_button( $name, $data, $compatible_php, $compatible
 				if ( $status['url'] ) {
 					if ( $compatible_php && $compatible_wp && $all_plugin_dependencies_installed && ! empty( $data->download_link ) ) {
 						$button = sprintf(
-							'<a class="install-now button" data-slug="%s" href="%s" aria-label="%s" data-name="%s" role="button">%s</a>',
+							'<a class="install-now button button-compact" data-slug="%s" href="%s" aria-label="%s" data-name="%s" role="button">%s</a>',
 							esc_attr( $data->slug ),
 							esc_url( $status['url'] ),
 							/* translators: %s: Plugin name and version. */
@@ -950,7 +950,7 @@ function wp_get_plugin_action_button( $name, $data, $compatible_php, $compatible
 						);
 					} else {
 						$button = sprintf(
-							'<button type="button" class="install-now button button-disabled" disabled="disabled">%s</button>',
+							'<button type="button" class="install-now button button-compact button-disabled" disabled="disabled">%s</button>',
 							_x( 'Install Now', 'plugin' )
 						);
 					}
@@ -961,7 +961,7 @@ function wp_get_plugin_action_button( $name, $data, $compatible_php, $compatible
 				if ( $status['url'] ) {
 					if ( $compatible_php && $compatible_wp ) {
 						$button = sprintf(
-							'<a class="update-now button aria-button-if-js" data-plugin="%s" data-slug="%s" href="%s" aria-label="%s" data-name="%s" role="button">%s</a>',
+							'<a class="update-now button button-compact aria-button-if-js" data-plugin="%s" data-slug="%s" href="%s" aria-label="%s" data-name="%s" role="button">%s</a>',
 							esc_attr( $status['file'] ),
 							esc_attr( $data->slug ),
 							esc_url( $status['url'] ),
@@ -972,7 +972,7 @@ function wp_get_plugin_action_button( $name, $data, $compatible_php, $compatible
 						);
 					} else {
 						$button = sprintf(
-							'<button type="button" class="button button-disabled" disabled="disabled">%s</button>',
+							'<button type="button" class="button button-compact button-disabled" disabled="disabled">%s</button>',
 							_x( 'Update Now', 'plugin' )
 						);
 					}
@@ -983,7 +983,7 @@ function wp_get_plugin_action_button( $name, $data, $compatible_php, $compatible
 			case 'newer_installed':
 				if ( is_plugin_active( $status['file'] ) ) {
 					$button = sprintf(
-						'<button type="button" class="button button-disabled" disabled="disabled">%s</button>',
+						'<button type="button" class="button button-compact button-disabled" disabled="disabled">%s</button>',
 						_x( 'Active', 'plugin' )
 					);
 				} elseif ( current_user_can( 'activate_plugin', $status['file'] ) ) {
@@ -1008,7 +1008,7 @@ function wp_get_plugin_action_button( $name, $data, $compatible_php, $compatible
 						}
 
 						$button = sprintf(
-							'<a href="%1$s" data-name="%2$s" data-slug="%3$s" data-plugin="%4$s" class="button button-primary activate-now" aria-label="%5$s" role="button">%6$s</a>',
+							'<a href="%1$s" data-name="%2$s" data-slug="%3$s" data-plugin="%4$s" class="button button-compact button-primary activate-now" aria-label="%5$s" role="button">%6$s</a>',
 							esc_url( $activate_url ),
 							esc_attr( $name ),
 							esc_attr( $data->slug ),
@@ -1018,13 +1018,13 @@ function wp_get_plugin_action_button( $name, $data, $compatible_php, $compatible
 						);
 					} else {
 						$button = sprintf(
-							'<button type="button" class="button button-disabled" disabled="disabled">%s</button>',
+							'<button type="button" class="button button-compact button-disabled" disabled="disabled">%s</button>',
 							is_network_admin() ? _x( 'Network Activate', 'plugin' ) : _x( 'Activate', 'plugin' )
 						);
 					}
 				} else {
 					$button = sprintf(
-						'<button type="button" class="button button-disabled" disabled="disabled">%s</button>',
+						'<button type="button" class="button button-compact button-disabled" disabled="disabled">%s</button>',
 						_x( 'Installed', 'plugin' )
 					);
 				}

--- a/src/wp-admin/theme-install.php
+++ b/src/wp-admin/theme-install.php
@@ -408,21 +408,21 @@ if ( $tab ) {
 					?>
 					<# if ( data.activate_url ) { #>
 						<# if ( ! data.active ) { #>
-							<a class="button button-primary activate" href="{{ data.activate_url }}" aria-label="<?php echo esc_attr( $aria_label ); ?>"><?php _e( 'Activate' ); ?></a>
+							<a class="button button-compact button-primary activate" href="{{ data.activate_url }}" aria-label="<?php echo esc_attr( $aria_label ); ?>"><?php _e( 'Activate' ); ?></a>
 						<# } else { #>
-							<button class="button button-primary disabled"><?php _ex( 'Activated', 'theme' ); ?></button>
+							<button class="button button-compact button-primary disabled"><?php _ex( 'Activated', 'theme' ); ?></button>
 						<# } #>
 					<# } #>
 					<# if ( data.customize_url ) { #>
 						<# if ( ! data.active ) { #>
 							<# if ( ! data.block_theme ) { #>
-								<a class="button load-customize" href="{{ data.customize_url }}"><?php _e( 'Live Preview' ); ?></a>
+								<a class="button button-compact load-customize" href="{{ data.customize_url }}"><?php _e( 'Live Preview' ); ?></a>
 							<# } #>
 						<# } else { #>
-							<a class="button load-customize" href="{{ data.customize_url }}"><?php _e( 'Customize' ); ?></a>
+							<a class="button button-compact load-customize" href="{{ data.customize_url }}"><?php _e( 'Customize' ); ?></a>
 						<# } #>
 					<# } else { #>
-						<button class="button preview install-theme-preview"><?php echo esc_html_x( 'Preview', 'verb' ); ?></button>
+						<button class="button button-compact preview install-theme-preview"><?php echo esc_html_x( 'Preview', 'verb' ); ?></button>
 					<# } #>
 				<# } else { #>
 					<?php
@@ -430,12 +430,12 @@ if ( $tab ) {
 					$aria_label = sprintf( _x( 'Cannot Activate %s', 'theme' ), '{{ data.name }}' );
 					?>
 					<# if ( data.activate_url ) { #>
-						<a class="button button-primary disabled" aria-label="<?php echo esc_attr( $aria_label ); ?>"><?php _ex( 'Cannot Activate', 'theme' ); ?></a>
+						<a class="button button-compact button-primary disabled" aria-label="<?php echo esc_attr( $aria_label ); ?>"><?php _ex( 'Cannot Activate', 'theme' ); ?></a>
 					<# } #>
 					<# if ( data.customize_url ) { #>
-						<a class="button disabled"><?php _e( 'Live Preview' ); ?></a>
+						<a class="button button-compact disabled"><?php _e( 'Live Preview' ); ?></a>
 					<# } else { #>
-						<button class="button disabled"><?php echo esc_html_x( 'Preview', 'verb' ); ?></button>
+						<button class="button button-compact disabled"><?php echo esc_html_x( 'Preview', 'verb' ); ?></button>
 					<# } #>
 				<# } #>
 			<# } else { #>
@@ -444,15 +444,15 @@ if ( $tab ) {
 					/* translators: %s: Theme name. */
 					$aria_label = sprintf( _x( 'Install %s', 'theme' ), '{{ data.name }}' );
 					?>
-					<a class="button button-primary theme-install" data-name="{{ data.name }}" data-slug="{{ data.id }}" href="{{ data.install_url }}" aria-label="<?php echo esc_attr( $aria_label ); ?>"><?php _e( 'Install' ); ?></a>
-					<button class="button preview install-theme-preview"><?php echo esc_html_x( 'Preview', 'verb' ); ?></button>
+					<a class="button button-compact button-primary theme-install" data-name="{{ data.name }}" data-slug="{{ data.id }}" href="{{ data.install_url }}" aria-label="<?php echo esc_attr( $aria_label ); ?>"><?php _e( 'Install' ); ?></a>
+					<button class="button button-compact preview install-theme-preview"><?php echo esc_html_x( 'Preview', 'verb' ); ?></button>
 				<# } else { #>
 					<?php
 					/* translators: %s: Theme name. */
 					$aria_label = sprintf( _x( 'Cannot Install %s', 'theme' ), '{{ data.name }}' );
 					?>
-					<a class="button button-primary disabled" data-name="{{ data.name }}" aria-label="<?php echo esc_attr( $aria_label ); ?>"><?php _ex( 'Cannot Install', 'theme' ); ?></a>
-					<button class="button disabled"><?php echo esc_html_x( 'Preview', 'verb' ); ?></button>
+					<a class="button button-compact button-primary disabled" data-name="{{ data.name }}" aria-label="<?php echo esc_attr( $aria_label ); ?>"><?php _ex( 'Cannot Install', 'theme' ); ?></a>
+					<button class="button button-compact disabled"><?php echo esc_html_x( 'Preview', 'verb' ); ?></button>
 				<# } #>
 			<# } #>
 		</div>

--- a/src/wp-admin/theme-install.php
+++ b/src/wp-admin/theme-install.php
@@ -408,21 +408,21 @@ if ( $tab ) {
 					?>
 					<# if ( data.activate_url ) { #>
 						<# if ( ! data.active ) { #>
-							<a class="button button-compact button-primary activate" href="{{ data.activate_url }}" aria-label="<?php echo esc_attr( $aria_label ); ?>"><?php _e( 'Activate' ); ?></a>
+							<a class="button button-primary activate" href="{{ data.activate_url }}" aria-label="<?php echo esc_attr( $aria_label ); ?>"><?php _e( 'Activate' ); ?></a>
 						<# } else { #>
-							<button class="button button-compact button-primary disabled"><?php _ex( 'Activated', 'theme' ); ?></button>
+							<button class="button button-primary disabled"><?php _ex( 'Activated', 'theme' ); ?></button>
 						<# } #>
 					<# } #>
 					<# if ( data.customize_url ) { #>
 						<# if ( ! data.active ) { #>
 							<# if ( ! data.block_theme ) { #>
-								<a class="button button-compact load-customize" href="{{ data.customize_url }}"><?php _e( 'Live Preview' ); ?></a>
+								<a class="button load-customize" href="{{ data.customize_url }}"><?php _e( 'Live Preview' ); ?></a>
 							<# } #>
 						<# } else { #>
-							<a class="button button-compact load-customize" href="{{ data.customize_url }}"><?php _e( 'Customize' ); ?></a>
+							<a class="button load-customize" href="{{ data.customize_url }}"><?php _e( 'Customize' ); ?></a>
 						<# } #>
 					<# } else { #>
-						<button class="button button-compact preview install-theme-preview"><?php echo esc_html_x( 'Preview', 'verb' ); ?></button>
+						<button class="button preview install-theme-preview"><?php echo esc_html_x( 'Preview', 'verb' ); ?></button>
 					<# } #>
 				<# } else { #>
 					<?php
@@ -430,12 +430,12 @@ if ( $tab ) {
 					$aria_label = sprintf( _x( 'Cannot Activate %s', 'theme' ), '{{ data.name }}' );
 					?>
 					<# if ( data.activate_url ) { #>
-						<a class="button button-compact button-primary disabled" aria-label="<?php echo esc_attr( $aria_label ); ?>"><?php _ex( 'Cannot Activate', 'theme' ); ?></a>
+						<a class="button button-primary disabled" aria-label="<?php echo esc_attr( $aria_label ); ?>"><?php _ex( 'Cannot Activate', 'theme' ); ?></a>
 					<# } #>
 					<# if ( data.customize_url ) { #>
-						<a class="button button-compact disabled"><?php _e( 'Live Preview' ); ?></a>
+						<a class="button disabled"><?php _e( 'Live Preview' ); ?></a>
 					<# } else { #>
-						<button class="button button-compact disabled"><?php echo esc_html_x( 'Preview', 'verb' ); ?></button>
+						<button class="button disabled"><?php echo esc_html_x( 'Preview', 'verb' ); ?></button>
 					<# } #>
 				<# } #>
 			<# } else { #>
@@ -444,15 +444,15 @@ if ( $tab ) {
 					/* translators: %s: Theme name. */
 					$aria_label = sprintf( _x( 'Install %s', 'theme' ), '{{ data.name }}' );
 					?>
-					<a class="button button-compact button-primary theme-install" data-name="{{ data.name }}" data-slug="{{ data.id }}" href="{{ data.install_url }}" aria-label="<?php echo esc_attr( $aria_label ); ?>"><?php _e( 'Install' ); ?></a>
-					<button class="button button-compact preview install-theme-preview"><?php echo esc_html_x( 'Preview', 'verb' ); ?></button>
+					<a class="button button-primary theme-install" data-name="{{ data.name }}" data-slug="{{ data.id }}" href="{{ data.install_url }}" aria-label="<?php echo esc_attr( $aria_label ); ?>"><?php _e( 'Install' ); ?></a>
+					<button class="button preview install-theme-preview"><?php echo esc_html_x( 'Preview', 'verb' ); ?></button>
 				<# } else { #>
 					<?php
 					/* translators: %s: Theme name. */
 					$aria_label = sprintf( _x( 'Cannot Install %s', 'theme' ), '{{ data.name }}' );
 					?>
-					<a class="button button-compact button-primary disabled" data-name="{{ data.name }}" aria-label="<?php echo esc_attr( $aria_label ); ?>"><?php _ex( 'Cannot Install', 'theme' ); ?></a>
-					<button class="button button-compact disabled"><?php echo esc_html_x( 'Preview', 'verb' ); ?></button>
+					<a class="button button-primary disabled" data-name="{{ data.name }}" aria-label="<?php echo esc_attr( $aria_label ); ?>"><?php _ex( 'Cannot Install', 'theme' ); ?></a>
+					<button class="button disabled"><?php echo esc_html_x( 'Preview', 'verb' ); ?></button>
 				<# } #>
 			<# } #>
 		</div>
@@ -487,18 +487,18 @@ if ( $tab ) {
 					$aria_label = sprintf( _x( 'Activate %s', 'theme' ), '{{ data.name }}' );
 					?>
 					<# if ( ! data.active ) { #>
-						<a class="button button-primary button-compact activate" href="{{ data.activate_url }}" aria-label="<?php echo esc_attr( $aria_label ); ?>"><?php _e( 'Activate' ); ?></a>
+						<a class="button button-primary activate" href="{{ data.activate_url }}" aria-label="<?php echo esc_attr( $aria_label ); ?>"><?php _e( 'Activate' ); ?></a>
 					<# } else { #>
-						<button class="button button-primary button-compact disabled"><?php _ex( 'Activated', 'theme' ); ?></button>
+						<button class="button button-primary disabled"><?php _ex( 'Activated', 'theme' ); ?></button>
 					<# } #>
 				<# } else { #>
-					<a class="button button-primary button-compact disabled" ><?php _ex( 'Cannot Activate', 'theme' ); ?></a>
+					<a class="button button-primary disabled" ><?php _ex( 'Cannot Activate', 'theme' ); ?></a>
 				<# } #>
 			<# } else { #>
 				<# if ( data.compatible_wp && data.compatible_php ) { #>
-					<a href="{{ data.install_url }}" class="button button-primary button-compact theme-install" data-name="{{ data.name }}" data-slug="{{ data.id }}"><?php _e( 'Install' ); ?></a>
+					<a href="{{ data.install_url }}" class="button button-primary theme-install" data-name="{{ data.name }}" data-slug="{{ data.id }}"><?php _e( 'Install' ); ?></a>
 				<# } else { #>
-					<a class="button button-primary button-compact disabled" ><?php _ex( 'Cannot Install', 'theme' ); ?></a>
+					<a class="button button-primary disabled" ><?php _ex( 'Cannot Install', 'theme' ); ?></a>
 				<# } #>
 			<# } #>
 		</div>

--- a/src/wp-admin/theme-install.php
+++ b/src/wp-admin/theme-install.php
@@ -408,21 +408,21 @@ if ( $tab ) {
 					?>
 					<# if ( data.activate_url ) { #>
 						<# if ( ! data.active ) { #>
-							<a class="button button-primary activate" href="{{ data.activate_url }}" aria-label="<?php echo esc_attr( $aria_label ); ?>"><?php _e( 'Activate' ); ?></a>
+							<a class="button button-primary button-compact activate" href="{{ data.activate_url }}" aria-label="<?php echo esc_attr( $aria_label ); ?>"><?php _e( 'Activate' ); ?></a>
 						<# } else { #>
-							<button class="button button-primary disabled"><?php _ex( 'Activated', 'theme' ); ?></button>
+							<button class="button button-primary button-compact disabled"><?php _ex( 'Activated', 'theme' ); ?></button>
 						<# } #>
 					<# } #>
 					<# if ( data.customize_url ) { #>
 						<# if ( ! data.active ) { #>
 							<# if ( ! data.block_theme ) { #>
-								<a class="button load-customize" href="{{ data.customize_url }}"><?php _e( 'Live Preview' ); ?></a>
+								<a class="button button-compact load-customize" href="{{ data.customize_url }}"><?php _e( 'Live Preview' ); ?></a>
 							<# } #>
 						<# } else { #>
-							<a class="button load-customize" href="{{ data.customize_url }}"><?php _e( 'Customize' ); ?></a>
+							<a class="button button-compact load-customize" href="{{ data.customize_url }}"><?php _e( 'Customize' ); ?></a>
 						<# } #>
 					<# } else { #>
-						<button class="button preview install-theme-preview"><?php echo esc_html_x( 'Preview', 'verb' ); ?></button>
+						<button class="button button-compact preview install-theme-preview"><?php echo esc_html_x( 'Preview', 'verb' ); ?></button>
 					<# } #>
 				<# } else { #>
 					<?php
@@ -430,12 +430,12 @@ if ( $tab ) {
 					$aria_label = sprintf( _x( 'Cannot Activate %s', 'theme' ), '{{ data.name }}' );
 					?>
 					<# if ( data.activate_url ) { #>
-						<a class="button button-primary disabled" aria-label="<?php echo esc_attr( $aria_label ); ?>"><?php _ex( 'Cannot Activate', 'theme' ); ?></a>
+						<a class="button button-primary button-compact disabled" aria-label="<?php echo esc_attr( $aria_label ); ?>"><?php _ex( 'Cannot Activate', 'theme' ); ?></a>
 					<# } #>
 					<# if ( data.customize_url ) { #>
-						<a class="button disabled"><?php _e( 'Live Preview' ); ?></a>
+						<a class="button button-compact disabled"><?php _e( 'Live Preview' ); ?></a>
 					<# } else { #>
-						<button class="button disabled"><?php echo esc_html_x( 'Preview', 'verb' ); ?></button>
+						<button class="button button-compact disabled"><?php echo esc_html_x( 'Preview', 'verb' ); ?></button>
 					<# } #>
 				<# } #>
 			<# } else { #>
@@ -444,15 +444,15 @@ if ( $tab ) {
 					/* translators: %s: Theme name. */
 					$aria_label = sprintf( _x( 'Install %s', 'theme' ), '{{ data.name }}' );
 					?>
-					<a class="button button-primary theme-install" data-name="{{ data.name }}" data-slug="{{ data.id }}" href="{{ data.install_url }}" aria-label="<?php echo esc_attr( $aria_label ); ?>"><?php _e( 'Install' ); ?></a>
-					<button class="button preview install-theme-preview"><?php echo esc_html_x( 'Preview', 'verb' ); ?></button>
+					<a class="button button-primary button-compact theme-install" data-name="{{ data.name }}" data-slug="{{ data.id }}" href="{{ data.install_url }}" aria-label="<?php echo esc_attr( $aria_label ); ?>"><?php _e( 'Install' ); ?></a>
+					<button class="button button-compact preview install-theme-preview"><?php echo esc_html_x( 'Preview', 'verb' ); ?></button>
 				<# } else { #>
 					<?php
 					/* translators: %s: Theme name. */
 					$aria_label = sprintf( _x( 'Cannot Install %s', 'theme' ), '{{ data.name }}' );
 					?>
-					<a class="button button-primary disabled" data-name="{{ data.name }}" aria-label="<?php echo esc_attr( $aria_label ); ?>"><?php _ex( 'Cannot Install', 'theme' ); ?></a>
-					<button class="button disabled"><?php echo esc_html_x( 'Preview', 'verb' ); ?></button>
+					<a class="button button-primary button-compact disabled" data-name="{{ data.name }}" aria-label="<?php echo esc_attr( $aria_label ); ?>"><?php _ex( 'Cannot Install', 'theme' ); ?></a>
+					<button class="button button-compact disabled"><?php echo esc_html_x( 'Preview', 'verb' ); ?></button>
 				<# } #>
 			<# } #>
 		</div>

--- a/src/wp-admin/themes.php
+++ b/src/wp-admin/themes.php
@@ -381,18 +381,18 @@ if ( is_array( $submenu ) && isset( $submenu['themes.php'] ) ) {
 			$menu_hook           = get_plugin_page_hook( $submenu[ $item[2] ][0][2], $item[2] );
 
 			if ( file_exists( WP_PLUGIN_DIR . "/{$submenu[$item[2]][0][2]}" ) || ! empty( $menu_hook ) ) {
-				$current_theme_actions[] = "<a class='button$class' href='admin.php?page={$submenu[$item[2]][0][2]}'>{$item[0]}</a>";
+				$current_theme_actions[] = "<a class='button button-compact$class' href='admin.php?page={$submenu[$item[2]][0][2]}'>{$item[0]}</a>";
 			} else {
-				$current_theme_actions[] = "<a class='button$class' href='{$submenu[$item[2]][0][2]}'>{$item[0]}</a>";
+				$current_theme_actions[] = "<a class='button button-compact$class' href='{$submenu[$item[2]][0][2]}'>{$item[0]}</a>";
 			}
 		} elseif ( ! empty( $item[2] ) && current_user_can( $item[1] ) ) {
 			$menu_file = $item[2];
 
 			if ( current_user_can( 'customize' ) ) {
 				if ( 'custom-header' === $menu_file ) {
-					$current_theme_actions[] = "<a class='button hide-if-no-customize$class' href='customize.php?autofocus[control]=header_image'>{$item[0]}</a>";
+					$current_theme_actions[] = "<a class='button button-compact hide-if-no-customize$class' href='customize.php?autofocus[control]=header_image'>{$item[0]}</a>";
 				} elseif ( 'custom-background' === $menu_file ) {
-					$current_theme_actions[] = "<a class='button hide-if-no-customize$class' href='customize.php?autofocus[control]=background_image'>{$item[0]}</a>";
+					$current_theme_actions[] = "<a class='button button-compact hide-if-no-customize$class' href='customize.php?autofocus[control]=background_image'>{$item[0]}</a>";
 				}
 			}
 
@@ -402,9 +402,9 @@ if ( is_array( $submenu ) && isset( $submenu['themes.php'] ) ) {
 			}
 
 			if ( file_exists( ABSPATH . "wp-admin/$menu_file" ) ) {
-				$current_theme_actions[] = "<a class='button$class' href='{$item[2]}'>{$item[0]}</a>";
+				$current_theme_actions[] = "<a class='button button-compact$class' href='{$item[2]}'>{$item[0]}</a>";
 			} else {
-				$current_theme_actions[] = "<a class='button$class' href='themes.php?page={$item[2]}'>{$item[0]}</a>";
+				$current_theme_actions[] = "<a class='button button-compact$class' href='themes.php?page={$item[2]}'>{$item[0]}</a>";
 			}
 		}
 	}

--- a/src/wp-admin/themes.php
+++ b/src/wp-admin/themes.php
@@ -609,7 +609,7 @@ foreach ( $themes as $theme ) :
 				/* translators: %s: Theme name. */
 				$customize_aria_label = sprintf( _x( 'Customize %s', 'theme' ), $theme['name'] );
 				?>
-				<a class="button button-primary customize load-customize hide-if-no-customize"
+				<a class="button button-compact button-primary customize load-customize hide-if-no-customize"
 					href="<?php echo esc_url( $theme['actions']['customize'] ); ?>"
 					aria-label="<?php echo esc_attr( $customize_aria_label ); ?>"
 				><?php _e( 'Customize' ); ?></a>
@@ -619,7 +619,7 @@ foreach ( $themes as $theme ) :
 			/* translators: %s: Theme name. */
 			$aria_label = sprintf( _x( 'Activate %s', 'theme' ), '{{ data.name }}' );
 			?>
-			<a class="button activate"
+			<a class="button button-compact activate"
 				href="<?php echo esc_url( $theme['actions']['activate'] ); ?>"
 				aria-label="<?php echo esc_attr( $aria_label ); ?>"
 			><?php _e( 'Activate' ); ?></a>
@@ -630,7 +630,7 @@ foreach ( $themes as $theme ) :
 				/* translators: %s: Theme name. */
 				$live_preview_aria_label = sprintf( _x( 'Live Preview %s', 'theme' ), '{{ data.name }}' );
 				?>
-				<a class="button button-primary load-customize hide-if-no-customize"
+				<a class="button button-compact button-primary load-customize hide-if-no-customize"
 					href="<?php echo esc_url( $theme['actions']['customize'] ); ?>"
 					aria-label="<?php echo esc_attr( $live_preview_aria_label ); ?>"
 				><?php _e( 'Live Preview' ); ?></a>
@@ -640,7 +640,7 @@ foreach ( $themes as $theme ) :
 			/* translators: %s: Theme name. */
 			$aria_label = sprintf( _x( 'Cannot Activate %s', 'theme' ), '{{ data.name }}' );
 			?>
-			<a class="button disabled"
+			<a class="button button-compact disabled"
 				aria-label="<?php echo esc_attr( $aria_label ); ?>"
 			><?php _ex( 'Cannot Activate', 'theme' ); ?></a>
 
@@ -649,7 +649,7 @@ foreach ( $themes as $theme ) :
 				/* translators: %s: Theme name. */
 				$live_preview_aria_label = sprintf( _x( 'Live Preview %s', 'theme' ), '{{ data.name }}' );
 				?>
-				<a class="button button-primary hide-if-no-customize disabled"
+				<a class="button button-compact button-primary hide-if-no-customize disabled"
 					aria-label="<?php echo esc_attr( $live_preview_aria_label ); ?>"
 				><?php _e( 'Live Preview' ); ?></a>
 			<?php } ?>
@@ -1001,7 +1001,7 @@ function wp_theme_auto_update_setting_template() {
 					/* translators: %s: Theme name. */
 					$customize_aria_label = sprintf( _x( 'Customize %s', 'theme' ), '{{ data.name }}' );
 					?>
-					<a class="button button-primary customize load-customize hide-if-no-customize"
+					<a class="button button-compact button-primary customize load-customize hide-if-no-customize"
 						href="{{{ data.actions.customize }}}"
 						aria-label="<?php echo esc_attr( $customize_aria_label ); ?>"
 					><?php _e( 'Customize' ); ?></a>
@@ -1012,7 +1012,7 @@ function wp_theme_auto_update_setting_template() {
 					/* translators: %s: Theme name. */
 					$aria_label = sprintf( _x( 'Activate %s', 'theme' ), '{{ data.name }}' );
 					?>
-					<a class="button activate"
+					<a class="button button-compact activate"
 						href="{{{ data.actions.activate }}}"
 						aria-label="<?php echo esc_attr( $aria_label ); ?>"
 					><?php _e( 'Activate' ); ?></a>
@@ -1021,7 +1021,7 @@ function wp_theme_auto_update_setting_template() {
 					/* translators: %s: Theme name. */
 					$live_preview_aria_label = sprintf( _x( 'Live Preview %s', 'theme' ), '{{ data.name }}' );
 					?>
-					<a class="button button-primary load-customize hide-if-no-customize"
+					<a class="button button-compact button-primary load-customize hide-if-no-customize"
 						href="{{{ data.actions.customize }}}"
 						aria-label="<?php echo esc_attr( $live_preview_aria_label ); ?>"
 					><?php _e( 'Live Preview' ); ?></a>
@@ -1030,7 +1030,7 @@ function wp_theme_auto_update_setting_template() {
 					/* translators: %s: Theme name. */
 					$aria_label = sprintf( _x( 'Cannot Activate %s', 'theme' ), '{{ data.name }}' );
 					?>
-					<a class="button disabled"
+					<a class="button button-compact disabled"
 						aria-label="<?php echo esc_attr( $aria_label ); ?>"
 					><?php _ex( 'Cannot Activate', 'theme' ); ?></a>
 
@@ -1038,7 +1038,7 @@ function wp_theme_auto_update_setting_template() {
 					/* translators: %s: Theme name. */
 					$live_preview_aria_label = sprintf( _x( 'Live Preview %s', 'theme' ), '{{ data.name }}' );
 					?>
-					<a class="button button-primary hide-if-no-customize disabled"
+					<a class="button button-compact button-primary hide-if-no-customize disabled"
 						aria-label="<?php echo esc_attr( $live_preview_aria_label ); ?>"
 					><?php _e( 'Live Preview' ); ?></a>
 				<# } #>
@@ -1251,7 +1251,7 @@ function wp_theme_auto_update_setting_template() {
 
 		<div class="theme-actions">
 			<div class="active-theme">
-				<a class="button button-primary customize load-customize hide-if-no-customize"
+				<a class="button button-compact button-primary customize load-customize hide-if-no-customize"
 					href="{{{ data.actions.customize }}}"
 				><?php _e( 'Customize' ); ?></a>
 				<?php echo implode( ' ', $current_theme_actions ); ?>
@@ -1263,7 +1263,7 @@ function wp_theme_auto_update_setting_template() {
 					/* translators: %s: Theme name. */
 					$live_preview_aria_label = sprintf( _x( 'Live Preview %s', 'theme' ), '{{ data.name }}' );
 					?>
-					<a class="button button-primary load-customize hide-if-no-customize"
+					<a class="button button-compact button-primary load-customize hide-if-no-customize"
 						href="{{{ data.actions.customize }}}"
 						aria-label="<?php echo esc_attr( $live_preview_aria_label ); ?>"
 					><?php _e( 'Live Preview' ); ?></a>
@@ -1273,7 +1273,7 @@ function wp_theme_auto_update_setting_template() {
 						/* translators: %s: Theme name. */
 						$aria_label = sprintf( _x( 'Activate %s', 'theme' ), '{{ data.name }}' );
 						?>
-						<a class="button activate"
+						<a class="button button-compact activate"
 							href="{{{ data.actions.activate }}}"
 							aria-label="<?php echo esc_attr( $aria_label ); ?>"
 						><?php _e( 'Activate' ); ?></a>
@@ -1283,7 +1283,7 @@ function wp_theme_auto_update_setting_template() {
 					/* translators: %s: Theme name. */
 					$live_preview_aria_label = sprintf( _x( 'Live Preview %s', 'theme' ), '{{ data.name }}' );
 					?>
-					<a class="button button-primary hide-if-no-customize disabled"
+					<a class="button button-compact button-primary hide-if-no-customize disabled"
 						aria-label="<?php echo esc_attr( $live_preview_aria_label ); ?>"
 					><?php _e( 'Live Preview' ); ?></a>
 
@@ -1292,7 +1292,7 @@ function wp_theme_auto_update_setting_template() {
 						/* translators: %s: Theme name. */
 						$aria_label = sprintf( _x( 'Cannot Activate %s', 'theme' ), '{{ data.name }}' );
 						?>
-						<a class="button disabled"
+						<a class="button button-compact disabled"
 							aria-label="<?php echo esc_attr( $aria_label ); ?>"
 						><?php _ex( 'Cannot Activate', 'theme' ); ?></a>
 					<# } #>
@@ -1304,7 +1304,7 @@ function wp_theme_auto_update_setting_template() {
 				/* translators: %s: Theme name. */
 				$aria_label = sprintf( _x( 'Delete %s', 'theme' ), '{{ data.name }}' );
 				?>
-				<a class="button delete-theme"
+				<a class="button button-compact delete-theme"
 					href="{{{ data.actions['delete'] }}}"
 					aria-label="<?php echo esc_attr( $aria_label ); ?>"
 				><?php _e( 'Delete' ); ?></a>

--- a/src/wp-includes/css/buttons.css
+++ b/src/wp-includes/css/buttons.css
@@ -404,7 +404,6 @@ TABLE OF CONTENTS:
 		font-size: 14px;
 		vertical-align: middle;
 		min-height: 40px;
-		margin-bottom: 4px;
 	}
 
 	/* Responsive Button Icons - Dashicons centering */

--- a/src/wp-includes/css/buttons.css
+++ b/src/wp-includes/css/buttons.css
@@ -404,6 +404,7 @@ TABLE OF CONTENTS:
 		font-size: 14px;
 		vertical-align: middle;
 		min-height: 40px;
+		margin-bottom: 4px;
 	}
 
 	/* Responsive Button Icons - Dashicons centering */


### PR DESCRIPTION

Trac ticket: https://core.trac.wordpress.org/ticket/64999

This PR fixes inconsistent interactive element heights to 40px in the admin mobile viewport (≤782px) on:

- **Plugins > Add Plugin**: search field, Keyword dropdown, Install button
- **Media Library > Grid**: filter dropdowns, search field, Bulk select button
- **Settings > General**: Custom date format and time format inputs

Follow-up to [62294].


Tested in Chrome at 782px viewport width (mobile emulation). Before/after
screenshots attached.

| Screen / Component | Before | After |
|---|---|---|
| Add Themes > Search field | <img width="619" height="665" alt="Before Add Themes Search Field" src="https://github.com/user-attachments/assets/da089ef7-7606-4aa2-bae7-49e25164527f" /> | <img width="605" height="666" alt="After Add Themes Search Field" src="https://github.com/user-attachments/assets/65cb0a15-ce39-4634-8ac7-a5c343e3762d" /> |
| Settings > General > Custom date/time format inputs | <img width="612" height="668" alt="Before Custom Date Time Inputs" src="https://github.com/user-attachments/assets/7f3cee14-9d04-45dc-ab81-99df3955608a" /> | <img width="607" height="667" alt="After Custom Date Time Inputs" src="https://github.com/user-attachments/assets/85c672c7-d253-4d9a-87f1-cffbea22b31c" /> |
| Plugins > Add Plugin > Search field | <img width="607" height="666" alt="Before Plugin Search Field" src="https://github.com/user-attachments/assets/e07af0a2-1edc-4a04-b40d-85b055047fb4" /> | <img width="606" height="663" alt="After Plugin Search Field" src="https://github.com/user-attachments/assets/15ab8ec5-70eb-44f8-9213-8a460248f724" /> |
| Plugins > Add Plugin > Keyword dropdown | <img width="610" height="663" alt="Before Plugin Keyword Dropdown" src="https://github.com/user-attachments/assets/aca8e78a-d7f1-44bd-859a-77900d6fb1e4" /> | <img width="614" height="664" alt="After Plugin Keyword Dropdown" src="https://github.com/user-attachments/assets/1a16ead1-5c12-4c06-bbbe-f627ae0c37c3" /> |
| Media Library > Grid > Filter dropdowns | <img width="805" height="665" alt="Before Media Filter Dropdowns" src="https://github.com/user-attachments/assets/89b9b26c-b5ee-4cfe-8610-9ae6030c023c" /> | <img width="809" height="672" alt="After Media Filter Dropdowns" src="https://github.com/user-attachments/assets/a50f6464-c873-4d56-b721-7dd8b452abf0" /> |
| Media Library > Grid > Search input | <img width="802" height="663" alt="Before Media Search Input" src="https://github.com/user-attachments/assets/91146225-51e3-4548-8876-9739135ac53e" /> | <img width="795" height="659" alt="After Media Search Input" src="https://github.com/user-attachments/assets/7d7bd55b-78aa-4bac-8bd7-86fde206e68a" /> |
| Media Library > Grid > Bulk select button | <img width="798" height="664" alt="Before Bulk Select Button" src="https://github.com/user-attachments/assets/70c14a7d-c019-4d44-879a-58604e6ed62a" /> | <img width="803" height="664" alt="After Bulk Select Button" src="https://github.com/user-attachments/assets/c7c02f78-1481-4220-9c8d-59777e44cb91" /> |