### PR TITLE
Admin bar: Make frontend search UX similar to prominent command palette

### DIFF
--- a/src/wp-admin/css/colors/_admin.scss
+++ b/src/wp-admin/css/colors/_admin.scss
@@ -492,9 +492,25 @@ ul#adminmenu > li.current > a.current:after {
 	color: variables.$menu-icon;
 }
 
-#wpadminbar > #wp-toolbar > #wp-admin-bar-top-secondary > #wp-admin-bar-search #adminbarsearch input.adminbar-input:focus {
+#wpadminbar > #wp-toolbar li:hover #adminbarsearch:before,
+#wpadminbar > #wp-toolbar li #adminbarsearch.adminbar-focused:before {
+	color: variables.$menu-icon;
+}
+
+#wpadminbar #adminbarsearch input.adminbar-input {
 	color: variables.$menu-text;
-	background: variables.$adminbar-input-background;
+	background: variables.$menu-submenu-background-alt;
+}
+
+#wpadminbar #adminbarsearch:hover input.adminbar-input,
+#wpadminbar #adminbarsearch:focus-within input.adminbar-input {
+	background: variables.$menu-submenu-background;
+}
+
+#wpadminbar #adminbarsearch input.adminbar-input:-webkit-autofill,
+#wpadminbar #adminbarsearch input.adminbar-input:-webkit-autofill:hover,
+#wpadminbar #adminbarsearch input.adminbar-input:-webkit-autofill:focus {
+	-webkit-text-fill-color: variables.$menu-text;
 }
 
 /* Admin Bar: recovery mode */

--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -1261,9 +1261,17 @@ function wp_admin_bar_search_menu( $wp_admin_bar ) {
 	$form .= '<input type="submit" class="adminbar-button" value="' . __( 'Search' ) . '" />';
 	$form .= '</form>';
 
+	$wp_admin_bar->add_group(
+		array(
+			'id'   => 'search-group',
+			'meta' => array(
+				'class' => 'ab-search',
+			),
+		)
+	);
 	$wp_admin_bar->add_node(
 		array(
-			'parent' => 'top-secondary',
+			'parent' => 'search-group',
 			'id'     => 'search',
 			'title'  => $form,
 			'meta'   => array(

--- a/src/wp-includes/class-wp-admin-bar.php
+++ b/src/wp-includes/class-wp-admin-bar.php
@@ -652,7 +652,6 @@ class WP_Admin_Bar {
 		add_action( 'admin_bar_menu', 'wp_admin_bar_my_account_menu', 0 );
 		add_action( 'admin_bar_menu', 'wp_admin_bar_my_account_item', 9991 );
 		add_action( 'admin_bar_menu', 'wp_admin_bar_recovery_mode_menu', 9992 );
-		add_action( 'admin_bar_menu', 'wp_admin_bar_search_menu', 9999 );
 
 		// Site-related.
 		add_action( 'admin_bar_menu', 'wp_admin_bar_sidebar_toggle', 0 );
@@ -663,8 +662,9 @@ class WP_Admin_Bar {
 		add_action( 'admin_bar_menu', 'wp_admin_bar_customize_menu', 40 );
 		add_action( 'admin_bar_menu', 'wp_admin_bar_updates_menu', 50 );
 
-		// Command palette.
+		// Command palette and search.
 		add_action( 'admin_bar_menu', 'wp_admin_bar_command_palette_menu', 55 );
+		add_action( 'admin_bar_menu', 'wp_admin_bar_search_menu', 55 );
 
 		// Content-related.
 		if ( ! is_network_admin() && ! is_user_admin() ) {

--- a/src/wp-includes/css/admin-bar.css
+++ b/src/wp-includes/css/admin-bar.css
@@ -374,8 +374,22 @@ html:lang(he-il) .rtl #wpadminbar * {
 	color: #000;
 }
 
+#wpadminbar .quicklinks {
+	display: flex;
+	align-items: center;
+}
+
+#wpadminbar #wp-admin-bar-root-default {
+	flex: 1 1 0;
+	min-width: fit-content;
+}
+
 #wpadminbar .ab-top-secondary {
 	float: right;
+	flex: 1 1 0;
+	min-width: fit-content;
+	display: flex;
+	justify-content: flex-end;
 }
 
 #wpadminbar ul li:last-child,
@@ -629,24 +643,40 @@ html:lang(he-il) .rtl #wpadminbar * {
  * Search
  */
 
+#wpadminbar .ab-search {
+	flex: 0 1 200px;
+	min-width: fit-content;
+	padding: 4px 0;
+}
+
+#wpadminbar .ab-search > #wp-admin-bar-search {
+	width: 100%;
+}
+
 #wpadminbar #wp-admin-bar-search .ab-item {
+	width: 100%;
+	height: 24px;
 	padding: 0;
 	background: transparent;
+	display: flex;
+	align-items: center;
 }
 
 #wpadminbar #adminbarsearch {
 	position: relative;
-	height: 32px;
-	padding: 0 2px;
+	width: 100%;
+	height: 24px;
 	z-index: 1;
 }
 
 #wpadminbar #adminbarsearch:before {
 	position: absolute;
-	top: 6px;
-	left: 5px;
-	z-index: 20;
-	font: normal 20px/1 dashicons !important;
+	top: 50%;
+	left: 6px;
+	z-index: 30;
+	pointer-events: none;
+	transform: translateY(-50%) scaleX(-1);
+	font: normal 18px/1 dashicons !important;
 	content: "\f179";
 	content: "\f179" / '';
 	speak: never;
@@ -655,39 +685,46 @@ html:lang(he-il) .rtl #wpadminbar * {
 }
 
 /* The admin bar search field needs to reset many styles that might be inherited from the active Theme CSS. See ticket #40313. */
-#wpadminbar > #wp-toolbar > #wp-admin-bar-top-secondary > #wp-admin-bar-search #adminbarsearch input.adminbar-input {
-	display: inline-block;
+#wpadminbar #adminbarsearch input.adminbar-input {
+	display: block;
 	float: none;
 	position: relative;
-	z-index: 30;
+	z-index: 20;
 	font-size: 13px;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 	line-height: 1.84615384;
 	text-indent: 0;
 	height: 24px;
-	width: 24px;
+	width: 100%;
 	max-width: none;
-	padding: 0 3px 0 24px;
+	padding: 0 6px 0 28px;
 	margin: 0;
-	color: #c3c4c7;
-	background-color: rgba(255, 255, 255, 0);
+	color: #f0f0f1;
+	background: #3c434a;
 	border: none;
 	outline: none;
-	cursor: pointer;
+	cursor: text;
 	box-shadow: none;
 	box-sizing: border-box;
-	transition-duration: 400ms;
-	transition-property: width, background;
-	transition-timing-function: ease;
+	border-radius: 2px;
 }
 
-#wpadminbar > #wp-toolbar > #wp-admin-bar-top-secondary > #wp-admin-bar-search #adminbarsearch input.adminbar-input:focus {
-	z-index: 10;
-	color: #000;
-	width: 200px;
-	background-color: rgba(255, 255, 255, 0.9);
-	cursor: text;
-	border: 0;
+#wpadminbar #adminbarsearch:hover input.adminbar-input,
+#wpadminbar #adminbarsearch:focus-within input.adminbar-input {
+	background: #2c3338;
+}
+
+#wpadminbar #adminbarsearch input.adminbar-input:-webkit-autofill,
+#wpadminbar #adminbarsearch input.adminbar-input:-webkit-autofill:hover,
+#wpadminbar #adminbarsearch input.adminbar-input:-webkit-autofill:focus {
+	-webkit-text-fill-color: #f0f0f1;
+	-webkit-transition: background-color 9999s ease-out 0s;
+	transition: background-color 9999s ease-out 0s;
+}
+
+#wpadminbar li:hover #adminbarsearch:before,
+#wpadminbar li #adminbarsearch.adminbar-focused:before {
+	color: rgba(240, 246, 252, 0.6);
 }
 
 #wpadminbar #adminbarsearch .adminbar-button {
@@ -926,8 +963,56 @@ html:lang(he-il) .rtl #wpadminbar * {
 	}
 
 	/* Search */
-	#wpadminbar #wp-admin-bar-search {
-		display: none;
+	#wpadminbar .ab-search {
+		flex: 0 0 auto;
+		padding: 0;
+	}
+
+	#wpadminbar .ab-top-secondary {
+		flex: 0 0 auto;
+	}
+
+	#wpadminbar #wp-admin-bar-search .ab-item {
+		position: relative;
+		width: 34px;
+		height: 32px;
+		padding: 0;
+		margin-right: 4px;
+	}
+
+	#wpadminbar #adminbarsearch {
+		position: absolute;
+		top: 0;
+		right: 0;
+		height: 32px;
+		width: 34px;
+		transition: width 400ms ease;
+	}
+
+	#wpadminbar #adminbarsearch:focus-within {
+		width: 200px;
+		z-index: 2;
+	}
+
+	#wpadminbar #adminbarsearch:before {
+		top: 50%;
+		left: 2px;
+		width: 30px;
+		font: 30px/1 dashicons !important;
+		text-align: center;
+	}
+
+	#wpadminbar #adminbarsearch input.adminbar-input {
+		width: 100%;
+		height: 32px;
+		padding: 0 4px 0 30px;
+		cursor: pointer;
+		border-radius: 4px;
+	}
+
+	#wpadminbar #adminbarsearch input.adminbar-input:focus {
+		padding-left: 38px;
+		cursor: text;
 	}
 
 	/* New Content */
@@ -1025,8 +1110,9 @@ html:lang(he-il) .rtl #wpadminbar * {
 	#wpadminbar li#wp-admin-bar-new-content,
 	#wpadminbar li#wp-admin-bar-edit,
 	#wpadminbar li#wp-admin-bar-comments,
-	#wpadminbar li#wp-admin-bar-my-account,
-	#wpadminbar li#wp-admin-bar-command-palette {
+	#wpadminbar li#wp-admin-bar-command-palette,
+	#wpadminbar li#wp-admin-bar-search,
+	#wpadminbar li#wp-admin-bar-my-account {
 		display: block;
 	}
 


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/65221

### Summary

This PR updates the frontend search admin bar node to make it similar with the command palette changes from https://github.com/WordPress/wordpress-develop/pull/11796. Now, both the "search" functionalities have more consistent UI.

### Desktop

Before
<img width="1840" height="64" alt="before" src="https://github.com/user-attachments/assets/48005c5e-9c94-42f0-9ae9-c33df85dff26" />

After
<img width="1840" height="64" alt="after" src="https://github.com/user-attachments/assets/726548ea-6bcd-46f3-a2a9-a32482173802" />


https://github.com/user-attachments/assets/25a30918-43d8-463e-885f-7488253cfdbd


### Mobile

| Before | After |
| - | - |
| <img width="760" height="92" alt="before-mobile" src="https://github.com/user-attachments/assets/e616b667-3cc8-4c55-89c0-97274fbedcb4" /> | <img width="760" height="92" alt="after-mobile" src="https://github.com/user-attachments/assets/985e48b5-dc12-4e61-9eff-bcdfcc3b1241" /> |

https://github.com/user-attachments/assets/0af5e0db-8da8-4fde-90eb-bd25d11bc21c

### Alternative considered

I considered making the search input collapsed first as per the current behavior, but move it to the left of the avatar node for more consistency, as follows:

https://github.com/user-attachments/assets/089e1f33-e283-4664-bcb5-e882205d062f

But I believe the proposed solution is better.

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 4.7
Used for: CSS implementation under my supervision.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
