### PR TITLE
Enhance attachment handling: Use attachment file URL when the pages are disabled

### DIFF
--- a/src/wp-admin/includes/post.php
+++ b/src/wp-admin/includes/post.php
@@ -1570,7 +1570,11 @@ function get_sample_permalink_html( $post, $new_title = null, $new_slug = null )
 			$preview_target = " target='wp-preview-{$post->ID}'";
 		} else {
 			if ( 'publish' === $post->post_status || 'attachment' === $post->post_type ) {
-				$view_link = get_permalink( $post );
+				if ( 'attachment' === $post->post_type && ! get_option( 'wp_attachment_pages_enabled' ) ) {
+					$view_link = wp_get_attachment_url( $post->ID );
+				} else {
+					$view_link = get_permalink( $post );
+				}
 			} else {
 				// Allow non-published (private, future) to be viewed at a pretty permalink, in case $post->post_name is set.
 				$view_link = str_replace( array( '%pagename%', '%postname%' ), $post->post_name, $permalink );

--- a/src/wp-admin/options-media.php
+++ b/src/wp-admin/options-media.php
@@ -98,6 +98,23 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 <?php do_settings_fields( 'media', 'default' ); ?>
 </table>
 
+<h2 class="title"><?php _e( 'Attachment pages' ); ?></h2>
+<table class="form-table" role="presentation">
+<tr>
+<th scope="row"><?php _e( 'Attachment pages' ); ?></th>
+<td>
+	<fieldset>
+		<legend class="screen-reader-text"><span><?php _e( 'Attachment pages' ); ?></span></legend>
+		<label for="wp_attachment_pages_enabled">
+			<input name="wp_attachment_pages_enabled" type="checkbox" id="wp_attachment_pages_enabled" value="1" <?php checked( '1', (string) get_option( 'wp_attachment_pages_enabled' ) ); ?> />
+			<?php _e( 'Enable attachment pages for uploaded media files' ); ?>
+		</label>
+		<p class="description"><?php _e( 'When disabled, attachment page URLs redirect to the media file URL.' ); ?></p>
+	</fieldset>
+</td>
+</tr>
+</table>
+
 <?php
 /**
  * @global array $wp_settings

--- a/src/wp-admin/options.php
+++ b/src/wp-admin/options.php
@@ -138,6 +138,7 @@ $allowed_options            = array(
 		'image_default_size',
 		'image_default_align',
 		'image_default_link_type',
+		'wp_attachment_pages_enabled',
 	),
 	'reading'    => array(
 		'posts_per_page',

--- a/src/wp-includes/media-template.php
+++ b/src/wp-includes/media-template.php
@@ -822,6 +822,7 @@ function wp_print_media_templates() {
 	</script>
 
 	<?php // Template for the Attachment display settings, used for example in the sidebar. ?>
+	<?php $wp_attachment_pages_enabled = (bool) get_option( 'wp_attachment_pages_enabled' ); ?>
 	<script type="text/html" id="tmpl-attachment-display-settings">
 		<h2><?php _e( 'Attachment Display Settings' ); ?></h2>
 
@@ -881,6 +882,7 @@ function wp_print_media_templates() {
 					<?php esc_html_e( 'Media File' ); ?>
 				<# } #>
 				</option>
+				<?php if ( $wp_attachment_pages_enabled ) : ?>
 				<option value="post">
 				<# if ( data.model.canEmbed ) { #>
 					<?php esc_html_e( 'Link to Attachment Page' ); ?>
@@ -888,6 +890,7 @@ function wp_print_media_templates() {
 					<?php esc_html_e( 'Attachment Page' ); ?>
 				<# } #>
 				</option>
+				<?php endif; ?>
 			<# if ( 'image' === data.type ) { #>
 				<option value="custom">
 					<?php esc_html_e( 'Custom URL' ); ?>
@@ -947,12 +950,16 @@ function wp_print_media_templates() {
 					data-user-setting="urlbutton"
 				<# } #>>
 
+				<?php if ( $wp_attachment_pages_enabled ) : ?>
 				<option value="post" <# if ( ! wp.media.galleryDefaults.link || 'post' === wp.media.galleryDefaults.link ) {
 					#>selected="selected"<# }
 				#>>
 					<?php esc_html_e( 'Attachment Page' ); ?>
 				</option>
 				<option value="file" <# if ( 'file' === wp.media.galleryDefaults.link ) { #>selected="selected"<# } #>>
+				<?php else : ?>
+				<option value="file" <# if ( ! wp.media.galleryDefaults.link || 'file' === wp.media.galleryDefaults.link || 'post' === wp.media.galleryDefaults.link ) { #>selected="selected"<# } #>>
+				<?php endif; ?>
 					<?php esc_html_e( 'Media File' ); ?>
 				</option>
 				<option value="none" <# if ( 'none' === wp.media.galleryDefaults.link ) { #>selected="selected"<# } #>>
@@ -1228,9 +1235,11 @@ function wp_print_media_templates() {
 							<option value="file">
 								<?php esc_html_e( 'Media File' ); ?>
 							</option>
+							<?php if ( $wp_attachment_pages_enabled ) : ?>
 							<option value="post">
 								<?php esc_html_e( 'Attachment Page' ); ?>
 							</option>
+							<?php endif; ?>
 						<# } else { #>
 							<option value="file">
 								<?php esc_html_e( 'Image URL' ); ?>

--- a/tests/phpunit/tests/admin/includesPost.php
+++ b/tests/phpunit/tests/admin/includesPost.php
@@ -707,6 +707,23 @@ class Tests_Admin_IncludesPost extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 65169
+	 */
+	public function test_get_sample_permalink_html_should_use_attachment_file_url_when_attachment_pages_are_disabled() {
+		$this->set_permalink_structure( '/%postname%/' );
+
+		wp_set_current_user( self::$admin_id );
+		update_option( 'wp_attachment_pages_enabled', 0 );
+
+		$attachment_id = self::factory()->attachment->create_upload_object( DIR_TESTDATA . '/images/canola.jpg' );
+
+		$found = get_sample_permalink_html( $attachment_id );
+
+		$this->assertStringContainsString( 'href="' . wp_get_attachment_url( $attachment_id ) . '"', $found );
+		$this->assertStringNotContainsString( 'href="' . get_permalink( $attachment_id ) . '"', $found );
+	}
+
+	/**
 	 * @ticket 32954
 	 * @ticket 18306
 	 */

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -495,6 +495,34 @@ https://w.org</a>',
 	}
 
 	/**
+	 * @ticket 65169
+	 */
+	public function test_wp_print_media_templates_hides_attachment_page_link_options_when_disabled() {
+		update_option( 'wp_attachment_pages_enabled', 0 );
+
+		ob_start();
+		wp_print_media_templates();
+		$output = ob_get_clean();
+
+		$this->assertStringNotContainsString( '<option value="post">', $output );
+		$this->assertStringContainsString( 'Media File', $output );
+	}
+
+	/**
+	 * @ticket 57913
+	 */
+	public function test_wp_print_media_templates_shows_attachment_page_link_options_when_enabled() {
+		update_option( 'wp_attachment_pages_enabled', 1 );
+
+		ob_start();
+		wp_print_media_templates();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( '<option value="post">', $output );
+		$this->assertStringContainsString( 'Attachment Page', $output );
+	}
+
+	/**
 	 * @ticket 19067
 	 * @expectedDeprecated wp_convert_bytes_to_hr
 	 */

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -509,7 +509,7 @@ https://w.org</a>',
 	}
 
 	/**
-	 * @ticket 57913
+	 * @ticket 65169
 	 */
 	public function test_wp_print_media_templates_shows_attachment_page_link_options_when_enabled() {
 		update_option( 'wp_attachment_pages_enabled', 1 );


### PR DESCRIPTION
### Summary

This PR makes WordPress consistently respect the `wp_attachment_pages_enabled` option across core UI surfaces. When attachment pages are disabled, attachment “View” links and media UI no longer surface attachment-page URLs; instead they point to (or default to) the underlying media file URL. It also introduces a Media Settings toggle for the option and adds/updates PHPUnit coverage for both enabled and disabled states.

Trac ticket: https://core.trac.wordpress.org/ticket/65169

---

### What’s changed

#### 1) Admin: Attachment “View” link respects disabled attachment pages
- In `get_sample_permalink_html()` (wp-admin permalink UI), when:
  - the post type is `attachment`, and
  - `wp_attachment_pages_enabled` is disabled,
- the “View” link now uses `wp_get_attachment_url()` instead of `get_permalink()`.

#### 2) Media templates: Hide “Attachment Page” link options when disabled
- In `wp_print_media_templates()`:
  - “Attachment Page” options are only rendered when `wp_attachment_pages_enabled` is enabled.
  - Gallery default/selection behavior is adjusted so that when attachment pages are disabled, “Media File” is treated as the default and “Attachment Page” is not offered.

#### 3) Settings: Provide a UI toggle for `wp_attachment_pages_enabled`
- Adds an “Attachment pages” section to **Settings → Media** (`options-media.php`) with a checkbox:
  - “Enable attachment pages for uploaded media files”
  - Description clarifies that when disabled, attachment page URLs redirect to the media file URL.
- Registers the option in `options.php` so it’s saved via the Settings API.

<img width="3012" height="1572" alt="image" src="https://github.com/user-attachments/assets/eabe649f-b279-4d81-9241-16ba7240d701" />


#### 4) Tests
- Adds a PHPUnit test to verify `get_sample_permalink_html()` uses the attachment file URL when attachment pages are disabled.
- Adds PHPUnit tests to confirm `wp_print_media_templates()` hides attachment-page link options when disabled and shows them when enabled.
- Includes a small test reference update related to the ticket.

---

### Behavior impact

- **User-facing:** prevents generating/showing links to attachment pages when that feature is disabled, aligning UI output with site configuration.
- **Scope:** admin permalink “View” link for attachments, media templates link options, Media Settings UI + option registration, and test coverage.

---

## Use of AI Tools

AI assistance: Yes  
Tool(s): GitHub Copilot  
Model(s): GPT-5.1  
Used for: Identifying relevant locations to respect `wp_attachment_pages_enabled` and drafting the corresponding code/test updates.