### PR TITLE
Add Code block bindings support

### DIFF
--- a/src/wp-includes/block-bindings.php
+++ b/src/wp-includes/block-bindings.php
@@ -142,6 +142,7 @@ function get_block_bindings_supported_attributes( $block_type ) {
 	$block_bindings_supported_attributes = array(
 		'core/paragraph'          => array( 'content' ),
 		'core/heading'            => array( 'content' ),
+		'core/code'               => array( 'content' ),
 		'core/image'              => array( 'id', 'url', 'title', 'alt', 'caption' ),
 		'core/button'             => array( 'url', 'text', 'linkTarget', 'rel' ),
 		'core/post-date'          => array( 'datetime' ),

--- a/tests/phpunit/tests/block-bindings/render.php
+++ b/tests/phpunit/tests/block-bindings/render.php
@@ -92,6 +92,16 @@ HTML
 				,
 				'<p class="wp-block-paragraph">test source value</p>',
 			),
+			'code block'      => array(
+				'content',
+				<<<HTML
+<!-- wp:code -->
+<pre class="wp-block-code"><code>This should not appear</code></pre>
+<!-- /wp:code -->
+HTML
+				,
+				'<pre class="wp-block-code"><code>test source value</code></pre>',
+			),
 			'button block'    => array(
 				'text',
 				<<<HTML
@@ -378,6 +388,53 @@ HTML;
 			$expected_bindings_metadata,
 			$block->attributes['metadata']['bindings'],
 			'The __default binding should be updated with the individual binding attributes in the block metadata.'
+		);
+	}
+
+	/**
+	 * Tests that the Code block supports the default binding for pattern
+	 * overrides.
+	 *
+	 * @ticket 61333
+	 * @ticket 62069
+	 *
+	 * @covers WP_Block::process_block_bindings
+	 */
+	public function test_default_binding_for_pattern_overrides_code() {
+		$block_content = <<<HTML
+<!-- wp:code {"metadata":{"bindings":{"__default":{"source":"core/pattern-overrides"}},"name":"Test code"}} -->
+<pre class="wp-block-code"><code>This should not appear</code></pre>
+<!-- /wp:code -->
+HTML;
+
+		$expected_content = 'This is the code content value';
+		$parsed_blocks    = parse_blocks( $block_content );
+		$block            = new WP_Block(
+			$parsed_blocks[0],
+			array(
+				'pattern/overrides' => array(
+					'Test code' => array(
+						'content' => $expected_content,
+					),
+				),
+			)
+		);
+
+		$result = $block->render();
+
+		$this->assertSame(
+			"<pre class=\"wp-block-code\"><code>$expected_content</code></pre>",
+			trim( $result ),
+			'The `__default` attribute should be replaced with the code content binding.'
+		);
+
+		$expected_bindings_metadata = array(
+			'content' => array( 'source' => 'core/pattern-overrides' ),
+		);
+		$this->assertSame(
+			$expected_bindings_metadata,
+			$block->attributes['metadata']['bindings'],
+			'The __default binding should be updated with the Code content binding.'
 		);
 	}
 


### PR DESCRIPTION
Adds block bindings support for the Code block `content` attribute.

Gutenberg PR: https://github.com/WordPress/gutenberg/pull/78862

This backports the server-side support and PHPUnit coverage for rendering bound Code content and pattern overrides.