### PR TITLE
Editor: Add native tooltips for meta box order buttons

### DIFF
--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -3345,6 +3345,50 @@ img {
 	outline: 1px solid transparent;
 }
 
+.postbox .handle-order-higher,
+.postbox .handle-order-lower {
+	position: relative;
+}
+
+.postbox-order-tooltip {
+	display: none;
+	position: absolute;
+	bottom: calc( 100% + 6px );
+	left: 50%;
+	transform: translateX( -50% );
+	padding: 6px 8px;
+	border-radius: 4px;
+	background-color: #1d2327;
+	color: #fff;
+	font-size: 12px;
+	font-weight: 400;
+	line-height: 1.4;
+	white-space: nowrap;
+	z-index: 100000;
+	pointer-events: none;
+}
+
+.postbox .handle-order-higher:is( :hover, :focus-visible ) .postbox-order-tooltip,
+.postbox .handle-order-lower:is( :hover, :focus-visible ) .postbox-order-tooltip {
+	display: block;
+}
+
+@supports ( anchor-name: --tooltip ) and ( position-anchor: --tooltip ) {
+	.postbox .handle-order-higher,
+	.postbox .handle-order-lower {
+		anchor-scope: all;
+		anchor-name: --postbox-order-button;
+	}
+
+	.postbox-order-tooltip {
+		position: fixed;
+		position-anchor: --postbox-order-button;
+		bottom: anchor( top );
+		left: anchor( center );
+		transform: translateX( -50% ) translateY( -6px );
+	}
+}
+
 /* @todo: appears to be Press This only and overridden */
 #photo-add-url-div input[type="text"] {
 	width: 300px;

--- a/src/wp-admin/includes/template.php
+++ b/src/wp-admin/includes/template.php
@@ -1403,6 +1403,10 @@ function do_meta_boxes( $screen, $context, $data_object ) {
 							__( 'Move up' ) .
 						'</span>';
 						echo '<span class="order-higher-indicator" aria-hidden="true"></span>';
+						echo '<span class="postbox-order-tooltip" aria-hidden="true">' .
+							/* translators: Tooltip for the meta box move up button. */
+							esc_html__( 'Move up' ) .
+						'</span>';
 						echo '</button>';
 						echo '<span class="hidden" id="' . $box['id'] . '-handle-order-higher-description">' . sprintf(
 							/* translators: %s: Meta box title. */
@@ -1416,6 +1420,10 @@ function do_meta_boxes( $screen, $context, $data_object ) {
 							__( 'Move down' ) .
 						'</span>';
 						echo '<span class="order-lower-indicator" aria-hidden="true"></span>';
+						echo '<span class="postbox-order-tooltip" aria-hidden="true">' .
+							/* translators: Tooltip for the meta box move down button. */
+							esc_html__( 'Move down' ) .
+						'</span>';
 						echo '</button>';
 						echo '<span class="hidden" id="' . $box['id'] . '-handle-order-lower-description">' . sprintf(
 							/* translators: %s: Meta box title. */

--- a/tests/phpunit/tests/admin/includesTemplate.php
+++ b/tests/phpunit/tests/admin/includesTemplate.php
@@ -510,4 +510,29 @@ class Tests_Admin_IncludesTemplate extends WP_UnitTestCase {
 		$result = get_post_states( null );
 		$this->assertSame( array(), $result, 'get_post_states() should return an empty array when WP_Post is not supplied.' );
 	}
+
+	/**
+	 * @ticket 50921
+	 *
+	 * @covers ::do_meta_boxes
+	 */
+	public function test_do_meta_boxes_order_buttons_include_tooltips() {
+		global $wp_meta_boxes;
+
+		set_current_screen( 'post' );
+
+		add_meta_box( 'testbox50921', 'Test Metabox', '__return_false', 'post' );
+
+		ob_start();
+		do_meta_boxes( 'post', 'advanced', null );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'postbox-order-tooltip', $output );
+		$this->assertStringContainsString( 'handle-order-higher', $output );
+		$this->assertStringContainsString( 'handle-order-lower', $output );
+		$this->assertStringContainsString( 'Move up', $output );
+		$this->assertStringContainsString( 'Move down', $output );
+
+		remove_meta_box( 'testbox50921', 'post', 'advanced' );
+	}
 }


### PR DESCRIPTION
## Summary

- Adds visible tooltips to the meta box order up/down buttons in the post editor.
- Uses CSS anchor positioning with an absolute-position fallback, shown on hover and keyboard focus (`:focus-visible`).
- Avoids `title` attributes in favor of accessible, supplemental visual hints while preserving existing `screen-reader-text` and `aria-describedby` behavior.

## Why

Sighted users had no visual hint for what the meta box order indicator buttons do. Core has moved away from `title` attributes for accessibility reasons ([#24766](https://core.trac.wordpress.org/ticket/24766)). Per recent committer feedback on the ticket, this uses native CSS tooltips now that CSS anchor positioning meets WordPress browser support criteria.

## Changes

- `src/wp-admin/includes/template.php` — Output `postbox-order-tooltip` spans inside order buttons.
- `src/wp-admin/css/common.css` — Tooltip styling and anchor-positioning support.
- `tests/phpunit/tests/admin/includesTemplate.php` — Assert tooltip markup is rendered by `do_meta_boxes()`.

Props ibachal. Fixes #50921.

Trac ticket: https://core.trac.wordpress.org/ticket/50921


## Use of AI Tools
AI assistance: Yes
Tool(s): Cursor
Model(s): GPT-5.1
Used for: testing purposes; final implementation and tests were reviewed and edited by me.

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
