### PR TITLE
Media: Fix update_attached_file() stripping backslashes from Windows directory separators

### DIFF
--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -897,7 +897,7 @@ function update_attached_file( $attachment_id, $file ) {
 	 */
 	$file = apply_filters( 'update_attached_file', $file, $attachment_id );
 
-	$file = _wp_relative_upload_path( $file );
+	$file = wp_normalize_path( _wp_relative_upload_path( $file ) );
 	if ( $file ) {
 		return update_post_meta( $attachment_id, '_wp_attached_file', $file );
 	} else {


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->
On Windows, PHP's realpath() returns paths with native backslash directory separators (e.g. C:\WWW\Sites\demo\wp-content\uploads\2016\03\example.jpg). When these paths are passed to update_attached_file(), the backslashes are stripped by wp_unslash() inside update_metadata(), resulting in an invalid path being stored in postmeta (e.g. C:WWWSitesdemowp-contentuploads201603example.jpg).

This breaks the media library entirely on Windows, as file_exists() and other file functions fail on the corrupted path.

The fix passes $file through wp_normalize_path() after _wp_relative_upload_path() converts it to a relative path, ensuring all backslashes are converted to forward slashes before the value is stored in the database.

Trac ticket: https://core.trac.wordpress.org/ticket/36273

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
AI assistance: Yes
Tool(s): Claude
Model(s): Opus 4.6
Used for: Initial code skeleton; final implementation was reviewed and edited by me.


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
