### PR TITLE
Customize: Improve added menu item color contrast

### DIFF
--- a/src/wp-admin/css/customize-nav-menus.css
+++ b/src/wp-admin/css/customize-nav-menus.css
@@ -672,7 +672,7 @@
 #available-menu-items .menu-item-handle.item-added .item-title,
 #available-menu-items .menu-item-handle.item-added:hover .item-add,
 #available-menu-items .menu-item-handle.item-added .item-add:focus {
-	color: #646970;
+	color: #50575e;
 }
 
 #available-menu-items .menu-item-handle.item-added .item-add:before {


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/64013

## Summary
Updates the color used for already-added available menu items in the Customizer from `#646970` to the standard admin secondary text color `#50575e`. This keeps the subdued "already added" state while improving contrast against the white background.

## Contrast
- Reported color `#8c8f94` on white: 3.24:1
- Current color `#646970` on white: 5.53:1
- Updated color `#50575e` on white: 7.33:1

## Testing
- `git diff --check -- src/wp-admin/css/customize-nav-menus.css`
- Verified contrast ratios for `#8c8f94`, `#646970`, and `#50575e` against white.