### PR TITLE
Admin: Fix plugin card overlap with localized install actions on Add Plugins

### DIFF
--- a/src/wp-admin/css/list-tables.css
+++ b/src/wp-admin/css/list-tables.css
@@ -1608,8 +1608,16 @@ div.action-links,
 }
 
 @media (min-width: 1101px) {
-	.plugin-card .name, .plugin-card .desc > p {
-		margin-right: 128px;
+	.plugin-card .action-links {
+		top: 152px;
+		left: 20px;
+		right: auto;
+		width: 128px;
+	}
+
+	.plugin-card .name,
+	.plugin-card .desc > p {
+		margin-right: 0;
 	}
 }
 

--- a/src/wp-admin/css/list-tables.css
+++ b/src/wp-admin/css/list-tables.css
@@ -1836,7 +1836,11 @@ div.action-links,
 	.plugin-card .action-links {
 		position: static;
 		margin-left: 148px;
-		width: auto;
+		width: calc(100% - 148px);
+	}
+
+	.plugin-card .desc > p {
+		margin-left: 0;
 	}
 
 	.plugin-action-buttons {


### PR DESCRIPTION
Fixes layout on **Plugins → Add New** where long translated strings for the install/update action (e.g. Japanese, Bengali, German, French) could overlap the plugin title and description. Compact buttons alone did not fully resolve this for all locales and widths ([PR #11021](https://github.com/WordPress/wordpress-develop/pull/11021), reopened in Trac).
## Approach
- **Wide viewports (≥1101px):** Position `.plugin-card .action-links` under the plugin icon (`top` / `left` / fixed width) so labels stay in the icon column instead of intruding on the text column; remove the large `margin-right` reserve on `.name` / `.desc > p` that fought absolute positioning.
- **Tablet / small breakpoints** (existing `max-width: 1100px` + `(min-width: 782px)` or `max-width: 480px` query): Give static `.action-links` full remaining width (`calc(100% - 148px)`) and reset `.desc > p` left margin so the description area can use space more sensibly.
CSS only: `src/wp-admin/css/list-tables.css` (no PHP/HTML).

Trac ticket: https://core.trac.wordpress.org/ticket/64686

## Use of AI Tools

N/A
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
