### PR TITLE
Add Preformatted block bindings support

### DIFF
--- a/src/wp-includes/block-bindings.php
+++ b/src/wp-includes/block-bindings.php
@@ -147,6 +147,7 @@ function get_block_bindings_supported_attributes( $block_type ) {
 		'core/post-date'          => array( 'datetime' ),
 		'core/navigation-link'    => array( 'url' ),
 		'core/navigation-submenu' => array( 'url' ),
+		'core/preformatted'       => array( 'content' ),
 	);
 
 	$supported_block_attributes =

--- a/tests/phpunit/tests/block-bindings/render.php
+++ b/tests/phpunit/tests/block-bindings/render.php
@@ -82,7 +82,7 @@ class WP_Block_Bindings_Render extends WP_UnitTestCase {
 
 	public function data_update_block_with_value_from_source() {
 		return array(
-			'paragraph block' => array(
+			'paragraph block'    => array(
 				'content',
 				<<<HTML
 <!-- wp:paragraph -->
@@ -92,7 +92,17 @@ HTML
 				,
 				'<p class="wp-block-paragraph">test source value</p>',
 			),
-			'button block'    => array(
+			'preformatted block' => array(
+				'content',
+				<<<HTML
+<!-- wp:preformatted -->
+<pre class="wp-block-preformatted">This should not appear</pre>
+<!-- /wp:preformatted -->
+HTML
+				,
+				'<pre class="wp-block-preformatted">test source value</pre>',
+			),
+			'button block'       => array(
 				'text',
 				<<<HTML
 <!-- wp:button -->
@@ -102,7 +112,7 @@ HTML
 				,
 				'<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">test source value</a></div>',
 			),
-			'image block'     => array(
+			'image block'        => array(
 				'caption',
 				<<<HTML
 <!-- wp:image {"id":66,"sizeSlug":"large","linkDestination":"none"} -->
@@ -112,7 +122,7 @@ HTML
 			,
 				'<figure class="wp-block-image size-large"><img src="breakfast.jpg" alt="" class="wp-image-1"/><figcaption class="wp-element-caption">test source value</figcaption></figure>',
 			),
-			'test block'      => array(
+			'test block'         => array(
 				'myAttribute',
 				<<<HTML
 <!-- wp:test/block -->
@@ -378,6 +388,50 @@ HTML;
 			$expected_bindings_metadata,
 			$block->attributes['metadata']['bindings'],
 			'The __default binding should be updated with the individual binding attributes in the block metadata.'
+		);
+	}
+
+	/**
+	 * Tests that the Preformatted block supports the default binding for pattern
+	 * overrides.
+	 *
+	 * @covers WP_Block::process_block_bindings
+	 */
+	public function test_default_binding_for_pattern_overrides_preformatted() {
+		$block_content = <<<HTML
+<!-- wp:preformatted {"metadata":{"bindings":{"__default":{"source":"core/pattern-overrides"}},"name":"Test preformatted"}} -->
+<pre class="wp-block-preformatted">This should not appear</pre>
+<!-- /wp:preformatted -->
+HTML;
+
+		$expected_content = 'This is the preformatted content value';
+		$parsed_blocks    = parse_blocks( $block_content );
+		$block            = new WP_Block(
+			$parsed_blocks[0],
+			array(
+				'pattern/overrides' => array(
+					'Test preformatted' => array(
+						'content' => $expected_content,
+					),
+				),
+			)
+		);
+
+		$result = $block->render();
+
+		$this->assertSame(
+			"<pre class=\"wp-block-preformatted\">$expected_content</pre>",
+			trim( $result ),
+			'The `__default` attribute should be replaced with the preformatted content binding.'
+		);
+
+		$expected_bindings_metadata = array(
+			'content' => array( 'source' => 'core/pattern-overrides' ),
+		);
+		$this->assertSame(
+			$expected_bindings_metadata,
+			$block->attributes['metadata']['bindings'],
+			'The __default binding should be updated with the Preformatted content binding.'
 		);
 	}
 


### PR DESCRIPTION
Adds block bindings support for the Preformatted block `content` attribute.

Gutenberg PR: https://github.com/WordPress/gutenberg/pull/78859

This backports the server-side support and PHPUnit coverage for rendering bound Preformatted content and pattern overrides.