### PR TITLE
65422 Tests: Add test for AI support check in WP_AI_Client_Prompt_Builder.

### DIFF
--- a/tests/phpunit/tests/ai-client/wpAiClientPromptBuilder.php
+++ b/tests/phpunit/tests/ai-client/wpAiClientPromptBuilder.php
@@ -2562,6 +2562,23 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that generate_result returns WP_Error when AI is not supported.
+	 *
+	 * @ticket 65422
+	 */
+	public function test_generate_result_returns_wp_error_when_ai_not_supported() {
+		add_filter( 'wp_supports_ai', '__return_false' );
+
+		$builder = new WP_AI_Client_Prompt_Builder( AiClient::defaultRegistry(), 'Test prompt' );
+
+		$result = $builder->generate_result();
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'prompt_prevented', $result->get_error_code() );
+		$this->assertSame( 'AI features are not supported in this environment.', $result->get_error_message() );
+	}
+
+	/**
 	 * Tests that prevent prompt filter receives a clone of the builder instance.
 	 *
 	 * @ticket 64591


### PR DESCRIPTION
Ensure that `generate_result()` returns a `WP_Error` with the `prompt_prevented` code when AI features are not supported in the environment.

Trac ticket: https://core.trac.wordpress.org/ticket/65422

## Use of AI Tools

N / A