### PR TITLE
Build/Test Tools: Add AGENTS.md for AI-assisted development

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,46 @@
+# Agent context for WordPress Core
+
+This file provides a starting point for AI-assisted coding tools working in the [WordPress Core development repository](https://github.com/WordPress/wordpress-develop). It follows the [AGENTS.md](https://agents.md/) convention and is intended to be readable by both humans and agents.
+
+For deeper context, see [README.md](README.md), [CONTRIBUTING.md](CONTRIBUTING.md), and [docs/architecture.md](docs/architecture.md).
+
+## Project brief
+
+WordPress is open source publishing software. This repository is the canonical development checkout for WordPress Core — the PHP application, bundled themes, and build tooling used to produce releases.
+
+Core development is tracked in [Trac](https://core.trac.wordpress.org/). GitHub pull requests are used for code review only; patches land in Core via SVN. Block Editor (Gutenberg) development happens in the separate [Gutenberg repository](https://github.com/WordPress/gutenberg/).
+
+## High-level architecture
+
+See [docs/architecture.md](docs/architecture.md) for directory layout, the `src/` and `build/` workflow, and where major subsystems live.
+
+## Development tooling and commands
+
+See [README.md](README.md) for environment setup, local development, and test commands. Common commands:
+
+```bash
+npm install && npm run build:dev && npm run env:start && npm run env:install  # First-time setup
+npm run dev                          # Watch and rebuild changed files
+npm run test:php -- --filter <name>  # Run PHPUnit tests
+npm run test:e2e                     # Run end-to-end tests
+composer lint                        # PHP_CodeSniffer
+composer format                      # Auto-fix PHPCS issues
+composer phpstan                     # Static analysis
+```
+
+PHP tests and Composer commands run inside the Docker environment. See README.md for WP-CLI, coverage, and workflow linting details.
+
+## Coding standards and best practices
+
+Follow the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [Inline Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/). See [CONTRIBUTING.md](CONTRIBUTING.md) for the contribution workflow, Trac tickets, and GitHub pull request requirements.
+
+When using AI tools, follow the [WordPress AI Guidelines](https://make.wordpress.org/ai/handbook/ai-guidelines/).
+
+For WordPress plugin, theme, and block development patterns outside Core, the community maintains [Agent Skills for WordPress](https://github.com/WordPress/agent-skills).
+
+## Common pitfalls
+
+- Edit source files under `src/`, not `build/`. Run `npm run dev` or `npm run build:dev` to sync changes.
+- Block Editor packages and compiled assets come from Gutenberg. Core-specific JavaScript is built with Grunt/Webpack; see `Gruntfile.js` and `webpack.config.js`.
+- Legacy code in Core may not match current coding standards. Match the style of surrounding code in the file you are editing.
+- Do not run `composer format` or `phpcbf` on unrelated legacy files.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,46 +1,70 @@
-# Agent context for WordPress Core
+# AGENTS.md
 
-This file provides a starting point for AI-assisted coding tools working in the [WordPress Core development repository](https://github.com/WordPress/wordpress-develop). It follows the [AGENTS.md](https://agents.md/) convention and is intended to be readable by both humans and agents.
+This file provides a starting point for AI-assisted coding tools working in the
+[WordPress Core development repository](https://github.com/WordPress/wordpress-develop).
+It follows the [AGENTS.md](https://agents.md/) convention and is intended to be
+readable by both humans and agents.
 
-For deeper context, see [README.md](README.md), [CONTRIBUTING.md](CONTRIBUTING.md), and [docs/architecture.md](docs/architecture.md).
+For deeper context, see [README.md](README.md), [CONTRIBUTING.md](CONTRIBUTING.md),
+and [docs/architecture.md](docs/architecture.md).
 
 ## Project brief
 
-WordPress is open source publishing software. This repository is the canonical development checkout for WordPress Core — the PHP application, bundled themes, and build tooling used to produce releases.
+WordPress is open source publishing software. This repository is the canonical
+development checkout for WordPress Core — the PHP application, bundled themes,
+and build tooling used to produce releases.
 
-Core development is tracked in [Trac](https://core.trac.wordpress.org/). GitHub pull requests are used for code review only; patches land in Core via SVN. Block Editor (Gutenberg) development happens in the separate [Gutenberg repository](https://github.com/WordPress/gutenberg/).
+Core development is tracked in [Trac](https://core.trac.wordpress.org/). GitHub
+pull requests are used for code review only; patches land in Core via SVN. Block
+Editor (Gutenberg) development happens in the separate
+[Gutenberg repository](https://github.com/WordPress/gutenberg/).
 
 ## High-level architecture
 
-See [docs/architecture.md](docs/architecture.md) for directory layout, the `src/` and `build/` workflow, and where major subsystems live.
+See [docs/architecture.md](docs/architecture.md) for directory layout, the `src/`
+and `build/` workflow, and where major subsystems live.
 
 ## Development tooling and commands
 
-See [README.md](README.md) for environment setup, local development, and test commands. Common commands:
+See [README.md](README.md) for environment setup, local development, and test
+commands. Common commands:
 
-```bash
-npm install && npm run build:dev && npm run env:start && npm run env:install  # First-time setup
-npm run dev                          # Watch and rebuild changed files
-npm run test:php -- --filter <name>  # Run PHPUnit tests
-npm run test:e2e                     # Run end-to-end tests
-composer lint                        # PHP_CodeSniffer
-composer format                      # Auto-fix PHPCS issues
-composer phpstan                     # Static analysis
+```
+npm install && npm run build:dev && npm run env:start && npm run env:install
+npm run dev
+npm run test:php -- --filter <test name>
+npm run test:e2e
+composer lint
+composer format
+composer phpstan
 ```
 
-PHP tests and Composer commands run inside the Docker environment. See README.md for WP-CLI, coverage, and workflow linting details.
+PHPUnit runs via `npm run test:php` inside the Docker environment. PHPCS,
+PHPStan, and related Composer scripts run on the host after `npm run env:start`
+installs dependencies into `vendor/`. See README.md for WP-CLI, coverage, and
+workflow linting details.
 
 ## Coding standards and best practices
 
-Follow the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [Inline Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/). See [CONTRIBUTING.md](CONTRIBUTING.md) for the contribution workflow, Trac tickets, and GitHub pull request requirements.
+Follow the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
+and [Inline Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/).
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the contribution workflow, Trac
+tickets, and GitHub pull request requirements.
 
-When using AI tools, follow the [WordPress AI Guidelines](https://make.wordpress.org/ai/handbook/ai-guidelines/).
+When using AI tools, follow the
+[WordPress AI Guidelines](https://make.wordpress.org/ai/handbook/ai-guidelines/).
 
-For WordPress plugin, theme, and block development patterns outside Core, the community maintains [Agent Skills for WordPress](https://github.com/WordPress/agent-skills).
+For WordPress plugin, theme, and block development patterns outside Core, the
+community maintains
+[Agent Skills for WordPress](https://github.com/WordPress/agent-skills).
 
 ## Common pitfalls
 
-- Edit source files under `src/`, not `build/`. Run `npm run dev` or `npm run build:dev` to sync changes.
-- Block Editor packages and compiled assets come from Gutenberg. Core-specific JavaScript is built with Grunt/Webpack; see `Gruntfile.js` and `webpack.config.js`.
-- Legacy code in Core may not match current coding standards. Match the style of surrounding code in the file you are editing.
+- Edit source files under `src/`, not `build/`. Run `npm run dev` or
+  `npm run build:dev` to sync changes.
+- Block Editor packages and compiled assets come from Gutenberg. Core-specific
+  JavaScript is built with Grunt/Webpack; see `Gruntfile.js` and
+  `webpack.config.js`.
+- Legacy code in Core may not match current coding standards. Match the style
+  of surrounding code in the file you are editing.
 - Do not run `composer format` or `phpcbf` on unrelated legacy files.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,7 @@
 # WordPress Core architecture
 
-This document describes the high-level layout of the WordPress Core development repository. For setup and commands, see [README.md](../README.md).
+This document describes the high-level layout of the WordPress Core development
+repository. For setup and commands, see [README.md](../README.md).
 
 ## Source and build directories
 
@@ -9,7 +10,9 @@ This document describes the high-level layout of the WordPress Core development 
 | `src/` | Source of truth for PHP, CSS, JavaScript, and bundled themes. Edit files here during development. |
 | `build/` | Generated output mirroring `src/`. Used by the local environment and PHPUnit. Do not edit directly. |
 
-Grunt copies and compiles assets from `src/` into `build/`. With `npm run dev`, a file watcher rebuilds changed files automatically. Without the watcher, run `npm run build:dev` after making changes.
+Grunt copies and compiles assets from `src/` into `build/`. With `npm run dev`,
+a file watcher rebuilds changed files automatically. Without the watcher, run
+`npm run build:dev` after making changes.
 
 ## Application layout (`src/`)
 
@@ -17,24 +20,35 @@ Grunt copies and compiles assets from `src/` into `build/`. With `npm run dev`, 
 | ---- | ------- |
 | `src/wp-includes/` | Core libraries, APIs, blocks infrastructure, REST API, and shared PHP. |
 | `src/wp-admin/` | Administration screens and admin-only includes. |
-| `src/wp-content/themes/` | Bundled default themes (Twenty * series). |
+| `src/wp-content/themes/` | Bundled default themes. |
 | `src/wp-content/plugins/` | Bundled plugins (Akismet, Hello Dolly). |
 | `src/js/` | JavaScript source enqueued by Core (admin, editor integrations, etc.). |
 
-Root-level PHP files in `src/` (`wp-settings.php`, `wp-load.php`, etc.) bootstrap the application.
+Root-level PHP files in `src/` (`wp-settings.php`, `wp-load.php`, etc.) bootstrap
+the application.
 
 ## Gutenberg integration
 
-The Block Editor is developed in the [Gutenberg](https://github.com/WordPress/gutenberg/) repository. Compiled Gutenberg assets (packages under `wp-includes/js/dist/`, block library, etc.) are copied into this repository via the Gutenberg sync workflow — they are not authored directly here.
+The Block Editor is developed in the
+[Gutenberg](https://github.com/WordPress/gutenberg/) repository. Compiled
+Gutenberg assets (packages under `wp-includes/js/dist/`, block library, etc.)
+are copied into this repository via the Gutenberg sync workflow — they are not
+authored directly here.
 
-For Block Editor changes, work in the Gutenberg repository. See [Gutenberg's AGENTS.md](https://github.com/WordPress/gutenberg/blob/trunk/AGENTS.md) for that project's conventions.
+For Block Editor changes, work in the Gutenberg repository. See
+[Gutenberg's AGENTS.md](https://github.com/WordPress/gutenberg/blob/trunk/AGENTS.md)
+for that project's conventions.
 
 ## Key design patterns
 
-- **Hooks**: Actions and filters (`add_action`, `add_filter`) are the primary extension mechanism. See `src/wp-includes/plugin.php`.
-- **REST API**: Routes registered under `src/wp-includes/rest-api/`. New endpoints extend `WP_REST_Controller`.
-- **Database**: `$wpdb` wrapper in `src/wp-includes/class-wpdb.php`. Schema changes require upgrade routines.
-- **Internationalization**: User-facing strings use gettext functions (`__()`, `_e()`, etc.) with the `default` text domain unless noted otherwise.
+- **Hooks**: Actions and filters (`add_action`, `add_filter`) are the primary
+  extension mechanism. See `src/wp-includes/plugin.php`.
+- **REST API**: Routes registered under `src/wp-includes/rest-api/`. New
+  endpoints extend `WP_REST_Controller`.
+- **Database**: `$wpdb` wrapper in `src/wp-includes/class-wpdb.php`. Schema
+  changes require upgrade routines.
+- **Internationalization**: User-facing strings use gettext functions (`__()`,
+  `_e()`, etc.) with the `default` text domain unless noted otherwise.
 
 ## Tests
 
@@ -47,10 +61,14 @@ For Block Editor changes, work in the Gutenberg repository. See [Gutenberg's AGE
 
 Run PHPUnit with `npm run test:php`. Filter by test name or Trac ticket group:
 
-```bash
-npm run test:php -- --filter Test_Class_Name
-npm run test:php -- --group 63901
 ```
+npm run test:php -- --filter Test_Class_Name
+npm run test:php -- --group <ticket number>
+```
+
+See [tests/phpunit/README.md](../tests/phpunit/README.md) and the
+[PHPUnit handbook](https://make.wordpress.org/core/handbook/testing/automated-testing/phpunit/)
+for more details.
 
 ## Related repositories
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,61 @@
+# WordPress Core architecture
+
+This document describes the high-level layout of the WordPress Core development repository. For setup and commands, see [README.md](../README.md).
+
+## Source and build directories
+
+| Directory | Purpose |
+| --------- | ------- |
+| `src/` | Source of truth for PHP, CSS, JavaScript, and bundled themes. Edit files here during development. |
+| `build/` | Generated output mirroring `src/`. Used by the local environment and PHPUnit. Do not edit directly. |
+
+Grunt copies and compiles assets from `src/` into `build/`. With `npm run dev`, a file watcher rebuilds changed files automatically. Without the watcher, run `npm run build:dev` after making changes.
+
+## Application layout (`src/`)
+
+| Path | Purpose |
+| ---- | ------- |
+| `src/wp-includes/` | Core libraries, APIs, blocks infrastructure, REST API, and shared PHP. |
+| `src/wp-admin/` | Administration screens and admin-only includes. |
+| `src/wp-content/themes/` | Bundled default themes (Twenty * series). |
+| `src/wp-content/plugins/` | Bundled plugins (Akismet, Hello Dolly). |
+| `src/js/` | JavaScript source enqueued by Core (admin, editor integrations, etc.). |
+
+Root-level PHP files in `src/` (`wp-settings.php`, `wp-load.php`, etc.) bootstrap the application.
+
+## Gutenberg integration
+
+The Block Editor is developed in the [Gutenberg](https://github.com/WordPress/gutenberg/) repository. Compiled Gutenberg assets (packages under `wp-includes/js/dist/`, block library, etc.) are copied into this repository via the Gutenberg sync workflow — they are not authored directly here.
+
+For Block Editor changes, work in the Gutenberg repository. See [Gutenberg's AGENTS.md](https://github.com/WordPress/gutenberg/blob/trunk/AGENTS.md) for that project's conventions.
+
+## Key design patterns
+
+- **Hooks**: Actions and filters (`add_action`, `add_filter`) are the primary extension mechanism. See `src/wp-includes/plugin.php`.
+- **REST API**: Routes registered under `src/wp-includes/rest-api/`. New endpoints extend `WP_REST_Controller`.
+- **Database**: `$wpdb` wrapper in `src/wp-includes/class-wpdb.php`. Schema changes require upgrade routines.
+- **Internationalization**: User-facing strings use gettext functions (`__()`, `_e()`, etc.) with the `default` text domain unless noted otherwise.
+
+## Tests
+
+| Path | Purpose |
+| ---- | ------- |
+| `tests/phpunit/` | PHPUnit test suite. Test files mirror Core file paths under `tests/phpunit/tests/`. |
+| `tests/e2e/` | Playwright end-to-end tests. |
+| `tests/qunit/` | QUnit tests for JavaScript. |
+| `tests/phpstan/` | PHPStan configuration and custom rules. |
+
+Run PHPUnit with `npm run test:php`. Filter by test name or Trac ticket group:
+
+```bash
+npm run test:php -- --filter Test_Class_Name
+npm run test:php -- --group 63901
+```
+
+## Related repositories
+
+| Repository | Scope |
+| ---------- | ----- |
+| [WordPress/wordpress-develop](https://github.com/WordPress/wordpress-develop) | Core development (this repo). |
+| [WordPress/gutenberg](https://github.com/WordPress/gutenberg) | Block Editor, `@wordpress/*` packages. |
+| [WordPress/agent-skills](https://github.com/WordPress/agent-skills) | Agent Skills for plugin, theme, and block development. |


### PR DESCRIPTION
Add a lightweight `AGENTS.md` entry point and `docs/architecture.md` to help AI-assisted coding tools understand the WordPress Core development repository.

Start simple, keep the file readable for humans, avoid duplicating existing documentation, and point to `README.md` and `CONTRIBUTING.md` as sources of truth.

Trac ticket: https://core.trac.wordpress.org/ticket/63901

## Summary

- Add `AGENTS.md` with project brief, architecture pointer, common commands, coding standards links, and common pitfalls.
- Add `docs/architecture.md` covering the `src/` and `build/` workflow, application layout, Gutenberg integration, design patterns, and test directories.
- Reference the [WordPress AI Guidelines](https://make.wordpress.org/ai/handbook/ai-guidelines/) and [Agent Skills for WordPress](https://github.com/WordPress/agent-skills).

## Test plan

- [x] Verified documentation matches existing `README.md` and `CONTRIBUTING.md` conventions.
- [x] Confirmed PHPCS does not apply to Markdown files (docs-only change).
- [x] Confirmed PHPUnit test runner still works (`npm run test:php`).


## Use of AI Tools

AI assistance: Yes
Tool(s): Claude
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**