### PR TITLE
Tests/admin/wpUserSearch: rename the original test class

### DIFF
--- a/tests/phpunit/tests/admin/Admin_WpUserSearch_Construct_Test.php
+++ b/tests/phpunit/tests/admin/Admin_WpUserSearch_Construct_Test.php
@@ -1,14 +1,14 @@
 <?php
+
 /**
  * @group admin
  * @group user
  *
- * @coversDefaultClass WP_User_Search
+ * @covers WP_User_Search::__construct
  */
-class Tests_Admin_wpUserSearch extends WP_UnitTestCase {
+class Admin_WpUserSearch_Construct_Test extends WP_UnitTestCase {
 
 	/**
-	 * @covers ::__construct()
 	 * @expectedDeprecated WP_User_Search
 	 */
 	public function test_class_is_deprecated() {


### PR DESCRIPTION

Trac ticket: https://core.trac.wordpress.org/ticket/65208

Rename the test class `Tests_Admin_wpUserSearch` to `Admin_WpUserSearch_Construct_Test` so that the name includes both the class under test (`WP_User_Search`) and the method being tested (`__construct`).

Replaces the `@coversDefaultClass` + relative `@covers ::__construct()` pattern with a single explicit class-level `@covers WP_User_Search::__construct` annotation. This is cleaner and compatible with PHPUnit 11.

