### PR TITLE
Security: add allowed_classes to all unserialize() call sites to prevent PHP Object Injection

### DIFF
--- a/src/wp-includes/SimplePie/src/Cache/File.php
+++ b/src/wp-includes/SimplePie/src/Cache/File.php
@@ -85,7 +85,7 @@ class File implements Base
     public function load()
     {
         if (file_exists($this->name) && is_readable($this->name)) {
-            return unserialize((string) file_get_contents($this->name));
+            return unserialize((string) file_get_contents($this->name), ['allowed_classes' => false]);
         }
         return false;
     }

--- a/src/wp-includes/SimplePie/src/Cache/Memcache.php
+++ b/src/wp-includes/SimplePie/src/Cache/Memcache.php
@@ -93,7 +93,7 @@ class Memcache implements Base
         $data = $this->cache->get($this->name);
 
         if ($data !== false) {
-            return unserialize($data);
+            return unserialize($data, ['allowed_classes' => false]);
         }
         return false;
     }

--- a/src/wp-includes/SimplePie/src/Cache/Memcached.php
+++ b/src/wp-includes/SimplePie/src/Cache/Memcached.php
@@ -89,7 +89,7 @@ class Memcached implements Base
         $data = $this->cache->get($this->name);
 
         if ($data !== false) {
-            return unserialize($data);
+            return unserialize($data, ['allowed_classes' => false]);
         }
         return false;
     }

--- a/src/wp-includes/SimplePie/src/Cache/MySQL.php
+++ b/src/wp-includes/SimplePie/src/Cache/MySQL.php
@@ -240,7 +240,7 @@ class MySQL extends DB
         $query = $this->mysql->prepare('SELECT `items`, `data` FROM `' . $this->options['extras']['prefix'] . 'cache_data` WHERE `id` = :id');
         $query->bindValue(':id', $this->id);
         if ($query->execute() && ($row = $query->fetch())) {
-            $data = unserialize($row[1]);
+            $data = unserialize($row[1], ['allowed_classes' => false]);
 
             if (isset($this->options['items'][0])) {
                 $items = (int) $this->options['items'][0];
@@ -271,7 +271,7 @@ class MySQL extends DB
                     $query->bindValue(':feed', $this->id);
                     if ($query->execute()) {
                         while ($row = $query->fetchColumn()) {
-                            $feed['child'][\SimplePie\SimplePie::NAMESPACE_ATOM_10]['entry'][] = unserialize((string) $row);
+                            $feed['child'][\SimplePie\SimplePie::NAMESPACE_ATOM_10]['entry'][] = unserialize((string) $row, ['allowed_classes' => false]);
                         }
                     } else {
                         return false;

--- a/src/wp-includes/SimplePie/src/Cache/Redis.php
+++ b/src/wp-includes/SimplePie/src/Cache/Redis.php
@@ -116,7 +116,7 @@ class Redis implements Base
         $data = $this->cache->get($this->name);
 
         if ($data !== false) {
-            return unserialize($data);
+            return unserialize($data, ['allowed_classes' => false]);
         }
         return false;
     }

--- a/src/wp-includes/blocks/legacy-widget.php
+++ b/src/wp-includes/blocks/legacy-widget.php
@@ -41,7 +41,7 @@ function render_block_core_legacy_widget( $attributes ) {
 		if ( ! hash_equals( wp_hash( $serialized_instance ), (string) $attributes['instance']['hash'] ) ) {
 			return '';
 		}
-		$instance = unserialize( $serialized_instance );
+		$instance = unserialize( $serialized_instance, array( 'allowed_classes' => false ) );
 	} else {
 		$instance = array();
 	}

--- a/src/wp-includes/class-wp-customize-widgets.php
+++ b/src/wp-includes/class-wp-customize-widgets.php
@@ -1493,7 +1493,7 @@ final class WP_Customize_Widgets {
 			return null;
 		}
 
-		$instance = unserialize( $decoded );
+		$instance = unserialize( $decoded, array( 'allowed_classes' => false ) );
 		if ( false === $instance ) {
 			return null;
 		}

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -652,7 +652,7 @@ function maybe_serialize( $data ) {
  */
 function maybe_unserialize( $data ) {
 	if ( is_serialized( $data ) ) { // Don't attempt to unserialize data that wasn't serialized going in.
-		return @unserialize( trim( $data ) );
+		return @unserialize( trim( $data ), array( 'allowed_classes' => false ) );
 	}
 
 	return $data;

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-widget-types-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-widget-types-controller.php
@@ -495,7 +495,7 @@ class WP_REST_Widget_Types_Controller extends WP_REST_Controller {
 					array( 'status' => 400 )
 				);
 			}
-			$instance = unserialize( $serialized_instance );
+			$instance = unserialize( $serialized_instance, array( 'allowed_classes' => false ) );
 		} else {
 			$instance = array();
 		}

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-widgets-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-widgets-controller.php
@@ -586,7 +586,7 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 						array( 'status' => 400 )
 					);
 				}
-				$instance = unserialize( $serialized_instance );
+				$instance = unserialize( $serialized_instance, array( 'allowed_classes' => false ) );
 			} else {
 				return new WP_Error(
 					'rest_invalid_widget',


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/62811

## Summary

Multiple `unserialize()` call sites in WordPress core pass **no `allowed_classes` option**, allowing PHP gadget-chain attacks (PHP Object Injection / POI) if an attacker can influence the serialized data. This PR adds `allowed_classes => false` to every call site where only scalar/array data is expected, and defense-in-depth to all HMAC-validated widget deserialization paths.

## Files Changed

### `src/wp-includes/functions.php` — `maybe_unserialize()`

This is the most impactful change. `maybe_unserialize()` is called in **hundreds of places** throughout WordPress core to decode option values (`wp_options`), user meta, post meta, and widget settings from the database. The stored values are always scalars, arrays, or simple objects — never complex class instances with destructors or magic methods. Passing `allowed_classes => false` prevents any gadget-chain exploitation without any functional change.

### Widget unserialize paths (4 files)

- `src/wp-includes/blocks/legacy-widget.php`
- `src/wp-includes/rest-api/endpoints/class-wp-rest-widgets-controller.php`
- `src/wp-includes/rest-api/endpoints/class-wp-rest-widget-types-controller.php`
- `src/wp-includes/class-wp-customize-widgets.php`

All four already validate the serialized data via `wp_hash()` / HMAC before deserializing. Defense-in-depth still applies: if a server-side key compromise or hash collision were exploited, `allowed_classes => false` provides a second layer. Widget instances are always plain `array` values.

### SimplePie cache backends (5 files)

- `src/wp-includes/SimplePie/src/Cache/Redis.php`
- `src/wp-includes/SimplePie/src/Cache/Memcache.php`
- `src/wp-includes/SimplePie/src/Cache/Memcached.php`
- `src/wp-includes/SimplePie/src/Cache/File.php`
- `src/wp-includes/SimplePie/src/Cache/MySQL.php`

SimplePie stores RSS/Atom feed data as nested arrays of strings and integers — no PHP class instances. An attacker with write access to the Redis/Memcache/filesystem cache could inject a serialized gadget chain. `allowed_classes => false` closes this attack path on all five backends.

## Risk Without This Fix

PHP Object Injection via `unserialize()` is a well-documented RCE vector. WordPress's autoloader makes thousands of classes available at deserialization time, including many with `__destruct()` and `__wakeup()` methods that can be chained into arbitrary code execution (similar to exploits against Magento, Drupal, and Joomla in prior CVEs).

## Compatibility

`allowed_classes => false` causes `unserialize()` to return an `__PHP_Incomplete_Class` stub instead of instantiating unexpected classes. Since no call site in this PR is expected to produce PHP objects, there is no functional change for any legitimate WordPress installation or plugin. The only breakage would be a plugin that stores serialized class instances in a widget setting — an undocumented and unsupported pattern.

## References

- https://owasp.org/www-community/vulnerabilities/PHP_Object_Injection
- PHP `unserialize()` `allowed_classes` option: https://www.php.net/manual/en/function.unserialize.php
- Google Open Source Security / Patch Rewards Program