### PR TITLE
Fix: Inconsistent responsive spacing and padding on multiple WordPress admin screens

### DIFF
--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -4287,16 +4287,6 @@ img {
 		/* This element is a flex item. */
 		min-width: 100%;
 	}
-
-	.import-php.auto-fold #wpcontent,
-	.export-php.auto-fold #wpcontent {
-		padding-left: 0;
-	}
-
-	.import-php.auto-fold #wpcontent #wpbody-content .wrap,
-	.export-php.auto-fold #wpcontent #wpbody-content .wrap {
-		margin: 0 22px;
-	}
 }
 
 /* Smartphone */

--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -4287,6 +4287,16 @@ img {
 		/* This element is a flex item. */
 		min-width: 100%;
 	}
+
+	.import-php.auto-fold #wpcontent,
+	.export-php.auto-fold #wpcontent {
+		padding-left: 0;
+	}
+
+	.import-php.auto-fold #wpcontent #wpbody-content .wrap,
+	.export-php.auto-fold #wpcontent #wpbody-content .wrap {
+		margin: 0 22px;
+	}
 }
 
 /* Smartphone */

--- a/src/wp-admin/css/edit.css
+++ b/src/wp-admin/css/edit.css
@@ -1030,6 +1030,15 @@ form#tags-filter {
 	border-left: 2px solid #787c82;
 }
 
+@media only screen and (max-width: 1004px) {
+
+	.privacy-settings-body,
+	.health-check-body {
+		margin: 0 22px;
+		width: auto;
+	}
+}
+
 /* Media queries */
 @media screen and (max-width: 782px) {
 
@@ -1065,15 +1074,6 @@ form#tags-filter {
 
 	#editable-post-name input {
 		min-height: 40px;
-	}
-}
-
-@media only screen and (max-width: 1004px) {
-
-	.privacy-settings-body,
-	.health-check-body {
-		margin: 0 22px;
-		width: auto;
 	}
 }
 


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/65338

- Updated the `site-health` screen to be consistent on mobile with other screens.
- When we check the `site-health` css, we see that it is consitent, but because of a media query that is added after `max-width: 782px`, the CSS precedes the other.

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->
- None

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
