### PR TITLE
Tests: Clean up redundant hook removals in Abilities API tests

### DIFF
--- a/tests/phpunit/tests/abilities-api/wpAbility.php
+++ b/tests/phpunit/tests/abilities-api/wpAbility.php
@@ -578,8 +578,6 @@ class Tests_Abilities_API_WpAbility extends WP_UnitTestCase {
 		$ability = new WP_Ability( self::$test_ability_name, $args );
 		$result  = $ability->execute( 5 );
 
-		remove_action( 'wp_before_execute_ability', $callback );
-
 		$this->assertSame( self::$test_ability_name, $action_ability_name, 'Action should receive correct ability name' );
 		$this->assertSame( 5, $action_input, 'Action should receive correct input' );
 		$this->assertSame( 10, $result, 'Ability should execute correctly' );
@@ -612,8 +610,6 @@ class Tests_Abilities_API_WpAbility extends WP_UnitTestCase {
 
 		$ability = new WP_Ability( self::$test_ability_name, $args );
 		$result  = $ability->execute();
-
-		remove_action( 'wp_before_execute_ability', $callback );
 
 		$this->assertSame( self::$test_ability_name, $action_ability_name, 'Action should receive correct ability name' );
 		$this->assertNull( $action_input, 'Action should receive null input when no input provided' );
@@ -655,8 +651,6 @@ class Tests_Abilities_API_WpAbility extends WP_UnitTestCase {
 		$ability = new WP_Ability( self::$test_ability_name, $args );
 		$result  = $ability->execute( 7 );
 
-		remove_action( 'wp_after_execute_ability', $callback );
-
 		$this->assertSame( self::$test_ability_name, $action_ability_name, 'Action should receive correct ability name' );
 		$this->assertSame( 7, $action_input, 'Action should receive correct input' );
 		$this->assertSame( 21, $action_result, 'Action should receive correct result' );
@@ -693,8 +687,6 @@ class Tests_Abilities_API_WpAbility extends WP_UnitTestCase {
 
 		$ability = new WP_Ability( self::$test_ability_name, $args );
 		$result  = $ability->execute();
-
-		remove_action( 'wp_after_execute_ability', $callback );
 
 		$this->assertSame( self::$test_ability_name, $action_ability_name, 'Action should receive correct ability name' );
 		$this->assertNull( $action_input, 'Action should receive null input when no input provided' );
@@ -734,9 +726,6 @@ class Tests_Abilities_API_WpAbility extends WP_UnitTestCase {
 		$ability = new WP_Ability( self::$test_ability_name, $args );
 		$result  = $ability->execute();
 
-		remove_action( 'wp_before_execute_ability', $before_callback );
-		remove_action( 'wp_after_execute_ability', $after_callback );
-
 		$this->assertFalse( $before_action_fired, 'before_execute_ability action should not be fired on permission failure' );
 		$this->assertFalse( $after_action_fired, 'after_execute_ability action should not be fired on permission failure' );
 		$this->assertInstanceOf( WP_Error::class, $result, 'Should return WP_Error on permission failure' );
@@ -773,9 +762,6 @@ class Tests_Abilities_API_WpAbility extends WP_UnitTestCase {
 
 		$ability = new WP_Ability( self::$test_ability_name, $args );
 		$result  = $ability->execute();
-
-		remove_action( 'wp_before_execute_ability', $before_callback );
-		remove_action( 'wp_after_execute_ability', $after_callback );
 
 		$this->assertTrue( $before_action_fired, 'before_execute_ability action should be fired even if execution fails' );
 		$this->assertFalse( $after_action_fired, 'after_execute_ability action should not be fired when execution returns WP_Error' );
@@ -818,9 +804,6 @@ class Tests_Abilities_API_WpAbility extends WP_UnitTestCase {
 
 		$ability = new WP_Ability( self::$test_ability_name, $args );
 		$result  = $ability->execute();
-
-		remove_action( 'wp_before_execute_ability', $before_callback );
-		remove_action( 'wp_after_execute_ability', $after_callback );
 
 		$this->assertTrue( $before_action_fired, 'before_execute_ability action should be fired even if output validation fails' );
 		$this->assertFalse( $after_action_fired, 'after_execute_ability action should not be fired when output validation fails' );

--- a/tests/phpunit/tests/abilities-api/wpRegisterAbility.php
+++ b/tests/phpunit/tests/abilities-api/wpRegisterAbility.php
@@ -539,8 +539,6 @@ class Test_Abilities_API_WpRegisterAbility extends WP_UnitTestCase {
 
 		$result = wp_get_ability( $name );
 
-		remove_action( 'wp_abilities_api_init', $callback );
-
 		$this->assertEquals(
 			new WP_Ability( $name, $args ),
 			$result,

--- a/tests/phpunit/tests/abilities-api/wpRegisterAbilityCategory.php
+++ b/tests/phpunit/tests/abilities-api/wpRegisterAbilityCategory.php
@@ -311,8 +311,6 @@ class Tests_Abilities_API_WpRegisterAbilityCategory extends WP_UnitTestCase {
 
 		$result = wp_get_ability_category( $name );
 
-		remove_action( 'wp_abilities_api_categories_init', $callback );
-
 		$this->assertInstanceOf( WP_Ability_Category::class, $result );
 		$this->assertSame( self::$test_ability_category_name, $result->get_slug() );
 	}

--- a/tests/phpunit/tests/rest-api/wpRestAbilitiesV1CategoriesController.php
+++ b/tests/phpunit/tests/rest-api/wpRestAbilitiesV1CategoriesController.php
@@ -206,7 +206,6 @@ class Tests_REST_API_WpRestAbilitiesV1CategoriesController extends WP_UnitTestCa
 		$response = $this->server->dispatch( $request );
 		add_filter( 'rest_post_dispatch', 'rest_filter_response_fields', 10, 3 );
 		$response = apply_filters( 'rest_post_dispatch', $response, $this->server, $request );
-		remove_filter( 'rest_post_dispatch', 'rest_filter_response_fields', 10 );
 
 		$this->assertEquals( 200, $response->get_status() );
 

--- a/tests/phpunit/tests/rest-api/wpRestAbilitiesV1ListController.php
+++ b/tests/phpunit/tests/rest-api/wpRestAbilitiesV1ListController.php
@@ -328,7 +328,6 @@ class Tests_REST_API_WpRestAbilitiesV1ListController extends WP_UnitTestCase {
 		$response = $this->server->dispatch( $request );
 		add_filter( 'rest_post_dispatch', 'rest_filter_response_fields', 10, 3 );
 		$response = apply_filters( 'rest_post_dispatch', $response, $this->server, $request );
-		remove_filter( 'rest_post_dispatch', 'rest_filter_response_fields', 10 );
 
 		$this->assertEquals( 200, $response->get_status() );
 
@@ -349,7 +348,6 @@ class Tests_REST_API_WpRestAbilitiesV1ListController extends WP_UnitTestCase {
 		$response = $this->server->dispatch( $request );
 		add_filter( 'rest_post_dispatch', 'rest_filter_response_fields', 10, 3 );
 		$response = apply_filters( 'rest_post_dispatch', $response, $this->server, $request );
-		remove_filter( 'rest_post_dispatch', 'rest_filter_response_fields', 10 );
 
 		$this->assertEquals( 200, $response->get_status() );
 


### PR DESCRIPTION
## Summary

Removes redundant `remove_filter()` and `remove_action()` calls in several Abilities API tests. 

Previously, these tests called `remove_filter()` or `remove_action()` purely to undo a hook added earlier in the same test. These manual removals are redundant because `WP_UnitTestCase_Base::tear_down()` natively runs `_restore_hooks()`, which restores `$wp_filter` and `$wp_actions` to a pre-test baseline, ensuring hooks added during a test are automatically removed. 

The removals targeted by this PR sit exactly after the hook's last use with only assertions following, meaning they functionally changed nothing. Removals that run in `set_up()` or `set_up_before_class()` (and their paired teardowns) have been explicitly preserved since they manage state outside the coverage of `_restore_hooks()`.

## Changes

### `tests/phpunit/tests/abilities-api/`
- **`wpAbility.php`**: Removed 10 redundant `remove_action()` calls.
- **`wpRegisterAbilityCategory.php`**: Removed 1 redundant `remove_action()` call.
- **`wpRegisterAbility.php`**: Removed 1 redundant `remove_action()` call.

### `tests/phpunit/tests/rest-api/`
- **`wpRestAbilitiesV1CategoriesController.php`**: Removed 1 redundant `remove_filter()` call.
- **`wpRestAbilitiesV1ListController.php`**: Removed 2 redundant `remove_filter()` calls.

## Testing

| Test | Result |
|------|--------|
| `npm run test:php -- --group abilities-api` | ✅ All 245 tests pass successfully |
| Verify `_restore_hooks()` handles hook cleanup | ✅ Verified |

Trac ticket: https://core.trac.wordpress.org/ticket/65301

## Use of AI Tools

AI assistance: Yes
Tool(s): Gemini (Antigravity IDE)
Model(s): Gemini 3.1 Pro (High)
Used for: Identifying redundant manual hook removals. Final implementation and testing were reviewed and validated by me.
