### PR TITLE
fix: support multiple slug fragments in Ability names

### DIFF
--- a/src/wp-includes/abilities-api/class-wp-abilities-registry.php
+++ b/src/wp-includes/abilities-api/class-wp-abilities-registry.php
@@ -44,8 +44,8 @@ final class WP_Abilities_Registry {
 	 * @see wp_register_ability()
 	 *
 	 * @param string               $name The name of the ability. The name must be a string containing a namespace
-	 *                                   prefix, i.e. `my-plugin/my-ability`. It can only contain lowercase
-	 *                                   alphanumeric characters, dashes and the forward slash.
+	 *                                   prefix, e.g. `my-plugin/my-ability`. It can only contain lowercase alphanumeric
+	 *                                   characters, dashes and forward slash.
 	 * @param array<string, mixed> $args {
 	 *     An associative array of arguments for the ability.
 	 *
@@ -78,11 +78,11 @@ final class WP_Abilities_Registry {
 	 * @return WP_Ability|null The registered ability instance on success, null on failure.
 	 */
 	public function register( string $name, array $args ): ?WP_Ability {
-		if ( ! preg_match( '/^[a-z0-9-]+\/[a-z0-9-]+$/', $name ) ) {
+		if ( ! preg_match( '/^[a-z0-9-]+(?:\/[a-z0-9-]+)+$/', $name ) ) {
 			_doing_it_wrong(
 				__METHOD__,
 				__(
-					'Ability name must be a string containing a namespace prefix, i.e. "my-plugin/my-ability". It can only contain lowercase alphanumeric characters, dashes and the forward slash.'
+					'Ability name must be a string containing a namespace prefix prefix, e.g. "my-plugin/my-ability". It can only contain lowercase alphanumeric characters, dashes, and forward slashes.'
 				),
 				'6.9.0'
 			);

--- a/tests/phpunit/tests/abilities-api/wpAbilitiesRegistry.php
+++ b/tests/phpunit/tests/abilities-api/wpAbilitiesRegistry.php
@@ -137,6 +137,33 @@ class Tests_Abilities_API_WpAbilitiesRegistry extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Should reject ability name that ends with a slash.
+	 *
+	 * @ticket 64596
+	 *
+	 * @covers WP_Abilities_Registry::register
+	 *
+	 * @expectedIncorrectUsage WP_Abilities_Registry::register
+	 */
+	public function test_register_invalid_name_ends_with_slash() {
+		$result = $this->registry->register( 'test/add-numbers/', self::$test_ability_args );
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * Should allow ability name with multiple slashes for deeper namespaces.
+	 *
+	 * @ticket 64596
+	 *
+	 * @covers WP_Abilities_Registry::register
+	 */
+	public function test_register_valid_name_with_multiple_slashes() {
+		$result = $this->registry->register( 'test/math/add-numbers', self::$test_ability_args );
+		$this->assertInstanceOf( WP_Ability::class, $result );
+		$this->assertSame( 'test/math/add-numbers', $result->get_name() );
+	}
+
+	/**
 	 * Should reject ability registration without a label.
 	 *
 	 * @ticket 64098


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

Trac ticket: https://core.trac.wordpress.org/ticket/64596

This PR fixes `WP_Abilities_Registry::register()` to allow multiple slug fragments e.g. `namespace/semantic-group/sub-group/ability`.

Supersedes https://core.trac.wordpress.org/changeset/61602, follow up to https://github.com/WordPress/wordpress-develop/pull/10929


## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

None

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
