### PR TITLE
Administration: Keep submenu arrows visible while menus stay open

### DIFF
--- a/src/wp-admin/css/admin-menu.css
+++ b/src/wp-admin/css/admin-menu.css
@@ -362,10 +362,10 @@ ul#adminmenu > li.current > a.current:after {
 }
 
 /* flyout menu arrow */
-#adminmenu li.wp-has-submenu.wp-not-current-submenu:hover:after,
-#adminmenu li.wp-has-submenu.wp-not-current-submenu:focus-within:after {
+#adminmenu li.wp-has-submenu.wp-not-current-submenu.opensub:after {
 	right: 0;
 	border: 8px solid transparent;
+	border-right-color: #2c3338;
 	content: " ";
 	height: 0;
 	width: 0;
@@ -375,16 +375,10 @@ ul#adminmenu > li.current > a.current:after {
 	z-index: 10000;
 }
 
-.folded ul#adminmenu li.wp-has-submenu.wp-not-current-submenu:hover:after,
-.folded ul#adminmenu li.wp-has-submenu.wp-not-current-submenu:focus-within:after {
+.folded ul#adminmenu li.wp-has-submenu.wp-not-current-submenu.opensub:after {
 	border-width: 4px;
 	margin-top: -4px;
 	top: 18px;
-}
-
-#adminmenu li.wp-has-submenu.wp-not-current-submenu.opensub:hover:after,
-#adminmenu li.wp-has-submenu.wp-not-current-submenu:focus-within:after {
-	border-right-color: #2c3338;
 }
 
 #adminmenu li.menu-top:hover .wp-menu-image img,

--- a/src/wp-admin/css/colors/_admin.scss
+++ b/src/wp-admin/css/colors/_admin.scss
@@ -296,8 +296,7 @@ input[type="radio"]:focus {
 	background: variables.$menu-submenu-background;
 }
 
-#adminmenu li.wp-has-submenu.wp-not-current-submenu.opensub:hover:after,
-#adminmenu li.wp-has-submenu.wp-not-current-submenu:focus-within:after {
+#adminmenu li.wp-has-submenu.wp-not-current-submenu.opensub:after {
 	border-right-color: variables.$menu-submenu-background;
 }
 


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/34088

## Summary
- tie the admin flyout arrow to the `opensub` state instead of transient `:hover` / `:focus-within`
- keep the folded-menu arrow aligned with the same open-state selector
- update the shared admin color-scheme Sass source so alternate color schemes use the same arrow behavior

## Testing
- `npx grunt precommit:css`
- `vendor/bin/phpcbf --standard=phpcs.xml.dist <touched css/scss files>`
- `vendor/bin/phpcs --standard=phpcs.xml.dist <touched css/scss files>`
- local browser verification on `http://localhost:8889/wp-admin/` with `admin` / `password`: forced `opensub` state in the `modern` color scheme keeps the arrow visible with matching submenu color even when the menu item itself is not hovered

## Notes
- local Docker verification needed a temporary `LOCAL_DB_VERSION=5.7` override because this checkout's existing MySQL volume is incompatible with the default `8.4` image in `.env` after an older fast shutdown.
