### PR TITLE
Code Modernization: Use `str_contains()` instead of `strpos()`

### DIFF
--- a/src/wp-includes/class-wp-block-processor.php
+++ b/src/wp-includes/class-wp-block-processor.php
@@ -1799,9 +1799,9 @@ class WP_Block_Processor {
 	 * @return string Fully-qualified block type including namespace.
 	 */
 	public static function normalize_block_type( string $block_type ): string {
-		return false === strpos( $block_type, '/' )
-			? "core/{$block_type}"
-			: $block_type;
+		return str_contains( $block_type, '/' )
+			? $block_type
+			: "core/{$block_type}";
 	}
 
 	/**

--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -4579,7 +4579,7 @@ function get_avatar_data( $id_or_email, $args = null ) {
 			}
 		} elseif ( $id_or_email instanceof WP_Comment ) {
 			$name = $id_or_email->comment_author;
-		} elseif ( is_string( $id_or_email ) && false !== strpos( $id_or_email, '@' ) ) {
+		} elseif ( is_string( $id_or_email ) && str_contains( $id_or_email, '@' ) ) {
 			$name = str_replace( array( '.', '_', '-' ), ' ', substr( $id_or_email, 0, strpos( $id_or_email, '@' ) ) );
 		}
 


### PR DESCRIPTION
`str_contains()` was introduced in PHP 8.0 to perform a case-sensitive check indicating if the string to search in (haystack) contains the given substring (needle).

WordPress core includes a polyfill for `str_contains()` on PHP < 8.0 as of WordPress 5.9.

This PR replaces `false !== strpos( ... )` and `false === strpos( ... )`  with `str_contains()` in core files, making the code more readable and consistent, as well as better aligned with modern development practices.

Introduced in [r60269](https://core.trac.wordpress.org/changeset/60269) and [r60939](https://core.trac.wordpress.org/changeset/60939)

Trac ticket: https://core.trac.wordpress.org/ticket/65408


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
