### PR TITLE
Add unit tests for wp_admin_canonical_url() in wp-admin/includes/misc…

### DIFF
--- a/tests/phpunit/tests/admin/includes/misc/wpAdminCanonicalUrl.php
+++ b/tests/phpunit/tests/admin/includes/misc/wpAdminCanonicalUrl.php
@@ -55,7 +55,7 @@ class Tests_Admin_Includes_Misc_WpAdminCanonicalUrl extends WP_UnitTestCase {
 	 */
 	public function data_wp_admin_canonical_url(): array {
 		return array(
-			'no removable query args'           => array(
+			'no removable query args'          => array(
 				'server_vars' => array(
 					'HTTP_HOST'   => 'example.org',
 					'REQUEST_URI' => '/wp-admin/index.php',

--- a/tests/phpunit/tests/admin/includes/misc/wpAdminCanonicalUrl.php
+++ b/tests/phpunit/tests/admin/includes/misc/wpAdminCanonicalUrl.php
@@ -59,7 +59,7 @@ class Tests_Admin_Includes_Misc_WpAdminCanonicalUrl extends WP_UnitTestCase {
 	 */
 	public function data_wp_admin_canonical_url(): array {
 		return array(
-			'no removable query args'          => array(
+			'no removable query args'            => array(
 				'server_vars' => array(
 					'HTTP_HOST'   => 'example.org',
 					'REQUEST_URI' => '/wp-admin/index.php',

--- a/tests/phpunit/tests/admin/includes/misc/wpAdminCanonicalUrl.php
+++ b/tests/phpunit/tests/admin/includes/misc/wpAdminCanonicalUrl.php
@@ -55,28 +55,28 @@ class Tests_Admin_Includes_Misc_WpAdminCanonicalUrl extends WP_UnitTestCase {
 	 */
 	public function data_wp_admin_canonical_url(): array {
 		return array(
-			'no removable query args'            => array(
+			'no removable query args'           => array(
 				'server_vars' => array(
 					'HTTP_HOST'   => 'example.org',
 					'REQUEST_URI' => '/wp-admin/index.php',
 				),
 				'expected'    => 'href="http://example.org/wp-admin/index.php"',
 			),
-			'with removable query args'           => array(
+			'with removable query args'          => array(
 				'server_vars' => array(
 					'HTTP_HOST'   => 'example.org',
 					'REQUEST_URI' => '/wp-admin/index.php?settings-updated=true&other=arg',
 				),
 				'expected'    => 'href="http://example.org/wp-admin/index.php?other=arg"',
 			),
-			'with multiple removable query args'  => array(
+			'with multiple removable query args' => array(
 				'server_vars' => array(
 					'HTTP_HOST'   => 'example.org',
 					'REQUEST_URI' => '/wp-admin/edit.php?trashed=1&locked=1&paged=2',
 				),
 				'expected'    => 'href="http://example.org/wp-admin/edit.php?paged=2"',
 			),
-			'with https'                          => array(
+			'with https'                         => array(
 				'server_vars' => array(
 					'HTTP_HOST'   => 'example.org',
 					'REQUEST_URI' => '/wp-admin/index.php',

--- a/tests/phpunit/tests/admin/includes/misc/wpAdminCanonicalUrl.php
+++ b/tests/phpunit/tests/admin/includes/misc/wpAdminCanonicalUrl.php
@@ -4,6 +4,8 @@
  *
  * @group admin
  * @group misc
+ *
+ * @covers ::wp_admin_canonical_url
  */
 class Tests_Admin_Includes_Misc_WpAdminCanonicalUrl extends WP_UnitTestCase {
 
@@ -26,6 +28,8 @@ class Tests_Admin_Includes_Misc_WpAdminCanonicalUrl extends WP_UnitTestCase {
 
 	/**
 	 * Tests wp_admin_canonical_url().
+	 *
+	 * @ticket 65192
 	 *
 	 * @dataProvider data_wp_admin_canonical_url
 	 *
@@ -55,7 +59,7 @@ class Tests_Admin_Includes_Misc_WpAdminCanonicalUrl extends WP_UnitTestCase {
 	 */
 	public function data_wp_admin_canonical_url(): array {
 		return array(
-			'no removable query args'           => array(
+			'no removable query args'          => array(
 				'server_vars' => array(
 					'HTTP_HOST'   => 'example.org',
 					'REQUEST_URI' => '/wp-admin/index.php',
@@ -89,6 +93,8 @@ class Tests_Admin_Includes_Misc_WpAdminCanonicalUrl extends WP_UnitTestCase {
 
 	/**
 	 * Tests wp_admin_canonical_url() when removable query args are filtered to be empty.
+	 *
+	 * @ticket 65192
 	 */
 	public function test_wp_admin_canonical_url_empty_removable_args() {
 		add_filter( 'removable_query_args', '__return_empty_array' );
@@ -104,6 +110,8 @@ class Tests_Admin_Includes_Misc_WpAdminCanonicalUrl extends WP_UnitTestCase {
 
 	/**
 	 * Tests the wp_admin_canonical_url filter.
+	 *
+	 * @ticket 65192
 	 */
 	public function test_wp_admin_canonical_url_filter() {
 		$_SERVER['HTTP_HOST']   = 'example.org';

--- a/tests/phpunit/tests/admin/includes/misc/wpAdminCanonicalUrl.php
+++ b/tests/phpunit/tests/admin/includes/misc/wpAdminCanonicalUrl.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * Test wp_admin_canonical_url().
+ *
+ * @group admin
+ * @group misc
+ */
+class Tests_Admin_Includes_Misc_WpAdminCanonicalUrl extends WP_UnitTestCase {
+
+	/**
+	 * Original $_SERVER values.
+	 *
+	 * @var array
+	 */
+	private $server_orig;
+
+	public function set_up() {
+		parent::set_up();
+		$this->server_orig = $_SERVER;
+	}
+
+	public function tear_down() {
+		$_SERVER = $this->server_orig;
+		parent::tear_down();
+	}
+
+	/**
+	 * Tests wp_admin_canonical_url().
+	 *
+	 * @dataProvider data_wp_admin_canonical_url
+	 *
+	 * @param array  $server_vars $_SERVER variables to set.
+	 * @param string $expected    Expected output substring.
+	 */
+	public function test_wp_admin_canonical_url( array $server_vars, $expected ) {
+		foreach ( $server_vars as $key => $value ) {
+			$_SERVER[ $key ] = $value;
+		}
+
+		ob_start();
+		wp_admin_canonical_url();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( $expected, $output );
+		$this->assertStringContainsString( '<script>', $output );
+	}
+
+	/**
+	 * Data provider for test_wp_admin_canonical_url.
+	 *
+	 * @return array<string, array{
+	 *     server_vars: array<string, string>,
+	 *     expected:    string
+	 * }>
+	 */
+	public function data_wp_admin_canonical_url(): array {
+		return array(
+			'no removable query args'            => array(
+				'server_vars' => array(
+					'HTTP_HOST'   => 'example.org',
+					'REQUEST_URI' => '/wp-admin/index.php',
+				),
+				'expected'    => 'href="http://example.org/wp-admin/index.php"',
+			),
+			'with removable query args'           => array(
+				'server_vars' => array(
+					'HTTP_HOST'   => 'example.org',
+					'REQUEST_URI' => '/wp-admin/index.php?settings-updated=true&other=arg',
+				),
+				'expected'    => 'href="http://example.org/wp-admin/index.php?other=arg"',
+			),
+			'with multiple removable query args'  => array(
+				'server_vars' => array(
+					'HTTP_HOST'   => 'example.org',
+					'REQUEST_URI' => '/wp-admin/edit.php?trashed=1&locked=1&paged=2',
+				),
+				'expected'    => 'href="http://example.org/wp-admin/edit.php?paged=2"',
+			),
+			'with https'                          => array(
+				'server_vars' => array(
+					'HTTP_HOST'   => 'example.org',
+					'REQUEST_URI' => '/wp-admin/index.php',
+					'HTTPS'       => 'on',
+				),
+				'expected'    => 'href="https://example.org/wp-admin/index.php"',
+			),
+		);
+	}
+
+	/**
+	 * Tests wp_admin_canonical_url() when removable query args are filtered to be empty.
+	 */
+	public function test_wp_admin_canonical_url_empty_removable_args() {
+		add_filter( 'removable_query_args', '__return_empty_array' );
+
+		ob_start();
+		wp_admin_canonical_url();
+		$output = ob_get_clean();
+
+		remove_filter( 'removable_query_args', '__return_empty_array' );
+
+		$this->assertEmpty( $output, 'Output should be empty when removable query args are filtered to be empty.' );
+	}
+
+	/**
+	 * Tests the wp_admin_canonical_url filter.
+	 */
+	public function test_wp_admin_canonical_url_filter() {
+		$_SERVER['HTTP_HOST']   = 'example.org';
+		$_SERVER['REQUEST_URI'] = '/wp-admin/index.php?settings-updated=true';
+
+		add_filter( 'wp_admin_canonical_url', array( $this, 'filter_canonical_url' ) );
+
+		ob_start();
+		wp_admin_canonical_url();
+		$output = ob_get_clean();
+
+		remove_filter( 'wp_admin_canonical_url', array( $this, 'filter_canonical_url' ) );
+
+		$this->assertStringContainsString( 'href="https://custom.example.org/canonical"', $output );
+	}
+
+	public function filter_canonical_url() {
+		return 'https://custom.example.org/canonical';
+	}
+}


### PR DESCRIPTION
….php
**Description**:
This PR adds unit tests for the `wp_admin_canonical_url()` function in `wp-admin/includes/misc.php`. These tests ensure that the function correctly identifies and removes single-use query parameters (such as `settings-updated`, `trashed`, etc.) from the administration URL to generate a clean canonical link.

The tests cover:
- Standard canonical URL generation for common admin screens.
- Successful removal of one or more "removable" query arguments.
- Correct handling of HTTPS URLs.
- Verification that no output is generated if the list of removable arguments is empty (via filter).
- Verification of the `wp_admin_canonical_url` filter for custom canonical URLs.

Trac ticket: https://core.trac.wordpress.org/ticket/65192

**AI Disclosure**:
- AI assistance: Yes
- Tool(s): Junie (JetBrains)
- Model(s): gemini-3-flash-preview
- Used for: Code analysis, test implementation, and workflow management.
