### PR TITLE
Add unit tests for wp_refresh_heartbeat_nonces() in wp-admin/includes…

### DIFF
--- a/tests/phpunit/tests/admin/includes/misc/wpRefreshHeartbeatNonces.php
+++ b/tests/phpunit/tests/admin/includes/misc/wpRefreshHeartbeatNonces.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * Tests for the wp_refresh_heartbeat_nonces() function.
+ *
+ * @group admin
+ * @group misc
+ *
+ * @covers ::wp_refresh_heartbeat_nonces
+ */
+class Tests_Admin_Includes_Misc_WpRefreshHeartbeatNonces extends WP_UnitTestCase {
+
+	/**
+	 * Tests that wp_refresh_heartbeat_nonces() correctly adds nonces to the response.
+	 *
+	 * @ticket 65199
+	 */
+	public function test_wp_refresh_heartbeat_nonces() {
+		$response = array( 'some_data' => 'value' );
+
+		$result = wp_refresh_heartbeat_nonces( $response );
+
+		$this->assertArrayHasKey( 'rest_nonce', $result, 'The response should contain the rest_nonce.' );
+		$this->assertArrayHasKey( 'heartbeat_nonce', $result, 'The response should contain the heartbeat_nonce.' );
+		$this->assertSame( 'value', $result['some_data'], 'Existing data in the response should be preserved.' );
+
+		$this->assertNotFalse( wp_verify_nonce( $result['rest_nonce'], 'wp_rest' ), 'The rest_nonce should be valid for "wp_rest".' );
+		$this->assertNotFalse( wp_verify_nonce( $result['heartbeat_nonce'], 'heartbeat-nonce' ), 'The heartbeat_nonce should be valid for "heartbeat-nonce".' );
+	}
+
+	/**
+	 * Tests that wp_refresh_heartbeat_nonces() overwrites existing nonces if they are already present.
+	 *
+	 * @ticket 65199
+	 */
+	public function test_wp_refresh_heartbeat_nonces_overwrites_existing() {
+		$response = array(
+			'rest_nonce'      => 'old_rest_nonce',
+			'heartbeat_nonce' => 'old_heartbeat_nonce',
+		);
+
+		$result = wp_refresh_heartbeat_nonces( $response );
+
+		$this->assertNotEquals( 'old_rest_nonce', $result['rest_nonce'], 'The rest_nonce should be updated.' );
+		$this->assertNotEquals( 'old_heartbeat_nonce', $result['heartbeat_nonce'], 'The heartbeat_nonce should be updated.' );
+
+		$this->assertNotFalse( wp_verify_nonce( $result['rest_nonce'], 'wp_rest' ), 'The rest_nonce should be valid for "wp_rest".' );
+		$this->assertNotFalse( wp_verify_nonce( $result['heartbeat_nonce'], 'heartbeat-nonce' ), 'The heartbeat_nonce should be valid for "heartbeat-nonce".' );
+	}
+}


### PR DESCRIPTION
…/misc.php
**Description**:
This PR adds unit tests for the `wp_refresh_heartbeat_nonces()` function in `wp-admin/includes/misc.php`. This function is responsible for adding refreshed REST API and Heartbeat nonces to the response sent back during Heartbeat requests.

The tests cover:
- Successful addition of `rest_nonce` and `heartbeat_nonce` to an existing response array.
- Verification that existing data in the response is preserved.
- Verification that if the nonces already exist in the response, they are correctly overwritten with new, valid nonces.

Trac ticket: https://core.trac.wordpress.org/ticket/65199

**AI Disclosure**:
- AI assistance: Yes
- Tool(s): Junie (JetBrains)
- Model(s): gemini-3-flash-preview
- Used for: Code analysis, test implementation, and workflow management.
