### PR TITLE
Revert cache busting string changes on about section images.

### DIFF
--- a/src/wp-admin/contribute.php
+++ b/src/wp-admin/contribute.php
@@ -25,7 +25,7 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 
 	<div class="about__header">
 		<div class="about__header-image">
-			<img src="<?php echo esc_url( admin_url( 'images/about-release-logo.svg?ver=7.0.1' ) ); ?>" alt="<?php echo esc_attr( $header_alt_text ); ?>" />
+			<img src="<?php echo esc_url( admin_url( 'images/about-release-logo.svg?ver=7.0' ) ); ?>" alt="<?php echo esc_attr( $header_alt_text ); ?>" />
 		</div>
 
 		<div class="about__header-title">

--- a/src/wp-admin/credits.php
+++ b/src/wp-admin/credits.php
@@ -28,7 +28,7 @@ $credits = wp_credits();
 
 	<div class="about__header">
 		<div class="about__header-image">
-			<img src="<?php echo esc_url( admin_url( 'images/about-release-logo.svg?ver=7.0.1' ) ); ?>" alt="<?php echo esc_attr( $header_alt_text ); ?>" />
+			<img src="<?php echo esc_url( admin_url( 'images/about-release-logo.svg?ver=7.0' ) ); ?>" alt="<?php echo esc_attr( $header_alt_text ); ?>" />
 		</div>
 
 		<div class="about__header-title">

--- a/src/wp-admin/freedoms.php
+++ b/src/wp-admin/freedoms.php
@@ -31,7 +31,7 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 
 	<div class="about__header">
 		<div class="about__header-image">
-			<img src="<?php echo esc_url( admin_url( 'images/about-release-logo.svg?ver=7.0.1' ) ); ?>" alt="<?php echo esc_attr( $header_alt_text ); ?>" />
+			<img src="<?php echo esc_url( admin_url( 'images/about-release-logo.svg?ver=7.0' ) ); ?>" alt="<?php echo esc_attr( $header_alt_text ); ?>" />
 		</div>
 
 		<div class="about__header-title">

--- a/src/wp-admin/privacy.php
+++ b/src/wp-admin/privacy.php
@@ -25,7 +25,7 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 
 	<div class="about__header">
 		<div class="about__header-image">
-			<img src="<?php echo esc_url( admin_url( 'images/about-release-logo.svg?ver=7.0.1' ) ); ?>" alt="<?php echo esc_attr( $header_alt_text ); ?>" />
+			<img src="<?php echo esc_url( admin_url( 'images/about-release-logo.svg?ver=7.0' ) ); ?>" alt="<?php echo esc_attr( $header_alt_text ); ?>" />
 		</div>
 
 		<div class="about__header-title">


### PR DESCRIPTION
Follow up to r62423.

This reverts the changes to the cache busting strings in the previous commit as the images are not changed so there's no need break any long term caches while making the URLs more robust.

Trac ticket: Core-65352

## Use of AI Tools

N/A