### PR TITLE
Sitemaps: do not 404 paginated sitemap pages beyond the post page count

### DIFF
--- a/src/wp-includes/sitemaps/class-wp-sitemaps.php
+++ b/src/wp-includes/sitemaps/class-wp-sitemaps.php
@@ -67,6 +67,7 @@ class WP_Sitemaps {
 		$this->register_rewrites();
 
 		add_action( 'template_redirect', array( $this, 'render_sitemaps' ) );
+		add_filter( 'pre_handle_404', array( $this, 'pre_handle_404' ), 10, 2 );
 
 		if ( ! $this->sitemaps_enabled() ) {
 			return;
@@ -76,6 +77,41 @@ class WP_Sitemaps {
 
 		// Add additional action callbacks.
 		add_filter( 'robots_txt', array( $this, 'add_robots' ), 0, 2 );
+	}
+
+	/**
+	 * Prevents the main query's 404 handling from running for sitemap requests.
+	 *
+	 * Sitemap URLs are routed by rewrite rules that set the `sitemap` (or
+	 * `sitemap-stylesheet`) query variable but no `post_type`. The resulting
+	 * main query therefore defaults to the `post` post type, and on a paginated
+	 * request whose page number exceeds the number of pages of regular posts it
+	 * returns no posts. WP::handle_404() then flags the request as a 404 before
+	 * WP_Sitemaps::render_sitemaps() runs on 'template_redirect', stamping a 404
+	 * status on a sitemap that render_sitemaps() goes on to output with valid
+	 * URLs.
+	 *
+	 * Short-circuiting handle_404() for sitemap routes leaves render_sitemaps()
+	 * fully responsible for the response, including issuing its own 404 when a
+	 * sitemap is disabled or a requested page genuinely has no URLs.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param bool     $preempt  Whether to short-circuit default header status handling. Default false.
+	 * @param WP_Query $wp_query WordPress Query object.
+	 * @return bool Whether to short-circuit default header status handling.
+	 */
+	public function pre_handle_404( $preempt, $wp_query ) {
+		// Respect an earlier short-circuit by another callback.
+		if ( false !== $preempt ) {
+			return $preempt;
+		}
+
+		if ( $wp_query->get( 'sitemap' ) || $wp_query->get( 'sitemap-stylesheet' ) ) {
+			return true;
+		}
+
+		return $preempt;
 	}
 
 	/**

--- a/tests/phpunit/tests/sitemaps/sitemaps.php
+++ b/tests/phpunit/tests/sitemaps/sitemaps.php
@@ -493,4 +493,90 @@ class Tests_Sitemaps_Sitemaps extends WP_UnitTestCase {
 
 		$this->assertTrue( is_404() );
 	}
+
+	/**
+	 * Ensures a populated, paginated sitemap page is not flagged as a 404 just
+	 * because its page number exceeds the number of pages of regular posts.
+	 *
+	 * A sitemap URL is routed with the `sitemap` query variable but no
+	 * `post_type`, so the main query defaults to `post`. Before the fix, on a
+	 * request for a custom post type sitemap page numbered higher than the
+	 * `post` sitemap's last page, the main query returned no posts and
+	 * WP::handle_404() flagged the request as a 404 even though the sitemap
+	 * provider had URLs to render for that page.
+	 *
+	 * @ticket 65375
+	 *
+	 * @covers WP_Sitemaps::pre_handle_404
+	 */
+	public function test_populated_paged_sitemap_should_not_return_404() {
+		register_post_type(
+			'sitemap_cpt',
+			array(
+				'public'      => true,
+				'has_archive' => true,
+			)
+		);
+
+		// Two custom post type posts. With one URL per sitemap page (filtered
+		// below), the custom post type sitemap spans two pages, so page 2 is a
+		// real, populated page.
+		self::factory()->post->create_many( 2, array( 'post_type' => 'sitemap_cpt' ) );
+
+		// Make the dummy main query (which defaults to the `post` post type)
+		// have a single page: all of the regular posts created in
+		// wpSetUpBeforeClass fit on page 1, so any paged > 1 request returns no
+		// posts. This is the condition that used to make WP::handle_404() flag a
+		// 404 for sitemap pages numbered beyond the post sitemap's last page.
+		update_option( 'posts_per_page', 100 );
+		add_filter( 'wp_sitemaps_max_urls', array( $this, 'filter_max_urls_to_one' ) );
+
+		// Ensure the sitemaps server is bootstrapped so its pre_handle_404 and
+		// rewrite registrations are in place before the request is simulated.
+		// In a real request this happens on the 'init' hook; the test harness
+		// resets the server between tests, so trigger it explicitly.
+		wp_sitemaps_get_server();
+
+		// Request page 2 of the custom post type sitemap. Its page number (2)
+		// exceeds the post sitemap's single page, but the page itself has a URL
+		// to render and must not be a 404.
+		$this->go_to( home_url( '/?sitemap=posts&sitemap-subtype=sitemap_cpt&paged=2' ) );
+
+		remove_filter( 'wp_sitemaps_max_urls', array( $this, 'filter_max_urls_to_one' ) );
+
+		$this->assertFalse( is_404(), 'A populated paginated sitemap page should not be a 404.' );
+
+		unregister_post_type( 'sitemap_cpt' );
+	}
+
+	/**
+	 * Ensures a sitemap page that genuinely has no URLs still returns a 404.
+	 *
+	 * Guards against the pre_handle_404 short-circuit suppressing the 404 that
+	 * WP_Sitemaps::render_sitemaps() issues for an out-of-range sitemap page.
+	 *
+	 * @ticket 65375
+	 *
+	 * @covers WP_Sitemaps::pre_handle_404
+	 * @covers WP_Sitemaps::render_sitemaps
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_out_of_range_paged_sitemap_should_still_return_404() {
+		$this->go_to( home_url( '/?sitemap=posts&sitemap-subtype=post&paged=9999' ) );
+
+		wp_sitemaps_get_server()->render_sitemaps();
+
+		$this->assertTrue( is_404(), 'An out-of-range sitemap page with no URLs should be a 404.' );
+	}
+
+	/**
+	 * Forces the sitemap per-page URL limit to one for pagination testing.
+	 *
+	 * @return int
+	 */
+	public function filter_max_urls_to_one() {
+		return 1;
+	}
 }


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65375

## Problem

A paginated core XML sitemap sub-page — `wp-sitemap-posts-<post_type>-N.xml` or `wp-sitemap-taxonomies-<tax>-N.xml` — is served with an HTTP **404** status once the page number `N` exceeds the number of pages in the blog (`post`) sitemap, even though `WP_Sitemaps` renders a full, valid `<urlset>` body for that page.

The 404 boundary tracks the site's regular `post` count and `posts_per_page`, **not** the post type or taxonomy actually requested. A site with many CPT/taxonomy URLs but few regular posts advertises (e.g.) 40 sub-sitemaps in the index but only the first few return `200`; the rest return `404` with valid XML in the body, so search engines discard them.

Present since core sitemaps shipped in 5.5; reproduces unchanged on 5.5 / 6.6 / 6.7 / 7.0 (not a regression).

## Root cause

The sitemap rewrite rule maps `wp-sitemap-posts-<cpt>-N.xml` to `index.php?sitemap=posts&sitemap-subtype=<cpt>&paged=N` with **no `post_type`** query var, so the dummy main `WP_Query` defaults to `post` at `posts_per_page`. In `WP::main()`, `handle_404()` runs against that main query **before** `WP_Sitemaps::render_sitemaps()` runs on `template_redirect`. For `paged` beyond the post page count the main query returns zero posts and `handle_404()` sets the 404. The sitemap renderer then builds the correct XML from its own provider query and `exit`s, but never resets the status header back to `200`.

## Fix

Register a `pre_handle_404` filter on `WP_Sitemaps` that short-circuits core 404 handling for sitemap routes (`sitemap` / `sitemap-stylesheet` query vars). `WP_Sitemaps::render_sitemaps()` remains fully responsible for the response and still issues its own 404 when sitemaps are disabled or a requested page genuinely has no URLs (the existing `empty( $url_list )` path).

Surgical, additive change: one new method + one `add_filter()` in `WP_Sitemaps::init()`.

## Tests

Adds two tests to `tests/phpunit/tests/sitemaps/sitemaps.php`:

- `test_populated_paged_sitemap_should_not_return_404` — registers a public CPT, sets `posts_per_page` so the `post` main query is a single page, lowers `wp_sitemaps_max_urls` to 1 so the CPT sitemap paginates, then `go_to()`s CPT sitemap page 2 (beyond the post page count) and asserts it is **not** a 404. Fails on trunk, passes with the fix.
- `test_out_of_range_paged_sitemap_should_still_return_404` — `go_to()`s an out-of-range page with no URLs and asserts the renderer's own 404 still fires, guarding against the short-circuit suppressing legitimate empty-page 404s.

Both verified against the real `WP::main()` / `handle_404()` lifecycle (vanilla: populated page 404s, fixed: 200; empty page 404s in both).

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code (Anthropic), WordPress Playground via WP Codebox (clean-room reproduction + behavior verification)
Model(s): Claude (Opus)
Used for: Investigation and root-cause analysis, the implementation, and the tests were authored by an AI coding agent under the direction of the contributor (@chubes). The bug was reproduced and the fix verified in clean vanilla WordPress (5.5 / 6.6 / 6.7 / 7.0) before submission. The contributor reviewed and takes responsibility for the change. Per the WordPress AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request.**