### PR TITLE
Connectors: Expose isFileModsDisabled to connector script module data

### DIFF
--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -723,7 +723,8 @@ function _wp_connectors_get_connector_script_module_data( array $data ): array {
 		$connectors[ $connector_id ] = $connector_out;
 	}
 	ksort( $connectors );
-	$data['connectors'] = $connectors;
+	$data['connectors']         = $connectors;
+	$data['isFileModsDisabled'] = ! wp_is_file_mod_allowed( 'install_plugins' );
 	return $data;
 }
 add_filter( 'script_module_data_options-connectors-wp-admin', '_wp_connectors_get_connector_script_module_data' );

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -724,7 +724,7 @@ function _wp_connectors_get_connector_script_module_data( array $data ): array {
 	}
 	ksort( $connectors );
 	$data['connectors']         = $connectors;
-	$data['isFileModsDisabled'] = ! wp_is_file_mod_allowed( 'install_plugins' );
+	$data['isFileModDisabled'] = ! wp_is_file_mod_allowed( 'install_plugins' );
 	return $data;
 }
 add_filter( 'script_module_data_options-connectors-wp-admin', '_wp_connectors_get_connector_script_module_data' );

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -723,7 +723,7 @@ function _wp_connectors_get_connector_script_module_data( array $data ): array {
 		$connectors[ $connector_id ] = $connector_out;
 	}
 	ksort( $connectors );
-	$data['connectors']         = $connectors;
+	$data['connectors']        = $connectors;
 	$data['isFileModDisabled'] = ! wp_is_file_mod_allowed( 'install_plugins' );
 	return $data;
 }


### PR DESCRIPTION
## Summary
- Adds `isFileModsDisabled` (derived from `wp_is_file_mod_allowed( 'install_plugins' )`) to the data exposed through the `script_module_data_options-connectors-wp-admin` filter so the connectors UI can react when plugin installs are disabled.

Ticket: https://core.trac.wordpress.org/ticket/65209

## Test plan
- [ ] Load the connectors admin screen and verify `isFileModsDisabled` is present on the script module data with the expected value.
- [ ] Toggle file mods off (e.g. `define( 'DISALLOW_FILE_MODS', true )`) and confirm the value flips to `true`.