### PR TITLE
Coding Standards: Use strict null comparison instead of is_null()

### DIFF
--- a/src/wp-admin/install.php
+++ b/src/wp-admin/install.php
@@ -102,7 +102,7 @@ function display_setup_form( $error = null ) {
 	$user_name    = isset( $_POST['user_name'] ) ? trim( wp_unslash( $_POST['user_name'] ) ) : '';
 	$admin_email  = isset( $_POST['admin_email'] ) ? trim( wp_unslash( $_POST['admin_email'] ) ) : '';
 
-	if ( ! is_null( $error ) ) {
+	if ( null !== $error ) {
 		?>
 <h1><?php _ex( 'Welcome', 'Howdy' ); ?></h1>
 <p class="message"><?php echo $error; ?></p>

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1688,7 +1688,7 @@ function strip_core_block_namespace( $block_name = null ) {
  * @return string Comment-delimited block content.
  */
 function get_comment_delimited_block_content( $block_name, $block_attributes, $block_content ) {
-	if ( is_null( $block_name ) ) {
+	if ( null === $block_name ) {
 		return $block_content;
 	}
 
@@ -2358,7 +2358,7 @@ function render_block( $parsed_block ) {
 	 * @param WP_Block|null $parent_block If this is a nested block, a reference to the parent block.
 	 */
 	$pre_render = apply_filters( 'pre_render_block', null, $parsed_block, $parent_block );
-	if ( ! is_null( $pre_render ) ) {
+	if ( null !== $pre_render ) {
 		return $pre_render;
 	}
 

--- a/src/wp-includes/blocks/icon.php
+++ b/src/wp-includes/blocks/icon.php
@@ -24,7 +24,7 @@ function render_block_core_icon( $attributes ) {
 	$registry = WP_Icons_Registry::get_instance();
 	$icon     = $registry->get_registered_icon( $attributes['icon'] );
 
-	if ( is_null( $icon ) ) {
+	if ( null === $icon ) {
 		return;
 	}
 

--- a/src/wp-includes/blocks/navigation-link.php
+++ b/src/wp-includes/blocks/navigation-link.php
@@ -48,10 +48,10 @@ function block_core_navigation_link_build_css_colors( $context, $attributes, $is
 	}
 
 	// If has text color.
-	if ( ! is_null( $named_text_color ) ) {
+	if ( null !== $named_text_color ) {
 		// Add the color class.
 		array_push( $colors['css_classes'], 'has-text-color', sprintf( 'has-%s-color', $named_text_color ) );
-	} elseif ( ! is_null( $custom_text_color ) ) {
+	} elseif ( null !== $custom_text_color ) {
 		// Add the custom color inline style.
 		$colors['css_classes'][]  = 'has-text-color';
 		$colors['inline_styles'] .= sprintf( 'color: %s;', $custom_text_color );
@@ -74,10 +74,10 @@ function block_core_navigation_link_build_css_colors( $context, $attributes, $is
 	}
 
 	// If has background color.
-	if ( ! is_null( $named_background_color ) ) {
+	if ( null !== $named_background_color ) {
 		// Add the background-color class.
 		array_push( $colors['css_classes'], 'has-background', sprintf( 'has-%s-background-color', $named_background_color ) );
-	} elseif ( ! is_null( $custom_background_color ) ) {
+	} elseif ( null !== $custom_background_color ) {
 		// Add the custom background-color inline style.
 		$colors['css_classes'][]  = 'has-background';
 		$colors['inline_styles'] .= sprintf( 'background-color: %s;', $custom_background_color );

--- a/src/wp-includes/blocks/template-part.php
+++ b/src/wp-includes/blocks/template-part.php
@@ -115,7 +115,7 @@ function render_block_core_template_part( $attributes ) {
 	// is set in `wp_debug_mode()`.
 	$is_debug = WP_DEBUG && WP_DEBUG_DISPLAY;
 
-	if ( is_null( $content ) ) {
+	if ( null === $content ) {
 		if ( $is_debug && isset( $attributes['slug'] ) ) {
 			return sprintf(
 				/* translators: %s: Template part slug. */

--- a/src/wp-includes/class-wp-http-cookie.php
+++ b/src/wp-includes/class-wp-http-cookie.php
@@ -179,7 +179,7 @@ class WP_Http_Cookie {
 	 * @return bool true if allowed, false otherwise.
 	 */
 	public function test( $url ) {
-		if ( is_null( $this->name ) ) {
+		if ( null === $this->name ) {
 			return false;
 		}
 

--- a/src/wp-includes/class-wp-http-proxy.php
+++ b/src/wp-includes/class-wp-http-proxy.php
@@ -192,7 +192,7 @@ class WP_HTTP_Proxy {
 		 * @param array     $home     Associative array result of parsing the site URL with `parse_url()`.
 		 */
 		$result = apply_filters( 'pre_http_send_through_proxy', null, $uri, $check, $home );
-		if ( ! is_null( $result ) ) {
+		if ( null !== $result ) {
 			return $result;
 		}
 

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -5581,7 +5581,7 @@ function normalize_whitespace( $str ) {
  * @return string The processed string.
  */
 function wp_strip_all_tags( $text, $remove_breaks = false ) {
-	if ( is_null( $text ) ) {
+	if ( null === $text ) {
 		return '';
 	}
 

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -4491,7 +4491,7 @@ function _wp_json_sanity_check( $value, $depth ) {
  */
 function _wp_json_convert_string( $input_string ) {
 	static $use_mb = null;
-	if ( is_null( $use_mb ) ) {
+	if ( null === $use_mb ) {
 		$use_mb = function_exists( 'mb_convert_encoding' );
 	}
 
@@ -5184,7 +5184,7 @@ function _wp_array_set( &$input_array, $path, $value = null ) {
 	foreach ( $path as $path_element ) {
 		if (
 			! is_string( $path_element ) && ! is_int( $path_element ) &&
-			! is_null( $path_element )
+			null !== $path_element
 		) {
 			return;
 		}
@@ -6331,7 +6331,7 @@ function validate_file( $file, $allowed_files = array() ) {
 function force_ssl_admin( $force = null ) {
 	static $forced = false;
 
-	if ( ! is_null( $force ) ) {
+	if ( null !== $force ) {
 		$old_forced = $forced;
 		$forced     = (bool) $force;
 		return $old_forced;
@@ -7122,7 +7122,7 @@ function _wp_mysql_week( $column ) {
  * @return array IDs of all members of loop.
  */
 function wp_find_hierarchy_loop( $callback, $start, $start_parent, $callback_args = array() ) {
-	$override = is_null( $start_parent ) ? array() : array( $start => $start_parent );
+	$override = null === $start_parent ? array() : array( $start => $start_parent );
 
 	$arbitrary_loop_member = wp_find_hierarchy_loop_tortoise_hare( $callback, $start, $override, $callback_args );
 	if ( ! $arbitrary_loop_member ) {
@@ -7284,7 +7284,7 @@ function wp_debug_backtrace_summary( $ignore_class = null, $skip_frames = 0, $pr
 
 	$trace       = debug_backtrace( false );
 	$caller      = array();
-	$check_class = ! is_null( $ignore_class );
+	$check_class = null !== $ignore_class;
 	++$skip_frames; // Skip this function.
 
 	if ( ! isset( $truncate_paths ) ) {
@@ -7692,7 +7692,7 @@ function mbstring_binary_safe_encoding( $reset = false ) {
 	static $encodings  = array();
 	static $overloaded = null;
 
-	if ( is_null( $overloaded ) ) {
+	if ( null === $overloaded ) {
 		if ( function_exists( 'mb_internal_encoding' )
 			&& ( (int) ini_get( 'mbstring.func_overload' ) & 2 ) // phpcs:ignore PHPCompatibility.IniDirectives.RemovedIniDirectives.mbstring_func_overloadDeprecated
 		) {

--- a/src/wp-includes/http.php
+++ b/src/wp-includes/http.php
@@ -20,7 +20,7 @@
 function _wp_http_get_object() {
 	static $http = null;
 
-	if ( is_null( $http ) ) {
+	if ( null === $http ) {
 		$http = new WP_Http();
 	}
 	return $http;

--- a/src/wp-includes/load.php
+++ b/src/wp-includes/load.php
@@ -1634,11 +1634,11 @@ function wp_installing( $is_installing = null ) {
 	static $installing = null;
 
 	// Support for the `WP_INSTALLING` constant, defined before WP is loaded.
-	if ( is_null( $installing ) ) {
+	if ( null === $installing ) {
 		$installing = defined( 'WP_INSTALLING' ) && WP_INSTALLING;
 	}
 
-	if ( ! is_null( $is_installing ) ) {
+	if ( null !== $is_installing ) {
 		$old_installing = $installing;
 		$installing     = $is_installing;
 

--- a/src/wp-includes/ms-functions.php
+++ b/src/wp-includes/ms-functions.php
@@ -2428,7 +2428,7 @@ Thanks!
 function force_ssl_content( $force = null ) {
 	static $forced_content = false;
 
-	if ( ! is_null( $force ) ) {
+	if ( null !== $force ) {
 		$old_forced     = $forced_content;
 		$forced_content = (bool) $force;
 		return $old_forced;

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -4553,7 +4553,7 @@ function wp_insert_post( $postarr, $wp_error = false, $fire_after_hooks = true )
 		$post_id     = $postarr['ID'];
 		$post_before = get_post( $post_id );
 
-		if ( is_null( $post_before ) ) {
+		if ( null === $post_before ) {
 			if ( $wp_error ) {
 				return new WP_Error( 'invalid_post', __( 'Invalid post ID.' ) );
 			}
@@ -5240,7 +5240,7 @@ function wp_update_post( $postarr = array(), $wp_error = false, $fire_after_hook
 	// First, get all of the original fields.
 	$post = get_post( $postarr['ID'], ARRAY_A );
 
-	if ( is_null( $post ) ) {
+	if ( null === $post ) {
 		if ( $wp_error ) {
 			return new WP_Error( 'invalid_post', __( 'Invalid post ID.' ) );
 		}

--- a/src/wp-includes/revision.php
+++ b/src/wp-includes/revision.php
@@ -26,7 +26,7 @@ function _wp_post_revision_fields( $post = array(), $deprecated = false ) {
 		$post = get_post( $post, ARRAY_A );
 	}
 
-	if ( is_null( $fields ) ) {
+	if ( null === $fields ) {
 		// Allow these to be versioned.
 		$fields = array(
 			'post_title'   => __( 'Title' ),


### PR DESCRIPTION
## Summary

Replace `is_null( $var )` with `null === $var` and `! is_null( $var )` with `null !== $var` across multiple core files.

WordPress Coding Standards prefer strict comparison operators over function calls for type checking. Using `null === $var` is functionally equivalent to `is_null( $var )` but:
- Aligns with the Yoda condition style used throughout WordPress core
- Is consistent with how other type checks are written (e.g. `false === $var`)
- Avoids the function call overhead (minor performance benefit)

## Files changed (14 files, 25 replacements)

- `src/wp-includes/functions.php` — 6 instances
- `src/wp-includes/blocks/navigation-link.php` — 4 instances
- `src/wp-includes/blocks.php` — 2 instances
- `src/wp-includes/post.php` — 2 instances
- `src/wp-includes/load.php` — 2 instances
- `src/wp-includes/blocks/icon.php` — 1 instance
- `src/wp-includes/blocks/template-part.php` — 1 instance
- `src/wp-includes/formatting.php` — 1 instance
- `src/wp-includes/http.php` — 1 instance
- `src/wp-includes/revision.php` — 1 instance
- `src/wp-includes/class-wp-http-cookie.php` — 1 instance
- `src/wp-includes/class-wp-http-proxy.php` — 1 instance
- `src/wp-includes/ms-functions.php` — 1 instance
- `src/wp-admin/install.php` — 1 instance

Third-party libraries and files with polyfill availability concerns were intentionally excluded.

## Test plan

- [x] Full PHPUnit test suite passes (29,457 tests, 0 failures)
- [x] PHPCS passes with no new violations
- [ ] Manual verification: All null checks behave identically (strict comparison is functionally equivalent to `is_null()`)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**