### PR TITLE
Code Quality: Declare WP globals and initialize variables for PHPStan level 1

### DIFF
--- a/src/wp-admin/plugins.php
+++ b/src/wp-admin/plugins.php
@@ -9,6 +9,14 @@
 /** WordPress Administration Bootstrap */
 require_once __DIR__ . '/admin.php';
 
+/**
+ * @global string $status   Current plugin status view, set by WP_Plugins_List_Table.
+ * @global int    $page     Current page number, set by WP_Plugins_List_Table.
+ * @global array  $plugins  Set by WP_Plugins_List_Table::prepare_items().
+ * @global int    $user_ID  ID of the current user, set during authentication.
+ */
+global $status, $page, $plugins, $user_ID;
+
 if ( ! current_user_can( 'activate_plugins' ) ) {
 	wp_die( __( 'Sorry, you are not allowed to manage plugins for this site.' ) );
 }

--- a/src/wp-admin/user-edit.php
+++ b/src/wp-admin/user-edit.php
@@ -12,6 +12,13 @@ require_once __DIR__ . '/admin.php';
 /** WordPress Translation Installation API */
 require_once ABSPATH . 'wp-admin/includes/translation-install.php';
 
+/**
+ * @global wpdb    $wpdb                  WordPress database abstraction object.
+ * @global array   $_wp_admin_css_colors  Registered admin color schemes.
+ * @global WP_Roles $wp_roles             The roles object.
+ */
+global $wpdb, $_wp_admin_css_colors, $wp_roles;
+
 $action          = ! empty( $_REQUEST['action'] ) ? sanitize_text_field( $_REQUEST['action'] ) : '';
 $user_id         = ! empty( $_REQUEST['user_id'] ) ? absint( $_REQUEST['user_id'] ) : 0;
 $wp_http_referer = ! empty( $_REQUEST['wp_http_referer'] ) ? sanitize_url( $_REQUEST['wp_http_referer'] ) : '';
@@ -163,7 +170,7 @@ switch ( $action ) {
 			$user = get_userdata( $user_id );
 
 			if ( $user->user_login && isset( $_POST['email'] ) && is_email( $_POST['email'] ) && $wpdb->get_var( $wpdb->prepare( "SELECT user_login FROM {$wpdb->signups} WHERE user_login = %s", $user->user_login ) ) ) {
-				$wpdb->query( $wpdb->prepare( "UPDATE {$wpdb->signups} SET user_email = %s WHERE user_login = %s", $_POST['email'], $user_login ) );
+				$wpdb->query( $wpdb->prepare( "UPDATE {$wpdb->signups} SET user_email = %s WHERE user_login = %s", $_POST['email'], $user->user_login ) );
 			}
 		}
 

--- a/src/wp-admin/users.php
+++ b/src/wp-admin/users.php
@@ -10,6 +10,15 @@
 /** WordPress Administration Bootstrap */
 require_once __DIR__ . '/admin.php';
 
+/**
+ * @global WP_User    $current_user The current user, set during authentication.
+ * @global WP_Roles   $wp_roles     The roles object.
+ * @global wpdb       $wpdb         WordPress database abstraction object.
+ * @global string     $usersearch   User search query, set by WP_Users_List_Table.
+ * @global int        $blog_id      The current site (blog) ID on multisite.
+ */
+global $current_user, $wp_roles, $wpdb, $usersearch, $blog_id;
+
 if ( ! current_user_can( 'list_users' ) ) {
 	wp_die(
 		'<h1>' . __( 'You need a higher level of permission.' ) . '</h1>' .
@@ -93,7 +102,8 @@ get_current_screen()->set_screen_reader_content(
 );
 
 if ( empty( $_REQUEST ) ) {
-	$referer = '<input type="hidden" name="wp_http_referer" value="' . esc_attr( wp_unslash( $_SERVER['REQUEST_URI'] ) ) . '" />';
+	$redirect = '';
+	$referer  = '<input type="hidden" name="wp_http_referer" value="' . esc_attr( wp_unslash( $_SERVER['REQUEST_URI'] ) ) . '" />';
 } elseif ( isset( $_REQUEST['wp_http_referer'] ) ) {
 	$redirect = remove_query_arg( array( 'wp_http_referer', 'updated', 'delete_count' ), wp_unslash( $_REQUEST['wp_http_referer'] ) );
 	$referer  = '<input type="hidden" name="wp_http_referer" value="' . esc_attr( $redirect ) . '" />';

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -2265,6 +2265,9 @@ function wp_insert_user( $userdata ) {
 		$userdata = (array) $userdata;
 	}
 
+	$user_id       = 0;
+	$old_user_data = null;
+
 	// Are we updating or creating?
 	if ( ! empty( $userdata['ID'] ) ) {
 		$user_id       = (int) $userdata['ID'];
@@ -4272,6 +4275,7 @@ function _wp_privacy_send_request_confirmation_notification( $request_id ) {
 		return;
 	}
 
+	$manage_url = '';
 	if ( 'export_personal_data' === $request->action_name ) {
 		$manage_url = admin_url( 'export-personal-data.php' );
 	} elseif ( 'remove_personal_data' === $request->action_name ) {


### PR DESCRIPTION
Resolves PHPStan **level 1** `variable.undefined` errors in four user/plugin admin files (98 of 564 project-wide level-1 errors). The project's enforced level (0) continues to pass.

- Declare `@global` docblocks + `global` statements for core globals (`$wpdb`, `$current_user`, `$wp_roles`, `$_wp_admin_css_colors`, `$status`, `$page`, `$plugins`, `$user_ID`, `$usersearch`, `$blog_id`).
- Initialize `$redirect` in `wp-admin/users.php` for the `empty( $_REQUEST )` branch.
- Initialize `$user_id`, `$old_user_data` at the top of `wp_insert_user()` and `$manage_url` in `_wp_privacy_send_request_confirmation_notification()` so they're always defined.
- **Bug fix:** `wp-admin/user-edit.php:166` referenced an undefined `$user_login` in the multisite signup-email update query; corrected to `$user->user_login`.

## Files changed

| File | Errors before (level 1) | After |
| --- | --- | --- |
| `src/wp-admin/plugins.php` | 40 | 0 |
| `src/wp-admin/users.php` | 25 | 0 |
| `src/wp-admin/user-edit.php` | 15 | 0 |
| `src/wp-includes/user.php` | 18 | 0 |

## Verification

```bash
vendor/bin/phpstan analyse --level=1 --memory-limit=2G \
  --configuration=phpstan.neon.dist \
  src/wp-admin/plugins.php \
  src/wp-admin/users.php \
  src/wp-admin/user-edit.php \
  src/wp-includes/user.php
```
### Expected: [OK] No errors

Trac ticket: https://core.trac.wordpress.org/ticket/64898