### PR TITLE
Admin bar: Make the user avatar image circular

### DIFF
--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -276,7 +276,7 @@ function wp_admin_bar_my_account_item( $wp_admin_bar ) {
 	/* translators: %s: Current user's display name. */
 	$howdy = sprintf( __( 'Howdy, %s' ), '<span class="display-name">' . wp_get_current_user()->display_name . '</span>' );
 
-	$avatar = get_avatar( $user_id, 26 );
+	$avatar = get_avatar( $user_id, 28 );
 	$wp_admin_bar->add_node(
 		array(
 			'id'     => 'my-account',

--- a/src/wp-includes/css/admin-bar.css
+++ b/src/wp-includes/css/admin-bar.css
@@ -455,6 +455,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 	top: 4px;
 	width: 64px;
 	height: 64px;
+	border-radius: 50%;
 }
 
 #wpadminbar #wp-admin-bar-user-info a {
@@ -481,9 +482,10 @@ html:lang(he-il) .rtl #wpadminbar * {
 #wpadminbar #wp-admin-bar-my-account.with-avatar > .ab-empty-item img,
 #wpadminbar #wp-admin-bar-my-account.with-avatar > a img {
 	width: auto;
-	height: 16px;
+	height: 20px;
 	padding: 0;
-	border: 1px solid #8c8f94;
+	border: 1px solid #2c353b;
+	border-radius: 50%;
 	background: #f0f0f1;
 	line-height: 1.84615384;
 	vertical-align: middle;
@@ -977,10 +979,11 @@ html:lang(he-il) .rtl #wpadminbar * {
 
 	#wpadminbar .quicklinks li#wp-admin-bar-my-account.with-avatar > a img {
 		position: absolute;
-		top: 13px;
+		top: 12px;
 		right: 10px;
-		width: 26px;
-		height: 26px;
+		width: 28px;
+		height: 28px;
+		border-radius: 50%;
 	}
 
 	#wpadminbar #wp-admin-bar-user-actions.ab-submenu {

--- a/src/wp-includes/css/admin-bar.css
+++ b/src/wp-includes/css/admin-bar.css
@@ -454,6 +454,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 	top: 4px;
 	width: 64px;
 	height: 64px;
+	border-radius: 50%;
 }
 
 #wpadminbar #wp-admin-bar-user-info a {
@@ -480,9 +481,10 @@ html:lang(he-il) .rtl #wpadminbar * {
 #wpadminbar #wp-admin-bar-my-account.with-avatar > .ab-empty-item img,
 #wpadminbar #wp-admin-bar-my-account.with-avatar > a img {
 	width: auto;
-	height: 16px;
+	height: 20px;
 	padding: 0;
 	border: 1px solid #8c8f94;
+	border-radius: 50%;
 	background: #f0f0f1;
 	line-height: 1.84615384;
 	vertical-align: middle;
@@ -976,10 +978,11 @@ html:lang(he-il) .rtl #wpadminbar * {
 
 	#wpadminbar .quicklinks li#wp-admin-bar-my-account.with-avatar > a img {
 		position: absolute;
-		top: 13px;
+		top: 12px;
 		right: 10px;
-		width: 26px;
-		height: 26px;
+		width: 28px;
+		height: 28px;
+		border-radius: 50%;
 	}
 
 	#wpadminbar #wp-admin-bar-user-actions.ab-submenu {


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/64667

### Summary

Make the user avatar in the admin bar circular as follows:

- Desktop viewport: bump the size from 18px to 20px; add border-radius: 50%
- Mobile viewport: bump the size from 26px to 28px; add border-radius: 50%

The size changes are made to make it look balanced with the rest of the icons in the admin bar.

This PR strictly updates the avatar on admin bar only. I did not update, for example, in `profile.php` page. I think it's better to let it display the original image without circular modification.

### Desktop

Before
<img width="1566" height="64" alt="before-desktop-closed" src="https://github.com/user-attachments/assets/a7dcac13-7556-4b57-872a-8f0720787bb6" />

After
<img width="1566" height="64" alt="after-desktop-closed" src="https://github.com/user-attachments/assets/25f02685-72a5-4075-a374-3d1165c6fb01" />


| Before | After |
| - | - |
| <img width="544" height="274" alt="before-desktop-open" src="https://github.com/user-attachments/assets/0e1bfa47-0c90-42fb-8ec6-7d701b479f64" /> | <img width="544" height="274" alt="after-desktop-open" src="https://github.com/user-attachments/assets/f7532946-7067-495d-8f11-e2e357cf91ff" /> |

### Mobile

| Before | After |
| - | - |
| <img width="600" height="92" alt="before-mobile-closed" src="https://github.com/user-attachments/assets/384d67be-b6f6-4375-9fd2-5446f24404c4" /> | <img width="600" height="92" alt="after-mobile-closed" src="https://github.com/user-attachments/assets/52a0b3f1-44b6-4a50-b54f-d02d3efcb288" /> |





## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 4.7
Used for: CSS and screenshots generation.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
