### PR TITLE
Plugins: Add hidden File column to plugin list table

### DIFF
--- a/src/wp-admin/css/list-tables.css
+++ b/src/wp-admin/css/list-tables.css
@@ -2292,6 +2292,11 @@ div.action-links,
 		display: table-cell;
 	}
 
+	/* Plugin columns hidden via Screen Options */
+	#wpbody-content .wp-list-table.plugins td.hidden {
+		display: none;
+	}
+
 	/* Plugin description hidden via Screen Options */
 	#wpbody-content .wp-list-table.plugins .desc.hidden {
 		display: none;

--- a/src/wp-admin/includes/class-wp-plugins-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugins-list-table.php
@@ -60,6 +60,8 @@ class WP_Plugins_List_Table extends WP_List_Table {
 		$this->show_autoupdates = wp_is_auto_update_enabled_for_type( 'plugin' )
 			&& current_user_can( 'update_plugins' )
 			&& ( ! is_multisite() || $this->screen->in_admin( 'network' ) );
+
+		add_filter( 'default_hidden_columns', array( $this, 'get_default_hidden_columns' ), 10, 2 );
 	}
 
 	/**
@@ -476,7 +478,30 @@ class WP_Plugins_List_Table extends WP_List_Table {
 			$columns['auto-updates'] = __( 'Automatic Updates' );
 		}
 
+		$columns['file'] = _x( 'File', 'plugin screen column name' );
+
 		return $columns;
+	}
+
+	/**
+	 * Filters the default hidden columns for the plugins list table.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param string[]  $hidden Array of IDs of columns hidden by default.
+	 * @param WP_Screen $screen WP_Screen object of the current screen.
+	 * @return string[] Array of IDs of columns hidden by default.
+	 */
+	public function get_default_hidden_columns( $hidden, $screen ) {
+		if ( ! in_array( $screen->id, array( 'plugins', 'plugins-network' ), true ) ) {
+			return $hidden;
+		}
+
+		if ( ! in_array( 'file', $hidden, true ) ) {
+			$hidden[] = 'file';
+		}
+
+		return $hidden;
 	}
 
 	/**
@@ -1174,6 +1199,9 @@ class WP_Plugins_List_Table extends WP_List_Table {
 					echo "<td class='plugin-title column-primary'><strong>$plugin_name</strong>";
 					echo $this->row_actions( $actions, true );
 					echo '</td>';
+					break;
+				case 'file':
+					echo "<td class='column-file{$extra_classes}'><code>" . esc_html( $plugin_file ) . '</code></td>';
 					break;
 				case 'description':
 					$classes = 'column-description desc';

--- a/tests/phpunit/tests/admin/wpPluginsListTable.php
+++ b/tests/phpunit/tests/admin/wpPluginsListTable.php
@@ -336,6 +336,7 @@ class Tests_Admin_wpPluginsListTable extends WP_UnitTestCase {
 
 		$original_status = $status;
 		$status          = 'all';
+		$plugins         = get_plugins();
 
 		$column_info = array(
 			array(
@@ -355,12 +356,12 @@ class Tests_Admin_wpPluginsListTable extends WP_UnitTestCase {
 		$list_table_mock->expects( $this->once() )->method( 'get_column_info' )->willReturn( $column_info );
 
 		ob_start();
-		$list_table_mock->single_row( array( 'fake-plugin.php', $this->fake_plugin['fake-plugin.php'] ) );
+		$list_table_mock->single_row( array( 'hello.php', $plugins['hello.php'] ) );
 		$actual = ob_get_clean();
 
 		$status = $original_status;
 
-		$this->assertStringContainsString( "<td class='column-file'><code>fake-plugin.php</code></td>", $actual );
+		$this->assertStringContainsString( "<td class='column-file'><code>hello.php</code></td>", $actual );
 	}
 
 	/**

--- a/tests/phpunit/tests/admin/wpPluginsListTable.php
+++ b/tests/phpunit/tests/admin/wpPluginsListTable.php
@@ -65,6 +65,7 @@ class Tests_Admin_wpPluginsListTable extends WP_UnitTestCase {
 
 	public function set_up() {
 		parent::set_up();
+		set_current_screen( 'plugins.php' );
 		$this->table = _get_list_table( 'WP_Plugins_List_Table', array( 'screen' => 'plugins' ) );
 	}
 
@@ -75,6 +76,7 @@ class Tests_Admin_wpPluginsListTable extends WP_UnitTestCase {
 		global $s;
 
 		$s = self::$original_s;
+		set_current_screen( 'front' );
 
 		parent::tear_down();
 	}
@@ -118,6 +120,42 @@ class Tests_Admin_wpPluginsListTable extends WP_UnitTestCase {
 		$totals = $totals_backup;
 
 		$this->assertSame( $expected, $actual );
+	}
+
+	/**
+	 * Tests that WP_Plugins_List_Table::get_columns() adds the file column.
+	 *
+	 * @ticket 65145
+	 *
+	 * @covers WP_Plugins_List_Table::get_columns
+	 */
+	public function test_get_columns_should_add_the_file_column() {
+		global $status;
+
+		$original_status = $status;
+		$status          = 'all';
+
+		$actual = $this->table->get_columns();
+
+		$status = $original_status;
+
+		$this->assertSame(
+			array( 'cb', 'name', 'description', 'file' ),
+			array_keys( $actual )
+		);
+	}
+
+	/**
+	 * Tests that the file column is hidden by default in Screen Options.
+	 *
+	 * @ticket 65145
+	 *
+	 * @covers WP_Plugins_List_Table::get_default_hidden_columns
+	 */
+	public function test_get_default_hidden_columns_should_hide_the_file_column() {
+		$hidden = get_hidden_columns( get_current_screen() );
+
+		$this->assertContains( 'file', $hidden );
 	}
 
 	/**
@@ -284,6 +322,45 @@ class Tests_Admin_wpPluginsListTable extends WP_UnitTestCase {
 		$this->assertIsString( $actual, 'Output was not captured.' );
 		$this->assertNotEmpty( $actual, 'The output string was empty.' );
 		$this->assertStringNotContainsString( 'column-auto-updates', $actual, 'The auto-updates column was output.' );
+	}
+
+	/**
+	 * Tests that WP_Plugins_List_Table::single_row() outputs the file column.
+	 *
+	 * @ticket 65145
+	 *
+	 * @covers WP_Plugins_List_Table::single_row
+	 */
+	public function test_single_row_should_output_the_file_column() {
+		global $status;
+
+		$original_status = $status;
+		$status          = 'all';
+
+		$column_info = array(
+			array(
+				'name'        => 'Plugin',
+				'description' => 'Description',
+				'file'        => 'File',
+			),
+			array(),
+			array(),
+			'name',
+		);
+
+		$list_table_mock = $this->getMockBuilder( 'WP_Plugins_List_Table' )
+			->setMethods( array( 'get_column_info' ) )
+			->getMock();
+
+		$list_table_mock->expects( $this->once() )->method( 'get_column_info' )->willReturn( $column_info );
+
+		ob_start();
+		$list_table_mock->single_row( array( 'fake-plugin.php', $this->fake_plugin['fake-plugin.php'] ) );
+		$actual = ob_get_clean();
+
+		$status = $original_status;
+
+		$this->assertStringContainsString( "<td class='column-file'><code>fake-plugin.php</code></td>", $actual );
 	}
 
 	/**


### PR DESCRIPTION
See Trac ticket: https://core.trac.wordpress.org/ticket/65145

## Summary
Adds a hidden-by-default `File` column to the plugins list table so installed plugins can be identified by their plugin file/basename.

This is an alternative to #11674. That PR helped validate the Screen Options direction, but this patch takes a slightly different approach by exposing the installed plugin file (`$plugin_file`) in a `File` column rather than exposing a `Slug` column.

## Why this approach
Using `File` may be a better fit for the concerns raised in the ticket because it reflects the actual installed plugin identifier that core already has reliably for all plugins, including:
- WordPress.org plugins
- premium/custom plugins
- plugins with multiple entry files in one directory
- must-use plugins
- drop-ins
- multisite and custom plugin directory setups

This also avoids labeling `directory/file.php` as a “slug”, which is not always technically accurate.

## What changed
- Adds a hidden-by-default `File` column to `WP_Plugins_List_Table`
- Displays the value of `$plugin_file`
- Places the column at the end of the plugins columns / Screen Options list
- Adds a responsive fix so hidden plugin columns remain hidden on narrow/mobile views
- Adds PHPUnit coverage for the new column, default hidden state, and row output

## Testing
- Browser-tested on local single-site and multisite Studio sites
- Verified `Installed`, `Must-Use`, and `Drop-ins` views
- Verified network and subsite plugin screens on multisite
- Confirmed the `File` column is hidden by default, appears when enabled, and hides again when disabled
- Ran:
  - `php -l src/wp-admin/includes/class-wp-plugins-list-table.php`
  - `php -l tests/phpunit/tests/admin/wpPluginsListTable.php`
  - `npm run test:php -- tests/phpunit/tests/admin/wpPluginsListTable.php`

## AI assistance
AI assistance: Yes  
Tool(s): OpenAI Codex
Model(s): GPT 5.4 High
Used for: implementation drafting, test drafting, and local QA assistance. Final code, testing, and validation were reviewed and completed by me.
