### PR TITLE
Fixed missing logo for wp7 on about pages (credit, freedoms, privacy, contribute)

### DIFF
--- a/src/wp-admin/contribute.php
+++ b/src/wp-admin/contribute.php
@@ -25,7 +25,7 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 
 	<div class="about__header">
 		<div class="about__header-image">
-			<img src="images/about-release-logo.svg?ver=7.0" alt="<?php echo esc_attr( $header_alt_text ); ?>" />
+			<img src="<?php echo esc_url( admin_url( 'images/about-release-logo.svg?ver=7.0.1' ) ); ?>" alt="<?php echo esc_attr( $header_alt_text ); ?>" />
 		</div>
 
 		<div class="about__header-title">

--- a/src/wp-admin/credits.php
+++ b/src/wp-admin/credits.php
@@ -28,7 +28,7 @@ $credits = wp_credits();
 
 	<div class="about__header">
 		<div class="about__header-image">
-			<img src="images/about-release-logo.svg?ver=7.0" alt="<?php echo esc_attr( $header_alt_text ); ?>" />
+			<img src="<?php echo esc_url( admin_url( 'images/about-release-logo.svg?ver=7.0.1' ) ); ?>" alt="<?php echo esc_attr( $header_alt_text ); ?>" />
 		</div>
 
 		<div class="about__header-title">

--- a/src/wp-admin/freedoms.php
+++ b/src/wp-admin/freedoms.php
@@ -31,7 +31,7 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 
 	<div class="about__header">
 		<div class="about__header-image">
-			<img src="images/about-release-logo.svg?ver=7.0" alt="<?php echo esc_attr( $header_alt_text ); ?>" />
+			<img src="<?php echo esc_url( admin_url( 'images/about-release-logo.svg?ver=7.0.1' ) ); ?>" alt="<?php echo esc_attr( $header_alt_text ); ?>" />
 		</div>
 
 		<div class="about__header-title">

--- a/src/wp-admin/privacy.php
+++ b/src/wp-admin/privacy.php
@@ -25,7 +25,7 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 
 	<div class="about__header">
 		<div class="about__header-image">
-			<img src="images/about-release-logo.svg?ver=7.0" alt="<?php echo esc_attr( $header_alt_text ); ?>" />
+			<img src="<?php echo esc_url( admin_url( 'images/about-release-logo.svg?ver=7.0.1' ) ); ?>" alt="<?php echo esc_attr( $header_alt_text ); ?>" />
 		</div>
 
 		<div class="about__header-title">


### PR DESCRIPTION
This PR fixes logo showing broken on about subpages on multisite.
The path was static to image, This PR change the path to image to dynamic. 

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/65352
Before fix: 
<img width="1388" height="956" alt="before" src="https://github.com/user-attachments/assets/04e64766-e885-48ba-b0b5-8c421b715c6b" />

After fix: 
<img width="1018" height="945" alt="after" src="https://github.com/user-attachments/assets/ba7c2b04-e47c-4548-a1a2-8a9b96857ac5" />
