### PR TITLE
Use user_email error code for malformed email on registration and profile

### DIFF
--- a/src/wp-admin/includes/user.php
+++ b/src/wp-admin/includes/user.php
@@ -206,7 +206,7 @@ function edit_user( $user_id = 0 ) {
 	if ( empty( $user->user_email ) ) {
 		$errors->add( 'empty_email', __( '<strong>Error:</strong> Please enter an email address.' ), array( 'form-field' => 'email' ) );
 	} elseif ( ! is_email( $user->user_email ) ) {
-		$errors->add( 'invalid_email', __( '<strong>Error:</strong> The email address is not correct.' ), array( 'form-field' => 'email' ) );
+		$errors->add( 'user_email', __( '<strong>Error:</strong> The email address is not correct.' ), array( 'form-field' => 'email' ) );
 	} else {
 		$owner_id = email_exists( $user->user_email );
 		if ( $owner_id && ( ! $update || ( $owner_id !== $user->ID ) ) ) {

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -3560,7 +3560,7 @@ function register_new_user( $user_login, $user_email ) {
 	if ( '' === $user_email ) {
 		$errors->add( 'empty_email', __( '<strong>Error:</strong> Please type your email address.' ) );
 	} elseif ( ! is_email( $user_email ) ) {
-		$errors->add( 'invalid_email', __( '<strong>Error:</strong> The email address is not correct.' ) );
+		$errors->add( 'user_email', __( '<strong>Error:</strong> The email address is not correct.' ) );
 		$user_email = '';
 	} elseif ( email_exists( $user_email ) ) {
 		$errors->add(

--- a/src/wp-login.php
+++ b/src/wp-login.php
@@ -56,7 +56,7 @@ function login_header( $title = null, $message = '', $wp_error = null ) {
 	}
 
 	// Shake it!
-	$shake_error_codes = array( 'empty_password', 'empty_email', 'invalid_email', 'invalidcombo', 'empty_username', 'invalid_username', 'incorrect_password', 'retrieve_password_email_failure' );
+	$shake_error_codes = array( 'empty_password', 'empty_email', 'invalid_email', 'user_email', 'invalidcombo', 'empty_username', 'invalid_username', 'incorrect_password', 'retrieve_password_email_failure' );
 	/**
 	 * Filters the error codes array for shaking the login form.
 	 *

--- a/tests/phpunit/tests/user.php
+++ b/tests/phpunit/tests/user.php
@@ -1202,6 +1202,40 @@ class Tests_User extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Malformed email addresses should use the user_email error code.
+	 *
+	 * @ticket 60737
+	 */
+	public function test_register_new_user_invalid_email_format_uses_user_email_error_code() {
+		$response = register_new_user( 'testuser60737', 'not-an-email' );
+
+		$this->assertInstanceOf( 'WP_Error', $response );
+		$this->assertSame( 'user_email', $response->get_error_code() );
+	}
+
+	/**
+	 * Malformed email addresses should use the user_email error code.
+	 *
+	 * @ticket 60737
+	 */
+	public function test_edit_user_invalid_email_format_uses_user_email_error_code() {
+		$user_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		$user    = get_userdata( $user_id );
+
+		$_POST['email']        = 'not-an-email';
+		$_POST['user_login']   = $user->user_login;
+		$_POST['nickname']     = $user->nickname;
+		$_POST['first_name']   = $user->first_name;
+		$_POST['last_name']    = $user->last_name;
+		$_POST['display_name'] = $user->display_name;
+
+		$response = edit_user( $user_id );
+
+		$this->assertInstanceOf( 'WP_Error', $response );
+		$this->assertSame( 'user_email', $response->get_error_code() );
+	}
+
+	/**
 	 * @ticket 27317
 	 * @group ms-required
 	 */


### PR DESCRIPTION
WordPress currently uses the invalid_email error code for two different situations:

Login / password reset — no user exists for the given email address.
Registration / profile update — the email fails is_email() format validation.
That overlap makes it hard for plugins and themes to branch on error type without inspecting translated message strings.

This change aligns format-validation errors with the existing user_email convention (already used in multisite signup validation):

user_email — malformed email on registration (register_new_user()) and profile/user edit (edit_user()).
invalid_email — unchanged for unknown/unregistered email during login, application passwords, and password reset.
Also adds user_email to the login form shake error codes in wp-login.php so registration errors shake the form consistently.

Includes PHPUnit coverage for both registration and profile validation paths.

Backward compatibility: Code that checks invalid_email only on registration or profile update for format errors will need to handle user_email as well.

Trac ticket: https://core.trac.wordpress.org/ticket/60737

Use of AI Tools
AI assistance: Yes
Tool(s): Cursor (Auto)
Used for: Exploring the codebase and drafting this PR description. Final code was edited and reviewed by me.

This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request.