### PR TITLE
Plugins: Update custom view counts when deleting a plugin.

### DIFF
--- a/src/js/_enqueues/wp/updates.js
+++ b/src/js/_enqueues/wp/updates.js
@@ -1377,6 +1377,11 @@
 				 * @type {Object}
 				 */
 				plugins          = settings.plugins,
+				knownKeys        = [
+					'all', 'search', 'upgrade', 'active', 'inactive',
+					'recently_activated', 'mustuse', 'dropins', 'paused',
+					'auto-update-enabled', 'auto-update-disabled'
+				],
 				remainingCount;
 
 			// Add a success message after deleting a plugin.
@@ -1444,6 +1449,29 @@
 					$views.find( '.auto-update-disabled' ).remove();
 				}
 			}
+
+			// Decrement counts for any custom group added through the
+			// `plugins_list` filter (e.g. a tab whose label is supplied
+			// via `plugins_list_status_text`, introduced in #60495).
+			_.each( _.keys( plugins ), function( key ) {
+				if ( -1 !== _.indexOf( knownKeys, key ) ) {
+					return;
+				}
+				if ( ! _.isArray( plugins[ key ] ) ) {
+					return;
+				}
+				if ( -1 === _.indexOf( plugins[ key ], response.plugin ) ) {
+					return;
+				}
+
+				plugins[ key ] = _.without( plugins[ key ], response.plugin );
+
+				if ( plugins[ key ].length ) {
+					$views.find( '.' + key + ' .count' ).text( '(' + plugins[ key ].length + ')' );
+				} else {
+					$views.find( '.' + key ).remove();
+				}
+			} );
 
 			plugins.all = _.without( plugins.all, response.plugin );
 


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65191

Decrements counts for groups registered via the `plugins_list` filter when a plugin is deleted via AJAX, so tabs whose label is supplied through `plugins_list_status_text` (introduced in [#60495](https://core.trac.wordpress.org/ticket/60495)) stay in sync without requiring a page reload. The four hardcoded buckets (`upgrade`, `inactive`, `active`, `recently_activated`) plus `auto-update-enabled` / `auto-update-disabled` keep their explicit fast paths; the new loop only runs for keys outside that set.

## Reproduction

See the steps in [Trac #65191](https://core.trac.wordpress.org/ticket/65191). TL;DR: register a group via `plugins_list` with a label supplied through `plugins_list_status_text`, delete a plugin in that group via the row action, and observe the count badge stay stale until reload.

## Test plan

- [x] Hardcoded tabs (`Active`, `Inactive`, `Update available`) still decrement on delete.
- [x] Custom group registered via `plugins_list`: count drops on delete; tab disappears at zero.
- [x] Sites with no custom groups: no behavior change.