### PR TITLE
Charset: Replace polyfill wp_has_noncharacters() with direct PCRE version.

### DIFF
--- a/src/wp-includes/compat-utf8.php
+++ b/src/wp-includes/compat-utf8.php
@@ -404,6 +404,7 @@ function _wp_utf8_codepoint_span( string $text, int $byte_offset, int $max_code_
  * Fallback support for determining if a string contains Unicode noncharacters.
  *
  * @since 6.9.0
+ * @deprecated 7.1.0
  * @access private
  *
  * @see \wp_has_noncharacters()
@@ -412,17 +413,9 @@ function _wp_utf8_codepoint_span( string $text, int $byte_offset, int $max_code_
  * @return bool Whether noncharacters were found in the string.
  */
 function _wp_has_noncharacters_fallback( string $text ): bool {
-	$at                = 0;
-	$invalid_length    = 0;
-	$has_noncharacters = false;
-	$end               = strlen( $text );
+	_deprecated_function( __FUNCTION__, '7.1.0' );
 
-	while ( $at < $end && ! $has_noncharacters ) {
-		_wp_scan_utf8( $text, $at, $invalid_length, null, null, $has_noncharacters );
-		$at += $invalid_length;
-	}
-
-	return $has_noncharacters;
+	return wp_has_noncharacters( $text );
 }
 
 /**

--- a/src/wp-includes/utf8.php
+++ b/src/wp-includes/utf8.php
@@ -134,44 +134,40 @@ else :
 	}
 endif;
 
-if ( _wp_can_use_pcre_u() ) :
-	/**
-	 * Returns whether the given string contains Unicode noncharacters.
-	 *
-	 * XML recommends against using noncharacters and HTML forbids their
-	 * use in attribute names. Unicode recommends that they not be used
-	 * in open exchange of data.
-	 *
-	 * Noncharacters are code points within the following ranges:
-	 *  - U+FDD0–U+FDEF
-	 *  - U+FFFE–U+FFFF
-	 *  - U+1FFFE, U+1FFFF, U+2FFFE, U+2FFFF, …, U+10FFFE, U+10FFFF
-	 *
-	 * @see https://www.unicode.org/versions/Unicode17.0.0/core-spec/chapter-23/#G12612
-	 * @see https://www.w3.org/TR/xml/#charsets
-	 * @see https://html.spec.whatwg.org/#attributes-2
-	 *
-	 * @since 6.9.0
-	 *
-	 * @param string $text Are there noncharacters in this string?
-	 * @return bool Whether noncharacters were found in the string.
+/**
+ * Returns whether the given string contains Unicode noncharacters.
+ *
+ * XML recommends against using noncharacters and HTML forbids their
+ * use in attribute names. Unicode recommends that they not be used
+ * in open exchange of data.
+ *
+ * Noncharacters are code points within the following ranges:
+ *  - U+FDD0–U+FDEF
+ *  - U+FFFE–U+FFFF
+ *  - U+1FFFE, U+1FFFF, U+2FFFE, U+2FFFF, …, U+10FFFE, U+10FFFF
+ *
+ * @see https://www.unicode.org/versions/Unicode17.0.0/core-spec/chapter-23/#G12612
+ * @see https://www.w3.org/TR/xml/#charsets
+ * @see https://html.spec.whatwg.org/#attributes-2
+ *
+ * @since 6.9.0
+ *
+ * @param string $text Are there noncharacters in this string?
+ * @return bool Whether noncharacters were found in the string.
+ */
+function wp_has_noncharacters( string $text ): bool {
+	/*
+	 * Match the UTF-8 byte sequences directly so malformed UTF-8 elsewhere
+	 * in the subject does not cause PCRE's Unicode mode to reject the string.
 	 */
-	function wp_has_noncharacters( string $text ): bool {
-		return 1 === preg_match(
-			'/[\x{FDD0}-\x{FDEF}\x{FFFE}\x{FFFF}\x{1FFFE}\x{1FFFF}\x{2FFFE}\x{2FFFF}\x{3FFFE}\x{3FFFF}\x{4FFFE}\x{4FFFF}\x{5FFFE}\x{5FFFF}\x{6FFFE}\x{6FFFF}\x{7FFFE}\x{7FFFF}\x{8FFFE}\x{8FFFF}\x{9FFFE}\x{9FFFF}\x{AFFFE}\x{AFFFF}\x{BFFFE}\x{BFFFF}\x{CFFFE}\x{CFFFF}\x{DFFFE}\x{DFFFF}\x{EFFFE}\x{EFFFF}\x{FFFFE}\x{FFFFF}\x{10FFFE}\x{10FFFF}]/u',
-			$text
-		);
-	}
-else :
-	/**
-	 * Fallback function for detecting noncharacters in a text.
-	 *
-	 * @ignore
-	 * @private
-	 *
-	 * @since 6.9.0
-	 */
-	function wp_has_noncharacters( string $text ): bool {
-		return _wp_has_noncharacters_fallback( $text );
-	}
-endif;
+	return 1 === preg_match(
+		'~
+			# U+FDD0-U+FDEF, U+FFFE-U+FFFF
+			\xEF(?:\xB7[\x90-\xAF]|\xBF[\xBE\xBF])
+			|
+			# U+nFFFE/U+nFFFF
+			(?:\xF0[\x9F\xAF\xBF]|[\xF1-\xF3][\x8F\x9F\xAF\xBF]|\xF4\x8F)\xBF[\xBE\xBF]
+		~x',
+		$text
+	);
+}

--- a/tests/phpunit/tests/unicode/wpHasNoncharacters.php
+++ b/tests/phpunit/tests/unicode/wpHasNoncharacters.php
@@ -63,38 +63,6 @@ class Tests_Unicode_WpHasNoncharacters extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Ensures that a noncharacter inside a string will be properly detected
-	 * using the fallback function when Unicode PCRE support is missing.
-	 *
-	 * @ticket 63863
-	 *
-	 * @dataProvider data_noncharacters
-	 *
-	 * @param string $noncharacter Noncharacter as a UTF-8 string.
-	 */
-	public function test_fallback_detects_non_characters( string $noncharacter ) {
-		$this->assertTrue(
-			_wp_has_noncharacters_fallback( $noncharacter ),
-			'Failed to detect entire string as noncharacter.'
-		);
-
-		$this->assertTrue(
-			_wp_has_noncharacters_fallback( "{$noncharacter} and more." ),
-			'Failed to detect noncharacter prefix.'
-		);
-
-		$this->assertTrue(
-			_wp_has_noncharacters_fallback( "Some text and then a {$noncharacter} and more." ),
-			'Failed to detect medial noncharacter.'
-		);
-
-		$this->assertTrue(
-			_wp_has_noncharacters_fallback( "Some text and a {$noncharacter}." ),
-			'Failed to detect noncharacter suffix.'
-		);
-	}
-
-	/**
 	 * Ensures that Unicode characters are not falsely detect as noncharacters.
 	 *
 	 * @ticket 63863
@@ -133,52 +101,6 @@ class Tests_Unicode_WpHasNoncharacters extends WP_UnitTestCase {
 			} else {
 				$this->assertFalse(
 					wp_has_noncharacters( $char ),
-					"Falsely detected noncharacter in U+{$hex_char}."
-				);
-			}
-		}
-	}
-
-	/**
-	 * Ensures that Unicode characters are not falsely detect as noncharacters
-	 * using the fallback function when Unicode PCRE support is missing.
-	 *
-	 * @ticket 63863
-	 */
-	public function test_fallback_avoids_false_positives() {
-		// Get all the noncharacters in one long string, each surrounded on both sides by null bytes.
-		$noncharacters = implode(
-			"\x00",
-			array_map(
-				static function ( $c ) {
-					return "\x00{$c}";
-				},
-				array_column( array_values( iterator_to_array( self::data_noncharacters() ) ), 0 )
-			)
-		) . "\x00";
-
-		$this->assertFalse(
-			_wp_has_noncharacters_fallback( "\x00" ),
-			'Falsely detected noncharacter in U+0000'
-		);
-
-		for ( $code_point = 1; $code_point <= 0x10FFFF; $code_point++ ) {
-			// Surrogate halves are invalid UTF-8.
-			if ( $code_point >= 0xD800 && $code_point <= 0xDFFF ) {
-				continue;
-			}
-
-			$char     = mb_chr( $code_point );
-			$hex_char = strtoupper( str_pad( dechex( $code_point ), 4, '0', STR_PAD_LEFT ) );
-
-			if ( str_contains( $noncharacters, $char ) ) {
-				$this->assertTrue(
-					_wp_has_noncharacters_fallback( $char ),
-					"Failed to detect noncharacter as test verification for U+{$hex_char}"
-				);
-			} else {
-				$this->assertFalse(
-					_wp_has_noncharacters_fallback( $char ),
 					"Falsely detected noncharacter in U+{$hex_char}."
 				);
 			}

--- a/tests/phpunit/tests/unicode/wpHasNoncharacters.php
+++ b/tests/phpunit/tests/unicode/wpHasNoncharacters.php
@@ -41,6 +41,28 @@ class Tests_Unicode_WpHasNoncharacters extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Ensures that invalid UTF-8 does not prevent noncharacter detection.
+	 *
+	 * @ticket 65372
+	 */
+	public function test_detects_non_characters_when_string_contains_invalid_utf8() {
+		$this->assertTrue(
+			wp_has_noncharacters( "Invalid byte \xF1 before \u{FDD0}." ),
+			'Failed to detect noncharacter after invalid UTF-8.'
+		);
+
+		$this->assertTrue(
+			wp_has_noncharacters( "Noncharacter \u{10FFFF} before invalid byte \xF1." ),
+			'Failed to detect noncharacter before invalid UTF-8.'
+		);
+
+		$this->assertFalse(
+			wp_has_noncharacters( "Invalid byte \xF1 without noncharacters." ),
+			'Falsely detected noncharacter in invalid UTF-8.'
+		);
+	}
+
+	/**
 	 * Ensures that a noncharacter inside a string will be properly detected
 	 * using the fallback function when Unicode PCRE support is missing.
 	 *


### PR DESCRIPTION
Trac ticket: Core-65372

Found during fuzzing work on the HTML API and adjacent code. The previous version of this function used a Unicode PCRE to detect noncharacter code points, but that invocation failed if the input string contained sequences of invalid UTF-8 bytes.

This patch replaces the Unicode PCRE with a mapped sequence of raw bytes. This version works in environments without Unicode support and it works when invalid bytes are present, making it possible to remove the fallback function as well.

Follow-up to [61000].