### PR TITLE
Docs: Fix contextual help replacement links

### DIFF
--- a/src/wp-admin/includes/class-wp-screen.php
+++ b/src/wp-admin/includes/class-wp-screen.php
@@ -792,8 +792,9 @@ final class WP_Screen {
 		 * Filters the legacy contextual help list.
 		 *
 		 * @since 2.7.0
-		 * @deprecated 3.3.0 Use {@see get_current_screen()->add_help_tab()} or
-		 *                   {@see get_current_screen()->remove_help_tab()} instead.
+		 * @deprecated 3.3.0 Use {@see get_current_screen()} with
+		 *                   {@see WP_Screen::add_help_tab()} or
+		 *                   {@see WP_Screen::remove_help_tab()} instead.
 		 *
 		 * @param array     $old_compat_help Old contextual help.
 		 * @param WP_Screen $screen          Current WP_Screen instance.
@@ -811,8 +812,9 @@ final class WP_Screen {
 		 * Filters the legacy contextual help text.
 		 *
 		 * @since 2.7.0
-		 * @deprecated 3.3.0 Use {@see get_current_screen()->add_help_tab()} or
-		 *                   {@see get_current_screen()->remove_help_tab()} instead.
+		 * @deprecated 3.3.0 Use {@see get_current_screen()} with
+		 *                   {@see WP_Screen::add_help_tab()} or
+		 *                   {@see WP_Screen::remove_help_tab()} instead.
 		 *
 		 * @param string    $old_help  Help text that appears on the screen.
 		 * @param string    $screen_id Screen ID.
@@ -832,8 +834,9 @@ final class WP_Screen {
 			 * Filters the default legacy contextual help text.
 			 *
 			 * @since 2.8.0
-			 * @deprecated 3.3.0 Use {@see get_current_screen()->add_help_tab()} or
-			 *                   {@see get_current_screen()->remove_help_tab()} instead.
+			 * @deprecated 3.3.0 Use {@see get_current_screen()} with
+			 *                   {@see WP_Screen::add_help_tab()} or
+			 *                   {@see WP_Screen::remove_help_tab()} instead.
 			 *
 			 * @param string $old_help_default Default contextual help text.
 			 */


### PR DESCRIPTION
## Summary

Fixes broken DevHub links for deprecated contextual help filters by replacing method-chain `@see` references with resolvable function and method references.

The updated docs now link to:

- `get_current_screen()`
- `WP_Screen::add_help_tab()`
- `WP_Screen::remove_help_tab()`

Trac ticket: https://core.trac.wordpress.org/ticket/65401
Related Documentation Issue Tracker issue: https://github.com/WordPress/Documentation-Issue-Tracker/issues/2290

## Testing

- `git diff --check`
- `php -l src/wp-admin/includes/class-wp-screen.php`