### PR TITLE
Tests/admin/wpTermsListTable: rename the original test class

### DIFF
--- a/tests/phpunit/tests/admin/Admin_WpTermsListTable_HandleRowActions_Test.php
+++ b/tests/phpunit/tests/admin/Admin_WpTermsListTable_HandleRowActions_Test.php
@@ -3,9 +3,9 @@
 /**
  * @group admin
  *
- * @covers WP_Terms_List_Table
+ * @covers WP_Terms_List_Table::handle_row_actions
  */
-class Tests_Admin_WpTermsListTable extends WP_UnitTestCase {
+class Admin_WpTermsListTable_HandleRowActions_Test extends WP_UnitTestCase {
 
 	/**
 	 * List table.
@@ -56,8 +56,6 @@ class Tests_Admin_WpTermsListTable extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @covers WP_Terms_List_Table::handle_row_actions()
-	 *
 	 * @ticket 59336
 	 */
 	public function test_handle_row_actions_as_author() {
@@ -72,8 +70,6 @@ class Tests_Admin_WpTermsListTable extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @covers WP_Terms_List_Table::handle_row_actions()
-	 *
 	 * @ticket 59336
 	 */
 	public function test_handle_row_actions_as_admin() {


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65208

Rename the test class `Tests_Admin_WpTermsListTable` to `Admin_WpTermsListTable_HandleRowActions_Test` so that the name includes both the class under test (`WP_Terms_List_Table`) and the method being tested (`handle_row_actions`).

Both existing test methods already covered the same production method, so no splitting was required. Consolidates the repeated method-level `@covers WP_Terms_List_Table::handle_row_actions` annotations into a single class-level declaration. This is cleaner and compatible with PHPUnit 11.

