### PR TITLE
I18N: Document wp-includes/pomo as the canonical pomo library source

### DIFF
--- a/src/wp-includes/pomo/entry.php
+++ b/src/wp-includes/pomo/entry.php
@@ -1,10 +1,10 @@
 <?php
 /**
- * Contains Translation_Entry class
+ * Contains Translation_Entry class.
  *
- * @version $Id: entry.php 1157 2015-11-20 04:30:11Z dd32 $
  * @package pomo
  * @subpackage entry
+ * @since 2.8.0
  */
 
 if ( ! class_exists( 'Translation_Entry', false ) ) :

--- a/src/wp-includes/pomo/mo.php
+++ b/src/wp-includes/pomo/mo.php
@@ -1,10 +1,10 @@
 <?php
 /**
- * Class for working with MO files
+ * Class for working with MO files.
  *
- * @version $Id: mo.php 1157 2015-11-20 04:30:11Z dd32 $
  * @package pomo
  * @subpackage mo
+ * @since 2.8.0
  */
 
 require_once __DIR__ . '/translations.php';

--- a/src/wp-includes/pomo/plural-forms.php
+++ b/src/wp-includes/pomo/plural-forms.php
@@ -3,6 +3,7 @@
 /**
  * A gettext Plural-Forms parser.
  *
+ * @package pomo
  * @since 4.9.0
  */
 if ( ! class_exists( 'Plural_Forms', false ) ) :

--- a/src/wp-includes/pomo/po.php
+++ b/src/wp-includes/pomo/po.php
@@ -1,10 +1,10 @@
 <?php
 /**
- * Class for working with PO files
+ * Class for working with PO files.
  *
- * @version $Id: po.php 1158 2015-11-20 04:31:23Z dd32 $
  * @package pomo
  * @subpackage po
+ * @since 2.8.0
  */
 
 require_once __DIR__ . '/translations.php';

--- a/src/wp-includes/pomo/streams.php
+++ b/src/wp-includes/pomo/streams.php
@@ -3,9 +3,9 @@
  * Classes, which help reading streams of data from files.
  * Based on the classes from Danilo Segan <danilo@kvota.net>
  *
- * @version $Id: streams.php 1157 2015-11-20 04:30:11Z dd32 $
  * @package pomo
  * @subpackage streams
+ * @since 2.8.0
  */
 
 if ( ! class_exists( 'POMO_Reader', false ) ) :

--- a/src/wp-includes/pomo/translations.php
+++ b/src/wp-includes/pomo/translations.php
@@ -1,8 +1,12 @@
 <?php
 /**
- * Class for a set of entries for translation and their associated headers
+ * Class for a set of entries for translation and their associated headers.
  *
- * @version $Id: translations.php 1157 2015-11-20 04:30:11Z dd32 $
+ * The wp-includes/pomo/ directory is the canonical upstream copy of the pomo
+ * library (PO/MO file reading and writing, translations, and plural-form helpers).
+ * All changes to the library should be made here and reviewed under the I18N
+ * component.
+ *
  * @package pomo
  * @subpackage translations
  * @since 2.8.0


### PR DESCRIPTION
## Summary

- Documents `wp-includes/pomo/` as the canonical upstream copy of the pomo library in `translations.php`.
- Removes legacy SVN `@version $Id:` headers from pomo library files, remnants of the former GlotPress SVN sync workflow.
- Adds consistent `@package pomo` and `@since` tags across all pomo library files.

This implements the proposal in [#65314](https://core.trac.wordpress.org/ticket/65314) to retire the dual-source arrangement where `glotpress.svn.wordpress.org/trunk/pomo/` was treated as upstream. Core is now the sole maintained copy; GlotPress consumes it at runtime.

The GlotPress SVN `sample/` fixtures are left as a frozen archive per the ticket — core already has comprehensive pomo test fixtures in `tests/phpunit/data/pomo/`.

## Test plan

- [x] `composer lint -- src/wp-includes/pomo/` — 0 errors
- [x] `npm run test:php -- --group pomo` — 48 tests passed
- [ ] Confirm with @ocean90 and @amieiro (cc'd on the ticket by @dd32)

Trac ticket: https://core.trac.wordpress.org/ticket/65314

## Use of AI Tools
N/A

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**