### PR TITLE
Twenty Nineteen: Replace whitespace character for heading decoration.

### DIFF
--- a/src/wp-content/themes/twentynineteen/sass/mixins/_mixins-master.scss
+++ b/src/wp-content/themes/twentynineteen/sass/mixins/_mixins-master.scss
@@ -68,7 +68,7 @@
 
 	&:before {
 		background: $color__text-light;
-		content: "\020";
+		content: "";
 		display: block;
 		height: 2px;
 		margin: $size__spacing-unit 0;

--- a/src/wp-content/themes/twentynineteen/style-editor.css
+++ b/src/wp-content/themes/twentynineteen/style-editor.css
@@ -706,7 +706,7 @@ h2 {
 h1:before,
 h2:before {
   background: #767676;
-  content: "\020";
+  content: "";
   display: block;
   height: 2px;
   margin: 1rem 0;
@@ -828,7 +828,7 @@ figcaption,
 
 .editor-post-title__block:before {
   background: #767676;
-  content: "\020";
+  content: "";
   display: block;
   height: 2px;
   margin: 1rem 0;

--- a/src/wp-content/themes/twentynineteen/style-rtl.css
+++ b/src/wp-content/themes/twentynineteen/style-rtl.css
@@ -2526,7 +2526,7 @@ h6 {
 h1:not(.site-title):before,
 h2:before {
   background: #767676;
-  content: "\020";
+  content: "";
   display: block;
   height: 2px;
   margin: 1rem 0;
@@ -4219,7 +4219,7 @@ body.page .main-navigation {
 
 .entry .entry-title:before {
   background: #767676;
-  content: "\020";
+  content: "";
   display: block;
   height: 2px;
   margin: 1rem 0;
@@ -4513,7 +4513,7 @@ body.page .main-navigation {
 
 .author-bio .author-title:before {
   background: #767676;
-  content: "\020";
+  content: "";
   display: block;
   height: 2px;
   margin: 1rem 0;
@@ -4616,7 +4616,7 @@ body.page .main-navigation {
 
 .comments-area .comments-title-wrap .comments-title:before {
   background: #767676;
-  content: "\020";
+  content: "";
   display: block;
   height: 2px;
   margin: 1rem 0;

--- a/src/wp-content/themes/twentynineteen/style.css
+++ b/src/wp-content/themes/twentynineteen/style.css
@@ -2526,7 +2526,7 @@ h6 {
 h1:not(.site-title):before,
 h2:before {
   background: #767676;
-  content: "\020";
+  content: "";
   display: block;
   height: 2px;
   margin: 1rem 0;
@@ -4225,7 +4225,7 @@ body.page .main-navigation {
 
 .entry .entry-title:before {
   background: #767676;
-  content: "\020";
+  content: "";
   display: block;
   height: 2px;
   margin: 1rem 0;
@@ -4519,7 +4519,7 @@ body.page .main-navigation {
 
 .author-bio .author-title:before {
   background: #767676;
-  content: "\020";
+  content: "";
   display: block;
   height: 2px;
   margin: 1rem 0;
@@ -4622,7 +4622,7 @@ body.page .main-navigation {
 
 .comments-area .comments-title-wrap .comments-title:before {
   background: #767676;
-  content: "\020";
+  content: "";
   display: block;
   height: 2px;
   margin: 1rem 0;


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65433

When a user inserts an empty heading block in the editor and applies an "Underline" or "Strikethrough" text decoration, the browser attempts to underline the pseudo-element's whitespace character. This interaction causes a stray, visible hyphen-like artifact to render inside the editor above the empty block as

<img width="1284" height="704" alt="Heading decorated with underline" src="https://github.com/user-attachments/assets/b6b7069d-c88e-4659-a48f-f00463ec1cb0" />

---

<img width="1283" height="700" alt="Heading decorated with strikethrough" src="https://github.com/user-attachments/assets/ce322734-4753-42c3-85c7-5e9449dfe48d" />

## What this Changes

- This PR updates the `post-section-dash` mixin in `sass/mixins/_mixins-master.scss` to use an empty string (`content: "";`) instead of `content: "\020"`. 
- By removing the whitespace character, the pseudo-element no longer contains an actual text node. 
- Since the element has explicit `display: block`, `width`, and `height` properties, the decorative dash continues to render identically on the frontend and backend. 
- However, because there is no text content, the browser can no longer underline a whitespace character, completely resolving the visual bug in the editor without requiring any editor-specific CSS overrides.

<img width="1279" height="679" alt="Decorated Heading blocks after fix" src="https://github.com/user-attachments/assets/1862b061-d8a9-47a9-a331-14a0b64b3714" />


## Use of AI Tools

AI assistance: Yes
Tool(s): GitHub Copilot
Model(s): GPT-4o
Used for: To verify optimality and efficiency of the patch.

---