### PR TITLE
KSES: Decode style attribute before sending to safecss_filter_attr().

### DIFF
--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -1556,7 +1556,8 @@ function wp_kses_attr_check( &$name, &$value, &$whole, $vless, $element, $allowe
 	}
 
 	if ( 'style' === $name_low ) {
-		$new_value = safecss_filter_attr( $value );
+		$decoded_value = WP_HTML_Decoder::decode_attribute( $value );
+		$new_value     = safecss_filter_attr( $decoded_value );
 
 		if ( empty( $new_value ) ) {
 			$name  = '';
@@ -1565,8 +1566,11 @@ function wp_kses_attr_check( &$name, &$value, &$whole, $vless, $element, $allowe
 			return false;
 		}
 
-		$whole = str_replace( $value, $new_value, $whole );
-		$value = $new_value;
+		if ( $new_value !== $decoded_value ) {
+			$encoded_value = esc_attr( $new_value );
+			$whole         = str_replace( $value, $encoded_value, $whole );
+			$value         = $encoded_value;
+		}
 	}
 
 	if ( is_array( $allowed_attr[ $name_low ] ) ) {
@@ -2554,9 +2558,9 @@ function kses_init() {
  * @since 6.6.0 Added support for `grid-column`, `grid-row`, and `container-type`.
  * @since 6.9.0 Added support for `white-space`.
  *
- * @param string $css        A string of CSS rules.
+ * @param string $css        A string of CSS rules, decoded from an HTML `style` attribute.
  * @param string $deprecated Not used.
- * @return string Filtered string of CSS rules.
+ * @return string Filtered string of CSS rules, needing HTML escaping before sending back to a `style` attribute.
  */
 function safecss_filter_attr( $css, $deprecated = '' ) {
 	if ( ! empty( $deprecated ) ) {
@@ -2568,6 +2572,7 @@ function safecss_filter_attr( $css, $deprecated = '' ) {
 
 	$allowed_protocols = wp_allowed_protocols();
 
+	/** @todo Parse enough CSS to split rules without breaking on things like quoted strings. */
 	$css_array = explode( ';', trim( $css ) );
 
 	/**

--- a/tests/phpunit/tests/kses.php
+++ b/tests/phpunit/tests/kses.php
@@ -1584,6 +1584,52 @@ EOF;
 	}
 
 	/**
+	 * Tests that style attribute values are decoded before CSS filtering.
+	 *
+	 * @ticket 65270
+	 *
+	 * @dataProvider data_wp_kses_style_attr_decodes_entities_before_css_filtering
+	 *
+	 * @param string $content  A string of HTML to test.
+	 * @param string $expected Expected result after passing through KSES.
+	 */
+	public function test_wp_kses_style_attr_decodes_entities_before_css_filtering( $content, $expected ) {
+		$allowed_html = array(
+			'div' => array(
+				'style' => true,
+			),
+		);
+
+		$this->assertEqualHTML( $expected, wp_kses( $content, $allowed_html ) );
+	}
+
+	/**
+	 * Data provider for test_wp_kses_style_attr_decodes_entities_before_css_filtering().
+	 *
+	 * @return array[]
+	 */
+	public function data_wp_kses_style_attr_decodes_entities_before_css_filtering() {
+		return array(
+			'background image URL with single quotes' => array(
+				'<div style="background-image: url(\'https://localhost/image.jpg\');"></div>',
+				'<div style="background-image: url(&#039;https://localhost/image.jpg&#039;)"></div>',
+			),
+			'background image URL with entity-encoded double quotes' => array(
+				'<div style="background-image: url(&quot;https://localhost/image.jpg&quot;);"></div>',
+				'<div style="background-image: url(&quot;https://localhost/image.jpg&quot;)"></div>',
+			),
+			'background image URL with query string ampersand' => array(
+				'<div style="background-image: url(https://localhost/image.jpg?a=1&b=2);"></div>',
+				'<div style="background-image: url(https://localhost/image.jpg?a=1&amp;b=2)"></div>',
+			),
+			'background image URL followed by another declaration' => array(
+				'<div style="background-image:url(\'https://localhost/image.jpg\');background-size:cover;"></div>',
+				'<div style="background-image:url(&#039;https://localhost/image.jpg&#039;);background-size:cover"></div>',
+			),
+		);
+	}
+
+	/**
 	 * Test URL sanitization in the style tag.
 	 *
 	 * @dataProvider data_kses_style_attr_with_url


### PR DESCRIPTION
Track ticket: Core-65270

`safecss_filter_attr()` assumes that it receives already-unescaped HTML attribute values. For example, consider the raw HTML string:

    style="background:url(&quot;bg.png&quot;)"

This should be decoded and passed into `safecss_filter_attr()` as:

    background:url("bg.png")

Unfortuantely this hasn’t been done in `wp_kses_attr_check()`, which takes the output from `wp_kses_hair()` and sends it directly to the filtering function.

In this patch, `wp_kses_attr_check()` unescapes the `style` attribute, filters it, and then re-escapes it when updating the style value.