### PR TITLE
Add unit tests for _wp_privacy_settings_filter_draft_page_titles() in…

### DIFF
--- a/tests/phpunit/tests/admin/includes/misc/wpPrivacySettingsFilterDraftPageTitles.php
+++ b/tests/phpunit/tests/admin/includes/misc/wpPrivacySettingsFilterDraftPageTitles.php
@@ -43,25 +43,25 @@ class Tests_Admin_Includes_Misc_WpPrivacySettingsFilterDraftPageTitles extends W
 	 */
 	public function data_wp_privacy_settings_filter_draft_page_titles(): array {
 		return array(
-			'draft page on privacy screen'     => array(
+			'draft page on privacy screen'   => array(
 				'expected'    => 'Privacy Policy (Draft)',
 				'title'       => 'Privacy Policy',
 				'post_status' => 'draft',
 				'screen_id'   => 'privacy',
 			),
-			'publish page on privacy screen'   => array(
+			'publish page on privacy screen' => array(
 				'expected'    => 'Privacy Policy',
 				'title'       => 'Privacy Policy',
 				'post_status' => 'publish',
 				'screen_id'   => 'privacy',
 			),
-			'draft page on other screen'       => array(
+			'draft page on other screen'     => array(
 				'expected'    => 'About Us',
 				'title'       => 'About Us',
 				'post_status' => 'draft',
 				'screen_id'   => 'edit-page',
 			),
-			'pending page on privacy screen'   => array(
+			'pending page on privacy screen' => array(
 				'expected'    => 'Privacy Policy',
 				'title'       => 'Privacy Policy',
 				'post_status' => 'pending',

--- a/tests/phpunit/tests/admin/includes/misc/wpPrivacySettingsFilterDraftPageTitles.php
+++ b/tests/phpunit/tests/admin/includes/misc/wpPrivacySettingsFilterDraftPageTitles.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Test _wp_privacy_settings_filter_draft_page_titles().
+ *
+ * @group admin
+ * @group privacy
+ *
+ * @covers ::_wp_privacy_settings_filter_draft_page_titles
+ */
+class Tests_Admin_Includes_Misc_WpPrivacySettingsFilterDraftPageTitles extends WP_UnitTestCase {
+
+	/**
+	 * Tests that _wp_privacy_settings_filter_draft_page_titles() appends '(Draft)' when appropriate.
+	 *
+	 * @ticket 65203
+	 *
+	 * @dataProvider data_wp_privacy_settings_filter_draft_page_titles
+	 *
+	 * @param string $expected    The expected title.
+	 * @param string $title       The input title.
+	 * @param string $post_status The post status.
+	 * @param string $screen_id   The current screen ID.
+	 */
+	public function test_wp_privacy_settings_filter_draft_page_titles( $expected, $title, $post_status, $screen_id ) {
+		set_current_screen( $screen_id );
+
+		$page = self::factory()->post->create_and_get( array( 'post_status' => $post_status ) );
+
+		$actual = _wp_privacy_settings_filter_draft_page_titles( $title, $page );
+
+		$this->assertSame( $expected, $actual );
+	}
+
+	/**
+	 * Data provider for test_wp_privacy_settings_filter_draft_page_titles.
+	 *
+	 * @return array<string, array{
+	 *     expected:    string,
+	 *     title:       string,
+	 *     post_status: string,
+	 *     screen_id:   string,
+	 * }>
+	 */
+	public function data_wp_privacy_settings_filter_draft_page_titles(): array {
+		return array(
+			'draft page on privacy screen'     => array(
+				'expected'    => 'Privacy Policy (Draft)',
+				'title'       => 'Privacy Policy',
+				'post_status' => 'draft',
+				'screen_id'   => 'privacy',
+			),
+			'publish page on privacy screen'   => array(
+				'expected'    => 'Privacy Policy',
+				'title'       => 'Privacy Policy',
+				'post_status' => 'publish',
+				'screen_id'   => 'privacy',
+			),
+			'draft page on other screen'       => array(
+				'expected'    => 'About Us',
+				'title'       => 'About Us',
+				'post_status' => 'draft',
+				'screen_id'   => 'edit-page',
+			),
+			'pending page on privacy screen'   => array(
+				'expected'    => 'Privacy Policy',
+				'title'       => 'Privacy Policy',
+				'post_status' => 'pending',
+				'screen_id'   => 'privacy',
+			),
+		);
+	}
+}


### PR DESCRIPTION
… wp-admin/includes/misc.php
**Description**:
This PR adds unit tests for the `_wp_privacy_settings_filter_draft_page_titles()` function in `wp-admin/includes/misc.php`. This function is responsible for appending "(Draft)" to the titles of draft pages when they are displayed in the privacy settings dropdown, ensuring that unpublished content is clearly identified.

The tests cover:
- Successful appending of "(Draft)" to a draft page title on the privacy screen.
- Verification that published page titles remain unchanged.
- Verification that draft page titles remain unchanged when not on the privacy screen.
- Verification that other non-draft statuses (like "pending") do not trigger the title modification.

Trac ticket: https://core.trac.wordpress.org/ticket/65202

**AI Disclosure**:
- AI assistance: Yes
- Tool(s): Junie (JetBrains)
- Model(s): gemini-3-flash-preview
- Used for: Code analysis, test implementation, and workflow management.
