### PR TITLE
Users: Add Home URL to new user registration admin notification email.

### DIFF
--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -2285,6 +2285,8 @@ if ( ! function_exists( 'wp_new_user_notification' ) ) :
 		 */
 		$blogname = wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES );
 
+		$homeurl = home_url( '/' );
+
 		/**
 		 * Filters whether the admin is notified of a new user registration.
 		 *
@@ -2305,8 +2307,8 @@ if ( ! function_exists( 'wp_new_user_notification' ) ) :
 				$switched_locale = switch_to_locale( get_locale() );
 			}
 
-			/* translators: %s: Site title. */
-			$message = sprintf( __( 'New user registration on your site %s:' ), $blogname ) . "\r\n\r\n";
+			/* translators: 1: Site title. 2: Site URL. */
+			$message = sprintf( __( 'New user registration on your site %1$s (%2$s):' ), $blogname, $homeurl ) . "\r\n\r\n";
 			/* translators: %s: User login. */
 			$message .= sprintf( __( 'Username: %s' ), $user->user_login ) . "\r\n\r\n";
 			/* translators: %s: User email address. */


### PR DESCRIPTION

Trac ticket: https://core.trac.wordpress.org/ticket/51792


This PR adds the site's home URL to the admin notification email sent when a new user registers.

Admins who manage multiple WordPress sites often receive new user registration emails with only the site name to identify the source, but two sites can share the same name. The home URL is a unique, unambiguous identifier. This is a UX improvement with no API impact.

Before - 
```md
New user registration on your site Example Blog:

Username: johndoe
Email: johndoe@example.com
```

After - 
```
New user registration on your site Example Blog (https://example.com/):

Username: johndoe
Email: johndoe@example.com
```

Props to @Ipstenu 