### PR TITLE
Editor: Allow Publish meta box action row to wrap.

### DIFF
--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -934,6 +934,7 @@ a#remove-post-thumbnail:hover,
 	border-top: 1px solid #dcdcde;
 	background: #f6f7f7;
 	display: flex;
+	flex-wrap: wrap;
 	align-items: center;
 	justify-content: space-between;
 }


### PR DESCRIPTION
Convert #major-publishing-actions to flex-wrap so third-party buttons injected via post_submitbox_misc_actions or post_submitbox_start fall to a new line instead of crowding the Move to Trash / Publish row.

Regression from [61645], which switched the container from floats to flex with space-between. Verified with WP Rocket and Yoast Duplicate Post.

Fixes #65286.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/65286

## Testing instructions

1. Install and activate WP Rocket (or Yoast Duplicate Post — free).
2. Edit any post.
3. Observe in the Publish meta box: "Move to Trash" is crowded between
   the plugin-injected button and Publish/Update.
4. Apply this patch.
5. Reload the editor — the injected button now wraps to its own line and
   "Move to Trash" / Publish are spaced cleanly. Default no-plugin layout
   is unchanged.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
