### PR TITLE
Administration: Fix black flash on Connectors screen before hydration.

### DIFF
--- a/src/wp-includes/build/pages/options-connectors/page-wp-admin.php
+++ b/src/wp-includes/build/pages/options-connectors/page-wp-admin.php
@@ -245,7 +245,7 @@ function wp_options_connectors_wp_admin_render_page() {
 
 		/* Background colors */
 		#wpwrap {
-			background: var(--wpds-color-fg-content-neutral, #1e1e1e);
+			background: var(--wpds-color-bg-surface-neutral-weak, #f0f0f0);
 			overflow-y: auto;
 		}
 		body {

--- a/tests/phpunit/tests/connectors/wpOptionsConnectorsWpAdminRenderPage.php
+++ b/tests/phpunit/tests/connectors/wpOptionsConnectorsWpAdminRenderPage.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Tests for the Connectors wp-admin page render output.
+ *
+ * @group connectors
+ */
+class Tests_Connectors_WpOptionsConnectorsWpAdminRenderPage extends WP_UnitTestCase {
+
+	/**
+	 * Critical styles should use a background token for #wpwrap, not a foreground color.
+	 *
+	 * @ticket 65247
+	 */
+	public function test_render_page_critical_styles_use_background_token_for_wpwrap() {
+		if ( ! function_exists( 'wp_options_connectors_wp_admin_render_page' ) ) {
+			$this->markTestSkipped( 'Connectors build files are not available.' );
+		}
+
+		ob_start();
+		wp_options_connectors_wp_admin_render_page();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString(
+			'background: var(--wpds-color-bg-surface-neutral-weak, #f0f0f0)',
+			$output,
+			'#wpwrap should use the same background token as .boot-layout before hydration.'
+		);
+		$this->assertStringNotContainsString(
+			'background: var(--wpds-color-fg-content-neutral, #1e1e1e)',
+			$output,
+			'#wpwrap must not use a foreground color token as its background fallback.'
+		);
+	}
+}


### PR DESCRIPTION
Use the boot layout background token for #wpwrap critical CSS instead of a foreground color fallback that rendered as near-black before React mounted.

Fixes #65247.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/65247
