### PR TITLE
Upgrade/Install: Remove accidentally shipped RTC files on upgrade

### DIFF
--- a/src/wp-admin/includes/update-core.php
+++ b/src/wp-admin/includes/update-core.php
@@ -903,6 +903,8 @@ $_old_files = array(
 	'wp-includes/collaboration/class-wp-http-polling-sync-server.php',
 	'wp-includes/collaboration/class-wp-sync-post-meta-storage.php',
 	'wp-includes/collaboration/interface-wp-sync-storage.php',
+	'wp-includes/js/dist/sync.js',
+	'wp-includes/js/dist/sync.min.js',
 );
 
 /**

--- a/src/wp-admin/includes/update-core.php
+++ b/src/wp-admin/includes/update-core.php
@@ -897,6 +897,12 @@ $_old_files = array(
 	'wp-includes/js/dist/script-modules/interactivity/debug.js',
 	'wp-includes/js/dist/script-modules/interactivity/debug.min.js',
 	'wp-includes/js/dist/vendor/react-jsx-runtime.min.js.LICENSE.txt',
+	// 7.0.1
+	'wp-includes/collaboration.php',
+	'wp-includes/collaboration/',
+	'wp-includes/collaboration/class-wp-http-polling-sync-server.php',
+	'wp-includes/collaboration/class-wp-sync-post-meta-storage.php',
+	'wp-includes/collaboration/interface-wp-sync-storage.php',
 );
 
 /**


### PR DESCRIPTION
## Summary

- Adds real-time collaboration files to the `$_old_files` array in `update-core.php` so they are removed during core upgrades.
- Addresses [#65325](https://core.trac.wordpress.org/ticket/65325), where RTC files removed in [62334] were unintentionally included in the WordPress 7.0 release package due to a build server issue.
- The existing `verify:old-files` Grunt task will also fail builds if these files are present in the `build/` directory, preventing recurrence.

## Context

Real-time collaboration was removed from core in [#65205](https://core.trac.wordpress.org/ticket/65205) ([62334](https://core.trac.wordpress.org/changeset/62334), [62337](https://core.trac.wordpress.org/changeset/62337), [62338](https://core.trac.wordpress.org/changeset/62338) on the 7.0 branch). However, the files still shipped in `wordpress-7.0.zip` and the `WordPress/WordPress` 7.0 tag. The impact is mostly benign since the files are not loaded, but they should be cleaned up on upgrade and excluded from future builds.

## Test plan

- [ ] Verify `php -l src/wp-admin/includes/update-core.php` passes
- [ ] Verify PHPCS reports no errors on the changed file
- [ ] Confirm `build/wp-includes/collaboration/` does not exist locally
- [ ] Run `npx grunt verify:old-files` as part of a full build in CI
- [ ] Confirm upgrading from a 7.0.0 install with RTC files to 7.0.1 removes:
  - `wp-includes/collaboration.php`
  - `wp-includes/collaboration/class-wp-http-polling-sync-server.php`
  - `wp-includes/collaboration/class-wp-sync-post-meta-storage.php`
  - `wp-includes/collaboration/interface-wp-sync-storage.php`

## Backport

This change should be backported to the **7.0 branch** for the **7.0.1** milestone.

Trac ticket: https://core.trac.wordpress.org/ticket/65325

## Use of AI Tools
N/A

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**