### PR TITLE
General Settings: Reject empty custom date and time formats.

### DIFF
--- a/src/wp-admin/includes/options.php
+++ b/src/wp-admin/includes/options.php
@@ -37,47 +37,7 @@ function options_general_add_js() {
 	jQuery( function($) {
 		var $siteName = $( '#wp-admin-bar-site-name' ).children( 'a' ).first(),
 			$siteIconPreview = $('#site-icon-preview-site-title'),
-			homeURL = ( <?php echo wp_json_encode( get_home_url(), JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ); ?> || '' ).replace( /^(https?:\/\/)?(www\.)?/, '' ),
-			invalidDateTimeFormatMessage = <?php echo wp_json_encode( __( 'Please configure a valid date and time format.' ) ); ?>;
-
-		function clearDateTimeFormatValidation( $input ) {
-			$input.closest( 'tr' ).removeClass( 'form-invalid form-required' );
-		}
-
-		function validateCustomDateTimeFormats( $form ) {
-			var invalid = false,
-				$dateFormatCustom = $form.find( '#date_format_custom' ),
-				$timeFormatCustom = $form.find( '#time_format_custom' ),
-				$firstInvalid = null;
-
-			clearDateTimeFormatValidation( $dateFormatCustom );
-			clearDateTimeFormatValidation( $timeFormatCustom );
-
-			if ( $( '#date_format_custom_radio' ).prop( 'checked' ) && ! $.trim( $dateFormatCustom.val() ) ) {
-				$dateFormatCustom.closest( 'tr' ).addClass( 'form-invalid form-required' );
-				invalid = true;
-				$firstInvalid = $dateFormatCustom;
-			}
-
-			if ( $( '#time_format_custom_radio' ).prop( 'checked' ) && ! $.trim( $timeFormatCustom.val() ) ) {
-				$timeFormatCustom.closest( 'tr' ).addClass( 'form-invalid form-required' );
-				invalid = true;
-
-				if ( ! $firstInvalid ) {
-					$firstInvalid = $timeFormatCustom;
-				}
-			}
-
-			if ( invalid ) {
-				if ( wp.a11y && wp.a11y.speak ) {
-					wp.a11y.speak( invalidDateTimeFormatMessage );
-				}
-
-				$firstInvalid.trigger( 'focus' );
-			}
-
-			return ! invalid;
-		}
+			homeURL = ( <?php echo wp_json_encode( get_home_url(), JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ); ?> || '' ).replace( /^(https?:\/\/)?(www\.)?/, '' );
 
 		$( '#blogname' ).on( 'input', function() {
 			var title = $.trim( $( this ).val() ) || homeURL;
@@ -92,33 +52,21 @@ function options_general_add_js() {
 		});
 
 		$( 'input[name="date_format"]' ).on( 'click', function() {
-			if ( 'date_format_custom_radio' !== $(this).attr( 'id' ) ) {
-				clearDateTimeFormatValidation( $( '#date_format_custom' ) );
+			if ( 'date_format_custom_radio' !== $(this).attr( 'id' ) )
 				$( 'input[name="date_format_custom"]' ).val( $( this ).val() ).closest( 'fieldset' ).find( '.example' ).text( $( this ).parent( 'label' ).children( '.format-i18n' ).text() );
-			}
 		});
 
 		$( 'input[name="date_format_custom"]' ).on( 'click input', function() {
 			$( '#date_format_custom_radio' ).prop( 'checked', true );
-
-			if ( $.trim( $( this ).val() ) ) {
-				clearDateTimeFormatValidation( $( this ) );
-			}
 		});
 
 		$( 'input[name="time_format"]' ).on( 'click', function() {
-			if ( 'time_format_custom_radio' !== $(this).attr( 'id' ) ) {
-				clearDateTimeFormatValidation( $( '#time_format_custom' ) );
+			if ( 'time_format_custom_radio' !== $(this).attr( 'id' ) )
 				$( 'input[name="time_format_custom"]' ).val( $( this ).val() ).closest( 'fieldset' ).find( '.example' ).text( $( this ).parent( 'label' ).children( '.format-i18n' ).text() );
-			}
 		});
 
 		$( 'input[name="time_format_custom"]' ).on( 'click input', function() {
 			$( '#time_format_custom_radio' ).prop( 'checked', true );
-
-			if ( $.trim( $( this ).val() ) ) {
-				clearDateTimeFormatValidation( $( this ) );
-			}
 		});
 
 		$( 'input[name="date_format_custom"], input[name="time_format_custom"]' ).on( 'input', function() {
@@ -143,12 +91,7 @@ function options_general_add_js() {
 		} );
 
 		var languageSelect = $( '#WPLANG' );
-		$( 'form' ).on( 'submit', function( event ) {
-			if ( ! validateCustomDateTimeFormats( $( this ) ) ) {
-				event.preventDefault();
-				return false;
-			}
-
+		$( 'form' ).on( 'submit', function() {
 			/*
 			 * Don't show a spinner for English and installed languages,
 			 * as there is nothing to download.

--- a/src/wp-admin/includes/options.php
+++ b/src/wp-admin/includes/options.php
@@ -37,7 +37,47 @@ function options_general_add_js() {
 	jQuery( function($) {
 		var $siteName = $( '#wp-admin-bar-site-name' ).children( 'a' ).first(),
 			$siteIconPreview = $('#site-icon-preview-site-title'),
-			homeURL = ( <?php echo wp_json_encode( get_home_url(), JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ); ?> || '' ).replace( /^(https?:\/\/)?(www\.)?/, '' );
+			homeURL = ( <?php echo wp_json_encode( get_home_url(), JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ); ?> || '' ).replace( /^(https?:\/\/)?(www\.)?/, '' ),
+			invalidDateTimeFormatMessage = <?php echo wp_json_encode( __( 'Please configure a valid date and time format.' ) ); ?>;
+
+		function clearDateTimeFormatValidation( $input ) {
+			$input.closest( 'tr' ).removeClass( 'form-invalid form-required' );
+		}
+
+		function validateCustomDateTimeFormats( $form ) {
+			var invalid = false,
+				$dateFormatCustom = $form.find( '#date_format_custom' ),
+				$timeFormatCustom = $form.find( '#time_format_custom' ),
+				$firstInvalid = null;
+
+			clearDateTimeFormatValidation( $dateFormatCustom );
+			clearDateTimeFormatValidation( $timeFormatCustom );
+
+			if ( $( '#date_format_custom_radio' ).prop( 'checked' ) && ! $.trim( $dateFormatCustom.val() ) ) {
+				$dateFormatCustom.closest( 'tr' ).addClass( 'form-invalid form-required' );
+				invalid = true;
+				$firstInvalid = $dateFormatCustom;
+			}
+
+			if ( $( '#time_format_custom_radio' ).prop( 'checked' ) && ! $.trim( $timeFormatCustom.val() ) ) {
+				$timeFormatCustom.closest( 'tr' ).addClass( 'form-invalid form-required' );
+				invalid = true;
+
+				if ( ! $firstInvalid ) {
+					$firstInvalid = $timeFormatCustom;
+				}
+			}
+
+			if ( invalid ) {
+				if ( wp.a11y && wp.a11y.speak ) {
+					wp.a11y.speak( invalidDateTimeFormatMessage );
+				}
+
+				$firstInvalid.trigger( 'focus' );
+			}
+
+			return ! invalid;
+		}
 
 		$( '#blogname' ).on( 'input', function() {
 			var title = $.trim( $( this ).val() ) || homeURL;
@@ -52,21 +92,33 @@ function options_general_add_js() {
 		});
 
 		$( 'input[name="date_format"]' ).on( 'click', function() {
-			if ( 'date_format_custom_radio' !== $(this).attr( 'id' ) )
+			if ( 'date_format_custom_radio' !== $(this).attr( 'id' ) ) {
+				clearDateTimeFormatValidation( $( '#date_format_custom' ) );
 				$( 'input[name="date_format_custom"]' ).val( $( this ).val() ).closest( 'fieldset' ).find( '.example' ).text( $( this ).parent( 'label' ).children( '.format-i18n' ).text() );
+			}
 		});
 
 		$( 'input[name="date_format_custom"]' ).on( 'click input', function() {
 			$( '#date_format_custom_radio' ).prop( 'checked', true );
+
+			if ( $.trim( $( this ).val() ) ) {
+				clearDateTimeFormatValidation( $( this ) );
+			}
 		});
 
 		$( 'input[name="time_format"]' ).on( 'click', function() {
-			if ( 'time_format_custom_radio' !== $(this).attr( 'id' ) )
+			if ( 'time_format_custom_radio' !== $(this).attr( 'id' ) ) {
+				clearDateTimeFormatValidation( $( '#time_format_custom' ) );
 				$( 'input[name="time_format_custom"]' ).val( $( this ).val() ).closest( 'fieldset' ).find( '.example' ).text( $( this ).parent( 'label' ).children( '.format-i18n' ).text() );
+			}
 		});
 
 		$( 'input[name="time_format_custom"]' ).on( 'click input', function() {
 			$( '#time_format_custom_radio' ).prop( 'checked', true );
+
+			if ( $.trim( $( this ).val() ) ) {
+				clearDateTimeFormatValidation( $( this ) );
+			}
 		});
 
 		$( 'input[name="date_format_custom"], input[name="time_format_custom"]' ).on( 'input', function() {
@@ -91,7 +143,12 @@ function options_general_add_js() {
 		} );
 
 		var languageSelect = $( '#WPLANG' );
-		$( 'form' ).on( 'submit', function() {
+		$( 'form' ).on( 'submit', function( event ) {
+			if ( ! validateCustomDateTimeFormats( $( this ) ) ) {
+				event.preventDefault();
+				return false;
+			}
+
 			/*
 			 * Don't show a spinner for English and installed languages,
 			 * as there is nothing to download.

--- a/src/wp-admin/options-general.php
+++ b/src/wp-admin/options-general.php
@@ -67,7 +67,7 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 <div class="wrap">
 <h1><?php echo esc_html( $title ); ?></h1>
 
-<form method="post" action="options.php" novalidate="novalidate">
+<form method="post" action="options.php">
 <?php settings_fields( 'general' ); ?>
 
 <table class="form-table" role="presentation">
@@ -518,7 +518,7 @@ foreach ( $date_formats as $format ) {
 			/* translators: Hidden accessibility text. */
 			__( 'Custom date format:' ) .
 		'</label>' .
-		'<input type="text" name="date_format_custom" id="date_format_custom" value="' . esc_attr( get_option( 'date_format' ) ) . '" class="small-text" />' .
+		'<input type="text" name="date_format_custom" id="date_format_custom" value="' . esc_attr( get_option( 'date_format' ) ) . '" class="small-text" required />' .
 		'<br />' .
 		'<p><strong>' . __( 'Preview:' ) . '</strong> <span class="example">' . date_i18n( get_option( 'date_format' ) ) . '</span>' .
 		"<span class='spinner'></span>\n" . '</p>';
@@ -563,7 +563,7 @@ foreach ( $time_formats as $format ) {
 			/* translators: Hidden accessibility text. */
 			__( 'Custom time format:' ) .
 		'</label>' .
-		'<input type="text" name="time_format_custom" id="time_format_custom" value="' . esc_attr( get_option( 'time_format' ) ) . '" class="small-text" />' .
+		'<input type="text" name="time_format_custom" id="time_format_custom" value="' . esc_attr( get_option( 'time_format' ) ) . '" class="small-text" required />' .
 		'<br />' .
 		'<p><strong>' . __( 'Preview:' ) . '</strong> <span class="example">' . date_i18n( get_option( 'time_format' ) ) . '</span>' .
 		"<span class='spinner'></span>\n" . '</p>';

--- a/src/wp-admin/options.php
+++ b/src/wp-admin/options.php
@@ -275,10 +275,10 @@ if ( 'update' === $action ) { // We are saving settings sent from a settings pag
 			$date_format_custom = trim( wp_unslash( $_POST['date_format_custom'] ) );
 
 			if ( '' === $date_format_custom ) {
-				$_POST['date_format']     = get_option( 'date_format' );
+				$_POST['date_format']     = wp_slash( get_option( 'date_format' ) );
 				$invalid_date_time_format = true;
 			} else {
-				$_POST['date_format'] = $date_format_custom;
+				$_POST['date_format'] = $_POST['date_format_custom'];
 			}
 		}
 
@@ -288,10 +288,10 @@ if ( 'update' === $action ) { // We are saving settings sent from a settings pag
 			$time_format_custom = trim( wp_unslash( $_POST['time_format_custom'] ) );
 
 			if ( '' === $time_format_custom ) {
-				$_POST['time_format']     = get_option( 'time_format' );
+				$_POST['time_format']     = wp_slash( get_option( 'time_format' ) );
 				$invalid_date_time_format = true;
 			} else {
-				$_POST['time_format'] = $time_format_custom;
+				$_POST['time_format'] = $_POST['time_format_custom'];
 			}
 		}
 

--- a/src/wp-admin/options.php
+++ b/src/wp-admin/options.php
@@ -267,16 +267,41 @@ if ( 'update' === $action ) { // We are saving settings sent from a settings pag
 
 	if ( 'general' === $option_page ) {
 		// Handle custom date/time formats.
+		$invalid_date_time_format = false;
+
 		if ( ! empty( $_POST['date_format'] ) && isset( $_POST['date_format_custom'] )
 			&& '\c\u\s\t\o\m' === wp_unslash( $_POST['date_format'] )
 		) {
-			$_POST['date_format'] = $_POST['date_format_custom'];
+			$date_format_custom = trim( wp_unslash( $_POST['date_format_custom'] ) );
+
+			if ( '' === $date_format_custom ) {
+				$_POST['date_format']     = get_option( 'date_format' );
+				$invalid_date_time_format = true;
+			} else {
+				$_POST['date_format'] = $date_format_custom;
+			}
 		}
 
 		if ( ! empty( $_POST['time_format'] ) && isset( $_POST['time_format_custom'] )
 			&& '\c\u\s\t\o\m' === wp_unslash( $_POST['time_format'] )
 		) {
-			$_POST['time_format'] = $_POST['time_format_custom'];
+			$time_format_custom = trim( wp_unslash( $_POST['time_format_custom'] ) );
+
+			if ( '' === $time_format_custom ) {
+				$_POST['time_format']     = get_option( 'time_format' );
+				$invalid_date_time_format = true;
+			} else {
+				$_POST['time_format'] = $time_format_custom;
+			}
+		}
+
+		if ( $invalid_date_time_format ) {
+			add_settings_error(
+				'general',
+				'invalid_date_time_format',
+				__( 'Please configure a valid date and time format.' ),
+				'error'
+			);
 		}
 
 		// Map UTC+- timezones to gmt_offsets and set timezone_string to empty.

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -4958,7 +4958,7 @@ function sanitize_option( $option, $value ) {
 				$value = strip_tags( $value );
 				$value = wp_kses_data( $value );
 
-				if ( ( 'date_format' === $option || 'time_format' === $option ) && '' === $value ) {
+				if ( ( 'date_format' === $option || 'time_format' === $option ) && '' === trim( $value ) ) {
 					$error = __( 'Please configure a valid date and time format.' );
 				}
 			}

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -4957,6 +4957,10 @@ function sanitize_option( $option, $value ) {
 			} else {
 				$value = strip_tags( $value );
 				$value = wp_kses_data( $value );
+
+				if ( ( 'date_format' === $option || 'time_format' === $option ) && '' === $value ) {
+					$error = __( 'Please configure a valid date and time format.' );
+				}
 			}
 			break;
 

--- a/tests/phpunit/tests/option/sanitizeOption.php
+++ b/tests/phpunit/tests/option/sanitizeOption.php
@@ -175,4 +175,43 @@ class Tests_Option_SanitizeOption extends WP_UnitTestCase {
 			array( new WP_Error( 'wpdb_get_table_charset_failure' ), false, false ), // @ticket 53986
 		);
 	}
+
+	/**
+	 * @ticket 65281
+	 *
+	 * @covers ::sanitize_option
+	 * @covers ::get_settings_errors
+	 *
+	 * @dataProvider data_sanitize_option_date_time_format
+	 */
+	public function test_sanitize_option_date_time_format( $option_name, $provided, $expected, $valid ) {
+		global $wp_settings_errors;
+
+		$old_wp_settings_errors = (array) $wp_settings_errors;
+
+		update_option( $option_name, $expected );
+
+		$actual = sanitize_option( $option_name, $provided );
+		$errors = get_settings_errors( $option_name );
+
+		$wp_settings_errors = $old_wp_settings_errors;
+
+		if ( $valid ) {
+			$this->assertEmpty( $errors );
+		} else {
+			$this->assertNotEmpty( $errors );
+			$this->assertSame( 'invalid_' . $option_name, $errors[0]['code'] );
+		}
+
+		$this->assertSame( $expected, $actual );
+	}
+
+	public function data_sanitize_option_date_time_format() {
+		return array(
+			array( 'date_format', 'F j, Y', 'F j, Y', true ),
+			array( 'date_format', '', 'Y-m-d', false ),
+			array( 'time_format', 'g:i a', 'g:i a', true ),
+			array( 'time_format', '', 'g:i a', false ),
+		);
+	}
 }

--- a/tests/phpunit/tests/option/sanitizeOption.php
+++ b/tests/phpunit/tests/option/sanitizeOption.php
@@ -210,8 +210,10 @@ class Tests_Option_SanitizeOption extends WP_UnitTestCase {
 		return array(
 			array( 'date_format', 'F j, Y', 'F j, Y', true ),
 			array( 'date_format', '', 'Y-m-d', false ),
+			array( 'date_format', '   ', 'Y-m-d', false ),
 			array( 'time_format', 'g:i a', 'g:i a', true ),
 			array( 'time_format', '', 'g:i a', false ),
+			array( 'time_format', '   ', 'g:i a', false ),
 		);
 	}
 }


### PR DESCRIPTION
Validate custom date and time format fields on the General Settings screen before saving. When either custom field is empty, restore the previous value, show an admin error, and reject empty values in sanitize_option() as well.

Fixes #65281.

Trac ticket: https://core.trac.wordpress.org/ticket/65281

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude
Used for: Initial test suggestions; final implementation and tests were reviewed by me.
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**