### PR TITLE
Build/Test Tools: Update stale step comment lists in reusable workflow files

### DIFF
--- a/.github/workflows/reusable-coding-standards-php.yml
+++ b/.github/workflows/reusable-coding-standards-php.yml
@@ -29,6 +29,7 @@ jobs:
   # Performs the following steps:
   # - Checks out the repository.
   # - Sets up PHP.
+  # - Gets last Monday's date for use in cache keys.
   # - Configures caching for PHPCS scans.
   # - Installs Composer dependencies.
   # - Make Composer packages available globally.

--- a/.github/workflows/reusable-phpstan-static-analysis-v1.yml
+++ b/.github/workflows/reusable-phpstan-static-analysis-v1.yml
@@ -23,11 +23,14 @@ jobs:
   #
   # Performs the following steps:
   # - Checks out the repository.
+  # - Sets up Node.js.
   # - Sets up PHP.
-  # - Installs Composer dependencies.
   # - Logs debug information.
-  # - Configures caching for PHP static analysis scans.
+  # - Installs Composer dependencies.
   # - Make Composer packages available globally.
+  # - Installs npm dependencies.
+  # - Builds WordPress.
+  # - Configures caching for PHP static analysis scans.
   # - Runs PHPStan static analysis (with Pull Request annotations).
   # - Saves the PHPStan result cache.
   # - Ensures version-controlled files are not modified or deleted.


### PR DESCRIPTION
The step comment lists (the `# - Step description.` comment blocks at the top of workflow jobs) in two reusable workflow files were out of sync with their actual steps. 
  
In `reusable-phpstan-static-analysis-v1.yml`, the comment list was not updated when the workflow was refactored to remove the `Get last Monday's date` step and add `Set up Node.js`, `Install npm dependencies`, and `Build WordPress` steps. Three steps were missing from the comment list and the order of two others was incorrect.
  
In `reusable-coding-standards-php.yml`, the `Get last Monday's date` step is present in the job but was absent from the step comment list.

Trac ticket: https://core.trac.wordpress.org/ticket/65391

## Use of AI Tools
N/A

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
