### PR TITLE
REST API: Allow-list ability schema response keywords

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-abilities-v1-list-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-abilities-v1-list-controller.php
@@ -191,8 +191,9 @@ class WP_REST_Abilities_V1_List_Controller extends WP_REST_Controller {
 	/**
 	 * Additional schema keywords to preserve in REST responses.
 	 *
-	 * These are not included in rest_get_allowed_schema_keywords(), but are
-	 * still recognized as schema traversal locations for ability schemas.
+	 * Ability schemas are exposed to clients as JSON Schema. Preserve additional
+	 * draft-04 keywords so clients can validate richer schemas, even when some
+	 * of those keywords are not enforced by the server-side REST schema validator.
 	 *
 	 * @since 7.1.0
 	 * @var string[]
@@ -201,6 +202,7 @@ class WP_REST_Abilities_V1_List_Controller extends WP_REST_Controller {
 		'required',
 		'allOf',
 		'not',
+		'$ref',
 		'definitions',
 		'dependencies',
 		'additionalItems',

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-abilities-v1-list-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-abilities-v1-list-controller.php
@@ -244,16 +244,17 @@ class WP_REST_Abilities_V1_List_Controller extends WP_REST_Controller {
 			}
 		}
 
-		$schema = array_intersect_key(
-			$schema,
-			array_fill_keys(
-				array_merge(
-					rest_get_allowed_schema_keywords(),
-					self::ADDITIONAL_ALLOWED_SCHEMA_KEYWORDS
-				),
-				true
-			)
+		// Computed once and reused across the recursive calls for every schema node.
+		static $allowed_keywords = null;
+		$allowed_keywords      ??= array_fill_keys(
+			array_merge(
+				rest_get_allowed_schema_keywords(),
+				self::ADDITIONAL_ALLOWED_SCHEMA_KEYWORDS
+			),
+			true
 		);
+
+		$schema = array_intersect_key( $schema, $allowed_keywords );
 
 		// Sub-schema maps: keys are user-defined, values are sub-schemas.
 		// Note: 'dependencies' values can also be property-dependency arrays

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-abilities-v1-list-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-abilities-v1-list-controller.php
@@ -189,15 +189,21 @@ class WP_REST_Abilities_V1_List_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * WordPress-internal schema keywords to strip from REST responses.
+	 * Additional schema keywords to preserve in REST responses.
 	 *
-	 * @since 7.0.0
-	 * @var array<string, true>
+	 * These are not included in rest_get_allowed_schema_keywords(), but are
+	 * still recognized as schema traversal locations for ability schemas.
+	 *
+	 * @since 7.1.0
+	 * @var string[]
 	 */
-	private const INTERNAL_SCHEMA_KEYWORDS = array(
-		'sanitize_callback' => true,
-		'validate_callback' => true,
-		'arg_options'       => true,
+	private const ADDITIONAL_ALLOWED_SCHEMA_KEYWORDS = array(
+		'required',
+		'allOf',
+		'not',
+		'definitions',
+		'dependencies',
+		'additionalItems',
 	);
 
 	/**
@@ -217,12 +223,11 @@ class WP_REST_Abilities_V1_List_Controller extends WP_REST_Controller {
 	/**
 	 * Transforms an ability schema for REST response output.
 	 *
-	 * Ability schemas may include WordPress-internal properties like
-	 * `sanitize_callback`, `validate_callback`, and `arg_options` that are
-	 * used server-side but are not valid JSON Schema keywords. This method
-	 * removes those specific keys so they are not exposed in REST responses.
-	 * It also converts empty array defaults to objects when the schema type is
-	 * 'object' to ensure proper JSON serialization as {} instead of [].
+	 * Ability schemas may include WordPress-internal properties or unsupported
+	 * schema keywords that should not be exposed in REST responses. This method
+	 * strips keys not recognized by the REST API schema handling. It also
+	 * converts empty array defaults to objects when the schema type is 'object'
+	 * to ensure proper JSON serialization as {} instead of [].
 	 *
 	 * @since 7.1.0
 	 *
@@ -237,7 +242,16 @@ class WP_REST_Abilities_V1_List_Controller extends WP_REST_Controller {
 			}
 		}
 
-		$schema = array_diff_key( $schema, self::INTERNAL_SCHEMA_KEYWORDS );
+		$schema = array_intersect_key(
+			$schema,
+			array_fill_keys(
+				array_merge(
+					rest_get_allowed_schema_keywords(),
+					self::ADDITIONAL_ALLOWED_SCHEMA_KEYWORDS
+				),
+				true
+			)
+		);
 
 		// Sub-schema maps: keys are user-defined, values are sub-schemas.
 		// Note: 'dependencies' values can also be property-dependency arrays

--- a/tests/phpunit/tests/rest-api/wpRestAbilitiesV1ListController.php
+++ b/tests/phpunit/tests/rest-api/wpRestAbilitiesV1ListController.php
@@ -962,6 +962,7 @@ class Tests_REST_API_WpRestAbilitiesV1ListController extends WP_UnitTestCase {
 				'category'            => 'general',
 				'input_schema'        => array(
 					'type'                 => 'object',
+					'$ref'                 => '#/definitions/address',
 					'anyOf'                => array(
 						array(
 							'type'              => 'object',
@@ -1063,6 +1064,7 @@ class Tests_REST_API_WpRestAbilitiesV1ListController extends WP_UnitTestCase {
 		$data = $response->get_data();
 
 		// Verify internal keywords are stripped from anyOf sub-schemas.
+		$this->assertSame( '#/definitions/address', $data['input_schema']['$ref'] );
 		$this->assertArrayHasKey( 'anyOf', $data['input_schema'] );
 		$this->assertArrayNotHasKey( 'sanitize_callback', $data['input_schema']['anyOf'][0] );
 		$this->assertSame( 'object', $data['input_schema']['anyOf'][0]['type'] );

--- a/tests/phpunit/tests/rest-api/wpRestAbilitiesV1ListController.php
+++ b/tests/phpunit/tests/rest-api/wpRestAbilitiesV1ListController.php
@@ -829,11 +829,11 @@ class Tests_REST_API_WpRestAbilitiesV1ListController extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that WordPress-internal schema keywords are stripped from ability schemas in REST response.
+	 * Test that schema keywords outside the allow-list are stripped from ability schemas in REST response.
 	 *
 	 * @ticket 65035
 	 */
-	public function test_internal_schema_keywords_stripped_from_response(): void {
+	public function test_unsupported_schema_keywords_stripped_from_response(): void {
 		$this->register_test_ability(
 			'test/with-internal-keywords',
 			array(
@@ -969,11 +969,11 @@ class Tests_REST_API_WpRestAbilitiesV1ListController extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that internal schema keywords are stripped from nested sub-schema locations.
+	 * Test that schema keywords outside the allow-list are stripped from nested sub-schema locations.
 	 *
 	 * @ticket 64098
 	 */
-	public function test_internal_schema_keywords_stripped_from_nested_sub_schemas(): void {
+	public function test_unsupported_schema_keywords_stripped_from_nested_sub_schemas(): void {
 		$this->register_test_ability(
 			'test/nested-internal-keywords',
 			array(

--- a/tests/phpunit/tests/rest-api/wpRestAbilitiesV1ListController.php
+++ b/tests/phpunit/tests/rest-api/wpRestAbilitiesV1ListController.php
@@ -842,11 +842,15 @@ class Tests_REST_API_WpRestAbilitiesV1ListController extends WP_UnitTestCase {
 				'category'            => 'general',
 				'input_schema'        => array(
 					'type'       => 'object',
+					'required'   => array( 'content' ),
 					'properties' => array(
 						'content' => array(
 							'type'              => 'string',
 							'description'       => 'The content value.',
+							'example'           => 'example content',
 							'examples'          => array( 'example content' ),
+							'context'           => array( 'view', 'edit', 'embed' ),
+							'readonly'          => true,
 							'sanitize_callback' => 'sanitize_text_field',
 							'validate_callback' => 'is_string',
 							'arg_options'       => array( 'sanitize_callback' => 'wp_kses_post' ),
@@ -855,7 +859,13 @@ class Tests_REST_API_WpRestAbilitiesV1ListController extends WP_UnitTestCase {
 				),
 				'output_schema'       => array(
 					'type'              => 'string',
+					'example'           => 'example output',
+					'examples'          => array( 'example output' ),
+					'context'           => array( 'view', 'edit', 'embed' ),
+					'readonly'          => true,
 					'sanitize_callback' => 'sanitize_text_field',
+					'validate_callback' => 'is_string',
+					'arg_options'       => array( 'sanitize_callback' => 'wp_kses_post' ),
 				),
 				'execute_callback'    => static function ( $input ) {
 					return $input['content'];
@@ -876,19 +886,29 @@ class Tests_REST_API_WpRestAbilitiesV1ListController extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'content', $data['input_schema']['properties'] );
 		$this->assertArrayHasKey( 'output_schema', $data );
 
-		// Verify internal keywords are stripped from input_schema properties.
+		// Verify unsupported schema keywords are stripped from input_schema properties.
 		$content_schema = $data['input_schema']['properties']['content'];
 		$this->assertArrayNotHasKey( 'sanitize_callback', $content_schema );
 		$this->assertArrayNotHasKey( 'validate_callback', $content_schema );
 		$this->assertArrayNotHasKey( 'arg_options', $content_schema );
+		$this->assertArrayNotHasKey( 'example', $content_schema );
 		$this->assertArrayNotHasKey( 'examples', $content_schema );
+		$this->assertArrayNotHasKey( 'context', $content_schema );
+		$this->assertArrayNotHasKey( 'readonly', $content_schema );
 
 		// Verify valid JSON Schema keywords are preserved.
 		$this->assertSame( 'string', $content_schema['type'] );
 		$this->assertSame( 'The content value.', $content_schema['description'] );
+		$this->assertSame( array( 'content' ), $data['input_schema']['required'] );
 
 		// Verify internal keywords are stripped from output_schema.
 		$this->assertArrayNotHasKey( 'sanitize_callback', $data['output_schema'] );
+		$this->assertArrayNotHasKey( 'validate_callback', $data['output_schema'] );
+		$this->assertArrayNotHasKey( 'arg_options', $data['output_schema'] );
+		$this->assertArrayNotHasKey( 'example', $data['output_schema'] );
+		$this->assertArrayNotHasKey( 'examples', $data['output_schema'] );
+		$this->assertArrayNotHasKey( 'context', $data['output_schema'] );
+		$this->assertArrayNotHasKey( 'readonly', $data['output_schema'] );
 		$this->assertSame( 'string', $data['output_schema']['type'] );
 	}
 

--- a/tests/phpunit/tests/rest-api/wpRestAbilitiesV1ListController.php
+++ b/tests/phpunit/tests/rest-api/wpRestAbilitiesV1ListController.php
@@ -835,10 +835,10 @@ class Tests_REST_API_WpRestAbilitiesV1ListController extends WP_UnitTestCase {
 	 */
 	public function test_unsupported_schema_keywords_stripped_from_response(): void {
 		$this->register_test_ability(
-			'test/with-internal-keywords',
+			'test/with-unsupported-keywords',
 			array(
-				'label'               => 'Test Internal Keywords',
-				'description'         => 'Tests stripping of internal schema keywords',
+				'label'               => 'Test Unsupported Keywords',
+				'description'         => 'Tests stripping of unsupported schema keywords',
 				'category'            => 'general',
 				'input_schema'        => array(
 					'type'       => 'object',
@@ -875,7 +875,7 @@ class Tests_REST_API_WpRestAbilitiesV1ListController extends WP_UnitTestCase {
 			)
 		);
 
-		$request  = new WP_REST_Request( 'GET', '/wp-abilities/v1/abilities/test/with-internal-keywords' );
+		$request  = new WP_REST_Request( 'GET', '/wp-abilities/v1/abilities/test/with-unsupported-keywords' );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertSame( 200, $response->get_status() );
@@ -975,9 +975,9 @@ class Tests_REST_API_WpRestAbilitiesV1ListController extends WP_UnitTestCase {
 	 */
 	public function test_unsupported_schema_keywords_stripped_from_nested_sub_schemas(): void {
 		$this->register_test_ability(
-			'test/nested-internal-keywords',
+			'test/nested-unsupported-keywords',
 			array(
-				'label'               => 'Test Nested Keywords',
+				'label'               => 'Test Nested Unsupported Keywords',
 				'description'         => 'Tests stripping from all sub-schema locations',
 				'category'            => 'general',
 				'input_schema'        => array(
@@ -1076,7 +1076,7 @@ class Tests_REST_API_WpRestAbilitiesV1ListController extends WP_UnitTestCase {
 			)
 		);
 
-		$request  = new WP_REST_Request( 'GET', '/wp-abilities/v1/abilities/test/nested-internal-keywords' );
+		$request  = new WP_REST_Request( 'GET', '/wp-abilities/v1/abilities/test/nested-unsupported-keywords' );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertSame( 200, $response->get_status() );

--- a/tests/phpunit/tests/rest-api/wpRestAbilitiesV1ListController.php
+++ b/tests/phpunit/tests/rest-api/wpRestAbilitiesV1ListController.php
@@ -846,6 +846,7 @@ class Tests_REST_API_WpRestAbilitiesV1ListController extends WP_UnitTestCase {
 						'content' => array(
 							'type'              => 'string',
 							'description'       => 'The content value.',
+							'examples'          => array( 'example content' ),
 							'sanitize_callback' => 'sanitize_text_field',
 							'validate_callback' => 'is_string',
 							'arg_options'       => array( 'sanitize_callback' => 'wp_kses_post' ),
@@ -880,6 +881,7 @@ class Tests_REST_API_WpRestAbilitiesV1ListController extends WP_UnitTestCase {
 		$this->assertArrayNotHasKey( 'sanitize_callback', $content_schema );
 		$this->assertArrayNotHasKey( 'validate_callback', $content_schema );
 		$this->assertArrayNotHasKey( 'arg_options', $content_schema );
+		$this->assertArrayNotHasKey( 'examples', $content_schema );
 
 		// Verify valid JSON Schema keywords are preserved.
 		$this->assertSame( 'string', $content_schema['type'] );


### PR DESCRIPTION
## What?

This hardens the Ability REST API schema response preparation by switching from an internal-keyword deny-list to a schema-keyword allow-list.

Ability input and output schemas exposed through REST responses now keep only:

- keywords returned by `rest_get_allowed_schema_keywords()`;
- a small local set of additional draft-04 schema keywords that clients may use for validation or schema traversal.

This continues to preserve nested schema structures while stripping WordPress-internal keys such as `sanitize_callback`, `validate_callback`, and `arg_options`, along with other unsupported schema keywords such as `example`, `examples`, `context`, and `readonly`.

## Why?

The previous implementation stripped only known internal keywords. An allow-list is stricter and better aligned with the REST API schema surface: unknown or unsupported schema keywords are not exposed to REST clients by default.

The local additional keyword list intentionally preserves a few draft-04 keywords that are useful to stricter client-side validators. This aligns with the approach documented in WordPress/gutenberg#78783, which adds tests for the strict JSON Schema keyword surface supported by the client-side abilities validator.

At the moment, the Core and Gutenberg changes aim to mirror the same allowed schema-property surface: unknown schema keywords should be skipped or stripped rather than passed through. Based on review feedback, we can also move in the opposite direction by relaxing the client-side validator to ignore unknown schema properties instead of treating them as unsupported. In practice, the two possible endpoints are either a strict shared allow-list or a relaxed client that skips unknown properties.

## Test Coverage

This PR now mirrors the WordPress-specific keyword cases covered in WordPress/gutenberg#78783 by documenting that unsupported schema keywords are stripped from both ability `input_schema` properties and top-level `output_schema` definitions:

- `sanitize_callback`
- `validate_callback`
- `arg_options`
- `example`
- `examples`
- `context`
- `readonly`

It also verifies that valid draft-04 `required` arrays are preserved. Boolean `required` handling is intentionally left for a follow-up PR.

## Related

- https://core.trac.wordpress.org/ticket/64955
- https://github.com/WordPress/gutenberg/pull/78783

## Testing

- `php -l tests/phpunit/tests/rest-api/wpRestAbilitiesV1ListController.php`
- `git diff --check -- tests/phpunit/tests/rest-api/wpRestAbilitiesV1ListController.php`

Attempted after the latest test-only update, but the local Docker runner hung after creating the PHPUnit container:

- `npm run test:php -- --filter Tests_REST_API_WpRestAbilitiesV1ListController`

Previously run on this branch before the latest test-only update:

- `php -l src/wp-includes/rest-api/endpoints/class-wp-rest-abilities-v1-list-controller.php`
- `npm run typecheck:php -- src/wp-includes/rest-api/endpoints/class-wp-rest-abilities-v1-list-controller.php --no-progress`
