### PR TITLE
Docs: Clarify return value of get_page_by_title() for duplicate titles

### DIFF
--- a/src/wp-includes/deprecated.php
+++ b/src/wp-includes/deprecated.php
@@ -4550,9 +4550,8 @@ function _filter_query_attachment_filenames( $clauses ) {
 /**
  * Retrieves a page given its title.
  *
- * If more than one post uses the same title, the post with the smallest ID will be returned.
- * Be careful: in case of more than one post having the same title, it will check the oldest
- * publication date, not the smallest ID.
+ * If more than one post uses the same title, which one is returned is not deterministic,
+ * as the query used to find the post does not specify an order.
  *
  * Because this function uses the MySQL '=' comparison, $page_title will usually be matched
  * as case-insensitive with default collation.


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/53495

The DocBlock for `get_page_by_title()` made two contradictory claims about which post is returned when more than one shares a title:

> If more than one post uses the same title, the post with the smallest ID will be returned.
> Be careful: in case of more than one post having the same title, it will check the oldest publication date, not the smallest ID.

Neither is accurate. The underlying query (`SELECT ID FROM $wpdb->posts WHERE post_title = %s AND post_type = %s`) has no `ORDER BY` clause, so per SQL-92 the order of returned rows is implementation-dependent — there is no guarantee of smallest ID *or* oldest publication date.

This updates the DocBlock to state that the returned post is not deterministic in that case, matching the reporter (@pbiron) analysis on the ticket.

Props pbiron.
Fixes #53495.