### PR TITLE
Media: Align the Scale button with the dimension inputs in image editor.

### DIFF
--- a/src/wp-admin/css/media.css
+++ b/src/wp-admin/css/media.css
@@ -1270,6 +1270,11 @@ span.imgedit-scale-warn {
 
 .image-editor .imgedit-scale-controls .button {
 	margin-bottom: 0;
+	/* Match the height of the adjacent dimension inputs so the controls align. */
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	min-height: 40px;
 }
 
 audio, video {


### PR DESCRIPTION
## Summary
  
  - On the Edit Image screen (media modal), the **Scale** button rendered 8px shorter than the adjacent width/height inputs and sat top-aligned, leaving a visible gap below it. See the "WP 7" vs "6.9" screenshots on the ticket.
  - Root cause: the 7.0 design-system reskin ([61645] / #64547) raised form inputs to a 40px min-height, while `.media-modal-content .button` applies a compact **32px** min-height to buttons in the modal. The Scale control row was missed, so its inputs are 40px but its button stayed 32px.
  - Fix: give the Scale button a 40px min-height within `.imgedit-scale-controls` and center its label with flexbox, so all three controls match in height and align. The inputs are kept at the accessible 40px target size rather than shrunk to 32px.

  ## Why this approach
  
  - Reverting the originating commit isn't viable — it's the full reskin touching many files; this is a targeted fix for the one missed control group.
  - Bumping the button to 40px (vs. shrinking inputs to 32px) keeps the larger, accessible target size, consistent with the rest of the reskin and matching the pre-7.0 (6.9) appearance where the controls were equal height.
  - Flexbox centering avoids hard-coded `line-height` magic numbers and follows the same "convert to flexbox" direction as the reskin.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/65428

## Use of AI Tools

N/A
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
