### PR TITLE
HTML API: Ensure that code points always encode to UTF-8

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-decoder.php
+++ b/src/wp-includes/html-api/class-wp-html-decoder.php
@@ -424,7 +424,7 @@ class WP_HTML_Decoder {
 	 * @return string Converted code point, or `�` if invalid.
 	 */
 	public static function code_point_to_utf8_bytes( $code_point ): string {
-		$string = mb_chr( $code_point );
+		$string = mb_chr( $code_point, 'UTF-8' );
 
 		return false !== $string ? $string : '�';
 	}


### PR DESCRIPTION
Trac ticket: Core-65372

> ⚠️ Not sure if this is a positive fix or not because things get really messy when a site isn’t running UTF-8. For example, if the `blog_charset` is non-UTF-8, then the encoded code points won’t render on the frontend; they will be corrupted. However, if we encode in the configured charset, it’s likely that the code points aren’t represented in that charset, and will be rendered as `?` instead, which is corrupt. It still makes most sense to run everything internally as UTF-8 and then only re-encode on transit to the browser if the site isn’t running UTF-8. In that case, this is a positive change.

This was brought up during fuzz testing of the HTML API. After polyfilling `mb_chr()` and relying on it in the HTML decoder, it became possible that for sites with a non-UTF-8 charset selected, then the creation of text from code points when decoding numeric character references might produce corrupted text, or text which encodes to non-UTF-8 bytes.

While for these sites, there are broader issues with non-UTF-8 support, this change ensures that code point encoding remains deterministic.

Follow-up to [62424].