### PR TITLE
REST API: Guard against missing language_packs in create_item().

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-plugins-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-plugins-controller.php
@@ -380,12 +380,16 @@ class WP_REST_Plugins_Controller extends WP_REST_Controller {
 		/** This filter is documented in wp-includes/update.php */
 		$installed_locales = apply_filters( 'plugins_update_check_locales', $installed_locales );
 
-		$language_packs = array_map(
-			static function ( $item ) {
-				return (object) $item;
-			},
-			$api->language_packs
-		);
+		$language_packs = array();
+
+		if ( ! empty( $api->language_packs ) && is_array( $api->language_packs ) ) {
+			$language_packs = array_map(
+				static function ( $item ) {
+					return (object) $item;
+				},
+				$api->language_packs
+			);
+		}
 
 		$language_packs = array_filter(
 			$language_packs,


### PR DESCRIPTION
`WP_REST_Plugins_Controller::create_item()` can throw a Fatal `TypeError` on PHP 8.x after a successful plugin install, causing the REST endpoint `POST /wp/v2/plugins` to return `HTTP 500` even though the plugin files are already on disk. This patch adds a one-line defensive guard to prevent the crash.

Trac ticket: https://core.trac.wordpress.org/ticket/65240

