### PR TITLE
Comments: Allow WP_Comment_Query fields to select arbitrary columns

### DIFF
--- a/src/wp-includes/class-wp-comment-query.php
+++ b/src/wp-includes/class-wp-comment-query.php
@@ -18,6 +18,30 @@
 class WP_Comment_Query {
 
 	/**
+	 * Columns of the `$wpdb->comments` table.
+	 *
+	 * @since 7.1.0
+	 * @var string[]
+	 */
+	private const COLUMNS = array(
+		'comment_ID',
+		'comment_post_ID',
+		'comment_author',
+		'comment_author_email',
+		'comment_author_url',
+		'comment_author_IP',
+		'comment_date',
+		'comment_date_gmt',
+		'comment_content',
+		'comment_karma',
+		'comment_approved',
+		'comment_agent',
+		'comment_type',
+		'comment_parent',
+		'user_id',
+	);
+
+	/**
 	 * SQL for database query.
 	 *
 	 * @since 4.0.1
@@ -1045,7 +1069,7 @@ class WP_Comment_Query {
 	 * Return shapes:
 	 *   - `array( 'col', $column )`            — single column, DISTINCT.
 	 *   - `array( 'map', $key_col, $val_col )` — `'col_a=>col_b'` associative map.
-	 *   - `array( 'list', $columns )`          — array form, returns `string[]`.
+	 *   - `array( 'list', $columns )`          — array form, returns `stdClass[]`.
 	 *
 	 * Column names must be passed in their exact case; the only exception is
 	 * the `ID` segment of `comment_ID` / `comment_post_ID`, which is accepted
@@ -1053,13 +1077,11 @@ class WP_Comment_Query {
 	 *
 	 * @since 7.1.0
 	 *
-	 * @param mixed $fields Raw `fields` query var.
 	 * @param string[]|string $fields Raw `fields` query var.
 	 * @return array{ 'list', non-empty-string[] }
 	 *         |array{ 'map', non-empty-string, non-empty-string }
 	 *         |array{ 'col', non-empty-string }
 	 *         |null
-	 */
 	 */
 	private function parse_fields( $fields ): ?array {
 		if ( is_array( $fields ) ) {
@@ -1107,25 +1129,7 @@ class WP_Comment_Query {
 	 * @return non-empty-string|null Canonical column name or null if unknown.
 	 */
 	private function parse_field_column( string $field ): ?string {
-		$columns = array(
-			'comment_ID',
-			'comment_post_ID',
-			'comment_author',
-			'comment_author_email',
-			'comment_author_url',
-			'comment_author_IP',
-			'comment_date',
-			'comment_date_gmt',
-			'comment_content',
-			'comment_karma',
-			'comment_approved',
-			'comment_agent',
-			'comment_type',
-			'comment_parent',
-			'user_id',
-		);
-
-		if ( in_array( $field, $columns, true ) ) {
+		if ( in_array( $field, self::COLUMNS, true ) ) {
 			return $field;
 		}
 
@@ -1371,23 +1375,7 @@ class WP_Comment_Query {
 	protected function parse_orderby( $orderby ) {
 		global $wpdb;
 
-		$allowed_keys = array(
-			'comment_agent',
-			'comment_approved',
-			'comment_author',
-			'comment_author_email',
-			'comment_author_IP',
-			'comment_author_url',
-			'comment_content',
-			'comment_date',
-			'comment_date_gmt',
-			'comment_ID',
-			'comment_karma',
-			'comment_parent',
-			'comment_post_ID',
-			'comment_type',
-			'user_id',
-		);
+		$allowed_keys = self::COLUMNS;
 
 		if ( ! empty( $this->query_vars['meta_key'] ) ) {
 			$allowed_keys[] = $this->query_vars['meta_key'];

--- a/src/wp-includes/class-wp-comment-query.php
+++ b/src/wp-includes/class-wp-comment-query.php
@@ -1045,7 +1045,7 @@ class WP_Comment_Query {
 	 * Return shapes:
 	 *   - `array( 'col', $column )`            — single column, DISTINCT.
 	 *   - `array( 'map', $key_col, $val_col )` — `'col_a=>col_b'` associative map.
-	 *   - `array( 'list', $columns )`          — array form, returns `stdClass[]`.
+	 *   - `array( 'list', $columns )`          — array form, returns `string[]`.
 	 *
 	 * Column names must be passed in their exact case; the only exception is
 	 * the `ID` segment of `comment_ID` / `comment_post_ID`, which is accepted
@@ -1054,9 +1054,14 @@ class WP_Comment_Query {
 	 * @since 7.1.0
 	 *
 	 * @param mixed $fields Raw `fields` query var.
-	 * @return array|null
+	 * @param string[]|string $fields Raw `fields` query var.
+	 * @return array{ 'list', non-empty-string[] }
+	 *         |array{ 'map', non-empty-string, non-empty-string }
+	 *         |array{ 'col', non-empty-string }
+	 *         |null
 	 */
-	private function parse_fields( $fields ) {
+	 */
+	private function parse_fields( $fields ): ?array {
 		if ( is_array( $fields ) ) {
 			$columns = array();
 			foreach ( $fields as $field ) {
@@ -1098,11 +1103,11 @@ class WP_Comment_Query {
 	 *
 	 * @since 7.1.0
 	 *
-	 * @param string $field
-	 * @return string|null
+	 * @param string $field Field name.
+	 * @return non-empty-string|null Canonical column name or null if unknown.
 	 */
-	private function parse_field_column( $field ) {
-		static $columns = array(
+	private function parse_field_column( string $field ): ?string {
+		$columns = array(
 			'comment_ID',
 			'comment_post_ID',
 			'comment_author',
@@ -1125,8 +1130,8 @@ class WP_Comment_Query {
 		}
 
 		// Accept any case for the `ID` segment of `comment_ID` / `comment_post_ID`.
-		if ( preg_match( '/^(comment(?:_post)?_)([iI][dD])$/', $field, $m ) ) {
-			return $m[1] . 'ID';
+		if ( preg_match( '/^(comment(?:_post)?_)([iI][dD])$/', $field, $matches ) ) {
+			return $matches[1] . 'ID';
 		}
 
 		return null;
@@ -1150,7 +1155,7 @@ class WP_Comment_Query {
 	 * @param array $fields      Tagged tuple from `parse_fields()`.
 	 * @return array
 	 */
-	private function get_comment_field_values( $comment_ids, $fields ) {
+	private function get_comment_field_values( array $comment_ids, array $fields ) {
 		global $wpdb;
 
 		if ( empty( $comment_ids ) ) {

--- a/src/wp-includes/class-wp-comment-query.php
+++ b/src/wp-includes/class-wp-comment-query.php
@@ -158,8 +158,23 @@ class WP_Comment_Query {
 	 *                                                      comment objects (false). Default false.
 	 *     @type array           $date_query                Date query clauses to limit comments by. See WP_Date_Query.
 	 *                                                      Default null.
-	 *     @type string          $fields                    Comment fields to return. Accepts 'ids' for comment IDs
-	 *                                                      only or empty for all fields. Default empty.
+	 *     @type string|string[] $fields                    Which fields to return. Accepts:
+	 *                                                      - '' (empty) Returns an array of `WP_Comment` objects (default).
+	 *                                                      - 'ids' Returns a flat array of comment IDs (`int[]`).
+	 *                                                      - Any column of the `$wpdb->comments` table (e.g.
+	 *                                                        'comment_post_ID', 'user_id', 'comment_parent') Returns
+	 *                                                        a flat array of distinct values for that column.
+	 *                                                      - A 'col_a=>col_b' pair of column names (e.g.
+	 *                                                        'comment_ID=>comment_post_ID') Returns an associative
+	 *                                                        array keyed by the first column's value with the second
+	 *                                                        column's value as the entry.
+	 *                                                      - An array of column names. Returns an array of `stdClass`
+	 *                                                        objects with the requested columns as properties
+	 *                                                        (one entry per matched comment, no deduplication).
+	 *                                                      Column names must be passed in their exact case, except
+	 *                                                      the `ID` segment of `comment_ID` / `comment_post_ID`,
+	 *                                                      which is accepted in any case.
+	 *                                                      Default empty.
 	 *     @type array           $include_unapproved        Array of IDs or email addresses of users whose unapproved
 	 *                                                      comments will be returned by the query regardless of
 	 *                                                      `$status`. Default empty.
@@ -451,6 +466,24 @@ class WP_Comment_Query {
 		$key          = md5( serialize( $_args ) );
 		$last_changed = wp_cache_get_last_changed( 'comment' );
 
+		/*
+		 * Projection-result cache. When `fields` selects a subset of columns,
+		 * cache the projected result separately so a repeat call skips both the
+		 * base SELECT and the projection SELECT. Both caches share the comment
+		 * `$last_changed` salt, so any comment mutation invalidates them
+		 * together.
+		 */
+		$field_selection = $this->query_vars['count'] ? null : $this->parse_fields( $this->query_vars['fields'] );
+		$field_cache_key = null;
+		if ( null !== $field_selection ) {
+			$field_cache_key   = "get_comments:$key:fields:" . md5( serialize( $field_selection ) );
+			$field_cache_value = wp_cache_get_salted( $field_cache_key, 'comment-queries', $last_changed );
+			if ( false !== $field_cache_value ) {
+				$this->comments = $field_cache_value;
+				return $this->comments;
+			}
+		}
+
 		$cache_key   = "get_comments:$key";
 		$cache_value = wp_cache_get_salted( $cache_key, 'comment-queries', $last_changed );
 		if ( false === $cache_value ) {
@@ -487,6 +520,12 @@ class WP_Comment_Query {
 
 		if ( 'ids' === $this->query_vars['fields'] ) {
 			$this->comments = $comment_ids;
+			return $this->comments;
+		}
+
+		if ( null !== $field_selection ) {
+			$this->comments = $this->get_comment_field_values( $comment_ids, $field_selection );
+			wp_cache_set_salted( $field_cache_key, $this->comments, 'comment-queries', $last_changed );
 			return $this->comments;
 		}
 
@@ -996,6 +1035,149 @@ class WP_Comment_Query {
 			$comment_ids = $wpdb->get_col( $this->request );
 			return array_map( 'intval', $comment_ids );
 		}
+	}
+
+	/**
+	 * Normalizes the `fields` query var into a tagged tuple consumed by
+	 * `get_comment_field_values()`, or null when `fields` is the default
+	 * empty value, `'ids'`, or anything else this method does not recognize.
+	 *
+	 * Return shapes:
+	 *   - `array( 'col', $column )`            — single column, DISTINCT.
+	 *   - `array( 'map', $key_col, $val_col )` — `'col_a=>col_b'` associative map.
+	 *   - `array( 'list', $columns )`          — array form, returns `stdClass[]`.
+	 *
+	 * Column names must be passed in their exact case; the only exception is
+	 * the `ID` segment of `comment_ID` / `comment_post_ID`, which is accepted
+	 * in any case.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param mixed $fields Raw `fields` query var.
+	 * @return array|null
+	 */
+	private function parse_fields( $fields ) {
+		if ( is_array( $fields ) ) {
+			$columns = array();
+			foreach ( $fields as $field ) {
+				$col = is_string( $field ) ? $this->parse_field_column( $field ) : null;
+				if ( null !== $col ) {
+					$columns[ $col ] = $col;
+				}
+			}
+			return $columns ? array( 'list', array_values( $columns ) ) : null;
+		}
+
+		if ( ! is_string( $fields ) || '' === $fields || 'ids' === $fields ) {
+			return null;
+		}
+
+		// 'col_a=>col_b' — associative array, keyed by col_a, valued by col_b.
+		if ( str_contains( $fields, '=>' ) ) {
+			list( $key, $value ) = array_map( 'trim', explode( '=>', $fields, 2 ) );
+
+			$key   = $this->parse_field_column( $key );
+			$value = $this->parse_field_column( $value );
+
+			if ( null === $key || null === $value ) {
+				return null;
+			}
+
+			return array( 'map', $key, $value );
+		}
+
+		$col = $this->parse_field_column( $fields );
+
+		return null === $col ? null : array( 'col', $col );
+	}
+
+	/**
+	 * Returns the canonical column name for a `fields` value, or null if it is
+	 * not a known column of `$wpdb->comments`. See `parse_fields()` for the case
+	 * rules.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param string $field
+	 * @return string|null
+	 */
+	private function parse_field_column( $field ) {
+		static $columns = array(
+			'comment_ID',
+			'comment_post_ID',
+			'comment_author',
+			'comment_author_email',
+			'comment_author_url',
+			'comment_author_IP',
+			'comment_date',
+			'comment_date_gmt',
+			'comment_content',
+			'comment_karma',
+			'comment_approved',
+			'comment_agent',
+			'comment_type',
+			'comment_parent',
+			'user_id',
+		);
+
+		if ( in_array( $field, $columns, true ) ) {
+			return $field;
+		}
+
+		// Accept any case for the `ID` segment of `comment_ID` / `comment_post_ID`.
+		if ( preg_match( '/^(comment(?:_post)?_)([iI][dD])$/', $field, $m ) ) {
+			return $m[1] . 'ID';
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns column values from the comments table for a given list of comment
+	 * IDs, dispatching on the tag produced by `parse_fields()`.
+	 *
+	 * Single-column results are `DISTINCT` so callers can drop the surrounding
+	 * `array_unique( wp_list_pluck( ... ) )`. Map results are an associative
+	 * array keyed by the first column; on duplicate keys, later rows overwrite
+	 * earlier ones (standard PHP array semantics). Array-form results return
+	 * one `stdClass` per matched row with no deduplication.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @global wpdb $wpdb WordPress database abstraction object.
+	 *
+	 * @param int[] $comment_ids Comment IDs to fetch values for.
+	 * @param array $fields      Tagged tuple from `parse_fields()`.
+	 * @return array
+	 */
+	private function get_comment_field_values( $comment_ids, $fields ) {
+		global $wpdb;
+
+		if ( empty( $comment_ids ) ) {
+			return array();
+		}
+
+		$ids_sql = implode( ',', array_map( 'intval', $comment_ids ) );
+
+		switch ( $fields[0] ) {
+			case 'col':
+				$column = $fields[1];
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				return $wpdb->get_col( "SELECT DISTINCT `$column` FROM $wpdb->comments WHERE comment_ID IN ($ids_sql)" );
+
+			case 'map':
+				list( , $key_column, $value_column ) = $fields;
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				$rows = $wpdb->get_results( "SELECT `$key_column`, `$value_column` FROM $wpdb->comments WHERE comment_ID IN ($ids_sql)", ARRAY_A );
+				return array_column( $rows, $value_column, $key_column );
+
+			case 'list':
+				$select = '`' . implode( '`, `', $fields[1] ) . '`';
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				return $wpdb->get_results( "SELECT $select FROM $wpdb->comments WHERE comment_ID IN ($ids_sql)" );
+		}
+
+		return array();
 	}
 
 	/**

--- a/tests/phpunit/tests/comment/query.php
+++ b/tests/phpunit/tests/comment/query.php
@@ -5534,4 +5534,361 @@ class Tests_Comment_Query extends WP_UnitTestCase {
 		$this->assertSame( 1, $counts['all'] );
 		$this->assertSame( 1, $counts['total_comments'] );
 	}
+
+	/**
+	 * A column-name fields value returns a distinct, flat array of that
+	 * column's values — replacing the common `array_unique( wp_list_pluck() )`
+	 * pattern.
+	 *
+	 * @ticket 65313
+	 *
+	 * @covers WP_Comment_Query::query
+	 */
+	public function test_fields_single_column_returns_distinct_values() {
+		$post1 = self::factory()->post->create();
+		$post2 = self::factory()->post->create();
+
+		// Two comments on post1, one on post2 — expect two distinct post IDs.
+		self::factory()->comment->create( array( 'comment_post_ID' => $post1 ) );
+		self::factory()->comment->create( array( 'comment_post_ID' => $post1 ) );
+		self::factory()->comment->create( array( 'comment_post_ID' => $post2 ) );
+
+		$q     = new WP_Comment_Query();
+		$found = $q->query( array( 'fields' => 'comment_post_ID' ) );
+
+		$this->assertIsArray( $found );
+		$this->assertSameSets( array( (string) $post1, (string) $post2 ), $found );
+	}
+
+	/**
+	 * @ticket 65313
+	 *
+	 * @covers WP_Comment_Query::query
+	 */
+	public function test_fields_single_column_user_id() {
+		$user_id = self::factory()->user->create();
+
+		self::factory()->comment->create(
+			array(
+				'comment_post_ID' => self::$post_id,
+				'user_id'         => $user_id,
+			)
+		);
+		self::factory()->comment->create(
+			array(
+				'comment_post_ID' => self::$post_id,
+				'user_id'         => $user_id,
+			)
+		);
+
+		$q     = new WP_Comment_Query();
+		$found = $q->query(
+			array(
+				'user_id' => $user_id,
+				'fields'  => 'user_id',
+			)
+		);
+
+		$this->assertSame( array( (string) $user_id ), $found );
+	}
+
+	/**
+	 * Column names must be passed in exact case; only the `ID` segment of
+	 * `comment_ID` / `comment_post_ID` accepts arbitrary case.
+	 *
+	 * @ticket 65313
+	 *
+	 * @covers WP_Comment_Query::query
+	 */
+	public function test_fields_id_segment_case_is_flexible() {
+		$post = self::factory()->post->create();
+		self::factory()->comment->create( array( 'comment_post_ID' => $post ) );
+
+		foreach ( array( 'comment_post_ID', 'comment_post_id', 'comment_post_Id' ) as $variant ) {
+			$q     = new WP_Comment_Query();
+			$found = $q->query( array( 'fields' => $variant ) );
+			$this->assertSame( array( (string) $post ), $found, "Variant: $variant" );
+		}
+	}
+
+	/**
+	 * Non-`ID` columns must be passed in their exact case; mismatched case is
+	 * treated as an unknown column and falls back to full WP_Comment objects.
+	 *
+	 * @ticket 65313
+	 *
+	 * @covers WP_Comment_Query::query
+	 */
+	public function test_fields_non_id_column_case_is_strict() {
+		self::factory()->comment->create( array( 'comment_post_ID' => self::$post_id ) );
+
+		$q = new WP_Comment_Query();
+		// 'comment_author_IP' is the canonical form; 'comment_author_ip' must not project.
+		$found = $q->query( array( 'fields' => 'comment_author_ip' ) );
+
+		$this->assertNotEmpty( $found );
+		$this->assertInstanceOf( 'WP_Comment', $found[0] );
+	}
+
+	/**
+	 * `'col_a=>col_b'` returns an associative array keyed by col_a's value
+	 * with col_b's value as the entry. Mirrors WP_Query / WP_Term_Query's
+	 * `'id=>parent'` idiom.
+	 *
+	 * @ticket 65313
+	 *
+	 * @covers WP_Comment_Query::query
+	 */
+	public function test_fields_map_syntax_id_to_post() {
+		$post = self::factory()->post->create();
+		$c1   = self::factory()->comment->create( array( 'comment_post_ID' => $post ) );
+		$c2   = self::factory()->comment->create( array( 'comment_post_ID' => $post ) );
+
+		$q     = new WP_Comment_Query();
+		$found = $q->query(
+			array(
+				'post_id' => $post,
+				'fields'  => 'comment_ID=>comment_post_ID',
+			)
+		);
+
+		$this->assertIsArray( $found );
+		$this->assertCount( 2, $found );
+		$this->assertArrayHasKey( $c1, $found );
+		$this->assertArrayHasKey( $c2, $found );
+		$this->assertEquals( $post, $found[ $c1 ] );
+		$this->assertEquals( $post, $found[ $c2 ] );
+	}
+
+	/**
+	 * The map form accepts the same case rules as single-column form: the `ID`
+	 * suffix is case-flexible on either side of `=>`.
+	 *
+	 * @ticket 65313
+	 *
+	 * @covers WP_Comment_Query::query
+	 */
+	public function test_fields_map_syntax_accepts_id_case_variants() {
+		$post = self::factory()->post->create();
+		$c1   = self::factory()->comment->create( array( 'comment_post_ID' => $post ) );
+
+		$q     = new WP_Comment_Query();
+		$found = $q->query( array( 'fields' => 'comment_id=>comment_post_id' ) );
+
+		$this->assertArrayHasKey( $c1, $found );
+		$this->assertEquals( $post, $found[ $c1 ] );
+	}
+
+	/**
+	 * Passing an array of columns returns an array of `stdClass` rows with
+	 * those properties populated. No `DISTINCT` is applied — the caller gets
+	 * one row per matched comment.
+	 *
+	 * @ticket 65313
+	 *
+	 * @covers WP_Comment_Query::query
+	 */
+	public function test_fields_array_returns_stdclass_rows() {
+		$post = self::factory()->post->create();
+		$c1   = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => $post,
+				'comment_approved' => '1',
+			)
+		);
+		$c2   = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => $post,
+				'comment_approved' => '1',
+			)
+		);
+
+		$q     = new WP_Comment_Query();
+		$found = $q->query(
+			array(
+				'post_id' => $post,
+				'fields'  => array( 'comment_ID', 'comment_post_ID' ),
+			)
+		);
+
+		$this->assertCount( 2, $found );
+		$this->assertInstanceOf( 'stdClass', $found[0] );
+		$this->assertObjectHasProperty( 'comment_ID', $found[0] );
+		$this->assertObjectHasProperty( 'comment_post_ID', $found[0] );
+
+		$ids = wp_list_pluck( $found, 'comment_ID' );
+		$this->assertEqualSets( array( $c1, $c2 ), array_map( 'intval', $ids ) );
+	}
+
+	/**
+	 * Array form returns one row per matched comment — no `DISTINCT`, unlike
+	 * the single-column form.
+	 *
+	 * @ticket 65313
+	 *
+	 * @covers WP_Comment_Query::query
+	 */
+	public function test_fields_array_does_not_distinct() {
+		$post = self::factory()->post->create();
+		self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => $post,
+				'comment_approved' => '1',
+			)
+		);
+		self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => $post,
+				'comment_approved' => '1',
+			)
+		);
+		self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => $post,
+				'comment_approved' => '1',
+			)
+		);
+
+		$q     = new WP_Comment_Query();
+		$found = $q->query(
+			array(
+				'post_id' => $post,
+				// Three rows with identical (comment_post_ID, comment_approved);
+				// without DISTINCT we should see all three.
+				'fields'  => array( 'comment_post_ID', 'comment_approved' ),
+			)
+		);
+
+		$this->assertCount( 3, $found );
+	}
+
+	/**
+	 * `fields` results are cached separately from the base comment-ID query,
+	 * so a repeat call short-circuits both the base SELECT and the projection
+	 * SELECT.
+	 *
+	 * @ticket 65313
+	 *
+	 * @covers WP_Comment_Query::query
+	 */
+	public function test_fields_result_is_cached() {
+		global $wpdb;
+
+		$post = self::factory()->post->create();
+		self::factory()->comment->create( array( 'comment_post_ID' => $post ) );
+		self::factory()->comment->create( array( 'comment_post_ID' => $post ) );
+
+		$args = array(
+			'post_id' => $post,
+			'fields'  => 'comment_post_ID',
+		);
+
+		// Warm both caches.
+		( new WP_Comment_Query() )->query( $args );
+
+		$queries_before = $wpdb->num_queries;
+		$found          = ( new WP_Comment_Query() )->query( $args );
+		$queries_after  = $wpdb->num_queries;
+
+		$this->assertSame( $queries_before, $queries_after, 'Repeat query should hit the cache and run zero SQL queries.' );
+		$this->assertSame( array( (string) $post ), $found );
+	}
+
+	/**
+	 * Mutating a comment must bust the projection cache via the comment
+	 * last_changed salt.
+	 *
+	 * @ticket 65313
+	 *
+	 * @covers WP_Comment_Query::query
+	 */
+	public function test_fields_cache_invalidates_on_mutation() {
+		$post1 = self::factory()->post->create();
+		$post2 = self::factory()->post->create();
+
+		$c1 = self::factory()->comment->create( array( 'comment_post_ID' => $post1 ) );
+
+		$args = array(
+			'post__in' => array( $post1, $post2 ),
+			'fields'   => 'comment_post_ID',
+		);
+
+		$this->assertSame( array( (string) $post1 ), ( new WP_Comment_Query() )->query( $args ) );
+
+		self::factory()->comment->create( array( 'comment_post_ID' => $post2 ) );
+
+		$this->assertEqualSets(
+			array( (string) $post1, (string) $post2 ),
+			( new WP_Comment_Query() )->query( $args )
+		);
+	}
+
+	/**
+	 * A `=>` with an unknown column on either side is not a valid map and
+	 * falls back to full `WP_Comment` objects.
+	 *
+	 * @ticket 65313
+	 *
+	 * @covers WP_Comment_Query::query
+	 */
+	public function test_fields_map_syntax_unknown_column_falls_back() {
+		self::factory()->comment->create( array( 'comment_post_ID' => self::$post_id ) );
+
+		$q     = new WP_Comment_Query();
+		$found = $q->query( array( 'fields' => 'comment_ID=>not_a_column' ) );
+
+		$this->assertNotEmpty( $found );
+		$this->assertInstanceOf( 'WP_Comment', $found[0] );
+	}
+
+	/**
+	 * @ticket 65313
+	 *
+	 * @covers WP_Comment_Query::query
+	 */
+	public function test_fields_unknown_column_falls_back_to_full_objects() {
+		self::factory()->comment->create( array( 'comment_post_ID' => self::$post_id ) );
+
+		$q     = new WP_Comment_Query();
+		$found = $q->query( array( 'fields' => 'not_a_real_column' ) );
+
+		$this->assertNotEmpty( $found );
+		$this->assertInstanceOf( 'WP_Comment', $found[0] );
+	}
+
+	/**
+	 * @ticket 65313
+	 *
+	 * @covers WP_Comment_Query::query
+	 */
+	public function test_fields_ids_behavior_is_unchanged() {
+		$c1 = self::factory()->comment->create( array( 'comment_post_ID' => self::$post_id ) );
+		$c2 = self::factory()->comment->create( array( 'comment_post_ID' => self::$post_id ) );
+
+		$q     = new WP_Comment_Query();
+		$found = $q->query( array( 'fields' => 'ids' ) );
+
+		$this->assertSameSets( array( $c1, $c2 ), $found );
+		// Legacy contract: comment IDs are returned as integers, not strings.
+		foreach ( $found as $id ) {
+			$this->assertIsInt( $id );
+		}
+	}
+
+	/**
+	 * @ticket 65313
+	 *
+	 * @covers WP_Comment_Query::query
+	 */
+	public function test_fields_empty_result_set_returns_empty_array() {
+		$q     = new WP_Comment_Query();
+		$found = $q->query(
+			array(
+				'post_id' => PHP_INT_MAX,
+				'fields'  => 'comment_post_ID',
+			)
+		);
+
+		$this->assertSame( array(), $found );
+	}
 }


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65313

## Summary

Extends `WP_Comment_Query`'s `fields` argument to accept:

- A column name from `$wpdb->comments` (e.g. `'comment_post_ID'`) — returns a flat array of **distinct** values for that column.
- A `'col_a=>col_b'` pair (e.g. `'comment_ID=>comment_post_ID'`) — returns an associative array keyed by col_a's value with col_b's value as the entry, mirroring the `'id=>parent'` idiom in `WP_Query` and `WP_Term_Query`.

`'ids'` and `''` (default) are unchanged — the new behaviour is purely additive.

## Why

Plugins that want "the distinct `comment_post_ID`s matching X" have three options today, none good:

1. `fields => ''` + `array_column( $q->comments, 'comment_post_ID' )` — hydrates every matched comment just to discard all but one field.
2. `fields => 'ids'` + `get_comment( $id )->comment_post_ID` in a loop — N+1 cache lookups.
3. Drop to raw SQL — bypasses filters, caching, and meta-query.

In the gp-translation-helpers reference case in the Trac ticket, hydrating ~32K comments to extract distinct post IDs took ~6.6s; the equivalent raw SQL returned the same 25,694 IDs in ~610ms (~11x speedup, all of it from skipping hydration).

## API

```php
// Distinct comment_post_IDs — replaces array_unique( wp_list_pluck( ... ) ).
$post_ids = ( new WP_Comment_Query() )->query( array(
    'meta_key'   => 'locale',
    'meta_value' => 'nl',
    'user_id'    => 42,
    'fields'     => 'comment_post_ID',
) );

// [ comment_ID => comment_post_ID ] map — same shape as WP_Query's 'id=>parent'.
$by_id = ( new WP_Comment_Query() )->query( array(
    'post_id' => $post_id,
    'fields'  => 'comment_ID=>comment_post_ID',
) );
```

Column names must be passed in their exact case. The only exception is the `ID` suffix of `comment_ID` / `comment_post_ID`, which is accepted in any case (`comment_id`, `comment_Id`, `comment_ID`). Unknown columns fall through to the default behaviour (`WP_Comment` objects), keeping the path forward-compatible.

## Test plan

- [x] `npm run test:php -- tests/phpunit/tests/comment/query.php` — 166 tests / 489 assertions pass.
- [x] `npm run test:php -- --group comment` — 540 tests / 1367 assertions pass (no regressions).
- [x] New tests cover:
  - Single-column form returns distinct values.
  - `'col_a=>col_b'` map form returns associative array.
  - Case-flexibility of the `ID` suffix on both sides of `=>`; strict case for non-`ID` columns.
  - Unknown column (single + map form) falls back to full `WP_Comment` objects.
  - `'ids'` semantics unchanged.
  - Empty result sets return `array()` without a follow-up query.
- [x] `phpcs --standard=phpcs.xml.dist` clean on both changed files (only pre-existing warnings on untouched lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)