### PR TITLE
Abilities API: Stop HTML-escaping the ability name in WP_Error messages

### DIFF
--- a/src/wp-includes/abilities-api/class-wp-ability.php
+++ b/src/wp-includes/abilities-api/class-wp-ability.php
@@ -561,7 +561,7 @@ class WP_Ability {
 				sprintf(
 					/* translators: 1: Ability name, 2: Exception message. */
 					__( 'Ability "%1$s" callback threw an exception: %2$s' ),
-					esc_html( $this->name ),
+					$this->name,
 					esc_html( $e->getMessage() )
 				)
 			);
@@ -590,7 +590,7 @@ class WP_Ability {
 			return new WP_Error(
 				'ability_invalid_permission_callback',
 				/* translators: %s ability name. */
-				sprintf( __( 'Ability "%s" does not have a valid permission callback.' ), esc_html( $this->name ) )
+				sprintf( __( 'Ability "%s" does not have a valid permission callback.' ), $this->name )
 			);
 		}
 
@@ -638,7 +638,7 @@ class WP_Ability {
 			$result = new WP_Error(
 				'ability_invalid_execute_callback',
 				/* translators: %s ability name. */
-				sprintf( __( 'Ability "%s" does not have a valid execute callback.' ), esc_html( $this->name ) )
+				sprintf( __( 'Ability "%s" does not have a valid execute callback.' ), $this->name )
 			);
 		} else {
 			$result = $this->invoke_callback( $this->execute_callback, $input );
@@ -783,7 +783,7 @@ class WP_Ability {
 			return new WP_Error(
 				'ability_invalid_permissions',
 				/* translators: %s ability name. */
-				sprintf( __( 'Ability "%s" does not have necessary permission.' ), esc_html( $this->name ) )
+				sprintf( __( 'Ability "%s" does not have necessary permission.' ), $this->name )
 			);
 		}
 


### PR DESCRIPTION
## Description

`WP_Ability` renders the ability name into several `WP_Error` messages that are commonly serialized to JSON (e.g. through the REST API), where HTML entities produced by `esc_html()` would be incorrect. This removes `esc_html()` from the ability name in those messages:

- `ability_callback_exception`
- `ability_invalid_permission_callback`
- `ability_invalid_execute_callback`
- `ability_invalid_permissions`

This aligns them with `validate_input()` / `validate_output()`, which already pass `$this->name` unescaped (see the decision in https://github.com/WordPress/wordpress-develop/pull/10557#discussion_r2575710801).

### Why this is safe

Ability names are pattern-validated at registration to `^[a-z0-9-]+\/[a-z0-9-]+$`, so they can never contain HTML special characters — `esc_html()` on the name is a no-op in every case. The change is purely about correctness/consistency for JSON-bound messages.

### What is intentionally left unchanged

- The `_doing_it_wrong()` calls render into HTML admin output, so they keep `esc_html()` (including `<code>`-wrapped values and the arbitrary `$property_name`).
- The arbitrary exception text (`$e->getMessage()`) and permission error text (`$has_permissions->get_error_message()`) keep `esc_html()`, since those can contain arbitrary content.

## Testing

- `tests/phpunit/tests/abilities-api/wpAbility.php` passes (57 tests, 89 assertions).
- PHPCS, PHP compatibility, and PHPStan all pass.

---

Trac ticket: https://core.trac.wordpress.org/ticket/64311

**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request.**