### PR TITLE
Add support for dynamic comment statuses

### DIFF
--- a/src/wp-admin/edit-form-comment.php
+++ b/src/wp-admin/edit-form-comment.php
@@ -112,17 +112,18 @@ if ( 'approved' === wp_get_comment_status( $comment ) && $comment->comment_post_
 <div class="misc-pub-section misc-pub-comment-status" id="comment-status">
 <?php _e( 'Status:' ); ?> <span id="comment-status-display">
 <?php
-switch ( $comment->comment_approved ) {
-	case '1':
-		_e( 'Approved' );
-		break;
-	case '0':
-		_e( 'Pending' );
-		break;
-	case 'spam':
-		_e( 'Spam' );
-		break;
-}
+$comment_statuses = _wp_get_custom_comment_statuses();
+$status_labels     = array_merge(
+	$comment_statuses,
+	array(
+		'0'    => _x( 'Pending', 'comment status' ),
+		'1'    => _x( 'Approved', 'comment status' ),
+		'spam'  => _x( 'Spam', 'comment status' ),
+		'trash' => _x( 'Trash', 'comment status' ),
+	)
+);
+
+echo esc_html( $status_labels[ $comment->comment_approved ] ?? $comment->comment_approved );
 ?>
 </span>
 
@@ -133,9 +134,43 @@ switch ( $comment->comment_approved ) {
 	_e( 'Comment status' );
 	?>
 </legend>
-<label><input type="radio"<?php checked( $comment->comment_approved, '1' ); ?> name="comment_status" value="1" /><?php _ex( 'Approved', 'comment status' ); ?></label><br />
-<label><input type="radio"<?php checked( $comment->comment_approved, '0' ); ?> name="comment_status" value="0" /><?php _ex( 'Pending', 'comment status' ); ?></label><br />
-<label><input type="radio"<?php checked( $comment->comment_approved, 'spam' ); ?> name="comment_status" value="spam" /><?php _ex( 'Spam', 'comment status' ); ?></label>
+<?php
+$comment_status_radio = array(
+	'1'    => _x( 'Approved', 'comment status' ),
+	'0'    => _x( 'Pending', 'comment status' ),
+	'spam' => _x( 'Spam', 'comment status' ),
+);
+
+foreach ( _wp_get_custom_comment_statuses() as $status => $label ) {
+	$comment_status_radio[ $status ] = $label;
+}
+
+/**
+ * Filters the editable comment statuses displayed on the edit comment screen.
+ *
+ * @since 7.1.0
+ *
+ * @param string[]   $comment_status_radio List of editable comment status labels keyed by status.
+ * @param WP_Comment $comment              Current comment object.
+ */
+$comment_status_radio = apply_filters( 'editable_comment_statuses', $comment_status_radio, $comment );
+
+$valid_comment_status_radio = array_merge(
+	array(
+		'1'    => true,
+		'0'    => true,
+		'spam' => true,
+	),
+	array_fill_keys( array_keys( _wp_get_custom_comment_statuses() ), true )
+);
+$comment_status_radio       = array_intersect_key( $comment_status_radio, $valid_comment_status_radio );
+
+foreach ( $comment_status_radio as $status => $label ) :
+	?>
+	<label><input type="radio"<?php checked( $comment->comment_approved, $status ); ?> name="comment_status" value="<?php echo esc_attr( $status ); ?>" /><?php echo esc_html( $label ); ?></label><br />
+	<?php
+endforeach;
+?>
 </fieldset>
 </div><!-- .misc-pub-section -->
 

--- a/src/wp-admin/edit-form-comment.php
+++ b/src/wp-admin/edit-form-comment.php
@@ -113,11 +113,11 @@ if ( 'approved' === wp_get_comment_status( $comment ) && $comment->comment_post_
 <?php _e( 'Status:' ); ?> <span id="comment-status-display">
 <?php
 $comment_statuses = _wp_get_custom_comment_statuses();
-$status_labels     = array_merge(
+$status_labels    = array_merge(
 	$comment_statuses,
 	array(
-		'0'    => _x( 'Pending', 'comment status' ),
-		'1'    => _x( 'Approved', 'comment status' ),
+		'0'     => _x( 'Pending', 'comment status' ),
+		'1'     => _x( 'Approved', 'comment status' ),
 		'spam'  => _x( 'Spam', 'comment status' ),
 		'trash' => _x( 'Trash', 'comment status' ),
 	)

--- a/src/wp-admin/includes/class-wp-comments-list-table.php
+++ b/src/wp-admin/includes/class-wp-comments-list-table.php
@@ -97,9 +97,14 @@ class WP_Comments_List_Table extends WP_List_Table {
 			$mode = get_user_setting( 'posts_list_mode', 'list' );
 		}
 
-		$comment_status = $_REQUEST['comment_status'] ?? 'all';
+		$comment_status = 'all';
+		if ( isset( $_REQUEST['comment_status'] ) && is_scalar( $_REQUEST['comment_status'] ) ) {
+			$comment_status = sanitize_key( wp_unslash( $_REQUEST['comment_status'] ) );
+		}
 
-		if ( ! in_array( $comment_status, array( 'all', 'mine', 'moderated', 'approved', 'spam', 'trash' ), true ) ) {
+		$valid_statuses = array_merge( array( 'all', 'mine', 'moderated', 'approved', 'spam', 'trash' ), array_keys( _wp_get_custom_comment_statuses() ) );
+
+		if ( ! in_array( $comment_status, $valid_statuses, true ) ) {
 			$comment_status = 'all';
 		}
 
@@ -301,6 +306,10 @@ class WP_Comments_List_Table extends WP_List_Table {
 			unset( $statuses['trash'] );
 		}
 
+		foreach ( _wp_get_custom_comment_statuses() as $status => $label ) {
+			$statuses[ $status ] = $label;
+		}
+
 		$link = admin_url( 'edit-comments.php' );
 
 		if ( ! empty( $comment_type ) && 'all' !== $comment_type ) {
@@ -324,7 +333,7 @@ class WP_Comments_List_Table extends WP_List_Table {
 			}
 
 			if ( ! isset( $num_comments->$status ) ) {
-				$num_comments->$status = 10;
+				$num_comments->$status = isset( _wp_get_custom_comment_statuses()[ $status ] ) ? 0 : 10;
 			}
 
 			$link = add_query_arg( 'comment_status', $status, $link );
@@ -339,16 +348,21 @@ class WP_Comments_List_Table extends WP_List_Table {
 				$link = add_query_arg( 's', esc_attr( wp_unslash( $_REQUEST['s'] ) ), $link );
 			*/
 
+			$count = sprintf(
+				'<span class="%s-count">%s</span>',
+				( 'moderated' === $status ) ? 'pending' : sanitize_html_class( $status ),
+				number_format_i18n( $num_comments->$status )
+			);
+
+			if ( is_array( $label ) ) {
+				$label = sprintf( translate_nooped_plural( $label, $num_comments->$status ), $count );
+			} else {
+				$label = sprintf( '%s <span class="count">(%s)</span>', esc_html( $label ), $count );
+			}
+
 			$status_links[ $status ] = array(
 				'url'     => esc_url( $link ),
-				'label'   => sprintf(
-					translate_nooped_plural( $label, $num_comments->$status ),
-					sprintf(
-						'<span class="%s-count">%s</span>',
-						( 'moderated' === $status ) ? 'pending' : $status,
-						number_format_i18n( $num_comments->$status )
-					)
-				),
+				'label'   => $label,
 				'current' => $status === $comment_status,
 			);
 		}

--- a/src/wp-admin/includes/comment.php
+++ b/src/wp-admin/includes/comment.php
@@ -64,8 +64,20 @@ function edit_comment() {
 	if ( isset( $_POST['newcomment_author_url'] ) ) {
 		$_POST['comment_author_url'] = $_POST['newcomment_author_url'];
 	}
-	if ( isset( $_POST['comment_status'] ) ) {
-		$_POST['comment_approved'] = $_POST['comment_status'];
+	if ( isset( $_POST['comment_status'] ) && is_scalar( $_POST['comment_status'] ) ) {
+		$comment_status         = sanitize_key( wp_unslash( $_POST['comment_status'] ) );
+		$valid_comment_statuses = array_merge(
+			array(
+				'1'    => true,
+				'0'    => true,
+				'spam' => true,
+			),
+			array_fill_keys( array_keys( _wp_get_custom_comment_statuses() ), true )
+		);
+
+		if ( isset( $valid_comment_statuses[ $comment_status ] ) ) {
+			$_POST['comment_approved'] = $comment_status;
+		}
 	}
 	if ( isset( $_POST['content'] ) ) {
 		$_POST['comment_content'] = $_POST['content'];

--- a/src/wp-includes/class-wp-comment-query.php
+++ b/src/wp-includes/class-wp-comment-query.php
@@ -571,7 +571,9 @@ class WP_Comment_Query {
 
 					case 'all':
 					case '':
-						$status_clauses[] = "( comment_approved = '0' OR comment_approved = '1' )";
+						$all_statuses = array_merge( array( '0', '1' ), array_keys( _wp_get_custom_comment_statuses() ) );
+						$placeholders  = implode( ', ', array_fill( 0, count( $all_statuses ), '%s' ) );
+						$status_clauses[] = $wpdb->prepare( "comment_approved IN ($placeholders)", $all_statuses );
 						break;
 
 					default:

--- a/src/wp-includes/class-wp-comment-query.php
+++ b/src/wp-includes/class-wp-comment-query.php
@@ -572,7 +572,7 @@ class WP_Comment_Query {
 					case 'all':
 					case '':
 						$all_statuses = array_merge( array( '0', '1' ), array_keys( _wp_get_custom_comment_statuses() ) );
-						$placeholders  = implode( ', ', array_fill( 0, count( $all_statuses ), '%s' ) );
+						$placeholders = implode( ', ', array_fill( 0, count( $all_statuses ), '%s' ) );
 						$status_clauses[] = $wpdb->prepare( "comment_approved IN ($placeholders)", $all_statuses );
 						break;
 

--- a/src/wp-includes/class-wp-xmlrpc-server.php
+++ b/src/wp-includes/class-wp-xmlrpc-server.php
@@ -3837,8 +3837,15 @@ class wp_xmlrpc_server extends IXR_Server {
 		);
 
 		if ( isset( $content_struct['status'] ) ) {
-			$statuses = get_comment_statuses();
-			$statuses = array_keys( $statuses );
+			$statuses = array_merge(
+				array(
+					'hold',
+					'approve',
+					'spam',
+					'trash',
+				),
+				array_keys( _wp_get_custom_comment_statuses() )
+			);
 
 			if ( ! in_array( $content_struct['status'], $statuses, true ) ) {
 				return new IXR_Error( 401, __( 'Invalid comment status.' ) );

--- a/src/wp-includes/comment.php
+++ b/src/wp-includes/comment.php
@@ -336,7 +336,7 @@ function _wp_get_custom_comment_statuses() {
 	$custom_statuses   = array_diff_key( get_comment_statuses(), array_flip( $reserved_statuses ) );
 
 	foreach ( $custom_statuses as $status => $label ) {
-		if ( $status !== sanitize_key( $status ) || strlen( $status ) > 20 ) {
+		if ( sanitize_key( $status ) !== $status || 20 < strlen( $status ) ) {
 			unset( $custom_statuses[ $status ] );
 		}
 	}

--- a/src/wp-includes/comment.php
+++ b/src/wp-includes/comment.php
@@ -291,7 +291,57 @@ function get_comment_statuses() {
 		'trash'   => _x( 'Trash', 'comment status' ),
 	);
 
-	return $status;
+	/**
+	 * Filters the list of supported comment statuses.
+	 *
+	 * The returned array is keyed by status and has translated status labels as values.
+	 * Custom statuses are stored in the `comment_approved` database field using the
+	 * array key as the raw status value. Custom status keys must be compatible with
+	 * sanitize_key() and no longer than 20 characters.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param string[] $status List of comment status labels keyed by status.
+	 */
+	return apply_filters( 'comment_statuses', $status );
+}
+
+/**
+ * Retrieves registered custom comment statuses.
+ *
+ * @since 7.1.0
+ * @access private
+ *
+ * @return string[] List of valid custom comment status labels keyed by status.
+ *                  Invalid and reserved filtered statuses are excluded.
+ */
+function _wp_get_custom_comment_statuses() {
+	$reserved_statuses = array(
+		'0',
+		'1',
+		'all',
+		'any',
+		'approve',
+		'approved',
+		'hold',
+		'mine',
+		'moderated',
+		'post-trashed',
+		'spam',
+		'trash',
+		'unapproved',
+		'unspam',
+		'untrash',
+	);
+	$custom_statuses   = array_diff_key( get_comment_statuses(), array_flip( $reserved_statuses ) );
+
+	foreach ( $custom_statuses as $status => $label ) {
+		if ( $status !== sanitize_key( $status ) || strlen( $status ) > 20 ) {
+			unset( $custom_statuses[ $status ] );
+		}
+	}
+
+	return $custom_statuses;
 }
 
 /**
@@ -400,7 +450,8 @@ function get_lastcommentmodified( $timezone = 'server' ) {
  *     @type int $trash               The number of trashed comments.
  *     @type int $post-trashed        The number of comments for posts that are in the trash.
  *     @type int $total_comments      The total number of non-trashed comments, including spam.
- *     @type int $all                 The total number of pending or approved comments.
+ *     @type int $all                 The total number of pending, approved, or custom status comments.
+ *     @type int ...$custom_statuses  The number of comments for each registered custom status.
  * }
  */
 function get_comment_count( $post_id = 0 ) {
@@ -436,7 +487,40 @@ function get_comment_count( $post_id = 0 ) {
 		$comment_count[ $key ] = get_comments( array_merge( $args, array( 'status' => $value ) ) );
 	}
 
-	$comment_count['all']            = $comment_count['approved'] + $comment_count['awaiting_moderation'];
+	$custom_statuses = _wp_get_custom_comment_statuses();
+	foreach ( $custom_statuses as $status => $label ) {
+		$comment_count[ $status ] = 0;
+	}
+
+	if ( $custom_statuses ) {
+		global $wpdb;
+
+		$custom_status_placeholders = implode( ', ', array_fill( 0, count( $custom_statuses ), '%s' ) );
+		$custom_status_args         = array_keys( $custom_statuses );
+		$post_id_sql                = '';
+
+		if ( $post_id > 0 ) {
+			$post_id_sql          = ' AND comment_post_ID = %d';
+			$custom_status_args[] = $post_id;
+		}
+
+		$custom_status_counts = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT comment_approved, COUNT(*) AS num_comments FROM $wpdb->comments WHERE comment_approved IN ($custom_status_placeholders)$post_id_sql GROUP BY comment_approved",
+				$custom_status_args
+			),
+			OBJECT_K
+		);
+
+		foreach ( $custom_status_counts as $status => $row ) {
+			$comment_count[ $status ] = (int) $row->num_comments;
+		}
+	}
+
+	$comment_count['all'] = $comment_count['approved'] + $comment_count['awaiting_moderation'];
+	foreach ( array_keys( $custom_statuses ) as $status ) {
+		$comment_count['all'] += $comment_count[ $status ];
+	}
 	$comment_count['total_comments'] = $comment_count['all'] + $comment_count['spam'];
 
 	return array_map( 'intval', $comment_count );
@@ -1825,7 +1909,8 @@ function wp_unspam_comment( $comment_id ) {
  * @since 1.0.0
  *
  * @param int|WP_Comment $comment_id Comment ID or WP_Comment object
- * @return string|false Status might be 'trash', 'approved', 'unapproved', 'spam'. False on failure.
+ * @return string|false Status might be 'trash', 'approved', 'unapproved', 'spam', or a custom status.
+ *                      False on failure.
  */
 function wp_get_comment_status( $comment_id ) {
 	$comment = get_comment( $comment_id );
@@ -1845,6 +1930,8 @@ function wp_get_comment_status( $comment_id ) {
 		return 'spam';
 	} elseif ( 'trash' === $approved ) {
 		return 'trash';
+	} elseif ( isset( _wp_get_custom_comment_statuses()[ $approved ] ) ) {
+		return $approved;
 	} else {
 		return false;
 	}
@@ -2529,7 +2616,8 @@ function wp_new_comment_via_rest_notify_postauthor( $comment ) {
  * @global wpdb $wpdb WordPress database abstraction object.
  *
  * @param int|WP_Comment $comment_id     Comment ID or WP_Comment object.
- * @param string         $comment_status New comment status, either 'hold', 'approve', 'spam', or 'trash'.
+ * @param string         $comment_status New comment status, either 'hold', 'approve', 'spam', 'trash',
+ *                                       or a custom status from get_comment_statuses().
  * @param bool           $wp_error       Whether to return a WP_Error object if there is a failure. Default false.
  * @return bool|WP_Error True on success, false or WP_Error on failure.
  */
@@ -2553,7 +2641,18 @@ function wp_set_comment_status( $comment_id, $comment_status, $wp_error = false 
 			$status = 'trash';
 			break;
 		default:
-			return false;
+			if ( ! is_scalar( $comment_status ) ) {
+				return false;
+			}
+
+			$comment_status = sanitize_key( (string) $comment_status );
+
+			if ( ! isset( _wp_get_custom_comment_statuses()[ $comment_status ] ) ) {
+				return false;
+			}
+
+			$status = $comment_status;
+			break;
 	}
 
 	$comment_old = clone get_comment( $comment_id );

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
@@ -790,6 +790,14 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 			return $prepared_comment;
 		}
 
+		if ( isset( $request['status'] ) && ! $this->is_valid_comment_status_param( $request['status'] ) ) {
+			return new WP_Error(
+				'rest_comment_invalid_status',
+				__( 'Invalid comment status.' ),
+				array( 'status' => 400 )
+			);
+		}
+
 		$comment_id = wp_insert_comment( wp_filter_comment( wp_slash( (array) $prepared_comment ) ) );
 
 		if ( ! $comment_id ) {
@@ -801,7 +809,18 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 		}
 
 		if ( isset( $request['status'] ) ) {
-			$this->handle_status_param( $request['status'], $comment_id );
+			$status_update = $this->handle_status_param( $request['status'], $comment_id );
+			$comment       = get_comment( $comment_id );
+
+			if ( ! $status_update && $this->normalize_status_param( $request['status'] ) !== $this->prepare_status_response( $comment->comment_approved ) ) {
+				wp_delete_comment( $comment_id, true );
+
+				return new WP_Error(
+					'rest_comment_failed_create',
+					__( 'Creating comment failed.' ),
+					array( 'status' => 500 )
+				);
+			}
 		}
 
 		$comment = get_comment( $comment_id );
@@ -927,9 +946,18 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 
 		if ( empty( $prepared_args ) && isset( $request['status'] ) ) {
 			// Only the comment status is being changed.
-			$change = $this->handle_status_param( $request['status'], $id );
+			if ( ! $this->is_valid_comment_status_param( $request['status'] ) ) {
+				return new WP_Error(
+					'rest_comment_invalid_status',
+					__( 'Invalid comment status.' ),
+					array( 'status' => 400 )
+				);
+			}
 
-			if ( ! $change ) {
+			$change  = $this->handle_status_param( $request['status'], $id );
+			$comment = get_comment( $id );
+
+			if ( ! $change && $this->normalize_status_param( $request['status'] ) !== $this->prepare_status_response( $comment->comment_approved ) ) {
 				return new WP_Error(
 					'rest_comment_failed_edit',
 					__( 'Updating comment status failed.' ),
@@ -948,6 +976,14 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 				);
 			}
 
+			if ( isset( $request['status'] ) && ! $this->is_valid_comment_status_param( $request['status'] ) ) {
+				return new WP_Error(
+					'rest_comment_invalid_status',
+					__( 'Invalid comment status.' ),
+					array( 'status' => 400 )
+				);
+			}
+
 			$prepared_args['comment_ID'] = $id;
 
 			$check_comment_lengths = wp_check_comment_data_max_lengths( $prepared_args );
@@ -961,18 +997,41 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 				);
 			}
 
+			$old_comment_approved = null;
+			if ( isset( $request['status'] ) ) {
+				$comment              = get_comment( $id );
+				$old_comment_approved = $comment->comment_approved;
+				$status_update        = $this->handle_status_param( $request['status'], $id );
+				$comment              = get_comment( $id );
+
+				if ( ! $status_update && $this->normalize_status_param( $request['status'] ) !== $this->prepare_status_response( $comment->comment_approved ) ) {
+					return new WP_Error(
+						'rest_comment_failed_edit',
+						__( 'Updating comment status failed.' ),
+						array( 'status' => 500 )
+					);
+				}
+			}
+
 			$updated = wp_update_comment( wp_slash( (array) $prepared_args ), true );
 
 			if ( is_wp_error( $updated ) ) {
+				if ( null !== $old_comment_approved && ! wp_set_comment_status( $id, $old_comment_approved ) ) {
+					global $wpdb;
+
+					$comment = get_comment( $id );
+					if ( $comment ) {
+						$wpdb->update( $wpdb->comments, array( 'comment_approved' => $old_comment_approved ), array( 'comment_ID' => $id ) );
+						clean_comment_cache( $id );
+						wp_update_comment_count( $comment->comment_post_ID );
+					}
+				}
+
 				return new WP_Error(
 					'rest_comment_failed_edit',
 					__( 'Updating comment failed.' ),
 					array( 'status' => 500 )
 				);
-			}
-
-			if ( isset( $request['status'] ) ) {
-				$this->handle_status_param( $request['status'], $id );
 			}
 		}
 
@@ -1811,6 +1870,65 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 	}
 
 	/**
+	 * Checks whether a comment status parameter can be handled.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param string|int $new_status New comment status.
+	 * @return bool Whether the status parameter is valid.
+	 */
+	protected function is_valid_comment_status_param( $new_status ) {
+		if ( ! is_scalar( $new_status ) ) {
+			return false;
+		}
+
+		$new_status = sanitize_key( (string) $new_status );
+
+		switch ( $new_status ) {
+			case 'approved':
+			case 'approve':
+			case '1':
+			case 'hold':
+			case '0':
+			case 'spam':
+			case 'unspam':
+			case 'trash':
+			case 'untrash':
+				return true;
+			default:
+				return isset( _wp_get_custom_comment_statuses()[ $new_status ] );
+		}
+	}
+
+	/**
+	 * Normalizes a comment status parameter for comparison with REST API responses.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param string|int $new_status New comment status.
+	 * @return string Normalized comment status.
+	 */
+	protected function normalize_status_param( $new_status ) {
+		if ( ! is_scalar( $new_status ) ) {
+			return '';
+		}
+
+		$new_status = sanitize_key( (string) $new_status );
+
+		switch ( $new_status ) {
+			case 'approved':
+			case 'approve':
+			case '1':
+				return 'approved';
+			case 'hold':
+			case '0':
+				return 'hold';
+			default:
+				return (string) $new_status;
+		}
+	}
+
+	/**
 	 * Sets the comment_status of a given comment object when creating or updating a comment.
 	 *
 	 * @since 4.7.0
@@ -1849,7 +1967,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 				$changed = wp_untrash_comment( $comment_id );
 				break;
 			default:
-				$changed = false;
+				$changed = wp_set_comment_status( $comment_id, $new_status );
 				break;
 		}
 

--- a/tests/phpunit/tests/comment/statuses.php
+++ b/tests/phpunit/tests/comment/statuses.php
@@ -1,0 +1,246 @@
+<?php
+
+/**
+ * @group comment
+ *
+ * @covers ::get_comment_statuses
+ * @covers ::wp_get_comment_status
+ * @covers ::wp_set_comment_status
+ * @covers ::wp_count_comments
+ * @covers ::_wp_get_custom_comment_statuses
+ */
+class Tests_Comment_Statuses extends WP_UnitTestCase {
+
+	public function tear_down() {
+		remove_filter( 'comment_statuses', array( $this, 'filter_comment_statuses' ) );
+		remove_filter( 'comment_statuses', array( $this, 'filter_invalid_comment_statuses' ) );
+		remove_filter( 'comment_statuses', array( $this, 'filter_reserved_comment_statuses' ) );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Adds a valid custom comment status.
+	 *
+	 * @ticket 20977
+	 *
+	 * @param string[] $statuses Comment statuses.
+	 * @return string[] Filtered comment statuses.
+	 */
+	public function filter_comment_statuses( $statuses ) {
+		$statuses['read'] = 'Read';
+
+		return $statuses;
+	}
+
+	/**
+	 * Adds invalid custom comment statuses.
+	 *
+	 * @ticket 20977
+	 *
+	 * @param string[] $statuses Comment statuses.
+	 * @return string[] Filtered comment statuses.
+	 */
+	public function filter_invalid_comment_statuses( $statuses ) {
+		$statuses['needs review']            = 'Needs Review';
+		$statuses['more-than-20-chars-long'] = 'Too Long';
+
+		return $statuses;
+	}
+
+	/**
+	 * Adds reserved custom comment statuses.
+	 *
+	 * @ticket 20977
+	 *
+	 * @param string[] $statuses Comment statuses.
+	 * @return string[] Filtered comment statuses.
+	 */
+	public function filter_reserved_comment_statuses( $statuses ) {
+		$statuses['approved']  = 'Custom Approved';
+		$statuses['moderated'] = 'Custom Moderated';
+		$statuses['all']       = 'Custom All';
+		$statuses['unspam']    = 'Custom Unspam';
+
+		return $statuses;
+	}
+
+	/**
+	 * @ticket 20977
+	 */
+	public function test_get_comment_statuses_is_filterable() {
+		add_filter( 'comment_statuses', array( $this, 'filter_comment_statuses' ) );
+
+		$this->assertSame( 'Read', get_comment_statuses()['read'] );
+	}
+
+	/**
+	 * @ticket 20977
+	 */
+	public function test_wp_set_comment_status_supports_custom_statuses() {
+		add_filter( 'comment_statuses', array( $this, 'filter_comment_statuses' ) );
+
+		$comment_id = self::factory()->comment->create();
+
+		$this->assertTrue( wp_set_comment_status( $comment_id, 'read' ) );
+		$this->assertSame( 'read', get_comment( $comment_id )->comment_approved );
+		$this->assertSame( 'read', wp_get_comment_status( $comment_id ) );
+	}
+
+	/**
+	 * @ticket 20977
+	 */
+	public function test_wp_set_comment_status_rejects_unregistered_custom_statuses() {
+		$comment_id = self::factory()->comment->create();
+
+		$this->assertFalse( wp_set_comment_status( $comment_id, 'read' ) );
+	}
+
+	/**
+	 * @ticket 20977
+	 */
+	public function test_wp_set_comment_status_rejects_invalid_custom_statuses() {
+		add_filter( 'comment_statuses', array( $this, 'filter_invalid_comment_statuses' ) );
+
+		$comment_id = self::factory()->comment->create();
+
+		$this->assertFalse( wp_set_comment_status( $comment_id, 'needs review' ) );
+		$this->assertFalse( wp_set_comment_status( $comment_id, 'more-than-20-chars-long' ) );
+		$this->assertFalse( wp_set_comment_status( $comment_id, array( 'read' ) ) );
+	}
+
+	/**
+	 * @ticket 20977
+	 */
+	public function test_wp_set_comment_status_rejects_reserved_custom_statuses() {
+		add_filter( 'comment_statuses', array( $this, 'filter_reserved_comment_statuses' ) );
+
+		$comment_id = self::factory()->comment->create();
+
+		$this->assertFalse( wp_set_comment_status( $comment_id, 'approved' ) );
+		$this->assertFalse( wp_set_comment_status( $comment_id, 'moderated' ) );
+		$this->assertFalse( wp_set_comment_status( $comment_id, 'all' ) );
+		$this->assertFalse( wp_set_comment_status( $comment_id, 'unspam' ) );
+	}
+
+	/**
+	 * @ticket 20977
+	 */
+	public function test_wp_count_comments_includes_custom_status_counts() {
+		add_filter( 'comment_statuses', array( $this, 'filter_comment_statuses' ) );
+
+		self::factory()->comment->create(
+			array(
+				'comment_approved' => 'read',
+			)
+		);
+
+		$count = wp_count_comments();
+
+		$this->assertSame( 1, $count->read );
+		$this->assertSame( 1, $count->total_comments );
+		$this->assertSame( 1, $count->all );
+	}
+
+	/**
+	 * @ticket 20977
+	 */
+	/**
+	 * @ticket 20977
+	 */
+	public function test_get_comments_all_includes_custom_statuses() {
+		add_filter( 'comment_statuses', array( $this, 'filter_comment_statuses' ) );
+
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_approved' => 'read',
+			)
+		);
+
+		$comments = get_comments(
+			array(
+				'status' => 'all',
+				'fields' => 'ids',
+			)
+		);
+
+		$this->assertContains( $comment_id, $comments );
+	}
+
+	public function test_wp_count_comments_ignores_invalid_custom_statuses() {
+		add_filter( 'comment_statuses', array( $this, 'filter_invalid_comment_statuses' ) );
+
+		self::factory()->comment->create(
+			array(
+				'comment_approved' => 'needs review',
+			)
+		);
+
+		$count = wp_count_comments();
+
+		$this->assertFalse( property_exists( $count, 'needs review' ) );
+		$this->assertFalse( property_exists( $count, 'more-than-20-chars-long' ) );
+	}
+
+	/**
+	 * @ticket 20977
+	 */
+	public function test_wp_count_comments_ignores_reserved_custom_statuses() {
+		add_filter( 'comment_statuses', array( $this, 'filter_reserved_comment_statuses' ) );
+
+		$count = wp_count_comments();
+
+		$this->assertFalse( property_exists( $count, 'unspam' ) );
+	}
+
+	/**
+	 * @ticket 20977
+	 *
+	 * @dataProvider data_invalid_edit_comment_statuses
+	 *
+	 * @param mixed $comment_status Invalid comment status.
+	 */
+	public function test_edit_comment_rejects_invalid_comment_status( $comment_status ) {
+		if ( ! function_exists( 'edit_comment' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/comment.php';
+		}
+
+		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user_id );
+
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_approved' => '0',
+			)
+		);
+
+		$_POST = add_magic_quotes(
+			array(
+				'comment_ID'              => $comment_id,
+				'comment_status'          => $comment_status,
+				'newcomment_author'       => 'Test Author',
+				'newcomment_author_url'   => '',
+				'newcomment_author_email' => '',
+				'content'                 => 'Test content',
+			)
+		);
+
+		edit_comment();
+
+		$this->assertSame( '0', get_comment( $comment_id )->comment_approved );
+	}
+
+	/**
+	 * Data provider for invalid comment statuses.
+	 *
+	 * @ticket 20977
+	 *
+	 * @return array[] Invalid comment statuses.
+	 */
+	public function data_invalid_edit_comment_statuses() {
+		return array(
+			'invalid string' => array( 'invalid-status' ),
+			'array'          => array( array( 'spam' ) ),
+		);
+	}
+}

--- a/tests/phpunit/tests/rest-api/rest-comments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-comments-controller.php
@@ -2582,6 +2582,41 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 		$this->assertEquals( 1, $updated->comment_approved );
 	}
 
+	/**
+	 * @ticket 20977
+	 */
+	public function test_update_comment_custom_status_no_change() {
+		wp_set_current_user( self::$admin_id );
+
+		$filter = static function ( $statuses ) {
+			$statuses['read'] = 'Read';
+
+			return $statuses;
+		};
+		add_filter( 'comment_statuses', $filter );
+
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_approved' => 'read',
+				'comment_post_ID'  => self::$post_id,
+			)
+		);
+
+		$params = array(
+			'status' => 'read',
+		);
+
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/comments/%d', $comment_id ) );
+		$request->add_header( 'Content-Type', 'application/json' );
+		$request->set_body( wp_json_encode( $params ) );
+
+		$response = rest_get_server()->dispatch( $request );
+		remove_filter( 'comment_statuses', $filter );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( 'read', get_comment( $comment_id )->comment_approved );
+	}
+
 	public function test_update_comment_field_does_not_use_default_values() {
 		wp_set_current_user( self::$admin_id );
 
@@ -2609,6 +2644,124 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 		$this->assertSame( 'approved', $comment['status'] );
 		$this->assertEquals( 1, $updated->comment_approved );
 		$this->assertSame( 'some content', $updated->comment_content );
+	}
+
+	/**
+	 * @ticket 20977
+	 */
+	public function test_create_comment_with_invalid_status_returns_error() {
+		wp_set_current_user( self::$admin_id );
+
+		$params = array(
+			'post'         => self::$post_id,
+			'author_name'  => 'Homer J. Simpson',
+			'author_email' => 'homer@example.org',
+			'author_url'   => 'http://compuglobalhypermeganet.com',
+			'content'      => 'Aw, he loves beer. Here, little fella.',
+			'status'       => 'invalid-status',
+		);
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/comments' );
+		$request->add_header( 'Content-Type', 'application/json' );
+		$request->set_body( wp_json_encode( $params ) );
+
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertErrorResponse( 'rest_comment_invalid_status', $response, 400 );
+	}
+
+	/**
+	 * @ticket 20977
+	 */
+	public function test_update_comment_with_invalid_status_only_returns_error() {
+		wp_set_current_user( self::$admin_id );
+
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_approved' => '0',
+				'comment_post_ID'  => self::$post_id,
+			)
+		);
+
+		$params = array(
+			'status' => 'invalid-status',
+		);
+
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/comments/%d', $comment_id ) );
+		$request->add_header( 'Content-Type', 'application/json' );
+		$request->set_body( wp_json_encode( $params ) );
+
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertErrorResponse( 'rest_comment_invalid_status', $response, 400 );
+		$this->assertSame( '0', get_comment( $comment_id )->comment_approved );
+	}
+
+	/**
+	 * @ticket 20977
+	 */
+	public function test_update_comment_status_is_rolled_back_when_comment_update_fails() {
+		wp_set_current_user( self::$admin_id );
+
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_approved' => '0',
+				'comment_post_ID'  => self::$post_id,
+				'comment_content'  => 'Original content.',
+			)
+		);
+
+		$filter = static function () {
+			return new WP_Error( 'comment_update_failed', 'Comment update failed.' );
+		};
+		add_filter( 'wp_update_comment_data', $filter );
+
+		$params = array(
+			'content' => 'Updated content.',
+			'status'  => 'approve',
+		);
+
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/comments/%d', $comment_id ) );
+		$request->add_header( 'Content-Type', 'application/json' );
+		$request->set_body( wp_json_encode( $params ) );
+
+		$response = rest_get_server()->dispatch( $request );
+		remove_filter( 'wp_update_comment_data', $filter );
+
+		$this->assertErrorResponse( 'rest_comment_failed_edit', $response, 500 );
+
+		$updated = get_comment( $comment_id );
+		$this->assertSame( '0', $updated->comment_approved );
+		$this->assertSame( 'Original content.', $updated->comment_content );
+	}
+
+	/**
+	 * @ticket 20977
+	 */
+	public function test_update_comment_with_invalid_status_returns_error() {
+		wp_set_current_user( self::$admin_id );
+
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_approved' => '0',
+				'comment_post_ID'  => self::$post_id,
+				'comment_content'  => 'Original content.',
+			)
+		);
+
+		$params = array(
+			'content' => 'Updated content.',
+			'status'  => 'invalid-status',
+		);
+
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/comments/%d', $comment_id ) );
+		$request->add_header( 'Content-Type', 'application/json' );
+		$request->set_body( wp_json_encode( $params ) );
+
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertErrorResponse( 'rest_comment_invalid_status', $response, 400 );
+
+		$updated = get_comment( $comment_id );
+		$this->assertSame( '0', $updated->comment_approved );
+		$this->assertSame( 'Original content.', $updated->comment_content );
 	}
 
 	public function test_update_comment_date_gmt() {

--- a/tests/phpunit/tests/xmlrpc/wp/editComment.php
+++ b/tests/phpunit/tests/xmlrpc/wp/editComment.php
@@ -5,6 +5,41 @@
  */
 class Tests_XMLRPC_wp_editComment extends WP_XMLRPC_UnitTestCase {
 
+	public function tear_down() {
+		remove_filter( 'comment_statuses', array( $this, 'filter_comment_statuses' ) );
+		remove_filter( 'comment_statuses', array( $this, 'filter_reserved_comment_statuses' ) );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Adds a valid custom comment status.
+	 *
+	 * @ticket 20977
+	 *
+	 * @param string[] $statuses Comment statuses.
+	 * @return string[] Filtered comment statuses.
+	 */
+	public function filter_comment_statuses( $statuses ) {
+		$statuses['read'] = 'Read';
+
+		return $statuses;
+	}
+
+	/**
+	 * Adds a reserved custom comment status.
+	 *
+	 * @ticket 20977
+	 *
+	 * @param string[] $statuses Comment statuses.
+	 * @return string[] Filtered comment statuses.
+	 */
+	public function filter_reserved_comment_statuses( $statuses ) {
+		$statuses['approved'] = 'Custom Approved';
+
+		return $statuses;
+	}
+
 	public function test_author_can_edit_own_comment() {
 		$author_id = $this->make_user_by_role( 'author' );
 		$post_id   = self::factory()->post->create(
@@ -92,5 +127,55 @@ class Tests_XMLRPC_wp_editComment extends WP_XMLRPC_UnitTestCase {
 		);
 
 		$this->assertSame( 'trash', get_comment( $comment_id )->comment_approved );
+	}
+
+	/**
+	 * @ticket 20977
+	 */
+	public function test_custom_comment_status() {
+		add_filter( 'comment_statuses', array( $this, 'filter_comment_statuses' ) );
+
+		$this->make_user_by_role( 'administrator' );
+		$comment_id = self::factory()->comment->create();
+
+		$result = $this->myxmlrpcserver->wp_editComment(
+			array(
+				1,
+				'administrator',
+				'administrator',
+				$comment_id,
+				array(
+					'status' => 'read',
+				),
+			)
+		);
+
+		$this->assertNotIXRError( $result );
+		$this->assertSame( 'read', get_comment( $comment_id )->comment_approved );
+	}
+
+	/**
+	 * @ticket 20977
+	 */
+	public function test_reserved_custom_comment_status_is_rejected() {
+		add_filter( 'comment_statuses', array( $this, 'filter_reserved_comment_statuses' ) );
+
+		$this->make_user_by_role( 'administrator' );
+		$comment_id = self::factory()->comment->create();
+
+		$result = $this->myxmlrpcserver->wp_editComment(
+			array(
+				1,
+				'administrator',
+				'administrator',
+				$comment_id,
+				array(
+					'status' => 'approved',
+				),
+			)
+		);
+
+		$this->assertIXRError( $result );
+		$this->assertSame( 401, $result->code );
 	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/20977

Adds support for dynamic/custom comment statuses.

Plugins can now register additional comment statuses by filtering get_comment_statuses(), and those statuses are supported across core comment flows.

Example:

 ```php
   add_filter( 'comment_statuses', function ( $statuses ) {
      $statuses['read'] = __( 'Read', 'textdomain' );
      return $statuses;
   } );
 ```
 
## What this fixes

Fixes the long-standing limitation where comments can only practically use core statuses:
 - Approved
 - Pending
 - Spam
 - Trash

Although comment_approved can technically store arbitrary values, core did not consistently recognize, validate, count, display, query, or update custom statuses.

This PR makes custom statuses usable without plugins needing to patch multiple disconnected code paths.


## Use of AI Tools

AI assistance: Yes
Tool(s): pi coding agent
Model(s): GPT-5.6
Used for: Initial code skeleton, Code review, and PR description drafting. Final implementation and tests were reviewed and edited by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
