### PR TITLE
I18N: Add translator context to all 'Preview' strings.

### DIFF
--- a/src/wp-admin/customize.php
+++ b/src/wp-admin/customize.php
@@ -210,7 +210,7 @@ do_action( 'customize_controls_head' );
 			<span class="spinner"></span>
 			<button type="button" class="customize-controls-preview-toggle">
 				<span class="controls"><?php _e( 'Customize' ); ?></span>
-				<span class="preview"><?php _e( 'Preview' ); ?></span>
+				<span class="preview"><?php echo esc_html_x( 'Preview', 'noun' ); ?></span>
 			</button>
 			<a class="customize-controls-close" href="<?php echo esc_url( $wp_customize->get_return_url() ); ?>">
 				<span class="screen-reader-text">

--- a/src/wp-admin/includes/class-custom-background.php
+++ b/src/wp-admin/includes/class-custom-background.php
@@ -279,7 +279,7 @@ class Custom_Background {
 <table class="form-table" role="presentation">
 <tbody>
 <tr>
-<th scope="row"><?php _e( 'Preview' ); ?></th>
+<th scope="row"><?php echo esc_html_x( 'Preview', 'noun' ); ?></th>
 <td>
 		<?php
 		if ( $this->admin_image_div_callback ) {

--- a/src/wp-admin/includes/class-custom-image-header.php
+++ b/src/wp-admin/includes/class-custom-image-header.php
@@ -550,7 +550,7 @@ class Custom_Image_Header {
 
 		<?php if ( get_custom_header() || display_header_text() ) : ?>
 <tr>
-<th scope="row"><?php _e( 'Preview' ); ?></th>
+<th scope="row"><?php echo esc_html_x( 'Preview', 'noun' ); ?></th>
 <td>
 			<?php
 			if ( $this->admin_image_div_callback ) {

--- a/src/wp-admin/includes/class-wp-posts-list-table.php
+++ b/src/wp-admin/includes/class-wp-posts-list-table.php
@@ -1548,7 +1548,7 @@ class WP_Posts_List_Table extends WP_List_Table {
 						esc_url( $preview_link ),
 						/* translators: %s: Post title. */
 						esc_attr( sprintf( __( 'Preview &#8220;%s&#8221;' ), $title ) ),
-						__( 'Preview' )
+						_x( 'Preview', 'verb' )
 					);
 				}
 			} elseif ( 'trash' !== $post->post_status ) {

--- a/src/wp-admin/includes/class-wp-theme-install-list-table.php
+++ b/src/wp-admin/includes/class-wp-theme-install-list-table.php
@@ -345,7 +345,7 @@ class WP_Theme_Install_List_Table extends WP_Themes_List_Table {
 			'<a class="install-theme-preview" href="%s" aria-label="%s">%s</a>',
 			esc_url( $preview_url ),
 			esc_attr( $preview_title ),
-			__( 'Preview' )
+			_x( 'Preview', 'verb' )
 		);
 
 		/**

--- a/src/wp-admin/includes/meta-boxes.php
+++ b/src/wp-admin/includes/meta-boxes.php
@@ -70,7 +70,7 @@ function post_submit_meta_box( $post, $args = array() ) {
 				if ( 'publish' === $post->post_status ) {
 					$preview_button_text = __( 'Preview Changes' );
 				} else {
-					$preview_button_text = __( 'Preview' );
+					$preview_button_text = _x( 'Preview', 'verb' );
 				}
 
 				$preview_button = sprintf(

--- a/src/wp-admin/includes/post.php
+++ b/src/wp-admin/includes/post.php
@@ -1900,7 +1900,7 @@ function _admin_notice_post_locked() {
 		<p>
 		<a class="button" href="<?php echo esc_url( $sendback ); ?>"><?php echo $sendback_text; ?></a>
 		<?php if ( $preview_link ) { ?>
-		<a class="button<?php echo $tab_last; ?>" href="<?php echo esc_url( $preview_link ); ?>"><?php _e( 'Preview' ); ?></a>
+		<a class="button<?php echo $tab_last; ?>" href="<?php echo esc_url( $preview_link ); ?>"><?php echo esc_html_x( 'Preview', 'verb' ); ?></a>
 			<?php
 		}
 

--- a/src/wp-admin/theme-install.php
+++ b/src/wp-admin/theme-install.php
@@ -422,7 +422,7 @@ if ( $tab ) {
 							<a class="button load-customize" href="{{ data.customize_url }}"><?php _e( 'Customize' ); ?></a>
 						<# } #>
 					<# } else { #>
-						<button class="button preview install-theme-preview"><?php _e( 'Preview' ); ?></button>
+						<button class="button preview install-theme-preview"><?php echo esc_html_x( 'Preview', 'verb' ); ?></button>
 					<# } #>
 				<# } else { #>
 					<?php
@@ -435,7 +435,7 @@ if ( $tab ) {
 					<# if ( data.customize_url ) { #>
 						<a class="button disabled"><?php _e( 'Live Preview' ); ?></a>
 					<# } else { #>
-						<button class="button disabled"><?php _e( 'Preview' ); ?></button>
+						<button class="button disabled"><?php echo esc_html_x( 'Preview', 'verb' ); ?></button>
 					<# } #>
 				<# } #>
 			<# } else { #>
@@ -445,14 +445,14 @@ if ( $tab ) {
 					$aria_label = sprintf( _x( 'Install %s', 'theme' ), '{{ data.name }}' );
 					?>
 					<a class="button button-primary theme-install" data-name="{{ data.name }}" data-slug="{{ data.id }}" href="{{ data.install_url }}" aria-label="<?php echo esc_attr( $aria_label ); ?>"><?php _e( 'Install' ); ?></a>
-					<button class="button preview install-theme-preview"><?php _e( 'Preview' ); ?></button>
+					<button class="button preview install-theme-preview"><?php echo esc_html_x( 'Preview', 'verb' ); ?></button>
 				<# } else { #>
 					<?php
 					/* translators: %s: Theme name. */
 					$aria_label = sprintf( _x( 'Cannot Install %s', 'theme' ), '{{ data.name }}' );
 					?>
 					<a class="button button-primary disabled" data-name="{{ data.name }}" aria-label="<?php echo esc_attr( $aria_label ); ?>"><?php _ex( 'Cannot Install', 'theme' ); ?></a>
-					<button class="button disabled"><?php _e( 'Preview' ); ?></button>
+					<button class="button disabled"><?php echo esc_html_x( 'Preview', 'verb' ); ?></button>
 				<# } #>
 			<# } #>
 		</div>
@@ -605,7 +605,7 @@ if ( $tab ) {
 			</div>
 		</div>
 		<div class="wp-full-overlay-main">
-		<iframe src="{{ data.preview_url }}" title="<?php esc_attr_e( 'Preview' ); ?>"></iframe>
+		<iframe src="{{ data.preview_url }}" title="<?php echo esc_attr_x( 'Preview', 'noun' ); ?>"></iframe>
 	</div>
 </script>
 

--- a/src/wp-includes/class-wp-customize-manager.php
+++ b/src/wp-includes/class-wp-customize-manager.php
@@ -4333,7 +4333,7 @@ final class WP_Customize_Manager {
 						<# if ( data.returnUrl !== data.previewUrl ) { #>
 							<a class="button customize-notice-go-back-button" href="{{ data.returnUrl }}"><?php _e( 'Go back' ); ?></a>
 						<# } #>
-						<a class="button customize-notice-preview-button" href="{{ data.frontendPreviewUrl }}"><?php _e( 'Preview' ); ?></a>
+						<a class="button customize-notice-preview-button" href="{{ data.frontendPreviewUrl }}"><?php echo esc_html_x( 'Preview', 'verb' ); ?></a>
 						<# if ( data.allowOverride ) { #>
 							<button class="button button-primary wp-tab-last customize-notice-take-over-button"><?php _e( 'Take over' ); ?></button>
 						<# } #>

--- a/src/wp-includes/class-wp-editor.php
+++ b/src/wp-includes/class-wp-editor.php
@@ -1252,7 +1252,7 @@ final class _WP_Editors {
 				'Nonbreaking space'                    => __( 'Nonbreaking space' ),
 				'Page break'                           => __( 'Page break' ),
 				'Paste as text'                        => __( 'Paste as text' ),
-				'Preview'                              => __( 'Preview' ),
+				'Preview'                              => _x( 'Preview', 'verb' ),
 				'Print'                                => __( 'Print' ),
 				'Save'                                 => __( 'Save' ),
 				'Fullscreen'                           => __( 'Fullscreen' ),


### PR DESCRIPTION
https://core.trac.wordpress.org/ticket/64986
Adds translator context to all in-tree occurrences of the 'Preview' string using a simplified `_x( 'Preview', 'noun' )` or `_x( 'Preview', 'verb' )`, so translators can correctly disambiguate it across languages (e.g. German) where the noun and verb forms differ.

* Buttons and action links use `'verb'`.
* Preview pane labels, table row headers, and the iframe title use `'noun'`.


