### PR TITLE
Build/Test Tools: Exclude generated css/dist files from PHPCS and PHP Compat scans

### DIFF
--- a/phpcompat.xml.dist
+++ b/phpcompat.xml.dist
@@ -52,6 +52,9 @@
 	<!-- Exclude translation files. -->
 	<exclude-pattern>/src/wp-content/languages/*</exclude-pattern>
 
+	<!-- Exclude generated Gutenberg style build artifacts. -->
+	<exclude-pattern>/src/wp-includes/css/dist/*</exclude-pattern>
+
 	<!--
 		PHPCompatibilityParagonieSodiumCompat prevents false positives in `sodium_compat`.
 		However, because these files are included in a non-standard path, false positives are triggered in WordPress Core.

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -72,6 +72,7 @@
 	<exclude-pattern>/src/wp-includes/blocks/*/*.asset.php</exclude-pattern>
 	<exclude-pattern>/src/wp-includes/blocks/blocks-json.php</exclude-pattern>
 	<exclude-pattern>/src/wp-includes/build/*</exclude-pattern>
+	<exclude-pattern>/src/wp-includes/css/dist/*</exclude-pattern>
 	<exclude-pattern>/src/wp-includes/ID3/*</exclude-pattern>
 	<exclude-pattern>/src/wp-includes/IXR/*</exclude-pattern>
 	<exclude-pattern>/src/wp-includes/js/*</exclude-pattern>


### PR DESCRIPTION
After running build:dev, the auto-generated registry.php file in css/dist is not formatted to WordPress coding standards and causes grunt prerelease PHPCS checks to fail.

Props desrosj.
Fixes #65278.

Trac ticket: https://core.trac.wordpress.org/ticket/65278


## Use of AI Tools

N/A
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**