### PR TITLE
Twenty Twenty: Fix post meta wrapper not rendering when action hooks add content without default meta

### DIFF
--- a/src/wp-content/themes/twentytwenty/inc/template-tags.php
+++ b/src/wp-content/themes/twentytwenty/inc/template-tags.php
@@ -524,8 +524,7 @@ function twentytwenty_get_post_meta( $post_id = null, $location = 'single-top' )
 		$meta_output = ob_get_clean();
 
 		// If there is meta to output, return it.
-		$meta_output_inner = trim( strip_tags( $meta_output ) );
-		if ( ( $has_meta || '' !== $meta_output_inner ) && $meta_output ) {
+		if ( ( $has_meta && $meta_output ) || '' !== wp_strip_all_tags( $meta_output ) ) {
 
 			return $meta_output;
 

--- a/src/wp-content/themes/twentytwenty/inc/template-tags.php
+++ b/src/wp-content/themes/twentytwenty/inc/template-tags.php
@@ -524,7 +524,8 @@ function twentytwenty_get_post_meta( $post_id = null, $location = 'single-top' )
 		$meta_output = ob_get_clean();
 
 		// If there is meta to output, return it.
-		if ( $has_meta && $meta_output ) {
+		$meta_output_inner = trim( strip_tags( $meta_output ) );
+		if ( ( $has_meta || '' !== $meta_output_inner ) && $meta_output ) {
 
 			return $meta_output;
 


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->
`twentytwenty_get_post_meta()` uses a `$has_meta` flag to decide whether to return the meta wrapper HTML. This flag is only set to `true` when default meta fields (author, date, tags, etc.) are present. As a result, content added via the`twentytwenty_start_of_post_meta_list` and `twentytwenty_end_of_post_meta_list` action hooks is silently discarded when no default meta exists — for example, on a post with no tags in the `single-bottom` location.

This fix checks whether the output buffer contains any content after stripping tags. The meta wrapper is now returned if either default meta or hook content is present.

Trac ticket: https://core.trac.wordpress.org/ticket/58223<!-- insert a link to the WordPress Trac ticket here -->

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
AI assistance: Yes
Tool(s): Claude
Model(s): Opus 4.6
Used for: Initial code skeleton and PR description; final implementation and tests were reviewed and edited by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
