### PR TITLE
Admin: Add navigation link to the access-denied error page in wp-admin

### DIFF
--- a/src/wp-admin/includes/menu.php
+++ b/src/wp-admin/includes/menu.php
@@ -381,7 +381,15 @@ if ( ! user_can_access_admin_page() ) {
 	 */
 	do_action( 'admin_page_access_denied' );
 
-	wp_die( __( 'Sorry, you are not allowed to access this page.' ), 403 );
+	wp_die(
+		__( 'Sorry, you are not allowed to access this page.' ),
+		__( 'You need a higher level of permission.' ),
+		array(
+			'response'  => 403,
+			'link_url'  => admin_url(),
+			'link_text' => __( 'Go to Dashboard' ),
+		)
+	);
 }
 
 $menu = add_menu_classes( $menu );


### PR DESCRIPTION

Trac ticket: https://core.trac.wordpress.org/ticket/24689

When a logged-in user without sufficient capability attempts to access a wp-admin page, WordPress terminates with wp_die() and displays a dead-end screen containing only: "Sorry, you are not allowed to access this page." There is no link to navigate away, and the user must rely on the browser's back button.

Because auth_redirect() runs before menu.php is processed, the user is always authenticated at this point. A "Go to Dashboard" link is therefore always the appropriate recovery action.


#### Testing

- Access a page whose access is denied to the current user (like an editor visiting some admin-restricted page)
- Confirm the error page now shows a "Go to Dashboard" link and that clicking it lands on the Dashboard

#### Before

https://github.com/user-attachments/assets/353a6f5e-20c2-4f08-b2ef-c46d846940b4




#### After



https://github.com/user-attachments/assets/a48b4605-3527-4117-92ca-b27f53756aab


