### PR TITLE
Media: Increase attachments browser toolbar height to fit filter controls

### DIFF
--- a/src/wp-includes/css/media-views.css
+++ b/src/wp-includes/css/media-views.css
@@ -310,7 +310,7 @@
 	left: 0;
 	right: 0;
 	z-index: 100;
-	height: 48px;
+	height: 60px;
 	padding: 0 16px;
 	border: 0 solid #dcdcde;
 	overflow: auto;
@@ -1273,7 +1273,7 @@ select#media-attachment-date-filters {
 .attachments-browser.has-load-more .attachments-wrapper,
 .attachments-browser .uploader-inline {
 	position: absolute;
-	top: 72px;
+	top: 84px;
 	left: 0;
 	right: 300px;
 	bottom: 0;


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/23562

## Screenshots

### Before

<img width="1006" height="356" alt="image" src="https://github.com/user-attachments/assets/95fc5da7-6193-46d6-804d-b43efb14e730" />

### After

<img width="995" height="347" alt="image" src="https://github.com/user-attachments/assets/8967d18f-5b86-44b9-844d-455d485bac68" />

## Use of AI Tools

None