### PR TITLE
Add missing return statement to `_mb_ord()`

### DIFF
--- a/src/wp-includes/compat.php
+++ b/src/wp-includes/compat.php
@@ -249,6 +249,8 @@ function _mb_ord( $string, $encoding = null ) {
 				( ( ord( $string[3] ) & 0x3F ) )
 			);
 	}
+
+	return false;
 }
 
 if ( ! function_exists( 'mb_substr' ) ) :


### PR DESCRIPTION
This is a follow-up to https://github.com/WordPress/wordpress-develop/pull/11965.

There is a PHPStan rule level 0 error introduced in that PR:

```
 ------ ----------------------------------------------------------------------------- 
  Line   src/wp-includes/compat.php                                                   
 ------ ----------------------------------------------------------------------------- 
  227    Function _mb_ord() should return int|false but return statement is missing.  
         🪪  return.missing                                                           
         at src/wp-includes/compat.php:227                                            
 ------ ----------------------------------------------------------------------------- 
```

While it doesn't seem that `$byte_length` can ever be anything other than `int<1, 4>` when `1 !== $found_count`, this is not picked up by PHPStan, leading ot the error.

An alternative to this would be to declare the type:

```diff
diff --git a/src/wp-includes/compat.php b/src/wp-includes/compat.php
index 5eb467280a..d67cea2d0c 100644
--- a/src/wp-includes/compat.php
+++ b/src/wp-includes/compat.php
@@ -221,6 +221,8 @@ function _mb_ord( $string, $encoding = null ) {
 		return false;
 	}
 
+	/** @var int<1, 4> $byte_length */
+
 	// These are valid code points, so no further validation is required.
 	$b0 = ord( $string[0] );
```

But this seems less clean.

Trac ticket: https://core.trac.wordpress.org/ticket/65342

## Use of AI Tools

None

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
