### PR TITLE
Editor: Replace translation functions with context-aware equivalents for 'Clear' button

### DIFF
--- a/src/js/_enqueues/lib/color-picker.js
+++ b/src/js/_enqueues/lib/color-picker.js
@@ -11,7 +11,8 @@
 		_button = '<input type="button" class="button button-small" />',
 		_wrappingLabel = '<label></label>',
 		_wrappingLabelText = '<span class="screen-reader-text"></span>',
-		__ = wp.i18n.__;
+		__ = wp.i18n.__,
+		_x = wp.i18n._x;
 
 	/**
 	 * Creates a jQuery UI color picker that is used in the theme customizer.
@@ -151,7 +152,7 @@
 			} else {
 				self.button
 					.addClass( 'wp-picker-clear' )
-					.val( __( 'Clear' ) )
+					.val( _x( 'Clear', 'reset color' ) )
 					.attr( 'aria-label', __( 'Clear color' ) );
 			}
 

--- a/src/wp-admin/theme-install.php
+++ b/src/wp-admin/theme-install.php
@@ -241,7 +241,7 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 		<div class="filter-drawer">
 			<div class="buttons">
 				<button type="button" class="apply-filters button"><?php _e( 'Apply Filters' ); ?><span></span></button>
-				<button type="button" class="clear-filters button" aria-label="<?php esc_attr_e( 'Clear current filters' ); ?>"><?php _e( 'Clear' ); ?></button>
+				<button type="button" class="clear-filters button" aria-label="<?php esc_attr_e( 'Clear current filters' ); ?>"><?php echo esc_html_x( 'Clear', 'clear filters' ); ?></button>
 			</div>
 		<?php
 		// Use the core list, rather than the .org API, due to inconsistencies
@@ -263,7 +263,7 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 		?>
 			<div class="buttons">
 				<button type="button" class="apply-filters button"><?php _e( 'Apply Filters' ); ?><span></span></button>
-				<button type="button" class="clear-filters button" aria-label="<?php esc_attr_e( 'Clear current filters' ); ?>"><?php _e( 'Clear' ); ?></button>
+				<button type="button" class="clear-filters button" aria-label="<?php esc_attr_e( 'Clear current filters' ); ?>"><?php echo esc_html_x( 'Clear', 'clear filters' ); ?></button>
 			</div>
 			<div class="filtered-by">
 				<span><?php _e( 'Filtering by:' ); ?></span>

--- a/src/wp-includes/media-template.php
+++ b/src/wp-includes/media-template.php
@@ -815,7 +815,7 @@ function wp_print_media_templates() {
 				<button type="button" class="button-link edit-selection"><?php _e( 'Edit Selection' ); ?></button>
 			<# } #>
 			<# if ( data.clearable ) { #>
-				<button type="button" class="button-link clear-selection"><?php _e( 'Clear' ); ?></button>
+				<button type="button" class="button-link clear-selection"><?php echo esc_html_x( 'Clear', 'reset selection' ); ?></button>
 			<# } #>
 		</div>
 		<div class="selection-view"></div>


### PR DESCRIPTION
This pull request updates the translation functions for the "Clear" button in several places to provide more context for translators. By switching to the contextual translation function (`_x` or `esc_html_x`) and supplying a descriptive context string, the changes help ensure accurate and meaningful translations in different scenarios.


Trac ticket: https://core.trac.wordpress.org/ticket/65255


