### PR TITLE
Administration: Improve admin notices accessibility.

### DIFF
--- a/src/js/_enqueues/admin/common.js
+++ b/src/js/_enqueues/admin/common.js
@@ -1087,7 +1087,11 @@ $( function() {
 	if ( ! $headerEnd.length ) {
 		$headerEnd = $( '.wrap h1, .wrap h2' ).first();
 	}
-	$( 'div.updated, div.error, div.notice' ).not( '.inline, .below-h2' ).insertAfter( $headerEnd );
+	if ( $( '#wp-admin-notices' ).length ) {
+		$( '#wp-admin-notices' ).insertAfter( $headerEnd );
+	} else {
+		$( 'div.updated, div.error, div.notice' ).not( '.inline, .below-h2' ).insertAfter( $headerEnd );
+	}
 
 	/**
 	 * Makes notices dismissible.

--- a/src/js/_enqueues/wp/updates.js
+++ b/src/js/_enqueues/wp/updates.js
@@ -267,6 +267,8 @@
 			$notice.replaceWith( $adminNotice );
 		} else if ( $headerEnd.length ) {
 			$headerEnd.after( $adminNotice );
+		} else if ( $( '#wp-admin-notices' ).length ) {
+			$( '#wp-admin-notices' ).append( $adminNotice );
 		} else {
 			if ( 'customize' === pagenow ) {
 				$( '.customize-themes-notifications' ).append( $adminNotice );

--- a/src/wp-admin/admin-header.php
+++ b/src/wp-admin/admin-header.php
@@ -78,6 +78,8 @@ if ( wp_is_recovery_mode() ) {
 	$admin_title = sprintf( __( 'Recovery Mode &#8212; %s' ), $admin_title );
 }
 
+wp_capture_admin_notices();
+
 /**
  * Filters the title tag content for an admin page.
  *
@@ -290,35 +292,7 @@ $current_screen->set_parentage( $parent_file );
 
 $current_screen->render_screen_meta();
 
-if ( is_network_admin() ) {
-	/**
-	 * Prints network admin screen notices.
-	 *
-	 * @since 3.1.0
-	 */
-	do_action( 'network_admin_notices' );
-} elseif ( is_user_admin() ) {
-	/**
-	 * Prints user admin screen notices.
-	 *
-	 * @since 3.1.0
-	 */
-	do_action( 'user_admin_notices' );
-} else {
-	/**
-	 * Prints admin screen notices.
-	 *
-	 * @since 3.1.0
-	 */
-	do_action( 'admin_notices' );
-}
-
-/**
- * Prints generic admin screen notices.
- *
- * @since 3.1.0
- */
-do_action( 'all_admin_notices' );
+wp_render_admin_notices();
 
 if ( 'options-general.php' === $parent_file ) {
 	require ABSPATH . 'wp-admin/options-head.php';

--- a/src/wp-admin/includes/admin-filters.php
+++ b/src/wp-admin/includes/admin-filters.php
@@ -116,6 +116,9 @@ add_action( 'customize_controls_print_footer_scripts', 'customize_themes_print_t
 // Theme Install hooks.
 add_action( 'install_themes_pre_theme-information', 'install_theme_information' );
 
+// Admin notices hooks.
+add_filter( 'admin_title', 'wp_prepend_admin_notices_count_to_admin_title' );
+
 // User hooks.
 add_action( 'admin_init', 'default_password_nag_handler' );
 

--- a/src/wp-admin/includes/admin-notices.php
+++ b/src/wp-admin/includes/admin-notices.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * Administration notices API.
+ *
+ * @package WordPress
+ * @subpackage Administration
+ * @since 7.1.0
+ */
+
+/**
+ * Captures admin notices output for the current screen.
+ *
+ * @since 7.1.0
+ *
+ * @return array {
+ *     @type string $html  The captured admin notices markup.
+ *     @type int    $count The number of non-inline admin notices.
+ * }
+ */
+function wp_capture_admin_notices() {
+	global $wp_captured_admin_notices;
+
+	if ( isset( $wp_captured_admin_notices ) ) {
+		return $wp_captured_admin_notices;
+	}
+
+	ob_start();
+
+	if ( is_network_admin() ) {
+		/**
+		 * Prints network admin screen notices.
+		 *
+		 * @since 3.1.0
+		 */
+		do_action( 'network_admin_notices' );
+	} elseif ( is_user_admin() ) {
+		/**
+		 * Prints user admin screen notices.
+		 *
+		 * @since 3.1.0
+		 */
+		do_action( 'user_admin_notices' );
+	} else {
+		/**
+		 * Prints admin screen notices.
+		 *
+		 * @since 3.1.0
+		 */
+		do_action( 'admin_notices' );
+	}
+
+	/**
+	 * Prints generic admin screen notices.
+	 *
+	 * @since 3.1.0
+	 */
+	do_action( 'all_admin_notices' );
+
+	$html = ob_get_clean();
+
+	$wp_captured_admin_notices = array(
+		'html'  => $html,
+		'count' => wp_count_admin_notices_from_html( $html ),
+	);
+
+	return $wp_captured_admin_notices;
+}
+
+/**
+ * Determines whether admin notices are present for the current screen.
+ *
+ * @since 7.1.0
+ *
+ * @return bool Whether admin notices are present.
+ */
+function wp_has_admin_notices() {
+	$notices = wp_capture_admin_notices();
+
+	return $notices['count'] > 0;
+}
+
+/**
+ * Returns the number of admin notices for the current screen.
+ *
+ * @since 7.1.0
+ *
+ * @return int The number of admin notices.
+ */
+function wp_get_admin_notices_count() {
+	$notices = wp_capture_admin_notices();
+
+	return $notices['count'];
+}
+
+/**
+ * Counts non-inline admin notices in the given HTML markup.
+ *
+ * @since 7.1.0
+ *
+ * @param string $html Admin notices HTML markup.
+ * @return int The number of admin notices.
+ */
+function wp_count_admin_notices_from_html( $html ) {
+	if ( '' === trim( $html ) ) {
+		return 0;
+	}
+
+	$count = 0;
+
+	if ( preg_match_all( '/<div\s[^>]*\bclass=["\'][^"\']*\b(?:notice|updated|error)\b[^"\']*["\'][^>]*>/i', $html, $matches ) ) {
+		foreach ( $matches[0] as $opening_tag ) {
+			if ( preg_match( '/\b(?:inline|below-h2)\b/', $opening_tag ) ) {
+				continue;
+			}
+
+			++$count;
+		}
+	}
+
+	return $count;
+}
+
+/**
+ * Prepends the admin notices count to the admin page title.
+ *
+ * @since 7.1.0
+ *
+ * @param string $admin_title The page title, with extra context added.
+ * @return string The filtered page title.
+ */
+function wp_prepend_admin_notices_count_to_admin_title( $admin_title ) {
+	$count = wp_get_admin_notices_count();
+
+	if ( $count < 1 ) {
+		return $admin_title;
+	}
+
+	return sprintf(
+		/* translators: 1: Number of admin notices, 2: Admin page title. */
+		_n( '(%1$s notice) %2$s', '(%1$s notices) %2$s', $count ),
+		number_format_i18n( $count ),
+		$admin_title
+	);
+}
+
+/**
+ * Renders captured admin notices within an accessible landmark container.
+ *
+ * @since 7.1.0
+ */
+function wp_render_admin_notices() {
+	$notices = wp_capture_admin_notices();
+
+	if ( '' === trim( $notices['html'] ) ) {
+		return;
+	}
+
+	printf(
+		'<aside id="wp-admin-notices" class="wp-admin-notices" aria-label="%s">%s</aside>',
+		esc_attr__( 'Administrative notices' ),
+		$notices['html'] // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	);
+}

--- a/src/wp-admin/includes/admin.php
+++ b/src/wp-admin/includes/admin.php
@@ -64,6 +64,9 @@ require_once ABSPATH . 'wp-admin/includes/taxonomy.php';
 /** WordPress Template Administration API */
 require_once ABSPATH . 'wp-admin/includes/template.php';
 
+/** WordPress Administration Notices API */
+require_once ABSPATH . 'wp-admin/includes/admin-notices.php';
+
 /** WordPress List Table Administration API and base class */
 require_once ABSPATH . 'wp-admin/includes/class-wp-list-table.php';
 require_once ABSPATH . 'wp-admin/includes/class-wp-list-table-compat.php';

--- a/src/wp-admin/includes/update.php
+++ b/src/wp-admin/includes/update.php
@@ -916,10 +916,10 @@ function maintenance_nag() {
 function wp_print_admin_notice_templates() {
 	?>
 	<script id="tmpl-wp-updates-admin-notice" type="text/html">
-		<div <# if ( data.id ) { #>id="{{ data.id }}"<# } #> class="notice {{ data.className }}"><p>{{{ data.message }}}</p></div>
+		<div <# if ( data.id ) { #>id="{{ data.id }}"<# } #> class="notice {{ data.className }}" role="alert"><p>{{{ data.message }}}</p></div>
 	</script>
 	<script id="tmpl-wp-bulk-updates-admin-notice" type="text/html">
-		<div id="{{ data.id }}" class="{{ data.className }} notice <# if ( data.errorMessage ) { #>notice-error<# } else { #>notice-success<# } #>">
+		<div id="{{ data.id }}" class="{{ data.className }} notice <# if ( data.errorMessage ) { #>notice-error<# } else { #>notice-success<# } #>" role="<# if ( data.errorMessage ) { #>alert<# } else { #>status<# } #>">
 			<p>
 				<# if ( data.successMessage ) { #>
 					{{{ data.successMessage }}}

--- a/src/wp-admin/menu-header.php
+++ b/src/wp-admin/menu-header.php
@@ -292,6 +292,9 @@ function _wp_menu_output( $menu, $submenu, $submenu_as_parent = true ) {
 
 <div id="adminmenumain" role="navigation" aria-label="<?php esc_attr_e( 'Main menu' ); ?>">
 <a href="#wpbody-content" class="screen-reader-shortcut"><?php _e( 'Skip to main content' ); ?></a>
+<?php if ( wp_has_admin_notices() ) : ?>
+<a href="#wp-admin-notices" class="screen-reader-shortcut"><?php esc_html_e( 'Skip to notices' ); ?></a>
+<?php endif; ?>
 <a href="#wp-toolbar" class="screen-reader-shortcut"><?php _e( 'Skip to toolbar' ); ?></a>
 <div id="adminmenuback"></div>
 <div id="adminmenuwrap">

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -9140,6 +9140,16 @@ function wp_get_admin_notice( $message, $args = array() ) {
 		$classes .= ' ' . implode( ' ', $args['additional_classes'] );
 	}
 
+	if ( is_array( $args['attributes'] ) && ! isset( $args['attributes']['role'] ) && is_string( $args['type'] ) ) {
+		$notice_type = trim( $args['type'] );
+
+		if ( 'error' === $notice_type ) {
+			$args['attributes']['role'] = 'alert';
+		} elseif ( in_array( $notice_type, array( 'success', 'warning', 'info' ), true ) ) {
+			$args['attributes']['role'] = 'status';
+		}
+	}
+
 	if ( is_array( $args['attributes'] ) && ! empty( $args['attributes'] ) ) {
 		$attributes = '';
 		foreach ( $args['attributes'] as $attr => $val ) {

--- a/tests/phpunit/tests/admin/wpAdminNotices.php
+++ b/tests/phpunit/tests/admin/wpAdminNotices.php
@@ -1,0 +1,121 @@
+<?php
+
+/**
+ * Tests for admin notices accessibility helpers.
+ *
+ * @group admin
+ *
+ * @covers ::wp_count_admin_notices_from_html
+ * @covers ::wp_prepend_admin_notices_count_to_admin_title
+ * @covers ::wp_render_admin_notices
+ */
+class Tests_Admin_WpAdminNotices extends WP_UnitTestCase {
+
+	/**
+	 * @inheritDoc
+	 */
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+
+		require_once ABSPATH . 'wp-admin/includes/admin-notices.php';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function tearDown(): void {
+		unset( $GLOBALS['wp_captured_admin_notices'] );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @ticket 50486
+	 *
+	 * @dataProvider data_should_count_admin_notices_from_html
+	 *
+	 * @param string $html     Admin notices HTML markup.
+	 * @param int    $expected Expected notice count.
+	 */
+	public function test_should_count_admin_notices_from_html( $html, $expected ) {
+		$this->assertSame( $expected, wp_count_admin_notices_from_html( $html ) );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_should_count_admin_notices_from_html() {
+		return array(
+			'empty string'           => array(
+				'html'     => '',
+				'expected' => 0,
+			),
+			'single notice'          => array(
+				'html'     => '<div class="notice notice-success"><p>Done!</p></div>',
+				'expected' => 1,
+			),
+			'legacy updated notice'  => array(
+				'html'     => '<div class="updated"><p>Settings saved.</p></div>',
+				'expected' => 1,
+			),
+			'legacy error notice'    => array(
+				'html'     => '<div class="error"><p>Something went wrong.</p></div>',
+				'expected' => 1,
+			),
+			'inline notice excluded' => array(
+				'html'     => '<div class="notice notice-error inline"><p>Inline notice.</p></div>',
+				'expected' => 0,
+			),
+			'multiple notices'       => array(
+				'html'     => '<div class="notice notice-success"><p>One</p></div><div class="notice notice-warning"><p>Two</p></div>',
+				'expected' => 2,
+			),
+		);
+	}
+
+	/**
+	 * @ticket 50486
+	 */
+	public function test_should_prepend_admin_notices_count_to_admin_title() {
+		$title = 'Plugins &lsaquo; Test Site &#8212; WordPress';
+
+		add_action(
+			'admin_notices',
+			static function () {
+				wp_admin_notice( 'Plugin activated.', array( 'type' => 'success' ) );
+			}
+		);
+
+		wp_capture_admin_notices();
+
+		$this->assertSame(
+			'(1 notice) ' . $title,
+			wp_prepend_admin_notices_count_to_admin_title( $title )
+		);
+	}
+
+	/**
+	 * @ticket 50486
+	 */
+	public function test_should_render_admin_notices_in_landmark_container() {
+		add_action(
+			'admin_notices',
+			static function () {
+				wp_admin_notice( 'Settings saved.', array( 'type' => 'success' ) );
+			}
+		);
+
+		wp_capture_admin_notices();
+
+		ob_start();
+		wp_render_admin_notices();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( '<aside id="wp-admin-notices"', $output );
+		$this->assertStringContainsString( 'class="wp-admin-notices"', $output );
+		$this->assertStringContainsString( 'notice-success', $output );
+		$this->assertStringContainsString( 'Settings saved.', $output );
+	}
+}

--- a/tests/phpunit/tests/functions/wpAdminNotice.php
+++ b/tests/phpunit/tests/functions/wpAdminNotice.php
@@ -48,7 +48,7 @@ class Tests_Functions_WpAdminNotice extends WP_UnitTestCase {
 					'id'                 => 'message',
 					'additional_classes' => array( 'inline', 'hidden' ),
 				),
-				'expected' => '<div id="message" class="notice notice-error is-dismissible inline hidden"><p></p></div>',
+				'expected' => '<div id="message" class="notice notice-error is-dismissible inline hidden" role="alert"><p></p></div>',
 			),
 			'an empty message (used for templates) without paragraph wrapping' => array(
 				'message'  => '',
@@ -59,35 +59,35 @@ class Tests_Functions_WpAdminNotice extends WP_UnitTestCase {
 					'additional_classes' => array( 'inline', 'hidden' ),
 					'paragraph_wrap'     => false,
 				),
-				'expected' => '<div id="message" class="notice notice-error is-dismissible inline hidden"></div>',
+				'expected' => '<div id="message" class="notice notice-error is-dismissible inline hidden" role="alert"></div>',
 			),
 			'an "error" notice'                         => array(
 				'message'  => 'An "error" notice.',
 				'args'     => array(
 					'type' => 'error',
 				),
-				'expected' => '<div class="notice notice-error"><p>An "error" notice.</p></div>',
+				'expected' => '<div class="notice notice-error" role="alert"><p>An "error" notice.</p></div>',
 			),
 			'a "success" notice'                        => array(
 				'message'  => 'A "success" notice.',
 				'args'     => array(
 					'type' => 'success',
 				),
-				'expected' => '<div class="notice notice-success"><p>A "success" notice.</p></div>',
+				'expected' => '<div class="notice notice-success" role="status"><p>A "success" notice.</p></div>',
 			),
 			'a "warning" notice'                        => array(
 				'message'  => 'A "warning" notice.',
 				'args'     => array(
 					'type' => 'warning',
 				),
-				'expected' => '<div class="notice notice-warning"><p>A "warning" notice.</p></div>',
+				'expected' => '<div class="notice notice-warning" role="status"><p>A "warning" notice.</p></div>',
 			),
 			'an "info" notice'                          => array(
 				'message'  => 'An "info" notice.',
 				'args'     => array(
 					'type' => 'info',
 				),
-				'expected' => '<div class="notice notice-info"><p>An "info" notice.</p></div>',
+				'expected' => '<div class="notice notice-info" role="status"><p>An "info" notice.</p></div>',
 			),
 			'a type that already starts with "notice-"' => array(
 				'message'  => 'A type that already starts with "notice-".',
@@ -116,7 +116,7 @@ class Tests_Functions_WpAdminNotice extends WP_UnitTestCase {
 					'type' => 'warning',
 					'id'   => 'message',
 				),
-				'expected' => '<div id="message" class="notice notice-warning"><p>A warning notice with an ID.</p></div>',
+				'expected' => '<div id="message" class="notice notice-warning" role="status"><p>A warning notice with an ID.</p></div>',
 			),
 			'no type and additional classes'            => array(
 				'message'  => 'A notice with additional classes.',
@@ -131,7 +131,7 @@ class Tests_Functions_WpAdminNotice extends WP_UnitTestCase {
 					'type'               => 'warning',
 					'additional_classes' => array( 'error', 'notice-alt' ),
 				),
-				'expected' => '<div class="notice notice-warning error notice-alt"><p>A warning notice with additional classes.</p></div>',
+				'expected' => '<div class="notice notice-warning error notice-alt" role="status"><p>A warning notice with additional classes.</p></div>',
 			),
 			'a dismissible notice with a type and additional classes' => array(
 				'message'  => 'A dismissible warning notice with a type and additional classes.',
@@ -140,7 +140,7 @@ class Tests_Functions_WpAdminNotice extends WP_UnitTestCase {
 					'dismissible'        => true,
 					'additional_classes' => array( 'error', 'notice-alt' ),
 				),
-				'expected' => '<div class="notice notice-warning is-dismissible error notice-alt"><p>A dismissible warning notice with a type and additional classes.</p></div>',
+				'expected' => '<div class="notice notice-warning is-dismissible error notice-alt" role="status"><p>A dismissible warning notice with a type and additional classes.</p></div>',
 			),
 			'a notice without paragraph wrapping'       => array(
 				'message'  => '<span>A notice without paragraph wrapping.</span>',

--- a/tests/phpunit/tests/functions/wpGetAdminNotice.php
+++ b/tests/phpunit/tests/functions/wpGetAdminNotice.php
@@ -44,7 +44,7 @@ class Tests_Functions_WpGetAdminNotice extends WP_UnitTestCase {
 					'id'                 => 'message',
 					'additional_classes' => array( 'inline', 'hidden' ),
 				),
-				'expected' => '<div id="message" class="notice notice-error is-dismissible inline hidden"><p></p></div>',
+				'expected' => '<div id="message" class="notice notice-error is-dismissible inline hidden" role="alert"><p></p></div>',
 			),
 			'an empty message (used for templates) without paragraph wrapping' => array(
 				'message'  => '',
@@ -55,35 +55,35 @@ class Tests_Functions_WpGetAdminNotice extends WP_UnitTestCase {
 					'additional_classes' => array( 'inline', 'hidden' ),
 					'paragraph_wrap'     => false,
 				),
-				'expected' => '<div id="message" class="notice notice-error is-dismissible inline hidden"></div>',
+				'expected' => '<div id="message" class="notice notice-error is-dismissible inline hidden" role="alert"></div>',
 			),
 			'an "error" notice'                         => array(
 				'message'  => 'An "error" notice.',
 				'args'     => array(
 					'type' => 'error',
 				),
-				'expected' => '<div class="notice notice-error"><p>An "error" notice.</p></div>',
+				'expected' => '<div class="notice notice-error" role="alert"><p>An "error" notice.</p></div>',
 			),
 			'a "success" notice'                        => array(
 				'message'  => 'A "success" notice.',
 				'args'     => array(
 					'type' => 'success',
 				),
-				'expected' => '<div class="notice notice-success"><p>A "success" notice.</p></div>',
+				'expected' => '<div class="notice notice-success" role="status"><p>A "success" notice.</p></div>',
 			),
 			'a "warning" notice'                        => array(
 				'message'  => 'A "warning" notice.',
 				'args'     => array(
 					'type' => 'warning',
 				),
-				'expected' => '<div class="notice notice-warning"><p>A "warning" notice.</p></div>',
+				'expected' => '<div class="notice notice-warning" role="status"><p>A "warning" notice.</p></div>',
 			),
 			'an "info" notice'                          => array(
 				'message'  => 'An "info" notice.',
 				'args'     => array(
 					'type' => 'info',
 				),
-				'expected' => '<div class="notice notice-info"><p>An "info" notice.</p></div>',
+				'expected' => '<div class="notice notice-info" role="status"><p>An "info" notice.</p></div>',
 			),
 			'a type that already starts with "notice-"' => array(
 				'message'  => 'A type that already starts with "notice-".',
@@ -112,7 +112,7 @@ class Tests_Functions_WpGetAdminNotice extends WP_UnitTestCase {
 					'type' => 'warning',
 					'id'   => 'message',
 				),
-				'expected' => '<div id="message" class="notice notice-warning"><p>A warning notice with an ID.</p></div>',
+				'expected' => '<div id="message" class="notice notice-warning" role="status"><p>A warning notice with an ID.</p></div>',
 			),
 			'no type and additional classes'            => array(
 				'message'  => 'A notice with additional classes.',
@@ -127,7 +127,7 @@ class Tests_Functions_WpGetAdminNotice extends WP_UnitTestCase {
 					'type'               => 'warning',
 					'additional_classes' => array( 'error', 'notice-alt' ),
 				),
-				'expected' => '<div class="notice notice-warning error notice-alt"><p>A warning notice with additional classes.</p></div>',
+				'expected' => '<div class="notice notice-warning error notice-alt" role="status"><p>A warning notice with additional classes.</p></div>',
 			),
 			'a dismissible notice with a type and additional classes' => array(
 				'message'  => 'A dismissible warning notice with a type and additional classes.',
@@ -136,7 +136,7 @@ class Tests_Functions_WpGetAdminNotice extends WP_UnitTestCase {
 					'dismissible'        => true,
 					'additional_classes' => array( 'error', 'notice-alt' ),
 				),
-				'expected' => '<div class="notice notice-warning is-dismissible error notice-alt"><p>A dismissible warning notice with a type and additional classes.</p></div>',
+				'expected' => '<div class="notice notice-warning is-dismissible error notice-alt" role="status"><p>A dismissible warning notice with a type and additional classes.</p></div>',
 			),
 			'a notice without paragraph wrapping'       => array(
 				'message'  => '<span>A notice without paragraph wrapping.</span>',


### PR DESCRIPTION
Wrap PHP admin notices in a complementary landmark, prepend the notice count to the admin document title, add a conditional skip link, and assign ARIA live region roles to standardized and JavaScript-generated notices.

Props afercia, joedolson.
Fixes #50486.

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/50486


## Use of AI Tools

AI assistance: Yes
Tool(s): Cursor
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**