### PR TITLE
Privacy: Fix checkbox alignment in personal data export request screen.

### DIFF
--- a/src/wp-admin/css/forms.css
+++ b/src/wp-admin/css/forms.css
@@ -1579,6 +1579,10 @@ table.form-table td .updated p {
 	margin: 0;
 }
 
+.wp-privacy-request-form input[type="checkbox"] {
+	margin-top: -2px;
+}
+
 /* =Media Queries
 -------------------------------------------------------------- */
 


### PR DESCRIPTION
## Summary

Adds missing checkbox alignment styling for the personal data export / erase request form.

The RTL stylesheet already contains this rule, but it was missing from the standard forms stylesheet, causing the confirmation email checkbox to appear vertically misaligned on the "Export Personal Data" and "Erase Personal Data" screens.

Trac ticket: https://core.trac.wordpress.org/ticket/65246

## Use of AI Tools

AI assistance: Yes
Tool(s): ChatGPT
Model(s): GPT-5
Used for: Verifying existing RTL stylesheet rules and contribution workflow guidance.