### PR TITLE
XML-RPC: Prevent fatal error when system.multicall params are scalar

### DIFF
--- a/src/wp-includes/IXR/class-IXR-server.php
+++ b/src/wp-includes/IXR/class-IXR-server.php
@@ -91,6 +91,12 @@ EOD;
         }
         $method = $this->callbacks[$methodname];
 
+        // Ensure $args is an array. Callers such as system.multicall can pass
+        // non-array params derived from untrusted client input.
+        if (!is_array($args)) {
+            $args = array($args);
+        }
+
         // Perform the callback and send the response
         if (count($args) == 1) {
             // If only one parameter just send that instead of the whole array
@@ -198,7 +204,17 @@ EOD;
     {
         // See http://www.xmlrpc.com/discuss/msgReader$1208
         $return = array();
+        if (!is_array($methodcalls)) {
+            return new IXR_Error(-32600, 'server error. invalid xml-rpc. methodcalls is not an array');
+        }
         foreach ($methodcalls as $call) {
+            if (!is_array($call) || !isset($call['methodName']) || !isset($call['params']) || !is_array($call['params'])) {
+                $return[] = array(
+                    'faultCode'   => -32602,
+                    'faultString' => 'server error. invalid method call structure',
+                );
+                continue;
+            }
             $method = $call['methodName'];
             $params = $call['params'];
             if ($method == 'system.multicall') {

--- a/tests/phpunit/tests/xmlrpc/basic.php
+++ b/tests/phpunit/tests/xmlrpc/basic.php
@@ -132,19 +132,31 @@ class Tests_XMLRPC_Basic extends WP_XMLRPC_UnitTestCase {
 
 	public function data_malformed_multicall_payloads() {
 		return array(
-			'params is a string'  => array(
-				array( array( 'methodName' => 'system.listMethods', 'params' => 'evil' ) ),
+			'params is a string' => array(
+				array(
+					array(
+						'methodName' => 'system.listMethods',
+						'params'     => 'evil',
+					),
+				),
 				0,
 			),
-			'params is null'      => array(
-				array( array( 'methodName' => 'system.listMethods', 'params' => null ) ),
+			'params is null'     => array(
+				array(
+					array(
+						'methodName' => 'system.listMethods',
+						'params'     => null,
+					),
+				),
 				0,
 			),
-			'missing params key'  => array(
-				array( array( 'methodName' => 'system.listMethods' ) ),
+			'missing params key' => array(
+				array(
+					array( 'methodName' => 'system.listMethods' ),
+				),
 				0,
 			),
-			'call is a scalar'    => array(
+			'call is a scalar'   => array(
 				array( 'just-a-string' ),
 				0,
 			),

--- a/tests/phpunit/tests/xmlrpc/basic.php
+++ b/tests/phpunit/tests/xmlrpc/basic.php
@@ -96,6 +96,77 @@ class Tests_XMLRPC_Basic extends WP_XMLRPC_UnitTestCase {
 	}
 
 	/**
+	 * Ensures IXR_Server::call() does not fatal when $args is not an array.
+	 *
+	 * @ticket 65124
+	 */
+	public function test_call_with_non_array_args_does_not_fatal() {
+		$this->myxmlrpcserver->callbacks = $this->myxmlrpcserver->methods;
+
+		// Passing a string instead of an array must not produce a TypeError on PHP 8+.
+		$result = $this->myxmlrpcserver->call( 'system.listMethods', 'not-an-array' );
+
+		// The dispatch may return an IXR_Error or a value, but it must not fatal.
+		$this->assertNotNull( $result );
+	}
+
+	/**
+	 * Ensures system.multicall returns a fault for malformed per-call entries
+	 * rather than triggering a fatal error.
+	 *
+	 * @ticket 65124
+	 *
+	 * @dataProvider data_malformed_multicall_payloads
+	 *
+	 * @param array $method_calls    Method calls payload supplied to multiCall().
+	 * @param int   $expected_index  Index in the response expected to contain a fault.
+	 */
+	public function test_multicall_rejects_malformed_calls( $method_calls, $expected_index ) {
+		$this->myxmlrpcserver->callbacks = $this->myxmlrpcserver->methods;
+
+		$result = $this->myxmlrpcserver->multiCall( $method_calls );
+
+		$this->assertArrayHasKey( 'faultCode', $result[ $expected_index ] );
+		$this->assertSame( -32602, $result[ $expected_index ]['faultCode'] );
+	}
+
+	public function data_malformed_multicall_payloads() {
+		return array(
+			'params is a string'  => array(
+				array( array( 'methodName' => 'system.listMethods', 'params' => 'evil' ) ),
+				0,
+			),
+			'params is null'      => array(
+				array( array( 'methodName' => 'system.listMethods', 'params' => null ) ),
+				0,
+			),
+			'missing params key'  => array(
+				array( array( 'methodName' => 'system.listMethods' ) ),
+				0,
+			),
+			'call is a scalar'    => array(
+				array( 'just-a-string' ),
+				0,
+			),
+		);
+	}
+
+	/**
+	 * Ensures system.multicall returns a top-level error when the methodcalls
+	 * payload itself is not an array.
+	 *
+	 * @ticket 65124
+	 */
+	public function test_multicall_with_non_array_methodcalls_returns_error() {
+		$this->myxmlrpcserver->callbacks = $this->myxmlrpcserver->methods;
+
+		$result = $this->myxmlrpcserver->multiCall( 'not-an-array' );
+
+		$this->assertInstanceOf( 'IXR_Error', $result );
+		$this->assertSame( -32600, $result->code );
+	}
+
+	/**
 	 * @ticket 36586
 	 */
 	public function test_isStruct_on_non_numerically_indexed_array() {


### PR DESCRIPTION



<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->

*AI Description*: Validates the per-call structure inside IXR_Server::multiCall() and returns a spec-compliant fault (-32602) for malformed entries, rather than passing non-array values to IXR_Server::call() where count() would TypeError on PHP 8+. Also adds a defensive guard inside call() mirroring the existing pattern in IXR_IntrospectionServer::call().

*Human Discussion*:
- Solves a 500 error being thrown in `wp-includes/IXR/class-IXR-server.php`, likely by malicious traffic.
- Expands upon the existing patch in 65124 to avoid creating issues downstream by simply checking `$args` is an array.
- Noting that pre PHP 8.0 this did not throw a fatal, but changes to `count()` mean that a fatal is now thown in 8.0+

Tested locally by creating an XML file with the following content:

```xml
<?xml version="1.0"?>
  <methodCall>
    <methodName>system.multicall</methodName>
    <params>
      <param><value><array><data>
        <value><struct>
          <member><name>methodName</name><value><string>system.listMethods</string></value></member>
          <member><name>params</name><value><string>malicious-non-array</string></value></member>
        </struct></value>
      </data></array></value></param>
    </params>
  </methodCall>
```
and then posting that to the local server:

```bash
curl -sS -X POST -H 'Content-Type: text/xml' \
    --data-binary @repro-ixr-multicall.xml \
    http://localhost:8889/xmlrpc.php -o /tmp/resp.xml -w '%{http_code}\n'
```

The return before this patch:

```console
500
<?xml version="1.0" encoding="UTF-8"?>
<methodResponse>
  <fault>
    <value>
      <struct>
        <member>
          <name>faultCode</name>
          <value><int>500</int></value>
        </member>
        <member>
          <name>faultString</name>
          <value><string>&lt;p&gt;There has been a critical error on this website.&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;https://wordpress.org/documentation/article/faq-troubleshooting/&quot;&gt;Learn more about troubleshooting WordPress.&lt;/a&gt;&lt;/p&gt;</string></value>
        </member>
      </struct>
    </value>
  </fault>
</methodResponse>
```

The return after this patch:

```console
200
<?xml version="1.0" encoding="UTF-8"?>
<methodResponse>
  <params>
    <param>
      <value>
      <array><data>
  <value><struct>
  <member><name>faultCode</name><value><int>-32602</int></value></member>
  <member><name>faultString</name><value><string>server error. invalid method call structure</string></value></member>
</struct></value>
</data></array>
      </value>
    </param>
  </params>
</methodResponse>
```

Trac ticket: https://core.trac.wordpress.org/ticket/65124

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

-->
AI assistance: Yes
Tool(s): Claude
Model(s): Opus 4.7
Used for: Initial investigation route and test suggestions; final implementation and tests were reviewed and edited by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
