### PR TITLE
Editor: Preload REST requests the post editor fetches on mount

### DIFF
--- a/src/wp-admin/edit-form-blocks.php
+++ b/src/wp-admin/edit-form-blocks.php
@@ -115,6 +115,13 @@ $preload_paths = array(
 		$template_lookup_slug,
 		'/wp/v2/templates/lookup'
 	),
+	'/wp/v2/templates/lookup?slug=front-page',
+	'/wp/v2/taxonomies?context=edit',
+	array( rest_get_route_for_post_type_items( $post_type ), 'OPTIONS' ),
+	sprintf(
+		'/wp/v2/users/%d?context=view&_fields=id,name',
+		(int) $post->post_author
+	),
 );
 
 block_editor_rest_api_preload( $preload_paths, $block_editor_context );

--- a/src/wp-admin/edit-form-blocks.php
+++ b/src/wp-admin/edit-form-blocks.php
@@ -118,11 +118,14 @@ $preload_paths = array(
 	'/wp/v2/templates/lookup?slug=front-page',
 	'/wp/v2/taxonomies?context=edit',
 	array( rest_get_route_for_post_type_items( $post_type ), 'OPTIONS' ),
-	sprintf(
+);
+
+if ( post_type_supports( $post_type, 'author' ) && $post->post_author > 0 ) {
+	$preload_paths[] = sprintf(
 		'/wp/v2/users/%d?context=view&_fields=id,name',
 		(int) $post->post_author
-	),
-);
+	);
+}
 
 block_editor_rest_api_preload( $preload_paths, $block_editor_context );
 


### PR DESCRIPTION
## What?

Adds four entries to `$preload_paths` in `wp-admin/edit-form-blocks.php`:

- `/wp/v2/templates/lookup?slug=front-page`: homepage actions (`getDefaultTemplateId`)
- `/wp/v2/taxonomies?context=edit`: taxonomies panel
- `OPTIONS` on the current post-type collection: `canUser` permission probe
- `/wp/v2/users/{author}?context=view&_fields=id,name`: post-author display name (only when the post type supports author)

## Why?

The post editor fetches all four on first mount. Preloading them serves the data from the inline cache and removes network round-trips from the boot path. Unbounded `per_page=-1` queries (comments, `wp_pattern_category`) are deliberately not preloaded.

## Gutenberg counterpart

https://github.com/WordPress/gutenberg/pull/78565

## Trac ticket

https://core.trac.wordpress.org/ticket/65636

## Testing

Gutenberg's preload spec (`test/e2e/specs/preload/post-editor.spec.js`) asserts these URLs no longer fire as post-mount network requests.


