### PR TITLE
Test using the `windows-2025-vs2026` runner image

### DIFF
--- a/.github/workflows/test-build-processes.yml
+++ b/.github/workflows/test-build-processes.yml
@@ -93,7 +93,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ 'macos-15', 'windows-2025' ]
+        os: [ 'macos-15', 'windows-2025-vs2026' ]
         directory: [ 'src', 'build' ]
     with:
       os: ${{ matrix.os }}


### PR DESCRIPTION
The "windows-latest" and “windows-2025” labels in GitHub Actions will be migrated to use Visual Studio 2026 by default. Customers needing Visual Studio 2022 must migrate to the windows-2022 image. 

See https://github.com/actions/runner-images/issues/14017 for more info.

Trac ticket: Core-64893

## Use of AI Tools

AI Assistance: None

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
