### PR TITLE
General: Add opt-in `<search>` element support to the core search form

### DIFF
--- a/src/wp-content/themes/twentyseventeen/searchform.php
+++ b/src/wp-content/themes/twentyseventeen/searchform.php
@@ -8,7 +8,7 @@
  * @version 1.0
  */
 
-/** @var array{ wrap_in_search?: bool, aria_label?: string } $args */
+/** @var array{ wrap_in_search: bool, aria_label: string } $args */
 
 ?>
 

--- a/src/wp-content/themes/twentyseventeen/searchform.php
+++ b/src/wp-content/themes/twentyseventeen/searchform.php
@@ -8,6 +8,8 @@
  * @version 1.0
  */
 
+/** @var array{ wrap_in_search?: bool, aria_label?: string } $args */
+
 ?>
 
 <?php $unique_id = esc_attr( twentyseventeen_unique_id( 'search-form-' ) ); ?>

--- a/src/wp-content/themes/twentyseventeen/searchform.php
+++ b/src/wp-content/themes/twentyseventeen/searchform.php
@@ -12,7 +12,11 @@
 
 <?php $unique_id = esc_attr( twentyseventeen_unique_id( 'search-form-' ) ); ?>
 
-<form role="search" method="get" class="search-form" action="<?php echo esc_url( home_url( '/' ) ); ?>">
+<?php $twentyseventeen_wrap_in_search = ! empty( $args['wrap_in_search'] ); ?>
+<?php if ( $twentyseventeen_wrap_in_search ) : ?>
+<search>
+<?php endif; ?>
+<form <?php echo $twentyseventeen_wrap_in_search ? '' : 'role="search" '; ?>method="get" class="search-form" action="<?php echo esc_url( home_url( '/' ) ); ?>">
 	<label for="<?php echo $unique_id; ?>">
 		<span class="screen-reader-text">
 			<?php
@@ -29,3 +33,6 @@
 		?>
 	</span></button>
 </form>
+<?php if ( $twentyseventeen_wrap_in_search ) : ?>
+</search>
+<?php endif; ?>

--- a/src/wp-content/themes/twentysixteen/searchform.php
+++ b/src/wp-content/themes/twentysixteen/searchform.php
@@ -7,7 +7,7 @@
  * @since Twenty Sixteen 1.0
  */
 
-/** @var array{ wrap_in_search?: bool, aria_label?: string } $args */
+/** @var array{ wrap_in_search: bool, aria_label: string } $args */
 
 ?>
 

--- a/src/wp-content/themes/twentysixteen/searchform.php
+++ b/src/wp-content/themes/twentysixteen/searchform.php
@@ -7,6 +7,8 @@
  * @since Twenty Sixteen 1.0
  */
 
+/** @var array{ wrap_in_search?: bool, aria_label?: string } $args */
+
 ?>
 
 <?php $twentysixteen_wrap_in_search = ! empty( $args['wrap_in_search'] ); ?>

--- a/src/wp-content/themes/twentysixteen/searchform.php
+++ b/src/wp-content/themes/twentysixteen/searchform.php
@@ -9,7 +9,11 @@
 
 ?>
 
-<form role="search" method="get" class="search-form" action="<?php echo esc_url( home_url( '/' ) ); ?>">
+<?php $twentysixteen_wrap_in_search = ! empty( $args['wrap_in_search'] ); ?>
+<?php if ( $twentysixteen_wrap_in_search ) : ?>
+<search>
+<?php endif; ?>
+<form <?php echo $twentysixteen_wrap_in_search ? '' : 'role="search" '; ?>method="get" class="search-form" action="<?php echo esc_url( home_url( '/' ) ); ?>">
 	<label>
 		<span class="screen-reader-text">
 			<?php
@@ -26,3 +30,6 @@
 		?>
 	</span></button>
 </form>
+<?php if ( $twentysixteen_wrap_in_search ) : ?>
+</search>
+<?php endif; ?>

--- a/src/wp-content/themes/twentytwenty/searchform.php
+++ b/src/wp-content/themes/twentytwenty/searchform.php
@@ -11,7 +11,7 @@
  * @since Twenty Twenty 1.0
  */
 
-/** @var array{ wrap_in_search?: bool, aria_label?: string } $args */
+/** @var array{ wrap_in_search: bool, aria_label: string } $args */
 
 /*
  * Generate a unique ID for each form and a string containing an aria-label

--- a/src/wp-content/themes/twentytwenty/searchform.php
+++ b/src/wp-content/themes/twentytwenty/searchform.php
@@ -11,6 +11,8 @@
  * @since Twenty Twenty 1.0
  */
 
+/** @var array{ wrap_in_search?: bool, aria_label?: string } $args */
+
 /*
  * Generate a unique ID for each form and a string containing an aria-label
  * if one was passed to get_search_form() in the args array.

--- a/src/wp-content/themes/twentytwenty/searchform.php
+++ b/src/wp-content/themes/twentytwenty/searchform.php
@@ -22,8 +22,13 @@ $twentytwenty_aria_label = ! empty( $args['aria_label'] ) ? 'aria-label="' . esc
 if ( empty( $twentytwenty_aria_label ) && ! empty( $args['label'] ) ) {
 	$twentytwenty_aria_label = 'aria-label="' . esc_attr( $args['label'] ) . '"';
 }
+
+$twentytwenty_wrap_in_search = ! empty( $args['wrap_in_search'] );
 ?>
-<form role="search" <?php echo $twentytwenty_aria_label; ?> method="get" class="search-form" action="<?php echo esc_url( home_url( '/' ) ); ?>">
+<?php if ( $twentytwenty_wrap_in_search ) : ?>
+<search<?php echo $twentytwenty_aria_label ? ' ' . $twentytwenty_aria_label : ''; ?>>
+<?php endif; ?>
+<form <?php echo $twentytwenty_wrap_in_search ? '' : 'role="search" ' . $twentytwenty_aria_label . ' '; ?>method="get" class="search-form" action="<?php echo esc_url( home_url( '/' ) ); ?>">
 	<label for="<?php echo esc_attr( $twentytwenty_unique_id ); ?>">
 		<span class="screen-reader-text">
 			<?php
@@ -35,3 +40,6 @@ if ( empty( $twentytwenty_aria_label ) && ! empty( $args['label'] ) ) {
 	</label>
 	<input type="submit" class="search-submit" value="<?php echo esc_attr_x( 'Search', 'submit button', 'twentytwenty' ); ?>" />
 </form>
+<?php if ( $twentytwenty_wrap_in_search ) : ?>
+</search>
+<?php endif; ?>

--- a/src/wp-content/themes/twentytwentyone/searchform.php
+++ b/src/wp-content/themes/twentytwentyone/searchform.php
@@ -19,9 +19,17 @@
 $twentytwentyone_unique_id = wp_unique_id( 'search-form-' );
 
 $twentytwentyone_aria_label = ! empty( $args['aria_label'] ) ? 'aria-label="' . esc_attr( $args['aria_label'] ) . '"' : '';
+
+$twentytwentyone_wrap_in_search = ! empty( $args['wrap_in_search'] );
 ?>
-<form role="search" <?php echo $twentytwentyone_aria_label; ?> method="get" class="search-form" action="<?php echo esc_url( home_url( '/' ) ); ?>">
+<?php if ( $twentytwentyone_wrap_in_search ) : ?>
+<search<?php echo $twentytwentyone_aria_label ? ' ' . $twentytwentyone_aria_label : ''; ?>>
+<?php endif; ?>
+<form <?php echo $twentytwentyone_wrap_in_search ? '' : 'role="search" ' . $twentytwentyone_aria_label . ' '; ?>method="get" class="search-form" action="<?php echo esc_url( home_url( '/' ) ); ?>">
 	<label for="<?php echo esc_attr( $twentytwentyone_unique_id ); ?>"><?php _e( 'Search&hellip;', 'twentytwentyone' ); // phpcs:ignore: WordPress.Security.EscapeOutput.UnsafePrintingFunction -- core trusts translations ?></label>
 	<input type="search" id="<?php echo esc_attr( $twentytwentyone_unique_id ); ?>" class="search-field" value="<?php echo get_search_query(); ?>" name="s" />
 	<input type="submit" class="search-submit" value="<?php echo esc_attr_x( 'Search', 'submit button', 'twentytwentyone' ); ?>" />
 </form>
+<?php if ( $twentytwentyone_wrap_in_search ) : ?>
+</search>
+<?php endif; ?>

--- a/src/wp-content/themes/twentytwentyone/searchform.php
+++ b/src/wp-content/themes/twentytwentyone/searchform.php
@@ -12,6 +12,8 @@
  * @since Twenty Twenty-One 1.0
  */
 
+/** @var array{ wrap_in_search?: bool, aria_label?: string } $args */
+
 /*
  * Generate a unique ID for each form and a string containing an aria-label
  * if one was passed to get_search_form() in the args array.

--- a/src/wp-content/themes/twentytwentyone/searchform.php
+++ b/src/wp-content/themes/twentytwentyone/searchform.php
@@ -12,7 +12,7 @@
  * @since Twenty Twenty-One 1.0
  */
 
-/** @var array{ wrap_in_search?: bool, aria_label?: string } $args */
+/** @var array{ wrap_in_search: bool, aria_label: string } $args */
 
 /*
  * Generate a unique ID for each form and a string containing an aria-label

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -243,9 +243,12 @@ function get_template_part( $slug, $name = null, $args = array() ) {
  *                                  Defaults to true when the theme declares support for the
  *                                  'search-element' feature, false otherwise.
  * }
- * @return void|string Void if 'echo' argument is true, search form HTML if 'echo' is false.
+ * @return null|string Null if 'echo' argument is true, search form HTML if 'echo' is false.
+ *
+ * @phpstan-param array{ echo?: bool, aria_label?: string, wrap_in_search?: bool } $args
+ * @phpstan-return ( $args is array{ echo: false } ? string : null )
  */
-function get_search_form( $args = array() ) {
+function get_search_form( $args = array() ): ?string {
 	/**
 	 * Fires before the search form is retrieved, at the start of get_search_form().
 	 *
@@ -391,6 +394,7 @@ function get_search_form( $args = array() ) {
 
 	if ( $args['echo'] ) {
 		echo $result;
+		return null;
 	} else {
 		return $result;
 	}

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -351,7 +351,7 @@ function get_search_form( $args = array() ): ?string {
 				 * from the form to avoid nesting two identical landmarks. Any aria-label
 				 * names the <search> landmark instead of the form.
 				 */
-				$form = '<search ' . $aria_label . '><form method="get" class="search-form" action="' . esc_url( home_url( '/' ) ) . '">' . $form_inner . '</form></search>';
+				$form = '<search' . ( $aria_label ? ' ' . trim( $aria_label ) : '' ) . '><form method="get" class="search-form" action="' . esc_url( home_url( '/' ) ) . '">' . $form_inner . '</form></search>';
 			} else {
 				$form = '<form role="search" ' . $aria_label . 'method="get" class="search-form" action="' . esc_url( home_url( '/' ) ) . '">' . $form_inner . '</form>';
 			}

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -227,14 +227,21 @@ function get_template_part( $slug, $name = null, $args = array() ) {
  *
  * @since 2.7.0
  * @since 5.2.0 The `$args` array parameter was added in place of an `$echo` boolean flag.
+ * @since 7.1.0 Added the `$wrap_in_search` argument and the `search-element` theme support
+ *              feature to wrap the form in a `<search>` element.
  *
  * @param array $args {
  *     Optional. Array of display arguments.
  *
- *     @type bool   $echo       Whether to echo or return the form. Default true.
- *     @type string $aria_label ARIA label for the search form. Useful to distinguish
- *                              multiple search forms on the same page and improve
- *                              accessibility. Default empty.
+ *     @type bool   $echo           Whether to echo or return the form. Default true.
+ *     @type string $aria_label     ARIA label for the search form. Useful to distinguish
+ *                                  multiple search forms on the same page and improve
+ *                                  accessibility. Default empty.
+ *     @type bool   $wrap_in_search Whether to wrap the form in a semantic HTML `<search>`
+ *                                  landmark element and drop the now-redundant `role="search"`
+ *                                  attribute on the form. Only applies to the 'html5' format.
+ *                                  Defaults to true when the theme declares support for the
+ *                                  'search-element' feature, false otherwise.
  * }
  * @return void|string Void if 'echo' argument is true, search form HTML if 'echo' is false.
  */
@@ -269,8 +276,9 @@ function get_search_form( $args = array() ) {
 
 	// Defaults are to echo and to output no custom label on the form.
 	$defaults = array(
-		'echo'       => $echo,
-		'aria_label' => '',
+		'echo'           => $echo,
+		'aria_label'     => '',
+		'wrap_in_search' => current_theme_supports( 'search-element' ),
 	);
 
 	$args = wp_parse_args( $args, $defaults );
@@ -321,7 +329,26 @@ function get_search_form( $args = array() ) {
 			$aria_label = '';
 		}
 
-		if ( 'html5' === $format ) {
+		if ( 'html5' === $format && $args['wrap_in_search'] ) {
+			/*
+			 * Wrap the form in a <search> landmark element. The implicit ARIA role
+			 * of <search> provides the search landmark, so role="search" is omitted
+			 * from the form to avoid nesting two identical landmarks. Any aria-label
+			 * names the <search> landmark instead of the form.
+			 */
+			$search_label = $args['aria_label'] ? ' aria-label="' . esc_attr( $args['aria_label'] ) . '"' : '';
+
+			$form = '<search' . $search_label . '><form method="get" class="search-form" action="' . esc_url( home_url( '/' ) ) . '">
+				<label>
+					<span class="screen-reader-text">' .
+					/* translators: Hidden accessibility text. */
+					_x( 'Search for:', 'label' ) .
+					'</span>
+					<input type="search" class="search-field" placeholder="' . esc_attr_x( 'Search &hellip;', 'placeholder' ) . '" value="' . get_search_query() . '" name="s" />
+				</label>
+				<input type="submit" class="search-submit" value="' . esc_attr_x( 'Search', 'submit button' ) . '" />
+			</form></search>';
+		} elseif ( 'html5' === $format ) {
 			$form = '<form role="search" ' . $aria_label . 'method="get" class="search-form" action="' . esc_url( home_url( '/' ) ) . '">
 				<label>
 					<span class="screen-reader-text">' .

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -351,9 +351,7 @@ function get_search_form( $args = array() ): ?string {
 				 * from the form to avoid nesting two identical landmarks. Any aria-label
 				 * names the <search> landmark instead of the form.
 				 */
-				$search_label = $args['aria_label'] ? ' aria-label="' . esc_attr( $args['aria_label'] ) . '"' : '';
-
-				$form = '<search' . $search_label . '><form method="get" class="search-form" action="' . esc_url( home_url( '/' ) ) . '">' . $form_inner . '</form></search>';
+				$form = '<search ' . $aria_label . '><form method="get" class="search-form" action="' . esc_url( home_url( '/' ) ) . '">' . $form_inner . '</form></search>';
 			} else {
 				$form = '<form role="search" ' . $aria_label . 'method="get" class="search-form" action="' . esc_url( home_url( '/' ) ) . '">' . $form_inner . '</form>';
 			}

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -332,36 +332,31 @@ function get_search_form( $args = array() ): ?string {
 			$aria_label = '';
 		}
 
-		if ( 'html5' === $format && $args['wrap_in_search'] ) {
-			/*
-			 * Wrap the form in a <search> landmark element. The implicit ARIA role
-			 * of <search> provides the search landmark, so role="search" is omitted
-			 * from the form to avoid nesting two identical landmarks. Any aria-label
-			 * names the <search> landmark instead of the form.
-			 */
-			$search_label = $args['aria_label'] ? ' aria-label="' . esc_attr( $args['aria_label'] ) . '"' : '';
+		if ( 'html5' === $format ) {
+			$form_inner = '
+				<label>
+					<span class="screen-reader-text">' .
+					/* translators: Hidden accessibility text. */
+					_x( 'Search for:', 'label' ) .
+					'</span>
+					<input type="search" class="search-field" placeholder="' . esc_attr_x( 'Search &hellip;', 'placeholder' ) . '" value="' . get_search_query() . '" name="s" />
+				</label>
+				<input type="submit" class="search-submit" value="' . esc_attr_x( 'Search', 'submit button' ) . '" />
+			';
 
-			$form = '<search' . $search_label . '><form method="get" class="search-form" action="' . esc_url( home_url( '/' ) ) . '">
-				<label>
-					<span class="screen-reader-text">' .
-					/* translators: Hidden accessibility text. */
-					_x( 'Search for:', 'label' ) .
-					'</span>
-					<input type="search" class="search-field" placeholder="' . esc_attr_x( 'Search &hellip;', 'placeholder' ) . '" value="' . get_search_query() . '" name="s" />
-				</label>
-				<input type="submit" class="search-submit" value="' . esc_attr_x( 'Search', 'submit button' ) . '" />
-			</form></search>';
-		} elseif ( 'html5' === $format ) {
-			$form = '<form role="search" ' . $aria_label . 'method="get" class="search-form" action="' . esc_url( home_url( '/' ) ) . '">
-				<label>
-					<span class="screen-reader-text">' .
-					/* translators: Hidden accessibility text. */
-					_x( 'Search for:', 'label' ) .
-					'</span>
-					<input type="search" class="search-field" placeholder="' . esc_attr_x( 'Search &hellip;', 'placeholder' ) . '" value="' . get_search_query() . '" name="s" />
-				</label>
-				<input type="submit" class="search-submit" value="' . esc_attr_x( 'Search', 'submit button' ) . '" />
-			</form>';
+			if ( $args['wrap_in_search'] ) {
+				/*
+				 * Wrap the form in a <search> landmark element. The implicit ARIA role
+				 * of <search> provides the search landmark, so role="search" is omitted
+				 * from the form to avoid nesting two identical landmarks. Any aria-label
+				 * names the <search> landmark instead of the form.
+				 */
+				$search_label = $args['aria_label'] ? ' aria-label="' . esc_attr( $args['aria_label'] ) . '"' : '';
+
+				$form = '<search' . $search_label . '><form method="get" class="search-form" action="' . esc_url( home_url( '/' ) ) . '">' . $form_inner . '</form></search>';
+			} else {
+				$form = '<form role="search" ' . $aria_label . 'method="get" class="search-form" action="' . esc_url( home_url( '/' ) ) . '">' . $form_inner . '</form>';
+			}
 		} else {
 			$form = '<form role="search" ' . $aria_label . 'method="get" id="searchform" class="searchform" action="' . esc_url( home_url( '/' ) ) . '">
 				<div>

--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -2647,6 +2647,8 @@ function get_theme_starter_content() {
  *              see `WP_Theme_JSON::APPEARANCE_TOOLS_OPT_INS` for a complete list.
  * @since 6.6.0 The `editor-spacing-sizes` feature was added.
  * @since 7.0.0 The `html5` feature's 'script' and 'style' arguments are deprecated and unused.
+ * @since 7.1.0 The `search-element` feature wraps the core search form markup in the
+ *              HTML `<search>` landmark element.
  *
  * @global array $_wp_theme_features
  *
@@ -2683,6 +2685,7 @@ function get_theme_starter_content() {
  *                          - 'post-formats'
  *                          - 'post-thumbnails'
  *                          - 'responsive-embeds'
+ *                          - 'search-element'
  *                          - 'starter-content'
  *                          - 'title-tag'
  *                          - 'widgets'

--- a/tests/phpunit/tests/general/getSearchForm.php
+++ b/tests/phpunit/tests/general/getSearchForm.php
@@ -153,7 +153,7 @@ class Tests_General_GetSearchForm extends WP_UnitTestCase {
 
 		add_filter(
 			'search_form_args',
-			static function ( $args ) {
+			static function ( array $args ) {
 				$args['wrap_in_search'] = true;
 				return $args;
 			}

--- a/tests/phpunit/tests/general/getSearchForm.php
+++ b/tests/phpunit/tests/general/getSearchForm.php
@@ -1,0 +1,202 @@
+<?php
+/**
+ * Tests for the get_search_form() function.
+ *
+ * @since 7.1.0
+ *
+ * @group general
+ * @group template
+ *
+ * @covers ::get_search_form
+ */
+class Tests_General_GetSearchForm extends WP_UnitTestCase {
+
+	/**
+	 * Removes any theme support added during a test.
+	 */
+	public function tear_down() {
+		remove_theme_support( 'html5' );
+		remove_theme_support( 'search-element' );
+		parent::tear_down();
+	}
+
+	/**
+	 * Enables the html5 'search-form' theme support so the html5 markup is used.
+	 */
+	private function enable_html5_search_form() {
+		add_theme_support( 'html5', array( 'search-form' ) );
+	}
+
+	/**
+	 * The html5 form should keep role="search" on the <form> by default.
+	 *
+	 * @ticket 65288
+	 */
+	public function test_html5_default_uses_form_role_search() {
+		$this->enable_html5_search_form();
+
+		$form = get_search_form( array( 'echo' => false ) );
+
+		$this->assertStringContainsString( '<form role="search"', $form, 'The default html5 form should keep role="search" on the form.' );
+		$this->assertStringNotContainsString( '<search', $form, 'The default html5 form should not be wrapped in a <search> element.' );
+	}
+
+	/**
+	 * Opting in should wrap the html5 form in a <search> element and drop role="search".
+	 *
+	 * @ticket 65288
+	 */
+	public function test_wrap_in_search_wraps_form_and_drops_role() {
+		$this->enable_html5_search_form();
+
+		$form = get_search_form(
+			array(
+				'echo'           => false,
+				'wrap_in_search' => true,
+			)
+		);
+
+		$this->assertStringContainsString( '<search>', $form, 'The opted-in form should open a <search> element.' );
+		$this->assertStringContainsString( '</search>', $form, 'The opted-in form should close the <search> element.' );
+		$this->assertStringContainsString( '<form method="get" class="search-form"', $form, 'The inner form markup should be preserved.' );
+		$this->assertStringNotContainsString( 'role="search"', $form, 'role="search" should be dropped to avoid a nested duplicate landmark.' );
+	}
+
+	/**
+	 * A custom aria_label should name the <search> landmark, not the inner form.
+	 *
+	 * @ticket 65288
+	 */
+	public function test_wrap_in_search_applies_aria_label_to_search_element() {
+		$this->enable_html5_search_form();
+
+		$form = get_search_form(
+			array(
+				'echo'           => false,
+				'wrap_in_search' => true,
+				'aria_label'     => 'Search products',
+			)
+		);
+
+		$this->assertStringContainsString( '<search aria-label="Search products">', $form, 'The aria-label should be applied to the <search> element.' );
+		$this->assertStringContainsString( '<form method="get"', $form, 'The inner form should not carry the aria-label.' );
+		$this->assertStringNotContainsString( '<form method="get" aria-label', $form, 'The aria-label should not appear on the inner form.' );
+	}
+
+	/**
+	 * Without a custom aria_label, the <search> element should have no attributes.
+	 *
+	 * @ticket 65288
+	 */
+	public function test_wrap_in_search_without_aria_label_has_no_attributes() {
+		$this->enable_html5_search_form();
+
+		$form = get_search_form(
+			array(
+				'echo'           => false,
+				'wrap_in_search' => true,
+			)
+		);
+
+		$this->assertStringContainsString( '<search>', $form, 'The <search> element should have no attributes when no aria-label is set.' );
+		$this->assertStringNotContainsString( '<search >', $form, 'The <search> element should not contain a stray space.' );
+	}
+
+	/**
+	 * The default html5 form should still apply a custom aria_label to the form.
+	 *
+	 * @ticket 65288
+	 */
+	public function test_html5_default_applies_aria_label_to_form() {
+		$this->enable_html5_search_form();
+
+		$form = get_search_form(
+			array(
+				'echo'       => false,
+				'aria_label' => 'Search the site',
+			)
+		);
+
+		$this->assertStringContainsString( '<form role="search" aria-label="Search the site"', $form, 'The aria-label should be applied to the form by default.' );
+		$this->assertStringNotContainsString( '<search', $form, 'The default form should not be wrapped in a <search> element.' );
+	}
+
+	/**
+	 * The wrap_in_search argument should not affect the xhtml format.
+	 *
+	 * The <search> element does not exist in XHTML 1.x, so themes without html5
+	 * 'search-form' support should continue to receive the unchanged xhtml markup.
+	 *
+	 * @ticket 65288
+	 */
+	public function test_wrap_in_search_is_ignored_for_xhtml_format() {
+		// No html5 theme support added: the format defaults to xhtml.
+		$form = get_search_form(
+			array(
+				'echo'           => false,
+				'wrap_in_search' => true,
+			)
+		);
+
+		$this->assertStringNotContainsString( '<search', $form, 'The xhtml format should not use the <search> element.' );
+		$this->assertStringContainsString( '<form role="search"', $form, 'The xhtml format should keep role="search" on the form.' );
+		$this->assertStringContainsString( 'id="searchform"', $form, 'The xhtml markup should be unchanged.' );
+	}
+
+	/**
+	 * The wrapping should be enableable globally via the search_form_args filter.
+	 *
+	 * @ticket 65288
+	 */
+	public function test_wrap_in_search_can_be_enabled_via_filter() {
+		$this->enable_html5_search_form();
+
+		add_filter(
+			'search_form_args',
+			static function ( $args ) {
+				$args['wrap_in_search'] = true;
+				return $args;
+			}
+		);
+
+		$form = get_search_form( array( 'echo' => false ) );
+
+		$this->assertStringContainsString( '<search>', $form, 'The search_form_args filter should be able to enable wrapping.' );
+		$this->assertStringNotContainsString( 'role="search"', $form, 'role="search" should be dropped when wrapping is enabled via filter.' );
+	}
+
+	/**
+	 * Declaring 'search-element' theme support should wrap the form by default.
+	 *
+	 * @ticket 65288
+	 */
+	public function test_search_element_theme_support_enables_wrap_by_default() {
+		$this->enable_html5_search_form();
+		add_theme_support( 'search-element' );
+
+		$form = get_search_form( array( 'echo' => false ) );
+
+		$this->assertStringContainsString( '<search>', $form, 'Declaring search-element support should wrap the form by default.' );
+		$this->assertStringNotContainsString( 'role="search"', $form, 'role="search" should be dropped when search-element support is declared.' );
+	}
+
+	/**
+	 * An explicit wrap_in_search => false should override 'search-element' theme support.
+	 *
+	 * @ticket 65288
+	 */
+	public function test_wrap_in_search_false_overrides_theme_support() {
+		$this->enable_html5_search_form();
+		add_theme_support( 'search-element' );
+
+		$form = get_search_form(
+			array(
+				'echo'           => false,
+				'wrap_in_search' => false,
+			)
+		);
+
+		$this->assertStringNotContainsString( '<search', $form, 'An explicit false should override search-element theme support.' );
+		$this->assertStringContainsString( '<form role="search"', $form, 'The form should keep role="search" when wrapping is explicitly disabled.' );
+	}
+}

--- a/tests/phpunit/tests/general/getSearchForm.php
+++ b/tests/phpunit/tests/general/getSearchForm.php
@@ -14,7 +14,7 @@ class Tests_General_GetSearchForm extends WP_UnitTestCase {
 	/**
 	 * Removes any theme support added during a test.
 	 */
-	public function tear_down() {
+	public function tear_down(): void {
 		remove_theme_support( 'html5' );
 		remove_theme_support( 'search-element' );
 		parent::tear_down();
@@ -23,7 +23,7 @@ class Tests_General_GetSearchForm extends WP_UnitTestCase {
 	/**
 	 * Enables the html5 'search-form' theme support so the html5 markup is used.
 	 */
-	private function enable_html5_search_form() {
+	private function enable_html5_search_form(): void {
 		add_theme_support( 'html5', array( 'search-form' ) );
 	}
 
@@ -32,7 +32,7 @@ class Tests_General_GetSearchForm extends WP_UnitTestCase {
 	 *
 	 * @ticket 65288
 	 */
-	public function test_html5_default_uses_form_role_search() {
+	public function test_html5_default_uses_form_role_search(): void {
 		$this->enable_html5_search_form();
 
 		$form = get_search_form( array( 'echo' => false ) );
@@ -46,7 +46,7 @@ class Tests_General_GetSearchForm extends WP_UnitTestCase {
 	 *
 	 * @ticket 65288
 	 */
-	public function test_wrap_in_search_wraps_form_and_drops_role() {
+	public function test_wrap_in_search_wraps_form_and_drops_role(): void {
 		$this->enable_html5_search_form();
 
 		$form = get_search_form(
@@ -67,7 +67,7 @@ class Tests_General_GetSearchForm extends WP_UnitTestCase {
 	 *
 	 * @ticket 65288
 	 */
-	public function test_wrap_in_search_applies_aria_label_to_search_element() {
+	public function test_wrap_in_search_applies_aria_label_to_search_element(): void {
 		$this->enable_html5_search_form();
 
 		$form = get_search_form(
@@ -88,7 +88,7 @@ class Tests_General_GetSearchForm extends WP_UnitTestCase {
 	 *
 	 * @ticket 65288
 	 */
-	public function test_wrap_in_search_without_aria_label_has_no_attributes() {
+	public function test_wrap_in_search_without_aria_label_has_no_attributes(): void {
 		$this->enable_html5_search_form();
 
 		$form = get_search_form(
@@ -107,7 +107,7 @@ class Tests_General_GetSearchForm extends WP_UnitTestCase {
 	 *
 	 * @ticket 65288
 	 */
-	public function test_html5_default_applies_aria_label_to_form() {
+	public function test_html5_default_applies_aria_label_to_form(): void {
 		$this->enable_html5_search_form();
 
 		$form = get_search_form(
@@ -129,7 +129,7 @@ class Tests_General_GetSearchForm extends WP_UnitTestCase {
 	 *
 	 * @ticket 65288
 	 */
-	public function test_wrap_in_search_is_ignored_for_xhtml_format() {
+	public function test_wrap_in_search_is_ignored_for_xhtml_format(): void {
 		// No html5 theme support added: the format defaults to xhtml.
 		$form = get_search_form(
 			array(
@@ -148,7 +148,7 @@ class Tests_General_GetSearchForm extends WP_UnitTestCase {
 	 *
 	 * @ticket 65288
 	 */
-	public function test_wrap_in_search_can_be_enabled_via_filter() {
+	public function test_wrap_in_search_can_be_enabled_via_filter(): void {
 		$this->enable_html5_search_form();
 
 		add_filter(
@@ -170,7 +170,7 @@ class Tests_General_GetSearchForm extends WP_UnitTestCase {
 	 *
 	 * @ticket 65288
 	 */
-	public function test_search_element_theme_support_enables_wrap_by_default() {
+	public function test_search_element_theme_support_enables_wrap_by_default(): void {
 		$this->enable_html5_search_form();
 		add_theme_support( 'search-element' );
 
@@ -185,7 +185,7 @@ class Tests_General_GetSearchForm extends WP_UnitTestCase {
 	 *
 	 * @ticket 65288
 	 */
-	public function test_wrap_in_search_false_overrides_theme_support() {
+	public function test_wrap_in_search_false_overrides_theme_support(): void {
 		$this->enable_html5_search_form();
 		add_theme_support( 'search-element' );
 


### PR DESCRIPTION
## Summary

Adds **opt-in** support for the HTML [`<search>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/search) landmark element in `get_search_form()` (the function behind core's default search markup and the search widget).

Trac ticket: https://core.trac.wordpress.org/ticket/65288

## Why opt-in?

The `<search>` element is in [Baseline](https://web.dev/baseline) (Chrome 118+, Firefox 118+, Safari 17+, Edge 118+) and carries an implicit ARIA role of `search`. But adopting it unconditionally is **not** back-compatible:

- Dropping `role="search"` breaks `form[role="search"]` CSS selectors (used by themes in the wild).
- Wrapping the form in `<search>` breaks direct-child selectors like `.search-container > form` and reparents the form for flex/grid layouts - regardless of whether the role is kept.
- Keeping `role="search"` alongside `<search>` produces **nested** `search` landmarks, which NVDA announces twice ("search landmark search landmark").

There is no way to add the native landmark without a new wrapper node, so the safe path is to make it opt-in now and plan to change the default later.

## What this adds

**1. A `search-element` theme support feature.** A theme that has audited its CSS opts in once:

```php
add_theme_support( 'search-element' );
```

**2. A `wrap_in_search` argument** on `get_search_form()`, defaulting to `current_theme_supports( 'search-element' )`:

```php
get_search_form( array( 'wrap_in_search' => true ) );
```

The existing `search_form_args` filter can enable it site-wide; a per-call value overrides the theme default.

When enabled (html5 format only): the `<form>` is wrapped in `<search>`, `role="search"` is dropped from the form to avoid a nested landmark, and any `aria_label` names the `<search>` element.

```html
<!-- default (unchanged) -->
<form role="search" class="search-form" ...>…</form>

<!-- opted in -->
<search><form method="get" class="search-form" ...>…</form></search>
```

## Scope and backward compatibility

- **Default output is unchanged** (byte-for-byte). Existing sites are unaffected unless they opt in.
- The **xhtml fallback is unchanged** (`<search>` does not exist in XHTML 1.x).
- The **bundled classic themes honor the flag** (Twenty Sixteen, Twenty Seventeen, Twenty Twenty, Twenty Twenty-One): their default `searchform.php` output is unchanged (byte-for-byte), and they emit the `<search>` wrapper only when a site opts in. In Twenty Twenty / Twenty Twenty-One the `aria_label` moves onto `<search>` when wrapping.
- The `core/search` block is handled in Gutenberg: https://github.com/WordPress/gutenberg/pull/78485

## Migration plan

- **7.1:** ship opt-in support + a developer note documenting the element, the opt-in mechanisms, and the CSS/accessibility considerations.
- **Later:** once the ecosystem has adapted, consider making the wrapper the default (e.g. for block themes first), tracked as a follow-up.

## Test plan

New tests in `tests/phpunit/tests/general/getSearchForm.php` cover:

- [x] Default html5 markup keeps `role="search"` and is not wrapped.
- [x] `wrap_in_search` wraps the form in `<search>` and drops `role="search"`.
- [x] `aria_label` lands on `<search>` (not the inner form) when wrapping; on the form by default.
- [x] The xhtml format is unaffected by `wrap_in_search`.
- [x] The `search_form_args` filter can enable wrapping site-wide.
- [x] `add_theme_support( 'search-element' )` enables wrapping by default; an explicit `wrap_in_search => false` overrides it.

9 tests, 22 assertions, passing.

The four bundled `searchform.php` templates were verified by rendering each in both states: default output is byte-identical to trunk, and the opt-in output wraps the form in `<search>`, drops `role="search"`, and (Twenty Twenty / Twenty Twenty-One) places `aria_label` on `<search>`.

## References

- MDN: <https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/search>
- HTML spec: <https://html.spec.whatwg.org/multipage/grouping-content.html#the-search-element>
- Gutenberg PR (block): <https://github.com/WordPress/gutenberg/pull/78485>
