### PR TITLE
Media: Add $include_default_sizes parameter to has_image_size() for core sizes.

### DIFF
--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -310,13 +310,31 @@ function add_image_size( $name, $width = 0, $height = 0, $crop = false ) {
 /**
  * Checks if an image size exists.
  *
- * @since 3.9.0
+ * By default, `has_image_size()` will return false for core image sizes. For
+ * this function to return true for core image sizes, pass true as the second
+ * parameter.
  *
- * @param string $name The image size to check.
+ * @since 3.9.0
+ * @since 7.1.0 Added the `$include_default_sizes` parameter.
+ *
+ * @param string $name                  The image size to check.
+ * @param bool   $include_default_sizes Optional. Whether to include default
+ *                                      core image sizes. Default false.
  * @return bool True if the image size exists, false if not.
  */
-function has_image_size( $name ) {
+function has_image_size( $name, $include_default_sizes = false ) {
 	$sizes = wp_get_additional_image_sizes();
+
+	if ( $include_default_sizes ) {
+		$default_sizes = array(
+			'thumbnail'    => true,
+			'medium'       => true,
+			'medium_large' => true,
+			'large'        => true,
+		);
+		$sizes = array_merge( $default_sizes, $sizes );
+	}
+
 	return isset( $sizes[ $name ] );
 }
 

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -1229,6 +1229,48 @@ VIDEO;
 	}
 
 	/**
+	 * Tests that has_image_size() returns false for core/default image sizes
+	 * when the second parameter is not passed (or false).
+	 *
+	 * @ticket 43046
+	 *
+	 * @dataProvider data_default_image_size_names
+	 *
+	 * @param string $size_name A core image size name.
+	 */
+	public function test_has_image_size_returns_false_for_default_sizes( $size_name ) {
+		$this->assertFalse( has_image_size( $size_name ) );
+	}
+
+	/**
+	 * Tests that has_image_size() returns true for core/default image sizes
+	 * when true is passed as the second parameter.
+	 *
+	 * @ticket 43046
+	 *
+	 * @dataProvider data_default_image_size_names
+	 *
+	 * @param string $size_name A core image size name.
+	 */
+	public function test_has_image_size_returns_true_for_default_sizes_with_include_default( $size_name ) {
+		$this->assertTrue( has_image_size( $size_name, true ) );
+	}
+
+	/**
+	 * Data provider for core image size names.
+	 *
+	 * @return array[]
+	 */
+	public function data_default_image_size_names() {
+		return array(
+			'thumbnail'    => array( 'thumbnail' ),
+			'medium'       => array( 'medium' ),
+			'medium_large' => array( 'medium_large' ),
+			'large'        => array( 'large' ),
+		);
+	}
+
+	/**
 	 * @ticket 30346
 	 */
 	public function test_attachment_url_to_postid() {


### PR DESCRIPTION
Trac ticket: [#43046](https://core.trac.wordpress.org/ticket/43046)

## Use of AI Tools

AI assistance: Yes
Tool(s): GitHub Copilot
Model(s): Gemini, Claude
Used for: Checking for potential edge cases, drafting the PR description, and assisting with local code review. The final implementation and testing were written and executed manually by me.

---

**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
