### PR TITLE
REST API: Preserve custom status for ability validation errors

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-abilities-v1-run-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-abilities-v1-run-controller.php
@@ -161,18 +161,12 @@ class WP_REST_Abilities_V1_Run_Controller extends WP_REST_Controller {
 		$input = $this->get_input_from_request( $request );
 		$input = $ability->normalize_input( $input );
 		if ( is_wp_error( $input ) ) {
-			$error_data = $input->get_error_data();
-			if ( ! is_array( $error_data ) || ! isset( $error_data['status'] ) ) {
-				$input->add_data( array( 'status' => 400 ) );
-			}
-
-			return $input;
+			return $this->add_default_error_status( $input, 400 );
 		}
 
 		$is_valid = $ability->validate_input( $input );
 		if ( is_wp_error( $is_valid ) ) {
-			$is_valid->add_data( array( 'status' => 400 ) );
-			return $is_valid;
+			return $this->add_default_error_status( $is_valid, 400 );
 		}
 
 		$result = $ability->check_permissions( $input );
@@ -189,6 +183,24 @@ class WP_REST_Abilities_V1_Run_Controller extends WP_REST_Controller {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Adds a default HTTP status to a WP_Error object if one is not already set.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param WP_Error $error  Error object to update.
+	 * @param int      $status HTTP status code to add if not already present.
+	 * @return WP_Error The error object, with a default status when needed.
+	 */
+	private function add_default_error_status( WP_Error $error, int $status ): WP_Error {
+		$error_data = $error->get_error_data();
+		if ( ! is_array( $error_data ) || ! isset( $error_data['status'] ) ) {
+			$error->add_data( array( 'status' => $status ) );
+		}
+
+		return $error;
 	}
 
 	/**

--- a/tests/phpunit/tests/rest-api/wpRestAbilitiesV1RunController.php
+++ b/tests/phpunit/tests/rest-api/wpRestAbilitiesV1RunController.php
@@ -977,6 +977,80 @@ class Tests_REST_API_WpRestAbilitiesV1RunController extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that a validation filter error defaults to a 400 REST response.
+	 *
+	 * @ticket 64311
+	 */
+	public function test_validate_input_filter_error_defaults_to_bad_request_status(): void {
+		$filter = static function () {
+			return new WP_Error( 'validate_rejected', 'Rejected input.' );
+		};
+
+		add_filter( 'wp_ability_validate_input', $filter );
+
+		$request = new WP_REST_Request( 'POST', '/wp-abilities/v1/abilities/test/calculator/run' );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'input' => array(
+						'a' => 5,
+						'b' => 3,
+					),
+				)
+			)
+		);
+
+		$response = $this->server->dispatch( $request );
+
+		remove_filter( 'wp_ability_validate_input', $filter );
+
+		$this->assertSame( 400, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertSame( 'validate_rejected', $data['code'] );
+		$this->assertSame( 'Rejected input.', $data['message'] );
+	}
+
+	/**
+	 * Tests that a validation filter error with custom status keeps that status.
+	 *
+	 * @ticket 64311
+	 */
+	public function test_validate_input_filter_error_preserves_custom_status(): void {
+		$filter = static function () {
+			return new WP_Error(
+				'validate_unprocessable',
+				'Input cannot be validated.',
+				array( 'status' => 422 )
+			);
+		};
+
+		add_filter( 'wp_ability_validate_input', $filter );
+
+		$request = new WP_REST_Request( 'POST', '/wp-abilities/v1/abilities/test/calculator/run' );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'input' => array(
+						'a' => 5,
+						'b' => 3,
+					),
+				)
+			)
+		);
+
+		$response = $this->server->dispatch( $request );
+
+		remove_filter( 'wp_ability_validate_input', $filter );
+
+		$this->assertSame( 422, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertSame( 'validate_unprocessable', $data['code'] );
+		$this->assertSame( 'Input cannot be validated.', $data['message'] );
+	}
+
+	/**
 	 * Test ability without annotations defaults to POST method.
 	 *
 	 * @ticket 64098


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/64311

Follow-up to https://github.com/WordPress/wordpress-develop/pull/10557.

Preserves custom REST response statuses returned by wp_ability_validate_input filter errors. The REST run controller already preserves custom statuses from wp_ability_normalize_input; this applies the same behavior to validation errors by only defaulting to 400 when the WP_Error does not already include a status value.

Testing:
- npm run test:php -- --filter Tests_REST_API_WpRestAbilitiesV1RunController
- npm run test:php -- --group abilities-api