### PR TITLE
Media: Make the image editor help toggle icon color admin scheme-aware

### DIFF
--- a/src/wp-admin/css/media.css
+++ b/src/wp-admin/css/media.css
@@ -1187,7 +1187,7 @@ border color while dragging a file over the uploader drop area */
 	margin: -1px 0 0 -1px;
 	padding: 0;
 	background: transparent;
-	color: #2271b1;
+	color: var(--wp-admin-theme-color);
 	font-size: 20px;
 	line-height: 1;
 	cursor: pointer;
@@ -1196,9 +1196,9 @@ border color while dragging a file over the uploader drop area */
 }
 
 .image-editor .imgedit-settings .imgedit-help-toggle:focus {
-	color: #2271b1;
-	border-color: #2271b1;
-	box-shadow: 0 0 0 1px #2271b1;
+	color: var(--wp-admin-theme-color);
+	border-color: var(--wp-admin-theme-color);
+	box-shadow: 0 0 0 1px var(--wp-admin-theme-color);
 	/* Only visible in Windows High Contrast mode */
 	outline: 2px solid transparent;
 }


### PR DESCRIPTION
The help icon color in the image editor was hardcoded with classic colors. By replacing this with a CSS variable, it will default to modern colors. Furthermore, the color will appropriately change according to the user's color scheme.

Trac ticket: https://core.trac.wordpress.org/ticket/64937

## Screenshots

Note that the button is intentionally focused to visually display the focus outline.

| Header | Header |
|--------|--------|
| Default  | <img width="266" height="142" alt="image" src="https://github.com/user-attachments/assets/051d9c86-7baa-4d40-83d6-6785023df2c7" /> |
| Fresh | <img width="279" height="148" alt="image" src="https://github.com/user-attachments/assets/f3452ad9-fdd7-4094-af93-f4752d0b32b7" /> |
| Light | <img width="270" height="149" alt="image" src="https://github.com/user-attachments/assets/b37ac677-3dff-4026-b898-bc5194dbf7d2" /> |
| Blue | <img width="279" height="144" alt="image" src="https://github.com/user-attachments/assets/d4846842-6e84-4967-a8ae-8f220410ead1" /> |
| Coffee | <img width="266" height="144" alt="image" src="https://github.com/user-attachments/assets/0876e4ee-a010-4d72-9e22-372278210a34" /> |
| Ectoplasm | <img width="266" height="148" alt="image" src="https://github.com/user-attachments/assets/acab1bc6-dad7-4d4e-b64b-8f01e63172eb" /> |
| Midnight | <img width="265" height="142" alt="image" src="https://github.com/user-attachments/assets/cc0d080b-881a-48f9-839d-0b7249a6eb59" /> |
| Ocean | <img width="270" height="141" alt="image" src="https://github.com/user-attachments/assets/098d84be-bc23-4b5c-a17f-e39c5837b12c" /> |
| Sunlinse | <img width="273" height="143" alt="image" src="https://github.com/user-attachments/assets/ef99355f-7e19-43a3-9ff5-df855ed227c2" />|

## Use of AI Tools

N/A