### PR TITLE
Formatting: Prevent PHP 8.1 deprecation when passing null to esc_url()

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -4538,8 +4538,8 @@ function esc_sql( $data ) {
 function esc_url( $url, $protocols = null, $_context = 'display' ) {
 	$original_url = $url;
 
-	if ( '' === $url ) {
-		return $url;
+	if ( '' === $url || null === $url ) {
+		return '';
 	}
 
 	$url = str_replace( ' ', '%20', ltrim( $url ) );

--- a/tests/phpunit/tests/formatting/escUrl.php
+++ b/tests/phpunit/tests/formatting/escUrl.php
@@ -311,4 +311,26 @@ EOT;
 		$this->assertSame( '//[::FFFF::127.0.0.1]/?foo%5Bbar%5D=baz', esc_url( '//[::FFFF::127.0.0.1]/?foo[bar]=baz' ) );
 		$this->assertSame( 'http://[::FFFF::127.0.0.1]/?foo%5Bbar%5D=baz', esc_url( 'http://[::FFFF::127.0.0.1]/?foo[bar]=baz' ) );
 	}
+
+	/**
+	 * Test that esc_url() handles null input without triggering
+	 * a PHP 8.1 "passing null to non-nullable" deprecation.
+	 *
+	 * @ticket 65432
+	 */
+	public function test_null_input_returns_empty_string() {
+		$this->assertSame( '', esc_url( null ) );
+	}
+
+	/**
+	 * Test that sanitize_url() handles null input without triggering
+	 * a PHP 8.1 "passing null to non-nullable" deprecation.
+	 *
+	 * @ticket 65432
+	 *
+	 * @covers ::sanitize_url
+	 */
+	public function test_sanitize_url_null_input_returns_empty_string() {
+		$this->assertSame( '', sanitize_url( null ) );
+	}
 }


### PR DESCRIPTION
## Summary

Fix a PHP 8.1+ deprecation notice in `esc_url()` when `null` is passed as the `$url` parameter.

Trac ticket: https://core.trac.wordpress.org/ticket/65441

On PHP 8.1+, passing `null` to `esc_url()` triggers:
```
Deprecated: ltrim(): Passing null to parameter #1 ($string) of type string is deprecated
```

This occurs because `esc_url()` calls `ltrim( $url )` on line 4545 without first checking for `null`. Multiple core functions that return `string|null` (such as `get_edit_post_link()`, `get_edit_comment_link()`, `get_edit_bookmark_link()`) have their return values passed directly to `esc_url()` throughout the codebase.

## Fix

Add `null === $url` to the existing empty check, returning an empty string. This matches the pre-PHP 8.1 behavior where `ltrim(null)` silently returned `''`.

Follow-up to [r62034] which fixed the same pattern in `previous_posts()`.

## Tests

- `test_null_input_returns_empty_string` — verifies `esc_url( null )` returns `''`
- `test_sanitize_url_null_input_returns_empty_string` — verifies `sanitize_url( null )` returns `''`

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**