### PR TITLE
Fix alignment of plugin favorites username form

### DIFF
--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -1204,14 +1204,16 @@ th.action-links {
 	overflow: hidden;
 }
 
-.wp-filter .favorites-form .favorites-username {
+.wp-filter .favorites-form .favorites-username,
+.plugin-install-tab-favorites .favorites-username {
 	display: flex;
 	align-items: center;
 	flex-wrap: wrap;
 	gap: 0.5rem;
 }
 
-.wp-filter .favorites-form .favorites-username input {
+.wp-filter .favorites-form .favorites-username input,
+.plugin-install-tab-favorites .favorites-username input {
 	margin: 0;
 }
 

--- a/src/wp-admin/includes/plugin-install.php
+++ b/src/wp-admin/includes/plugin-install.php
@@ -370,7 +370,7 @@ function install_plugins_favorites_form() {
 	<p><?php _e( 'If you have marked plugins as favorites on WordPress.org, you can browse them here.' ); ?></p>
 	<form method="get">
 		<input type="hidden" name="tab" value="favorites" />
-		<p>
+		<p class="favorites-username">
 			<label for="user"><?php _e( 'Your WordPress.org username:' ); ?></label>
 			<input type="search" id="user" name="user" value="<?php echo esc_attr( $user ); ?>" />
 			<input type="submit" class="button" value="<?php esc_attr_e( 'Get Favorites' ); ?>" />


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65231

## What?
Fixes the alignment of the username input and “Get Favorites” button on the Add Plugins > Favorites screen.

## Why?
The plugin favorites form used plain paragraph markup, so the input and submit button were not vertically aligned.

## How?
- Added the existing `favorites-username` class to the plugin favorites form row.
- Reused the existing flex alignment styles already used by the theme favorites form.

## Testing
- Confirmed the input field and “Get Favorites” button align correctly on Plugins > Add New > Favorites.

## Use of AI Tools
None

## Screenshot
| Before | After |
| --- | --- |
| <img width="811" height="556" alt="Screenshot 2026-05-13 at 12 23 31 PM" src="https://github.com/user-attachments/assets/3acc731e-443e-472c-a9f7-e454755b55be" /> | <img width="811" height="556" alt="Screenshot 2026-05-13 at 12 23 03 PM" src="https://github.com/user-attachments/assets/152f815f-2533-49fa-94c5-50ab7b8c4446" /> |
