### PR TITLE
Media: Ensure wp_get_attachment_image_src checks the same icon file directories as wp_mime_type_icon.

### DIFF
--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -989,25 +989,45 @@ function wp_get_attachment_image_src( $attachment_id, $size = 'thumbnail', $icon
 				/** This filter is documented in wp-includes/post.php */
 				$icon_dir = apply_filters( 'icon_dir', ABSPATH . WPINC . '/images/media' );
 
-				$src_file = $icon_dir . '/' . wp_basename( $src );
-
-				$image_size = wp_getimagesize( $src_file );
-				if ( is_array( $image_size ) ) {
-					$width  = $image_size[0];
-					$height = $image_size[1];
-				}
-
-				$ext = strtolower( substr( $src_file, -4 ) );
-
+				$src_file_name = wp_basename( $src );
+				$ext           = strtolower( substr( $src_file_name, -4 ) );
 				if ( '.svg' === $ext ) {
 					// SVG does not have true dimensions, so this assigns width and height directly.
 					$width  = 48;
 					$height = 64;
 				} else {
-					$image_size = wp_getimagesize( $src_file );
-					if ( is_array( $image_size ) ) {
-						$width  = $image_size[0];
-						$height = $image_size[1];
+					/** These filters are documented in wp-includes/post.php */
+					$icon_dir_uri = apply_filters( 'icon_dir_uri', includes_url( 'images/media' ) );
+					$dirs         = array_keys( apply_filters( 'icon_dirs', array( $icon_dir => $icon_dir_uri ) ) );
+
+					while ( $dirs ) {
+						$dir        = array_shift( $dirs );
+						$src_file   = $dir . '/' . $src_file_name;
+						$image_size = wp_getimagesize( $src_file );
+						if ( is_array( $image_size ) ) {
+							$width  = $image_size[0];
+							$height = $image_size[1];
+							break;
+						}
+
+						$dh = opendir( $dir );
+						if ( $dh ) {
+							while ( false !== $file = readdir( $dh ) ) {
+								$file = wp_basename( $file );
+								if ( str_starts_with( $file, '.' ) ) {
+									continue;
+								}
+
+								$sub_dir = "$dir/$file";
+								if ( ! is_dir( $sub_dir ) ) {
+									continue;
+								}
+
+								$dirs[] = $sub_dir;
+							}
+
+							closedir( $dh );
+						}
 					}
 				}
 			}


### PR DESCRIPTION
This ensures wp_get_attachment_image_src checks the same directories as wp_mime_type_icon; simply a refresher of the patch in the Trac ticket.

Trac ticket: https://core.trac.wordpress.org/ticket/36418

## Use of AI Tools

AI assistance: No
Tool(s): n/a
Model(s): n/a
Used for: n/a

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
