### PR TITLE
Admin color schemes: make sidebars compatible with Gutenberg editor chrome by improving contrast

### DIFF
--- a/src/wp-admin/css/colors/blue/colors.scss
+++ b/src/wp-admin/css/colors/blue/colors.scss
@@ -1,16 +1,16 @@
-$highlight-color: #096484;
+$highlight-color: #437aa8;
 
 @use "../_admin.scss" with (
 	$scheme-name: "blue",
-	$base-color: #52accc,
+	$base-color: #245278,
 	$icon-color: #e5f8ff,
 	$highlight-color: $highlight-color,
 	$notification-color: #e1a948,
-	$button-color: #e1a948,
-
+	$menu-highlight-text: #fff,
+	$menu-highlight-icon: #fff,
+	$menu-bubble-text: #1e1e1e,
 	$menu-submenu-text: #e2ecf1,
 	$menu-submenu-focus-text: #fff,
-	$menu-submenu-background: #4796b3,
 
 	$dashboard-icon-background: $highlight-color
 );

--- a/src/wp-admin/css/colors/coffee/colors.scss
+++ b/src/wp-admin/css/colors/coffee/colors.scss
@@ -1,11 +1,13 @@
-$base-color: #59524c;
+$base-color: #5c4c40;
 
 @use "../_admin.scss" with (
 	$scheme-name: "coffee",
 	$base-color: $base-color,
-	$highlight-color: #c7a589,
+	$highlight-color: #916745,
 	$notification-color: #9ea476,
+	$menu-highlight-text: #fff,
+	$menu-highlight-icon: #fff,
+	$menu-bubble-text: #1e1e1e,
+	$menu-submenu-focus-text: #fff,
 	$form-checked: $base-color,
-
-	$low-contrast-theme: "true"
 );

--- a/src/wp-admin/css/colors/ectoplasm/colors.scss
+++ b/src/wp-admin/css/colors/ectoplasm/colors.scss
@@ -1,11 +1,15 @@
-$base-color: #523f6d;
+$base-color: #4a3369;
 
 @use "../_admin.scss" with (
 	$scheme-name: "ectoplasm",
 	$base-color: $base-color,
 	$icon-color: #ece6f6,
-	$highlight-color: #a3b745,
+	$highlight-color: #646c3e,
 	$notification-color: #d46f15,
+	$menu-highlight-text: #fff,
+	$menu-highlight-icon: #fff,
+	$menu-bubble-text: #1e1e1e,
+	$menu-submenu-focus-text: #fff,
 
 	$form-checked: $base-color,
 );

--- a/src/wp-admin/css/colors/light/colors.scss
+++ b/src/wp-admin/css/colors/light/colors.scss
@@ -1,22 +1,22 @@
 @use "sass:color";
 
-$highlight-color: #04a4cc;
+$highlight-color: #007cba;
 $text-color: #333;
 $menu-avatar-frame: #aaa;
 
 @use "../_admin.scss" with (
 	$scheme-name: "light",
 	$base-color: #e5e5e5,
-	$icon-color: #999,
+	$icon-color: #6a6a6a,
 	$text-color: $text-color,
 	$highlight-color: $highlight-color,
-	$notification-color: #d64e07,
+	$notification-color: #c64606,
 
 	$body-background: #f5f5f5,
 
 	$menu-highlight-text: #fff,
-	$menu-highlight-icon: #ccc,
-	$menu-highlight-background: #888,
+	$menu-highlight-icon: #fff,
+	$menu-highlight-background: #6e6e6e,
 
 	$menu-bubble-text: #fff,
 	$menu-submenu-background: #fff,

--- a/src/wp-admin/css/colors/midnight/colors.scss
+++ b/src/wp-admin/css/colors/midnight/colors.scss
@@ -1,7 +1,7 @@
 @use "sass:color";
 
-$base-color: #363b3f;
-$highlight-color: #e14d43;
+$base-color: #333c42;
+$highlight-color: #cf4339;
 $notification-color: #69a8bb;
 
 @use "../_admin.scss" with (
@@ -9,6 +9,10 @@ $notification-color: #69a8bb;
 	$base-color: $base-color,
 	$highlight-color: $highlight-color,
 	$notification-color: $notification-color,
+	$menu-highlight-text: #fff,
+	$menu-highlight-icon: #fff,
+	$menu-bubble-text: #1e1e1e,
+	$menu-submenu-focus-text: #fff,
 
 	$dashboard-accent-2: color.mix($base-color, $notification-color, 90%),
 );

--- a/src/wp-admin/css/colors/ocean/colors.scss
+++ b/src/wp-admin/css/colors/ocean/colors.scss
@@ -1,12 +1,14 @@
-$base-color: #738e96;
+$base-color: #39535a;
 
 @use "../_admin.scss" with (
 	$scheme-name: "ocean",
 	$base-color: $base-color,
 	$icon-color: #f2fcff,
-	$highlight-color: #9ebaa0,
+	$highlight-color: #567958,
 	$notification-color: #aa9d88,
+	$menu-highlight-text: #fff,
+	$menu-highlight-icon: #fff,
+	$menu-bubble-text: #1e1e1e,
+	$menu-submenu-focus-text: #fff,
 	$form-checked: $base-color,
-
-	$low-contrast-theme: "true"
 );

--- a/src/wp-admin/css/colors/sunrise/colors.scss
+++ b/src/wp-admin/css/colors/sunrise/colors.scss
@@ -1,11 +1,10 @@
-@use "sass:color";
-
-$highlight-color: #dd823b;
-
 @use "../_admin.scss" with (
   $scheme-name: "sunrise",
-  $base-color: #cf4944,
-  $highlight-color: $highlight-color,
+  $base-color: #8a312d,
+  $highlight-color: #ad631e,
   $notification-color: #ccaf0b,
-  $menu-submenu-focus-text: color.adjust($highlight-color, $lightness: 35%)
+  $menu-highlight-text: #fff,
+  $menu-highlight-icon: #fff,
+  $menu-bubble-text: #1e1e1e,
+  $menu-submenu-focus-text: #fff
 );

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -4941,7 +4941,7 @@ function register_admin_color_schemes() {
 		'light',
 		_x( 'Light', 'admin color scheme' ),
 		admin_url( "css/colors/light/colors$suffix.css" ),
-		array( '#e5e5e5', '#999', '#d64e07', '#04a4cc' ),
+		array( '#e5e5e5', '#6a6a6a', '#c64606', '#007cba' ),
 		array(
 			'base'    => '#999',
 			'focus'   => '#ccc',
@@ -4953,7 +4953,7 @@ function register_admin_color_schemes() {
 		'blue',
 		_x( 'Blue', 'admin color scheme' ),
 		admin_url( "css/colors/blue/colors$suffix.css" ),
-		array( '#096484', '#4796b3', '#52accc', '#74B6CE' ),
+		array( '#183751', '#245278', '#437aa8', '#e1a948' ),
 		array(
 			'base'    => '#e5f8ff',
 			'focus'   => '#fff',
@@ -4965,7 +4965,7 @@ function register_admin_color_schemes() {
 		'midnight',
 		_x( 'Midnight', 'admin color scheme' ),
 		admin_url( "css/colors/midnight/colors$suffix.css" ),
-		array( '#25282b', '#363b3f', '#69a8bb', '#e14d43' ),
+		array( '#232a2e', '#333c42', '#69a8bb', '#cf4339' ),
 		array(
 			'base'    => '#f1f2f3',
 			'focus'   => '#fff',
@@ -4977,7 +4977,7 @@ function register_admin_color_schemes() {
 		'sunrise',
 		_x( 'Sunrise', 'admin color scheme' ),
 		admin_url( "css/colors/sunrise/colors$suffix.css" ),
-		array( '#b43c38', '#cf4944', '#dd823b', '#ccaf0b' ),
+		array( '#6f2724', '#8a312d', '#ad631e', '#ccaf0b' ),
 		array(
 			'base'    => '#f3f1f1',
 			'focus'   => '#fff',
@@ -4989,7 +4989,7 @@ function register_admin_color_schemes() {
 		'ectoplasm',
 		_x( 'Ectoplasm', 'admin color scheme' ),
 		admin_url( "css/colors/ectoplasm/colors$suffix.css" ),
-		array( '#413256', '#523f6d', '#a3b745', '#d46f15' ),
+		array( '#392751', '#4a3369', '#646c3e', '#d46f15' ),
 		array(
 			'base'    => '#ece6f6',
 			'focus'   => '#fff',
@@ -5001,7 +5001,7 @@ function register_admin_color_schemes() {
 		'ocean',
 		_x( 'Ocean', 'admin color scheme' ),
 		admin_url( "css/colors/ocean/colors$suffix.css" ),
-		array( '#627c83', '#738e96', '#9ebaa0', '#aa9d88' ),
+		array( '#2b3f44', '#39535a', '#567958', '#aa9d88' ),
 		array(
 			'base'    => '#f2fcff',
 			'focus'   => '#fff',
@@ -5013,7 +5013,7 @@ function register_admin_color_schemes() {
 		'coffee',
 		_x( 'Coffee', 'admin color scheme' ),
 		admin_url( "css/colors/coffee/colors$suffix.css" ),
-		array( '#46403c', '#59524c', '#c7a589', '#9ea476' ),
+		array( '#382e27', '#5c4c40', '#916745', '#9ea476' ),
 		array(
 			'base'    => '#f3f2f1',
 			'focus'   => '#fff',


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65382

## Summary

The block editor and Site Editor are moving toward applying the user's admin color scheme (see https://github.com/WordPress/gutenberg/pull/78397). With that, the editor chrome will use the color scheme, instead of being always black. However, as also discussed in the linked PR, this has a few problems with the current color schemes:

1. The editor chrome's background color is generated from a seed, through the WPDS ramp algorithm ([buildBgRamp()](https://github.com/WordPress/gutenberg/blob/35487a041c6569399988a96d5956b92cd3da0a71/packages/theme/src/color-ramps/index.ts#L18)). This function emits surface colors within a specific luminance bands, and cannot reproduce arbitrary colors. Most of the current scheme sidebars are outside the bands, so the editor chrome will NEVER match them regardless of the seed.
2. The primary button may appear in the editor chrome, e.g. as `Review X changes...` button. So, the background color should be distinct enough from the sidebar. Currently several schemes have similar colors (e.g. the purple Ectoplasm).

This PR updates the core admin color schemes to satisfy both, while maintaining each scheme's characteristics.

Several notes:

- With this PR I also try to reduce the number of distinct colors in each scheme. Except for the Light scheme, the primary button's background color is made equal to the currently selected sidebar menu's background color. This simplifies the color schemes.
- I believe some color schemes currently being low-contrast is expected. However, the `buildBgRamp()` function CANNOT produce low-contrast colors. So, for each such schemes (like Coffee, Ocean) I tried to produce the color with the lowest contrast possible while still being similar to the original color.
- This PR: https://github.com/WordPress/gutenberg/pull/23048 changed the primary button color to be the sidebar color, for several schemes (such as Ectoplasm). This PR reverts that behavior due to the reason mentioned before.

> [!WARNING]  
> The [linked Gutenberg PR](https://github.com/WordPress/gutenberg/pull/78397) must also be backported, because the primary colors are also being updated in `base-styles`.

### Sidebar contrast (white/black text vs sidebar background)

And whether they pass WCAG 2.x AA (it requires > 4.5:1 for normal text)

| Scheme | Before | After |
|---|---|---|
| Modern | 16.67 ✅ | *unchanged* |
| Fresh | 15.89 ✅ | *unchanged* |
| Light | 10.03 ✅ | 10.03 ✅ |
| Blue | 2.58 ❌ | 8.23 ✅ |
| Coffee | 7.68 ✅ | 8.19 ✅ |
| Ectoplasm | 9.17 ✅ | 10.67 ✅ |
| Midnight | 11.33 ✅ | 11.26 ✅ |
| Ocean | 3.48 ❌ | 8.21 ✅ |
| Sunrise | 4.48 ❌ | 8.21 ✅ |

### Primary button contrast (white text vs button background)

Note that except for Light scheme, this primary button background color is now equal to that of the currently selected menu item.

| Scheme | Before | After |
|---|---|---|
| Modern | 5.61 ✅ | *unchanged*|
| Fresh | 5.17 ✅ | *unchanged*|
| Light | **4.15 ❌** | **4.57 ✅** |
| Blue | 6.63 ✅ | 4.58 ✅ |
| Coffee | 10.2 ✅ | 4.96 ✅ |
| Ectoplasm | 9.17 ✅ | 5.59 ✅ |
| Midnight | 3.93 ❌ | 4.65 ✅ |
| Ocean | 4.44 ❌ | 4.92 ✅ |
| Sunrise | 2.86 ❌ | 4.58 ✅ |

### Screenshots

| Before | After |
| --- | --- |
| **Blue**<br><img src="https://github.com/user-attachments/assets/fbf99386-0584-4228-8b86-88b811ea96bd" width="450"> | **Blue**<br><img src="https://github.com/user-attachments/assets/a5b2777d-8f7b-4a71-9506-8bb923424cc5" width="450"> |
| **Coffee**<br><img src="https://github.com/user-attachments/assets/7f8aa683-644c-43f2-976a-a4d446d9091b" width="450"> | **Coffee**<br><img src="https://github.com/user-attachments/assets/847e04bc-5b06-4eb2-85c3-97278f4c7c8e" width="450"> |
| **Ectoplasm**<br><img src="https://github.com/user-attachments/assets/a92ce2a2-f25c-48bf-b844-4ac45a1285ec" width="450"> | **Ectoplasm**<br><img src="https://github.com/user-attachments/assets/488b6d3c-e87e-4166-a36b-cfa8d0ff8738" width="450"> |
| **Light**<br><img src="https://github.com/user-attachments/assets/c52f744e-bc41-4f7b-912e-2abe3303b41d" width="450"> | **Light**<br><img src="https://github.com/user-attachments/assets/77746ac4-6e26-4435-b6e0-1bef2a916c7c" width="450"> |
| **Midnight**<br><img src="https://github.com/user-attachments/assets/159ecebd-666f-4ca7-befe-732f42b92ddf" width="450"> | **Midnight**<br><img src="https://github.com/user-attachments/assets/4410d0ef-c264-48d5-91fc-5272d058b5fe" width="450"> |
| **Ocean**<br><img src="https://github.com/user-attachments/assets/cdc3a3d2-7617-4fbb-8bf0-676c64244dcc" width="450"> | **Ocean**<br><img src="https://github.com/user-attachments/assets/70baa458-587b-4b03-97ed-7c4a0077d26d" width="450"> |
| **Sunrise**<br><img src="https://github.com/user-attachments/assets/84ab785a-44af-4765-bd8d-a110abfa33e0" width="450"> | **Sunrise**<br><img src="https://github.com/user-attachments/assets/41571b45-f20d-40b3-a33a-16643bcbc7d9" width="450"> |



## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Opus 4.7-4.8
Used for: iterating the color gradients


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
