### PR TITLE
Interactivity API: Remove unused local variable `$all_class_directives`.

### DIFF
--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -1086,8 +1086,7 @@ final class WP_Interactivity_API {
 	 */
 	private function data_wp_class_processor( WP_Interactivity_API_Directives_Processor $p, string $mode ) {
 		if ( 'enter' === $mode ) {
-			$all_class_directives = $p->get_attribute_names_with_prefix( 'data-wp-class--' );
-			$entries              = $this->get_directive_entries( $p, 'class' );
+			$entries = $this->get_directive_entries( $p, 'class' );
 			foreach ( $entries as $entry ) {
 				if ( empty( $entry['suffix'] ) ) {
 					continue;


### PR DESCRIPTION
This PR removes a unused local variable `$all_class_directives` from the `data_wp_class_processor()` function.

Follow-up to [r58327](https://core.trac.wordpress.org/changeset/61020/trunk/src/wp-includes/interactivity-api/class-wp-interactivity-api.php).

Trac ticket: https://core.trac.wordpress.org/ticket/64897

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
