### PR TITLE
Address memory exhaustion errors within performance testing workflow

### DIFF
--- a/.github/workflows/reusable-performance-test-v2.yml
+++ b/.github/workflows/reusable-performance-test-v2.yml
@@ -190,7 +190,7 @@ jobs:
         if: ${{ inputs.subject == 'base' }}
         run: |
           VERSION="${BASE_TAG%.0}"
-          wp core download --version="$VERSION" --force --path="/var/www/${LOCAL_DIR}"
+          wp core download --version="$VERSION" --force --path="${LOCAL_DIR}"
 
       - name: Install object cache drop-in
         if: ${{ inputs.memcached }}

--- a/.github/workflows/reusable-performance-test-v2.yml
+++ b/.github/workflows/reusable-performance-test-v2.yml
@@ -131,7 +131,7 @@ jobs:
         if: ${{ inputs.subject == 'base' }}
         uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
-          php-version: '8.5'
+          php-version: ${{ inputs.php-version }}
           tools: wp-cli
           coverage: none
 

--- a/.github/workflows/reusable-performance-test-v2.yml
+++ b/.github/workflows/reusable-performance-test-v2.yml
@@ -133,6 +133,7 @@ jobs:
         with:
           php-version: '8.5'
           tools: wp-cli
+          coverage: none
 
       - name: Log debug information
         run: |

--- a/.github/workflows/reusable-performance-test-v2.yml
+++ b/.github/workflows/reusable-performance-test-v2.yml
@@ -127,6 +127,13 @@ jobs:
           node-version-file: '.nvmrc'
           cache: npm
 
+      - name: Set up PHP
+        if: ${{ inputs.subject == 'base' }}
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # 2.37.0
+        with:
+          php-version: '8.5'
+          tools: wp-cli
+
       - name: Log debug information
         run: |
           npm --version
@@ -183,7 +190,7 @@ jobs:
         if: ${{ inputs.subject == 'base' }}
         run: |
           VERSION="${BASE_TAG%.0}"
-          npm run env:cli -- core download --version="$VERSION" --force --path="/var/www/${LOCAL_DIR}"
+          wp core download --version="$VERSION" --force --path="/var/www/${LOCAL_DIR}"
 
       - name: Install object cache drop-in
         if: ${{ inputs.memcached }}

--- a/.github/workflows/reusable-performance-test-v2.yml
+++ b/.github/workflows/reusable-performance-test-v2.yml
@@ -129,7 +129,7 @@ jobs:
 
       - name: Set up PHP
         if: ${{ inputs.subject == 'base' }}
-        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # 2.37.0
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           php-version: '8.5'
           tools: wp-cli

--- a/.github/workflows/reusable-performance-test-v2.yml
+++ b/.github/workflows/reusable-performance-test-v2.yml
@@ -78,6 +78,7 @@ jobs:
   # - Configure environment variables.
   # - Checkout repository.
   # - Set up Node.js.
+  # - Set up PHP.
   # - Log debug information.
   # - Install npm dependencies.
   # - Install Playwright browsers.


### PR DESCRIPTION
This attempts to address memory exhaustion errors that have been happening any time the `BASE_TAG` within the performance testing workflow is set to any value higher than `6.7.0` by downloading the needed version of WordPress using WP-CLI inside the GitHub Actions runner instead of within the Docker environment.


- Most [recent failure](https://github.com/WordPress/wordpress-develop/actions/runs/26229315517/job/77187906084#step:12:50) after bumping to `7.0.0`.
- Previous attempts in r60324 was reverted in r60326.

Trac ticket: Core-65289.

## Use of AI Tools

None

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
