### PR TITLE
Export: Apply author and date filters to custom post types in export_wp()

### DIFF
--- a/src/wp-admin/includes/export.php
+++ b/src/wp-admin/includes/export.php
@@ -38,16 +38,15 @@ define( 'WXR_VERSION', '1.2' );
  *                              type is supplied but `can_export` is disabled, then 'posts' will be exported
  *                              instead. When 'all' is supplied, only post types with `can_export` enabled will
  *                              be exported. Default 'all'.
- *     @type string $author     Author to export content for. Only used when `$content` is 'post', 'page', or
- *                              'attachment'. Accepts false (all) or a specific author ID. Default false (all).
+ *     @type string $author     Author to export content for. Not used when `$content` is 'all'.
+ *                              Accepts false (all) or a specific author ID. Default false (all).
  *     @type string $category   Category (slug) to export content for. Used only when `$content` is 'post'. If
  *                              set, only post content assigned to `$category` will be exported. Accepts false
  *                              or a specific category slug. Default is false (all categories).
- *     @type string $start_date Start date to export content from. Expected date format is 'Y-m-d'. Used only
- *                              when `$content` is 'post', 'page' or 'attachment'. Default false (since the
- *                              beginning of time).
- *     @type string $end_date   End date to export content to. Expected date format is 'Y-m-d'. Used only when
- *                              `$content` is 'post', 'page' or 'attachment'. Default false (latest publish date).
+ *     @type string $start_date Start date to export content from. Expected date format is 'Y-m-d'.
+ *                              Not used when `$content` is 'all'. Default false (since the beginning of time).
+ *     @type string $end_date   End date to export content to. Expected date format is 'Y-m-d'.
+ *                              Not used when `$content` is 'all'. Default false (latest publish date).
  *     @type string $status     Post status to export posts for. Used only when `$content` is 'post' or 'page'.
  *                              Accepts false (all statuses except 'auto-draft'), or a specific status, i.e.
  *                              'publish', 'pending', 'draft', 'auto-draft', 'future', 'private', 'inherit', or
@@ -127,7 +126,7 @@ function export_wp( $args = array() ) {
 		}
 	}
 
-	if ( in_array( $args['content'], array( 'post', 'page', 'attachment' ), true ) ) {
+	if ( 'all' !== $args['content'] ) {
 		if ( $args['author'] ) {
 			$where .= $wpdb->prepare( " AND {$wpdb->posts}.post_author = %d", $args['author'] );
 		}


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->
Previously, the author, start_date, and end_date arguments passed to export_wp() were silently ignored when exporting a custom post type. Only the built-in post types (post, page, attachment) respected these filters due to an in_array() guard that excluded CPTs.

Remove the in_array() restriction and replace it with a simpler 'all' !== $args['content'] check. By this point in the function, any invalid CPT has already fallen back to 'post' and any CPT with can_export disabled has also fallen back to 'post', so all remaining non-'all' values are guaranteed to be valid exportable post types.

Update the docblock for the author, start_date, and end_date params to reflect that these arguments now apply to all post types except when content is 'all'.

Note: the export UI does not yet show author, date, or status filter controls when a CPT is selected — that is a separate follow-up.

Trac ticket: https://core.trac.wordpress.org/ticket/36340

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->
AI assistance: Yes
Tool(s): Claude
Model(s): Opus 4.6
Used for: Initial code skeleton; final implementation was reviewed and edited by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
