### PR TITLE
Abilities API: Normalize `required` schema shape for REST responses

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-abilities-v1-list-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-abilities-v1-list-controller.php
@@ -275,7 +275,7 @@ class WP_REST_Abilities_V1_List_Controller extends WP_REST_Controller {
 		// published schema describes exactly what gets enforced.
 		if ( isset( $schema['properties'] ) && is_array( $schema['properties'] ) ) {
 			$has_required_array = isset( $schema['required'] ) && is_array( $schema['required'] );
-			$required           = $has_required_array ? array_map( 'strval', $schema['required'] ) : array();
+			$required           = array();
 			foreach ( $schema['properties'] as $property => &$property_schema ) {
 				if ( $this->is_associative_array( $property_schema ) && isset( $property_schema['required'] ) && is_bool( $property_schema['required'] ) ) {
 					if ( ! $has_required_array && true === $property_schema['required'] ) {
@@ -285,8 +285,11 @@ class WP_REST_Abilities_V1_List_Controller extends WP_REST_Controller {
 				}
 			}
 			unset( $property_schema );
-			if ( count( $required ) > 0 ) {
-				$schema['required'] = array_values( array_unique( $required ) );
+
+			// Property keys are unique, so the collected list needs no deduplication.
+			// When a draft-04 array is already present, leave it untouched.
+			if ( ! $has_required_array && count( $required ) > 0 ) {
+				$schema['required'] = $required;
 			}
 		}
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-abilities-v1-list-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-abilities-v1-list-controller.php
@@ -267,16 +267,24 @@ class WP_REST_Abilities_V1_List_Controller extends WP_REST_Controller {
 
 		// Collect draft-03 per-property `required: true` flags into a draft-04
 		// `required` array of property names on the parent object schema.
+		//
+		// This mirrors rest_validate_object_value_from_schema(), where a draft-04
+		// `required` array takes precedence: when one is present, per-property
+		// booleans are ignored during validation. They are therefore left out of
+		// the array here as well (but still stripped from the output) so the
+		// published schema describes exactly what gets enforced.
 		if ( isset( $schema['properties'] ) && is_array( $schema['properties'] ) ) {
-			$required = ( isset( $schema['required'] ) && is_array( $schema['required'] ) ) ? array_map( 'strval', $schema['required'] ) : array();
+			$has_required_array = isset( $schema['required'] ) && is_array( $schema['required'] );
+			$required           = $has_required_array ? array_map( 'strval', $schema['required'] ) : array();
 			foreach ( $schema['properties'] as $property => &$property_schema ) {
 				if ( $this->is_associative_array( $property_schema ) && isset( $property_schema['required'] ) && is_bool( $property_schema['required'] ) ) {
-					if ( true === $property_schema['required'] ) {
+					if ( ! $has_required_array && true === $property_schema['required'] ) {
 						$required[] = (string) $property;
 					}
 					unset( $property_schema['required'] );
 				}
 			}
+			unset( $property_schema );
 			if ( count( $required ) > 0 ) {
 				$schema['required'] = array_values( array_unique( $required ) );
 			}

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-abilities-v1-list-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-abilities-v1-list-controller.php
@@ -268,16 +268,16 @@ class WP_REST_Abilities_V1_List_Controller extends WP_REST_Controller {
 		// Collect draft-03 per-property `required: true` flags into a draft-04
 		// `required` array of property names on the parent object schema.
 		if ( isset( $schema['properties'] ) && is_array( $schema['properties'] ) ) {
-			$required = ( isset( $schema['required'] ) && is_array( $schema['required'] ) ) ? $schema['required'] : array();
-			foreach ( $schema['properties'] as $property => $property_schema ) {
+			$required = ( isset( $schema['required'] ) && is_array( $schema['required'] ) ) ? array_map( 'strval', $schema['required'] ) : array();
+			foreach ( $schema['properties'] as $property => &$property_schema ) {
 				if ( $this->is_associative_array( $property_schema ) && isset( $property_schema['required'] ) && is_bool( $property_schema['required'] ) ) {
 					if ( true === $property_schema['required'] ) {
-						$required[] = $property;
+						$required[] = (string) $property;
 					}
-					unset( $schema['properties'][ $property ]['required'] );
+					unset( $property_schema['required'] );
 				}
 			}
-			if ( ! empty( $required ) ) {
+			if ( count( $required ) > 0 ) {
 				$schema['required'] = array_values( array_unique( $required ) );
 			}
 		}

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-abilities-v1-list-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-abilities-v1-list-controller.php
@@ -225,11 +225,20 @@ class WP_REST_Abilities_V1_List_Controller extends WP_REST_Controller {
 	/**
 	 * Transforms an ability schema for REST response output.
 	 *
+	 * The input and output schemas are a public contract: REST clients (such as
+	 * the `@wordpress/abilities` JS client) consume them as standard JSON Schema
+	 * and validate ability input and output against them. The response must
+	 * therefore use JSON Schema draft-04 forms that standard validators
+	 * understand, not the WordPress-internal conventions that
+	 * `rest_validate_value_from_schema()` also accepts on the server.
+	 *
 	 * Ability schemas may include WordPress-internal properties or unsupported
 	 * schema keywords that should not be exposed in REST responses. This method
 	 * strips keys not recognized by the REST API schema handling. It also
 	 * converts empty array defaults to objects when the schema type is 'object'
-	 * to ensure proper JSON serialization as {} instead of [].
+	 * to ensure proper JSON serialization as {} instead of [], and normalizes
+	 * the `required` keyword from the draft-03 per-property boolean form into
+	 * the draft-04 array of property names.
 	 *
 	 * @since 7.1.0
 	 *
@@ -255,6 +264,29 @@ class WP_REST_Abilities_V1_List_Controller extends WP_REST_Controller {
 		);
 
 		$schema = array_intersect_key( $schema, $allowed_keywords );
+
+		// Collect draft-03 per-property `required: true` flags into a draft-04
+		// `required` array of property names on the parent object schema.
+		if ( isset( $schema['properties'] ) && is_array( $schema['properties'] ) ) {
+			$required = ( isset( $schema['required'] ) && is_array( $schema['required'] ) ) ? $schema['required'] : array();
+			foreach ( $schema['properties'] as $property => $property_schema ) {
+				if ( $this->is_associative_array( $property_schema ) && isset( $property_schema['required'] ) && is_bool( $property_schema['required'] ) ) {
+					if ( true === $property_schema['required'] ) {
+						$required[] = $property;
+					}
+					unset( $schema['properties'][ $property ]['required'] );
+				}
+			}
+			if ( ! empty( $required ) ) {
+				$schema['required'] = array_values( array_unique( $required ) );
+			}
+		}
+
+		// A boolean `required` outside of an object's property list has no draft-04
+		// equivalent, so drop it rather than emit an invalid keyword.
+		if ( isset( $schema['required'] ) && is_bool( $schema['required'] ) ) {
+			unset( $schema['required'] );
+		}
 
 		// Sub-schema maps: keys are user-defined, values are sub-schemas.
 		// Note: 'dependencies' values can also be property-dependency arrays

--- a/tests/phpunit/tests/rest-api/rest-schema-validation.php
+++ b/tests/phpunit/tests/rest-api/rest-schema-validation.php
@@ -1506,6 +1506,31 @@ class WP_Test_REST_Schema_Validation extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A draft-04 `required` array takes precedence over per-property
+	 * `required` booleans on the same object node: the booleans are ignored.
+	 *
+	 * @ticket 64955
+	 */
+	public function test_required_v4_array_takes_precedence_over_v3_booleans() {
+		$schema = array(
+			'type'       => 'object',
+			'required'   => array( 'listed' ),
+			'properties' => array(
+				'listed'  => array( 'type' => 'string' ),
+				'flagged' => array(
+					'type'     => 'string',
+					'required' => true, // Ignored because the array is present.
+				),
+			),
+		);
+
+		// Missing the array-listed prop fails.
+		$this->assertWPError( rest_validate_value_from_schema( array( 'flagged' => 'x' ), $schema ) );
+		// Missing only the boolean-flagged prop passes — the boolean is not enforced.
+		$this->assertTrue( rest_validate_value_from_schema( array( 'listed' => 'x' ), $schema ) );
+	}
+
+	/**
 	 * @ticket 51023
 	 */
 	public function test_object_min_properties() {

--- a/tests/phpunit/tests/rest-api/wpRestAbilitiesV1ListController.php
+++ b/tests/phpunit/tests/rest-api/wpRestAbilitiesV1ListController.php
@@ -1147,4 +1147,303 @@ class Tests_REST_API_WpRestAbilitiesV1ListController extends WP_UnitTestCase {
 		$this->assertArrayNotHasKey( 'sanitize_callback', $data['output_schema']['additionalItems'] );
 		$this->assertSame( 'boolean', $data['output_schema']['additionalItems']['type'] );
 	}
+
+	/**
+	 * Test that per-property `required` booleans become a draft-04 `required` array.
+	 *
+	 * @ticket 64955
+	 */
+	public function test_required_property_booleans_converted_to_draft_04_array(): void {
+		$this->register_test_ability(
+			'test/required-booleans',
+			array(
+				'label'               => 'Required Booleans',
+				'description'         => 'Tests conversion of per-property required booleans.',
+				'category'            => 'general',
+				'input_schema'        => array(
+					'type'       => 'object',
+					'properties' => array(
+						'title'    => array(
+							'type'     => 'string',
+							'required' => true,
+						),
+						'content'  => array(
+							'type'     => 'string',
+							'required' => true,
+						),
+						'optional' => array(
+							'type' => 'string',
+						),
+					),
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'id' => array(
+							'type'     => 'integer',
+							'required' => true,
+						),
+					),
+				),
+				'execute_callback'    => static function (): array {
+					return array( 'id' => 1 );
+				},
+				'permission_callback' => '__return_true',
+				'meta'                => array( 'show_in_rest' => true ),
+			)
+		);
+
+		$request  = new WP_REST_Request( 'GET', '/wp-abilities/v1/abilities/test/required-booleans' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+
+		// The `required` array lists the names of the properties flagged as required.
+		$this->assertArrayHasKey( 'required', $data['input_schema'] );
+		$this->assertSameSets( array( 'title', 'content' ), $data['input_schema']['required'] );
+
+		// The boolean flag is removed from each property sub-schema.
+		$this->assertArrayNotHasKey( 'required', $data['input_schema']['properties']['title'] );
+		$this->assertArrayNotHasKey( 'required', $data['input_schema']['properties']['content'] );
+		$this->assertArrayNotHasKey( 'required', $data['input_schema']['properties']['optional'] );
+
+		// Output schemas are normalized the same way.
+		$this->assertSame( array( 'id' ), $data['output_schema']['required'] );
+		$this->assertArrayNotHasKey( 'required', $data['output_schema']['properties']['id'] );
+	}
+
+	/**
+	 * Test that per-property `required` booleans are converted in nested object schemas.
+	 *
+	 * @ticket 64955
+	 */
+	public function test_required_booleans_converted_in_nested_object_schemas(): void {
+		$this->register_test_ability(
+			'test/required-nested',
+			array(
+				'label'               => 'Required Nested',
+				'description'         => 'Tests conversion within nested object schemas.',
+				'category'            => 'general',
+				'input_schema'        => array(
+					'type'       => 'object',
+					'properties' => array(
+						'address' => array(
+							'type'       => 'object',
+							'required'   => true,
+							'properties' => array(
+								'street' => array(
+									'type'     => 'string',
+									'required' => true,
+								),
+								'city'   => array(
+									'type' => 'string',
+								),
+							),
+						),
+					),
+				),
+				'execute_callback'    => static function () {
+					return null;
+				},
+				'permission_callback' => '__return_true',
+				'meta'                => array( 'show_in_rest' => true ),
+			)
+		);
+
+		$request  = new WP_REST_Request( 'GET', '/wp-abilities/v1/abilities/test/required-nested' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$data    = $response->get_data();
+		$address = $data['input_schema']['properties']['address'];
+
+		// The outer object lists the nested object as a required property.
+		$this->assertSame( array( 'address' ), $data['input_schema']['required'] );
+
+		// The nested object's own boolean flag is replaced by a draft-04 array
+		// collecting its own required properties (proving the boolean was converted).
+		$this->assertSame( array( 'street' ), $address['required'] );
+		$this->assertArrayNotHasKey( 'required', $address['properties']['street'] );
+		$this->assertArrayNotHasKey( 'required', $address['properties']['city'] );
+	}
+
+	/**
+	 * Test that `required: false` is removed without emitting an empty `required` array.
+	 *
+	 * @ticket 64955
+	 */
+	public function test_required_false_booleans_removed_without_required_array(): void {
+		$this->register_test_ability(
+			'test/required-false',
+			array(
+				'label'               => 'Required False',
+				'description'         => 'Tests that required:false is stripped.',
+				'category'            => 'general',
+				'input_schema'        => array(
+					'type'       => 'object',
+					'properties' => array(
+						'maybe' => array(
+							'type'     => 'string',
+							'required' => false,
+						),
+					),
+				),
+				'execute_callback'    => static function () {
+					return null;
+				},
+				'permission_callback' => '__return_true',
+				'meta'                => array( 'show_in_rest' => true ),
+			)
+		);
+
+		$request  = new WP_REST_Request( 'GET', '/wp-abilities/v1/abilities/test/required-false' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+
+		$this->assertArrayNotHasKey( 'required', $data['input_schema'] );
+		$this->assertArrayNotHasKey( 'required', $data['input_schema']['properties']['maybe'] );
+	}
+
+	/**
+	 * Test that a draft-04 `required` array and per-property booleans merge without duplicates.
+	 *
+	 * @ticket 64955
+	 */
+	public function test_required_draft_04_array_merged_with_booleans(): void {
+		$this->register_test_ability(
+			'test/required-mixed',
+			array(
+				'label'               => 'Required Mixed',
+				'description'         => 'Tests merging of a draft-04 array with draft-03 booleans.',
+				'category'            => 'general',
+				'input_schema'        => array(
+					'type'       => 'object',
+					'required'   => array( 'title' ),
+					'properties' => array(
+						'title'   => array(
+							'type'     => 'string',
+							'required' => true,
+						),
+						'content' => array(
+							'type'     => 'string',
+							'required' => true,
+						),
+					),
+				),
+				'execute_callback'    => static function () {
+					return null;
+				},
+				'permission_callback' => '__return_true',
+				'meta'                => array( 'show_in_rest' => true ),
+			)
+		);
+
+		$request  = new WP_REST_Request( 'GET', '/wp-abilities/v1/abilities/test/required-mixed' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+
+		// 'title' is listed in the array and flagged via boolean, but not duplicated.
+		$this->assertSameSets( array( 'title', 'content' ), $data['input_schema']['required'] );
+		$this->assertCount( 2, $data['input_schema']['required'] );
+	}
+
+	/**
+	 * Test that a boolean `required` with no draft-04 equivalent (e.g. on a scalar) is dropped.
+	 *
+	 * @ticket 64955
+	 */
+	public function test_required_boolean_on_scalar_schema_removed(): void {
+		$this->register_test_ability(
+			'test/required-scalar',
+			array(
+				'label'               => 'Required Scalar',
+				'description'         => 'Tests stripping of a boolean required on a scalar schema.',
+				'category'            => 'general',
+				'input_schema'        => array(
+					'type'        => 'string',
+					'description' => 'The text to analyze.',
+					'required'    => true,
+				),
+				'output_schema'       => array(
+					'type'     => 'string',
+					'required' => true,
+				),
+				'execute_callback'    => static function ( $input ) {
+					return $input;
+				},
+				'permission_callback' => '__return_true',
+				'meta'                => array( 'show_in_rest' => true ),
+			)
+		);
+
+		$request  = new WP_REST_Request( 'GET', '/wp-abilities/v1/abilities/test/required-scalar' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+
+		$this->assertArrayNotHasKey( 'required', $data['input_schema'] );
+		$this->assertSame( 'string', $data['input_schema']['type'] );
+		$this->assertArrayNotHasKey( 'required', $data['output_schema'] );
+	}
+
+	/**
+	 * Test that per-property `required` booleans are converted in an array's `items` object.
+	 *
+	 * @ticket 64955
+	 */
+	public function test_required_booleans_converted_in_array_items_object_schemas(): void {
+		$this->register_test_ability(
+			'test/required-array-items',
+			array(
+				'label'               => 'Required Array Items',
+				'description'         => 'Tests conversion within array item object schemas.',
+				'category'            => 'general',
+				'input_schema'        => array(
+					'type'  => 'array',
+					'items' => array(
+						'type'       => 'object',
+						'properties' => array(
+							'id'    => array(
+								'type'     => 'integer',
+								'required' => true,
+							),
+							'label' => array(
+								'type' => 'string',
+							),
+						),
+					),
+				),
+				'execute_callback'    => static function () {
+					return null;
+				},
+				'permission_callback' => '__return_true',
+				'meta'                => array( 'show_in_rest' => true ),
+			)
+		);
+
+		$request  = new WP_REST_Request( 'GET', '/wp-abilities/v1/abilities/test/required-array-items' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$data  = $response->get_data();
+		$items = $data['input_schema']['items'];
+
+		// The object schema inside `items` collects its own required properties
+		// into a draft-04 array, and the per-property boolean is removed.
+		$this->assertSame( array( 'id' ), $items['required'] );
+		$this->assertArrayNotHasKey( 'required', $items['properties']['id'] );
+		$this->assertArrayNotHasKey( 'required', $items['properties']['label'] );
+	}
 }

--- a/tests/phpunit/tests/rest-api/wpRestAbilitiesV1ListController.php
+++ b/tests/phpunit/tests/rest-api/wpRestAbilitiesV1ListController.php
@@ -1311,16 +1311,20 @@ class Tests_REST_API_WpRestAbilitiesV1ListController extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that a draft-04 `required` array and per-property booleans merge without duplicates.
+	 * Test that an existing draft-04 `required` array takes precedence over per-property booleans.
+	 *
+	 * This mirrors rest_validate_object_value_from_schema(), which ignores
+	 * per-property `required` booleans when a draft-04 `required` array is
+	 * present, so the published schema matches what is actually enforced.
 	 *
 	 * @ticket 64955
 	 */
-	public function test_required_draft_04_array_merged_with_booleans(): void {
+	public function test_required_draft_04_array_takes_precedence_over_booleans(): void {
 		$this->register_test_ability(
 			'test/required-mixed',
 			array(
 				'label'               => 'Required Mixed',
-				'description'         => 'Tests merging of a draft-04 array with draft-03 booleans.',
+				'description'         => 'Tests precedence of a draft-04 array over draft-03 booleans.',
 				'category'            => 'general',
 				'input_schema'        => array(
 					'type'       => 'object',
@@ -1351,9 +1355,12 @@ class Tests_REST_API_WpRestAbilitiesV1ListController extends WP_UnitTestCase {
 
 		$data = $response->get_data();
 
-		// 'title' is listed in the array and flagged via boolean, but not duplicated.
-		$this->assertSameSets( array( 'title', 'content' ), $data['input_schema']['required'] );
-		$this->assertCount( 2, $data['input_schema']['required'] );
+		// The draft-04 array wins: the `content` boolean is ignored, not merged in.
+		$this->assertSame( array( 'title' ), $data['input_schema']['required'] );
+
+		// The per-property booleans are still stripped from the output.
+		$this->assertArrayNotHasKey( 'required', $data['input_schema']['properties']['title'] );
+		$this->assertArrayNotHasKey( 'required', $data['input_schema']['properties']['content'] );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Normalizes the `required` keyword in an ability's input and output schemas to its JSON Schema draft-04 form when those schemas are exposed through the REST API (`wp-abilities/v1`).

## Background

Ability input and output schemas are a public contract. Clients, including the `@wordpress/abilities` JavaScript client, consume these schemas as standard JSON Schema and validate ability input and output against them. They therefore need a draft-04-conformant shape that standard validators understand.

On the server, WordPress accepts both forms supported by `rest_validate_value_from_schema()`:

- A draft-04 `required` array of property names on the object schema.
- A draft-03 per-property `required` boolean.

Both forms validate server-side, but only the array form is valid JSON Schema draft-04. Ability schemas registered with per-property booleans, including examples shown for `wp_register_ability()`, were therefore exposed to clients in a shape that standard draft-04 validators do not recognize.

## Changes

In `WP_REST_Abilities_V1_List_Controller::prepare_schema_for_response()`:

- Collects per-property `required: true` booleans and emits them as a parent `required: [ ... ]` array of property names.
- Applies the conversion recursively, so nested object schemas each get their own `required` array.
- Converts object schemas inside array `items` as well.
- Strips `required: false` from property schemas without emitting an empty parent array.
- Strips boolean `required` values that have no draft-04 equivalent, such as on scalar root schemas.
- Mirrors `rest_validate_object_value_from_schema()` precedence: when an object already has a draft-04 `required` array, that array wins; per-property booleans on the same object are ignored for collection but still removed from the REST response.

The transformation only rewrites the REST response copy. Stored ability schemas and server-side validation behavior are unchanged.

## Tests

Adds coverage for:

- Top-level per-property boolean conversion.
- Nested object conversion.
- Object schemas nested inside array `items`.
- `required: false` stripping.
- Scalar-root boolean `required` stripping.
- Mixed draft-04 array plus draft-03 booleans, confirming the draft-04 array takes precedence.
- The underlying `rest_validate_value_from_schema()` precedence contract.

Trac ticket: https://core.trac.wordpress.org/ticket/64955
