### PR TITLE
Admin bar: Make command palette prominent in the center

### DIFF
--- a/src/wp-admin/css/colors/_admin.scss
+++ b/src/wp-admin/css/colors/_admin.scss
@@ -487,22 +487,22 @@ ul#adminmenu > li.current > a.current:after {
 
 /* Admin Bar: command palette */
 
-#wpadminbar > #wp-toolbar #wp-admin-bar-command-palette-trigger .ab-item {
+#wpadminbar > #wp-toolbar #wp-admin-bar-command-palette .ab-item {
 	background: variables.$menu-submenu-background-alt;
 }
 
-#wpadminbar > #wp-toolbar #wp-admin-bar-command-palette-trigger:hover .ab-item,
-#wpadminbar > #wp-toolbar #wp-admin-bar-command-palette-trigger > .ab-item:focus-visible {
+#wpadminbar > #wp-toolbar #wp-admin-bar-command-palette:hover .ab-item,
+#wpadminbar > #wp-toolbar #wp-admin-bar-command-palette > .ab-item:focus-visible {
 	background: variables.$menu-submenu-background;
 }
 
-#wpadminbar > #wp-toolbar #wp-admin-bar-command-palette-trigger:hover .ab-icon:before,
-#wpadminbar > #wp-toolbar #wp-admin-bar-command-palette-trigger > .ab-item:focus .ab-icon:before {
+#wpadminbar > #wp-toolbar #wp-admin-bar-command-palette:hover .ab-icon:before,
+#wpadminbar > #wp-toolbar #wp-admin-bar-command-palette > .ab-item:focus .ab-icon:before {
 	color: variables.$menu-icon;
 }
 
-#wpadminbar > #wp-toolbar #wp-admin-bar-command-palette-trigger:hover span.ab-label,
-#wpadminbar > #wp-toolbar #wp-admin-bar-command-palette-trigger > .ab-item:focus span.ab-label {
+#wpadminbar > #wp-toolbar #wp-admin-bar-command-palette:hover span.ab-label,
+#wpadminbar > #wp-toolbar #wp-admin-bar-command-palette > .ab-item:focus span.ab-label {
 	color: variables.$menu-text;
 }
 

--- a/src/wp-admin/css/colors/_admin.scss
+++ b/src/wp-admin/css/colors/_admin.scss
@@ -485,10 +485,25 @@ ul#adminmenu > li.current > a.current:after {
 	color: variables.$menu-icon;
 }
 
-/* Admin Bar: Command Palette */
+/* Admin Bar: command palette */
 
-#wpadminbar #wp-admin-bar-command-palette-trigger .ab-item {
+#wpadminbar > #wp-toolbar #wp-admin-bar-command-palette-trigger .ab-item {
+	background: variables.$menu-submenu-background-alt;
+}
+
+#wpadminbar > #wp-toolbar #wp-admin-bar-command-palette-trigger:hover .ab-item,
+#wpadminbar > #wp-toolbar #wp-admin-bar-command-palette-trigger > .ab-item:focus-visible {
 	background: variables.$menu-submenu-background;
+}
+
+#wpadminbar > #wp-toolbar #wp-admin-bar-command-palette-trigger:hover .ab-icon:before,
+#wpadminbar > #wp-toolbar #wp-admin-bar-command-palette-trigger > .ab-item:focus .ab-icon:before {
+	color: variables.$menu-icon;
+}
+
+#wpadminbar > #wp-toolbar #wp-admin-bar-command-palette-trigger:hover span.ab-label,
+#wpadminbar > #wp-toolbar #wp-admin-bar-command-palette-trigger > .ab-item:focus span.ab-label {
+	color: variables.$menu-text;
 }
 
 /* Admin Bar: search */

--- a/src/wp-admin/css/colors/_admin.scss
+++ b/src/wp-admin/css/colors/_admin.scss
@@ -485,6 +485,11 @@ ul#adminmenu > li.current > a.current:after {
 	color: variables.$menu-icon;
 }
 
+/* Admin Bar: Command Palette */
+
+#wpadminbar #wp-admin-bar-command-palette-trigger .ab-item {
+	background: variables.$menu-submenu-background;
+}
 
 /* Admin Bar: search */
 

--- a/src/wp-admin/css/colors/modern/colors.scss
+++ b/src/wp-admin/css/colors/modern/colors.scss
@@ -14,3 +14,8 @@ $highlight-color: #3858e9;
 
 	$custom-welcome-panel: "false"
 );
+
+// Override the command palette background color for this scheme
+#wpadminbar #wp-admin-bar-command-palette-trigger .ab-item {
+	background: #3c434a;
+}

--- a/src/wp-admin/css/colors/modern/colors.scss
+++ b/src/wp-admin/css/colors/modern/colors.scss
@@ -14,8 +14,3 @@ $highlight-color: #3858e9;
 
 	$custom-welcome-panel: "false"
 );
-
-// Override the command palette background color for this scheme
-#wpadminbar #wp-admin-bar-command-palette-trigger .ab-item {
-	background: #3c434a;
-}

--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -974,7 +974,7 @@ function wp_admin_bar_command_palette_menu( WP_Admin_Bar $wp_admin_bar ): void {
 			if ( ! ( new RegExp( applePattern, 'i' ) ).test( navigator.userAgent ) ) {
 				return;
 			}
-			const kbd = document.querySelector( '#wp-admin-bar-command-palette-trigger .ab-label kbd' );
+			const kbd = document.querySelector( '#wp-admin-bar-command-palette .ab-label kbd' );
 			if ( kbd ) {
 				kbd.textContent = appleOSLabel;
 			}
@@ -989,7 +989,7 @@ function wp_admin_bar_command_palette_menu( WP_Admin_Bar $wp_admin_bar ): void {
 	$script  .= "\n//# sourceURL=" . rawurlencode( __FUNCTION__ );
 	$wp_admin_bar->add_group(
 		array(
-			'id'   => 'command-palette',
+			'id'   => 'command-palette-group',
 			'meta' => array(
 				'class' => 'ab-command-palette hide-if-no-js',
 			),
@@ -997,8 +997,8 @@ function wp_admin_bar_command_palette_menu( WP_Admin_Bar $wp_admin_bar ): void {
 	);
 	$wp_admin_bar->add_node(
 		array(
-			'parent' => 'command-palette',
-			'id'     => 'command-palette-trigger',
+			'parent' => 'command-palette-group',
+			'id'     => 'command-palette',
 			'title'  => $title,
 			'href'   => '#',
 			'meta'   => array(

--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -974,7 +974,7 @@ function wp_admin_bar_command_palette_menu( WP_Admin_Bar $wp_admin_bar ): void {
 			if ( ! ( new RegExp( applePattern, 'i' ) ).test( navigator.userAgent ) ) {
 				return;
 			}
-			const kbd = document.querySelector( '#wp-admin-bar-command-palette .ab-label kbd' );
+			const kbd = document.querySelector( '#wp-admin-bar-command-palette-trigger .ab-label kbd' );
 			if ( kbd ) {
 				kbd.textContent = appleOSLabel;
 			}
@@ -987,13 +987,21 @@ function wp_admin_bar_command_palette_menu( WP_Admin_Bar $wp_admin_bar ): void {
 		wp_json_encode( $shortcut_labels['appleOS'], JSON_HEX_TAG | JSON_UNESCAPED_SLASHES )
 	);
 	$script  .= "\n//# sourceURL=" . rawurlencode( __FUNCTION__ );
+	$wp_admin_bar->add_group(
+		array(
+			'id'   => 'command-palette',
+			'meta' => array(
+				'class' => 'ab-command-palette hide-if-no-js',
+			),
+		)
+	);
 	$wp_admin_bar->add_node(
 		array(
-			'id'    => 'command-palette',
-			'title' => $title,
-			'href'  => '#',
-			'meta'  => array(
-				'class'   => 'hide-if-no-js',
+			'parent' => 'command-palette',
+			'id'     => 'command-palette-trigger',
+			'title'  => $title,
+			'href'   => '#',
+			'meta'   => array(
 				'onclick' => 'wp.data.dispatch( "core/commands" ).open(); return false;',
 				'html'    => wp_get_inline_script_tag( $script ),
 			),

--- a/src/wp-includes/css/admin-bar.css
+++ b/src/wp-includes/css/admin-bar.css
@@ -649,7 +649,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 
 #wpadminbar #wp-admin-bar-command-palette-trigger .ab-item {
 	width: 200px;
-	background: #757575;
+	background: #3c434a;
 	height: 24px;
 	display: flex;
 	justify-content: space-between;
@@ -668,6 +668,21 @@ html:lang(he-il) .rtl #wpadminbar * {
 #wpadminbar #wp-admin-bar-command-palette-trigger .ab-icon:before {
 	content: "\f179";
 	content: "\f179" / '';
+}
+
+#wpadminbar #wp-admin-bar-command-palette-trigger:hover .ab-item,
+#wpadminbar #wp-admin-bar-command-palette-trigger > .ab-item:focus-visible {
+	background: #2c3338;
+}
+
+#wpadminbar #wp-admin-bar-command-palette-trigger:hover .ab-icon:before,
+#wpadminbar #wp-admin-bar-command-palette-trigger > .ab-item:focus .ab-icon:before {
+	color: rgba(240, 246, 252, 0.6);
+}
+
+#wpadminbar > #wp-toolbar #wp-admin-bar-command-palette-trigger:hover span.ab-label,
+#wpadminbar > #wp-toolbar #wp-admin-bar-command-palette-trigger > .ab-item:focus span.ab-label {
+	color: #f0f0f1;
 }
 
 /**

--- a/src/wp-includes/css/admin-bar.css
+++ b/src/wp-includes/css/admin-bar.css
@@ -643,12 +643,18 @@ html:lang(he-il) .rtl #wpadminbar * {
  * Command Palette
  */
 #wpadminbar .ab-command-palette {
-	flex: 0 0 auto;
+	flex: 0 1 200px;
+	min-width: fit-content;
 	padding: 4px 0;
 }
 
+#wpadminbar .ab-command-palette > #wp-admin-bar-command-palette-trigger {
+	width: 100%;
+}
+
 #wpadminbar #wp-admin-bar-command-palette-trigger .ab-item {
-	width: 200px;
+	width: 100%;
+	box-sizing: border-box;
 	background: #3c434a;
 	height: 24px;
 	display: flex;
@@ -1009,6 +1015,10 @@ html:lang(he-il) .rtl #wpadminbar * {
 	}
 
 	/* Command Palette */
+	#wpadminbar .ab-command-palette {
+		flex: 0 0 auto;
+	}
+
 	#wpadminbar #wp-admin-bar-command-palette-trigger .ab-item {
 		width: auto;
 		height: 32px;

--- a/src/wp-includes/css/admin-bar.css
+++ b/src/wp-includes/css/admin-bar.css
@@ -691,6 +691,10 @@ html:lang(he-il) .rtl #wpadminbar * {
 	color: #f0f0f1;
 }
 
+body .commands-command-menu {
+	top: 4px;
+}
+
 /**
  * Search
  */

--- a/src/wp-includes/css/admin-bar.css
+++ b/src/wp-includes/css/admin-bar.css
@@ -374,8 +374,22 @@ html:lang(he-il) .rtl #wpadminbar * {
 	color: #000;
 }
 
+#wpadminbar .quicklinks {
+	display: flex;
+	align-items: center;
+}
+
+#wpadminbar #wp-admin-bar-root-default {
+	flex: 1 1 0;
+	min-width: fit-content;
+}
+
 #wpadminbar .ab-top-secondary {
 	float: right;
+	flex: 1 1 0;
+	min-width: fit-content;
+	display: flex;
+	justify-content: flex-end;
 }
 
 #wpadminbar ul li:last-child,
@@ -626,6 +640,37 @@ html:lang(he-il) .rtl #wpadminbar * {
 }
 
 /**
+ * Command Palette
+ */
+#wpadminbar .ab-command-palette {
+	flex: 0 0 auto;
+	padding: 4px 0;
+}
+
+#wpadminbar #wp-admin-bar-command-palette-trigger .ab-item {
+	width: 200px;
+	background: #757575;
+	height: 24px;
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	border-radius: 2px;
+}
+
+#wpadminbar #wp-admin-bar-command-palette-trigger .ab-label kbd {
+	background: transparent;
+}
+
+#wpadminbar #wp-admin-bar-command-palette-trigger .ab-icon {
+	transform: scaleX(-1);
+}
+
+#wpadminbar #wp-admin-bar-command-palette-trigger .ab-icon:before {
+	content: "\f179";
+	content: "\f179" / '';
+}
+
+/**
  * Search
  */
 
@@ -692,19 +737,6 @@ html:lang(he-il) .rtl #wpadminbar * {
 
 #wpadminbar #adminbarsearch .adminbar-button {
 	display: none;
-}
-
-/**
- * Command Palette
- */
-#wpadminbar #wp-admin-bar-command-palette .ab-icon:before {
-	content: "\f179";
-	content: "\f179" / '';
-	top: 3px;
-}
-
-#wpadminbar #wp-admin-bar-command-palette kbd {
-	background: transparent;
 }
 
 /**
@@ -906,7 +938,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 	#wpadminbar #wp-admin-bar-site-editor > .ab-item:before,
 	#wpadminbar #wp-admin-bar-customize > .ab-item:before,
 	#wpadminbar #wp-admin-bar-my-account > .ab-item:before,
-	#wpadminbar #wp-admin-bar-command-palette .ab-icon:before {
+	#wpadminbar #wp-admin-bar-command-palette-trigger .ab-icon:before {
 		display: block;
 		text-indent: 0;
 		font: normal 32px/1 dashicons;
@@ -951,12 +983,12 @@ html:lang(he-il) .rtl #wpadminbar * {
 
 	/* Comments and Command Palette */
 	#wpadminbar #wp-admin-bar-comments .ab-icon,
-	#wpadminbar #wp-admin-bar-command-palette .ab-icon {
+	#wpadminbar #wp-admin-bar-command-palette-trigger .ab-icon {
 		margin: 0;
 	}
 
 	#wpadminbar #wp-admin-bar-comments .ab-icon:before,
-	#wpadminbar #wp-admin-bar-command-palette .ab-icon:before {
+	#wpadminbar #wp-admin-bar-command-palette-trigger .ab-icon:before {
 		display: block;
 		font-size: 34px;
 		height: 46px;
@@ -1026,7 +1058,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 	#wpadminbar li#wp-admin-bar-edit,
 	#wpadminbar li#wp-admin-bar-comments,
 	#wpadminbar li#wp-admin-bar-my-account,
-	#wpadminbar li#wp-admin-bar-command-palette {
+	#wpadminbar li#wp-admin-bar-command-palette-trigger {
 		display: block;
 	}
 
@@ -1058,7 +1090,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 	#wpadminbar #wp-admin-bar-new-content,
 	#wpadminbar #wp-admin-bar-edit,
 	#wpadminbar #wp-admin-bar-my-account,
-	#wpadminbar #wp-admin-bar-command-palette {
+	#wpadminbar #wp-admin-bar-command-palette-trigger {
 		position: static;
 	}
 

--- a/src/wp-includes/css/admin-bar.css
+++ b/src/wp-includes/css/admin-bar.css
@@ -937,8 +937,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 	#wpadminbar #wp-admin-bar-site-name > .ab-item:before,
 	#wpadminbar #wp-admin-bar-site-editor > .ab-item:before,
 	#wpadminbar #wp-admin-bar-customize > .ab-item:before,
-	#wpadminbar #wp-admin-bar-my-account > .ab-item:before,
-	#wpadminbar #wp-admin-bar-command-palette-trigger .ab-icon:before {
+	#wpadminbar #wp-admin-bar-my-account > .ab-item:before {
 		display: block;
 		text-indent: 0;
 		font: normal 32px/1 dashicons;
@@ -981,19 +980,39 @@ html:lang(he-il) .rtl #wpadminbar * {
 		top: 3px;
 	}
 
-	/* Comments and Command Palette */
-	#wpadminbar #wp-admin-bar-comments .ab-icon,
-	#wpadminbar #wp-admin-bar-command-palette-trigger .ab-icon {
+	/* Comments */
+	#wpadminbar #wp-admin-bar-comments .ab-icon {
 		margin: 0;
 	}
 
-	#wpadminbar #wp-admin-bar-comments .ab-icon:before,
-	#wpadminbar #wp-admin-bar-command-palette-trigger .ab-icon:before {
+	#wpadminbar #wp-admin-bar-comments .ab-icon:before {
 		display: block;
 		font-size: 34px;
 		height: 46px;
 		line-height: 1.38235294;
 		top: 0;
+	}
+
+	/* Command Palette */
+	#wpadminbar #wp-admin-bar-command-palette-trigger .ab-item {
+		width: auto;
+		height: 32px;
+		padding: 0 2px;
+		margin-right: 4px;
+		border-radius: 4px;
+	}
+
+	#wpadminbar #wp-admin-bar-command-palette-trigger .ab-icon {
+		font: 30px/1 dashicons !important;
+		width: auto;
+		height: auto;
+		margin-right: 0;
+		padding: 4px 0;
+		text-align: center;
+	}
+
+	#wpadminbar .ab-top-secondary {
+		flex: 0 0 auto;
 	}
 
 	/* My Account */

--- a/src/wp-includes/css/admin-bar.css
+++ b/src/wp-includes/css/admin-bar.css
@@ -648,11 +648,11 @@ html:lang(he-il) .rtl #wpadminbar * {
 	padding: 4px 0;
 }
 
-#wpadminbar .ab-command-palette > #wp-admin-bar-command-palette-trigger {
+#wpadminbar .ab-command-palette > #wp-admin-bar-command-palette {
 	width: 100%;
 }
 
-#wpadminbar #wp-admin-bar-command-palette-trigger .ab-item {
+#wpadminbar #wp-admin-bar-command-palette .ab-item {
 	width: 100%;
 	box-sizing: border-box;
 	background: #3c434a;
@@ -663,31 +663,31 @@ html:lang(he-il) .rtl #wpadminbar * {
 	border-radius: 2px;
 }
 
-#wpadminbar #wp-admin-bar-command-palette-trigger .ab-label kbd {
+#wpadminbar #wp-admin-bar-command-palette .ab-label kbd {
 	background: transparent;
 }
 
-#wpadminbar #wp-admin-bar-command-palette-trigger .ab-icon {
+#wpadminbar #wp-admin-bar-command-palette .ab-icon {
 	transform: scaleX(-1);
 }
 
-#wpadminbar #wp-admin-bar-command-palette-trigger .ab-icon:before {
+#wpadminbar #wp-admin-bar-command-palette .ab-icon:before {
 	content: "\f179";
 	content: "\f179" / '';
 }
 
-#wpadminbar #wp-admin-bar-command-palette-trigger:hover .ab-item,
-#wpadminbar #wp-admin-bar-command-palette-trigger > .ab-item:focus-visible {
+#wpadminbar #wp-admin-bar-command-palette:hover .ab-item,
+#wpadminbar #wp-admin-bar-command-palette > .ab-item:focus-visible {
 	background: #2c3338;
 }
 
-#wpadminbar #wp-admin-bar-command-palette-trigger:hover .ab-icon:before,
-#wpadminbar #wp-admin-bar-command-palette-trigger > .ab-item:focus .ab-icon:before {
+#wpadminbar #wp-admin-bar-command-palette:hover .ab-icon:before,
+#wpadminbar #wp-admin-bar-command-palette > .ab-item:focus .ab-icon:before {
 	color: rgba(240, 246, 252, 0.6);
 }
 
-#wpadminbar > #wp-toolbar #wp-admin-bar-command-palette-trigger:hover span.ab-label,
-#wpadminbar > #wp-toolbar #wp-admin-bar-command-palette-trigger > .ab-item:focus span.ab-label {
+#wpadminbar > #wp-toolbar #wp-admin-bar-command-palette:hover span.ab-label,
+#wpadminbar > #wp-toolbar #wp-admin-bar-command-palette > .ab-item:focus span.ab-label {
 	color: #f0f0f1;
 }
 
@@ -1023,7 +1023,7 @@ body .commands-command-menu {
 		flex: 0 0 auto;
 	}
 
-	#wpadminbar #wp-admin-bar-command-palette-trigger .ab-item {
+	#wpadminbar #wp-admin-bar-command-palette .ab-item {
 		width: auto;
 		height: 32px;
 		padding: 0 2px;
@@ -1031,7 +1031,7 @@ body .commands-command-menu {
 		border-radius: 4px;
 	}
 
-	#wpadminbar #wp-admin-bar-command-palette-trigger .ab-icon {
+	#wpadminbar #wp-admin-bar-command-palette .ab-icon {
 		font: 30px/1 dashicons !important;
 		width: auto;
 		height: auto;
@@ -1106,7 +1106,7 @@ body .commands-command-menu {
 	#wpadminbar li#wp-admin-bar-edit,
 	#wpadminbar li#wp-admin-bar-comments,
 	#wpadminbar li#wp-admin-bar-my-account,
-	#wpadminbar li#wp-admin-bar-command-palette-trigger {
+	#wpadminbar li#wp-admin-bar-command-palette {
 		display: block;
 	}
 
@@ -1138,7 +1138,7 @@ body .commands-command-menu {
 	#wpadminbar #wp-admin-bar-new-content,
 	#wpadminbar #wp-admin-bar-edit,
 	#wpadminbar #wp-admin-bar-my-account,
-	#wpadminbar #wp-admin-bar-command-palette-trigger {
+	#wpadminbar #wp-admin-bar-command-palette {
 		position: static;
 	}
 


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/65219

This PR is an attempt to take https://github.com/WordPress/wordpress-develop/pull/11171 to the finish line. On top of that PR, I improved mobile styles, background colors, and command palette overlay behavior.

Basically, we want to make the command palette "trigger node" more prominent in the center of the admin bar. On mobile viewport, to make the layout balanced, I propose to put the icon at top-right, together with the user avatar icon.

| Desktop | Mobile |
| - | - |
| <img width="1566" height="64" alt="scheme-modern-normal" src="https://github.com/user-attachments/assets/13921f1a-dafc-4859-8ccd-5a20363b3767" /> | <img width="1202" height="92" alt="image" src="https://github.com/user-attachments/assets/ad7d035e-a2c7-46ec-b526-5173c5db7006" /> |

---

The trigger node is not an actual text input form. So, I made the following improvements:

- Change color on hover to make it look like a button.
- Move the command palette overlay to the top, to cover the node. This behavior is similar to Slack. (I was inspired by this comment https://github.com/WordPress/wordpress-develop/pull/11171#pullrequestreview-3917555903)

https://github.com/user-attachments/assets/229fd39f-e98e-45c7-83ab-3381f630a7fc

I used the following color variables, which is a bit different from the original PR. I believe the new color is more subtle and look better. It looks more like button than text input now.

|Normal|Hover|
|-|-|
|<img width="515" height="260" alt="image" src="https://github.com/user-attachments/assets/33d1447e-b7b1-4779-b015-340d873d0b6a" />|<img width="515" height="260" alt="image" src="https://github.com/user-attachments/assets/7cad1cf5-5e9b-4724-b0ef-68951897ba09" />

Here's how it looks like on all color schemes:

| Normal | Hover |
| - | - |
| <img width="1566" height="64" alt="scheme-modern-normal" src="https://github.com/user-attachments/assets/13921f1a-dafc-4859-8ccd-5a20363b3767" /> | <img width="1566" height="64" alt="scheme-modern-hover" src="https://github.com/user-attachments/assets/46a221fa-8a77-4b78-a55f-b58fdc79df73" /> |
| <img width="1566" height="64" alt="scheme-fresh-normal" src="https://github.com/user-attachments/assets/5b3312c3-0619-4653-9302-f88be54613d9" /> | <img width="1566" height="64" alt="scheme-fresh-hover" src="https://github.com/user-attachments/assets/17438a89-018d-464d-ab49-e508c6c76d7f" /> |
| <img width="1566" height="64" alt="scheme-light-normal" src="https://github.com/user-attachments/assets/295346fb-b3ab-4ca2-80da-156451bab948" /> | <img width="1566" height="64" alt="scheme-light-hover" src="https://github.com/user-attachments/assets/c368b2fe-3fd1-4c5c-b7b8-b91becc568a8" /> |
| <img width="1566" height="64" alt="scheme-blue-normal" src="https://github.com/user-attachments/assets/c14dd058-5d8f-4f7e-9801-bb98d42530cf" /> | <img width="1566" height="64" alt="scheme-blue-hover" src="https://github.com/user-attachments/assets/3175f6ba-5192-4a56-a4fb-1fa5b6ef7d45" /> |
| <img width="1566" height="64" alt="scheme-coffee-normal" src="https://github.com/user-attachments/assets/5ef5371f-8882-4158-8ddf-9a3f37cb9dc3" /> | <img width="1566" height="64" alt="scheme-coffee-hover" src="https://github.com/user-attachments/assets/4724cc23-21a9-4717-b3bc-eeb90e96b5b8" /> |
| <img width="1566" height="64" alt="scheme-ectoplasm-normal" src="https://github.com/user-attachments/assets/e6bceb0e-ae6b-42ea-9bd1-019a2bf6deba" /> | <img width="1566" height="64" alt="scheme-ectoplasm-hover" src="https://github.com/user-attachments/assets/fd995ea1-be41-4620-935e-ebb57ba69faf" /> |
| <img width="1566" height="64" alt="scheme-midnight-normal" src="https://github.com/user-attachments/assets/c4f63578-292a-43e0-aa51-789e56a4354e" /> | <img width="1566" height="64" alt="scheme-midnight-hover" src="https://github.com/user-attachments/assets/29e3032c-4f44-48ca-a2d0-0999b6cd601e" /> |
| <img width="1566" height="64" alt="scheme-ocean-normal" src="https://github.com/user-attachments/assets/16376d07-c624-44f5-b6af-7b5357cc2b0b" /> | <img width="1566" height="64" alt="scheme-ocean-hover" src="https://github.com/user-attachments/assets/b9f7783d-be24-4a60-bfd9-8fcd6795ca38" /> |
| <img width="1566" height="64" alt="scheme-sunrise-normal" src="https://github.com/user-attachments/assets/8f98961d-6b52-4ebd-869a-9da96190b1b1" /> | <img width="1566" height="64" alt="scheme-sunrise-hover" src="https://github.com/user-attachments/assets/6bca0427-4bd1-4d76-afb8-00e373e78674" /> |

---

The trigger node is responsive; it can reposition and resize itself in a crowded admin bar:

https://github.com/user-attachments/assets/c8120b13-9a05-4127-ab1c-c5527c337aea


## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 4.7
Used for: CSS implementation under my supervision.


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
