### PR TITLE
Fix incorrect casing of `Chr()` and `Ord()` in `class-pclzip.php`

### DIFF
--- a/src/wp-admin/includes/class-pclzip.php
+++ b/src/wp-admin/includes/class-pclzip.php
@@ -3988,7 +3988,7 @@
 
 
     // ----- Write gz file format header
-    $v_binary_data = pack('va1a1Va1a1', 0x8b1f, Chr($p_entry['compression']), Chr(0x00), time(), Chr(0x00), Chr(3));
+    $v_binary_data = pack('va1a1Va1a1', 0x8b1f, chr($p_entry['compression']), chr(0x00), time(), chr(0x00), chr(3));
     @fwrite($v_dest_file, $v_binary_data, 10);
 
     // ----- Read the file by PCLZIP_READ_BLOCK_SIZE octets blocks
@@ -4616,10 +4616,10 @@
         $v_byte = @fread($this->zip_fd, 1);
 
         // -----  Add the byte
-        //$v_bytes = ($v_bytes << 8) | Ord($v_byte);
+        //$v_bytes = ($v_bytes << 8) | ord($v_byte);
         // Note we mask the old value down such that once shifted we can never end up with more than a 32bit number
         // Otherwise on systems where we have 64bit integers the check below for the magic number will fail.
-        $v_bytes = ( ($v_bytes & 0xFFFFFF) << 8) | Ord($v_byte);
+        $v_bytes = ( ($v_bytes & 0xFFFFFF) << 8) | ord($v_byte);
 
         // ----- Compare the bytes
         if ($v_bytes == 0x504b0506)


### PR DESCRIPTION
Replace `Chr()` and `Ord()` with their canonical lowercase forms `chr()` and `ord()`.

This is flagged as a case-sensitivity violation by the upcoming [PHP 8.6 RFC](https://wiki.php.net/rfc/case_sensitive_php), which will emit `E_DEPRECATED` for function references that don't match their declared casing. Fixing it now keeps WordPress ahead of the deprecation.

Trac ticket: https://core.trac.wordpress.org/ticket/64897

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
