### PR TITLE
Charset: Fix broken test for utf8_decode() fallback.

### DIFF
--- a/tests/phpunit/tests/formatting/deprecatedUtfEncodeDecode.php
+++ b/tests/phpunit/tests/formatting/deprecatedUtfEncodeDecode.php
@@ -68,9 +68,9 @@ class Tests_DeprecatedUtf8EncodeDecodeTest extends WP_UnitTestCase {
 				 * Since the UTF-16 surrogate halves are not valid Unicode characters,
 				 * these have to be manually constructed as invalid UTF-8.
 				 */
-				$byte1 = 0xE0 | ( $i >> 12 );
-				$byte2 = 0x80 | ( ( $i >> 6 ) & 0x3F );
-				$byte3 = 0x80 | ( $i & 0x3F );
+				$byte1 = chr( 0xE0 | ( $i >> 12 ) );
+				$byte2 = chr( 0x80 | ( ( $i >> 6 ) & 0x3F ) );
+				$byte3 = chr( 0x80 | ( $i & 0x3F ) );
 
 				$c = "{$byte1}{$byte2}{$byte3}";
 			}


### PR DESCRIPTION
Trac ticket: Core-65372

Detected while fuzz-testing the UTF-8 handling code, this defect meant that the tests were verifying the wrong behavior. Namely, they verified a stringification of ASCII digits, which always converted plainly, when they were meant to test handling of invalid UTF-8 sequences.

This patch fixes the test by calling `chr()` on the byte values before concatenating into a big string.

Follow-up to: [60950].