### PR TITLE
Tests: Preserve default excluded groups when using --exclude-group

### DIFF
--- a/tests/phpunit/includes/abstract-testcase.php
+++ b/tests/phpunit/includes/abstract-testcase.php
@@ -108,6 +108,8 @@ abstract class WP_UnitTestCase_Base extends PHPUnit_Adapter_TestCase {
 
 		set_time_limit( 0 );
 
+		$this->skip_default_excluded_groups();
+
 		$this->factory = static::factory();
 
 		if ( ! self::$ignore_files ) {
@@ -141,6 +143,43 @@ abstract class WP_UnitTestCase_Base extends PHPUnit_Adapter_TestCase {
 		$this->expectDeprecated();
 		add_filter( 'wp_die_handler', array( $this, 'get_wp_die_handler' ) );
 		add_filter( 'wp_hash_password_options', array( $this, 'wp_hash_password_options' ), 1, 2 );
+	}
+
+	/**
+	 * Skips tests that belong to groups excluded by default unless those groups were explicitly requested.
+	 */
+	protected function skip_default_excluded_groups() {
+		$skipped_groups = self::get_default_excluded_groups_for_test( $this->getGroups() );
+
+		if ( $skipped_groups ) {
+			$this->markTestSkipped(
+				sprintf(
+					'This test belongs to a group that is skipped by default: %s. Use --group %s to run it.',
+					implode( ', ', $skipped_groups ),
+					$skipped_groups[0]
+				)
+			);
+		}
+	}
+
+	/**
+	 * Returns the default-excluded groups that apply to a test and were not explicitly requested.
+	 *
+	 * @param string[] $groups Test groups.
+	 * @return string[] Matching excluded groups.
+	 */
+	public static function get_default_excluded_groups_for_test( array $groups ) {
+		$default_excluded_groups = WP_PHPUnit_Util_Getopt::get_skipped_groups();
+
+		return array_values(
+			array_filter(
+				$groups,
+				static function ( $group ) use ( $default_excluded_groups ) {
+					return in_array( $group, $default_excluded_groups, true )
+						&& ! WP_PHPUnit_Util_Getopt::is_group_requested( $group );
+				}
+			)
+		);
 	}
 
 	/**

--- a/tests/phpunit/includes/bootstrap.php
+++ b/tests/phpunit/includes/bootstrap.php
@@ -345,13 +345,53 @@ require __DIR__ . '/class-wp-sitemaps-large-test-provider.php';
  * how you call phpunit has no effect.
  */
 class WP_PHPUnit_Util_Getopt {
+	/**
+	 * Groups that are skipped by default for the current test run.
+	 *
+	 * @var array<string, bool>
+	 */
+	protected static $skipped_groups = array();
+
+	/**
+	 * Groups that were explicitly requested via the command line.
+	 *
+	 * @var array<string, bool>
+	 */
+	protected static $requested_groups = array();
+
+	/**
+	 * Initializes the default skipped groups for the current test mode.
+	 *
+	 * @return array<string, bool> The groups skipped by default.
+	 */
+	protected static function get_default_skipped_groups() {
+		$skipped_groups = array(
+			'ajax'                   => true,
+			'ms-files'               => true,
+			'external-http'          => true,
+			'html-api-html5lib-tests' => true,
+		);
+
+		if ( defined( 'WP_TESTS_MULTISITE' ) && WP_TESTS_MULTISITE ) {
+			$skipped_groups['ms-excluded']    = true;
+			$skipped_groups['oembed-headers'] = true;
+		} else {
+			$skipped_groups['ms-required'] = true;
+		}
+
+		return $skipped_groups;
+	}
+
+	/**
+	 * Resets the parsed command line state.
+	 */
+	public static function reset() {
+		self::$skipped_groups  = self::get_default_skipped_groups();
+		self::$requested_groups = array();
+	}
 
 	public function __construct( $argv ) {
-		$skipped_groups = array(
-			'ajax'          => true,
-			'ms-files'      => true,
-			'external-http' => true,
-		);
+		self::reset();
 
 		while ( current( $argv ) ) {
 			$option = current( $argv );
@@ -359,28 +399,29 @@ class WP_PHPUnit_Util_Getopt {
 
 			switch ( $option ) {
 				case '--exclude-group':
-					foreach ( $skipped_groups as $group_name => $skipped ) {
-						$skipped_groups[ $group_name ] = false;
-					}
+					// PHPUnit replaces XML exclusions when this option is provided.
+					// Keep our default skipped groups active unless they are requested explicitly.
 					continue 2;
 				case '--group':
 					$groups = explode( ',', $value );
 					foreach ( $groups as $group ) {
+						self::$requested_groups[ $group ] = true;
+
 						if ( is_numeric( $group ) || preg_match( '/^(UT|Plugin)\d+$/', $group ) ) {
 							WP_UnitTestCase::forceTicket( $group );
 						}
 					}
 
-					foreach ( $skipped_groups as $group_name => $skipped ) {
+					foreach ( self::$skipped_groups as $group_name => $skipped ) {
 						if ( in_array( $group_name, $groups, true ) ) {
-							$skipped_groups[ $group_name ] = false;
+							self::$skipped_groups[ $group_name ] = false;
 						}
 					}
 					continue 2;
 			}
 		}
 
-		$skipped_groups = array_filter( $skipped_groups );
+		$skipped_groups = array_filter( self::$skipped_groups );
 		foreach ( $skipped_groups as $group_name => $skipped ) {
 			echo sprintf( 'Not running %1$s tests. To execute these, use --group %1$s.', $group_name ) . PHP_EOL;
 		}
@@ -391,6 +432,25 @@ class WP_PHPUnit_Util_Getopt {
 			echo 'If this changeset includes changes to HTTP, make sure there are no timeouts.' . PHP_EOL;
 			echo PHP_EOL;
 		}
+	}
+
+	/**
+	 * Returns the groups that are still skipped by default for this run.
+	 *
+	 * @return string[]
+	 */
+	public static function get_skipped_groups() {
+		return array_keys( array_filter( self::$skipped_groups ) );
+	}
+
+	/**
+	 * Determines whether a group was explicitly requested via the command line.
+	 *
+	 * @param string $group Group name.
+	 * @return bool Whether the group was explicitly requested.
+	 */
+	public static function is_group_requested( $group ) {
+		return isset( self::$requested_groups[ $group ] );
 	}
 }
 new WP_PHPUnit_Util_Getopt( $_SERVER['argv'] );

--- a/tests/phpunit/includes/bootstrap.php
+++ b/tests/phpunit/includes/bootstrap.php
@@ -366,9 +366,9 @@ class WP_PHPUnit_Util_Getopt {
 	 */
 	protected static function get_default_skipped_groups() {
 		$skipped_groups = array(
-			'ajax'                   => true,
-			'ms-files'               => true,
-			'external-http'          => true,
+			'ajax'                    => true,
+			'ms-files'                => true,
+			'external-http'           => true,
 			'html-api-html5lib-tests' => true,
 		);
 
@@ -386,7 +386,7 @@ class WP_PHPUnit_Util_Getopt {
 	 * Resets the parsed command line state.
 	 */
 	public static function reset() {
-		self::$skipped_groups  = self::get_default_skipped_groups();
+		self::$skipped_groups   = self::get_default_skipped_groups();
 		self::$requested_groups = array();
 	}
 

--- a/tests/phpunit/tests/phpunit/groupFilters.php
+++ b/tests/phpunit/tests/phpunit/groupFilters.php
@@ -44,9 +44,11 @@ class Tests_PHPUnit_GroupFilters extends WP_UnitTestCase {
 		);
 		ob_end_clean();
 
+		$multisite_excluded_group = is_multisite() ? 'ms-excluded' : 'ms-required';
+
 		$this->assertSame(
-			array( 'ajax', 'ms-required' ),
-			WP_UnitTestCase_Base::get_default_excluded_groups_for_test( array( 'ajax', 'ms-required' ) )
+			array( 'ajax', $multisite_excluded_group ),
+			WP_UnitTestCase_Base::get_default_excluded_groups_for_test( array( 'ajax', $multisite_excluded_group ) )
 		);
 	}
 }

--- a/tests/phpunit/tests/phpunit/groupFilters.php
+++ b/tests/phpunit/tests/phpunit/groupFilters.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * @group phpunit
+ */
+class Tests_PHPUnit_GroupFilters extends WP_UnitTestCase {
+
+	public function tear_down() {
+		WP_PHPUnit_Util_Getopt::reset();
+		parent::tear_down();
+	}
+
+	public function test_single_site_default_excluded_groups_are_reported() {
+		$this->assertSame(
+			array( 'ajax', 'external-http' ),
+			WP_UnitTestCase_Base::get_default_excluded_groups_for_test( array( 'ajax', 'external-http', 'query' ) )
+		);
+	}
+
+	public function test_requested_group_is_not_reported_as_default_excluded() {
+		ob_start();
+		new WP_PHPUnit_Util_Getopt(
+			array(
+				'phpunit',
+				'--group',
+				'ajax',
+			)
+		);
+		ob_end_clean();
+
+		$this->assertSame(
+			array(),
+			WP_UnitTestCase_Base::get_default_excluded_groups_for_test( array( 'ajax' ) )
+		);
+	}
+
+	public function test_exclude_group_does_not_clear_default_excluded_groups() {
+		ob_start();
+		new WP_PHPUnit_Util_Getopt(
+			array(
+				'phpunit',
+				'--exclude-group',
+				'import',
+			)
+		);
+		ob_end_clean();
+
+		$this->assertSame(
+			array( 'ajax', 'ms-required' ),
+			WP_UnitTestCase_Base::get_default_excluded_groups_for_test( array( 'ajax', 'ms-required' ) )
+		);
+	}
+}


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

## Summary

Preserves the default excluded PHPUnit groups when an additional `--exclude-group` argument is passed.

## Trac

https://core.trac.wordpress.org/ticket/34185

## Testing

- Run `npm run test:php -- --filter Tests_PHPUnit_GroupFilters`
- Run `npm run test:php -- --exclude-group import --filter test_populate_site_meta`
- Run `npm run test:php -- --group ajax` and verify ajax tests are no longer skipped by default

Trac ticket: https://core.trac.wordpress.org/ticket/34185

## Use of AI Tools

AI assistance: Yes
Tool(s): OpenAI Codex
Model(s): GPT-5
Used for: Reviewing the Trac ticket and relevant code, helping with the initial implementation and regression-test approach, and assisting with validation and PR-description drafting. The final implementation, tests, validation results, and description were reviewed and accepted by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**