### PR TITLE
Script Loader: Respect global styles opt-out in classic themes with on-demand assets

### DIFF
--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2546,6 +2546,9 @@ function wp_filter_out_block_nodes( $nodes ) {
  * @since 5.8.0
  */
 function wp_enqueue_global_styles() {
+	static $should_enqueue            = true;
+	static $deferred_check_registered = false;
+
 	$assets_on_demand = wp_should_load_block_assets_on_demand();
 	$is_block_theme   = wp_is_block_theme();
 	$is_classic_theme = ! $is_block_theme;
@@ -2576,14 +2579,67 @@ function wp_enqueue_global_styles() {
 	 * HEAD, replacing the placeholder.
 	 *
 	 * @link https://core.trac.wordpress.org/ticket/64099
+	 * @link https://core.trac.wordpress.org/ticket/65336
 	 */
 	if ( $is_classic_theme && doing_action( 'wp_enqueue_scripts' ) && $assets_on_demand ) {
+		$should_enqueue = true;
+
+		/*
+		 * Queue the handle early so themes and plugins can dequeue it during wp_enqueue_scripts, even though the
+		 * stylesheet itself is not generated until wp_footer.
+		 */
+		wp_enqueue_style( 'global-styles' );
+
+		if ( ! $deferred_check_registered ) {
+			$deferred_check_registered = true;
+			add_action(
+				'wp_enqueue_scripts',
+				static function () use ( &$should_enqueue ) {
+					if ( false === has_action( 'wp_enqueue_scripts', 'wp_enqueue_global_styles' ) ) {
+						$should_enqueue = false;
+						return;
+					}
+
+					if ( wp_style_is( 'global-styles', 'registered' ) ) {
+						$should_enqueue = wp_style_is( 'global-styles', 'enqueued' );
+						return;
+					}
+
+					/*
+					 * The handle was queued before registration. Attempt registration so its enqueue state reflects
+					 * whether it was dequeued during wp_enqueue_scripts.
+					 */
+					wp_register_style( 'global-styles', false );
+
+					if ( wp_style_is( 'global-styles', 'enqueued' ) ) {
+						wp_dequeue_style( 'global-styles' );
+						wp_deregister_style( 'global-styles' );
+						$should_enqueue = true;
+					} else {
+						wp_deregister_style( 'global-styles' );
+						$should_enqueue = false;
+					}
+				},
+				PHP_INT_MAX
+			);
+		}
+
 		if ( has_action( 'wp_template_enhancement_output_buffer_started', 'wp_hoist_late_printed_styles' ) ) {
 			wp_register_style( 'wp-global-styles-placeholder', false );
 			wp_add_inline_style( 'wp-global-styles-placeholder', ':root { --wp-internal-comment: "Placeholder for wp_hoist_late_printed_styles() to replace with the global-styles printed at wp_footer." }' );
 			wp_enqueue_style( 'wp-global-styles-placeholder' );
 		}
 		return;
+	}
+
+	/*
+	 * When loading block assets on demand in classic themes, global styles are generated in the footer. Respect
+	 * opt-outs that removed the wp_enqueue_scripts callback or dequeued the handle during wp_enqueue_scripts.
+	 */
+	if ( doing_action( 'wp_footer' ) && $is_classic_theme && $assets_on_demand ) {
+		if ( false === has_action( 'wp_enqueue_scripts', 'wp_enqueue_global_styles' ) || ! $should_enqueue ) {
+			return;
+		}
 	}
 
 	/*

--- a/tests/phpunit/tests/template.php
+++ b/tests/phpunit/tests/template.php
@@ -1637,8 +1637,32 @@ class Tests_Template extends WP_UnitTestCase {
 					$dequeue = static function () {
 						wp_dequeue_style( 'global-styles' );
 					};
-					add_action( 'wp_enqueue_scripts', $dequeue, 1000 );
+					add_action( 'wp_enqueue_scripts', $dequeue, 100 );
 					add_action( 'wp_footer', $dequeue, 2 );
+				},
+				'content'           => $blocks_content,
+				'inline_size_limit' => PHP_INT_MAX,
+				'expected_styles'   => array(
+					'HEAD' => array_merge(
+						$early_common_styles,
+						array(
+							'wp-block-library-inline-css',
+							'wp-block-separator-inline-css',
+							'classic-theme-styles-inline-css',
+							'third-party-test-block-css',
+							'custom-block-styles-css',
+						),
+						$common_at_wp_enqueue_scripts,
+						$common_late_in_head,
+						$common_late_in_body
+					),
+					'BODY' => array(),
+				),
+			),
+
+			'no_global_styles_via_remove_action'          => array(
+				'set_up'            => static function () {
+					remove_action( 'wp_enqueue_scripts', 'wp_enqueue_global_styles' );
 				},
 				'content'           => $blocks_content,
 				'inline_size_limit' => PHP_INT_MAX,
@@ -1952,6 +1976,7 @@ class Tests_Template extends WP_UnitTestCase {
 	 *
 	 * @ticket 64099
 	 * @ticket 64354
+	 * @ticket 65336
 	 * @covers ::wp_load_classic_theme_block_styles_on_demand
 	 * @covers ::wp_hoist_late_printed_styles
 	 *
@@ -2121,6 +2146,10 @@ class Tests_Template extends WP_UnitTestCase {
 
 		if ( $assert ) {
 			$assert( $buffer, $filtered_buffer );
+		}
+
+		if ( false === has_action( 'wp_enqueue_scripts', 'wp_enqueue_global_styles' ) ) {
+			add_action( 'wp_enqueue_scripts', 'wp_enqueue_global_styles' );
 		}
 	}
 

--- a/tests/phpunit/tests/template.php
+++ b/tests/phpunit/tests/template.php
@@ -1979,6 +1979,7 @@ class Tests_Template extends WP_UnitTestCase {
 	 * @ticket 65336
 	 * @covers ::wp_load_classic_theme_block_styles_on_demand
 	 * @covers ::wp_hoist_late_printed_styles
+	 * @covers ::wp_enqueue_global_styles
 	 *
 	 * @dataProvider data_wp_hoist_late_printed_styles
 	 *


### PR DESCRIPTION
## Summary

- Fixes a regression where `global-styles-inline-css` could not be removed in classic themes after WordPress 6.9/7.0.
- Since global styles are now generated in `wp_footer` and hoisted into `<head>`, older opt-out patterns (`remove_action( 'wp_enqueue_scripts', 'wp_enqueue_global_styles' )` and `wp_dequeue_style( 'global-styles' )` during `wp_enqueue_scripts`) no longer prevented the inline CSS from appearing.
- This change detects theme/plugin opt-outs and skips generating/hoisting global styles when requested.

## What changed

In `wp_enqueue_global_styles()` for classic themes with on-demand block assets:

1. Queue the `global-styles` handle during `wp_enqueue_scripts` so it can be dequeued before footer processing.
2. Run a deferred check at the end of `wp_enqueue_scripts` to detect dequeue/remove opt-outs.
3. Skip footer global styles generation when an opt-out is detected.

## Why this is a valid bug

Before 6.9/7.0, dequeuing or removing the `wp_enqueue_scripts` callback was sufficient to prevent `global-styles-inline-css`. With footer-based generation + hoisting, those calls became ineffective, breaking existing classic theme setups that intentionally disable global styles.

## Test plan

- [x] `npm run test:php -- --filter test_wp_hoist_late_printed_styles` (15/15 passing)
- [x] PHPCS on `src/wp-includes/script-loader.php` and `tests/phpunit/tests/template.php`
- [ ] On a classic theme (no blocks), confirm `global-styles-inline-css` appears by default
- [ ] Confirm `wp_dequeue_style( 'global-styles' )` on `wp_enqueue_scripts` removes it
- [ ] Confirm `remove_action( 'wp_enqueue_scripts', 'wp_enqueue_global_styles' )` removes it
- [ ] Confirm block themes and normal global styles loading are unaffected

Trac ticket: https://core.trac.wordpress.org/ticket/65336

## Use of AI Tools 
  
 AI assistance: Yes 
 Tool(s): Claude 

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**