### PR TITLE
Tests/admin/wpThemeInstallListTable: rename the original test class

### DIFF
--- a/tests/phpunit/tests/admin/Admin_WpThemeInstallListTable_GetViews_Test.php
+++ b/tests/phpunit/tests/admin/Admin_WpThemeInstallListTable_GetViews_Test.php
@@ -3,9 +3,9 @@
 /**
  * @group admin
  *
- * @covers WP_Theme_Install_List_Table
+ * @covers WP_Theme_Install_List_Table::get_views
  */
-class Tests_Admin_wpThemeInstallListTable extends WP_UnitTestCase {
+class Admin_WpThemeInstallListTable_GetViews_Test extends WP_UnitTestCase {
 	/**
 	 * @var WP_Theme_Install_List_Table
 	 */
@@ -18,8 +18,6 @@ class Tests_Admin_wpThemeInstallListTable extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 42066
-	 *
-	 * @covers WP_Theme_Install_List_Table::get_views
 	 */
 	public function test_get_views_should_return_no_views_by_default() {
 		$this->assertSame( array(), $this->table->get_views() );


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65208

Rename the test class `Tests_Admin_wpThemeInstallListTable` to `Admin_WpThemeInstallListTable_GetViews_Test` so that the name includes both the class under test and the method being tested.

Moves the `@covers` annotation to the class level and removes the duplicate method-level annotation. This makes the test class compatible with PHPUnit 11.

