### PR TITLE
Users: Migrate misnamed user_roles options after database prefix changes

### DIFF
--- a/src/wp-includes/class-wp-roles.php
+++ b/src/wp-includes/class-wp-roles.php
@@ -395,7 +395,7 @@ class WP_Roles {
 	/**
 	 * Retrieves the roles option for the current site.
 	 *
-	 * @since 7.0.1
+	 * @since TBD
 	 *
 	 * @return array Roles array.
 	 */
@@ -417,7 +417,7 @@ class WP_Roles {
 	 * the database table prefix is changed, migration tools may update table names
 	 * but fail to update these option names, leaving roles inaccessible.
 	 *
-	 * @since 7.0.1
+	 * @since TBD
 	 *
 	 * @param array $roles Current roles array, usually empty.
 	 * @return array Roles array.

--- a/src/wp-includes/class-wp-roles.php
+++ b/src/wp-includes/class-wp-roles.php
@@ -380,13 +380,88 @@ class WP_Roles {
 		if ( is_multisite() && get_current_blog_id() !== $this->site_id ) {
 			remove_action( 'switch_blog', 'wp_switch_roles_and_user', 1 );
 
-			$roles = get_blog_option( $this->site_id, $this->role_key, array() );
+			switch_to_blog( $this->site_id );
+			$roles = $this->get_roles_option_value();
+			restore_current_blog();
 
 			add_action( 'switch_blog', 'wp_switch_roles_and_user', 1, 2 );
 
 			return $roles;
 		}
 
-		return get_option( $this->role_key, array() );
+		return $this->get_roles_option_value();
+	}
+
+	/**
+	 * Retrieves the roles option for the current site.
+	 *
+	 * @since 7.0.1
+	 *
+	 * @return array Roles array.
+	 */
+	protected function get_roles_option_value() {
+		$roles = get_option( $this->role_key, array() );
+
+		if ( ! empty( $roles ) ) {
+			return $roles;
+		}
+
+		return $this->maybe_fix_misnamed_user_roles_option( $roles );
+	}
+
+	/**
+	 * Migrates misnamed user roles options after a table prefix change.
+	 *
+	 * In multisite, user roles for a site are stored in that site's options table
+	 * using an option name that includes the site ID (e.g. `wp_3_user_roles`). When
+	 * the database table prefix is changed, migration tools may update table names
+	 * but fail to update these option names, leaving roles inaccessible.
+	 *
+	 * @since 7.0.1
+	 *
+	 * @param array $roles Current roles array, usually empty.
+	 * @return array Roles array.
+	 */
+	protected function maybe_fix_misnamed_user_roles_option( $roles = array() ) {
+		global $wpdb;
+
+		if ( ! $this->use_db ) {
+			return $roles;
+		}
+
+		if ( is_multisite() && 1 !== $this->site_id ) {
+			$suffix = $this->site_id . '_user_roles';
+		} else {
+			$suffix = 'user_roles';
+		}
+
+		$legacy_option_name = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT option_name FROM {$wpdb->options} WHERE option_name LIKE %s AND option_name != %s LIMIT 1",
+				'%' . $wpdb->esc_like( $suffix ),
+				$this->role_key
+			)
+		);
+
+		if ( ! $legacy_option_name ) {
+			return $roles;
+		}
+
+		$legacy_roles = get_option( $legacy_option_name, array() );
+
+		if ( ! is_array( $legacy_roles ) || empty( $legacy_roles ) ) {
+			return $roles;
+		}
+
+		foreach ( $legacy_roles as $role_data ) {
+			if ( ! is_array( $role_data ) || ! isset( $role_data['capabilities'] ) ) {
+				return $roles;
+			}
+		}
+
+		update_option( $this->role_key, $legacy_roles, true );
+		delete_option( $legacy_option_name );
+
+		return $legacy_roles;
 	}
 }

--- a/tests/phpunit/tests/multisite/site.php
+++ b/tests/phpunit/tests/multisite/site.php
@@ -1997,6 +1997,79 @@ class Tests_Multisite_Site extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 65241
+	 */
+	public function test_get_roles_data_migrates_misnamed_user_roles_option_on_subsite() {
+		global $wpdb, $wp_roles;
+
+		$blog_id = self::$site_ids['make.wordpress.org/foo/'];
+
+		$custom_roles = array(
+			'test_role' => array(
+				'name'         => 'Test Role',
+				'capabilities' => array(
+					'do_foo' => true,
+				),
+			),
+		);
+
+		switch_to_blog( $blog_id );
+
+		$correct_key = $wpdb->get_blog_prefix( $blog_id ) . 'user_roles';
+		$legacy_key  = 'oldprefix_' . $blog_id . '_user_roles';
+
+		delete_option( $correct_key );
+		update_option( $legacy_key, $custom_roles, true );
+
+		unset( $GLOBALS['wp_user_roles'] );
+		$wp_roles = new WP_Roles( $blog_id );
+
+		$this->assertSame( $custom_roles, $wp_roles->roles );
+		$this->assertSame( $custom_roles, get_option( $correct_key ) );
+		$this->assertFalse( get_option( $legacy_key ) );
+
+		update_option( $correct_key, $custom_roles, true );
+		delete_option( $legacy_key );
+
+		restore_current_blog();
+	}
+
+	/**
+	 * @ticket 65241
+	 */
+	public function test_get_editable_roles_after_misnamed_user_roles_option_migration() {
+		$blog_id = self::$site_ids['make.wordpress.org/foo/'];
+
+		$custom_roles = array(
+			'test_role' => array(
+				'name'         => 'Test Role',
+				'capabilities' => array(
+					'do_foo' => true,
+				),
+			),
+		);
+
+		switch_to_blog( $blog_id );
+
+		global $wpdb;
+		$correct_key = $wpdb->get_blog_prefix( $blog_id ) . 'user_roles';
+		$legacy_key  = 'oldprefix_' . $blog_id . '_user_roles';
+
+		delete_option( $correct_key );
+		update_option( $legacy_key, $custom_roles, true );
+
+		unset( $GLOBALS['wp_user_roles'] );
+		wp_roles()->for_site( $blog_id );
+
+		$this->assertSame( $custom_roles, get_editable_roles() );
+
+		update_option( $correct_key, $custom_roles, true );
+		delete_option( $legacy_key );
+
+		restore_current_blog();
+	}
+
+	/**
 	 * @ticket 41333
 	 */
 	public function test_wp_initialize_site_user_is_admin() {

--- a/tests/phpunit/tests/user/capabilities.php
+++ b/tests/phpunit/tests/user/capabilities.php
@@ -2401,6 +2401,38 @@ class Tests_User_Capabilities extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 65241
+	 */
+	public function test_get_roles_data_migrates_misnamed_user_roles_option() {
+		global $wpdb, $wp_roles;
+
+		$custom_roles = array(
+			'test_role' => array(
+				'name'         => 'Test Role',
+				'capabilities' => array(
+					'do_foo' => true,
+				),
+			),
+		);
+
+		$correct_key = $wpdb->get_blog_prefix( get_current_blog_id() ) . 'user_roles';
+		$legacy_key  = 'oldprefix_user_roles';
+
+		delete_option( $correct_key );
+		update_option( $legacy_key, $custom_roles, true );
+
+		unset( $GLOBALS['wp_user_roles'] );
+		$wp_roles = new WP_Roles();
+
+		$this->assertSame( $custom_roles, $wp_roles->roles );
+		$this->assertSame( $custom_roles, get_option( $correct_key ) );
+		$this->assertFalse( get_option( $legacy_key ) );
+
+		update_option( $correct_key, $custom_roles, true );
+		delete_option( $legacy_key );
+	}
+
+	/**
 	 * @ticket 38645
 	 */
 	public function test_roles_get_site_id_default() {


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

## Summary

- Fixes [#65241](https://core.trac.wordpress.org/ticket/65241): `get_editable_roles()` can return an empty array on multisite when user role options use a stale database prefix.
- Adds automatic detection and migration of misnamed `*_user_roles` options in `WP_Roles::get_roles_data()` when the expected option is missing but a legacy option exists (e.g. after cPanel or other migrations that rename tables but not option names).
- Adds PHPUnit coverage for single-site and multisite subsite scenarios, including `get_editable_roles()` after migration.

## Problem

On multisite subsites, roles are stored in each site’s `options` table under a key such as `{prefix}{blog_id}_user_roles` (e.g. `wp_33_user_roles`). After a table prefix change, migration tools often update table names but leave option names on the old prefix. WordPress then looks up `newprefix_33_user_roles` while the database still has `oldprefix_33_user_roles`, so roles load as empty and admin UI role dropdowns break.

## Solution

When the expected roles option is empty, core looks for a legacy option ending in `{blog_id}_user_roles` (multisite subsite) or `user_roles` (main site / single site), validates the data, copies it to the correct option name, and removes the legacy option.

Trac ticket: https://core.trac.wordpress.org/ticket/65241

## Use of AI Tools

N/A
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
