### PR TITLE
REST API: Harden ability schema preparation

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-abilities-v1-list-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-abilities-v1-list-controller.php
@@ -189,27 +189,6 @@ class WP_REST_Abilities_V1_List_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Normalizes schema empty object defaults.
-	 *
-	 * Converts empty array defaults to objects when the schema type is 'object'
-	 * to ensure proper JSON serialization as {} instead of [].
-	 *
-	 * @since 6.9.0
-	 *
-	 * @param array<string, mixed> $schema The schema array.
-	 * @return array<string, mixed> The normalized schema.
-	 */
-	private function normalize_schema_empty_object_defaults( array $schema ): array {
-		if ( isset( $schema['type'] ) && 'object' === $schema['type'] && isset( $schema['default'] ) ) {
-			$default = $schema['default'];
-			if ( is_array( $default ) && empty( $default ) ) {
-				$schema['default'] = (object) $default;
-			}
-		}
-		return $schema;
-	}
-
-	/**
 	 * WordPress-internal schema keywords to strip from REST responses.
 	 *
 	 * @since 7.0.0
@@ -222,19 +201,28 @@ class WP_REST_Abilities_V1_List_Controller extends WP_REST_Controller {
 	);
 
 	/**
-	 * Recursively removes WordPress-internal keywords from a schema.
+	 * Transforms an ability schema for REST response output.
 	 *
 	 * Ability schemas may include WordPress-internal properties like
 	 * `sanitize_callback`, `validate_callback`, and `arg_options` that are
 	 * used server-side but are not valid JSON Schema keywords. This method
 	 * removes those specific keys so they are not exposed in REST responses.
+	 * It also converts empty array defaults to objects when the schema type is
+	 * 'object' to ensure proper JSON serialization as {} instead of [].
 	 *
-	 * @since 7.0.0
+	 * @since 7.1.0
 	 *
 	 * @param array<string, mixed> $schema The schema array.
-	 * @return array<string, mixed> The schema without WordPress-internal keywords.
+	 * @return array<string, mixed> The transformed schema.
 	 */
-	private function strip_internal_schema_keywords( array $schema ): array {
+	private function prepare_schema_for_response( array $schema ): array {
+		if ( isset( $schema['type'] ) && 'object' === $schema['type'] && isset( $schema['default'] ) ) {
+			$default = $schema['default'];
+			if ( is_array( $default ) && empty( $default ) ) {
+				$schema['default'] = (object) $default;
+			}
+		}
+
 		$schema = array_diff_key( $schema, self::INTERNAL_SCHEMA_KEYWORDS );
 
 		// Sub-schema maps: keys are user-defined, values are sub-schemas.
@@ -244,7 +232,7 @@ class WP_REST_Abilities_V1_List_Controller extends WP_REST_Controller {
 			if ( isset( $schema[ $keyword ] ) && is_array( $schema[ $keyword ] ) ) {
 				foreach ( $schema[ $keyword ] as $key => $child_schema ) {
 					if ( is_array( $child_schema ) && ! wp_is_numeric_array( $child_schema ) ) {
-						$schema[ $keyword ][ $key ] = $this->strip_internal_schema_keywords( $child_schema );
+						$schema[ $keyword ][ $key ] = $this->prepare_schema_for_response( $child_schema );
 					}
 				}
 			}
@@ -253,7 +241,7 @@ class WP_REST_Abilities_V1_List_Controller extends WP_REST_Controller {
 		// Single sub-schema keywords.
 		foreach ( array( 'not', 'additionalProperties', 'additionalItems' ) as $keyword ) {
 			if ( isset( $schema[ $keyword ] ) && is_array( $schema[ $keyword ] ) ) {
-				$schema[ $keyword ] = $this->strip_internal_schema_keywords( $schema[ $keyword ] );
+				$schema[ $keyword ] = $this->prepare_schema_for_response( $schema[ $keyword ] );
 			}
 		}
 
@@ -262,11 +250,11 @@ class WP_REST_Abilities_V1_List_Controller extends WP_REST_Controller {
 			if ( wp_is_numeric_array( $schema['items'] ) ) {
 				foreach ( $schema['items'] as $index => $item_schema ) {
 					if ( is_array( $item_schema ) ) {
-						$schema['items'][ $index ] = $this->strip_internal_schema_keywords( $item_schema );
+						$schema['items'][ $index ] = $this->prepare_schema_for_response( $item_schema );
 					}
 				}
 			} elseif ( is_array( $schema['items'] ) ) {
-				$schema['items'] = $this->strip_internal_schema_keywords( $schema['items'] );
+				$schema['items'] = $this->prepare_schema_for_response( $schema['items'] );
 			}
 		}
 
@@ -275,7 +263,7 @@ class WP_REST_Abilities_V1_List_Controller extends WP_REST_Controller {
 			if ( isset( $schema[ $keyword ] ) && is_array( $schema[ $keyword ] ) ) {
 				foreach ( $schema[ $keyword ] as $index => $sub_schema ) {
 					if ( is_array( $sub_schema ) ) {
-						$schema[ $keyword ][ $index ] = $this->strip_internal_schema_keywords( $sub_schema );
+						$schema[ $keyword ][ $index ] = $this->prepare_schema_for_response( $sub_schema );
 					}
 				}
 			}
@@ -299,12 +287,8 @@ class WP_REST_Abilities_V1_List_Controller extends WP_REST_Controller {
 			'label'         => $ability->get_label(),
 			'description'   => $ability->get_description(),
 			'category'      => $ability->get_category(),
-			'input_schema'  => $this->strip_internal_schema_keywords(
-				$this->normalize_schema_empty_object_defaults( $ability->get_input_schema() )
-			),
-			'output_schema' => $this->strip_internal_schema_keywords(
-				$this->normalize_schema_empty_object_defaults( $ability->get_output_schema() )
-			),
+			'input_schema'  => $this->prepare_schema_for_response( $ability->get_input_schema() ),
+			'output_schema' => $this->prepare_schema_for_response( $ability->get_output_schema() ),
 			'meta'          => $ability->get_meta(),
 		);
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-abilities-v1-list-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-abilities-v1-list-controller.php
@@ -201,6 +201,20 @@ class WP_REST_Abilities_V1_List_Controller extends WP_REST_Controller {
 	);
 
 	/**
+	 * Determines whether the value is an associative array.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param mixed $value Value.
+	 * @return bool Whether it is associative array.
+	 *
+	 * @phpstan-assert-if-true array<string, mixed> $value
+	 */
+	private function is_associative_array( $value ): bool {
+		return is_array( $value ) && ! wp_is_numeric_array( $value );
+	}
+
+	/**
 	 * Transforms an ability schema for REST response output.
 	 *
 	 * Ability schemas may include WordPress-internal properties like
@@ -231,7 +245,7 @@ class WP_REST_Abilities_V1_List_Controller extends WP_REST_Controller {
 		foreach ( array( 'properties', 'patternProperties', 'definitions', 'dependencies' ) as $keyword ) {
 			if ( isset( $schema[ $keyword ] ) && is_array( $schema[ $keyword ] ) ) {
 				foreach ( $schema[ $keyword ] as $key => $child_schema ) {
-					if ( is_array( $child_schema ) && ! wp_is_numeric_array( $child_schema ) ) {
+					if ( $this->is_associative_array( $child_schema ) ) {
 						$schema[ $keyword ][ $key ] = $this->prepare_schema_for_response( $child_schema );
 					}
 				}
@@ -240,21 +254,21 @@ class WP_REST_Abilities_V1_List_Controller extends WP_REST_Controller {
 
 		// Single sub-schema keywords.
 		foreach ( array( 'not', 'additionalProperties', 'additionalItems' ) as $keyword ) {
-			if ( isset( $schema[ $keyword ] ) && is_array( $schema[ $keyword ] ) ) {
+			if ( isset( $schema[ $keyword ] ) && $this->is_associative_array( $schema[ $keyword ] ) ) {
 				$schema[ $keyword ] = $this->prepare_schema_for_response( $schema[ $keyword ] );
 			}
 		}
 
 		// Items: single schema or tuple array of schemas.
-		if ( isset( $schema['items'] ) ) {
-			if ( wp_is_numeric_array( $schema['items'] ) ) {
+		if ( isset( $schema['items'] ) && is_array( $schema['items'] ) ) {
+			if ( $this->is_associative_array( $schema['items'] ) ) {
+				$schema['items'] = $this->prepare_schema_for_response( $schema['items'] );
+			} else {
 				foreach ( $schema['items'] as $index => $item_schema ) {
-					if ( is_array( $item_schema ) ) {
+					if ( $this->is_associative_array( $item_schema ) ) {
 						$schema['items'][ $index ] = $this->prepare_schema_for_response( $item_schema );
 					}
 				}
-			} elseif ( is_array( $schema['items'] ) ) {
-				$schema['items'] = $this->prepare_schema_for_response( $schema['items'] );
 			}
 		}
 
@@ -262,7 +276,7 @@ class WP_REST_Abilities_V1_List_Controller extends WP_REST_Controller {
 		foreach ( array( 'anyOf', 'oneOf', 'allOf' ) as $keyword ) {
 			if ( isset( $schema[ $keyword ] ) && is_array( $schema[ $keyword ] ) ) {
 				foreach ( $schema[ $keyword ] as $index => $sub_schema ) {
-					if ( is_array( $sub_schema ) ) {
+					if ( $this->is_associative_array( $sub_schema ) ) {
 						$schema[ $keyword ][ $index ] = $this->prepare_schema_for_response( $sub_schema );
 					}
 				}

--- a/tests/phpunit/tests/rest-api/wpRestAbilitiesV1ListController.php
+++ b/tests/phpunit/tests/rest-api/wpRestAbilitiesV1ListController.php
@@ -891,6 +891,62 @@ class Tests_REST_API_WpRestAbilitiesV1ListController extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that nested empty object defaults are prepared as objects in REST response schemas.
+	 *
+	 * @ticket 64955
+	 */
+	public function test_nested_empty_object_schema_defaults_prepared_for_response(): void {
+		$this->register_test_ability(
+			'test/nested-object-defaults',
+			array(
+				'label'               => 'Test Nested Object Defaults',
+				'description'         => 'Tests preparing nested empty object defaults.',
+				'category'            => 'general',
+				'input_schema'        => array(
+					'type'       => 'object',
+					'properties' => array(
+						'settings' => array(
+							'type'       => 'object',
+							'default'    => array(),
+							'properties' => array(
+								'options' => array(
+									'type'    => 'object',
+									'default' => array(),
+								),
+							),
+						),
+					),
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'result' => array(
+							'type'    => 'object',
+							'default' => array(),
+						),
+					),
+				),
+				'execute_callback'    => static function (): array {
+					return array();
+				},
+				'permission_callback' => '__return_true',
+				'meta'                => array( 'show_in_rest' => true ),
+			)
+		);
+
+		$request  = new WP_REST_Request( 'GET', '/wp-abilities/v1/abilities/test/nested-object-defaults' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+
+		$this->assertEquals( new stdClass(), $data['input_schema']['properties']['settings']['default'] );
+		$this->assertEquals( new stdClass(), $data['input_schema']['properties']['settings']['properties']['options']['default'] );
+		$this->assertEquals( new stdClass(), $data['output_schema']['properties']['result']['default'] );
+	}
+
+	/**
 	 * Test that internal schema keywords are stripped from nested sub-schema locations.
 	 *
 	 * @ticket 64098


### PR DESCRIPTION
## What?

This hardens the Ability REST API schema preparation path by centralizing response schema transformations in one recursive helper.

The REST list controller now prepares both input and output schemas through `prepare_schema_for_response()`, which:

- strips WordPress-internal schema keywords before exposing ability schemas through REST responses;
- normalizes empty object defaults from `array()` to `stdClass` so they serialize as `{}`;
- applies those transformations recursively to nested sub-schemas.

## Why?

Ability schemas are consumed by REST clients and AI-facing tooling. The implementation already stripped internal schema keywords recursively, while empty object default normalization was only applied at the top level before that recursion. Combining these transformations into one helper gives core a clearer extraction point for future schema transformation work and ensures nested object defaults are represented consistently.

This follows the direction discussed in Core Trac ticket #64955 and builds on the REST cleanup from #65035.

## Testing

- `php -l src/wp-includes/rest-api/endpoints/class-wp-rest-abilities-v1-list-controller.php`
- `php -l tests/phpunit/tests/rest-api/wpRestAbilitiesV1ListController.php`
- `git diff --check -- src/wp-includes/rest-api/endpoints/class-wp-rest-abilities-v1-list-controller.php tests/phpunit/tests/rest-api/wpRestAbilitiesV1ListController.php`
- `npm run test:php -- --filter Tests_REST_API_WpRestAbilitiesV1ListController`

Trac ticket: https://core.trac.wordpress.org/ticket/64955
