### PR TITLE
Block Supports: Prevent Additional CSS duplication inside Query Loop

### DIFF
--- a/src/wp-includes/block-supports/custom-css.php
+++ b/src/wp-includes/block-supports/custom-css.php
@@ -49,6 +49,15 @@ function wp_render_custom_css_support_styles( $parsed_block ) {
 		 * The style depends on global-styles to ensure custom CSS loads after
 		 * and can override global styles.
 		 */
+		static $enqueued_class_names = array();
+
+		// Skip if already enqueued — prevents duplication inside Query Loop.
+		if ( isset( $enqueued_class_names[ $class_name ] ) ) {
+			return $parsed_block;
+		}
+
+		$enqueued_class_names[ $class_name ] = true;
+
 		wp_register_style( 'wp-block-custom-css', false, array( 'global-styles' ) );
 		wp_add_inline_style( 'wp-block-custom-css', $processed_css );
 	}

--- a/src/wp-includes/block-supports/custom-css.php
+++ b/src/wp-includes/block-supports/custom-css.php
@@ -49,16 +49,19 @@ function wp_render_custom_css_support_styles( $parsed_block ) {
 		 * The style depends on global-styles to ensure custom CSS loads after
 		 * and can override global styles.
 		 */
-		static $enqueued_class_names = array();
+		wp_register_style( 'wp-block-custom-css', false, array( 'global-styles' ) );
 
 		// Skip if already enqueued — prevents duplication inside Query Loop.
-		if ( isset( $enqueued_class_names[ $class_name ] ) ) {
-			return $parsed_block;
+		global $wp_styles;
+		$existing_inline_styles = $wp_styles->get_data( 'wp-block-custom-css', 'after' );
+		if ( is_array( $existing_inline_styles ) ) {
+			foreach ( $existing_inline_styles as $style ) {
+				if ( str_contains( $style, $selector ) ) {
+					return $parsed_block;
+				}
+			}
 		}
 
-		$enqueued_class_names[ $class_name ] = true;
-
-		wp_register_style( 'wp-block-custom-css', false, array( 'global-styles' ) );
 		wp_add_inline_style( 'wp-block-custom-css', $processed_css );
 	}
 

--- a/tests/phpunit/tests/block-supports/wpRenderCustomCssSupportStyles.php
+++ b/tests/phpunit/tests/block-supports/wpRenderCustomCssSupportStyles.php
@@ -264,4 +264,51 @@ class Tests_Block_Supports_WpRenderCustomCssSupportStyles extends WP_UnitTestCas
 			),
 		);
 	}
+
+	/**
+	 * Tests that CSS is not duplicated when the same block renders multiple times (e.g. inside a Query Loop).
+	 *
+	 * @ticket 65268
+	 *
+	 * @covers ::wp_render_custom_css_support_styles
+	 */
+	public function test_css_not_duplicated_inside_query_loop() {
+		$this->test_block_name = 'test/custom-css-query-loop';
+		register_block_type(
+			$this->test_block_name,
+			array(
+				'api_version' => 3,
+				'attributes'  => array(
+					'style' => array(
+						'type' => 'object',
+					),
+				),
+				'supports'    => array( 'customCSS' => true ),
+			)
+		);
+
+		$parsed_block = array(
+			'blockName' => 'test/custom-css-query-loop',
+			'attrs'     => array(
+				'style' => array(
+					'css' => 'color: fuchsia;',
+				),
+			),
+		);
+
+		// Simulate the same block rendering 3 times inside a Query Loop.
+		wp_render_custom_css_support_styles( $parsed_block );
+		wp_render_custom_css_support_styles( $parsed_block );
+		wp_render_custom_css_support_styles( $parsed_block );
+
+		// Get the inline styles registered for wp-block-custom-css.
+		global $wp_styles;
+		$inline_css = $wp_styles->get_data( 'wp-block-custom-css', 'after' );
+
+		// CSS should appear only once, not 3 times.
+		$this->assertIsArray( $inline_css, 'Inline styles should be registered.' );
+		$combined = implode( '', $inline_css );
+		$count    = substr_count( $combined, 'color: fuchsia' );
+		$this->assertSame( 1, $count, 'CSS should only be enqueued once even when block renders multiple times.' );
+	}
 }


### PR DESCRIPTION
When a block inside a Query Loop has Additional CSS, wp_add_inline_style was called once per post in the loop, duplicating the same CSS N times. This was because wp_unique_id_from_values produces the same hash for the same block data on every loop iteration.

This fix adds a static $enqueued_class_names array to track already-enqueued class names so subsequent loop iterations skip the redundant wp_add_inline_style call.

Props mustafabharmal, westonruter.
Fixes #65268.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
