### PR TITLE
[REVERT] WP_Theme_JSON: Prevent implicit coercion in to_ruleset 

### DIFF
--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -1982,7 +1982,6 @@ class WP_Theme_JSON {
 	 * creates the corresponding ruleset.
 	 *
 	 * @since 5.8.0
-	 * @since 7.1.0 Skip declarations whose value is not a plain string (booleans, arrays, objects, etc.).
 	 *
 	 * @param string $selector     CSS selector.
 	 * @param array  $declarations List of declarations.
@@ -1996,18 +1995,7 @@ class WP_Theme_JSON {
 		$declaration_block = array_reduce(
 			$declarations,
 			static function ( $carry, $element ) {
-				$value = $element['value'];
-
-				if ( is_numeric( $value ) ) {
-					$value = (string) $value;
-				}
-
-				if ( ! is_string( $value ) ) {
-					return $carry;
-				}
-
-				return $carry .= $element['name'] . ': ' . $value . ';';
-			},
+				return $carry .= $element['name'] . ': ' . $element['value'] . ';'; },
 			''
 		);
 

--- a/tests/phpunit/tests/theme/wpThemeJson.php
+++ b/tests/phpunit/tests/theme/wpThemeJson.php
@@ -4138,7 +4138,6 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 	 * @ticket 60936
 	 * @ticket 61165
 	 * @ticket 61829
-	 * @ticket 64848
 	 */
 	public function test_get_styles_with_appearance_tools() {
 		$theme_json = new WP_Theme_JSON(
@@ -4151,11 +4150,11 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 		);
 
 		$metadata = array(
-			'path'     => array( 'styles' ),
+			'path'     => array( 'settings' ),
 			'selector' => 'body',
 		);
 
-		$expected = ':where(body) { margin: 0; }.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }:where(.wp-site-blocks) > * { margin-block-start: ; margin-block-end: 0; }:where(.wp-site-blocks) > :first-child { margin-block-start: 0; }:where(.wp-site-blocks) > :last-child { margin-block-end: 0; }:root { --wp--style--block-gap: ; }.is-layout-flow > .alignleft{float: left;margin-inline-start: 0;margin-inline-end: 2em;}.is-layout-flow > .alignright{float: right;margin-inline-start: 2em;margin-inline-end: 0;}.is-layout-flow > .aligncenter{margin-left: auto !important;margin-right: auto !important;}.is-layout-constrained > .alignleft{float: left;margin-inline-start: 0;margin-inline-end: 2em;}.is-layout-constrained > .alignright{float: right;margin-inline-start: 2em;margin-inline-end: 0;}.is-layout-constrained > .aligncenter{margin-left: auto !important;margin-right: auto !important;}.is-layout-constrained > :where(:not(.alignleft):not(.alignright):not(.alignfull)){margin-left: auto !important;margin-right: auto !important;}body .is-layout-flex{display: flex;}.is-layout-flex{flex-wrap: wrap;align-items: center;}.is-layout-flex > :is(*, div){margin: 0;}body .is-layout-grid{display: grid;}.is-layout-grid > :is(*, div){margin: 0;}';
+		$expected = ':where(body) { margin: 0; }.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }:where(.wp-site-blocks) > * { margin-block-start: ; margin-block-end: 0; }:where(.wp-site-blocks) > :first-child { margin-block-start: 0; }:where(.wp-site-blocks) > :last-child { margin-block-end: 0; }:root { --wp--style--block-gap: ; }:root :where(.is-layout-flow) > :first-child{margin-block-start: 0;}:root :where(.is-layout-flow) > :last-child{margin-block-end: 0;}:root :where(.is-layout-flow) > *{margin-block-start: 1;margin-block-end: 0;}:root :where(.is-layout-constrained) > :first-child{margin-block-start: 0;}:root :where(.is-layout-constrained) > :last-child{margin-block-end: 0;}:root :where(.is-layout-constrained) > *{margin-block-start: 1;margin-block-end: 0;}:root :where(.is-layout-flex){gap: 1;}:root :where(.is-layout-grid){gap: 1;}.is-layout-flow > .alignleft{float: left;margin-inline-start: 0;margin-inline-end: 2em;}.is-layout-flow > .alignright{float: right;margin-inline-start: 2em;margin-inline-end: 0;}.is-layout-flow > .aligncenter{margin-left: auto !important;margin-right: auto !important;}.is-layout-constrained > .alignleft{float: left;margin-inline-start: 0;margin-inline-end: 2em;}.is-layout-constrained > .alignright{float: right;margin-inline-start: 2em;margin-inline-end: 0;}.is-layout-constrained > .aligncenter{margin-left: auto !important;margin-right: auto !important;}.is-layout-constrained > :where(:not(.alignleft):not(.alignright):not(.alignfull)){margin-left: auto !important;margin-right: auto !important;}body .is-layout-flex{display: flex;}.is-layout-flex{flex-wrap: wrap;align-items: center;}.is-layout-flex > :is(*, div){margin: 0;}body .is-layout-grid{display: grid;}.is-layout-grid > :is(*, div){margin: 0;}';
 		$this->assertSame( $expected, $theme_json->get_root_layout_rules( WP_Theme_JSON::ROOT_BLOCK_SELECTOR, $metadata ) );
 	}
 
@@ -7054,45 +7053,5 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 		$settings = $theme_json->get_settings();
 		$this->assertSame( 'string-value', $settings['appearanceTools'], 'Appearance tools should be string value' );
 		$this->assertSame( array( 'nested' => 'value' ), $settings['custom'], 'Custom should be array value' );
-	}
-
-	/**
-	 * @covers WP_Theme_JSON::to_ruleset
-	 *
-	 * @ticket 64848
-	 */
-	public function test_to_ruleset_skips_non_scalar_values_and_casts_numerics() {
-		$reflection = new ReflectionMethod( WP_Theme_JSON::class, 'to_ruleset' );
-		if ( PHP_VERSION_ID < 80100 ) {
-			$reflection->setAccessible( true );
-		}
-		$declarations = array(
-			array(
-				'name'  => 'color',
-				'value' => 'red',
-			),
-			array(
-				'name'  => 'opacity',
-				'value' => true,
-			),
-			array(
-				'name'  => 'margin',
-				'value' => 0,
-			),
-			array(
-				'name'  => 'padding',
-				'value' => false,
-			),
-			array(
-				'name'  => 'gap',
-				'value' => array(),
-			),
-		);
-		$result       = $reflection->invoke( null, '.test', $declarations );
-		$this->assertStringContainsString( 'color: red;', $result, 'Color declaration should be included' );
-		$this->assertStringContainsString( 'margin: 0;', $result, 'Numeric value should be cast to string' );
-		$this->assertStringNotContainsString( 'opacity', $result, 'Boolean value should be skipped' );
-		$this->assertStringNotContainsString( 'padding', $result, 'Boolean value should be skipped' );
-		$this->assertStringNotContainsString( 'gap', $result, 'Array value should be skipped' );
 	}
 }


### PR DESCRIPTION
Reverts:

- https://github.com/WordPress/wordpress-develop/pull/11236

And therefore https://core.trac.wordpress.org/changeset/62347

This is because there's a block on commits to trunk for 7.1 patches until 7.0 is released.


Related trac ticket: [core.trac.wordpress.org/ticket/64848](https://core.trac.wordpress.org/ticket/64848)