### PR TITLE
58764: Fix return type and improve regex safety in WP_Rewrite::using_index_permalinks()

### DIFF
--- a/src/wp-includes/class-wp-rewrite.php
+++ b/src/wp-includes/class-wp-rewrite.php
@@ -369,7 +369,10 @@ class WP_Rewrite {
 		}
 
 		// If the index is not in the permalink, we're using mod_rewrite.
-		return preg_match( '#^/*' . $this->index . '#', $this->permalink_structure );
+		return (bool) preg_match(
+			'#^/*' . preg_quote( $this->index, '#' ) . '#',
+			$this->permalink_structure
+		);
 	}
 
 	/**

--- a/tests/phpunit/tests/rewrite.php
+++ b/tests/phpunit/tests/rewrite.php
@@ -504,4 +504,34 @@ class Tests_Rewrite extends WP_UnitTestCase {
 		$this->assertIsArray( $rewrite_rules );
 		$this->assertNotEmpty( $rewrite_rules );
 	}
+
+	/**
+	 * @ticket 58764
+	 */
+	public function test_using_index_permalinks_returns_bool() {
+		global $wp_rewrite;
+
+		$wp_rewrite->init();
+
+		$wp_rewrite->set_permalink_structure( '/index.php/%postname%/' );
+
+		$this->assertTrue( $wp_rewrite->using_index_permalinks() );
+
+		$wp_rewrite->set_permalink_structure( '/%postname%/' );
+
+		$this->assertFalse( $wp_rewrite->using_index_permalinks() );
+	}
+
+	/**
+	 * @ticket 58764
+	 */
+	public function test_using_index_permalinks_escaped_index() {
+		global $wp_rewrite;
+
+		$wp_rewrite->index = 'index#.php';
+
+		$wp_rewrite->set_permalink_structure( '/index#.php/%postname%/' );
+
+		$this->assertTrue( $wp_rewrite->using_index_permalinks() );
+	}
 }


### PR DESCRIPTION
### Summary

This change fixes the return type consistency of `WP_Rewrite::using_index_permalinks()` and improves regex safety.

### Changes included

* Casts the return value of `preg_match()` to `bool` to ensure the method always returns a boolean value as documented.
* Uses `preg_quote()` on `$this->index` to prevent potential regex issues when special characters are present.
* Aligns actual behavior with documented return type (`bool`), improving consistency and developer expectations.

### Rationale

Currently, `using_index_permalinks()` returns the raw result of `preg_match()`, which can be `1`, `0`, or `false`. This does not match the documented return type of `bool`.

Additionally, the regex pattern is vulnerable to unexpected behavior if `$this->index` contains special regex characters. While unlikely in core usage, escaping it improves robustness and prevents edge-case false positives.

### Testing

* Verified existing permalink behavior remains unchanged.
* Added/updated unit tests covering:

  * Standard permalink structure with `/index.php/`
  * Non-index permalink structure
  * Handling of special characters in `$index`

### Trac ticket

https://core.trac.wordpress.org/ticket/58764

---

This Pull Request is for code review only. Please keep all discussion in the Trac ticket. No merge action is required on GitHub.
