### PR TITLE
Emoji: Print the emoji detection script in the admin footer.

### DIFF
--- a/src/wp-admin/edit-form-blocks.php
+++ b/src/wp-admin/edit-form-blocks.php
@@ -39,7 +39,7 @@ add_filter(
 /*
  * Emoji replacement is disabled for now, until it plays nicely with React.
  */
-remove_action( 'admin_print_scripts', 'print_emoji_detection_script' );
+remove_action( 'admin_print_footer_scripts', 'print_emoji_detection_script' );
 
 /*
  * Block editor implements its own Options menu for toggling Document Panels.

--- a/src/wp-admin/includes/admin-filters.php
+++ b/src/wp-admin/includes/admin-filters.php
@@ -56,7 +56,7 @@ if ( ! is_customize_preview() ) {
 	add_action( 'admin_print_styles', 'wp_resource_hints', 1 );
 }
 
-add_action( 'admin_print_scripts', 'print_emoji_detection_script' );
+add_action( 'admin_print_footer_scripts', 'print_emoji_detection_script' );
 add_action( 'admin_print_scripts', 'print_head_scripts', 20 );
 add_action( 'admin_print_footer_scripts', '_wp_footer_scripts' );
 add_action( 'admin_enqueue_scripts', 'wp_enqueue_emoji_styles' );

--- a/tests/phpunit/tests/formatting/emoji.php
+++ b/tests/phpunit/tests/formatting/emoji.php
@@ -216,4 +216,28 @@ class Tests_Formatting_Emoji extends WP_UnitTestCase {
 	public function test_wp_staticize_emoji( $emoji, $expected ) {
 		$this->assertSame( $expected, wp_staticize_emoji( $emoji ) );
 	}
+
+	/**
+	 * The emoji detection script outputs a `<script type="module">`. In the admin it must
+	 * be printed in the footer (after the script-module import map) rather than the head,
+	 * otherwise the import map is encountered after a module script and is treated as
+	 * inert by browsers that follow the spec strictly (e.g. Firefox).
+	 *
+	 * @ticket 65260
+	 *
+	 * @covers ::print_emoji_detection_script
+	 */
+	public function test_print_emoji_detection_script_is_hooked_to_admin_footer() {
+		require_once ABSPATH . 'wp-admin/includes/admin-filters.php';
+
+		$this->assertFalse(
+			has_action( 'admin_print_scripts', 'print_emoji_detection_script' ),
+			'print_emoji_detection_script must not run on admin_print_scripts; the resulting <script type="module"> would precede the import map.'
+		);
+		$this->assertSame(
+			10,
+			has_action( 'admin_print_footer_scripts', 'print_emoji_detection_script' ),
+			'print_emoji_detection_script must run on admin_print_footer_scripts, after the import map.'
+		);
+	}
 }


### PR DESCRIPTION
Move the emoji detection script to the footer in WP Admin. This ensures it should be printed after an importmap and avoid an issue where Firefox does not process importmaps once a module has been encountered.

This implements [a minimal fix suggested by](https://core.trac.wordpress.org/ticket/65260#comment:1) @westonruter.

Since [60899], the emoji detection script is output as a `<script type="module">`. In the admin it was hooked to `admin_print_scripts`, so the module script tag was emitted inside `<head>` ahead of the script-module import map (which is printed at `admin_print_footer_scripts` priority 9).

Move the hook to `admin_print_footer_scripts`, mirroring the frontend behavior put in place by [60902] for #64076. Update the matching `remove_action()` in `edit-form-blocks.php` so the post editor continues to suppress the emoji detection script.

Trac ticket: https://core.trac.wordpress.org/ticket/65260

---

## Testing

This can be tested by following the reproduction steps in the ticket. Firefox should be used.

In the site editor on `trunk`, module specifiers cannot be resolved because the importmap is not processed. For example `await import('@wordpress/route')` will throw an error like:

> TypeError: The specifier “@wordpress/route” was a bare specifier, but was not remapped to anything. Relative module specifiers must start with “./”, “../” or “/”.

On this branch, the import will work correctly.

---

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude
Model(s): Opus-4.7
Used for: Complete implementation, verification, and testing based on ticket.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
