### PR TITLE
REST API: Add tests for the sideload convert_format boolean arg (backport GB #77565)

### DIFF
--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -801,6 +801,9 @@ function validate_file_to_edit( $file, $allowed_files = array() ) {
  *     @type string $url  URL of the newly-uploaded file.
  *     @type string $type Mime type of the newly-uploaded file.
  * }
+ *
+ * @phpstan-return array{ file: non-empty-string, url: non-empty-string, type: non-empty-string }
+ *                |array{ error: non-empty-string }
  */
 function _wp_handle_upload( &$file, $overrides, $time, $action ) {
 	// The default error handler.
@@ -1094,6 +1097,9 @@ function _wp_handle_upload( &$file, $overrides, $time, $action ) {
  *                               See _wp_handle_upload() for accepted values.
  * @param string|null $time      Optional. Time formatted in 'yyyy/mm'. Default null.
  * @return array See _wp_handle_upload() for return value.
+ *
+ * @phpstan-return array{ file: non-empty-string, url: non-empty-string, type: non-empty-string }
+ *                |array{ error: non-empty-string }
  */
 function wp_handle_upload( &$file, $overrides = false, $time = null ) {
 	/*
@@ -1121,6 +1127,9 @@ function wp_handle_upload( &$file, $overrides = false, $time = null ) {
  *                               See _wp_handle_upload() for accepted values.
  * @param string|null $time      Optional. Time formatted in 'yyyy/mm'. Default null.
  * @return array See _wp_handle_upload() for return value.
+ *
+ * @phpstan-return array{ file: non-empty-string, url: non-empty-string, type: non-empty-string }
+ *                |array{ error: non-empty-string }
  */
 function wp_handle_sideload( &$file, $overrides = false, $time = null ) {
 	/*

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -6888,6 +6888,18 @@ function wp_delete_attachment_files( $post_id, $meta, $backup_sizes, $file ) {
  *     @type array  $image_meta Image metadata.
  *     @type int    $filesize   File size of the attachment.
  * }
+ *
+ * @phpstan-return array{
+ *                     width: int<1, max>,
+ *                     height: int<1, max>,
+ *                     file: non-empty-string,
+ *                     sizes: array<non-empty-string, array{
+ *                                                        file: non-empty-string,
+ *                                                        width: int<1, max>,
+ *                                                        height: int<1, max>,
+ *                                                        'mime-type': non-empty-string,
+ *                                                    }>
+ *                 }|false
  */
 function wp_get_attachment_metadata( $attachment_id = 0, $unfiltered = false ) {
 	$attachment_id = (int) $attachment_id;

--- a/src/wp-includes/rest-api/class-wp-rest-request.php
+++ b/src/wp-includes/rest-api/class-wp-rest-request.php
@@ -52,7 +52,7 @@ class WP_REST_Request implements ArrayAccess {
 	 * HTTP headers for the request.
 	 *
 	 * @since 4.4.0
-	 * @var array Map of key to value. Key is always lowercase, as per HTTP specification.
+	 * @var array<string, string[]> Map of key to value. Key is always lowercase, as per HTTP specification.
 	 */
 	protected $headers = array();
 
@@ -155,7 +155,7 @@ class WP_REST_Request implements ArrayAccess {
 	 *
 	 * @since 4.4.0
 	 *
-	 * @return array Map of key to value. Key is always lowercase, as per HTTP specification.
+	 * @return array<string, string[]> Map of key to value. Key is always lowercase, as per HTTP specification.
 	 */
 	public function get_headers() {
 		return $this->headers;
@@ -226,7 +226,7 @@ class WP_REST_Request implements ArrayAccess {
 	 * @since 4.4.0
 	 *
 	 * @param string $key Header name, will be canonicalized to lowercase.
-	 * @return array|null List of string values if set, null otherwise.
+	 * @return string[]|null List of string values if set, null otherwise.
 	 */
 	public function get_header_as_array( $key ) {
 		$key = $this->canonicalize_header_name( $key );
@@ -588,6 +588,15 @@ class WP_REST_Request implements ArrayAccess {
 	 * @since 4.4.0
 	 *
 	 * @return array Parameter map of key to value.
+	 *
+	 * @phpstan-return array<string, array{
+	 *                              name: non-empty-string,
+	 *                              type: non-empty-string,
+	 *                              size: non-negative-int,
+	 *                              tmp_name: non-empty-string,
+	 *                              error: int<0, 8>,
+	 *                              full_path?: non-empty-string,
+	 *                          }>
 	 */
 	public function get_file_params() {
 		return $this->params['FILES'];
@@ -601,6 +610,15 @@ class WP_REST_Request implements ArrayAccess {
 	 * @since 4.4.0
 	 *
 	 * @param array $params Parameter map of key to value.
+	 *
+	 * @phpstan-param array<string, array{
+	 *                                  name: non-empty-string,
+	 *                                  type: non-empty-string,
+	 *                                  size: non-negative-int,
+	 *                                  tmp_name: non-empty-string,
+	 *                                  error: int<0, 8>,
+	 *                                  full_path?: non-empty-string,
+	 *                              }> $params
 	 */
 	public function set_file_params( $params ) {
 		$this->params['FILES'] = $params;

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
@@ -93,7 +93,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 								 * the current list of registered sizes, which reflects sizes added
 								 * after route registration (e.g. via add_image_size()).
 								 */
-								'validate_callback' => static function ( $value, $request, $param ) {
+								'validate_callback' => static function ( $value, WP_REST_Request $request, string $param ) {
 									$valid_sizes   = array_keys( wp_get_registered_image_subsizes() );
 									$valid_sizes[] = 'original';
 									$valid_sizes[] = 'scaled';

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
@@ -1457,10 +1457,10 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 	 * @since 4.7.0
 	 * @since 6.6.0 Added the `$time` parameter.
 	 *
-	 * @param string      $data    Supplied file data.
-	 * @param array       $headers HTTP headers from the request.
-	 * @param string|null $time    Optional. Time formatted in 'yyyy/mm'. Default null.
-	 * @return array|WP_Error Data from wp_handle_sideload().
+	 * @param string                  $data    Supplied file data.
+	 * @param array<string, string[]> $headers HTTP headers from the request.
+	 * @param string|null             $time    Optional. Time formatted in 'yyyy/mm'. Default null.
+	 * @return array{ file: non-empty-string, url: non-empty-string, type: non-empty-string }|WP_Error Data from wp_handle_sideload().
 	 */
 	protected function upload_from_data( $data, $headers, $time = null ) {
 		if ( empty( $data ) ) {
@@ -1677,10 +1677,19 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 	 * @since 4.7.0
 	 * @since 6.6.0 Added the `$time` parameter.
 	 *
-	 * @param array       $files   Data from the `$_FILES` superglobal.
-	 * @param array       $headers HTTP headers from the request.
-	 * @param string|null $time    Optional. Time formatted in 'yyyy/mm'. Default null.
-	 * @return array|WP_Error Data from wp_handle_upload().
+	 * @param array                   $files   Data from the `$_FILES` superglobal.
+	 * @param array<string, string[]> $headers HTTP headers from the request.
+	 * @param string|null             $time    Optional. Time formatted in 'yyyy/mm'. Default null.
+	 * @return array{ file: non-empty-string, url: non-empty-string, type: non-empty-string }|WP_Error Data from wp_handle_upload().
+	 *
+	 * @phpstan-param array<string, array{
+	 *                                  name: non-empty-string,
+	 *                                  type: non-empty-string,
+	 *                                  size: non-negative-int,
+	 *                                  tmp_name: non-empty-string,
+	 *                                  error: int<0, 8>,
+	 *                                  full_path?: non-empty-string,
+	 *                              }> $files
 	 */
 	protected function upload_from_file( $files, $headers, $time = null ) {
 		if ( empty( $files ) ) {
@@ -2305,6 +2314,17 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 		}
 
 		// Apply all sub-size metadata collected from sideload responses.
+		/**
+		 * @var list<array{
+		 *          image_size: string|string[],
+		 *          width?: int<1, max>,
+		 *          height?: int<1, max>,
+		 *          file?: non-empty-string,
+		 *          mime_type?: non-empty-string,
+		 *          filesize?: int<1, max>,
+		 *          original_image?: non-empty-string,
+		 *      }> $sub_sizes
+		 */
 		$sub_sizes = $request['sub_sizes'] ?? array();
 
 		foreach ( $sub_sizes as $sub_size ) {

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
@@ -170,7 +170,8 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 											'minimum' => 1,
 										),
 										'file'           => array(
-											'type' => 'string',
+											'type'      => 'string',
+											'minLength' => 1,
 										),
 										'mime_type'      => array(
 											'type'    => 'string',
@@ -181,7 +182,8 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 											'minimum' => 1,
 										),
 										'original_image' => array(
-											'type' => 'string',
+											'type'      => 'string',
+											'minLength' => 1,
 										),
 									),
 								),

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
@@ -113,9 +113,45 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 						'callback'            => array( $this, 'finalize_item' ),
 						'permission_callback' => array( $this, 'edit_media_item_permissions_check' ),
 						'args'                => array(
-							'id' => array(
+							'id'        => array(
 								'description' => __( 'Unique identifier for the attachment.' ),
 								'type'        => 'integer',
+							),
+							'sub_sizes' => array(
+								'description' => __( 'Array of sub-size metadata collected from sideload responses.' ),
+								'type'        => 'array',
+								'default'     => array(),
+								'items'       => array(
+									'type'       => 'object',
+									'properties' => array(
+										'image_size'     => array(
+											'type'     => 'string',
+											'required' => true,
+										),
+										'width'          => array(
+											'type'    => 'integer',
+											'minimum' => 1,
+										),
+										'height'         => array(
+											'type'    => 'integer',
+											'minimum' => 1,
+										),
+										'file'           => array(
+											'type' => 'string',
+										),
+										'mime_type'      => array(
+											'type'    => 'string',
+											'pattern' => '^image/.*',
+										),
+										'filesize'       => array(
+											'type'    => 'integer',
+											'minimum' => 1,
+										),
+										'original_image' => array(
+											'type' => 'string',
+										),
+									),
+								),
 							),
 						),
 					),
@@ -2082,16 +2118,19 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 
 		$image_size = $request['image_size'];
 
-		$metadata = wp_get_attachment_metadata( $attachment_id, true );
-
-		if ( ! $metadata ) {
-			$metadata = array();
-		}
+		// Build sub-size data to return to the client.
+		// The client accumulates these and sends them all to the finalize
+		// endpoint, which writes the metadata in a single operation. This
+		// avoids the read-modify-write race that concurrent sideloads for the
+		// same attachment would otherwise hit.
+		$sub_size_data = array(
+			'image_size' => $image_size,
+		);
 
 		if ( 'original' === $image_size ) {
-			$metadata['original_image'] = wp_basename( $path );
+			$sub_size_data['file'] = wp_basename( $path );
 		} elseif ( 'scaled' === $image_size ) {
-			// The current attached file is the original; record it as original_image.
+			// Record the current attached file as the original.
 			$current_file = get_attached_file( $attachment_id, true );
 
 			if ( ! $current_file ) {
@@ -2102,7 +2141,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 				);
 			}
 
-			$metadata['original_image'] = wp_basename( $current_file );
+			$sub_size_data['original_image'] = wp_basename( $current_file );
 
 			// Validate the scaled image before updating the attached file.
 			$size     = wp_getimagesize( $path );
@@ -2117,6 +2156,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 			}
 
 			// Update the attached file to point to the scaled version.
+			// This writes to _wp_attached_file meta, not _wp_attachment_metadata.
 			if (
 				get_attached_file( $attachment_id, true ) !== $path &&
 				! update_attached_file( $attachment_id, $path )
@@ -2128,42 +2168,21 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 				);
 			}
 
-			$metadata['width']    = $size[0];
-			$metadata['height']   = $size[1];
-			$metadata['filesize'] = $filesize;
-			$metadata['file']     = _wp_relative_upload_path( $path );
+			$sub_size_data['width']    = $size[0];
+			$sub_size_data['height']   = $size[1];
+			$sub_size_data['filesize'] = $filesize;
+			$sub_size_data['file']     = _wp_relative_upload_path( $path );
 		} else {
-			$metadata['sizes'] = $metadata['sizes'] ?? array();
-
 			$size = wp_getimagesize( $path );
 
-			$metadata['sizes'][ $image_size ] = array(
-				'width'     => $size ? $size[0] : 0,
-				'height'    => $size ? $size[1] : 0,
-				'file'      => wp_basename( $path ),
-				'mime-type' => $type,
-				'filesize'  => wp_filesize( $path ),
-			);
+			$sub_size_data['width']     = $size ? $size[0] : 0;
+			$sub_size_data['height']    = $size ? $size[1] : 0;
+			$sub_size_data['file']      = wp_basename( $path );
+			$sub_size_data['mime_type'] = $type;
+			$sub_size_data['filesize']  = wp_filesize( $path );
 		}
 
-		wp_update_attachment_metadata( $attachment_id, $metadata );
-
-		$response_request = new WP_REST_Request(
-			WP_REST_Server::READABLE,
-			rest_get_route_for_post( $attachment_id )
-		);
-
-		$response_request['context'] = 'edit';
-
-		if ( isset( $request['_fields'] ) ) {
-			$response_request['_fields'] = $request['_fields'];
-		}
-
-		$response = $this->prepare_item_for_response( get_post( $attachment_id ), $response_request );
-
-		$response->header( 'Location', rest_url( rest_get_route_for_post( $attachment_id ) ) );
-
-		return $response;
+		return rest_ensure_response( $sub_size_data );
 	}
 
 	/**
@@ -2215,9 +2234,11 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 	/**
 	 * Finalizes an attachment after client-side media processing.
 	 *
-	 * Triggers the 'wp_generate_attachment_metadata' filter so that
-	 * server-side plugins can process the attachment after all client-side
-	 * operations (upload, thumbnail generation, sideloads) are complete.
+	 * Applies the sub-size metadata collected from sideload responses in a
+	 * single metadata update, then triggers the 'wp_generate_attachment_metadata'
+	 * filter so that server-side plugins can process the attachment after all
+	 * client-side operations (upload, thumbnail generation, sideloads) are
+	 * complete.
 	 *
 	 * @since 7.1.0
 	 *
@@ -2235,6 +2256,35 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 		$metadata = wp_get_attachment_metadata( $attachment_id );
 		if ( ! is_array( $metadata ) ) {
 			$metadata = array();
+		}
+
+		// Apply all sub-size metadata collected from sideload responses.
+		$sub_sizes = $request['sub_sizes'] ?? array();
+
+		foreach ( $sub_sizes as $sub_size ) {
+			$image_size = $sub_size['image_size'];
+
+			if ( 'original' === $image_size ) {
+				$metadata['original_image'] = $sub_size['file'];
+			} elseif ( 'scaled' === $image_size ) {
+				if ( ! empty( $sub_size['original_image'] ) ) {
+					$metadata['original_image'] = $sub_size['original_image'];
+				}
+				$metadata['width']    = $sub_size['width'] ?? 0;
+				$metadata['height']   = $sub_size['height'] ?? 0;
+				$metadata['filesize'] = $sub_size['filesize'] ?? 0;
+				$metadata['file']     = $sub_size['file'] ?? '';
+			} else {
+				$metadata['sizes'] = $metadata['sizes'] ?? array();
+
+				$metadata['sizes'][ $image_size ] = array(
+					'width'     => $sub_size['width'] ?? 0,
+					'height'    => $sub_size['height'] ?? 0,
+					'file'      => $sub_size['file'] ?? '',
+					'mime-type' => $sub_size['mime_type'] ?? '',
+					'filesize'  => $sub_size['filesize'] ?? 0,
+				);
+			}
 		}
 
 		/** This filter is documented in wp-admin/includes/image.php */

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
@@ -94,29 +94,22 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 								 * after route registration (e.g. via add_image_size()).
 								 */
 								'validate_callback' => static function ( $value, WP_REST_Request $request, string $param ) {
+                					$valid = rest_validate_request_arg( $locations, $request, $param );
+                					if ( true !== $valid ) {
+                						return $valid;
+                					}
 									$valid_sizes   = array_keys( wp_get_registered_image_subsizes() );
 									$valid_sizes[] = 'original';
 									$valid_sizes[] = 'scaled';
 									$valid_sizes[] = 'full';
 
-									$items = is_string( $value ) ? array( $value ) : ( is_array( $value ) ? $value : null );
-									if ( null === $items ) {
-										return new WP_Error(
-											'rest_invalid_type',
-											/* translators: %s: Parameter name. */
-											sprintf( __( '%s must be a string or an array of strings.' ), $param )
-										);
-									}
-
-									foreach ( $items as $item ) {
-										if ( ! is_string( $item ) || ! in_array( $item, $valid_sizes, true ) ) {
-											return new WP_Error(
-												'rest_not_in_enum',
-												/* translators: %s: Parameter name. */
-												sprintf( __( '%s contains an invalid image size.' ), $param )
-											);
-										}
-									}
+									$items = (array) $value;
+									$schema = array(
+										'type'  => 'array',
+										'items' => array( 'type' => 'string' ),
+										'enum'  => $valid_sizes,
+									);
+									return rest_validate_enum( $items, $schema, $param );
 
 									return true;
 								},

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
@@ -2348,7 +2348,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 				continue;
 			}
 
-			if ( 'original' === $image_size ) {
+			if ( 'original' === $image_size && isset( $sub_size['file'] ) ) {
 				$metadata['original_image'] = $sub_size['file'];
 			} elseif ( 'scaled' === $image_size ) {
 				if ( ! empty( $sub_size['original_image'] ) ) {

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
@@ -94,24 +94,25 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 								 * after route registration (e.g. via add_image_size()).
 								 */
 								'validate_callback' => static function ( $value, WP_REST_Request $request, string $param ) {
-                					$valid = rest_validate_request_arg( $locations, $request, $param );
-                					if ( true !== $valid ) {
-                						return $valid;
-                					}
+									$valid = rest_validate_request_arg( $value, $request, $param );
+									if ( true !== $valid ) {
+										return $valid;
+									}
+
 									$valid_sizes   = array_keys( wp_get_registered_image_subsizes() );
 									$valid_sizes[] = 'original';
 									$valid_sizes[] = 'scaled';
 									$valid_sizes[] = 'full';
 
-									$items = (array) $value;
 									$schema = array(
 										'type'  => 'array',
-										'items' => array( 'type' => 'string' ),
-										'enum'  => $valid_sizes,
+										'items' => array(
+											'type' => 'string',
+											'enum' => $valid_sizes,
+										),
 									);
-									return rest_validate_enum( $items, $schema, $param );
 
-									return true;
+									return rest_validate_value_from_schema( (array) $value, $schema, $param );
 								},
 							),
 							'convert_format' => array(

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
@@ -65,14 +65,6 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 		);
 
 		if ( wp_is_client_side_media_processing_enabled() ) {
-			$valid_image_sizes = array_keys( wp_get_registered_image_subsizes() );
-			// Special case to set 'original_image' in attachment metadata.
-			$valid_image_sizes[] = 'original';
-			// Used for PDF thumbnails.
-			$valid_image_sizes[] = 'full';
-			// Client-side big image threshold: sideload the scaled version.
-			$valid_image_sizes[] = 'scaled';
-
 			register_rest_route(
 				$this->namespace,
 				'/' . $this->rest_base . '/(?P<id>[\d]+)/sideload',
@@ -87,10 +79,47 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 								'type'        => 'integer',
 							),
 							'image_size'     => array(
-								'description' => __( 'Image size.' ),
-								'type'        => 'string',
-								'enum'        => $valid_image_sizes,
-								'required'    => true,
+								'description'       => __( 'Image size. Can be a single size name or an array of size names to register the same file under multiple sizes.' ),
+								'type'              => array( 'string', 'array' ),
+								'items'             => array(
+									'type' => 'string',
+								),
+								'required'          => true,
+								/*
+								 * A custom callback is used instead of the default enum validation
+								 * because rest_is_array() treats scalar strings as single-element
+								 * lists (via wp_parse_list()), so a [ 'string', 'array' ] type alone
+								 * cannot enforce the enum. The callback validates each item against
+								 * the current list of registered sizes, which reflects sizes added
+								 * after route registration (e.g. via add_image_size()).
+								 */
+								'validate_callback' => static function ( $value, $request, $param ) {
+									$valid_sizes   = array_keys( wp_get_registered_image_subsizes() );
+									$valid_sizes[] = 'original';
+									$valid_sizes[] = 'scaled';
+									$valid_sizes[] = 'full';
+
+									$items = is_string( $value ) ? array( $value ) : ( is_array( $value ) ? $value : null );
+									if ( null === $items ) {
+										return new WP_Error(
+											'rest_invalid_type',
+											/* translators: %s: Parameter name. */
+											sprintf( __( '%s must be a string or an array of strings.' ), $param )
+										);
+									}
+
+									foreach ( $items as $item ) {
+										if ( ! is_string( $item ) || ! in_array( $item, $valid_sizes, true ) ) {
+											return new WP_Error(
+												'rest_not_in_enum',
+												/* translators: %s: Parameter name. */
+												sprintf( __( '%s contains an invalid image size.' ), $param )
+											);
+										}
+									}
+
+									return true;
+								},
 							),
 							'convert_format' => array(
 								'type'        => 'boolean',
@@ -125,8 +154,12 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 									'type'       => 'object',
 									'properties' => array(
 										'image_size'     => array(
-											'type'     => 'string',
-											'required' => true,
+											'description' => __( 'Size name, or an array of size names when a single file is registered under multiple sizes with matching dimensions.' ),
+											'type'        => array( 'string', 'array' ),
+											'items'       => array(
+												'type' => 'string',
+											),
+											'required'    => true,
 										),
 										'width'          => array(
 											'type'    => 'integer',
@@ -2127,7 +2160,18 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 			'image_size' => $image_size,
 		);
 
-		if ( 'original' === $image_size ) {
+		if ( is_array( $image_size ) ) {
+			// Multiple registered sizes share these dimensions, so a single
+			// sideloaded file is reused for all of them. Arrays only carry
+			// regular sub-sizes; the special keys below are always scalar.
+			$size = wp_getimagesize( $path );
+
+			$sub_size_data['width']     = $size ? $size[0] : 0;
+			$sub_size_data['height']    = $size ? $size[1] : 0;
+			$sub_size_data['file']      = wp_basename( $path );
+			$sub_size_data['mime_type'] = $type;
+			$sub_size_data['filesize']  = wp_filesize( $path );
+		} elseif ( 'original' === $image_size ) {
 			$sub_size_data['file'] = wp_basename( $path );
 		} elseif ( 'scaled' === $image_size ) {
 			// Record the current attached file as the original.
@@ -2263,6 +2307,24 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 
 		foreach ( $sub_sizes as $sub_size ) {
 			$image_size = $sub_size['image_size'];
+
+			// When multiple size names share identical dimensions the client
+			// sends a single sub-size entry with an array of names. Register the
+			// same file under each name. Arrays only contain regular sizes.
+			if ( is_array( $image_size ) ) {
+				$metadata['sizes'] = $metadata['sizes'] ?? array();
+
+				foreach ( $image_size as $name ) {
+					$metadata['sizes'][ $name ] = array(
+						'width'     => $sub_size['width'] ?? 0,
+						'height'    => $sub_size['height'] ?? 0,
+						'file'      => $sub_size['file'] ?? '',
+						'mime-type' => $sub_size['mime_type'] ?? '',
+						'filesize'  => $sub_size['filesize'] ?? 0,
+					);
+				}
+				continue;
+			}
 
 			if ( 'original' === $image_size ) {
 				$metadata['original_image'] = $sub_size['file'];

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
@@ -2321,6 +2321,12 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 		 */
 		$sub_sizes = $request['sub_sizes'] ?? array();
 
+		// Accumulate sub-sizes in a dedicated array. Writing them back through
+		// $metadata['sizes'] inside the loop makes PHPStan generalize $metadata
+		// to a union of all its value types, after which it can no longer treat
+		// the 'sizes' offset as an array.
+		$sizes = ( isset( $metadata['sizes'] ) && is_array( $metadata['sizes'] ) ) ? $metadata['sizes'] : array();
+
 		foreach ( $sub_sizes as $sub_size ) {
 			$image_size = $sub_size['image_size'];
 
@@ -2328,10 +2334,8 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 			// sends a single sub-size entry with an array of names. Register the
 			// same file under each name. Arrays only contain regular sizes.
 			if ( is_array( $image_size ) ) {
-				$metadata['sizes'] = $metadata['sizes'] ?? array();
-
 				foreach ( $image_size as $name ) {
-					$metadata['sizes'][ $name ] = array(
+					$sizes[ $name ] = array(
 						'width'     => $sub_size['width'] ?? 0,
 						'height'    => $sub_size['height'] ?? 0,
 						'file'      => $sub_size['file'] ?? '',
@@ -2353,9 +2357,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 				$metadata['filesize'] = $sub_size['filesize'] ?? 0;
 				$metadata['file']     = $sub_size['file'] ?? '';
 			} else {
-				$metadata['sizes'] = $metadata['sizes'] ?? array();
-
-				$metadata['sizes'][ $image_size ] = array(
+				$sizes[ $image_size ] = array(
 					'width'     => $sub_size['width'] ?? 0,
 					'height'    => $sub_size['height'] ?? 0,
 					'file'      => $sub_size['file'] ?? '',
@@ -2363,6 +2365,10 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 					'filesize'  => $sub_size['filesize'] ?? 0,
 				);
 			}
+		}
+
+		if ( $sizes ) {
+			$metadata['sizes'] = $sizes;
 		}
 
 		/** This filter is documented in wp-admin/includes/image.php */

--- a/tests/phpunit/tests/rest-api/rest-attachments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-attachments-controller.php
@@ -3562,7 +3562,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 	 * Tests that the finalize endpoint writes regular sub-size metadata
 	 * collected from sideload responses.
 	 *
-	 * @ticket 62243
+	 * @ticket 65329
 	 * @covers WP_REST_Attachments_Controller::finalize_item
 	 * @requires function imagejpeg
 	 */
@@ -3613,7 +3613,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 	 * Tests that the finalize endpoint records original_image from an
 	 * 'original' sub-size collected from a sideload response.
 	 *
-	 * @ticket 62243
+	 * @ticket 65329
 	 * @covers WP_REST_Attachments_Controller::finalize_item
 	 * @requires function imagejpeg
 	 */
@@ -3666,7 +3666,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 	 * Tests that the finalize endpoint preserves existing image_meta (EXIF)
 	 * when adding sub-sizes collected from sideload responses.
 	 *
-	 * @ticket 62243
+	 * @ticket 65329
 	 * @covers WP_REST_Attachments_Controller::finalize_item
 	 * @requires function imagejpeg
 	 * @requires extension exif

--- a/tests/phpunit/tests/rest-api/rest-attachments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-attachments-controller.php
@@ -3346,11 +3346,14 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 	}
 
 	/**
-	 * Tests that the sideload endpoint includes 'scaled' in the image_size enum.
+	 * Tests that the sideload endpoint accepts 'scaled' as a valid image_size.
+	 *
+	 * The image_size argument is validated with a custom validate_callback rather
+	 * than an enum, so this confirms the callback accepts the 'scaled' size.
 	 *
 	 * @ticket 64737
 	 */
-	public function test_sideload_route_includes_scaled_enum() {
+	public function test_sideload_route_accepts_scaled_image_size() {
 		$this->enable_client_side_media_processing();
 
 		$server = rest_get_server();
@@ -3365,7 +3368,19 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 
 		$param_name = 'image_size';
 		$this->assertArrayHasKey( $param_name, $args, 'Route should have image_size arg.' );
-		$this->assertContains( 'scaled', $args[ $param_name ]['enum'], 'image_size enum should include scaled.' );
+		$this->assertArrayHasKey( 'validate_callback', $args[ $param_name ], 'image_size arg should have a validate_callback.' );
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/media/1/sideload' );
+
+		$this->assertTrue(
+			call_user_func( $args[ $param_name ]['validate_callback'], 'scaled', $request, $param_name ),
+			'image_size validation should accept the "scaled" size.'
+		);
+
+		$this->assertWPError(
+			call_user_func( $args[ $param_name ]['validate_callback'], 'not-a-real-size', $request, $param_name ),
+			'image_size validation should reject an unregistered size.'
+		);
 	}
 
 	/**

--- a/tests/phpunit/tests/rest-api/rest-attachments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-attachments-controller.php
@@ -3245,6 +3245,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 	 * Tests sideloading a scaled image for an existing attachment.
 	 *
 	 * @ticket 64737
+	 * @ticket 65329
 	 * @requires function imagejpeg
 	 */
 	public function test_sideload_scaled_image() {

--- a/tests/phpunit/tests/rest-api/rest-attachments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-attachments-controller.php
@@ -3722,4 +3722,87 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		$this->assertSame( $original_image_meta['focal_length'], $metadata['image_meta']['focal_length'], 'Focal length should be preserved.' );
 		$this->assertSame( $original_image_meta['iso'], $metadata['image_meta']['iso'], 'ISO should be preserved.' );
 	}
+
+	/**
+	 * Tests that sideloading with an array of image sizes registers the single
+	 * file under each size name when finalized.
+	 *
+	 * @ticket 64737
+	 * @covers WP_REST_Attachments_Controller::sideload_item
+	 * @covers WP_REST_Attachments_Controller::finalize_item
+	 * @requires function imagejpeg
+	 */
+	public function test_sideload_image_size_array() {
+		$this->enable_client_side_media_processing();
+
+		wp_set_current_user( self::$author_id );
+
+		// Create an attachment without generating sub-sizes server-side.
+		$request = new WP_REST_Request( 'POST', '/wp/v2/media' );
+		$request->set_header( 'Content-Type', 'image/jpeg' );
+		$request->set_header( 'Content-Disposition', 'attachment; filename=canola.jpg' );
+		$request->set_param( 'generate_sub_sizes', false );
+		$request->set_body( (string) file_get_contents( self::$test_file ) );
+		$response      = rest_get_server()->dispatch( $request );
+		$attachment_id = $response->get_data()['id'];
+
+		$this->assertSame( 201, $response->get_status() );
+
+		// Sideload a single file registered under multiple sizes.
+		$request = new WP_REST_Request( 'POST', "/wp/v2/media/{$attachment_id}/sideload" );
+		$request->set_header( 'Content-Type', 'image/jpeg' );
+		$request->set_header( 'Content-Disposition', 'attachment; filename=canola-dup.jpg' );
+		$request->set_param( 'image_size', array( 'thumbnail', 'medium' ) );
+		$request->set_body( (string) file_get_contents( self::$test_file ) );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status(), 'Sideloading with an array of sizes should succeed.' );
+
+		$sub_size = $response->get_data();
+		$this->assertSame( array( 'thumbnail', 'medium' ), $sub_size['image_size'], 'Response should echo the array of sizes.' );
+
+		// Finalize with the collected sub-size.
+		$request = new WP_REST_Request( 'POST', "/wp/v2/media/{$attachment_id}/finalize" );
+		$request->set_param( 'sub_sizes', array( $sub_size ) );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status(), 'Finalize should succeed.' );
+
+		$metadata = wp_get_attachment_metadata( $attachment_id );
+		$this->assertArrayHasKey( 'thumbnail', $metadata['sizes'], 'Metadata should register the thumbnail size.' );
+		$this->assertArrayHasKey( 'medium', $metadata['sizes'], 'Metadata should register the medium size.' );
+		$this->assertSame(
+			$metadata['sizes']['thumbnail']['file'],
+			$metadata['sizes']['medium']['file'],
+			'Both sizes should reference the same physical file.'
+		);
+	}
+
+	/**
+	 * Tests that the sideload endpoint rejects an invalid image size name.
+	 *
+	 * @ticket 64737
+	 * @requires function imagejpeg
+	 */
+	public function test_sideload_image_size_invalid() {
+		$this->enable_client_side_media_processing();
+
+		wp_set_current_user( self::$author_id );
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/media' );
+		$request->set_header( 'Content-Type', 'image/jpeg' );
+		$request->set_header( 'Content-Disposition', 'attachment; filename=canola.jpg' );
+		$request->set_body( (string) file_get_contents( self::$test_file ) );
+		$response      = rest_get_server()->dispatch( $request );
+		$attachment_id = $response->get_data()['id'];
+
+		$request = new WP_REST_Request( 'POST', "/wp/v2/media/{$attachment_id}/sideload" );
+		$request->set_header( 'Content-Type', 'image/jpeg' );
+		$request->set_header( 'Content-Disposition', 'attachment; filename=canola-x.jpg' );
+		$request->set_param( 'image_size', array( 'thumbnail', 'not-a-real-size' ) );
+		$request->set_body( (string) file_get_contents( self::$test_file ) );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 400, $response->get_status(), 'An unknown size name should be rejected.' );
+	}
 }

--- a/tests/phpunit/tests/rest-api/rest-attachments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-attachments-controller.php
@@ -3275,15 +3275,31 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 
 		$this->assertSame( 200, $response->get_status(), 'Sideloading scaled image should succeed.' );
 
+		// The sideload endpoint returns lightweight sub-size data; the metadata
+		// is written later by the finalize endpoint.
+		$sub_size = $response->get_data();
+		$this->assertSame( 'scaled', $sub_size['image_size'], 'Response should echo the image_size.' );
+		$this->assertSame( wp_basename( $original_file ), $sub_size['original_image'], 'Response original_image should be the basename of the original attached file.' );
+		$this->assertGreaterThan( 0, $sub_size['width'], 'Response width should be positive.' );
+		$this->assertGreaterThan( 0, $sub_size['height'], 'Response height should be positive.' );
+		$this->assertGreaterThan( 0, $sub_size['filesize'], 'Response filesize should be positive.' );
+		$this->assertStringContainsString( 'scaled', $sub_size['file'], 'Response file should reference the scaled version.' );
+
+		// The attached file is still repointed to the scaled version during sideload.
+		$new_file = get_attached_file( $attachment_id, true );
+		$this->assertStringContainsString( 'scaled', wp_basename( $new_file ), 'Attached file should now be the scaled version.' );
+
+		// Finalize with the collected sub-size, which writes the metadata.
+		$request = new WP_REST_Request( 'POST', "/wp/v2/media/{$attachment_id}/finalize" );
+		$request->set_param( 'sub_sizes', array( $sub_size ) );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertSame( 200, $response->get_status(), 'Finalize should succeed.' );
+
 		$metadata = wp_get_attachment_metadata( $attachment_id );
 
 		// The original file should now be recorded as original_image.
 		$this->assertArrayHasKey( 'original_image', $metadata, 'Metadata should contain original_image.' );
 		$this->assertSame( wp_basename( $original_file ), $metadata['original_image'], 'original_image should be the basename of the original attached file.' );
-
-		// The attached file should now point to the scaled version.
-		$new_file = get_attached_file( $attachment_id, true );
-		$this->assertStringContainsString( 'scaled', wp_basename( $new_file ), 'Attached file should now be the scaled version.' );
 
 		// Metadata should have width, height, filesize, and file updated.
 		$this->assertArrayHasKey( 'width', $metadata, 'Metadata should contain width.' );
@@ -3540,5 +3556,169 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		$response = rest_get_server()->dispatch( $request );
 
 		$this->assertErrorResponse( 'rest_post_invalid_id', $response, 404 );
+	}
+
+	/**
+	 * Tests that the finalize endpoint writes regular sub-size metadata
+	 * collected from sideload responses.
+	 *
+	 * @ticket 62243
+	 * @covers WP_REST_Attachments_Controller::finalize_item
+	 * @requires function imagejpeg
+	 */
+	public function test_finalize_writes_regular_sub_sizes(): void {
+		$this->enable_client_side_media_processing();
+
+		wp_set_current_user( self::$author_id );
+
+		// Create an attachment without generating sub-sizes server-side.
+		$request = new WP_REST_Request( 'POST', '/wp/v2/media' );
+		$request->set_header( 'Content-Type', 'image/jpeg' );
+		$request->set_header( 'Content-Disposition', 'attachment; filename=canola.jpg' );
+		$request->set_param( 'generate_sub_sizes', false );
+		$request->set_body( (string) file_get_contents( self::$test_file ) );
+		$response      = rest_get_server()->dispatch( $request );
+		$attachment_id = $response->get_data()['id'];
+
+		$this->assertSame( 201, $response->get_status() );
+
+		// Sideload a thumbnail sub-size; the response carries its metadata.
+		$request = new WP_REST_Request( 'POST', "/wp/v2/media/{$attachment_id}/sideload" );
+		$request->set_header( 'Content-Type', 'image/jpeg' );
+		$request->set_header( 'Content-Disposition', 'attachment; filename=canola-thumb.jpg' );
+		$request->set_param( 'image_size', 'thumbnail' );
+		$request->set_body( (string) file_get_contents( self::$test_file ) );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status(), 'Sideloading a thumbnail should succeed.' );
+
+		$sub_size = $response->get_data();
+		$this->assertSame( 'thumbnail', $sub_size['image_size'], 'Response should echo the image_size.' );
+
+		// Finalize with the collected sub-size, which writes it into metadata.
+		$request = new WP_REST_Request( 'POST', "/wp/v2/media/{$attachment_id}/finalize" );
+		$request->set_param( 'sub_sizes', array( $sub_size ) );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status(), 'Finalize should succeed.' );
+
+		$metadata = wp_get_attachment_metadata( $attachment_id );
+		$this->assertArrayHasKey( 'sizes', $metadata, 'Metadata should contain sizes.' );
+		$this->assertArrayHasKey( 'thumbnail', $metadata['sizes'], 'Metadata sizes should contain the sideloaded thumbnail.' );
+		$this->assertSame( 'image/jpeg', $metadata['sizes']['thumbnail']['mime-type'], 'Thumbnail mime-type should be recorded.' );
+		$this->assertGreaterThan( 0, $metadata['sizes']['thumbnail']['filesize'], 'Thumbnail filesize should be positive.' );
+	}
+
+	/**
+	 * Tests that the finalize endpoint records original_image from an
+	 * 'original' sub-size collected from a sideload response.
+	 *
+	 * @ticket 62243
+	 * @covers WP_REST_Attachments_Controller::finalize_item
+	 * @requires function imagejpeg
+	 */
+	public function test_finalize_writes_original_metadata(): void {
+		$this->enable_client_side_media_processing();
+
+		wp_set_current_user( self::$author_id );
+
+		// Create an attachment without generating sub-sizes server-side.
+		$request = new WP_REST_Request( 'POST', '/wp/v2/media' );
+		$request->set_header( 'Content-Type', 'image/jpeg' );
+		$request->set_header( 'Content-Disposition', 'attachment; filename=canola.jpg' );
+		$request->set_param( 'generate_sub_sizes', false );
+		$request->set_body( (string) file_get_contents( self::$test_file ) );
+		$response      = rest_get_server()->dispatch( $request );
+		$attachment_id = $response->get_data()['id'];
+
+		$this->assertSame( 201, $response->get_status() );
+
+		// Sideload the 'original' version (simulating a rotated image), which
+		// returns the basename without writing metadata.
+		$request = new WP_REST_Request( 'POST', "/wp/v2/media/{$attachment_id}/sideload" );
+		$request->set_header( 'Content-Type', 'image/jpeg' );
+		$request->set_header( 'Content-Disposition', 'attachment; filename=canola-original.jpg' );
+		$request->set_param( 'image_size', 'original' );
+		$request->set_body( (string) file_get_contents( self::$test_file ) );
+		$response      = rest_get_server()->dispatch( $request );
+		$original_data = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status(), 'Sideloading the original should succeed.' );
+		$this->assertSame( 'original', $original_data['image_size'], 'Response should echo the image_size.' );
+		$this->assertSame( 'canola-original.jpg', $original_data['file'], 'Response should return the file basename.' );
+
+		// Sideload must not write metadata; that happens in finalize.
+		$metadata = wp_get_attachment_metadata( $attachment_id, true );
+		$this->assertArrayNotHasKey( 'original_image', $metadata, 'Sideload should not write original_image metadata.' );
+
+		// Finalize with the collected original sub-size.
+		$request = new WP_REST_Request( 'POST', "/wp/v2/media/{$attachment_id}/finalize" );
+		$request->set_param( 'sub_sizes', array( $original_data ) );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status(), 'Finalize should succeed.' );
+
+		$metadata = wp_get_attachment_metadata( $attachment_id );
+		$this->assertSame( 'canola-original.jpg', $metadata['original_image'], 'Finalize should record original_image from the sub-size.' );
+	}
+
+	/**
+	 * Tests that the finalize endpoint preserves existing image_meta (EXIF)
+	 * when adding sub-sizes collected from sideload responses.
+	 *
+	 * @ticket 62243
+	 * @covers WP_REST_Attachments_Controller::finalize_item
+	 * @requires function imagejpeg
+	 * @requires extension exif
+	 */
+	public function test_finalize_preserves_image_meta(): void {
+		$this->enable_client_side_media_processing();
+
+		wp_set_current_user( self::$author_id );
+
+		$exif_file = DIR_TESTDATA . '/images/2004-07-22-DSC_0008.jpg';
+
+		// Create an attachment without generating sub-sizes server-side.
+		$request = new WP_REST_Request( 'POST', '/wp/v2/media' );
+		$request->set_header( 'Content-Type', 'image/jpeg' );
+		$request->set_header( 'Content-Disposition', 'attachment; filename=2004-07-22-DSC_0008.jpg' );
+		$request->set_param( 'generate_sub_sizes', false );
+		$request->set_body( (string) file_get_contents( $exif_file ) );
+		$response      = rest_get_server()->dispatch( $request );
+		$attachment_id = $response->get_data()['id'];
+
+		$this->assertSame( 201, $response->get_status() );
+
+		$original_image_meta = wp_get_attachment_metadata( $attachment_id, true )['image_meta'];
+
+		// Finalize with a thumbnail sub-size.
+		$request = new WP_REST_Request( 'POST', "/wp/v2/media/{$attachment_id}/finalize" );
+		$request->set_param(
+			'sub_sizes',
+			array(
+				array(
+					'image_size' => 'thumbnail',
+					'width'      => 150,
+					'height'     => 150,
+					'file'       => '2004-07-22-DSC_0008-150x150.jpg',
+					'mime_type'  => 'image/jpeg',
+					'filesize'   => 5000,
+				),
+			)
+		);
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status(), 'Finalize should succeed.' );
+
+		$metadata = wp_get_attachment_metadata( $attachment_id );
+
+		// The sub-size should have been added.
+		$this->assertArrayHasKey( 'thumbnail', $metadata['sizes'], 'Finalize should add the thumbnail sub-size.' );
+
+		// The EXIF image_meta should be unchanged.
+		$this->assertSame( $original_image_meta['aperture'], $metadata['image_meta']['aperture'], 'Aperture should be preserved.' );
+		$this->assertSame( $original_image_meta['camera'], $metadata['image_meta']['camera'], 'Camera should be preserved.' );
+		$this->assertSame( $original_image_meta['focal_length'], $metadata['image_meta']['focal_length'], 'Focal length should be preserved.' );
+		$this->assertSame( $original_image_meta['iso'], $metadata['image_meta']['iso'], 'ISO should be preserved.' );
 	}
 }

--- a/tests/phpunit/tests/rest-api/rest-attachments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-attachments-controller.php
@@ -3805,4 +3805,96 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 
 		$this->assertSame( 400, $response->get_status(), 'An unknown size name should be rejected.' );
 	}
+
+	/**
+	 * Tests that the sideload route declares `convert_format` as a boolean arg.
+	 *
+	 * Without this declaration, multipart/form-data requests deliver the value as
+	 * a string ("false") which evaluates truthy in PHP, so the sideload handler's
+	 * `if ( ! $request['convert_format'] )` check never fires and the
+	 * `image_editor_output_format` filter is never suppressed - meaning the
+	 * server still performs the format conversion the client opted out of.
+	 *
+	 * @ticket 64737
+	 * @covers WP_REST_Attachments_Controller::register_routes
+	 */
+	public function test_sideload_route_declares_convert_format_boolean() {
+		$this->enable_client_side_media_processing();
+
+		$routes   = rest_get_server()->get_routes();
+		$endpoint = '/wp/v2/media/(?P<id>[\d]+)/sideload';
+		$this->assertArrayHasKey( $endpoint, $routes, 'Sideload route should exist.' );
+
+		$args = $routes[ $endpoint ][0]['args'];
+
+		$this->assertArrayHasKey( 'convert_format', $args, 'Route should declare convert_format.' );
+		$this->assertSame( 'boolean', $args['convert_format']['type'], 'convert_format should be a boolean.' );
+		$this->assertTrue( $args['convert_format']['default'], 'convert_format should default to true.' );
+	}
+
+	/**
+	 * Tests that sideloading with `convert_format=false` (sent as the string
+	 * "false", matching multipart/form-data semantics) suppresses the
+	 * alt-extension collision check in `wp_unique_filename()`, so a companion
+	 * file sharing the attachment basename does not get a numeric suffix.
+	 *
+	 * Mirrors the HEIC companion upload flow: a JPEG derivative is created via
+	 * the media endpoint, then the original is sideloaded under the same stem.
+	 * Without the arg declared as boolean, "false" coerces truthy, the filter
+	 * is never added, and the companion is bumped to `-1` while the JPEG stays
+	 * unsuffixed. PNG stands in for HEIC because core's default
+	 * `image_editor_output_format` only maps HEIC/HEIF to JPEG; a local filter
+	 * adds a PNG to JPEG mapping to trigger the same alt-ext check.
+	 *
+	 * @ticket 64737
+	 * @covers WP_REST_Attachments_Controller::sideload_item
+	 * @covers WP_REST_Attachments_Controller::register_routes
+	 * @requires function imagejpeg
+	 */
+	public function test_sideload_convert_format_false_suppresses_alt_ext_suffix() {
+		$this->enable_client_side_media_processing();
+
+		wp_set_current_user( self::$author_id );
+
+		// Upload a JPEG "parent" attachment the way client-side uploads do.
+		$request = new WP_REST_Request( 'POST', '/wp/v2/media' );
+		$request->set_header( 'Content-Type', 'image/jpeg' );
+		$request->set_header( 'Content-Disposition', 'attachment; filename=heic-companion.jpg' );
+		$request->set_param( 'generate_sub_sizes', false );
+		$request->set_body( (string) file_get_contents( self::$test_file ) );
+
+		$response      = rest_get_server()->dispatch( $request );
+		$attachment_id = $response->get_data()['id'];
+		$this->assertSame( 201, $response->get_status() );
+
+		// Simulate an alt-ext conversion mapping so an alt-extension companion
+		// (PNG here, HEIC in production) would otherwise get a `-1` suffix.
+		$add_png_mapping = static function ( $formats ) {
+			$formats['image/png'] = 'image/jpeg';
+			return $formats;
+		};
+		add_filter( 'image_editor_output_format', $add_png_mapping, 5 );
+
+		// Sideload a companion sharing the same basename. Pass convert_format as
+		// the string "false" to match multipart/form-data request semantics.
+		$request = new WP_REST_Request( 'POST', "/wp/v2/media/{$attachment_id}/sideload" );
+		$request->set_header( 'Content-Type', 'image/png' );
+		$request->set_header( 'Content-Disposition', 'attachment; filename=heic-companion.png' );
+		$request->set_param( 'image_size', 'original' );
+		$request->set_param( 'convert_format', 'false' );
+		$request->set_body( (string) file_get_contents( DIR_TESTDATA . '/images/one-blue-pixel-100x100.png' ) );
+
+		$response = rest_get_server()->dispatch( $request );
+
+		remove_filter( 'image_editor_output_format', $add_png_mapping, 5 );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertSame(
+			'heic-companion.png',
+			$data['file'],
+			'Companion file should share the attachment basename without a numeric suffix.'
+		);
+	}
 }

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -3693,19 +3693,14 @@ mockedApiResponse.Schema = {
                             "required": false
                         },
                         "image_size": {
-                            "description": "Image size.",
-                            "type": "string",
-                            "enum": [
-                                "thumbnail",
-                                "medium",
-                                "medium_large",
-                                "large",
-                                "1536x1536",
-                                "2048x2048",
-                                "original",
-                                "full",
-                                "scaled"
+                            "description": "Image size. Can be a single size name or an array of size names to register the same file under multiple sizes.",
+                            "type": [
+                                "string",
+                                "array"
                             ],
+                            "items": {
+                                "type": "string"
+                            },
                             "required": true
                         },
                         "convert_format": {
@@ -3732,6 +3727,52 @@ mockedApiResponse.Schema = {
                         "id": {
                             "description": "Unique identifier for the attachment.",
                             "type": "integer",
+                            "required": false
+                        },
+                        "sub_sizes": {
+                            "description": "Array of sub-size metadata collected from sideload responses.",
+                            "type": "array",
+                            "default": [],
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "image_size": {
+                                        "description": "Size name, or an array of size names when a single file is registered under multiple sizes with matching dimensions.",
+                                        "type": [
+                                            "string",
+                                            "array"
+                                        ],
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "required": true
+                                    },
+                                    "width": {
+                                        "type": "integer",
+                                        "minimum": 1
+                                    },
+                                    "height": {
+                                        "type": "integer",
+                                        "minimum": 1
+                                    },
+                                    "file": {
+                                        "type": "string",
+                                        "minLength": 1
+                                    },
+                                    "mime_type": {
+                                        "type": "string",
+                                        "pattern": "^image/.*"
+                                    },
+                                    "filesize": {
+                                        "type": "integer",
+                                        "minimum": 1
+                                    },
+                                    "original_image": {
+                                        "type": "string",
+                                        "minLength": 1
+                                    }
+                                }
+                            },
                             "required": false
                         }
                     }


### PR DESCRIPTION
## What

Core backport of Gutenberg [#77565 — Media uploading: declare `convert_format` as boolean arg on sideload route](https://github.com/WordPress/gutenberg/pull/77565).

Part of the post-restore client-side-media backport stack (see [#11324](https://github.com/WordPress/wordpress-develop/pull/11324)). Stacks logically on top of GB #75888 ([#12002](https://github.com/WordPress/wordpress-develop/pull/12002)) and GB #77036 ([#12001](https://github.com/WordPress/wordpress-develop/pull/12001)); diff shown against trunk for standalone-mergeability.

## Why

The sideload handler reads `$request['convert_format']`, and the client sends `convert_format: false` in `additionalData` when uploading a HEIC companion. With `multipart/form-data`, an undeclared arg arrives as the string `"false"`, which is truthy in PHP - so `if ( ! $request['convert_format'] )` never fires and `add_filter( 'image_editor_output_format', '__return_empty_array', 100 )` is skipped. The default HEIC->JPEG output mapping then survives and `wp_unique_filename()`'s alt-extension collision check bumps the original to `-1` while the JPEG derivative stays unsuffixed, so the two companion files drift apart on repeat uploads. Declaring the arg as boolean lets REST coerce `"false"` -> PHP `false`, the filter fires, and the companions keep a shared basename.

## How

**The controller change is already in Core.** When client-side media processing was reintroduced (#11324), the sideload route already declared `convert_format` as a boolean (default `true`) and `sideload_item()` already suppresses `image_editor_output_format` when it is false. So this backport is **tests only** - it adds the coverage from GB #77565 to `tests/phpunit/tests/rest-api/rest-attachments-controller.php`:

- `test_sideload_route_declares_convert_format_boolean` - asserts the sideload route declares `convert_format` as a boolean defaulting to `true`.
- `test_sideload_convert_format_false_suppresses_alt_ext_suffix` - simulates the HEIC companion flow (PNG stand-in + a local PNG->JPEG mapping) and verifies that passing `convert_format` as the string `"false"` keeps the companion's shared basename with no numeric suffix.

## Notes

- Adapted to Core conventions: `self::$author_id`, `self::$test_file`, `$this->enable_client_side_media_processing()`, and `: void`-style test setup. The behavior test uses `image_size => 'original'` (a valid enum value) rather than the Gutenberg test's `'original-heic'`, since Core's `image_size` validation strictly enforces the registered-size enum.
- Validated locally with `php -l` and PHPCS (WordPress-Core).