### PR TITLE
Admin bar: Replace home/odometer dashicon with actual site icon if set

### DIFF
--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -393,12 +393,9 @@ function wp_admin_bar_site_menu( $wp_admin_bar ) {
 		/** This filter is documented in wp-includes/admin-bar.php */
 		$show_site_icons = apply_filters( 'wp_admin_bar_show_site_icons', true );
 
-		if ( $show_site_icons ) {
-			$site_icon_url = get_site_icon_url( 64 );
-			if ( $site_icon_url ) {
-				$title         = '<img class="site-icon" src="' . esc_url( $site_icon_url ) . '" alt="" />' . $title;
-				$meta['class'] = 'has-site-icon';
-			}
+		if ( true === $show_site_icons && has_site_icon() ) {
+			$title         = '<img class="site-icon" src="' . esc_url( get_site_icon_url( 64 ) ) . '" alt="" />' . $title;
+			$meta['class'] = 'has-site-icon';
 		}
 	}
 

--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -389,10 +389,17 @@ function wp_admin_bar_site_menu( $wp_admin_bar ) {
 		'menu_title' => $title,
 	);
 
-	$site_icon_url = get_site_icon_url( 64 );
-	if ( $site_icon_url ) {
-		$title          = '<img class="site-icon" src="' . esc_url( $site_icon_url ) . '" alt="" />' . $title;
-		$meta['class']  = 'has-site-icon';
+	if ( ! is_network_admin() && ! is_user_admin() ) {
+		/** This filter is documented in wp-includes/admin-bar.php */
+		$show_site_icons = apply_filters( 'wp_admin_bar_show_site_icons', true );
+
+		if ( $show_site_icons ) {
+			$site_icon_url = get_site_icon_url( 64 );
+			if ( $site_icon_url ) {
+				$title         = '<img class="site-icon" src="' . esc_url( $site_icon_url ) . '" alt="" />' . $title;
+				$meta['class'] = 'has-site-icon';
+			}
+		}
 	}
 
 	$wp_admin_bar->add_node(

--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -385,15 +385,22 @@ function wp_admin_bar_site_menu( $wp_admin_bar ) {
 	}
 
 	$title = wp_html_excerpt( $blogname, 40, '&hellip;' );
+	$meta  = array(
+		'menu_title' => $title,
+	);
+
+	$site_icon_url = get_site_icon_url( 64 );
+	if ( $site_icon_url ) {
+		$title          = '<img class="site-icon" src="' . esc_url( $site_icon_url ) . '" alt="" />' . $title;
+		$meta['class']  = 'has-site-icon';
+	}
 
 	$wp_admin_bar->add_node(
 		array(
 			'id'    => 'site-name',
 			'title' => $title,
 			'href'  => ( is_admin() || ! current_user_can( 'read' ) ) ? home_url( '/' ) : admin_url(),
-			'meta'  => array(
-				'menu_title' => $title,
-			),
+			'meta'  => $meta,
 		)
 	);
 

--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -395,9 +395,9 @@ function wp_admin_bar_site_menu( $wp_admin_bar ) {
 
 		if ( true === $show_site_icons && has_site_icon() ) {
 			$site_icon = sprintf(
-				'<img class="site-icon" src="%s" srcset="%s 2x" alt="" width="28" height="28" />',
-				esc_url( get_site_icon_url( 28 ) ),
-				esc_url( get_site_icon_url( 56 ) )
+				'<img class="site-icon" src="%s" srcset="%s 2x" alt="" width="20" height="20" />',
+				esc_url( get_site_icon_url( 32 ) ),
+				esc_url( get_site_icon_url( 64 ) )
 			);
 
 			$title         = $site_icon . $title;

--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -394,10 +394,13 @@ function wp_admin_bar_site_menu( $wp_admin_bar ) {
 		$show_site_icons = apply_filters( 'wp_admin_bar_show_site_icons', true );
 
 		if ( true === $show_site_icons && has_site_icon() ) {
-			$site_icon = sprintf(
-				'<img class="site-icon" src="%s" srcset="%s 2x" alt="" width="20" height="20" />',
-				esc_url( get_site_icon_url( 32 ) ),
-				esc_url( get_site_icon_url( 64 ) )
+			$site_icon_url    = get_site_icon_url( 32 );
+			$site_icon_url_2x = get_site_icon_url( 64 );
+			$srcset           = ( $site_icon_url_2x && $site_icon_url !== $site_icon_url_2x ) ? sprintf( ' srcset="%s 2x"', esc_url( $site_icon_url_2x ) ) : '';
+			$site_icon        = sprintf(
+				'<img class="site-icon" src="%s"%s alt="" width="20" height="20" />',
+				esc_url( $site_icon_url ),
+				$srcset
 			);
 
 			$title         = $site_icon . $title;

--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -394,7 +394,13 @@ function wp_admin_bar_site_menu( $wp_admin_bar ) {
 		$show_site_icons = apply_filters( 'wp_admin_bar_show_site_icons', true );
 
 		if ( true === $show_site_icons && has_site_icon() ) {
-			$title         = '<img class="site-icon" src="' . esc_url( get_site_icon_url( 64 ) ) . '" alt="" />' . $title;
+			$site_icon = sprintf(
+				'<img class="site-icon" src="%s" srcset="%s 2x" alt="" width="28" height="28" />',
+				esc_url( get_site_icon_url( 28 ) ),
+				esc_url( get_site_icon_url( 56 ) )
+			);
+
+			$title         = $site_icon . $title;
 			$meta['class'] = 'has-site-icon';
 		}
 	}

--- a/src/wp-includes/css/admin-bar.css
+++ b/src/wp-includes/css/admin-bar.css
@@ -596,7 +596,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 	width: 20px;
 	height: 20px;
 	vertical-align: middle;
-	margin: -2px 6px 0 0;
+	margin: -3px 6px 0 0;
 	background: #f0f0f1; /* matching my-account (user avatar) node's background */
 	border-radius: 2px;
 }

--- a/src/wp-includes/css/admin-bar.css
+++ b/src/wp-includes/css/admin-bar.css
@@ -581,6 +581,19 @@ html:lang(he-il) .rtl #wpadminbar * {
 	content: "\f102" / '';
 }
 
+#wpadminbar #wp-admin-bar-site-name.has-site-icon > .ab-item:before {
+	content: none;
+}
+
+#wpadminbar #wp-admin-bar-site-name > .ab-item .site-icon {
+	width: 20px;
+	height: 20px;
+	margin: 0 6px 0 0;
+	vertical-align: -5px;
+	background: #f0f0f1;
+	border-radius: 4px;
+}
+
 
 
 /**
@@ -902,7 +915,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 
 	#wpadminbar #wp-admin-bar-edit > .ab-item:before,
 	#wpadminbar #wp-admin-bar-my-sites > .ab-item:before,
-	#wpadminbar #wp-admin-bar-site-name > .ab-item:before,
+	#wpadminbar #wp-admin-bar-site-name:not(.has-site-icon) > .ab-item:before,
 	#wpadminbar #wp-admin-bar-site-editor > .ab-item:before,
 	#wpadminbar #wp-admin-bar-customize > .ab-item:before,
 	#wpadminbar #wp-admin-bar-my-account > .ab-item:before,
@@ -915,6 +928,15 @@ html:lang(he-il) .rtl #wpadminbar * {
 		text-align: center;
 		-webkit-font-smoothing: antialiased;
 		-moz-osx-font-smoothing: grayscale;
+	}
+
+	#wpadminbar #wp-admin-bar-site-name > .ab-item .site-icon {
+		position: absolute;
+		top: 9px;
+		left: 12px;
+		width: 28px;
+		height: 28px;
+		margin: 0;
 	}
 
 	#wpadminbar #wp-admin-bar-appearance {

--- a/src/wp-includes/css/admin-bar.css
+++ b/src/wp-includes/css/admin-bar.css
@@ -584,6 +584,19 @@ html:lang(he-il) .rtl #wpadminbar * {
 	content: "\f102" / '';
 }
 
+#wpadminbar #wp-admin-bar-site-name.has-site-icon > .ab-item:before {
+	content: none;
+}
+
+#wpadminbar #wp-admin-bar-site-name > .ab-item .site-icon {
+	width: 20px;
+	height: 20px;
+	margin: 0 6px 0 0;
+	vertical-align: -5px;
+	background: #f0f0f1;
+	border-radius: 4px;
+}
+
 
 
 /**
@@ -905,7 +918,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 
 	#wpadminbar #wp-admin-bar-edit > .ab-item:before,
 	#wpadminbar #wp-admin-bar-my-sites > .ab-item:before,
-	#wpadminbar #wp-admin-bar-site-name > .ab-item:before,
+	#wpadminbar #wp-admin-bar-site-name:not(.has-site-icon) > .ab-item:before,
 	#wpadminbar #wp-admin-bar-site-editor > .ab-item:before,
 	#wpadminbar #wp-admin-bar-customize > .ab-item:before,
 	#wpadminbar #wp-admin-bar-my-account > .ab-item:before,
@@ -918,6 +931,15 @@ html:lang(he-il) .rtl #wpadminbar * {
 		text-align: center;
 		-webkit-font-smoothing: antialiased;
 		-moz-osx-font-smoothing: grayscale;
+	}
+
+	#wpadminbar #wp-admin-bar-site-name > .ab-item .site-icon {
+		position: absolute;
+		top: 9px;
+		left: 12px;
+		width: 28px;
+		height: 28px;
+		margin: 0;
 	}
 
 	#wpadminbar #wp-admin-bar-appearance {

--- a/src/wp-includes/css/admin-bar.css
+++ b/src/wp-includes/css/admin-bar.css
@@ -539,6 +539,10 @@ html:lang(he-il) .rtl #wpadminbar * {
 	margin: 0 8px 2px -2px;
 }
 
+#wpadminbar .quicklinks li img.blavatar {
+	border-radius: 2px;
+}
+
 #wpadminbar .quicklinks li div.blavatar:before {
 	content: "\f120";
 	content: "\f120" / '';

--- a/src/wp-includes/css/admin-bar.css
+++ b/src/wp-includes/css/admin-bar.css
@@ -597,7 +597,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 	height: 20px;
 	vertical-align: middle;
 	margin: -2px 6px 0 0;
-	background: #f0f0f1;
+	background: #f0f0f1; /* matching my-account (user avatar) node's background */
 	border-radius: 2px;
 }
 

--- a/src/wp-includes/css/admin-bar.css
+++ b/src/wp-includes/css/admin-bar.css
@@ -595,8 +595,8 @@ html:lang(he-il) .rtl #wpadminbar * {
 #wpadminbar #wp-admin-bar-site-name > .ab-item .site-icon {
 	width: 20px;
 	height: 20px;
-	margin: 0 6px 0 0;
-	vertical-align: -5px;
+	vertical-align: middle;
+	margin: -2px 6px 0 0;
 	background: #f0f0f1;
 	border-radius: 2px;
 }

--- a/src/wp-includes/css/admin-bar.css
+++ b/src/wp-includes/css/admin-bar.css
@@ -594,7 +594,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 	margin: 0 6px 0 0;
 	vertical-align: -5px;
 	background: #f0f0f1;
-	border-radius: 4px;
+	border-radius: 2px;
 }
 
 
@@ -940,6 +940,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 		width: 28px;
 		height: 28px;
 		margin: 0;
+		border-radius: 4px;
 	}
 
 	#wpadminbar #wp-admin-bar-appearance {

--- a/src/wp-includes/css/admin-bar.css
+++ b/src/wp-includes/css/admin-bar.css
@@ -591,7 +591,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 	margin: 0 6px 0 0;
 	vertical-align: -5px;
 	background: #f0f0f1;
-	border-radius: 4px;
+	border-radius: 2px;
 }
 
 
@@ -937,6 +937,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 		width: 28px;
 		height: 28px;
 		margin: 0;
+		border-radius: 4px;
 	}
 
 	#wpadminbar #wp-admin-bar-appearance {

--- a/src/wp-includes/css/admin-bar.css
+++ b/src/wp-includes/css/admin-bar.css
@@ -588,6 +588,12 @@ html:lang(he-il) .rtl #wpadminbar * {
 	content: "\f102" / '';
 }
 
+#wpadminbar #wp-admin-bar-site-name.has-site-icon > .ab-item {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+}
+
 #wpadminbar #wp-admin-bar-site-name.has-site-icon > .ab-item:before {
 	content: none;
 }
@@ -595,8 +601,6 @@ html:lang(he-il) .rtl #wpadminbar * {
 #wpadminbar #wp-admin-bar-site-name > .ab-item .site-icon {
 	width: 20px;
 	height: 20px;
-	vertical-align: middle;
-	margin: -3px 6px 0 0;
 	background: #f0f0f1; /* matching my-account (user avatar) node's background */
 	border-radius: 2px;
 }

--- a/tests/phpunit/tests/adminbar.php
+++ b/tests/phpunit/tests/adminbar.php
@@ -811,6 +811,37 @@ class Tests_AdminBar extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @covers ::wp_admin_bar_site_menu
+	 */
+	public function test_site_name_menu_has_no_site_icon_when_unset() {
+		wp_set_current_user( self::$editor_id );
+
+		$wp_admin_bar   = $this->get_standard_admin_bar();
+		$node_site_name = $wp_admin_bar->get_node( 'site-name' );
+
+		$this->assertStringNotContainsString( 'site-icon', $node_site_name->title );
+		$this->assertArrayNotHasKey( 'class', $node_site_name->meta );
+	}
+
+	/**
+	 * @covers ::wp_admin_bar_site_menu
+	 * @requires function imagejpeg
+	 */
+	public function test_site_name_menu_includes_site_icon_when_set() {
+		wp_set_current_user( self::$editor_id );
+
+		$attachment_id = self::factory()->attachment->create_upload_object( DIR_TESTDATA . '/images/test-image.jpg' );
+		update_option( 'site_icon', $attachment_id );
+
+		$wp_admin_bar   = $this->get_standard_admin_bar();
+		$node_site_name = $wp_admin_bar->get_node( 'site-name' );
+
+		$this->assertStringContainsString( '<img class="site-icon"', $node_site_name->title );
+		$this->assertStringContainsString( esc_url( get_site_icon_url( 64 ) ), $node_site_name->title );
+		$this->assertSame( 'has-site-icon', $node_site_name->meta['class'] );
+	}
+
+	/**
 	 * This test ensures that WP_Admin_Bar::$proto is not defined (including magic methods).
 	 *
 	 * @ticket 56876

--- a/tests/phpunit/tests/adminbar.php
+++ b/tests/phpunit/tests/adminbar.php
@@ -837,7 +837,7 @@ class Tests_AdminBar extends WP_UnitTestCase {
 		$node_site_name = $wp_admin_bar->get_node( 'site-name' );
 
 		$this->assertStringContainsString( '<img class="site-icon"', $node_site_name->title );
-		$this->assertStringContainsString( esc_url( get_site_icon_url( 28 ) ), $node_site_name->title );
+		$this->assertStringContainsString( esc_url( get_site_icon_url( 32 ) ), $node_site_name->title );
 		$this->assertSame( 'has-site-icon', $node_site_name->meta['class'] );
 	}
 

--- a/tests/phpunit/tests/adminbar.php
+++ b/tests/phpunit/tests/adminbar.php
@@ -837,7 +837,7 @@ class Tests_AdminBar extends WP_UnitTestCase {
 		$node_site_name = $wp_admin_bar->get_node( 'site-name' );
 
 		$this->assertStringContainsString( '<img class="site-icon"', $node_site_name->title );
-		$this->assertStringContainsString( esc_url( get_site_icon_url( 64 ) ), $node_site_name->title );
+		$this->assertStringContainsString( esc_url( get_site_icon_url( 28 ) ), $node_site_name->title );
 		$this->assertSame( 'has-site-icon', $node_site_name->meta['class'] );
 	}
 

--- a/tests/phpunit/tests/adminbar.php
+++ b/tests/phpunit/tests/adminbar.php
@@ -842,6 +842,69 @@ class Tests_AdminBar extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @covers ::wp_admin_bar_site_menu
+	 * @requires function imagejpeg
+	 */
+	public function test_site_name_menu_respects_show_site_icons_filter() {
+		wp_set_current_user( self::$editor_id );
+
+		$attachment_id = self::factory()->attachment->create_upload_object( DIR_TESTDATA . '/images/test-image.jpg' );
+		update_option( 'site_icon', $attachment_id );
+
+		add_filter( 'wp_admin_bar_show_site_icons', '__return_false' );
+
+		$wp_admin_bar   = $this->get_standard_admin_bar();
+		$node_site_name = $wp_admin_bar->get_node( 'site-name' );
+
+		$this->assertStringNotContainsString( 'site-icon', $node_site_name->title );
+		$this->assertArrayNotHasKey( 'class', $node_site_name->meta );
+	}
+
+	/**
+	 * @covers ::wp_admin_bar_site_menu
+	 * @group multisite
+	 * @group ms-required
+	 * @requires function imagejpeg
+	 */
+	public function test_site_name_menu_has_no_site_icon_in_network_admin() {
+		wp_set_current_user( self::$admin_id );
+
+		$attachment_id = self::factory()->attachment->create_upload_object( DIR_TESTDATA . '/images/test-image.jpg' );
+		update_option( 'site_icon', $attachment_id );
+
+		set_current_screen( 'dashboard-network' );
+
+		$wp_admin_bar   = $this->get_standard_admin_bar();
+		$node_site_name = $wp_admin_bar->get_node( 'site-name' );
+
+		$this->assertTrue( is_network_admin() );
+		$this->assertStringNotContainsString( 'site-icon', $node_site_name->title );
+		$this->assertArrayNotHasKey( 'class', $node_site_name->meta );
+	}
+
+	/**
+	 * @covers ::wp_admin_bar_site_menu
+	 * @group multisite
+	 * @group ms-required
+	 * @requires function imagejpeg
+	 */
+	public function test_site_name_menu_has_no_site_icon_in_user_admin() {
+		wp_set_current_user( self::$admin_id );
+
+		$attachment_id = self::factory()->attachment->create_upload_object( DIR_TESTDATA . '/images/test-image.jpg' );
+		update_option( 'site_icon', $attachment_id );
+
+		set_current_screen( 'dashboard-user' );
+
+		$wp_admin_bar   = $this->get_standard_admin_bar();
+		$node_site_name = $wp_admin_bar->get_node( 'site-name' );
+
+		$this->assertTrue( is_user_admin() );
+		$this->assertStringNotContainsString( 'site-icon', $node_site_name->title );
+		$this->assertArrayNotHasKey( 'class', $node_site_name->meta );
+	}
+
+	/**
 	 * This test ensures that WP_Admin_Bar::$proto is not defined (including magic methods).
 	 *
 	 * @ticket 56876


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65088

This PR replaces the home / odometer dashicon, with the actual site icon, if set, in the admin bar. The icon will be 20x20px, with border-radius of 2px and background-color of `#f0f0f1`.

If the site has not set site icon, then the default dashicons (home / odometer) is NOT changed.

## Screenshot

### Before

<img width="350" height="32" alt="image" src="https://github.com/user-attachments/assets/123f6b2d-a5fa-45d3-b3f8-2196b93e5948" />

<img width="350" height="32" alt="image" src="https://github.com/user-attachments/assets/560ab716-22c4-494e-a7ec-cc3fd0d66143" />


### After

<img width="350" alt="fresh" src="https://github.com/user-attachments/assets/0096af12-b457-4a5e-b62e-021947cef433" />
<img width="350" alt="modern" src="https://github.com/user-attachments/assets/045cdb0b-b1e0-4a0e-8a61-ec783b983e0f" />
<img width="350" alt="blue" src="https://github.com/user-attachments/assets/da95bee7-318e-407b-9d0d-6b3bc993a4db" />
<img width="350" alt="coffee" src="https://github.com/user-attachments/assets/237ee40a-b075-4c97-a484-73ec3c07e33e" />
<img width="350" alt="ectoplasm" src="https://github.com/user-attachments/assets/f41f8459-9021-4e7b-a2a6-404d1626c173" />
<img width="350" alt="light" src="https://github.com/user-attachments/assets/c911d875-cce1-4f82-b4d0-f523fa4181d5" />
<img width="350" alt="midnight" src="https://github.com/user-attachments/assets/cec833d0-257b-44b2-b71d-bb53c3694142" />
<img width="350" alt="ocean" src="https://github.com/user-attachments/assets/e4f786db-e006-4818-8315-521270efb1bd" />
<img width="350" alt="sunrise" src="https://github.com/user-attachments/assets/1aa79a1f-ef36-49fc-8e95-621420606810" />


### Before (mobile)

<img width="511" height="46" alt="image" src="https://github.com/user-attachments/assets/a9a39acf-00e2-494a-b948-ba56fa0f0fb6" />

<img width="511" height="46" alt="image" src="https://github.com/user-attachments/assets/e347dc60-7f9c-4d4d-9833-d40bc6adb90b" />


### After (mobile)

<img width="511" height="46" alt="image" src="https://github.com/user-attachments/assets/33384a31-3e02-49f1-a3c1-edd4f7703739" />

<img width="511" height="46" alt="image" src="https://github.com/user-attachments/assets/94343b23-7fb6-4eec-8b87-5f31bbf1f814" />


## Use of AI Tools

I used Codex with GPT-5.5 to help with the CSS implementation, with my supervision.

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
