### PR TITLE
iAPI: align server-side negation truthiness with client side

### DIFF
--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -747,7 +747,15 @@ final class WP_Interactivity_API {
 		}
 
 		// Returns the opposite if it contains a negation operator (!).
-		return $should_negate_value ? ! $current : $current;
+		// Uses JavaScript-compatible truthiness rules to ensure server and client
+		// rendering agree. PHP and JavaScript differ on two values:
+		// - [] (empty array): falsy in PHP, truthy in JavaScript.
+		// - '0' (string zero): falsy in PHP, truthy in JavaScript.
+		if ( $should_negate_value ) {
+			$is_truthy = is_array( $current ) || '0' === $current ? true : (bool) $current;
+			return ! $is_truthy;
+		}
+		return $current;
 	}
 
 	/**


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->
The Interactivity API supports a negation prefix `!` in directive values. However, the server-side negation logic relies on PHP's native boolean casting, which disagrees with JavaScript on two values:
- `[]` (empty array): falsy in PHP, truthy in JavaScript.
- `'0'` (string zero): falsy in PHP, truthy in JavaScript.

This causes a mismatch between server and client rendering of the same state, breaking the hydration contract of the Interactivity API.

This fix updates the server-side negation logic in `WP_Interactivity_API::evaluate()` to use JavaScript-compatible truthiness rules for these two cases, ensuring server and client rendering agree.

Trac ticket: https://core.trac.wordpress.org/ticket/62628

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

AI assistance: Yes
Tool(s): Claude
Model(s): Opus 4.6
Used for: Initial code skeleton and PR description; final implementation was reviewed and edited by me.


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
