### PR TITLE
Add: wp_ability_permission_error_message filter

### DIFF
--- a/src/wp-includes/abilities-api/class-wp-ability.php
+++ b/src/wp-includes/abilities-api/class-wp-ability.php
@@ -727,6 +727,7 @@ class WP_Ability {
 	 * @since 6.9.0
 	 * @since 7.1.0 Added the `wp_ability_invoked` action.
 	 * @since 7.1.0 Added the `wp_pre_execute_ability` filter.
+	 * @since 7.1.0 Added the `wp_ability_permission_error_message` filter.
 	 *
 	 * @param mixed $input Optional. The input data for the ability. Default `null`.
 	 * @return mixed|WP_Error The result of the ability execution, or WP_Error on failure.
@@ -787,6 +788,12 @@ class WP_Ability {
 
 		$has_permissions = $this->check_permissions( $input );
 		if ( true !== $has_permissions ) {
+			$permission_error_message = sprintf(
+				/* translators: %s ability name. */
+				__( 'Ability "%s" does not have necessary permission.' ),
+				$this->name
+			);
+
 			if ( is_wp_error( $has_permissions ) ) {
 				// Don't leak the permission check error to someone without the correct perms.
 				_doing_it_wrong(
@@ -794,12 +801,31 @@ class WP_Ability {
 					esc_html( $has_permissions->get_error_message() ),
 					'6.9.0'
 				);
+
+				/**
+				 * Filters the message returned when an ability permission check fails.
+				 *
+				 * @since 7.1.0
+				 *
+				 * @param string     $permission_error_message The generic permission error message.
+				 * @param WP_Error   $has_permissions          The failed permission result.
+				 * @param string     $ability_name             The name of the ability.
+				 * @param mixed      $input                    The input data for the ability.
+				 * @param WP_Ability $ability                  The ability instance.
+				 */
+				$permission_error_message = apply_filters(
+					'wp_ability_permission_error_message',
+					$permission_error_message,
+					$has_permissions,
+					$this->name,
+					$input,
+					$this
+				);
 			}
 
 			return new WP_Error(
 				'ability_invalid_permissions',
-				/* translators: %s ability name. */
-				sprintf( __( 'Ability "%s" does not have necessary permission.' ), $this->name )
+				$permission_error_message
 			);
 		}
 

--- a/tests/phpunit/tests/abilities-api/wpAbility.php
+++ b/tests/phpunit/tests/abilities-api/wpAbility.php
@@ -1082,6 +1082,46 @@ class Tests_Abilities_API_WpAbility extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that the wp_ability_permission_error_message filter can replace the permission error message.
+	 *
+	 * @ticket 64989
+	 */
+	public function test_permission_error_message_filter_can_replace_permission_error_message() {
+		$this->setExpectedIncorrectUsage( 'WP_Ability::execute' );
+
+		$args = array_merge(
+			self::$test_ability_properties,
+			array(
+				'execute_callback'    => static function (): int {
+					return 1;
+				},
+				'permission_callback' => static function (): WP_Error {
+					return new WP_Error( 'callback_denied', 'Denied by callback.' );
+				},
+			)
+		);
+
+		$filter = static function ( $message, $permission_result, $ability_name ) {
+			if ( is_wp_error( $permission_result ) && self::$test_ability_name === $ability_name ) {
+				return 'Custom permission denied.';
+			}
+
+			return $message;
+		};
+
+		add_filter( 'wp_ability_permission_error_message', $filter, 10, 5 );
+
+		$ability = new WP_Ability( self::$test_ability_name, $args );
+		$result  = $ability->execute();
+
+		remove_filter( 'wp_ability_permission_error_message', $filter, 10 );
+
+		$this->assertInstanceOf( WP_Error::class, $result, 'Denied permission should produce a WP_Error.' );
+		$this->assertSame( 'ability_invalid_permissions', $result->get_error_code() );
+		$this->assertSame( 'Custom permission denied.', $result->get_error_message() );
+	}
+
+	/**
 	 * Tests that the wp_ability_permission_result filter can convert a WP_Error denial from the
 	 * callback into a grant, proving the filter receives the WP_Error verbatim.
 	 *


### PR DESCRIPTION
It would be nice to be able to customize the error message. Especially given that the permissions issue is dependent on 2FA.

Trac ticket: https://core.trac.wordpress.org/ticket/65427

## Use of AI Tools

AI assistance: Yes
Tool(s): Codex
Model(s): 5.5
Used for: code and tests

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
