### PR TITLE
Posts: Add `disabled` argument to wp_dropdown_categories() and wp_dropdown_pages()

### DIFF
--- a/src/wp-includes/category-template.php
+++ b/src/wp-includes/category-template.php
@@ -301,7 +301,7 @@ function category_description( $category = 0 ) {
  * @since 4.2.0 Introduced the `value_field` argument.
  * @since 4.6.0 Introduced the `required` argument.
  * @since 6.1.0 Introduced the `aria_describedby` argument.
- * @since 6.8.0 Introduced the `disabled` argument.
+ * @since 7.2.0 Introduced the `disabled` argument.
  *
  * @param array|string $args {
  *     Optional. Array or string of arguments to generate a categories drop-down element. See WP_Term_Query::__construct()
@@ -413,12 +413,12 @@ function wp_dropdown_categories( $args = '' ) {
 	$class    = esc_attr( $parsed_args['class'] );
 	$id       = $parsed_args['id'] ? esc_attr( $parsed_args['id'] ) : $name;
 	$required = $parsed_args['required'] ? 'required' : '';
-	$disabled = $parsed_args['disabled'] ? 'disabled' : '';
+	$disabled = $parsed_args['disabled'] ? ' disabled' : '';
 
 	$aria_describedby_attribute = $parsed_args['aria_describedby'] ? ' aria-describedby="' . esc_attr( $parsed_args['aria_describedby'] ) . '"' : '';
 
 	if ( ! $parsed_args['hide_if_empty'] || ! empty( $categories ) ) {
-		$output = "<select $required $disabled name='$name' id='$id' class='$class'$tab_index_attribute$aria_describedby_attribute>\n";
+		$output = "<select $required$disabled name='$name' id='$id' class='$class'$tab_index_attribute$aria_describedby_attribute>\n";
 	} else {
 		$output = '';
 	}

--- a/src/wp-includes/category-template.php
+++ b/src/wp-includes/category-template.php
@@ -301,6 +301,7 @@ function category_description( $category = 0 ) {
  * @since 4.2.0 Introduced the `value_field` argument.
  * @since 4.6.0 Introduced the `required` argument.
  * @since 6.1.0 Introduced the `aria_describedby` argument.
+ * @since 6.8.0 Introduced the `disabled` argument.
  *
  * @param array|string $args {
  *     Optional. Array or string of arguments to generate a categories drop-down element. See WP_Term_Query::__construct()
@@ -334,6 +335,8 @@ function category_description( $category = 0 ) {
  *                                           Default false (create select element even if no categories are found).
  *     @type bool         $required          Whether the `<select>` element should have the HTML5 'required' attribute.
  *                                           Default false.
+ *     @type bool         $disabled          Whether the `<select>` element should have the HTML5 'disabled' attribute.
+ *                                           Default false.
  *     @type Walker       $walker            Walker object to use to build the output. Default empty which results in a
  *                                           Walker_CategoryDropdown instance being used.
  *     @type string       $aria_describedby  The 'id' of an element that contains descriptive text for the select.
@@ -364,6 +367,7 @@ function wp_dropdown_categories( $args = '' ) {
 		'option_none_value' => -1,
 		'value_field'       => 'term_id',
 		'required'          => false,
+		'disabled'          => false,
 		'aria_describedby'  => '',
 	);
 
@@ -409,11 +413,12 @@ function wp_dropdown_categories( $args = '' ) {
 	$class    = esc_attr( $parsed_args['class'] );
 	$id       = $parsed_args['id'] ? esc_attr( $parsed_args['id'] ) : $name;
 	$required = $parsed_args['required'] ? 'required' : '';
+	$disabled = $parsed_args['disabled'] ? 'disabled' : '';
 
 	$aria_describedby_attribute = $parsed_args['aria_describedby'] ? ' aria-describedby="' . esc_attr( $parsed_args['aria_describedby'] ) . '"' : '';
 
 	if ( ! $parsed_args['hide_if_empty'] || ! empty( $categories ) ) {
-		$output = "<select $required name='$name' id='$id' class='$class'$tab_index_attribute$aria_describedby_attribute>\n";
+		$output = "<select $required $disabled name='$name' id='$id' class='$class'$tab_index_attribute$aria_describedby_attribute>\n";
 	} else {
 		$output = '';
 	}

--- a/src/wp-includes/post-template.php
+++ b/src/wp-includes/post-template.php
@@ -1174,7 +1174,7 @@ function the_meta() {
  * @since 2.1.0
  * @since 4.2.0 The `$value_field` argument was added.
  * @since 4.3.0 The `$class` argument was added.
- * @since 6.8.0 The `$disabled` argument was added.
+ * @since 7.2.0 The `$disabled` argument was added.
  *
  * @see get_pages()
  *

--- a/src/wp-includes/post-template.php
+++ b/src/wp-includes/post-template.php
@@ -1174,6 +1174,7 @@ function the_meta() {
  * @since 2.1.0
  * @since 4.2.0 The `$value_field` argument was added.
  * @since 4.3.0 The `$class` argument was added.
+ * @since 6.8.0 The `$disabled` argument was added.
  *
  * @see get_pages()
  *
@@ -1195,6 +1196,8 @@ function the_meta() {
  *     @type string       $option_none_value     Value to use when no page is selected. Default empty.
  *     @type string       $value_field           Post field used to populate the 'value' attribute of the option
  *                                               elements. Accepts any valid post field. Default 'ID'.
+ *     @type bool         $disabled              Whether the `<select>` element should have the HTML5 'disabled'
+ *                                               attribute. Default false.
  * }
  * @return string HTML dropdown list of pages.
  */
@@ -1211,6 +1214,7 @@ function wp_dropdown_pages( $args = '' ) {
 		'show_option_no_change' => '',
 		'option_none_value'     => '',
 		'value_field'           => 'ID',
+		'disabled'              => false,
 	);
 
 	$parsed_args = wp_parse_args( $args, $defaults );
@@ -1228,7 +1232,9 @@ function wp_dropdown_pages( $args = '' ) {
 			$class = " class='" . esc_attr( $parsed_args['class'] ) . "'";
 		}
 
-		$output = "<select name='" . esc_attr( $parsed_args['name'] ) . "'" . $class . " id='" . esc_attr( $parsed_args['id'] ) . "'>\n";
+		$disabled = $parsed_args['disabled'] ? ' disabled' : '';
+
+		$output = "<select name='" . esc_attr( $parsed_args['name'] ) . "'" . $class . " id='" . esc_attr( $parsed_args['id'] ) . "'" . $disabled . ">\n";
 		if ( $parsed_args['show_option_no_change'] ) {
 			$output .= "\t<option value=\"-1\">" . $parsed_args['show_option_no_change'] . "</option>\n";
 		}

--- a/tests/phpunit/tests/category/wpDropdownCategories.php
+++ b/tests/phpunit/tests/category/wpDropdownCategories.php
@@ -257,7 +257,7 @@ class Tests_Category_WpDropdownCategories extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @ticket 21474
+	 * @ticket 20810
 	 */
 	public function test_disabled_true_should_add_disabled_attribute() {
 		// Create a test category.
@@ -280,7 +280,7 @@ class Tests_Category_WpDropdownCategories extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @ticket 21474
+	 * @ticket 20810
 	 */
 	public function test_disabled_should_default_to_false() {
 		// Create a test category.

--- a/tests/phpunit/tests/category/wpDropdownCategories.php
+++ b/tests/phpunit/tests/category/wpDropdownCategories.php
@@ -255,4 +255,49 @@ class Tests_Category_WpDropdownCategories extends WP_UnitTestCase {
 		// Test to see if it contains the "required" attribute.
 		$this->assertDoesNotMatchRegularExpression( '/<select[^>]+required/', $dropdown_categories );
 	}
+
+	/**
+	 * @ticket 21474
+	 */
+	public function test_disabled_true_should_add_disabled_attribute() {
+		// Create a test category.
+		$cat_id = self::factory()->category->create(
+			array(
+				'name' => 'Test Category',
+				'slug' => 'test_category',
+			)
+		);
+
+		$args                = array(
+			'disabled'   => true,
+			'hide_empty' => 0,
+			'echo'       => 0,
+		);
+		$dropdown_categories = wp_dropdown_categories( $args );
+
+		// Test to see if it contains the "disabled" attribute.
+		$this->assertMatchesRegularExpression( '/<select[^>]+disabled/', $dropdown_categories );
+	}
+
+	/**
+	 * @ticket 21474
+	 */
+	public function test_disabled_should_default_to_false() {
+		// Create a test category.
+		$cat_id = self::factory()->category->create(
+			array(
+				'name' => 'Test Category',
+				'slug' => 'test_category',
+			)
+		);
+
+		$args                = array(
+			'hide_empty' => 0,
+			'echo'       => 0,
+		);
+		$dropdown_categories = wp_dropdown_categories( $args );
+
+		// Test to see if it contains the "disabled" attribute.
+		$this->assertDoesNotMatchRegularExpression( '/<select[^>]+disabled/', $dropdown_categories );
+	}
 }

--- a/tests/phpunit/tests/post/wpDropdownPages.php
+++ b/tests/phpunit/tests/post/wpDropdownPages.php
@@ -221,7 +221,7 @@ NO;
 	}
 
 	/**
-	 * @ticket 21474
+	 * @ticket 20810
 	 */
 	public function test_disabled_true_should_add_disabled_attribute() {
 		$p = self::factory()->post->create(
@@ -241,7 +241,7 @@ NO;
 	}
 
 	/**
-	 * @ticket 21474
+	 * @ticket 20810
 	 */
 	public function test_disabled_should_default_to_false() {
 		$p = self::factory()->post->create(

--- a/tests/phpunit/tests/post/wpDropdownPages.php
+++ b/tests/phpunit/tests/post/wpDropdownPages.php
@@ -219,4 +219,43 @@ NO;
 
 		$this->assertMatchesRegularExpression( '/<select[^>]+class=\'bar\'/', $found );
 	}
+
+	/**
+	 * @ticket 21474
+	 */
+	public function test_disabled_true_should_add_disabled_attribute() {
+		$p = self::factory()->post->create(
+			array(
+				'post_type' => 'page',
+			)
+		);
+
+		$found = wp_dropdown_pages(
+			array(
+				'echo'     => 0,
+				'disabled' => true,
+			)
+		);
+
+		$this->assertMatchesRegularExpression( '/<select[^>]+disabled/', $found );
+	}
+
+	/**
+	 * @ticket 21474
+	 */
+	public function test_disabled_should_default_to_false() {
+		$p = self::factory()->post->create(
+			array(
+				'post_type' => 'page',
+			)
+		);
+
+		$found = wp_dropdown_pages(
+			array(
+				'echo' => 0,
+			)
+		);
+
+		$this->assertDoesNotMatchRegularExpression( '/<select[^>]+disabled/', $found );
+	}
 }


### PR DESCRIPTION
This PR adds a `disabled` boolean argument to both `wp_dropdown_categories()` and `wp_dropdown_pages()`. When set to `true`, the generated `<select>` dropdowns are rendered with the HTML5 `disabled` attribute (`<select disabled>`). 

<img width="596" height="384" alt="Screenshot 2026-06-10 at 8 39 14 PM" src="https://github.com/user-attachments/assets/a8cf79a3-a027-44c1-ae02-00d3b3f48811" />

Trac ticket: [#20810](https://core.trac.wordpress.org/ticket/20810)

## Use of AI Tools

AI assistance: Yes
Tool(s): GitHub Copilot
Model(s): Gemini, Claude
Used for: Checking for potential edge cases, drafting the PR description, and assisting with local code review. The final implementation and testing were written and executed manually by me.

---

**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
