### PR TITLE
Fix rich-text attribute type normalization in WP_Block_Type

### DIFF
--- a/src/wp-includes/class-wp-block-type.php
+++ b/src/wp-includes/class-wp-block-type.php
@@ -536,6 +536,7 @@ class WP_Block_Type {
 	 * Sets block type properties.
 	 *
 	 * @since 5.0.0
+	 * @since 7.0.1 Added Support for rich-text attribute type, which is normalized to string for server-side rendering.
 	 *
 	 * @param array|string $args Array or string of arguments for registering a block type.
 	 *                           See WP_Block_Type::__construct() for information on accepted arguments.
@@ -559,6 +560,16 @@ class WP_Block_Type {
 		foreach ( static::GLOBAL_ATTRIBUTES as $attr_key => $attr_schema ) {
 			if ( ! array_key_exists( $attr_key, $args['attributes'] ) ) {
 				$args['attributes'][ $attr_key ] = $attr_schema;
+			}
+		}
+
+		// Normalize block attribute types. The 'rich-text' type is used in
+		// block.json for the editor, but is not a valid JSON Schema type.
+		// Map it to 'string' since rich text values are always strings on
+		// the server side.
+		foreach ( $args['attributes'] as $key => $attribute ) {
+			if ( isset( $attribute['type'] ) && 'rich-text' === $attribute['type'] ) {
+				$args['attributes'][ $key ]['type'] = 'string';
 			}
 		}
 

--- a/src/wp-includes/class-wp-block-type.php
+++ b/src/wp-includes/class-wp-block-type.php
@@ -536,7 +536,7 @@ class WP_Block_Type {
 	 * Sets block type properties.
 	 *
 	 * @since 5.0.0
-	 * @since 7.0.1 Added Support for rich-text attribute type, which is normalized to string for server-side rendering.
+	 * @since 7.1.0 Added Support for rich-text attribute type, which is normalized to string for server-side rendering.
 	 *
 	 * @param array|string $args Array or string of arguments for registering a block type.
 	 *                           See WP_Block_Type::__construct() for information on accepted arguments.

--- a/tests/phpunit/tests/blocks/wpBlockType.php
+++ b/tests/phpunit/tests/blocks/wpBlockType.php
@@ -211,6 +211,7 @@ class Tests_Blocks_wpBlockType extends WP_UnitTestCase {
 			/* missingDefaulted */
 			'undefined'          => 'include',
 			'intendedNull'       => null,
+			'richtext'           => 'rich text content',
 		);
 
 		$block_type = new WP_Block_Type(
@@ -235,6 +236,9 @@ class Tests_Blocks_wpBlockType extends WP_UnitTestCase {
 						'type'    => array( 'string', 'null' ),
 						'default' => 'wrong',
 					),
+					'richtext'           => array(
+						'type' => 'rich-text',
+					),
 				),
 			)
 		);
@@ -249,6 +253,7 @@ class Tests_Blocks_wpBlockType extends WP_UnitTestCase {
 				'missingDefaulted'   => 'define',
 				'undefined'          => 'include',
 				'intendedNull'       => null,
+				'richtext'           => 'rich text content',
 			),
 			$prepared_attributes
 		);


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!
Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**
See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/
If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

Trac ticket: https://core.trac.wordpress.org/ticket/61406

> Normalize `rich-text` block attribute type to `string` in `WP_Block_Type::set_props()`

Block attributes with `type: "rich-text"` (used in `block.json` for the editor) are not valid JSON Schema types. When `WP_Block_Type::prepare_attributes_for_render()` calls `rest_validate_value_from_schema()`, the unrecognised `rich-text` type triggers a `_doing_it_wrong()` notice:
> The "type" schema keyword for content can only be one of the built-in types: array, object, string, number, integer, boolean, and null.
This affects all core blocks that define attributes as `rich-text`: paragraph, heading, list-item, image (caption), embed (caption), quote, pullquote, verse, code, preformatted, table, gallery, button, file, video, audio, details, and accordion-heading.

**Changes in this PR:**

1. **`src/wp-includes/class-wp-block-type.php`** — In `set_props()`, normalise `rich-text` to `string` at block registration time. This runs once (not per-render) and occurs before the `register_block_type_args` filter, so plugins can still override if needed.
2. **`tests/phpunit/tests/blocks/wpBlockType.php`** — Added a `richtext` attribute case to `test_prepare_attributes()` to verify that `rich-text` typed attributes pass validation without triggering `_doing_it_wrong`.

> **Related:** Gutenberg issue https://github.com/WordPress/gutenberg/issues/72180

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
