### PR TITLE
Abilities API: Unify schema conventions across core abilities

### DIFF
--- a/src/wp-includes/abilities.php
+++ b/src/wp-includes/abilities.php
@@ -320,6 +320,7 @@ function wp_register_core_abilities(): void {
 			'execute_callback'    => static function ( $input = array() ) use ( $environment_info_fields ): array {
 				global $wpdb;
 
+				/** @var array{ fields?: string[] } $input */
 				$input            = is_array( $input ) ? $input : array();
 				$requested_fields = ! empty( $input['fields'] ) ? $input['fields'] : $environment_info_fields;
 

--- a/src/wp-includes/abilities.php
+++ b/src/wp-includes/abilities.php
@@ -71,7 +71,7 @@ function wp_register_core_abilities(): void {
 		),
 		'charset'     => array(
 			'type'        => 'string',
-			'title'       => __( 'Encoding for pages and feeds' ),
+			'title'       => __( 'Site Charset' ),
 			'description' => __( 'The site character encoding.' ),
 		),
 		'language'    => array(
@@ -82,7 +82,7 @@ function wp_register_core_abilities(): void {
 		'version'     => array(
 			'type'        => 'string',
 			'title'       => __( 'WordPress Version' ),
-			'description' => __( 'The WordPress version.' ),
+			'description' => __( 'The WordPress core version running on this site.' ),
 		),
 	);
 	$site_info_fields     = array_keys( $site_info_properties );
@@ -269,7 +269,7 @@ function wp_register_core_abilities(): void {
 	$environment_info_properties = array(
 		'environment'    => array(
 			'type'        => 'string',
-			'title'       => __( 'Environment type' ),
+			'title'       => __( 'Environment Type' ),
 			'description' => __( 'The site\'s runtime environment classification (can be one of these: production, staging, development, local).' ),
 			'enum'        => array( 'production', 'staging', 'development', 'local' ),
 		),
@@ -280,7 +280,7 @@ function wp_register_core_abilities(): void {
 		),
 		'db_server_info' => array(
 			'type'        => 'string',
-			'title'       => __( 'Database Server version' ),
+			'title'       => __( 'Database Server Info' ),
 			'description' => __( 'The database server vendor and version string reported by the driver.' ),
 		),
 		'wp_version'     => array(

--- a/src/wp-includes/abilities.php
+++ b/src/wp-includes/abilities.php
@@ -261,7 +261,7 @@ function wp_register_core_abilities(): void {
 					'destructive' => false,
 					'idempotent'  => true,
 				),
-				'show_in_rest' => false,
+				'show_in_rest' => true,
 			),
 		)
 	);

--- a/src/wp-includes/abilities.php
+++ b/src/wp-includes/abilities.php
@@ -266,57 +266,76 @@ function wp_register_core_abilities(): void {
 		)
 	);
 
+	$environment_info_properties = array(
+		'environment'    => array(
+			'type'        => 'string',
+			'title'       => __( 'Environment type' ),
+			'description' => __( 'The site\'s runtime environment classification (can be one of these: production, staging, development, local).' ),
+			'enum'        => array( 'production', 'staging', 'development', 'local' ),
+		),
+		'php_version'    => array(
+			'type'        => 'string',
+			'title'       => __( 'PHP Version' ),
+			'description' => __( 'The PHP runtime version executing WordPress.' ),
+		),
+		'db_server_info' => array(
+			'type'        => 'string',
+			'title'       => __( 'Database Server version' ),
+			'description' => __( 'The database server vendor and version string reported by the driver.' ),
+		),
+		'wp_version'     => array(
+			'type'        => 'string',
+			'title'       => __( 'WordPress Version' ),
+			'description' => __( 'The WordPress core version running on this site.' ),
+		),
+	);
+	$environment_info_fields     = array_keys( $environment_info_properties );
+
 	wp_register_ability(
 		'core/get-environment-info',
 		array(
 			'label'               => __( 'Get Environment Info' ),
-			'description'         => __( 'Returns core details about the site\'s runtime context for diagnostics and compatibility (environment, PHP runtime, database server info, WordPress version).' ),
+			'description'         => __( 'Returns core details about the site\'s runtime context for diagnostics and compatibility (environment, PHP runtime, database server info, WordPress version). By default returns all fields, or optionally a filtered subset.' ),
 			'category'            => $category_site,
-			'output_schema'       => array(
+			'input_schema'        => array(
 				'type'                 => 'object',
-				'required'             => array( 'environment', 'php_version', 'db_server_info', 'wp_version' ),
 				'properties'           => array(
-					'environment'    => array(
-						'type'        => 'string',
-						'title'       => __( 'Environment type' ),
-						'description' => __( 'The site\'s runtime environment classification (can be one of these: production, staging, development, local).' ),
-						'enum'        => array( 'production', 'staging', 'development', 'local' ),
-					),
-					'php_version'    => array(
-						'type'        => 'string',
-						'title'       => __( 'PHP Version' ),
-						'description' => __( 'The PHP runtime version executing WordPress.' ),
-					),
-					'db_server_info' => array(
-						'type'        => 'string',
-						'title'       => __( 'Database Server version' ),
-						'description' => __( 'The database server vendor and version string reported by the driver.' ),
-					),
-					'wp_version'     => array(
-						'type'        => 'string',
-						'title'       => __( 'WordPress Version' ),
-						'description' => __( 'The WordPress core version running on this site.' ),
+					'fields' => array(
+						'type'        => 'array',
+						'items'       => array(
+							'type' => 'string',
+							'enum' => $environment_info_fields,
+						),
+						'description' => __( 'Optional: Limit response to specific fields. If omitted, all fields are returned.' ),
 					),
 				),
 				'additionalProperties' => false,
+				'default'              => array(),
 			),
-			'execute_callback'    => static function (): array {
+			'output_schema'       => array(
+				'type'                 => 'object',
+				'properties'           => $environment_info_properties,
+				'additionalProperties' => false,
+			),
+			'execute_callback'    => static function ( $input = array() ) use ( $environment_info_fields ): array {
 				global $wpdb;
 
-				$env          = wp_get_environment_type();
-				$php_version  = phpversion();
-				$db_server_info  = '';
+				$input            = is_array( $input ) ? $input : array();
+				$requested_fields = ! empty( $input['fields'] ) ? $input['fields'] : $environment_info_fields;
+
+				$db_server_info = '';
 				if ( method_exists( $wpdb, 'db_server_info' ) ) {
 					$db_server_info = $wpdb->db_server_info() ?? '';
 				}
-				$wp_version   = get_bloginfo( 'version' );
 
-				return array(
-					'environment'    => $env,
-					'php_version'    => $php_version,
+				$all = array(
+					'environment'    => wp_get_environment_type(),
+					'php_version'    => phpversion(),
 					'db_server_info' => $db_server_info,
-					'wp_version'     => $wp_version,
+					'wp_version'     => get_bloginfo( 'version' ),
 				);
+
+				return array_intersect_key( $all, array_flip( $requested_fields ) );
 			},
 			'permission_callback' => static function (): bool {
 				return current_user_can( 'manage_options' );

--- a/src/wp-includes/abilities.php
+++ b/src/wp-includes/abilities.php
@@ -57,12 +57,12 @@ function wp_register_core_abilities(): void {
 		'url'         => array(
 			'type'        => 'string',
 			'title'       => __( 'Site Address (URL)' ),
-			'description' => __( 'The site home URL.' ),
+			'description' => __( 'The public URL where visitors access the site. May differ from the WordPress installation URL.' ),
 		),
 		'wpurl'       => array(
 			'type'        => 'string',
 			'title'       => __( 'WordPress Address (URL)' ),
-			'description' => __( 'The WordPress installation URL.' ),
+			'description' => __( 'The URL where WordPress core files are served. May differ from the public site URL.' ),
 		),
 		'admin_email' => array(
 			'type'        => 'string',
@@ -77,7 +77,7 @@ function wp_register_core_abilities(): void {
 		'language'    => array(
 			'type'        => 'string',
 			'title'       => __( 'Site Language' ),
-			'description' => __( 'The site language locale code.' ),
+			'description' => __( 'The site locale in dash form (e.g. en-US).' ),
 		),
 		'version'     => array(
 			'type'        => 'string',
@@ -146,7 +146,7 @@ function wp_register_core_abilities(): void {
 		'id'            => array(
 			'type'        => 'integer',
 			'title'       => __( 'User ID' ),
-			'description' => __( 'Unique numeric identifier for the user.' ),
+			'description' => __( 'Unique identifier for the user.' ),
 		),
 		'display_name'  => array(
 			'type'        => 'string',
@@ -194,7 +194,7 @@ function wp_register_core_abilities(): void {
 		'description'   => array(
 			'type'        => 'string',
 			'title'       => __( 'Biographical Info' ),
-			'description' => __( 'User-authored biography, often shown on author pages.' ),
+			'description' => __( 'User-authored biography. May be empty.' ),
 		),
 		'user_url'      => array(
 			'type'        => 'string',
@@ -270,7 +270,7 @@ function wp_register_core_abilities(): void {
 		'environment'    => array(
 			'type'        => 'string',
 			'title'       => __( 'Environment Type' ),
-			'description' => __( 'The site\'s runtime environment classification (can be one of these: production, staging, development, local).' ),
+			'description' => __( 'The site\'s runtime environment classification.' ),
 			'enum'        => array( 'production', 'staging', 'development', 'local' ),
 		),
 		'php_version'    => array(

--- a/src/wp-includes/abilities.php
+++ b/src/wp-includes/abilities.php
@@ -46,34 +46,42 @@ function wp_register_core_abilities(): void {
 	$site_info_properties = array(
 		'name'        => array(
 			'type'        => 'string',
+			'title'       => __( 'Site Title' ),
 			'description' => __( 'The site title.' ),
 		),
 		'description' => array(
 			'type'        => 'string',
+			'title'       => __( 'Tagline' ),
 			'description' => __( 'The site tagline.' ),
 		),
 		'url'         => array(
 			'type'        => 'string',
+			'title'       => __( 'Site Address (URL)' ),
 			'description' => __( 'The site home URL.' ),
 		),
 		'wpurl'       => array(
 			'type'        => 'string',
+			'title'       => __( 'WordPress Address (URL)' ),
 			'description' => __( 'The WordPress installation URL.' ),
 		),
 		'admin_email' => array(
 			'type'        => 'string',
+			'title'       => __( 'Administration Email Address' ),
 			'description' => __( 'The site administrator email address.' ),
 		),
 		'charset'     => array(
 			'type'        => 'string',
+			'title'       => __( 'Encoding for pages and feeds' ),
 			'description' => __( 'The site character encoding.' ),
 		),
 		'language'    => array(
 			'type'        => 'string',
+			'title'       => __( 'Site Language' ),
 			'description' => __( 'The site language locale code.' ),
 		),
 		'version'     => array(
 			'type'        => 'string',
+			'title'       => __( 'WordPress Version' ),
 			'description' => __( 'The WordPress version.' ),
 		),
 	);
@@ -270,19 +278,23 @@ function wp_register_core_abilities(): void {
 				'properties'           => array(
 					'environment'    => array(
 						'type'        => 'string',
+						'title'       => __( 'Environment type' ),
 						'description' => __( 'The site\'s runtime environment classification (can be one of these: production, staging, development, local).' ),
 						'enum'        => array( 'production', 'staging', 'development', 'local' ),
 					),
 					'php_version'    => array(
 						'type'        => 'string',
+						'title'       => __( 'PHP Version' ),
 						'description' => __( 'The PHP runtime version executing WordPress.' ),
 					),
 					'db_server_info' => array(
 						'type'        => 'string',
+						'title'       => __( 'Database Server version' ),
 						'description' => __( 'The database server vendor and version string reported by the driver.' ),
 					),
 					'wp_version'     => array(
 						'type'        => 'string',
+						'title'       => __( 'WordPress Version' ),
 						'description' => __( 'The WordPress core version running on this site.' ),
 					),
 				),

--- a/tests/phpunit/tests/abilities-api/wpRegisterCoreAbilities.php
+++ b/tests/phpunit/tests/abilities-api/wpRegisterCoreAbilities.php
@@ -311,7 +311,20 @@ class Tests_Abilities_API_WpRegisterCoreAbilities extends WP_UnitTestCase {
 		$this->assertInstanceOf( WP_Ability::class, $ability );
 		$this->assertTrue( $ability->get_meta_item( 'show_in_rest', false ) );
 
+		$input_schema  = $ability->get_input_schema();
 		$output_schema = $ability->get_output_schema();
+
+		// Input schema should expose an optional `fields` array with an enum of valid field names.
+		$this->assertSame( 'object', $input_schema['type'] );
+		$this->assertArrayHasKey( 'default', $input_schema );
+		$this->assertSame( array(), $input_schema['default'] );
+		$this->assertArrayHasKey( 'fields', $input_schema['properties'] );
+		$this->assertSame( 'array', $input_schema['properties']['fields']['type'] );
+
+		$enum = $input_schema['properties']['fields']['items']['enum'];
+		foreach ( array( 'environment', 'php_version', 'db_server_info', 'wp_version' ) as $field ) {
+			$this->assertContains( $field, $enum );
+		}
 
 		// Output schema should document each field with title + description.
 		foreach ( array( 'environment', 'php_version', 'db_server_info', 'wp_version' ) as $field ) {
@@ -319,6 +332,52 @@ class Tests_Abilities_API_WpRegisterCoreAbilities extends WP_UnitTestCase {
 			$this->assertArrayHasKey( 'title', $output_schema['properties'][ $field ] );
 			$this->assertArrayHasKey( 'description', $output_schema['properties'][ $field ] );
 		}
+	}
+
+	/**
+	 * Tests that the `core/get-environment-info` ability filters its output by the `fields` input parameter.
+	 *
+	 * @ticket 65234
+	 */
+	public function test_core_get_environment_info_filters_fields(): void {
+		$admin_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+
+		$ability = wp_get_ability( 'core/get-environment-info' );
+
+		$result = $ability->execute(
+			array(
+				'fields' => array( 'environment', 'wp_version' ),
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertCount( 2, $result );
+		$this->assertArrayHasKey( 'environment', $result );
+		$this->assertArrayHasKey( 'wp_version', $result );
+		$this->assertArrayNotHasKey( 'php_version', $result );
+		$this->assertArrayNotHasKey( 'db_server_info', $result );
+	}
+
+	/**
+	 * Tests that the `core/get-environment-info` ability rejects unknown field names via schema validation.
+	 *
+	 * @ticket 65234
+	 */
+	public function test_core_get_environment_info_rejects_invalid_fields(): void {
+		$admin_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+
+		$ability = wp_get_ability( 'core/get-environment-info' );
+
+		$result = $ability->execute(
+			array(
+				'fields' => array( 'environment', 'not_a_real_field' ),
+			)
+		);
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'ability_invalid_input', $result->get_error_code() );
 	}
 
 	/**

--- a/tests/phpunit/tests/abilities-api/wpRegisterCoreAbilities.php
+++ b/tests/phpunit/tests/abilities-api/wpRegisterCoreAbilities.php
@@ -75,10 +75,12 @@ class Tests_Abilities_API_WpRegisterCoreAbilities extends WP_UnitTestCase {
 		$this->assertSame( 'array', $input_schema['properties']['fields']['type'] );
 		$this->assertContains( 'name', $input_schema['properties']['fields']['items']['enum'] );
 
-		// Output schema should have all fields documented.
-		$this->assertArrayHasKey( 'name', $output_schema['properties'] );
-		$this->assertArrayHasKey( 'url', $output_schema['properties'] );
-		$this->assertArrayHasKey( 'version', $output_schema['properties'] );
+		// Output schema should document each field with title + description.
+		foreach ( array( 'name', 'description', 'url', 'wpurl', 'admin_email', 'charset', 'language', 'version' ) as $field ) {
+			$this->assertArrayHasKey( $field, $output_schema['properties'] );
+			$this->assertArrayHasKey( 'title', $output_schema['properties'][ $field ] );
+			$this->assertArrayHasKey( 'description', $output_schema['properties'][ $field ] );
+		}
 	}
 
 	/**
@@ -296,6 +298,27 @@ class Tests_Abilities_API_WpRegisterCoreAbilities extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'db_server_info', $ability_data );
 		$this->assertArrayHasKey( 'wp_version', $ability_data );
 		$this->assertSame( $environment, $ability_data['environment'] );
+	}
+
+	/**
+	 * Tests that the `core/get-environment-info` ability is registered with the expected schema.
+	 *
+	 * @ticket 65234
+	 */
+	public function test_core_get_environment_info_ability_is_registered(): void {
+		$ability = wp_get_ability( 'core/get-environment-info' );
+
+		$this->assertInstanceOf( WP_Ability::class, $ability );
+		$this->assertTrue( $ability->get_meta_item( 'show_in_rest', false ) );
+
+		$output_schema = $ability->get_output_schema();
+
+		// Output schema should document each field with title + description.
+		foreach ( array( 'environment', 'php_version', 'db_server_info', 'wp_version' ) as $field ) {
+			$this->assertArrayHasKey( $field, $output_schema['properties'] );
+			$this->assertArrayHasKey( 'title', $output_schema['properties'][ $field ] );
+			$this->assertArrayHasKey( 'description', $output_schema['properties'][ $field ] );
+		}
 	}
 
 	/**

--- a/tests/phpunit/tests/abilities-api/wpRegisterCoreAbilities.php
+++ b/tests/phpunit/tests/abilities-api/wpRegisterCoreAbilities.php
@@ -73,11 +73,15 @@ class Tests_Abilities_API_WpRegisterCoreAbilities extends WP_UnitTestCase {
 		// Input schema should have optional fields array.
 		$this->assertArrayHasKey( 'fields', $input_schema['properties'] );
 		$this->assertSame( 'array', $input_schema['properties']['fields']['type'] );
-		$this->assertContains( 'name', $input_schema['properties']['fields']['items']['enum'] );
 
-		// Output schema should document each field with title + description.
-		foreach ( array( 'name', 'description', 'url', 'wpurl', 'admin_email', 'charset', 'language', 'version' ) as $field ) {
-			$this->assertArrayHasKey( $field, $output_schema['properties'] );
+		// Locking the exact set of fields guards against properties being added without test coverage.
+		$expected_fields = array( 'name', 'description', 'url', 'wpurl', 'admin_email', 'charset', 'language', 'version' );
+
+		$this->assertSame( $expected_fields, $input_schema['properties']['fields']['items']['enum'] );
+		$this->assertSame( $expected_fields, array_keys( $output_schema['properties'] ) );
+
+		// Each output property must document a title + description.
+		foreach ( $expected_fields as $field ) {
 			$this->assertArrayHasKey( 'title', $output_schema['properties'][ $field ] );
 			$this->assertArrayHasKey( 'description', $output_schema['properties'][ $field ] );
 		}
@@ -214,14 +218,14 @@ class Tests_Abilities_API_WpRegisterCoreAbilities extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'fields', $input_schema['properties'] );
 		$this->assertSame( 'array', $input_schema['properties']['fields']['type'] );
 
-		$enum = $input_schema['properties']['fields']['items']['enum'];
-		foreach ( array( 'id', 'display_name', 'first_name', 'last_name', 'nickname', 'description', 'user_url' ) as $field ) {
-			$this->assertContains( $field, $enum );
-		}
+		// Locking the exact set of fields guards against properties being added without test coverage.
+		$expected_fields = array( 'id', 'display_name', 'user_nicename', 'user_login', 'roles', 'locale', 'first_name', 'last_name', 'nickname', 'description', 'user_url' );
 
-		// Output schema should document the original and new profile fields with title + description.
-		foreach ( array( 'id', 'display_name', 'first_name', 'last_name', 'nickname', 'description', 'user_url' ) as $field ) {
-			$this->assertArrayHasKey( $field, $output_schema['properties'] );
+		$this->assertSame( $expected_fields, $input_schema['properties']['fields']['items']['enum'] );
+		$this->assertSame( $expected_fields, array_keys( $output_schema['properties'] ) );
+
+		// Each output property must document a title + description.
+		foreach ( $expected_fields as $field ) {
 			$this->assertArrayHasKey( 'title', $output_schema['properties'][ $field ] );
 			$this->assertArrayHasKey( 'description', $output_schema['properties'][ $field ] );
 		}
@@ -322,14 +326,14 @@ class Tests_Abilities_API_WpRegisterCoreAbilities extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'fields', $input_schema['properties'] );
 		$this->assertSame( 'array', $input_schema['properties']['fields']['type'] );
 
-		$enum = $input_schema['properties']['fields']['items']['enum'];
-		foreach ( array( 'environment', 'php_version', 'db_server_info', 'wp_version' ) as $field ) {
-			$this->assertContains( $field, $enum );
-		}
+		// Locking the exact set of fields guards against properties being added without test coverage.
+		$expected_fields = array( 'environment', 'php_version', 'db_server_info', 'wp_version' );
 
-		// Output schema should document each field with title + description.
-		foreach ( array( 'environment', 'php_version', 'db_server_info', 'wp_version' ) as $field ) {
-			$this->assertArrayHasKey( $field, $output_schema['properties'] );
+		$this->assertSame( $expected_fields, $input_schema['properties']['fields']['items']['enum'] );
+		$this->assertSame( $expected_fields, array_keys( $output_schema['properties'] ) );
+
+		// Each output property must document a title + description.
+		foreach ( $expected_fields as $field ) {
 			$this->assertArrayHasKey( 'title', $output_schema['properties'][ $field ] );
 			$this->assertArrayHasKey( 'description', $output_schema['properties'][ $field ] );
 		}

--- a/tests/phpunit/tests/abilities-api/wpRegisterCoreAbilities.php
+++ b/tests/phpunit/tests/abilities-api/wpRegisterCoreAbilities.php
@@ -202,6 +202,7 @@ class Tests_Abilities_API_WpRegisterCoreAbilities extends WP_UnitTestCase {
 		$ability = wp_get_ability( 'core/get-user-info' );
 
 		$this->assertInstanceOf( WP_Ability::class, $ability );
+		$this->assertTrue( $ability->get_meta_item( 'show_in_rest', false ) );
 
 		$input_schema  = $ability->get_input_schema();
 		$output_schema = $ability->get_output_schema();

--- a/tests/phpunit/tests/abilities-api/wpRegisterCoreAbilities.php
+++ b/tests/phpunit/tests/abilities-api/wpRegisterCoreAbilities.php
@@ -302,7 +302,7 @@ class Tests_Abilities_API_WpRegisterCoreAbilities extends WP_UnitTestCase {
 	/**
 	 * Tests that the `core/get-environment-info` ability is registered with the expected schema.
 	 *
-	 * @ticket 65234
+	 * @ticket 65355
 	 */
 	public function test_core_get_environment_info_ability_is_registered(): void {
 		$ability = wp_get_ability( 'core/get-environment-info' );
@@ -333,7 +333,7 @@ class Tests_Abilities_API_WpRegisterCoreAbilities extends WP_UnitTestCase {
 	/**
 	 * Tests that the `core/get-environment-info` ability filters its output by the `fields` input parameter.
 	 *
-	 * @ticket 65234
+	 * @ticket 65355
 	 */
 	public function test_core_get_environment_info_filters_fields(): void {
 		$admin_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
@@ -358,7 +358,7 @@ class Tests_Abilities_API_WpRegisterCoreAbilities extends WP_UnitTestCase {
 	/**
 	 * Tests that the `core/get-environment-info` ability rejects unknown field names via schema validation.
 	 *
-	 * @ticket 65234
+	 * @ticket 65355
 	 */
 	public function test_core_get_environment_info_rejects_invalid_fields(): void {
 		$admin_id = self::factory()->user->create( array( 'role' => 'administrator' ) );

--- a/tests/phpunit/tests/abilities-api/wpRegisterCoreAbilities.php
+++ b/tests/phpunit/tests/abilities-api/wpRegisterCoreAbilities.php
@@ -70,7 +70,6 @@ class Tests_Abilities_API_WpRegisterCoreAbilities extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'default', $input_schema );
 		$this->assertSame( array(), $input_schema['default'] );
 
-		// Input schema should have optional fields array.
 		$this->assertArrayHasKey( 'fields', $input_schema['properties'] );
 		$this->assertSame( 'array', $input_schema['properties']['fields']['type'] );
 
@@ -79,7 +78,6 @@ class Tests_Abilities_API_WpRegisterCoreAbilities extends WP_UnitTestCase {
 		$this->assertSame( $expected_fields, $input_schema['properties']['fields']['items']['enum'] );
 		$this->assertSame( $expected_fields, array_keys( $output_schema['properties'] ) );
 
-		// Each output property must document a title + description.
 		foreach ( $expected_fields as $field ) {
 			$this->assertArrayHasKey( 'title', $output_schema['properties'][ $field ] );
 			$this->assertArrayHasKey( 'description', $output_schema['properties'][ $field ] );
@@ -210,7 +208,6 @@ class Tests_Abilities_API_WpRegisterCoreAbilities extends WP_UnitTestCase {
 		$input_schema  = $ability->get_input_schema();
 		$output_schema = $ability->get_output_schema();
 
-		// Input schema should expose an optional `fields` array with an enum of valid field names.
 		$this->assertSame( 'object', $input_schema['type'] );
 		$this->assertArrayHasKey( 'default', $input_schema );
 		$this->assertSame( array(), $input_schema['default'] );
@@ -222,7 +219,6 @@ class Tests_Abilities_API_WpRegisterCoreAbilities extends WP_UnitTestCase {
 		$this->assertSame( $expected_fields, $input_schema['properties']['fields']['items']['enum'] );
 		$this->assertSame( $expected_fields, array_keys( $output_schema['properties'] ) );
 
-		// Each output property must document a title + description.
 		foreach ( $expected_fields as $field ) {
 			$this->assertArrayHasKey( 'title', $output_schema['properties'][ $field ] );
 			$this->assertArrayHasKey( 'description', $output_schema['properties'][ $field ] );
@@ -317,7 +313,6 @@ class Tests_Abilities_API_WpRegisterCoreAbilities extends WP_UnitTestCase {
 		$input_schema  = $ability->get_input_schema();
 		$output_schema = $ability->get_output_schema();
 
-		// Input schema should expose an optional `fields` array with an enum of valid field names.
 		$this->assertSame( 'object', $input_schema['type'] );
 		$this->assertArrayHasKey( 'default', $input_schema );
 		$this->assertSame( array(), $input_schema['default'] );
@@ -329,7 +324,6 @@ class Tests_Abilities_API_WpRegisterCoreAbilities extends WP_UnitTestCase {
 		$this->assertSame( $expected_fields, $input_schema['properties']['fields']['items']['enum'] );
 		$this->assertSame( $expected_fields, array_keys( $output_schema['properties'] ) );
 
-		// Each output property must document a title + description.
 		foreach ( $expected_fields as $field ) {
 			$this->assertArrayHasKey( 'title', $output_schema['properties'][ $field ] );
 			$this->assertArrayHasKey( 'description', $output_schema['properties'][ $field ] );

--- a/tests/phpunit/tests/abilities-api/wpRegisterCoreAbilities.php
+++ b/tests/phpunit/tests/abilities-api/wpRegisterCoreAbilities.php
@@ -74,7 +74,6 @@ class Tests_Abilities_API_WpRegisterCoreAbilities extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'fields', $input_schema['properties'] );
 		$this->assertSame( 'array', $input_schema['properties']['fields']['type'] );
 
-		// Locking the exact set of fields guards against properties being added without test coverage.
 		$expected_fields = array( 'name', 'description', 'url', 'wpurl', 'admin_email', 'charset', 'language', 'version' );
 
 		$this->assertSame( $expected_fields, $input_schema['properties']['fields']['items']['enum'] );
@@ -218,7 +217,6 @@ class Tests_Abilities_API_WpRegisterCoreAbilities extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'fields', $input_schema['properties'] );
 		$this->assertSame( 'array', $input_schema['properties']['fields']['type'] );
 
-		// Locking the exact set of fields guards against properties being added without test coverage.
 		$expected_fields = array( 'id', 'display_name', 'user_nicename', 'user_login', 'roles', 'locale', 'first_name', 'last_name', 'nickname', 'description', 'user_url' );
 
 		$this->assertSame( $expected_fields, $input_schema['properties']['fields']['items']['enum'] );
@@ -326,7 +324,6 @@ class Tests_Abilities_API_WpRegisterCoreAbilities extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'fields', $input_schema['properties'] );
 		$this->assertSame( 'array', $input_schema['properties']['fields']['type'] );
 
-		// Locking the exact set of fields guards against properties being added without test coverage.
 		$expected_fields = array( 'environment', 'php_version', 'db_server_info', 'wp_version' );
 
 		$this->assertSame( $expected_fields, $input_schema['properties']['fields']['items']['enum'] );


### PR DESCRIPTION
## Summary

The three core abilities shipped in 6.9.0 (`core/get-site-info`, `core/get-user-info`, `core/get-environment-info`) drifted in small but visible ways. This PR aligns them on a shared blueprint so they're predictable to consume from REST clients and easier to extend.

- Every output property declares both `title` and `description`, reusing existing WP Admin translations where possible.
- `core/get-environment-info` accepts the optional `fields` input parameter already supported by the other two, with an `enum` of valid keys.
- `core/get-user-info` is exposed via REST (`show_in_rest => true`) so clients can discover and invoke it under `/wp-json/wp-abilities/v1/abilities`.
- Property titles are normalized to Title Case. `db_server_info` is relabeled `Database Server Info` since `$wpdb->db_server_info()` returns vendor+version, not just a version.
- Schema descriptions are tightened for programmatic consumers: redundant restatement of `title`/`type` is removed, the `environment` description no longer repeats the `enum`, and the `url`/`wpurl` and site-`language`/user-`locale` pairs are explicitly contrasted so an AI client can pick the right field and format.
- Registration tests lock the exact ordered set of property keys on both the input `enum` and the output `properties`, so any future field addition forces a test update.

Trac ticket: https://core.trac.wordpress.org/ticket/65355

## Test plan

- [ ] `npm run test:php -- --filter=Tests_Abilities_API_WpRegisterCoreAbilities` is green
- [ ] `core/get-user-info` is listed at `/wp-json/wp-abilities/v1/abilities` for an authenticated user
- [ ] `core/get-environment-info` accepts `{"fields":["php_version"]}` and returns only that key
- [ ] Unknown field names on any of the three abilities yield an `ability_invalid_input` error
- [ ] `npm run env:composer -- lint -- src/wp-includes/abilities.php` reports no violations
- [ ] `npm run typecheck:php` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)