### PR TITLE
Editor: Align media attachment filters in CSS grid layout

### DIFF
--- a/src/wp-includes/css/media-views.css
+++ b/src/wp-includes/css/media-views.css
@@ -348,21 +348,15 @@
 	align-items: end;
 }
 
-label[for="media-attachment-filters"] { 
-	grid-area: 1 / 1 / 2 / 2; 
+label[for="media-attachment-filters"],
+label[for="media-attachment-date-filters"] {
+	grid-row: 1;
 }
 
-select#media-attachment-filters { 
-	grid-area: 2 / 1 / 3 / 2; 
+select#media-attachment-filters,
+select#media-attachment-date-filters {
+	grid-row: 2;
 }
-
-label[for="media-attachment-date-filters"] { 
-	grid-area: 1 / 2 / 2 / 3; 
-}
-
-select#media-attachment-date-filters { 
-	grid-area: 2 / 2 / 3 / 3; 
-} 
 
 .media-toolbar-primary > .media-button,
 .media-toolbar-primary > .media-button-group {


### PR DESCRIPTION
## What?

Fixes the visual offset and alignment of the "Filter by date" dropdown in the Media Library modal when the "Filter by type" dropdown is hidden. It also ensures that the filters and the search input box are vertically aligned on the same row.

## Why?

When a `wp.media()` frame is opened with the library restricted to a single MIME type (e.g., `library: { type: 'image' }`), the "Filter by type" dropdown is hidden. Because column placement in the media toolbar was previously hardcoded, this caused the "Filter by date" dropdown remained offset in the second column, leaving a large empty space to its left.


## How?

**CSS Grid Auto-Placement**: Updated the toolbar filters in `src/wp-includes/css/media-views.css` to use CSS Grid auto-placement (placing labels on `grid-row: 1` and selects on `grid-row: 2`) rather than hardcoded columns. This allows the date filter dropdown to slide flush-left naturally when the type filter is hidden.


## Screenshots

<img width="2328" height="1360" alt="image" src="https://github.com/user-attachments/assets/e3805cc6-b6aa-4a96-86be-2fed56cfd611" />


## Testing Instructions

1. Go to `/wp-admin/post-new.php`.
2. Open the browser DevTools console and run:
   ```javascript
   wp.media({ library: { type: 'image' } }).open();
   ```
3. Switch to the "Media Library" tab.
4. Confirm that the "Filter by date" dropdown is aligned flush-left (where the type filter would normally be) when the type filter is hidden.
5. Open a normal media frame where both filters are visible (e.g. standard Media Library).
6. Confirm that "Filter by type" and "Filter by date" still appear side by side.

Trac ticket: https://core.trac.wordpress.org/ticket/65276

## Use of AI Tools

AI assistance: Yes
Tool(s): Antigravity
Model(s): Gemini
Used for: Refactoring styling rules to use auto-placement grids. 
