### PR TITLE
Docs: Fix duplicate-word and spelling typos in comments and docblocks

### DIFF
--- a/src/js/_enqueues/deprecated/fakejshint.js
+++ b/src/js/_enqueues/deprecated/fakejshint.js
@@ -1,5 +1,5 @@
 /**
- * JSHINT has some GPL Compatability issues, so we are faking it out and using esprima for validation
+ * JSHINT has some GPL Compatibility issues, so we are faking it out and using esprima for validation
  * Based on https://github.com/jquery/esprima/blob/gh-pages/demo/validate.js which is MIT licensed.
  * This is now deprecated in favor of Espree.
  *

--- a/src/js/_enqueues/wp/dashboard.js
+++ b/src/js/_enqueues/wp/dashboard.js
@@ -756,8 +756,8 @@ jQuery( function( $ ) {
 		 *
 		 * @since 5.5.2
 		 *
-		 * @param {int}    startDate   The Unix timestamp in milliseconds when the the event starts.
-		 * @param {int}    endDate     The Unix timestamp in milliseconds when the the event ends.
+		 * @param {int}    startDate   The Unix timestamp in milliseconds when the event starts.
+		 * @param {int}    endDate     The Unix timestamp in milliseconds when the event ends.
 		 * @param {string} timeZone    A time zone string or offset which is parsable by `wp.date.i18n()`.
 		 *
 		 * @returns {string}

--- a/src/js/_enqueues/wp/widgets/custom-html.js
+++ b/src/js/_enqueues/wp/widgets/custom-html.js
@@ -307,7 +307,7 @@ wp.customHtmlWidgets = ( function( $ ) {
 
 		/*
 		 * Create a container element for the widget control fields.
-		 * This is inserted into the DOM immediately before the the .widget-content
+		 * This is inserted into the DOM immediately before the .widget-content
 		 * element because the contents of this element are essentially "managed"
 		 * by PHP, where each widget update cause the entire element to be emptied
 		 * and replaced with the rendered output of WP_Widget::form() which is

--- a/src/wp-includes/block-supports/settings.php
+++ b/src/wp-includes/block-supports/settings.php
@@ -131,7 +131,7 @@ function _wp_add_block_level_preset_styles( $pre_render, $block ) {
 		)
 	);
 
-	// include preset css classes on the the stylesheet.
+	// include preset css classes on the stylesheet.
 	$styles .= $theme_json_object->get_stylesheet(
 		array( 'presets' ),
 		null,

--- a/src/wp-includes/block-template.php
+++ b/src/wp-includes/block-template.php
@@ -452,7 +452,7 @@ function _block_template_render_without_post_block_context( $context ) {
 /**
  * Sets the current WP_Query to return auto-draft posts.
  *
- * The auto-draft status indicates a new post, so allow the the WP_Query instance to
+ * The auto-draft status indicates a new post, so allow the WP_Query instance to
  * return an auto-draft post for template resolution when editing a new post.
  *
  * @access private

--- a/src/wp-includes/class-wp-customize-manager.php
+++ b/src/wp-includes/class-wp-customize-manager.php
@@ -3056,7 +3056,7 @@ final class WP_Customize_Manager {
 	 *
 	 * The following re-formulates the logic from `wp_trash_post()` as done in
 	 * `wp_publish_post()`. The reason for bypassing `wp_trash_post()` is that it
-	 * will mutate the the `post_content` and the `post_name` when they should be
+	 * will mutate the `post_content` and the `post_name` when they should be
 	 * untouched.
 	 *
 	 * @since 4.9.0

--- a/src/wp-includes/class-wp-recovery-mode-email-service.php
+++ b/src/wp-includes/class-wp-recovery-mode-email-service.php
@@ -132,7 +132,7 @@ final class WP_Recovery_Mode_Email_Service {
 		}
 
 		/**
-		 * Filters the support message sent with the the fatal error protection email.
+		 * Filters the support message sent with the fatal error protection email.
 		 *
 		 * @since 5.2.0
 		 *

--- a/src/wp-includes/class-wp-theme-json-data.php
+++ b/src/wp-includes/class-wp-theme-json-data.php
@@ -45,7 +45,7 @@ class WP_Theme_JSON_Data {
 	}
 
 	/**
-	 * Updates the theme.json with the the given data.
+	 * Updates the theme.json with the given data.
 	 *
 	 * @since 6.1.0
 	 *

--- a/src/wp-includes/comment.php
+++ b/src/wp-includes/comment.php
@@ -2693,7 +2693,7 @@ function wp_update_comment( $commentarr, $wp_error = false ) {
 	 */
 	$data = apply_filters( 'wp_update_comment_data', $data, $comment, $commentarr );
 
-	// Do not carry on on failure.
+	// Do not continue on failure.
 	if ( is_wp_error( $data ) ) {
 		if ( $wp_error ) {
 			return $data;

--- a/src/wp-includes/fonts.php
+++ b/src/wp-includes/fonts.php
@@ -55,7 +55,7 @@ function wp_print_font_faces( $fonts = array() ) {
 }
 
 /**
- * Generates and prints font-face styles defined the the theme style variations.
+ * Generates and prints font-face styles defined in the theme style variations.
  *
  * @since 6.7.0
  *

--- a/src/wp-includes/rest-api/class-wp-rest-server.php
+++ b/src/wp-includes/rest-api/class-wp-rest-server.php
@@ -1995,7 +1995,7 @@ class WP_REST_Server {
 			} elseif ( 'REDIRECT_HTTP_AUTHORIZATION' === $key && empty( $server['HTTP_AUTHORIZATION'] ) ) {
 				/*
 				 * In some server configurations, the authorization header is passed in this alternate location.
-				 * Since it would not be passed in in both places we do not check for both headers and resolve.
+				 * Since it would not be passed in both places we do not check for both headers and resolve.
 				 */
 				$headers['AUTHORIZATION'] = $value;
 			} elseif ( isset( $additional[ $key ] ) ) {

--- a/tests/phpunit/includes/class-wp-sitemaps-large-test-provider.php
+++ b/tests/phpunit/includes/class-wp-sitemaps-large-test-provider.php
@@ -16,7 +16,7 @@ class WP_Sitemaps_Large_Test_Provider extends WP_Sitemaps_Provider {
 	/**
 	 * WP_Sitemaps_Large_Test_Provider constructor.
 	 *
-	 * @param int $num_entries Optional. Number of entries in in the sitemap.
+	 * @param int $num_entries Optional. Number of entries in the sitemap.
 	 */
 	public function __construct( $num_entries = 50001 ) {
 		$this->name        = 'tests';

--- a/tests/phpunit/tests/customize/setting.php
+++ b/tests/phpunit/tests/customize/setting.php
@@ -436,7 +436,7 @@ class Tests_WP_Customize_Setting extends WP_UnitTestCase {
 		$this->assertSame( $this->undefined, $this->custom_type_getter( $name, $this->undefined ) );
 		$this->assertSame( $default, $setting->value() );
 		$this->assertTrue( $setting->preview() );
-		$this->assertSame( 1, did_action( "customize_preview_{$setting->id}" ), 'One preview action now because initial value was not set and/or there is no incoming post value, so there is is a preview to apply.' );
+		$this->assertSame( 1, did_action( "customize_preview_{$setting->id}" ), 'One preview action now because initial value was not set and/or there is no incoming post value, so there is a preview to apply.' );
 		$this->assertSame( 3, did_action( "customize_preview_{$setting->type}" ) );
 		$this->assertSame( $post_data_overrides[ $name ], $this->custom_type_getter( $name, $this->undefined ) );
 		$this->assertSame( $post_data_overrides[ $name ], $setting->value() );

--- a/tests/phpunit/tests/date/currentTime.php
+++ b/tests/phpunit/tests/date/currentTime.php
@@ -242,7 +242,7 @@ class Tests_Date_CurrentTime extends WP_UnitTestCase {
 		 * Adjust for daylight saving time.
 		 *
 		 * DST adds an hour to the offset, the partial hour offset
-		 * is set the the standard time offset so this removes the
+		 * is set the standard time offset so this removes the
 		 * DST offset to avoid false negatives.
 		 */
 		$offset -= $dst_offset;

--- a/tests/phpunit/tests/date/currentTime.php
+++ b/tests/phpunit/tests/date/currentTime.php
@@ -242,7 +242,7 @@ class Tests_Date_CurrentTime extends WP_UnitTestCase {
 		 * Adjust for daylight saving time.
 		 *
 		 * DST adds an hour to the offset, the partial hour offset
-		 * is set the standard time offset so this removes the
+		 * is set to the standard time offset, so this removes the
 		 * DST offset to avoid false negatives.
 		 */
 		$offset -= $dst_offset;

--- a/tests/phpunit/tests/formatting/normalizeWhitespace.php
+++ b/tests/phpunit/tests/formatting/normalizeWhitespace.php
@@ -7,7 +7,7 @@
 class Tests_Formatting_NormalizeWhitespace extends WP_UnitTestCase {
 
 	/**
-	 * Tests the the normalize_whitespace() function.
+	 * Tests the normalize_whitespace() function.
 	 *
 	 * @dataProvider data_normalize_whitespace
 	 */

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -5654,7 +5654,7 @@ EOF;
 		copy( DIR_TESTDATA . '/images/33772.jpg', $file );
 
 		// Set JPEG output quality very low and WebP quality very high, this should force all generated WebP images to
-		// be larger than the the matching generated JPEGs.
+		// be larger than the matching generated JPEGs.
 		add_filter( 'wp_editor_set_quality', array( $this, 'image_editor_change_quality_low_jpeg' ), 10, 2 );
 
 		$editor = wp_get_image_editor( $file );

--- a/tests/phpunit/tests/multisite/bootstrap.php
+++ b/tests/phpunit/tests/multisite/bootstrap.php
@@ -178,7 +178,7 @@ class Tests_Multisite_Bootstrap extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Even if a matching network is available, it should not match if the the filtered
+	 * Even if a matching network is available, it should not match if the filtered
 	 * value for network path segments is fewer than the number of paths passed.
 	 */
 	public function test_get_network_by_path_with_forced_single_path_segment_returns_single_path_network() {

--- a/tests/phpunit/tests/multisite/cleanDirsizeCache.php
+++ b/tests/phpunit/tests/multisite/cleanDirsizeCache.php
@@ -270,7 +270,7 @@ class Tests_Multisite_CleanDirsizeCache extends WP_UnitTestCase {
 
 		/*
 		 * Now that it's confirmed that old cached values aren't being returned, create the
-		 * folder on disk, so that the the rest of the function can be tested.
+		 * folder on disk, so that the rest of the function can be tested.
 		 */
 		wp_mkdir_p( $upload_dir['basedir'] . '/2/1' );
 		$filename = $upload_dir['basedir'] . '/2/1/this-needs-to-exist.txt';

--- a/tests/phpunit/tests/theme.php
+++ b/tests/phpunit/tests/theme.php
@@ -565,7 +565,7 @@ class Tests_Theme extends WP_UnitTestCase {
 		do_action( 'customize_register', $wp_customize );
 
 		// The post_date for auto-drafts is bumped to match the changeset post_date whenever it is modified
-		// to keep them from from being garbage collected by wp_delete_auto_drafts().
+		// to keep them from being garbage collected by wp_delete_auto_drafts().
 		$wp_customize->save_changeset_post(
 			array(
 				'data' => $data,

--- a/tests/phpunit/tests/user.php
+++ b/tests/phpunit/tests/user.php
@@ -1726,7 +1726,7 @@ class Tests_User extends WP_UnitTestCase {
 
 		/*
 		 * Check to see if a notification email was sent to the
-		 * post author `blackburn@battlefield3.com` and and site admin `admin@example.org`.
+		 * post author `blackburn@battlefield3.com` and site admin `admin@example.org`.
 		 */
 		$first_recipient = $mailer->get_recipient( 'to' );
 		if ( $first_recipient ) {
@@ -1803,7 +1803,7 @@ class Tests_User extends WP_UnitTestCase {
 
 		/*
 		 * Check to see if a notification email was sent to the
-		 * post author `blackburn@battlefield3.com` and and site admin `admin@example.org`.
+		 * post author `blackburn@battlefield3.com` and site admin `admin@example.org`.
 		 */
 		if ( ! empty( $GLOBALS['phpmailer']->mock_sent ) ) {
 			$was_admin_email_sent = ( isset( $GLOBALS['phpmailer']->mock_sent[0] ) && WP_TESTS_EMAIL === $GLOBALS['phpmailer']->mock_sent[0]['to'][0][0] );
@@ -1828,7 +1828,7 @@ class Tests_User extends WP_UnitTestCase {
 
 		/*
 		 * Check to see if a notification email was sent to the
-		 * post author `blackburn@battlefield3.com` and and site admin `admin@example.org`.
+		 * post author `blackburn@battlefield3.com` and site admin `admin@example.org`.
 		 */
 		if ( ! empty( $GLOBALS['phpmailer']->mock_sent ) ) {
 			$was_admin_email_sent = ( isset( $GLOBALS['phpmailer']->mock_sent[0] ) && WP_TESTS_EMAIL === $GLOBALS['phpmailer']->mock_sent[0]['to'][0][0] );
@@ -1976,7 +1976,7 @@ class Tests_User extends WP_UnitTestCase {
 
 		/*
 		 * Check to see if a notification email was sent to the
-		 * post author `blackburn@battlefield3.com` and and site admin `admin@example.org`.
+		 * post author `blackburn@battlefield3.com` and site admin `admin@example.org`.
 		 */
 		$first_recipient = $mailer->get_recipient( 'to' );
 		if ( $first_recipient ) {


### PR DESCRIPTION
Corrects duplicated words (such as "the the", "in in", "on on", "is is", "from from", "and and") and a misspelling ("Compatability") in WordPress-owned docblocks and inline comments across src/ and the PHPUnit test suite. These are comment-only edits with no functional or behavioral change.

Third-party and bundled libraries (ID3, PHPMailer, SimplePie, plupload, jQuery UI, etc.) are intentionally left untouched, as they are maintained upstream.

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/65384

## Use of AI Tools
AI assistance: Yes
Tool(s): Claude
Used for: Initial searching to find out similar pages and all changes were done and edited by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
