### PR TITLE
Docs: Fix @since tags for responsive block nodes additions in WP_Theme_JSON

### DIFF
--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -2861,6 +2861,7 @@ class WP_Theme_JSON {
 	 * @since 6.3.0 Refactored and stabilized selectors API.
 	 * @since 6.6.0 Added optional selectors and options for generating block nodes.
 	 * @since 6.7.0 Added $include_node_paths_only option.
+	 * @since 7.1.0 Added responsive block nodes for breakpoint-based styles.
 	 *
 	 * @param array $theme_json The theme.json converted to an array.
 	 * @param array $selectors  Optional list of selectors per block.
@@ -5238,7 +5239,7 @@ class WP_Theme_JSON {
 	/**
 	 * Extracts the block name from the block metadata path.
 	 *
-	 * @since 7.1
+	 * @since 7.1.0
 	 *
 	 * @param array $block_metadata Block metadata.
 	 * @return string|null The block name or null if not found.


### PR DESCRIPTION
## Summary
  
Fixes two `@since` documentation issues introduced in [5bc40a6] when responsive global styles for blocks were added. 
  
  - `WP_Theme_JSON::get_block_name_from_metadata_path()` had `@since 7.1` (missing patch version).
  WordPress always uses three-part version strings (`major.minor.patch`). Corrected to `@since 7.1.0`.
  - `WP_Theme_JSON::get_block_nodes()` was significantly extended to generate responsive block nodes
  for breakpoint-based styles, but the docblock was not updated with a new `@since 7.1.0` changelog
  entry. Added the missing entry.
  
  No functional changes.

Trac ticket: https://core.trac.wordpress.org/ticket/65390

## Use of AI Tools
N/A

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**