### PR TITLE
Build/Test Tools: Account for missing performance artifacts on older branches

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -59,6 +59,7 @@ jobs:
     if: ${{ ( github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' ) && ! contains( github.event.before, '00000000' ) }}
     permissions:
       actions: read
+      contents: read
     env:
       TARGET_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
     outputs:
@@ -75,12 +76,40 @@ jobs:
         id: set-subjects
         with:
           script: |
+            function compareReleaseBranches( a, b ) {
+              const [ aMajor, aMinor ] = a.split( '.' ).map( Number );
+              const [ bMajor, bMinor ] = b.split( '.' ).map( Number );
+
+              if ( aMajor !== bMajor ) {
+                return bMajor - aMajor;
+              }
+
+              return bMinor - aMinor;
+            }
+
             const artifacts = await github.rest.actions.listArtifactsForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
               name: 'wordpress-build-' + process.env.TARGET_SHA,
             });
             const has_previous_build = !! artifacts.data.artifacts[0];
+            const targetRef = context.eventName === 'pull_request'
+              ? context.payload.pull_request.base.ref
+              : context.ref.replace( 'refs/heads/', '' );
+            const releaseBranches = ( await github.paginate(
+              github.rest.repos.listBranches,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                per_page: 100,
+              }
+            ) )
+              .map( ( { name } ) => name )
+              .filter( ( name ) => /^\d+\.\d+$/.test( name ) )
+              .sort( compareReleaseBranches );
+            const latestReleaseBranch = releaseBranches[0];
+            const requiresPreviousBuild =
+              targetRef === 'trunk' || targetRef === latestReleaseBranch;
 
             const subjects = [
               'current',
@@ -90,6 +119,16 @@ jobs:
               subjects.push( 'base' );
             } else if ( has_previous_build ) {
               subjects.push( 'before' );
+            } else if ( requiresPreviousBuild ) {
+              core.setFailed(
+                `No artifact found for the target commit ${ process.env.TARGET_SHA } on ${ targetRef }.`
+              );
+              return;
+            } else {
+              core.warning(
+                `No artifact found for the target commit ${ process.env.TARGET_SHA } on ${ targetRef }. ` +
+                `Skipping previous-build comparison for this older branch.`
+              );
             }
 
             return subjects;


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

## What?
Updates the performance workflow so missing previous-build artifacts only fail the workflow for 	runk and the latest release branch.

For older branches, the workflow now logs a warning and skips the previous-build comparison instead of failing.

## Why?
Build artifacts for older branches are more likely to expire or be missing due to long gaps between commits. In those cases, failing the workflow is too strict.`n`nContribution tracking issue: https://github.com/rtCamp/wp-contributions/issues/2953

Trac ticket: https://core.trac.wordpress.org/ticket/63617

## Use of AI Tools

AI assistance: Yes
Tool(s): OpenAI Codex
Model(s): GPT-5
Used for: Reviewing the Trac ticket and relevant code, helping with the initial implementation and regression-test approach, and assisting with validation and PR-description drafting. The final implementation, tests, validation results, and description were reviewed and accepted by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**