### PR TITLE
Coding Standards: Use more meaningful variable names in wp-admin media/files

### DIFF
--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -914,7 +914,7 @@ function _wp_handle_upload( &$file, $overrides, $time, $action ) {
 	$test_form = $overrides['test_form'] ?? true;
 	$test_size = $overrides['test_size'] ?? true;
 
-	// If you override this, you must provide $ext and $type!!
+	// If you override this, you must provide $extension and $type!!
 	$test_type = $overrides['test_type'] ?? true;
 	$mimes     = $overrides['mimes'] ?? null;
 
@@ -955,7 +955,7 @@ function _wp_handle_upload( &$file, $overrides, $time, $action ) {
 	// A correct MIME type will pass this test. Override $mimes or use the upload_mimes filter.
 	if ( $test_type ) {
 		$wp_filetype     = wp_check_filetype_and_ext( $file['tmp_name'], $file['name'], $mimes );
-		$ext             = empty( $wp_filetype['ext'] ) ? '' : $wp_filetype['ext'];
+		$extension       = empty( $wp_filetype['ext'] ) ? '' : $wp_filetype['ext'];
 		$type            = empty( $wp_filetype['type'] ) ? '' : $wp_filetype['type'];
 		$proper_filename = empty( $wp_filetype['proper_filename'] ) ? '' : $wp_filetype['proper_filename'];
 
@@ -964,7 +964,7 @@ function _wp_handle_upload( &$file, $overrides, $time, $action ) {
 			$file['name'] = $proper_filename;
 		}
 
-		if ( ( ! $type || ! $ext ) && ! current_user_can( 'unfiltered_upload' ) ) {
+		if ( ( ! $type || ! $extension ) && ! current_user_can( 'unfiltered_upload' ) ) {
 			return call_user_func_array( $upload_error_handler, array( &$file, __( 'Sorry, you are not allowed to upload this file type.' ) ) );
 		}
 

--- a/src/wp-admin/includes/image-edit.php
+++ b/src/wp-admin/includes/image-edit.php
@@ -985,18 +985,18 @@ function wp_save_image( $post_id ) {
 	// Generate new filename.
 	$path = get_attached_file( $post_id );
 
-	$basename = pathinfo( $path, PATHINFO_BASENAME );
-	$dirname  = pathinfo( $path, PATHINFO_DIRNAME );
-	$ext      = pathinfo( $path, PATHINFO_EXTENSION );
-	$filename = pathinfo( $path, PATHINFO_FILENAME );
-	$suffix   = time() . rand( 100, 999 );
+	$basename  = pathinfo( $path, PATHINFO_BASENAME );
+	$dirname   = pathinfo( $path, PATHINFO_DIRNAME );
+	$extension = pathinfo( $path, PATHINFO_EXTENSION );
+	$filename  = pathinfo( $path, PATHINFO_FILENAME );
+	$suffix    = time() . rand( 100, 999 );
 
 	if ( defined( 'IMAGE_EDIT_OVERWRITE' ) && IMAGE_EDIT_OVERWRITE
 		&& isset( $backup_sizes['full-orig'] ) && $backup_sizes['full-orig']['file'] !== $basename
 	) {
 
 		if ( $edit_thumbnails_separately && 'thumbnail' === $target ) {
-			$new_path = "{$dirname}/{$filename}-temp.{$ext}";
+			$new_path = "{$dirname}/{$filename}-temp.{$extension}";
 		} else {
 			$new_path = $path;
 		}
@@ -1004,7 +1004,7 @@ function wp_save_image( $post_id ) {
 		while ( true ) {
 			$filename     = preg_replace( '/-e([0-9]+)$/', '', $filename );
 			$filename    .= "-e{$suffix}";
-			$new_filename = "{$filename}.{$ext}";
+			$new_filename = "{$filename}.{$extension}";
 			$new_path     = "{$dirname}/$new_filename";
 
 			if ( file_exists( $new_path ) ) {

--- a/src/wp-admin/includes/image.php
+++ b/src/wp-admin/includes/image.php
@@ -622,19 +622,19 @@ function wp_generate_attachment_metadata( $attachment_id, $file ) {
 		if ( ! empty( $exists ) ) {
 			update_post_meta( $attachment_id, '_thumbnail_id', $exists );
 		} else {
-			$ext = '.jpg';
+			$extension = '.jpg';
 			switch ( $metadata['image']['mime'] ) {
 				case 'image/gif':
-					$ext = '.gif';
+					$extension = '.gif';
 					break;
 				case 'image/png':
-					$ext = '.png';
+					$extension = '.png';
 					break;
 				case 'image/webp':
-					$ext = '.webp';
+					$extension = '.webp';
 					break;
 			}
-			$basename = str_replace( '.', '-', wp_basename( $file ) ) . '-image' . $ext;
+			$basename = str_replace( '.', '-', wp_basename( $file ) ) . '-image' . $extension;
 			$uploaded = wp_upload_bits( $basename, '', $metadata['image']['data'] );
 			if ( false === $uploaded['error'] ) {
 				$image_attachment = array(
@@ -703,8 +703,8 @@ function wp_generate_attachment_metadata( $attachment_id, $file ) {
 				 * Ensure the PDF preview image does not overwrite any JPEG images that already exist.
 				 */
 				$dirname      = dirname( $file ) . '/';
-				$ext          = '.' . pathinfo( $file, PATHINFO_EXTENSION );
-				$preview_file = $dirname . wp_unique_filename( $dirname, wp_basename( $file, $ext ) . '-pdf.jpg' );
+				$extension    = '.' . pathinfo( $file, PATHINFO_EXTENSION );
+				$preview_file = $dirname . wp_unique_filename( $dirname, wp_basename( $file, $extension ) . '-pdf.jpg' );
 
 				$uploaded = $editor->save( $preview_file, 'image/jpeg' );
 				unset( $editor );

--- a/src/wp-admin/includes/media.php
+++ b/src/wp-admin/includes/media.php
@@ -310,9 +310,9 @@ function media_handle_upload( $file_id, $post_id, $post_data = array(), $overrid
 		return new WP_Error( 'upload_error', $file['error'] );
 	}
 
-	$name = $_FILES[ $file_id ]['name'];
-	$ext  = pathinfo( $name, PATHINFO_EXTENSION );
-	$name = wp_basename( $name, ".$ext" );
+	$name      = $_FILES[ $file_id ]['name'];
+	$extension = pathinfo( $name, PATHINFO_EXTENSION );
+	$name      = wp_basename( $name, ".$extension" );
 
 	$url     = $file['url'];
 	$type    = $file['type'];
@@ -921,13 +921,13 @@ function wp_media_upload_handler() {
 				$html = "<a href='" . esc_url( $src ) . "'>$title</a>";
 			}
 
-			$type = 'file';
-			$ext  = preg_replace( '/^.+?\.([^.]+)$/', '$1', $src );
+			$type      = 'file';
+			$extension = preg_replace( '/^.+?\.([^.]+)$/', '$1', $src );
 
-			if ( $ext ) {
-				$ext_type = wp_ext2type( $ext );
-				if ( 'audio' === $ext_type || 'video' === $ext_type ) {
-					$type = $ext_type;
+			if ( $extension ) {
+				$extension_type = wp_ext2type( $extension );
+				if ( 'audio' === $extension_type || 'video' === $extension_type ) {
+					$type = $extension_type;
 				}
 			}
 

--- a/src/wp-admin/includes/post.php
+++ b/src/wp-admin/includes/post.php
@@ -350,17 +350,17 @@ function edit_post( $post_data = null ) {
 	}
 
 	if ( 'attachment' === $post_data['post_type'] && preg_match( '#^(audio|video)/#', $post_data['post_mime_type'] ) ) {
-		$id3data = wp_get_attachment_metadata( $post_id );
-		if ( ! is_array( $id3data ) ) {
-			$id3data = array();
+		$id3_data = wp_get_attachment_metadata( $post_id );
+		if ( ! is_array( $id3_data ) ) {
+			$id3_data = array();
 		}
 
 		foreach ( wp_get_attachment_id3_keys( $post, 'edit' ) as $key => $label ) {
 			if ( isset( $post_data[ 'id3_' . $key ] ) ) {
-				$id3data[ $key ] = sanitize_text_field( wp_unslash( $post_data[ 'id3_' . $key ] ) );
+				$id3_data[ $key ] = sanitize_text_field( wp_unslash( $post_data[ 'id3_' . $key ] ) );
 			}
 		}
-		wp_update_attachment_metadata( $post_id, $id3data );
+		wp_update_attachment_metadata( $post_id, $id3_data );
 	}
 
 	// Meta stuff.


### PR DESCRIPTION
Renames abbreviated local variables in wp-admin media and file handling code to follow WordPress [Naming Conventions](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#naming-conventions):
- `$ext` → `$extension`
- `$ext_type` → `$extension_type`
- `$id3data` → `$id3_data`
Follow-up to [61224].

Trac ticket: https://core.trac.wordpress.org/ticket/64897
