### PR TITLE
Blocks: Add missing esc_url() to href output in post-author-name and …

### DIFF
--- a/src/wp-includes/blocks/post-author-name.php
+++ b/src/wp-includes/blocks/post-author-name.php
@@ -32,7 +32,7 @@ function render_block_core_post_author_name( $attributes, $content, $block ) {
 
 	$author_name = get_the_author_meta( 'display_name', $author_id );
 	if ( isset( $attributes['isLink'] ) && $attributes['isLink'] ) {
-		$author_name = sprintf( '<a href="%1$s" target="%2$s" class="wp-block-post-author-name__link">%3$s</a>', get_author_posts_url( $author_id ), esc_attr( $attributes['linkTarget'] ), $author_name );
+		$author_name = sprintf( '<a href="%1$s" target="%2$s" class="wp-block-post-author-name__link">%3$s</a>', esc_url( get_author_posts_url( $author_id ) ), esc_attr( $attributes['linkTarget'] ), $author_name );
 	}
 
 	$classes = array();

--- a/src/wp-includes/blocks/post-date.php
+++ b/src/wp-includes/blocks/post-date.php
@@ -84,7 +84,7 @@ function render_block_core_post_date( $attributes, $content, $block ) {
 	$time_tag = sprintf( '<time datetime="%1$s">%2$s</time>', $unformatted_date, $formatted_date );
 
 	if ( isset( $attributes['isLink'] ) && $attributes['isLink'] && isset( $block->context['postId'] ) ) {
-		$time_tag = sprintf( '<a href="%1s">%2s</a>', get_the_permalink( $block->context['postId'] ), $time_tag );
+		$time_tag = sprintf( '<a href="%1$s">%2$s</a>', esc_url( get_the_permalink( $block->context['postId'] ) ), $time_tag );
 	}
 
 	return sprintf( '<div %1$s>%2$s</div>', $wrapper_attributes, $time_tag );


### PR DESCRIPTION
## Summary
- Wraps `get_author_posts_url()` with `esc_url()` in `post-author-name.php` — it was passed directly into the sprintf href placeholder
- Wraps `get_the_permalink()` with `esc_url()` in `post-date.php` — same issue, plus corrects `%1s`/`%2s` to `%1$s`/`%2$s` to match the positional format specifiers used in all sibling block renderers

`post-author.php`, `comment-author-name.php`, and `post-title.php` all wrap their href values with `esc_url()`. These two files were missed.

## Testing
- `php -l src/wp-includes/blocks/post-author-name.php`
- `php -l src/wp-includes/blocks/post-date.php`
- `vendor/bin/phpcs --standard=phpcs.xml.dist src/wp-includes/blocks/post-author-name.php src/wp-includes/blocks/post-date.php`
- Enable the Post Author Name and Post Date blocks on a post; confirm author link and date link render correctly

Trac ticket: https://core.trac.wordpress.org/ticket/65396

(full disclosure, I used AI help with the testing and tweaks - Christopher)
