### PR TITLE
Docs: Update parameter types of `WP_Image_Editor_GD->update_size()`

### DIFF
--- a/src/wp-includes/class-wp-image-editor-gd.php
+++ b/src/wp-includes/class-wp-image-editor-gd.php
@@ -144,8 +144,8 @@ class WP_Image_Editor_GD extends WP_Image_Editor {
 	 *
 	 * @since 3.5.0
 	 *
-	 * @param int $width
-	 * @param int $height
+	 * @param int|false $width
+	 * @param int|false $height
 	 * @return true
 	 */
 	protected function update_size( $width = false, $height = false ) {


### PR DESCRIPTION
This pull request makes a minor improvement to the documentation of the `update_size` method in the `WP_Image_Editor_GD`claaa. The change clarifies that the `$width` and `$height` parameters can accept either an `int` or `false` as their value.

Trac ticket: https://core.trac.wordpress.org/ticket/64897

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
