### PR TITLE
Docs: Clarify that meta_query REGEXP values are raw MySQL patterns

### DIFF
--- a/src/wp-includes/class-wp-meta-query.php
+++ b/src/wp-includes/class-wp-meta-query.php
@@ -130,7 +130,9 @@ class WP_Meta_Query {
 	 *         @type string          $type_key    MySQL data type that the meta_key column will be CAST to for
 	 *                                            comparisons. Accepts 'BINARY' for case-sensitive regular expression
 	 *                                            comparisons. Default is ''.
-	 *         @type string|string[] $value       Meta value or values to filter by.
+	 *         @type string|string[] $value       Meta value or values to filter by. When $compare is set to
+	 *                                            'REGEXP', 'NOT REGEXP', or 'RLIKE', the value is used as a raw MySQL regular
+	 *                                            expression and should not be wrapped in delimiters such as '/'.
 	 *         @type string          $compare     MySQL operator used for comparing the $value. Accepts:
 	 *                                            - '='
 	 *                                            - '!='


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/58180

When a `meta_query` clause uses `'compare' => 'REGEXP'` (or `'NOT REGEXP' / 'RLIKE'`), the `value` is passed directly to MySQL's `REGEXP` operator. This is not obvious from the DocBlock, and a common mistake is to wrap the pattern in PCRE-style delimiters (e.g. `/^bar/`), which MySQL treats as literal characters.

This adds a note to the `$value` parameter in the `WP_Meta_Query` DocBlock clarifying that for the REGEXP-family compares the value is used as a raw MySQL regular expression and should not be wrapped in delimiters such as `/`.

Documentation only; no behavioral change.

Props letraceursnork.
Fixes #58180.