### PR TITLE
Menus: Deprecate block_core_navigation_submenu_render_submenu_icon() rather than removing it

### DIFF
--- a/src/wp-includes/blocks/navigation-submenu.php
+++ b/src/wp-includes/blocks/navigation-submenu.php
@@ -56,6 +56,19 @@ if ( file_exists( __DIR__ . '/../navigation-link/shared/item-should-render.php' 
 }
 
 /**
+ * Renders the submenu icon SVG for the Navigation Submenu block.
+ *
+ * @since 5.9.0
+ * @deprecated 7.0.0 Use block_core_shared_navigation_render_submenu_icon() instead.
+ *
+ * @return string SVG markup for the submenu icon.
+ */
+function block_core_navigation_submenu_render_submenu_icon() {
+	_deprecated_function( __FUNCTION__, '7.0.0', 'block_core_shared_navigation_render_submenu_icon()' );
+	return block_core_shared_navigation_render_submenu_icon();
+}
+
+/**
  * Build an array with CSS classes and inline styles defining the font sizes
  * which will be applied to the navigation markup in the front-end.
  *

--- a/tests/phpunit/tests/blocks/navigationSubmenuRenderSubmenuIcon.php
+++ b/tests/phpunit/tests/blocks/navigationSubmenuRenderSubmenuIcon.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Tests for the deprecated block_core_navigation_submenu_render_submenu_icon() shim.
+ *
+ * @package WordPress
+ * @subpackage Blocks
+ *
+ * @group blocks
+ */
+class Tests_Blocks_NavigationSubmenuRenderSubmenuIcon extends WP_UnitTestCase {
+	/**
+	 * @ticket 65287
+	 * @expectedDeprecated block_core_navigation_submenu_render_submenu_icon
+	 */
+	public function test_returns_same_markup_as_shared_helper() {
+		$this->assertSame(
+			block_core_shared_navigation_render_submenu_icon(),
+			block_core_navigation_submenu_render_submenu_icon()
+		);
+	}
+}


### PR DESCRIPTION
## Summary

`block_core_navigation_submenu_render_submenu_icon()` was removed from `src/wp-includes/blocks/navigation-submenu.php` in [60810] (Gutenberg PR [#74853](https://github.com/WordPress/gutenberg/pull/74853), synced via wordpress-develop PR [#10865](https://github.com/WordPress/wordpress-develop/pull/10865)) as part of consolidating submenu icon rendering into the new shared helper `block_core_shared_navigation_render_submenu_icon()`.

The removal landed without a `_deprecated_function()` notice or a backwards-compatible shim, so any theme or plugin that previously called the function — for example from a `render_block_core/navigation-submenu` filter to customise the dropdown chevron — now triggers a fatal PHP error on 7.0.

This PR restores the function as a thin deprecation shim:

- Triggers `_deprecated_function()` so callers see actionable guidance to migrate to `block_core_shared_navigation_render_submenu_icon()`.
- Returns the output of the new helper, preserving the original rendered markup.
- Includes a phpunit test asserting the deprecation notice fires and the return value matches the new helper.

Trac ticket: https://core.trac.wordpress.org/ticket/65287

## Test plan

- [ ] `php -l src/wp-includes/blocks/navigation-submenu.php` passes (verified locally).
- [ ] `phpunit --filter Tests_Blocks_NavigationSubmenuRenderSubmenuIcon` passes.
- [ ] On a site whose theme calls `block_core_navigation_submenu_render_submenu_icon()`, the page renders without a fatal and a deprecation notice is logged.
- [ ] Existing Navigation Submenu rendering is unchanged (the shim is only used by external callers).

Props ecairol.