### PR TITLE
Administration: Improve Dashboard widget drag-and-drop styling

### DIFF
--- a/src/wp-admin/css/dashboard.css
+++ b/src/wp-admin/css/dashboard.css
@@ -39,7 +39,7 @@
 }
 
 #dashboard-widgets-wrap {
-	overflow: hidden;
+	overflow: visible;
 	margin: 0 -8px;
 }
 
@@ -55,14 +55,25 @@
 }
 
 #dashboard-widgets .postbox-container .empty-container {
-	outline: 3px dashed #c3c4c7;
-	height: 250px;
+	height: auto;
+	min-height: 100px;
 }
 
-/* Only highlight drop zones when dragging and only in the 2 columns layout. */
+#dashboard-widgets .postbox-container .empty-container,
+#dashboard-widgets .sortable-placeholder,
 .is-dragging-metaboxes #dashboard-widgets .meta-box-sortables {
-	outline: 3px dashed #646970;
+	outline: 3px dashed #8c8f94;
+	outline-offset: -3px;
+}
+
+#dashboard-widgets .sortable-placeholder {
+	box-sizing: border-box;
+	margin-bottom: 20px;
+}
+
+.is-dragging-metaboxes #dashboard-widgets .meta-box-sortables {
 	/* Prevent margin on the child from collapsing with margin on the parent. */
+	background: transparent;
 	display: flow-root;
 }
 


### PR DESCRIPTION
## Summary
- normalize dashboard widget drop-zone outlines while dragging
- reduce the oversized empty-column spacing so vacant and populated columns feel more consistent
- allow dragged dashboard widgets to extend beyond the wrapper without being clipped

Trac ticket: https://core.trac.wordpress.org/ticket/64942

## Testing Instructions
1. Open `/wp-admin/index.php` on a wide desktop viewport so the Dashboard uses multiple columns.
2. Ensure there is an empty dashboard widget column.
3. Drag a widget into and across the empty column.
4. Confirm the drop zones use consistent dashed outlines, the vacant column spacing feels closer to populated columns, and the dragged widget is not clipped while moving.
