### PR TITLE
HTML API: Replace Open Elements handlers with explicit stack accounting

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-open-elements.php
+++ b/src/wp-includes/html-api/class-wp-html-open-elements.php
@@ -530,22 +530,23 @@ class WP_HTML_Open_Elements {
 	 *
 	 * @see https://html.spec.whatwg.org/#stack-of-open-elements
 	 *
-	 * @return WP_HTML_Token|null The node that was popped off of the stack, or null if the stack was empty.
+	 * @return bool Whether a node was popped off of the stack.
 	 */
-	public function pop(): ?WP_HTML_Token {
+	public function pop(): bool {
 		$item = array_pop( $this->stack );
 		if ( null === $item ) {
-			return null;
+			return false;
 		}
 
 		$this->after_element_pop( $item );
-		return $item;
+		return true;
 	}
 
 	/**
 	 * Pops nodes off of the stack of open elements until an HTML tag with the given name has been popped.
 	 *
 	 * @since 6.4.0
+	 * @since 7.1.0 Returns all of the nodes popped from the stack.
 	 *
 	 * @see WP_HTML_Open_Elements::pop
 	 *

--- a/src/wp-includes/html-api/class-wp-html-open-elements.php
+++ b/src/wp-includes/html-api/class-wp-html-open-elements.php
@@ -47,10 +47,77 @@ class WP_HTML_Open_Elements {
 	 * This avoids frequent iteration over the stack.
 	 *
 	 * @since 6.4.0
+	 * @deprecated 7.1.0 Manage push/pop handlers externally.
 	 *
 	 * @var bool
 	 */
 	private $has_p_in_button_scope = false;
+
+	/**
+	 * A function that will be called when an item is popped off the stack of open elements.
+	 *
+	 * The function will be called with the popped item as its argument.
+	 *
+	 * @since 6.6.0
+	 * @deprecated 7.1.0 Manage push/pop handlers externally.
+	 *
+	 * @var Closure|null
+	 */
+	private $pop_handler = null;
+
+	/**
+	 * A function that will be called when an item is pushed onto the stack of open elements.
+	 *
+	 * The function will be called with the pushed item as its argument.
+	 *
+	 * @since 6.6.0
+	 * @deprecated 7.1.0 Manage push/pop handlers externally.
+	 *
+	 * @var Closure|null
+	 */
+	private $push_handler = null;
+
+	/**
+	 * Sets a pop handler that will be called when an item is popped off the stack of
+	 * open elements.
+	 *
+	 * The function will be called with the pushed item as its argument.
+	 *
+	 * @since 6.6.0
+	 * @deprecated 7.1.0 Manage push/pop handlers externally.
+	 *
+	 * @param Closure $handler The handler function.
+	 */
+	public function set_pop_handler( Closure $handler ): void {
+		_deprecated_function(
+			__METHOD__,
+			'7.1.0',
+			'Manage push/pop events from the HTML open-elements stack externally.'
+		);
+
+		$this->pop_handler = $handler;
+	}
+
+	/**
+	 * Sets a push handler that will be called when an item is pushed onto the stack of
+	 * open elements.
+	 *
+	 * The function will be called with the pushed item as its argument.
+	 *
+	 * @since 6.6.0
+	 * @deprecated 7.1.0 Manage push/pop handlers externally.
+	 *
+	 * @param Closure $handler The handler function.
+	 */
+	public function set_push_handler( Closure $handler ): void {
+		_deprecated_function(
+			__METHOD__,
+			'7.1.0',
+			'Manage push/pop events from the HTML open-elements stack externally.'
+		);
+
+		$this->push_handler = $handler;
+	}
 
 	/**
 	 * Returns the name of the node at the nth position on the stack

--- a/src/wp-includes/html-api/class-wp-html-open-elements.php
+++ b/src/wp-includes/html-api/class-wp-html-open-elements.php
@@ -530,16 +530,16 @@ class WP_HTML_Open_Elements {
 	 *
 	 * @see https://html.spec.whatwg.org/#stack-of-open-elements
 	 *
-	 * @return bool Whether a node was popped off of the stack.
+	 * @return WP_HTML_Token|null The node that was popped off of the stack, or null if the stack was empty.
 	 */
-	public function pop(): bool {
+	public function pop(): ?WP_HTML_Token {
 		$item = array_pop( $this->stack );
 		if ( null === $item ) {
-			return false;
+			return null;
 		}
 
 		$this->after_element_pop( $item );
-		return true;
+		return $item;
 	}
 
 	/**

--- a/src/wp-includes/html-api/class-wp-html-open-elements.php
+++ b/src/wp-includes/html-api/class-wp-html-open-elements.php
@@ -21,6 +21,7 @@
  * > for misnested tags).
  *
  * @since 6.4.0
+ * @deprecated 7.1.0 WP_HTML_Processor manages its stack of open elements internally.
  *
  * @access private
  * @ignore
@@ -76,6 +77,20 @@ class WP_HTML_Open_Elements {
 	 * @var Closure|null
 	 */
 	private $push_handler = null;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 7.1.0
+	 * @deprecated 7.1.0 WP_HTML_Processor manages its stack of open elements internally.
+	 */
+	public function __construct() {
+		_deprecated_function(
+			__METHOD__,
+			'7.1.0',
+			'WP_HTML_Processor'
+		);
+	}
 
 	/**
 	 * Sets a pop handler that will be called when an item is popped off the stack of

--- a/src/wp-includes/html-api/class-wp-html-open-elements.php
+++ b/src/wp-includes/html-api/class-wp-html-open-elements.php
@@ -521,12 +521,10 @@ class WP_HTML_Open_Elements {
 	 * @see https://html.spec.whatwg.org/#stack-of-open-elements
 	 *
 	 * @param WP_HTML_Token $stack_item Item to add onto stack.
-	 * @return WP_HTML_Token The node that was pushed onto the stack of open elements.
 	 */
-	public function push( WP_HTML_Token $stack_item ): WP_HTML_Token {
+	public function push( WP_HTML_Token $stack_item ): void {
 		$this->stack[] = $stack_item;
 		$this->after_element_push( $stack_item );
-		return $stack_item;
 	}
 
 	/**

--- a/src/wp-includes/html-api/class-wp-html-open-elements.php
+++ b/src/wp-includes/html-api/class-wp-html-open-elements.php
@@ -53,56 +53,6 @@ class WP_HTML_Open_Elements {
 	private $has_p_in_button_scope = false;
 
 	/**
-	 * A function that will be called when an item is popped off the stack of open elements.
-	 *
-	 * The function will be called with the popped item as its argument.
-	 *
-	 * @since 6.6.0
-	 *
-	 * @var Closure|null
-	 */
-	private $pop_handler = null;
-
-	/**
-	 * A function that will be called when an item is pushed onto the stack of open elements.
-	 *
-	 * The function will be called with the pushed item as its argument.
-	 *
-	 * @since 6.6.0
-	 *
-	 * @var Closure|null
-	 */
-	private $push_handler = null;
-
-	/**
-	 * Sets a pop handler that will be called when an item is popped off the stack of
-	 * open elements.
-	 *
-	 * The function will be called with the pushed item as its argument.
-	 *
-	 * @since 6.6.0
-	 *
-	 * @param Closure $handler The handler function.
-	 */
-	public function set_pop_handler( Closure $handler ): void {
-		$this->pop_handler = $handler;
-	}
-
-	/**
-	 * Sets a push handler that will be called when an item is pushed onto the stack of
-	 * open elements.
-	 *
-	 * The function will be called with the pushed item as its argument.
-	 *
-	 * @since 6.6.0
-	 *
-	 * @param Closure $handler The handler function.
-	 */
-	public function set_push_handler( Closure $handler ): void {
-		$this->push_handler = $handler;
-	}
-
-	/**
 	 * Returns the name of the node at the nth position on the stack
 	 * of open elements, or `null` if no such position exists.
 	 *
@@ -513,16 +463,16 @@ class WP_HTML_Open_Elements {
 	 *
 	 * @see https://html.spec.whatwg.org/#stack-of-open-elements
 	 *
-	 * @return bool Whether a node was popped off of the stack.
+	 * @return WP_HTML_Token|null The node that was popped off of the stack, or null if the stack was empty.
 	 */
-	public function pop(): bool {
+	public function pop(): ?WP_HTML_Token {
 		$item = array_pop( $this->stack );
 		if ( null === $item ) {
-			return false;
+			return null;
 		}
 
 		$this->after_element_pop( $item );
-		return true;
+		return $item;
 	}
 
 	/**
@@ -533,11 +483,16 @@ class WP_HTML_Open_Elements {
 	 * @see WP_HTML_Open_Elements::pop
 	 *
 	 * @param string $html_tag_name Name of tag that needs to be popped off of the stack of open elements.
-	 * @return bool Whether a tag of the given name was found and popped off of the stack of open elements.
+	 * @return WP_HTML_Token[] The nodes that were popped off of the stack of open elements.
 	 */
-	public function pop_until( string $html_tag_name ): bool {
+	public function pop_until( string $html_tag_name ): array {
+		$popped = array();
+
 		foreach ( $this->walk_up() as $item ) {
-			$this->pop();
+			$popped_item = $this->pop();
+			if ( null !== $popped_item ) {
+				$popped[] = $popped_item;
+			}
 
 			if ( 'html' !== $item->namespace ) {
 				continue;
@@ -547,15 +502,15 @@ class WP_HTML_Open_Elements {
 				'(internal: H1 through H6 - do not use)' === $html_tag_name &&
 				in_array( $item->node_name, array( 'H1', 'H2', 'H3', 'H4', 'H5', 'H6' ), true )
 			) {
-				return true;
+				return $popped;
 			}
 
 			if ( $html_tag_name === $item->node_name ) {
-				return true;
+				return $popped;
 			}
 		}
 
-		return false;
+		return $popped;
 	}
 
 	/**
@@ -566,10 +521,12 @@ class WP_HTML_Open_Elements {
 	 * @see https://html.spec.whatwg.org/#stack-of-open-elements
 	 *
 	 * @param WP_HTML_Token $stack_item Item to add onto stack.
+	 * @return WP_HTML_Token The node that was pushed onto the stack of open elements.
 	 */
-	public function push( WP_HTML_Token $stack_item ): void {
+	public function push( WP_HTML_Token $stack_item ): WP_HTML_Token {
 		$this->stack[] = $stack_item;
 		$this->after_element_push( $stack_item );
+		return $stack_item;
 	}
 
 	/**
@@ -578,9 +535,9 @@ class WP_HTML_Open_Elements {
 	 * @since 6.4.0
 	 *
 	 * @param WP_HTML_Token $token The node to remove from the stack of open elements.
-	 * @return bool Whether the node was found and removed from the stack of open elements.
+	 * @return WP_HTML_Token|null The node that was removed from the stack of open elements, or null if it was not found.
 	 */
-	public function remove_node( WP_HTML_Token $token ): bool {
+	public function remove_node( WP_HTML_Token $token ): ?WP_HTML_Token {
 		foreach ( $this->walk_up() as $position_from_end => $item ) {
 			if ( $token->bookmark_name !== $item->bookmark_name ) {
 				continue;
@@ -589,10 +546,10 @@ class WP_HTML_Open_Elements {
 			$position_from_start = $this->count() - $position_from_end - 1;
 			array_splice( $this->stack, $position_from_start, 1 );
 			$this->after_element_pop( $item );
-			return true;
+			return $item;
 		}
 
-		return false;
+		return null;
 	}
 
 
@@ -714,10 +671,6 @@ class WP_HTML_Open_Elements {
 				$this->has_p_in_button_scope = true;
 				break;
 		}
-
-		if ( null !== $this->push_handler ) {
-			call_user_func( $this->push_handler, $item );
-		}
 	}
 
 	/**
@@ -766,10 +719,6 @@ class WP_HTML_Open_Elements {
 				$this->has_p_in_button_scope = $this->has_element_in_button_scope( 'P' );
 				break;
 		}
-
-		if ( null !== $this->pop_handler ) {
-			call_user_func( $this->pop_handler, $item );
-		}
 	}
 
 	/**
@@ -782,8 +731,12 @@ class WP_HTML_Open_Elements {
 	 * @see https://html.spec.whatwg.org/multipage/parsing.html#clear-the-stack-back-to-a-table-context
 	 *
 	 * @since 6.7.0
+	 *
+	 * @return WP_HTML_Token[] The nodes that were popped off of the stack of open elements.
 	 */
-	public function clear_to_table_context(): void {
+	public function clear_to_table_context(): array {
+		$popped = array();
+
 		foreach ( $this->walk_up() as $item ) {
 			if (
 				'TABLE' === $item->node_name ||
@@ -792,8 +745,13 @@ class WP_HTML_Open_Elements {
 			) {
 				break;
 			}
-			$this->pop();
+			$popped_item = $this->pop();
+			if ( null !== $popped_item ) {
+				$popped[] = $popped_item;
+			}
 		}
+
+		return $popped;
 	}
 
 	/**
@@ -806,8 +764,12 @@ class WP_HTML_Open_Elements {
 	 * @see https://html.spec.whatwg.org/multipage/parsing.html#clear-the-stack-back-to-a-table-body-context
 	 *
 	 * @since 6.7.0
+	 *
+	 * @return WP_HTML_Token[] The nodes that were popped off of the stack of open elements.
 	 */
-	public function clear_to_table_body_context(): void {
+	public function clear_to_table_body_context(): array {
+		$popped = array();
+
 		foreach ( $this->walk_up() as $item ) {
 			if (
 				'TBODY' === $item->node_name ||
@@ -818,8 +780,13 @@ class WP_HTML_Open_Elements {
 			) {
 				break;
 			}
-			$this->pop();
+			$popped_item = $this->pop();
+			if ( null !== $popped_item ) {
+				$popped[] = $popped_item;
+			}
 		}
+
+		return $popped;
 	}
 
 	/**
@@ -832,8 +799,12 @@ class WP_HTML_Open_Elements {
 	 * @see https://html.spec.whatwg.org/multipage/parsing.html#clear-the-stack-back-to-a-table-row-context
 	 *
 	 * @since 6.7.0
+	 *
+	 * @return WP_HTML_Token[] The nodes that were popped off of the stack of open elements.
 	 */
-	public function clear_to_table_row_context(): void {
+	public function clear_to_table_row_context(): array {
+		$popped = array();
+
 		foreach ( $this->walk_up() as $item ) {
 			if (
 				'TR' === $item->node_name ||
@@ -842,8 +813,13 @@ class WP_HTML_Open_Elements {
 			) {
 				break;
 			}
-			$this->pop();
+			$popped_item = $this->pop();
+			if ( null !== $popped_item ) {
+				$popped[] = $popped_item;
+			}
 		}
+
+		return $popped;
 	}
 
 	/**

--- a/src/wp-includes/html-api/class-wp-html-processor-state.php
+++ b/src/wp-includes/html-api/class-wp-html-processor-state.php
@@ -314,15 +314,25 @@ class WP_HTML_Processor_State {
 	/**
 	 * Tracks open elements while scanning HTML.
 	 *
-	 * This property is initialized in the constructor and never null.
-	 *
 	 * @since 6.4.0
 	 *
 	 * @see https://html.spec.whatwg.org/#stack-of-open-elements
 	 *
-	 * @var WP_HTML_Open_Elements
+	 * @var WP_HTML_Token[]
 	 */
-	public $stack_of_open_elements;
+	public $stack_of_open_elements = array();
+
+	/**
+	 * Whether a P element is in button scope currently.
+	 *
+	 * This value is maintained when elements are added and removed to avoid
+	 * frequent iteration over the stack of open elements.
+	 *
+	 * @since 6.4.0
+	 *
+	 * @var bool
+	 */
+	public $has_p_in_button_scope = false;
 
 	/**
 	 * Tracks open formatting elements, used to handle mis-nested formatting element tags.
@@ -449,7 +459,6 @@ class WP_HTML_Processor_State {
 	 * @see WP_HTML_Processor
 	 */
 	public function __construct() {
-		$this->stack_of_open_elements     = new WP_HTML_Open_Elements();
 		$this->active_formatting_elements = new WP_HTML_Active_Formatting_Elements();
 	}
 }

--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -397,34 +397,6 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 
 		$this->state = new WP_HTML_Processor_State();
 
-		$this->state->stack_of_open_elements->set_push_handler(
-			function ( WP_HTML_Token $token ): void {
-				$is_virtual            = ! isset( $this->state->current_token ) || $this->is_tag_closer();
-				$same_node             = isset( $this->state->current_token ) && $token->node_name === $this->state->current_token->node_name;
-				$provenance            = ( ! $same_node || $is_virtual ) ? 'virtual' : 'real';
-				$this->element_queue[] = new WP_HTML_Stack_Event( $token, WP_HTML_Stack_Event::PUSH, $provenance );
-
-				$this->change_parsing_namespace( $token->integration_node_type ? 'html' : $token->namespace );
-			}
-		);
-
-		$this->state->stack_of_open_elements->set_pop_handler(
-			function ( WP_HTML_Token $token ): void {
-				$is_virtual            = ! isset( $this->state->current_token ) || ! $this->is_tag_closer();
-				$same_node             = isset( $this->state->current_token ) && $token->node_name === $this->state->current_token->node_name;
-				$provenance            = ( ! $same_node || $is_virtual ) ? 'virtual' : 'real';
-				$this->element_queue[] = new WP_HTML_Stack_Event( $token, WP_HTML_Stack_Event::POP, $provenance );
-
-				$adjusted_current_node = $this->get_adjusted_current_node();
-
-				if ( $adjusted_current_node ) {
-					$this->change_parsing_namespace( $adjusted_current_node->integration_node_type ? 'html' : $adjusted_current_node->namespace );
-				} else {
-					$this->change_parsing_namespace( 'html' );
-				}
-			}
-		);
-
 		/*
 		 * Create this wrapper so that it's possible to pass
 		 * a private method into WP_HTML_Token classes without
@@ -533,7 +505,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			'HTML',
 			false
 		);
-		$fragment_processor->state->stack_of_open_elements->push( $root_node );
+		$fragment_processor->push_open_element( $root_node );
 
 		$fragment_processor->bookmarks['context-node']   = new WP_HTML_Span( 0, 0 );
 		$fragment_processor->context_node                = clone $this->current_element->token;
@@ -827,7 +799,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 		$this->current_element = array_shift( $this->element_queue );
 		if ( ! isset( $this->current_element ) ) {
 			// There are no tokens left, so close all remaining open elements.
-			while ( $this->state->stack_of_open_elements->pop() ) {
+			while ( $this->pop_open_element() ) {
 				continue;
 			}
 
@@ -1025,7 +997,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			 */
 			$top_node = $this->state->stack_of_open_elements->current_node();
 			if ( isset( $top_node ) && ! $this->expects_closer( $top_node ) ) {
-				$this->state->stack_of_open_elements->pop();
+				$this->pop_open_element();
 			}
 		}
 
@@ -1930,7 +1902,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			 * > An end tag whose tag name is "head"
 			 */
 			case '-HEAD':
-				$this->state->stack_of_open_elements->pop();
+				$this->pop_open_element();
 				$this->state->insertion_mode = WP_HTML_Processor_State::INSERTION_MODE_AFTER_HEAD;
 				return true;
 
@@ -1976,7 +1948,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 					// @todo Indicate a parse error once it's possible.
 				}
 
-				$this->state->stack_of_open_elements->pop_until( 'TEMPLATE' );
+				$this->pop_open_elements_until( 'TEMPLATE' );
 				$this->state->active_formatting_elements->clear_up_to_last_marker();
 				array_pop( $this->state->stack_of_template_insertion_modes );
 				$this->reset_insertion_mode_appropriately();
@@ -1996,7 +1968,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 		 * > Anything else
 		 */
 		in_head_anything_else:
-		$this->state->stack_of_open_elements->pop();
+		$this->pop_open_element();
 		$this->state->insertion_mode = WP_HTML_Processor_State::INSERTION_MODE_AFTER_HEAD;
 		return $this->step( self::REPROCESS_CURRENT_NODE );
 	}
@@ -2057,7 +2029,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			 * > An end tag whose tag name is "noscript"
 			 */
 			case '-NOSCRIPT':
-				$this->state->stack_of_open_elements->pop();
+				$this->pop_open_element();
 				$this->state->insertion_mode = WP_HTML_Processor_State::INSERTION_MODE_IN_HEAD;
 				return true;
 
@@ -2100,7 +2072,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 		 * Anything here is a parse error.
 		 */
 		in_head_noscript_anything_else:
-		$this->state->stack_of_open_elements->pop();
+		$this->pop_open_element();
 		$this->state->insertion_mode = WP_HTML_Processor_State::INSERTION_MODE_IN_HEAD;
 		return $this->step( self::REPROCESS_CURRENT_NODE );
 	}
@@ -2508,7 +2480,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 					)
 				) {
 					// @todo Indicate a parse error once it's possible.
-					$this->state->stack_of_open_elements->pop();
+					$this->pop_open_element();
 				}
 
 				$this->insert_html_element( $this->state->current_token );
@@ -2580,7 +2552,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 						// @todo Indicate a parse error once it's possible. This error does not impact the logic here.
 					}
 
-					$this->state->stack_of_open_elements->pop_until( $node_name );
+					$this->pop_open_elements_until( $node_name );
 					goto in_body_list_done;
 				}
 
@@ -2635,7 +2607,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 				if ( $this->state->stack_of_open_elements->has_element_in_scope( 'BUTTON' ) ) {
 					// @todo Indicate a parse error once it's possible. This error does not impact the logic here.
 					$this->generate_implied_end_tags();
-					$this->state->stack_of_open_elements->pop_until( 'BUTTON' );
+					$this->pop_open_elements_until( 'BUTTON' );
 				}
 
 				$this->reconstruct_active_formatting_elements();
@@ -2687,7 +2659,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 				if ( ! $this->state->stack_of_open_elements->current_node_is( $token_name ) ) {
 					// @todo Record parse error: this error doesn't impact parsing.
 				}
-				$this->state->stack_of_open_elements->pop_until( $token_name );
+				$this->pop_open_elements_until( $token_name );
 				return true;
 
 			/*
@@ -2728,7 +2700,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 						$this->bail( 'Cannot close a FORM when other elements remain open as this would throw off the breadcrumbs for the following tokens.' );
 					}
 
-					$this->state->stack_of_open_elements->remove_node( $node );
+					$this->remove_open_element( $node );
 					return true;
 				} else {
 					/*
@@ -2748,7 +2720,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 						// @todo Indicate a parse error once it's possible. This error does not impact the logic here.
 					}
 
-					$this->state->stack_of_open_elements->pop_until( 'FORM' );
+					$this->pop_open_elements_until( 'FORM' );
 					return true;
 				}
 				break;
@@ -2806,7 +2778,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 					// @todo Indicate a parse error once it's possible. This error does not impact the logic here.
 				}
 
-				$this->state->stack_of_open_elements->pop_until( $token_name );
+				$this->pop_open_elements_until( $token_name );
 				return true;
 
 			/*
@@ -2833,7 +2805,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 					// @todo Record parse error: this error doesn't impact parsing.
 				}
 
-				$this->state->stack_of_open_elements->pop_until( '(internal: H1 through H6 - do not use)' );
+				$this->pop_open_elements_until( '(internal: H1 through H6 - do not use)' );
 				return true;
 
 			/*
@@ -2848,7 +2820,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 						case 'A':
 							$this->run_adoption_agency_algorithm();
 							$this->state->active_formatting_elements->remove_node( $item );
-							$this->state->stack_of_open_elements->remove_node( $item );
+							$this->remove_open_element( $item );
 							break 2;
 					}
 				}
@@ -2944,7 +2916,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 					// This is a parse error.
 				}
 
-				$this->state->stack_of_open_elements->pop_until( $token_name );
+				$this->pop_open_elements_until( $token_name );
 				$this->state->active_formatting_elements->clear_up_to_last_marker();
 				return true;
 
@@ -3142,7 +3114,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			case '+OPTGROUP':
 			case '+OPTION':
 				if ( $this->state->stack_of_open_elements->current_node_is( 'OPTION' ) ) {
-					$this->state->stack_of_open_elements->pop();
+					$this->pop_open_element();
 				}
 				$this->reconstruct_active_formatting_elements();
 				$this->insert_html_element( $this->state->current_token );
@@ -3196,7 +3168,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 				$this->state->current_token->namespace = 'math';
 				$this->insert_html_element( $this->state->current_token );
 				if ( $this->state->current_token->has_self_closing_flag ) {
-					$this->state->stack_of_open_elements->pop();
+					$this->pop_open_element();
 				}
 				return true;
 
@@ -3215,7 +3187,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 				$this->state->current_token->namespace = 'svg';
 				$this->insert_html_element( $this->state->current_token );
 				if ( $this->state->current_token->has_self_closing_flag ) {
-					$this->state->stack_of_open_elements->pop();
+					$this->pop_open_element();
 				}
 				return true;
 
@@ -3273,7 +3245,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			}
 
 			foreach ( $this->state->stack_of_open_elements->walk_up() as $item ) {
-				$this->state->stack_of_open_elements->pop();
+				$this->pop_open_element();
 				if ( $node === $item ) {
 					return true;
 				}
@@ -3383,7 +3355,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			 * > A start tag whose tag name is "caption"
 			 */
 			case '+CAPTION':
-				$this->state->stack_of_open_elements->clear_to_table_context();
+				$this->clear_stack_to_table_context();
 				$this->state->active_formatting_elements->insert_marker();
 				$this->insert_html_element( $this->state->current_token );
 				$this->state->insertion_mode = WP_HTML_Processor_State::INSERTION_MODE_IN_CAPTION;
@@ -3393,7 +3365,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			 * > A start tag whose tag name is "colgroup"
 			 */
 			case '+COLGROUP':
-				$this->state->stack_of_open_elements->clear_to_table_context();
+				$this->clear_stack_to_table_context();
 				$this->insert_html_element( $this->state->current_token );
 				$this->state->insertion_mode = WP_HTML_Processor_State::INSERTION_MODE_IN_COLUMN_GROUP;
 				return true;
@@ -3402,7 +3374,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			 * > A start tag whose tag name is "col"
 			 */
 			case '+COL':
-				$this->state->stack_of_open_elements->clear_to_table_context();
+				$this->clear_stack_to_table_context();
 
 				/*
 				 * > Insert an HTML element for a "colgroup" start tag token with no attributes,
@@ -3418,7 +3390,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			case '+TBODY':
 			case '+TFOOT':
 			case '+THEAD':
-				$this->state->stack_of_open_elements->clear_to_table_context();
+				$this->clear_stack_to_table_context();
 				$this->insert_html_element( $this->state->current_token );
 				$this->state->insertion_mode = WP_HTML_Processor_State::INSERTION_MODE_IN_TABLE_BODY;
 				return true;
@@ -3429,7 +3401,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			case '+TD':
 			case '+TH':
 			case '+TR':
-				$this->state->stack_of_open_elements->clear_to_table_context();
+				$this->clear_stack_to_table_context();
 				/*
 				 * > Insert an HTML element for a "tbody" start tag token with no attributes,
 				 * > then switch the insertion mode to "in table body".
@@ -3448,7 +3420,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 					return $this->step();
 				}
 
-				$this->state->stack_of_open_elements->pop_until( 'TABLE' );
+				$this->pop_open_elements_until( 'TABLE' );
 				$this->reset_insertion_mode_appropriately();
 				return $this->step( self::REPROCESS_CURRENT_NODE );
 
@@ -3461,7 +3433,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 					return $this->step();
 				}
 
-				$this->state->stack_of_open_elements->pop_until( 'TABLE' );
+				$this->pop_open_elements_until( 'TABLE' );
 				$this->reset_insertion_mode_appropriately();
 				return true;
 
@@ -3527,7 +3499,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 				// This FORM is special because it immediately closes and cannot have other children.
 				$this->insert_html_element( $this->state->current_token );
 				$this->state->form_element = $this->state->current_token;
-				$this->state->stack_of_open_elements->pop();
+				$this->pop_open_element();
 				return true;
 		}
 
@@ -3613,7 +3585,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 					// @todo Indicate a parse error once it's possible.
 				}
 
-				$this->state->stack_of_open_elements->pop_until( 'CAPTION' );
+				$this->pop_open_elements_until( 'CAPTION' );
 				$this->state->active_formatting_elements->clear_up_to_last_marker();
 				$this->state->insertion_mode = WP_HTML_Processor_State::INSERTION_MODE_IN_TABLE;
 
@@ -3711,7 +3683,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			 */
 			case '+COL':
 				$this->insert_html_element( $this->state->current_token );
-				$this->state->stack_of_open_elements->pop();
+				$this->pop_open_element();
 				return true;
 
 			/*
@@ -3722,7 +3694,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 					// @todo Indicate a parse error once it's possible.
 					return $this->step();
 				}
-				$this->state->stack_of_open_elements->pop();
+				$this->pop_open_element();
 				$this->state->insertion_mode = WP_HTML_Processor_State::INSERTION_MODE_IN_TABLE;
 				return true;
 
@@ -3750,7 +3722,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			// @todo Indicate a parse error once it's possible.
 			return $this->step();
 		}
-		$this->state->stack_of_open_elements->pop();
+		$this->pop_open_element();
 		$this->state->insertion_mode = WP_HTML_Processor_State::INSERTION_MODE_IN_TABLE;
 		return $this->step( self::REPROCESS_CURRENT_NODE );
 	}
@@ -3781,7 +3753,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			 * > A start tag whose tag name is "tr"
 			 */
 			case '+TR':
-				$this->state->stack_of_open_elements->clear_to_table_body_context();
+				$this->clear_stack_to_table_body_context();
 				$this->insert_html_element( $this->state->current_token );
 				$this->state->insertion_mode = WP_HTML_Processor_State::INSERTION_MODE_IN_ROW;
 				return true;
@@ -3792,7 +3764,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			case '+TH':
 			case '+TD':
 				// @todo Indicate a parse error once it's possible.
-				$this->state->stack_of_open_elements->clear_to_table_body_context();
+				$this->clear_stack_to_table_body_context();
 				$this->insert_virtual_node( 'TR' );
 				$this->state->insertion_mode = WP_HTML_Processor_State::INSERTION_MODE_IN_ROW;
 				return $this->step( self::REPROCESS_CURRENT_NODE );
@@ -3808,8 +3780,8 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 					return $this->step();
 				}
 
-				$this->state->stack_of_open_elements->clear_to_table_body_context();
-				$this->state->stack_of_open_elements->pop();
+				$this->clear_stack_to_table_body_context();
+				$this->pop_open_element();
 				$this->state->insertion_mode = WP_HTML_Processor_State::INSERTION_MODE_IN_TABLE;
 				return true;
 
@@ -3832,8 +3804,8 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 					// Parse error: ignore the token.
 					return $this->step();
 				}
-				$this->state->stack_of_open_elements->clear_to_table_body_context();
-				$this->state->stack_of_open_elements->pop();
+				$this->clear_stack_to_table_body_context();
+				$this->pop_open_element();
 				$this->state->insertion_mode = WP_HTML_Processor_State::INSERTION_MODE_IN_TABLE;
 				return $this->step( self::REPROCESS_CURRENT_NODE );
 
@@ -3886,7 +3858,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			 */
 			case '+TH':
 			case '+TD':
-				$this->state->stack_of_open_elements->clear_to_table_row_context();
+				$this->clear_stack_to_table_row_context();
 				$this->insert_html_element( $this->state->current_token );
 				$this->state->insertion_mode = WP_HTML_Processor_State::INSERTION_MODE_IN_CELL;
 				$this->state->active_formatting_elements->insert_marker();
@@ -3901,8 +3873,8 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 					return $this->step();
 				}
 
-				$this->state->stack_of_open_elements->clear_to_table_row_context();
-				$this->state->stack_of_open_elements->pop();
+				$this->clear_stack_to_table_row_context();
+				$this->pop_open_element();
 				$this->state->insertion_mode = WP_HTML_Processor_State::INSERTION_MODE_IN_TABLE_BODY;
 				return true;
 
@@ -3923,8 +3895,8 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 					return $this->step();
 				}
 
-				$this->state->stack_of_open_elements->clear_to_table_row_context();
-				$this->state->stack_of_open_elements->pop();
+				$this->clear_stack_to_table_row_context();
+				$this->pop_open_element();
 				$this->state->insertion_mode = WP_HTML_Processor_State::INSERTION_MODE_IN_TABLE_BODY;
 				return $this->step( self::REPROCESS_CURRENT_NODE );
 
@@ -3944,8 +3916,8 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 					return $this->step();
 				}
 
-				$this->state->stack_of_open_elements->clear_to_table_row_context();
-				$this->state->stack_of_open_elements->pop();
+				$this->clear_stack_to_table_row_context();
+				$this->pop_open_element();
 				$this->state->insertion_mode = WP_HTML_Processor_State::INSERTION_MODE_IN_TABLE_BODY;
 				return $this->step( self::REPROCESS_CURRENT_NODE );
 
@@ -4014,7 +3986,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 					// @todo Indicate a parse error once it's possible.
 				}
 
-				$this->state->stack_of_open_elements->pop_until( $tag_name );
+				$this->pop_open_elements_until( $tag_name );
 				$this->state->active_formatting_elements->clear_up_to_last_marker();
 				$this->state->insertion_mode = WP_HTML_Processor_State::INSERTION_MODE_IN_ROW;
 				return true;
@@ -4143,7 +4115,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			 */
 			case '+OPTION':
 				if ( $this->state->stack_of_open_elements->current_node_is( 'OPTION' ) ) {
-					$this->state->stack_of_open_elements->pop();
+					$this->pop_open_element();
 				}
 				$this->insert_html_element( $this->state->current_token );
 				return true;
@@ -4158,11 +4130,11 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			case '+OPTGROUP':
 			case '+HR':
 				if ( $this->state->stack_of_open_elements->current_node_is( 'OPTION' ) ) {
-					$this->state->stack_of_open_elements->pop();
+					$this->pop_open_element();
 				}
 
 				if ( $this->state->stack_of_open_elements->current_node_is( 'OPTGROUP' ) ) {
-					$this->state->stack_of_open_elements->pop();
+					$this->pop_open_element();
 				}
 
 				$this->insert_html_element( $this->state->current_token );
@@ -4178,12 +4150,12 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 						break;
 					}
 					if ( $parent && 'OPTGROUP' === $parent->node_name ) {
-						$this->state->stack_of_open_elements->pop();
+						$this->pop_open_element();
 					}
 				}
 
 				if ( $this->state->stack_of_open_elements->current_node_is( 'OPTGROUP' ) ) {
-					$this->state->stack_of_open_elements->pop();
+					$this->pop_open_element();
 					return true;
 				}
 
@@ -4195,7 +4167,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			 */
 			case '-OPTION':
 				if ( $this->state->stack_of_open_elements->current_node_is( 'OPTION' ) ) {
-					$this->state->stack_of_open_elements->pop();
+					$this->pop_open_element();
 					return true;
 				}
 
@@ -4214,7 +4186,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 					// Parse error: ignore the token.
 					return $this->step();
 				}
-				$this->state->stack_of_open_elements->pop_until( 'SELECT' );
+				$this->pop_open_elements_until( 'SELECT' );
 				$this->reset_insertion_mode_appropriately();
 				return true;
 
@@ -4230,7 +4202,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 					// Ignore the token.
 					return $this->step();
 				}
-				$this->state->stack_of_open_elements->pop_until( 'SELECT' );
+				$this->pop_open_elements_until( 'SELECT' );
 				$this->reset_insertion_mode_appropriately();
 				return $this->step( self::REPROCESS_CURRENT_NODE );
 
@@ -4286,7 +4258,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			case '+TD':
 			case '+TH':
 				// @todo Indicate a parse error once it's possible.
-				$this->state->stack_of_open_elements->pop_until( 'SELECT' );
+				$this->pop_open_elements_until( 'SELECT' );
 				$this->reset_insertion_mode_appropriately();
 				return $this->step( self::REPROCESS_CURRENT_NODE );
 
@@ -4305,7 +4277,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 				if ( ! $this->state->stack_of_open_elements->has_element_in_table_scope( $token_name ) ) {
 					return $this->step();
 				}
-				$this->state->stack_of_open_elements->pop_until( 'SELECT' );
+				$this->pop_open_elements_until( 'SELECT' );
 				$this->reset_insertion_mode_appropriately();
 				return $this->step( self::REPROCESS_CURRENT_NODE );
 		}
@@ -4439,7 +4411,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 		}
 
 		// @todo Indicate a parse error once it's possible.
-		$this->state->stack_of_open_elements->pop_until( 'TEMPLATE' );
+		$this->pop_open_elements_until( 'TEMPLATE' );
 		$this->state->active_formatting_elements->clear_up_to_last_marker();
 		array_pop( $this->state->stack_of_template_insertion_modes );
 		$this->reset_insertion_mode_appropriately();
@@ -4619,7 +4591,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 				/*
 				 * > Otherwise, pop the current node from the stack of open elements.
 				 */
-				$this->state->stack_of_open_elements->pop();
+				$this->pop_open_element();
 
 				/*
 				 * > If the parser was not created as part of the HTML fragment parsing algorithm
@@ -4642,7 +4614,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			 */
 			case '+FRAME':
 				$this->insert_html_element( $this->state->current_token );
-				$this->state->stack_of_open_elements->pop();
+				$this->pop_open_element();
 				return true;
 
 			/*
@@ -5038,7 +5010,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 						break;
 					}
 
-					$this->state->stack_of_open_elements->pop();
+					$this->pop_open_element();
 				}
 				goto in_foreign_content_process_in_current_insertion_mode;
 		}
@@ -5067,7 +5039,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			 * flag enabled, and executes the script, which this parser does not support.
 			 */
 			if ( $this->state->current_token->has_self_closing_flag ) {
-				$this->state->stack_of_open_elements->pop();
+				$this->pop_open_element();
 			}
 			return true;
 		}
@@ -5076,7 +5048,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 		 * > An end tag whose name is "script", if the current node is an SVG script element.
 		 */
 		if ( $this->is_tag_closer() && 'SCRIPT' === $this->state->current_token->node_name && 'svg' === $this->state->current_token->namespace ) {
-			$this->state->stack_of_open_elements->pop();
+			$this->pop_open_element();
 			return true;
 		}
 
@@ -5100,7 +5072,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			 */
 			if ( 0 === strcasecmp( $node->node_name, $tag_name ) ) {
 				foreach ( $this->state->stack_of_open_elements->walk_up() as $item ) {
-					$this->state->stack_of_open_elements->pop();
+					$this->pop_open_element();
 					if ( $node === $item ) {
 						return true;
 					}
@@ -5656,7 +5628,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			 * When moving backward, stateful stacks should be cleared.
 			 */
 			foreach ( $this->state->stack_of_open_elements->walk_up() as $item ) {
-				$this->state->stack_of_open_elements->remove_node( $item );
+				$this->remove_open_element( $item );
 			}
 
 			foreach ( $this->state->active_formatting_elements->walk_up() as $item ) {
@@ -5696,7 +5668,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 				 * Fragment parsers require this extra bit of setup.
 				 * It's handled in full parsers by advancing the processor state.
 				 */
-				$this->state->stack_of_open_elements->push(
+				$this->push_open_element(
 					new WP_HTML_Token(
 						'root-node',
 						'HTML',
@@ -5866,7 +5838,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 */
 	private function close_a_p_element(): void {
 		$this->generate_implied_end_tags( 'P' );
-		$this->state->stack_of_open_elements->pop_until( 'P' );
+		$this->pop_open_elements_until( 'P' );
 	}
 
 	/**
@@ -5900,7 +5872,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			( $no_exclusions || ! $this->state->stack_of_open_elements->current_node_is( $except_for_this_element ) ) &&
 			in_array( $this->state->stack_of_open_elements->current_node()->node_name, $elements_with_implied_end_tags, true )
 		) {
-			$this->state->stack_of_open_elements->pop();
+			$this->pop_open_element();
 		}
 	}
 
@@ -5940,7 +5912,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 		);
 
 		while ( in_array( $this->state->stack_of_open_elements->current_node()->node_name, $elements_with_implied_end_tags, true ) ) {
-			$this->state->stack_of_open_elements->pop();
+			$this->pop_open_element();
 		}
 	}
 
@@ -6228,7 +6200,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			// > the current node is not in the list of active formatting elements
 			! $this->state->active_formatting_elements->contains_node( $current_node )
 		) {
-			$this->state->stack_of_open_elements->pop();
+			$this->pop_open_element();
 			return;
 		}
 
@@ -6301,7 +6273,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			 */
 			if ( null === $furthest_block ) {
 				foreach ( $this->state->stack_of_open_elements->walk_up() as $item ) {
-					$this->state->stack_of_open_elements->pop();
+					$this->pop_open_element();
 
 					if ( $formatting_element->bookmark_name === $item->bookmark_name ) {
 						$this->state->active_formatting_elements->remove_node( $formatting_element );
@@ -6335,13 +6307,137 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 		$this->generate_implied_end_tags();
 		// @todo Parse error if the current node is a "td" or "th" element.
 		foreach ( $this->state->stack_of_open_elements->walk_up() as $element ) {
-			$this->state->stack_of_open_elements->pop();
+			$this->pop_open_element();
 			if ( 'TD' === $element->node_name || 'TH' === $element->node_name ) {
 				break;
 			}
 		}
 		$this->state->active_formatting_elements->clear_up_to_last_marker();
 		$this->state->insertion_mode = WP_HTML_Processor_State::INSERTION_MODE_IN_ROW;
+	}
+
+	/**
+	 * Pushes an element onto the stack of open elements and tracks the event.
+	 *
+	 * @since 6.9.0
+	 *
+	 * @param WP_HTML_Token $token Element to push onto the stack.
+	 * @return WP_HTML_Token Element that was pushed onto the stack.
+	 */
+	private function push_open_element( WP_HTML_Token $token ): WP_HTML_Token {
+		$pushed = $this->state->stack_of_open_elements->push( $token );
+
+		$is_virtual            = ! isset( $this->state->current_token ) || $this->is_tag_closer();
+		$same_node             = isset( $this->state->current_token ) && $pushed->node_name === $this->state->current_token->node_name;
+		$provenance            = ( ! $same_node || $is_virtual ) ? 'virtual' : 'real';
+		$this->element_queue[] = new WP_HTML_Stack_Event( $pushed, WP_HTML_Stack_Event::PUSH, $provenance );
+
+		$this->change_parsing_namespace( $pushed->integration_node_type ? 'html' : $pushed->namespace );
+
+		return $pushed;
+	}
+
+	/**
+	 * Pops an element off of the stack of open elements and tracks the event.
+	 *
+	 * @since 6.9.0
+	 *
+	 * @return WP_HTML_Token|null Element that was popped off of the stack, or null if the stack was empty.
+	 */
+	private function pop_open_element(): ?WP_HTML_Token {
+		$popped = $this->state->stack_of_open_elements->pop();
+		if ( null === $popped ) {
+			return null;
+		}
+
+		$this->after_pop_open_element( $popped );
+		return $popped;
+	}
+
+	/**
+	 * Removes an element from the stack of open elements and tracks the event.
+	 *
+	 * @since 6.9.0
+	 *
+	 * @param WP_HTML_Token $token Element to remove from the stack.
+	 * @return bool Whether the element was found and removed.
+	 */
+	private function remove_open_element( WP_HTML_Token $token ): bool {
+		$removed = $this->state->stack_of_open_elements->remove_node( $token );
+		if ( null === $removed ) {
+			return false;
+		}
+
+		$this->after_pop_open_element( $removed );
+		return true;
+	}
+
+	/**
+	 * Pops elements off the stack until an element with the given name has been popped.
+	 *
+	 * @since 6.9.0
+	 *
+	 * @param string $tag_name Name of the element to pop through.
+	 */
+	private function pop_open_elements_until( string $tag_name ): void {
+		foreach ( $this->state->stack_of_open_elements->pop_until( $tag_name ) as $popped ) {
+			$this->after_pop_open_element( $popped );
+		}
+	}
+
+	/**
+	 * Clears the stack of open elements back to a table context.
+	 *
+	 * @since 6.9.0
+	 */
+	private function clear_stack_to_table_context(): void {
+		foreach ( $this->state->stack_of_open_elements->clear_to_table_context() as $popped ) {
+			$this->after_pop_open_element( $popped );
+		}
+	}
+
+	/**
+	 * Clears the stack of open elements back to a table body context.
+	 *
+	 * @since 6.9.0
+	 */
+	private function clear_stack_to_table_body_context(): void {
+		foreach ( $this->state->stack_of_open_elements->clear_to_table_body_context() as $popped ) {
+			$this->after_pop_open_element( $popped );
+		}
+	}
+
+	/**
+	 * Clears the stack of open elements back to a table row context.
+	 *
+	 * @since 6.9.0
+	 */
+	private function clear_stack_to_table_row_context(): void {
+		foreach ( $this->state->stack_of_open_elements->clear_to_table_row_context() as $popped ) {
+			$this->after_pop_open_element( $popped );
+		}
+	}
+
+	/**
+	 * Tracks accounting for an element popped off of the stack of open elements.
+	 *
+	 * @since 6.9.0
+	 *
+	 * @param WP_HTML_Token $token Element that was popped off of the stack.
+	 */
+	private function after_pop_open_element( WP_HTML_Token $token ): void {
+		$is_virtual            = ! isset( $this->state->current_token ) || ! $this->is_tag_closer();
+		$same_node             = isset( $this->state->current_token ) && $token->node_name === $this->state->current_token->node_name;
+		$provenance            = ( ! $same_node || $is_virtual ) ? 'virtual' : 'real';
+		$this->element_queue[] = new WP_HTML_Stack_Event( $token, WP_HTML_Stack_Event::POP, $provenance );
+
+		$adjusted_current_node = $this->get_adjusted_current_node();
+
+		if ( $adjusted_current_node ) {
+			$this->change_parsing_namespace( $adjusted_current_node->integration_node_type ? 'html' : $adjusted_current_node->namespace );
+		} else {
+			$this->change_parsing_namespace( 'html' );
+		}
 	}
 
 	/**
@@ -6355,7 +6451,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 * @param WP_HTML_Token $token Name of bookmark pointing to element in original input HTML.
 	 */
 	private function insert_html_element( WP_HTML_Token $token ): void {
-		$this->state->stack_of_open_elements->push( $token );
+		$this->push_open_element( $token );
 	}
 
 	/**

--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -526,7 +526,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 		 * > itself, if it is a form element), if any. (If there is no such form element, the
 		 * > form element pointer keeps its initial value, null.)
 		 */
-		foreach ( $this->state->stack_of_open_elements->walk_up() as $element ) {
+		foreach ( $this->walk_up_open_elements() as $element ) {
 			if ( 'FORM' === $element->node_name && 'html' === $element->namespace ) {
 				$fragment_processor->state->form_element                = clone $element;
 				$fragment_processor->state->form_element->bookmark_name = null;
@@ -565,7 +565,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 		$token = substr( $this->html, $here->start, $here->length );
 
 		$open_elements = array();
-		foreach ( $this->state->stack_of_open_elements->stack as $item ) {
+		foreach ( $this->walk_down_open_elements() as $item ) {
 			$open_elements[] = $item->node_name;
 		}
 
@@ -995,7 +995,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			 * When moving on to the next node, therefore, if the bottom-most element
 			 * on the stack is a void element, it must be closed.
 			 */
-			$top_node = $this->state->stack_of_open_elements->current_node();
+			$top_node = $this->current_open_element();
 			if ( isset( $top_node ) && ! $this->expects_closer( $top_node ) ) {
 				$this->pop_open_element();
 			}
@@ -1040,7 +1040,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 		}
 
 		$parse_in_current_insertion_mode = (
-			0 === $this->state->stack_of_open_elements->count() ||
+			0 === $this->count_open_elements() ||
 			'html' === $adjusted_current_node->namespace ||
 			(
 				'math' === $adjusted_current_node->integration_node_type &&
@@ -1938,13 +1938,13 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			 * > An end tag whose tag name is "template"
 			 */
 			case '-TEMPLATE':
-				if ( ! $this->state->stack_of_open_elements->contains( 'TEMPLATE' ) ) {
+				if ( ! $this->open_elements_contains( 'TEMPLATE' ) ) {
 					// @todo Indicate a parse error once it's possible.
 					return $this->step();
 				}
 
 				$this->generate_implied_end_tags_thoroughly();
-				if ( ! $this->state->stack_of_open_elements->current_node_is( 'TEMPLATE' ) ) {
+				if ( ! $this->current_open_element_is( 'TEMPLATE' ) ) {
 					// @todo Indicate a parse error once it's possible.
 				}
 
@@ -2291,7 +2291,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			 * > A start tag whose tag name is "html"
 			 */
 			case '+HTML':
-				if ( ! $this->state->stack_of_open_elements->contains( 'TEMPLATE' ) ) {
+				if ( ! $this->open_elements_contains( 'TEMPLATE' ) ) {
 					/*
 					 * > Otherwise, for each attribute on the token, check to see if the attribute
 					 * > is already present on the top element of the stack of open elements. If
@@ -2330,9 +2330,9 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			 */
 			case '+BODY':
 				if (
-					1 === $this->state->stack_of_open_elements->count() ||
-					'BODY' !== ( $this->state->stack_of_open_elements->at( 2 )->node_name ?? null ) ||
-					$this->state->stack_of_open_elements->contains( 'TEMPLATE' )
+					1 === $this->count_open_elements() ||
+					'BODY' !== ( $this->get_open_element_at( 2 )->node_name ?? null ) ||
+					$this->open_elements_contains( 'TEMPLATE' )
 				) {
 					// Ignore the token.
 					return $this->step();
@@ -2356,8 +2356,8 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			 */
 			case '+FRAMESET':
 				if (
-					1 === $this->state->stack_of_open_elements->count() ||
-					'BODY' !== ( $this->state->stack_of_open_elements->at( 2 )->node_name ?? null ) ||
+					1 === $this->count_open_elements() ||
+					'BODY' !== ( $this->get_open_element_at( 2 )->node_name ?? null ) ||
 					false === $this->state->frameset_ok
 				) {
 					// Ignore the token.
@@ -2374,7 +2374,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			 * > An end tag whose tag name is "body"
 			 */
 			case '-BODY':
-				if ( ! $this->state->stack_of_open_elements->has_element_in_scope( 'BODY' ) ) {
+				if ( ! $this->has_element_in_scope( 'BODY' ) ) {
 					// Parse error: ignore the token.
 					return $this->step();
 				}
@@ -2403,7 +2403,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			 * > An end tag whose tag name is "html"
 			 */
 			case '-HTML':
-				if ( ! $this->state->stack_of_open_elements->has_element_in_scope( 'BODY' ) ) {
+				if ( ! $this->has_element_in_scope( 'BODY' ) ) {
 					// Parse error: ignore the token.
 					return $this->step();
 				}
@@ -2452,7 +2452,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			case '+SECTION':
 			case '+SUMMARY':
 			case '+UL':
-				if ( $this->state->stack_of_open_elements->has_p_in_button_scope() ) {
+				if ( $this->has_p_in_button_scope() ) {
 					$this->close_a_p_element();
 				}
 
@@ -2468,13 +2468,13 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			case '+H4':
 			case '+H5':
 			case '+H6':
-				if ( $this->state->stack_of_open_elements->has_p_in_button_scope() ) {
+				if ( $this->has_p_in_button_scope() ) {
 					$this->close_a_p_element();
 				}
 
 				if (
 					in_array(
-						$this->state->stack_of_open_elements->current_node()->node_name,
+						$this->current_open_element()->node_name,
 						array( 'H1', 'H2', 'H3', 'H4', 'H5', 'H6' ),
 						true
 					)
@@ -2491,7 +2491,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			 */
 			case '+PRE':
 			case '+LISTING':
-				if ( $this->state->stack_of_open_elements->has_p_in_button_scope() ) {
+				if ( $this->has_p_in_button_scope() ) {
 					$this->close_a_p_element();
 				}
 
@@ -2511,14 +2511,14 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			 * > A start tag whose tag name is "form"
 			 */
 			case '+FORM':
-				$stack_contains_template = $this->state->stack_of_open_elements->contains( 'TEMPLATE' );
+				$stack_contains_template = $this->open_elements_contains( 'TEMPLATE' );
 
 				if ( isset( $this->state->form_element ) && ! $stack_contains_template ) {
 					// Parse error: ignore the token.
 					return $this->step();
 				}
 
-				if ( $this->state->stack_of_open_elements->has_p_in_button_scope() ) {
+				if ( $this->has_p_in_button_scope() ) {
 					$this->close_a_p_element();
 				}
 
@@ -2537,7 +2537,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			case '+DT':
 			case '+LI':
 				$this->state->frameset_ok = false;
-				$node                     = $this->state->stack_of_open_elements->current_node();
+				$node                     = $this->current_open_element();
 				$is_li                    = 'LI' === $token_name;
 
 				in_body_list_loop:
@@ -2548,7 +2548,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 				if ( $is_li ? 'LI' === $node->node_name : ( 'DD' === $node->node_name || 'DT' === $node->node_name ) ) {
 					$node_name = $is_li ? 'LI' : $node->node_name;
 					$this->generate_implied_end_tags( $node_name );
-					if ( ! $this->state->stack_of_open_elements->current_node_is( $node_name ) ) {
+					if ( ! $this->current_open_element_is( $node_name ) ) {
 						// @todo Indicate a parse error once it's possible. This error does not impact the logic here.
 					}
 
@@ -2572,7 +2572,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 					 * > Otherwise, set node to the previous entry in the stack of open elements
 					 * > and return to the step labeled loop.
 					 */
-					foreach ( $this->state->stack_of_open_elements->walk_up( $node ) as $item ) {
+					foreach ( $this->walk_up_open_elements( $node ) as $item ) {
 						$node = $item;
 						break;
 					}
@@ -2580,7 +2580,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 				}
 
 				in_body_list_done:
-				if ( $this->state->stack_of_open_elements->has_p_in_button_scope() ) {
+				if ( $this->has_p_in_button_scope() ) {
 					$this->close_a_p_element();
 				}
 
@@ -2588,7 +2588,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 				return true;
 
 			case '+PLAINTEXT':
-				if ( $this->state->stack_of_open_elements->has_p_in_button_scope() ) {
+				if ( $this->has_p_in_button_scope() ) {
 					$this->close_a_p_element();
 				}
 
@@ -2604,7 +2604,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			 * > A start tag whose tag name is "button"
 			 */
 			case '+BUTTON':
-				if ( $this->state->stack_of_open_elements->has_element_in_scope( 'BUTTON' ) ) {
+				if ( $this->has_element_in_scope( 'BUTTON' ) ) {
 					// @todo Indicate a parse error once it's possible. This error does not impact the logic here.
 					$this->generate_implied_end_tags();
 					$this->pop_open_elements_until( 'BUTTON' );
@@ -2649,14 +2649,14 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			case '-SECTION':
 			case '-SUMMARY':
 			case '-UL':
-				if ( ! $this->state->stack_of_open_elements->has_element_in_scope( $token_name ) ) {
+				if ( ! $this->has_element_in_scope( $token_name ) ) {
 					// @todo Report parse error.
 					// Ignore the token.
 					return $this->step();
 				}
 
 				$this->generate_implied_end_tags();
-				if ( ! $this->state->stack_of_open_elements->current_node_is( $token_name ) ) {
+				if ( ! $this->current_open_element_is( $token_name ) ) {
 					// @todo Record parse error: this error doesn't impact parsing.
 				}
 				$this->pop_open_elements_until( $token_name );
@@ -2666,7 +2666,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			 * > An end tag whose tag name is "form"
 			 */
 			case '-FORM':
-				if ( ! $this->state->stack_of_open_elements->contains( 'TEMPLATE' ) ) {
+				if ( ! $this->open_elements_contains( 'TEMPLATE' ) ) {
 					$node = $this->state->form_element;
 
 					/*
@@ -2678,7 +2678,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 					 */
 					if (
 						null === $node ||
-						! $this->state->stack_of_open_elements->has_element_in_scope( 'FORM' )
+						! $this->has_element_in_scope( 'FORM' )
 					) {
 						/*
 						 * Parse error: ignore the token.
@@ -2695,7 +2695,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 					$this->state->form_element = null;
 
 					$this->generate_implied_end_tags();
-					if ( $node !== $this->state->stack_of_open_elements->current_node() ) {
+					if ( $node !== $this->current_open_element() ) {
 						// @todo Indicate a parse error once it's possible. This error does not impact the logic here.
 						$this->bail( 'Cannot close a FORM when other elements remain open as this would throw off the breadcrumbs for the following tokens.' );
 					}
@@ -2709,14 +2709,14 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 					 *
 					 * Note that unlike in the clause above, this is checking for any FORM in scope.
 					 */
-					if ( ! $this->state->stack_of_open_elements->has_element_in_scope( 'FORM' ) ) {
+					if ( ! $this->has_element_in_scope( 'FORM' ) ) {
 						// Parse error: ignore the token.
 						return $this->step();
 					}
 
 					$this->generate_implied_end_tags();
 
-					if ( ! $this->state->stack_of_open_elements->current_node_is( 'FORM' ) ) {
+					if ( ! $this->current_open_element_is( 'FORM' ) ) {
 						// @todo Indicate a parse error once it's possible. This error does not impact the logic here.
 					}
 
@@ -2729,7 +2729,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			 * > An end tag whose tag name is "p"
 			 */
 			case '-P':
-				if ( ! $this->state->stack_of_open_elements->has_p_in_button_scope() ) {
+				if ( ! $this->has_p_in_button_scope() ) {
 					$this->insert_html_element( $this->state->current_token );
 				}
 
@@ -2751,7 +2751,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 					 */
 					(
 						'LI' === $token_name &&
-						! $this->state->stack_of_open_elements->has_element_in_list_item_scope( 'LI' )
+						! $this->has_element_in_list_item_scope( 'LI' )
 					) ||
 					/*
 					 * An end tag whose tag name is one of: "dd", "dt":
@@ -2761,7 +2761,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 					 */
 					(
 						'LI' !== $token_name &&
-						! $this->state->stack_of_open_elements->has_element_in_scope( $token_name )
+						! $this->has_element_in_scope( $token_name )
 					)
 				) {
 					/*
@@ -2774,7 +2774,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 
 				$this->generate_implied_end_tags( $token_name );
 
-				if ( ! $this->state->stack_of_open_elements->current_node_is( $token_name ) ) {
+				if ( ! $this->current_open_element_is( $token_name ) ) {
 					// @todo Indicate a parse error once it's possible. This error does not impact the logic here.
 				}
 
@@ -2790,7 +2790,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			case '-H4':
 			case '-H5':
 			case '-H6':
-				if ( ! $this->state->stack_of_open_elements->has_element_in_scope( '(internal: H1 through H6 - do not use)' ) ) {
+				if ( ! $this->has_element_in_scope( '(internal: H1 through H6 - do not use)' ) ) {
 					/*
 					 * This is a parse error; ignore the token.
 					 *
@@ -2801,7 +2801,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 
 				$this->generate_implied_end_tags();
 
-				if ( ! $this->state->stack_of_open_elements->current_node_is( $token_name ) ) {
+				if ( ! $this->current_open_element_is( $token_name ) ) {
 					// @todo Record parse error: this error doesn't impact parsing.
 				}
 
@@ -2857,7 +2857,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			case '+NOBR':
 				$this->reconstruct_active_formatting_elements();
 
-				if ( $this->state->stack_of_open_elements->has_element_in_scope( 'NOBR' ) ) {
+				if ( $this->has_element_in_scope( 'NOBR' ) ) {
 					// Parse error.
 					$this->run_adoption_agency_algorithm();
 					$this->reconstruct_active_formatting_elements();
@@ -2906,13 +2906,13 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			case '-APPLET':
 			case '-MARQUEE':
 			case '-OBJECT':
-				if ( ! $this->state->stack_of_open_elements->has_element_in_scope( $token_name ) ) {
+				if ( ! $this->has_element_in_scope( $token_name ) ) {
 					// Parse error: ignore the token.
 					return $this->step();
 				}
 
 				$this->generate_implied_end_tags();
-				if ( ! $this->state->stack_of_open_elements->current_node_is( $token_name ) ) {
+				if ( ! $this->current_open_element_is( $token_name ) ) {
 					// This is a parse error.
 				}
 
@@ -2930,7 +2930,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 				 */
 				if (
 					WP_HTML_Tag_Processor::QUIRKS_MODE !== $this->compat_mode &&
-					$this->state->stack_of_open_elements->has_p_in_button_scope()
+					$this->has_p_in_button_scope()
 				) {
 					$this->close_a_p_element();
 				}
@@ -2993,7 +2993,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			 * > A start tag whose tag name is "hr"
 			 */
 			case '+HR':
-				if ( $this->state->stack_of_open_elements->has_p_in_button_scope() ) {
+				if ( $this->has_p_in_button_scope() ) {
 					$this->close_a_p_element();
 				}
 				$this->insert_html_element( $this->state->current_token );
@@ -3039,7 +3039,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			 * > A start tag whose tag name is "xmp"
 			 */
 			case '+XMP':
-				if ( $this->state->stack_of_open_elements->has_p_in_button_scope() ) {
+				if ( $this->has_p_in_button_scope() ) {
 					$this->close_a_p_element();
 				}
 
@@ -3113,7 +3113,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			 */
 			case '+OPTGROUP':
 			case '+OPTION':
-				if ( $this->state->stack_of_open_elements->current_node_is( 'OPTION' ) ) {
+				if ( $this->current_open_element_is( 'OPTION' ) ) {
 					$this->pop_open_element();
 				}
 				$this->reconstruct_active_formatting_elements();
@@ -3125,10 +3125,10 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			 */
 			case '+RB':
 			case '+RTC':
-				if ( $this->state->stack_of_open_elements->has_element_in_scope( 'RUBY' ) ) {
+				if ( $this->has_element_in_scope( 'RUBY' ) ) {
 					$this->generate_implied_end_tags();
 
-					if ( $this->state->stack_of_open_elements->current_node_is( 'RUBY' ) ) {
+					if ( $this->current_open_element_is( 'RUBY' ) ) {
 						// @todo Indicate a parse error once it's possible.
 					}
 				}
@@ -3141,10 +3141,10 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			 */
 			case '+RP':
 			case '+RT':
-				if ( $this->state->stack_of_open_elements->has_element_in_scope( 'RUBY' ) ) {
+				if ( $this->has_element_in_scope( 'RUBY' ) ) {
 					$this->generate_implied_end_tags( 'RTC' );
 
-					$current_node_name = $this->state->stack_of_open_elements->current_node()->node_name;
+					$current_node_name = $this->current_open_element()->node_name;
 					if ( 'RTC' === $current_node_name || 'RUBY' === $current_node_name ) {
 						// @todo Indicate a parse error once it's possible.
 					}
@@ -3228,7 +3228,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			 * of boundary in the stack. For example, a `</custom-tag>` should not
 			 * close anything beyond its containing `P` or `DIV` element.
 			 */
-			foreach ( $this->state->stack_of_open_elements->walk_up() as $node ) {
+			foreach ( $this->walk_up_open_elements() as $node ) {
 				if ( 'html' === $node->namespace && $token_name === $node->node_name ) {
 					break;
 				}
@@ -3240,11 +3240,11 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			}
 
 			$this->generate_implied_end_tags( $token_name );
-			if ( $node !== $this->state->stack_of_open_elements->current_node() ) {
+			if ( $node !== $this->current_open_element() ) {
 				// @todo Record parse error: this error doesn't impact parsing.
 			}
 
-			foreach ( $this->state->stack_of_open_elements->walk_up() as $item ) {
+			foreach ( $this->walk_up_open_elements() as $item ) {
 				$this->pop_open_element();
 				if ( $node === $item ) {
 					return true;
@@ -3285,7 +3285,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			 * > tbody, template, tfoot, thead, or tr element
 			 */
 			case '#text':
-				$current_node      = $this->state->stack_of_open_elements->current_node();
+				$current_node      = $this->current_open_element();
 				$current_node_name = $current_node ? $current_node->node_name : null;
 				if (
 					$current_node_name && (
@@ -3416,7 +3416,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			 * This tag in the IN TABLE insertion mode is a parse error.
 			 */
 			case '+TABLE':
-				if ( ! $this->state->stack_of_open_elements->has_element_in_table_scope( 'TABLE' ) ) {
+				if ( ! $this->has_element_in_table_scope( 'TABLE' ) ) {
 					return $this->step();
 				}
 
@@ -3428,7 +3428,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			 * > An end tag whose tag name is "table"
 			 */
 			case '-TABLE':
-				if ( ! $this->state->stack_of_open_elements->has_element_in_table_scope( 'TABLE' ) ) {
+				if ( ! $this->has_element_in_table_scope( 'TABLE' ) ) {
 					// @todo Indicate a parse error once it's possible.
 					return $this->step();
 				}
@@ -3490,7 +3490,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			 */
 			case '+FORM':
 				if (
-					$this->state->stack_of_open_elements->has_element_in_scope( 'TEMPLATE' ) ||
+					$this->has_element_in_scope( 'TEMPLATE' ) ||
 					isset( $this->state->form_element )
 				) {
 					return $this->step();
@@ -3575,13 +3575,13 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			case '+THEAD':
 			case '+TR':
 			case '-TABLE':
-				if ( ! $this->state->stack_of_open_elements->has_element_in_table_scope( 'CAPTION' ) ) {
+				if ( ! $this->has_element_in_table_scope( 'CAPTION' ) ) {
 					// Parse error: ignore the token.
 					return $this->step();
 				}
 
 				$this->generate_implied_end_tags();
-				if ( ! $this->state->stack_of_open_elements->current_node_is( 'CAPTION' ) ) {
+				if ( ! $this->current_open_element_is( 'CAPTION' ) ) {
 					// @todo Indicate a parse error once it's possible.
 				}
 
@@ -3690,7 +3690,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			 * > An end tag whose tag name is "colgroup"
 			 */
 			case '-COLGROUP':
-				if ( ! $this->state->stack_of_open_elements->current_node_is( 'COLGROUP' ) ) {
+				if ( ! $this->current_open_element_is( 'COLGROUP' ) ) {
 					// @todo Indicate a parse error once it's possible.
 					return $this->step();
 				}
@@ -3718,7 +3718,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 		/*
 		 * > Anything else
 		 */
-		if ( ! $this->state->stack_of_open_elements->current_node_is( 'COLGROUP' ) ) {
+		if ( ! $this->current_open_element_is( 'COLGROUP' ) ) {
 			// @todo Indicate a parse error once it's possible.
 			return $this->step();
 		}
@@ -3775,7 +3775,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			case '-TBODY':
 			case '-TFOOT':
 			case '-THEAD':
-				if ( ! $this->state->stack_of_open_elements->has_element_in_table_scope( $tag_name ) ) {
+				if ( ! $this->has_element_in_table_scope( $tag_name ) ) {
 					// Parse error: ignore the token.
 					return $this->step();
 				}
@@ -3797,9 +3797,9 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			case '+THEAD':
 			case '-TABLE':
 				if (
-					! $this->state->stack_of_open_elements->has_element_in_table_scope( 'TBODY' ) &&
-					! $this->state->stack_of_open_elements->has_element_in_table_scope( 'THEAD' ) &&
-					! $this->state->stack_of_open_elements->has_element_in_table_scope( 'TFOOT' )
+					! $this->has_element_in_table_scope( 'TBODY' ) &&
+					! $this->has_element_in_table_scope( 'THEAD' ) &&
+					! $this->has_element_in_table_scope( 'TFOOT' )
 				) {
 					// Parse error: ignore the token.
 					return $this->step();
@@ -3868,7 +3868,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			 * > An end tag whose tag name is "tr"
 			 */
 			case '-TR':
-				if ( ! $this->state->stack_of_open_elements->has_element_in_table_scope( 'TR' ) ) {
+				if ( ! $this->has_element_in_table_scope( 'TR' ) ) {
 					// Parse error: ignore the token.
 					return $this->step();
 				}
@@ -3890,7 +3890,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			case '+THEAD':
 			case '+TR':
 			case '-TABLE':
-				if ( ! $this->state->stack_of_open_elements->has_element_in_table_scope( 'TR' ) ) {
+				if ( ! $this->has_element_in_table_scope( 'TR' ) ) {
 					// Parse error: ignore the token.
 					return $this->step();
 				}
@@ -3906,12 +3906,12 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			case '-TBODY':
 			case '-TFOOT':
 			case '-THEAD':
-				if ( ! $this->state->stack_of_open_elements->has_element_in_table_scope( $tag_name ) ) {
+				if ( ! $this->has_element_in_table_scope( $tag_name ) ) {
 					// Parse error: ignore the token.
 					return $this->step();
 				}
 
-				if ( ! $this->state->stack_of_open_elements->has_element_in_table_scope( 'TR' ) ) {
+				if ( ! $this->has_element_in_table_scope( 'TR' ) ) {
 					// Ignore the token.
 					return $this->step();
 				}
@@ -3969,7 +3969,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			 */
 			case '-TD':
 			case '-TH':
-				if ( ! $this->state->stack_of_open_elements->has_element_in_table_scope( $tag_name ) ) {
+				if ( ! $this->has_element_in_table_scope( $tag_name ) ) {
 					// Parse error: ignore the token.
 					return $this->step();
 				}
@@ -3982,7 +3982,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 				 *       HTML element of the given name, such as `<center>`, and a foreign element of
 				 *       the same given name.
 				 */
-				if ( ! $this->state->stack_of_open_elements->current_node_is( $tag_name ) ) {
+				if ( ! $this->current_open_element_is( $tag_name ) ) {
 					// @todo Indicate a parse error once it's possible.
 				}
 
@@ -4032,7 +4032,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			case '-TFOOT':
 			case '-THEAD':
 			case '-TR':
-				if ( ! $this->state->stack_of_open_elements->has_element_in_table_scope( $tag_name ) ) {
+				if ( ! $this->has_element_in_table_scope( $tag_name ) ) {
 					// Parse error: ignore the token.
 					return $this->step();
 				}
@@ -4114,7 +4114,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			 * > A start tag whose tag name is "option"
 			 */
 			case '+OPTION':
-				if ( $this->state->stack_of_open_elements->current_node_is( 'OPTION' ) ) {
+				if ( $this->current_open_element_is( 'OPTION' ) ) {
 					$this->pop_open_element();
 				}
 				$this->insert_html_element( $this->state->current_token );
@@ -4129,11 +4129,11 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			 */
 			case '+OPTGROUP':
 			case '+HR':
-				if ( $this->state->stack_of_open_elements->current_node_is( 'OPTION' ) ) {
+				if ( $this->current_open_element_is( 'OPTION' ) ) {
 					$this->pop_open_element();
 				}
 
-				if ( $this->state->stack_of_open_elements->current_node_is( 'OPTGROUP' ) ) {
+				if ( $this->current_open_element_is( 'OPTGROUP' ) ) {
 					$this->pop_open_element();
 				}
 
@@ -4144,9 +4144,9 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			 * > An end tag whose tag name is "optgroup"
 			 */
 			case '-OPTGROUP':
-				$current_node = $this->state->stack_of_open_elements->current_node();
+				$current_node = $this->current_open_element();
 				if ( $current_node && 'OPTION' === $current_node->node_name ) {
-					foreach ( $this->state->stack_of_open_elements->walk_up( $current_node ) as $parent ) {
+					foreach ( $this->walk_up_open_elements( $current_node ) as $parent ) {
 						break;
 					}
 					if ( $parent && 'OPTGROUP' === $parent->node_name ) {
@@ -4154,7 +4154,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 					}
 				}
 
-				if ( $this->state->stack_of_open_elements->current_node_is( 'OPTGROUP' ) ) {
+				if ( $this->current_open_element_is( 'OPTGROUP' ) ) {
 					$this->pop_open_element();
 					return true;
 				}
@@ -4166,7 +4166,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			 * > An end tag whose tag name is "option"
 			 */
 			case '-OPTION':
-				if ( $this->state->stack_of_open_elements->current_node_is( 'OPTION' ) ) {
+				if ( $this->current_open_element_is( 'OPTION' ) ) {
 					$this->pop_open_element();
 					return true;
 				}
@@ -4182,7 +4182,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			 */
 			case '-SELECT':
 			case '+SELECT':
-				if ( ! $this->state->stack_of_open_elements->has_element_in_select_scope( 'SELECT' ) ) {
+				if ( ! $this->has_element_in_select_scope( 'SELECT' ) ) {
 					// Parse error: ignore the token.
 					return $this->step();
 				}
@@ -4198,7 +4198,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			case '+INPUT':
 			case '+KEYGEN':
 			case '+TEXTAREA':
-				if ( ! $this->state->stack_of_open_elements->has_element_in_select_scope( 'SELECT' ) ) {
+				if ( ! $this->has_element_in_select_scope( 'SELECT' ) ) {
 					// Ignore the token.
 					return $this->step();
 				}
@@ -4274,7 +4274,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			case '-TD':
 			case '-TH':
 				// @todo Indicate a parse error once it's possible.
-				if ( ! $this->state->stack_of_open_elements->has_element_in_table_scope( $token_name ) ) {
+				if ( ! $this->has_element_in_table_scope( $token_name ) ) {
 					return $this->step();
 				}
 				$this->pop_open_elements_until( 'SELECT' );
@@ -4405,7 +4405,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 		/*
 		 * > An end-of-file token
 		 */
-		if ( ! $this->state->stack_of_open_elements->contains( 'TEMPLATE' ) ) {
+		if ( ! $this->open_elements_contains( 'TEMPLATE' ) ) {
 			// Stop parsing.
 			return false;
 		}
@@ -4584,7 +4584,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 				 * > If the current node is the root html element, then this is a parse error;
 				 * > ignore the token. (fragment case)
 				 */
-				if ( $this->state->stack_of_open_elements->current_node_is( 'HTML' ) ) {
+				if ( $this->current_open_element_is( 'HTML' ) ) {
 					return $this->step();
 				}
 
@@ -4598,7 +4598,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 				 * > (fragment case), and the current node is no longer a frameset element, then
 				 * > switch the insertion mode to "after frameset".
 				 */
-				if ( ! isset( $this->context_node ) && ! $this->state->stack_of_open_elements->current_node_is( 'FRAMESET' ) ) {
+				if ( ! isset( $this->context_node ) && ! $this->current_open_element_is( 'FRAMESET' ) ) {
 					$this->state->insertion_mode = WP_HTML_Processor_State::INSERTION_MODE_AFTER_FRAMESET;
 				}
 
@@ -5001,7 +5001,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			case '-BR':
 			case '-P':
 				// @todo Indicate a parse error once it's possible.
-				foreach ( $this->state->stack_of_open_elements->walk_up() as $current_node ) {
+				foreach ( $this->walk_up_open_elements() as $current_node ) {
 					if (
 						'math' === $current_node->integration_node_type ||
 						'html' === $current_node->integration_node_type ||
@@ -5056,12 +5056,12 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 		 * > Any other end tag
 		 */
 		if ( $this->is_tag_closer() ) {
-			$node = $this->state->stack_of_open_elements->current_node();
+			$node = $this->current_open_element();
 			if ( $tag_name !== $node->node_name ) {
 				// @todo Indicate a parse error once it's possible.
 			}
 			in_foreign_content_end_tag_loop:
-			if ( $node === $this->state->stack_of_open_elements->at( 1 ) ) {
+			if ( $node === $this->get_open_element_at( 1 ) ) {
 				return true;
 			}
 
@@ -5071,7 +5071,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			 * > been popped from the stack, and then return.
 			 */
 			if ( 0 === strcasecmp( $node->node_name, $tag_name ) ) {
-				foreach ( $this->state->stack_of_open_elements->walk_up() as $item ) {
+				foreach ( $this->walk_up_open_elements() as $item ) {
 					$this->pop_open_element();
 					if ( $node === $item ) {
 						return true;
@@ -5079,7 +5079,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 				}
 			}
 
-			foreach ( $this->state->stack_of_open_elements->walk_up( $node ) as $item ) {
+			foreach ( $this->walk_up_open_elements( $node ) as $item ) {
 				$node = $item;
 				break;
 			}
@@ -5627,7 +5627,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			/*
 			 * When moving backward, stateful stacks should be cleared.
 			 */
-			foreach ( $this->state->stack_of_open_elements->walk_up() as $item ) {
+			foreach ( $this->walk_up_open_elements() as $item ) {
 				$this->remove_open_element( $item );
 			}
 
@@ -5869,8 +5869,8 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 		$no_exclusions = ! isset( $except_for_this_element );
 
 		while (
-			( $no_exclusions || ! $this->state->stack_of_open_elements->current_node_is( $except_for_this_element ) ) &&
-			in_array( $this->state->stack_of_open_elements->current_node()->node_name, $elements_with_implied_end_tags, true )
+			( $no_exclusions || ! $this->current_open_element_is( $except_for_this_element ) ) &&
+			in_array( $this->current_open_element()->node_name, $elements_with_implied_end_tags, true )
 		) {
 			$this->pop_open_element();
 		}
@@ -5911,7 +5911,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			'TR',
 		);
 
-		while ( in_array( $this->state->stack_of_open_elements->current_node()->node_name, $elements_with_implied_end_tags, true ) ) {
+		while ( in_array( $this->current_open_element()->node_name, $elements_with_implied_end_tags, true ) ) {
 			$this->pop_open_element();
 		}
 	}
@@ -5932,11 +5932,11 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 * @return WP_HTML_Token|null The adjusted current node.
 	 */
 	private function get_adjusted_current_node(): ?WP_HTML_Token {
-		if ( isset( $this->context_node ) && 1 === $this->state->stack_of_open_elements->count() ) {
+		if ( isset( $this->context_node ) && 1 === $this->count_open_elements() ) {
 			return $this->context_node;
 		}
 
-		return $this->state->stack_of_open_elements->current_node();
+		return $this->current_open_element();
 	}
 
 	/**
@@ -5978,7 +5978,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			 * > element that is in the stack of open elements, then there is nothing to reconstruct;
 			 * > stop this algorithm.
 			 */
-			$this->state->stack_of_open_elements->contains_node( $last_entry )
+			$this->open_elements_contains_node( $last_entry )
 		) {
 			return false;
 		}
@@ -5997,7 +5997,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	private function reset_insertion_mode_appropriately(): void {
 		// Set the first node.
 		$first_node = null;
-		foreach ( $this->state->stack_of_open_elements->walk_down() as $first_node ) {
+		foreach ( $this->walk_down_open_elements() as $first_node ) {
 			break;
 		}
 
@@ -6005,7 +6005,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 		 * > 1. Let _last_ be false.
 		 */
 		$last = false;
-		foreach ( $this->state->stack_of_open_elements->walk_up() as $node ) {
+		foreach ( $this->walk_up_open_elements() as $node ) {
 			/*
 			 * > 2. Let _node_ be the last node in the stack of open elements.
 			 * > 3. _Loop_: If _node_ is the first node in the stack of open elements, then set _last_
@@ -6040,7 +6040,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 				 */
 				case 'SELECT':
 					if ( ! $last ) {
-						foreach ( $this->state->stack_of_open_elements->walk_up( $node ) as $ancestor ) {
+						foreach ( $this->walk_up_open_elements( $node ) as $ancestor ) {
 							if ( 'html' !== $ancestor->namespace ) {
 								continue;
 							}
@@ -6192,7 +6192,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	private function run_adoption_agency_algorithm(): void {
 		$budget       = 1000;
 		$subject      = $this->get_tag();
-		$current_node = $this->state->stack_of_open_elements->current_node();
+		$current_node = $this->current_open_element();
 
 		if (
 			// > If the current node is an HTML element whose tag name is subject
@@ -6234,13 +6234,13 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			}
 
 			// > If formatting element is not in the stack of open elements, then this is a parse error; remove the element from the list, and return.
-			if ( ! $this->state->stack_of_open_elements->contains_node( $formatting_element ) ) {
+			if ( ! $this->open_elements_contains_node( $formatting_element ) ) {
 				$this->state->active_formatting_elements->remove_node( $formatting_element );
 				return;
 			}
 
 			// > If formatting element is in the stack of open elements, but the element is not in scope, then this is a parse error; return.
-			if ( ! $this->state->stack_of_open_elements->has_element_in_scope( $formatting_element->node_name ) ) {
+			if ( ! $this->has_element_in_scope( $formatting_element->node_name ) ) {
 				return;
 			}
 
@@ -6250,7 +6250,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			 */
 			$is_above_formatting_element = true;
 			$furthest_block              = null;
-			foreach ( $this->state->stack_of_open_elements->walk_down() as $item ) {
+			foreach ( $this->walk_down_open_elements() as $item ) {
 				if ( $is_above_formatting_element && $formatting_element->bookmark_name !== $item->bookmark_name ) {
 					continue;
 				}
@@ -6272,7 +6272,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			 * > remove formatting element from the list of active formatting elements, and finally return.
 			 */
 			if ( null === $furthest_block ) {
-				foreach ( $this->state->stack_of_open_elements->walk_up() as $item ) {
+				foreach ( $this->walk_up_open_elements() as $item ) {
 					$this->pop_open_element();
 
 					if ( $formatting_element->bookmark_name === $item->bookmark_name ) {
@@ -6306,7 +6306,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	private function close_cell(): void {
 		$this->generate_implied_end_tags();
 		// @todo Parse error if the current node is a "td" or "th" element.
-		foreach ( $this->state->stack_of_open_elements->walk_up() as $element ) {
+		foreach ( $this->walk_up_open_elements() as $element ) {
 			$this->pop_open_element();
 			if ( 'TD' === $element->node_name || 'TH' === $element->node_name ) {
 				break;
@@ -6314,6 +6314,439 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 		}
 		$this->state->active_formatting_elements->clear_up_to_last_marker();
 		$this->state->insertion_mode = WP_HTML_Processor_State::INSERTION_MODE_IN_ROW;
+	}
+
+	/**
+	 * Returns the node at the nth position on the stack of open elements.
+	 *
+	 * @since 7.1.0
+	 * @private
+	 *
+	 * @param int $nth Retrieve the nth item on the stack, with 1 being the top element.
+	 * @return WP_HTML_Token|null Node on the stack at the given location, or null if it doesn't exist.
+	 */
+	private function get_open_element_at( int $nth ): ?WP_HTML_Token {
+		foreach ( $this->walk_down_open_elements() as $item ) {
+			if ( 0 === --$nth ) {
+				return $item;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Reports if a node of a given name is in the stack of open elements.
+	 *
+	 * @since 7.1.0
+	 * @private
+	 *
+	 * @param string $node_name Name of node for which to check.
+	 * @return bool Whether a node of the given name is in the stack of open elements.
+	 */
+	private function open_elements_contains( string $node_name ): bool {
+		foreach ( $this->walk_up_open_elements() as $item ) {
+			if ( $node_name === $item->node_name ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Reports if a specific node is in the stack of open elements.
+	 *
+	 * @since 7.1.0
+	 * @private
+	 *
+	 * @param WP_HTML_Token $token Look for this node in the stack.
+	 * @return bool Whether the referenced node is in the stack of open elements.
+	 */
+	private function open_elements_contains_node( WP_HTML_Token $token ): bool {
+		foreach ( $this->walk_up_open_elements() as $item ) {
+			if ( $token === $item ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Returns how many nodes are currently in the stack of open elements.
+	 *
+	 * @since 7.1.0
+	 * @private
+	 *
+	 * @return int How many nodes are in the stack of open elements.
+	 */
+	private function count_open_elements(): int {
+		return count( $this->state->stack_of_open_elements );
+	}
+
+	/**
+	 * Returns the current node in the stack of open elements.
+	 *
+	 * @since 7.1.0
+	 * @private
+	 *
+	 * @return WP_HTML_Token|null Current node, if one exists, otherwise null.
+	 */
+	private function current_open_element(): ?WP_HTML_Token {
+		$current_node = end( $this->state->stack_of_open_elements );
+
+		return $current_node ? $current_node : null;
+	}
+
+	/**
+	 * Indicates if the current node is of a given type or name.
+	 *
+	 * @since 7.1.0
+	 * @private
+	 *
+	 * @param string $identity Check if the current node has this name or type.
+	 * @return bool Whether there is a current element that matches the given identity.
+	 */
+	private function current_open_element_is( string $identity ): bool {
+		$current_node = end( $this->state->stack_of_open_elements );
+		if ( false === $current_node ) {
+			return false;
+		}
+
+		$current_node_name = $current_node->node_name;
+
+		return (
+			$current_node_name === $identity ||
+			( '#doctype' === $identity && 'html' === $current_node_name ) ||
+			( '#tag' === $identity && ctype_upper( $current_node_name ) )
+		);
+	}
+
+	/**
+	 * Returns whether an element is in a specific scope.
+	 *
+	 * @since 7.1.0
+	 * @private
+	 *
+	 * @param string   $tag_name         Name of tag check.
+	 * @param string[] $termination_list List of elements that terminate the search.
+	 * @return bool Whether the element was found in a specific scope.
+	 */
+	private function has_element_in_specific_scope( string $tag_name, array $termination_list ): bool {
+		foreach ( $this->walk_up_open_elements() as $node ) {
+			$namespaced_name = 'html' === $node->namespace
+				? $node->node_name
+				: "{$node->namespace} {$node->node_name}";
+
+			if ( $namespaced_name === $tag_name ) {
+				return true;
+			}
+
+			if (
+				'(internal: H1 through H6 - do not use)' === $tag_name &&
+				in_array( $namespaced_name, array( 'H1', 'H2', 'H3', 'H4', 'H5', 'H6' ), true )
+			) {
+				return true;
+			}
+
+			if ( in_array( $namespaced_name, $termination_list, true ) ) {
+				return false;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Returns whether a particular element is in scope.
+	 *
+	 * @since 7.1.0
+	 * @private
+	 *
+	 * @param string $tag_name Name of tag to check.
+	 * @return bool Whether given element is in scope.
+	 */
+	private function has_element_in_scope( string $tag_name ): bool {
+		return $this->has_element_in_specific_scope(
+			$tag_name,
+			array(
+				'APPLET',
+				'CAPTION',
+				'HTML',
+				'TABLE',
+				'TD',
+				'TH',
+				'MARQUEE',
+				'OBJECT',
+				'TEMPLATE',
+
+				'math MI',
+				'math MO',
+				'math MN',
+				'math MS',
+				'math MTEXT',
+				'math ANNOTATION-XML',
+
+				'svg FOREIGNOBJECT',
+				'svg DESC',
+				'svg TITLE',
+			)
+		);
+	}
+
+	/**
+	 * Returns whether a particular element is in list item scope.
+	 *
+	 * @since 7.1.0
+	 * @private
+	 *
+	 * @param string $tag_name Name of tag to check.
+	 * @return bool Whether given element is in scope.
+	 */
+	private function has_element_in_list_item_scope( string $tag_name ): bool {
+		return $this->has_element_in_specific_scope(
+			$tag_name,
+			array(
+				'APPLET',
+				'BUTTON',
+				'CAPTION',
+				'HTML',
+				'TABLE',
+				'TD',
+				'TH',
+				'MARQUEE',
+				'OBJECT',
+				'OL',
+				'TEMPLATE',
+				'UL',
+
+				'math MI',
+				'math MO',
+				'math MN',
+				'math MS',
+				'math MTEXT',
+				'math ANNOTATION-XML',
+
+				'svg FOREIGNOBJECT',
+				'svg DESC',
+				'svg TITLE',
+			)
+		);
+	}
+
+	/**
+	 * Returns whether a particular element is in button scope.
+	 *
+	 * @since 7.1.0
+	 * @private
+	 *
+	 * @param string $tag_name Name of tag to check.
+	 * @return bool Whether given element is in scope.
+	 */
+	private function has_element_in_button_scope( string $tag_name ): bool {
+		return $this->has_element_in_specific_scope(
+			$tag_name,
+			array(
+				'APPLET',
+				'BUTTON',
+				'CAPTION',
+				'HTML',
+				'TABLE',
+				'TD',
+				'TH',
+				'MARQUEE',
+				'OBJECT',
+				'TEMPLATE',
+
+				'math MI',
+				'math MO',
+				'math MN',
+				'math MS',
+				'math MTEXT',
+				'math ANNOTATION-XML',
+
+				'svg FOREIGNOBJECT',
+				'svg DESC',
+				'svg TITLE',
+			)
+		);
+	}
+
+	/**
+	 * Returns whether a particular element is in table scope.
+	 *
+	 * @since 7.1.0
+	 * @private
+	 *
+	 * @param string $tag_name Name of tag to check.
+	 * @return bool Whether given element is in scope.
+	 */
+	private function has_element_in_table_scope( string $tag_name ): bool {
+		return $this->has_element_in_specific_scope(
+			$tag_name,
+			array(
+				'HTML',
+				'TABLE',
+				'TEMPLATE',
+			)
+		);
+	}
+
+	/**
+	 * Returns whether a particular element is in select scope.
+	 *
+	 * @since 7.1.0
+	 * @private
+	 *
+	 * @param string $tag_name Name of tag to check.
+	 * @return bool Whether the given element is in SELECT scope.
+	 */
+	private function has_element_in_select_scope( string $tag_name ): bool {
+		foreach ( $this->walk_up_open_elements() as $node ) {
+			if ( $node->node_name === $tag_name ) {
+				return true;
+			}
+
+			if (
+				'OPTION' !== $node->node_name &&
+				'OPTGROUP' !== $node->node_name
+			) {
+				return false;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Returns whether a P is in BUTTON scope.
+	 *
+	 * @since 7.1.0
+	 * @private
+	 *
+	 * @return bool Whether a P is in BUTTON scope.
+	 */
+	private function has_p_in_button_scope(): bool {
+		return $this->state->has_p_in_button_scope;
+	}
+
+	/**
+	 * Steps through the stack of open elements, starting with the top element.
+	 *
+	 * @since 7.1.0
+	 * @private
+	 */
+	private function walk_down_open_elements() {
+		$count = count( $this->state->stack_of_open_elements );
+
+		for ( $i = 0; $i < $count; $i++ ) {
+			yield $this->state->stack_of_open_elements[ $i ];
+		}
+	}
+
+	/**
+	 * Steps through the stack of open elements, starting with the current node.
+	 *
+	 * @since 7.1.0
+	 * @private
+	 *
+	 * @param WP_HTML_Token|null $above_this_node Optional. Start traversing above this node, if provided.
+	 */
+	private function walk_up_open_elements( ?WP_HTML_Token $above_this_node = null ) {
+		$has_found_node = null === $above_this_node;
+
+		for ( $i = count( $this->state->stack_of_open_elements ) - 1; $i >= 0; $i-- ) {
+			$node = $this->state->stack_of_open_elements[ $i ];
+
+			if ( ! $has_found_node ) {
+				$has_found_node = $node === $above_this_node;
+				continue;
+			}
+
+			yield $node;
+		}
+	}
+
+	/**
+	 * Updates open-elements stack state after adding an element.
+	 *
+	 * @since 7.1.0
+	 * @private
+	 *
+	 * @param WP_HTML_Token $item Element that was added to the stack of open elements.
+	 */
+	private function after_push_open_element( WP_HTML_Token $item ): void {
+		$namespaced_name = 'html' === $item->namespace
+			? $item->node_name
+			: "{$item->namespace} {$item->node_name}";
+
+		switch ( $namespaced_name ) {
+			case 'APPLET':
+			case 'BUTTON':
+			case 'CAPTION':
+			case 'HTML':
+			case 'TABLE':
+			case 'TD':
+			case 'TH':
+			case 'MARQUEE':
+			case 'OBJECT':
+			case 'TEMPLATE':
+			case 'math MI':
+			case 'math MO':
+			case 'math MN':
+			case 'math MS':
+			case 'math MTEXT':
+			case 'math ANNOTATION-XML':
+			case 'svg FOREIGNOBJECT':
+			case 'svg DESC':
+			case 'svg TITLE':
+				$this->state->has_p_in_button_scope = false;
+				break;
+
+			case 'P':
+				$this->state->has_p_in_button_scope = true;
+				break;
+		}
+	}
+
+	/**
+	 * Updates open-elements stack state after removing an element.
+	 *
+	 * @since 7.1.0
+	 * @private
+	 *
+	 * @param WP_HTML_Token $item Element that was removed from the stack of open elements.
+	 */
+	private function after_open_element_pop( WP_HTML_Token $item ): void {
+		$namespaced_name = 'html' === $item->namespace
+			? $item->node_name
+			: "{$item->namespace} {$item->node_name}";
+
+		switch ( $namespaced_name ) {
+			case 'APPLET':
+			case 'BUTTON':
+			case 'CAPTION':
+			case 'HTML':
+			case 'P':
+			case 'TABLE':
+			case 'TD':
+			case 'TH':
+			case 'MARQUEE':
+			case 'OBJECT':
+			case 'TEMPLATE':
+			case 'math MI':
+			case 'math MO':
+			case 'math MN':
+			case 'math MS':
+			case 'math MTEXT':
+			case 'math ANNOTATION-XML':
+			case 'svg FOREIGNOBJECT':
+			case 'svg DESC':
+			case 'svg TITLE':
+				$this->state->has_p_in_button_scope = $this->has_element_in_button_scope( 'P' );
+				break;
+		}
 	}
 
 	/**
@@ -6325,7 +6758,8 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 * @param WP_HTML_Token $token Push this element onto the stack of open elements.
 	 */
 	private function push_open_element( WP_HTML_Token $token ): void {
-		$this->state->stack_of_open_elements->push( $token );
+		$this->state->stack_of_open_elements[] = $token;
+		$this->after_push_open_element( $token );
 
 		$is_virtual            = ! isset( $this->state->current_token ) || $this->is_tag_closer();
 		$same_node             = isset( $this->state->current_token ) && $token->node_name === $this->state->current_token->node_name;
@@ -6344,11 +6778,12 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 * @return WP_HTML_Token|null Element that was popped off of the stack, or null if the stack was empty.
 	 */
 	private function pop_open_element(): ?WP_HTML_Token {
-		$popped = $this->state->stack_of_open_elements->pop();
+		$popped = array_pop( $this->state->stack_of_open_elements );
 		if ( null === $popped ) {
 			return null;
 		}
 
+		$this->after_open_element_pop( $popped );
 		$this->after_pop_open_element( $popped );
 		return $popped;
 	}
@@ -6363,13 +6798,19 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 * @return bool Whether the element was found and removed.
 	 */
 	private function remove_open_element( WP_HTML_Token $token ): bool {
-		$removed = $this->state->stack_of_open_elements->remove_node( $token );
-		if ( null === $removed ) {
-			return false;
+		foreach ( $this->walk_up_open_elements() as $position_from_end => $item ) {
+			if ( $token->bookmark_name !== $item->bookmark_name ) {
+				continue;
+			}
+
+			$position_from_start = $this->count_open_elements() - $position_from_end - 1;
+			array_splice( $this->state->stack_of_open_elements, $position_from_start, 1 );
+			$this->after_open_element_pop( $item );
+			$this->after_pop_open_element( $item );
+			return true;
 		}
 
-		$this->after_pop_open_element( $removed );
-		return true;
+		return false;
 	}
 
 	/**
@@ -6381,8 +6822,23 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 * @param string $tag_name Name of the element to pop through.
 	 */
 	private function pop_open_elements_until( string $tag_name ): void {
-		foreach ( $this->state->stack_of_open_elements->pop_until( $tag_name ) as $popped ) {
-			$this->after_pop_open_element( $popped );
+		foreach ( $this->walk_up_open_elements() as $item ) {
+			$this->pop_open_element();
+
+			if ( 'html' !== $item->namespace ) {
+				continue;
+			}
+
+			if (
+				'(internal: H1 through H6 - do not use)' === $tag_name &&
+				in_array( $item->node_name, array( 'H1', 'H2', 'H3', 'H4', 'H5', 'H6' ), true )
+			) {
+				return;
+			}
+
+			if ( $tag_name === $item->node_name ) {
+				return;
+			}
 		}
 	}
 
@@ -6393,8 +6849,16 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 * @private
 	 */
 	private function clear_stack_to_table_context(): void {
-		foreach ( $this->state->stack_of_open_elements->clear_to_table_context() as $popped ) {
-			$this->after_pop_open_element( $popped );
+		foreach ( $this->walk_up_open_elements() as $item ) {
+			if (
+				'TABLE' === $item->node_name ||
+				'TEMPLATE' === $item->node_name ||
+				'HTML' === $item->node_name
+			) {
+				return;
+			}
+
+			$this->pop_open_element();
 		}
 	}
 
@@ -6405,8 +6869,18 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 * @private
 	 */
 	private function clear_stack_to_table_body_context(): void {
-		foreach ( $this->state->stack_of_open_elements->clear_to_table_body_context() as $popped ) {
-			$this->after_pop_open_element( $popped );
+		foreach ( $this->walk_up_open_elements() as $item ) {
+			if (
+				'TBODY' === $item->node_name ||
+				'TFOOT' === $item->node_name ||
+				'THEAD' === $item->node_name ||
+				'TEMPLATE' === $item->node_name ||
+				'HTML' === $item->node_name
+			) {
+				return;
+			}
+
+			$this->pop_open_element();
 		}
 	}
 
@@ -6417,8 +6891,16 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 * @private
 	 */
 	private function clear_stack_to_table_row_context(): void {
-		foreach ( $this->state->stack_of_open_elements->clear_to_table_row_context() as $popped ) {
-			$this->after_pop_open_element( $popped );
+		foreach ( $this->walk_up_open_elements() as $item ) {
+			if (
+				'TR' === $item->node_name ||
+				'TEMPLATE' === $item->node_name ||
+				'HTML' === $item->node_name
+			) {
+				return;
+			}
+
+			$this->pop_open_element();
 		}
 	}
 

--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -6319,28 +6319,27 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	/**
 	 * Pushes an element onto the stack of open elements and tracks the event.
 	 *
-	 * @since 6.9.0
+	 * @since 7.1.0
+	 * @private
 	 *
-	 * @param WP_HTML_Token $token Element to push onto the stack.
-	 * @return WP_HTML_Token Element that was pushed onto the stack.
+	 * @param WP_HTML_Token $token Push this element onto the stack of open elements.
 	 */
-	private function push_open_element( WP_HTML_Token $token ): WP_HTML_Token {
-		$pushed = $this->state->stack_of_open_elements->push( $token );
+	private function push_open_element( WP_HTML_Token $token ): void {
+		$this->state->stack_of_open_elements->push( $token );
 
 		$is_virtual            = ! isset( $this->state->current_token ) || $this->is_tag_closer();
-		$same_node             = isset( $this->state->current_token ) && $pushed->node_name === $this->state->current_token->node_name;
+		$same_node             = isset( $this->state->current_token ) && $token->node_name === $this->state->current_token->node_name;
 		$provenance            = ( ! $same_node || $is_virtual ) ? 'virtual' : 'real';
-		$this->element_queue[] = new WP_HTML_Stack_Event( $pushed, WP_HTML_Stack_Event::PUSH, $provenance );
+		$this->element_queue[] = new WP_HTML_Stack_Event( $token, WP_HTML_Stack_Event::PUSH, $provenance );
 
-		$this->change_parsing_namespace( $pushed->integration_node_type ? 'html' : $pushed->namespace );
-
-		return $pushed;
+		$this->change_parsing_namespace( $token->integration_node_type ? 'html' : $token->namespace );
 	}
 
 	/**
 	 * Pops an element off of the stack of open elements and tracks the event.
 	 *
-	 * @since 6.9.0
+	 * @since 7.1.0
+	 * @private
 	 *
 	 * @return WP_HTML_Token|null Element that was popped off of the stack, or null if the stack was empty.
 	 */
@@ -6357,7 +6356,8 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	/**
 	 * Removes an element from the stack of open elements and tracks the event.
 	 *
-	 * @since 6.9.0
+	 * @since 7.1.0
+	 * @private
 	 *
 	 * @param WP_HTML_Token $token Element to remove from the stack.
 	 * @return bool Whether the element was found and removed.
@@ -6375,7 +6375,8 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	/**
 	 * Pops elements off the stack until an element with the given name has been popped.
 	 *
-	 * @since 6.9.0
+	 * @since 7.1.0
+	 * @private
 	 *
 	 * @param string $tag_name Name of the element to pop through.
 	 */
@@ -6388,7 +6389,8 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	/**
 	 * Clears the stack of open elements back to a table context.
 	 *
-	 * @since 6.9.0
+	 * @since 7.1.0
+	 * @private
 	 */
 	private function clear_stack_to_table_context(): void {
 		foreach ( $this->state->stack_of_open_elements->clear_to_table_context() as $popped ) {
@@ -6399,7 +6401,8 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	/**
 	 * Clears the stack of open elements back to a table body context.
 	 *
-	 * @since 6.9.0
+	 * @since 7.1.0
+	 * @private
 	 */
 	private function clear_stack_to_table_body_context(): void {
 		foreach ( $this->state->stack_of_open_elements->clear_to_table_body_context() as $popped ) {
@@ -6410,7 +6413,8 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	/**
 	 * Clears the stack of open elements back to a table row context.
 	 *
-	 * @since 6.9.0
+	 * @since 7.1.0
+	 * @private
 	 */
 	private function clear_stack_to_table_row_context(): void {
 		foreach ( $this->state->stack_of_open_elements->clear_to_table_row_context() as $popped ) {
@@ -6421,7 +6425,8 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	/**
 	 * Tracks accounting for an element popped off of the stack of open elements.
 	 *
-	 * @since 6.9.0
+	 * @since 7.1.0
+	 * @private
 	 *
 	 * @param WP_HTML_Token $token Element that was popped off of the stack.
 	 */


### PR DESCRIPTION
Trac ticket: Core-65383

The push and pop handlers in the HTML API were convenient when initially building the class, but being indirect, they involve an overhead when calling and require additional protection for avoiding calling the wrong handlers when and if an instance of the class were to be unserialized.

This patch replaces the direct calls by modifying the return values of the methods in the Open Elements calss to return pushed or popped elements. This makes it possible for the HTML Processor to track its own accounting directly while still delegating the stack operations to the Open Elements.

Patch developed by Codex on instruction from dmsnell.