### PR TITLE
Administration: Align border-radius values with design system tokens

### DIFF
--- a/src/wp-admin/css/admin-menu.css
+++ b/src/wp-admin/css/admin-menu.css
@@ -433,7 +433,7 @@ ul#adminmenu > li.current > a.current:after {
 	padding: 0 5px;
 	min-width: 18px;
 	height: 18px;
-	border-radius: 9px;
+	border-radius: 8px;
 	background-color: #d63638;
 	color: #fff;
 	font-size: 11px;

--- a/src/wp-admin/css/customize-controls.css
+++ b/src/wp-admin/css/customize-controls.css
@@ -78,13 +78,13 @@ body:not(.ready) #customize-save-button-wrapper .save {
 }
 #customize-save-button-wrapper .save {
 	float: left;
-	border-radius: 3px;
+	border-radius: 2px;
 	box-shadow: none; /* @todo Adjust box shadow based on the disable states of paired button. */
 	margin-top: 0;
 }
 
 #customize-save-button-wrapper .save.has-next-sibling {
-	border-radius: 3px 0 0 3px;
+	border-radius: 2px 0 0 2px;
 }
 
 #customize-sidebar-outer-content {
@@ -162,7 +162,7 @@ body:not(.ready) #customize-save-button-wrapper .save {
 
 #publish-settings {
 	text-indent: 0;
-	border-radius: 0 3px 3px 0;
+	border-radius: 0 2px 2px 0;
 	padding-left: 0;
 	padding-right: 0;
 	box-shadow: none; /* @todo Adjust box shadow based on the disable states of paired button. */

--- a/src/wp-admin/css/forms.css
+++ b/src/wp-admin/css/forms.css
@@ -1150,7 +1150,7 @@ table.form-table td .updated p {
 	cursor: move;
 	color: #2c3338;
 	background: #dcdcde;
-	border-radius: 5px;
+	border-radius: 4px;
 	border: 1px solid #c3c4c7;
 	font-style: normal;
 	line-height: 16px;

--- a/src/wp-admin/css/list-tables.css
+++ b/src/wp-admin/css/list-tables.css
@@ -54,7 +54,7 @@
 	padding: 0 8px;
 	min-width: 24px;
 	height: 2em;
-	border-radius: 5px;
+	border-radius: 4px;
 	background-color: #646970;
 	color: #fff;
 	font-size: 11px;
@@ -98,7 +98,7 @@
 	min-width: 7px;
 	height: 17px;
 	border: 2px solid #fff;
-	border-radius: 11px;
+	border-radius: 12px;
 	background: #d63638;
 	color: #fff;
 	font-size: 9px;
@@ -396,7 +396,7 @@ table.media .column-title .filename {
 	transform: translate(-50%, -100%);
 	background: #000;
 	color: #fff;
-	border-radius: 5px;
+	border-radius: 4px;
 	margin: 0;
 	padding: 2px 5px;
 }
@@ -1196,7 +1196,7 @@ ul.cat-checklist input[name="post_category[]"]:indeterminate::before {
 	height: 26px;
 	margin: 0 0 0 -26px;
 	text-align: center;
-	border-radius: 3px;
+	border-radius: 2px;
 }
 
 #bulk-titles .ntdelbutton:before {

--- a/src/wp-admin/css/nav-menus.css
+++ b/src/wp-admin/css/nav-menus.css
@@ -144,7 +144,7 @@ ul.add-menu-item-tabs li {
 	border: 1px solid #dcdcde;
 	margin: 0;
 	cursor: pointer;
-	border-radius: 3px;
+	border-radius: 2px;
 	white-space: nowrap;
 	box-sizing: border-box;
 }

--- a/src/wp-admin/css/site-icon.css
+++ b/src/wp-admin/css/site-icon.css
@@ -96,7 +96,7 @@
 
 .site-icon-preview .app-icon-preview {
 	aspect-ratio: 1/1;
-	border-radius: 10px;
+	border-radius: 8px;
 	box-shadow: 0 1px 5px 0 var(--site-icon-shadow-3);
 	flex-shrink: 0;
 	width: 100%;

--- a/src/wp-admin/css/themes.css
+++ b/src/wp-admin/css/themes.css
@@ -201,7 +201,7 @@ body.js .theme-browser.search-loading {
 	font-weight: 600;
 	padding: 15px 12px;
 	text-align: center;
-	border-radius: 3px;
+	border-radius: 2px;
 	border: none;
 	transition: opacity 0.1s ease-in-out;
 	cursor: pointer;
@@ -1373,7 +1373,7 @@ div#custom-background-image img {
 }
 
 .background-position-control .button-group:first-child > label:first-child .button {
-	border-radius: 3px 0 0;
+	border-radius: 2px 0 0;
 }
 
 .background-position-control .button-group:first-child > label:first-child .dashicons {
@@ -1381,7 +1381,7 @@ div#custom-background-image img {
 }
 
 .background-position-control .button-group:first-child > label:last-child .button {
-	border-radius: 0 3px 0 0;
+	border-radius: 0 2px 0 0;
 }
 
 .background-position-control .button-group:first-child > label:last-child .dashicons {
@@ -1389,7 +1389,7 @@ div#custom-background-image img {
 }
 
 .background-position-control .button-group:last-child > label:first-child .button {
-	border-radius: 0 0 0 3px;
+	border-radius: 0 0 0 2px;
 }
 
 .background-position-control .button-group:last-child > label:first-child .dashicons {
@@ -1397,7 +1397,7 @@ div#custom-background-image img {
 }
 
 .background-position-control .button-group:last-child > label:last-child .button {
-	border-radius: 0 0 3px;
+	border-radius: 0 0 2px;
 }
 
 .background-position-control .button-group:last-child > label:last-child .dashicons {


### PR DESCRIPTION
## Summary

Replace non-standard border-radius values across 7 admin CSS files with their nearest equivalents from the WordPress design system defined in `_tokens.scss`.

Trac ticket: https://core.trac.wordpress.org/ticket/65444

## Problem

The WordPress design system (`_tokens.scss`) defines a clear border-radius scale: `1px`, `2px`, `4px`, `8px`, `12px`, `9999px`. However, several admin CSS files still use legacy values (`3px`, `5px`, `9px`, `10px`, `11px`) that fall outside this scale, creating visual inconsistency.

## Changes

| Old value | New value | Design token | Locations | Elements |
|-----------|-----------|-------------|-----------|----------|
| `3px` | `2px` | `radius-s` | 10 | Buttons, save controls, theme cards, menu items |
| `5px` | `4px` | `radius-m` | 3 | Comment count badges, bookmarklet button |
| `9px` | `8px` | `radius-l` | 1 | Admin menu notification badges |
| `10px` | `8px` | `radius-l` | 1 | Site icon previews |
| `11px` | `12px` | `radius-30` | 1 | Pending comment count badge |

## Files changed

- `src/wp-admin/css/themes.css` — 5 replacements
- `src/wp-admin/css/list-tables.css` — 4 replacements
- `src/wp-admin/css/customize-controls.css` — 3 replacements
- `src/wp-admin/css/admin-menu.css` — 1 replacement
- `src/wp-admin/css/forms.css` — 1 replacement
- `src/wp-admin/css/nav-menus.css` — 1 replacement
- `src/wp-admin/css/site-icon.css` — 1 replacement

## Test plan

- [ ] `npm run build:dev` — builds successfully
- [ ] Verify theme browser cards, customizer save button, admin menu badges, comment count badges all render correctly
- [ ] Compare against trunk — differences should be 1px or less, barely perceptible

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**