### PR TITLE
Docs: Fix @var type for WP_User_Request::$user_id to string

### DIFF
--- a/src/wp-includes/class-wp-post.php
+++ b/src/wp-includes/class-wp-post.php
@@ -36,6 +36,7 @@ final class WP_Post {
 	 *
 	 * @since 3.5.0
 	 * @var string
+	 * @phpstan-var numeric-string
 	 */
 	public $post_author = '0';
 

--- a/src/wp-includes/class-wp-post.php
+++ b/src/wp-includes/class-wp-post.php
@@ -207,6 +207,7 @@ final class WP_Post {
 	 *
 	 * @since 3.5.0
 	 * @var string
+	 * @phpstan-var numeric-string
 	 */
 	public $comment_count = '0';
 

--- a/src/wp-includes/class-wp-user-request.php
+++ b/src/wp-includes/class-wp-user-request.php
@@ -21,9 +21,9 @@ final class WP_User_Request {
 	 *
 	 * @since 4.9.6
 	 * @var string
-	 * @phpstan-var numeric-string
+	 * @var string
 	 */
-	public $user_id = 0;
+	public $user_id = '0';
 
 	/**
 	 * User email.

--- a/src/wp-includes/class-wp-user-request.php
+++ b/src/wp-includes/class-wp-user-request.php
@@ -21,6 +21,7 @@ final class WP_User_Request {
 	 *
 	 * @since 4.9.6
 	 * @var string
+	 * @phpstan-var numeric-string
 	 */
 	public $user_id = 0;
 

--- a/src/wp-includes/class-wp-user-request.php
+++ b/src/wp-includes/class-wp-user-request.php
@@ -21,7 +21,7 @@ final class WP_User_Request {
 	 *
 	 * @since 4.9.6
 	 * @var string
-	 * @var string
+	 * @phpstan-var numeric-string
 	 */
 	public $user_id = '0';
 

--- a/src/wp-includes/class-wp-user-request.php
+++ b/src/wp-includes/class-wp-user-request.php
@@ -20,7 +20,7 @@ final class WP_User_Request {
 	 * User ID.
 	 *
 	 * @since 4.9.6
-	 * @var int
+	 * @var string
 	 */
 	public $user_id = 0;
 


### PR DESCRIPTION
Fix the inline documentation for `WP_User_Request::$user_id`, which is 
documented as `int` but is actually a `string`. The value is assigned 
directly from `$post->post_author` in the constructor with no type cast, 
so it reflects the raw database value, which is always a string.

This incorrect type hint was the root cause of the bug described in the 
ticket, where a strict comparison against `0` in `get_user_locale()` 
evaluated incorrectly because `"0" !== 0`. The runtime fix was addressed 
in #43985; this corrects the documentation to match actual behavior.

Precedent: `WP_Post::$post_author` is documented as `string` for the same 
reason (see #25092).

Trac ticket: https://core.trac.wordpress.org/ticket/44723

## Use of AI Tools
-

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**