### PR TITLE
Add Copy buttons for site URLs in General Settings

### DIFF
--- a/src/wp-admin/includes/options.php
+++ b/src/wp-admin/includes/options.php
@@ -51,6 +51,19 @@ function options_general_add_js() {
 			$siteIconPreview.text( title );
 		});
 
+		if ( typeof ClipboardJS !== 'undefined' ) {
+			var copySiteURLClipboard = new ClipboardJS( '.copy-site-url', {
+				text: function( trigger ) {
+					return $( $( trigger ).data( 'clipboard-target' ) ).val();
+				}
+			} );
+
+			copySiteURLClipboard.on( 'success', function( event ) {
+				event.clearSelection();
+				wp.a11y.speak( <?php echo wp_json_encode( __( 'The URL has been copied to your clipboard.' ) ); ?> );
+			} );
+		}
+
 		$( 'input[name="date_format"]' ).on( 'click', function() {
 			if ( 'date_format_custom_radio' !== $(this).attr( 'id' ) )
 				$( 'input[name="date_format_custom"]' ).val( $( this ).val() ).closest( 'fieldset' ).find( '.example' ).text( $( this ).parent( 'label' ).children( '.format-i18n' ).text() );

--- a/src/wp-admin/options-general.php
+++ b/src/wp-admin/options-general.php
@@ -61,6 +61,9 @@ get_current_screen()->set_help_sidebar(
 	'<p>' . __( '<a href="https://wordpress.org/support/forums/">Support forums</a>' ) . '</p>'
 );
 
+wp_enqueue_script( 'clipboard' );
+wp_enqueue_script( 'wp-a11y' );
+
 require_once ABSPATH . 'wp-admin/admin-header.php';
 ?>
 
@@ -239,12 +242,15 @@ if ( ! is_multisite() ) {
 
 <tr>
 <th scope="row"><label for="siteurl"><?php _e( 'WordPress Address (URL)' ); ?></label></th>
-<td><input name="siteurl" type="url" id="siteurl" value="<?php form_option( 'siteurl' ); ?>"<?php disabled( defined( 'WP_SITEURL' ) ); ?> class="regular-text code<?php echo $wp_site_url_class; ?>" /></td>
+<td><input name="siteurl" type="url" id="siteurl" value="<?php form_option( 'siteurl' ); ?>"<?php disabled( defined( 'WP_SITEURL' ) ); ?> class="regular-text code<?php echo $wp_site_url_class; ?>" />
+	<button type="button" class="button copy-site-url" data-clipboard-target="#siteurl" aria-label="<?php esc_attr_e( 'Copy WordPress Address to clipboard' ); ?>"><?php _e( 'Copy' ); ?></button>
+</td>
 </tr>
 
 <tr>
 <th scope="row"><label for="home"><?php _e( 'Site Address (URL)' ); ?></label></th>
 <td><input name="home" type="url" id="home" aria-describedby="home-description" value="<?php form_option( 'home' ); ?>"<?php disabled( defined( 'WP_HOME' ) ); ?> class="regular-text code<?php echo $wp_home_class; ?>" />
+	<button type="button" class="button copy-site-url" data-clipboard-target="#home" aria-label="<?php esc_attr_e( 'Copy Site Address to clipboard' ); ?>"><?php _e( 'Copy' ); ?></button>
 	<?php if ( ! defined( 'WP_HOME' ) ) : ?>
 <p class="description" id="home-description">
 		<?php


### PR DESCRIPTION
## Summary
Adds small copy-to-clipboard buttons next to the WordPress Address and Site Address fields in Settings → General.

## Why
Site owners, developers, and support teams often copy these URLs when configuring tools, debugging, or sharing site details. This adds a low-risk convenience directly where the URLs are managed.

## Changes
- Adds a `Copy` button beside the WordPress Address field.
- Adds a `Copy` button beside the Site Address field.
- Uses the existing `clipboard` script registered in core.
- Announces successful copies with `wp.a11y.speak()` for screen reader users.
- Keeps the UI scoped to the existing General Settings screen.

## Testing
- `php -l src/wp-admin/options-general.php`
- `php -l src/wp-admin/includes/options.php`
- `vendor/bin/phpcs --standard=phpcs.xml.dist --runtime-set testVersion 7.4- src/wp-admin/options-general.php src/wp-admin/includes/options.php`
