### PR TITLE
Block Supports: Prevent Additional CSS duplication inside Query Loop

### DIFF
--- a/src/wp-includes/block-supports/custom-css.php
+++ b/src/wp-includes/block-supports/custom-css.php
@@ -68,7 +68,7 @@ function wp_render_custom_css_support_styles( $parsed_block ) {
 	$processed_css = WP_Theme_JSON::process_blocks_custom_css( $custom_css, $selector );
 
 	if ( ! empty( $processed_css ) ) {
-		/**
+		/*
 		 * Skip CSS that has already been added. Blocks with identical attributes
 		 * share the same class name and processed CSS via {@see wp_unique_id_from_values()},
 		 * so the same style would otherwise be enqueued more than once (e.g. inside

--- a/src/wp-includes/block-supports/custom-css.php
+++ b/src/wp-includes/block-supports/custom-css.php
@@ -61,17 +61,16 @@ function wp_render_custom_css_support_styles( $parsed_block ) {
 		 * duplicate styles when the same block is rendered multiple times inside
 		 * a Query Loop (render_block_data fires once per loop iteration).
 		 */
-		static $enqueued_class_names = array();
-
-		if ( ! isset( $enqueued_class_names[ $class_name ] ) ) {
-			$enqueued_class_names[ $class_name ] = true;
-			/*
-			 * Register and add inline style for block custom CSS.
-			 * The style depends on global-styles to ensure custom CSS loads after
-			 * and can override global styles.
-			 */
-			wp_register_style( 'wp-block-custom-css', false, array( 'global-styles' ) );
-			wp_add_inline_style( 'wp-block-custom-css', $processed_css );
+		$handle = 'wp-block-custom-css';
+		if ( ! wp_style_is( $handle, 'registered' ) ) {
+			wp_register_style( $handle, false, array( 'global-styles' ) );
+		}
+		$after_styles = wp_styles()->get_data( $handle, 'after' );
+		if ( ! is_array( $after_styles ) ) {
+			$after_styles = array();
+		}
+		if ( ! in_array( $processed_css, $after_styles, true ) ) {
+			wp_add_inline_style( $handle, $processed_css );
 		}
 	}
 

--- a/src/wp-includes/block-supports/custom-css.php
+++ b/src/wp-includes/block-supports/custom-css.php
@@ -61,7 +61,7 @@ function wp_render_custom_css_support_styles( $parsed_block ) {
 		? "$existing_class_name $class_name"
 		: $class_name;
 
-	_wp_array_set( $parsed_block, array( 'attrs', 'className' ), $updated_class_name );
+	$parsed_block['attrs']['className'] = $updated_class_name;
 
 	// Process the custom CSS using the same method as global styles.
 	$selector      = '.' . $class_name;

--- a/src/wp-includes/block-supports/custom-css.php
+++ b/src/wp-includes/block-supports/custom-css.php
@@ -57,12 +57,22 @@ function wp_render_custom_css_support_styles( $parsed_block ) {
 
 	if ( ! empty( $processed_css ) ) {
 		/*
-		 * Register and add inline style for block custom CSS.
-		 * The style depends on global-styles to ensure custom CSS loads after
-		 * and can override global styles.
-		 */
-		wp_register_style( 'wp-block-custom-css', false, array( 'global-styles' ) );
-		wp_add_inline_style( 'wp-block-custom-css', $processed_css );
+		* Track which class names have already had their CSS enqueued to prevent
+		* duplicate styles when the same block is rendered multiple times inside
+		* a Query Loop (render_block_data fires once per loop iteration).
+		*/
+		static $enqueued_class_names = array();
+
+		if ( ! isset( $enqueued_class_names[ $class_name ] ) ) {
+			$enqueued_class_names[ $class_name ] = true;
+			/*
+			* Register and add inline style for block custom CSS.
+			* The style depends on global-styles to ensure custom CSS loads after
+			* and can override global styles.
+			*/
+			wp_register_style( 'wp-block-custom-css', false, array( 'global-styles' ) );
+			wp_add_inline_style( 'wp-block-custom-css', $processed_css );
+		}
 	}
 
 	return $parsed_block;

--- a/src/wp-includes/block-supports/custom-css.php
+++ b/src/wp-includes/block-supports/custom-css.php
@@ -68,7 +68,7 @@ function wp_render_custom_css_support_styles( $parsed_block ) {
 	$processed_css = WP_Theme_JSON::process_blocks_custom_css( $custom_css, $selector );
 
 	if ( ! empty( $processed_css ) ) {
-		/*
+		/**
 		 * Skip CSS that has already been added. Blocks with identical attributes
 		 * share the same class name and processed CSS via {@see wp_unique_id_from_values()},
 		 * so the same style would otherwise be enqueued more than once (e.g. inside

--- a/src/wp-includes/block-supports/custom-css.php
+++ b/src/wp-includes/block-supports/custom-css.php
@@ -57,19 +57,19 @@ function wp_render_custom_css_support_styles( $parsed_block ) {
 
 	if ( ! empty( $processed_css ) ) {
 		/*
-		* Track which class names have already had their CSS enqueued to prevent
-		* duplicate styles when the same block is rendered multiple times inside
-		* a Query Loop (render_block_data fires once per loop iteration).
-		*/
+		 * Track which class names have already had their CSS enqueued to prevent
+		 * duplicate styles when the same block is rendered multiple times inside
+		 * a Query Loop (render_block_data fires once per loop iteration).
+		 */
 		static $enqueued_class_names = array();
 
 		if ( ! isset( $enqueued_class_names[ $class_name ] ) ) {
 			$enqueued_class_names[ $class_name ] = true;
 			/*
-			* Register and add inline style for block custom CSS.
-			* The style depends on global-styles to ensure custom CSS loads after
-			* and can override global styles.
-			*/
+			 * Register and add inline style for block custom CSS.
+			 * The style depends on global-styles to ensure custom CSS loads after
+			 * and can override global styles.
+			 */
 			wp_register_style( 'wp-block-custom-css', false, array( 'global-styles' ) );
 			wp_add_inline_style( 'wp-block-custom-css', $processed_css );
 		}

--- a/src/wp-includes/block-supports/custom-css.php
+++ b/src/wp-includes/block-supports/custom-css.php
@@ -25,6 +25,18 @@
  *     },
  *     ...
  * } $parsed_block
+ * @phpstan-return array{
+ *     blockName: string|null,
+ *     attrs: array{
+ *         className?: string,
+ *         style?: array{
+ *             css?: string,
+ *             ...
+ *         },
+ *         ...
+ *     },
+ *     ...
+ * }
  */
 function wp_render_custom_css_support_styles( $parsed_block ) {
 	$custom_css = $parsed_block['attrs']['style']['css'] ?? null;

--- a/src/wp-includes/block-supports/custom-css.php
+++ b/src/wp-includes/block-supports/custom-css.php
@@ -56,10 +56,11 @@ function wp_render_custom_css_support_styles( $parsed_block ) {
 	$processed_css = WP_Theme_JSON::process_blocks_custom_css( $custom_css, $selector );
 
 	if ( ! empty( $processed_css ) ) {
-		/*
-		 * Track which class names have already had their CSS enqueued to prevent
-		 * duplicate styles when the same block is rendered multiple times inside
-		 * a Query Loop (render_block_data fires once per loop iteration).
+		/**
+		 * Skip CSS that has already been added. Blocks with identical attributes
+		 * share the same class name and processed CSS via {@see wp_unique_id_from_values()},
+		 * so the same style would otherwise be enqueued more than once (e.g. inside
+		 * a Query Loop or when blocks share identical custom CSS).
 		 */
 		$handle = 'wp-block-custom-css';
 		if ( ! wp_style_is( $handle, 'registered' ) ) {

--- a/tests/phpunit/tests/block-supports/wpRenderCustomCssSupportStyles.php
+++ b/tests/phpunit/tests/block-supports/wpRenderCustomCssSupportStyles.php
@@ -264,4 +264,63 @@ class Tests_Block_Supports_WpRenderCustomCssSupportStyles extends WP_UnitTestCas
 			),
 		);
 	}
+
+	/**
+	 * Tests that CSS is enqueued only once when the same block is rendered
+	 * multiple times, as happens inside a Query Loop.
+	 *
+	 * @ticket 65268
+	 *
+	 * @covers ::wp_render_custom_css_support_styles
+	 */
+	public function test_css_not_duplicated_on_repeated_renders() {
+		$this->test_block_name = 'test/custom-css-query-loop-dedup';
+		register_block_type(
+			$this->test_block_name,
+			array(
+				'api_version' => 3,
+				'attributes'  => array(
+					'style' => array(
+						'type' => 'object',
+					),
+				),
+				'supports'    => array( 'customCSS' => true ),
+			)
+		);
+
+		$parsed_block = array(
+			'blockName' => 'test/custom-css-query-loop-dedup',
+			'attrs'     => array(
+				'style' => array(
+					'css' => 'font-size: 2em; /* query-loop-dedup-test */',
+				),
+			),
+		);
+
+		// Simulate the same block being rendered multiple times inside a Query Loop.
+		$result = wp_render_custom_css_support_styles( $parsed_block );
+		wp_render_custom_css_support_styles( $parsed_block );
+		wp_render_custom_css_support_styles( $parsed_block );
+
+		// Extract the generated class name from the first render's result.
+		preg_match( '/wp-custom-css-\S+/', $result['attrs']['className'], $matches );
+		$class_name = $matches[0];
+
+		// Count how many times the CSS selector for this block appears in the enqueued inline styles.
+		$inline_styles = (array) wp_styles()->get_data( 'wp-block-custom-css', 'after' );
+		$occurrences   = 0;
+		foreach ( $inline_styles as $style ) {
+			if ( false !== strpos( $style, '.' . $class_name ) ) {
+				++$occurrences;
+			}
+		}
+
+		$this->assertSame(
+			1,
+			$occurrences,
+			'CSS should be enqueued exactly once even when the same block renders multiple times.'
+		);
+
+		wp_deregister_style( 'wp-block-custom-css' );
+	}
 }

--- a/tests/phpunit/tests/block-supports/wpRenderCustomCssSupportStyles.php
+++ b/tests/phpunit/tests/block-supports/wpRenderCustomCssSupportStyles.php
@@ -14,6 +14,9 @@ class Tests_Block_Supports_WpRenderCustomCssSupportStyles extends WP_UnitTestCas
 	public function set_up() {
 		parent::set_up();
 		$this->test_block_name = null;
+
+		global $wp_styles;
+		$wp_styles = null;
 	}
 
 	public function tear_down() {
@@ -21,6 +24,10 @@ class Tests_Block_Supports_WpRenderCustomCssSupportStyles extends WP_UnitTestCas
 			unregister_block_type( $this->test_block_name );
 		}
 		$this->test_block_name = null;
+
+		global $wp_styles;
+		$wp_styles = null;
+
 		parent::tear_down();
 	}
 
@@ -319,7 +326,5 @@ class Tests_Block_Supports_WpRenderCustomCssSupportStyles extends WP_UnitTestCas
 			$occurrences,
 			'CSS should be enqueued exactly once even when the same block renders multiple times.'
 		);
-
-		wp_deregister_style( 'wp-block-custom-css' );
 	}
 }

--- a/tests/phpunit/tests/block-supports/wpRenderCustomCssSupportStyles.php
+++ b/tests/phpunit/tests/block-supports/wpRenderCustomCssSupportStyles.php
@@ -310,7 +310,7 @@ class Tests_Block_Supports_WpRenderCustomCssSupportStyles extends WP_UnitTestCas
 		wp_render_custom_css_support_styles( $parsed_block );
 
 		// Extract the generated class name from the first render's result.
-		$this->assertSame( 1, preg_match( '/(^|\s)(wp-custom-css-\S+)/', $result['attrs']['className'] ?? '', $matches ) );
+		$this->assertSame( 1, preg_match( '/(?:^|\s)(wp-custom-css-\S+)/', $result['attrs']['className'] ?? '', $matches ) );
 		$class_name = $matches[1];
 
 		// Count how many times the CSS selector for this block appears in the enqueued inline styles.

--- a/tests/phpunit/tests/block-supports/wpRenderCustomCssSupportStyles.php
+++ b/tests/phpunit/tests/block-supports/wpRenderCustomCssSupportStyles.php
@@ -273,7 +273,7 @@ class Tests_Block_Supports_WpRenderCustomCssSupportStyles extends WP_UnitTestCas
 	 *
 	 * @covers ::wp_render_custom_css_support_styles
 	 */
-	public function test_css_not_duplicated_on_repeated_renders() {
+	public function test_css_not_duplicated_on_repeated_renders(): void {
 		$this->test_block_name = 'test/custom-css-query-loop-dedup';
 		register_block_type(
 			$this->test_block_name,
@@ -303,16 +303,15 @@ class Tests_Block_Supports_WpRenderCustomCssSupportStyles extends WP_UnitTestCas
 		wp_render_custom_css_support_styles( $parsed_block );
 
 		// Extract the generated class name from the first render's result.
-		preg_match( '/wp-custom-css-\S+/', $result['attrs']['className'], $matches );
-		$class_name = $matches[0];
+		$this->assertSame( 1, preg_match( '/(^|\s)(wp-custom-css-\S+)/', $result['attrs']['className'] ?? '', $matches ) );
+		$class_name = $matches[1];
 
 		// Count how many times the CSS selector for this block appears in the enqueued inline styles.
 		$inline_styles = (array) wp_styles()->get_data( 'wp-block-custom-css', 'after' );
 		$occurrences   = 0;
 		foreach ( $inline_styles as $style ) {
-			if ( false !== strpos( $style, '.' . $class_name ) ) {
-				++$occurrences;
-			}
+			$this->assertIsString( $style );
+			$occurrences += substr_count( $style, '.' . $class_name );
 		}
 
 		$this->assertSame(


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/65268

## What
When a block inside a Query Loop has Additional CSS, `wp_add_inline_style` was called once per post in the loop, duplicating the same CSS N times.

## Why
`wp_render_custom_css_support_styles` hooks `render_block_data`, which fires for every block render. `wp_unique_id_from_values` produces the same hash for the same block template data on every loop iteration, so the same CSS gets injected repeatedly.

## How
Added a `static $enqueued_class_names` array. The first time a class name is seen the CSS is enqueued; subsequent renders skip it.

Gutenberg PR: https://github.com/WordPress/gutenberg/pull/78282