### PR TITLE
Admin bar: Always show site title on mobile and move shortcut menus under it

### DIFF
--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -999,6 +999,20 @@ function wp_admin_bar_command_palette_menu( WP_Admin_Bar $wp_admin_bar ): void {
 			),
 		)
 	);
+
+	// Duplicate into top-secondary for mobile viewport.
+	$wp_admin_bar->add_node(
+		array(
+			'parent' => 'top-secondary',
+			'id'     => 'mobile-command-palette',
+			'title'  => $title,
+			'href'   => '#',
+			'meta'   => array(
+				'class'   => 'hide-if-no-js',
+				'onclick' => 'wp.data.dispatch( "core/commands" ).open(); return false;',
+			),
+		)
+	);
 }
 
 /**
@@ -1121,6 +1135,15 @@ function wp_admin_bar_comments_menu( $wp_admin_bar ) {
 			'id'    => 'comments',
 			'title' => $icon . $title,
 			'href'  => admin_url( 'edit-comments.php' ),
+			'meta'  => array(
+				'menu_title' => $awaiting_mod > 0
+					? sprintf(
+						/* translators: %s: Number of comments awaiting moderation. */
+						__( 'Comments %s' ),
+						number_format_i18n( $awaiting_mod )
+					)
+					: __( 'Comments' ),
+			),
 		)
 	);
 }
@@ -1236,6 +1259,13 @@ function wp_admin_bar_updates_menu( $wp_admin_bar ) {
 			'id'    => 'updates',
 			'title' => $icon . $title,
 			'href'  => network_admin_url( 'update-core.php' ),
+			'meta'  => array(
+				'menu_title' => sprintf(
+					/* translators: %s: Number of updates available. */
+					__( 'Updates %s' ),
+					number_format_i18n( $update_data['counts']['total'] )
+				),
+			),
 		)
 	);
 }
@@ -1298,6 +1328,91 @@ function wp_admin_bar_recovery_mode_menu( $wp_admin_bar ) {
 			'href'   => $url,
 		)
 	);
+}
+
+/**
+ * Duplicate site and content-related shortcut menus (such as Updates and New)
+ * under the `site-name` menu and show them on mobile viewport, where
+ * the original shortcut menus are hidden to make room for the site title.
+ *
+ * @since 7.1.0
+ *
+ * @param WP_Admin_Bar $wp_admin_bar The WP_Admin_Bar instance.
+ */
+function wp_admin_bar_duplicate_shortcut_menus( $wp_admin_bar ) {
+	if ( ! $wp_admin_bar->get_node( 'site-name' ) ) {
+		return;
+	}
+
+	$shortcut_node_ids = array(
+		'site-editor',
+		'customize',
+		'updates',
+		'comments',
+		'new-content',
+		'edit',
+	);
+
+	$nodes = $wp_admin_bar->get_nodes();
+
+	$shortcut_nodes = array();
+	foreach ( $shortcut_node_ids as $node_id ) {
+		if ( isset( $nodes[ $node_id ] ) ) {
+			$shortcut_nodes[] = $nodes[ $node_id ];
+		}
+	}
+
+	if ( empty( $shortcut_nodes ) ) {
+		return;
+	}
+
+	$children_by_parent = array();
+	foreach ( $nodes as $node ) {
+		if ( ! empty( $node->parent ) ) {
+			$children_by_parent[ $node->parent ][] = $node;
+		}
+	}
+
+	$wp_admin_bar->add_group(
+		array(
+			'parent' => 'site-name',
+			'id'     => 'mobile-site-shortcuts',
+			'meta'   => array(
+				'class' => 'ab-sub-secondary',
+			),
+		)
+	);
+
+	foreach ( $shortcut_nodes as $node ) {
+		// Swap potentially icon-only markup for a plain text label
+		if ( ! empty( $node->meta['menu_title'] ) ) {
+			$node->title = $node->meta['menu_title'];
+		}
+		_wp_admin_bar_clone_subtree( $wp_admin_bar, $node, 'mobile-site-shortcuts', $children_by_parent );
+	}
+}
+
+/**
+ * Recursively clones a node and its descendants under a new parent.
+ *
+ * @since 7.1.0
+ * @access private
+ *
+ * @param WP_Admin_Bar $wp_admin_bar       The WP_Admin_Bar instance.
+ * @param object       $node               The original node to clone.
+ * @param string       $new_parent         The ID of the new parent node.
+ * @param array        $children_by_parent Map of parent id => array of child node objects.
+ */
+function _wp_admin_bar_clone_subtree( $wp_admin_bar, $node, $new_parent, $children_by_parent ) {
+	$new_id        = 'mobile-site-shortcut-' . $node->id;
+	$clone         = clone $node;
+	$clone->id     = $new_id;
+	$clone->parent = $new_parent;
+	$wp_admin_bar->add_node( $clone );
+
+	foreach ( $children_by_parent[ $node->id ] ?? array() as $child ) {
+		_wp_admin_bar_clone_subtree( $wp_admin_bar, $child, $new_id, $children_by_parent );
+	}
 }
 
 /**

--- a/src/wp-includes/class-wp-admin-bar.php
+++ b/src/wp-includes/class-wp-admin-bar.php
@@ -673,6 +673,9 @@ class WP_Admin_Bar {
 		}
 		add_action( 'admin_bar_menu', 'wp_admin_bar_edit_menu', 80 );
 
+		// Duplicate site and content-related shortcut menus under site menu for mobile viewport.
+		add_action( 'admin_bar_menu', 'wp_admin_bar_duplicate_shortcut_menus', 90 );
+
 		add_action( 'admin_bar_menu', 'wp_admin_bar_add_secondary_groups', 200 );
 
 		/**

--- a/src/wp-includes/css/admin-bar.css
+++ b/src/wp-includes/css/admin-bar.css
@@ -581,7 +581,11 @@ html:lang(he-il) .rtl #wpadminbar * {
 	content: "\f102" / '';
 }
 
-
+/* Hide the duplicated mobile-only menus on desktop viewport */
+#wpadminbar #wp-admin-bar-mobile-site-shortcuts,
+#wpadminbar #wp-admin-bar-mobile-command-palette {
+	display: none;
+}
 
 /**
  * Comments
@@ -697,7 +701,8 @@ html:lang(he-il) .rtl #wpadminbar * {
 /**
  * Command Palette
  */
-#wpadminbar #wp-admin-bar-command-palette .ab-icon:before {
+#wpadminbar #wp-admin-bar-command-palette .ab-icon:before,
+#wpadminbar #wp-admin-bar-mobile-command-palette .ab-icon:before {
 	content: "\f179";
 	content: "\f179" / '';
 	top: 3px;
@@ -840,7 +845,8 @@ html:lang(he-il) .rtl #wpadminbar * {
 		padding-right: 30px;
 	}
 
-	#wpadminbar .menupop .menupop > .ab-item:before {
+	#wpadminbar .menupop .menupop > .ab-item:before,
+	#wpadminbar .menupop .menupop > .ab-item .wp-admin-bar-arrow:before {
 		top: 10px;
 		right: 6px;
 	}
@@ -877,9 +883,8 @@ html:lang(he-il) .rtl #wpadminbar * {
 		padding: 0;
 	}
 
-	/* My Sites and "Site Title" menu */
+	/* My Sites menu */
 	#wpadminbar #wp-admin-bar-my-sites > .ab-item,
-	#wpadminbar #wp-admin-bar-site-name > .ab-item,
 	#wpadminbar #wp-admin-bar-site-editor > .ab-item,
 	#wpadminbar #wp-admin-bar-customize > .ab-item,
 	#wpadminbar #wp-admin-bar-edit > .ab-item,
@@ -951,12 +956,14 @@ html:lang(he-il) .rtl #wpadminbar * {
 
 	/* Comments and Command Palette */
 	#wpadminbar #wp-admin-bar-comments .ab-icon,
-	#wpadminbar #wp-admin-bar-command-palette .ab-icon {
+	#wpadminbar #wp-admin-bar-command-palette .ab-icon,
+	#wpadminbar #wp-admin-bar-mobile-command-palette .ab-icon {
 		margin: 0;
 	}
 
 	#wpadminbar #wp-admin-bar-comments .ab-icon:before,
-	#wpadminbar #wp-admin-bar-command-palette .ab-icon:before {
+	#wpadminbar #wp-admin-bar-command-palette .ab-icon:before,
+	#wpadminbar #wp-admin-bar-mobile-command-palette .ab-icon:before {
 		display: block;
 		font-size: 34px;
 		height: 46px;
@@ -1018,16 +1025,62 @@ html:lang(he-il) .rtl #wpadminbar * {
 	#wpadminbar li#wp-admin-bar-menu-toggle,
 	#wpadminbar li#wp-admin-bar-wp-logo,
 	#wpadminbar li#wp-admin-bar-my-sites,
-	#wpadminbar li#wp-admin-bar-updates,
 	#wpadminbar li#wp-admin-bar-site-name,
-	#wpadminbar li#wp-admin-bar-site-editor,
-	#wpadminbar li#wp-admin-bar-customize,
-	#wpadminbar li#wp-admin-bar-new-content,
-	#wpadminbar li#wp-admin-bar-edit,
-	#wpadminbar li#wp-admin-bar-comments,
-	#wpadminbar li#wp-admin-bar-my-account,
-	#wpadminbar li#wp-admin-bar-command-palette {
+	#wpadminbar li#wp-admin-bar-my-account {
 		display: block;
+	}
+
+	#wpadminbar li#wp-admin-bar-site-name > .ab-item {
+		position: relative;
+		padding: 0 12px 0 52px;
+	}
+
+	#wpadminbar li#wp-admin-bar-site-name > .ab-item:before {
+		position: absolute;
+		left: 0;
+		top: 7px;
+	}
+
+	/* Show the duplicated mobile-only menus on mobile viewport */
+	#wpadminbar #wp-admin-bar-mobile-site-shortcuts,
+	#wpadminbar #wp-admin-bar-mobile-command-palette {
+		display: block;
+	}
+
+	/* Allow the root left nodes to overflow past the viewport */
+	#wpadminbar .ab-top-menu {
+		min-width: max-content;
+	}
+
+	#wpadminbar {
+		overflow-x: clip;
+	}
+
+	/* Pin the secondary group to the right edge instead of letting it float,
+	 * covering the root left nodes when they overflow */
+	#wpadminbar #wp-admin-bar-top-secondary {
+		float: none;
+		position: absolute;
+		right: 0;
+	}
+
+	/* Add a fade-out effect to the left edge of the right-pinned secondary group */
+	#wpadminbar .quicklinks,
+	#wpadminbar .quicklinks #wp-admin-bar-top-secondary {
+		background-color: inherit;
+	}
+
+	#wpadminbar #wp-admin-bar-top-secondary::before {
+		content: '';
+		position: absolute;
+		right: 100%;
+		top: 0;
+		bottom: 0;
+		width: 24px;
+		background-color: inherit;
+		-webkit-mask-image: linear-gradient(to left, black, transparent);
+		mask-image: linear-gradient(to left, black, transparent);
+		pointer-events: none;
 	}
 
 	/* Allow dropdown list items to appear normally */
@@ -1119,8 +1172,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 		display: list-item;
 	}
 
-	#wpadminbar li#wp-admin-bar-wp-logo,
-	#wpadminbar li#wp-admin-bar-updates {
+	#wpadminbar li#wp-admin-bar-wp-logo {
 		display: none;
 	}
 
@@ -1129,12 +1181,5 @@ html:lang(he-il) .rtl #wpadminbar * {
 	#wpadminbar .ab-top-menu > .menupop li > .ab-sub-wrapper {
 		position: static;
 		box-shadow: none;
-	}
-}
-
-/* Very narrow screens */
-@media screen and (max-width: 400px) {
-	#wpadminbar li#wp-admin-bar-comments {
-		display: none;
 	}
 }

--- a/tests/phpunit/tests/adminbar.php
+++ b/tests/phpunit/tests/adminbar.php
@@ -811,6 +811,25 @@ class Tests_AdminBar extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @covers ::wp_admin_bar_duplicate_shortcut_menus
+	 */
+	public function test_site_name_menu_contains_duplicated_shortcut_menus() {
+		wp_set_current_user( self::$admin_id );
+
+		$wp_admin_bar = $this->get_standard_admin_bar();
+
+		$shortcuts = $wp_admin_bar->get_node( 'mobile-site-shortcuts' );
+		$this->assertNotNull( $shortcuts );
+		$this->assertSame( 'site-name', $shortcuts->parent );
+
+		foreach ( array( 'comments', 'new-content' ) as $node_id ) {
+			$clone = $wp_admin_bar->get_node( 'mobile-site-shortcut-' . $node_id );
+			$this->assertNotNull( $clone );
+			$this->assertSame( 'mobile-site-shortcuts', $clone->parent );
+		}
+	}
+
+	/**
 	 * This test ensures that WP_Admin_Bar::$proto is not defined (including magic methods).
 	 *
 	 * @ticket 56876


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65220

## Summary

We want to make the site title prominent even on mobile viewport. This helps users quickly identify which site they’re working on, even on smaller screens.

On mobile viewport width, we made the following changes:

- To make room for the site title, hide the site/content-related "shortcut" menus (Updates, Comments, New etc) from the top level and move them under the site menu.
   - This is implemented by duplicating those shortcut menus, and showing/hiding them via CSS depending on the viewport size.
- Move the command palette menu to the top-secondary area (right side).
   - This is also implemented by duplicating the menu as explained above.
- Allow the main left nodes to overflow, while pinning the right-side secondary nodes using `position: absolute` and `right: 0`.
   - So, when the site title is long, it flows underneath the right nodes. To make the visual smoother, we add a subtle fade/blur effect to the left edge of the secondary nodes.
   - Note that plugins that show icons on mobile by overriding CSS could get pushed out of view. However, Core's contract is to only show its own nodes on mobile viewport: 

https://github.com/WordPress/wordpress-develop/blob/556437068a54eefddff449c811ebad90bb53e968/src/wp-includes/css/admin-bar.css#L1013-L1016

## Screenshots

#### 600px < width <= 782px

| Before | After |
| - | - |
| <img width="1202" height="92" alt="image" src="https://github.com/user-attachments/assets/ea09d68b-f25d-45a5-a4fd-e6a25f60213b" /> | <img width="1202" height="92" alt="image" src="https://github.com/user-attachments/assets/ca357538-048f-4638-91bf-30d2386cffea" />|
| | <img width="1202" height="606" alt="image" src="https://github.com/user-attachments/assets/18b8c394-f51d-4947-ae18-604c57d54a69" /> |

#### 400px < width <= 600px

Observe that there's a fade/blur effect that hides the right end of the site title if it's too long.

| Before | After |
| - | - |
| <img width="802" height="92" alt="image" src="https://github.com/user-attachments/assets/8f3eb557-5593-4842-9da5-6143d5a3c318" /> | <img width="802" height="92" alt="image" src="https://github.com/user-attachments/assets/a2289cc7-4611-4cbf-8594-a12c8e7eea21" /> |


## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 4.7
Used for: CSS and test suggestions.


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
