### PR TITLE
Improve layout of publish meta box secondary actions

### DIFF
--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -930,12 +930,14 @@ a#remove-post-thumbnail:hover,
 
 #major-publishing-actions {
 	padding: 10px;
-	clear: both;
-	border-top: 1px solid #dcdcde;
-	background: #f6f7f7;
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
+    clear: both;
+    border-top: 1px solid #dcdcde;
+    background: #f6f7f7;
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    flex-direction: column-reverse;
+    gap: 7px;
 }
 
 #delete-action {
@@ -947,9 +949,9 @@ a#remove-post-thumbnail:hover,
 }
 
 #publishing-action {
-	text-align: right;
-	margin-left: auto;
-	line-height: 1.9;
+    display: flex;
+    margin: 0;
+    flex-direction: row-reverse;
 }
 
 #publishing-action .spinner {


### PR DESCRIPTION
The Publish button in the classic editor becomes visually cluttered when plugins like "Yoast Duplicate Post" add additional action links below the primary Update button.

Currently, core places all secondary actions inline in a cramped horizontal layout, which causes wrapping, inconsistent spacing, and poor readability.

AI assistance: Yes
Tool(s): ChatGPT
Used for: Writing ticket title and description. 

Trac Ticket : https://core.trac.wordpress.org/ticket/65351