### PR TITLE
Replace `node-sass` with `dart-sass`

### DIFF
--- a/src/wp-content/themes/twentynineteen/package-lock.json
+++ b/src/wp-content/themes/twentynineteen/package-lock.json
@@ -1,7 +1,7 @@
 {
   "name": "twentynineteen",
   "version": "3.3.0",
-  "lockfileVersion": 2,
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
@@ -11,138 +11,364 @@
         "@wordpress/browserslist-config": "^6.34.0",
         "autoprefixer": "^10.4.22",
         "chokidar-cli": "^3.0.0",
-        "node-sass": "^9.0.0",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.5.6",
         "postcss-cli": "^11.0.1",
         "postcss-focus-within": "^9.0.1",
-        "rtlcss": "^4.3.0"
+        "rtlcss": "^4.3.0",
+        "sass": "^1.83.0"
       },
       "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
+        "node": ">=24.15.0",
+        "npm": ">=11.12.1"
       }
     },
-    "node_modules/@babel/code-frame": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
-      "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
+    "node_modules/@parcel/watcher": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
+      "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
       "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
       "dependencies": {
-        "@babel/highlight": "^7.18.6"
+        "detect-libc": "^2.0.3",
+        "is-glob": "^4.0.3",
+        "node-addon-api": "^7.0.0",
+        "picomatch": "^4.0.3"
       },
       "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.19.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
-      "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/highlight": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
-      "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.18.6",
-        "chalk": "^2.0.0",
-        "js-tokens": "^4.0.0"
+        "node": ">= 10.0.0"
       },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@gar/promisify": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
-      "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
-      "dev": true
-    },
-    "node_modules/@npmcli/fs": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-2.1.2.tgz",
-      "integrity": "sha512-yOJKRvohFOaLqipNtwYB9WugyZKhC/DZC4VYPmpaCzDBrA8YpK3qHZ8/HGscMnE4GqbkLNuVcCnxkeQEdGt6LQ==",
-      "dev": true,
-      "dependencies": {
-        "@gar/promisify": "^1.1.3",
-        "semver": "^7.3.5"
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      "optionalDependencies": {
+        "@parcel/watcher-android-arm64": "2.5.6",
+        "@parcel/watcher-darwin-arm64": "2.5.6",
+        "@parcel/watcher-darwin-x64": "2.5.6",
+        "@parcel/watcher-freebsd-x64": "2.5.6",
+        "@parcel/watcher-linux-arm-glibc": "2.5.6",
+        "@parcel/watcher-linux-arm-musl": "2.5.6",
+        "@parcel/watcher-linux-arm64-glibc": "2.5.6",
+        "@parcel/watcher-linux-arm64-musl": "2.5.6",
+        "@parcel/watcher-linux-x64-glibc": "2.5.6",
+        "@parcel/watcher-linux-x64-musl": "2.5.6",
+        "@parcel/watcher-win32-arm64": "2.5.6",
+        "@parcel/watcher-win32-ia32": "2.5.6",
+        "@parcel/watcher-win32-x64": "2.5.6"
       }
     },
-    "node_modules/@npmcli/fs/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+    "node_modules/@parcel/watcher-android-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.6.tgz",
+      "integrity": "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==",
+      "cpu": [
+        "arm64"
+      ],
       "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
       "engines": {
-        "node": ">=10"
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/@npmcli/fs/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+    "node_modules/@parcel/watcher-darwin-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.6.tgz",
+      "integrity": "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==",
+      "cpu": [
+        "arm64"
+      ],
       "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
       "engines": {
-        "node": ">=10"
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/@npmcli/move-file": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-2.0.1.tgz",
-      "integrity": "sha512-mJd2Z5TjYWq/ttPLLGqArdtnC74J6bOzg4rMDnN+p1xTacZ2yPRCk2y0oSWQtygLR9YVQXgOcONrwtnk3JupxQ==",
-      "deprecated": "This functionality has been moved to @npmcli/fs",
+    "node_modules/@parcel/watcher-darwin-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.6.tgz",
+      "integrity": "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==",
+      "cpu": [
+        "x64"
+      ],
       "dev": true,
-      "dependencies": {
-        "mkdirp": "^1.0.4",
-        "rimraf": "^3.0.2"
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
       },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/@tootallnate/once": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+    "node_modules/@parcel/watcher-freebsd-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.6.tgz",
+      "integrity": "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==",
+      "cpu": [
+        "x64"
+      ],
       "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/@types/minimist": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
-      "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
-      "dev": true
+    "node_modules/@parcel/watcher-linux-arm-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.6.tgz",
+      "integrity": "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
     },
-    "node_modules/@types/normalize-package-data": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
-      "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
-      "dev": true
+    "node_modules/@parcel/watcher-linux-arm-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz",
+      "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz",
+      "integrity": "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz",
+      "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz",
+      "integrity": "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz",
+      "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz",
+      "integrity": "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-ia32": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.6.tgz",
+      "integrity": "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.6.tgz",
+      "integrity": "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/@wordpress/browserslist-config": {
-      "version": "6.34.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.34.0.tgz",
-      "integrity": "sha512-pmcCkqG2jW+UUBSkX7rSZS33mcW6M0fKcJPD40TlK2cUZvECS5TDa2BC/b80PfIsT2kSw+Z9Wv+8eyX6I8HGjQ==",
+      "version": "6.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.48.0.tgz",
+      "integrity": "sha512-bPcrwFqlG9i4qLrcrYBj8lOYhB547SYelEZ+HCesfrkUHr5YDM2mnUdqKhj0+E6/T/iSBAht9uK4SEqj/hShqA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
@@ -150,56 +376,12 @@
         "npm": ">=8.19.2"
       }
     },
-    "node_modules/abbrev": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-      "dev": true
-    },
-    "node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/agentkeepalive": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.2.1.tgz",
-      "integrity": "sha512-Zn4cw2NEqd+9fiSVWMscnjyQ1a8Yfoc5oBajLeo5w+YBHgDUcEBY2hS4YpTz6iN5f/2zQiktcuM6tS8x1p9dpA==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^4.1.0",
-        "depd": "^1.1.2",
-        "humanize-ms": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
-      }
-    },
-    "node_modules/aggregate-error": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
-      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-      "dev": true,
-      "dependencies": {
-        "clean-stack": "^2.0.0",
-        "indent-string": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/ansi-regex": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
       "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -209,6 +391,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -221,6 +404,7 @@
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -229,47 +413,59 @@
         "node": ">= 8"
       }
     },
-    "node_modules/aproba": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
-      "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
-      "dev": true
-    },
-    "node_modules/are-we-there-yet": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
-      "integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^3.6.0"
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/arrify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
+    "node_modules/arraybuffer.prototype.slice": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+      "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.1",
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "is-array-buffer": "^3.0.4"
+      },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/async-foreach": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
-      "integrity": "sha512-VUeSMD8nEGBWaZK4lizI1sf3yEC7pnAQ/mrI7pC2fBz2s/tq5jWWEngTwaf0Gruu/OoXRGLGg1XFqpYBiGTYJA==",
+    "node_modules/async-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+      "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": "*"
+        "node": ">= 0.4"
       }
     },
     "node_modules/autoprefixer": {
-      "version": "10.4.22",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.22.tgz",
-      "integrity": "sha512-ARe0v/t9gO28Bznv6GgqARmVqcWOV3mfgUPn9becPHMiD3o9BwlRgaeccZnwTpZ7Zwqrm+c1sUSsMxIzQzc8Xg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.0.tgz",
+      "integrity": "sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==",
       "dev": true,
       "funding": [
         {
@@ -287,10 +483,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.27.0",
-        "caniuse-lite": "^1.0.30001754",
+        "browserslist": "^4.28.2",
+        "caniuse-lite": "^1.0.30001787",
         "fraction.js": "^5.3.4",
-        "normalize-range": "^0.1.2",
         "picocolors": "^1.1.1",
         "postcss-value-parser": "^4.2.0"
       },
@@ -304,35 +499,59 @@
         "postcss": "^8.1.0"
       }
     },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/balanced-match": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.8.25",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.25.tgz",
-      "integrity": "sha512-2NovHVesVF5TXefsGX1yzx1xgr7+m9JQenvz6FQY3qd+YXkKkYiv+vTCc7OriP9mcDZpTC5mAOYN4ocd29+erA==",
+      "version": "2.10.35",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.35.tgz",
+      "integrity": "sha512-honAfLBde0HAFLdNyBEfuuENkF6zR+ozxqxa/2zJKHBe1qzLqyTSeRKpdPEHAP03rlDGyQOPnCSxnVpVqQo9Mg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
-        "baseline-browser-mapping": "dist/cli.js"
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/binary-extensions": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
-      "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -345,6 +564,7 @@
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
       },
@@ -353,9 +573,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.0.tgz",
-      "integrity": "sha512-tbydkR/CxfMwelN0vwdP/pLkDwyAASZ+VfWm4EOwlB6SWhx1sYnWLqo8N5j0rAzPfzfRaxt0mM/4wPU/Su84RQ==",
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
       "dev": true,
       "funding": [
         {
@@ -373,11 +593,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.8.25",
-        "caniuse-lite": "^1.0.30001754",
-        "electron-to-chromium": "^1.5.249",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.1.4"
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -386,74 +606,54 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
-    "node_modules/cacache": {
-      "version": "16.1.3",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-16.1.3.tgz",
-      "integrity": "sha512-/+Emcj9DAXxX4cwlLmRI9c166RuL3w30zp4R7Joiv2cQTtTtA+jeuCAjH3ZlGnYS3tKENSrKhAzVVP9GVyzeYQ==",
-      "dev": true,
-      "dependencies": {
-        "@npmcli/fs": "^2.1.0",
-        "@npmcli/move-file": "^2.0.0",
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.1.0",
-        "glob": "^8.0.1",
-        "infer-owner": "^1.0.4",
-        "lru-cache": "^7.7.1",
-        "minipass": "^3.1.6",
-        "minipass-collect": "^1.0.2",
-        "minipass-flush": "^1.0.5",
-        "minipass-pipeline": "^1.2.4",
-        "mkdirp": "^1.0.4",
-        "p-map": "^4.0.0",
-        "promise-inflight": "^1.0.1",
-        "rimraf": "^3.0.2",
-        "ssri": "^9.0.0",
-        "tar": "^6.1.11",
-        "unique-filename": "^2.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/cacache/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/cacache/node_modules/glob": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
-      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
-      "dev": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^5.0.1",
-        "once": "^1.3.0"
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">= 0.4"
       },
       "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/cacache/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/camelcase": {
@@ -461,31 +661,15 @@
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
-    "node_modules/camelcase-keys": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
-      "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
-      "dev": true,
-      "dependencies": {
-        "camelcase": "^5.3.1",
-        "map-obj": "^4.0.0",
-        "quick-lru": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001754",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001754.tgz",
-      "integrity": "sha512-x6OeBXueoAceOmotzx3PO4Zpt4rzpeIFsSr6AAePTZxSkXiYDUmpypEl7e2+8NCd9bD7bXjqyef8CJYPC1jfxg==",
+      "version": "1.0.30001799",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
       "dev": true,
       "funding": [
         {
@@ -508,6 +692,7 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -518,16 +703,11 @@
       }
     },
     "node_modules/chokidar": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
-      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
       "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ],
+      "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -540,6 +720,9 @@
       "engines": {
         "node": ">= 8.10.0"
       },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
       }
@@ -549,6 +732,7 @@
       "resolved": "https://registry.npmjs.org/chokidar-cli/-/chokidar-cli-3.0.0.tgz",
       "integrity": "sha512-xVW+Qeh7z15uZRxHOkP93Ux8A0xbPzwK4GaqD8dQOYc34TlkqUhVSS59fK36DOp5WdJlrRzlYSy02Ht99FjZqQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "chokidar": "^3.5.2",
         "lodash.debounce": "^4.0.8",
@@ -562,47 +746,16 @@
         "node": ">= 8.10.0"
       }
     },
-    "node_modules/chownr": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/clean-stack": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/cliui": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
       "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "string-width": "^3.1.0",
         "strip-ansi": "^5.2.0",
         "wrap-ansi": "^5.1.0"
-      }
-    },
-    "node_modules/cliui/node_modules/string-width": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-      "dev": true,
-      "dependencies": {
-        "emoji-regex": "^7.0.1",
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^5.1.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/color-convert": {
@@ -610,6 +763,7 @@
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-name": "1.1.3"
       }
@@ -617,35 +771,16 @@
     "node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
-    },
-    "node_modules/color-support": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
       "dev": true,
-      "bin": {
-        "color-support": "bin.js"
-      }
+      "license": "MIT"
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
-    },
-    "node_modules/console-control-strings": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
-      "dev": true
-    },
-    "node_modules/core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "dev": true
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "6.0.6",
@@ -677,82 +812,104 @@
         "node": ">=4"
       }
     },
-    "node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+    "node_modules/data-view-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+      "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
       },
       "engines": {
-        "node": ">=6.0"
+        "node": ">= 0.4"
       },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+      "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/inspect-js"
+      }
+    },
+    "node_modules/data-view-byte-offset": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+      "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
-    "node_modules/decamelize-keys": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.1.tgz",
-      "integrity": "sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==",
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "decamelize": "^1.1.0",
-        "map-obj": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/decamelize-keys/node_modules/map-obj": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-      "integrity": "sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/define-properties": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-      "dev": true,
-      "dependencies": {
-        "object-keys": "^1.0.12"
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/delegates": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
-      "dev": true
-    },
-    "node_modules/depd": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/dependency-graph": {
@@ -765,10 +922,36 @@
         "node": ">=4"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.249",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.249.tgz",
-      "integrity": "sha512-5vcfL3BBe++qZ5kuFhD/p8WOM1N9m3nwvJPULJx+4xf2usSlZFJ0qoNYO2fOX4hi3ocuDcmDobtA+5SFr4OmBg==",
+      "version": "1.5.371",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.371.tgz",
+      "integrity": "sha512-e9htk9mAYL6AzmkEhSvVVw7IWGSBJ/Bqdn2eRyRLrj1g6sncN4WbFt5qnILYoCktktr45pyjIrOiRvBThQ808w==",
       "dev": true,
       "license": "ISC"
     },
@@ -776,71 +959,153 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
       "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-      "dev": true
-    },
-    "node_modules/encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
       "dev": true,
-      "optional": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
-      }
-    },
-    "node_modules/env-paths": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
-      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/err-code": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
-      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
-      "dev": true
+      "license": "MIT"
     },
     "node_modules/error-ex": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
-      "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
+      "integrity": "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "es-to-primitive": "^1.2.0",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "is-callable": "^1.1.4",
-        "is-regex": "^1.0.4",
-        "object-keys": "^1.0.12"
+        "array-buffer-byte-length": "^1.0.2",
+        "arraybuffer.prototype.slice": "^1.0.4",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "data-view-buffer": "^1.0.2",
+        "data-view-byte-length": "^1.0.2",
+        "data-view-byte-offset": "^1.0.1",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-set-tostringtag": "^2.1.0",
+        "es-to-primitive": "^1.3.0",
+        "function.prototype.name": "^1.1.8",
+        "get-intrinsic": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "get-symbol-description": "^1.1.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "internal-slot": "^1.1.0",
+        "is-array-buffer": "^3.0.5",
+        "is-callable": "^1.2.7",
+        "is-data-view": "^1.0.2",
+        "is-negative-zero": "^2.0.3",
+        "is-regex": "^1.2.1",
+        "is-set": "^2.0.3",
+        "is-shared-array-buffer": "^1.0.4",
+        "is-string": "^1.1.1",
+        "is-typed-array": "^1.1.15",
+        "is-weakref": "^1.1.1",
+        "math-intrinsics": "^1.1.0",
+        "object-inspect": "^1.13.4",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.7",
+        "own-keys": "^1.0.1",
+        "regexp.prototype.flags": "^1.5.4",
+        "safe-array-concat": "^1.1.3",
+        "safe-push-apply": "^1.0.0",
+        "safe-regex-test": "^1.1.0",
+        "set-proto": "^1.0.0",
+        "stop-iteration-iterator": "^1.1.0",
+        "string.prototype.trim": "^1.2.10",
+        "string.prototype.trimend": "^1.0.9",
+        "string.prototype.trimstart": "^1.0.8",
+        "typed-array-buffer": "^1.0.3",
+        "typed-array-byte-length": "^1.0.3",
+        "typed-array-byte-offset": "^1.0.4",
+        "typed-array-length": "^1.0.7",
+        "unbox-primitive": "^1.1.0",
+        "which-typed-array": "^1.1.19"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/es-to-primitive": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
-      "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
+      "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "is-callable": "^1.1.4",
-        "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.2"
+        "is-callable": "^1.2.7",
+        "is-date-object": "^1.0.5",
+        "is-symbol": "^1.0.4"
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/escalade": {
@@ -856,8 +1121,9 @@
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
       }
@@ -867,6 +1133,7 @@
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -879,11 +1146,28 @@
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
       "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "locate-path": "^3.0.0"
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/fraction.js": {
@@ -901,10 +1185,11 @@
       }
     },
     "node_modules/fs-extra": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
-      "integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
+      "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -914,30 +1199,13 @@
         "node": ">=14.14"
       }
     },
-    "node_modules/fs-minipass": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-      "dev": true,
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true
-    },
     "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -947,61 +1215,54 @@
       }
     },
     "node_modules/function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
-    },
-    "node_modules/gauge": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
-      "integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "dev": true,
-      "dependencies": {
-        "aproba": "^1.0.3 || ^2.0.0",
-        "color-support": "^1.1.3",
-        "console-control-strings": "^1.1.0",
-        "has-unicode": "^2.0.1",
-        "signal-exit": "^3.0.7",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1",
-        "wide-align": "^1.1.5"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/gauge/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+    "node_modules/function.prototype.name": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
+      "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
       "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/gauge/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^5.0.1"
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "functions-have-names": "^1.2.3",
+        "hasown": "^2.0.2",
+        "is-callable": "^1.2.7"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/gaze": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
-      "integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
       "dev": true,
-      "dependencies": {
-        "globule": "^1.0.0"
-      },
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">= 4.0.0"
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-caller-file": {
@@ -1009,37 +1270,66 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
     },
-    "node_modules/get-stdin": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-      "integrity": "sha512-F5aQMywwJ2n85s4hJPTT9RPxGmubonuB10MNYo17/xph174n2MIR33HRguhzVag10O/npM7SPk73LMZNP+FaWw==",
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
       },
       "engines": {
-        "node": "*"
+        "node": ">= 0.4"
       },
       "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-symbol-description": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+      "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/glob-parent": {
@@ -1047,6 +1337,7 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -1054,229 +1345,233 @@
         "node": ">= 6"
       }
     },
-    "node_modules/glob/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
       },
       "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/globule": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/globule/-/globule-1.3.4.tgz",
-      "integrity": "sha512-OPTIfhMBh7JbBYDpa5b+Q5ptmMWKwcNcFSR/0c6t8V4f3ZAVBEsKNY37QdVqmLRYSMhOUGYrY0QhSoEpzGr/Eg==",
-      "dev": true,
-      "dependencies": {
-        "glob": "~7.1.1",
-        "lodash": "^4.17.21",
-        "minimatch": "~3.0.2"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/globule/node_modules/glob": {
-      "version": "7.1.7",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
-      "dev": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
+        "node": ">= 0.4"
       },
       "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/graceful-fs": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
-      "integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg==",
-      "dev": true
-    },
-    "node_modules/hard-rejection": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
-      "integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/has-bigints": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/has": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
-      "dependencies": {
-        "function-bind": "^1.1.1"
+        "node": ">= 0.4"
       },
-      "engines": {
-        "node": ">= 0.4.0"
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
-    "node_modules/has-symbols": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
+      "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/has-unicode": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
-      "dev": true
     },
     "node_modules/hosted-git-info": {
       "version": "2.8.9",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
-      "dev": true
-    },
-    "node_modules/http-cache-semantics": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
-      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
-      "dev": true
-    },
-    "node_modules/http-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
       "dev": true,
-      "dependencies": {
-        "@tootallnate/once": "2",
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
+      "license": "ISC"
     },
-    "node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+    "node_modules/immutable": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.6.tgz",
+      "integrity": "sha512-q1swsS8K7L8usSHuOqF2TAoCCkonYz0SG38wLAggaa4Wml70zixIvt2ql4coQ2C2B3hTjltJry4r6bULwgAXLQ==",
       "dev": true,
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
+      "license": "MIT"
     },
-    "node_modules/humanize-ms": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
-      "dev": true,
-      "dependencies": {
-        "ms": "^2.0.0"
-      }
-    },
-    "node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/imurmurhash": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.19"
-      }
-    },
-    "node_modules/indent-string": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/infer-owner": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
-      "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
-      "dev": true
-    },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "dev": true,
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
-    },
-    "node_modules/ip-address": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
-      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+    "node_modules/internal-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "jsbn": "1.1.0",
-        "sprintf-js": "^1.1.3"
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
       },
       "engines": {
-        "node": ">= 12"
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-      "dev": true
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-async-function": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
+      "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-function": "^1.0.0",
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "binary-extensions": "^2.0.0"
       },
@@ -1284,59 +1579,149 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-callable": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+    "node_modules/is-boolean-object": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
-      "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "has": "^1.0.3"
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-data-view": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+      "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-date-object": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-finalizationregistry": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+      "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
-    "node_modules/is-glob": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+    "node_modules/is-generator-function": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -1344,102 +1729,231 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-lambda": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
-      "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
-      "dev": true
+    "node_modules/is-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
       }
     },
-    "node_modules/is-plain-obj": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-      "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
+    "node_modules/is-number-object": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-regex": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
-      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "has": "^1.0.1"
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-set": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-string": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-symbol": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
-      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "has-symbols": "^1.0.0"
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
+      "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "dev": true
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
-    },
-    "node_modules/js-base64": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.4.tgz",
-      "integrity": "sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ==",
-      "dev": true
-    },
-    "node_modules/js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
-    },
-    "node_modules/jsbn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
-      "license": "MIT"
+      "license": "ISC"
     },
     "node_modules/json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
-      "dev": true
-    },
-    "node_modules/json-parse-even-better-errors": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -1447,35 +1961,51 @@
         "graceful-fs": "^4.1.6"
       }
     },
-    "node_modules/kind-of": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/lilconfig": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.0.0.tgz",
-      "integrity": "sha512-K2U4W2Ff5ibV7j7ydLr+zLAkIg5JJ4lPn1Ltsdt+Tz/IjQ8buJ55pZAxoP34lqIiwtF9iAvtLv3JGv7CAyAg+g==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
       }
     },
-    "node_modules/lines-and-columns": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true
+    "node_modules/load-json-file": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+      "integrity": "sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^4.0.0",
+        "pify": "^3.0.0",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/load-json-file/node_modules/pify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/locate-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
       "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "p-locate": "^3.0.0",
         "path-exists": "^3.0.0"
@@ -1484,184 +2014,45 @@
         "node": ">=6"
       }
     },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
-    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
-      "dev": true
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.throttle": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
-      "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=",
-      "dev": true
-    },
-    "node_modules/lru-cache": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.1.tgz",
-      "integrity": "sha512-8/HcIENyQnfUTCDizRu9rrDyG6XG/21M4X7/YEGZeD76ZJilFPAUVb/2zysFf7VVO1LEjCDFyHp8pMMvozIrvg==",
+      "integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==",
       "dev": true,
-      "engines": {
-        "node": ">=12"
-      }
+      "license": "MIT"
     },
-    "node_modules/make-fetch-happen": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-10.2.1.tgz",
-      "integrity": "sha512-NgOPbRiaQM10DYXvN3/hhGVI2M5MtITFryzBGxHM5p4wnFxsVCbxkrBrDsk+EZ5OB4jEOT7AjDxtdF+KVEFT7w==",
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
       "dev": true,
-      "dependencies": {
-        "agentkeepalive": "^4.2.1",
-        "cacache": "^16.1.0",
-        "http-cache-semantics": "^4.1.0",
-        "http-proxy-agent": "^5.0.0",
-        "https-proxy-agent": "^5.0.0",
-        "is-lambda": "^1.0.1",
-        "lru-cache": "^7.7.1",
-        "minipass": "^3.1.6",
-        "minipass-collect": "^1.0.2",
-        "minipass-fetch": "^2.0.3",
-        "minipass-flush": "^1.0.5",
-        "minipass-pipeline": "^1.2.4",
-        "negotiator": "^0.6.3",
-        "promise-retry": "^2.0.1",
-        "socks-proxy-agent": "^7.0.0",
-        "ssri": "^9.0.0"
-      },
+      "license": "MIT",
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/map-obj": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
-      "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">= 0.4"
       }
     },
     "node_modules/memorystream": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
-      "integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI=",
+      "integrity": "sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==",
       "dev": true,
       "engines": {
         "node": ">= 0.10.0"
       }
     },
-    "node_modules/meow": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-9.0.0.tgz",
-      "integrity": "sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/minimist": "^1.2.0",
-        "camelcase-keys": "^6.2.2",
-        "decamelize": "^1.2.0",
-        "decamelize-keys": "^1.1.0",
-        "hard-rejection": "^2.1.0",
-        "minimist-options": "4.1.0",
-        "normalize-package-data": "^3.0.0",
-        "read-pkg-up": "^7.0.1",
-        "redent": "^3.0.0",
-        "trim-newlines": "^3.0.0",
-        "type-fest": "^0.18.0",
-        "yargs-parser": "^20.2.3"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/meow/node_modules/hosted-git-info": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
-      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/meow/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/meow/node_modules/normalize-package-data": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
-      "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
-      "dev": true,
-      "dependencies": {
-        "hosted-git-info": "^4.0.1",
-        "is-core-module": "^2.5.0",
-        "semver": "^7.3.4",
-        "validate-npm-package-license": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/meow/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/meow/node_modules/yargs-parser": {
-      "version": "20.2.9",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/min-indent": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
-      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/minimatch": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
-      "integrity": "sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -1669,138 +2060,10 @@
         "node": "*"
       }
     },
-    "node_modules/minimist-options": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
-      "integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
-      "dev": true,
-      "dependencies": {
-        "arrify": "^1.0.1",
-        "is-plain-obj": "^1.1.0",
-        "kind-of": "^6.0.3"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/minipass-collect": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
-      "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
-      "dev": true,
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/minipass-fetch": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-2.1.2.tgz",
-      "integrity": "sha512-LT49Zi2/WMROHYoqGgdlQIZh8mLPZmOrN2NdJjMXxYe4nkN6FUyuPuOAOedNJDrx0IRGg9+4guZewtp8hE6TxA==",
-      "dev": true,
-      "dependencies": {
-        "minipass": "^3.1.6",
-        "minipass-sized": "^1.0.3",
-        "minizlib": "^2.1.2"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      },
-      "optionalDependencies": {
-        "encoding": "^0.1.13"
-      }
-    },
-    "node_modules/minipass-flush": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
-      "integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
-      "dev": true,
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/minipass-pipeline": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
-      "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
-      "dev": true,
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/minipass-sized": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
-      "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
-      "dev": true,
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/minizlib": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-      "dev": true,
-      "dependencies": {
-        "minipass": "^3.0.0",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "dev": true,
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
-    },
-    "node_modules/nan": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
-      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==",
-      "dev": true
-    },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -1816,436 +2079,29 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
-    "node_modules/negotiator": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
-      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
-      "dev": true
-    },
-    "node_modules/node-gyp": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-8.4.1.tgz",
-      "integrity": "sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==",
-      "dev": true,
-      "dependencies": {
-        "env-paths": "^2.2.0",
-        "glob": "^7.1.4",
-        "graceful-fs": "^4.2.6",
-        "make-fetch-happen": "^9.1.0",
-        "nopt": "^5.0.0",
-        "npmlog": "^6.0.0",
-        "rimraf": "^3.0.2",
-        "semver": "^7.3.5",
-        "tar": "^6.1.2",
-        "which": "^2.0.2"
-      },
-      "bin": {
-        "node-gyp": "bin/node-gyp.js"
-      },
-      "engines": {
-        "node": ">= 10.12.0"
-      }
-    },
-    "node_modules/node-gyp/node_modules/@npmcli/fs": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.1.1.tgz",
-      "integrity": "sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==",
-      "dev": true,
-      "dependencies": {
-        "@gar/promisify": "^1.0.1",
-        "semver": "^7.3.5"
-      }
-    },
-    "node_modules/node-gyp/node_modules/@npmcli/move-file": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
-      "integrity": "sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==",
-      "deprecated": "This functionality has been moved to @npmcli/fs",
-      "dev": true,
-      "dependencies": {
-        "mkdirp": "^1.0.4",
-        "rimraf": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/node-gyp/node_modules/@tootallnate/once": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/node-gyp/node_modules/cacache": {
-      "version": "15.3.0",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-15.3.0.tgz",
-      "integrity": "sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==",
-      "dev": true,
-      "dependencies": {
-        "@npmcli/fs": "^1.0.0",
-        "@npmcli/move-file": "^1.0.1",
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "glob": "^7.1.4",
-        "infer-owner": "^1.0.4",
-        "lru-cache": "^6.0.0",
-        "minipass": "^3.1.1",
-        "minipass-collect": "^1.0.2",
-        "minipass-flush": "^1.0.5",
-        "minipass-pipeline": "^1.2.2",
-        "mkdirp": "^1.0.3",
-        "p-map": "^4.0.0",
-        "promise-inflight": "^1.0.1",
-        "rimraf": "^3.0.2",
-        "ssri": "^8.0.1",
-        "tar": "^6.0.2",
-        "unique-filename": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/node-gyp/node_modules/graceful-fs": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
-      "dev": true
-    },
-    "node_modules/node-gyp/node_modules/http-proxy-agent": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
-      "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
-      "dev": true,
-      "dependencies": {
-        "@tootallnate/once": "1",
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/node-gyp/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/node-gyp/node_modules/make-fetch-happen": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
-      "integrity": "sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==",
-      "dev": true,
-      "dependencies": {
-        "agentkeepalive": "^4.1.3",
-        "cacache": "^15.2.0",
-        "http-cache-semantics": "^4.1.0",
-        "http-proxy-agent": "^4.0.1",
-        "https-proxy-agent": "^5.0.0",
-        "is-lambda": "^1.0.1",
-        "lru-cache": "^6.0.0",
-        "minipass": "^3.1.3",
-        "minipass-collect": "^1.0.2",
-        "minipass-fetch": "^1.3.2",
-        "minipass-flush": "^1.0.5",
-        "minipass-pipeline": "^1.2.4",
-        "negotiator": "^0.6.2",
-        "promise-retry": "^2.0.1",
-        "socks-proxy-agent": "^6.0.0",
-        "ssri": "^8.0.0"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/node-gyp/node_modules/minipass-fetch": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
-      "integrity": "sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==",
-      "dev": true,
-      "dependencies": {
-        "minipass": "^3.1.0",
-        "minipass-sized": "^1.0.3",
-        "minizlib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "optionalDependencies": {
-        "encoding": "^0.1.12"
-      }
-    },
-    "node_modules/node-gyp/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/node-gyp/node_modules/socks-proxy-agent": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.2.1.tgz",
-      "integrity": "sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ==",
-      "dev": true,
-      "dependencies": {
-        "agent-base": "^6.0.2",
-        "debug": "^4.3.3",
-        "socks": "^2.6.2"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/node-gyp/node_modules/ssri": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
-      "integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
-      "dev": true,
-      "dependencies": {
-        "minipass": "^3.1.1"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/node-gyp/node_modules/unique-filename": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
-      "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
-      "dev": true,
-      "dependencies": {
-        "unique-slug": "^2.0.0"
-      }
-    },
-    "node_modules/node-gyp/node_modules/unique-slug": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
-      "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
-      "dev": true,
-      "dependencies": {
-        "imurmurhash": "^0.1.4"
-      }
-    },
-    "node_modules/node-gyp/node_modules/which": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/node-releases": {
-      "version": "2.0.27",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
-      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/node-sass": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-9.0.0.tgz",
-      "integrity": "sha512-yltEuuLrfH6M7Pq2gAj5B6Zm7m+gdZoG66wTqG6mIZV/zijq3M2OO2HswtT6oBspPyFhHDcaxWpsBm0fRNDHPg==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "async-foreach": "^0.1.3",
-        "chalk": "^4.1.2",
-        "cross-spawn": "^7.0.3",
-        "gaze": "^1.0.0",
-        "get-stdin": "^4.0.1",
-        "glob": "^7.0.3",
-        "lodash": "^4.17.15",
-        "make-fetch-happen": "^10.0.4",
-        "meow": "^9.0.0",
-        "nan": "^2.17.0",
-        "node-gyp": "^8.4.1",
-        "sass-graph": "^4.0.1",
-        "stdout-stream": "^1.4.0",
-        "true-case-path": "^2.2.1"
-      },
-      "bin": {
-        "node-sass": "bin/node-sass"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/node-sass/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/node-sass/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/node-sass/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/node-sass/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/node-sass/node_modules/cross-spawn": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
-      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
+      "optional": true
     },
-    "node_modules/node-sass/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+    "node_modules/node-releases": {
+      "version": "2.0.47",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
+      "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/node-sass/node_modules/path-key": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/node-sass/node_modules/shebang-command": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
-      "dependencies": {
-        "shebang-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/node-sass/node_modules/shebang-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/node-sass/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/node-sass/node_modules/which": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/nopt": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
-      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
-      "dev": true,
-      "dependencies": {
-        "abbrev": "1"
-      },
-      "bin": {
-        "nopt": "bin/nopt.js"
-      },
-      "engines": {
-        "node": ">=6"
+        "node": ">=18"
       }
     },
     "node_modules/normalize-package-data": {
@@ -2253,6 +2109,7 @@
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
       "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "hosted-git-info": "^2.1.4",
         "resolve": "^1.10.0",
@@ -2265,15 +2122,7 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/normalize-range": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
-      "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
-      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2283,6 +2132,7 @@
       "resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.5.tgz",
       "integrity": "sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "chalk": "^2.4.1",
@@ -2303,26 +2153,113 @@
         "node": ">= 4"
       }
     },
-    "node_modules/npm-run-all/node_modules/load-json-file": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-      "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^4.0.0",
-        "pify": "^3.0.0",
-        "strip-bom": "^3.0.0"
-      },
+      "license": "MIT",
       "engines": {
-        "node": ">=4"
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/npm-run-all/node_modules/parse-json": {
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/own-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
+      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.2.6",
+        "object-keys": "^1.1.1",
+        "safe-push-apply": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+      "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "error-ex": "^1.3.1",
         "json-parse-better-errors": "^1.0.1"
@@ -2331,172 +2268,22 @@
         "node": ">=4"
       }
     },
-    "node_modules/npm-run-all/node_modules/path-type": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-      "dev": true,
-      "dependencies": {
-        "pify": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/npm-run-all/node_modules/pify": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/npm-run-all/node_modules/read-pkg": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-      "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-      "dev": true,
-      "dependencies": {
-        "load-json-file": "^4.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/npm-run-all/node_modules/strip-bom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/npmlog": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
-      "integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
-      "dev": true,
-      "dependencies": {
-        "are-we-there-yet": "^3.0.0",
-        "console-control-strings": "^1.1.0",
-        "gauge": "^4.0.3",
-        "set-blocking": "^2.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/object-keys": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
-      "dependencies": {
-        "wrappy": "1"
-      }
-    },
-    "node_modules/p-limit": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-      "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
-      "dev": true,
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/p-locate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-      "dev": true,
-      "dependencies": {
-        "p-limit": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/p-map": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-      "dev": true,
-      "dependencies": {
-        "aggregate-error": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-try": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/parse-json": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.0.0",
-        "error-ex": "^1.3.1",
-        "json-parse-even-better-errors": "^2.3.0",
-        "lines-and-columns": "^1.1.6"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -2505,7 +2292,31 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-type": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/path-type/node_modules/pify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -2515,10 +2326,11 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -2527,10 +2339,11 @@
       }
     },
     "node_modules/pidtree": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.3.0.tgz",
-      "integrity": "sha512-9CT4NFlDcosssyg8KVFltgokyKZIFjoBxw8CTGy+5F38Y1eQWrt8tRayiUOXE+zVKQnYu5BR8JjCtvK3BcnBhg==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.3.1.tgz",
+      "integrity": "sha512-qQbW94hLHEqCg7nhby4yRC7G2+jYHY4Rguc2bjw7Uug4GIJuu1tvf2uHaZv5Q8zdt+WKJ6qK1FOI6amaWUo5FA==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "pidtree": "bin/pidtree.js"
       },
@@ -2543,14 +2356,25 @@
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -2568,7 +2392,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -2610,6 +2434,7 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -2619,6 +2444,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -2634,6 +2460,7 @@
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.1",
@@ -2648,6 +2475,7 @@
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -2659,13 +2487,47 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/postcss-cli/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/postcss-cli/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/postcss-cli/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/postcss-cli/node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -2678,6 +2540,7 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -2695,15 +2558,17 @@
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=10"
       }
     },
     "node_modules/postcss-cli/node_modules/yargs": {
-      "version": "17.6.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
-      "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -2722,6 +2587,7 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=12"
       }
@@ -2753,9 +2619,9 @@
       }
     },
     "node_modules/postcss-load-config": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-5.0.2.tgz",
-      "integrity": "sha512-Q8QR3FYbqOKa0bnC1UQ2bFq9/ulHX5Bi34muzitMr8aDtUelO5xKeJEYC/5smE0jNE9zdB/NBnOwXKexELbRlw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-5.1.0.tgz",
+      "integrity": "sha512-G5AJ+IX0aD0dygOE0yFZQ/huFFMSNneyfp0e3/bT05a8OfPC5FUoZRPfGijUdGOJNMewJiwzcHJXFafFzeKFVA==",
       "dev": true,
       "funding": [
         {
@@ -2767,16 +2633,18 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "lilconfig": "^3.0.0",
-        "yaml": "^2.3.4"
+        "lilconfig": "^3.1.1",
+        "yaml": "^2.4.2"
       },
       "engines": {
         "node": ">= 18"
       },
       "peerDependencies": {
         "jiti": ">=1.21.0",
-        "postcss": ">=8.0.9"
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1"
       },
       "peerDependenciesMeta": {
         "jiti": {
@@ -2784,14 +2652,28 @@
         },
         "postcss": {
           "optional": true
+        },
+        "tsx": {
+          "optional": true
         }
       }
     },
     "node_modules/postcss-reporter": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-7.0.5.tgz",
-      "integrity": "sha512-glWg7VZBilooZGOFPhN9msJ3FQs19Hie7l5a/eE6WglzYqVeH3ong3ShFcp9kDWJT1g2Y/wd59cocf9XxBtkWA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-7.1.0.tgz",
+      "integrity": "sha512-/eoEylGWyy6/DOiMP5lmFRdmDKThqgn7D6hP2dXKJI/0rJSO1ADFNngZfDzxL0YAxFvws+Rtpuji1YIHj4mySA==",
       "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
       "dependencies": {
         "picocolors": "^1.0.0",
         "thenby": "^1.3.4"
@@ -2799,18 +2681,14 @@
       "engines": {
         "node": ">=10"
       },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/postcss/"
-      },
       "peerDependencies": {
         "postcss": "^8.1.0"
       }
     },
     "node_modules/postcss-selector-parser": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.0.0.tgz",
-      "integrity": "sha512-9RbEr1Y7FFfptd/1eEdntyjMwLeghW1bHX9GWjXo19vx4ytPQhANltvVxDggzJl7mnWM+dX28kb6cyS/4iQjlQ==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
+      "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2825,49 +2703,17 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pretty-hrtime": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
       "integrity": "sha512-66hKPCr+72mlfiSjlEB1+45IjXSqvVAIy6mocupoww4tBFE9R9IhwwUGoI4G++Tc9Aq+2rxOt0RFU6gPcrte0A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
-    },
-    "node_modules/promise-inflight": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
-      "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
-      "dev": true
-    },
-    "node_modules/promise-retry": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
-      "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
-      "dev": true,
-      "dependencies": {
-        "err-code": "^2.0.2",
-        "retry": "^0.12.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/quick-lru": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
-      "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/read-cache": {
@@ -2875,118 +2721,24 @@
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
       "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
       }
     },
     "node_modules/read-pkg": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
-      "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+      "integrity": "sha512-BLq/cCO9two+lBgiTYNqD6GdtK8s4NpaWrl6/rCO9w0TUS8oJl7cmToOZfRYllKTISY6nt1U7jQ53brmKqY6BA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@types/normalize-package-data": "^2.4.0",
-        "normalize-package-data": "^2.5.0",
-        "parse-json": "^5.0.0",
-        "type-fest": "^0.6.0"
+        "load-json-file": "^4.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^3.0.0"
       },
       "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/read-pkg-up": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
-      "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
-      "dev": true,
-      "dependencies": {
-        "find-up": "^4.1.0",
-        "read-pkg": "^5.2.0",
-        "type-fest": "^0.8.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/find-up": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "dev": true,
-      "dependencies": {
-        "locate-path": "^5.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "dev": true,
-      "dependencies": {
-        "p-locate": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/p-locate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "dev": true,
-      "dependencies": {
-        "p-limit": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/path-exists": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/type-fest": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/read-pkg/node_modules/type-fest": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
-      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/readable-stream": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.1.tgz",
-      "integrity": "sha512-+rQmrWMYGA90yenhTYsLWAsLsqVC8osOw6PKE1HDYiO0gdPeKe/xDHNzIAIn4C91YQ6oenEhfYqqc1883qHbjQ==",
-      "dev": true,
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
+        "node": ">=4"
       }
     },
     "node_modules/readdirp": {
@@ -2994,6 +2746,7 @@
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "picomatch": "^2.2.1"
       },
@@ -3001,24 +2754,56 @@
         "node": ">=8.10.0"
       }
     },
-    "node_modules/redent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
-      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+    "node_modules/reflect.getprototypeof": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+      "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "indent-string": "^4.0.0",
-        "strip-indent": "^3.0.0"
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.1",
+        "which-builtin-type": "^1.2.1"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3027,39 +2812,29 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/resolve": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
-      "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "path-parse": "^1.0.6"
-      }
-    },
-    "node_modules/retry": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
-      "dev": true,
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.1.3"
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
       },
       "bin": {
-        "rimraf": "bin.js"
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/rtlcss": {
@@ -3081,180 +2856,110 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+    "node_modules/safe-array-concat": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.4.tgz",
+      "integrity": "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==",
       "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
-    "node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/sass-graph": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-4.0.1.tgz",
-      "integrity": "sha512-5YCfmGBmxoIRYHnKK2AKzrAkCoQ8ozO+iumT8K4tXJXRVCPf+7s1/9KxTSW3Rbvf+7Y7b4FR3mWyLnQr3PHocA==",
-      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "glob": "^7.0.0",
-        "lodash": "^4.17.11",
-        "scss-tokenizer": "^0.4.3",
-        "yargs": "^17.2.1"
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "get-intrinsic": "^1.3.0",
+        "has-symbols": "^1.1.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-push-apply": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+      "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/sass": {
+      "version": "1.100.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.100.0.tgz",
+      "integrity": "sha512-B5j0rYMlinhhOo9tjQebMVVn0TfyXAF+wB3b2ggZUuJ/is/Y+7+JGjirAMxHZ9Z3hIP98NPfamlAkBHa1lAaXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^5.0.0",
+        "immutable": "^5.1.5",
+        "source-map-js": ">=0.6.2 <2.0.0"
       },
       "bin": {
-        "sassgraph": "bin/sassgraph"
+        "sass": "sass.js"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=20.19.0"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher": "^2.4.1"
       }
     },
-    "node_modules/sass-graph/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+    "node_modules/sass/node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
       "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/sass-graph/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "color-convert": "^2.0.1"
+        "readdirp": "^5.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">= 20.19.0"
       },
       "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+        "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/sass-graph/node_modules/cliui": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+    "node_modules/sass/node_modules/readdirp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
       "dev": true,
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
-      },
+      "license": "MIT",
       "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/sass-graph/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/sass-graph/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/sass-graph/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/sass-graph/node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
+        "node": ">= 20.19.0"
       },
       "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/sass-graph/node_modules/y18n": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/sass-graph/node_modules/yargs": {
-      "version": "17.7.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
-      "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
-      "dev": true,
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/sass-graph/node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/scss-tokenizer": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.4.3.tgz",
-      "integrity": "sha512-raKLgf1LI5QMQnG+RxHz6oK0sL3x3I4FN2UDLqgLOGO8hodECNnNh5BXn7fAyBxrA8zVzdQizQ6XjNJQ+uBwMw==",
-      "dev": true,
-      "dependencies": {
-        "js-base64": "^2.4.9",
-        "source-map": "^0.7.3"
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/semver": {
@@ -3262,6 +2967,7 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
       "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver"
       }
@@ -3269,14 +2975,65 @@
     "node_modules/set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-      "dev": true
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-proto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
+      "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "shebang-regex": "^1.0.0"
       },
@@ -3287,23 +3044,101 @@
     "node_modules/shebang-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz",
-      "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==",
-      "dev": true
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
-    "node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/slash": {
       "version": "5.1.0",
@@ -3318,54 +3153,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/smart-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
-      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 6.0.0",
-        "npm": ">= 3.0.0"
-      }
-    },
-    "node_modules/socks": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
-      "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ip-address": "^9.0.5",
-        "smart-buffer": "^4.2.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0",
-        "npm": ">= 3.0.0"
-      }
-    },
-    "node_modules/socks-proxy-agent": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-7.0.0.tgz",
-      "integrity": "sha512-Fgl0YPZ902wEsAyiQ+idGd1A7rSFx/ayC1CQVMw5P+EQx2V0SgpGtf6OKFhVjPflPUl9YMmEOnmfjCdMUsygww==",
-      "dev": true,
-      "dependencies": {
-        "agent-base": "^6.0.2",
-        "debug": "^4.3.3",
-        "socks": "^2.6.2"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/source-map": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
-      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3377,166 +3164,147 @@
       }
     },
     "node_modules/spdx-correct": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
-      "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
+      "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "spdx-expression-parse": "^3.0.0",
         "spdx-license-ids": "^3.0.0"
       }
     },
     "node_modules/spdx-exceptions": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
-      "dev": true
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+      "dev": true,
+      "license": "CC-BY-3.0"
     },
     "node_modules/spdx-expression-parse": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "spdx-exceptions": "^2.1.0",
         "spdx-license-ids": "^3.0.0"
       }
     },
     "node_modules/spdx-license-ids": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.4.tgz",
-      "integrity": "sha512-7j8LYJLeY/Yb6ACbQ7F76qy5jHkp0U6jgBfJsk97bwWlVUnUWsAgpyaCvo17h0/RQGnQ036tVDomiwoI4pDkQA==",
-      "dev": true
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+      "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "CC0-1.0"
     },
-    "node_modules/ssri": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-9.0.1.tgz",
-      "integrity": "sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q==",
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "minipass": "^3.1.1"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/stdout-stream": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.1.tgz",
-      "integrity": "sha512-j4emi03KXqJWcIeF8eIXkjMFN1Cmb8gUlDYGeBALLPo5qdyTfA9bOtl8m33lRoC+vFMkP3gl0WsDr6+gzxbbTA==",
-      "dev": true,
-      "dependencies": {
-        "readable-stream": "^2.0.1"
-      }
-    },
-    "node_modules/stdout-stream/node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "dev": true,
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/stdout-stream/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
-    },
-    "node_modules/stdout-stream/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
-    "node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
-    },
-    "node_modules/string-width/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string.prototype.padend": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.0.0.tgz",
-      "integrity": "sha1-86rvfBcZ8XDF6rHDK/eA2W4h8vA=",
-      "dev": true,
-      "dependencies": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.4.3",
-        "function-bind": "^1.0.2"
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^7.0.1",
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/string.prototype.padend": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.1.6.tgz",
+      "integrity": "sha512-XZpspuSB7vJWhvJc9DLSlrXl1mcA2BdoY5jjnS135ydXqLoqhs96JjDtCkjJEQHvfqZIp9hBuBMgI589peyx9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.11.tgz",
+      "integrity": "sha512-PwvK7BU+CMTJGYQCTZb5RWXIML92lftJLhQz1tBzgKiqGxJaMlBAa48POXaNAC2s4y8jr3EFqrkF9+44neS46w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "define-data-property": "^1.1.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.2",
+        "es-object-atoms": "^1.1.2",
+        "has-property-descriptors": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.10.tgz",
+      "integrity": "sha512-2+3aDAOmPTmuFwjDnmJG2ctEkQKVki7vOSqaxkv42Mowj1V6PnvuwFCRrR5lChUux1TBskPjfkeTOhqczDMxTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/strip-ansi": {
@@ -3544,6 +3312,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
       "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^4.1.0"
       },
@@ -3551,16 +3320,14 @@
         "node": ">=6"
       }
     },
-    "node_modules/strip-indent": {
+    "node_modules/strip-bom": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
-      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
       "dev": true,
-      "dependencies": {
-        "min-indent": "^1.0.0"
-      },
+      "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=4"
       }
     },
     "node_modules/strip-json-comments": {
@@ -3568,6 +3335,7 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       },
@@ -3580,6 +3348,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -3587,47 +3356,35 @@
         "node": ">=4"
       }
     },
-    "node_modules/tar": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
-      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true,
-      "dependencies": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^5.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/tar/node_modules/minipass": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/thenby": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/thenby/-/thenby-1.3.4.tgz",
-      "integrity": "sha512-89Gi5raiWA3QZ4b2ePcEwswC3me9JIg+ToSgtE0JWeCynLnLxNr/f9G+xfo9K+Oj4AFdom8YNJjibIARTJmapQ==",
-      "dev": true
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/thenby/-/thenby-1.4.1.tgz",
+      "integrity": "sha512-D5a/bO0KdalOE3q8MlrRmSxjbKZHT3MQmXkJP+r97Vw8MMwOZKOwUSEyTtK7eSMj2y0kyAjpYMRMZmmLw1FtNQ==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -3655,9 +3412,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3672,6 +3429,7 @@
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -3679,70 +3437,117 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/trim-newlines": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
-      "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
       "engines": {
-        "node": ">=8"
+        "node": ">= 0.4"
       }
     },
-    "node_modules/true-case-path": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-2.2.1.tgz",
-      "integrity": "sha512-0z3j8R7MCjy10kc/g+qg7Ln3alJTodw9aDuVWZa3uiWqfuBMKeAeP2ocWcxoyM3D73yz3Jt/Pu4qPr4wHSdB/Q==",
-      "dev": true
-    },
-    "node_modules/type-fest": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
-      "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
+    "node_modules/typed-array-byte-length": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+      "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.14"
+      },
       "engines": {
-        "node": ">=10"
+        "node": ">= 0.4"
       },
       "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/unique-filename": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-2.0.1.tgz",
-      "integrity": "sha512-ODWHtkkdx3IAR+veKxFV+VBkUMcN+FaqzUUd7IZzt+0zhDZFPFxhlqwPF3YQvMHx1TD0tdgYl+kuPnJ8E6ql7A==",
+    "node_modules/typed-array-byte-offset": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+      "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "unique-slug": "^3.0.0"
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "reflect.getprototypeof": "^1.0.9"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/unique-slug": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-3.0.0.tgz",
-      "integrity": "sha512-8EyMynh679x/0gqE9fT9oilG+qEt+ibFyqjuVTsZn1+CMxH+XLlpvr2UZx4nVcCwTpx81nICr2JQFkM+HPLq4w==",
+    "node_modules/typed-array-length": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.8.tgz",
+      "integrity": "sha512-phPGCwqr2+Qo0fwniCE8e4pKnGu/yFb5nD5Y8bf0EEeiI5GklnACYA9GFy/DrAeRrKHXvHn+1SUsOWgJp6RO+g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "imurmurhash": "^0.1.4"
+        "call-bind": "^1.0.9",
+        "for-each": "^0.3.5",
+        "gopd": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "possible-typed-array-names": "^1.1.0",
+        "reflect.getprototypeof": "^1.0.10"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+      "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "which-boxed-primitive": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/universalify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.4.tgz",
-      "integrity": "sha512-q0SPT4xyU84saUX+tomz1WLkxUbuaJnR1xWt17M7fJtEJigJeWUNGUqrauFXsHnqev9y9JTRGwk13tFBuKby4A==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
       "dev": true,
       "funding": [
         {
@@ -3774,13 +3579,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
       "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
@@ -3791,6 +3598,7 @@
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -3798,19 +3606,100 @@
         "which": "bin/which"
       }
     },
-    "node_modules/which-module": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-      "dev": true
-    },
-    "node_modules/wide-align": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
-      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+    "node_modules/which-boxed-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "string-width": "^1.0.2 || 2 || 3 || 4"
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-builtin-type": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+      "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "function.prototype.name": "^1.1.6",
+        "has-tostringtag": "^1.0.2",
+        "is-async-function": "^2.0.0",
+        "is-date-object": "^1.1.0",
+        "is-finalizationregistry": "^1.1.0",
+        "is-generator-function": "^1.0.10",
+        "is-regex": "^1.2.1",
+        "is-weakref": "^1.0.2",
+        "isarray": "^2.0.5",
+        "which-boxed-primitive": "^1.1.0",
+        "which-collection": "^1.0.2",
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/wrap-ansi": {
@@ -3818,6 +3707,7 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
       "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^3.2.0",
         "string-width": "^3.0.0",
@@ -3827,45 +3717,27 @@
         "node": ">=6"
       }
     },
-    "node_modules/wrap-ansi/node_modules/string-width": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-      "dev": true,
-      "dependencies": {
-        "emoji-regex": "^7.0.1",
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^5.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true
-    },
     "node_modules/y18n": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
-      "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
-      "dev": true
-    },
-    "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.4.tgz",
-      "integrity": "sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yargs": {
@@ -3873,6 +3745,7 @@
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
       "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "cliui": "^5.0.0",
         "find-up": "^3.0.0",
@@ -3891,2897 +3764,8 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
       "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
-      }
-    },
-    "node_modules/yargs/node_modules/string-width": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-      "dev": true,
-      "dependencies": {
-        "emoji-regex": "^7.0.1",
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^5.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    }
-  },
-  "dependencies": {
-    "@babel/code-frame": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
-      "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
-      "dev": true,
-      "requires": {
-        "@babel/highlight": "^7.18.6"
-      }
-    },
-    "@babel/helper-validator-identifier": {
-      "version": "7.19.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
-      "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
-      "dev": true
-    },
-    "@babel/highlight": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
-      "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-validator-identifier": "^7.18.6",
-        "chalk": "^2.0.0",
-        "js-tokens": "^4.0.0"
-      }
-    },
-    "@gar/promisify": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
-      "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
-      "dev": true
-    },
-    "@npmcli/fs": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-2.1.2.tgz",
-      "integrity": "sha512-yOJKRvohFOaLqipNtwYB9WugyZKhC/DZC4VYPmpaCzDBrA8YpK3qHZ8/HGscMnE4GqbkLNuVcCnxkeQEdGt6LQ==",
-      "dev": true,
-      "requires": {
-        "@gar/promisify": "^1.1.3",
-        "semver": "^7.3.5"
-      },
-      "dependencies": {
-        "lru-cache": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "dev": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "semver": {
-          "version": "7.5.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        }
-      }
-    },
-    "@npmcli/move-file": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-2.0.1.tgz",
-      "integrity": "sha512-mJd2Z5TjYWq/ttPLLGqArdtnC74J6bOzg4rMDnN+p1xTacZ2yPRCk2y0oSWQtygLR9YVQXgOcONrwtnk3JupxQ==",
-      "dev": true,
-      "requires": {
-        "mkdirp": "^1.0.4",
-        "rimraf": "^3.0.2"
-      }
-    },
-    "@tootallnate/once": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
-      "dev": true
-    },
-    "@types/minimist": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
-      "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
-      "dev": true
-    },
-    "@types/normalize-package-data": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
-      "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
-      "dev": true
-    },
-    "@wordpress/browserslist-config": {
-      "version": "6.34.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.34.0.tgz",
-      "integrity": "sha512-pmcCkqG2jW+UUBSkX7rSZS33mcW6M0fKcJPD40TlK2cUZvECS5TDa2BC/b80PfIsT2kSw+Z9Wv+8eyX6I8HGjQ==",
-      "dev": true
-    },
-    "abbrev": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-      "dev": true
-    },
-    "agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
-      "requires": {
-        "debug": "4"
-      }
-    },
-    "agentkeepalive": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.2.1.tgz",
-      "integrity": "sha512-Zn4cw2NEqd+9fiSVWMscnjyQ1a8Yfoc5oBajLeo5w+YBHgDUcEBY2hS4YpTz6iN5f/2zQiktcuM6tS8x1p9dpA==",
-      "dev": true,
-      "requires": {
-        "debug": "^4.1.0",
-        "depd": "^1.1.2",
-        "humanize-ms": "^1.2.1"
-      }
-    },
-    "aggregate-error": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
-      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-      "dev": true,
-      "requires": {
-        "clean-stack": "^2.0.0",
-        "indent-string": "^4.0.0"
-      }
-    },
-    "ansi-regex": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
-      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
-      "dev": true
-    },
-    "ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "requires": {
-        "color-convert": "^1.9.0"
-      }
-    },
-    "anymatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
-      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "dev": true,
-      "requires": {
-        "normalize-path": "^3.0.0",
-        "picomatch": "^2.0.4"
-      }
-    },
-    "aproba": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
-      "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
-      "dev": true
-    },
-    "are-we-there-yet": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
-      "integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
-      "dev": true,
-      "requires": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^3.6.0"
-      }
-    },
-    "arrify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
-      "dev": true
-    },
-    "async-foreach": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
-      "integrity": "sha512-VUeSMD8nEGBWaZK4lizI1sf3yEC7pnAQ/mrI7pC2fBz2s/tq5jWWEngTwaf0Gruu/OoXRGLGg1XFqpYBiGTYJA==",
-      "dev": true
-    },
-    "autoprefixer": {
-      "version": "10.4.22",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.22.tgz",
-      "integrity": "sha512-ARe0v/t9gO28Bznv6GgqARmVqcWOV3mfgUPn9becPHMiD3o9BwlRgaeccZnwTpZ7Zwqrm+c1sUSsMxIzQzc8Xg==",
-      "dev": true,
-      "requires": {
-        "browserslist": "^4.27.0",
-        "caniuse-lite": "^1.0.30001754",
-        "fraction.js": "^5.3.4",
-        "normalize-range": "^0.1.2",
-        "picocolors": "^1.1.1",
-        "postcss-value-parser": "^4.2.0"
-      }
-    },
-    "balanced-match": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
-    },
-    "baseline-browser-mapping": {
-      "version": "2.8.25",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.25.tgz",
-      "integrity": "sha512-2NovHVesVF5TXefsGX1yzx1xgr7+m9JQenvz6FQY3qd+YXkKkYiv+vTCc7OriP9mcDZpTC5mAOYN4ocd29+erA==",
-      "dev": true
-    },
-    "binary-extensions": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
-      "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
-      "dev": true
-    },
-    "brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
-      "requires": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "braces": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
-      "requires": {
-        "fill-range": "^7.1.1"
-      }
-    },
-    "browserslist": {
-      "version": "4.28.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.0.tgz",
-      "integrity": "sha512-tbydkR/CxfMwelN0vwdP/pLkDwyAASZ+VfWm4EOwlB6SWhx1sYnWLqo8N5j0rAzPfzfRaxt0mM/4wPU/Su84RQ==",
-      "dev": true,
-      "requires": {
-        "baseline-browser-mapping": "^2.8.25",
-        "caniuse-lite": "^1.0.30001754",
-        "electron-to-chromium": "^1.5.249",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.1.4"
-      }
-    },
-    "cacache": {
-      "version": "16.1.3",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-16.1.3.tgz",
-      "integrity": "sha512-/+Emcj9DAXxX4cwlLmRI9c166RuL3w30zp4R7Joiv2cQTtTtA+jeuCAjH3ZlGnYS3tKENSrKhAzVVP9GVyzeYQ==",
-      "dev": true,
-      "requires": {
-        "@npmcli/fs": "^2.1.0",
-        "@npmcli/move-file": "^2.0.0",
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.1.0",
-        "glob": "^8.0.1",
-        "infer-owner": "^1.0.4",
-        "lru-cache": "^7.7.1",
-        "minipass": "^3.1.6",
-        "minipass-collect": "^1.0.2",
-        "minipass-flush": "^1.0.5",
-        "minipass-pipeline": "^1.2.4",
-        "mkdirp": "^1.0.4",
-        "p-map": "^4.0.0",
-        "promise-inflight": "^1.0.1",
-        "rimraf": "^3.0.2",
-        "ssri": "^9.0.0",
-        "tar": "^6.1.11",
-        "unique-filename": "^2.0.0"
-      },
-      "dependencies": {
-        "brace-expansion": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-          "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-          "dev": true,
-          "requires": {
-            "balanced-match": "^1.0.0"
-          }
-        },
-        "glob": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
-          "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^5.0.1",
-            "once": "^1.3.0"
-          }
-        },
-        "minimatch": {
-          "version": "5.1.6",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-          "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^2.0.1"
-          }
-        }
-      }
-    },
-    "camelcase": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "dev": true
-    },
-    "camelcase-keys": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
-      "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
-      "dev": true,
-      "requires": {
-        "camelcase": "^5.3.1",
-        "map-obj": "^4.0.0",
-        "quick-lru": "^4.0.1"
-      }
-    },
-    "caniuse-lite": {
-      "version": "1.0.30001754",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001754.tgz",
-      "integrity": "sha512-x6OeBXueoAceOmotzx3PO4Zpt4rzpeIFsSr6AAePTZxSkXiYDUmpypEl7e2+8NCd9bD7bXjqyef8CJYPC1jfxg==",
-      "dev": true
-    },
-    "chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
-      "requires": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      }
-    },
-    "chokidar": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
-      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
-      "dev": true,
-      "requires": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "fsevents": "~2.3.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
-      }
-    },
-    "chokidar-cli": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chokidar-cli/-/chokidar-cli-3.0.0.tgz",
-      "integrity": "sha512-xVW+Qeh7z15uZRxHOkP93Ux8A0xbPzwK4GaqD8dQOYc34TlkqUhVSS59fK36DOp5WdJlrRzlYSy02Ht99FjZqQ==",
-      "dev": true,
-      "requires": {
-        "chokidar": "^3.5.2",
-        "lodash.debounce": "^4.0.8",
-        "lodash.throttle": "^4.1.1",
-        "yargs": "^13.3.0"
-      }
-    },
-    "chownr": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-      "dev": true
-    },
-    "clean-stack": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-      "dev": true
-    },
-    "cliui": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
-      "dev": true,
-      "requires": {
-        "string-width": "^3.1.0",
-        "strip-ansi": "^5.2.0",
-        "wrap-ansi": "^5.1.0"
-      },
-      "dependencies": {
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
-          }
-        }
-      }
-    },
-    "color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "requires": {
-        "color-name": "1.1.3"
-      }
-    },
-    "color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
-    },
-    "color-support": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
-      "dev": true
-    },
-    "concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
-    },
-    "console-control-strings": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
-      "dev": true
-    },
-    "core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "dev": true
-    },
-    "cross-spawn": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.6.tgz",
-      "integrity": "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==",
-      "dev": true,
-      "requires": {
-        "nice-try": "^1.0.4",
-        "path-key": "^2.0.1",
-        "semver": "^5.5.0",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
-      }
-    },
-    "cssesc": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
-      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-      "dev": true
-    },
-    "debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
-      "requires": {
-        "ms": "2.1.2"
-      }
-    },
-    "decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-      "dev": true
-    },
-    "decamelize-keys": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.1.tgz",
-      "integrity": "sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==",
-      "dev": true,
-      "requires": {
-        "decamelize": "^1.1.0",
-        "map-obj": "^1.0.0"
-      },
-      "dependencies": {
-        "map-obj": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-          "integrity": "sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==",
-          "dev": true
-        }
-      }
-    },
-    "define-properties": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-      "dev": true,
-      "requires": {
-        "object-keys": "^1.0.12"
-      }
-    },
-    "delegates": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
-      "dev": true
-    },
-    "depd": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
-      "dev": true
-    },
-    "dependency-graph": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-1.0.0.tgz",
-      "integrity": "sha512-cW3gggJ28HZ/LExwxP2B++aiKxhJXMSIt9K48FOXQkm+vuG5gyatXnLsONRJdzO/7VfjDIiaOOa/bs4l464Lwg==",
-      "dev": true
-    },
-    "electron-to-chromium": {
-      "version": "1.5.249",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.249.tgz",
-      "integrity": "sha512-5vcfL3BBe++qZ5kuFhD/p8WOM1N9m3nwvJPULJx+4xf2usSlZFJ0qoNYO2fOX4hi3ocuDcmDobtA+5SFr4OmBg==",
-      "dev": true
-    },
-    "emoji-regex": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-      "dev": true
-    },
-    "encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "iconv-lite": "^0.6.2"
-      }
-    },
-    "env-paths": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
-      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
-      "dev": true
-    },
-    "err-code": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
-      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
-      "dev": true
-    },
-    "error-ex": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-      "dev": true,
-      "requires": {
-        "is-arrayish": "^0.2.1"
-      }
-    },
-    "es-abstract": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
-      "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
-      "dev": true,
-      "requires": {
-        "es-to-primitive": "^1.2.0",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "is-callable": "^1.1.4",
-        "is-regex": "^1.0.4",
-        "object-keys": "^1.0.12"
-      }
-    },
-    "es-to-primitive": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
-      "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
-      "dev": true,
-      "requires": {
-        "is-callable": "^1.1.4",
-        "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.2"
-      }
-    },
-    "escalade": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
-      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true
-    },
-    "escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
-    },
-    "fill-range": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
-      "requires": {
-        "to-regex-range": "^5.0.1"
-      }
-    },
-    "find-up": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-      "dev": true,
-      "requires": {
-        "locate-path": "^3.0.0"
-      }
-    },
-    "fraction.js": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
-      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
-      "dev": true
-    },
-    "fs-extra": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
-      "integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      }
-    },
-    "fs-minipass": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-      "dev": true,
-      "requires": {
-        "minipass": "^3.0.0"
-      }
-    },
-    "fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true
-    },
-    "fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "optional": true
-    },
-    "function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
-    },
-    "gauge": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
-      "integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
-      "dev": true,
-      "requires": {
-        "aproba": "^1.0.3 || ^2.0.0",
-        "color-support": "^1.1.3",
-        "console-control-strings": "^1.1.0",
-        "has-unicode": "^2.0.1",
-        "signal-exit": "^3.0.7",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1",
-        "wide-align": "^1.1.5"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.1"
-          }
-        }
-      }
-    },
-    "gaze": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
-      "integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
-      "dev": true,
-      "requires": {
-        "globule": "^1.0.0"
-      }
-    },
-    "get-caller-file": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true
-    },
-    "get-stdin": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-      "integrity": "sha512-F5aQMywwJ2n85s4hJPTT9RPxGmubonuB10MNYo17/xph174n2MIR33HRguhzVag10O/npM7SPk73LMZNP+FaWw==",
-      "dev": true
-    },
-    "glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "dev": true,
-      "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "dependencies": {
-        "minimatch": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        }
-      }
-    },
-    "glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
-      "requires": {
-        "is-glob": "^4.0.1"
-      }
-    },
-    "globule": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/globule/-/globule-1.3.4.tgz",
-      "integrity": "sha512-OPTIfhMBh7JbBYDpa5b+Q5ptmMWKwcNcFSR/0c6t8V4f3ZAVBEsKNY37QdVqmLRYSMhOUGYrY0QhSoEpzGr/Eg==",
-      "dev": true,
-      "requires": {
-        "glob": "~7.1.1",
-        "lodash": "^4.17.21",
-        "minimatch": "~3.0.2"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "7.1.7",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-          "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        }
-      }
-    },
-    "graceful-fs": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
-      "integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg==",
-      "dev": true
-    },
-    "hard-rejection": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
-      "integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
-      "dev": true
-    },
-    "has": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
-      "requires": {
-        "function-bind": "^1.1.1"
-      }
-    },
-    "has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
-    },
-    "has-symbols": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
-      "dev": true
-    },
-    "has-unicode": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
-      "dev": true
-    },
-    "hosted-git-info": {
-      "version": "2.8.9",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
-      "dev": true
-    },
-    "http-cache-semantics": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
-      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
-      "dev": true
-    },
-    "http-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
-      "dev": true,
-      "requires": {
-        "@tootallnate/once": "2",
-        "agent-base": "6",
-        "debug": "4"
-      }
-    },
-    "https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dev": true,
-      "requires": {
-        "agent-base": "6",
-        "debug": "4"
-      }
-    },
-    "humanize-ms": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
-      "dev": true,
-      "requires": {
-        "ms": "^2.0.0"
-      }
-    },
-    "iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      }
-    },
-    "imurmurhash": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-      "dev": true
-    },
-    "indent-string": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-      "dev": true
-    },
-    "infer-owner": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
-      "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
-      "dev": true
-    },
-    "inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "dev": true,
-      "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
-    },
-    "ip-address": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
-      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
-      "dev": true,
-      "requires": {
-        "jsbn": "1.1.0",
-        "sprintf-js": "^1.1.3"
-      }
-    },
-    "is-arrayish": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-      "dev": true
-    },
-    "is-binary-path": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
-      "requires": {
-        "binary-extensions": "^2.0.0"
-      }
-    },
-    "is-callable": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
-      "dev": true
-    },
-    "is-core-module": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
-      "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
-      "dev": true,
-      "requires": {
-        "has": "^1.0.3"
-      }
-    },
-    "is-date-object": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
-      "dev": true
-    },
-    "is-extglob": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-      "dev": true
-    },
-    "is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-      "dev": true
-    },
-    "is-glob": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
-      "dev": true,
-      "requires": {
-        "is-extglob": "^2.1.1"
-      }
-    },
-    "is-lambda": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
-      "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
-      "dev": true
-    },
-    "is-number": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true
-    },
-    "is-plain-obj": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-      "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
-      "dev": true
-    },
-    "is-regex": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
-      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-      "dev": true,
-      "requires": {
-        "has": "^1.0.1"
-      }
-    },
-    "is-symbol": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
-      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
-      "dev": true,
-      "requires": {
-        "has-symbols": "^1.0.0"
-      }
-    },
-    "isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "dev": true
-    },
-    "isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
-    },
-    "js-base64": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.4.tgz",
-      "integrity": "sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ==",
-      "dev": true
-    },
-    "js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
-    },
-    "jsbn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
-      "dev": true
-    },
-    "json-parse-better-errors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
-      "dev": true
-    },
-    "json-parse-even-better-errors": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "dev": true
-    },
-    "jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.6",
-        "universalify": "^2.0.0"
-      }
-    },
-    "kind-of": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-      "dev": true
-    },
-    "lilconfig": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.0.0.tgz",
-      "integrity": "sha512-K2U4W2Ff5ibV7j7ydLr+zLAkIg5JJ4lPn1Ltsdt+Tz/IjQ8buJ55pZAxoP34lqIiwtF9iAvtLv3JGv7CAyAg+g==",
-      "dev": true
-    },
-    "lines-and-columns": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true
-    },
-    "locate-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-      "dev": true,
-      "requires": {
-        "p-locate": "^3.0.0",
-        "path-exists": "^3.0.0"
-      }
-    },
-    "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
-    },
-    "lodash.debounce": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
-      "dev": true
-    },
-    "lodash.throttle": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
-      "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=",
-      "dev": true
-    },
-    "lru-cache": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.1.tgz",
-      "integrity": "sha512-8/HcIENyQnfUTCDizRu9rrDyG6XG/21M4X7/YEGZeD76ZJilFPAUVb/2zysFf7VVO1LEjCDFyHp8pMMvozIrvg==",
-      "dev": true
-    },
-    "make-fetch-happen": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-10.2.1.tgz",
-      "integrity": "sha512-NgOPbRiaQM10DYXvN3/hhGVI2M5MtITFryzBGxHM5p4wnFxsVCbxkrBrDsk+EZ5OB4jEOT7AjDxtdF+KVEFT7w==",
-      "dev": true,
-      "requires": {
-        "agentkeepalive": "^4.2.1",
-        "cacache": "^16.1.0",
-        "http-cache-semantics": "^4.1.0",
-        "http-proxy-agent": "^5.0.0",
-        "https-proxy-agent": "^5.0.0",
-        "is-lambda": "^1.0.1",
-        "lru-cache": "^7.7.1",
-        "minipass": "^3.1.6",
-        "minipass-collect": "^1.0.2",
-        "minipass-fetch": "^2.0.3",
-        "minipass-flush": "^1.0.5",
-        "minipass-pipeline": "^1.2.4",
-        "negotiator": "^0.6.3",
-        "promise-retry": "^2.0.1",
-        "socks-proxy-agent": "^7.0.0",
-        "ssri": "^9.0.0"
-      }
-    },
-    "map-obj": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
-      "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
-      "dev": true
-    },
-    "memorystream": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
-      "integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI=",
-      "dev": true
-    },
-    "meow": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-9.0.0.tgz",
-      "integrity": "sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==",
-      "dev": true,
-      "requires": {
-        "@types/minimist": "^1.2.0",
-        "camelcase-keys": "^6.2.2",
-        "decamelize": "^1.2.0",
-        "decamelize-keys": "^1.1.0",
-        "hard-rejection": "^2.1.0",
-        "minimist-options": "4.1.0",
-        "normalize-package-data": "^3.0.0",
-        "read-pkg-up": "^7.0.1",
-        "redent": "^3.0.0",
-        "trim-newlines": "^3.0.0",
-        "type-fest": "^0.18.0",
-        "yargs-parser": "^20.2.3"
-      },
-      "dependencies": {
-        "hosted-git-info": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
-          "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
-        "lru-cache": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "dev": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "normalize-package-data": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
-          "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
-          "dev": true,
-          "requires": {
-            "hosted-git-info": "^4.0.1",
-            "is-core-module": "^2.5.0",
-            "semver": "^7.3.4",
-            "validate-npm-package-license": "^3.0.1"
-          }
-        },
-        "semver": {
-          "version": "7.5.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
-        "yargs-parser": {
-          "version": "20.2.9",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-          "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-          "dev": true
-        }
-      }
-    },
-    "min-indent": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
-      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
-      "dev": true
-    },
-    "minimatch": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
-      "integrity": "sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==",
-      "dev": true,
-      "requires": {
-        "brace-expansion": "^1.1.7"
-      }
-    },
-    "minimist-options": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
-      "integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
-      "dev": true,
-      "requires": {
-        "arrify": "^1.0.1",
-        "is-plain-obj": "^1.1.0",
-        "kind-of": "^6.0.3"
-      }
-    },
-    "minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "dev": true,
-      "requires": {
-        "yallist": "^4.0.0"
-      }
-    },
-    "minipass-collect": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
-      "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
-      "dev": true,
-      "requires": {
-        "minipass": "^3.0.0"
-      }
-    },
-    "minipass-fetch": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-2.1.2.tgz",
-      "integrity": "sha512-LT49Zi2/WMROHYoqGgdlQIZh8mLPZmOrN2NdJjMXxYe4nkN6FUyuPuOAOedNJDrx0IRGg9+4guZewtp8hE6TxA==",
-      "dev": true,
-      "requires": {
-        "encoding": "^0.1.13",
-        "minipass": "^3.1.6",
-        "minipass-sized": "^1.0.3",
-        "minizlib": "^2.1.2"
-      }
-    },
-    "minipass-flush": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
-      "integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
-      "dev": true,
-      "requires": {
-        "minipass": "^3.0.0"
-      }
-    },
-    "minipass-pipeline": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
-      "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
-      "dev": true,
-      "requires": {
-        "minipass": "^3.0.0"
-      }
-    },
-    "minipass-sized": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
-      "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
-      "dev": true,
-      "requires": {
-        "minipass": "^3.0.0"
-      }
-    },
-    "minizlib": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-      "dev": true,
-      "requires": {
-        "minipass": "^3.0.0",
-        "yallist": "^4.0.0"
-      }
-    },
-    "mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "dev": true
-    },
-    "ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
-    },
-    "nan": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
-      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==",
-      "dev": true
-    },
-    "nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true
-    },
-    "negotiator": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
-      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
-      "dev": true
-    },
-    "nice-try": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
-      "dev": true
-    },
-    "node-gyp": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-8.4.1.tgz",
-      "integrity": "sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==",
-      "dev": true,
-      "requires": {
-        "env-paths": "^2.2.0",
-        "glob": "^7.1.4",
-        "graceful-fs": "^4.2.6",
-        "make-fetch-happen": "^9.1.0",
-        "nopt": "^5.0.0",
-        "npmlog": "^6.0.0",
-        "rimraf": "^3.0.2",
-        "semver": "^7.3.5",
-        "tar": "^6.1.2",
-        "which": "^2.0.2"
-      },
-      "dependencies": {
-        "@npmcli/fs": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.1.1.tgz",
-          "integrity": "sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==",
-          "dev": true,
-          "requires": {
-            "@gar/promisify": "^1.0.1",
-            "semver": "^7.3.5"
-          }
-        },
-        "@npmcli/move-file": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
-          "integrity": "sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==",
-          "dev": true,
-          "requires": {
-            "mkdirp": "^1.0.4",
-            "rimraf": "^3.0.2"
-          }
-        },
-        "@tootallnate/once": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-          "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
-          "dev": true
-        },
-        "cacache": {
-          "version": "15.3.0",
-          "resolved": "https://registry.npmjs.org/cacache/-/cacache-15.3.0.tgz",
-          "integrity": "sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==",
-          "dev": true,
-          "requires": {
-            "@npmcli/fs": "^1.0.0",
-            "@npmcli/move-file": "^1.0.1",
-            "chownr": "^2.0.0",
-            "fs-minipass": "^2.0.0",
-            "glob": "^7.1.4",
-            "infer-owner": "^1.0.4",
-            "lru-cache": "^6.0.0",
-            "minipass": "^3.1.1",
-            "minipass-collect": "^1.0.2",
-            "minipass-flush": "^1.0.5",
-            "minipass-pipeline": "^1.2.2",
-            "mkdirp": "^1.0.3",
-            "p-map": "^4.0.0",
-            "promise-inflight": "^1.0.1",
-            "rimraf": "^3.0.2",
-            "ssri": "^8.0.1",
-            "tar": "^6.0.2",
-            "unique-filename": "^1.1.1"
-          }
-        },
-        "graceful-fs": {
-          "version": "4.2.10",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-          "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
-          "dev": true
-        },
-        "http-proxy-agent": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
-          "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
-          "dev": true,
-          "requires": {
-            "@tootallnate/once": "1",
-            "agent-base": "6",
-            "debug": "4"
-          }
-        },
-        "lru-cache": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "dev": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "make-fetch-happen": {
-          "version": "9.1.0",
-          "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
-          "integrity": "sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==",
-          "dev": true,
-          "requires": {
-            "agentkeepalive": "^4.1.3",
-            "cacache": "^15.2.0",
-            "http-cache-semantics": "^4.1.0",
-            "http-proxy-agent": "^4.0.1",
-            "https-proxy-agent": "^5.0.0",
-            "is-lambda": "^1.0.1",
-            "lru-cache": "^6.0.0",
-            "minipass": "^3.1.3",
-            "minipass-collect": "^1.0.2",
-            "minipass-fetch": "^1.3.2",
-            "minipass-flush": "^1.0.5",
-            "minipass-pipeline": "^1.2.4",
-            "negotiator": "^0.6.2",
-            "promise-retry": "^2.0.1",
-            "socks-proxy-agent": "^6.0.0",
-            "ssri": "^8.0.0"
-          }
-        },
-        "minipass-fetch": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
-          "integrity": "sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==",
-          "dev": true,
-          "requires": {
-            "encoding": "^0.1.12",
-            "minipass": "^3.1.0",
-            "minipass-sized": "^1.0.3",
-            "minizlib": "^2.0.0"
-          }
-        },
-        "semver": {
-          "version": "7.5.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
-        "socks-proxy-agent": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.2.1.tgz",
-          "integrity": "sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ==",
-          "dev": true,
-          "requires": {
-            "agent-base": "^6.0.2",
-            "debug": "^4.3.3",
-            "socks": "^2.6.2"
-          }
-        },
-        "ssri": {
-          "version": "8.0.1",
-          "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
-          "integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
-          "dev": true,
-          "requires": {
-            "minipass": "^3.1.1"
-          }
-        },
-        "unique-filename": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
-          "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
-          "dev": true,
-          "requires": {
-            "unique-slug": "^2.0.0"
-          }
-        },
-        "unique-slug": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
-          "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
-          "dev": true,
-          "requires": {
-            "imurmurhash": "^0.1.4"
-          }
-        },
-        "which": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-          "dev": true,
-          "requires": {
-            "isexe": "^2.0.0"
-          }
-        }
-      }
-    },
-    "node-releases": {
-      "version": "2.0.27",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
-      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
-      "dev": true
-    },
-    "node-sass": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-9.0.0.tgz",
-      "integrity": "sha512-yltEuuLrfH6M7Pq2gAj5B6Zm7m+gdZoG66wTqG6mIZV/zijq3M2OO2HswtT6oBspPyFhHDcaxWpsBm0fRNDHPg==",
-      "dev": true,
-      "requires": {
-        "async-foreach": "^0.1.3",
-        "chalk": "^4.1.2",
-        "cross-spawn": "^7.0.3",
-        "gaze": "^1.0.0",
-        "get-stdin": "^4.0.1",
-        "glob": "^7.0.3",
-        "lodash": "^4.17.15",
-        "make-fetch-happen": "^10.0.4",
-        "meow": "^9.0.0",
-        "nan": "^2.17.0",
-        "node-gyp": "^8.4.1",
-        "sass-graph": "^4.0.1",
-        "stdout-stream": "^1.4.0",
-        "true-case-path": "^2.2.1"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "cross-spawn": {
-          "version": "7.0.6",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
-          "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-          "dev": true,
-          "requires": {
-            "path-key": "^3.1.0",
-            "shebang-command": "^2.0.0",
-            "which": "^2.0.1"
-          }
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "path-key": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-          "dev": true
-        },
-        "shebang-command": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-          "dev": true,
-          "requires": {
-            "shebang-regex": "^3.0.0"
-          }
-        },
-        "shebang-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        },
-        "which": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-          "dev": true,
-          "requires": {
-            "isexe": "^2.0.0"
-          }
-        }
-      }
-    },
-    "nopt": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
-      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
-      "dev": true,
-      "requires": {
-        "abbrev": "1"
-      }
-    },
-    "normalize-package-data": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
-      "dev": true,
-      "requires": {
-        "hosted-git-info": "^2.1.4",
-        "resolve": "^1.10.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
-      }
-    },
-    "normalize-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true
-    },
-    "normalize-range": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
-      "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
-      "dev": true
-    },
-    "npm-run-all": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.5.tgz",
-      "integrity": "sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==",
-      "dev": true,
-      "requires": {
-        "ansi-styles": "^3.2.1",
-        "chalk": "^2.4.1",
-        "cross-spawn": "^6.0.5",
-        "memorystream": "^0.3.1",
-        "minimatch": "^3.0.4",
-        "pidtree": "^0.3.0",
-        "read-pkg": "^3.0.0",
-        "shell-quote": "^1.6.1",
-        "string.prototype.padend": "^3.0.0"
-      },
-      "dependencies": {
-        "load-json-file": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-          "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^4.0.0",
-            "pify": "^3.0.0",
-            "strip-bom": "^3.0.0"
-          }
-        },
-        "parse-json": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-          "dev": true,
-          "requires": {
-            "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1"
-          }
-        },
-        "path-type": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-          "dev": true,
-          "requires": {
-            "pify": "^3.0.0"
-          }
-        },
-        "pify": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-          "dev": true
-        },
-        "read-pkg": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-          "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "^4.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^3.0.0"
-          }
-        },
-        "strip-bom": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-          "dev": true
-        }
-      }
-    },
-    "npmlog": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
-      "integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
-      "dev": true,
-      "requires": {
-        "are-we-there-yet": "^3.0.0",
-        "console-control-strings": "^1.1.0",
-        "gauge": "^4.0.3",
-        "set-blocking": "^2.0.0"
-      }
-    },
-    "object-keys": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true
-    },
-    "once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
-      "requires": {
-        "wrappy": "1"
-      }
-    },
-    "p-limit": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-      "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
-      "dev": true,
-      "requires": {
-        "p-try": "^2.0.0"
-      }
-    },
-    "p-locate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-      "dev": true,
-      "requires": {
-        "p-limit": "^2.0.0"
-      }
-    },
-    "p-map": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-      "dev": true,
-      "requires": {
-        "aggregate-error": "^3.0.0"
-      }
-    },
-    "p-try": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true
-    },
-    "parse-json": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "error-ex": "^1.3.1",
-        "json-parse-even-better-errors": "^2.3.0",
-        "lines-and-columns": "^1.1.6"
-      }
-    },
-    "path-exists": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-      "dev": true
-    },
-    "path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true
-    },
-    "path-key": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-      "dev": true
-    },
-    "path-parse": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true
-    },
-    "picocolors": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true
-    },
-    "picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true
-    },
-    "pidtree": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.3.0.tgz",
-      "integrity": "sha512-9CT4NFlDcosssyg8KVFltgokyKZIFjoBxw8CTGy+5F38Y1eQWrt8tRayiUOXE+zVKQnYu5BR8JjCtvK3BcnBhg==",
-      "dev": true
-    },
-    "pify": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
-      "dev": true
-    },
-    "postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
-      "dev": true,
-      "requires": {
-        "nanoid": "^3.3.11",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      }
-    },
-    "postcss-cli": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-cli/-/postcss-cli-11.0.1.tgz",
-      "integrity": "sha512-0UnkNPSayHKRe/tc2YGW6XnSqqOA9eqpiRMgRlV1S6HdGi16vwJBx7lviARzbV1HpQHqLLRH3o8vTcB0cLc+5g==",
-      "dev": true,
-      "requires": {
-        "chokidar": "^3.3.0",
-        "dependency-graph": "^1.0.0",
-        "fs-extra": "^11.0.0",
-        "picocolors": "^1.0.0",
-        "postcss-load-config": "^5.0.0",
-        "postcss-reporter": "^7.0.0",
-        "pretty-hrtime": "^1.0.3",
-        "read-cache": "^1.0.0",
-        "slash": "^5.0.0",
-        "tinyglobby": "^0.2.12",
-        "yargs": "^17.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "cliui": {
-          "version": "8.0.1",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-          "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-          "dev": true,
-          "requires": {
-            "string-width": "^4.2.0",
-            "strip-ansi": "^6.0.1",
-            "wrap-ansi": "^7.0.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.1"
-          }
-        },
-        "wrap-ansi": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.0.0",
-            "string-width": "^4.1.0",
-            "strip-ansi": "^6.0.0"
-          }
-        },
-        "y18n": {
-          "version": "5.0.8",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-          "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-          "dev": true
-        },
-        "yargs": {
-          "version": "17.6.2",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
-          "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
-          "dev": true,
-          "requires": {
-            "cliui": "^8.0.1",
-            "escalade": "^3.1.1",
-            "get-caller-file": "^2.0.5",
-            "require-directory": "^2.1.1",
-            "string-width": "^4.2.3",
-            "y18n": "^5.0.5",
-            "yargs-parser": "^21.1.1"
-          }
-        },
-        "yargs-parser": {
-          "version": "21.1.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-          "dev": true
-        }
-      }
-    },
-    "postcss-focus-within": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-focus-within/-/postcss-focus-within-9.0.1.tgz",
-      "integrity": "sha512-fzNUyS1yOYa7mOjpci/bR+u+ESvdar6hk8XNK/TRR0fiGTp2QT5N+ducP0n3rfH/m9I7H/EQU6lsa2BrgxkEjw==",
-      "dev": true,
-      "requires": {
-        "postcss-selector-parser": "^7.0.0"
-      }
-    },
-    "postcss-load-config": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-5.0.2.tgz",
-      "integrity": "sha512-Q8QR3FYbqOKa0bnC1UQ2bFq9/ulHX5Bi34muzitMr8aDtUelO5xKeJEYC/5smE0jNE9zdB/NBnOwXKexELbRlw==",
-      "dev": true,
-      "requires": {
-        "lilconfig": "^3.0.0",
-        "yaml": "^2.3.4"
-      }
-    },
-    "postcss-reporter": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-7.0.5.tgz",
-      "integrity": "sha512-glWg7VZBilooZGOFPhN9msJ3FQs19Hie7l5a/eE6WglzYqVeH3ong3ShFcp9kDWJT1g2Y/wd59cocf9XxBtkWA==",
-      "dev": true,
-      "requires": {
-        "picocolors": "^1.0.0",
-        "thenby": "^1.3.4"
-      }
-    },
-    "postcss-selector-parser": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.0.0.tgz",
-      "integrity": "sha512-9RbEr1Y7FFfptd/1eEdntyjMwLeghW1bHX9GWjXo19vx4ytPQhANltvVxDggzJl7mnWM+dX28kb6cyS/4iQjlQ==",
-      "dev": true,
-      "requires": {
-        "cssesc": "^3.0.0",
-        "util-deprecate": "^1.0.2"
-      }
-    },
-    "postcss-value-parser": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "dev": true
-    },
-    "pretty-hrtime": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
-      "integrity": "sha512-66hKPCr+72mlfiSjlEB1+45IjXSqvVAIy6mocupoww4tBFE9R9IhwwUGoI4G++Tc9Aq+2rxOt0RFU6gPcrte0A==",
-      "dev": true
-    },
-    "process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
-    },
-    "promise-inflight": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
-      "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
-      "dev": true
-    },
-    "promise-retry": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
-      "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
-      "dev": true,
-      "requires": {
-        "err-code": "^2.0.2",
-        "retry": "^0.12.0"
-      }
-    },
-    "quick-lru": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
-      "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
-      "dev": true
-    },
-    "read-cache": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
-      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
-      "dev": true,
-      "requires": {
-        "pify": "^2.3.0"
-      }
-    },
-    "read-pkg": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
-      "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
-      "dev": true,
-      "requires": {
-        "@types/normalize-package-data": "^2.4.0",
-        "normalize-package-data": "^2.5.0",
-        "parse-json": "^5.0.0",
-        "type-fest": "^0.6.0"
-      },
-      "dependencies": {
-        "type-fest": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
-          "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
-          "dev": true
-        }
-      }
-    },
-    "read-pkg-up": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
-      "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
-      "dev": true,
-      "requires": {
-        "find-up": "^4.1.0",
-        "read-pkg": "^5.2.0",
-        "type-fest": "^0.8.1"
-      },
-      "dependencies": {
-        "find-up": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-          "dev": true,
-          "requires": {
-            "locate-path": "^5.0.0",
-            "path-exists": "^4.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-          "dev": true,
-          "requires": {
-            "p-locate": "^4.1.0"
-          }
-        },
-        "p-locate": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-          "dev": true,
-          "requires": {
-            "p-limit": "^2.2.0"
-          }
-        },
-        "path-exists": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-          "dev": true
-        },
-        "type-fest": {
-          "version": "0.8.1",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-          "dev": true
-        }
-      }
-    },
-    "readable-stream": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.1.tgz",
-      "integrity": "sha512-+rQmrWMYGA90yenhTYsLWAsLsqVC8osOw6PKE1HDYiO0gdPeKe/xDHNzIAIn4C91YQ6oenEhfYqqc1883qHbjQ==",
-      "dev": true,
-      "requires": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      }
-    },
-    "readdirp": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
-      "requires": {
-        "picomatch": "^2.2.1"
-      }
-    },
-    "redent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
-      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
-      "dev": true,
-      "requires": {
-        "indent-string": "^4.0.0",
-        "strip-indent": "^3.0.0"
-      }
-    },
-    "require-directory": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-      "dev": true
-    },
-    "require-main-filename": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-      "dev": true
-    },
-    "resolve": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
-      "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
-      "dev": true,
-      "requires": {
-        "path-parse": "^1.0.6"
-      }
-    },
-    "retry": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
-      "dev": true
-    },
-    "rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
-      "requires": {
-        "glob": "^7.1.3"
-      }
-    },
-    "rtlcss": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/rtlcss/-/rtlcss-4.3.0.tgz",
-      "integrity": "sha512-FI+pHEn7Wc4NqKXMXFM+VAYKEj/mRIcW4h24YVwVtyjI+EqGrLc2Hx/Ny0lrZ21cBWU2goLy36eqMcNj3AQJig==",
-      "dev": true,
-      "requires": {
-        "escalade": "^3.1.1",
-        "picocolors": "^1.0.0",
-        "postcss": "^8.4.21",
-        "strip-json-comments": "^3.1.1"
-      }
-    },
-    "safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true
-    },
-    "safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
-      "optional": true
-    },
-    "sass-graph": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-4.0.1.tgz",
-      "integrity": "sha512-5YCfmGBmxoIRYHnKK2AKzrAkCoQ8ozO+iumT8K4tXJXRVCPf+7s1/9KxTSW3Rbvf+7Y7b4FR3mWyLnQr3PHocA==",
-      "dev": true,
-      "requires": {
-        "glob": "^7.0.0",
-        "lodash": "^4.17.11",
-        "scss-tokenizer": "^0.4.3",
-        "yargs": "^17.2.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "cliui": {
-          "version": "8.0.1",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-          "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-          "dev": true,
-          "requires": {
-            "string-width": "^4.2.0",
-            "strip-ansi": "^6.0.1",
-            "wrap-ansi": "^7.0.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.1"
-          }
-        },
-        "wrap-ansi": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.0.0",
-            "string-width": "^4.1.0",
-            "strip-ansi": "^6.0.0"
-          }
-        },
-        "y18n": {
-          "version": "5.0.8",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-          "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-          "dev": true
-        },
-        "yargs": {
-          "version": "17.7.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
-          "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
-          "dev": true,
-          "requires": {
-            "cliui": "^8.0.1",
-            "escalade": "^3.1.1",
-            "get-caller-file": "^2.0.5",
-            "require-directory": "^2.1.1",
-            "string-width": "^4.2.3",
-            "y18n": "^5.0.5",
-            "yargs-parser": "^21.1.1"
-          }
-        },
-        "yargs-parser": {
-          "version": "21.1.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-          "dev": true
-        }
-      }
-    },
-    "scss-tokenizer": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.4.3.tgz",
-      "integrity": "sha512-raKLgf1LI5QMQnG+RxHz6oK0sL3x3I4FN2UDLqgLOGO8hodECNnNh5BXn7fAyBxrA8zVzdQizQ6XjNJQ+uBwMw==",
-      "dev": true,
-      "requires": {
-        "js-base64": "^2.4.9",
-        "source-map": "^0.7.3"
-      }
-    },
-    "semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "dev": true
-    },
-    "set-blocking": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-      "dev": true
-    },
-    "shebang-command": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-      "dev": true,
-      "requires": {
-        "shebang-regex": "^1.0.0"
-      }
-    },
-    "shebang-regex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-      "dev": true
-    },
-    "shell-quote": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz",
-      "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==",
-      "dev": true
-    },
-    "signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true
-    },
-    "slash": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
-      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
-      "dev": true
-    },
-    "smart-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
-      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-      "dev": true
-    },
-    "socks": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
-      "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
-      "dev": true,
-      "requires": {
-        "ip-address": "^9.0.5",
-        "smart-buffer": "^4.2.0"
-      }
-    },
-    "socks-proxy-agent": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-7.0.0.tgz",
-      "integrity": "sha512-Fgl0YPZ902wEsAyiQ+idGd1A7rSFx/ayC1CQVMw5P+EQx2V0SgpGtf6OKFhVjPflPUl9YMmEOnmfjCdMUsygww==",
-      "dev": true,
-      "requires": {
-        "agent-base": "^6.0.2",
-        "debug": "^4.3.3",
-        "socks": "^2.6.2"
-      }
-    },
-    "source-map": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
-      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
-      "dev": true
-    },
-    "source-map-js": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
-      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true
-    },
-    "spdx-correct": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
-      "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
-      "dev": true,
-      "requires": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "spdx-exceptions": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
-      "dev": true
-    },
-    "spdx-expression-parse": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
-      "dev": true,
-      "requires": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "spdx-license-ids": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.4.tgz",
-      "integrity": "sha512-7j8LYJLeY/Yb6ACbQ7F76qy5jHkp0U6jgBfJsk97bwWlVUnUWsAgpyaCvo17h0/RQGnQ036tVDomiwoI4pDkQA==",
-      "dev": true
-    },
-    "sprintf-js": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-      "dev": true
-    },
-    "ssri": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-9.0.1.tgz",
-      "integrity": "sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q==",
-      "dev": true,
-      "requires": {
-        "minipass": "^3.1.1"
-      }
-    },
-    "stdout-stream": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.1.tgz",
-      "integrity": "sha512-j4emi03KXqJWcIeF8eIXkjMFN1Cmb8gUlDYGeBALLPo5qdyTfA9bOtl8m33lRoC+vFMkP3gl0WsDr6+gzxbbTA==",
-      "dev": true,
-      "requires": {
-        "readable-stream": "^2.0.1"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.8",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-          "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
-      }
-    },
-    "string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
-    "string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "requires": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-          "dev": true
-        },
-        "emoji-regex": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.1"
-          }
-        }
-      }
-    },
-    "string.prototype.padend": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.0.0.tgz",
-      "integrity": "sha1-86rvfBcZ8XDF6rHDK/eA2W4h8vA=",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.4.3",
-        "function-bind": "^1.0.2"
-      }
-    },
-    "strip-ansi": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "^4.1.0"
-      }
-    },
-    "strip-indent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
-      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
-      "dev": true,
-      "requires": {
-        "min-indent": "^1.0.0"
-      }
-    },
-    "strip-json-comments": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "dev": true
-    },
-    "supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "requires": {
-        "has-flag": "^3.0.0"
-      }
-    },
-    "tar": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
-      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
-      "dev": true,
-      "requires": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^5.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
-      },
-      "dependencies": {
-        "minipass": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-          "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-          "dev": true
-        }
-      }
-    },
-    "thenby": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/thenby/-/thenby-1.3.4.tgz",
-      "integrity": "sha512-89Gi5raiWA3QZ4b2ePcEwswC3me9JIg+ToSgtE0JWeCynLnLxNr/f9G+xfo9K+Oj4AFdom8YNJjibIARTJmapQ==",
-      "dev": true
-    },
-    "tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
-      "dev": true,
-      "requires": {
-        "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
-      },
-      "dependencies": {
-        "fdir": {
-          "version": "6.5.0",
-          "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-          "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-          "dev": true,
-          "requires": {}
-        },
-        "picomatch": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-          "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-          "dev": true
-        }
-      }
-    },
-    "to-regex-range": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
-      "requires": {
-        "is-number": "^7.0.0"
-      }
-    },
-    "trim-newlines": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
-      "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
-      "dev": true
-    },
-    "true-case-path": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-2.2.1.tgz",
-      "integrity": "sha512-0z3j8R7MCjy10kc/g+qg7Ln3alJTodw9aDuVWZa3uiWqfuBMKeAeP2ocWcxoyM3D73yz3Jt/Pu4qPr4wHSdB/Q==",
-      "dev": true
-    },
-    "type-fest": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
-      "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
-      "dev": true
-    },
-    "unique-filename": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-2.0.1.tgz",
-      "integrity": "sha512-ODWHtkkdx3IAR+veKxFV+VBkUMcN+FaqzUUd7IZzt+0zhDZFPFxhlqwPF3YQvMHx1TD0tdgYl+kuPnJ8E6ql7A==",
-      "dev": true,
-      "requires": {
-        "unique-slug": "^3.0.0"
-      }
-    },
-    "unique-slug": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-3.0.0.tgz",
-      "integrity": "sha512-8EyMynh679x/0gqE9fT9oilG+qEt+ibFyqjuVTsZn1+CMxH+XLlpvr2UZx4nVcCwTpx81nICr2JQFkM+HPLq4w==",
-      "dev": true,
-      "requires": {
-        "imurmurhash": "^0.1.4"
-      }
-    },
-    "universalify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-      "dev": true
-    },
-    "update-browserslist-db": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.4.tgz",
-      "integrity": "sha512-q0SPT4xyU84saUX+tomz1WLkxUbuaJnR1xWt17M7fJtEJigJeWUNGUqrauFXsHnqev9y9JTRGwk13tFBuKby4A==",
-      "dev": true,
-      "requires": {
-        "escalade": "^3.2.0",
-        "picocolors": "^1.1.1"
-      }
-    },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true
-    },
-    "validate-npm-package-license": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
-      "dev": true,
-      "requires": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
-      }
-    },
-    "which": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "dev": true,
-      "requires": {
-        "isexe": "^2.0.0"
-      }
-    },
-    "which-module": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-      "dev": true
-    },
-    "wide-align": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
-      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
-      "dev": true,
-      "requires": {
-        "string-width": "^1.0.2 || 2 || 3 || 4"
-      }
-    },
-    "wrap-ansi": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-      "dev": true,
-      "requires": {
-        "ansi-styles": "^3.2.0",
-        "string-width": "^3.0.0",
-        "strip-ansi": "^5.0.0"
-      },
-      "dependencies": {
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
-          }
-        }
-      }
-    },
-    "wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true
-    },
-    "y18n": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
-      "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
-      "dev": true
-    },
-    "yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
-    },
-    "yaml": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.4.tgz",
-      "integrity": "sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==",
-      "dev": true
-    },
-    "yargs": {
-      "version": "13.3.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
-      "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
-      "dev": true,
-      "requires": {
-        "cliui": "^5.0.0",
-        "find-up": "^3.0.0",
-        "get-caller-file": "^2.0.1",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^2.0.0",
-        "set-blocking": "^2.0.0",
-        "string-width": "^3.0.0",
-        "which-module": "^2.0.0",
-        "y18n": "^4.0.0",
-        "yargs-parser": "^13.1.2"
-      },
-      "dependencies": {
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
-          }
-        }
-      }
-    },
-    "yargs-parser": {
-      "version": "13.1.2",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
-      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
-      "dev": true,
-      "requires": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
       }

--- a/src/wp-content/themes/twentynineteen/package.json
+++ b/src/wp-content/themes/twentynineteen/package.json
@@ -14,7 +14,7 @@
     "@wordpress/browserslist-config": "^6.34.0",
     "autoprefixer": "^10.4.22",
     "chokidar-cli": "^3.0.0",
-    "node-sass": "^9.0.0",
+    "sass": "^1.83.0",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.5.6",
     "postcss-cli": "^11.0.1",
@@ -38,11 +38,11 @@
     "extends @wordpress/browserslist-config"
   ],
   "scripts": {
-    "build:style": "node-sass style.scss style.css --output-style expanded && postcss -r style.css",
-    "build:style-editor": "node-sass style-editor.scss style-editor.css --output-style expanded && postcss -r style-editor.css",
-    "build:style-editor-customizer": "node-sass style-editor-customizer.scss style-editor-customizer.css --output-style expanded && postcss -r style-editor-customizer.css",
+    "build:style": "sass style.scss:style.css --style=expanded --no-source-map && postcss -r style.css",
+    "build:style-editor": "sass style-editor.scss:style-editor.css --style=expanded --no-source-map && postcss -r style-editor.css",
+    "build:style-editor-customizer": "sass style-editor-customizer.scss:style-editor-customizer.css --style=expanded --no-source-map && postcss -r style-editor-customizer.css",
     "build:rtl": "rtlcss style.css style-rtl.css",
-    "build:print": "node-sass print.scss print.css --output-style expanded && postcss -r print.css",
+    "build:print": "sass print.scss:print.css --style=expanded --no-source-map && postcss -r print.css",
     "build": "run-p \"build:*\"",
     "watch": "chokidar \"**/*.scss\" -c \"npm run build\" --initial"
   }

--- a/src/wp-content/themes/twentynineteen/postcss.config.js
+++ b/src/wp-content/themes/twentynineteen/postcss.config.js
@@ -6,10 +6,25 @@ module.exports = {
     }
 };
 
+var oneSelectorPerLine = function () {
+    return {
+        postcssPlugin: 'one-selector-per-line',
+        Rule: function (rule) {
+            if (rule.selector.indexOf(',') !== -1) {
+                var before = rule.raws.before || '';
+                var indent = before.substring(before.lastIndexOf('\n') + 1);
+                rule.selector = rule.selector.split(/,\s*/).join(',\n' + indent);
+            }
+        }
+    };
+};
+oneSelectorPerLine.postcss = true;
+
 module.exports = {
     plugins: [
         postcssFocusWithin({
             disablePolyfillReadyClass: true
-        })
+        }),
+        oneSelectorPerLine
     ]
 };

--- a/src/wp-content/themes/twentynineteen/print.css
+++ b/src/wp-content/themes/twentynineteen/print.css
@@ -129,8 +129,7 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
   .site-header.featured-image .main-navigation li,
   .site-header.featured-image .social-navigation li,
   .site-header.featured-image .entry-meta,
-  .site-header.featured-image .entry-title,
-  .site-header.featured-image#masthead .site-title a {
+  .site-header.featured-image .entry-title, .site-header.featured-image#masthead .site-title a {
     color: #000;
     text-shadow: none;
   }

--- a/src/wp-content/themes/twentynineteen/print.css
+++ b/src/wp-content/themes/twentynineteen/print.css
@@ -21,7 +21,8 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
   .entry {
     margin-top: 1em;
   }
-  .entry .entry-header, .site-footer .site-info {
+  .entry .entry-header,
+  .site-footer .site-info {
     margin: 0;
   }
   /* Fonts */
@@ -41,7 +42,8 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
   .has-large-font-size,
   h2.author-title,
   p.author-bio,
-  .comments-title, h3 {
+  .comments-title,
+  h3 {
     font-size: 14pt;
     margin-top: 25px;
   }
@@ -65,14 +67,19 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
     page-break-inside: avoid;
     page-break-after: avoid;
   }
-  table, pre {
+  table,
+  pre {
     page-break-inside: avoid;
   }
-  ul, ol, dl {
+  ul,
+  ol,
+  dl {
     page-break-before: avoid;
   }
   /* Links */
-  a:link, a:visited, a {
+  a:link,
+  a:visited,
+  a {
     background: transparent;
     font-weight: bold;
     text-decoration: underline;
@@ -129,7 +136,8 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
   .site-header.featured-image .main-navigation li,
   .site-header.featured-image .social-navigation li,
   .site-header.featured-image .entry-meta,
-  .site-header.featured-image .entry-title, .site-header.featured-image#masthead .site-title a {
+  .site-header.featured-image .entry-title,
+  .site-header.featured-image#masthead .site-title a {
     color: #000;
     text-shadow: none;
   }

--- a/src/wp-content/themes/twentynineteen/sass/mixins/_mixins-master.scss
+++ b/src/wp-content/themes/twentynineteen/sass/mixins/_mixins-master.scss
@@ -126,11 +126,7 @@
 /* Ensure all font family declarations come with non-latin fallbacks */
 @mixin font-family( $font_family: $font__body ) {
 	font-family: $font_family;
-	@extend %non-latin-fonts;
-}
 
-/* Build our non-latin font styles */
-%non-latin-fonts {
 	@each $lang, $font__fallback in $font__fallbacks {
 		&:lang(#{$lang}) {
 			font-family: unquote( $font__fallback );

--- a/src/wp-content/themes/twentynineteen/sass/site/primary/_comments.scss
+++ b/src/wp-content/themes/twentynineteen/sass/site/primary/_comments.scss
@@ -237,7 +237,7 @@
 			display: block;
 			height: 18px;
 			position: absolute;
-			background: lighten( $color__link, 8% );
+			background: #008fd3;
 			right: calc(100% - #{$size__spacing-unit * 2.5});
 			top: -3px;
 			width: 18px;

--- a/src/wp-content/themes/twentynineteen/sass/variables-site/_colors.scss
+++ b/src/wp-content/themes/twentynineteen/sass/variables-site/_colors.scss
@@ -13,7 +13,7 @@ $color__background_selection: mix( $color__background-body, $color__background-b
 // Text
 $color__text-main: #111;
 $color__text-light: #767676;
-$color__text-hover: lighten( #111, 22.5% );
+$color__text-hover: #4a4a4a;
 $color__text-screen: #21759b;
 $color__text-input: #666;
 $color__text-input-focus: #111;
@@ -21,12 +21,12 @@ $color__text-input-focus: #111;
 // Links
 $color__link: #0073aa;
 $color__link-visited: #0073aa;
-$color__link-hover: darken( $color__link, 10% );
+$color__link-hover: #005177;
 
 // Borders
 $color__border: #ccc;
 $color__border-link: #0073aa;
-$color__border-link-hover: darken( $color__link, 10% );
+$color__border-link-hover: #005177;
 $color__border-button: #ccc #ccc #bbb;
 $color__border-button-hover: #ccc #bbb #aaa;
 $color__border-button-focus: #aaa #bbb #bbb;

--- a/src/wp-content/themes/twentynineteen/style-editor.css
+++ b/src/wp-content/themes/twentynineteen/style-editor.css
@@ -524,7 +524,7 @@ a {
   color: #0073aa;
 }
 a:hover, a:active {
-  color: rgb(0, 80.5, 119);
+  color: #005177;
   outline: 0;
   text-decoration: none;
 }
@@ -2238,7 +2238,7 @@ figcaption,
   color: #0073aa;
 }
 .wp-block-file .wp-block-file__textlink:hover {
-  color: rgb(0, 80.5, 119);
+  color: #005177;
   text-decoration: none;
 }
 .wp-block-file .wp-block-file__button {
@@ -2293,8 +2293,8 @@ figcaption,
   background-color: #0073aa;
 }
 .wp-block-separator.has-secondary-background-color {
-  color: rgb(0, 80.5, 119);
-  background-color: rgb(0, 80.5, 119);
+  color: #005177;
+  background-color: #005177;
 }
 .wp-block-separator.has-dark-gray-background-color {
   color: #111;

--- a/src/wp-content/themes/twentynineteen/style-editor.css
+++ b/src/wp-content/themes/twentynineteen/style-editor.css
@@ -11,599 +11,35 @@ Twenty Nineteen Editor Styles
  * character instead.
  */
 @font-face {
-  font-family: 'NonBreakingSpaceOverride';
+  font-family: "NonBreakingSpaceOverride";
   src: url(data:application/font-woff2;charset=utf-8;base64,d09GMgABAAAAAAMoAA0AAAAACDQAAALTAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP0ZGVE0cGh4GYACCahEICjx3CywAATYCJANUBCAFhiEHgWwbXQfILgpsY+rQRRARwyAs6uL7pxzYhxEE+32b3aeHmifR6tklkS9hiZA0ewkqGRJE+H7/+6378ASViK/PGeavqJyOzsceKi1s3BCiQsiOdn1r/RBgIJYEgCUhbm/8/8/h4saPssnTNkkiWUBrTRtjmQSajw3Ui3pZ3LYDPD+XG2C3JA/yKAS8/rU5eNfuGqRf4eNNgV4YAlIIgxglEkWe6FYpq10+wi3g+/nUgvgPFczNrz/RsTgVm/zfbPuHZlsuQECxuyqBcQwKFBjFgKO8AqP4bAN9tFJtnM9xPcbNjeXS/x1wY/xU52f5W/X1+9cnH4YwKIaoRRAkUkj/YlAAeF/624foiIDBgBmgQBeGAyhBljUPZUm/l2dTvmpqcBDUOHdbPZWd8JsBAsGr4w8/EDn82/bUPx4eh0YNrQTBuHO2FjQEAGBwK0DeI37DpQVqdERS4gZBhpeUhWCfLFz7J99aEBgsJCHvUGAdAPp4IADDCAPCEFMGpMZ9AQpTfQtQGhLbGVBZFV8BaqNyP68oTZgHNj3M8kBPfXTTC9t90UuzYhy9ciH0grVlOcqyCytisvbsERsEYztiznR0WCrmTksJwbSNK6fd1Rvr25I9oLvctUoEbNOmXJbqgYgPXEHJ82IUsrCnpkxh23F1rfZ2zcRnJYoXtauB3VTFkFXQg3uoZYD5qE0kdjDtoDoF1h2bulGmev5HbYhbrjtohQSRI4aNOkffIcT+d3v6atpaYh3JvPoQsztCcqvaBkppDSPcQ3bw3KaCBo1f5CJWTZEgW3LjLofYg51MaVezrx8xZitYbQ9KYeoRaqQdVLwSEfrKXLK1otCWOKNdR/YwYAfon5Yk8O2MJfSD10dPGA5PIJJQMkah0ugMJiv6x4Dm7LEa8xnrRGGGLAg4sAlbsA07sAt76DOsXKO3hIjtIlpnnFrt1qW4kh6NhS83P/6HB/fl1SMAAA==) format("woff2"), url(data:application/font-woff;charset=utf-8;base64,d09GRgABAAAAAAUQAA0AAAAACDQAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAABGRlRNAAAE9AAAABwAAAAchf5yU0dERUYAAATYAAAAHAAAAB4AJwAbT1MvMgAAAaAAAABJAAAAYJAcgU5jbWFwAAACIAAAAF4AAAFqUUxBZ2dhc3AAAATQAAAACAAAAAgAAAAQZ2x5ZgAAApAAAAAyAAAAPL0n8y9oZWFkAAABMAAAADAAAAA2Fi93Z2hoZWEAAAFgAAAAHQAAACQOSgWaaG10eAAAAewAAAAzAAAAVC7TAQBsb2NhAAACgAAAABAAAAAsAOQBAm1heHAAAAGAAAAAHQAAACAAWQALbmFtZQAAAsQAAAF6AAADIYvD/Adwb3N0AAAEQAAAAI4AAADsapk2o3jaY2BkYGAA4ov5mwzj+W2+MnCzXwCKMNzgCBSB0LfbQDQ7AxuI4mBgAlEAFKQIRHjaY2BkYGD3+NvCwMDBAALsDAyMDKhAFAA3+wH3AAAAeNpjYGRgYBBl4GBgYgABEMnIABJzAPMZAAVmAGUAAAB42mNgZlJhnMDAysDCKsKygYGBYRqEZtrDYMT4D8gHSmEHjgUFOQwODAqqf9g9/rYwMLB7MNUAhRlBcsxBrMlASoGBEQAj8QtyAAAAeNrjYGBkAAGmWQwMjO8gmBnIZ2NA0ExAzNjAAFYJVn0ASBsD6VAIDZb7AtELAgANIgb9AHjaY2BgYGaAYBkGRgYQSAHyGMF8FgYPIM3HwMHAxMDGoMCwQIFLQV8hXvXP//9AcRCfAcb///h/ygPW+w/vb7olBjUHCTCyMcAFGZmABBO6AogThgZgIUsXAEDcEzcAAHjaY2BgECMCyoEgACZaAed42mNgYmRgYGBnYGNgYAZSDJqMgorCgoqCjECRXwwNrCAKSP5mAAFGBiRgyAAAi/YFBQAAeNqtkc1OwkAUhU/5M25cEhcsZick0AwlBJq6MWwgJkAgYV/KAA2lJeUn+hY+gktXvpKv4dLTMqKycGHsTZNv7px7z50ZAFd4hYHjdw1Ls4EiHjVncIFnzVnc4F1zDkWjrzmPW+NNcwGlzIRKI3fJlUyrEjZQxb3mDH2fNGfRx4vmHKqG0JzHg6E0F9DOlFBGBxUI1GEzLNT4S0aLuTtsGAEUuYcQHkyg3KmIum1bNUvKlrjbbAIleqHHnS4iSudpQcySMYtdFiXlAxzSbAwfMxK6kZoHKhbjjespMTioOPZnzI+4ucCeTVyKMVKLfeAS6vSWaTinuZwzyy/Dc7vaed+6KaV0kukdPUk6yOcctZPvvxxqksq2lEW8RvHjMEO2FCl/zy6p3NEm0R9OFSafJdldc4QVeyaaObMBO0/5cCaa6d9Ggyubxire+lEojscdjoWUR1xGOy8KD8mG2ZLO2l2paDc3A39qmU2z2W5YNv5+u79e6QfGJY/hAAB42m3NywrCMBQE0DupWp/1AYI7/6DEaLQu66Mrd35BKUWKJSlFv1+rue4cGM7shgR981qSon+ZNwUJ8iDgoYU2OvDRRQ99DDDECAHGmGCKmf80hZSx/Kik/LliFbtmN6xmt+yOjdg9GztV4tROnRwX/Bsaaw51nt4Lc7tWaZYHp/MlzKx51LZs5htNri+2AAAAAQAB//8AD3jaY2BkYGDgAWIxIGZiYARCESBmAfMYAAR6AEMAAAABAAAAANXtRbgAAAAA2AhRFAAAAADYCNuG) format("woff");
 }
-
 /* If we add the border using a regular CSS border, it won't look good on non-retina devices,
  * since its edges can look jagged due to lack of antialiasing. In this case, we are several
  * layers of box-shadow to add the border visually, which will render the border smoother. */
 /* Calculates maximum width for post content */
 /* Nested sub-menu padding: 10 levels deep */
 /* Ensure all font family declarations come with non-latin fallbacks */
-/* Build our non-latin font styles */
-body:lang(ar), h1:lang(ar),
-h2:lang(ar),
-h3:lang(ar),
-h4:lang(ar),
-h5:lang(ar),
-h6:lang(ar), figcaption:lang(ar),
-.gallery-caption:lang(ar), .editor-post-title__block .editor-post-title__input:lang(ar), .block-editor-default-block-appender textarea.block-editor-default-block-appender__content:lang(ar), .wp-block-paragraph.has-drop-cap:lang(ar):not(:focus)::first-letter, .wp-block-table:lang(ar), .wp-block-cover h2:lang(ar),
-.wp-block-cover .wp-block-cover-text:lang(ar), .wp-block-button .wp-block-button__link:lang(ar), .wp-block-search .wp-block-search__button:lang(ar), .wp-block-quote cite:lang(ar),
-.wp-block-quote footer:lang(ar),
-.wp-block-quote .wp-block-quote__citation:lang(ar), .wp-block-pullquote[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(ar),
-.wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(ar),
-.wp-block[data-type="core/pullquote"][data-align="left"] .wp-block-pullquote__citation:lang(ar),
-.wp-block[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation:lang(ar), .wp-block-file:lang(ar), ul.wp-block-archives li > a:lang(ar),
-.wp-block-categories li > a:lang(ar),
-.wp-block-latest-posts li > a:lang(ar), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ar), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ar), .wp-caption dd:lang(ar), .wp-block-freeform blockquote cite:lang(ar), .wp-calendar-table:lang(ar) {
-  font-family: Tahoma, Arial, sans-serif;
-}
-
-body:lang(ary), h1:lang(ary),
-h2:lang(ary),
-h3:lang(ary),
-h4:lang(ary),
-h5:lang(ary),
-h6:lang(ary), figcaption:lang(ary),
-.gallery-caption:lang(ary), .editor-post-title__block .editor-post-title__input:lang(ary), .block-editor-default-block-appender textarea.block-editor-default-block-appender__content:lang(ary), .wp-block-paragraph.has-drop-cap:lang(ary):not(:focus)::first-letter, .wp-block-table:lang(ary), .wp-block-cover h2:lang(ary),
-.wp-block-cover .wp-block-cover-text:lang(ary), .wp-block-button .wp-block-button__link:lang(ary), .wp-block-search .wp-block-search__button:lang(ary), .wp-block-quote cite:lang(ary),
-.wp-block-quote footer:lang(ary),
-.wp-block-quote .wp-block-quote__citation:lang(ary), .wp-block-pullquote[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(ary),
-.wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(ary),
-.wp-block[data-type="core/pullquote"][data-align="left"] .wp-block-pullquote__citation:lang(ary),
-.wp-block[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation:lang(ary), .wp-block-file:lang(ary), ul.wp-block-archives li > a:lang(ary),
-.wp-block-categories li > a:lang(ary),
-.wp-block-latest-posts li > a:lang(ary), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ary), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ary), .wp-caption dd:lang(ary), .wp-block-freeform blockquote cite:lang(ary), .wp-calendar-table:lang(ary) {
-  font-family: Tahoma, Arial, sans-serif;
-}
-
-body:lang(azb), h1:lang(azb),
-h2:lang(azb),
-h3:lang(azb),
-h4:lang(azb),
-h5:lang(azb),
-h6:lang(azb), figcaption:lang(azb),
-.gallery-caption:lang(azb), .editor-post-title__block .editor-post-title__input:lang(azb), .block-editor-default-block-appender textarea.block-editor-default-block-appender__content:lang(azb), .wp-block-paragraph.has-drop-cap:lang(azb):not(:focus)::first-letter, .wp-block-table:lang(azb), .wp-block-cover h2:lang(azb),
-.wp-block-cover .wp-block-cover-text:lang(azb), .wp-block-button .wp-block-button__link:lang(azb), .wp-block-search .wp-block-search__button:lang(azb), .wp-block-quote cite:lang(azb),
-.wp-block-quote footer:lang(azb),
-.wp-block-quote .wp-block-quote__citation:lang(azb), .wp-block-pullquote[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(azb),
-.wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(azb),
-.wp-block[data-type="core/pullquote"][data-align="left"] .wp-block-pullquote__citation:lang(azb),
-.wp-block[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation:lang(azb), .wp-block-file:lang(azb), ul.wp-block-archives li > a:lang(azb),
-.wp-block-categories li > a:lang(azb),
-.wp-block-latest-posts li > a:lang(azb), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(azb), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(azb), .wp-caption dd:lang(azb), .wp-block-freeform blockquote cite:lang(azb), .wp-calendar-table:lang(azb) {
-  font-family: Tahoma, Arial, sans-serif;
-}
-
-body:lang(ckb), h1:lang(ckb),
-h2:lang(ckb),
-h3:lang(ckb),
-h4:lang(ckb),
-h5:lang(ckb),
-h6:lang(ckb), figcaption:lang(ckb),
-.gallery-caption:lang(ckb), .editor-post-title__block .editor-post-title__input:lang(ckb), .block-editor-default-block-appender textarea.block-editor-default-block-appender__content:lang(ckb), .wp-block-paragraph.has-drop-cap:lang(ckb):not(:focus)::first-letter, .wp-block-table:lang(ckb), .wp-block-cover h2:lang(ckb),
-.wp-block-cover .wp-block-cover-text:lang(ckb), .wp-block-button .wp-block-button__link:lang(ckb), .wp-block-search .wp-block-search__button:lang(ckb), .wp-block-quote cite:lang(ckb),
-.wp-block-quote footer:lang(ckb),
-.wp-block-quote .wp-block-quote__citation:lang(ckb), .wp-block-pullquote[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(ckb),
-.wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(ckb),
-.wp-block[data-type="core/pullquote"][data-align="left"] .wp-block-pullquote__citation:lang(ckb),
-.wp-block[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation:lang(ckb), .wp-block-file:lang(ckb), ul.wp-block-archives li > a:lang(ckb),
-.wp-block-categories li > a:lang(ckb),
-.wp-block-latest-posts li > a:lang(ckb), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ckb), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ckb), .wp-caption dd:lang(ckb), .wp-block-freeform blockquote cite:lang(ckb), .wp-calendar-table:lang(ckb) {
-  font-family: Tahoma, Arial, sans-serif;
-}
-
-body:lang(fa-IR), h1:lang(fa-IR),
-h2:lang(fa-IR),
-h3:lang(fa-IR),
-h4:lang(fa-IR),
-h5:lang(fa-IR),
-h6:lang(fa-IR), figcaption:lang(fa-IR),
-.gallery-caption:lang(fa-IR), .editor-post-title__block .editor-post-title__input:lang(fa-IR), .block-editor-default-block-appender textarea.block-editor-default-block-appender__content:lang(fa-IR), .wp-block-paragraph.has-drop-cap:lang(fa-IR):not(:focus)::first-letter, .wp-block-table:lang(fa-IR), .wp-block-cover h2:lang(fa-IR),
-.wp-block-cover .wp-block-cover-text:lang(fa-IR), .wp-block-button .wp-block-button__link:lang(fa-IR), .wp-block-search .wp-block-search__button:lang(fa-IR), .wp-block-quote cite:lang(fa-IR),
-.wp-block-quote footer:lang(fa-IR),
-.wp-block-quote .wp-block-quote__citation:lang(fa-IR), .wp-block-pullquote[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(fa-IR),
-.wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(fa-IR),
-.wp-block[data-type="core/pullquote"][data-align="left"] .wp-block-pullquote__citation:lang(fa-IR),
-.wp-block[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation:lang(fa-IR), .wp-block-file:lang(fa-IR), ul.wp-block-archives li > a:lang(fa-IR),
-.wp-block-categories li > a:lang(fa-IR),
-.wp-block-latest-posts li > a:lang(fa-IR), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(fa-IR), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(fa-IR), .wp-caption dd:lang(fa-IR), .wp-block-freeform blockquote cite:lang(fa-IR), .wp-calendar-table:lang(fa-IR) {
-  font-family: Tahoma, Arial, sans-serif;
-}
-
-body:lang(haz), h1:lang(haz),
-h2:lang(haz),
-h3:lang(haz),
-h4:lang(haz),
-h5:lang(haz),
-h6:lang(haz), figcaption:lang(haz),
-.gallery-caption:lang(haz), .editor-post-title__block .editor-post-title__input:lang(haz), .block-editor-default-block-appender textarea.block-editor-default-block-appender__content:lang(haz), .wp-block-paragraph.has-drop-cap:lang(haz):not(:focus)::first-letter, .wp-block-table:lang(haz), .wp-block-cover h2:lang(haz),
-.wp-block-cover .wp-block-cover-text:lang(haz), .wp-block-button .wp-block-button__link:lang(haz), .wp-block-search .wp-block-search__button:lang(haz), .wp-block-quote cite:lang(haz),
-.wp-block-quote footer:lang(haz),
-.wp-block-quote .wp-block-quote__citation:lang(haz), .wp-block-pullquote[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(haz),
-.wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(haz),
-.wp-block[data-type="core/pullquote"][data-align="left"] .wp-block-pullquote__citation:lang(haz),
-.wp-block[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation:lang(haz), .wp-block-file:lang(haz), ul.wp-block-archives li > a:lang(haz),
-.wp-block-categories li > a:lang(haz),
-.wp-block-latest-posts li > a:lang(haz), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(haz), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(haz), .wp-caption dd:lang(haz), .wp-block-freeform blockquote cite:lang(haz), .wp-calendar-table:lang(haz) {
-  font-family: Tahoma, Arial, sans-serif;
-}
-
-body:lang(ps), h1:lang(ps),
-h2:lang(ps),
-h3:lang(ps),
-h4:lang(ps),
-h5:lang(ps),
-h6:lang(ps), figcaption:lang(ps),
-.gallery-caption:lang(ps), .editor-post-title__block .editor-post-title__input:lang(ps), .block-editor-default-block-appender textarea.block-editor-default-block-appender__content:lang(ps), .wp-block-paragraph.has-drop-cap:lang(ps):not(:focus)::first-letter, .wp-block-table:lang(ps), .wp-block-cover h2:lang(ps),
-.wp-block-cover .wp-block-cover-text:lang(ps), .wp-block-button .wp-block-button__link:lang(ps), .wp-block-search .wp-block-search__button:lang(ps), .wp-block-quote cite:lang(ps),
-.wp-block-quote footer:lang(ps),
-.wp-block-quote .wp-block-quote__citation:lang(ps), .wp-block-pullquote[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(ps),
-.wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(ps),
-.wp-block[data-type="core/pullquote"][data-align="left"] .wp-block-pullquote__citation:lang(ps),
-.wp-block[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation:lang(ps), .wp-block-file:lang(ps), ul.wp-block-archives li > a:lang(ps),
-.wp-block-categories li > a:lang(ps),
-.wp-block-latest-posts li > a:lang(ps), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ps), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ps), .wp-caption dd:lang(ps), .wp-block-freeform blockquote cite:lang(ps), .wp-calendar-table:lang(ps) {
-  font-family: Tahoma, Arial, sans-serif;
-}
-
-body:lang(be), h1:lang(be),
-h2:lang(be),
-h3:lang(be),
-h4:lang(be),
-h5:lang(be),
-h6:lang(be), figcaption:lang(be),
-.gallery-caption:lang(be), .editor-post-title__block .editor-post-title__input:lang(be), .block-editor-default-block-appender textarea.block-editor-default-block-appender__content:lang(be), .wp-block-paragraph.has-drop-cap:lang(be):not(:focus)::first-letter, .wp-block-table:lang(be), .wp-block-cover h2:lang(be),
-.wp-block-cover .wp-block-cover-text:lang(be), .wp-block-button .wp-block-button__link:lang(be), .wp-block-search .wp-block-search__button:lang(be), .wp-block-quote cite:lang(be),
-.wp-block-quote footer:lang(be),
-.wp-block-quote .wp-block-quote__citation:lang(be), .wp-block-pullquote[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(be),
-.wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(be),
-.wp-block[data-type="core/pullquote"][data-align="left"] .wp-block-pullquote__citation:lang(be),
-.wp-block[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation:lang(be), .wp-block-file:lang(be), ul.wp-block-archives li > a:lang(be),
-.wp-block-categories li > a:lang(be),
-.wp-block-latest-posts li > a:lang(be), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(be), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(be), .wp-caption dd:lang(be), .wp-block-freeform blockquote cite:lang(be), .wp-calendar-table:lang(be) {
-  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
-}
-
-body:lang(bg-BG), h1:lang(bg-BG),
-h2:lang(bg-BG),
-h3:lang(bg-BG),
-h4:lang(bg-BG),
-h5:lang(bg-BG),
-h6:lang(bg-BG), figcaption:lang(bg-BG),
-.gallery-caption:lang(bg-BG), .editor-post-title__block .editor-post-title__input:lang(bg-BG), .block-editor-default-block-appender textarea.block-editor-default-block-appender__content:lang(bg-BG), .wp-block-paragraph.has-drop-cap:lang(bg-BG):not(:focus)::first-letter, .wp-block-table:lang(bg-BG), .wp-block-cover h2:lang(bg-BG),
-.wp-block-cover .wp-block-cover-text:lang(bg-BG), .wp-block-button .wp-block-button__link:lang(bg-BG), .wp-block-search .wp-block-search__button:lang(bg-BG), .wp-block-quote cite:lang(bg-BG),
-.wp-block-quote footer:lang(bg-BG),
-.wp-block-quote .wp-block-quote__citation:lang(bg-BG), .wp-block-pullquote[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(bg-BG),
-.wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(bg-BG),
-.wp-block[data-type="core/pullquote"][data-align="left"] .wp-block-pullquote__citation:lang(bg-BG),
-.wp-block[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation:lang(bg-BG), .wp-block-file:lang(bg-BG), ul.wp-block-archives li > a:lang(bg-BG),
-.wp-block-categories li > a:lang(bg-BG),
-.wp-block-latest-posts li > a:lang(bg-BG), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(bg-BG), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(bg-BG), .wp-caption dd:lang(bg-BG), .wp-block-freeform blockquote cite:lang(bg-BG), .wp-calendar-table:lang(bg-BG) {
-  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
-}
-
-body:lang(kk), h1:lang(kk),
-h2:lang(kk),
-h3:lang(kk),
-h4:lang(kk),
-h5:lang(kk),
-h6:lang(kk), figcaption:lang(kk),
-.gallery-caption:lang(kk), .editor-post-title__block .editor-post-title__input:lang(kk), .block-editor-default-block-appender textarea.block-editor-default-block-appender__content:lang(kk), .wp-block-paragraph.has-drop-cap:lang(kk):not(:focus)::first-letter, .wp-block-table:lang(kk), .wp-block-cover h2:lang(kk),
-.wp-block-cover .wp-block-cover-text:lang(kk), .wp-block-button .wp-block-button__link:lang(kk), .wp-block-search .wp-block-search__button:lang(kk), .wp-block-quote cite:lang(kk),
-.wp-block-quote footer:lang(kk),
-.wp-block-quote .wp-block-quote__citation:lang(kk), .wp-block-pullquote[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(kk),
-.wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(kk),
-.wp-block[data-type="core/pullquote"][data-align="left"] .wp-block-pullquote__citation:lang(kk),
-.wp-block[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation:lang(kk), .wp-block-file:lang(kk), ul.wp-block-archives li > a:lang(kk),
-.wp-block-categories li > a:lang(kk),
-.wp-block-latest-posts li > a:lang(kk), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(kk), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(kk), .wp-caption dd:lang(kk), .wp-block-freeform blockquote cite:lang(kk), .wp-calendar-table:lang(kk) {
-  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
-}
-
-body:lang(mk-MK), h1:lang(mk-MK),
-h2:lang(mk-MK),
-h3:lang(mk-MK),
-h4:lang(mk-MK),
-h5:lang(mk-MK),
-h6:lang(mk-MK), figcaption:lang(mk-MK),
-.gallery-caption:lang(mk-MK), .editor-post-title__block .editor-post-title__input:lang(mk-MK), .block-editor-default-block-appender textarea.block-editor-default-block-appender__content:lang(mk-MK), .wp-block-paragraph.has-drop-cap:lang(mk-MK):not(:focus)::first-letter, .wp-block-table:lang(mk-MK), .wp-block-cover h2:lang(mk-MK),
-.wp-block-cover .wp-block-cover-text:lang(mk-MK), .wp-block-button .wp-block-button__link:lang(mk-MK), .wp-block-search .wp-block-search__button:lang(mk-MK), .wp-block-quote cite:lang(mk-MK),
-.wp-block-quote footer:lang(mk-MK),
-.wp-block-quote .wp-block-quote__citation:lang(mk-MK), .wp-block-pullquote[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(mk-MK),
-.wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(mk-MK),
-.wp-block[data-type="core/pullquote"][data-align="left"] .wp-block-pullquote__citation:lang(mk-MK),
-.wp-block[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation:lang(mk-MK), .wp-block-file:lang(mk-MK), ul.wp-block-archives li > a:lang(mk-MK),
-.wp-block-categories li > a:lang(mk-MK),
-.wp-block-latest-posts li > a:lang(mk-MK), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(mk-MK), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(mk-MK), .wp-caption dd:lang(mk-MK), .wp-block-freeform blockquote cite:lang(mk-MK), .wp-calendar-table:lang(mk-MK) {
-  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
-}
-
-body:lang(mn), h1:lang(mn),
-h2:lang(mn),
-h3:lang(mn),
-h4:lang(mn),
-h5:lang(mn),
-h6:lang(mn), figcaption:lang(mn),
-.gallery-caption:lang(mn), .editor-post-title__block .editor-post-title__input:lang(mn), .block-editor-default-block-appender textarea.block-editor-default-block-appender__content:lang(mn), .wp-block-paragraph.has-drop-cap:lang(mn):not(:focus)::first-letter, .wp-block-table:lang(mn), .wp-block-cover h2:lang(mn),
-.wp-block-cover .wp-block-cover-text:lang(mn), .wp-block-button .wp-block-button__link:lang(mn), .wp-block-search .wp-block-search__button:lang(mn), .wp-block-quote cite:lang(mn),
-.wp-block-quote footer:lang(mn),
-.wp-block-quote .wp-block-quote__citation:lang(mn), .wp-block-pullquote[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(mn),
-.wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(mn),
-.wp-block[data-type="core/pullquote"][data-align="left"] .wp-block-pullquote__citation:lang(mn),
-.wp-block[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation:lang(mn), .wp-block-file:lang(mn), ul.wp-block-archives li > a:lang(mn),
-.wp-block-categories li > a:lang(mn),
-.wp-block-latest-posts li > a:lang(mn), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(mn), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(mn), .wp-caption dd:lang(mn), .wp-block-freeform blockquote cite:lang(mn), .wp-calendar-table:lang(mn) {
-  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
-}
-
-body:lang(ru-RU), h1:lang(ru-RU),
-h2:lang(ru-RU),
-h3:lang(ru-RU),
-h4:lang(ru-RU),
-h5:lang(ru-RU),
-h6:lang(ru-RU), figcaption:lang(ru-RU),
-.gallery-caption:lang(ru-RU), .editor-post-title__block .editor-post-title__input:lang(ru-RU), .block-editor-default-block-appender textarea.block-editor-default-block-appender__content:lang(ru-RU), .wp-block-paragraph.has-drop-cap:lang(ru-RU):not(:focus)::first-letter, .wp-block-table:lang(ru-RU), .wp-block-cover h2:lang(ru-RU),
-.wp-block-cover .wp-block-cover-text:lang(ru-RU), .wp-block-button .wp-block-button__link:lang(ru-RU), .wp-block-search .wp-block-search__button:lang(ru-RU), .wp-block-quote cite:lang(ru-RU),
-.wp-block-quote footer:lang(ru-RU),
-.wp-block-quote .wp-block-quote__citation:lang(ru-RU), .wp-block-pullquote[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(ru-RU),
-.wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(ru-RU),
-.wp-block[data-type="core/pullquote"][data-align="left"] .wp-block-pullquote__citation:lang(ru-RU),
-.wp-block[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation:lang(ru-RU), .wp-block-file:lang(ru-RU), ul.wp-block-archives li > a:lang(ru-RU),
-.wp-block-categories li > a:lang(ru-RU),
-.wp-block-latest-posts li > a:lang(ru-RU), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ru-RU), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ru-RU), .wp-caption dd:lang(ru-RU), .wp-block-freeform blockquote cite:lang(ru-RU), .wp-calendar-table:lang(ru-RU) {
-  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
-}
-
-body:lang(sah), h1:lang(sah),
-h2:lang(sah),
-h3:lang(sah),
-h4:lang(sah),
-h5:lang(sah),
-h6:lang(sah), figcaption:lang(sah),
-.gallery-caption:lang(sah), .editor-post-title__block .editor-post-title__input:lang(sah), .block-editor-default-block-appender textarea.block-editor-default-block-appender__content:lang(sah), .wp-block-paragraph.has-drop-cap:lang(sah):not(:focus)::first-letter, .wp-block-table:lang(sah), .wp-block-cover h2:lang(sah),
-.wp-block-cover .wp-block-cover-text:lang(sah), .wp-block-button .wp-block-button__link:lang(sah), .wp-block-search .wp-block-search__button:lang(sah), .wp-block-quote cite:lang(sah),
-.wp-block-quote footer:lang(sah),
-.wp-block-quote .wp-block-quote__citation:lang(sah), .wp-block-pullquote[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(sah),
-.wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(sah),
-.wp-block[data-type="core/pullquote"][data-align="left"] .wp-block-pullquote__citation:lang(sah),
-.wp-block[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation:lang(sah), .wp-block-file:lang(sah), ul.wp-block-archives li > a:lang(sah),
-.wp-block-categories li > a:lang(sah),
-.wp-block-latest-posts li > a:lang(sah), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(sah), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(sah), .wp-caption dd:lang(sah), .wp-block-freeform blockquote cite:lang(sah), .wp-calendar-table:lang(sah) {
-  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
-}
-
-body:lang(sr-RS), h1:lang(sr-RS),
-h2:lang(sr-RS),
-h3:lang(sr-RS),
-h4:lang(sr-RS),
-h5:lang(sr-RS),
-h6:lang(sr-RS), figcaption:lang(sr-RS),
-.gallery-caption:lang(sr-RS), .editor-post-title__block .editor-post-title__input:lang(sr-RS), .block-editor-default-block-appender textarea.block-editor-default-block-appender__content:lang(sr-RS), .wp-block-paragraph.has-drop-cap:lang(sr-RS):not(:focus)::first-letter, .wp-block-table:lang(sr-RS), .wp-block-cover h2:lang(sr-RS),
-.wp-block-cover .wp-block-cover-text:lang(sr-RS), .wp-block-button .wp-block-button__link:lang(sr-RS), .wp-block-search .wp-block-search__button:lang(sr-RS), .wp-block-quote cite:lang(sr-RS),
-.wp-block-quote footer:lang(sr-RS),
-.wp-block-quote .wp-block-quote__citation:lang(sr-RS), .wp-block-pullquote[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(sr-RS),
-.wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(sr-RS),
-.wp-block[data-type="core/pullquote"][data-align="left"] .wp-block-pullquote__citation:lang(sr-RS),
-.wp-block[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation:lang(sr-RS), .wp-block-file:lang(sr-RS), ul.wp-block-archives li > a:lang(sr-RS),
-.wp-block-categories li > a:lang(sr-RS),
-.wp-block-latest-posts li > a:lang(sr-RS), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(sr-RS), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(sr-RS), .wp-caption dd:lang(sr-RS), .wp-block-freeform blockquote cite:lang(sr-RS), .wp-calendar-table:lang(sr-RS) {
-  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
-}
-
-body:lang(tt-RU), h1:lang(tt-RU),
-h2:lang(tt-RU),
-h3:lang(tt-RU),
-h4:lang(tt-RU),
-h5:lang(tt-RU),
-h6:lang(tt-RU), figcaption:lang(tt-RU),
-.gallery-caption:lang(tt-RU), .editor-post-title__block .editor-post-title__input:lang(tt-RU), .block-editor-default-block-appender textarea.block-editor-default-block-appender__content:lang(tt-RU), .wp-block-paragraph.has-drop-cap:lang(tt-RU):not(:focus)::first-letter, .wp-block-table:lang(tt-RU), .wp-block-cover h2:lang(tt-RU),
-.wp-block-cover .wp-block-cover-text:lang(tt-RU), .wp-block-button .wp-block-button__link:lang(tt-RU), .wp-block-search .wp-block-search__button:lang(tt-RU), .wp-block-quote cite:lang(tt-RU),
-.wp-block-quote footer:lang(tt-RU),
-.wp-block-quote .wp-block-quote__citation:lang(tt-RU), .wp-block-pullquote[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(tt-RU),
-.wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(tt-RU),
-.wp-block[data-type="core/pullquote"][data-align="left"] .wp-block-pullquote__citation:lang(tt-RU),
-.wp-block[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation:lang(tt-RU), .wp-block-file:lang(tt-RU), ul.wp-block-archives li > a:lang(tt-RU),
-.wp-block-categories li > a:lang(tt-RU),
-.wp-block-latest-posts li > a:lang(tt-RU), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(tt-RU), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(tt-RU), .wp-caption dd:lang(tt-RU), .wp-block-freeform blockquote cite:lang(tt-RU), .wp-calendar-table:lang(tt-RU) {
-  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
-}
-
-body:lang(uk), h1:lang(uk),
-h2:lang(uk),
-h3:lang(uk),
-h4:lang(uk),
-h5:lang(uk),
-h6:lang(uk), figcaption:lang(uk),
-.gallery-caption:lang(uk), .editor-post-title__block .editor-post-title__input:lang(uk), .block-editor-default-block-appender textarea.block-editor-default-block-appender__content:lang(uk), .wp-block-paragraph.has-drop-cap:lang(uk):not(:focus)::first-letter, .wp-block-table:lang(uk), .wp-block-cover h2:lang(uk),
-.wp-block-cover .wp-block-cover-text:lang(uk), .wp-block-button .wp-block-button__link:lang(uk), .wp-block-search .wp-block-search__button:lang(uk), .wp-block-quote cite:lang(uk),
-.wp-block-quote footer:lang(uk),
-.wp-block-quote .wp-block-quote__citation:lang(uk), .wp-block-pullquote[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(uk),
-.wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(uk),
-.wp-block[data-type="core/pullquote"][data-align="left"] .wp-block-pullquote__citation:lang(uk),
-.wp-block[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation:lang(uk), .wp-block-file:lang(uk), ul.wp-block-archives li > a:lang(uk),
-.wp-block-categories li > a:lang(uk),
-.wp-block-latest-posts li > a:lang(uk), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(uk), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(uk), .wp-caption dd:lang(uk), .wp-block-freeform blockquote cite:lang(uk), .wp-calendar-table:lang(uk) {
-  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
-}
-
-body:lang(zh-HK), h1:lang(zh-HK),
-h2:lang(zh-HK),
-h3:lang(zh-HK),
-h4:lang(zh-HK),
-h5:lang(zh-HK),
-h6:lang(zh-HK), figcaption:lang(zh-HK),
-.gallery-caption:lang(zh-HK), .editor-post-title__block .editor-post-title__input:lang(zh-HK), .block-editor-default-block-appender textarea.block-editor-default-block-appender__content:lang(zh-HK), .wp-block-paragraph.has-drop-cap:lang(zh-HK):not(:focus)::first-letter, .wp-block-table:lang(zh-HK), .wp-block-cover h2:lang(zh-HK),
-.wp-block-cover .wp-block-cover-text:lang(zh-HK), .wp-block-button .wp-block-button__link:lang(zh-HK), .wp-block-search .wp-block-search__button:lang(zh-HK), .wp-block-quote cite:lang(zh-HK),
-.wp-block-quote footer:lang(zh-HK),
-.wp-block-quote .wp-block-quote__citation:lang(zh-HK), .wp-block-pullquote[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(zh-HK),
-.wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(zh-HK),
-.wp-block[data-type="core/pullquote"][data-align="left"] .wp-block-pullquote__citation:lang(zh-HK),
-.wp-block[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation:lang(zh-HK), .wp-block-file:lang(zh-HK), ul.wp-block-archives li > a:lang(zh-HK),
-.wp-block-categories li > a:lang(zh-HK),
-.wp-block-latest-posts li > a:lang(zh-HK), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(zh-HK), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(zh-HK), .wp-caption dd:lang(zh-HK), .wp-block-freeform blockquote cite:lang(zh-HK), .wp-calendar-table:lang(zh-HK) {
-  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
-}
-
-body:lang(zh-TW), h1:lang(zh-TW),
-h2:lang(zh-TW),
-h3:lang(zh-TW),
-h4:lang(zh-TW),
-h5:lang(zh-TW),
-h6:lang(zh-TW), figcaption:lang(zh-TW),
-.gallery-caption:lang(zh-TW), .editor-post-title__block .editor-post-title__input:lang(zh-TW), .block-editor-default-block-appender textarea.block-editor-default-block-appender__content:lang(zh-TW), .wp-block-paragraph.has-drop-cap:lang(zh-TW):not(:focus)::first-letter, .wp-block-table:lang(zh-TW), .wp-block-cover h2:lang(zh-TW),
-.wp-block-cover .wp-block-cover-text:lang(zh-TW), .wp-block-button .wp-block-button__link:lang(zh-TW), .wp-block-search .wp-block-search__button:lang(zh-TW), .wp-block-quote cite:lang(zh-TW),
-.wp-block-quote footer:lang(zh-TW),
-.wp-block-quote .wp-block-quote__citation:lang(zh-TW), .wp-block-pullquote[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(zh-TW),
-.wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(zh-TW),
-.wp-block[data-type="core/pullquote"][data-align="left"] .wp-block-pullquote__citation:lang(zh-TW),
-.wp-block[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation:lang(zh-TW), .wp-block-file:lang(zh-TW), ul.wp-block-archives li > a:lang(zh-TW),
-.wp-block-categories li > a:lang(zh-TW),
-.wp-block-latest-posts li > a:lang(zh-TW), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(zh-TW), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(zh-TW), .wp-caption dd:lang(zh-TW), .wp-block-freeform blockquote cite:lang(zh-TW), .wp-calendar-table:lang(zh-TW) {
-  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
-}
-
-body:lang(zh-CN), h1:lang(zh-CN),
-h2:lang(zh-CN),
-h3:lang(zh-CN),
-h4:lang(zh-CN),
-h5:lang(zh-CN),
-h6:lang(zh-CN), figcaption:lang(zh-CN),
-.gallery-caption:lang(zh-CN), .editor-post-title__block .editor-post-title__input:lang(zh-CN), .block-editor-default-block-appender textarea.block-editor-default-block-appender__content:lang(zh-CN), .wp-block-paragraph.has-drop-cap:lang(zh-CN):not(:focus)::first-letter, .wp-block-table:lang(zh-CN), .wp-block-cover h2:lang(zh-CN),
-.wp-block-cover .wp-block-cover-text:lang(zh-CN), .wp-block-button .wp-block-button__link:lang(zh-CN), .wp-block-search .wp-block-search__button:lang(zh-CN), .wp-block-quote cite:lang(zh-CN),
-.wp-block-quote footer:lang(zh-CN),
-.wp-block-quote .wp-block-quote__citation:lang(zh-CN), .wp-block-pullquote[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(zh-CN),
-.wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(zh-CN),
-.wp-block[data-type="core/pullquote"][data-align="left"] .wp-block-pullquote__citation:lang(zh-CN),
-.wp-block[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation:lang(zh-CN), .wp-block-file:lang(zh-CN), ul.wp-block-archives li > a:lang(zh-CN),
-.wp-block-categories li > a:lang(zh-CN),
-.wp-block-latest-posts li > a:lang(zh-CN), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(zh-CN), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(zh-CN), .wp-caption dd:lang(zh-CN), .wp-block-freeform blockquote cite:lang(zh-CN), .wp-calendar-table:lang(zh-CN) {
-  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
-}
-
-body:lang(bn-BD), h1:lang(bn-BD),
-h2:lang(bn-BD),
-h3:lang(bn-BD),
-h4:lang(bn-BD),
-h5:lang(bn-BD),
-h6:lang(bn-BD), figcaption:lang(bn-BD),
-.gallery-caption:lang(bn-BD), .editor-post-title__block .editor-post-title__input:lang(bn-BD), .block-editor-default-block-appender textarea.block-editor-default-block-appender__content:lang(bn-BD), .wp-block-paragraph.has-drop-cap:lang(bn-BD):not(:focus)::first-letter, .wp-block-table:lang(bn-BD), .wp-block-cover h2:lang(bn-BD),
-.wp-block-cover .wp-block-cover-text:lang(bn-BD), .wp-block-button .wp-block-button__link:lang(bn-BD), .wp-block-search .wp-block-search__button:lang(bn-BD), .wp-block-quote cite:lang(bn-BD),
-.wp-block-quote footer:lang(bn-BD),
-.wp-block-quote .wp-block-quote__citation:lang(bn-BD), .wp-block-pullquote[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(bn-BD),
-.wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(bn-BD),
-.wp-block[data-type="core/pullquote"][data-align="left"] .wp-block-pullquote__citation:lang(bn-BD),
-.wp-block[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation:lang(bn-BD), .wp-block-file:lang(bn-BD), ul.wp-block-archives li > a:lang(bn-BD),
-.wp-block-categories li > a:lang(bn-BD),
-.wp-block-latest-posts li > a:lang(bn-BD), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(bn-BD), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(bn-BD), .wp-caption dd:lang(bn-BD), .wp-block-freeform blockquote cite:lang(bn-BD), .wp-calendar-table:lang(bn-BD) {
-  font-family: Arial, sans-serif;
-}
-
-body:lang(hi-IN), h1:lang(hi-IN),
-h2:lang(hi-IN),
-h3:lang(hi-IN),
-h4:lang(hi-IN),
-h5:lang(hi-IN),
-h6:lang(hi-IN), figcaption:lang(hi-IN),
-.gallery-caption:lang(hi-IN), .editor-post-title__block .editor-post-title__input:lang(hi-IN), .block-editor-default-block-appender textarea.block-editor-default-block-appender__content:lang(hi-IN), .wp-block-paragraph.has-drop-cap:lang(hi-IN):not(:focus)::first-letter, .wp-block-table:lang(hi-IN), .wp-block-cover h2:lang(hi-IN),
-.wp-block-cover .wp-block-cover-text:lang(hi-IN), .wp-block-button .wp-block-button__link:lang(hi-IN), .wp-block-search .wp-block-search__button:lang(hi-IN), .wp-block-quote cite:lang(hi-IN),
-.wp-block-quote footer:lang(hi-IN),
-.wp-block-quote .wp-block-quote__citation:lang(hi-IN), .wp-block-pullquote[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(hi-IN),
-.wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(hi-IN),
-.wp-block[data-type="core/pullquote"][data-align="left"] .wp-block-pullquote__citation:lang(hi-IN),
-.wp-block[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation:lang(hi-IN), .wp-block-file:lang(hi-IN), ul.wp-block-archives li > a:lang(hi-IN),
-.wp-block-categories li > a:lang(hi-IN),
-.wp-block-latest-posts li > a:lang(hi-IN), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(hi-IN), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(hi-IN), .wp-caption dd:lang(hi-IN), .wp-block-freeform blockquote cite:lang(hi-IN), .wp-calendar-table:lang(hi-IN) {
-  font-family: Arial, sans-serif;
-}
-
-body:lang(mr), h1:lang(mr),
-h2:lang(mr),
-h3:lang(mr),
-h4:lang(mr),
-h5:lang(mr),
-h6:lang(mr), figcaption:lang(mr),
-.gallery-caption:lang(mr), .editor-post-title__block .editor-post-title__input:lang(mr), .block-editor-default-block-appender textarea.block-editor-default-block-appender__content:lang(mr), .wp-block-paragraph.has-drop-cap:lang(mr):not(:focus)::first-letter, .wp-block-table:lang(mr), .wp-block-cover h2:lang(mr),
-.wp-block-cover .wp-block-cover-text:lang(mr), .wp-block-button .wp-block-button__link:lang(mr), .wp-block-search .wp-block-search__button:lang(mr), .wp-block-quote cite:lang(mr),
-.wp-block-quote footer:lang(mr),
-.wp-block-quote .wp-block-quote__citation:lang(mr), .wp-block-pullquote[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(mr),
-.wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(mr),
-.wp-block[data-type="core/pullquote"][data-align="left"] .wp-block-pullquote__citation:lang(mr),
-.wp-block[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation:lang(mr), .wp-block-file:lang(mr), ul.wp-block-archives li > a:lang(mr),
-.wp-block-categories li > a:lang(mr),
-.wp-block-latest-posts li > a:lang(mr), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(mr), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(mr), .wp-caption dd:lang(mr), .wp-block-freeform blockquote cite:lang(mr), .wp-calendar-table:lang(mr) {
-  font-family: Arial, sans-serif;
-}
-
-body:lang(ne-NP), h1:lang(ne-NP),
-h2:lang(ne-NP),
-h3:lang(ne-NP),
-h4:lang(ne-NP),
-h5:lang(ne-NP),
-h6:lang(ne-NP), figcaption:lang(ne-NP),
-.gallery-caption:lang(ne-NP), .editor-post-title__block .editor-post-title__input:lang(ne-NP), .block-editor-default-block-appender textarea.block-editor-default-block-appender__content:lang(ne-NP), .wp-block-paragraph.has-drop-cap:lang(ne-NP):not(:focus)::first-letter, .wp-block-table:lang(ne-NP), .wp-block-cover h2:lang(ne-NP),
-.wp-block-cover .wp-block-cover-text:lang(ne-NP), .wp-block-button .wp-block-button__link:lang(ne-NP), .wp-block-search .wp-block-search__button:lang(ne-NP), .wp-block-quote cite:lang(ne-NP),
-.wp-block-quote footer:lang(ne-NP),
-.wp-block-quote .wp-block-quote__citation:lang(ne-NP), .wp-block-pullquote[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(ne-NP),
-.wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(ne-NP),
-.wp-block[data-type="core/pullquote"][data-align="left"] .wp-block-pullquote__citation:lang(ne-NP),
-.wp-block[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation:lang(ne-NP), .wp-block-file:lang(ne-NP), ul.wp-block-archives li > a:lang(ne-NP),
-.wp-block-categories li > a:lang(ne-NP),
-.wp-block-latest-posts li > a:lang(ne-NP), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ne-NP), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ne-NP), .wp-caption dd:lang(ne-NP), .wp-block-freeform blockquote cite:lang(ne-NP), .wp-calendar-table:lang(ne-NP) {
-  font-family: Arial, sans-serif;
-}
-
-body:lang(el), h1:lang(el),
-h2:lang(el),
-h3:lang(el),
-h4:lang(el),
-h5:lang(el),
-h6:lang(el), figcaption:lang(el),
-.gallery-caption:lang(el), .editor-post-title__block .editor-post-title__input:lang(el), .block-editor-default-block-appender textarea.block-editor-default-block-appender__content:lang(el), .wp-block-paragraph.has-drop-cap:lang(el):not(:focus)::first-letter, .wp-block-table:lang(el), .wp-block-cover h2:lang(el),
-.wp-block-cover .wp-block-cover-text:lang(el), .wp-block-button .wp-block-button__link:lang(el), .wp-block-search .wp-block-search__button:lang(el), .wp-block-quote cite:lang(el),
-.wp-block-quote footer:lang(el),
-.wp-block-quote .wp-block-quote__citation:lang(el), .wp-block-pullquote[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(el),
-.wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(el),
-.wp-block[data-type="core/pullquote"][data-align="left"] .wp-block-pullquote__citation:lang(el),
-.wp-block[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation:lang(el), .wp-block-file:lang(el), ul.wp-block-archives li > a:lang(el),
-.wp-block-categories li > a:lang(el),
-.wp-block-latest-posts li > a:lang(el), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(el), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(el), .wp-caption dd:lang(el), .wp-block-freeform blockquote cite:lang(el), .wp-calendar-table:lang(el) {
-  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-}
-
-body:lang(gu), h1:lang(gu),
-h2:lang(gu),
-h3:lang(gu),
-h4:lang(gu),
-h5:lang(gu),
-h6:lang(gu), figcaption:lang(gu),
-.gallery-caption:lang(gu), .editor-post-title__block .editor-post-title__input:lang(gu), .block-editor-default-block-appender textarea.block-editor-default-block-appender__content:lang(gu), .wp-block-paragraph.has-drop-cap:lang(gu):not(:focus)::first-letter, .wp-block-table:lang(gu), .wp-block-cover h2:lang(gu),
-.wp-block-cover .wp-block-cover-text:lang(gu), .wp-block-button .wp-block-button__link:lang(gu), .wp-block-search .wp-block-search__button:lang(gu), .wp-block-quote cite:lang(gu),
-.wp-block-quote footer:lang(gu),
-.wp-block-quote .wp-block-quote__citation:lang(gu), .wp-block-pullquote[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(gu),
-.wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(gu),
-.wp-block[data-type="core/pullquote"][data-align="left"] .wp-block-pullquote__citation:lang(gu),
-.wp-block[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation:lang(gu), .wp-block-file:lang(gu), ul.wp-block-archives li > a:lang(gu),
-.wp-block-categories li > a:lang(gu),
-.wp-block-latest-posts li > a:lang(gu), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(gu), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(gu), .wp-caption dd:lang(gu), .wp-block-freeform blockquote cite:lang(gu), .wp-calendar-table:lang(gu) {
-  font-family: Arial, sans-serif;
-}
-
-body:lang(he-IL), h1:lang(he-IL),
-h2:lang(he-IL),
-h3:lang(he-IL),
-h4:lang(he-IL),
-h5:lang(he-IL),
-h6:lang(he-IL), figcaption:lang(he-IL),
-.gallery-caption:lang(he-IL), .editor-post-title__block .editor-post-title__input:lang(he-IL), .block-editor-default-block-appender textarea.block-editor-default-block-appender__content:lang(he-IL), .wp-block-paragraph.has-drop-cap:lang(he-IL):not(:focus)::first-letter, .wp-block-table:lang(he-IL), .wp-block-cover h2:lang(he-IL),
-.wp-block-cover .wp-block-cover-text:lang(he-IL), .wp-block-button .wp-block-button__link:lang(he-IL), .wp-block-search .wp-block-search__button:lang(he-IL), .wp-block-quote cite:lang(he-IL),
-.wp-block-quote footer:lang(he-IL),
-.wp-block-quote .wp-block-quote__citation:lang(he-IL), .wp-block-pullquote[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(he-IL),
-.wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(he-IL),
-.wp-block[data-type="core/pullquote"][data-align="left"] .wp-block-pullquote__citation:lang(he-IL),
-.wp-block[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation:lang(he-IL), .wp-block-file:lang(he-IL), ul.wp-block-archives li > a:lang(he-IL),
-.wp-block-categories li > a:lang(he-IL),
-.wp-block-latest-posts li > a:lang(he-IL), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(he-IL), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(he-IL), .wp-caption dd:lang(he-IL), .wp-block-freeform blockquote cite:lang(he-IL), .wp-calendar-table:lang(he-IL) {
-  font-family: "Arial Hebrew", Arial, sans-serif;
-}
-
-body:lang(ja), h1:lang(ja),
-h2:lang(ja),
-h3:lang(ja),
-h4:lang(ja),
-h5:lang(ja),
-h6:lang(ja), figcaption:lang(ja),
-.gallery-caption:lang(ja), .editor-post-title__block .editor-post-title__input:lang(ja), .block-editor-default-block-appender textarea.block-editor-default-block-appender__content:lang(ja), .wp-block-paragraph.has-drop-cap:lang(ja):not(:focus)::first-letter, .wp-block-table:lang(ja), .wp-block-cover h2:lang(ja),
-.wp-block-cover .wp-block-cover-text:lang(ja), .wp-block-button .wp-block-button__link:lang(ja), .wp-block-search .wp-block-search__button:lang(ja), .wp-block-quote cite:lang(ja),
-.wp-block-quote footer:lang(ja),
-.wp-block-quote .wp-block-quote__citation:lang(ja), .wp-block-pullquote[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(ja),
-.wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(ja),
-.wp-block[data-type="core/pullquote"][data-align="left"] .wp-block-pullquote__citation:lang(ja),
-.wp-block[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation:lang(ja), .wp-block-file:lang(ja), ul.wp-block-archives li > a:lang(ja),
-.wp-block-categories li > a:lang(ja),
-.wp-block-latest-posts li > a:lang(ja), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ja), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ja), .wp-caption dd:lang(ja), .wp-block-freeform blockquote cite:lang(ja), .wp-calendar-table:lang(ja) {
-  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
-}
-
-body:lang(ko-KR), h1:lang(ko-KR),
-h2:lang(ko-KR),
-h3:lang(ko-KR),
-h4:lang(ko-KR),
-h5:lang(ko-KR),
-h6:lang(ko-KR), figcaption:lang(ko-KR),
-.gallery-caption:lang(ko-KR), .editor-post-title__block .editor-post-title__input:lang(ko-KR), .block-editor-default-block-appender textarea.block-editor-default-block-appender__content:lang(ko-KR), .wp-block-paragraph.has-drop-cap:lang(ko-KR):not(:focus)::first-letter, .wp-block-table:lang(ko-KR), .wp-block-cover h2:lang(ko-KR),
-.wp-block-cover .wp-block-cover-text:lang(ko-KR), .wp-block-button .wp-block-button__link:lang(ko-KR), .wp-block-search .wp-block-search__button:lang(ko-KR), .wp-block-quote cite:lang(ko-KR),
-.wp-block-quote footer:lang(ko-KR),
-.wp-block-quote .wp-block-quote__citation:lang(ko-KR), .wp-block-pullquote[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(ko-KR),
-.wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(ko-KR),
-.wp-block[data-type="core/pullquote"][data-align="left"] .wp-block-pullquote__citation:lang(ko-KR),
-.wp-block[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation:lang(ko-KR), .wp-block-file:lang(ko-KR), ul.wp-block-archives li > a:lang(ko-KR),
-.wp-block-categories li > a:lang(ko-KR),
-.wp-block-latest-posts li > a:lang(ko-KR), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ko-KR), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ko-KR), .wp-caption dd:lang(ko-KR), .wp-block-freeform blockquote cite:lang(ko-KR), .wp-calendar-table:lang(ko-KR) {
-  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
-}
-
-body:lang(th), h1:lang(th),
-h2:lang(th),
-h3:lang(th),
-h4:lang(th),
-h5:lang(th),
-h6:lang(th), figcaption:lang(th),
-.gallery-caption:lang(th), .editor-post-title__block .editor-post-title__input:lang(th), .block-editor-default-block-appender textarea.block-editor-default-block-appender__content:lang(th), .wp-block-paragraph.has-drop-cap:lang(th):not(:focus)::first-letter, .wp-block-table:lang(th), .wp-block-cover h2:lang(th),
-.wp-block-cover .wp-block-cover-text:lang(th), .wp-block-button .wp-block-button__link:lang(th), .wp-block-search .wp-block-search__button:lang(th), .wp-block-quote cite:lang(th),
-.wp-block-quote footer:lang(th),
-.wp-block-quote .wp-block-quote__citation:lang(th), .wp-block-pullquote[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(th),
-.wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(th),
-.wp-block[data-type="core/pullquote"][data-align="left"] .wp-block-pullquote__citation:lang(th),
-.wp-block[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation:lang(th), .wp-block-file:lang(th), ul.wp-block-archives li > a:lang(th),
-.wp-block-categories li > a:lang(th),
-.wp-block-latest-posts li > a:lang(th), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(th), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(th), .wp-caption dd:lang(th), .wp-block-freeform blockquote cite:lang(th), .wp-calendar-table:lang(th) {
-  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
-}
-
-body:lang(vi), h1:lang(vi),
-h2:lang(vi),
-h3:lang(vi),
-h4:lang(vi),
-h5:lang(vi),
-h6:lang(vi), figcaption:lang(vi),
-.gallery-caption:lang(vi), .editor-post-title__block .editor-post-title__input:lang(vi), .block-editor-default-block-appender textarea.block-editor-default-block-appender__content:lang(vi), .wp-block-paragraph.has-drop-cap:lang(vi):not(:focus)::first-letter, .wp-block-table:lang(vi), .wp-block-cover h2:lang(vi),
-.wp-block-cover .wp-block-cover-text:lang(vi), .wp-block-button .wp-block-button__link:lang(vi), .wp-block-search .wp-block-search__button:lang(vi), .wp-block-quote cite:lang(vi),
-.wp-block-quote footer:lang(vi),
-.wp-block-quote .wp-block-quote__citation:lang(vi), .wp-block-pullquote[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(vi),
-.wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(vi),
-.wp-block[data-type="core/pullquote"][data-align="left"] .wp-block-pullquote__citation:lang(vi),
-.wp-block[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation:lang(vi), .wp-block-file:lang(vi), ul.wp-block-archives li > a:lang(vi),
-.wp-block-categories li > a:lang(vi),
-.wp-block-latest-posts li > a:lang(vi), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(vi), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(vi), .wp-caption dd:lang(vi), .wp-block-freeform blockquote cite:lang(vi), .wp-calendar-table:lang(vi) {
-  font-family: "Libre Franklin", sans-serif;
-}
-
 /** === Editor Frame === */
-body .wp-block[data-align="full"],
+body .wp-block[data-align=full],
 body .wp-block.alignfull {
   max-width: calc(100% + 16px);
   width: calc(100% + 16px);
 }
-
-body .wp-block[data-align="left"],
+body .wp-block[data-align=left],
 body .wp-block.alignleft {
   margin-right: 1rem;
   width: inherit;
 }
-
-body .wp-block[data-align="right"],
+body .wp-block[data-align=right],
 body .wp-block.alignright {
   margin-left: 1rem;
   width: inherit;
 }
-
-body .wp-block[data-align="center"],
+body .wp-block[data-align=center],
 body .wp-block.aligncenter {
   margin-left: 0;
 }
-
 @media only screen and (min-width: 768px) {
   body.block-editor-iframe__body, body.block-editor-writing-flow,
   body .block-editor-writing-flow {
@@ -615,19 +51,19 @@ body .wp-block.aligncenter {
     margin-left: 0;
     margin-right: 0;
   }
-  body .wp-block[data-align="wide"],
+  body .wp-block[data-align=wide],
   body .wp-block.alignwide {
     width: 100%;
   }
-  body .wp-block[data-align="full"],
+  body .wp-block[data-align=full],
   body .wp-block.alignfull {
     width: calc(125% + 16px);
     max-width: calc(125% + 16px);
     position: relative;
     left: -12.5%;
   }
-  body .wp-block[data-align="wide"] .wp-block[data-align="full"],
-  body .wp-block[data-align="full"] .wp-block[data-align="full"],
+  body .wp-block[data-align=wide] .wp-block[data-align=full],
+  body .wp-block[data-align=full] .wp-block[data-align=full],
   body .wp-block.alignwide .wp-block.alignfull,
   body .wp-block.alignfull .wp-block.alignfull {
     left: 0;
@@ -640,19 +76,16 @@ body .wp-block.aligncenter {
 .wp-block {
   max-width: 100%;
 }
-
 @media only screen and (min-width: 768px) {
   .wp-block {
-    width: calc(8 * (100vw / 12));
+    width: 66.6666666667vw;
   }
 }
-
 @media only screen and (min-width: 1168px) {
   .wp-block {
-    width: calc(6 * (100vw / 12 ));
+    width: 50vw;
   }
 }
-
 .wp-block .wp-block {
   width: initial;
 }
@@ -663,6 +96,101 @@ body {
   -moz-osx-font-smoothing: grayscale;
   font-size: 22px;
   font-family: "NonBreakingSpaceOverride", "Hoefler Text", Garamond, "Times New Roman", serif;
+}
+body:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+body:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+body:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+body:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+body:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+body:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+body:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+body:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+body:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+body:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+body:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+body:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+body:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+body:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+body:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+body:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+body:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+body:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+body:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+body:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+body:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+body:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+body:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+body:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+body:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+body:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+body:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+body:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+body:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+body:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+body:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
+body {
   line-height: 1.8;
   color: #111;
 }
@@ -678,13 +206,267 @@ h4,
 h5,
 h6 {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+}
+h1:lang(ar),
+h2:lang(ar),
+h3:lang(ar),
+h4:lang(ar),
+h5:lang(ar),
+h6:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+h1:lang(ary),
+h2:lang(ary),
+h3:lang(ary),
+h4:lang(ary),
+h5:lang(ary),
+h6:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+h1:lang(azb),
+h2:lang(azb),
+h3:lang(azb),
+h4:lang(azb),
+h5:lang(azb),
+h6:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+h1:lang(ckb),
+h2:lang(ckb),
+h3:lang(ckb),
+h4:lang(ckb),
+h5:lang(ckb),
+h6:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+h1:lang(fa-IR),
+h2:lang(fa-IR),
+h3:lang(fa-IR),
+h4:lang(fa-IR),
+h5:lang(fa-IR),
+h6:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+h1:lang(haz),
+h2:lang(haz),
+h3:lang(haz),
+h4:lang(haz),
+h5:lang(haz),
+h6:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+h1:lang(ps),
+h2:lang(ps),
+h3:lang(ps),
+h4:lang(ps),
+h5:lang(ps),
+h6:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+h1:lang(be),
+h2:lang(be),
+h3:lang(be),
+h4:lang(be),
+h5:lang(be),
+h6:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+h1:lang(bg-BG),
+h2:lang(bg-BG),
+h3:lang(bg-BG),
+h4:lang(bg-BG),
+h5:lang(bg-BG),
+h6:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+h1:lang(kk),
+h2:lang(kk),
+h3:lang(kk),
+h4:lang(kk),
+h5:lang(kk),
+h6:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+h1:lang(mk-MK),
+h2:lang(mk-MK),
+h3:lang(mk-MK),
+h4:lang(mk-MK),
+h5:lang(mk-MK),
+h6:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+h1:lang(mn),
+h2:lang(mn),
+h3:lang(mn),
+h4:lang(mn),
+h5:lang(mn),
+h6:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+h1:lang(ru-RU),
+h2:lang(ru-RU),
+h3:lang(ru-RU),
+h4:lang(ru-RU),
+h5:lang(ru-RU),
+h6:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+h1:lang(sah),
+h2:lang(sah),
+h3:lang(sah),
+h4:lang(sah),
+h5:lang(sah),
+h6:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+h1:lang(sr-RS),
+h2:lang(sr-RS),
+h3:lang(sr-RS),
+h4:lang(sr-RS),
+h5:lang(sr-RS),
+h6:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+h1:lang(tt-RU),
+h2:lang(tt-RU),
+h3:lang(tt-RU),
+h4:lang(tt-RU),
+h5:lang(tt-RU),
+h6:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+h1:lang(uk),
+h2:lang(uk),
+h3:lang(uk),
+h4:lang(uk),
+h5:lang(uk),
+h6:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+h1:lang(zh-HK),
+h2:lang(zh-HK),
+h3:lang(zh-HK),
+h4:lang(zh-HK),
+h5:lang(zh-HK),
+h6:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+h1:lang(zh-TW),
+h2:lang(zh-TW),
+h3:lang(zh-TW),
+h4:lang(zh-TW),
+h5:lang(zh-TW),
+h6:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+h1:lang(zh-CN),
+h2:lang(zh-CN),
+h3:lang(zh-CN),
+h4:lang(zh-CN),
+h5:lang(zh-CN),
+h6:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+h1:lang(bn-BD),
+h2:lang(bn-BD),
+h3:lang(bn-BD),
+h4:lang(bn-BD),
+h5:lang(bn-BD),
+h6:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+h1:lang(hi-IN),
+h2:lang(hi-IN),
+h3:lang(hi-IN),
+h4:lang(hi-IN),
+h5:lang(hi-IN),
+h6:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+h1:lang(mr),
+h2:lang(mr),
+h3:lang(mr),
+h4:lang(mr),
+h5:lang(mr),
+h6:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+h1:lang(ne-NP),
+h2:lang(ne-NP),
+h3:lang(ne-NP),
+h4:lang(ne-NP),
+h5:lang(ne-NP),
+h6:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+h1:lang(el),
+h2:lang(el),
+h3:lang(el),
+h4:lang(el),
+h5:lang(el),
+h6:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+h1:lang(gu),
+h2:lang(gu),
+h3:lang(gu),
+h4:lang(gu),
+h5:lang(gu),
+h6:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+h1:lang(he-IL),
+h2:lang(he-IL),
+h3:lang(he-IL),
+h4:lang(he-IL),
+h5:lang(he-IL),
+h6:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+h1:lang(ja),
+h2:lang(ja),
+h3:lang(ja),
+h4:lang(ja),
+h5:lang(ja),
+h6:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+h1:lang(ko-KR),
+h2:lang(ko-KR),
+h3:lang(ko-KR),
+h4:lang(ko-KR),
+h5:lang(ko-KR),
+h6:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+h1:lang(th),
+h2:lang(th),
+h3:lang(th),
+h4:lang(th),
+h5:lang(th),
+h6:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+h1:lang(vi),
+h2:lang(vi),
+h3:lang(vi),
+h4:lang(vi),
+h5:lang(vi),
+h6:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
   font-weight: 700;
 }
 
 h1 {
   font-size: 2.25em;
 }
-
 @media only screen and (min-width: 768px) {
   h1 {
     font-size: 2.8125em;
@@ -695,7 +477,6 @@ h1 {
 h2 {
   font-size: 1.6875em;
 }
-
 @media only screen and (min-width: 768px) {
   .wp-block-post-title,
   h2 {
@@ -706,19 +487,17 @@ h2 {
 h1:before,
 h2:before {
   background: #767676;
-  content: "\020";
+  content: " ";
   display: block;
   height: 2px;
   margin: 1rem 0;
   width: 1em;
 }
-
 h1.has-text-align-center:before,
 h2.has-text-align-center:before {
   margin-left: auto;
   margin-right: auto;
 }
-
 h1.has-text-align-right:before,
 h2.has-text-align-right:before {
   margin-left: auto;
@@ -733,24 +512,22 @@ h4 {
 }
 
 h5 {
-  font-size: 0.88889em;
+  font-size: 0.8888888889em;
 }
 
 h6 {
-  font-size: 0.71111em;
+  font-size: 0.7111111111em;
 }
 
 a {
   transition: color 110ms ease-in-out;
   color: #0073aa;
 }
-
 a:hover, a:active {
-  color: #005177;
+  color: rgb(0, 80.5, 119);
   outline: 0;
   text-decoration: none;
 }
-
 a:focus {
   outline: 0;
   text-decoration: underline;
@@ -762,7 +539,6 @@ a:focus {
 .has-light-gray-background-color {
   color: #fff;
 }
-
 .has-primary-background-color p,
 .has-primary-background-color h1,
 .has-primary-background-color h2,
@@ -801,7 +577,6 @@ a:focus {
 .has-white-background-color {
   color: #111;
 }
-
 .has-white-background-color p,
 .has-white-background-color h1,
 .has-white-background-color h2,
@@ -816,7 +591,134 @@ a:focus {
 figcaption,
 .gallery-caption {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  font-size: 0.71111em;
+}
+figcaption:lang(ar),
+.gallery-caption:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+figcaption:lang(ary),
+.gallery-caption:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+figcaption:lang(azb),
+.gallery-caption:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+figcaption:lang(ckb),
+.gallery-caption:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+figcaption:lang(fa-IR),
+.gallery-caption:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+figcaption:lang(haz),
+.gallery-caption:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+figcaption:lang(ps),
+.gallery-caption:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+figcaption:lang(be),
+.gallery-caption:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+figcaption:lang(bg-BG),
+.gallery-caption:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+figcaption:lang(kk),
+.gallery-caption:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+figcaption:lang(mk-MK),
+.gallery-caption:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+figcaption:lang(mn),
+.gallery-caption:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+figcaption:lang(ru-RU),
+.gallery-caption:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+figcaption:lang(sah),
+.gallery-caption:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+figcaption:lang(sr-RS),
+.gallery-caption:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+figcaption:lang(tt-RU),
+.gallery-caption:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+figcaption:lang(uk),
+.gallery-caption:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+figcaption:lang(zh-HK),
+.gallery-caption:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+figcaption:lang(zh-TW),
+.gallery-caption:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+figcaption:lang(zh-CN),
+.gallery-caption:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+figcaption:lang(bn-BD),
+.gallery-caption:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+figcaption:lang(hi-IN),
+.gallery-caption:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+figcaption:lang(mr),
+.gallery-caption:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+figcaption:lang(ne-NP),
+.gallery-caption:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+figcaption:lang(el),
+.gallery-caption:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+figcaption:lang(gu),
+.gallery-caption:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+figcaption:lang(he-IL),
+.gallery-caption:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+figcaption:lang(ja),
+.gallery-caption:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+figcaption:lang(ko-KR),
+.gallery-caption:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+figcaption:lang(th),
+.gallery-caption:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+figcaption:lang(vi),
+.gallery-caption:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
+figcaption,
+.gallery-caption {
+  font-size: 0.7111111111em;
   line-height: 1.6;
   color: #767676;
 }
@@ -825,25 +727,21 @@ figcaption,
 .editor-post-title__block {
   width: 100%;
 }
-
 .editor-post-title__block:before {
   background: #767676;
-  content: "\020";
+  content: " ";
   display: block;
   height: 2px;
   margin: 1rem 0;
   width: 1em;
 }
-
 .editor-post-title__block.has-text-align-center:before {
   margin-left: auto;
   margin-right: auto;
 }
-
 .editor-post-title__block.has-text-align-right:before {
   margin-left: auto;
 }
-
 .editor-post-title__block:before {
   width: 2.8125em;
   margin-top: 0;
@@ -852,15 +750,108 @@ figcaption,
   position: relative;
   top: 0.5em;
 }
-
 @media only screen and (min-width: 600px) {
   .editor-post-title__block:before {
     margin-left: 0;
   }
 }
-
 .editor-post-title__block .editor-post-title__input {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+}
+.editor-post-title__block .editor-post-title__input:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.editor-post-title__block .editor-post-title__input:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.editor-post-title__block .editor-post-title__input:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.editor-post-title__block .editor-post-title__input:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.editor-post-title__block .editor-post-title__input:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.editor-post-title__block .editor-post-title__input:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.editor-post-title__block .editor-post-title__input:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.editor-post-title__block .editor-post-title__input:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.editor-post-title__block .editor-post-title__input:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.editor-post-title__block .editor-post-title__input:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.editor-post-title__block .editor-post-title__input:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.editor-post-title__block .editor-post-title__input:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.editor-post-title__block .editor-post-title__input:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.editor-post-title__block .editor-post-title__input:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.editor-post-title__block .editor-post-title__input:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.editor-post-title__block .editor-post-title__input:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.editor-post-title__block .editor-post-title__input:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.editor-post-title__block .editor-post-title__input:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.editor-post-title__block .editor-post-title__input:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.editor-post-title__block .editor-post-title__input:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.editor-post-title__block .editor-post-title__input:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+.editor-post-title__block .editor-post-title__input:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+.editor-post-title__block .editor-post-title__input:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+.editor-post-title__block .editor-post-title__input:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+.editor-post-title__block .editor-post-title__input:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+.editor-post-title__block .editor-post-title__input:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+.editor-post-title__block .editor-post-title__input:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+.editor-post-title__block .editor-post-title__input:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+.editor-post-title__block .editor-post-title__input:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+.editor-post-title__block .editor-post-title__input:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+.editor-post-title__block .editor-post-title__input:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
+.editor-post-title__block .editor-post-title__input {
   font-size: 2.8125em;
   font-weight: 700;
 }
@@ -868,6 +859,101 @@ figcaption,
 /** === Default Appender === */
 .block-editor-default-block-appender textarea.block-editor-default-block-appender__content {
   font-family: "NonBreakingSpaceOverride", "Hoefler Text", Garamond, "Times New Roman", serif;
+}
+.block-editor-default-block-appender textarea.block-editor-default-block-appender__content:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.block-editor-default-block-appender textarea.block-editor-default-block-appender__content:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.block-editor-default-block-appender textarea.block-editor-default-block-appender__content:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.block-editor-default-block-appender textarea.block-editor-default-block-appender__content:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.block-editor-default-block-appender textarea.block-editor-default-block-appender__content:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.block-editor-default-block-appender textarea.block-editor-default-block-appender__content:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.block-editor-default-block-appender textarea.block-editor-default-block-appender__content:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.block-editor-default-block-appender textarea.block-editor-default-block-appender__content:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.block-editor-default-block-appender textarea.block-editor-default-block-appender__content:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.block-editor-default-block-appender textarea.block-editor-default-block-appender__content:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.block-editor-default-block-appender textarea.block-editor-default-block-appender__content:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.block-editor-default-block-appender textarea.block-editor-default-block-appender__content:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.block-editor-default-block-appender textarea.block-editor-default-block-appender__content:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.block-editor-default-block-appender textarea.block-editor-default-block-appender__content:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.block-editor-default-block-appender textarea.block-editor-default-block-appender__content:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.block-editor-default-block-appender textarea.block-editor-default-block-appender__content:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.block-editor-default-block-appender textarea.block-editor-default-block-appender__content:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.block-editor-default-block-appender textarea.block-editor-default-block-appender__content:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.block-editor-default-block-appender textarea.block-editor-default-block-appender__content:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.block-editor-default-block-appender textarea.block-editor-default-block-appender__content:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.block-editor-default-block-appender textarea.block-editor-default-block-appender__content:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+.block-editor-default-block-appender textarea.block-editor-default-block-appender__content:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+.block-editor-default-block-appender textarea.block-editor-default-block-appender__content:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+.block-editor-default-block-appender textarea.block-editor-default-block-appender__content:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+.block-editor-default-block-appender textarea.block-editor-default-block-appender__content:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+.block-editor-default-block-appender textarea.block-editor-default-block-appender__content:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+.block-editor-default-block-appender textarea.block-editor-default-block-appender__content:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+.block-editor-default-block-appender textarea.block-editor-default-block-appender__content:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+.block-editor-default-block-appender textarea.block-editor-default-block-appender__content:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+.block-editor-default-block-appender textarea.block-editor-default-block-appender__content:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+.block-editor-default-block-appender textarea.block-editor-default-block-appender__content:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
+.block-editor-default-block-appender textarea.block-editor-default-block-appender__content {
   font-size: 22px;
 }
 
@@ -879,12 +965,106 @@ figcaption,
 /** === Paragraph === */
 .wp-block-paragraph.has-drop-cap:not(:focus)::first-letter {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+}
+.wp-block-paragraph.has-drop-cap:not(:focus)::first-letter:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-paragraph.has-drop-cap:not(:focus)::first-letter:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-paragraph.has-drop-cap:not(:focus)::first-letter:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-paragraph.has-drop-cap:not(:focus)::first-letter:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-paragraph.has-drop-cap:not(:focus)::first-letter:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-paragraph.has-drop-cap:not(:focus)::first-letter:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-paragraph.has-drop-cap:not(:focus)::first-letter:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-paragraph.has-drop-cap:not(:focus)::first-letter:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-paragraph.has-drop-cap:not(:focus)::first-letter:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-paragraph.has-drop-cap:not(:focus)::first-letter:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-paragraph.has-drop-cap:not(:focus)::first-letter:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-paragraph.has-drop-cap:not(:focus)::first-letter:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-paragraph.has-drop-cap:not(:focus)::first-letter:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-paragraph.has-drop-cap:not(:focus)::first-letter:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-paragraph.has-drop-cap:not(:focus)::first-letter:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-paragraph.has-drop-cap:not(:focus)::first-letter:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-paragraph.has-drop-cap:not(:focus)::first-letter:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-paragraph.has-drop-cap:not(:focus)::first-letter:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.wp-block-paragraph.has-drop-cap:not(:focus)::first-letter:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.wp-block-paragraph.has-drop-cap:not(:focus)::first-letter:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.wp-block-paragraph.has-drop-cap:not(:focus)::first-letter:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+.wp-block-paragraph.has-drop-cap:not(:focus)::first-letter:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+.wp-block-paragraph.has-drop-cap:not(:focus)::first-letter:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+.wp-block-paragraph.has-drop-cap:not(:focus)::first-letter:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+.wp-block-paragraph.has-drop-cap:not(:focus)::first-letter:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+.wp-block-paragraph.has-drop-cap:not(:focus)::first-letter:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+.wp-block-paragraph.has-drop-cap:not(:focus)::first-letter:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+.wp-block-paragraph.has-drop-cap:not(:focus)::first-letter:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+.wp-block-paragraph.has-drop-cap:not(:focus)::first-letter:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+.wp-block-paragraph.has-drop-cap:not(:focus)::first-letter:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+.wp-block-paragraph.has-drop-cap:not(:focus)::first-letter:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
+.wp-block-paragraph.has-drop-cap:not(:focus)::first-letter {
   font-size: 3.375em;
   line-height: 1;
   font-weight: bold;
   margin: 0 0.25em 0 0;
 }
-
 @-moz-document url-prefix() {
   .wp-block-paragraph.has-drop-cap:not(:focus)::first-letter {
     margin-top: 0.2em;
@@ -895,23 +1075,241 @@ figcaption,
 .wp-block-table {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 }
+.wp-block-table:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-table:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-table:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-table:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-table:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-table:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-table:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-table:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-table:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-table:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-table:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-table:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-table:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-table:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-table:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-table:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-table:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-table:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.wp-block-table:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.wp-block-table:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.wp-block-table:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+.wp-block-table:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+.wp-block-table:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+.wp-block-table:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+.wp-block-table:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+.wp-block-table:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+.wp-block-table:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+.wp-block-table:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+.wp-block-table:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+.wp-block-table:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+.wp-block-table:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
 
 /** === Cover === */
 .wp-block-cover h2,
 .wp-block-cover .wp-block-cover-text {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+}
+.wp-block-cover h2:lang(ar),
+.wp-block-cover .wp-block-cover-text:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-cover h2:lang(ary),
+.wp-block-cover .wp-block-cover-text:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-cover h2:lang(azb),
+.wp-block-cover .wp-block-cover-text:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-cover h2:lang(ckb),
+.wp-block-cover .wp-block-cover-text:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-cover h2:lang(fa-IR),
+.wp-block-cover .wp-block-cover-text:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-cover h2:lang(haz),
+.wp-block-cover .wp-block-cover-text:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-cover h2:lang(ps),
+.wp-block-cover .wp-block-cover-text:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-cover h2:lang(be),
+.wp-block-cover .wp-block-cover-text:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-cover h2:lang(bg-BG),
+.wp-block-cover .wp-block-cover-text:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-cover h2:lang(kk),
+.wp-block-cover .wp-block-cover-text:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-cover h2:lang(mk-MK),
+.wp-block-cover .wp-block-cover-text:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-cover h2:lang(mn),
+.wp-block-cover .wp-block-cover-text:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-cover h2:lang(ru-RU),
+.wp-block-cover .wp-block-cover-text:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-cover h2:lang(sah),
+.wp-block-cover .wp-block-cover-text:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-cover h2:lang(sr-RS),
+.wp-block-cover .wp-block-cover-text:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-cover h2:lang(tt-RU),
+.wp-block-cover .wp-block-cover-text:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-cover h2:lang(uk),
+.wp-block-cover .wp-block-cover-text:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-cover h2:lang(zh-HK),
+.wp-block-cover .wp-block-cover-text:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.wp-block-cover h2:lang(zh-TW),
+.wp-block-cover .wp-block-cover-text:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.wp-block-cover h2:lang(zh-CN),
+.wp-block-cover .wp-block-cover-text:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.wp-block-cover h2:lang(bn-BD),
+.wp-block-cover .wp-block-cover-text:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+.wp-block-cover h2:lang(hi-IN),
+.wp-block-cover .wp-block-cover-text:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+.wp-block-cover h2:lang(mr),
+.wp-block-cover .wp-block-cover-text:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+.wp-block-cover h2:lang(ne-NP),
+.wp-block-cover .wp-block-cover-text:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+.wp-block-cover h2:lang(el),
+.wp-block-cover .wp-block-cover-text:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+.wp-block-cover h2:lang(gu),
+.wp-block-cover .wp-block-cover-text:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+.wp-block-cover h2:lang(he-IL),
+.wp-block-cover .wp-block-cover-text:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+.wp-block-cover h2:lang(ja),
+.wp-block-cover .wp-block-cover-text:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+.wp-block-cover h2:lang(ko-KR),
+.wp-block-cover .wp-block-cover-text:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+.wp-block-cover h2:lang(th),
+.wp-block-cover .wp-block-cover-text:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+.wp-block-cover h2:lang(vi),
+.wp-block-cover .wp-block-cover-text:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
+.wp-block-cover h2,
+.wp-block-cover .wp-block-cover-text {
   font-size: 1.6875em;
   font-weight: bold;
   line-height: 1.4;
   padding-left: 1rem;
   padding-right: 1rem;
 }
-
 .wp-block-cover h2 strong,
 .wp-block-cover .wp-block-cover-text strong {
   font-weight: bolder;
 }
-
 @media only screen and (min-width: 768px) {
   .wp-block-cover h2,
   .wp-block-cover .wp-block-cover-text {
@@ -920,7 +1318,6 @@ figcaption,
     padding: 0;
   }
 }
-
 @media only screen and (min-width: 768px) {
   .wp-block-cover {
     padding-left: 10%;
@@ -932,51 +1329,47 @@ figcaption,
   }
 }
 
-.wp-block[data-type="core/cover"][data-align="left"] .editor-block-list__block-edit,
-.wp-block[data-type="core/cover"][data-align="right"] .editor-block-list__block-edit {
-  width: calc(4 * (100vw / 12));
+.wp-block[data-type="core/cover"][data-align=left] .editor-block-list__block-edit,
+.wp-block[data-type="core/cover"][data-align=right] .editor-block-list__block-edit {
+  width: 33.3333333333vw;
 }
-
-.wp-block[data-type="core/cover"][data-align="left"] .wp-block-cover,
-.wp-block[data-type="core/cover"][data-align="right"] .wp-block-cover {
+.wp-block[data-type="core/cover"][data-align=left] .wp-block-cover,
+.wp-block[data-type="core/cover"][data-align=right] .wp-block-cover {
   width: 100%;
   max-width: 100%;
   padding: calc(1.375 * 1rem);
 }
-
-.wp-block[data-type="core/cover"][data-align="left"] .wp-block-cover p,
-.wp-block[data-type="core/cover"][data-align="right"] .wp-block-cover p {
+.wp-block[data-type="core/cover"][data-align=left] .wp-block-cover p,
+.wp-block[data-type="core/cover"][data-align=right] .wp-block-cover p {
   padding-left: 0;
   padding-right: 0;
 }
-
 @media only screen and (min-width: 768px) {
-  .wp-block[data-type="core/cover"][data-align="left"] .wp-block-cover,
-  .wp-block[data-type="core/cover"][data-align="right"] .wp-block-cover {
+  .wp-block[data-type="core/cover"][data-align=left] .wp-block-cover,
+  .wp-block[data-type="core/cover"][data-align=right] .wp-block-cover {
     padding: calc(2.75 * 1rem) calc(2.75 * 1rem) calc(3.125 * 1rem);
   }
 }
 
 @media only screen and (min-width: 768px) {
-  .wp-block[data-type="core/cover"][data-align="wide"] h2,
-  .wp-block[data-type="core/cover"][data-align="wide"] .wp-block-cover-text,
-  .wp-block[data-type="core/cover"][data-align="full"] h2,
-  .wp-block[data-type="core/cover"][data-align="full"] .wp-block-cover-text {
-    max-width: calc(8 * (100vw / 12));
+  .wp-block[data-type="core/cover"][data-align=wide] h2,
+  .wp-block[data-type="core/cover"][data-align=wide] .wp-block-cover-text,
+  .wp-block[data-type="core/cover"][data-align=full] h2,
+  .wp-block[data-type="core/cover"][data-align=full] .wp-block-cover-text {
+    max-width: 66.6666666667vw;
   }
 }
-
 @media only screen and (min-width: 1168px) {
-  .wp-block[data-type="core/cover"][data-align="wide"] h2,
-  .wp-block[data-type="core/cover"][data-align="wide"] .wp-block-cover-text,
-  .wp-block[data-type="core/cover"][data-align="full"] h2,
-  .wp-block[data-type="core/cover"][data-align="full"] .wp-block-cover-text {
-    max-width: calc(6 * (100vw / 12));
+  .wp-block[data-type="core/cover"][data-align=wide] h2,
+  .wp-block[data-type="core/cover"][data-align=wide] .wp-block-cover-text,
+  .wp-block[data-type="core/cover"][data-align=full] h2,
+  .wp-block[data-type="core/cover"][data-align=full] .wp-block-cover-text {
+    max-width: 50vw;
   }
 }
 
 @media only screen and (min-width: 768px) {
-  .wp-block[data-type="core/cover"][data-align="full"] .wp-block-cover {
+  .wp-block[data-type="core/cover"][data-align=full] .wp-block-cover {
     padding-left: calc(10% + 64px);
     padding-right: calc(10% + 64px);
   }
@@ -986,7 +1379,7 @@ figcaption,
 .wp-block-gallery .blocks-gallery-image figcaption,
 .wp-block-gallery .blocks-gallery-item figcaption,
 .wp-block-gallery .gallery-item .gallery-caption {
-  font-size: 0.71111em;
+  font-size: 0.7111111111em;
   line-height: 1.6;
 }
 
@@ -1002,57 +1395,238 @@ figcaption,
 
 .wp-block-button .wp-block-button__link {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  font-size: 0.88889em;
+}
+.wp-block-button .wp-block-button__link:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-button .wp-block-button__link:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-button .wp-block-button__link:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-button .wp-block-button__link:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-button .wp-block-button__link:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-button .wp-block-button__link:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-button .wp-block-button__link:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-button .wp-block-button__link:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-button .wp-block-button__link:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-button .wp-block-button__link:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-button .wp-block-button__link:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-button .wp-block-button__link:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-button .wp-block-button__link:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-button .wp-block-button__link:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-button .wp-block-button__link:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-button .wp-block-button__link:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-button .wp-block-button__link:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-button .wp-block-button__link:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.wp-block-button .wp-block-button__link:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.wp-block-button .wp-block-button__link:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.wp-block-button .wp-block-button__link:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+.wp-block-button .wp-block-button__link:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+.wp-block-button .wp-block-button__link:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+.wp-block-button .wp-block-button__link:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+.wp-block-button .wp-block-button__link:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+.wp-block-button .wp-block-button__link:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+.wp-block-button .wp-block-button__link:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+.wp-block-button .wp-block-button__link:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+.wp-block-button .wp-block-button__link:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+.wp-block-button .wp-block-button__link:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+.wp-block-button .wp-block-button__link:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
+.wp-block-button .wp-block-button__link {
+  font-size: 0.8888888889em;
   font-weight: bold;
   padding: 16.72px 22px;
 }
-
 .wp-block-button .wp-block-button__link:not(.has-text-color) {
   color: #fff;
 }
-
 .wp-block-button:not(.is-style-outline) .wp-block-button__link {
   background: #0073aa;
 }
-
 .wp-block-button:not(.is-style-squared) .wp-block-button__link {
   border-radius: 5px;
 }
-
 .wp-block-button.is-style-outline, .wp-block-button.is-style-outline:hover, .wp-block-button.is-style-outline:focus, .wp-block-button.is-style-outline:active {
   background: transparent;
   color: #0073aa;
 }
-
 .wp-block-button.is-style-outline .wp-block-button__link, .wp-block-button.is-style-outline:hover .wp-block-button__link, .wp-block-button.is-style-outline:focus .wp-block-button__link, .wp-block-button.is-style-outline:active .wp-block-button__link {
   background: transparent;
 }
-
 .wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color), .wp-block-button.is-style-outline:hover .wp-block-button__link:not(.has-text-color), .wp-block-button.is-style-outline:focus .wp-block-button__link:not(.has-text-color), .wp-block-button.is-style-outline:active .wp-block-button__link:not(.has-text-color) {
   color: #0073aa;
 }
 
-.wp-block-buttons[style*="font-weight"] .wp-block-button__link,
-.wp-block-button[style*="font-weight"] .wp-block-button__link {
+.wp-block-buttons[style*=font-weight] .wp-block-button__link,
+.wp-block-button[style*=font-weight] .wp-block-button__link {
   font-weight: inherit;
 }
-
-.wp-block-buttons[style*="text-decoration"] .wp-block-button__link,
-.wp-block-button[style*="text-decoration"] .wp-block-button__link {
+.wp-block-buttons[style*=text-decoration] .wp-block-button__link,
+.wp-block-button[style*=text-decoration] .wp-block-button__link {
   text-decoration: inherit;
 }
 
 .wp-block-search .wp-block-search__button {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  font-size: 0.88889em;
+}
+.wp-block-search .wp-block-search__button:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-search .wp-block-search__button:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-search .wp-block-search__button:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-search .wp-block-search__button:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-search .wp-block-search__button:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-search .wp-block-search__button:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-search .wp-block-search__button:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-search .wp-block-search__button:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-search .wp-block-search__button:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-search .wp-block-search__button:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-search .wp-block-search__button:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-search .wp-block-search__button:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-search .wp-block-search__button:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-search .wp-block-search__button:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-search .wp-block-search__button:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-search .wp-block-search__button:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-search .wp-block-search__button:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-search .wp-block-search__button:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.wp-block-search .wp-block-search__button:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.wp-block-search .wp-block-search__button:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.wp-block-search .wp-block-search__button:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+.wp-block-search .wp-block-search__button:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+.wp-block-search .wp-block-search__button:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+.wp-block-search .wp-block-search__button:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+.wp-block-search .wp-block-search__button:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+.wp-block-search .wp-block-search__button:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+.wp-block-search .wp-block-search__button:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+.wp-block-search .wp-block-search__button:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+.wp-block-search .wp-block-search__button:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+.wp-block-search .wp-block-search__button:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+.wp-block-search .wp-block-search__button:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
+.wp-block-search .wp-block-search__button {
+  font-size: 0.8888888889em;
   font-weight: bold;
   border-radius: 5px;
 }
-
 .wp-block-search .wp-block-search__button:not(.has-text-color) {
   color: #fff;
 }
-
 .wp-block-search .wp-block-search__button:not(.has-background-color) {
   background: #0073aa;
 }
@@ -1062,25 +1636,180 @@ figcaption,
   border-width: 2px;
   border-color: #0073aa;
 }
-
 .wp-block-quote.is-large, .wp-block-quote.is-style-large {
   margin-top: 2.8125em;
   margin-bottom: 2.8125em;
 }
-
-.wp-block-quote.is-large p,
-.wp-block-quote.is-style-large p {
+.wp-block-quote.is-large p, .wp-block-quote.is-style-large p {
   font-size: 1.6875em;
   line-height: 1.3;
   margin-bottom: 0.5em;
   margin-top: 0.5em;
 }
-
 .wp-block-quote cite,
 .wp-block-quote footer,
 .wp-block-quote .wp-block-quote__citation {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  font-size: 0.71111em;
+}
+.wp-block-quote cite:lang(ar),
+.wp-block-quote footer:lang(ar),
+.wp-block-quote .wp-block-quote__citation:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-quote cite:lang(ary),
+.wp-block-quote footer:lang(ary),
+.wp-block-quote .wp-block-quote__citation:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-quote cite:lang(azb),
+.wp-block-quote footer:lang(azb),
+.wp-block-quote .wp-block-quote__citation:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-quote cite:lang(ckb),
+.wp-block-quote footer:lang(ckb),
+.wp-block-quote .wp-block-quote__citation:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-quote cite:lang(fa-IR),
+.wp-block-quote footer:lang(fa-IR),
+.wp-block-quote .wp-block-quote__citation:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-quote cite:lang(haz),
+.wp-block-quote footer:lang(haz),
+.wp-block-quote .wp-block-quote__citation:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-quote cite:lang(ps),
+.wp-block-quote footer:lang(ps),
+.wp-block-quote .wp-block-quote__citation:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-quote cite:lang(be),
+.wp-block-quote footer:lang(be),
+.wp-block-quote .wp-block-quote__citation:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-quote cite:lang(bg-BG),
+.wp-block-quote footer:lang(bg-BG),
+.wp-block-quote .wp-block-quote__citation:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-quote cite:lang(kk),
+.wp-block-quote footer:lang(kk),
+.wp-block-quote .wp-block-quote__citation:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-quote cite:lang(mk-MK),
+.wp-block-quote footer:lang(mk-MK),
+.wp-block-quote .wp-block-quote__citation:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-quote cite:lang(mn),
+.wp-block-quote footer:lang(mn),
+.wp-block-quote .wp-block-quote__citation:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-quote cite:lang(ru-RU),
+.wp-block-quote footer:lang(ru-RU),
+.wp-block-quote .wp-block-quote__citation:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-quote cite:lang(sah),
+.wp-block-quote footer:lang(sah),
+.wp-block-quote .wp-block-quote__citation:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-quote cite:lang(sr-RS),
+.wp-block-quote footer:lang(sr-RS),
+.wp-block-quote .wp-block-quote__citation:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-quote cite:lang(tt-RU),
+.wp-block-quote footer:lang(tt-RU),
+.wp-block-quote .wp-block-quote__citation:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-quote cite:lang(uk),
+.wp-block-quote footer:lang(uk),
+.wp-block-quote .wp-block-quote__citation:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-quote cite:lang(zh-HK),
+.wp-block-quote footer:lang(zh-HK),
+.wp-block-quote .wp-block-quote__citation:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.wp-block-quote cite:lang(zh-TW),
+.wp-block-quote footer:lang(zh-TW),
+.wp-block-quote .wp-block-quote__citation:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.wp-block-quote cite:lang(zh-CN),
+.wp-block-quote footer:lang(zh-CN),
+.wp-block-quote .wp-block-quote__citation:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.wp-block-quote cite:lang(bn-BD),
+.wp-block-quote footer:lang(bn-BD),
+.wp-block-quote .wp-block-quote__citation:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+.wp-block-quote cite:lang(hi-IN),
+.wp-block-quote footer:lang(hi-IN),
+.wp-block-quote .wp-block-quote__citation:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+.wp-block-quote cite:lang(mr),
+.wp-block-quote footer:lang(mr),
+.wp-block-quote .wp-block-quote__citation:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+.wp-block-quote cite:lang(ne-NP),
+.wp-block-quote footer:lang(ne-NP),
+.wp-block-quote .wp-block-quote__citation:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+.wp-block-quote cite:lang(el),
+.wp-block-quote footer:lang(el),
+.wp-block-quote .wp-block-quote__citation:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+.wp-block-quote cite:lang(gu),
+.wp-block-quote footer:lang(gu),
+.wp-block-quote .wp-block-quote__citation:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+.wp-block-quote cite:lang(he-IL),
+.wp-block-quote footer:lang(he-IL),
+.wp-block-quote .wp-block-quote__citation:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+.wp-block-quote cite:lang(ja),
+.wp-block-quote footer:lang(ja),
+.wp-block-quote .wp-block-quote__citation:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+.wp-block-quote cite:lang(ko-KR),
+.wp-block-quote footer:lang(ko-KR),
+.wp-block-quote .wp-block-quote__citation:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+.wp-block-quote cite:lang(th),
+.wp-block-quote footer:lang(th),
+.wp-block-quote .wp-block-quote__citation:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+.wp-block-quote cite:lang(vi),
+.wp-block-quote footer:lang(vi),
+.wp-block-quote .wp-block-quote__citation:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
+.wp-block-quote cite,
+.wp-block-quote footer,
+.wp-block-quote .wp-block-quote__citation {
+  font-size: 0.7111111111em;
   line-height: 1.6;
   color: inherit;
 }
@@ -1091,147 +1820,318 @@ figcaption,
   border-width: 2px;
   color: #000;
 }
-
 .wp-block-pullquote blockquote {
   margin-top: calc(3 * 1rem);
   margin-bottom: calc(3.33 * 1rem);
   hyphens: auto;
   word-break: break-word;
 }
-
 .wp-block-pullquote:not(.is-style-solid-color) .wp-block-pullquote__citation {
   color: #767676;
 }
-
-.wp-block-pullquote.has-text-color .wp-block-pullquote__citation,
-.wp-block-pullquote.has-primary-background-color blockquote p,
-.wp-block-pullquote.has-dark-gray-background-color blockquote p {
+.wp-block-pullquote.has-text-color .wp-block-pullquote__citation, .wp-block-pullquote.has-primary-background-color blockquote p, .wp-block-pullquote.has-dark-gray-background-color blockquote p {
   color: inherit;
 }
-
 .wp-block-pullquote.is-style-solid-color blockquote {
-  width: calc(100% - (2 * 1rem));
-  max-width: calc( 100% - (2 * 1rem));
+  width: calc(100% - 2 * 1rem);
+  max-width: calc(100% - 2 * 1rem);
 }
-
-.wp-block-pullquote.is-style-solid-color blockquote a,
-.wp-block-pullquote.is-style-solid-color blockquote.has-text-color p,
-.wp-block-pullquote.is-style-solid-color blockquote.has-text-color a {
+.wp-block-pullquote.is-style-solid-color blockquote a, .wp-block-pullquote.is-style-solid-color blockquote.has-text-color p, .wp-block-pullquote.is-style-solid-color blockquote.has-text-color a {
   color: inherit;
 }
-
 .wp-block-pullquote.is-style-solid-color blockquote:not(.has-text-color) {
   color: #fff;
 }
-
 @media only screen and (min-width: 768px) {
   .wp-block-pullquote.is-style-solid-color blockquote {
     max-width: 80%;
   }
 }
-
 .wp-block-pullquote.is-style-solid-color:not(.has-background-color) {
   background-color: #0073aa;
 }
 
-.wp-block-pullquote[data-type="core/pullquote"] blockquote > .block-library-pullquote__content .editor-rich-text__tinymce[data-is-empty="true"]::before,
+.wp-block-pullquote[data-type="core/pullquote"] blockquote > .block-library-pullquote__content .editor-rich-text__tinymce[data-is-empty=true]::before,
 .wp-block-pullquote[data-type="core/pullquote"] blockquote > .editor-rich-text p,
 .wp-block-pullquote[data-type="core/pullquote"] p,
-.wp-block[data-type="core/pullquote"] blockquote > .block-library-pullquote__content .editor-rich-text__tinymce[data-is-empty="true"]::before,
+.wp-block[data-type="core/pullquote"] blockquote > .block-library-pullquote__content .editor-rich-text__tinymce[data-is-empty=true]::before,
 .wp-block[data-type="core/pullquote"] blockquote > .editor-rich-text p,
 .wp-block[data-type="core/pullquote"] p,
-.wp-block[data-type="core/pullquote"][data-align="left"] blockquote > .block-library-pullquote__content .editor-rich-text__tinymce[data-is-empty="true"]::before,
-.wp-block[data-type="core/pullquote"][data-align="left"] blockquote > .editor-rich-text p,
-.wp-block[data-type="core/pullquote"][data-align="left"] p,
-.wp-block[data-type="core/pullquote"][data-align="right"] blockquote > .block-library-pullquote__content .editor-rich-text__tinymce[data-is-empty="true"]::before,
-.wp-block[data-type="core/pullquote"][data-align="right"] blockquote > .editor-rich-text p,
-.wp-block[data-type="core/pullquote"][data-align="right"] p {
+.wp-block[data-type="core/pullquote"][data-align=left] blockquote > .block-library-pullquote__content .editor-rich-text__tinymce[data-is-empty=true]::before,
+.wp-block[data-type="core/pullquote"][data-align=left] blockquote > .editor-rich-text p,
+.wp-block[data-type="core/pullquote"][data-align=left] p,
+.wp-block[data-type="core/pullquote"][data-align=right] blockquote > .block-library-pullquote__content .editor-rich-text__tinymce[data-is-empty=true]::before,
+.wp-block[data-type="core/pullquote"][data-align=right] blockquote > .editor-rich-text p,
+.wp-block[data-type="core/pullquote"][data-align=right] p {
   font-size: 1.6875em;
   font-style: italic;
   line-height: 1.3;
   margin-bottom: 0.5em;
   margin-top: 0.5em;
 }
-
 @media only screen and (min-width: 768px) {
-  .wp-block-pullquote[data-type="core/pullquote"] blockquote > .block-library-pullquote__content .editor-rich-text__tinymce[data-is-empty="true"]::before,
+  .wp-block-pullquote[data-type="core/pullquote"] blockquote > .block-library-pullquote__content .editor-rich-text__tinymce[data-is-empty=true]::before,
   .wp-block-pullquote[data-type="core/pullquote"] blockquote > .editor-rich-text p,
   .wp-block-pullquote[data-type="core/pullquote"] p,
-  .wp-block[data-type="core/pullquote"] blockquote > .block-library-pullquote__content .editor-rich-text__tinymce[data-is-empty="true"]::before,
+  .wp-block[data-type="core/pullquote"] blockquote > .block-library-pullquote__content .editor-rich-text__tinymce[data-is-empty=true]::before,
   .wp-block[data-type="core/pullquote"] blockquote > .editor-rich-text p,
   .wp-block[data-type="core/pullquote"] p,
-  .wp-block[data-type="core/pullquote"][data-align="left"] blockquote > .block-library-pullquote__content .editor-rich-text__tinymce[data-is-empty="true"]::before,
-  .wp-block[data-type="core/pullquote"][data-align="left"] blockquote > .editor-rich-text p,
-  .wp-block[data-type="core/pullquote"][data-align="left"] p,
-  .wp-block[data-type="core/pullquote"][data-align="right"] blockquote > .block-library-pullquote__content .editor-rich-text__tinymce[data-is-empty="true"]::before,
-  .wp-block[data-type="core/pullquote"][data-align="right"] blockquote > .editor-rich-text p,
-  .wp-block[data-type="core/pullquote"][data-align="right"] p {
+  .wp-block[data-type="core/pullquote"][data-align=left] blockquote > .block-library-pullquote__content .editor-rich-text__tinymce[data-is-empty=true]::before,
+  .wp-block[data-type="core/pullquote"][data-align=left] blockquote > .editor-rich-text p,
+  .wp-block[data-type="core/pullquote"][data-align=left] p,
+  .wp-block[data-type="core/pullquote"][data-align=right] blockquote > .block-library-pullquote__content .editor-rich-text__tinymce[data-is-empty=true]::before,
+  .wp-block[data-type="core/pullquote"][data-align=right] blockquote > .editor-rich-text p,
+  .wp-block[data-type="core/pullquote"][data-align=right] p {
     font-size: 2.25em;
   }
 }
-
 .wp-block-pullquote[data-type="core/pullquote"] .wp-block-pullquote__citation,
 .wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation,
-.wp-block[data-type="core/pullquote"][data-align="left"] .wp-block-pullquote__citation,
-.wp-block[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation {
+.wp-block[data-type="core/pullquote"][data-align=left] .wp-block-pullquote__citation,
+.wp-block[data-type="core/pullquote"][data-align=right] .wp-block-pullquote__citation {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  font-size: 0.71111em;
+}
+.wp-block-pullquote[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(ar),
+.wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(ar),
+.wp-block[data-type="core/pullquote"][data-align=left] .wp-block-pullquote__citation:lang(ar),
+.wp-block[data-type="core/pullquote"][data-align=right] .wp-block-pullquote__citation:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-pullquote[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(ary),
+.wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(ary),
+.wp-block[data-type="core/pullquote"][data-align=left] .wp-block-pullquote__citation:lang(ary),
+.wp-block[data-type="core/pullquote"][data-align=right] .wp-block-pullquote__citation:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-pullquote[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(azb),
+.wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(azb),
+.wp-block[data-type="core/pullquote"][data-align=left] .wp-block-pullquote__citation:lang(azb),
+.wp-block[data-type="core/pullquote"][data-align=right] .wp-block-pullquote__citation:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-pullquote[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(ckb),
+.wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(ckb),
+.wp-block[data-type="core/pullquote"][data-align=left] .wp-block-pullquote__citation:lang(ckb),
+.wp-block[data-type="core/pullquote"][data-align=right] .wp-block-pullquote__citation:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-pullquote[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(fa-IR),
+.wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(fa-IR),
+.wp-block[data-type="core/pullquote"][data-align=left] .wp-block-pullquote__citation:lang(fa-IR),
+.wp-block[data-type="core/pullquote"][data-align=right] .wp-block-pullquote__citation:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-pullquote[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(haz),
+.wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(haz),
+.wp-block[data-type="core/pullquote"][data-align=left] .wp-block-pullquote__citation:lang(haz),
+.wp-block[data-type="core/pullquote"][data-align=right] .wp-block-pullquote__citation:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-pullquote[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(ps),
+.wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(ps),
+.wp-block[data-type="core/pullquote"][data-align=left] .wp-block-pullquote__citation:lang(ps),
+.wp-block[data-type="core/pullquote"][data-align=right] .wp-block-pullquote__citation:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-pullquote[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(be),
+.wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(be),
+.wp-block[data-type="core/pullquote"][data-align=left] .wp-block-pullquote__citation:lang(be),
+.wp-block[data-type="core/pullquote"][data-align=right] .wp-block-pullquote__citation:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-pullquote[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(bg-BG),
+.wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(bg-BG),
+.wp-block[data-type="core/pullquote"][data-align=left] .wp-block-pullquote__citation:lang(bg-BG),
+.wp-block[data-type="core/pullquote"][data-align=right] .wp-block-pullquote__citation:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-pullquote[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(kk),
+.wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(kk),
+.wp-block[data-type="core/pullquote"][data-align=left] .wp-block-pullquote__citation:lang(kk),
+.wp-block[data-type="core/pullquote"][data-align=right] .wp-block-pullquote__citation:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-pullquote[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(mk-MK),
+.wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(mk-MK),
+.wp-block[data-type="core/pullquote"][data-align=left] .wp-block-pullquote__citation:lang(mk-MK),
+.wp-block[data-type="core/pullquote"][data-align=right] .wp-block-pullquote__citation:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-pullquote[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(mn),
+.wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(mn),
+.wp-block[data-type="core/pullquote"][data-align=left] .wp-block-pullquote__citation:lang(mn),
+.wp-block[data-type="core/pullquote"][data-align=right] .wp-block-pullquote__citation:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-pullquote[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(ru-RU),
+.wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(ru-RU),
+.wp-block[data-type="core/pullquote"][data-align=left] .wp-block-pullquote__citation:lang(ru-RU),
+.wp-block[data-type="core/pullquote"][data-align=right] .wp-block-pullquote__citation:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-pullquote[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(sah),
+.wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(sah),
+.wp-block[data-type="core/pullquote"][data-align=left] .wp-block-pullquote__citation:lang(sah),
+.wp-block[data-type="core/pullquote"][data-align=right] .wp-block-pullquote__citation:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-pullquote[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(sr-RS),
+.wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(sr-RS),
+.wp-block[data-type="core/pullquote"][data-align=left] .wp-block-pullquote__citation:lang(sr-RS),
+.wp-block[data-type="core/pullquote"][data-align=right] .wp-block-pullquote__citation:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-pullquote[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(tt-RU),
+.wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(tt-RU),
+.wp-block[data-type="core/pullquote"][data-align=left] .wp-block-pullquote__citation:lang(tt-RU),
+.wp-block[data-type="core/pullquote"][data-align=right] .wp-block-pullquote__citation:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-pullquote[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(uk),
+.wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(uk),
+.wp-block[data-type="core/pullquote"][data-align=left] .wp-block-pullquote__citation:lang(uk),
+.wp-block[data-type="core/pullquote"][data-align=right] .wp-block-pullquote__citation:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-pullquote[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(zh-HK),
+.wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(zh-HK),
+.wp-block[data-type="core/pullquote"][data-align=left] .wp-block-pullquote__citation:lang(zh-HK),
+.wp-block[data-type="core/pullquote"][data-align=right] .wp-block-pullquote__citation:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.wp-block-pullquote[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(zh-TW),
+.wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(zh-TW),
+.wp-block[data-type="core/pullquote"][data-align=left] .wp-block-pullquote__citation:lang(zh-TW),
+.wp-block[data-type="core/pullquote"][data-align=right] .wp-block-pullquote__citation:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.wp-block-pullquote[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(zh-CN),
+.wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(zh-CN),
+.wp-block[data-type="core/pullquote"][data-align=left] .wp-block-pullquote__citation:lang(zh-CN),
+.wp-block[data-type="core/pullquote"][data-align=right] .wp-block-pullquote__citation:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.wp-block-pullquote[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(bn-BD),
+.wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(bn-BD),
+.wp-block[data-type="core/pullquote"][data-align=left] .wp-block-pullquote__citation:lang(bn-BD),
+.wp-block[data-type="core/pullquote"][data-align=right] .wp-block-pullquote__citation:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+.wp-block-pullquote[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(hi-IN),
+.wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(hi-IN),
+.wp-block[data-type="core/pullquote"][data-align=left] .wp-block-pullquote__citation:lang(hi-IN),
+.wp-block[data-type="core/pullquote"][data-align=right] .wp-block-pullquote__citation:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+.wp-block-pullquote[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(mr),
+.wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(mr),
+.wp-block[data-type="core/pullquote"][data-align=left] .wp-block-pullquote__citation:lang(mr),
+.wp-block[data-type="core/pullquote"][data-align=right] .wp-block-pullquote__citation:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+.wp-block-pullquote[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(ne-NP),
+.wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(ne-NP),
+.wp-block[data-type="core/pullquote"][data-align=left] .wp-block-pullquote__citation:lang(ne-NP),
+.wp-block[data-type="core/pullquote"][data-align=right] .wp-block-pullquote__citation:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+.wp-block-pullquote[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(el),
+.wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(el),
+.wp-block[data-type="core/pullquote"][data-align=left] .wp-block-pullquote__citation:lang(el),
+.wp-block[data-type="core/pullquote"][data-align=right] .wp-block-pullquote__citation:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+.wp-block-pullquote[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(gu),
+.wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(gu),
+.wp-block[data-type="core/pullquote"][data-align=left] .wp-block-pullquote__citation:lang(gu),
+.wp-block[data-type="core/pullquote"][data-align=right] .wp-block-pullquote__citation:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+.wp-block-pullquote[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(he-IL),
+.wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(he-IL),
+.wp-block[data-type="core/pullquote"][data-align=left] .wp-block-pullquote__citation:lang(he-IL),
+.wp-block[data-type="core/pullquote"][data-align=right] .wp-block-pullquote__citation:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+.wp-block-pullquote[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(ja),
+.wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(ja),
+.wp-block[data-type="core/pullquote"][data-align=left] .wp-block-pullquote__citation:lang(ja),
+.wp-block[data-type="core/pullquote"][data-align=right] .wp-block-pullquote__citation:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+.wp-block-pullquote[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(ko-KR),
+.wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(ko-KR),
+.wp-block[data-type="core/pullquote"][data-align=left] .wp-block-pullquote__citation:lang(ko-KR),
+.wp-block[data-type="core/pullquote"][data-align=right] .wp-block-pullquote__citation:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+.wp-block-pullquote[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(th),
+.wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(th),
+.wp-block[data-type="core/pullquote"][data-align=left] .wp-block-pullquote__citation:lang(th),
+.wp-block[data-type="core/pullquote"][data-align=right] .wp-block-pullquote__citation:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+.wp-block-pullquote[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(vi),
+.wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation:lang(vi),
+.wp-block[data-type="core/pullquote"][data-align=left] .wp-block-pullquote__citation:lang(vi),
+.wp-block[data-type="core/pullquote"][data-align=right] .wp-block-pullquote__citation:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
+.wp-block-pullquote[data-type="core/pullquote"] .wp-block-pullquote__citation,
+.wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation,
+.wp-block[data-type="core/pullquote"][data-align=left] .wp-block-pullquote__citation,
+.wp-block[data-type="core/pullquote"][data-align=right] .wp-block-pullquote__citation {
+  font-size: 0.7111111111em;
   line-height: 1.6;
   text-transform: none;
 }
-
 .wp-block-pullquote[data-type="core/pullquote"] em,
 .wp-block[data-type="core/pullquote"] em,
-.wp-block[data-type="core/pullquote"][data-align="left"] em,
-.wp-block[data-type="core/pullquote"][data-align="right"] em {
+.wp-block[data-type="core/pullquote"][data-align=left] em,
+.wp-block[data-type="core/pullquote"][data-align=right] em {
   font-style: normal;
 }
 
-.wp-block[data-align="left"] > .wp-block-pullquote,
-.wp-block[data-align="right"] > .wp-block-pullquote {
+.wp-block[data-align=left] > .wp-block-pullquote,
+.wp-block[data-align=right] > .wp-block-pullquote {
   max-width: 50%;
   text-align: inherit;
 }
-
-.wp-block[data-align="left"] > .wp-block-pullquote:not(.is-style-solid-color),
-.wp-block[data-align="right"] > .wp-block-pullquote:not(.is-style-solid-color) {
+.wp-block[data-align=left] > .wp-block-pullquote:not(.is-style-solid-color),
+.wp-block[data-align=right] > .wp-block-pullquote:not(.is-style-solid-color) {
   padding: 0;
 }
-
-.wp-block[data-align="left"] > .wp-block-pullquote.is-style-solid-color,
-.wp-block[data-align="right"] > .wp-block-pullquote.is-style-solid-color {
+.wp-block[data-align=left] > .wp-block-pullquote.is-style-solid-color,
+.wp-block[data-align=right] > .wp-block-pullquote.is-style-solid-color {
   padding: 1em;
 }
 
-.wp-block[data-type="core/pullquote"][data-align="left"] .editor-block-list__block-edit,
-.wp-block[data-type="core/pullquote"][data-align="right"] .editor-block-list__block-edit {
-  width: calc(4 * (100vw / 12));
+.wp-block[data-type="core/pullquote"][data-align=left] .editor-block-list__block-edit,
+.wp-block[data-type="core/pullquote"][data-align=right] .editor-block-list__block-edit {
+  width: 33.3333333333vw;
   max-width: 50%;
 }
-
-.wp-block[data-type="core/pullquote"][data-align="left"] .editor-block-list__block-edit .wp-block-pullquote:not(.is-style-solid-color),
-.wp-block[data-type="core/pullquote"][data-align="right"] .editor-block-list__block-edit .wp-block-pullquote:not(.is-style-solid-color) {
+.wp-block[data-type="core/pullquote"][data-align=left] .editor-block-list__block-edit .wp-block-pullquote:not(.is-style-solid-color),
+.wp-block[data-type="core/pullquote"][data-align=right] .editor-block-list__block-edit .wp-block-pullquote:not(.is-style-solid-color) {
   padding: 0;
 }
-
-.wp-block[data-type="core/pullquote"][data-align="left"] .editor-block-list__block-edit .wp-block-pullquote.is-style-solid-color,
-.wp-block[data-type="core/pullquote"][data-align="right"] .editor-block-list__block-edit .wp-block-pullquote.is-style-solid-color {
+.wp-block[data-type="core/pullquote"][data-align=left] .editor-block-list__block-edit .wp-block-pullquote.is-style-solid-color,
+.wp-block[data-type="core/pullquote"][data-align=right] .editor-block-list__block-edit .wp-block-pullquote.is-style-solid-color {
   padding: 1em;
 }
-
-.wp-block[data-type="core/pullquote"][data-align="left"] blockquote > .block-library-pullquote__content .editor-rich-text__tinymce[data-is-empty="true"]::before,
-.wp-block[data-type="core/pullquote"][data-align="left"] blockquote > .editor-rich-text p,
-.wp-block[data-type="core/pullquote"][data-align="left"] p,
-.wp-block[data-type="core/pullquote"][data-align="left"] .wp-block-pullquote__citation,
-.wp-block[data-type="core/pullquote"][data-align="right"] blockquote > .block-library-pullquote__content .editor-rich-text__tinymce[data-is-empty="true"]::before,
-.wp-block[data-type="core/pullquote"][data-align="right"] blockquote > .editor-rich-text p,
-.wp-block[data-type="core/pullquote"][data-align="right"] p,
-.wp-block[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation {
+.wp-block[data-type="core/pullquote"][data-align=left] blockquote > .block-library-pullquote__content .editor-rich-text__tinymce[data-is-empty=true]::before,
+.wp-block[data-type="core/pullquote"][data-align=left] blockquote > .editor-rich-text p,
+.wp-block[data-type="core/pullquote"][data-align=left] p,
+.wp-block[data-type="core/pullquote"][data-align=left] .wp-block-pullquote__citation,
+.wp-block[data-type="core/pullquote"][data-align=right] blockquote > .block-library-pullquote__content .editor-rich-text__tinymce[data-is-empty=true]::before,
+.wp-block[data-type="core/pullquote"][data-align=right] blockquote > .editor-rich-text p,
+.wp-block[data-type="core/pullquote"][data-align=right] p,
+.wp-block[data-type="core/pullquote"][data-align=right] .wp-block-pullquote__citation {
   text-align: left;
 }
 
 @media only screen and (min-width: 768px) {
-  .wp-block[data-type="core/pullquote"][data-align="full"] .wp-block-pullquote blockquote {
+  .wp-block[data-type="core/pullquote"][data-align=full] .wp-block-pullquote blockquote {
     max-width: calc(80% - 128px);
   }
 }
@@ -1240,26 +2140,115 @@ figcaption,
 .wp-block-file {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 }
-
+.wp-block-file:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-file:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-file:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-file:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-file:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-file:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-file:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-file:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-file:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-file:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-file:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-file:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-file:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-file:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-file:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-file:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-file:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-file:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.wp-block-file:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.wp-block-file:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.wp-block-file:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+.wp-block-file:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+.wp-block-file:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+.wp-block-file:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+.wp-block-file:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+.wp-block-file:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+.wp-block-file:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+.wp-block-file:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+.wp-block-file:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+.wp-block-file:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+.wp-block-file:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
 .wp-block-file .wp-block-file__textlink {
   text-decoration: underline;
   color: #0073aa;
 }
-
 .wp-block-file .wp-block-file__textlink:hover {
-  color: #005177;
+  color: rgb(0, 80.5, 119);
   text-decoration: none;
 }
-
 .wp-block-file .wp-block-file__button {
   display: table;
   line-height: 1.8;
-  font-size: 0.88889em;
+  font-size: 0.8888888889em;
   font-weight: bold;
   background-color: #0073aa;
   border-radius: 5px;
 }
-
 .wp-block-file .wp-block-file__button-richtext-wrapper {
   display: block;
   margin-top: calc(0.75 * 1rem);
@@ -1287,42 +2276,34 @@ figcaption,
   background-color: #767676;
   height: 2px;
 }
-
 .wp-block-separator:not(.is-style-wide):not(.is-style-dots) {
   width: 2.25em;
   margin-left: 0;
 }
-
 .wp-block-separator.is-style-dots {
   color: #767676;
 }
-
 .wp-block-separator.is-style-dots:before {
   font-size: 1.6875em;
   letter-spacing: calc(2 * 1rem);
   padding-left: calc(2 * 1rem);
 }
-
 .wp-block-separator.has-primary-background-color {
   color: #0073aa;
   background-color: #0073aa;
 }
-
 .wp-block-separator.has-secondary-background-color {
-  color: #005177;
-  background-color: #005177;
+  color: rgb(0, 80.5, 119);
+  background-color: rgb(0, 80.5, 119);
 }
-
 .wp-block-separator.has-dark-gray-background-color {
   color: #111;
   background-color: #111;
 }
-
 .wp-block-separator.has-light-gray-background-color {
   color: #767676;
   background-color: #767676;
 }
-
 .wp-block-separator.has-white-background-color {
   color: #fff;
   background-color: #fff;
@@ -1342,24 +2323,180 @@ ul.wp-block-archives,
   padding: 0;
   list-style-type: none;
 }
-
 ul.wp-block-archives ul,
 .wp-block-categories ul,
 .wp-block-latest-posts ul {
   padding: 0;
   list-style-type: none;
 }
-
 ul.wp-block-archives li > a,
 .wp-block-categories li > a,
 .wp-block-latest-posts li > a {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+}
+ul.wp-block-archives li > a:lang(ar),
+.wp-block-categories li > a:lang(ar),
+.wp-block-latest-posts li > a:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+ul.wp-block-archives li > a:lang(ary),
+.wp-block-categories li > a:lang(ary),
+.wp-block-latest-posts li > a:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+ul.wp-block-archives li > a:lang(azb),
+.wp-block-categories li > a:lang(azb),
+.wp-block-latest-posts li > a:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+ul.wp-block-archives li > a:lang(ckb),
+.wp-block-categories li > a:lang(ckb),
+.wp-block-latest-posts li > a:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+ul.wp-block-archives li > a:lang(fa-IR),
+.wp-block-categories li > a:lang(fa-IR),
+.wp-block-latest-posts li > a:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+ul.wp-block-archives li > a:lang(haz),
+.wp-block-categories li > a:lang(haz),
+.wp-block-latest-posts li > a:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+ul.wp-block-archives li > a:lang(ps),
+.wp-block-categories li > a:lang(ps),
+.wp-block-latest-posts li > a:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+ul.wp-block-archives li > a:lang(be),
+.wp-block-categories li > a:lang(be),
+.wp-block-latest-posts li > a:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+ul.wp-block-archives li > a:lang(bg-BG),
+.wp-block-categories li > a:lang(bg-BG),
+.wp-block-latest-posts li > a:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+ul.wp-block-archives li > a:lang(kk),
+.wp-block-categories li > a:lang(kk),
+.wp-block-latest-posts li > a:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+ul.wp-block-archives li > a:lang(mk-MK),
+.wp-block-categories li > a:lang(mk-MK),
+.wp-block-latest-posts li > a:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+ul.wp-block-archives li > a:lang(mn),
+.wp-block-categories li > a:lang(mn),
+.wp-block-latest-posts li > a:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+ul.wp-block-archives li > a:lang(ru-RU),
+.wp-block-categories li > a:lang(ru-RU),
+.wp-block-latest-posts li > a:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+ul.wp-block-archives li > a:lang(sah),
+.wp-block-categories li > a:lang(sah),
+.wp-block-latest-posts li > a:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+ul.wp-block-archives li > a:lang(sr-RS),
+.wp-block-categories li > a:lang(sr-RS),
+.wp-block-latest-posts li > a:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+ul.wp-block-archives li > a:lang(tt-RU),
+.wp-block-categories li > a:lang(tt-RU),
+.wp-block-latest-posts li > a:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+ul.wp-block-archives li > a:lang(uk),
+.wp-block-categories li > a:lang(uk),
+.wp-block-latest-posts li > a:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+ul.wp-block-archives li > a:lang(zh-HK),
+.wp-block-categories li > a:lang(zh-HK),
+.wp-block-latest-posts li > a:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+ul.wp-block-archives li > a:lang(zh-TW),
+.wp-block-categories li > a:lang(zh-TW),
+.wp-block-latest-posts li > a:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+ul.wp-block-archives li > a:lang(zh-CN),
+.wp-block-categories li > a:lang(zh-CN),
+.wp-block-latest-posts li > a:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+ul.wp-block-archives li > a:lang(bn-BD),
+.wp-block-categories li > a:lang(bn-BD),
+.wp-block-latest-posts li > a:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+ul.wp-block-archives li > a:lang(hi-IN),
+.wp-block-categories li > a:lang(hi-IN),
+.wp-block-latest-posts li > a:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+ul.wp-block-archives li > a:lang(mr),
+.wp-block-categories li > a:lang(mr),
+.wp-block-latest-posts li > a:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+ul.wp-block-archives li > a:lang(ne-NP),
+.wp-block-categories li > a:lang(ne-NP),
+.wp-block-latest-posts li > a:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+ul.wp-block-archives li > a:lang(el),
+.wp-block-categories li > a:lang(el),
+.wp-block-latest-posts li > a:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+ul.wp-block-archives li > a:lang(gu),
+.wp-block-categories li > a:lang(gu),
+.wp-block-latest-posts li > a:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+ul.wp-block-archives li > a:lang(he-IL),
+.wp-block-categories li > a:lang(he-IL),
+.wp-block-latest-posts li > a:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+ul.wp-block-archives li > a:lang(ja),
+.wp-block-categories li > a:lang(ja),
+.wp-block-latest-posts li > a:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+ul.wp-block-archives li > a:lang(ko-KR),
+.wp-block-categories li > a:lang(ko-KR),
+.wp-block-latest-posts li > a:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+ul.wp-block-archives li > a:lang(th),
+.wp-block-categories li > a:lang(th),
+.wp-block-latest-posts li > a:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+ul.wp-block-archives li > a:lang(vi),
+.wp-block-categories li > a:lang(vi),
+.wp-block-latest-posts li > a:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
+ul.wp-block-archives li > a,
+.wp-block-categories li > a,
+.wp-block-latest-posts li > a {
   font-size: calc(22px * 1.125);
   font-weight: bold;
   line-height: 1.2;
   text-decoration: none;
 }
-
 ul.wp-block-archives li ul,
 .wp-block-categories li ul,
 .wp-block-latest-posts li ul {
@@ -1369,35 +2506,32 @@ ul.wp-block-archives li ul,
 .wp-block-categories ul {
   padding-top: 0.75rem;
 }
-
 .wp-block-categories ul ul {
   counter-reset: submenu;
 }
-
 .wp-block-categories ul ul > li > a::before {
   font-family: "NonBreakingSpaceOverride", "Hoefler Text", Garamond, "Times New Roman", serif;
   font-weight: normal;
   content: "– " counters(submenu, "– ", none);
   counter-increment: submenu;
 }
-
 .wp-block-categories li ul {
   list-style: none;
   padding-left: 0;
   margin-bottom: -0.75rem;
 }
 
-.wp-block[data-align="center"] > .wp-block-archives,
-.wp-block[data-align="center"] > .wp-block-categories {
+.wp-block[data-align=center] > .wp-block-archives,
+.wp-block[data-align=center] > .wp-block-categories {
   text-align: center;
 }
 
-.wp-block[data-align="center"] .wp-block-file__button {
+.wp-block[data-align=center] .wp-block-file__button {
   margin-left: auto;
   margin-right: auto;
 }
 
-.wp-block[data-align="right"] .wp-block-file__button {
+.wp-block[data-align=right] .wp-block-file__button {
   margin-left: auto;
   margin-right: 0;
 }
@@ -1405,78 +2539,351 @@ ul.wp-block-archives li ul,
 /** === Latest Posts === */
 .wp-block-latest-posts .wp-block-latest-posts__post-date {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  font-size: 0.71111em;
+}
+.wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-latest-posts .wp-block-latest-posts__post-date:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-latest-posts .wp-block-latest-posts__post-date:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-latest-posts .wp-block-latest-posts__post-date:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-latest-posts .wp-block-latest-posts__post-date:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-latest-posts .wp-block-latest-posts__post-date:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-latest-posts .wp-block-latest-posts__post-date:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-latest-posts .wp-block-latest-posts__post-date:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-latest-posts .wp-block-latest-posts__post-date:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-latest-posts .wp-block-latest-posts__post-date:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-latest-posts .wp-block-latest-posts__post-date:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-latest-posts .wp-block-latest-posts__post-date:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-latest-posts .wp-block-latest-posts__post-date:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-latest-posts .wp-block-latest-posts__post-date:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.wp-block-latest-posts .wp-block-latest-posts__post-date:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.wp-block-latest-posts .wp-block-latest-posts__post-date:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.wp-block-latest-posts .wp-block-latest-posts__post-date:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+.wp-block-latest-posts .wp-block-latest-posts__post-date:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+.wp-block-latest-posts .wp-block-latest-posts__post-date:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+.wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+.wp-block-latest-posts .wp-block-latest-posts__post-date:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+.wp-block-latest-posts .wp-block-latest-posts__post-date:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+.wp-block-latest-posts .wp-block-latest-posts__post-date:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+.wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+.wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+.wp-block-latest-posts .wp-block-latest-posts__post-date:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+.wp-block-latest-posts .wp-block-latest-posts__post-date:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
+.wp-block-latest-posts .wp-block-latest-posts__post-date {
+  font-size: 0.7111111111em;
   color: #767676;
   line-height: 1.2;
 }
-
 .wp-block-latest-posts .wp-block-latest-posts__post-full-content,
 .wp-block-latest-posts .wp-block-latest-posts__post-excerpt {
   margin-top: 22px;
   margin-bottom: 22px;
 }
-
 .wp-block-latest-posts .wp-block-latest-posts__post-full-content > div > p:first-child,
 .wp-block-latest-posts .wp-block-latest-posts__post-excerpt > div > p:first-child {
   margin-top: 22px;
 }
-
 .wp-block-latest-posts li {
   padding-bottom: 0.5rem;
 }
-
 .wp-block-latest-posts li.menu-item-has-children, .wp-block-latest-posts li:last-child {
   padding-bottom: 0;
 }
-
 .wp-block-latest-posts li :not(:last-child) .wp-block-latest-posts__post-excerpt {
   padding-bottom: 0.5rem;
 }
-
 .wp-block-latest-posts.is-grid li {
   border-top: 2px solid #ccc;
   padding-top: 1rem;
   margin-bottom: 2rem;
 }
-
 .wp-block-latest-posts.is-grid li a:after {
-  content: '';
+  content: "";
 }
-
 .wp-block-latest-posts.is-grid li:last-child {
   margin-bottom: auto;
 }
-
 .wp-block-latest-posts.is-grid li:last-child a:after {
-  content: '';
+  content: "";
 }
 
 /** === Latest Comments === */
 .wp-block-latest-comments .wp-block-latest-comments__comment-meta {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+}
+.wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+.wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+.wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+.wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+.wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+.wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+.wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+.wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+.wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+.wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+.wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
+.wp-block-latest-comments .wp-block-latest-comments__comment-meta {
   font-weight: bold;
 }
-
 .wp-block-latest-comments .wp-block-latest-comments__comment-meta .wp-block-latest-comments__comment-date {
   font-weight: normal;
 }
-
 .wp-block-latest-comments .wp-block-latest-comments__comment,
 .wp-block-latest-comments .wp-block-latest-comments__comment-date,
 .wp-block-latest-comments .wp-block-latest-comments__comment-excerpt p {
   font-size: inherit;
 }
-
 .wp-block-latest-comments .wp-block-latest-comments__comment-date {
-  font-size: 0.71111em;
+  font-size: 0.7111111111em;
 }
 
 /** === Classic Editor === */
 /* Properly center-align captions in the classic-editor block */
 .wp-caption dd {
   color: #767676;
-  font-size: 0.71111em;
+  font-size: 0.7111111111em;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+}
+.wp-caption dd:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-caption dd:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-caption dd:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-caption dd:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-caption dd:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-caption dd:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-caption dd:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-caption dd:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-caption dd:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-caption dd:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-caption dd:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-caption dd:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-caption dd:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-caption dd:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-caption dd:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-caption dd:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-caption dd:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-caption dd:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.wp-caption dd:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.wp-caption dd:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.wp-caption dd:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+.wp-caption dd:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+.wp-caption dd:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+.wp-caption dd:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+.wp-caption dd:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+.wp-caption dd:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+.wp-caption dd:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+.wp-caption dd:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+.wp-caption dd:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+.wp-caption dd:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+.wp-caption dd:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
+.wp-caption dd {
   line-height: 1.6;
   margin: 0;
   padding: 0.5rem;
@@ -1489,28 +2896,120 @@ ul.wp-block-archives li ul,
 .wp-block-freeform blockquote {
   border-left: 2px solid #0073aa;
 }
-
 .wp-block-freeform blockquote cite {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  font-size: 0.71111em;
+}
+.wp-block-freeform blockquote cite:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-freeform blockquote cite:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-freeform blockquote cite:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-freeform blockquote cite:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-freeform blockquote cite:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-freeform blockquote cite:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-freeform blockquote cite:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-block-freeform blockquote cite:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-freeform blockquote cite:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-freeform blockquote cite:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-freeform blockquote cite:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-freeform blockquote cite:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-freeform blockquote cite:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-freeform blockquote cite:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-freeform blockquote cite:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-freeform blockquote cite:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-freeform blockquote cite:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-block-freeform blockquote cite:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.wp-block-freeform blockquote cite:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.wp-block-freeform blockquote cite:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.wp-block-freeform blockquote cite:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+.wp-block-freeform blockquote cite:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+.wp-block-freeform blockquote cite:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+.wp-block-freeform blockquote cite:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+.wp-block-freeform blockquote cite:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+.wp-block-freeform blockquote cite:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+.wp-block-freeform blockquote cite:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+.wp-block-freeform blockquote cite:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+.wp-block-freeform blockquote cite:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+.wp-block-freeform blockquote cite:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+.wp-block-freeform blockquote cite:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
+.wp-block-freeform blockquote cite {
+  font-size: 0.7111111111em;
   font-style: normal;
   line-height: 1.6;
   color: #767676;
 }
 
 /** === Group Block === */
-.wp-block-group > .wp-block-group__inner-container > .wp-block[data-align="full"],
+.wp-block-group > .wp-block-group__inner-container > .wp-block[data-align=full],
 .wp-block-group > .wp-block-group__inner-container > .wp-block.alignfull {
   margin-left: 0;
   margin-right: 0;
   left: 0;
 }
-
 .wp-block-group.has-background {
   padding: 22px;
 }
-
-.wp-block-group.has-background > .wp-block-group__inner-container > .wp-block[data-align="full"],
+.wp-block-group.has-background > .wp-block-group__inner-container > .wp-block[data-align=full],
 .wp-block-group.has-background > .wp-block-group__inner-container > .wp-block.alignfull {
   margin-left: -22px;
   width: calc(100% + 44px);
@@ -1518,37 +3017,33 @@ ul.wp-block-archives li ul,
 }
 
 @media only screen and (min-width: 768px) {
-  .wp-block[data-align="wide"] > .wp-block-group > .wp-block-group__inner-container > .wp-block:not([data-align="wide"]):not([data-align="full"]):not(.alignwide):not(.alignfull) {
-    width: calc(8 * (100vw / 12));
+  .wp-block[data-align=wide] > .wp-block-group > .wp-block-group__inner-container > .wp-block:not([data-align=wide]):not([data-align=full]):not(.alignwide):not(.alignfull) {
+    width: 66.6666666667vw;
   }
 }
-
 @media only screen and (min-width: 1168px) {
-  .wp-block[data-align="wide"] > .wp-block-group > .wp-block-group__inner-container > .wp-block:not([data-align="wide"]):not([data-align="full"]):not(.alignwide):not(.alignfull) {
-    width: calc(6 * (100vw / 12 ));
+  .wp-block[data-align=wide] > .wp-block-group > .wp-block-group__inner-container > .wp-block:not([data-align=wide]):not([data-align=full]):not(.alignwide):not(.alignfull) {
+    width: 50vw;
   }
 }
-
-.wp-block[data-align="wide"] > .wp-block-group > .wp-block-group__inner-container > .wp-block[data-align="full"],
-.wp-block[data-align="wide"] > .wp-block-group > .wp-block-group__inner-container > .wp-block.alignfull {
+.wp-block[data-align=wide] > .wp-block-group > .wp-block-group__inner-container > .wp-block[data-align=full],
+.wp-block[data-align=wide] > .wp-block-group > .wp-block-group__inner-container > .wp-block.alignfull {
   padding-left: 0;
   padding-right: 0;
 }
-
 @media only screen and (min-width: 768px) {
-  .wp-block[data-align="wide"] > .wp-block-group.has-background > .wp-block-group__inner-container > .wp-block:not([data-align="wide"]):not([data-align="full"]):not(.alignwide):not(.alignfull) {
-    width: calc(8 * (100vw / 12) - 44px);
+  .wp-block[data-align=wide] > .wp-block-group.has-background > .wp-block-group__inner-container > .wp-block:not([data-align=wide]):not([data-align=full]):not(.alignwide):not(.alignfull) {
+    width: calc(66.6666666667vw - 44px);
   }
 }
-
 @media only screen and (min-width: 1168px) {
-  .wp-block[data-align="wide"] > .wp-block-group.has-background > .wp-block-group__inner-container > .wp-block:not([data-align="wide"]):not([data-align="full"]):not(.alignwide):not(.alignfull) {
-    width: calc(6 * (100vw / 12 ) - 44px);
+  .wp-block[data-align=wide] > .wp-block-group.has-background > .wp-block-group__inner-container > .wp-block:not([data-align=wide]):not([data-align=full]):not(.alignwide):not(.alignfull) {
+    width: calc(50vw - 44px);
   }
 }
 
 @media only screen and (min-width: 768px) {
-  .wp-block[data-align="full"] > .wp-block-group > .wp-block-group__inner-container {
+  .wp-block[data-align=full] > .wp-block-group > .wp-block-group__inner-container {
     width: 80%;
     margin-left: 10%;
     margin-right: 10%;
@@ -1556,86 +3051,74 @@ ul.wp-block-archives li ul,
     padding-right: 10px;
   }
 }
-
 @media only screen and (min-width: 768px) {
-  .wp-block[data-align="full"] > .wp-block-group > .wp-block-group__inner-container > .wp-block:not([data-align="wide"]):not(.alignwide):not([data-align="full"]):not(.alignfull) {
-    max-width: calc(8 * (100vw / 12));
+  .wp-block[data-align=full] > .wp-block-group > .wp-block-group__inner-container > .wp-block:not([data-align=wide]):not(.alignwide):not([data-align=full]):not(.alignfull) {
+    max-width: 66.6666666667vw;
   }
 }
-
 @media only screen and (min-width: 1168px) {
-  .wp-block[data-align="full"] > .wp-block-group > .wp-block-group__inner-container > .wp-block:not([data-align="wide"]):not(.alignwide):not([data-align="full"]):not(.alignfull) {
-    max-width: calc(6 * (100vw / 12));
+  .wp-block[data-align=full] > .wp-block-group > .wp-block-group__inner-container > .wp-block:not([data-align=wide]):not(.alignwide):not([data-align=full]):not(.alignfull) {
+    max-width: 50vw;
   }
 }
-
-.wp-block[data-align="full"] > .wp-block-group > .wp-block-group__inner-container > .wp-block:not([data-align="full"]):not(.alignfull) {
+.wp-block[data-align=full] > .wp-block-group > .wp-block-group__inner-container > .wp-block:not([data-align=full]):not(.alignfull) {
   padding-left: 10px;
   padding-right: 10px;
 }
-
 @media only screen and (min-width: 768px) {
-  .wp-block[data-align="full"] > .wp-block-group > .wp-block-group__inner-container > .wp-block:not([data-align="full"]):not(.alignfull) {
+  .wp-block[data-align=full] > .wp-block-group > .wp-block-group__inner-container > .wp-block:not([data-align=full]):not(.alignfull) {
     padding-left: 0;
     padding-right: 0;
   }
 }
-
 @media only screen and (min-width: 768px) {
-  .wp-block[data-align="full"] > .wp-block-group > .wp-block-group__inner-container > .wp-block[data-align="right"] {
+  .wp-block[data-align=full] > .wp-block-group > .wp-block-group__inner-container > .wp-block[data-align=right] {
     max-width: 125%;
   }
 }
-
 @media only screen and (min-width: 768px) {
-  .wp-block[data-align="full"] > .wp-block-group > .wp-block-group__inner-container > .wp-block[data-align="wide"],
-  .wp-block[data-align="full"] > .wp-block-group > .wp-block-group__inner-container > .wp-block.alignwide {
+  .wp-block[data-align=full] > .wp-block-group > .wp-block-group__inner-container > .wp-block[data-align=wide],
+  .wp-block[data-align=full] > .wp-block-group > .wp-block-group__inner-container > .wp-block.alignwide {
     width: 100%;
     max-width: 100%;
   }
 }
-
 @media only screen and (min-width: 768px) {
-  .wp-block[data-align="full"] > .wp-block-group > .wp-block-group__inner-container > .wp-block[data-align=full],
-  .wp-block[data-align="full"] > .wp-block-group > .wp-block-group__inner-container > .wp-block.alignfull {
-    left: calc( -12.5% - 13px);
-    width: calc( 125% + 26px);
-    max-width: calc( 125% + 25px);
+  .wp-block[data-align=full] > .wp-block-group > .wp-block-group__inner-container > .wp-block[data-align=full],
+  .wp-block[data-align=full] > .wp-block-group > .wp-block-group__inner-container > .wp-block.alignfull {
+    left: calc(-12.5% - 13px);
+    width: calc(125% + 26px);
+    max-width: calc(125% + 25px);
   }
 }
-
-.wp-block[data-align="full"] > .wp-block-group.has-background {
+.wp-block[data-align=full] > .wp-block-group.has-background {
   padding: 22px 0;
 }
-
 @media only screen and (min-width: 600px) {
-  .wp-block[data-align="full"] > .wp-block-group.has-background {
+  .wp-block[data-align=full] > .wp-block-group.has-background {
     padding-left: 0;
     padding-right: 0;
   }
 }
-
-.wp-block[data-align="full"] > .wp-block-group.has-background > .wp-block-group__inner-container > .wp-block[data-align="full"],
-.wp-block[data-align="full"] > .wp-block-group.has-background > .wp-block-group__inner-container > .wp-block.alignfull {
+.wp-block[data-align=full] > .wp-block-group.has-background > .wp-block-group__inner-container > .wp-block[data-align=full],
+.wp-block[data-align=full] > .wp-block-group.has-background > .wp-block-group__inner-container > .wp-block.alignfull {
   margin-left: 0;
   width: 100%;
 }
-
 @media only screen and (min-width: 600px) {
-  .wp-block[data-align="full"] > .wp-block-group.has-background > .wp-block-group__inner-container > .wp-block[data-align="full"],
-  .wp-block[data-align="full"] > .wp-block-group.has-background > .wp-block-group__inner-container > .wp-block.alignfull {
+  .wp-block[data-align=full] > .wp-block-group.has-background > .wp-block-group__inner-container > .wp-block[data-align=full],
+  .wp-block[data-align=full] > .wp-block-group.has-background > .wp-block-group__inner-container > .wp-block.alignfull {
     width: calc(100% + 92px);
   }
 }
-
 @media only screen and (min-width: 768px) {
-  .wp-block[data-align="full"] > .wp-block-group.has-background > .wp-block-group__inner-container > .wp-block[data-align="full"],
-  .wp-block[data-align="full"] > .wp-block-group.has-background > .wp-block-group__inner-container > .wp-block.alignfull {
+  .wp-block[data-align=full] > .wp-block-group.has-background > .wp-block-group__inner-container > .wp-block[data-align=full],
+  .wp-block[data-align=full] > .wp-block-group.has-background > .wp-block-group__inner-container > .wp-block.alignfull {
     width: calc(125% + 120px);
   }
 }
 
-.wp-block-post-template .wp-block[data-align="full"],
+.wp-block-post-template .wp-block[data-align=full],
 .wp-block-post-template .wp-block.alignfull {
   left: 0;
   max-width: 100%;
@@ -1653,4 +3136,97 @@ ul.wp-block-archives li ul,
 /** === Calendar Block === */
 .wp-calendar-table {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+}
+.wp-calendar-table:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-calendar-table:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-calendar-table:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-calendar-table:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-calendar-table:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-calendar-table:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-calendar-table:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-calendar-table:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-calendar-table:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-calendar-table:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-calendar-table:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-calendar-table:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-calendar-table:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-calendar-table:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-calendar-table:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-calendar-table:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-calendar-table:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-calendar-table:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.wp-calendar-table:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.wp-calendar-table:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.wp-calendar-table:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+.wp-calendar-table:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+.wp-calendar-table:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+.wp-calendar-table:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+.wp-calendar-table:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+.wp-calendar-table:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+.wp-calendar-table:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+.wp-calendar-table:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+.wp-calendar-table:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+.wp-calendar-table:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+.wp-calendar-table:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
 }

--- a/src/wp-content/themes/twentynineteen/style-editor.css
+++ b/src/wp-content/themes/twentynineteen/style-editor.css
@@ -41,7 +41,8 @@ body .wp-block.aligncenter {
   margin-left: 0;
 }
 @media only screen and (min-width: 768px) {
-  body.block-editor-iframe__body, body.block-editor-writing-flow,
+  body.block-editor-iframe__body,
+  body.block-editor-writing-flow,
   body .block-editor-writing-flow {
     max-width: 80%;
     margin: 0 10%;
@@ -523,7 +524,8 @@ a {
   transition: color 110ms ease-in-out;
   color: #0073aa;
 }
-a:hover, a:active {
+a:hover,
+a:active {
   color: #005177;
   outline: 0;
   text-decoration: none;
@@ -1503,14 +1505,23 @@ figcaption,
 .wp-block-button:not(.is-style-squared) .wp-block-button__link {
   border-radius: 5px;
 }
-.wp-block-button.is-style-outline, .wp-block-button.is-style-outline:hover, .wp-block-button.is-style-outline:focus, .wp-block-button.is-style-outline:active {
+.wp-block-button.is-style-outline,
+.wp-block-button.is-style-outline:hover,
+.wp-block-button.is-style-outline:focus,
+.wp-block-button.is-style-outline:active {
   background: transparent;
   color: #0073aa;
 }
-.wp-block-button.is-style-outline .wp-block-button__link, .wp-block-button.is-style-outline:hover .wp-block-button__link, .wp-block-button.is-style-outline:focus .wp-block-button__link, .wp-block-button.is-style-outline:active .wp-block-button__link {
+.wp-block-button.is-style-outline .wp-block-button__link,
+.wp-block-button.is-style-outline:hover .wp-block-button__link,
+.wp-block-button.is-style-outline:focus .wp-block-button__link,
+.wp-block-button.is-style-outline:active .wp-block-button__link {
   background: transparent;
 }
-.wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color), .wp-block-button.is-style-outline:hover .wp-block-button__link:not(.has-text-color), .wp-block-button.is-style-outline:focus .wp-block-button__link:not(.has-text-color), .wp-block-button.is-style-outline:active .wp-block-button__link:not(.has-text-color) {
+.wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color),
+.wp-block-button.is-style-outline:hover .wp-block-button__link:not(.has-text-color),
+.wp-block-button.is-style-outline:focus .wp-block-button__link:not(.has-text-color),
+.wp-block-button.is-style-outline:active .wp-block-button__link:not(.has-text-color) {
   color: #0073aa;
 }
 
@@ -1636,11 +1647,13 @@ figcaption,
   border-width: 2px;
   border-color: #0073aa;
 }
-.wp-block-quote.is-large, .wp-block-quote.is-style-large {
+.wp-block-quote.is-large,
+.wp-block-quote.is-style-large {
   margin-top: 2.8125em;
   margin-bottom: 2.8125em;
 }
-.wp-block-quote.is-large p, .wp-block-quote.is-style-large p {
+.wp-block-quote.is-large p,
+.wp-block-quote.is-style-large p {
   font-size: 1.6875em;
   line-height: 1.3;
   margin-bottom: 0.5em;
@@ -1829,14 +1842,18 @@ figcaption,
 .wp-block-pullquote:not(.is-style-solid-color) .wp-block-pullquote__citation {
   color: #767676;
 }
-.wp-block-pullquote.has-text-color .wp-block-pullquote__citation, .wp-block-pullquote.has-primary-background-color blockquote p, .wp-block-pullquote.has-dark-gray-background-color blockquote p {
+.wp-block-pullquote.has-text-color .wp-block-pullquote__citation,
+.wp-block-pullquote.has-primary-background-color blockquote p,
+.wp-block-pullquote.has-dark-gray-background-color blockquote p {
   color: inherit;
 }
 .wp-block-pullquote.is-style-solid-color blockquote {
   width: calc(100% - 2 * 1rem);
   max-width: calc(100% - 2 * 1rem);
 }
-.wp-block-pullquote.is-style-solid-color blockquote a, .wp-block-pullquote.is-style-solid-color blockquote.has-text-color p, .wp-block-pullquote.is-style-solid-color blockquote.has-text-color a {
+.wp-block-pullquote.is-style-solid-color blockquote a,
+.wp-block-pullquote.is-style-solid-color blockquote.has-text-color p,
+.wp-block-pullquote.is-style-solid-color blockquote.has-text-color a {
   color: inherit;
 }
 .wp-block-pullquote.is-style-solid-color blockquote:not(.has-text-color) {
@@ -2267,7 +2284,8 @@ figcaption,
 }
 
 /** === Table === */
-.wp-block-table td, .wp-block-table th {
+.wp-block-table td,
+.wp-block-table th {
   border-color: #767676;
 }
 
@@ -2650,7 +2668,8 @@ ul.wp-block-archives li ul,
 .wp-block-latest-posts li {
   padding-bottom: 0.5rem;
 }
-.wp-block-latest-posts li.menu-item-has-children, .wp-block-latest-posts li:last-child {
+.wp-block-latest-posts li.menu-item-has-children,
+.wp-block-latest-posts li:last-child {
   padding-bottom: 0;
 }
 .wp-block-latest-posts li :not(:last-child) .wp-block-latest-posts__post-excerpt {

--- a/src/wp-content/themes/twentynineteen/style-rtl.css
+++ b/src/wp-content/themes/twentynineteen/style-rtl.css
@@ -69,10 +69,9 @@ Colorful Bokeh by HD Wallpapers, CC0. https://stocksnap.io/photo/colorful-bokeh-
  * character instead.
  */
 @font-face {
-  font-family: 'NonBreakingSpaceOverride';
+  font-family: "NonBreakingSpaceOverride";
   src: url(data:application/font-woff2;charset=utf-8;base64,d09GMgABAAAAAAMoAA0AAAAACDQAAALTAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP0ZGVE0cGh4GYACCahEICjx3CywAATYCJANUBCAFhiEHgWwbXQfILgpsY+rQRRARwyAs6uL7pxzYhxEE+32b3aeHmifR6tklkS9hiZA0ewkqGRJE+H7/+6378ASViK/PGeavqJyOzsceKi1s3BCiQsiOdn1r/RBgIJYEgCUhbm/8/8/h4saPssnTNkkiWUBrTRtjmQSajw3Ui3pZ3LYDPD+XG2C3JA/yKAS8/rU5eNfuGqRf4eNNgV4YAlIIgxglEkWe6FYpq10+wi3g+/nUgvgPFczNrz/RsTgVm/zfbPuHZlsuQECxuyqBcQwKFBjFgKO8AqP4bAN9tFJtnM9xPcbNjeXS/x1wY/xU52f5W/X1+9cnH4YwKIaoRRAkUkj/YlAAeF/624foiIDBgBmgQBeGAyhBljUPZUm/l2dTvmpqcBDUOHdbPZWd8JsBAsGr4w8/EDn82/bUPx4eh0YNrQTBuHO2FjQEAGBwK0DeI37DpQVqdERS4gZBhpeUhWCfLFz7J99aEBgsJCHvUGAdAPp4IADDCAPCEFMGpMZ9AQpTfQtQGhLbGVBZFV8BaqNyP68oTZgHNj3M8kBPfXTTC9t90UuzYhy9ciH0grVlOcqyCytisvbsERsEYztiznR0WCrmTksJwbSNK6fd1Rvr25I9oLvctUoEbNOmXJbqgYgPXEHJ82IUsrCnpkxh23F1rfZ2zcRnJYoXtauB3VTFkFXQg3uoZYD5qE0kdjDtoDoF1h2bulGmev5HbYhbrjtohQSRI4aNOkffIcT+d3v6atpaYh3JvPoQsztCcqvaBkppDSPcQ3bw3KaCBo1f5CJWTZEgW3LjLofYg51MaVezrx8xZitYbQ9KYeoRaqQdVLwSEfrKXLK1otCWOKNdR/YwYAfon5Yk8O2MJfSD10dPGA5PIJJQMkah0ugMJiv6x4Dm7LEa8xnrRGGGLAg4sAlbsA07sAt76DOsXKO3hIjtIlpnnFrt1qW4kh6NhS83P/6HB/fl1SMAAA==) format("woff2"), url(data:application/font-woff;charset=utf-8;base64,d09GRgABAAAAAAUQAA0AAAAACDQAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAABGRlRNAAAE9AAAABwAAAAchf5yU0dERUYAAATYAAAAHAAAAB4AJwAbT1MvMgAAAaAAAABJAAAAYJAcgU5jbWFwAAACIAAAAF4AAAFqUUxBZ2dhc3AAAATQAAAACAAAAAgAAAAQZ2x5ZgAAApAAAAAyAAAAPL0n8y9oZWFkAAABMAAAADAAAAA2Fi93Z2hoZWEAAAFgAAAAHQAAACQOSgWaaG10eAAAAewAAAAzAAAAVC7TAQBsb2NhAAACgAAAABAAAAAsAOQBAm1heHAAAAGAAAAAHQAAACAAWQALbmFtZQAAAsQAAAF6AAADIYvD/Adwb3N0AAAEQAAAAI4AAADsapk2o3jaY2BkYGAA4ov5mwzj+W2+MnCzXwCKMNzgCBSB0LfbQDQ7AxuI4mBgAlEAFKQIRHjaY2BkYGD3+NvCwMDBAALsDAyMDKhAFAA3+wH3AAAAeNpjYGRgYBBl4GBgYgABEMnIABJzAPMZAAVmAGUAAAB42mNgZlJhnMDAysDCKsKygYGBYRqEZtrDYMT4D8gHSmEHjgUFOQwODAqqf9g9/rYwMLB7MNUAhRlBcsxBrMlASoGBEQAj8QtyAAAAeNrjYGBkAAGmWQwMjO8gmBnIZ2NA0ExAzNjAAFYJVn0ASBsD6VAIDZb7AtELAgANIgb9AHjaY2BgYGaAYBkGRgYQSAHyGMF8FgYPIM3HwMHAxMDGoMCwQIFLQV8hXvXP//9AcRCfAcb///h/ygPW+w/vb7olBjUHCTCyMcAFGZmABBO6AogThgZgIUsXAEDcEzcAAHjaY2BgECMCyoEgACZaAed42mNgYmRgYGBnYGNgYAZSDJqMgorCgoqCjECRXwwNrCAKSP5mAAFGBiRgyAAAi/YFBQAAeNqtkc1OwkAUhU/5M25cEhcsZick0AwlBJq6MWwgJkAgYV/KAA2lJeUn+hY+gktXvpKv4dLTMqKycGHsTZNv7px7z50ZAFd4hYHjdw1Ls4EiHjVncIFnzVnc4F1zDkWjrzmPW+NNcwGlzIRKI3fJlUyrEjZQxb3mDH2fNGfRx4vmHKqG0JzHg6E0F9DOlFBGBxUI1GEzLNT4S0aLuTtsGAEUuYcQHkyg3KmIum1bNUvKlrjbbAIleqHHnS4iSudpQcySMYtdFiXlAxzSbAwfMxK6kZoHKhbjjespMTioOPZnzI+4ucCeTVyKMVKLfeAS6vSWaTinuZwzyy/Dc7vaed+6KaV0kukdPUk6yOcctZPvvxxqksq2lEW8RvHjMEO2FCl/zy6p3NEm0R9OFSafJdldc4QVeyaaObMBO0/5cCaa6d9Ggyubxire+lEojscdjoWUR1xGOy8KD8mG2ZLO2l2paDc3A39qmU2z2W5YNv5+u79e6QfGJY/hAAB42m3NywrCMBQE0DupWp/1AYI7/6DEaLQu66Mrd35BKUWKJSlFv1+rue4cGM7shgR981qSon+ZNwUJ8iDgoYU2OvDRRQ99DDDECAHGmGCKmf80hZSx/Kik/LliFbtmN6xmt+yOjdg9GztV4tROnRwX/Bsaaw51nt4Lc7tWaZYHp/MlzKx51LZs5htNri+2AAAAAQAB//8AD3jaY2BkYGDgAWIxIGZiYARCESBmAfMYAAR6AEMAAAABAAAAANXtRbgAAAAA2AhRFAAAAADYCNuG) format("woff");
 }
-
 /* If we add the border using a regular CSS border, it won't look good on non-retina devices,
  * since its edges can look jagged due to lack of antialiasing. In this case, we are several
  * layers of box-shadow to add the border visually, which will render the border smoother. */
@@ -80,11 +79,29 @@ Colorful Bokeh by HD Wallpapers, CC0. https://stocksnap.io/photo/colorful-bokeh-
 /* Nested sub-menu padding: 10 levels deep */
 /* Ensure all font family declarations come with non-latin fallbacks */
 /* Build our non-latin font styles */
-body:lang(ar), button:lang(ar),
-input:lang(ar),
-select:lang(ar),
-optgroup:lang(ar),
-textarea:lang(ar), .author-description .author-link:lang(ar),
+.gallery-caption:lang(ar), .wp-caption-text:lang(ar), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ar), .entry .entry-content .wp-block-file .wp-block-file__button:lang(ar), .entry .entry-content .wp-block-file:lang(ar), .entry .entry-content .wp-block-audio figcaption:lang(ar),
+.entry .entry-content .wp-block-video figcaption:lang(ar),
+.entry .entry-content .wp-block-image figcaption:lang(ar),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(ar),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(ar), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(ar),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(ar),
+.entry .entry-content .wp-block-cover-image h2:lang(ar),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(ar),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(ar),
+.entry .entry-content .wp-block-cover h2:lang(ar), .entry .entry-content .wp-block-pullquote cite:lang(ar), .entry .entry-content .has-drop-cap:lang(ar):not(:focus):first-letter, .entry .entry-content .wp-block-verse:lang(ar), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ar), .entry .entry-content .wp-block-archives li > a:lang(ar),
+.entry .entry-content .wp-block-categories li > a:lang(ar),
+.entry .entry-content .wp-block-latest-posts li > a:lang(ar), .entry .entry-content .wp-block-button .wp-block-button__link:lang(ar), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(ar), .widget_tag_cloud .tagcloud:lang(ar), .widget_archive ul li:lang(ar),
+.widget_categories ul li:lang(ar),
+.widget_meta ul li:lang(ar),
+.widget_nav_menu ul li:lang(ar),
+.widget_pages ul li:lang(ar),
+.widget_recent_comments ul li:lang(ar),
+.widget_recent_entries ul li:lang(ar),
+.widget_rss ul li:lang(ar), .comment-form .comment-notes:lang(ar),
+.comment-form label:lang(ar), .comment-list .pingback .comment-body .comment-edit-link:lang(ar),
+.comment-list .trackback .comment-body .comment-edit-link:lang(ar), .comment-list .pingback .comment-body:lang(ar),
+.comment-list .trackback .comment-body:lang(ar), .comment-navigation .nav-previous:lang(ar),
+.comment-navigation .nav-next:lang(ar), .button:lang(ar), table:lang(ar), blockquote cite:lang(ar), .page-title:lang(ar), .author-description .author-link:lang(ar),
 .comment-metadata:lang(ar),
 .comment-reply-link:lang(ar),
 .comments-title:lang(ar),
@@ -94,8 +111,6 @@ textarea:lang(ar), .author-description .author-link:lang(ar),
 .entry-footer:lang(ar),
 .main-navigation:lang(ar),
 .no-comments:lang(ar),
-.not-found .page-title:lang(ar),
-.error-404 .page-title:lang(ar),
 .post-navigation .post-title:lang(ar),
 .page-links:lang(ar),
 .page-description:lang(ar),
@@ -109,40 +124,36 @@ h2:lang(ar),
 h3:lang(ar),
 h4:lang(ar),
 h5:lang(ar),
-h6:lang(ar), .page-title:lang(ar), blockquote cite:lang(ar), table:lang(ar), .button:lang(ar),
-input:lang(ar)[type="button"],
-input:lang(ar)[type="reset"],
-input:lang(ar)[type="submit"], .comment-navigation .nav-previous:lang(ar),
-.comment-navigation .nav-next:lang(ar), .comment-list .pingback .comment-body:lang(ar),
-.comment-list .trackback .comment-body:lang(ar), .comment-list .pingback .comment-body .comment-edit-link:lang(ar),
-.comment-list .trackback .comment-body .comment-edit-link:lang(ar), .comment-form .comment-notes:lang(ar),
-.comment-form label:lang(ar), .widget_archive ul li:lang(ar),
-.widget_categories ul li:lang(ar),
-.widget_meta ul li:lang(ar),
-.widget_nav_menu ul li:lang(ar),
-.widget_pages ul li:lang(ar),
-.widget_recent_comments ul li:lang(ar),
-.widget_recent_entries ul li:lang(ar),
-.widget_rss ul li:lang(ar), .widget_tag_cloud .tagcloud:lang(ar), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(ar), .entry .entry-content .wp-block-button .wp-block-button__link:lang(ar), .entry .entry-content .wp-block-archives li > a:lang(ar),
-.entry .entry-content .wp-block-categories li > a:lang(ar),
-.entry .entry-content .wp-block-latest-posts li > a:lang(ar), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ar), .entry .entry-content .wp-block-verse:lang(ar), .entry .entry-content .has-drop-cap:lang(ar):not(:focus):first-letter, .entry .entry-content .wp-block-pullquote cite:lang(ar), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(ar),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(ar),
-.entry .entry-content .wp-block-cover-image h2:lang(ar),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(ar),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(ar),
-.entry .entry-content .wp-block-cover h2:lang(ar), .entry .entry-content .wp-block-audio figcaption:lang(ar),
-.entry .entry-content .wp-block-video figcaption:lang(ar),
-.entry .entry-content .wp-block-image figcaption:lang(ar),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(ar),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(ar), .entry .entry-content .wp-block-file:lang(ar), .entry .entry-content .wp-block-file .wp-block-file__button:lang(ar), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ar), .wp-caption-text:lang(ar), .gallery-caption:lang(ar) {
+h6:lang(ar), button:lang(ar),
+input:lang(ar),
+select:lang(ar),
+optgroup:lang(ar),
+textarea:lang(ar), body:lang(ar) {
   font-family: Tahoma, Arial, sans-serif;
 }
-
-body:lang(ary), button:lang(ary),
-input:lang(ary),
-select:lang(ary),
-optgroup:lang(ary),
-textarea:lang(ary), .author-description .author-link:lang(ary),
+.gallery-caption:lang(ary), .wp-caption-text:lang(ary), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ary), .entry .entry-content .wp-block-file .wp-block-file__button:lang(ary), .entry .entry-content .wp-block-file:lang(ary), .entry .entry-content .wp-block-audio figcaption:lang(ary),
+.entry .entry-content .wp-block-video figcaption:lang(ary),
+.entry .entry-content .wp-block-image figcaption:lang(ary),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(ary),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(ary), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(ary),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(ary),
+.entry .entry-content .wp-block-cover-image h2:lang(ary),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(ary),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(ary),
+.entry .entry-content .wp-block-cover h2:lang(ary), .entry .entry-content .wp-block-pullquote cite:lang(ary), .entry .entry-content .has-drop-cap:lang(ary):not(:focus):first-letter, .entry .entry-content .wp-block-verse:lang(ary), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ary), .entry .entry-content .wp-block-archives li > a:lang(ary),
+.entry .entry-content .wp-block-categories li > a:lang(ary),
+.entry .entry-content .wp-block-latest-posts li > a:lang(ary), .entry .entry-content .wp-block-button .wp-block-button__link:lang(ary), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(ary), .widget_tag_cloud .tagcloud:lang(ary), .widget_archive ul li:lang(ary),
+.widget_categories ul li:lang(ary),
+.widget_meta ul li:lang(ary),
+.widget_nav_menu ul li:lang(ary),
+.widget_pages ul li:lang(ary),
+.widget_recent_comments ul li:lang(ary),
+.widget_recent_entries ul li:lang(ary),
+.widget_rss ul li:lang(ary), .comment-form .comment-notes:lang(ary),
+.comment-form label:lang(ary), .comment-list .pingback .comment-body .comment-edit-link:lang(ary),
+.comment-list .trackback .comment-body .comment-edit-link:lang(ary), .comment-list .pingback .comment-body:lang(ary),
+.comment-list .trackback .comment-body:lang(ary), .comment-navigation .nav-previous:lang(ary),
+.comment-navigation .nav-next:lang(ary), .button:lang(ary), table:lang(ary), blockquote cite:lang(ary), .page-title:lang(ary), .author-description .author-link:lang(ary),
 .comment-metadata:lang(ary),
 .comment-reply-link:lang(ary),
 .comments-title:lang(ary),
@@ -152,8 +163,6 @@ textarea:lang(ary), .author-description .author-link:lang(ary),
 .entry-footer:lang(ary),
 .main-navigation:lang(ary),
 .no-comments:lang(ary),
-.not-found .page-title:lang(ary),
-.error-404 .page-title:lang(ary),
 .post-navigation .post-title:lang(ary),
 .page-links:lang(ary),
 .page-description:lang(ary),
@@ -167,40 +176,36 @@ h2:lang(ary),
 h3:lang(ary),
 h4:lang(ary),
 h5:lang(ary),
-h6:lang(ary), .page-title:lang(ary), blockquote cite:lang(ary), table:lang(ary), .button:lang(ary),
-input:lang(ary)[type="button"],
-input:lang(ary)[type="reset"],
-input:lang(ary)[type="submit"], .comment-navigation .nav-previous:lang(ary),
-.comment-navigation .nav-next:lang(ary), .comment-list .pingback .comment-body:lang(ary),
-.comment-list .trackback .comment-body:lang(ary), .comment-list .pingback .comment-body .comment-edit-link:lang(ary),
-.comment-list .trackback .comment-body .comment-edit-link:lang(ary), .comment-form .comment-notes:lang(ary),
-.comment-form label:lang(ary), .widget_archive ul li:lang(ary),
-.widget_categories ul li:lang(ary),
-.widget_meta ul li:lang(ary),
-.widget_nav_menu ul li:lang(ary),
-.widget_pages ul li:lang(ary),
-.widget_recent_comments ul li:lang(ary),
-.widget_recent_entries ul li:lang(ary),
-.widget_rss ul li:lang(ary), .widget_tag_cloud .tagcloud:lang(ary), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(ary), .entry .entry-content .wp-block-button .wp-block-button__link:lang(ary), .entry .entry-content .wp-block-archives li > a:lang(ary),
-.entry .entry-content .wp-block-categories li > a:lang(ary),
-.entry .entry-content .wp-block-latest-posts li > a:lang(ary), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ary), .entry .entry-content .wp-block-verse:lang(ary), .entry .entry-content .has-drop-cap:lang(ary):not(:focus):first-letter, .entry .entry-content .wp-block-pullquote cite:lang(ary), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(ary),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(ary),
-.entry .entry-content .wp-block-cover-image h2:lang(ary),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(ary),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(ary),
-.entry .entry-content .wp-block-cover h2:lang(ary), .entry .entry-content .wp-block-audio figcaption:lang(ary),
-.entry .entry-content .wp-block-video figcaption:lang(ary),
-.entry .entry-content .wp-block-image figcaption:lang(ary),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(ary),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(ary), .entry .entry-content .wp-block-file:lang(ary), .entry .entry-content .wp-block-file .wp-block-file__button:lang(ary), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ary), .wp-caption-text:lang(ary), .gallery-caption:lang(ary) {
+h6:lang(ary), button:lang(ary),
+input:lang(ary),
+select:lang(ary),
+optgroup:lang(ary),
+textarea:lang(ary), body:lang(ary) {
   font-family: Tahoma, Arial, sans-serif;
 }
-
-body:lang(azb), button:lang(azb),
-input:lang(azb),
-select:lang(azb),
-optgroup:lang(azb),
-textarea:lang(azb), .author-description .author-link:lang(azb),
+.gallery-caption:lang(azb), .wp-caption-text:lang(azb), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(azb), .entry .entry-content .wp-block-file .wp-block-file__button:lang(azb), .entry .entry-content .wp-block-file:lang(azb), .entry .entry-content .wp-block-audio figcaption:lang(azb),
+.entry .entry-content .wp-block-video figcaption:lang(azb),
+.entry .entry-content .wp-block-image figcaption:lang(azb),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(azb),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(azb), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(azb),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(azb),
+.entry .entry-content .wp-block-cover-image h2:lang(azb),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(azb),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(azb),
+.entry .entry-content .wp-block-cover h2:lang(azb), .entry .entry-content .wp-block-pullquote cite:lang(azb), .entry .entry-content .has-drop-cap:lang(azb):not(:focus):first-letter, .entry .entry-content .wp-block-verse:lang(azb), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(azb), .entry .entry-content .wp-block-archives li > a:lang(azb),
+.entry .entry-content .wp-block-categories li > a:lang(azb),
+.entry .entry-content .wp-block-latest-posts li > a:lang(azb), .entry .entry-content .wp-block-button .wp-block-button__link:lang(azb), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(azb), .widget_tag_cloud .tagcloud:lang(azb), .widget_archive ul li:lang(azb),
+.widget_categories ul li:lang(azb),
+.widget_meta ul li:lang(azb),
+.widget_nav_menu ul li:lang(azb),
+.widget_pages ul li:lang(azb),
+.widget_recent_comments ul li:lang(azb),
+.widget_recent_entries ul li:lang(azb),
+.widget_rss ul li:lang(azb), .comment-form .comment-notes:lang(azb),
+.comment-form label:lang(azb), .comment-list .pingback .comment-body .comment-edit-link:lang(azb),
+.comment-list .trackback .comment-body .comment-edit-link:lang(azb), .comment-list .pingback .comment-body:lang(azb),
+.comment-list .trackback .comment-body:lang(azb), .comment-navigation .nav-previous:lang(azb),
+.comment-navigation .nav-next:lang(azb), .button:lang(azb), table:lang(azb), blockquote cite:lang(azb), .page-title:lang(azb), .author-description .author-link:lang(azb),
 .comment-metadata:lang(azb),
 .comment-reply-link:lang(azb),
 .comments-title:lang(azb),
@@ -210,8 +215,6 @@ textarea:lang(azb), .author-description .author-link:lang(azb),
 .entry-footer:lang(azb),
 .main-navigation:lang(azb),
 .no-comments:lang(azb),
-.not-found .page-title:lang(azb),
-.error-404 .page-title:lang(azb),
 .post-navigation .post-title:lang(azb),
 .page-links:lang(azb),
 .page-description:lang(azb),
@@ -225,40 +228,36 @@ h2:lang(azb),
 h3:lang(azb),
 h4:lang(azb),
 h5:lang(azb),
-h6:lang(azb), .page-title:lang(azb), blockquote cite:lang(azb), table:lang(azb), .button:lang(azb),
-input:lang(azb)[type="button"],
-input:lang(azb)[type="reset"],
-input:lang(azb)[type="submit"], .comment-navigation .nav-previous:lang(azb),
-.comment-navigation .nav-next:lang(azb), .comment-list .pingback .comment-body:lang(azb),
-.comment-list .trackback .comment-body:lang(azb), .comment-list .pingback .comment-body .comment-edit-link:lang(azb),
-.comment-list .trackback .comment-body .comment-edit-link:lang(azb), .comment-form .comment-notes:lang(azb),
-.comment-form label:lang(azb), .widget_archive ul li:lang(azb),
-.widget_categories ul li:lang(azb),
-.widget_meta ul li:lang(azb),
-.widget_nav_menu ul li:lang(azb),
-.widget_pages ul li:lang(azb),
-.widget_recent_comments ul li:lang(azb),
-.widget_recent_entries ul li:lang(azb),
-.widget_rss ul li:lang(azb), .widget_tag_cloud .tagcloud:lang(azb), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(azb), .entry .entry-content .wp-block-button .wp-block-button__link:lang(azb), .entry .entry-content .wp-block-archives li > a:lang(azb),
-.entry .entry-content .wp-block-categories li > a:lang(azb),
-.entry .entry-content .wp-block-latest-posts li > a:lang(azb), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(azb), .entry .entry-content .wp-block-verse:lang(azb), .entry .entry-content .has-drop-cap:lang(azb):not(:focus):first-letter, .entry .entry-content .wp-block-pullquote cite:lang(azb), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(azb),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(azb),
-.entry .entry-content .wp-block-cover-image h2:lang(azb),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(azb),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(azb),
-.entry .entry-content .wp-block-cover h2:lang(azb), .entry .entry-content .wp-block-audio figcaption:lang(azb),
-.entry .entry-content .wp-block-video figcaption:lang(azb),
-.entry .entry-content .wp-block-image figcaption:lang(azb),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(azb),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(azb), .entry .entry-content .wp-block-file:lang(azb), .entry .entry-content .wp-block-file .wp-block-file__button:lang(azb), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(azb), .wp-caption-text:lang(azb), .gallery-caption:lang(azb) {
+h6:lang(azb), button:lang(azb),
+input:lang(azb),
+select:lang(azb),
+optgroup:lang(azb),
+textarea:lang(azb), body:lang(azb) {
   font-family: Tahoma, Arial, sans-serif;
 }
-
-body:lang(ckb), button:lang(ckb),
-input:lang(ckb),
-select:lang(ckb),
-optgroup:lang(ckb),
-textarea:lang(ckb), .author-description .author-link:lang(ckb),
+.gallery-caption:lang(ckb), .wp-caption-text:lang(ckb), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ckb), .entry .entry-content .wp-block-file .wp-block-file__button:lang(ckb), .entry .entry-content .wp-block-file:lang(ckb), .entry .entry-content .wp-block-audio figcaption:lang(ckb),
+.entry .entry-content .wp-block-video figcaption:lang(ckb),
+.entry .entry-content .wp-block-image figcaption:lang(ckb),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(ckb),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(ckb), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(ckb),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(ckb),
+.entry .entry-content .wp-block-cover-image h2:lang(ckb),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(ckb),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(ckb),
+.entry .entry-content .wp-block-cover h2:lang(ckb), .entry .entry-content .wp-block-pullquote cite:lang(ckb), .entry .entry-content .has-drop-cap:lang(ckb):not(:focus):first-letter, .entry .entry-content .wp-block-verse:lang(ckb), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ckb), .entry .entry-content .wp-block-archives li > a:lang(ckb),
+.entry .entry-content .wp-block-categories li > a:lang(ckb),
+.entry .entry-content .wp-block-latest-posts li > a:lang(ckb), .entry .entry-content .wp-block-button .wp-block-button__link:lang(ckb), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(ckb), .widget_tag_cloud .tagcloud:lang(ckb), .widget_archive ul li:lang(ckb),
+.widget_categories ul li:lang(ckb),
+.widget_meta ul li:lang(ckb),
+.widget_nav_menu ul li:lang(ckb),
+.widget_pages ul li:lang(ckb),
+.widget_recent_comments ul li:lang(ckb),
+.widget_recent_entries ul li:lang(ckb),
+.widget_rss ul li:lang(ckb), .comment-form .comment-notes:lang(ckb),
+.comment-form label:lang(ckb), .comment-list .pingback .comment-body .comment-edit-link:lang(ckb),
+.comment-list .trackback .comment-body .comment-edit-link:lang(ckb), .comment-list .pingback .comment-body:lang(ckb),
+.comment-list .trackback .comment-body:lang(ckb), .comment-navigation .nav-previous:lang(ckb),
+.comment-navigation .nav-next:lang(ckb), .button:lang(ckb), table:lang(ckb), blockquote cite:lang(ckb), .page-title:lang(ckb), .author-description .author-link:lang(ckb),
 .comment-metadata:lang(ckb),
 .comment-reply-link:lang(ckb),
 .comments-title:lang(ckb),
@@ -268,8 +267,6 @@ textarea:lang(ckb), .author-description .author-link:lang(ckb),
 .entry-footer:lang(ckb),
 .main-navigation:lang(ckb),
 .no-comments:lang(ckb),
-.not-found .page-title:lang(ckb),
-.error-404 .page-title:lang(ckb),
 .post-navigation .post-title:lang(ckb),
 .page-links:lang(ckb),
 .page-description:lang(ckb),
@@ -283,40 +280,36 @@ h2:lang(ckb),
 h3:lang(ckb),
 h4:lang(ckb),
 h5:lang(ckb),
-h6:lang(ckb), .page-title:lang(ckb), blockquote cite:lang(ckb), table:lang(ckb), .button:lang(ckb),
-input:lang(ckb)[type="button"],
-input:lang(ckb)[type="reset"],
-input:lang(ckb)[type="submit"], .comment-navigation .nav-previous:lang(ckb),
-.comment-navigation .nav-next:lang(ckb), .comment-list .pingback .comment-body:lang(ckb),
-.comment-list .trackback .comment-body:lang(ckb), .comment-list .pingback .comment-body .comment-edit-link:lang(ckb),
-.comment-list .trackback .comment-body .comment-edit-link:lang(ckb), .comment-form .comment-notes:lang(ckb),
-.comment-form label:lang(ckb), .widget_archive ul li:lang(ckb),
-.widget_categories ul li:lang(ckb),
-.widget_meta ul li:lang(ckb),
-.widget_nav_menu ul li:lang(ckb),
-.widget_pages ul li:lang(ckb),
-.widget_recent_comments ul li:lang(ckb),
-.widget_recent_entries ul li:lang(ckb),
-.widget_rss ul li:lang(ckb), .widget_tag_cloud .tagcloud:lang(ckb), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(ckb), .entry .entry-content .wp-block-button .wp-block-button__link:lang(ckb), .entry .entry-content .wp-block-archives li > a:lang(ckb),
-.entry .entry-content .wp-block-categories li > a:lang(ckb),
-.entry .entry-content .wp-block-latest-posts li > a:lang(ckb), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ckb), .entry .entry-content .wp-block-verse:lang(ckb), .entry .entry-content .has-drop-cap:lang(ckb):not(:focus):first-letter, .entry .entry-content .wp-block-pullquote cite:lang(ckb), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(ckb),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(ckb),
-.entry .entry-content .wp-block-cover-image h2:lang(ckb),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(ckb),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(ckb),
-.entry .entry-content .wp-block-cover h2:lang(ckb), .entry .entry-content .wp-block-audio figcaption:lang(ckb),
-.entry .entry-content .wp-block-video figcaption:lang(ckb),
-.entry .entry-content .wp-block-image figcaption:lang(ckb),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(ckb),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(ckb), .entry .entry-content .wp-block-file:lang(ckb), .entry .entry-content .wp-block-file .wp-block-file__button:lang(ckb), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ckb), .wp-caption-text:lang(ckb), .gallery-caption:lang(ckb) {
+h6:lang(ckb), button:lang(ckb),
+input:lang(ckb),
+select:lang(ckb),
+optgroup:lang(ckb),
+textarea:lang(ckb), body:lang(ckb) {
   font-family: Tahoma, Arial, sans-serif;
 }
-
-body:lang(fa-IR), button:lang(fa-IR),
-input:lang(fa-IR),
-select:lang(fa-IR),
-optgroup:lang(fa-IR),
-textarea:lang(fa-IR), .author-description .author-link:lang(fa-IR),
+.gallery-caption:lang(fa-IR), .wp-caption-text:lang(fa-IR), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(fa-IR), .entry .entry-content .wp-block-file .wp-block-file__button:lang(fa-IR), .entry .entry-content .wp-block-file:lang(fa-IR), .entry .entry-content .wp-block-audio figcaption:lang(fa-IR),
+.entry .entry-content .wp-block-video figcaption:lang(fa-IR),
+.entry .entry-content .wp-block-image figcaption:lang(fa-IR),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(fa-IR),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(fa-IR), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(fa-IR),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(fa-IR),
+.entry .entry-content .wp-block-cover-image h2:lang(fa-IR),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(fa-IR),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(fa-IR),
+.entry .entry-content .wp-block-cover h2:lang(fa-IR), .entry .entry-content .wp-block-pullquote cite:lang(fa-IR), .entry .entry-content .has-drop-cap:lang(fa-IR):not(:focus):first-letter, .entry .entry-content .wp-block-verse:lang(fa-IR), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(fa-IR), .entry .entry-content .wp-block-archives li > a:lang(fa-IR),
+.entry .entry-content .wp-block-categories li > a:lang(fa-IR),
+.entry .entry-content .wp-block-latest-posts li > a:lang(fa-IR), .entry .entry-content .wp-block-button .wp-block-button__link:lang(fa-IR), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(fa-IR), .widget_tag_cloud .tagcloud:lang(fa-IR), .widget_archive ul li:lang(fa-IR),
+.widget_categories ul li:lang(fa-IR),
+.widget_meta ul li:lang(fa-IR),
+.widget_nav_menu ul li:lang(fa-IR),
+.widget_pages ul li:lang(fa-IR),
+.widget_recent_comments ul li:lang(fa-IR),
+.widget_recent_entries ul li:lang(fa-IR),
+.widget_rss ul li:lang(fa-IR), .comment-form .comment-notes:lang(fa-IR),
+.comment-form label:lang(fa-IR), .comment-list .pingback .comment-body .comment-edit-link:lang(fa-IR),
+.comment-list .trackback .comment-body .comment-edit-link:lang(fa-IR), .comment-list .pingback .comment-body:lang(fa-IR),
+.comment-list .trackback .comment-body:lang(fa-IR), .comment-navigation .nav-previous:lang(fa-IR),
+.comment-navigation .nav-next:lang(fa-IR), .button:lang(fa-IR), table:lang(fa-IR), blockquote cite:lang(fa-IR), .page-title:lang(fa-IR), .author-description .author-link:lang(fa-IR),
 .comment-metadata:lang(fa-IR),
 .comment-reply-link:lang(fa-IR),
 .comments-title:lang(fa-IR),
@@ -326,8 +319,6 @@ textarea:lang(fa-IR), .author-description .author-link:lang(fa-IR),
 .entry-footer:lang(fa-IR),
 .main-navigation:lang(fa-IR),
 .no-comments:lang(fa-IR),
-.not-found .page-title:lang(fa-IR),
-.error-404 .page-title:lang(fa-IR),
 .post-navigation .post-title:lang(fa-IR),
 .page-links:lang(fa-IR),
 .page-description:lang(fa-IR),
@@ -341,40 +332,36 @@ h2:lang(fa-IR),
 h3:lang(fa-IR),
 h4:lang(fa-IR),
 h5:lang(fa-IR),
-h6:lang(fa-IR), .page-title:lang(fa-IR), blockquote cite:lang(fa-IR), table:lang(fa-IR), .button:lang(fa-IR),
-input:lang(fa-IR)[type="button"],
-input:lang(fa-IR)[type="reset"],
-input:lang(fa-IR)[type="submit"], .comment-navigation .nav-previous:lang(fa-IR),
-.comment-navigation .nav-next:lang(fa-IR), .comment-list .pingback .comment-body:lang(fa-IR),
-.comment-list .trackback .comment-body:lang(fa-IR), .comment-list .pingback .comment-body .comment-edit-link:lang(fa-IR),
-.comment-list .trackback .comment-body .comment-edit-link:lang(fa-IR), .comment-form .comment-notes:lang(fa-IR),
-.comment-form label:lang(fa-IR), .widget_archive ul li:lang(fa-IR),
-.widget_categories ul li:lang(fa-IR),
-.widget_meta ul li:lang(fa-IR),
-.widget_nav_menu ul li:lang(fa-IR),
-.widget_pages ul li:lang(fa-IR),
-.widget_recent_comments ul li:lang(fa-IR),
-.widget_recent_entries ul li:lang(fa-IR),
-.widget_rss ul li:lang(fa-IR), .widget_tag_cloud .tagcloud:lang(fa-IR), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(fa-IR), .entry .entry-content .wp-block-button .wp-block-button__link:lang(fa-IR), .entry .entry-content .wp-block-archives li > a:lang(fa-IR),
-.entry .entry-content .wp-block-categories li > a:lang(fa-IR),
-.entry .entry-content .wp-block-latest-posts li > a:lang(fa-IR), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(fa-IR), .entry .entry-content .wp-block-verse:lang(fa-IR), .entry .entry-content .has-drop-cap:lang(fa-IR):not(:focus):first-letter, .entry .entry-content .wp-block-pullquote cite:lang(fa-IR), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(fa-IR),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(fa-IR),
-.entry .entry-content .wp-block-cover-image h2:lang(fa-IR),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(fa-IR),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(fa-IR),
-.entry .entry-content .wp-block-cover h2:lang(fa-IR), .entry .entry-content .wp-block-audio figcaption:lang(fa-IR),
-.entry .entry-content .wp-block-video figcaption:lang(fa-IR),
-.entry .entry-content .wp-block-image figcaption:lang(fa-IR),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(fa-IR),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(fa-IR), .entry .entry-content .wp-block-file:lang(fa-IR), .entry .entry-content .wp-block-file .wp-block-file__button:lang(fa-IR), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(fa-IR), .wp-caption-text:lang(fa-IR), .gallery-caption:lang(fa-IR) {
+h6:lang(fa-IR), button:lang(fa-IR),
+input:lang(fa-IR),
+select:lang(fa-IR),
+optgroup:lang(fa-IR),
+textarea:lang(fa-IR), body:lang(fa-IR) {
   font-family: Tahoma, Arial, sans-serif;
 }
-
-body:lang(haz), button:lang(haz),
-input:lang(haz),
-select:lang(haz),
-optgroup:lang(haz),
-textarea:lang(haz), .author-description .author-link:lang(haz),
+.gallery-caption:lang(haz), .wp-caption-text:lang(haz), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(haz), .entry .entry-content .wp-block-file .wp-block-file__button:lang(haz), .entry .entry-content .wp-block-file:lang(haz), .entry .entry-content .wp-block-audio figcaption:lang(haz),
+.entry .entry-content .wp-block-video figcaption:lang(haz),
+.entry .entry-content .wp-block-image figcaption:lang(haz),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(haz),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(haz), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(haz),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(haz),
+.entry .entry-content .wp-block-cover-image h2:lang(haz),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(haz),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(haz),
+.entry .entry-content .wp-block-cover h2:lang(haz), .entry .entry-content .wp-block-pullquote cite:lang(haz), .entry .entry-content .has-drop-cap:lang(haz):not(:focus):first-letter, .entry .entry-content .wp-block-verse:lang(haz), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(haz), .entry .entry-content .wp-block-archives li > a:lang(haz),
+.entry .entry-content .wp-block-categories li > a:lang(haz),
+.entry .entry-content .wp-block-latest-posts li > a:lang(haz), .entry .entry-content .wp-block-button .wp-block-button__link:lang(haz), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(haz), .widget_tag_cloud .tagcloud:lang(haz), .widget_archive ul li:lang(haz),
+.widget_categories ul li:lang(haz),
+.widget_meta ul li:lang(haz),
+.widget_nav_menu ul li:lang(haz),
+.widget_pages ul li:lang(haz),
+.widget_recent_comments ul li:lang(haz),
+.widget_recent_entries ul li:lang(haz),
+.widget_rss ul li:lang(haz), .comment-form .comment-notes:lang(haz),
+.comment-form label:lang(haz), .comment-list .pingback .comment-body .comment-edit-link:lang(haz),
+.comment-list .trackback .comment-body .comment-edit-link:lang(haz), .comment-list .pingback .comment-body:lang(haz),
+.comment-list .trackback .comment-body:lang(haz), .comment-navigation .nav-previous:lang(haz),
+.comment-navigation .nav-next:lang(haz), .button:lang(haz), table:lang(haz), blockquote cite:lang(haz), .page-title:lang(haz), .author-description .author-link:lang(haz),
 .comment-metadata:lang(haz),
 .comment-reply-link:lang(haz),
 .comments-title:lang(haz),
@@ -384,8 +371,6 @@ textarea:lang(haz), .author-description .author-link:lang(haz),
 .entry-footer:lang(haz),
 .main-navigation:lang(haz),
 .no-comments:lang(haz),
-.not-found .page-title:lang(haz),
-.error-404 .page-title:lang(haz),
 .post-navigation .post-title:lang(haz),
 .page-links:lang(haz),
 .page-description:lang(haz),
@@ -399,40 +384,36 @@ h2:lang(haz),
 h3:lang(haz),
 h4:lang(haz),
 h5:lang(haz),
-h6:lang(haz), .page-title:lang(haz), blockquote cite:lang(haz), table:lang(haz), .button:lang(haz),
-input:lang(haz)[type="button"],
-input:lang(haz)[type="reset"],
-input:lang(haz)[type="submit"], .comment-navigation .nav-previous:lang(haz),
-.comment-navigation .nav-next:lang(haz), .comment-list .pingback .comment-body:lang(haz),
-.comment-list .trackback .comment-body:lang(haz), .comment-list .pingback .comment-body .comment-edit-link:lang(haz),
-.comment-list .trackback .comment-body .comment-edit-link:lang(haz), .comment-form .comment-notes:lang(haz),
-.comment-form label:lang(haz), .widget_archive ul li:lang(haz),
-.widget_categories ul li:lang(haz),
-.widget_meta ul li:lang(haz),
-.widget_nav_menu ul li:lang(haz),
-.widget_pages ul li:lang(haz),
-.widget_recent_comments ul li:lang(haz),
-.widget_recent_entries ul li:lang(haz),
-.widget_rss ul li:lang(haz), .widget_tag_cloud .tagcloud:lang(haz), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(haz), .entry .entry-content .wp-block-button .wp-block-button__link:lang(haz), .entry .entry-content .wp-block-archives li > a:lang(haz),
-.entry .entry-content .wp-block-categories li > a:lang(haz),
-.entry .entry-content .wp-block-latest-posts li > a:lang(haz), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(haz), .entry .entry-content .wp-block-verse:lang(haz), .entry .entry-content .has-drop-cap:lang(haz):not(:focus):first-letter, .entry .entry-content .wp-block-pullquote cite:lang(haz), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(haz),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(haz),
-.entry .entry-content .wp-block-cover-image h2:lang(haz),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(haz),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(haz),
-.entry .entry-content .wp-block-cover h2:lang(haz), .entry .entry-content .wp-block-audio figcaption:lang(haz),
-.entry .entry-content .wp-block-video figcaption:lang(haz),
-.entry .entry-content .wp-block-image figcaption:lang(haz),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(haz),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(haz), .entry .entry-content .wp-block-file:lang(haz), .entry .entry-content .wp-block-file .wp-block-file__button:lang(haz), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(haz), .wp-caption-text:lang(haz), .gallery-caption:lang(haz) {
+h6:lang(haz), button:lang(haz),
+input:lang(haz),
+select:lang(haz),
+optgroup:lang(haz),
+textarea:lang(haz), body:lang(haz) {
   font-family: Tahoma, Arial, sans-serif;
 }
-
-body:lang(ps), button:lang(ps),
-input:lang(ps),
-select:lang(ps),
-optgroup:lang(ps),
-textarea:lang(ps), .author-description .author-link:lang(ps),
+.gallery-caption:lang(ps), .wp-caption-text:lang(ps), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ps), .entry .entry-content .wp-block-file .wp-block-file__button:lang(ps), .entry .entry-content .wp-block-file:lang(ps), .entry .entry-content .wp-block-audio figcaption:lang(ps),
+.entry .entry-content .wp-block-video figcaption:lang(ps),
+.entry .entry-content .wp-block-image figcaption:lang(ps),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(ps),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(ps), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(ps),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(ps),
+.entry .entry-content .wp-block-cover-image h2:lang(ps),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(ps),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(ps),
+.entry .entry-content .wp-block-cover h2:lang(ps), .entry .entry-content .wp-block-pullquote cite:lang(ps), .entry .entry-content .has-drop-cap:lang(ps):not(:focus):first-letter, .entry .entry-content .wp-block-verse:lang(ps), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ps), .entry .entry-content .wp-block-archives li > a:lang(ps),
+.entry .entry-content .wp-block-categories li > a:lang(ps),
+.entry .entry-content .wp-block-latest-posts li > a:lang(ps), .entry .entry-content .wp-block-button .wp-block-button__link:lang(ps), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(ps), .widget_tag_cloud .tagcloud:lang(ps), .widget_archive ul li:lang(ps),
+.widget_categories ul li:lang(ps),
+.widget_meta ul li:lang(ps),
+.widget_nav_menu ul li:lang(ps),
+.widget_pages ul li:lang(ps),
+.widget_recent_comments ul li:lang(ps),
+.widget_recent_entries ul li:lang(ps),
+.widget_rss ul li:lang(ps), .comment-form .comment-notes:lang(ps),
+.comment-form label:lang(ps), .comment-list .pingback .comment-body .comment-edit-link:lang(ps),
+.comment-list .trackback .comment-body .comment-edit-link:lang(ps), .comment-list .pingback .comment-body:lang(ps),
+.comment-list .trackback .comment-body:lang(ps), .comment-navigation .nav-previous:lang(ps),
+.comment-navigation .nav-next:lang(ps), .button:lang(ps), table:lang(ps), blockquote cite:lang(ps), .page-title:lang(ps), .author-description .author-link:lang(ps),
 .comment-metadata:lang(ps),
 .comment-reply-link:lang(ps),
 .comments-title:lang(ps),
@@ -442,8 +423,6 @@ textarea:lang(ps), .author-description .author-link:lang(ps),
 .entry-footer:lang(ps),
 .main-navigation:lang(ps),
 .no-comments:lang(ps),
-.not-found .page-title:lang(ps),
-.error-404 .page-title:lang(ps),
 .post-navigation .post-title:lang(ps),
 .page-links:lang(ps),
 .page-description:lang(ps),
@@ -457,40 +436,36 @@ h2:lang(ps),
 h3:lang(ps),
 h4:lang(ps),
 h5:lang(ps),
-h6:lang(ps), .page-title:lang(ps), blockquote cite:lang(ps), table:lang(ps), .button:lang(ps),
-input:lang(ps)[type="button"],
-input:lang(ps)[type="reset"],
-input:lang(ps)[type="submit"], .comment-navigation .nav-previous:lang(ps),
-.comment-navigation .nav-next:lang(ps), .comment-list .pingback .comment-body:lang(ps),
-.comment-list .trackback .comment-body:lang(ps), .comment-list .pingback .comment-body .comment-edit-link:lang(ps),
-.comment-list .trackback .comment-body .comment-edit-link:lang(ps), .comment-form .comment-notes:lang(ps),
-.comment-form label:lang(ps), .widget_archive ul li:lang(ps),
-.widget_categories ul li:lang(ps),
-.widget_meta ul li:lang(ps),
-.widget_nav_menu ul li:lang(ps),
-.widget_pages ul li:lang(ps),
-.widget_recent_comments ul li:lang(ps),
-.widget_recent_entries ul li:lang(ps),
-.widget_rss ul li:lang(ps), .widget_tag_cloud .tagcloud:lang(ps), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(ps), .entry .entry-content .wp-block-button .wp-block-button__link:lang(ps), .entry .entry-content .wp-block-archives li > a:lang(ps),
-.entry .entry-content .wp-block-categories li > a:lang(ps),
-.entry .entry-content .wp-block-latest-posts li > a:lang(ps), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ps), .entry .entry-content .wp-block-verse:lang(ps), .entry .entry-content .has-drop-cap:lang(ps):not(:focus):first-letter, .entry .entry-content .wp-block-pullquote cite:lang(ps), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(ps),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(ps),
-.entry .entry-content .wp-block-cover-image h2:lang(ps),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(ps),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(ps),
-.entry .entry-content .wp-block-cover h2:lang(ps), .entry .entry-content .wp-block-audio figcaption:lang(ps),
-.entry .entry-content .wp-block-video figcaption:lang(ps),
-.entry .entry-content .wp-block-image figcaption:lang(ps),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(ps),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(ps), .entry .entry-content .wp-block-file:lang(ps), .entry .entry-content .wp-block-file .wp-block-file__button:lang(ps), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ps), .wp-caption-text:lang(ps), .gallery-caption:lang(ps) {
+h6:lang(ps), button:lang(ps),
+input:lang(ps),
+select:lang(ps),
+optgroup:lang(ps),
+textarea:lang(ps), body:lang(ps) {
   font-family: Tahoma, Arial, sans-serif;
 }
-
-body:lang(be), button:lang(be),
-input:lang(be),
-select:lang(be),
-optgroup:lang(be),
-textarea:lang(be), .author-description .author-link:lang(be),
+.gallery-caption:lang(be), .wp-caption-text:lang(be), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(be), .entry .entry-content .wp-block-file .wp-block-file__button:lang(be), .entry .entry-content .wp-block-file:lang(be), .entry .entry-content .wp-block-audio figcaption:lang(be),
+.entry .entry-content .wp-block-video figcaption:lang(be),
+.entry .entry-content .wp-block-image figcaption:lang(be),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(be),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(be), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(be),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(be),
+.entry .entry-content .wp-block-cover-image h2:lang(be),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(be),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(be),
+.entry .entry-content .wp-block-cover h2:lang(be), .entry .entry-content .wp-block-pullquote cite:lang(be), .entry .entry-content .has-drop-cap:lang(be):not(:focus):first-letter, .entry .entry-content .wp-block-verse:lang(be), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(be), .entry .entry-content .wp-block-archives li > a:lang(be),
+.entry .entry-content .wp-block-categories li > a:lang(be),
+.entry .entry-content .wp-block-latest-posts li > a:lang(be), .entry .entry-content .wp-block-button .wp-block-button__link:lang(be), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(be), .widget_tag_cloud .tagcloud:lang(be), .widget_archive ul li:lang(be),
+.widget_categories ul li:lang(be),
+.widget_meta ul li:lang(be),
+.widget_nav_menu ul li:lang(be),
+.widget_pages ul li:lang(be),
+.widget_recent_comments ul li:lang(be),
+.widget_recent_entries ul li:lang(be),
+.widget_rss ul li:lang(be), .comment-form .comment-notes:lang(be),
+.comment-form label:lang(be), .comment-list .pingback .comment-body .comment-edit-link:lang(be),
+.comment-list .trackback .comment-body .comment-edit-link:lang(be), .comment-list .pingback .comment-body:lang(be),
+.comment-list .trackback .comment-body:lang(be), .comment-navigation .nav-previous:lang(be),
+.comment-navigation .nav-next:lang(be), .button:lang(be), table:lang(be), blockquote cite:lang(be), .page-title:lang(be), .author-description .author-link:lang(be),
 .comment-metadata:lang(be),
 .comment-reply-link:lang(be),
 .comments-title:lang(be),
@@ -500,8 +475,6 @@ textarea:lang(be), .author-description .author-link:lang(be),
 .entry-footer:lang(be),
 .main-navigation:lang(be),
 .no-comments:lang(be),
-.not-found .page-title:lang(be),
-.error-404 .page-title:lang(be),
 .post-navigation .post-title:lang(be),
 .page-links:lang(be),
 .page-description:lang(be),
@@ -515,40 +488,36 @@ h2:lang(be),
 h3:lang(be),
 h4:lang(be),
 h5:lang(be),
-h6:lang(be), .page-title:lang(be), blockquote cite:lang(be), table:lang(be), .button:lang(be),
-input:lang(be)[type="button"],
-input:lang(be)[type="reset"],
-input:lang(be)[type="submit"], .comment-navigation .nav-previous:lang(be),
-.comment-navigation .nav-next:lang(be), .comment-list .pingback .comment-body:lang(be),
-.comment-list .trackback .comment-body:lang(be), .comment-list .pingback .comment-body .comment-edit-link:lang(be),
-.comment-list .trackback .comment-body .comment-edit-link:lang(be), .comment-form .comment-notes:lang(be),
-.comment-form label:lang(be), .widget_archive ul li:lang(be),
-.widget_categories ul li:lang(be),
-.widget_meta ul li:lang(be),
-.widget_nav_menu ul li:lang(be),
-.widget_pages ul li:lang(be),
-.widget_recent_comments ul li:lang(be),
-.widget_recent_entries ul li:lang(be),
-.widget_rss ul li:lang(be), .widget_tag_cloud .tagcloud:lang(be), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(be), .entry .entry-content .wp-block-button .wp-block-button__link:lang(be), .entry .entry-content .wp-block-archives li > a:lang(be),
-.entry .entry-content .wp-block-categories li > a:lang(be),
-.entry .entry-content .wp-block-latest-posts li > a:lang(be), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(be), .entry .entry-content .wp-block-verse:lang(be), .entry .entry-content .has-drop-cap:lang(be):not(:focus):first-letter, .entry .entry-content .wp-block-pullquote cite:lang(be), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(be),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(be),
-.entry .entry-content .wp-block-cover-image h2:lang(be),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(be),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(be),
-.entry .entry-content .wp-block-cover h2:lang(be), .entry .entry-content .wp-block-audio figcaption:lang(be),
-.entry .entry-content .wp-block-video figcaption:lang(be),
-.entry .entry-content .wp-block-image figcaption:lang(be),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(be),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(be), .entry .entry-content .wp-block-file:lang(be), .entry .entry-content .wp-block-file .wp-block-file__button:lang(be), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(be), .wp-caption-text:lang(be), .gallery-caption:lang(be) {
+h6:lang(be), button:lang(be),
+input:lang(be),
+select:lang(be),
+optgroup:lang(be),
+textarea:lang(be), body:lang(be) {
   font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
 }
-
-body:lang(bg-BG), button:lang(bg-BG),
-input:lang(bg-BG),
-select:lang(bg-BG),
-optgroup:lang(bg-BG),
-textarea:lang(bg-BG), .author-description .author-link:lang(bg-BG),
+.gallery-caption:lang(bg-BG), .wp-caption-text:lang(bg-BG), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(bg-BG), .entry .entry-content .wp-block-file .wp-block-file__button:lang(bg-BG), .entry .entry-content .wp-block-file:lang(bg-BG), .entry .entry-content .wp-block-audio figcaption:lang(bg-BG),
+.entry .entry-content .wp-block-video figcaption:lang(bg-BG),
+.entry .entry-content .wp-block-image figcaption:lang(bg-BG),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(bg-BG),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(bg-BG), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(bg-BG),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(bg-BG),
+.entry .entry-content .wp-block-cover-image h2:lang(bg-BG),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(bg-BG),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(bg-BG),
+.entry .entry-content .wp-block-cover h2:lang(bg-BG), .entry .entry-content .wp-block-pullquote cite:lang(bg-BG), .entry .entry-content .has-drop-cap:lang(bg-BG):not(:focus):first-letter, .entry .entry-content .wp-block-verse:lang(bg-BG), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(bg-BG), .entry .entry-content .wp-block-archives li > a:lang(bg-BG),
+.entry .entry-content .wp-block-categories li > a:lang(bg-BG),
+.entry .entry-content .wp-block-latest-posts li > a:lang(bg-BG), .entry .entry-content .wp-block-button .wp-block-button__link:lang(bg-BG), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(bg-BG), .widget_tag_cloud .tagcloud:lang(bg-BG), .widget_archive ul li:lang(bg-BG),
+.widget_categories ul li:lang(bg-BG),
+.widget_meta ul li:lang(bg-BG),
+.widget_nav_menu ul li:lang(bg-BG),
+.widget_pages ul li:lang(bg-BG),
+.widget_recent_comments ul li:lang(bg-BG),
+.widget_recent_entries ul li:lang(bg-BG),
+.widget_rss ul li:lang(bg-BG), .comment-form .comment-notes:lang(bg-BG),
+.comment-form label:lang(bg-BG), .comment-list .pingback .comment-body .comment-edit-link:lang(bg-BG),
+.comment-list .trackback .comment-body .comment-edit-link:lang(bg-BG), .comment-list .pingback .comment-body:lang(bg-BG),
+.comment-list .trackback .comment-body:lang(bg-BG), .comment-navigation .nav-previous:lang(bg-BG),
+.comment-navigation .nav-next:lang(bg-BG), .button:lang(bg-BG), table:lang(bg-BG), blockquote cite:lang(bg-BG), .page-title:lang(bg-BG), .author-description .author-link:lang(bg-BG),
 .comment-metadata:lang(bg-BG),
 .comment-reply-link:lang(bg-BG),
 .comments-title:lang(bg-BG),
@@ -558,8 +527,6 @@ textarea:lang(bg-BG), .author-description .author-link:lang(bg-BG),
 .entry-footer:lang(bg-BG),
 .main-navigation:lang(bg-BG),
 .no-comments:lang(bg-BG),
-.not-found .page-title:lang(bg-BG),
-.error-404 .page-title:lang(bg-BG),
 .post-navigation .post-title:lang(bg-BG),
 .page-links:lang(bg-BG),
 .page-description:lang(bg-BG),
@@ -573,40 +540,36 @@ h2:lang(bg-BG),
 h3:lang(bg-BG),
 h4:lang(bg-BG),
 h5:lang(bg-BG),
-h6:lang(bg-BG), .page-title:lang(bg-BG), blockquote cite:lang(bg-BG), table:lang(bg-BG), .button:lang(bg-BG),
-input:lang(bg-BG)[type="button"],
-input:lang(bg-BG)[type="reset"],
-input:lang(bg-BG)[type="submit"], .comment-navigation .nav-previous:lang(bg-BG),
-.comment-navigation .nav-next:lang(bg-BG), .comment-list .pingback .comment-body:lang(bg-BG),
-.comment-list .trackback .comment-body:lang(bg-BG), .comment-list .pingback .comment-body .comment-edit-link:lang(bg-BG),
-.comment-list .trackback .comment-body .comment-edit-link:lang(bg-BG), .comment-form .comment-notes:lang(bg-BG),
-.comment-form label:lang(bg-BG), .widget_archive ul li:lang(bg-BG),
-.widget_categories ul li:lang(bg-BG),
-.widget_meta ul li:lang(bg-BG),
-.widget_nav_menu ul li:lang(bg-BG),
-.widget_pages ul li:lang(bg-BG),
-.widget_recent_comments ul li:lang(bg-BG),
-.widget_recent_entries ul li:lang(bg-BG),
-.widget_rss ul li:lang(bg-BG), .widget_tag_cloud .tagcloud:lang(bg-BG), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(bg-BG), .entry .entry-content .wp-block-button .wp-block-button__link:lang(bg-BG), .entry .entry-content .wp-block-archives li > a:lang(bg-BG),
-.entry .entry-content .wp-block-categories li > a:lang(bg-BG),
-.entry .entry-content .wp-block-latest-posts li > a:lang(bg-BG), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(bg-BG), .entry .entry-content .wp-block-verse:lang(bg-BG), .entry .entry-content .has-drop-cap:lang(bg-BG):not(:focus):first-letter, .entry .entry-content .wp-block-pullquote cite:lang(bg-BG), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(bg-BG),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(bg-BG),
-.entry .entry-content .wp-block-cover-image h2:lang(bg-BG),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(bg-BG),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(bg-BG),
-.entry .entry-content .wp-block-cover h2:lang(bg-BG), .entry .entry-content .wp-block-audio figcaption:lang(bg-BG),
-.entry .entry-content .wp-block-video figcaption:lang(bg-BG),
-.entry .entry-content .wp-block-image figcaption:lang(bg-BG),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(bg-BG),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(bg-BG), .entry .entry-content .wp-block-file:lang(bg-BG), .entry .entry-content .wp-block-file .wp-block-file__button:lang(bg-BG), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(bg-BG), .wp-caption-text:lang(bg-BG), .gallery-caption:lang(bg-BG) {
+h6:lang(bg-BG), button:lang(bg-BG),
+input:lang(bg-BG),
+select:lang(bg-BG),
+optgroup:lang(bg-BG),
+textarea:lang(bg-BG), body:lang(bg-BG) {
   font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
 }
-
-body:lang(kk), button:lang(kk),
-input:lang(kk),
-select:lang(kk),
-optgroup:lang(kk),
-textarea:lang(kk), .author-description .author-link:lang(kk),
+.gallery-caption:lang(kk), .wp-caption-text:lang(kk), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(kk), .entry .entry-content .wp-block-file .wp-block-file__button:lang(kk), .entry .entry-content .wp-block-file:lang(kk), .entry .entry-content .wp-block-audio figcaption:lang(kk),
+.entry .entry-content .wp-block-video figcaption:lang(kk),
+.entry .entry-content .wp-block-image figcaption:lang(kk),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(kk),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(kk), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(kk),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(kk),
+.entry .entry-content .wp-block-cover-image h2:lang(kk),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(kk),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(kk),
+.entry .entry-content .wp-block-cover h2:lang(kk), .entry .entry-content .wp-block-pullquote cite:lang(kk), .entry .entry-content .has-drop-cap:lang(kk):not(:focus):first-letter, .entry .entry-content .wp-block-verse:lang(kk), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(kk), .entry .entry-content .wp-block-archives li > a:lang(kk),
+.entry .entry-content .wp-block-categories li > a:lang(kk),
+.entry .entry-content .wp-block-latest-posts li > a:lang(kk), .entry .entry-content .wp-block-button .wp-block-button__link:lang(kk), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(kk), .widget_tag_cloud .tagcloud:lang(kk), .widget_archive ul li:lang(kk),
+.widget_categories ul li:lang(kk),
+.widget_meta ul li:lang(kk),
+.widget_nav_menu ul li:lang(kk),
+.widget_pages ul li:lang(kk),
+.widget_recent_comments ul li:lang(kk),
+.widget_recent_entries ul li:lang(kk),
+.widget_rss ul li:lang(kk), .comment-form .comment-notes:lang(kk),
+.comment-form label:lang(kk), .comment-list .pingback .comment-body .comment-edit-link:lang(kk),
+.comment-list .trackback .comment-body .comment-edit-link:lang(kk), .comment-list .pingback .comment-body:lang(kk),
+.comment-list .trackback .comment-body:lang(kk), .comment-navigation .nav-previous:lang(kk),
+.comment-navigation .nav-next:lang(kk), .button:lang(kk), table:lang(kk), blockquote cite:lang(kk), .page-title:lang(kk), .author-description .author-link:lang(kk),
 .comment-metadata:lang(kk),
 .comment-reply-link:lang(kk),
 .comments-title:lang(kk),
@@ -616,8 +579,6 @@ textarea:lang(kk), .author-description .author-link:lang(kk),
 .entry-footer:lang(kk),
 .main-navigation:lang(kk),
 .no-comments:lang(kk),
-.not-found .page-title:lang(kk),
-.error-404 .page-title:lang(kk),
 .post-navigation .post-title:lang(kk),
 .page-links:lang(kk),
 .page-description:lang(kk),
@@ -631,40 +592,36 @@ h2:lang(kk),
 h3:lang(kk),
 h4:lang(kk),
 h5:lang(kk),
-h6:lang(kk), .page-title:lang(kk), blockquote cite:lang(kk), table:lang(kk), .button:lang(kk),
-input:lang(kk)[type="button"],
-input:lang(kk)[type="reset"],
-input:lang(kk)[type="submit"], .comment-navigation .nav-previous:lang(kk),
-.comment-navigation .nav-next:lang(kk), .comment-list .pingback .comment-body:lang(kk),
-.comment-list .trackback .comment-body:lang(kk), .comment-list .pingback .comment-body .comment-edit-link:lang(kk),
-.comment-list .trackback .comment-body .comment-edit-link:lang(kk), .comment-form .comment-notes:lang(kk),
-.comment-form label:lang(kk), .widget_archive ul li:lang(kk),
-.widget_categories ul li:lang(kk),
-.widget_meta ul li:lang(kk),
-.widget_nav_menu ul li:lang(kk),
-.widget_pages ul li:lang(kk),
-.widget_recent_comments ul li:lang(kk),
-.widget_recent_entries ul li:lang(kk),
-.widget_rss ul li:lang(kk), .widget_tag_cloud .tagcloud:lang(kk), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(kk), .entry .entry-content .wp-block-button .wp-block-button__link:lang(kk), .entry .entry-content .wp-block-archives li > a:lang(kk),
-.entry .entry-content .wp-block-categories li > a:lang(kk),
-.entry .entry-content .wp-block-latest-posts li > a:lang(kk), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(kk), .entry .entry-content .wp-block-verse:lang(kk), .entry .entry-content .has-drop-cap:lang(kk):not(:focus):first-letter, .entry .entry-content .wp-block-pullquote cite:lang(kk), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(kk),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(kk),
-.entry .entry-content .wp-block-cover-image h2:lang(kk),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(kk),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(kk),
-.entry .entry-content .wp-block-cover h2:lang(kk), .entry .entry-content .wp-block-audio figcaption:lang(kk),
-.entry .entry-content .wp-block-video figcaption:lang(kk),
-.entry .entry-content .wp-block-image figcaption:lang(kk),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(kk),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(kk), .entry .entry-content .wp-block-file:lang(kk), .entry .entry-content .wp-block-file .wp-block-file__button:lang(kk), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(kk), .wp-caption-text:lang(kk), .gallery-caption:lang(kk) {
+h6:lang(kk), button:lang(kk),
+input:lang(kk),
+select:lang(kk),
+optgroup:lang(kk),
+textarea:lang(kk), body:lang(kk) {
   font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
 }
-
-body:lang(mk-MK), button:lang(mk-MK),
-input:lang(mk-MK),
-select:lang(mk-MK),
-optgroup:lang(mk-MK),
-textarea:lang(mk-MK), .author-description .author-link:lang(mk-MK),
+.gallery-caption:lang(mk-MK), .wp-caption-text:lang(mk-MK), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(mk-MK), .entry .entry-content .wp-block-file .wp-block-file__button:lang(mk-MK), .entry .entry-content .wp-block-file:lang(mk-MK), .entry .entry-content .wp-block-audio figcaption:lang(mk-MK),
+.entry .entry-content .wp-block-video figcaption:lang(mk-MK),
+.entry .entry-content .wp-block-image figcaption:lang(mk-MK),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(mk-MK),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(mk-MK), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(mk-MK),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(mk-MK),
+.entry .entry-content .wp-block-cover-image h2:lang(mk-MK),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(mk-MK),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(mk-MK),
+.entry .entry-content .wp-block-cover h2:lang(mk-MK), .entry .entry-content .wp-block-pullquote cite:lang(mk-MK), .entry .entry-content .has-drop-cap:lang(mk-MK):not(:focus):first-letter, .entry .entry-content .wp-block-verse:lang(mk-MK), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(mk-MK), .entry .entry-content .wp-block-archives li > a:lang(mk-MK),
+.entry .entry-content .wp-block-categories li > a:lang(mk-MK),
+.entry .entry-content .wp-block-latest-posts li > a:lang(mk-MK), .entry .entry-content .wp-block-button .wp-block-button__link:lang(mk-MK), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(mk-MK), .widget_tag_cloud .tagcloud:lang(mk-MK), .widget_archive ul li:lang(mk-MK),
+.widget_categories ul li:lang(mk-MK),
+.widget_meta ul li:lang(mk-MK),
+.widget_nav_menu ul li:lang(mk-MK),
+.widget_pages ul li:lang(mk-MK),
+.widget_recent_comments ul li:lang(mk-MK),
+.widget_recent_entries ul li:lang(mk-MK),
+.widget_rss ul li:lang(mk-MK), .comment-form .comment-notes:lang(mk-MK),
+.comment-form label:lang(mk-MK), .comment-list .pingback .comment-body .comment-edit-link:lang(mk-MK),
+.comment-list .trackback .comment-body .comment-edit-link:lang(mk-MK), .comment-list .pingback .comment-body:lang(mk-MK),
+.comment-list .trackback .comment-body:lang(mk-MK), .comment-navigation .nav-previous:lang(mk-MK),
+.comment-navigation .nav-next:lang(mk-MK), .button:lang(mk-MK), table:lang(mk-MK), blockquote cite:lang(mk-MK), .page-title:lang(mk-MK), .author-description .author-link:lang(mk-MK),
 .comment-metadata:lang(mk-MK),
 .comment-reply-link:lang(mk-MK),
 .comments-title:lang(mk-MK),
@@ -674,8 +631,6 @@ textarea:lang(mk-MK), .author-description .author-link:lang(mk-MK),
 .entry-footer:lang(mk-MK),
 .main-navigation:lang(mk-MK),
 .no-comments:lang(mk-MK),
-.not-found .page-title:lang(mk-MK),
-.error-404 .page-title:lang(mk-MK),
 .post-navigation .post-title:lang(mk-MK),
 .page-links:lang(mk-MK),
 .page-description:lang(mk-MK),
@@ -689,40 +644,36 @@ h2:lang(mk-MK),
 h3:lang(mk-MK),
 h4:lang(mk-MK),
 h5:lang(mk-MK),
-h6:lang(mk-MK), .page-title:lang(mk-MK), blockquote cite:lang(mk-MK), table:lang(mk-MK), .button:lang(mk-MK),
-input:lang(mk-MK)[type="button"],
-input:lang(mk-MK)[type="reset"],
-input:lang(mk-MK)[type="submit"], .comment-navigation .nav-previous:lang(mk-MK),
-.comment-navigation .nav-next:lang(mk-MK), .comment-list .pingback .comment-body:lang(mk-MK),
-.comment-list .trackback .comment-body:lang(mk-MK), .comment-list .pingback .comment-body .comment-edit-link:lang(mk-MK),
-.comment-list .trackback .comment-body .comment-edit-link:lang(mk-MK), .comment-form .comment-notes:lang(mk-MK),
-.comment-form label:lang(mk-MK), .widget_archive ul li:lang(mk-MK),
-.widget_categories ul li:lang(mk-MK),
-.widget_meta ul li:lang(mk-MK),
-.widget_nav_menu ul li:lang(mk-MK),
-.widget_pages ul li:lang(mk-MK),
-.widget_recent_comments ul li:lang(mk-MK),
-.widget_recent_entries ul li:lang(mk-MK),
-.widget_rss ul li:lang(mk-MK), .widget_tag_cloud .tagcloud:lang(mk-MK), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(mk-MK), .entry .entry-content .wp-block-button .wp-block-button__link:lang(mk-MK), .entry .entry-content .wp-block-archives li > a:lang(mk-MK),
-.entry .entry-content .wp-block-categories li > a:lang(mk-MK),
-.entry .entry-content .wp-block-latest-posts li > a:lang(mk-MK), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(mk-MK), .entry .entry-content .wp-block-verse:lang(mk-MK), .entry .entry-content .has-drop-cap:lang(mk-MK):not(:focus):first-letter, .entry .entry-content .wp-block-pullquote cite:lang(mk-MK), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(mk-MK),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(mk-MK),
-.entry .entry-content .wp-block-cover-image h2:lang(mk-MK),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(mk-MK),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(mk-MK),
-.entry .entry-content .wp-block-cover h2:lang(mk-MK), .entry .entry-content .wp-block-audio figcaption:lang(mk-MK),
-.entry .entry-content .wp-block-video figcaption:lang(mk-MK),
-.entry .entry-content .wp-block-image figcaption:lang(mk-MK),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(mk-MK),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(mk-MK), .entry .entry-content .wp-block-file:lang(mk-MK), .entry .entry-content .wp-block-file .wp-block-file__button:lang(mk-MK), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(mk-MK), .wp-caption-text:lang(mk-MK), .gallery-caption:lang(mk-MK) {
+h6:lang(mk-MK), button:lang(mk-MK),
+input:lang(mk-MK),
+select:lang(mk-MK),
+optgroup:lang(mk-MK),
+textarea:lang(mk-MK), body:lang(mk-MK) {
   font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
 }
-
-body:lang(mn), button:lang(mn),
-input:lang(mn),
-select:lang(mn),
-optgroup:lang(mn),
-textarea:lang(mn), .author-description .author-link:lang(mn),
+.gallery-caption:lang(mn), .wp-caption-text:lang(mn), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(mn), .entry .entry-content .wp-block-file .wp-block-file__button:lang(mn), .entry .entry-content .wp-block-file:lang(mn), .entry .entry-content .wp-block-audio figcaption:lang(mn),
+.entry .entry-content .wp-block-video figcaption:lang(mn),
+.entry .entry-content .wp-block-image figcaption:lang(mn),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(mn),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(mn), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(mn),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(mn),
+.entry .entry-content .wp-block-cover-image h2:lang(mn),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(mn),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(mn),
+.entry .entry-content .wp-block-cover h2:lang(mn), .entry .entry-content .wp-block-pullquote cite:lang(mn), .entry .entry-content .has-drop-cap:lang(mn):not(:focus):first-letter, .entry .entry-content .wp-block-verse:lang(mn), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(mn), .entry .entry-content .wp-block-archives li > a:lang(mn),
+.entry .entry-content .wp-block-categories li > a:lang(mn),
+.entry .entry-content .wp-block-latest-posts li > a:lang(mn), .entry .entry-content .wp-block-button .wp-block-button__link:lang(mn), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(mn), .widget_tag_cloud .tagcloud:lang(mn), .widget_archive ul li:lang(mn),
+.widget_categories ul li:lang(mn),
+.widget_meta ul li:lang(mn),
+.widget_nav_menu ul li:lang(mn),
+.widget_pages ul li:lang(mn),
+.widget_recent_comments ul li:lang(mn),
+.widget_recent_entries ul li:lang(mn),
+.widget_rss ul li:lang(mn), .comment-form .comment-notes:lang(mn),
+.comment-form label:lang(mn), .comment-list .pingback .comment-body .comment-edit-link:lang(mn),
+.comment-list .trackback .comment-body .comment-edit-link:lang(mn), .comment-list .pingback .comment-body:lang(mn),
+.comment-list .trackback .comment-body:lang(mn), .comment-navigation .nav-previous:lang(mn),
+.comment-navigation .nav-next:lang(mn), .button:lang(mn), table:lang(mn), blockquote cite:lang(mn), .page-title:lang(mn), .author-description .author-link:lang(mn),
 .comment-metadata:lang(mn),
 .comment-reply-link:lang(mn),
 .comments-title:lang(mn),
@@ -732,8 +683,6 @@ textarea:lang(mn), .author-description .author-link:lang(mn),
 .entry-footer:lang(mn),
 .main-navigation:lang(mn),
 .no-comments:lang(mn),
-.not-found .page-title:lang(mn),
-.error-404 .page-title:lang(mn),
 .post-navigation .post-title:lang(mn),
 .page-links:lang(mn),
 .page-description:lang(mn),
@@ -747,40 +696,36 @@ h2:lang(mn),
 h3:lang(mn),
 h4:lang(mn),
 h5:lang(mn),
-h6:lang(mn), .page-title:lang(mn), blockquote cite:lang(mn), table:lang(mn), .button:lang(mn),
-input:lang(mn)[type="button"],
-input:lang(mn)[type="reset"],
-input:lang(mn)[type="submit"], .comment-navigation .nav-previous:lang(mn),
-.comment-navigation .nav-next:lang(mn), .comment-list .pingback .comment-body:lang(mn),
-.comment-list .trackback .comment-body:lang(mn), .comment-list .pingback .comment-body .comment-edit-link:lang(mn),
-.comment-list .trackback .comment-body .comment-edit-link:lang(mn), .comment-form .comment-notes:lang(mn),
-.comment-form label:lang(mn), .widget_archive ul li:lang(mn),
-.widget_categories ul li:lang(mn),
-.widget_meta ul li:lang(mn),
-.widget_nav_menu ul li:lang(mn),
-.widget_pages ul li:lang(mn),
-.widget_recent_comments ul li:lang(mn),
-.widget_recent_entries ul li:lang(mn),
-.widget_rss ul li:lang(mn), .widget_tag_cloud .tagcloud:lang(mn), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(mn), .entry .entry-content .wp-block-button .wp-block-button__link:lang(mn), .entry .entry-content .wp-block-archives li > a:lang(mn),
-.entry .entry-content .wp-block-categories li > a:lang(mn),
-.entry .entry-content .wp-block-latest-posts li > a:lang(mn), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(mn), .entry .entry-content .wp-block-verse:lang(mn), .entry .entry-content .has-drop-cap:lang(mn):not(:focus):first-letter, .entry .entry-content .wp-block-pullquote cite:lang(mn), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(mn),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(mn),
-.entry .entry-content .wp-block-cover-image h2:lang(mn),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(mn),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(mn),
-.entry .entry-content .wp-block-cover h2:lang(mn), .entry .entry-content .wp-block-audio figcaption:lang(mn),
-.entry .entry-content .wp-block-video figcaption:lang(mn),
-.entry .entry-content .wp-block-image figcaption:lang(mn),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(mn),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(mn), .entry .entry-content .wp-block-file:lang(mn), .entry .entry-content .wp-block-file .wp-block-file__button:lang(mn), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(mn), .wp-caption-text:lang(mn), .gallery-caption:lang(mn) {
+h6:lang(mn), button:lang(mn),
+input:lang(mn),
+select:lang(mn),
+optgroup:lang(mn),
+textarea:lang(mn), body:lang(mn) {
   font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
 }
-
-body:lang(ru-RU), button:lang(ru-RU),
-input:lang(ru-RU),
-select:lang(ru-RU),
-optgroup:lang(ru-RU),
-textarea:lang(ru-RU), .author-description .author-link:lang(ru-RU),
+.gallery-caption:lang(ru-RU), .wp-caption-text:lang(ru-RU), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ru-RU), .entry .entry-content .wp-block-file .wp-block-file__button:lang(ru-RU), .entry .entry-content .wp-block-file:lang(ru-RU), .entry .entry-content .wp-block-audio figcaption:lang(ru-RU),
+.entry .entry-content .wp-block-video figcaption:lang(ru-RU),
+.entry .entry-content .wp-block-image figcaption:lang(ru-RU),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(ru-RU),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(ru-RU), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(ru-RU),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(ru-RU),
+.entry .entry-content .wp-block-cover-image h2:lang(ru-RU),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(ru-RU),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(ru-RU),
+.entry .entry-content .wp-block-cover h2:lang(ru-RU), .entry .entry-content .wp-block-pullquote cite:lang(ru-RU), .entry .entry-content .has-drop-cap:lang(ru-RU):not(:focus):first-letter, .entry .entry-content .wp-block-verse:lang(ru-RU), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ru-RU), .entry .entry-content .wp-block-archives li > a:lang(ru-RU),
+.entry .entry-content .wp-block-categories li > a:lang(ru-RU),
+.entry .entry-content .wp-block-latest-posts li > a:lang(ru-RU), .entry .entry-content .wp-block-button .wp-block-button__link:lang(ru-RU), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(ru-RU), .widget_tag_cloud .tagcloud:lang(ru-RU), .widget_archive ul li:lang(ru-RU),
+.widget_categories ul li:lang(ru-RU),
+.widget_meta ul li:lang(ru-RU),
+.widget_nav_menu ul li:lang(ru-RU),
+.widget_pages ul li:lang(ru-RU),
+.widget_recent_comments ul li:lang(ru-RU),
+.widget_recent_entries ul li:lang(ru-RU),
+.widget_rss ul li:lang(ru-RU), .comment-form .comment-notes:lang(ru-RU),
+.comment-form label:lang(ru-RU), .comment-list .pingback .comment-body .comment-edit-link:lang(ru-RU),
+.comment-list .trackback .comment-body .comment-edit-link:lang(ru-RU), .comment-list .pingback .comment-body:lang(ru-RU),
+.comment-list .trackback .comment-body:lang(ru-RU), .comment-navigation .nav-previous:lang(ru-RU),
+.comment-navigation .nav-next:lang(ru-RU), .button:lang(ru-RU), table:lang(ru-RU), blockquote cite:lang(ru-RU), .page-title:lang(ru-RU), .author-description .author-link:lang(ru-RU),
 .comment-metadata:lang(ru-RU),
 .comment-reply-link:lang(ru-RU),
 .comments-title:lang(ru-RU),
@@ -790,8 +735,6 @@ textarea:lang(ru-RU), .author-description .author-link:lang(ru-RU),
 .entry-footer:lang(ru-RU),
 .main-navigation:lang(ru-RU),
 .no-comments:lang(ru-RU),
-.not-found .page-title:lang(ru-RU),
-.error-404 .page-title:lang(ru-RU),
 .post-navigation .post-title:lang(ru-RU),
 .page-links:lang(ru-RU),
 .page-description:lang(ru-RU),
@@ -805,40 +748,36 @@ h2:lang(ru-RU),
 h3:lang(ru-RU),
 h4:lang(ru-RU),
 h5:lang(ru-RU),
-h6:lang(ru-RU), .page-title:lang(ru-RU), blockquote cite:lang(ru-RU), table:lang(ru-RU), .button:lang(ru-RU),
-input:lang(ru-RU)[type="button"],
-input:lang(ru-RU)[type="reset"],
-input:lang(ru-RU)[type="submit"], .comment-navigation .nav-previous:lang(ru-RU),
-.comment-navigation .nav-next:lang(ru-RU), .comment-list .pingback .comment-body:lang(ru-RU),
-.comment-list .trackback .comment-body:lang(ru-RU), .comment-list .pingback .comment-body .comment-edit-link:lang(ru-RU),
-.comment-list .trackback .comment-body .comment-edit-link:lang(ru-RU), .comment-form .comment-notes:lang(ru-RU),
-.comment-form label:lang(ru-RU), .widget_archive ul li:lang(ru-RU),
-.widget_categories ul li:lang(ru-RU),
-.widget_meta ul li:lang(ru-RU),
-.widget_nav_menu ul li:lang(ru-RU),
-.widget_pages ul li:lang(ru-RU),
-.widget_recent_comments ul li:lang(ru-RU),
-.widget_recent_entries ul li:lang(ru-RU),
-.widget_rss ul li:lang(ru-RU), .widget_tag_cloud .tagcloud:lang(ru-RU), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(ru-RU), .entry .entry-content .wp-block-button .wp-block-button__link:lang(ru-RU), .entry .entry-content .wp-block-archives li > a:lang(ru-RU),
-.entry .entry-content .wp-block-categories li > a:lang(ru-RU),
-.entry .entry-content .wp-block-latest-posts li > a:lang(ru-RU), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ru-RU), .entry .entry-content .wp-block-verse:lang(ru-RU), .entry .entry-content .has-drop-cap:lang(ru-RU):not(:focus):first-letter, .entry .entry-content .wp-block-pullquote cite:lang(ru-RU), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(ru-RU),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(ru-RU),
-.entry .entry-content .wp-block-cover-image h2:lang(ru-RU),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(ru-RU),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(ru-RU),
-.entry .entry-content .wp-block-cover h2:lang(ru-RU), .entry .entry-content .wp-block-audio figcaption:lang(ru-RU),
-.entry .entry-content .wp-block-video figcaption:lang(ru-RU),
-.entry .entry-content .wp-block-image figcaption:lang(ru-RU),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(ru-RU),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(ru-RU), .entry .entry-content .wp-block-file:lang(ru-RU), .entry .entry-content .wp-block-file .wp-block-file__button:lang(ru-RU), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ru-RU), .wp-caption-text:lang(ru-RU), .gallery-caption:lang(ru-RU) {
+h6:lang(ru-RU), button:lang(ru-RU),
+input:lang(ru-RU),
+select:lang(ru-RU),
+optgroup:lang(ru-RU),
+textarea:lang(ru-RU), body:lang(ru-RU) {
   font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
 }
-
-body:lang(sah), button:lang(sah),
-input:lang(sah),
-select:lang(sah),
-optgroup:lang(sah),
-textarea:lang(sah), .author-description .author-link:lang(sah),
+.gallery-caption:lang(sah), .wp-caption-text:lang(sah), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(sah), .entry .entry-content .wp-block-file .wp-block-file__button:lang(sah), .entry .entry-content .wp-block-file:lang(sah), .entry .entry-content .wp-block-audio figcaption:lang(sah),
+.entry .entry-content .wp-block-video figcaption:lang(sah),
+.entry .entry-content .wp-block-image figcaption:lang(sah),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(sah),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(sah), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(sah),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(sah),
+.entry .entry-content .wp-block-cover-image h2:lang(sah),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(sah),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(sah),
+.entry .entry-content .wp-block-cover h2:lang(sah), .entry .entry-content .wp-block-pullquote cite:lang(sah), .entry .entry-content .has-drop-cap:lang(sah):not(:focus):first-letter, .entry .entry-content .wp-block-verse:lang(sah), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(sah), .entry .entry-content .wp-block-archives li > a:lang(sah),
+.entry .entry-content .wp-block-categories li > a:lang(sah),
+.entry .entry-content .wp-block-latest-posts li > a:lang(sah), .entry .entry-content .wp-block-button .wp-block-button__link:lang(sah), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(sah), .widget_tag_cloud .tagcloud:lang(sah), .widget_archive ul li:lang(sah),
+.widget_categories ul li:lang(sah),
+.widget_meta ul li:lang(sah),
+.widget_nav_menu ul li:lang(sah),
+.widget_pages ul li:lang(sah),
+.widget_recent_comments ul li:lang(sah),
+.widget_recent_entries ul li:lang(sah),
+.widget_rss ul li:lang(sah), .comment-form .comment-notes:lang(sah),
+.comment-form label:lang(sah), .comment-list .pingback .comment-body .comment-edit-link:lang(sah),
+.comment-list .trackback .comment-body .comment-edit-link:lang(sah), .comment-list .pingback .comment-body:lang(sah),
+.comment-list .trackback .comment-body:lang(sah), .comment-navigation .nav-previous:lang(sah),
+.comment-navigation .nav-next:lang(sah), .button:lang(sah), table:lang(sah), blockquote cite:lang(sah), .page-title:lang(sah), .author-description .author-link:lang(sah),
 .comment-metadata:lang(sah),
 .comment-reply-link:lang(sah),
 .comments-title:lang(sah),
@@ -848,8 +787,6 @@ textarea:lang(sah), .author-description .author-link:lang(sah),
 .entry-footer:lang(sah),
 .main-navigation:lang(sah),
 .no-comments:lang(sah),
-.not-found .page-title:lang(sah),
-.error-404 .page-title:lang(sah),
 .post-navigation .post-title:lang(sah),
 .page-links:lang(sah),
 .page-description:lang(sah),
@@ -863,40 +800,36 @@ h2:lang(sah),
 h3:lang(sah),
 h4:lang(sah),
 h5:lang(sah),
-h6:lang(sah), .page-title:lang(sah), blockquote cite:lang(sah), table:lang(sah), .button:lang(sah),
-input:lang(sah)[type="button"],
-input:lang(sah)[type="reset"],
-input:lang(sah)[type="submit"], .comment-navigation .nav-previous:lang(sah),
-.comment-navigation .nav-next:lang(sah), .comment-list .pingback .comment-body:lang(sah),
-.comment-list .trackback .comment-body:lang(sah), .comment-list .pingback .comment-body .comment-edit-link:lang(sah),
-.comment-list .trackback .comment-body .comment-edit-link:lang(sah), .comment-form .comment-notes:lang(sah),
-.comment-form label:lang(sah), .widget_archive ul li:lang(sah),
-.widget_categories ul li:lang(sah),
-.widget_meta ul li:lang(sah),
-.widget_nav_menu ul li:lang(sah),
-.widget_pages ul li:lang(sah),
-.widget_recent_comments ul li:lang(sah),
-.widget_recent_entries ul li:lang(sah),
-.widget_rss ul li:lang(sah), .widget_tag_cloud .tagcloud:lang(sah), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(sah), .entry .entry-content .wp-block-button .wp-block-button__link:lang(sah), .entry .entry-content .wp-block-archives li > a:lang(sah),
-.entry .entry-content .wp-block-categories li > a:lang(sah),
-.entry .entry-content .wp-block-latest-posts li > a:lang(sah), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(sah), .entry .entry-content .wp-block-verse:lang(sah), .entry .entry-content .has-drop-cap:lang(sah):not(:focus):first-letter, .entry .entry-content .wp-block-pullquote cite:lang(sah), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(sah),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(sah),
-.entry .entry-content .wp-block-cover-image h2:lang(sah),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(sah),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(sah),
-.entry .entry-content .wp-block-cover h2:lang(sah), .entry .entry-content .wp-block-audio figcaption:lang(sah),
-.entry .entry-content .wp-block-video figcaption:lang(sah),
-.entry .entry-content .wp-block-image figcaption:lang(sah),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(sah),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(sah), .entry .entry-content .wp-block-file:lang(sah), .entry .entry-content .wp-block-file .wp-block-file__button:lang(sah), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(sah), .wp-caption-text:lang(sah), .gallery-caption:lang(sah) {
+h6:lang(sah), button:lang(sah),
+input:lang(sah),
+select:lang(sah),
+optgroup:lang(sah),
+textarea:lang(sah), body:lang(sah) {
   font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
 }
-
-body:lang(sr-RS), button:lang(sr-RS),
-input:lang(sr-RS),
-select:lang(sr-RS),
-optgroup:lang(sr-RS),
-textarea:lang(sr-RS), .author-description .author-link:lang(sr-RS),
+.gallery-caption:lang(sr-RS), .wp-caption-text:lang(sr-RS), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(sr-RS), .entry .entry-content .wp-block-file .wp-block-file__button:lang(sr-RS), .entry .entry-content .wp-block-file:lang(sr-RS), .entry .entry-content .wp-block-audio figcaption:lang(sr-RS),
+.entry .entry-content .wp-block-video figcaption:lang(sr-RS),
+.entry .entry-content .wp-block-image figcaption:lang(sr-RS),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(sr-RS),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(sr-RS), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(sr-RS),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(sr-RS),
+.entry .entry-content .wp-block-cover-image h2:lang(sr-RS),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(sr-RS),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(sr-RS),
+.entry .entry-content .wp-block-cover h2:lang(sr-RS), .entry .entry-content .wp-block-pullquote cite:lang(sr-RS), .entry .entry-content .has-drop-cap:lang(sr-RS):not(:focus):first-letter, .entry .entry-content .wp-block-verse:lang(sr-RS), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(sr-RS), .entry .entry-content .wp-block-archives li > a:lang(sr-RS),
+.entry .entry-content .wp-block-categories li > a:lang(sr-RS),
+.entry .entry-content .wp-block-latest-posts li > a:lang(sr-RS), .entry .entry-content .wp-block-button .wp-block-button__link:lang(sr-RS), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(sr-RS), .widget_tag_cloud .tagcloud:lang(sr-RS), .widget_archive ul li:lang(sr-RS),
+.widget_categories ul li:lang(sr-RS),
+.widget_meta ul li:lang(sr-RS),
+.widget_nav_menu ul li:lang(sr-RS),
+.widget_pages ul li:lang(sr-RS),
+.widget_recent_comments ul li:lang(sr-RS),
+.widget_recent_entries ul li:lang(sr-RS),
+.widget_rss ul li:lang(sr-RS), .comment-form .comment-notes:lang(sr-RS),
+.comment-form label:lang(sr-RS), .comment-list .pingback .comment-body .comment-edit-link:lang(sr-RS),
+.comment-list .trackback .comment-body .comment-edit-link:lang(sr-RS), .comment-list .pingback .comment-body:lang(sr-RS),
+.comment-list .trackback .comment-body:lang(sr-RS), .comment-navigation .nav-previous:lang(sr-RS),
+.comment-navigation .nav-next:lang(sr-RS), .button:lang(sr-RS), table:lang(sr-RS), blockquote cite:lang(sr-RS), .page-title:lang(sr-RS), .author-description .author-link:lang(sr-RS),
 .comment-metadata:lang(sr-RS),
 .comment-reply-link:lang(sr-RS),
 .comments-title:lang(sr-RS),
@@ -906,8 +839,6 @@ textarea:lang(sr-RS), .author-description .author-link:lang(sr-RS),
 .entry-footer:lang(sr-RS),
 .main-navigation:lang(sr-RS),
 .no-comments:lang(sr-RS),
-.not-found .page-title:lang(sr-RS),
-.error-404 .page-title:lang(sr-RS),
 .post-navigation .post-title:lang(sr-RS),
 .page-links:lang(sr-RS),
 .page-description:lang(sr-RS),
@@ -921,40 +852,36 @@ h2:lang(sr-RS),
 h3:lang(sr-RS),
 h4:lang(sr-RS),
 h5:lang(sr-RS),
-h6:lang(sr-RS), .page-title:lang(sr-RS), blockquote cite:lang(sr-RS), table:lang(sr-RS), .button:lang(sr-RS),
-input:lang(sr-RS)[type="button"],
-input:lang(sr-RS)[type="reset"],
-input:lang(sr-RS)[type="submit"], .comment-navigation .nav-previous:lang(sr-RS),
-.comment-navigation .nav-next:lang(sr-RS), .comment-list .pingback .comment-body:lang(sr-RS),
-.comment-list .trackback .comment-body:lang(sr-RS), .comment-list .pingback .comment-body .comment-edit-link:lang(sr-RS),
-.comment-list .trackback .comment-body .comment-edit-link:lang(sr-RS), .comment-form .comment-notes:lang(sr-RS),
-.comment-form label:lang(sr-RS), .widget_archive ul li:lang(sr-RS),
-.widget_categories ul li:lang(sr-RS),
-.widget_meta ul li:lang(sr-RS),
-.widget_nav_menu ul li:lang(sr-RS),
-.widget_pages ul li:lang(sr-RS),
-.widget_recent_comments ul li:lang(sr-RS),
-.widget_recent_entries ul li:lang(sr-RS),
-.widget_rss ul li:lang(sr-RS), .widget_tag_cloud .tagcloud:lang(sr-RS), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(sr-RS), .entry .entry-content .wp-block-button .wp-block-button__link:lang(sr-RS), .entry .entry-content .wp-block-archives li > a:lang(sr-RS),
-.entry .entry-content .wp-block-categories li > a:lang(sr-RS),
-.entry .entry-content .wp-block-latest-posts li > a:lang(sr-RS), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(sr-RS), .entry .entry-content .wp-block-verse:lang(sr-RS), .entry .entry-content .has-drop-cap:lang(sr-RS):not(:focus):first-letter, .entry .entry-content .wp-block-pullquote cite:lang(sr-RS), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(sr-RS),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(sr-RS),
-.entry .entry-content .wp-block-cover-image h2:lang(sr-RS),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(sr-RS),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(sr-RS),
-.entry .entry-content .wp-block-cover h2:lang(sr-RS), .entry .entry-content .wp-block-audio figcaption:lang(sr-RS),
-.entry .entry-content .wp-block-video figcaption:lang(sr-RS),
-.entry .entry-content .wp-block-image figcaption:lang(sr-RS),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(sr-RS),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(sr-RS), .entry .entry-content .wp-block-file:lang(sr-RS), .entry .entry-content .wp-block-file .wp-block-file__button:lang(sr-RS), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(sr-RS), .wp-caption-text:lang(sr-RS), .gallery-caption:lang(sr-RS) {
+h6:lang(sr-RS), button:lang(sr-RS),
+input:lang(sr-RS),
+select:lang(sr-RS),
+optgroup:lang(sr-RS),
+textarea:lang(sr-RS), body:lang(sr-RS) {
   font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
 }
-
-body:lang(tt-RU), button:lang(tt-RU),
-input:lang(tt-RU),
-select:lang(tt-RU),
-optgroup:lang(tt-RU),
-textarea:lang(tt-RU), .author-description .author-link:lang(tt-RU),
+.gallery-caption:lang(tt-RU), .wp-caption-text:lang(tt-RU), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(tt-RU), .entry .entry-content .wp-block-file .wp-block-file__button:lang(tt-RU), .entry .entry-content .wp-block-file:lang(tt-RU), .entry .entry-content .wp-block-audio figcaption:lang(tt-RU),
+.entry .entry-content .wp-block-video figcaption:lang(tt-RU),
+.entry .entry-content .wp-block-image figcaption:lang(tt-RU),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(tt-RU),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(tt-RU), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(tt-RU),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(tt-RU),
+.entry .entry-content .wp-block-cover-image h2:lang(tt-RU),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(tt-RU),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(tt-RU),
+.entry .entry-content .wp-block-cover h2:lang(tt-RU), .entry .entry-content .wp-block-pullquote cite:lang(tt-RU), .entry .entry-content .has-drop-cap:lang(tt-RU):not(:focus):first-letter, .entry .entry-content .wp-block-verse:lang(tt-RU), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(tt-RU), .entry .entry-content .wp-block-archives li > a:lang(tt-RU),
+.entry .entry-content .wp-block-categories li > a:lang(tt-RU),
+.entry .entry-content .wp-block-latest-posts li > a:lang(tt-RU), .entry .entry-content .wp-block-button .wp-block-button__link:lang(tt-RU), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(tt-RU), .widget_tag_cloud .tagcloud:lang(tt-RU), .widget_archive ul li:lang(tt-RU),
+.widget_categories ul li:lang(tt-RU),
+.widget_meta ul li:lang(tt-RU),
+.widget_nav_menu ul li:lang(tt-RU),
+.widget_pages ul li:lang(tt-RU),
+.widget_recent_comments ul li:lang(tt-RU),
+.widget_recent_entries ul li:lang(tt-RU),
+.widget_rss ul li:lang(tt-RU), .comment-form .comment-notes:lang(tt-RU),
+.comment-form label:lang(tt-RU), .comment-list .pingback .comment-body .comment-edit-link:lang(tt-RU),
+.comment-list .trackback .comment-body .comment-edit-link:lang(tt-RU), .comment-list .pingback .comment-body:lang(tt-RU),
+.comment-list .trackback .comment-body:lang(tt-RU), .comment-navigation .nav-previous:lang(tt-RU),
+.comment-navigation .nav-next:lang(tt-RU), .button:lang(tt-RU), table:lang(tt-RU), blockquote cite:lang(tt-RU), .page-title:lang(tt-RU), .author-description .author-link:lang(tt-RU),
 .comment-metadata:lang(tt-RU),
 .comment-reply-link:lang(tt-RU),
 .comments-title:lang(tt-RU),
@@ -964,8 +891,6 @@ textarea:lang(tt-RU), .author-description .author-link:lang(tt-RU),
 .entry-footer:lang(tt-RU),
 .main-navigation:lang(tt-RU),
 .no-comments:lang(tt-RU),
-.not-found .page-title:lang(tt-RU),
-.error-404 .page-title:lang(tt-RU),
 .post-navigation .post-title:lang(tt-RU),
 .page-links:lang(tt-RU),
 .page-description:lang(tt-RU),
@@ -979,40 +904,36 @@ h2:lang(tt-RU),
 h3:lang(tt-RU),
 h4:lang(tt-RU),
 h5:lang(tt-RU),
-h6:lang(tt-RU), .page-title:lang(tt-RU), blockquote cite:lang(tt-RU), table:lang(tt-RU), .button:lang(tt-RU),
-input:lang(tt-RU)[type="button"],
-input:lang(tt-RU)[type="reset"],
-input:lang(tt-RU)[type="submit"], .comment-navigation .nav-previous:lang(tt-RU),
-.comment-navigation .nav-next:lang(tt-RU), .comment-list .pingback .comment-body:lang(tt-RU),
-.comment-list .trackback .comment-body:lang(tt-RU), .comment-list .pingback .comment-body .comment-edit-link:lang(tt-RU),
-.comment-list .trackback .comment-body .comment-edit-link:lang(tt-RU), .comment-form .comment-notes:lang(tt-RU),
-.comment-form label:lang(tt-RU), .widget_archive ul li:lang(tt-RU),
-.widget_categories ul li:lang(tt-RU),
-.widget_meta ul li:lang(tt-RU),
-.widget_nav_menu ul li:lang(tt-RU),
-.widget_pages ul li:lang(tt-RU),
-.widget_recent_comments ul li:lang(tt-RU),
-.widget_recent_entries ul li:lang(tt-RU),
-.widget_rss ul li:lang(tt-RU), .widget_tag_cloud .tagcloud:lang(tt-RU), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(tt-RU), .entry .entry-content .wp-block-button .wp-block-button__link:lang(tt-RU), .entry .entry-content .wp-block-archives li > a:lang(tt-RU),
-.entry .entry-content .wp-block-categories li > a:lang(tt-RU),
-.entry .entry-content .wp-block-latest-posts li > a:lang(tt-RU), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(tt-RU), .entry .entry-content .wp-block-verse:lang(tt-RU), .entry .entry-content .has-drop-cap:lang(tt-RU):not(:focus):first-letter, .entry .entry-content .wp-block-pullquote cite:lang(tt-RU), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(tt-RU),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(tt-RU),
-.entry .entry-content .wp-block-cover-image h2:lang(tt-RU),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(tt-RU),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(tt-RU),
-.entry .entry-content .wp-block-cover h2:lang(tt-RU), .entry .entry-content .wp-block-audio figcaption:lang(tt-RU),
-.entry .entry-content .wp-block-video figcaption:lang(tt-RU),
-.entry .entry-content .wp-block-image figcaption:lang(tt-RU),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(tt-RU),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(tt-RU), .entry .entry-content .wp-block-file:lang(tt-RU), .entry .entry-content .wp-block-file .wp-block-file__button:lang(tt-RU), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(tt-RU), .wp-caption-text:lang(tt-RU), .gallery-caption:lang(tt-RU) {
+h6:lang(tt-RU), button:lang(tt-RU),
+input:lang(tt-RU),
+select:lang(tt-RU),
+optgroup:lang(tt-RU),
+textarea:lang(tt-RU), body:lang(tt-RU) {
   font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
 }
-
-body:lang(uk), button:lang(uk),
-input:lang(uk),
-select:lang(uk),
-optgroup:lang(uk),
-textarea:lang(uk), .author-description .author-link:lang(uk),
+.gallery-caption:lang(uk), .wp-caption-text:lang(uk), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(uk), .entry .entry-content .wp-block-file .wp-block-file__button:lang(uk), .entry .entry-content .wp-block-file:lang(uk), .entry .entry-content .wp-block-audio figcaption:lang(uk),
+.entry .entry-content .wp-block-video figcaption:lang(uk),
+.entry .entry-content .wp-block-image figcaption:lang(uk),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(uk),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(uk), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(uk),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(uk),
+.entry .entry-content .wp-block-cover-image h2:lang(uk),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(uk),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(uk),
+.entry .entry-content .wp-block-cover h2:lang(uk), .entry .entry-content .wp-block-pullquote cite:lang(uk), .entry .entry-content .has-drop-cap:lang(uk):not(:focus):first-letter, .entry .entry-content .wp-block-verse:lang(uk), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(uk), .entry .entry-content .wp-block-archives li > a:lang(uk),
+.entry .entry-content .wp-block-categories li > a:lang(uk),
+.entry .entry-content .wp-block-latest-posts li > a:lang(uk), .entry .entry-content .wp-block-button .wp-block-button__link:lang(uk), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(uk), .widget_tag_cloud .tagcloud:lang(uk), .widget_archive ul li:lang(uk),
+.widget_categories ul li:lang(uk),
+.widget_meta ul li:lang(uk),
+.widget_nav_menu ul li:lang(uk),
+.widget_pages ul li:lang(uk),
+.widget_recent_comments ul li:lang(uk),
+.widget_recent_entries ul li:lang(uk),
+.widget_rss ul li:lang(uk), .comment-form .comment-notes:lang(uk),
+.comment-form label:lang(uk), .comment-list .pingback .comment-body .comment-edit-link:lang(uk),
+.comment-list .trackback .comment-body .comment-edit-link:lang(uk), .comment-list .pingback .comment-body:lang(uk),
+.comment-list .trackback .comment-body:lang(uk), .comment-navigation .nav-previous:lang(uk),
+.comment-navigation .nav-next:lang(uk), .button:lang(uk), table:lang(uk), blockquote cite:lang(uk), .page-title:lang(uk), .author-description .author-link:lang(uk),
 .comment-metadata:lang(uk),
 .comment-reply-link:lang(uk),
 .comments-title:lang(uk),
@@ -1022,8 +943,6 @@ textarea:lang(uk), .author-description .author-link:lang(uk),
 .entry-footer:lang(uk),
 .main-navigation:lang(uk),
 .no-comments:lang(uk),
-.not-found .page-title:lang(uk),
-.error-404 .page-title:lang(uk),
 .post-navigation .post-title:lang(uk),
 .page-links:lang(uk),
 .page-description:lang(uk),
@@ -1037,40 +956,36 @@ h2:lang(uk),
 h3:lang(uk),
 h4:lang(uk),
 h5:lang(uk),
-h6:lang(uk), .page-title:lang(uk), blockquote cite:lang(uk), table:lang(uk), .button:lang(uk),
-input:lang(uk)[type="button"],
-input:lang(uk)[type="reset"],
-input:lang(uk)[type="submit"], .comment-navigation .nav-previous:lang(uk),
-.comment-navigation .nav-next:lang(uk), .comment-list .pingback .comment-body:lang(uk),
-.comment-list .trackback .comment-body:lang(uk), .comment-list .pingback .comment-body .comment-edit-link:lang(uk),
-.comment-list .trackback .comment-body .comment-edit-link:lang(uk), .comment-form .comment-notes:lang(uk),
-.comment-form label:lang(uk), .widget_archive ul li:lang(uk),
-.widget_categories ul li:lang(uk),
-.widget_meta ul li:lang(uk),
-.widget_nav_menu ul li:lang(uk),
-.widget_pages ul li:lang(uk),
-.widget_recent_comments ul li:lang(uk),
-.widget_recent_entries ul li:lang(uk),
-.widget_rss ul li:lang(uk), .widget_tag_cloud .tagcloud:lang(uk), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(uk), .entry .entry-content .wp-block-button .wp-block-button__link:lang(uk), .entry .entry-content .wp-block-archives li > a:lang(uk),
-.entry .entry-content .wp-block-categories li > a:lang(uk),
-.entry .entry-content .wp-block-latest-posts li > a:lang(uk), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(uk), .entry .entry-content .wp-block-verse:lang(uk), .entry .entry-content .has-drop-cap:lang(uk):not(:focus):first-letter, .entry .entry-content .wp-block-pullquote cite:lang(uk), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(uk),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(uk),
-.entry .entry-content .wp-block-cover-image h2:lang(uk),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(uk),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(uk),
-.entry .entry-content .wp-block-cover h2:lang(uk), .entry .entry-content .wp-block-audio figcaption:lang(uk),
-.entry .entry-content .wp-block-video figcaption:lang(uk),
-.entry .entry-content .wp-block-image figcaption:lang(uk),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(uk),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(uk), .entry .entry-content .wp-block-file:lang(uk), .entry .entry-content .wp-block-file .wp-block-file__button:lang(uk), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(uk), .wp-caption-text:lang(uk), .gallery-caption:lang(uk) {
+h6:lang(uk), button:lang(uk),
+input:lang(uk),
+select:lang(uk),
+optgroup:lang(uk),
+textarea:lang(uk), body:lang(uk) {
   font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
 }
-
-body:lang(zh-HK), button:lang(zh-HK),
-input:lang(zh-HK),
-select:lang(zh-HK),
-optgroup:lang(zh-HK),
-textarea:lang(zh-HK), .author-description .author-link:lang(zh-HK),
+.gallery-caption:lang(zh-HK), .wp-caption-text:lang(zh-HK), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(zh-HK), .entry .entry-content .wp-block-file .wp-block-file__button:lang(zh-HK), .entry .entry-content .wp-block-file:lang(zh-HK), .entry .entry-content .wp-block-audio figcaption:lang(zh-HK),
+.entry .entry-content .wp-block-video figcaption:lang(zh-HK),
+.entry .entry-content .wp-block-image figcaption:lang(zh-HK),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(zh-HK),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(zh-HK), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(zh-HK),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(zh-HK),
+.entry .entry-content .wp-block-cover-image h2:lang(zh-HK),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(zh-HK),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(zh-HK),
+.entry .entry-content .wp-block-cover h2:lang(zh-HK), .entry .entry-content .wp-block-pullquote cite:lang(zh-HK), .entry .entry-content .has-drop-cap:lang(zh-HK):not(:focus):first-letter, .entry .entry-content .wp-block-verse:lang(zh-HK), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(zh-HK), .entry .entry-content .wp-block-archives li > a:lang(zh-HK),
+.entry .entry-content .wp-block-categories li > a:lang(zh-HK),
+.entry .entry-content .wp-block-latest-posts li > a:lang(zh-HK), .entry .entry-content .wp-block-button .wp-block-button__link:lang(zh-HK), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(zh-HK), .widget_tag_cloud .tagcloud:lang(zh-HK), .widget_archive ul li:lang(zh-HK),
+.widget_categories ul li:lang(zh-HK),
+.widget_meta ul li:lang(zh-HK),
+.widget_nav_menu ul li:lang(zh-HK),
+.widget_pages ul li:lang(zh-HK),
+.widget_recent_comments ul li:lang(zh-HK),
+.widget_recent_entries ul li:lang(zh-HK),
+.widget_rss ul li:lang(zh-HK), .comment-form .comment-notes:lang(zh-HK),
+.comment-form label:lang(zh-HK), .comment-list .pingback .comment-body .comment-edit-link:lang(zh-HK),
+.comment-list .trackback .comment-body .comment-edit-link:lang(zh-HK), .comment-list .pingback .comment-body:lang(zh-HK),
+.comment-list .trackback .comment-body:lang(zh-HK), .comment-navigation .nav-previous:lang(zh-HK),
+.comment-navigation .nav-next:lang(zh-HK), .button:lang(zh-HK), table:lang(zh-HK), blockquote cite:lang(zh-HK), .page-title:lang(zh-HK), .author-description .author-link:lang(zh-HK),
 .comment-metadata:lang(zh-HK),
 .comment-reply-link:lang(zh-HK),
 .comments-title:lang(zh-HK),
@@ -1080,8 +995,6 @@ textarea:lang(zh-HK), .author-description .author-link:lang(zh-HK),
 .entry-footer:lang(zh-HK),
 .main-navigation:lang(zh-HK),
 .no-comments:lang(zh-HK),
-.not-found .page-title:lang(zh-HK),
-.error-404 .page-title:lang(zh-HK),
 .post-navigation .post-title:lang(zh-HK),
 .page-links:lang(zh-HK),
 .page-description:lang(zh-HK),
@@ -1095,40 +1008,36 @@ h2:lang(zh-HK),
 h3:lang(zh-HK),
 h4:lang(zh-HK),
 h5:lang(zh-HK),
-h6:lang(zh-HK), .page-title:lang(zh-HK), blockquote cite:lang(zh-HK), table:lang(zh-HK), .button:lang(zh-HK),
-input:lang(zh-HK)[type="button"],
-input:lang(zh-HK)[type="reset"],
-input:lang(zh-HK)[type="submit"], .comment-navigation .nav-previous:lang(zh-HK),
-.comment-navigation .nav-next:lang(zh-HK), .comment-list .pingback .comment-body:lang(zh-HK),
-.comment-list .trackback .comment-body:lang(zh-HK), .comment-list .pingback .comment-body .comment-edit-link:lang(zh-HK),
-.comment-list .trackback .comment-body .comment-edit-link:lang(zh-HK), .comment-form .comment-notes:lang(zh-HK),
-.comment-form label:lang(zh-HK), .widget_archive ul li:lang(zh-HK),
-.widget_categories ul li:lang(zh-HK),
-.widget_meta ul li:lang(zh-HK),
-.widget_nav_menu ul li:lang(zh-HK),
-.widget_pages ul li:lang(zh-HK),
-.widget_recent_comments ul li:lang(zh-HK),
-.widget_recent_entries ul li:lang(zh-HK),
-.widget_rss ul li:lang(zh-HK), .widget_tag_cloud .tagcloud:lang(zh-HK), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(zh-HK), .entry .entry-content .wp-block-button .wp-block-button__link:lang(zh-HK), .entry .entry-content .wp-block-archives li > a:lang(zh-HK),
-.entry .entry-content .wp-block-categories li > a:lang(zh-HK),
-.entry .entry-content .wp-block-latest-posts li > a:lang(zh-HK), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(zh-HK), .entry .entry-content .wp-block-verse:lang(zh-HK), .entry .entry-content .has-drop-cap:lang(zh-HK):not(:focus):first-letter, .entry .entry-content .wp-block-pullquote cite:lang(zh-HK), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(zh-HK),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(zh-HK),
-.entry .entry-content .wp-block-cover-image h2:lang(zh-HK),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(zh-HK),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(zh-HK),
-.entry .entry-content .wp-block-cover h2:lang(zh-HK), .entry .entry-content .wp-block-audio figcaption:lang(zh-HK),
-.entry .entry-content .wp-block-video figcaption:lang(zh-HK),
-.entry .entry-content .wp-block-image figcaption:lang(zh-HK),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(zh-HK),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(zh-HK), .entry .entry-content .wp-block-file:lang(zh-HK), .entry .entry-content .wp-block-file .wp-block-file__button:lang(zh-HK), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(zh-HK), .wp-caption-text:lang(zh-HK), .gallery-caption:lang(zh-HK) {
+h6:lang(zh-HK), button:lang(zh-HK),
+input:lang(zh-HK),
+select:lang(zh-HK),
+optgroup:lang(zh-HK),
+textarea:lang(zh-HK), body:lang(zh-HK) {
   font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
 }
-
-body:lang(zh-TW), button:lang(zh-TW),
-input:lang(zh-TW),
-select:lang(zh-TW),
-optgroup:lang(zh-TW),
-textarea:lang(zh-TW), .author-description .author-link:lang(zh-TW),
+.gallery-caption:lang(zh-TW), .wp-caption-text:lang(zh-TW), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(zh-TW), .entry .entry-content .wp-block-file .wp-block-file__button:lang(zh-TW), .entry .entry-content .wp-block-file:lang(zh-TW), .entry .entry-content .wp-block-audio figcaption:lang(zh-TW),
+.entry .entry-content .wp-block-video figcaption:lang(zh-TW),
+.entry .entry-content .wp-block-image figcaption:lang(zh-TW),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(zh-TW),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(zh-TW), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(zh-TW),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(zh-TW),
+.entry .entry-content .wp-block-cover-image h2:lang(zh-TW),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(zh-TW),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(zh-TW),
+.entry .entry-content .wp-block-cover h2:lang(zh-TW), .entry .entry-content .wp-block-pullquote cite:lang(zh-TW), .entry .entry-content .has-drop-cap:lang(zh-TW):not(:focus):first-letter, .entry .entry-content .wp-block-verse:lang(zh-TW), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(zh-TW), .entry .entry-content .wp-block-archives li > a:lang(zh-TW),
+.entry .entry-content .wp-block-categories li > a:lang(zh-TW),
+.entry .entry-content .wp-block-latest-posts li > a:lang(zh-TW), .entry .entry-content .wp-block-button .wp-block-button__link:lang(zh-TW), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(zh-TW), .widget_tag_cloud .tagcloud:lang(zh-TW), .widget_archive ul li:lang(zh-TW),
+.widget_categories ul li:lang(zh-TW),
+.widget_meta ul li:lang(zh-TW),
+.widget_nav_menu ul li:lang(zh-TW),
+.widget_pages ul li:lang(zh-TW),
+.widget_recent_comments ul li:lang(zh-TW),
+.widget_recent_entries ul li:lang(zh-TW),
+.widget_rss ul li:lang(zh-TW), .comment-form .comment-notes:lang(zh-TW),
+.comment-form label:lang(zh-TW), .comment-list .pingback .comment-body .comment-edit-link:lang(zh-TW),
+.comment-list .trackback .comment-body .comment-edit-link:lang(zh-TW), .comment-list .pingback .comment-body:lang(zh-TW),
+.comment-list .trackback .comment-body:lang(zh-TW), .comment-navigation .nav-previous:lang(zh-TW),
+.comment-navigation .nav-next:lang(zh-TW), .button:lang(zh-TW), table:lang(zh-TW), blockquote cite:lang(zh-TW), .page-title:lang(zh-TW), .author-description .author-link:lang(zh-TW),
 .comment-metadata:lang(zh-TW),
 .comment-reply-link:lang(zh-TW),
 .comments-title:lang(zh-TW),
@@ -1138,8 +1047,6 @@ textarea:lang(zh-TW), .author-description .author-link:lang(zh-TW),
 .entry-footer:lang(zh-TW),
 .main-navigation:lang(zh-TW),
 .no-comments:lang(zh-TW),
-.not-found .page-title:lang(zh-TW),
-.error-404 .page-title:lang(zh-TW),
 .post-navigation .post-title:lang(zh-TW),
 .page-links:lang(zh-TW),
 .page-description:lang(zh-TW),
@@ -1153,40 +1060,36 @@ h2:lang(zh-TW),
 h3:lang(zh-TW),
 h4:lang(zh-TW),
 h5:lang(zh-TW),
-h6:lang(zh-TW), .page-title:lang(zh-TW), blockquote cite:lang(zh-TW), table:lang(zh-TW), .button:lang(zh-TW),
-input:lang(zh-TW)[type="button"],
-input:lang(zh-TW)[type="reset"],
-input:lang(zh-TW)[type="submit"], .comment-navigation .nav-previous:lang(zh-TW),
-.comment-navigation .nav-next:lang(zh-TW), .comment-list .pingback .comment-body:lang(zh-TW),
-.comment-list .trackback .comment-body:lang(zh-TW), .comment-list .pingback .comment-body .comment-edit-link:lang(zh-TW),
-.comment-list .trackback .comment-body .comment-edit-link:lang(zh-TW), .comment-form .comment-notes:lang(zh-TW),
-.comment-form label:lang(zh-TW), .widget_archive ul li:lang(zh-TW),
-.widget_categories ul li:lang(zh-TW),
-.widget_meta ul li:lang(zh-TW),
-.widget_nav_menu ul li:lang(zh-TW),
-.widget_pages ul li:lang(zh-TW),
-.widget_recent_comments ul li:lang(zh-TW),
-.widget_recent_entries ul li:lang(zh-TW),
-.widget_rss ul li:lang(zh-TW), .widget_tag_cloud .tagcloud:lang(zh-TW), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(zh-TW), .entry .entry-content .wp-block-button .wp-block-button__link:lang(zh-TW), .entry .entry-content .wp-block-archives li > a:lang(zh-TW),
-.entry .entry-content .wp-block-categories li > a:lang(zh-TW),
-.entry .entry-content .wp-block-latest-posts li > a:lang(zh-TW), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(zh-TW), .entry .entry-content .wp-block-verse:lang(zh-TW), .entry .entry-content .has-drop-cap:lang(zh-TW):not(:focus):first-letter, .entry .entry-content .wp-block-pullquote cite:lang(zh-TW), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(zh-TW),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(zh-TW),
-.entry .entry-content .wp-block-cover-image h2:lang(zh-TW),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(zh-TW),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(zh-TW),
-.entry .entry-content .wp-block-cover h2:lang(zh-TW), .entry .entry-content .wp-block-audio figcaption:lang(zh-TW),
-.entry .entry-content .wp-block-video figcaption:lang(zh-TW),
-.entry .entry-content .wp-block-image figcaption:lang(zh-TW),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(zh-TW),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(zh-TW), .entry .entry-content .wp-block-file:lang(zh-TW), .entry .entry-content .wp-block-file .wp-block-file__button:lang(zh-TW), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(zh-TW), .wp-caption-text:lang(zh-TW), .gallery-caption:lang(zh-TW) {
+h6:lang(zh-TW), button:lang(zh-TW),
+input:lang(zh-TW),
+select:lang(zh-TW),
+optgroup:lang(zh-TW),
+textarea:lang(zh-TW), body:lang(zh-TW) {
   font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
 }
-
-body:lang(zh-CN), button:lang(zh-CN),
-input:lang(zh-CN),
-select:lang(zh-CN),
-optgroup:lang(zh-CN),
-textarea:lang(zh-CN), .author-description .author-link:lang(zh-CN),
+.gallery-caption:lang(zh-CN), .wp-caption-text:lang(zh-CN), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(zh-CN), .entry .entry-content .wp-block-file .wp-block-file__button:lang(zh-CN), .entry .entry-content .wp-block-file:lang(zh-CN), .entry .entry-content .wp-block-audio figcaption:lang(zh-CN),
+.entry .entry-content .wp-block-video figcaption:lang(zh-CN),
+.entry .entry-content .wp-block-image figcaption:lang(zh-CN),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(zh-CN),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(zh-CN), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(zh-CN),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(zh-CN),
+.entry .entry-content .wp-block-cover-image h2:lang(zh-CN),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(zh-CN),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(zh-CN),
+.entry .entry-content .wp-block-cover h2:lang(zh-CN), .entry .entry-content .wp-block-pullquote cite:lang(zh-CN), .entry .entry-content .has-drop-cap:lang(zh-CN):not(:focus):first-letter, .entry .entry-content .wp-block-verse:lang(zh-CN), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(zh-CN), .entry .entry-content .wp-block-archives li > a:lang(zh-CN),
+.entry .entry-content .wp-block-categories li > a:lang(zh-CN),
+.entry .entry-content .wp-block-latest-posts li > a:lang(zh-CN), .entry .entry-content .wp-block-button .wp-block-button__link:lang(zh-CN), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(zh-CN), .widget_tag_cloud .tagcloud:lang(zh-CN), .widget_archive ul li:lang(zh-CN),
+.widget_categories ul li:lang(zh-CN),
+.widget_meta ul li:lang(zh-CN),
+.widget_nav_menu ul li:lang(zh-CN),
+.widget_pages ul li:lang(zh-CN),
+.widget_recent_comments ul li:lang(zh-CN),
+.widget_recent_entries ul li:lang(zh-CN),
+.widget_rss ul li:lang(zh-CN), .comment-form .comment-notes:lang(zh-CN),
+.comment-form label:lang(zh-CN), .comment-list .pingback .comment-body .comment-edit-link:lang(zh-CN),
+.comment-list .trackback .comment-body .comment-edit-link:lang(zh-CN), .comment-list .pingback .comment-body:lang(zh-CN),
+.comment-list .trackback .comment-body:lang(zh-CN), .comment-navigation .nav-previous:lang(zh-CN),
+.comment-navigation .nav-next:lang(zh-CN), .button:lang(zh-CN), table:lang(zh-CN), blockquote cite:lang(zh-CN), .page-title:lang(zh-CN), .author-description .author-link:lang(zh-CN),
 .comment-metadata:lang(zh-CN),
 .comment-reply-link:lang(zh-CN),
 .comments-title:lang(zh-CN),
@@ -1196,8 +1099,6 @@ textarea:lang(zh-CN), .author-description .author-link:lang(zh-CN),
 .entry-footer:lang(zh-CN),
 .main-navigation:lang(zh-CN),
 .no-comments:lang(zh-CN),
-.not-found .page-title:lang(zh-CN),
-.error-404 .page-title:lang(zh-CN),
 .post-navigation .post-title:lang(zh-CN),
 .page-links:lang(zh-CN),
 .page-description:lang(zh-CN),
@@ -1211,40 +1112,36 @@ h2:lang(zh-CN),
 h3:lang(zh-CN),
 h4:lang(zh-CN),
 h5:lang(zh-CN),
-h6:lang(zh-CN), .page-title:lang(zh-CN), blockquote cite:lang(zh-CN), table:lang(zh-CN), .button:lang(zh-CN),
-input:lang(zh-CN)[type="button"],
-input:lang(zh-CN)[type="reset"],
-input:lang(zh-CN)[type="submit"], .comment-navigation .nav-previous:lang(zh-CN),
-.comment-navigation .nav-next:lang(zh-CN), .comment-list .pingback .comment-body:lang(zh-CN),
-.comment-list .trackback .comment-body:lang(zh-CN), .comment-list .pingback .comment-body .comment-edit-link:lang(zh-CN),
-.comment-list .trackback .comment-body .comment-edit-link:lang(zh-CN), .comment-form .comment-notes:lang(zh-CN),
-.comment-form label:lang(zh-CN), .widget_archive ul li:lang(zh-CN),
-.widget_categories ul li:lang(zh-CN),
-.widget_meta ul li:lang(zh-CN),
-.widget_nav_menu ul li:lang(zh-CN),
-.widget_pages ul li:lang(zh-CN),
-.widget_recent_comments ul li:lang(zh-CN),
-.widget_recent_entries ul li:lang(zh-CN),
-.widget_rss ul li:lang(zh-CN), .widget_tag_cloud .tagcloud:lang(zh-CN), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(zh-CN), .entry .entry-content .wp-block-button .wp-block-button__link:lang(zh-CN), .entry .entry-content .wp-block-archives li > a:lang(zh-CN),
-.entry .entry-content .wp-block-categories li > a:lang(zh-CN),
-.entry .entry-content .wp-block-latest-posts li > a:lang(zh-CN), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(zh-CN), .entry .entry-content .wp-block-verse:lang(zh-CN), .entry .entry-content .has-drop-cap:lang(zh-CN):not(:focus):first-letter, .entry .entry-content .wp-block-pullquote cite:lang(zh-CN), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(zh-CN),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(zh-CN),
-.entry .entry-content .wp-block-cover-image h2:lang(zh-CN),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(zh-CN),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(zh-CN),
-.entry .entry-content .wp-block-cover h2:lang(zh-CN), .entry .entry-content .wp-block-audio figcaption:lang(zh-CN),
-.entry .entry-content .wp-block-video figcaption:lang(zh-CN),
-.entry .entry-content .wp-block-image figcaption:lang(zh-CN),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(zh-CN),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(zh-CN), .entry .entry-content .wp-block-file:lang(zh-CN), .entry .entry-content .wp-block-file .wp-block-file__button:lang(zh-CN), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(zh-CN), .wp-caption-text:lang(zh-CN), .gallery-caption:lang(zh-CN) {
+h6:lang(zh-CN), button:lang(zh-CN),
+input:lang(zh-CN),
+select:lang(zh-CN),
+optgroup:lang(zh-CN),
+textarea:lang(zh-CN), body:lang(zh-CN) {
   font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
 }
-
-body:lang(bn-BD), button:lang(bn-BD),
-input:lang(bn-BD),
-select:lang(bn-BD),
-optgroup:lang(bn-BD),
-textarea:lang(bn-BD), .author-description .author-link:lang(bn-BD),
+.gallery-caption:lang(bn-BD), .wp-caption-text:lang(bn-BD), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(bn-BD), .entry .entry-content .wp-block-file .wp-block-file__button:lang(bn-BD), .entry .entry-content .wp-block-file:lang(bn-BD), .entry .entry-content .wp-block-audio figcaption:lang(bn-BD),
+.entry .entry-content .wp-block-video figcaption:lang(bn-BD),
+.entry .entry-content .wp-block-image figcaption:lang(bn-BD),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(bn-BD),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(bn-BD), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(bn-BD),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(bn-BD),
+.entry .entry-content .wp-block-cover-image h2:lang(bn-BD),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(bn-BD),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(bn-BD),
+.entry .entry-content .wp-block-cover h2:lang(bn-BD), .entry .entry-content .wp-block-pullquote cite:lang(bn-BD), .entry .entry-content .has-drop-cap:lang(bn-BD):not(:focus):first-letter, .entry .entry-content .wp-block-verse:lang(bn-BD), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(bn-BD), .entry .entry-content .wp-block-archives li > a:lang(bn-BD),
+.entry .entry-content .wp-block-categories li > a:lang(bn-BD),
+.entry .entry-content .wp-block-latest-posts li > a:lang(bn-BD), .entry .entry-content .wp-block-button .wp-block-button__link:lang(bn-BD), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(bn-BD), .widget_tag_cloud .tagcloud:lang(bn-BD), .widget_archive ul li:lang(bn-BD),
+.widget_categories ul li:lang(bn-BD),
+.widget_meta ul li:lang(bn-BD),
+.widget_nav_menu ul li:lang(bn-BD),
+.widget_pages ul li:lang(bn-BD),
+.widget_recent_comments ul li:lang(bn-BD),
+.widget_recent_entries ul li:lang(bn-BD),
+.widget_rss ul li:lang(bn-BD), .comment-form .comment-notes:lang(bn-BD),
+.comment-form label:lang(bn-BD), .comment-list .pingback .comment-body .comment-edit-link:lang(bn-BD),
+.comment-list .trackback .comment-body .comment-edit-link:lang(bn-BD), .comment-list .pingback .comment-body:lang(bn-BD),
+.comment-list .trackback .comment-body:lang(bn-BD), .comment-navigation .nav-previous:lang(bn-BD),
+.comment-navigation .nav-next:lang(bn-BD), .button:lang(bn-BD), table:lang(bn-BD), blockquote cite:lang(bn-BD), .page-title:lang(bn-BD), .author-description .author-link:lang(bn-BD),
 .comment-metadata:lang(bn-BD),
 .comment-reply-link:lang(bn-BD),
 .comments-title:lang(bn-BD),
@@ -1254,8 +1151,6 @@ textarea:lang(bn-BD), .author-description .author-link:lang(bn-BD),
 .entry-footer:lang(bn-BD),
 .main-navigation:lang(bn-BD),
 .no-comments:lang(bn-BD),
-.not-found .page-title:lang(bn-BD),
-.error-404 .page-title:lang(bn-BD),
 .post-navigation .post-title:lang(bn-BD),
 .page-links:lang(bn-BD),
 .page-description:lang(bn-BD),
@@ -1269,40 +1164,36 @@ h2:lang(bn-BD),
 h3:lang(bn-BD),
 h4:lang(bn-BD),
 h5:lang(bn-BD),
-h6:lang(bn-BD), .page-title:lang(bn-BD), blockquote cite:lang(bn-BD), table:lang(bn-BD), .button:lang(bn-BD),
-input:lang(bn-BD)[type="button"],
-input:lang(bn-BD)[type="reset"],
-input:lang(bn-BD)[type="submit"], .comment-navigation .nav-previous:lang(bn-BD),
-.comment-navigation .nav-next:lang(bn-BD), .comment-list .pingback .comment-body:lang(bn-BD),
-.comment-list .trackback .comment-body:lang(bn-BD), .comment-list .pingback .comment-body .comment-edit-link:lang(bn-BD),
-.comment-list .trackback .comment-body .comment-edit-link:lang(bn-BD), .comment-form .comment-notes:lang(bn-BD),
-.comment-form label:lang(bn-BD), .widget_archive ul li:lang(bn-BD),
-.widget_categories ul li:lang(bn-BD),
-.widget_meta ul li:lang(bn-BD),
-.widget_nav_menu ul li:lang(bn-BD),
-.widget_pages ul li:lang(bn-BD),
-.widget_recent_comments ul li:lang(bn-BD),
-.widget_recent_entries ul li:lang(bn-BD),
-.widget_rss ul li:lang(bn-BD), .widget_tag_cloud .tagcloud:lang(bn-BD), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(bn-BD), .entry .entry-content .wp-block-button .wp-block-button__link:lang(bn-BD), .entry .entry-content .wp-block-archives li > a:lang(bn-BD),
-.entry .entry-content .wp-block-categories li > a:lang(bn-BD),
-.entry .entry-content .wp-block-latest-posts li > a:lang(bn-BD), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(bn-BD), .entry .entry-content .wp-block-verse:lang(bn-BD), .entry .entry-content .has-drop-cap:lang(bn-BD):not(:focus):first-letter, .entry .entry-content .wp-block-pullquote cite:lang(bn-BD), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(bn-BD),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(bn-BD),
-.entry .entry-content .wp-block-cover-image h2:lang(bn-BD),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(bn-BD),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(bn-BD),
-.entry .entry-content .wp-block-cover h2:lang(bn-BD), .entry .entry-content .wp-block-audio figcaption:lang(bn-BD),
-.entry .entry-content .wp-block-video figcaption:lang(bn-BD),
-.entry .entry-content .wp-block-image figcaption:lang(bn-BD),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(bn-BD),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(bn-BD), .entry .entry-content .wp-block-file:lang(bn-BD), .entry .entry-content .wp-block-file .wp-block-file__button:lang(bn-BD), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(bn-BD), .wp-caption-text:lang(bn-BD), .gallery-caption:lang(bn-BD) {
+h6:lang(bn-BD), button:lang(bn-BD),
+input:lang(bn-BD),
+select:lang(bn-BD),
+optgroup:lang(bn-BD),
+textarea:lang(bn-BD), body:lang(bn-BD) {
   font-family: Arial, sans-serif;
 }
-
-body:lang(hi-IN), button:lang(hi-IN),
-input:lang(hi-IN),
-select:lang(hi-IN),
-optgroup:lang(hi-IN),
-textarea:lang(hi-IN), .author-description .author-link:lang(hi-IN),
+.gallery-caption:lang(hi-IN), .wp-caption-text:lang(hi-IN), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(hi-IN), .entry .entry-content .wp-block-file .wp-block-file__button:lang(hi-IN), .entry .entry-content .wp-block-file:lang(hi-IN), .entry .entry-content .wp-block-audio figcaption:lang(hi-IN),
+.entry .entry-content .wp-block-video figcaption:lang(hi-IN),
+.entry .entry-content .wp-block-image figcaption:lang(hi-IN),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(hi-IN),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(hi-IN), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(hi-IN),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(hi-IN),
+.entry .entry-content .wp-block-cover-image h2:lang(hi-IN),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(hi-IN),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(hi-IN),
+.entry .entry-content .wp-block-cover h2:lang(hi-IN), .entry .entry-content .wp-block-pullquote cite:lang(hi-IN), .entry .entry-content .has-drop-cap:lang(hi-IN):not(:focus):first-letter, .entry .entry-content .wp-block-verse:lang(hi-IN), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(hi-IN), .entry .entry-content .wp-block-archives li > a:lang(hi-IN),
+.entry .entry-content .wp-block-categories li > a:lang(hi-IN),
+.entry .entry-content .wp-block-latest-posts li > a:lang(hi-IN), .entry .entry-content .wp-block-button .wp-block-button__link:lang(hi-IN), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(hi-IN), .widget_tag_cloud .tagcloud:lang(hi-IN), .widget_archive ul li:lang(hi-IN),
+.widget_categories ul li:lang(hi-IN),
+.widget_meta ul li:lang(hi-IN),
+.widget_nav_menu ul li:lang(hi-IN),
+.widget_pages ul li:lang(hi-IN),
+.widget_recent_comments ul li:lang(hi-IN),
+.widget_recent_entries ul li:lang(hi-IN),
+.widget_rss ul li:lang(hi-IN), .comment-form .comment-notes:lang(hi-IN),
+.comment-form label:lang(hi-IN), .comment-list .pingback .comment-body .comment-edit-link:lang(hi-IN),
+.comment-list .trackback .comment-body .comment-edit-link:lang(hi-IN), .comment-list .pingback .comment-body:lang(hi-IN),
+.comment-list .trackback .comment-body:lang(hi-IN), .comment-navigation .nav-previous:lang(hi-IN),
+.comment-navigation .nav-next:lang(hi-IN), .button:lang(hi-IN), table:lang(hi-IN), blockquote cite:lang(hi-IN), .page-title:lang(hi-IN), .author-description .author-link:lang(hi-IN),
 .comment-metadata:lang(hi-IN),
 .comment-reply-link:lang(hi-IN),
 .comments-title:lang(hi-IN),
@@ -1312,8 +1203,6 @@ textarea:lang(hi-IN), .author-description .author-link:lang(hi-IN),
 .entry-footer:lang(hi-IN),
 .main-navigation:lang(hi-IN),
 .no-comments:lang(hi-IN),
-.not-found .page-title:lang(hi-IN),
-.error-404 .page-title:lang(hi-IN),
 .post-navigation .post-title:lang(hi-IN),
 .page-links:lang(hi-IN),
 .page-description:lang(hi-IN),
@@ -1327,40 +1216,36 @@ h2:lang(hi-IN),
 h3:lang(hi-IN),
 h4:lang(hi-IN),
 h5:lang(hi-IN),
-h6:lang(hi-IN), .page-title:lang(hi-IN), blockquote cite:lang(hi-IN), table:lang(hi-IN), .button:lang(hi-IN),
-input:lang(hi-IN)[type="button"],
-input:lang(hi-IN)[type="reset"],
-input:lang(hi-IN)[type="submit"], .comment-navigation .nav-previous:lang(hi-IN),
-.comment-navigation .nav-next:lang(hi-IN), .comment-list .pingback .comment-body:lang(hi-IN),
-.comment-list .trackback .comment-body:lang(hi-IN), .comment-list .pingback .comment-body .comment-edit-link:lang(hi-IN),
-.comment-list .trackback .comment-body .comment-edit-link:lang(hi-IN), .comment-form .comment-notes:lang(hi-IN),
-.comment-form label:lang(hi-IN), .widget_archive ul li:lang(hi-IN),
-.widget_categories ul li:lang(hi-IN),
-.widget_meta ul li:lang(hi-IN),
-.widget_nav_menu ul li:lang(hi-IN),
-.widget_pages ul li:lang(hi-IN),
-.widget_recent_comments ul li:lang(hi-IN),
-.widget_recent_entries ul li:lang(hi-IN),
-.widget_rss ul li:lang(hi-IN), .widget_tag_cloud .tagcloud:lang(hi-IN), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(hi-IN), .entry .entry-content .wp-block-button .wp-block-button__link:lang(hi-IN), .entry .entry-content .wp-block-archives li > a:lang(hi-IN),
-.entry .entry-content .wp-block-categories li > a:lang(hi-IN),
-.entry .entry-content .wp-block-latest-posts li > a:lang(hi-IN), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(hi-IN), .entry .entry-content .wp-block-verse:lang(hi-IN), .entry .entry-content .has-drop-cap:lang(hi-IN):not(:focus):first-letter, .entry .entry-content .wp-block-pullquote cite:lang(hi-IN), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(hi-IN),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(hi-IN),
-.entry .entry-content .wp-block-cover-image h2:lang(hi-IN),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(hi-IN),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(hi-IN),
-.entry .entry-content .wp-block-cover h2:lang(hi-IN), .entry .entry-content .wp-block-audio figcaption:lang(hi-IN),
-.entry .entry-content .wp-block-video figcaption:lang(hi-IN),
-.entry .entry-content .wp-block-image figcaption:lang(hi-IN),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(hi-IN),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(hi-IN), .entry .entry-content .wp-block-file:lang(hi-IN), .entry .entry-content .wp-block-file .wp-block-file__button:lang(hi-IN), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(hi-IN), .wp-caption-text:lang(hi-IN), .gallery-caption:lang(hi-IN) {
+h6:lang(hi-IN), button:lang(hi-IN),
+input:lang(hi-IN),
+select:lang(hi-IN),
+optgroup:lang(hi-IN),
+textarea:lang(hi-IN), body:lang(hi-IN) {
   font-family: Arial, sans-serif;
 }
-
-body:lang(mr), button:lang(mr),
-input:lang(mr),
-select:lang(mr),
-optgroup:lang(mr),
-textarea:lang(mr), .author-description .author-link:lang(mr),
+.gallery-caption:lang(mr), .wp-caption-text:lang(mr), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(mr), .entry .entry-content .wp-block-file .wp-block-file__button:lang(mr), .entry .entry-content .wp-block-file:lang(mr), .entry .entry-content .wp-block-audio figcaption:lang(mr),
+.entry .entry-content .wp-block-video figcaption:lang(mr),
+.entry .entry-content .wp-block-image figcaption:lang(mr),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(mr),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(mr), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(mr),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(mr),
+.entry .entry-content .wp-block-cover-image h2:lang(mr),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(mr),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(mr),
+.entry .entry-content .wp-block-cover h2:lang(mr), .entry .entry-content .wp-block-pullquote cite:lang(mr), .entry .entry-content .has-drop-cap:lang(mr):not(:focus):first-letter, .entry .entry-content .wp-block-verse:lang(mr), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(mr), .entry .entry-content .wp-block-archives li > a:lang(mr),
+.entry .entry-content .wp-block-categories li > a:lang(mr),
+.entry .entry-content .wp-block-latest-posts li > a:lang(mr), .entry .entry-content .wp-block-button .wp-block-button__link:lang(mr), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(mr), .widget_tag_cloud .tagcloud:lang(mr), .widget_archive ul li:lang(mr),
+.widget_categories ul li:lang(mr),
+.widget_meta ul li:lang(mr),
+.widget_nav_menu ul li:lang(mr),
+.widget_pages ul li:lang(mr),
+.widget_recent_comments ul li:lang(mr),
+.widget_recent_entries ul li:lang(mr),
+.widget_rss ul li:lang(mr), .comment-form .comment-notes:lang(mr),
+.comment-form label:lang(mr), .comment-list .pingback .comment-body .comment-edit-link:lang(mr),
+.comment-list .trackback .comment-body .comment-edit-link:lang(mr), .comment-list .pingback .comment-body:lang(mr),
+.comment-list .trackback .comment-body:lang(mr), .comment-navigation .nav-previous:lang(mr),
+.comment-navigation .nav-next:lang(mr), .button:lang(mr), table:lang(mr), blockquote cite:lang(mr), .page-title:lang(mr), .author-description .author-link:lang(mr),
 .comment-metadata:lang(mr),
 .comment-reply-link:lang(mr),
 .comments-title:lang(mr),
@@ -1370,8 +1255,6 @@ textarea:lang(mr), .author-description .author-link:lang(mr),
 .entry-footer:lang(mr),
 .main-navigation:lang(mr),
 .no-comments:lang(mr),
-.not-found .page-title:lang(mr),
-.error-404 .page-title:lang(mr),
 .post-navigation .post-title:lang(mr),
 .page-links:lang(mr),
 .page-description:lang(mr),
@@ -1385,40 +1268,36 @@ h2:lang(mr),
 h3:lang(mr),
 h4:lang(mr),
 h5:lang(mr),
-h6:lang(mr), .page-title:lang(mr), blockquote cite:lang(mr), table:lang(mr), .button:lang(mr),
-input:lang(mr)[type="button"],
-input:lang(mr)[type="reset"],
-input:lang(mr)[type="submit"], .comment-navigation .nav-previous:lang(mr),
-.comment-navigation .nav-next:lang(mr), .comment-list .pingback .comment-body:lang(mr),
-.comment-list .trackback .comment-body:lang(mr), .comment-list .pingback .comment-body .comment-edit-link:lang(mr),
-.comment-list .trackback .comment-body .comment-edit-link:lang(mr), .comment-form .comment-notes:lang(mr),
-.comment-form label:lang(mr), .widget_archive ul li:lang(mr),
-.widget_categories ul li:lang(mr),
-.widget_meta ul li:lang(mr),
-.widget_nav_menu ul li:lang(mr),
-.widget_pages ul li:lang(mr),
-.widget_recent_comments ul li:lang(mr),
-.widget_recent_entries ul li:lang(mr),
-.widget_rss ul li:lang(mr), .widget_tag_cloud .tagcloud:lang(mr), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(mr), .entry .entry-content .wp-block-button .wp-block-button__link:lang(mr), .entry .entry-content .wp-block-archives li > a:lang(mr),
-.entry .entry-content .wp-block-categories li > a:lang(mr),
-.entry .entry-content .wp-block-latest-posts li > a:lang(mr), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(mr), .entry .entry-content .wp-block-verse:lang(mr), .entry .entry-content .has-drop-cap:lang(mr):not(:focus):first-letter, .entry .entry-content .wp-block-pullquote cite:lang(mr), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(mr),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(mr),
-.entry .entry-content .wp-block-cover-image h2:lang(mr),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(mr),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(mr),
-.entry .entry-content .wp-block-cover h2:lang(mr), .entry .entry-content .wp-block-audio figcaption:lang(mr),
-.entry .entry-content .wp-block-video figcaption:lang(mr),
-.entry .entry-content .wp-block-image figcaption:lang(mr),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(mr),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(mr), .entry .entry-content .wp-block-file:lang(mr), .entry .entry-content .wp-block-file .wp-block-file__button:lang(mr), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(mr), .wp-caption-text:lang(mr), .gallery-caption:lang(mr) {
+h6:lang(mr), button:lang(mr),
+input:lang(mr),
+select:lang(mr),
+optgroup:lang(mr),
+textarea:lang(mr), body:lang(mr) {
   font-family: Arial, sans-serif;
 }
-
-body:lang(ne-NP), button:lang(ne-NP),
-input:lang(ne-NP),
-select:lang(ne-NP),
-optgroup:lang(ne-NP),
-textarea:lang(ne-NP), .author-description .author-link:lang(ne-NP),
+.gallery-caption:lang(ne-NP), .wp-caption-text:lang(ne-NP), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ne-NP), .entry .entry-content .wp-block-file .wp-block-file__button:lang(ne-NP), .entry .entry-content .wp-block-file:lang(ne-NP), .entry .entry-content .wp-block-audio figcaption:lang(ne-NP),
+.entry .entry-content .wp-block-video figcaption:lang(ne-NP),
+.entry .entry-content .wp-block-image figcaption:lang(ne-NP),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(ne-NP),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(ne-NP), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(ne-NP),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(ne-NP),
+.entry .entry-content .wp-block-cover-image h2:lang(ne-NP),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(ne-NP),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(ne-NP),
+.entry .entry-content .wp-block-cover h2:lang(ne-NP), .entry .entry-content .wp-block-pullquote cite:lang(ne-NP), .entry .entry-content .has-drop-cap:lang(ne-NP):not(:focus):first-letter, .entry .entry-content .wp-block-verse:lang(ne-NP), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ne-NP), .entry .entry-content .wp-block-archives li > a:lang(ne-NP),
+.entry .entry-content .wp-block-categories li > a:lang(ne-NP),
+.entry .entry-content .wp-block-latest-posts li > a:lang(ne-NP), .entry .entry-content .wp-block-button .wp-block-button__link:lang(ne-NP), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(ne-NP), .widget_tag_cloud .tagcloud:lang(ne-NP), .widget_archive ul li:lang(ne-NP),
+.widget_categories ul li:lang(ne-NP),
+.widget_meta ul li:lang(ne-NP),
+.widget_nav_menu ul li:lang(ne-NP),
+.widget_pages ul li:lang(ne-NP),
+.widget_recent_comments ul li:lang(ne-NP),
+.widget_recent_entries ul li:lang(ne-NP),
+.widget_rss ul li:lang(ne-NP), .comment-form .comment-notes:lang(ne-NP),
+.comment-form label:lang(ne-NP), .comment-list .pingback .comment-body .comment-edit-link:lang(ne-NP),
+.comment-list .trackback .comment-body .comment-edit-link:lang(ne-NP), .comment-list .pingback .comment-body:lang(ne-NP),
+.comment-list .trackback .comment-body:lang(ne-NP), .comment-navigation .nav-previous:lang(ne-NP),
+.comment-navigation .nav-next:lang(ne-NP), .button:lang(ne-NP), table:lang(ne-NP), blockquote cite:lang(ne-NP), .page-title:lang(ne-NP), .author-description .author-link:lang(ne-NP),
 .comment-metadata:lang(ne-NP),
 .comment-reply-link:lang(ne-NP),
 .comments-title:lang(ne-NP),
@@ -1428,8 +1307,6 @@ textarea:lang(ne-NP), .author-description .author-link:lang(ne-NP),
 .entry-footer:lang(ne-NP),
 .main-navigation:lang(ne-NP),
 .no-comments:lang(ne-NP),
-.not-found .page-title:lang(ne-NP),
-.error-404 .page-title:lang(ne-NP),
 .post-navigation .post-title:lang(ne-NP),
 .page-links:lang(ne-NP),
 .page-description:lang(ne-NP),
@@ -1443,40 +1320,36 @@ h2:lang(ne-NP),
 h3:lang(ne-NP),
 h4:lang(ne-NP),
 h5:lang(ne-NP),
-h6:lang(ne-NP), .page-title:lang(ne-NP), blockquote cite:lang(ne-NP), table:lang(ne-NP), .button:lang(ne-NP),
-input:lang(ne-NP)[type="button"],
-input:lang(ne-NP)[type="reset"],
-input:lang(ne-NP)[type="submit"], .comment-navigation .nav-previous:lang(ne-NP),
-.comment-navigation .nav-next:lang(ne-NP), .comment-list .pingback .comment-body:lang(ne-NP),
-.comment-list .trackback .comment-body:lang(ne-NP), .comment-list .pingback .comment-body .comment-edit-link:lang(ne-NP),
-.comment-list .trackback .comment-body .comment-edit-link:lang(ne-NP), .comment-form .comment-notes:lang(ne-NP),
-.comment-form label:lang(ne-NP), .widget_archive ul li:lang(ne-NP),
-.widget_categories ul li:lang(ne-NP),
-.widget_meta ul li:lang(ne-NP),
-.widget_nav_menu ul li:lang(ne-NP),
-.widget_pages ul li:lang(ne-NP),
-.widget_recent_comments ul li:lang(ne-NP),
-.widget_recent_entries ul li:lang(ne-NP),
-.widget_rss ul li:lang(ne-NP), .widget_tag_cloud .tagcloud:lang(ne-NP), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(ne-NP), .entry .entry-content .wp-block-button .wp-block-button__link:lang(ne-NP), .entry .entry-content .wp-block-archives li > a:lang(ne-NP),
-.entry .entry-content .wp-block-categories li > a:lang(ne-NP),
-.entry .entry-content .wp-block-latest-posts li > a:lang(ne-NP), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ne-NP), .entry .entry-content .wp-block-verse:lang(ne-NP), .entry .entry-content .has-drop-cap:lang(ne-NP):not(:focus):first-letter, .entry .entry-content .wp-block-pullquote cite:lang(ne-NP), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(ne-NP),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(ne-NP),
-.entry .entry-content .wp-block-cover-image h2:lang(ne-NP),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(ne-NP),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(ne-NP),
-.entry .entry-content .wp-block-cover h2:lang(ne-NP), .entry .entry-content .wp-block-audio figcaption:lang(ne-NP),
-.entry .entry-content .wp-block-video figcaption:lang(ne-NP),
-.entry .entry-content .wp-block-image figcaption:lang(ne-NP),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(ne-NP),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(ne-NP), .entry .entry-content .wp-block-file:lang(ne-NP), .entry .entry-content .wp-block-file .wp-block-file__button:lang(ne-NP), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ne-NP), .wp-caption-text:lang(ne-NP), .gallery-caption:lang(ne-NP) {
+h6:lang(ne-NP), button:lang(ne-NP),
+input:lang(ne-NP),
+select:lang(ne-NP),
+optgroup:lang(ne-NP),
+textarea:lang(ne-NP), body:lang(ne-NP) {
   font-family: Arial, sans-serif;
 }
-
-body:lang(el), button:lang(el),
-input:lang(el),
-select:lang(el),
-optgroup:lang(el),
-textarea:lang(el), .author-description .author-link:lang(el),
+.gallery-caption:lang(el), .wp-caption-text:lang(el), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(el), .entry .entry-content .wp-block-file .wp-block-file__button:lang(el), .entry .entry-content .wp-block-file:lang(el), .entry .entry-content .wp-block-audio figcaption:lang(el),
+.entry .entry-content .wp-block-video figcaption:lang(el),
+.entry .entry-content .wp-block-image figcaption:lang(el),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(el),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(el), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(el),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(el),
+.entry .entry-content .wp-block-cover-image h2:lang(el),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(el),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(el),
+.entry .entry-content .wp-block-cover h2:lang(el), .entry .entry-content .wp-block-pullquote cite:lang(el), .entry .entry-content .has-drop-cap:lang(el):not(:focus):first-letter, .entry .entry-content .wp-block-verse:lang(el), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(el), .entry .entry-content .wp-block-archives li > a:lang(el),
+.entry .entry-content .wp-block-categories li > a:lang(el),
+.entry .entry-content .wp-block-latest-posts li > a:lang(el), .entry .entry-content .wp-block-button .wp-block-button__link:lang(el), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(el), .widget_tag_cloud .tagcloud:lang(el), .widget_archive ul li:lang(el),
+.widget_categories ul li:lang(el),
+.widget_meta ul li:lang(el),
+.widget_nav_menu ul li:lang(el),
+.widget_pages ul li:lang(el),
+.widget_recent_comments ul li:lang(el),
+.widget_recent_entries ul li:lang(el),
+.widget_rss ul li:lang(el), .comment-form .comment-notes:lang(el),
+.comment-form label:lang(el), .comment-list .pingback .comment-body .comment-edit-link:lang(el),
+.comment-list .trackback .comment-body .comment-edit-link:lang(el), .comment-list .pingback .comment-body:lang(el),
+.comment-list .trackback .comment-body:lang(el), .comment-navigation .nav-previous:lang(el),
+.comment-navigation .nav-next:lang(el), .button:lang(el), table:lang(el), blockquote cite:lang(el), .page-title:lang(el), .author-description .author-link:lang(el),
 .comment-metadata:lang(el),
 .comment-reply-link:lang(el),
 .comments-title:lang(el),
@@ -1486,8 +1359,6 @@ textarea:lang(el), .author-description .author-link:lang(el),
 .entry-footer:lang(el),
 .main-navigation:lang(el),
 .no-comments:lang(el),
-.not-found .page-title:lang(el),
-.error-404 .page-title:lang(el),
 .post-navigation .post-title:lang(el),
 .page-links:lang(el),
 .page-description:lang(el),
@@ -1501,40 +1372,36 @@ h2:lang(el),
 h3:lang(el),
 h4:lang(el),
 h5:lang(el),
-h6:lang(el), .page-title:lang(el), blockquote cite:lang(el), table:lang(el), .button:lang(el),
-input:lang(el)[type="button"],
-input:lang(el)[type="reset"],
-input:lang(el)[type="submit"], .comment-navigation .nav-previous:lang(el),
-.comment-navigation .nav-next:lang(el), .comment-list .pingback .comment-body:lang(el),
-.comment-list .trackback .comment-body:lang(el), .comment-list .pingback .comment-body .comment-edit-link:lang(el),
-.comment-list .trackback .comment-body .comment-edit-link:lang(el), .comment-form .comment-notes:lang(el),
-.comment-form label:lang(el), .widget_archive ul li:lang(el),
-.widget_categories ul li:lang(el),
-.widget_meta ul li:lang(el),
-.widget_nav_menu ul li:lang(el),
-.widget_pages ul li:lang(el),
-.widget_recent_comments ul li:lang(el),
-.widget_recent_entries ul li:lang(el),
-.widget_rss ul li:lang(el), .widget_tag_cloud .tagcloud:lang(el), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(el), .entry .entry-content .wp-block-button .wp-block-button__link:lang(el), .entry .entry-content .wp-block-archives li > a:lang(el),
-.entry .entry-content .wp-block-categories li > a:lang(el),
-.entry .entry-content .wp-block-latest-posts li > a:lang(el), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(el), .entry .entry-content .wp-block-verse:lang(el), .entry .entry-content .has-drop-cap:lang(el):not(:focus):first-letter, .entry .entry-content .wp-block-pullquote cite:lang(el), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(el),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(el),
-.entry .entry-content .wp-block-cover-image h2:lang(el),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(el),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(el),
-.entry .entry-content .wp-block-cover h2:lang(el), .entry .entry-content .wp-block-audio figcaption:lang(el),
-.entry .entry-content .wp-block-video figcaption:lang(el),
-.entry .entry-content .wp-block-image figcaption:lang(el),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(el),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(el), .entry .entry-content .wp-block-file:lang(el), .entry .entry-content .wp-block-file .wp-block-file__button:lang(el), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(el), .wp-caption-text:lang(el), .gallery-caption:lang(el) {
+h6:lang(el), button:lang(el),
+input:lang(el),
+select:lang(el),
+optgroup:lang(el),
+textarea:lang(el), body:lang(el) {
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
 }
-
-body:lang(gu), button:lang(gu),
-input:lang(gu),
-select:lang(gu),
-optgroup:lang(gu),
-textarea:lang(gu), .author-description .author-link:lang(gu),
+.gallery-caption:lang(gu), .wp-caption-text:lang(gu), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(gu), .entry .entry-content .wp-block-file .wp-block-file__button:lang(gu), .entry .entry-content .wp-block-file:lang(gu), .entry .entry-content .wp-block-audio figcaption:lang(gu),
+.entry .entry-content .wp-block-video figcaption:lang(gu),
+.entry .entry-content .wp-block-image figcaption:lang(gu),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(gu),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(gu), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(gu),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(gu),
+.entry .entry-content .wp-block-cover-image h2:lang(gu),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(gu),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(gu),
+.entry .entry-content .wp-block-cover h2:lang(gu), .entry .entry-content .wp-block-pullquote cite:lang(gu), .entry .entry-content .has-drop-cap:lang(gu):not(:focus):first-letter, .entry .entry-content .wp-block-verse:lang(gu), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(gu), .entry .entry-content .wp-block-archives li > a:lang(gu),
+.entry .entry-content .wp-block-categories li > a:lang(gu),
+.entry .entry-content .wp-block-latest-posts li > a:lang(gu), .entry .entry-content .wp-block-button .wp-block-button__link:lang(gu), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(gu), .widget_tag_cloud .tagcloud:lang(gu), .widget_archive ul li:lang(gu),
+.widget_categories ul li:lang(gu),
+.widget_meta ul li:lang(gu),
+.widget_nav_menu ul li:lang(gu),
+.widget_pages ul li:lang(gu),
+.widget_recent_comments ul li:lang(gu),
+.widget_recent_entries ul li:lang(gu),
+.widget_rss ul li:lang(gu), .comment-form .comment-notes:lang(gu),
+.comment-form label:lang(gu), .comment-list .pingback .comment-body .comment-edit-link:lang(gu),
+.comment-list .trackback .comment-body .comment-edit-link:lang(gu), .comment-list .pingback .comment-body:lang(gu),
+.comment-list .trackback .comment-body:lang(gu), .comment-navigation .nav-previous:lang(gu),
+.comment-navigation .nav-next:lang(gu), .button:lang(gu), table:lang(gu), blockquote cite:lang(gu), .page-title:lang(gu), .author-description .author-link:lang(gu),
 .comment-metadata:lang(gu),
 .comment-reply-link:lang(gu),
 .comments-title:lang(gu),
@@ -1544,8 +1411,6 @@ textarea:lang(gu), .author-description .author-link:lang(gu),
 .entry-footer:lang(gu),
 .main-navigation:lang(gu),
 .no-comments:lang(gu),
-.not-found .page-title:lang(gu),
-.error-404 .page-title:lang(gu),
 .post-navigation .post-title:lang(gu),
 .page-links:lang(gu),
 .page-description:lang(gu),
@@ -1559,40 +1424,36 @@ h2:lang(gu),
 h3:lang(gu),
 h4:lang(gu),
 h5:lang(gu),
-h6:lang(gu), .page-title:lang(gu), blockquote cite:lang(gu), table:lang(gu), .button:lang(gu),
-input:lang(gu)[type="button"],
-input:lang(gu)[type="reset"],
-input:lang(gu)[type="submit"], .comment-navigation .nav-previous:lang(gu),
-.comment-navigation .nav-next:lang(gu), .comment-list .pingback .comment-body:lang(gu),
-.comment-list .trackback .comment-body:lang(gu), .comment-list .pingback .comment-body .comment-edit-link:lang(gu),
-.comment-list .trackback .comment-body .comment-edit-link:lang(gu), .comment-form .comment-notes:lang(gu),
-.comment-form label:lang(gu), .widget_archive ul li:lang(gu),
-.widget_categories ul li:lang(gu),
-.widget_meta ul li:lang(gu),
-.widget_nav_menu ul li:lang(gu),
-.widget_pages ul li:lang(gu),
-.widget_recent_comments ul li:lang(gu),
-.widget_recent_entries ul li:lang(gu),
-.widget_rss ul li:lang(gu), .widget_tag_cloud .tagcloud:lang(gu), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(gu), .entry .entry-content .wp-block-button .wp-block-button__link:lang(gu), .entry .entry-content .wp-block-archives li > a:lang(gu),
-.entry .entry-content .wp-block-categories li > a:lang(gu),
-.entry .entry-content .wp-block-latest-posts li > a:lang(gu), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(gu), .entry .entry-content .wp-block-verse:lang(gu), .entry .entry-content .has-drop-cap:lang(gu):not(:focus):first-letter, .entry .entry-content .wp-block-pullquote cite:lang(gu), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(gu),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(gu),
-.entry .entry-content .wp-block-cover-image h2:lang(gu),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(gu),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(gu),
-.entry .entry-content .wp-block-cover h2:lang(gu), .entry .entry-content .wp-block-audio figcaption:lang(gu),
-.entry .entry-content .wp-block-video figcaption:lang(gu),
-.entry .entry-content .wp-block-image figcaption:lang(gu),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(gu),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(gu), .entry .entry-content .wp-block-file:lang(gu), .entry .entry-content .wp-block-file .wp-block-file__button:lang(gu), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(gu), .wp-caption-text:lang(gu), .gallery-caption:lang(gu) {
+h6:lang(gu), button:lang(gu),
+input:lang(gu),
+select:lang(gu),
+optgroup:lang(gu),
+textarea:lang(gu), body:lang(gu) {
   font-family: Arial, sans-serif;
 }
-
-body:lang(he-IL), button:lang(he-IL),
-input:lang(he-IL),
-select:lang(he-IL),
-optgroup:lang(he-IL),
-textarea:lang(he-IL), .author-description .author-link:lang(he-IL),
+.gallery-caption:lang(he-IL), .wp-caption-text:lang(he-IL), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(he-IL), .entry .entry-content .wp-block-file .wp-block-file__button:lang(he-IL), .entry .entry-content .wp-block-file:lang(he-IL), .entry .entry-content .wp-block-audio figcaption:lang(he-IL),
+.entry .entry-content .wp-block-video figcaption:lang(he-IL),
+.entry .entry-content .wp-block-image figcaption:lang(he-IL),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(he-IL),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(he-IL), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(he-IL),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(he-IL),
+.entry .entry-content .wp-block-cover-image h2:lang(he-IL),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(he-IL),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(he-IL),
+.entry .entry-content .wp-block-cover h2:lang(he-IL), .entry .entry-content .wp-block-pullquote cite:lang(he-IL), .entry .entry-content .has-drop-cap:lang(he-IL):not(:focus):first-letter, .entry .entry-content .wp-block-verse:lang(he-IL), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(he-IL), .entry .entry-content .wp-block-archives li > a:lang(he-IL),
+.entry .entry-content .wp-block-categories li > a:lang(he-IL),
+.entry .entry-content .wp-block-latest-posts li > a:lang(he-IL), .entry .entry-content .wp-block-button .wp-block-button__link:lang(he-IL), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(he-IL), .widget_tag_cloud .tagcloud:lang(he-IL), .widget_archive ul li:lang(he-IL),
+.widget_categories ul li:lang(he-IL),
+.widget_meta ul li:lang(he-IL),
+.widget_nav_menu ul li:lang(he-IL),
+.widget_pages ul li:lang(he-IL),
+.widget_recent_comments ul li:lang(he-IL),
+.widget_recent_entries ul li:lang(he-IL),
+.widget_rss ul li:lang(he-IL), .comment-form .comment-notes:lang(he-IL),
+.comment-form label:lang(he-IL), .comment-list .pingback .comment-body .comment-edit-link:lang(he-IL),
+.comment-list .trackback .comment-body .comment-edit-link:lang(he-IL), .comment-list .pingback .comment-body:lang(he-IL),
+.comment-list .trackback .comment-body:lang(he-IL), .comment-navigation .nav-previous:lang(he-IL),
+.comment-navigation .nav-next:lang(he-IL), .button:lang(he-IL), table:lang(he-IL), blockquote cite:lang(he-IL), .page-title:lang(he-IL), .author-description .author-link:lang(he-IL),
 .comment-metadata:lang(he-IL),
 .comment-reply-link:lang(he-IL),
 .comments-title:lang(he-IL),
@@ -1602,8 +1463,6 @@ textarea:lang(he-IL), .author-description .author-link:lang(he-IL),
 .entry-footer:lang(he-IL),
 .main-navigation:lang(he-IL),
 .no-comments:lang(he-IL),
-.not-found .page-title:lang(he-IL),
-.error-404 .page-title:lang(he-IL),
 .post-navigation .post-title:lang(he-IL),
 .page-links:lang(he-IL),
 .page-description:lang(he-IL),
@@ -1617,40 +1476,36 @@ h2:lang(he-IL),
 h3:lang(he-IL),
 h4:lang(he-IL),
 h5:lang(he-IL),
-h6:lang(he-IL), .page-title:lang(he-IL), blockquote cite:lang(he-IL), table:lang(he-IL), .button:lang(he-IL),
-input:lang(he-IL)[type="button"],
-input:lang(he-IL)[type="reset"],
-input:lang(he-IL)[type="submit"], .comment-navigation .nav-previous:lang(he-IL),
-.comment-navigation .nav-next:lang(he-IL), .comment-list .pingback .comment-body:lang(he-IL),
-.comment-list .trackback .comment-body:lang(he-IL), .comment-list .pingback .comment-body .comment-edit-link:lang(he-IL),
-.comment-list .trackback .comment-body .comment-edit-link:lang(he-IL), .comment-form .comment-notes:lang(he-IL),
-.comment-form label:lang(he-IL), .widget_archive ul li:lang(he-IL),
-.widget_categories ul li:lang(he-IL),
-.widget_meta ul li:lang(he-IL),
-.widget_nav_menu ul li:lang(he-IL),
-.widget_pages ul li:lang(he-IL),
-.widget_recent_comments ul li:lang(he-IL),
-.widget_recent_entries ul li:lang(he-IL),
-.widget_rss ul li:lang(he-IL), .widget_tag_cloud .tagcloud:lang(he-IL), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(he-IL), .entry .entry-content .wp-block-button .wp-block-button__link:lang(he-IL), .entry .entry-content .wp-block-archives li > a:lang(he-IL),
-.entry .entry-content .wp-block-categories li > a:lang(he-IL),
-.entry .entry-content .wp-block-latest-posts li > a:lang(he-IL), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(he-IL), .entry .entry-content .wp-block-verse:lang(he-IL), .entry .entry-content .has-drop-cap:lang(he-IL):not(:focus):first-letter, .entry .entry-content .wp-block-pullquote cite:lang(he-IL), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(he-IL),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(he-IL),
-.entry .entry-content .wp-block-cover-image h2:lang(he-IL),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(he-IL),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(he-IL),
-.entry .entry-content .wp-block-cover h2:lang(he-IL), .entry .entry-content .wp-block-audio figcaption:lang(he-IL),
-.entry .entry-content .wp-block-video figcaption:lang(he-IL),
-.entry .entry-content .wp-block-image figcaption:lang(he-IL),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(he-IL),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(he-IL), .entry .entry-content .wp-block-file:lang(he-IL), .entry .entry-content .wp-block-file .wp-block-file__button:lang(he-IL), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(he-IL), .wp-caption-text:lang(he-IL), .gallery-caption:lang(he-IL) {
+h6:lang(he-IL), button:lang(he-IL),
+input:lang(he-IL),
+select:lang(he-IL),
+optgroup:lang(he-IL),
+textarea:lang(he-IL), body:lang(he-IL) {
   font-family: "Arial Hebrew", Arial, sans-serif;
 }
-
-body:lang(ja), button:lang(ja),
-input:lang(ja),
-select:lang(ja),
-optgroup:lang(ja),
-textarea:lang(ja), .author-description .author-link:lang(ja),
+.gallery-caption:lang(ja), .wp-caption-text:lang(ja), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ja), .entry .entry-content .wp-block-file .wp-block-file__button:lang(ja), .entry .entry-content .wp-block-file:lang(ja), .entry .entry-content .wp-block-audio figcaption:lang(ja),
+.entry .entry-content .wp-block-video figcaption:lang(ja),
+.entry .entry-content .wp-block-image figcaption:lang(ja),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(ja),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(ja), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(ja),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(ja),
+.entry .entry-content .wp-block-cover-image h2:lang(ja),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(ja),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(ja),
+.entry .entry-content .wp-block-cover h2:lang(ja), .entry .entry-content .wp-block-pullquote cite:lang(ja), .entry .entry-content .has-drop-cap:lang(ja):not(:focus):first-letter, .entry .entry-content .wp-block-verse:lang(ja), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ja), .entry .entry-content .wp-block-archives li > a:lang(ja),
+.entry .entry-content .wp-block-categories li > a:lang(ja),
+.entry .entry-content .wp-block-latest-posts li > a:lang(ja), .entry .entry-content .wp-block-button .wp-block-button__link:lang(ja), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(ja), .widget_tag_cloud .tagcloud:lang(ja), .widget_archive ul li:lang(ja),
+.widget_categories ul li:lang(ja),
+.widget_meta ul li:lang(ja),
+.widget_nav_menu ul li:lang(ja),
+.widget_pages ul li:lang(ja),
+.widget_recent_comments ul li:lang(ja),
+.widget_recent_entries ul li:lang(ja),
+.widget_rss ul li:lang(ja), .comment-form .comment-notes:lang(ja),
+.comment-form label:lang(ja), .comment-list .pingback .comment-body .comment-edit-link:lang(ja),
+.comment-list .trackback .comment-body .comment-edit-link:lang(ja), .comment-list .pingback .comment-body:lang(ja),
+.comment-list .trackback .comment-body:lang(ja), .comment-navigation .nav-previous:lang(ja),
+.comment-navigation .nav-next:lang(ja), .button:lang(ja), table:lang(ja), blockquote cite:lang(ja), .page-title:lang(ja), .author-description .author-link:lang(ja),
 .comment-metadata:lang(ja),
 .comment-reply-link:lang(ja),
 .comments-title:lang(ja),
@@ -1660,8 +1515,6 @@ textarea:lang(ja), .author-description .author-link:lang(ja),
 .entry-footer:lang(ja),
 .main-navigation:lang(ja),
 .no-comments:lang(ja),
-.not-found .page-title:lang(ja),
-.error-404 .page-title:lang(ja),
 .post-navigation .post-title:lang(ja),
 .page-links:lang(ja),
 .page-description:lang(ja),
@@ -1675,40 +1528,36 @@ h2:lang(ja),
 h3:lang(ja),
 h4:lang(ja),
 h5:lang(ja),
-h6:lang(ja), .page-title:lang(ja), blockquote cite:lang(ja), table:lang(ja), .button:lang(ja),
-input:lang(ja)[type="button"],
-input:lang(ja)[type="reset"],
-input:lang(ja)[type="submit"], .comment-navigation .nav-previous:lang(ja),
-.comment-navigation .nav-next:lang(ja), .comment-list .pingback .comment-body:lang(ja),
-.comment-list .trackback .comment-body:lang(ja), .comment-list .pingback .comment-body .comment-edit-link:lang(ja),
-.comment-list .trackback .comment-body .comment-edit-link:lang(ja), .comment-form .comment-notes:lang(ja),
-.comment-form label:lang(ja), .widget_archive ul li:lang(ja),
-.widget_categories ul li:lang(ja),
-.widget_meta ul li:lang(ja),
-.widget_nav_menu ul li:lang(ja),
-.widget_pages ul li:lang(ja),
-.widget_recent_comments ul li:lang(ja),
-.widget_recent_entries ul li:lang(ja),
-.widget_rss ul li:lang(ja), .widget_tag_cloud .tagcloud:lang(ja), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(ja), .entry .entry-content .wp-block-button .wp-block-button__link:lang(ja), .entry .entry-content .wp-block-archives li > a:lang(ja),
-.entry .entry-content .wp-block-categories li > a:lang(ja),
-.entry .entry-content .wp-block-latest-posts li > a:lang(ja), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ja), .entry .entry-content .wp-block-verse:lang(ja), .entry .entry-content .has-drop-cap:lang(ja):not(:focus):first-letter, .entry .entry-content .wp-block-pullquote cite:lang(ja), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(ja),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(ja),
-.entry .entry-content .wp-block-cover-image h2:lang(ja),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(ja),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(ja),
-.entry .entry-content .wp-block-cover h2:lang(ja), .entry .entry-content .wp-block-audio figcaption:lang(ja),
-.entry .entry-content .wp-block-video figcaption:lang(ja),
-.entry .entry-content .wp-block-image figcaption:lang(ja),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(ja),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(ja), .entry .entry-content .wp-block-file:lang(ja), .entry .entry-content .wp-block-file .wp-block-file__button:lang(ja), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ja), .wp-caption-text:lang(ja), .gallery-caption:lang(ja) {
+h6:lang(ja), button:lang(ja),
+input:lang(ja),
+select:lang(ja),
+optgroup:lang(ja),
+textarea:lang(ja), body:lang(ja) {
   font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
 }
-
-body:lang(ko-KR), button:lang(ko-KR),
-input:lang(ko-KR),
-select:lang(ko-KR),
-optgroup:lang(ko-KR),
-textarea:lang(ko-KR), .author-description .author-link:lang(ko-KR),
+.gallery-caption:lang(ko-KR), .wp-caption-text:lang(ko-KR), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ko-KR), .entry .entry-content .wp-block-file .wp-block-file__button:lang(ko-KR), .entry .entry-content .wp-block-file:lang(ko-KR), .entry .entry-content .wp-block-audio figcaption:lang(ko-KR),
+.entry .entry-content .wp-block-video figcaption:lang(ko-KR),
+.entry .entry-content .wp-block-image figcaption:lang(ko-KR),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(ko-KR),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(ko-KR), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(ko-KR),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(ko-KR),
+.entry .entry-content .wp-block-cover-image h2:lang(ko-KR),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(ko-KR),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(ko-KR),
+.entry .entry-content .wp-block-cover h2:lang(ko-KR), .entry .entry-content .wp-block-pullquote cite:lang(ko-KR), .entry .entry-content .has-drop-cap:lang(ko-KR):not(:focus):first-letter, .entry .entry-content .wp-block-verse:lang(ko-KR), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ko-KR), .entry .entry-content .wp-block-archives li > a:lang(ko-KR),
+.entry .entry-content .wp-block-categories li > a:lang(ko-KR),
+.entry .entry-content .wp-block-latest-posts li > a:lang(ko-KR), .entry .entry-content .wp-block-button .wp-block-button__link:lang(ko-KR), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(ko-KR), .widget_tag_cloud .tagcloud:lang(ko-KR), .widget_archive ul li:lang(ko-KR),
+.widget_categories ul li:lang(ko-KR),
+.widget_meta ul li:lang(ko-KR),
+.widget_nav_menu ul li:lang(ko-KR),
+.widget_pages ul li:lang(ko-KR),
+.widget_recent_comments ul li:lang(ko-KR),
+.widget_recent_entries ul li:lang(ko-KR),
+.widget_rss ul li:lang(ko-KR), .comment-form .comment-notes:lang(ko-KR),
+.comment-form label:lang(ko-KR), .comment-list .pingback .comment-body .comment-edit-link:lang(ko-KR),
+.comment-list .trackback .comment-body .comment-edit-link:lang(ko-KR), .comment-list .pingback .comment-body:lang(ko-KR),
+.comment-list .trackback .comment-body:lang(ko-KR), .comment-navigation .nav-previous:lang(ko-KR),
+.comment-navigation .nav-next:lang(ko-KR), .button:lang(ko-KR), table:lang(ko-KR), blockquote cite:lang(ko-KR), .page-title:lang(ko-KR), .author-description .author-link:lang(ko-KR),
 .comment-metadata:lang(ko-KR),
 .comment-reply-link:lang(ko-KR),
 .comments-title:lang(ko-KR),
@@ -1718,8 +1567,6 @@ textarea:lang(ko-KR), .author-description .author-link:lang(ko-KR),
 .entry-footer:lang(ko-KR),
 .main-navigation:lang(ko-KR),
 .no-comments:lang(ko-KR),
-.not-found .page-title:lang(ko-KR),
-.error-404 .page-title:lang(ko-KR),
 .post-navigation .post-title:lang(ko-KR),
 .page-links:lang(ko-KR),
 .page-description:lang(ko-KR),
@@ -1733,40 +1580,36 @@ h2:lang(ko-KR),
 h3:lang(ko-KR),
 h4:lang(ko-KR),
 h5:lang(ko-KR),
-h6:lang(ko-KR), .page-title:lang(ko-KR), blockquote cite:lang(ko-KR), table:lang(ko-KR), .button:lang(ko-KR),
-input:lang(ko-KR)[type="button"],
-input:lang(ko-KR)[type="reset"],
-input:lang(ko-KR)[type="submit"], .comment-navigation .nav-previous:lang(ko-KR),
-.comment-navigation .nav-next:lang(ko-KR), .comment-list .pingback .comment-body:lang(ko-KR),
-.comment-list .trackback .comment-body:lang(ko-KR), .comment-list .pingback .comment-body .comment-edit-link:lang(ko-KR),
-.comment-list .trackback .comment-body .comment-edit-link:lang(ko-KR), .comment-form .comment-notes:lang(ko-KR),
-.comment-form label:lang(ko-KR), .widget_archive ul li:lang(ko-KR),
-.widget_categories ul li:lang(ko-KR),
-.widget_meta ul li:lang(ko-KR),
-.widget_nav_menu ul li:lang(ko-KR),
-.widget_pages ul li:lang(ko-KR),
-.widget_recent_comments ul li:lang(ko-KR),
-.widget_recent_entries ul li:lang(ko-KR),
-.widget_rss ul li:lang(ko-KR), .widget_tag_cloud .tagcloud:lang(ko-KR), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(ko-KR), .entry .entry-content .wp-block-button .wp-block-button__link:lang(ko-KR), .entry .entry-content .wp-block-archives li > a:lang(ko-KR),
-.entry .entry-content .wp-block-categories li > a:lang(ko-KR),
-.entry .entry-content .wp-block-latest-posts li > a:lang(ko-KR), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ko-KR), .entry .entry-content .wp-block-verse:lang(ko-KR), .entry .entry-content .has-drop-cap:lang(ko-KR):not(:focus):first-letter, .entry .entry-content .wp-block-pullquote cite:lang(ko-KR), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(ko-KR),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(ko-KR),
-.entry .entry-content .wp-block-cover-image h2:lang(ko-KR),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(ko-KR),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(ko-KR),
-.entry .entry-content .wp-block-cover h2:lang(ko-KR), .entry .entry-content .wp-block-audio figcaption:lang(ko-KR),
-.entry .entry-content .wp-block-video figcaption:lang(ko-KR),
-.entry .entry-content .wp-block-image figcaption:lang(ko-KR),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(ko-KR),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(ko-KR), .entry .entry-content .wp-block-file:lang(ko-KR), .entry .entry-content .wp-block-file .wp-block-file__button:lang(ko-KR), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ko-KR), .wp-caption-text:lang(ko-KR), .gallery-caption:lang(ko-KR) {
+h6:lang(ko-KR), button:lang(ko-KR),
+input:lang(ko-KR),
+select:lang(ko-KR),
+optgroup:lang(ko-KR),
+textarea:lang(ko-KR), body:lang(ko-KR) {
   font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
 }
-
-body:lang(th), button:lang(th),
-input:lang(th),
-select:lang(th),
-optgroup:lang(th),
-textarea:lang(th), .author-description .author-link:lang(th),
+.gallery-caption:lang(th), .wp-caption-text:lang(th), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(th), .entry .entry-content .wp-block-file .wp-block-file__button:lang(th), .entry .entry-content .wp-block-file:lang(th), .entry .entry-content .wp-block-audio figcaption:lang(th),
+.entry .entry-content .wp-block-video figcaption:lang(th),
+.entry .entry-content .wp-block-image figcaption:lang(th),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(th),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(th), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(th),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(th),
+.entry .entry-content .wp-block-cover-image h2:lang(th),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(th),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(th),
+.entry .entry-content .wp-block-cover h2:lang(th), .entry .entry-content .wp-block-pullquote cite:lang(th), .entry .entry-content .has-drop-cap:lang(th):not(:focus):first-letter, .entry .entry-content .wp-block-verse:lang(th), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(th), .entry .entry-content .wp-block-archives li > a:lang(th),
+.entry .entry-content .wp-block-categories li > a:lang(th),
+.entry .entry-content .wp-block-latest-posts li > a:lang(th), .entry .entry-content .wp-block-button .wp-block-button__link:lang(th), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(th), .widget_tag_cloud .tagcloud:lang(th), .widget_archive ul li:lang(th),
+.widget_categories ul li:lang(th),
+.widget_meta ul li:lang(th),
+.widget_nav_menu ul li:lang(th),
+.widget_pages ul li:lang(th),
+.widget_recent_comments ul li:lang(th),
+.widget_recent_entries ul li:lang(th),
+.widget_rss ul li:lang(th), .comment-form .comment-notes:lang(th),
+.comment-form label:lang(th), .comment-list .pingback .comment-body .comment-edit-link:lang(th),
+.comment-list .trackback .comment-body .comment-edit-link:lang(th), .comment-list .pingback .comment-body:lang(th),
+.comment-list .trackback .comment-body:lang(th), .comment-navigation .nav-previous:lang(th),
+.comment-navigation .nav-next:lang(th), .button:lang(th), table:lang(th), blockquote cite:lang(th), .page-title:lang(th), .author-description .author-link:lang(th),
 .comment-metadata:lang(th),
 .comment-reply-link:lang(th),
 .comments-title:lang(th),
@@ -1776,8 +1619,6 @@ textarea:lang(th), .author-description .author-link:lang(th),
 .entry-footer:lang(th),
 .main-navigation:lang(th),
 .no-comments:lang(th),
-.not-found .page-title:lang(th),
-.error-404 .page-title:lang(th),
 .post-navigation .post-title:lang(th),
 .page-links:lang(th),
 .page-description:lang(th),
@@ -1791,40 +1632,36 @@ h2:lang(th),
 h3:lang(th),
 h4:lang(th),
 h5:lang(th),
-h6:lang(th), .page-title:lang(th), blockquote cite:lang(th), table:lang(th), .button:lang(th),
-input:lang(th)[type="button"],
-input:lang(th)[type="reset"],
-input:lang(th)[type="submit"], .comment-navigation .nav-previous:lang(th),
-.comment-navigation .nav-next:lang(th), .comment-list .pingback .comment-body:lang(th),
-.comment-list .trackback .comment-body:lang(th), .comment-list .pingback .comment-body .comment-edit-link:lang(th),
-.comment-list .trackback .comment-body .comment-edit-link:lang(th), .comment-form .comment-notes:lang(th),
-.comment-form label:lang(th), .widget_archive ul li:lang(th),
-.widget_categories ul li:lang(th),
-.widget_meta ul li:lang(th),
-.widget_nav_menu ul li:lang(th),
-.widget_pages ul li:lang(th),
-.widget_recent_comments ul li:lang(th),
-.widget_recent_entries ul li:lang(th),
-.widget_rss ul li:lang(th), .widget_tag_cloud .tagcloud:lang(th), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(th), .entry .entry-content .wp-block-button .wp-block-button__link:lang(th), .entry .entry-content .wp-block-archives li > a:lang(th),
-.entry .entry-content .wp-block-categories li > a:lang(th),
-.entry .entry-content .wp-block-latest-posts li > a:lang(th), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(th), .entry .entry-content .wp-block-verse:lang(th), .entry .entry-content .has-drop-cap:lang(th):not(:focus):first-letter, .entry .entry-content .wp-block-pullquote cite:lang(th), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(th),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(th),
-.entry .entry-content .wp-block-cover-image h2:lang(th),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(th),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(th),
-.entry .entry-content .wp-block-cover h2:lang(th), .entry .entry-content .wp-block-audio figcaption:lang(th),
-.entry .entry-content .wp-block-video figcaption:lang(th),
-.entry .entry-content .wp-block-image figcaption:lang(th),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(th),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(th), .entry .entry-content .wp-block-file:lang(th), .entry .entry-content .wp-block-file .wp-block-file__button:lang(th), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(th), .wp-caption-text:lang(th), .gallery-caption:lang(th) {
+h6:lang(th), button:lang(th),
+input:lang(th),
+select:lang(th),
+optgroup:lang(th),
+textarea:lang(th), body:lang(th) {
   font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
 }
-
-body:lang(vi), button:lang(vi),
-input:lang(vi),
-select:lang(vi),
-optgroup:lang(vi),
-textarea:lang(vi), .author-description .author-link:lang(vi),
+.gallery-caption:lang(vi), .wp-caption-text:lang(vi), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(vi), .entry .entry-content .wp-block-file .wp-block-file__button:lang(vi), .entry .entry-content .wp-block-file:lang(vi), .entry .entry-content .wp-block-audio figcaption:lang(vi),
+.entry .entry-content .wp-block-video figcaption:lang(vi),
+.entry .entry-content .wp-block-image figcaption:lang(vi),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(vi),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(vi), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(vi),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(vi),
+.entry .entry-content .wp-block-cover-image h2:lang(vi),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(vi),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(vi),
+.entry .entry-content .wp-block-cover h2:lang(vi), .entry .entry-content .wp-block-pullquote cite:lang(vi), .entry .entry-content .has-drop-cap:lang(vi):not(:focus):first-letter, .entry .entry-content .wp-block-verse:lang(vi), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(vi), .entry .entry-content .wp-block-archives li > a:lang(vi),
+.entry .entry-content .wp-block-categories li > a:lang(vi),
+.entry .entry-content .wp-block-latest-posts li > a:lang(vi), .entry .entry-content .wp-block-button .wp-block-button__link:lang(vi), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(vi), .widget_tag_cloud .tagcloud:lang(vi), .widget_archive ul li:lang(vi),
+.widget_categories ul li:lang(vi),
+.widget_meta ul li:lang(vi),
+.widget_nav_menu ul li:lang(vi),
+.widget_pages ul li:lang(vi),
+.widget_recent_comments ul li:lang(vi),
+.widget_recent_entries ul li:lang(vi),
+.widget_rss ul li:lang(vi), .comment-form .comment-notes:lang(vi),
+.comment-form label:lang(vi), .comment-list .pingback .comment-body .comment-edit-link:lang(vi),
+.comment-list .trackback .comment-body .comment-edit-link:lang(vi), .comment-list .pingback .comment-body:lang(vi),
+.comment-list .trackback .comment-body:lang(vi), .comment-navigation .nav-previous:lang(vi),
+.comment-navigation .nav-next:lang(vi), .button:lang(vi), table:lang(vi), blockquote cite:lang(vi), .page-title:lang(vi), .author-description .author-link:lang(vi),
 .comment-metadata:lang(vi),
 .comment-reply-link:lang(vi),
 .comments-title:lang(vi),
@@ -1834,8 +1671,6 @@ textarea:lang(vi), .author-description .author-link:lang(vi),
 .entry-footer:lang(vi),
 .main-navigation:lang(vi),
 .no-comments:lang(vi),
-.not-found .page-title:lang(vi),
-.error-404 .page-title:lang(vi),
 .post-navigation .post-title:lang(vi),
 .page-links:lang(vi),
 .page-description:lang(vi),
@@ -1849,32 +1684,11 @@ h2:lang(vi),
 h3:lang(vi),
 h4:lang(vi),
 h5:lang(vi),
-h6:lang(vi), .page-title:lang(vi), blockquote cite:lang(vi), table:lang(vi), .button:lang(vi),
-input:lang(vi)[type="button"],
-input:lang(vi)[type="reset"],
-input:lang(vi)[type="submit"], .comment-navigation .nav-previous:lang(vi),
-.comment-navigation .nav-next:lang(vi), .comment-list .pingback .comment-body:lang(vi),
-.comment-list .trackback .comment-body:lang(vi), .comment-list .pingback .comment-body .comment-edit-link:lang(vi),
-.comment-list .trackback .comment-body .comment-edit-link:lang(vi), .comment-form .comment-notes:lang(vi),
-.comment-form label:lang(vi), .widget_archive ul li:lang(vi),
-.widget_categories ul li:lang(vi),
-.widget_meta ul li:lang(vi),
-.widget_nav_menu ul li:lang(vi),
-.widget_pages ul li:lang(vi),
-.widget_recent_comments ul li:lang(vi),
-.widget_recent_entries ul li:lang(vi),
-.widget_rss ul li:lang(vi), .widget_tag_cloud .tagcloud:lang(vi), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(vi), .entry .entry-content .wp-block-button .wp-block-button__link:lang(vi), .entry .entry-content .wp-block-archives li > a:lang(vi),
-.entry .entry-content .wp-block-categories li > a:lang(vi),
-.entry .entry-content .wp-block-latest-posts li > a:lang(vi), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(vi), .entry .entry-content .wp-block-verse:lang(vi), .entry .entry-content .has-drop-cap:lang(vi):not(:focus):first-letter, .entry .entry-content .wp-block-pullquote cite:lang(vi), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(vi),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(vi),
-.entry .entry-content .wp-block-cover-image h2:lang(vi),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(vi),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(vi),
-.entry .entry-content .wp-block-cover h2:lang(vi), .entry .entry-content .wp-block-audio figcaption:lang(vi),
-.entry .entry-content .wp-block-video figcaption:lang(vi),
-.entry .entry-content .wp-block-image figcaption:lang(vi),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(vi),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(vi), .entry .entry-content .wp-block-file:lang(vi), .entry .entry-content .wp-block-file .wp-block-file__button:lang(vi), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(vi), .wp-caption-text:lang(vi), .gallery-caption:lang(vi) {
+h6:lang(vi), button:lang(vi),
+input:lang(vi),
+select:lang(vi),
+optgroup:lang(vi),
+textarea:lang(vi), body:lang(vi) {
   font-family: "Libre Franklin", sans-serif;
 }
 
@@ -1887,10 +1701,8 @@ input:lang(vi)[type="submit"], .comment-navigation .nav-previous:lang(vi),
  * 2. Prevent adjustments of font size after orientation changes in iOS.
  */
 html {
-  line-height: 1.15;
-  /* 1 */
-  -webkit-text-size-adjust: 100%;
-  /* 2 */
+  line-height: 1.15; /* 1 */
+  -webkit-text-size-adjust: 100%; /* 2 */
 }
 
 /* Sections
@@ -1918,12 +1730,9 @@ h1 {
  * 2. Show the overflow in Edge and IE.
  */
 hr {
-  box-sizing: content-box;
-  /* 1 */
-  height: 0;
-  /* 1 */
-  overflow: visible;
-  /* 2 */
+  box-sizing: content-box; /* 1 */
+  height: 0; /* 1 */
+  overflow: visible; /* 2 */
 }
 
 /**
@@ -1931,10 +1740,8 @@ hr {
  * 2. Correct the odd `em` font sizing in all browsers.
  */
 pre {
-  font-family: monospace, monospace;
-  /* 1 */
-  font-size: 1em;
-  /* 2 */
+  font-family: monospace, monospace; /* 1 */
+  font-size: 1em; /* 2 */
 }
 
 /* Text-level semantics
@@ -1951,12 +1758,9 @@ a {
  * 2. Add the correct text decoration in Chrome, Edge, IE, Opera, and Safari.
  */
 abbr[title] {
-  border-bottom: none;
-  /* 1 */
-  text-decoration: underline;
-  /* 2 */
-  text-decoration: underline dotted;
-  /* 2 */
+  border-bottom: none; /* 1 */
+  text-decoration: underline; /* 2 */
+  text-decoration: underline dotted; /* 2 */
 }
 
 /**
@@ -1974,10 +1778,8 @@ strong {
 code,
 kbd,
 samp {
-  font-family: monospace, monospace;
-  /* 1 */
-  font-size: 1em;
-  /* 2 */
+  font-family: monospace, monospace; /* 1 */
+  font-size: 1em; /* 2 */
 }
 
 /**
@@ -2027,14 +1829,10 @@ input,
 optgroup,
 select,
 textarea {
-  font-family: inherit;
-  /* 1 */
-  font-size: 100%;
-  /* 1 */
-  line-height: 1.15;
-  /* 1 */
-  margin: 0;
-  /* 2 */
+  font-family: inherit; /* 1 */
+  font-size: 100%; /* 1 */
+  line-height: 1.15; /* 1 */
+  margin: 0; /* 2 */
 }
 
 /**
@@ -2042,8 +1840,7 @@ textarea {
  * 1. Show the overflow in Edge.
  */
 button,
-input {
-  /* 1 */
+input { /* 1 */
   overflow: visible;
 }
 
@@ -2052,8 +1849,7 @@ input {
  * 1. Remove the inheritance of text transform in Firefox.
  */
 button,
-select {
-  /* 1 */
+select { /* 1 */
   text-transform: none;
 }
 
@@ -2061,9 +1857,9 @@ select {
  * Correct the inability to style clickable types in iOS and Safari.
  */
 button,
-[type="button"],
-[type="reset"],
-[type="submit"] {
+[type=button],
+[type=reset],
+[type=submit] {
   -webkit-appearance: button;
 }
 
@@ -2071,9 +1867,9 @@ button,
  * Remove the inner border and padding in Firefox.
  */
 button::-moz-focus-inner,
-[type="button"]::-moz-focus-inner,
-[type="reset"]::-moz-focus-inner,
-[type="submit"]::-moz-focus-inner {
+[type=button]::-moz-focus-inner,
+[type=reset]::-moz-focus-inner,
+[type=submit]::-moz-focus-inner {
   border-style: none;
   padding: 0;
 }
@@ -2082,9 +1878,9 @@ button::-moz-focus-inner,
  * Restore the focus styles unset by the previous rule.
  */
 button:-moz-focusring,
-[type="button"]:-moz-focusring,
-[type="reset"]:-moz-focusring,
-[type="submit"]:-moz-focusring {
+[type=button]:-moz-focusring,
+[type=reset]:-moz-focusring,
+[type=submit]:-moz-focusring {
   outline: 1px dotted ButtonText;
 }
 
@@ -2102,18 +1898,12 @@ fieldset {
  *		`fieldset` elements in all browsers.
  */
 legend {
-  box-sizing: border-box;
-  /* 1 */
-  color: inherit;
-  /* 2 */
-  display: table;
-  /* 1 */
-  max-width: 100%;
-  /* 1 */
-  padding: 0;
-  /* 3 */
-  white-space: normal;
-  /* 1 */
+  box-sizing: border-box; /* 1 */
+  color: inherit; /* 2 */
+  display: table; /* 1 */
+  max-width: 100%; /* 1 */
+  padding: 0; /* 3 */
+  white-space: normal; /* 1 */
 }
 
 /**
@@ -2134,19 +1924,17 @@ textarea {
  * 1. Add the correct box sizing in IE 10.
  * 2. Remove the padding in IE 10.
  */
-[type="checkbox"],
-[type="radio"] {
-  box-sizing: border-box;
-  /* 1 */
-  padding: 0;
-  /* 2 */
+[type=checkbox],
+[type=radio] {
+  box-sizing: border-box; /* 1 */
+  padding: 0; /* 2 */
 }
 
 /**
  * Correct the cursor style of increment and decrement buttons in Chrome.
  */
-[type="number"]::-webkit-inner-spin-button,
-[type="number"]::-webkit-outer-spin-button {
+[type=number]::-webkit-inner-spin-button,
+[type=number]::-webkit-outer-spin-button {
   height: auto;
 }
 
@@ -2154,17 +1942,15 @@ textarea {
  * 1. Correct the odd appearance in Chrome and Safari.
  * 2. Correct the outline style in Safari.
  */
-[type="search"] {
-  -webkit-appearance: textfield;
-  /* 1 */
-  outline-offset: -2px;
-  /* 2 */
+[type=search] {
+  -webkit-appearance: textfield; /* 1 */
+  outline-offset: -2px; /* 2 */
 }
 
 /**
  * Remove the inner padding in Chrome and Safari on macOS.
  */
-[type="search"]::-webkit-search-decoration {
+[type=search]::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
@@ -2173,10 +1959,8 @@ textarea {
  * 2. Change font properties to `inherit` in Safari.
  */
 ::-webkit-file-upload-button {
-  -webkit-appearance: button;
-  /* 1 */
-  font: inherit;
-  /* 2 */
+  -webkit-appearance: button; /* 1 */
+  font: inherit; /* 2 */
 }
 
 /* Interactive
@@ -2309,7 +2093,6 @@ h6 {
 h1 {
   font-size: 2.25em;
 }
-
 @media only screen and (min-width: 768px) {
   h1 {
     font-size: 2.8125em;
@@ -2323,7 +2106,6 @@ h1 {
 h2 {
   font-size: 1.6875em;
 }
-
 @media only screen and (min-width: 768px) {
   .entry-title,
   .not-found .page-title,
@@ -2358,7 +2140,7 @@ h4 {
 .pagination .nav-links,
 .comment-content,
 h5 {
-  font-size: 0.88889em;
+  font-size: 0.8888888889em;
 }
 
 .entry-meta,
@@ -2373,7 +2155,7 @@ h5 {
 #cancel-comment-reply-link,
 img:after,
 h6 {
-  font-size: 0.71111em;
+  font-size: 0.7111111111em;
 }
 
 .site-title,
@@ -2427,13 +2209,13 @@ i {
 }
 
 blockquote cite {
-  font-size: 0.71111em;
+  font-size: 0.7111111111em;
   font-style: normal;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 }
 
 pre {
-  font-size: 0.88889em;
+  font-size: 0.8888888889em;
   font-family: "Courier 10 Pitch", Courier, monospace;
   line-height: 1.8;
   overflow: auto;
@@ -2443,7 +2225,7 @@ code,
 kbd,
 tt,
 var {
-  font-size: 0.88889em;
+  font-size: 0.8888888889em;
   font-family: Menlo, monaco, Consolas, Lucida Console, monospace;
 }
 
@@ -2465,11 +2247,9 @@ big {
 a {
   text-decoration: none;
 }
-
 a:hover {
   text-decoration: none;
 }
-
 a:focus {
   text-decoration: underline;
   text-decoration-thickness: 2px;
@@ -2481,11 +2261,11 @@ html {
 }
 
 ::-moz-selection {
-  background-color: #bfdcea;
+  background-color: rgb(191.25, 220, 233.75);
 }
 
 ::selection {
-  background-color: #bfdcea;
+  background-color: rgb(191.25, 220, 233.75);
 }
 
 *,
@@ -2501,7 +2281,7 @@ a {
 
 a:hover,
 a:active {
-  color: #005177;
+  color: rgb(0, 80.5, 119);
   outline: 0;
   text-decoration: none;
 }
@@ -2526,19 +2306,17 @@ h6 {
 h1:not(.site-title):before,
 h2:before {
   background: #767676;
-  content: "\020";
+  content: " ";
   display: block;
   height: 2px;
   margin: 1rem 0;
   width: 1em;
 }
-
 h1:not(.site-title).has-text-align-center:before,
 h2.has-text-align-center:before {
   margin-right: auto;
   margin-left: auto;
 }
-
 h1:not(.site-title).has-text-align-right:before,
 h2.has-text-align-right:before {
   margin-right: auto;
@@ -2558,7 +2336,6 @@ ol {
 ul {
   list-style: disc;
 }
-
 ul ul {
   list-style-type: circle;
 }
@@ -2599,11 +2376,9 @@ blockquote {
   margin-right: 0;
   padding: 0 1rem 0 0;
 }
-
 blockquote > p {
   margin: 0 0 1rem;
 }
-
 blockquote cite {
   color: #767676;
 }
@@ -2614,7 +2389,6 @@ table {
   width: 100%;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 }
-
 table td,
 table th {
   padding: 0.5em;
@@ -2625,9 +2399,9 @@ table th {
 /* Forms */
 .button,
 button,
-input[type="button"],
-input[type="reset"],
-input[type="submit"] {
+input[type=button],
+input[type=reset],
+input[type=submit] {
   transition: background 150ms ease-in-out;
   background: #0073aa;
   border: none;
@@ -2635,7 +2409,7 @@ input[type="submit"] {
   box-sizing: border-box;
   color: #fff;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  font-size: 0.88889em;
+  font-size: 0.8888888889em;
   font-weight: 700;
   line-height: 1.2;
   outline: none;
@@ -2643,50 +2417,47 @@ input[type="submit"] {
   text-decoration: none;
   vertical-align: bottom;
 }
-
 .button:hover,
 button:hover,
-input[type="button"]:hover,
-input[type="reset"]:hover,
-input[type="submit"]:hover {
+input[type=button]:hover,
+input[type=reset]:hover,
+input[type=submit]:hover {
   background: #111;
   cursor: pointer;
 }
-
 .button:visited,
 button:visited,
-input[type="button"]:visited,
-input[type="reset"]:visited,
-input[type="submit"]:visited {
+input[type=button]:visited,
+input[type=reset]:visited,
+input[type=submit]:visited {
   color: #fff;
   text-decoration: none;
 }
-
 .button:focus,
 button:focus,
-input[type="button"]:focus,
-input[type="reset"]:focus,
-input[type="submit"]:focus {
+input[type=button]:focus,
+input[type=reset]:focus,
+input[type=submit]:focus {
   background: #111;
   outline: thin dotted;
   outline-offset: -4px;
 }
 
-input[type="text"],
-input[type="email"],
-input[type="url"],
-input[type="password"],
-input[type="search"],
-input[type="number"],
-input[type="tel"],
-input[type="range"],
-input[type="date"],
-input[type="month"],
-input[type="week"],
-input[type="time"],
-input[type="datetime"],
-input[type="datetime-local"],
-input[type="color"],
+input[type=text],
+input[type=email],
+input[type=url],
+input[type=password],
+input[type=search],
+input[type=number],
+input[type=tel],
+input[type=range],
+input[type=date],
+input[type=month],
+input[type=week],
+input[type=time],
+input[type=datetime],
+input[type=datetime-local],
+input[type=color],
 textarea {
   -webkit-backface-visibility: hidden;
   background: #fff;
@@ -2698,29 +2469,28 @@ textarea {
   outline-offset: 0;
   border-radius: 0;
 }
-
-input[type="text"]:focus,
-input[type="email"]:focus,
-input[type="url"]:focus,
-input[type="password"]:focus,
-input[type="search"]:focus,
-input[type="number"]:focus,
-input[type="tel"]:focus,
-input[type="range"]:focus,
-input[type="date"]:focus,
-input[type="month"]:focus,
-input[type="week"]:focus,
-input[type="time"]:focus,
-input[type="datetime"]:focus,
-input[type="datetime-local"]:focus,
-input[type="color"]:focus,
+input[type=text]:focus,
+input[type=email]:focus,
+input[type=url]:focus,
+input[type=password]:focus,
+input[type=search]:focus,
+input[type=number]:focus,
+input[type=tel]:focus,
+input[type=range]:focus,
+input[type=date]:focus,
+input[type=month]:focus,
+input[type=week]:focus,
+input[type=time]:focus,
+input[type=datetime]:focus,
+input[type=datetime-local]:focus,
+input[type=color]:focus,
 textarea:focus {
   border-color: #0073aa;
   outline: thin solid rgba(0, 115, 170, 0.15);
   outline-offset: -4px;
 }
 
-input[type="search"]::-webkit-search-decoration {
+input[type=search]::-webkit-search-decoration {
   display: none;
 }
 
@@ -2744,18 +2514,14 @@ a {
   transition: color 110ms ease-in-out;
   color: #0073aa;
 }
-
 a:visited {
   color: #0073aa;
 }
-
-a:hover,
-a:active {
-  color: #005177;
+a:hover, a:active {
+  color: rgb(0, 80.5, 119);
   outline: 0;
   text-decoration: none;
 }
-
 a:focus {
   outline: thin dotted;
   text-decoration: underline;
@@ -2769,29 +2535,16 @@ a:focus {
 .main-navigation {
   display: block;
   margin-top: 0.25rem;
-  /* Un-style buttons */
-  /*
-	 * Sub-menu styles
-	 *
-	 * :focus-within needs its own selector so other similar
-	 * selectors don’t get ignored if a browser doesn’t recognize it
-	 */
-  /**
-	 * Fade-in animation for top-level submenus
-	 */
-  /**
-	 * Off-canvas touch device styles
-	 */
 }
-
 body.page .main-navigation {
   display: block;
 }
-
 .main-navigation > div {
   display: inline;
 }
-
+.main-navigation {
+  /* Un-style buttons */
+}
 .main-navigation button {
   display: inline-block;
   border: none;
@@ -2808,74 +2561,59 @@ body.page .main-navigation {
   -webkit-appearance: none;
   -moz-appearance: none;
 }
-
 .main-navigation button:hover, .main-navigation button:focus {
   background: transparent;
 }
-
 .main-navigation button:focus {
   outline: 1px solid transparent;
   outline-offset: -4px;
 }
-
 .main-navigation button:active {
   transform: scale(0.99);
 }
-
 .main-navigation .main-menu {
   display: inline-block;
   margin: 0;
   padding: 0;
 }
-
 .main-navigation .main-menu > li {
   color: #0073aa;
   display: inline-block;
   position: relative;
 }
-
 .main-navigation .main-menu > li > a {
   font-weight: 700;
   color: #0073aa;
   margin-left: 0.5rem;
 }
-
 .main-navigation .main-menu > li > a + svg {
   margin-left: 0.5rem;
 }
-
-.main-navigation .main-menu > li > a:hover,
-.main-navigation .main-menu > li > a:hover + svg {
-  color: #005177;
+.main-navigation .main-menu > li > a:hover, .main-navigation .main-menu > li > a:hover + svg {
+  color: rgb(0, 80.5, 119);
 }
-
 .main-navigation .main-menu > li.menu-item-has-children {
   display: inline-block;
   position: inherit;
 }
-
 @media only screen and (min-width: 768px) {
   .main-navigation .main-menu > li.menu-item-has-children {
     position: relative;
   }
 }
-
 .main-navigation .main-menu > li.menu-item-has-children > a {
   margin-left: 0.125rem;
 }
-
 .main-navigation .main-menu > li.menu-item-has-children > a:after,
 .main-navigation .main-menu > li.menu-item-has-children .menu-item-has-children > a:after {
   content: "";
   display: none;
 }
-
 .main-navigation .main-menu > li.menu-item-has-children .submenu-expand {
   display: inline-block;
   margin-left: 0.25rem;
   /* Priority+ Menu */
 }
-
 .main-navigation .main-menu > li.menu-item-has-children .submenu-expand.main-menu-more-toggle {
   position: relative;
   height: 24px;
@@ -2884,28 +2622,22 @@ body.page .main-navigation {
   padding: 0;
   margin-right: 0.5rem;
 }
-
 .main-navigation .main-menu > li.menu-item-has-children .submenu-expand.main-menu-more-toggle svg {
   height: 24px;
   width: 24px;
   top: -0.125rem;
   vertical-align: text-bottom;
 }
-
 .wp-customizer-unloading .main-navigation .main-menu > li.menu-item-has-children .submenu-expand, .main-navigation .main-menu > li.menu-item-has-children .submenu-expand.is-empty {
   display: none;
 }
-
 .main-navigation .main-menu > li.menu-item-has-children .submenu-expand svg {
   position: relative;
   top: 0.2rem;
 }
-
-.main-navigation .main-menu > li:last-child > a,
-.main-navigation .main-menu > li:last-child.menu-item-has-children .submenu-expand {
+.main-navigation .main-menu > li:last-child > a, .main-navigation .main-menu > li:last-child.menu-item-has-children .submenu-expand {
   margin-left: 0;
 }
-
 .main-navigation .sub-menu {
   background-color: #0073aa;
   color: #fff;
@@ -2916,7 +2648,6 @@ body.page .main-navigation {
   right: -9999px;
   z-index: 99999;
 }
-
 @media only screen and (min-width: 768px) {
   .main-navigation .sub-menu {
     width: auto;
@@ -2925,84 +2656,79 @@ body.page .main-navigation {
     min-width: max-content;
   }
 }
-
 .main-navigation .sub-menu > li {
   display: block;
   float: none;
   position: relative;
 }
-
 .main-navigation .sub-menu > li.menu-item-has-children .submenu-expand {
   display: inline-block;
   position: absolute;
-  width: calc( 24px + 1rem);
+  width: calc(24px + 1rem);
   left: 0;
-  top: calc( .125 * 1rem);
+  top: calc(0.125 * 1rem);
   bottom: 0;
   color: white;
   line-height: 1;
-  padding: calc( .5 * 1rem);
+  padding: calc(0.5 * 1rem);
 }
-
 .main-navigation .sub-menu > li.menu-item-has-children .submenu-expand svg {
   top: 0;
 }
-
 .main-navigation .sub-menu > li.menu-item-has-children .submenu-expand {
   margin-left: 0;
 }
-
 @media only screen and (min-width: 768px) {
   .main-navigation .sub-menu > li.menu-item-has-children .menu-item-has-children > a:after {
-    content: "\203a";
+    content: "›";
   }
 }
-
 .main-navigation .sub-menu > li > a,
 .main-navigation .sub-menu > li > .menu-item-link-return {
   color: #fff;
   display: block;
   line-height: 1.2;
   text-shadow: none;
-  padding: calc( .5 * 1rem) 1rem calc( .5 * 1rem) calc( 24px + 1rem);
+  padding: calc(0.5 * 1rem) 1rem calc(0.5 * 1rem) calc(24px + 1rem);
   max-width: 20rem;
 }
-
 .main-navigation .sub-menu > li > a:hover, .main-navigation .sub-menu > li > a:focus,
 .main-navigation .sub-menu > li > .menu-item-link-return:hover,
 .main-navigation .sub-menu > li > .menu-item-link-return:focus {
-  background: #005177;
+  background: rgb(0, 80.5, 119);
 }
-
 .main-navigation .sub-menu > li > a:hover:after, .main-navigation .sub-menu > li > a:focus:after,
 .main-navigation .sub-menu > li > .menu-item-link-return:hover:after,
 .main-navigation .sub-menu > li > .menu-item-link-return:focus:after {
-  background: #005177;
+  background: rgb(0, 80.5, 119);
 }
-
 .main-navigation .sub-menu > li > .menu-item-link-return {
   width: 100%;
   font-size: 22px;
   font-weight: normal;
   text-align: right;
 }
-
 .main-navigation .sub-menu > li > a:empty {
   display: none;
 }
-
 .main-navigation .sub-menu > li.mobile-parent-nav-menu-item {
   display: none;
-  font-size: 0.88889em;
+  font-size: 0.8888888889em;
   font-weight: normal;
 }
-
 .main-navigation .sub-menu > li.mobile-parent-nav-menu-item svg {
   position: relative;
   top: 0.2rem;
-  margin-left: calc( .25 * 1rem);
+  margin-left: calc(0.25 * 1rem);
 }
-
+.main-navigation {
+  /*
+   * Sub-menu styles
+   *
+   * :focus-within needs its own selector so other similar
+   * selectors don’t get ignored if a browser doesn’t recognize it
+   */
+}
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu {
   display: block;
   right: 0;
@@ -3011,9 +2737,7 @@ body.page .main-navigation {
   width: auto;
   min-width: 100%;
   /* Non-mobile position */
-  /* Nested sub-menu dashes */
 }
-
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu {
   display: block;
   right: 0;
@@ -3022,9 +2746,7 @@ body.page .main-navigation {
   width: auto;
   min-width: 100%;
   /* Non-mobile position */
-  /* Nested sub-menu dashes */
 }
-
 @media only screen and (min-width: 768px) {
   .main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu {
     display: block;
@@ -3057,21 +2779,18 @@ body.page .main-navigation {
     transform: none;
   }
 }
-
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu.hidden-links {
   right: 0;
   width: 100%;
   display: table;
   position: absolute;
 }
-
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu.hidden-links {
   right: 0;
   width: 100%;
   display: table;
   position: absolute;
 }
-
 @media only screen and (min-width: 768px) {
   .main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu.hidden-links {
     left: 0;
@@ -3086,15 +2805,12 @@ body.page .main-navigation {
     width: max-content;
   }
 }
-
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .submenu-expand {
   display: none;
 }
-
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu .submenu-expand {
   display: none;
 }
-
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu {
   display: block;
   margin-top: inherit;
@@ -3104,7 +2820,6 @@ body.page .main-navigation {
   opacity: 1;
   /* Non-mobile position */
 }
-
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu .sub-menu {
   display: block;
   margin-top: inherit;
@@ -3114,7 +2829,6 @@ body.page .main-navigation {
   opacity: 1;
   /* Non-mobile position */
 }
-
 @media only screen and (min-width: 768px) {
   .main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu {
     float: none;
@@ -3125,29 +2839,30 @@ body.page .main-navigation {
     max-width: 100%;
   }
 }
-
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu {
+  /* Nested sub-menu dashes */
+}
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu {
+  /* Nested sub-menu dashes */
+}
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu {
   counter-reset: submenu;
 }
-
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu .sub-menu {
   counter-reset: submenu;
 }
-
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu > li > a::before {
   font-family: "NonBreakingSpaceOverride", "Hoefler Text", Garamond, "Times New Roman", serif;
   font-weight: normal;
   content: "– " counters(submenu, "– ", none);
   counter-increment: submenu;
 }
-
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu .sub-menu > li > a::before {
   font-family: "NonBreakingSpaceOverride", "Hoefler Text", Garamond, "Times New Roman", serif;
   font-weight: normal;
   content: "– " counters(submenu, "– ", none);
   counter-increment: submenu;
 }
-
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):hover > .sub-menu,
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus > .sub-menu,
 .main-navigation .main-menu .menu-item-has-children.is-focused:not(.off-canvas) > .sub-menu {
@@ -3158,9 +2873,7 @@ body.page .main-navigation {
   width: auto;
   min-width: 100%;
   /* Non-mobile position */
-  /* Nested sub-menu dashes */
 }
-
 @media only screen and (min-width: 768px) {
   .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):hover > .sub-menu,
   .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus > .sub-menu,
@@ -3181,7 +2894,6 @@ body.page .main-navigation {
     transform: none;
   }
 }
-
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):hover > .sub-menu.hidden-links,
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus > .sub-menu.hidden-links,
 .main-navigation .main-menu .menu-item-has-children.is-focused:not(.off-canvas) > .sub-menu.hidden-links {
@@ -3190,7 +2902,6 @@ body.page .main-navigation {
   display: table;
   position: absolute;
 }
-
 @media only screen and (min-width: 768px) {
   .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):hover > .sub-menu.hidden-links,
   .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus > .sub-menu.hidden-links,
@@ -3201,13 +2912,11 @@ body.page .main-navigation {
     width: max-content;
   }
 }
-
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):hover > .sub-menu .submenu-expand,
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus > .sub-menu .submenu-expand,
 .main-navigation .main-menu .menu-item-has-children.is-focused:not(.off-canvas) > .sub-menu .submenu-expand {
   display: none;
 }
-
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):hover > .sub-menu .sub-menu,
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus > .sub-menu .sub-menu,
 .main-navigation .main-menu .menu-item-has-children.is-focused:not(.off-canvas) > .sub-menu .sub-menu {
@@ -3219,7 +2928,6 @@ body.page .main-navigation {
   opacity: 1;
   /* Non-mobile position */
 }
-
 @media only screen and (min-width: 768px) {
   .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):hover > .sub-menu .sub-menu,
   .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus > .sub-menu .sub-menu,
@@ -3228,13 +2936,16 @@ body.page .main-navigation {
     max-width: 100%;
   }
 }
-
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):hover > .sub-menu,
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus > .sub-menu,
+.main-navigation .main-menu .menu-item-has-children.is-focused:not(.off-canvas) > .sub-menu {
+  /* Nested sub-menu dashes */
+}
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):hover > .sub-menu .sub-menu,
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus > .sub-menu .sub-menu,
 .main-navigation .main-menu .menu-item-has-children.is-focused:not(.off-canvas) > .sub-menu .sub-menu {
   counter-reset: submenu;
 }
-
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):hover > .sub-menu .sub-menu > li > a::before,
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus > .sub-menu .sub-menu > li > a::before,
 .main-navigation .main-menu .menu-item-has-children.is-focused:not(.off-canvas) > .sub-menu .sub-menu > li > a::before {
@@ -3243,38 +2954,41 @@ body.page .main-navigation {
   content: "– " counters(submenu, "– ", none);
   counter-increment: submenu;
 }
-
+.main-navigation {
+  /**
+   * Fade-in animation for top-level submenus
+   */
+}
 .main-navigation .main-menu > .menu-item-has-children:not(.off-canvas):hover > .sub-menu {
   animation: fade_in 0.1s forwards;
 }
-
+.main-navigation {
+  /**
+   * Off-canvas touch device styles
+   */
+}
 .main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu .submenu-expand .svg-icon {
   transform: rotate(-270deg);
 }
-
 .main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu .sub-menu {
   opacity: 0;
   position: absolute;
   z-index: 0;
   transform: translateX(100%);
 }
-
 .main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu li:hover,
 .main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu li:focus,
 .main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu li > a:hover,
 .main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu li > a:focus {
   background-color: transparent;
 }
-
 .main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu > li > a,
 .main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu > li > .menu-item-link-return {
   white-space: inherit;
 }
-
 .main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu:not(:has(.sub-menu.expanded-true)) {
   overflow-y: scroll;
 }
-
 .main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu.expanded-true {
   display: block;
   margin-top: 0;
@@ -3286,40 +3000,38 @@ body.page .main-navigation {
   left: 0;
   bottom: 0;
   position: fixed;
-  z-index: 100000;
-  /* Make sure appears above mobile admin bar */
+  z-index: 100000; /* Make sure appears above mobile admin bar */
   width: 100vw;
   height: 100vh;
   max-width: 100vw;
   transform: translateX(-100%);
   animation: slide_in_right 0.3s forwards;
-  /* Prevent menu from being blocked by admin bar */
 }
-
 .main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu.expanded-true > .mobile-parent-nav-menu-item {
   display: block;
 }
-
+.main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu.expanded-true {
+  /* Prevent menu from being blocked by admin bar */
+}
 .admin-bar .main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu.expanded-true {
   top: 46px;
-  height: calc( 100vh - 46px);
-  /* WP core breakpoint */
+  height: calc(100vh - 46px);
 }
-
 .admin-bar .main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu.expanded-true .sub-menu.expanded-true {
   top: 0;
 }
-
+.admin-bar .main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu.expanded-true {
+  /* WP core breakpoint */
+}
 @media only screen and (min-width: 782px) {
   .admin-bar .main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu.expanded-true {
     top: 32px;
-    height: calc( 100vh - 32px);
+    height: calc(100vh - 32px);
   }
   .admin-bar .main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu.expanded-true .sub-menu.expanded-true {
     top: 0;
   }
 }
-
 .main-navigation .main-menu-more:nth-child(n+3) {
   display: none;
 }
@@ -3330,7 +3042,6 @@ body.page .main-navigation {
     transform: translateX(0%);
   }
 }
-
 @keyframes fade_in {
   from {
     opacity: 0;
@@ -3339,13 +3050,11 @@ body.page .main-navigation {
     opacity: 1;
   }
 }
-
 /* Social menu */
 .social-navigation {
   margin-top: calc(1rem / 2);
   text-align: right;
 }
-
 .social-navigation ul.social-links-menu {
   content: "";
   display: table;
@@ -3354,18 +3063,15 @@ body.page .main-navigation {
   margin: 0;
   padding: 0;
 }
-
 .social-navigation ul.social-links-menu li {
   display: inline-block;
   vertical-align: bottom;
   vertical-align: -webkit-baseline-middle;
   list-style: none;
 }
-
 .social-navigation ul.social-links-menu li:nth-child(n+2) {
   margin-right: 0.1em;
 }
-
 .social-navigation ul.social-links-menu li a {
   border-bottom: 1px solid transparent;
   display: block;
@@ -3373,25 +3079,21 @@ body.page .main-navigation {
   margin-bottom: -1px;
   transition: opacity 110ms ease-in-out;
 }
-
 .social-navigation ul.social-links-menu li a:hover, .social-navigation ul.social-links-menu li a:active {
   color: #111;
   opacity: 0.6;
 }
-
 .social-navigation ul.social-links-menu li a:focus {
   color: #111;
   opacity: 1;
   border-bottom: 1px solid #111;
 }
-
 .social-navigation ul.social-links-menu li a svg {
   display: block;
   width: 32px;
   height: 32px;
   transform: translateZ(0);
 }
-
 .social-navigation ul.social-links-menu li a svg#ui-icon-link {
   transform: rotate(45deg);
 }
@@ -3407,16 +3109,13 @@ body.page .main-navigation {
 .footer-navigation {
   display: inline;
 }
-
 .footer-navigation > div {
   display: inline;
 }
-
 .footer-navigation .footer-menu {
   display: inline;
   padding-right: 0;
 }
-
 .footer-navigation .footer-menu li {
   display: inline;
   margin-left: 1rem;
@@ -3427,49 +3126,42 @@ body.page .main-navigation {
 --------------------------------------------------------------*/
 /* Next/Previous navigation */
 .post-navigation {
-  margin: calc(3 * 1rem) 0;
+  margin: 3rem 0;
 }
-
 @media only screen and (min-width: 768px) {
   .post-navigation {
-    margin: calc(3 * 1rem) calc(10% + 60px);
-    max-width: calc(6 * (100vw / 12));
+    margin: 3rem calc(10% + 60px);
+    max-width: 50vw;
   }
 }
-
 @media only screen and (min-width: 1168px) {
   .post-navigation {
-    margin: calc(3 * 1rem) 0;
+    margin: 3rem 0;
     max-width: 100%;
   }
 }
-
 .post-navigation .nav-links {
   margin: 0 1rem;
   max-width: 100%;
   display: flex;
   flex-direction: column;
 }
-
 @media only screen and (min-width: 768px) {
   .post-navigation .nav-links {
     margin: 0;
   }
 }
-
 @media only screen and (min-width: 1168px) {
   .post-navigation .nav-links {
     flex-direction: row;
     margin: 0 calc(10% + 60px);
-    max-width: calc(6 * (100vw / 12) - 28px);
+    max-width: calc(50vw - 28px);
   }
 }
-
 .post-navigation .nav-links a .meta-nav {
   color: #767676;
   user-select: none;
 }
-
 .post-navigation .nav-links a .meta-nav:before, .post-navigation .nav-links a .meta-nav:after {
   display: none;
   content: "—";
@@ -3477,51 +3169,41 @@ body.page .main-navigation {
   color: #767676;
   height: 1em;
 }
-
 .post-navigation .nav-links a .post-title {
   hyphens: auto;
 }
-
 .post-navigation .nav-links a:hover {
-  color: #005177;
+  color: rgb(0, 80.5, 119);
 }
-
 @media only screen and (min-width: 1168px) {
   .post-navigation .nav-links .nav-previous,
   .post-navigation .nav-links .nav-next {
     min-width: calc(50% - 2 * 1rem);
   }
 }
-
 .post-navigation .nav-links .nav-previous {
   order: 2;
 }
-
 @media only screen and (min-width: 1168px) {
   .post-navigation .nav-links .nav-previous {
     order: 1;
   }
 }
-
 .post-navigation .nav-links .nav-previous + .nav-next {
   margin-bottom: 1rem;
 }
-
 .post-navigation .nav-links .nav-previous .meta-nav:before {
   display: inline;
 }
-
 .post-navigation .nav-links .nav-next {
   order: 1;
 }
-
 @media only screen and (min-width: 1168px) {
   .post-navigation .nav-links .nav-next {
     order: 2;
     padding-right: 1rem;
   }
 }
-
 .post-navigation .nav-links .nav-next .meta-nav:after {
   display: inline;
 }
@@ -3529,41 +3211,33 @@ body.page .main-navigation {
 .pagination .nav-links {
   display: flex;
   flex-wrap: wrap;
-  padding: 0 calc(.5 * 1rem);
+  padding: 0 calc(0.5 * 1rem);
 }
-
 .pagination .nav-links > * {
-  padding: calc(.5 * 1rem);
+  padding: calc(0.5 * 1rem);
 }
-
 .pagination .nav-links > *.dots, .pagination .nav-links > *.prev {
   padding-right: 0;
 }
-
 .pagination .nav-links > *.dots, .pagination .nav-links > *.next {
   padding-left: 0;
 }
-
 .pagination .nav-links a:focus {
   text-decoration: underline;
   outline-offset: -1px;
 }
-
 .pagination .nav-links a:focus.prev, .pagination .nav-links a:focus.next {
   text-decoration: none;
 }
-
 .pagination .nav-links a:focus.prev .nav-prev-text,
 .pagination .nav-links a:focus.prev .nav-next-text, .pagination .nav-links a:focus.next .nav-prev-text,
 .pagination .nav-links a:focus.next .nav-next-text {
   text-decoration: underline;
 }
-
 .pagination .nav-links .nav-next-text,
 .pagination .nav-links .nav-prev-text {
   display: none;
 }
-
 @media only screen and (min-width: 768px) {
   .pagination .nav-links {
     margin-right: calc(10% + 60px);
@@ -3583,7 +3257,6 @@ body.page .main-navigation {
   display: flex;
   flex-direction: row;
 }
-
 .comment-navigation .nav-previous,
 .comment-navigation .nav-next {
   min-width: 50%;
@@ -3591,19 +3264,16 @@ body.page .main-navigation {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-weight: bold;
 }
-
 .comment-navigation .nav-previous .secondary-text,
 .comment-navigation .nav-next .secondary-text {
   display: none;
 }
-
 @media only screen and (min-width: 768px) {
   .comment-navigation .nav-previous .secondary-text,
   .comment-navigation .nav-next .secondary-text {
     display: inline;
   }
 }
-
 .comment-navigation .nav-previous svg,
 .comment-navigation .nav-next svg {
   vertical-align: middle;
@@ -3611,7 +3281,6 @@ body.page .main-navigation {
   margin: 0 -0.35em;
   top: -1px;
 }
-
 .comment-navigation .nav-next {
   text-align: left;
 }
@@ -3631,7 +3300,6 @@ body.page .main-navigation {
   word-wrap: normal !important;
   word-break: normal !important;
 }
-
 .screen-reader-text:focus {
   background-color: #f1f1f1;
   border-radius: 3px;
@@ -3648,8 +3316,7 @@ body.page .main-navigation {
   text-decoration: none;
   top: 5px;
   width: auto;
-  z-index: 100000;
-  /* Above WP toolbar. */
+  z-index: 100000; /* Above WP toolbar. */
 }
 
 /* Do not show the outline on the skip link target. */
@@ -3662,7 +3329,6 @@ body.page .main-navigation {
   float: left;
   margin-right: 1rem;
 }
-
 @media only screen and (min-width: 768px) {
   .alignleft {
     margin-right: calc(2 * 1rem);
@@ -3673,7 +3339,6 @@ body.page .main-navigation {
   float: right;
   margin-left: 1rem;
 }
-
 @media only screen and (min-width: 768px) {
   .alignright {
     margin-left: calc(2 * 1rem);
@@ -3731,18 +3396,15 @@ body.page .main-navigation {
 .site-header {
   padding: 1em;
 }
-
 .site-header.featured-image {
   display: flex;
   flex-direction: column;
   justify-content: space-between;
   min-height: 90vh;
 }
-
 .site-header.featured-image .site-branding-container {
   margin-bottom: auto;
 }
-
 @media only screen and (min-width: 768px) {
   .site-header {
     margin: 0;
@@ -3763,7 +3425,6 @@ body.page .main-navigation {
   position: relative;
   word-wrap: break-word;
 }
-
 @media only screen and (min-width: 768px) {
   .site-branding {
     margin: 0 calc(10% + 60px);
@@ -3773,19 +3434,17 @@ body.page .main-navigation {
 .site-logo {
   position: relative;
   z-index: 999;
-  margin-bottom: calc(.66 * 1rem);
+  margin-bottom: calc(0.66 * 1rem);
 }
-
 @media only screen and (min-width: 768px) {
   .site-logo {
     margin-bottom: 0;
     position: absolute;
-    left: calc(100% + (1.25 * 1rem));
+    left: calc(100% + 1.25 * 1rem);
     top: 4px;
     z-index: 999;
   }
 }
-
 .site-logo .custom-logo-link {
   border-radius: 100%;
   box-sizing: content-box;
@@ -3796,15 +3455,12 @@ body.page .main-navigation {
   overflow: hidden;
   transition: box-shadow 200ms ease-in-out;
 }
-
 .site-logo .custom-logo-link .custom-logo {
   min-height: inherit;
 }
-
 .site-logo .custom-logo-link:hover, .site-logo .custom-logo-link:active, .site-logo .custom-logo-link:focus {
-  box-shadow: 0 0 0 2px black;
+  box-shadow: 0 0 0 2px rgb(0, 0, 0);
 }
-
 @media only screen and (min-width: 768px) {
   .site-logo .custom-logo-link {
     width: 64px;
@@ -3816,44 +3472,38 @@ body.page .main-navigation {
   margin: auto;
   display: inline;
   color: #111;
-  /* When there is no description set, make sure navigation appears below title. */
 }
-
 .site-title a {
   color: #111;
 }
-
 .site-title a:link, .site-title a:visited {
   color: #111;
 }
-
 .site-title a:hover {
-  color: #4a4a4a;
+  color: rgb(74.375, 74.375, 74.375);
 }
-
 .featured-image .site-title {
   margin: 0;
 }
-
 @media only screen and (min-width: 768px) {
   .featured-image .site-title {
     display: inline-block;
   }
 }
-
+.site-title {
+  /* When there is no description set, make sure navigation appears below title. */
+}
 .site-title + .main-navigation {
   display: block;
 }
-
 @media only screen and (min-width: 768px) {
   .site-title {
     display: inline;
   }
 }
-
 .site-title:not(:empty) + .site-description:not(:empty):before {
-  content: "\2014";
-  margin: 0 .2em;
+  content: "—";
+  margin: 0 0.2em;
 }
 
 .site-description {
@@ -3871,24 +3521,7 @@ body.page .main-navigation {
   /* Add text shadow to text, to increase readability. */
   text-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
   /* Set white text color when featured image is set. */
-  /* add focus state to social media icons */
-  /* Entry header */
-  /* Custom Logo Link */
-  /* Make sure important elements are above pseudo elements used for effects. */
-  /* Set up image filter layer positioning */
-  /* Background & Effects */
-  /* Shared background settings between pseudo elements. */
-  background-position: center;
-  background-repeat: no-repeat;
-  background-size: cover;
-  /* The intensity of each blend mode is controlled via layer opacity. */
-  /* Second layer: screen. */
-  /* Third layer: multiply. */
-  /* When image filters are inactive, a black overlay is added. */
-  /* Fourth layer: overlay. */
-  /* Fifth layer: readability overlay */
 }
-
 .site-header.featured-image .site-branding .site-title,
 .site-header.featured-image .site-branding .site-description,
 .site-header.featured-image .main-navigation a:after,
@@ -3899,7 +3532,6 @@ body.page .main-navigation {
 .site-header.featured-image .entry-title {
   color: #fff;
 }
-
 .site-header.featured-image .main-navigation a,
 .site-header.featured-image .main-navigation a + svg,
 .site-header.featured-image .social-navigation a,
@@ -3908,10 +3540,7 @@ body.page .main-navigation {
   color: #fff;
   transition: opacity 110ms ease-in-out;
 }
-
-.site-header.featured-image .main-navigation a:hover, .site-header.featured-image .main-navigation a:active,
-.site-header.featured-image .main-navigation a:hover + svg,
-.site-header.featured-image .main-navigation a:active + svg,
+.site-header.featured-image .main-navigation a:hover, .site-header.featured-image .main-navigation a:active, .site-header.featured-image .main-navigation a:hover + svg, .site-header.featured-image .main-navigation a:active + svg,
 .site-header.featured-image .main-navigation a + svg:hover,
 .site-header.featured-image .main-navigation a + svg:active,
 .site-header.featured-image .main-navigation a + svg:hover + svg,
@@ -3931,9 +3560,7 @@ body.page .main-navigation {
   color: #fff;
   opacity: 0.6;
 }
-
-.site-header.featured-image .main-navigation a:focus,
-.site-header.featured-image .main-navigation a:focus + svg,
+.site-header.featured-image .main-navigation a:focus, .site-header.featured-image .main-navigation a:focus + svg,
 .site-header.featured-image .main-navigation a + svg:focus,
 .site-header.featured-image .main-navigation a + svg:focus + svg,
 .site-header.featured-image .social-navigation a:focus,
@@ -3944,24 +3571,26 @@ body.page .main-navigation {
 .site-header.featured-image .site-featured-image a:focus + svg {
   color: #fff;
 }
-
 .site-header.featured-image .main-navigation .sub-menu a {
   opacity: inherit;
 }
-
+.site-header.featured-image {
+  /* add focus state to social media icons */
+}
 .site-header.featured-image .social-navigation a:focus {
   color: #fff;
   opacity: 1;
   border-bottom: 1px solid #fff;
 }
-
 .site-header.featured-image .social-navigation svg,
 .site-header.featured-image .site-featured-image svg {
   /* Use -webkit- only if supporting: Chrome < 54, iOS < 9.3, Android < 4.4.4 */
   -webkit-filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.35));
   filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.35));
 }
-
+.site-header.featured-image {
+  /* Entry header */
+}
 .site-header.featured-image .site-featured-image .post-thumbnail img {
   height: auto;
   right: 50%;
@@ -3974,7 +3603,6 @@ body.page .main-navigation {
   width: auto;
   z-index: 1;
 }
-
 @supports (object-fit: cover) {
   .site-header.featured-image .site-featured-image .post-thumbnail img {
     height: 100%;
@@ -3985,72 +3613,62 @@ body.page .main-navigation {
     width: 100%;
   }
 }
-
 .image-filters-enabled .site-header.featured-image .site-featured-image .post-thumbnail img {
   /* First layer: grayscale. */
   /* When image filters are active, make it grayscale to colorize it blue. */
   filter: grayscale(100%);
 }
-
 .site-header.featured-image .site-featured-image .entry-header {
-  margin-top: calc( 4 * 1rem);
+  margin-top: calc(4 * 1rem);
   margin-bottom: 0;
   margin-right: 0;
   margin-left: 0;
-  /* Entry meta */
 }
-
 @media only screen and (min-width: 768px) {
   .site-header.featured-image .site-featured-image .entry-header {
     margin-right: calc(10% + 60px);
     margin-left: calc(10% + 60px);
   }
 }
-
 .site-header.featured-image .site-featured-image .entry-header .entry-title:before {
   background: #fff;
 }
-
+.site-header.featured-image .site-featured-image .entry-header {
+  /* Entry meta */
+}
 .site-header.featured-image .site-featured-image .entry-header .entry-meta {
   font-weight: 500;
 }
-
 .site-header.featured-image .site-featured-image .entry-header .entry-meta > span {
   margin-left: 1rem;
   display: inline-block;
 }
-
 .site-header.featured-image .site-featured-image .entry-header .entry-meta > span:last-child {
   margin-left: 0;
 }
-
 .site-header.featured-image .site-featured-image .entry-header .entry-meta a {
   transition: color 110ms ease-in-out;
   color: currentColor;
 }
-
 .site-header.featured-image .site-featured-image .entry-header .entry-meta a:hover {
   text-decoration: none;
 }
-
 .site-header.featured-image .site-featured-image .entry-header .entry-meta .svg-icon {
   position: relative;
   display: inline-block;
   vertical-align: middle;
   margin-left: 0.5em;
 }
-
 .site-header.featured-image .site-featured-image .entry-header .entry-meta .discussion-avatar-list {
   display: none;
 }
-
 @media only screen and (min-width: 768px) {
   .site-header.featured-image .site-featured-image .entry-header.has-discussion .entry-meta {
     display: flex;
     position: relative;
   }
   .site-header.featured-image .site-featured-image .entry-header.has-discussion .entry-title {
-    padding-left: calc(1 * (100vw / 12) + 1rem);
+    padding-left: calc(8.3333333333vw + 1rem);
   }
   .site-header.featured-image .site-featured-image .entry-header.has-discussion .entry-meta .comment-count {
     position: absolute;
@@ -4062,26 +3680,30 @@ body.page .main-navigation {
     bottom: 100%;
   }
 }
-
+.site-header.featured-image {
+  /* Custom Logo Link */
+}
 .site-header.featured-image .custom-logo-link {
   background: #fff;
   box-shadow: 0 0 0 0 rgba(255, 255, 255, 0);
 }
-
 .site-header.featured-image .custom-logo-link:hover, .site-header.featured-image .custom-logo-link:active, .site-header.featured-image .custom-logo-link:focus {
   box-shadow: 0 0 0 2px white;
 }
-
+.site-header.featured-image {
+  /* Make sure important elements are above pseudo elements used for effects. */
+}
 .site-header.featured-image .site-branding {
   position: relative;
   z-index: 10;
 }
-
 .site-header.featured-image .site-featured-image .entry-header {
   position: relative;
   z-index: 9;
 }
-
+.site-header.featured-image {
+  /* Set up image filter layer positioning */
+}
 .site-header.featured-image .site-branding-container:after,
 .site-header.featured-image .site-featured-image:before,
 .site-header.featured-image .site-featured-image:after, .site-header.featured-image:after {
@@ -4089,37 +3711,48 @@ body.page .main-navigation {
   position: absolute;
   top: 0;
   right: 0;
-  content: "\020";
+  content: " ";
   width: 100%;
   height: 100%;
 }
-
+.site-header.featured-image {
+  /* Background & Effects */
+  /* Shared background settings between pseudo elements. */
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: cover;
+  /* The intensity of each blend mode is controlled via layer opacity. */
+  /* Second layer: screen. */
+}
 .image-filters-enabled .site-header.featured-image .site-featured-image:before {
   background: #0073aa;
   mix-blend-mode: screen;
   opacity: 0.1;
 }
-
+.site-header.featured-image {
+  /* Third layer: multiply. */
+  /* When image filters are inactive, a black overlay is added. */
+}
 .site-header.featured-image .site-featured-image:after {
   background: #000;
   mix-blend-mode: multiply;
-  opacity: .7;
+  opacity: 0.7;
   /* When image filters are active, a blue overlay is added. */
 }
-
 .image-filters-enabled .site-header.featured-image .site-featured-image:after {
   background: #0073aa;
-  opacity: .8;
+  opacity: 0.8;
   z-index: 3;
   /* Browsers supporting mix-blend-mode don't need opacity < 1 */
 }
-
 @supports (mix-blend-mode: multiply) {
   .image-filters-enabled .site-header.featured-image .site-featured-image:after {
     opacity: 1;
   }
 }
-
+.site-header.featured-image {
+  /* Fourth layer: overlay. */
+}
 .image-filters-enabled .site-header.featured-image .site-branding-container:after {
   background: rgba(0, 0, 0, 0.35);
   mix-blend-mode: overlay;
@@ -4127,40 +3760,37 @@ body.page .main-navigation {
   z-index: 4;
   /* Browsers supporting mix-blend-mode can have a light overlay */
 }
-
 @supports (mix-blend-mode: overlay) {
   .image-filters-enabled .site-header.featured-image .site-branding-container:after {
     background: rgba(255, 255, 255, 0.35);
   }
 }
-
+.site-header.featured-image {
+  /* Fifth layer: readability overlay */
+}
 .site-header.featured-image:after {
   background: #000;
   /**
-		 * Add a transition to the readability overlay, to add a subtle
-		 * but smooth effect when resizing the screen.
-		 */
+   * Add a transition to the readability overlay, to add a subtle
+   * but smooth effect when resizing the screen.
+   */
   transition: opacity 1200ms ease-in-out;
   opacity: 0.7;
   z-index: 5;
   /* When image filters are active, a blue overlay is added. */
 }
-
 .image-filters-enabled .site-header.featured-image:after {
-  background: #000e14;
+  background: rgb(0, 13.8, 20.4);
   opacity: 0.38;
 }
-
 @media only screen and (min-width: 768px) {
   .image-filters-enabled .site-header.featured-image:after {
     opacity: 0.18;
   }
 }
-
 .site-header.featured-image ::-moz-selection {
   background: rgba(255, 255, 255, 0.17);
 }
-
 .site-header.featured-image ::selection {
   background: rgba(255, 255, 255, 0.17);
 }
@@ -4178,7 +3808,7 @@ body.page .main-navigation {
   display: inline-block;
   font-weight: bold;
   line-height: 1;
-  padding: .25rem;
+  padding: 0.25rem;
   position: absolute;
   text-transform: uppercase;
   top: -1rem;
@@ -4197,81 +3827,66 @@ body.page .main-navigation {
 .entry {
   margin-top: calc(6 * 1rem);
 }
-
 .entry:first-of-type {
   margin-top: 0;
 }
-
 .entry .entry-header {
   margin: calc(3 * 1rem) 1rem 1rem;
   position: relative;
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-header {
     margin: calc(3 * 1rem) calc(10% + 60px) 1rem;
   }
 }
-
-.entry .entry-title {
-  margin: 0;
-}
-
 .entry .entry-title:before {
   background: #767676;
-  content: "\020";
+  content: " ";
   display: block;
   height: 2px;
   margin: 1rem 0;
   width: 1em;
 }
-
 .entry .entry-title.has-text-align-center:before {
   margin-right: auto;
   margin-left: auto;
 }
-
 .entry .entry-title.has-text-align-right:before {
   margin-right: auto;
 }
-
+.entry .entry-title {
+  margin: 0;
+}
 .entry .entry-title a {
   color: inherit;
 }
-
 .entry .entry-title a:hover {
-  color: #4a4a4a;
+  color: rgb(74.375, 74.375, 74.375);
 }
-
 .entry .entry-meta,
 .entry .entry-footer {
   color: #767676;
   font-weight: 500;
 }
-
 .entry .entry-meta > span,
 .entry .entry-footer > span {
   margin-left: 1rem;
   display: inline-block;
 }
-
 .entry .entry-meta > span:last-child,
 .entry .entry-footer > span:last-child {
   margin-left: 0;
 }
-
 .entry .entry-meta a,
 .entry .entry-footer a {
   transition: color 110ms ease-in-out;
   color: currentColor;
 }
-
 .entry .entry-meta a:hover,
 .entry .entry-footer a:hover {
   text-decoration: none;
   color: #0073aa;
 }
-
 .entry .entry-meta .svg-icon,
 .entry .entry-footer .svg-icon {
   position: relative;
@@ -4279,80 +3894,66 @@ body.page .main-navigation {
   vertical-align: middle;
   margin-left: 0.5em;
 }
-
 .entry .entry-meta {
   margin: 1rem 0;
 }
-
 .entry .entry-footer {
   margin: calc(2 * 1rem) 1rem 1rem;
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-footer {
     margin: 1rem calc(10% + 60px) calc(3 * 1rem);
-    max-width: calc(8 * (100vw / 12) - 28px);
+    max-width: calc(66.6666666667vw - 28px);
   }
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-footer {
-    max-width: calc(6 * (100vw / 12) - 28px);
+    max-width: calc(50vw - 28px);
   }
 }
-
 .entry .post-thumbnail {
   margin: 1rem;
 }
-
 @media only screen and (min-width: 768px) {
   .entry .post-thumbnail {
     margin: 1rem calc(10% + 60px);
   }
 }
-
 .entry .post-thumbnail:focus {
   outline: none;
 }
-
 .entry .post-thumbnail .post-thumbnail-inner {
   display: block;
 }
-
 .entry .post-thumbnail .post-thumbnail-inner img {
   position: relative;
   display: block;
   width: 100%;
 }
-
 .image-filters-enabled .entry .post-thumbnail {
   position: relative;
   display: block;
 }
-
 .image-filters-enabled .entry .post-thumbnail .post-thumbnail-inner {
   filter: grayscale(100%);
 }
-
 .image-filters-enabled .entry .post-thumbnail .post-thumbnail-inner:after {
   background: rgba(0, 0, 0, 0.35);
   content: "";
   display: block;
   height: 100%;
-  opacity: .5;
+  opacity: 0.5;
   pointer-events: none;
   position: absolute;
   top: 0;
   width: 100%;
   z-index: 4;
 }
-
 @supports (mix-blend-mode: multiply) {
   .image-filters-enabled .entry .post-thumbnail .post-thumbnail-inner:after {
     display: none;
   }
 }
-
 .image-filters-enabled .entry .post-thumbnail:before, .image-filters-enabled .entry .post-thumbnail:after {
   position: absolute;
   display: block;
@@ -4360,37 +3961,32 @@ body.page .main-navigation {
   height: 100%;
   top: 0;
   right: 0;
-  content: "\020";
+  content: " ";
   pointer-events: none;
 }
-
 .image-filters-enabled .entry .post-thumbnail:before {
   background: #0073aa;
   mix-blend-mode: screen;
   opacity: 0.1;
   z-index: 2;
 }
-
 .image-filters-enabled .entry .post-thumbnail:after {
   background: #0073aa;
   mix-blend-mode: multiply;
-  opacity: .8;
+  opacity: 0.8;
   z-index: 3;
   /* Browsers supporting mix-blend-mode don't need opacity < 1 */
 }
-
 @supports (mix-blend-mode: multiply) {
   .image-filters-enabled .entry .post-thumbnail:after {
     opacity: 1;
   }
 }
-
 .entry .entry-content,
 .entry .entry-summary {
-  max-width: calc(100% - (2 * 1rem));
+  max-width: calc(100% - 2 * 1rem);
   margin: 0 1rem;
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content,
   .entry .entry-summary {
@@ -4399,82 +3995,67 @@ body.page .main-navigation {
     padding: 0 60px;
   }
 }
-
 .entry .entry-content p {
   word-wrap: break-word;
 }
-
 .entry .entry-content .more-link {
   transition: color 110ms ease-in-out;
   display: inline;
   color: inherit;
 }
-
 .entry .entry-content .more-link:after {
-  content: "\02192";
+  content: "→";
   display: inline-block;
   margin-right: 0.5em;
 }
-
 .entry .entry-content .more-link:hover {
   color: #0073aa;
   text-decoration: none;
 }
-
 .entry .entry-content a {
   text-decoration: underline;
   text-decoration-thickness: 2px;
 }
-
 .entry .entry-content a.button, .entry .entry-content a:hover {
   text-decoration: none;
 }
-
 .entry .entry-content a.button {
   display: inline-block;
 }
-
 .entry .entry-content a.button:hover {
   background: #111;
   color: #fff;
   cursor: pointer;
 }
-
 .entry .entry-content > iframe[style] {
   margin: 32px 0 !important;
   max-width: 100% !important;
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content > iframe[style] {
-    max-width: calc(8 * (100vw / 12) - 28px) !important;
+    max-width: calc(66.6666666667vw - 28px) !important;
   }
 }
-
 @media only screen and (min-width: 1168px) {
   .entry .entry-content > iframe[style] {
-    max-width: calc(6 * (100vw / 12) - 28px) !important;
+    max-width: calc(50vw - 28px) !important;
   }
 }
-
 .entry .entry-content .page-links a {
   margin: calc(0.5 * 1rem);
   text-decoration: none;
 }
-
 .entry .entry-content .wp-audio-shortcode {
-  max-width: calc(100vw - (2 * 1rem));
+  max-width: calc(100vw - 2 * 1rem);
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-audio-shortcode {
-    max-width: calc(8 * (100vw / 12) - 28px);
+    max-width: calc(66.6666666667vw - 28px);
   }
 }
-
 @media only screen and (min-width: 1168px) {
   .entry .entry-content .wp-audio-shortcode {
-    max-width: calc(6 * (100vw / 12) - 28px);
+    max-width: calc(50vw - 28px);
   }
 }
 
@@ -4482,66 +4063,55 @@ body.page .main-navigation {
 .author-bio {
   margin: calc(2 * 1rem) 1rem 1rem;
 }
-
 @media only screen and (min-width: 768px) {
   .author-bio {
-    max-width: calc(8 * (100vw / 12) - 28px);
+    max-width: calc(66.6666666667vw - 28px);
   }
 }
-
 @media only screen and (min-width: 1168px) {
   .author-bio {
-    max-width: calc(6 * (100vw / 12) - 28px);
+    max-width: calc(50vw - 28px);
   }
 }
-
 @media only screen and (min-width: 768px) {
   .author-bio {
     margin: calc(3 * 1rem) calc(10% + 60px);
   }
 }
-
 @media only screen and (min-width: 1168px) {
   .author-bio {
     margin: calc(3 * 1rem) calc(10% + 60px);
   }
 }
-
-.author-bio .author-title {
-  display: inline;
-}
-
 .author-bio .author-title:before {
   background: #767676;
-  content: "\020";
+  content: " ";
   display: block;
   height: 2px;
   margin: 1rem 0;
   width: 1em;
 }
-
 .author-bio .author-title.has-text-align-center:before {
   margin-right: auto;
   margin-left: auto;
 }
-
 .author-bio .author-title.has-text-align-right:before {
   margin-right: auto;
 }
-
+.author-bio .author-title {
+  display: inline;
+}
 .author-bio .author-description {
   display: inline;
   color: #767676;
   font-size: 1.125em;
   line-height: 1.2;
 }
-
 .author-bio .author-description .author-link {
   display: inline-block;
 }
-
 .author-bio .author-description .author-link:hover {
-  color: #005177;
+  color: rgb(0, 80.5, 119);
   text-decoration: none;
 }
 
@@ -4563,45 +4133,40 @@ body.page .main-navigation {
   hyphens: auto;
   margin: calc(2 * 1rem) 1rem;
   word-wrap: break-word;
-  /* Add extra margin when the comments section is located immediately after the
-	 * post itself (this happens on pages).
-	 */
 }
-
 @media only screen and (min-width: 768px) {
   .comments-area {
-    max-width: calc(8 * (100vw / 12) - 28px);
+    max-width: calc(66.6666666667vw - 28px);
   }
 }
-
 @media only screen and (min-width: 1168px) {
   .comments-area {
-    max-width: calc(6 * (100vw / 12) - 28px);
+    max-width: calc(50vw - 28px);
   }
 }
-
 @media only screen and (min-width: 768px) {
   .comments-area {
     margin: calc(3 * 1rem) calc(10% + 60px);
   }
 }
-
 .comments-area > * {
   margin-top: calc(2 * 1rem);
   margin-bottom: calc(2 * 1rem);
 }
-
 @media only screen and (min-width: 768px) {
   .comments-area > * {
     margin-top: calc(3 * 1rem);
     margin-bottom: calc(3 * 1rem);
   }
 }
-
+.comments-area {
+  /* Add extra margin when the comments section is located immediately after the
+   * post itself (this happens on pages).
+   */
+}
 .entry + .comments-area {
   margin-top: calc(3 * 1rem);
 }
-
 @media only screen and (min-width: 768px) {
   .comments-area .comments-title-wrap {
     align-items: baseline;
@@ -4609,38 +4174,32 @@ body.page .main-navigation {
     justify-content: space-between;
   }
 }
-
-.comments-area .comments-title-wrap .comments-title {
-  margin: 0;
-}
-
 .comments-area .comments-title-wrap .comments-title:before {
   background: #767676;
-  content: "\020";
+  content: " ";
   display: block;
   height: 2px;
   margin: 1rem 0;
   width: 1em;
 }
-
 .comments-area .comments-title-wrap .comments-title.has-text-align-center:before {
   margin-right: auto;
   margin-left: auto;
 }
-
 .comments-area .comments-title-wrap .comments-title.has-text-align-right:before {
   margin-right: auto;
 }
-
+.comments-area .comments-title-wrap .comments-title {
+  margin: 0;
+}
 @media only screen and (min-width: 768px) {
   .comments-area .comments-title-wrap .comments-title {
-    flex: 1 0 calc(3 * (100vw / 12));
+    flex: 1 0 25vw;
   }
 }
-
 @media only screen and (min-width: 768px) {
   .comments-area .comments-title-wrap .discussion-meta {
-    flex: 0 0 calc(2 * (100vw / 12));
+    flex: 0 0 16.6666666667vw;
     margin-right: 1rem;
   }
 }
@@ -4653,24 +4212,20 @@ body.page .main-navigation {
 #respond {
   position: relative;
 }
-
 #respond .comment-user-avatar {
   margin: 1rem 0 -1rem;
 }
-
 #respond .comment .comment-form {
   padding-right: 0;
 }
-
 #respond > small {
   display: block;
   font-size: 22px;
   position: absolute;
   right: calc(1rem + 100%);
   top: calc(-3.5 * 1rem);
-  width: calc(100vw / 12);
+  width: 8.3333333333vw;
 }
-
 #respond .comment-reply-title small {
   margin-right: 0.5em;
 }
@@ -4683,17 +4238,14 @@ body.page .main-navigation {
   display: flex;
   flex-direction: column;
 }
-
 .comment-form-flex .comments-title {
   display: none;
   margin: 0;
   order: 1;
 }
-
 .comment-form-flex #respond {
   order: 2;
 }
-
 .comment-form-flex #respond + .comments-title {
   display: block;
 }
@@ -4707,35 +4259,30 @@ body.page .main-navigation {
   list-style: none;
   padding: 0;
 }
-
 .comment-list .children {
   margin: 0;
   padding: 0 1rem 0 0;
 }
-
 .comment-list > .comment:first-child {
   margin-top: 0;
 }
-
 .comment-list .pingback .comment-body,
 .comment-list .trackback .comment-body {
   color: #767676;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  font-size: 0.71111em;
+  font-size: 0.7111111111em;
   font-weight: 500;
   margin-top: 1rem;
   margin-bottom: 1rem;
 }
-
 .comment-list .pingback .comment-body a:not(.comment-edit-link),
 .comment-list .trackback .comment-body a:not(.comment-edit-link) {
   font-weight: bold;
-  font-size: 19.55556px;
+  font-size: 19.5555555556px;
   line-height: 1.5;
   padding-left: 0.5rem;
   display: block;
 }
-
 .comment-list .pingback .comment-body .comment-edit-link,
 .comment-list .trackback .comment-body .comment-edit-link {
   color: #767676;
@@ -4746,7 +4293,6 @@ body.page .main-navigation {
 #respond + .comment-reply {
   display: none;
 }
-
 .comment-reply .comment-reply-link {
   display: inline-block;
 }
@@ -4755,10 +4301,9 @@ body.page .main-navigation {
   list-style: none;
   position: relative;
 }
-
 @media only screen and (min-width: 768px) {
   .comment {
-    padding-right: calc(.5 * (1rem + calc(100vw / 12 )));
+    padding-right: calc(0.5 * (1rem + 8.3333333333vw));
   }
   .comment.depth-1,
   .comment .children {
@@ -4768,15 +4313,12 @@ body.page .main-navigation {
     margin-right: calc(3.25 * 1rem);
   }
 }
-
 .comment .comment-body {
   margin: calc(2 * 1rem) 0 0;
 }
-
 .comment .comment-meta {
   position: relative;
 }
-
 .comment .comment-author .avatar {
   float: right;
   height: calc(2.25 * 1rem);
@@ -4784,7 +4326,6 @@ body.page .main-navigation {
   position: relative;
   width: calc(2.25 * 1rem);
 }
-
 @media only screen and (min-width: 768px) {
   .comment .comment-author .avatar {
     float: inherit;
@@ -4794,37 +4335,31 @@ body.page .main-navigation {
     left: calc(100% + 1rem);
   }
 }
-
 .comment .comment-author .fn {
   position: relative;
   display: block;
 }
-
 .comment .comment-author .fn a {
   color: inherit;
 }
-
 .comment .comment-author .fn a:hover {
-  color: #005177;
+  color: rgb(0, 80.5, 119);
 }
-
 .comment .comment-author .post-author-badge {
   border-radius: 100%;
   display: block;
   height: 18px;
   position: absolute;
-  background: #008fd3;
+  background: rgb(0, 142.6, 210.8);
   left: calc(100% - 2.5rem);
   top: -3px;
   width: 18px;
 }
-
 @media only screen and (min-width: 768px) {
   .comment .comment-author .post-author-badge {
     left: calc(100% + 0.75rem);
   }
 }
-
 .comment .comment-author .post-author-badge svg {
   width: inherit;
   height: inherit;
@@ -4832,7 +4367,6 @@ body.page .main-navigation {
   fill: white;
   transform: scale(0.875);
 }
-
 .comment .comment-metadata > a,
 .comment .comment-metadata .comment-edit-link {
   display: inline;
@@ -4840,76 +4374,61 @@ body.page .main-navigation {
   color: #767676;
   vertical-align: baseline;
 }
-
 .comment .comment-metadata > a time,
 .comment .comment-metadata .comment-edit-link time {
   vertical-align: baseline;
 }
-
 .comment .comment-metadata > a:hover,
 .comment .comment-metadata .comment-edit-link:hover {
-  color: #005177;
+  color: rgb(0, 80.5, 119);
   text-decoration: none;
 }
-
 .comment .comment-metadata > * {
   display: inline-block;
 }
-
 .comment .comment-metadata .edit-link-sep {
   color: #767676;
   margin: 0 0.2em;
   vertical-align: baseline;
 }
-
 .comment .comment-metadata .edit-link {
   color: #767676;
 }
-
 .comment .comment-metadata .edit-link svg {
   transform: scale(0.8);
   vertical-align: baseline;
   margin-left: 0.1em;
 }
-
 .comment .comment-metadata .comment-edit-link {
   position: relative;
   padding-right: 1rem;
   margin-right: -1rem;
   z-index: 1;
 }
-
 .comment .comment-metadata .comment-edit-link:hover {
   color: #0073aa;
 }
-
 .comment .comment-content {
   margin: 1rem 0;
 }
-
 @media only screen and (min-width: 1168px) {
   .comment .comment-content {
     padding-left: 1rem;
   }
 }
-
 .comment .comment-content > *:first-child {
   margin-top: 0;
 }
-
 .comment .comment-content > *:last-child {
   margin-bottom: 0;
 }
-
 .comment .comment-content blockquote {
   margin-right: 0;
 }
-
 .comment .comment-content a {
   text-decoration: underline;
   text-decoration-thickness: 2px;
 }
-
 .comment .comment-content a:hover {
   text-decoration: none;
 }
@@ -4918,10 +4437,9 @@ body.page .main-navigation {
 #cancel-comment-reply-link {
   font-weight: 500;
 }
-
 .comment-reply-link:hover,
 #cancel-comment-reply-link:hover {
-  color: #005177;
+  color: rgb(0, 80.5, 119);
 }
 
 .discussion-avatar-list {
@@ -4931,7 +4449,6 @@ body.page .main-navigation {
   margin: 0;
   padding: 0;
 }
-
 .discussion-avatar-list li {
   position: relative;
   list-style: none;
@@ -4939,7 +4456,6 @@ body.page .main-navigation {
   padding: 0;
   float: right;
 }
-
 .discussion-avatar-list .comment-user-avatar img {
   height: calc(1.5 * 1rem);
   width: calc(1.5 * 1rem);
@@ -4948,7 +4464,6 @@ body.page .main-navigation {
 .discussion-meta .discussion-meta-info {
   margin: 0;
 }
-
 .discussion-meta .discussion-meta-info .svg-icon {
   vertical-align: middle;
   fill: currentColor;
@@ -4959,14 +4474,12 @@ body.page .main-navigation {
 .comment-form .comment-notes,
 .comment-form label {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  font-size: 0.71111em;
+  font-size: 0.7111111111em;
   color: #767676;
 }
-
 .comment-form #wp-comment-cookies-consent {
   margin: 0 0 0 10px;
 }
-
 @media only screen and (min-width: 768px) {
   .comment-form .comment-form-author,
   .comment-form .comment-form-email {
@@ -4974,16 +4487,14 @@ body.page .main-navigation {
     float: right;
   }
 }
-
 @media only screen and (min-width: 768px) {
   .comment-form .comment-form-email {
     margin-right: 1rem;
   }
 }
-
-.comment-form input[name="author"],
-.comment-form input[name="email"],
-.comment-form input[name="url"] {
+.comment-form input[name=author],
+.comment-form input[name=email],
+.comment-form input[name=url] {
   display: block;
   width: 100%;
 }
@@ -4996,7 +4507,6 @@ body.page .main-navigation {
 .error404 .page-header {
   margin: 1rem 1rem calc(3 * 1rem);
 }
-
 @media only screen and (min-width: 768px) {
   .archive .page-header,
   .search .page-header,
@@ -5004,7 +4514,6 @@ body.page .main-navigation {
     margin: 0 calc(10% + 60px) calc(3 * 1rem);
   }
 }
-
 .archive .page-header .page-title,
 .search .page-header .page-title,
 .error404 .page-header .page-title {
@@ -5012,13 +4521,11 @@ body.page .main-navigation {
   display: inline;
   letter-spacing: normal;
 }
-
 .archive .page-header .page-title:before,
 .search .page-header .page-title:before,
 .error404 .page-header .page-title:before {
   display: none;
 }
-
 .archive .page-header .search-term,
 .archive .page-header .page-description,
 .search .page-header .search-term,
@@ -5047,20 +4554,17 @@ body.page .main-navigation {
 .no-results.not-found .page-content {
   margin: calc(3 * 1rem) 1rem;
 }
-
 @media only screen and (min-width: 768px) {
   .error-404.not-found .page-content,
   .no-results.not-found .page-content {
     margin: calc(3 * 1rem) calc(10% + 60px) calc(1rem / 2);
   }
 }
-
 .error-404.not-found .search-submit,
 .no-results.not-found .search-submit {
   vertical-align: middle;
   margin: 1rem 0;
 }
-
 .error-404.not-found .search-field,
 .no-results.not-found .search-field {
   width: 100%;
@@ -5074,19 +4578,16 @@ body.page .main-navigation {
 #colophon .site-info {
   margin: calc(2 * 1rem) 1rem;
 }
-
 @media only screen and (min-width: 768px) {
   #colophon .widget-area,
   #colophon .site-info {
     margin: calc(3 * 1rem) calc(10% + 60px);
   }
 }
-
 #colophon .widget-column {
   display: flex;
   flex-wrap: wrap;
 }
-
 #colophon .widget-column .widget {
   -webkit-hyphens: auto;
   -moz-hyphens: auto;
@@ -5095,14 +4596,12 @@ body.page .main-navigation {
   width: 100%;
   word-wrap: break-word;
 }
-
 @media only screen and (min-width: 1168px) {
   #colophon .widget-column .widget {
     margin-left: calc(3 * 1rem);
-    width: calc(50% - (3 * 1rem));
+    width: calc(50% - 3 * 1rem);
   }
 }
-
 #colophon .site-info {
   color: #767676;
   -webkit-hyphens: auto;
@@ -5111,16 +4610,13 @@ body.page .main-navigation {
   hyphens: auto;
   word-wrap: break-word;
 }
-
 #colophon .site-info a {
   color: inherit;
 }
-
 #colophon .site-info a:hover {
   text-decoration: none;
   color: #0073aa;
 }
-
 #colophon .site-info .imprint,
 #colophon .site-info .privacy-policy-link {
   margin-left: 1rem;
@@ -5129,23 +4625,21 @@ body.page .main-navigation {
 /* Widgets */
 .widget {
   margin: 0 0 1rem;
-  /* Make sure select elements fit in widgets. */
 }
-
 .widget .widget-title {
   font-size: 1.6875em;
 }
-
+.widget {
+  /* Make sure select elements fit in widgets. */
+}
 .widget select {
   max-width: 100%;
 }
-
 .widget a {
   color: #0073aa;
 }
-
 .widget a:hover {
-  color: #005177;
+  color: rgb(0, 80.5, 119);
 }
 
 .widget_archive ul,
@@ -5159,7 +4653,6 @@ body.page .main-navigation {
   padding: 0;
   list-style: none;
 }
-
 .widget_archive ul li,
 .widget_categories ul li,
 .widget_meta ul li,
@@ -5176,7 +4669,6 @@ body.page .main-navigation {
   margin-top: 0.5rem;
   margin-bottom: 0.5rem;
 }
-
 .widget_archive ul ul,
 .widget_categories ul ul,
 .widget_meta ul ul,
@@ -5187,7 +4679,6 @@ body.page .main-navigation {
 .widget_rss ul ul {
   counter-reset: submenu;
 }
-
 .widget_archive ul ul > li > a::before,
 .widget_categories ul ul > li > a::before,
 .widget_meta ul ul > li > a::before,
@@ -5210,13 +4701,11 @@ body.page .main-navigation {
 .widget_search .search-field {
   width: 100%;
 }
-
 @media only screen and (min-width: 600px) {
   .widget_search .search-field {
     width: auto;
   }
 }
-
 .widget_search .search-submit {
   display: block;
   margin-top: 1rem;
@@ -5225,33 +4714,27 @@ body.page .main-navigation {
 .widget_calendar .calendar_wrap {
   text-align: center;
 }
-
 .widget_calendar .calendar_wrap table td,
 .widget_calendar .calendar_wrap table th {
   border: none;
 }
-
 .widget_calendar .calendar_wrap a {
   text-decoration: underline;
   text-decoration-thickness: 2px;
 }
-
 .widget_calendar .calendar_wrap .wp-calendar-table {
   margin-bottom: 0;
 }
-
 .widget_calendar .calendar_wrap .wp-calendar-nav {
   margin: 0 0 1rem;
   display: table;
   width: 100%;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 }
-
 .widget_calendar .calendar_wrap .wp-calendar-nav span {
   display: table-cell;
   padding: 0.5em;
 }
-
 .widget_calendar .calendar_wrap .wp-calendar-nav-prev,
 .widget_calendar .calendar_wrap .wp-calendar-nav-next {
   width: 40%;
@@ -5266,25 +4749,22 @@ body.page .main-navigation {
   margin: 32px 0;
   max-width: 100%;
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content > *,
   .entry .entry-summary > *,
   .entry .entry-summary > .wp-block-group > .wp-block-group__inner-container > *,
   .entry .entry-content > .wp-block-group > .wp-block-group__inner-container > * {
-    max-width: calc(8 * (100vw / 12) - 28px);
+    max-width: calc(66.6666666667vw - 28px);
   }
 }
-
 @media only screen and (min-width: 1168px) {
   .entry .entry-content > *,
   .entry .entry-summary > *,
   .entry .entry-summary > .wp-block-group > .wp-block-group__inner-container > *,
   .entry .entry-content > .wp-block-group > .wp-block-group__inner-container > * {
-    max-width: calc(6 * (100vw / 12) - 28px);
+    max-width: calc(50vw - 28px);
   }
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content > *,
   .entry .entry-summary > *,
@@ -5293,7 +4773,6 @@ body.page .main-navigation {
     margin: 32px 0;
   }
 }
-
 .entry .entry-content > *.alignwide,
 .entry .entry-summary > *.alignwide,
 .entry .entry-summary > .wp-block-group > .wp-block-group__inner-container > *.alignwide,
@@ -5302,7 +4781,6 @@ body.page .main-navigation {
   margin-left: auto;
   clear: both;
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content > *.alignwide,
   .entry .entry-summary > *.alignwide,
@@ -5312,18 +4790,16 @@ body.page .main-navigation {
     max-width: 100%;
   }
 }
-
 .entry .entry-content > *.alignfull,
 .entry .entry-summary > *.alignfull,
 .entry .entry-summary > .wp-block-group > .wp-block-group__inner-container > *.alignfull,
 .entry .entry-content > .wp-block-group > .wp-block-group__inner-container > *.alignfull {
   position: relative;
   right: -1rem;
-  width: calc( 100% + (2 * 1rem));
-  max-width: calc( 100% + (2 * 1rem));
+  width: calc(100% + 2 * 1rem);
+  max-width: calc(100% + 2 * 1rem);
   clear: both;
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content > *.alignfull,
   .entry .entry-summary > *.alignfull,
@@ -5331,55 +4807,50 @@ body.page .main-navigation {
   .entry .entry-content > .wp-block-group > .wp-block-group__inner-container > *.alignfull {
     margin-top: calc(2 * 1rem);
     margin-bottom: calc(2 * 1rem);
-    right: calc( -12.5% - 75px);
-    width: calc( 125% + 150px);
-    max-width: calc( 125% + 150px);
+    right: calc(-12.5% - 75px);
+    width: calc(125% + 150px);
+    max-width: calc(125% + 150px);
   }
 }
-
 .entry .entry-content > *.alignleft,
 .entry .entry-summary > *.alignleft,
 .entry .entry-summary > .wp-block-group > .wp-block-group__inner-container > *.alignleft,
 .entry .entry-content > .wp-block-group > .wp-block-group__inner-container > *.alignleft {
   float: left;
-  max-width: calc(5 * (100vw / 12));
+  max-width: 41.6666666667vw;
   margin-top: 0;
   margin-right: 0;
   margin-right: 1rem;
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content > *.alignleft,
   .entry .entry-summary > *.alignleft,
   .entry .entry-summary > .wp-block-group > .wp-block-group__inner-container > *.alignleft,
   .entry .entry-content > .wp-block-group > .wp-block-group__inner-container > *.alignleft {
-    max-width: calc(4 * (100vw / 12));
+    max-width: 33.3333333333vw;
     margin-right: calc(2 * 1rem);
   }
 }
-
 .entry .entry-content > *.alignright,
 .entry .entry-summary > *.alignright,
 .entry .entry-summary > .wp-block-group > .wp-block-group__inner-container > *.alignright,
 .entry .entry-content > .wp-block-group > .wp-block-group__inner-container > *.alignright {
   float: right;
-  max-width: calc(5 * (100vw / 12));
+  max-width: 41.6666666667vw;
   margin-top: 0;
   margin-left: 0;
   margin-left: 1rem;
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content > *.alignright,
   .entry .entry-summary > *.alignright,
   .entry .entry-summary > .wp-block-group > .wp-block-group__inner-container > *.alignright,
   .entry .entry-content > .wp-block-group > .wp-block-group__inner-container > *.alignright {
-    max-width: calc(4 * (100vw / 12));
+    max-width: 33.3333333333vw;
     margin-left: 0;
     margin-left: calc(2 * 1rem);
   }
 }
-
 .entry .entry-content > *.aligncenter,
 .entry .entry-summary > *.aligncenter,
 .entry .entry-summary > .wp-block-group > .wp-block-group__inner-container > *.aligncenter,
@@ -5387,25 +4858,22 @@ body.page .main-navigation {
   margin-right: auto;
   margin-left: auto;
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content > *.aligncenter,
   .entry .entry-summary > *.aligncenter,
   .entry .entry-summary > .wp-block-group > .wp-block-group__inner-container > *.aligncenter,
   .entry .entry-content > .wp-block-group > .wp-block-group__inner-container > *.aligncenter {
-    max-width: calc(8 * (100vw / 12) - 28px);
+    max-width: calc(66.6666666667vw - 28px);
   }
 }
-
 @media only screen and (min-width: 1168px) {
   .entry .entry-content > *.aligncenter,
   .entry .entry-summary > *.aligncenter,
   .entry .entry-summary > .wp-block-group > .wp-block-group__inner-container > *.aligncenter,
   .entry .entry-content > .wp-block-group > .wp-block-group__inner-container > *.aligncenter {
-    max-width: calc(6 * (100vw / 12) - 28px);
+    max-width: calc(50vw - 28px);
   }
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content > *.aligncenter,
   .entry .entry-summary > *.aligncenter,
@@ -5420,7 +4888,6 @@ body.page .main-navigation {
 .entry .entry-summary > * > *:first-child {
   margin-top: 0;
 }
-
 .entry .entry-content > * > *:last-child,
 .entry .entry-summary > * > *:last-child {
   margin-bottom: 0;
@@ -5441,7 +4908,6 @@ body.page .main-navigation {
   max-width: inherit;
   padding: inherit;
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content .entry-content,
   .entry .entry-content .entry-summary,
@@ -5458,47 +4924,36 @@ body.page .main-navigation {
 .entry .entry-content p.has-background {
   padding: 20px 30px;
 }
-
 .entry .entry-content .wp-block-audio {
   width: 100%;
 }
-
 .entry .entry-content .wp-block-audio audio {
   display: block;
   width: 100%;
 }
-
-.entry .entry-content .wp-block-audio.alignleft audio,
-.entry .entry-content .wp-block-audio.alignright audio {
+.entry .entry-content .wp-block-audio.alignleft audio, .entry .entry-content .wp-block-audio.alignright audio {
   max-width: 198px;
 }
-
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-audio.alignleft audio,
-  .entry .entry-content .wp-block-audio.alignright audio {
+  .entry .entry-content .wp-block-audio.alignleft audio, .entry .entry-content .wp-block-audio.alignright audio {
     max-width: 384px;
   }
 }
-
 @media only screen and (min-width: 1379px) {
-  .entry .entry-content .wp-block-audio.alignleft audio,
-  .entry .entry-content .wp-block-audio.alignright audio {
+  .entry .entry-content .wp-block-audio.alignleft audio, .entry .entry-content .wp-block-audio.alignright audio {
     max-width: 385.44px;
   }
 }
-
 .entry .entry-content .wp-block-video video {
   width: 100%;
 }
-
 .entry .entry-content .wp-block-buttons {
   line-height: 1.2;
 }
-
 .entry .entry-content .wp-block-button .wp-block-button__link {
   transition: background 150ms ease-in-out;
   border: none;
-  font-size: 0.88889em;
+  font-size: 0.8888888889em;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   box-sizing: border-box;
   font-weight: bold;
@@ -5506,92 +4961,69 @@ body.page .main-navigation {
   padding: 0.76rem 1rem;
   outline: none;
 }
-
 .entry .entry-content .wp-block-button .wp-block-button__link:not(.has-background) {
   background-color: #0073aa;
 }
-
 .entry .entry-content .wp-block-button .wp-block-button__link:not(.has-text-color) {
   color: white;
 }
-
 .entry .entry-content .wp-block-button .wp-block-button__link:hover {
   color: white;
   background: #111;
   cursor: pointer;
 }
-
 .entry .entry-content .wp-block-button .wp-block-button__link:hover:not(.has-background) {
   background: #111;
 }
-
 .entry .entry-content .wp-block-button .wp-block-button__link:focus {
   color: white;
   background: #111;
   outline: thin dotted;
   outline-offset: -4px;
 }
-
 .entry .entry-content .wp-block-button .wp-block-button__link:focus:not(.has-background) {
   background: #111;
 }
-
 .entry .entry-content .wp-block-button:not(.is-style-squared) .wp-block-button__link {
   border-radius: 5px;
 }
-
-.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link,
-.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:focus,
-.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active {
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link, .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:focus, .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active {
   transition: all 150ms ease-in-out;
   border-width: 2px;
   border-style: solid;
 }
-
-.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:not(.has-background),
-.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:focus:not(.has-background),
-.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active:not(.has-background) {
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:not(.has-background), .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:focus:not(.has-background), .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active:not(.has-background) {
   background: transparent;
 }
-
-.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color),
-.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:focus:not(.has-text-color),
-.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active:not(.has-text-color) {
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color), .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:focus:not(.has-text-color), .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active:not(.has-text-color) {
   color: #0073aa;
   border-color: currentColor;
 }
-
 .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:hover {
   color: white;
   border-color: #111;
 }
-
 .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:hover:not(.has-background) {
   color: #111;
 }
-
 .entry .entry-content .wp-block-buttons.has-custom-font-size .wp-block-button__link,
 .entry .entry-content .wp-block-button.has-custom-font-size .wp-block-button__link {
   font-size: 1em;
 }
-
-.entry .entry-content .wp-block-buttons[style*="font-weight"] .wp-block-button__link,
-.entry .entry-content .wp-block-button[style*="font-weight"] .wp-block-button__link {
+.entry .entry-content .wp-block-buttons[style*=font-weight] .wp-block-button__link,
+.entry .entry-content .wp-block-button[style*=font-weight] .wp-block-button__link {
   font-weight: inherit;
 }
-
-.entry .entry-content .wp-block-buttons[style*="text-decoration"] .wp-block-button__link,
-.entry .entry-content .wp-block-button[style*="text-decoration"] .wp-block-button__link {
+.entry .entry-content .wp-block-buttons[style*=text-decoration] .wp-block-button__link,
+.entry .entry-content .wp-block-button[style*=text-decoration] .wp-block-button__link {
   text-decoration: inherit;
 }
-
 .entry .entry-content .wp-block-archives,
 .entry .entry-content .wp-block-categories,
 .entry .entry-content .wp-block-latest-posts {
   padding: 0;
   list-style: none;
 }
-
 .entry .entry-content .wp-block-archives li > a,
 .entry .entry-content .wp-block-categories li > a,
 .entry .entry-content .wp-block-latest-posts li > a {
@@ -5601,87 +5033,70 @@ body.page .main-navigation {
   line-height: 1.2;
   text-decoration: none;
 }
-
 .entry .entry-content .wp-block-archives.aligncenter,
 .entry .entry-content .wp-block-categories.aligncenter {
   text-align: center;
 }
-
 .entry .entry-content .wp-block-categories ul {
   padding-top: 0.75rem;
 }
-
 .entry .entry-content .wp-block-categories li ul {
   list-style: none;
   padding-right: 0;
 }
-
 .entry .entry-content .wp-block-categories ul {
   counter-reset: submenu;
 }
-
 .entry .entry-content .wp-block-categories ul > li > a::before {
   font-family: "NonBreakingSpaceOverride", "Hoefler Text", Garamond, "Times New Roman", serif;
   font-weight: normal;
   content: "– " counters(submenu, "– ", none);
   counter-increment: submenu;
 }
-
 .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  font-size: 0.71111em;
+  font-size: 0.7111111111em;
   color: #767676;
   line-height: 1.2;
 }
-
 .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-full-content,
 .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-excerpt {
   margin-top: 1rem;
   margin-bottom: 1rem;
 }
-
 .entry .entry-content .wp-block-latest-posts li {
   padding-bottom: 0.5rem;
 }
-
 .entry .entry-content .wp-block-latest-posts li.menu-item-has-children, .entry .entry-content .wp-block-latest-posts li:last-child {
   padding-bottom: 0;
 }
-
 .entry .entry-content .wp-block-latest-posts li :not(:last-child) .wp-block-latest-posts__post-excerpt {
   padding-bottom: 0.5rem;
 }
-
 .entry .entry-content .wp-block-latest-posts.is-grid li {
   border-top: 2px solid #ccc;
   padding-top: 1rem;
   margin-bottom: 2rem;
 }
-
 .entry .entry-content .wp-block-latest-posts.is-grid li a:after {
-  content: '';
+  content: "";
 }
-
 .entry .entry-content .wp-block-latest-posts.is-grid li:last-child {
   margin-bottom: auto;
 }
-
 .entry .entry-content .wp-block-latest-posts.is-grid li:last-child a:after {
-  content: '';
+  content: "";
 }
-
 .entry .entry-content .wp-block-preformatted {
-  font-size: 0.71111em;
+  font-size: 0.7111111111em;
   line-height: 1.8;
   padding: 1rem;
 }
-
 .entry .entry-content .wp-block-verse {
   font-family: "NonBreakingSpaceOverride", "Hoefler Text", Garamond, "Times New Roman", serif;
   font-size: 22px;
   line-height: 1.8;
 }
-
 .entry .entry-content .has-drop-cap:not(:focus):first-letter {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-size: 3.375em;
@@ -5689,13 +5104,11 @@ body.page .main-navigation {
   font-weight: bold;
   margin: 0 0 0 0.25em;
 }
-
 @-moz-document url-prefix() {
   .entry .entry-content .has-drop-cap:not(:focus):first-letter {
     margin-top: 0.2em;
   }
 }
-
 .entry .entry-content .wp-block-pullquote {
   color: #111;
   border-color: transparent;
@@ -5703,7 +5116,6 @@ body.page .main-navigation {
   padding: 1rem;
   font-size: 1em;
 }
-
 .entry .entry-content .wp-block-pullquote blockquote {
   border: none;
   margin-top: calc(4 * 1rem);
@@ -5711,7 +5123,6 @@ body.page .main-navigation {
   margin-left: 0;
   padding-right: 0;
 }
-
 .entry .entry-content .wp-block-pullquote p {
   font-size: 1.6875em;
   font-style: italic;
@@ -5719,17 +5130,14 @@ body.page .main-navigation {
   margin-bottom: 0.5em;
   margin-top: 0.5em;
 }
-
 .entry .entry-content .wp-block-pullquote p em {
   font-style: normal;
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-pullquote p {
     font-size: 2.25em;
   }
 }
-
 .entry .entry-content .wp-block-pullquote cite {
   display: block;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
@@ -5737,66 +5145,55 @@ body.page .main-navigation {
   text-transform: none;
   color: #767676;
   /*
-			 * This requires a rem-based font size calculation instead of our normal em-based one,
-			 * because the cite tag sometimes gets wrapped in a p tag. This is equivalent to $font-size_xs.
-			 */
+   * This requires a rem-based font size calculation instead of our normal em-based one,
+   * because the cite tag sometimes gets wrapped in a p tag. This is equivalent to $font-size_xs.
+   */
   font-size: calc(1rem / (1.25 * 1.125));
 }
-
 .entry .entry-content .wp-block-pullquote.alignleft, .entry .entry-content .wp-block-pullquote.alignright {
   width: 100%;
   padding: 0;
 }
-
 .entry .entry-content .wp-block-pullquote.alignleft blockquote, .entry .entry-content .wp-block-pullquote.alignright blockquote {
   margin: 1rem 0;
   padding: 0;
   text-align: right;
   max-width: 100%;
 }
-
 .entry .entry-content .wp-block-pullquote.alignleft blockquote p:first-child, .entry .entry-content .wp-block-pullquote.alignright blockquote p:first-child {
   margin-top: 0;
 }
-
 .entry .entry-content .wp-block-pullquote.has-text-color cite {
   color: inherit;
 }
-
 .entry .entry-content .wp-block-pullquote.is-style-solid-color {
   background-color: #0073aa;
   padding-right: 0;
   padding-left: 0;
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-pullquote.is-style-solid-color {
     padding-right: 10%;
     padding-left: 10%;
   }
 }
-
 .entry .entry-content .wp-block-pullquote.is-style-solid-color p {
   font-size: 1.6875em;
   line-height: 1.3;
   margin-bottom: 0.5em;
   margin-top: 0.5em;
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-pullquote.is-style-solid-color p {
     font-size: 2.25em;
   }
 }
-
 .entry .entry-content .wp-block-pullquote.is-style-solid-color a {
   color: #fff;
 }
-
 .entry .entry-content .wp-block-pullquote.is-style-solid-color cite {
   color: inherit;
 }
-
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote {
   max-width: 100%;
   color: #fff;
@@ -5804,75 +5201,63 @@ body.page .main-navigation {
   margin-right: 1rem;
   margin-left: 1rem;
 }
-
-.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-text-color p,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-text-color a, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-white-color {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-text-color p, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-text-color a, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-white-color {
   color: inherit;
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote {
     margin-right: 0;
     margin-left: 0;
   }
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignright, .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignleft {
     padding: 1rem calc(2 * 1rem);
   }
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignfull {
-    padding-right: calc(10% + 58px + (2 * 1rem));
-    padding-left: calc(10% + 58px + (2 * 1rem));
+    padding-right: calc(10% + 58px + 2 * 1rem);
+    padding-left: calc(10% + 58px + 2 * 1rem);
   }
 }
-
 .entry .entry-content .wp-block-quote:not(.is-large), .entry .entry-content .wp-block-quote:not(.is-style-large) {
   border-width: 2px;
   border-color: #0073aa;
   padding-top: 0;
   padding-bottom: 0;
 }
-
 .entry .entry-content .wp-block-quote p {
   font-size: 1em;
   font-style: normal;
   line-height: 1.8;
 }
-
 .entry .entry-content .wp-block-quote cite {
   /*
-			 * This requires a rem-based font size calculation instead of our normal em-based one,
-			 * because the cite tag sometimes gets wrapped in a p tag. This is equivalent to $font-size_xs.
-			 */
+   * This requires a rem-based font size calculation instead of our normal em-based one,
+   * because the cite tag sometimes gets wrapped in a p tag. This is equivalent to $font-size_xs.
+   */
   font-size: calc(1rem / (1.25 * 1.125));
 }
-
 .entry .entry-content .wp-block-quote.is-large, .entry .entry-content .wp-block-quote.is-style-large {
   margin: 1rem 0;
   padding: 0;
   border-right: none;
 }
-
 .entry .entry-content .wp-block-quote.is-large p, .entry .entry-content .wp-block-quote.is-style-large p {
   font-size: 1.6875em;
   line-height: 1.4;
   font-style: italic;
 }
-
 .entry .entry-content .wp-block-quote.is-large cite,
 .entry .entry-content .wp-block-quote.is-large footer, .entry .entry-content .wp-block-quote.is-style-large cite,
 .entry .entry-content .wp-block-quote.is-style-large footer {
   /*
-				 * This requires a rem-based font size calculation instead of our normal em-based one,
-				 * because the cite tag sometimes gets wrapped in a p tag. This is equivalent to $font-size_xs.
-				 */
+   * This requires a rem-based font size calculation instead of our normal em-based one,
+   * because the cite tag sometimes gets wrapped in a p tag. This is equivalent to $font-size_xs.
+   */
   font-size: calc(1rem / (1.25 * 1.125));
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-quote.is-large, .entry .entry-content .wp-block-quote.is-style-large {
     margin: 1rem 0;
@@ -5882,91 +5267,72 @@ body.page .main-navigation {
     font-size: 1.6875em;
   }
 }
-
 .entry .entry-content .wp-block-image {
   max-width: 100%;
 }
-
 .entry .entry-content .wp-block-image img {
   display: block;
 }
-
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-image:not(.alignwide):not(.alignfull) > img,
-  .entry .entry-content .wp-block-image:not(.alignwide):not(.alignfull) > a > img,
-  .entry .entry-content .wp-block-image:not(.alignwide):not(.alignfull) > img + figcaption,
-  .entry .entry-content .wp-block-image:not(.alignwide):not(.alignfull) > a + figcaption {
-    max-width: calc(8 * (100vw / 12) - 28px);
+  .entry .entry-content .wp-block-image:not(.alignwide):not(.alignfull) > img, .entry .entry-content .wp-block-image:not(.alignwide):not(.alignfull) > a > img, .entry .entry-content .wp-block-image:not(.alignwide):not(.alignfull) > img + figcaption, .entry .entry-content .wp-block-image:not(.alignwide):not(.alignfull) > a + figcaption {
+    max-width: calc(66.6666666667vw - 28px);
   }
 }
-
 @media only screen and (min-width: 1168px) {
-  .entry .entry-content .wp-block-image:not(.alignwide):not(.alignfull) > img,
-  .entry .entry-content .wp-block-image:not(.alignwide):not(.alignfull) > a > img,
-  .entry .entry-content .wp-block-image:not(.alignwide):not(.alignfull) > img + figcaption,
-  .entry .entry-content .wp-block-image:not(.alignwide):not(.alignfull) > a + figcaption {
-    max-width: calc(6 * (100vw / 12) - 28px);
+  .entry .entry-content .wp-block-image:not(.alignwide):not(.alignfull) > img, .entry .entry-content .wp-block-image:not(.alignwide):not(.alignfull) > a > img, .entry .entry-content .wp-block-image:not(.alignwide):not(.alignfull) > img + figcaption, .entry .entry-content .wp-block-image:not(.alignwide):not(.alignfull) > a + figcaption {
+    max-width: calc(50vw - 28px);
   }
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-image .aligncenter {
-    max-width: calc(8 * (100vw / 12) - 28px);
+    max-width: calc(66.6666666667vw - 28px);
   }
 }
-
 @media only screen and (min-width: 1168px) {
   .entry .entry-content .wp-block-image .aligncenter {
-    max-width: calc(6 * (100vw / 12) - 28px);
+    max-width: calc(50vw - 28px);
   }
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-image .aligncenter {
     margin: 0;
-    width: calc(8 * (100vw / 12) - 28px);
+    width: calc(66.6666666667vw - 28px);
   }
   .entry .entry-content .wp-block-image .aligncenter img {
     margin: 0 auto;
   }
 }
-
 @media only screen and (min-width: 1168px) {
   .entry .entry-content .wp-block-image .aligncenter {
-    width: calc(6 * (100vw / 12) - 28px);
+    width: calc(50vw - 28px);
   }
   .entry .entry-content .wp-block-image .aligncenter img {
     margin: 0 auto;
   }
 }
-
 .entry .entry-content .wp-block-image.alignfull img {
   width: 100vw;
-  max-width: calc( 100% + (2 * 1rem));
+  max-width: calc(100% + 2 * 1rem);
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-image.alignfull img {
-    max-width: calc( 125% + 150px);
+    max-width: calc(125% + 150px);
     margin-right: auto;
     margin-left: auto;
   }
 }
-
 .entry .entry-content .wp-block-cover-image,
 .entry .entry-content .wp-block-cover {
   position: relative;
   min-height: 430px;
   padding: 1rem;
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-cover-image,
   .entry .entry-content .wp-block-cover {
     padding: 1rem 10%;
   }
 }
-
 .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text,
 .entry .entry-content .wp-block-cover-image .wp-block-cover-text,
 .entry .entry-content .wp-block-cover-image h2,
@@ -5980,7 +5346,6 @@ body.page .main-navigation {
   padding: 0;
   color: #fff;
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text,
   .entry .entry-content .wp-block-cover-image .wp-block-cover-text,
@@ -5992,13 +5357,11 @@ body.page .main-navigation {
     max-width: 100%;
   }
 }
-
 .entry .entry-content .wp-block-cover-image.alignleft, .entry .entry-content .wp-block-cover-image.alignright,
 .entry .entry-content .wp-block-cover.alignleft,
 .entry .entry-content .wp-block-cover.alignright {
   width: 100%;
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-cover-image.alignleft, .entry .entry-content .wp-block-cover-image.alignright,
   .entry .entry-content .wp-block-cover.alignleft,
@@ -6006,7 +5369,6 @@ body.page .main-navigation {
     padding: 1rem calc(2 * 1rem);
   }
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-cover-image.alignfull .wp-block-cover-image-text,
   .entry .entry-content .wp-block-cover-image.alignfull .wp-block-cover-text,
@@ -6014,10 +5376,9 @@ body.page .main-navigation {
   .entry .entry-content .wp-block-cover.alignfull .wp-block-cover-image-text,
   .entry .entry-content .wp-block-cover.alignfull .wp-block-cover-text,
   .entry .entry-content .wp-block-cover.alignfull h2 {
-    max-width: calc(8 * (100vw / 12) - 28px);
+    max-width: calc(66.6666666667vw - 28px);
   }
 }
-
 @media only screen and (min-width: 1168px) {
   .entry .entry-content .wp-block-cover-image.alignfull .wp-block-cover-image-text,
   .entry .entry-content .wp-block-cover-image.alignfull .wp-block-cover-text,
@@ -6025,15 +5386,14 @@ body.page .main-navigation {
   .entry .entry-content .wp-block-cover.alignfull .wp-block-cover-image-text,
   .entry .entry-content .wp-block-cover.alignfull .wp-block-cover-text,
   .entry .entry-content .wp-block-cover.alignfull h2 {
-    max-width: calc(6 * (100vw / 12) - 28px);
+    max-width: calc(50vw - 28px);
   }
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-cover-image.alignfull,
   .entry .entry-content .wp-block-cover.alignfull {
-    padding-right: calc(10% + 58px + (2 * 1rem));
-    padding-left: calc(10% + 58px + (2 * 1rem));
+    padding-right: calc(10% + 58px + 2 * 1rem);
+    padding-left: calc(10% + 58px + 2 * 1rem);
   }
   .entry .entry-content .wp-block-cover-image.alignfull .wp-block-cover-image-text,
   .entry .entry-content .wp-block-cover-image.alignfull .wp-block-cover-text,
@@ -6044,34 +5404,29 @@ body.page .main-navigation {
     padding: 0;
   }
 }
-
 .entry .entry-content .wp-block-gallery {
   list-style-type: none;
   padding-right: 0;
 }
-
 .entry .entry-content .wp-block-gallery .blocks-gallery-image:last-child,
 .entry .entry-content .wp-block-gallery .blocks-gallery-item:last-child {
   margin-bottom: 16px;
 }
-
 .entry .entry-content .wp-block-gallery figcaption a {
   color: #fff;
 }
-
 .entry .entry-content .wp-block-audio figcaption,
 .entry .entry-content .wp-block-video figcaption,
 .entry .entry-content .wp-block-image figcaption,
 .entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption,
 .entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption {
-  font-size: 0.71111em;
+  font-size: 0.7111111111em;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   line-height: 1.6;
   margin: 0;
   padding: 0.5rem;
   text-align: center;
 }
-
 .entry .entry-content .wp-block-separator,
 .entry .entry-content hr {
   background-color: #767676;
@@ -6081,103 +5436,92 @@ body.page .main-navigation {
   margin-top: 2rem;
   max-width: 2.25em;
   text-align: right;
-  /* Remove duplicate rule-line when a separator
-		 * is followed by an H1, or H2 */
 }
-
 .entry .entry-content .wp-block-separator:not(.wp-block-separator),
 .entry .entry-content hr:not(.wp-block-separator) {
   max-width: 100%;
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-separator:not(.wp-block-separator),
   .entry .entry-content hr:not(.wp-block-separator) {
-    max-width: calc(8 * (100vw / 12) - 28px);
+    max-width: calc(66.6666666667vw - 28px);
   }
 }
-
 @media only screen and (min-width: 1168px) {
   .entry .entry-content .wp-block-separator:not(.wp-block-separator),
   .entry .entry-content hr:not(.wp-block-separator) {
-    max-width: calc(6 * (100vw / 12) - 28px);
+    max-width: calc(50vw - 28px);
   }
 }
-
 .entry .entry-content .wp-block-separator.is-style-wide,
 .entry .entry-content hr.is-style-wide {
   max-width: 100%;
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-separator.is-style-wide,
   .entry .entry-content hr.is-style-wide {
-    max-width: calc(8 * (100vw / 12) - 28px);
+    max-width: calc(66.6666666667vw - 28px);
   }
 }
-
 @media only screen and (min-width: 1168px) {
   .entry .entry-content .wp-block-separator.is-style-wide,
   .entry .entry-content hr.is-style-wide {
-    max-width: calc(6 * (100vw / 12) - 28px);
+    max-width: calc(50vw - 28px);
   }
 }
-
 .entry .entry-content .wp-block-separator.is-style-dots,
 .entry .entry-content hr.is-style-dots {
   max-width: 100%;
+}
+@media only screen and (min-width: 768px) {
+  .entry .entry-content .wp-block-separator.is-style-dots,
+  .entry .entry-content hr.is-style-dots {
+    max-width: calc(66.6666666667vw - 28px);
+  }
+}
+@media only screen and (min-width: 1168px) {
+  .entry .entry-content .wp-block-separator.is-style-dots,
+  .entry .entry-content hr.is-style-dots {
+    max-width: calc(50vw - 28px);
+  }
+}
+.entry .entry-content .wp-block-separator.is-style-dots,
+.entry .entry-content hr.is-style-dots {
   background-color: inherit;
   border: inherit;
   height: inherit;
   text-align: center;
 }
-
-@media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-separator.is-style-dots,
-  .entry .entry-content hr.is-style-dots {
-    max-width: calc(8 * (100vw / 12) - 28px);
-  }
-}
-
-@media only screen and (min-width: 1168px) {
-  .entry .entry-content .wp-block-separator.is-style-dots,
-  .entry .entry-content hr.is-style-dots {
-    max-width: calc(6 * (100vw / 12) - 28px);
-  }
-}
-
 .entry .entry-content .wp-block-separator.is-style-dots:not(.has-text-color):not(.has-background),
 .entry .entry-content hr.is-style-dots:not(.has-text-color):not(.has-background) {
   color: #767676;
 }
-
 .entry .entry-content .wp-block-separator.is-style-dots:before,
 .entry .entry-content hr.is-style-dots:before {
   font-size: 1.6875em;
-  letter-spacing: 0.88889em;
-  padding-right: 0.88889em;
+  letter-spacing: 0.8888888889em;
+  padding-right: 0.8888888889em;
 }
-
-.entry .entry-content .wp-block-separator + h1:before,
-.entry .entry-content .wp-block-separator + h2:before,
+.entry .entry-content .wp-block-separator,
+.entry .entry-content hr {
+  /* Remove duplicate rule-line when a separator
+   * is followed by an H1, or H2 */
+}
+.entry .entry-content .wp-block-separator + h1:before, .entry .entry-content .wp-block-separator + h2:before,
 .entry .entry-content hr + h1:before,
 .entry .entry-content hr + h2:before {
   display: none;
 }
-
 .entry .entry-content .wp-block-embed-twitter {
   word-break: break-word;
 }
-
 .entry .entry-content .wp-block-table th,
 .entry .entry-content .wp-block-table td {
   border-color: #767676;
 }
-
 .entry .entry-content .wp-block-file {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 }
-
 .entry .entry-content .wp-block-file .wp-block-file__button {
   display: table;
   transition: background 150ms ease-in-out;
@@ -6194,53 +5538,43 @@ body.page .main-navigation {
   margin-right: 0;
   margin-top: calc(0.75 * 1rem);
 }
-
 @media only screen and (min-width: 1168px) {
   .entry .entry-content .wp-block-file .wp-block-file__button {
     font-size: 22px;
     padding: 0.875rem 1.5rem;
   }
 }
-
 .entry .entry-content .wp-block-file .wp-block-file__button:hover {
   background: #111;
   cursor: pointer;
 }
-
 .entry .entry-content .wp-block-file .wp-block-file__button:focus {
   background: #111;
   outline: thin dotted;
   outline-offset: -4px;
 }
-
 .entry .entry-content .wp-block-file.aligncenter .wp-block-file__button {
   margin-right: auto;
   margin-left: auto;
 }
-
 .entry .entry-content .wp-block-file.alignright .wp-block-file__button {
   margin-right: auto;
   margin-left: 0;
 }
-
 .entry .entry-content .wp-block-code {
   border-radius: 0;
 }
-
 .entry .entry-content .wp-block-code code {
   font-size: 1.125em;
   white-space: pre-wrap;
   word-break: break-word;
 }
-
 .entry .entry-content .wp-block-columns .wp-block-column > *:first-child {
   margin-top: 0;
 }
-
 .entry .entry-content .wp-block-columns .wp-block-column > *:last-child {
   margin-bottom: 0;
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-columns .wp-block-image:not(.alignwide):not(.alignfull) > img,
   .entry .entry-content .wp-block-columns .wp-block-image:not(.alignwide):not(.alignfull) > a > img,
@@ -6249,7 +5583,6 @@ body.page .main-navigation {
     max-width: 100%;
   }
 }
-
 @media only screen and (min-width: 1168px) {
   .entry .entry-content .wp-block-columns .wp-block-image:not(.alignwide):not(.alignfull) > img,
   .entry .entry-content .wp-block-columns .wp-block-image:not(.alignwide):not(.alignfull) > a > img,
@@ -6258,7 +5591,6 @@ body.page .main-navigation {
     max-width: 100%;
   }
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-columns {
     flex-wrap: nowrap;
@@ -6267,20 +5599,16 @@ body.page .main-navigation {
     margin-right: 32px;
   }
 }
-
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-group:not(.alignfull) > .wp-block-group__inner-container > .alignfull,
-  .entry .entry-content .wp-block-group:not(.alignfull) > .wp-block-group__inner-container > .wp-block-image > img {
+  .entry .entry-content .wp-block-group:not(.alignfull) > .wp-block-group__inner-container > .alignfull, .entry .entry-content .wp-block-group:not(.alignfull) > .wp-block-group__inner-container > .wp-block-image > img {
     right: 0;
     max-width: 100%;
   }
 }
-
 .entry .entry-content .wp-block-group.alignfull > .wp-block-group__inner-container {
-  max-width: calc(100% - (2 * 1rem));
+  max-width: calc(100% - 2 * 1rem);
   margin: 0 1rem;
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-group.alignfull > .wp-block-group__inner-container {
     max-width: 80%;
@@ -6288,88 +5616,71 @@ body.page .main-navigation {
     padding: 0 60px;
   }
 }
-
 .entry .entry-content .wp-block-group.has-background {
   padding: 1rem;
   margin-top: 0;
   margin-bottom: 0;
 }
-
 .entry .entry-content .wp-block-group.has-background .wp-block-group__inner-container > *:first-child {
   margin-top: 0;
 }
-
 .entry .entry-content .wp-block-group.has-background .wp-block-group__inner-container > *:last-child {
   margin-bottom: 0;
 }
-
 .entry .entry-content .wp-block-group.has-background.alignfull {
   padding-right: 0;
   padding-left: 0;
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-group.has-background.alignfull {
     padding-top: 1rem;
     padding-bottom: 1rem;
   }
 }
-
 .entry .entry-content .wp-block-group.has-background:not(.alignfull) > .wp-block-group__inner-container > .alignfull {
   width: 100%;
   max-width: 100%;
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-group.has-background:not(.alignfull) > .wp-block-group__inner-container > .alignfull {
-    width: calc( 100% + 2rem);
-    max-width: calc( 100% + 2rem);
+    width: calc(100% + 2rem);
+    max-width: calc(100% + 2rem);
     margin-right: -1rem;
   }
 }
-
 .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-weight: bold;
 }
-
 .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta .wp-block-latest-comments__comment-date {
   font-weight: normal;
 }
-
 .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment,
 .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-date,
 .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-excerpt p {
   font-size: inherit;
 }
-
 .entry .entry-content .wp-block-latest-comments.has-dates .wp-block-latest-comments__comment-date {
-  font-size: 0.71111em;
+  font-size: 0.7111111111em;
 }
-
 .entry .entry-content .has-small-font-size {
-  font-size: 0.88889em;
+  font-size: 0.8888888889em;
 }
-
 .entry .entry-content .has-normal-font-size {
   font-size: 1.125em;
 }
-
 .entry .entry-content .has-large-font-size {
   font-size: 1.6875em;
 }
-
 .entry .entry-content .has-huge-font-size {
   font-size: 2.25em;
 }
-
 .entry .entry-content .has-primary-background-color,
 .entry .entry-content .has-secondary-background-color,
 .entry .entry-content .has-dark-gray-background-color,
 .entry .entry-content .has-light-gray-background-color {
   color: #fff;
 }
-
 .entry .entry-content .has-primary-background-color > p,
 .entry .entry-content .has-primary-background-color > h1,
 .entry .entry-content .has-primary-background-color > h2,
@@ -6404,11 +5715,9 @@ body.page .main-navigation {
 .entry .entry-content .has-light-gray-background-color > a {
   color: #fff;
 }
-
 .entry .entry-content .has-white-background-color {
   color: #111;
 }
-
 .entry .entry-content .has-white-background-color > p,
 .entry .entry-content .has-white-background-color > h1,
 .entry .entry-content .has-white-background-color > h2,
@@ -6419,59 +5728,49 @@ body.page .main-navigation {
 .entry .entry-content .has-white-background-color > a {
   color: #111;
 }
-
 .entry .entry-content .has-primary-background-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color.has-primary-background-color {
   background-color: #0073aa;
 }
-
 .entry .entry-content .has-secondary-background-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color.has-secondary-background-color {
-  background-color: #005177;
+  background-color: rgb(0, 80.5, 119);
 }
-
 .entry .entry-content .has-dark-gray-background-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color.has-dark-gray-background-color {
   background-color: #111;
 }
-
 .entry .entry-content .has-light-gray-background-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color.has-light-gray-background-color {
   background-color: #767676;
 }
-
 .entry .entry-content .has-white-background-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color.has-white-background-color {
   background-color: #FFF;
 }
-
 .entry .entry-content .has-primary-color,
 .entry .entry-content .wp-block-pullquote blockquote.has-primary-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color > p {
   color: #0073aa;
 }
-
 .entry .entry-content .has-secondary-color,
 .entry .entry-content .wp-block-pullquote blockquote.has-secondary-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color > p {
-  color: #005177;
+  color: rgb(0, 80.5, 119);
 }
-
 .entry .entry-content .has-dark-gray-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color > p {
   color: #111;
 }
-
 .entry .entry-content .has-light-gray-color,
 .entry .entry-content .wp-block-pullquote blockquote.has-light-gray-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color > p {
   color: #767676;
 }
-
 .entry .entry-content .has-white-color,
 .entry .entry-content .wp-block-pullquote blockquote.has-white-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-white-color {
@@ -6515,22 +5814,20 @@ svg {
 .wp-caption {
   margin-bottom: calc(1.5 * 1rem);
 }
-
 @media only screen and (min-width: 768px) {
   .wp-caption.aligncenter {
     position: relative;
-    right: calc( calc(8 * (100vw / 12) - 28px) / 2);
+    right: calc(calc(66.6666666667vw - 28px) / 2);
     transform: translateX(50%);
   }
 }
-
 @media only screen and (min-width: 1168px) {
   .wp-caption.aligncenter {
-    right: calc( calc(6 * (100vw / 12) - 28px) / 2);
+    right: calc(calc(50vw - 28px) / 2);
   }
 }
 
-.wp-caption img[class*="wp-image-"] {
+.wp-caption img[class*=wp-image-] {
   display: block;
   margin-right: auto;
   margin-left: auto;
@@ -6538,7 +5835,7 @@ svg {
 
 .wp-caption-text {
   color: #767676;
-  font-size: 0.71111em;
+  font-size: 0.7111111111em;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   line-height: 1.6;
   margin: 0;
@@ -6564,78 +5861,61 @@ svg {
   vertical-align: top;
   width: 100%;
 }
-
 .gallery-columns-2 .gallery-item {
   max-width: calc((100% - 16px * 1) / 2);
 }
-
 .gallery-columns-2 .gallery-item:nth-of-type(2n+2) {
   margin-left: 0;
 }
-
 .gallery-columns-3 .gallery-item {
   max-width: calc((100% - 16px * 2) / 3);
 }
-
 .gallery-columns-3 .gallery-item:nth-of-type(3n+3) {
   margin-left: 0;
 }
-
 .gallery-columns-4 .gallery-item {
   max-width: calc((100% - 16px * 3) / 4);
 }
-
 .gallery-columns-4 .gallery-item:nth-of-type(4n+4) {
   margin-left: 0;
 }
-
 .gallery-columns-5 .gallery-item {
   max-width: calc((100% - 16px * 4) / 5);
 }
-
 .gallery-columns-5 .gallery-item:nth-of-type(5n+5) {
   margin-left: 0;
 }
-
 .gallery-columns-6 .gallery-item {
   max-width: calc((100% - 16px * 5) / 6);
 }
-
 .gallery-columns-6 .gallery-item:nth-of-type(6n+6) {
   margin-left: 0;
 }
-
 .gallery-columns-7 .gallery-item {
   max-width: calc((100% - 16px * 6) / 7);
 }
-
 .gallery-columns-7 .gallery-item:nth-of-type(7n+7) {
   margin-left: 0;
 }
-
 .gallery-columns-8 .gallery-item {
   max-width: calc((100% - 16px * 7) / 8);
 }
-
 .gallery-columns-8 .gallery-item:nth-of-type(8n+8) {
   margin-left: 0;
 }
-
 .gallery-columns-9 .gallery-item {
   max-width: calc((100% - 16px * 8) / 9);
 }
-
 .gallery-columns-9 .gallery-item:nth-of-type(9n+9) {
   margin-left: 0;
 }
-
 .gallery-item:last-of-type {
   padding-left: 0;
 }
 
 .gallery-caption {
   display: block;
-  font-size: 0.71111em;
+  font-size: 0.7111111111em;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   line-height: 1.6;
   margin: 0;
@@ -6647,7 +5927,6 @@ svg {
   line-height: 0;
   box-shadow: 0 0 0 0 transparent;
 }
-
 .gallery-item > div > a:focus {
   box-shadow: 0 0 0 2px #0073aa;
 }

--- a/src/wp-content/themes/twentynineteen/style-rtl.css
+++ b/src/wp-content/themes/twentynineteen/style-rtl.css
@@ -78,1620 +78,6 @@ Colorful Bokeh by HD Wallpapers, CC0. https://stocksnap.io/photo/colorful-bokeh-
 /* Calculates maximum width for post content */
 /* Nested sub-menu padding: 10 levels deep */
 /* Ensure all font family declarations come with non-latin fallbacks */
-/* Build our non-latin font styles */
-.gallery-caption:lang(ar), .wp-caption-text:lang(ar), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ar), .entry .entry-content .wp-block-file .wp-block-file__button:lang(ar), .entry .entry-content .wp-block-file:lang(ar), .entry .entry-content .wp-block-audio figcaption:lang(ar),
-.entry .entry-content .wp-block-video figcaption:lang(ar),
-.entry .entry-content .wp-block-image figcaption:lang(ar),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(ar),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(ar), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(ar),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(ar),
-.entry .entry-content .wp-block-cover-image h2:lang(ar),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(ar),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(ar),
-.entry .entry-content .wp-block-cover h2:lang(ar), .entry .entry-content .wp-block-pullquote cite:lang(ar), .entry .entry-content .has-drop-cap:lang(ar):not(:focus):first-letter, .entry .entry-content .wp-block-verse:lang(ar), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ar), .entry .entry-content .wp-block-archives li > a:lang(ar),
-.entry .entry-content .wp-block-categories li > a:lang(ar),
-.entry .entry-content .wp-block-latest-posts li > a:lang(ar), .entry .entry-content .wp-block-button .wp-block-button__link:lang(ar), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(ar), .widget_tag_cloud .tagcloud:lang(ar), .widget_archive ul li:lang(ar),
-.widget_categories ul li:lang(ar),
-.widget_meta ul li:lang(ar),
-.widget_nav_menu ul li:lang(ar),
-.widget_pages ul li:lang(ar),
-.widget_recent_comments ul li:lang(ar),
-.widget_recent_entries ul li:lang(ar),
-.widget_rss ul li:lang(ar), .comment-form .comment-notes:lang(ar),
-.comment-form label:lang(ar), .comment-list .pingback .comment-body .comment-edit-link:lang(ar),
-.comment-list .trackback .comment-body .comment-edit-link:lang(ar), .comment-list .pingback .comment-body:lang(ar),
-.comment-list .trackback .comment-body:lang(ar), .comment-navigation .nav-previous:lang(ar),
-.comment-navigation .nav-next:lang(ar), .button:lang(ar), table:lang(ar), blockquote cite:lang(ar), .page-title:lang(ar), .author-description .author-link:lang(ar),
-.comment-metadata:lang(ar),
-.comment-reply-link:lang(ar),
-.comments-title:lang(ar),
-.comment-author .fn:lang(ar),
-.discussion-meta-info:lang(ar),
-.entry-meta:lang(ar),
-.entry-footer:lang(ar),
-.main-navigation:lang(ar),
-.no-comments:lang(ar),
-.post-navigation .post-title:lang(ar),
-.page-links:lang(ar),
-.page-description:lang(ar),
-.pagination .nav-links:lang(ar),
-.sticky-post:lang(ar),
-.site-title:lang(ar),
-.site-info:lang(ar),
-#cancel-comment-reply-link:lang(ar),
-h1:lang(ar),
-h2:lang(ar),
-h3:lang(ar),
-h4:lang(ar),
-h5:lang(ar),
-h6:lang(ar), button:lang(ar),
-input:lang(ar),
-select:lang(ar),
-optgroup:lang(ar),
-textarea:lang(ar), body:lang(ar) {
-  font-family: Tahoma, Arial, sans-serif;
-}
-.gallery-caption:lang(ary), .wp-caption-text:lang(ary), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ary), .entry .entry-content .wp-block-file .wp-block-file__button:lang(ary), .entry .entry-content .wp-block-file:lang(ary), .entry .entry-content .wp-block-audio figcaption:lang(ary),
-.entry .entry-content .wp-block-video figcaption:lang(ary),
-.entry .entry-content .wp-block-image figcaption:lang(ary),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(ary),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(ary), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(ary),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(ary),
-.entry .entry-content .wp-block-cover-image h2:lang(ary),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(ary),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(ary),
-.entry .entry-content .wp-block-cover h2:lang(ary), .entry .entry-content .wp-block-pullquote cite:lang(ary), .entry .entry-content .has-drop-cap:lang(ary):not(:focus):first-letter, .entry .entry-content .wp-block-verse:lang(ary), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ary), .entry .entry-content .wp-block-archives li > a:lang(ary),
-.entry .entry-content .wp-block-categories li > a:lang(ary),
-.entry .entry-content .wp-block-latest-posts li > a:lang(ary), .entry .entry-content .wp-block-button .wp-block-button__link:lang(ary), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(ary), .widget_tag_cloud .tagcloud:lang(ary), .widget_archive ul li:lang(ary),
-.widget_categories ul li:lang(ary),
-.widget_meta ul li:lang(ary),
-.widget_nav_menu ul li:lang(ary),
-.widget_pages ul li:lang(ary),
-.widget_recent_comments ul li:lang(ary),
-.widget_recent_entries ul li:lang(ary),
-.widget_rss ul li:lang(ary), .comment-form .comment-notes:lang(ary),
-.comment-form label:lang(ary), .comment-list .pingback .comment-body .comment-edit-link:lang(ary),
-.comment-list .trackback .comment-body .comment-edit-link:lang(ary), .comment-list .pingback .comment-body:lang(ary),
-.comment-list .trackback .comment-body:lang(ary), .comment-navigation .nav-previous:lang(ary),
-.comment-navigation .nav-next:lang(ary), .button:lang(ary), table:lang(ary), blockquote cite:lang(ary), .page-title:lang(ary), .author-description .author-link:lang(ary),
-.comment-metadata:lang(ary),
-.comment-reply-link:lang(ary),
-.comments-title:lang(ary),
-.comment-author .fn:lang(ary),
-.discussion-meta-info:lang(ary),
-.entry-meta:lang(ary),
-.entry-footer:lang(ary),
-.main-navigation:lang(ary),
-.no-comments:lang(ary),
-.post-navigation .post-title:lang(ary),
-.page-links:lang(ary),
-.page-description:lang(ary),
-.pagination .nav-links:lang(ary),
-.sticky-post:lang(ary),
-.site-title:lang(ary),
-.site-info:lang(ary),
-#cancel-comment-reply-link:lang(ary),
-h1:lang(ary),
-h2:lang(ary),
-h3:lang(ary),
-h4:lang(ary),
-h5:lang(ary),
-h6:lang(ary), button:lang(ary),
-input:lang(ary),
-select:lang(ary),
-optgroup:lang(ary),
-textarea:lang(ary), body:lang(ary) {
-  font-family: Tahoma, Arial, sans-serif;
-}
-.gallery-caption:lang(azb), .wp-caption-text:lang(azb), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(azb), .entry .entry-content .wp-block-file .wp-block-file__button:lang(azb), .entry .entry-content .wp-block-file:lang(azb), .entry .entry-content .wp-block-audio figcaption:lang(azb),
-.entry .entry-content .wp-block-video figcaption:lang(azb),
-.entry .entry-content .wp-block-image figcaption:lang(azb),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(azb),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(azb), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(azb),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(azb),
-.entry .entry-content .wp-block-cover-image h2:lang(azb),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(azb),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(azb),
-.entry .entry-content .wp-block-cover h2:lang(azb), .entry .entry-content .wp-block-pullquote cite:lang(azb), .entry .entry-content .has-drop-cap:lang(azb):not(:focus):first-letter, .entry .entry-content .wp-block-verse:lang(azb), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(azb), .entry .entry-content .wp-block-archives li > a:lang(azb),
-.entry .entry-content .wp-block-categories li > a:lang(azb),
-.entry .entry-content .wp-block-latest-posts li > a:lang(azb), .entry .entry-content .wp-block-button .wp-block-button__link:lang(azb), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(azb), .widget_tag_cloud .tagcloud:lang(azb), .widget_archive ul li:lang(azb),
-.widget_categories ul li:lang(azb),
-.widget_meta ul li:lang(azb),
-.widget_nav_menu ul li:lang(azb),
-.widget_pages ul li:lang(azb),
-.widget_recent_comments ul li:lang(azb),
-.widget_recent_entries ul li:lang(azb),
-.widget_rss ul li:lang(azb), .comment-form .comment-notes:lang(azb),
-.comment-form label:lang(azb), .comment-list .pingback .comment-body .comment-edit-link:lang(azb),
-.comment-list .trackback .comment-body .comment-edit-link:lang(azb), .comment-list .pingback .comment-body:lang(azb),
-.comment-list .trackback .comment-body:lang(azb), .comment-navigation .nav-previous:lang(azb),
-.comment-navigation .nav-next:lang(azb), .button:lang(azb), table:lang(azb), blockquote cite:lang(azb), .page-title:lang(azb), .author-description .author-link:lang(azb),
-.comment-metadata:lang(azb),
-.comment-reply-link:lang(azb),
-.comments-title:lang(azb),
-.comment-author .fn:lang(azb),
-.discussion-meta-info:lang(azb),
-.entry-meta:lang(azb),
-.entry-footer:lang(azb),
-.main-navigation:lang(azb),
-.no-comments:lang(azb),
-.post-navigation .post-title:lang(azb),
-.page-links:lang(azb),
-.page-description:lang(azb),
-.pagination .nav-links:lang(azb),
-.sticky-post:lang(azb),
-.site-title:lang(azb),
-.site-info:lang(azb),
-#cancel-comment-reply-link:lang(azb),
-h1:lang(azb),
-h2:lang(azb),
-h3:lang(azb),
-h4:lang(azb),
-h5:lang(azb),
-h6:lang(azb), button:lang(azb),
-input:lang(azb),
-select:lang(azb),
-optgroup:lang(azb),
-textarea:lang(azb), body:lang(azb) {
-  font-family: Tahoma, Arial, sans-serif;
-}
-.gallery-caption:lang(ckb), .wp-caption-text:lang(ckb), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ckb), .entry .entry-content .wp-block-file .wp-block-file__button:lang(ckb), .entry .entry-content .wp-block-file:lang(ckb), .entry .entry-content .wp-block-audio figcaption:lang(ckb),
-.entry .entry-content .wp-block-video figcaption:lang(ckb),
-.entry .entry-content .wp-block-image figcaption:lang(ckb),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(ckb),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(ckb), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(ckb),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(ckb),
-.entry .entry-content .wp-block-cover-image h2:lang(ckb),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(ckb),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(ckb),
-.entry .entry-content .wp-block-cover h2:lang(ckb), .entry .entry-content .wp-block-pullquote cite:lang(ckb), .entry .entry-content .has-drop-cap:lang(ckb):not(:focus):first-letter, .entry .entry-content .wp-block-verse:lang(ckb), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ckb), .entry .entry-content .wp-block-archives li > a:lang(ckb),
-.entry .entry-content .wp-block-categories li > a:lang(ckb),
-.entry .entry-content .wp-block-latest-posts li > a:lang(ckb), .entry .entry-content .wp-block-button .wp-block-button__link:lang(ckb), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(ckb), .widget_tag_cloud .tagcloud:lang(ckb), .widget_archive ul li:lang(ckb),
-.widget_categories ul li:lang(ckb),
-.widget_meta ul li:lang(ckb),
-.widget_nav_menu ul li:lang(ckb),
-.widget_pages ul li:lang(ckb),
-.widget_recent_comments ul li:lang(ckb),
-.widget_recent_entries ul li:lang(ckb),
-.widget_rss ul li:lang(ckb), .comment-form .comment-notes:lang(ckb),
-.comment-form label:lang(ckb), .comment-list .pingback .comment-body .comment-edit-link:lang(ckb),
-.comment-list .trackback .comment-body .comment-edit-link:lang(ckb), .comment-list .pingback .comment-body:lang(ckb),
-.comment-list .trackback .comment-body:lang(ckb), .comment-navigation .nav-previous:lang(ckb),
-.comment-navigation .nav-next:lang(ckb), .button:lang(ckb), table:lang(ckb), blockquote cite:lang(ckb), .page-title:lang(ckb), .author-description .author-link:lang(ckb),
-.comment-metadata:lang(ckb),
-.comment-reply-link:lang(ckb),
-.comments-title:lang(ckb),
-.comment-author .fn:lang(ckb),
-.discussion-meta-info:lang(ckb),
-.entry-meta:lang(ckb),
-.entry-footer:lang(ckb),
-.main-navigation:lang(ckb),
-.no-comments:lang(ckb),
-.post-navigation .post-title:lang(ckb),
-.page-links:lang(ckb),
-.page-description:lang(ckb),
-.pagination .nav-links:lang(ckb),
-.sticky-post:lang(ckb),
-.site-title:lang(ckb),
-.site-info:lang(ckb),
-#cancel-comment-reply-link:lang(ckb),
-h1:lang(ckb),
-h2:lang(ckb),
-h3:lang(ckb),
-h4:lang(ckb),
-h5:lang(ckb),
-h6:lang(ckb), button:lang(ckb),
-input:lang(ckb),
-select:lang(ckb),
-optgroup:lang(ckb),
-textarea:lang(ckb), body:lang(ckb) {
-  font-family: Tahoma, Arial, sans-serif;
-}
-.gallery-caption:lang(fa-IR), .wp-caption-text:lang(fa-IR), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(fa-IR), .entry .entry-content .wp-block-file .wp-block-file__button:lang(fa-IR), .entry .entry-content .wp-block-file:lang(fa-IR), .entry .entry-content .wp-block-audio figcaption:lang(fa-IR),
-.entry .entry-content .wp-block-video figcaption:lang(fa-IR),
-.entry .entry-content .wp-block-image figcaption:lang(fa-IR),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(fa-IR),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(fa-IR), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(fa-IR),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(fa-IR),
-.entry .entry-content .wp-block-cover-image h2:lang(fa-IR),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(fa-IR),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(fa-IR),
-.entry .entry-content .wp-block-cover h2:lang(fa-IR), .entry .entry-content .wp-block-pullquote cite:lang(fa-IR), .entry .entry-content .has-drop-cap:lang(fa-IR):not(:focus):first-letter, .entry .entry-content .wp-block-verse:lang(fa-IR), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(fa-IR), .entry .entry-content .wp-block-archives li > a:lang(fa-IR),
-.entry .entry-content .wp-block-categories li > a:lang(fa-IR),
-.entry .entry-content .wp-block-latest-posts li > a:lang(fa-IR), .entry .entry-content .wp-block-button .wp-block-button__link:lang(fa-IR), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(fa-IR), .widget_tag_cloud .tagcloud:lang(fa-IR), .widget_archive ul li:lang(fa-IR),
-.widget_categories ul li:lang(fa-IR),
-.widget_meta ul li:lang(fa-IR),
-.widget_nav_menu ul li:lang(fa-IR),
-.widget_pages ul li:lang(fa-IR),
-.widget_recent_comments ul li:lang(fa-IR),
-.widget_recent_entries ul li:lang(fa-IR),
-.widget_rss ul li:lang(fa-IR), .comment-form .comment-notes:lang(fa-IR),
-.comment-form label:lang(fa-IR), .comment-list .pingback .comment-body .comment-edit-link:lang(fa-IR),
-.comment-list .trackback .comment-body .comment-edit-link:lang(fa-IR), .comment-list .pingback .comment-body:lang(fa-IR),
-.comment-list .trackback .comment-body:lang(fa-IR), .comment-navigation .nav-previous:lang(fa-IR),
-.comment-navigation .nav-next:lang(fa-IR), .button:lang(fa-IR), table:lang(fa-IR), blockquote cite:lang(fa-IR), .page-title:lang(fa-IR), .author-description .author-link:lang(fa-IR),
-.comment-metadata:lang(fa-IR),
-.comment-reply-link:lang(fa-IR),
-.comments-title:lang(fa-IR),
-.comment-author .fn:lang(fa-IR),
-.discussion-meta-info:lang(fa-IR),
-.entry-meta:lang(fa-IR),
-.entry-footer:lang(fa-IR),
-.main-navigation:lang(fa-IR),
-.no-comments:lang(fa-IR),
-.post-navigation .post-title:lang(fa-IR),
-.page-links:lang(fa-IR),
-.page-description:lang(fa-IR),
-.pagination .nav-links:lang(fa-IR),
-.sticky-post:lang(fa-IR),
-.site-title:lang(fa-IR),
-.site-info:lang(fa-IR),
-#cancel-comment-reply-link:lang(fa-IR),
-h1:lang(fa-IR),
-h2:lang(fa-IR),
-h3:lang(fa-IR),
-h4:lang(fa-IR),
-h5:lang(fa-IR),
-h6:lang(fa-IR), button:lang(fa-IR),
-input:lang(fa-IR),
-select:lang(fa-IR),
-optgroup:lang(fa-IR),
-textarea:lang(fa-IR), body:lang(fa-IR) {
-  font-family: Tahoma, Arial, sans-serif;
-}
-.gallery-caption:lang(haz), .wp-caption-text:lang(haz), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(haz), .entry .entry-content .wp-block-file .wp-block-file__button:lang(haz), .entry .entry-content .wp-block-file:lang(haz), .entry .entry-content .wp-block-audio figcaption:lang(haz),
-.entry .entry-content .wp-block-video figcaption:lang(haz),
-.entry .entry-content .wp-block-image figcaption:lang(haz),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(haz),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(haz), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(haz),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(haz),
-.entry .entry-content .wp-block-cover-image h2:lang(haz),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(haz),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(haz),
-.entry .entry-content .wp-block-cover h2:lang(haz), .entry .entry-content .wp-block-pullquote cite:lang(haz), .entry .entry-content .has-drop-cap:lang(haz):not(:focus):first-letter, .entry .entry-content .wp-block-verse:lang(haz), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(haz), .entry .entry-content .wp-block-archives li > a:lang(haz),
-.entry .entry-content .wp-block-categories li > a:lang(haz),
-.entry .entry-content .wp-block-latest-posts li > a:lang(haz), .entry .entry-content .wp-block-button .wp-block-button__link:lang(haz), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(haz), .widget_tag_cloud .tagcloud:lang(haz), .widget_archive ul li:lang(haz),
-.widget_categories ul li:lang(haz),
-.widget_meta ul li:lang(haz),
-.widget_nav_menu ul li:lang(haz),
-.widget_pages ul li:lang(haz),
-.widget_recent_comments ul li:lang(haz),
-.widget_recent_entries ul li:lang(haz),
-.widget_rss ul li:lang(haz), .comment-form .comment-notes:lang(haz),
-.comment-form label:lang(haz), .comment-list .pingback .comment-body .comment-edit-link:lang(haz),
-.comment-list .trackback .comment-body .comment-edit-link:lang(haz), .comment-list .pingback .comment-body:lang(haz),
-.comment-list .trackback .comment-body:lang(haz), .comment-navigation .nav-previous:lang(haz),
-.comment-navigation .nav-next:lang(haz), .button:lang(haz), table:lang(haz), blockquote cite:lang(haz), .page-title:lang(haz), .author-description .author-link:lang(haz),
-.comment-metadata:lang(haz),
-.comment-reply-link:lang(haz),
-.comments-title:lang(haz),
-.comment-author .fn:lang(haz),
-.discussion-meta-info:lang(haz),
-.entry-meta:lang(haz),
-.entry-footer:lang(haz),
-.main-navigation:lang(haz),
-.no-comments:lang(haz),
-.post-navigation .post-title:lang(haz),
-.page-links:lang(haz),
-.page-description:lang(haz),
-.pagination .nav-links:lang(haz),
-.sticky-post:lang(haz),
-.site-title:lang(haz),
-.site-info:lang(haz),
-#cancel-comment-reply-link:lang(haz),
-h1:lang(haz),
-h2:lang(haz),
-h3:lang(haz),
-h4:lang(haz),
-h5:lang(haz),
-h6:lang(haz), button:lang(haz),
-input:lang(haz),
-select:lang(haz),
-optgroup:lang(haz),
-textarea:lang(haz), body:lang(haz) {
-  font-family: Tahoma, Arial, sans-serif;
-}
-.gallery-caption:lang(ps), .wp-caption-text:lang(ps), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ps), .entry .entry-content .wp-block-file .wp-block-file__button:lang(ps), .entry .entry-content .wp-block-file:lang(ps), .entry .entry-content .wp-block-audio figcaption:lang(ps),
-.entry .entry-content .wp-block-video figcaption:lang(ps),
-.entry .entry-content .wp-block-image figcaption:lang(ps),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(ps),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(ps), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(ps),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(ps),
-.entry .entry-content .wp-block-cover-image h2:lang(ps),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(ps),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(ps),
-.entry .entry-content .wp-block-cover h2:lang(ps), .entry .entry-content .wp-block-pullquote cite:lang(ps), .entry .entry-content .has-drop-cap:lang(ps):not(:focus):first-letter, .entry .entry-content .wp-block-verse:lang(ps), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ps), .entry .entry-content .wp-block-archives li > a:lang(ps),
-.entry .entry-content .wp-block-categories li > a:lang(ps),
-.entry .entry-content .wp-block-latest-posts li > a:lang(ps), .entry .entry-content .wp-block-button .wp-block-button__link:lang(ps), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(ps), .widget_tag_cloud .tagcloud:lang(ps), .widget_archive ul li:lang(ps),
-.widget_categories ul li:lang(ps),
-.widget_meta ul li:lang(ps),
-.widget_nav_menu ul li:lang(ps),
-.widget_pages ul li:lang(ps),
-.widget_recent_comments ul li:lang(ps),
-.widget_recent_entries ul li:lang(ps),
-.widget_rss ul li:lang(ps), .comment-form .comment-notes:lang(ps),
-.comment-form label:lang(ps), .comment-list .pingback .comment-body .comment-edit-link:lang(ps),
-.comment-list .trackback .comment-body .comment-edit-link:lang(ps), .comment-list .pingback .comment-body:lang(ps),
-.comment-list .trackback .comment-body:lang(ps), .comment-navigation .nav-previous:lang(ps),
-.comment-navigation .nav-next:lang(ps), .button:lang(ps), table:lang(ps), blockquote cite:lang(ps), .page-title:lang(ps), .author-description .author-link:lang(ps),
-.comment-metadata:lang(ps),
-.comment-reply-link:lang(ps),
-.comments-title:lang(ps),
-.comment-author .fn:lang(ps),
-.discussion-meta-info:lang(ps),
-.entry-meta:lang(ps),
-.entry-footer:lang(ps),
-.main-navigation:lang(ps),
-.no-comments:lang(ps),
-.post-navigation .post-title:lang(ps),
-.page-links:lang(ps),
-.page-description:lang(ps),
-.pagination .nav-links:lang(ps),
-.sticky-post:lang(ps),
-.site-title:lang(ps),
-.site-info:lang(ps),
-#cancel-comment-reply-link:lang(ps),
-h1:lang(ps),
-h2:lang(ps),
-h3:lang(ps),
-h4:lang(ps),
-h5:lang(ps),
-h6:lang(ps), button:lang(ps),
-input:lang(ps),
-select:lang(ps),
-optgroup:lang(ps),
-textarea:lang(ps), body:lang(ps) {
-  font-family: Tahoma, Arial, sans-serif;
-}
-.gallery-caption:lang(be), .wp-caption-text:lang(be), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(be), .entry .entry-content .wp-block-file .wp-block-file__button:lang(be), .entry .entry-content .wp-block-file:lang(be), .entry .entry-content .wp-block-audio figcaption:lang(be),
-.entry .entry-content .wp-block-video figcaption:lang(be),
-.entry .entry-content .wp-block-image figcaption:lang(be),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(be),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(be), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(be),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(be),
-.entry .entry-content .wp-block-cover-image h2:lang(be),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(be),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(be),
-.entry .entry-content .wp-block-cover h2:lang(be), .entry .entry-content .wp-block-pullquote cite:lang(be), .entry .entry-content .has-drop-cap:lang(be):not(:focus):first-letter, .entry .entry-content .wp-block-verse:lang(be), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(be), .entry .entry-content .wp-block-archives li > a:lang(be),
-.entry .entry-content .wp-block-categories li > a:lang(be),
-.entry .entry-content .wp-block-latest-posts li > a:lang(be), .entry .entry-content .wp-block-button .wp-block-button__link:lang(be), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(be), .widget_tag_cloud .tagcloud:lang(be), .widget_archive ul li:lang(be),
-.widget_categories ul li:lang(be),
-.widget_meta ul li:lang(be),
-.widget_nav_menu ul li:lang(be),
-.widget_pages ul li:lang(be),
-.widget_recent_comments ul li:lang(be),
-.widget_recent_entries ul li:lang(be),
-.widget_rss ul li:lang(be), .comment-form .comment-notes:lang(be),
-.comment-form label:lang(be), .comment-list .pingback .comment-body .comment-edit-link:lang(be),
-.comment-list .trackback .comment-body .comment-edit-link:lang(be), .comment-list .pingback .comment-body:lang(be),
-.comment-list .trackback .comment-body:lang(be), .comment-navigation .nav-previous:lang(be),
-.comment-navigation .nav-next:lang(be), .button:lang(be), table:lang(be), blockquote cite:lang(be), .page-title:lang(be), .author-description .author-link:lang(be),
-.comment-metadata:lang(be),
-.comment-reply-link:lang(be),
-.comments-title:lang(be),
-.comment-author .fn:lang(be),
-.discussion-meta-info:lang(be),
-.entry-meta:lang(be),
-.entry-footer:lang(be),
-.main-navigation:lang(be),
-.no-comments:lang(be),
-.post-navigation .post-title:lang(be),
-.page-links:lang(be),
-.page-description:lang(be),
-.pagination .nav-links:lang(be),
-.sticky-post:lang(be),
-.site-title:lang(be),
-.site-info:lang(be),
-#cancel-comment-reply-link:lang(be),
-h1:lang(be),
-h2:lang(be),
-h3:lang(be),
-h4:lang(be),
-h5:lang(be),
-h6:lang(be), button:lang(be),
-input:lang(be),
-select:lang(be),
-optgroup:lang(be),
-textarea:lang(be), body:lang(be) {
-  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
-}
-.gallery-caption:lang(bg-BG), .wp-caption-text:lang(bg-BG), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(bg-BG), .entry .entry-content .wp-block-file .wp-block-file__button:lang(bg-BG), .entry .entry-content .wp-block-file:lang(bg-BG), .entry .entry-content .wp-block-audio figcaption:lang(bg-BG),
-.entry .entry-content .wp-block-video figcaption:lang(bg-BG),
-.entry .entry-content .wp-block-image figcaption:lang(bg-BG),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(bg-BG),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(bg-BG), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(bg-BG),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(bg-BG),
-.entry .entry-content .wp-block-cover-image h2:lang(bg-BG),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(bg-BG),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(bg-BG),
-.entry .entry-content .wp-block-cover h2:lang(bg-BG), .entry .entry-content .wp-block-pullquote cite:lang(bg-BG), .entry .entry-content .has-drop-cap:lang(bg-BG):not(:focus):first-letter, .entry .entry-content .wp-block-verse:lang(bg-BG), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(bg-BG), .entry .entry-content .wp-block-archives li > a:lang(bg-BG),
-.entry .entry-content .wp-block-categories li > a:lang(bg-BG),
-.entry .entry-content .wp-block-latest-posts li > a:lang(bg-BG), .entry .entry-content .wp-block-button .wp-block-button__link:lang(bg-BG), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(bg-BG), .widget_tag_cloud .tagcloud:lang(bg-BG), .widget_archive ul li:lang(bg-BG),
-.widget_categories ul li:lang(bg-BG),
-.widget_meta ul li:lang(bg-BG),
-.widget_nav_menu ul li:lang(bg-BG),
-.widget_pages ul li:lang(bg-BG),
-.widget_recent_comments ul li:lang(bg-BG),
-.widget_recent_entries ul li:lang(bg-BG),
-.widget_rss ul li:lang(bg-BG), .comment-form .comment-notes:lang(bg-BG),
-.comment-form label:lang(bg-BG), .comment-list .pingback .comment-body .comment-edit-link:lang(bg-BG),
-.comment-list .trackback .comment-body .comment-edit-link:lang(bg-BG), .comment-list .pingback .comment-body:lang(bg-BG),
-.comment-list .trackback .comment-body:lang(bg-BG), .comment-navigation .nav-previous:lang(bg-BG),
-.comment-navigation .nav-next:lang(bg-BG), .button:lang(bg-BG), table:lang(bg-BG), blockquote cite:lang(bg-BG), .page-title:lang(bg-BG), .author-description .author-link:lang(bg-BG),
-.comment-metadata:lang(bg-BG),
-.comment-reply-link:lang(bg-BG),
-.comments-title:lang(bg-BG),
-.comment-author .fn:lang(bg-BG),
-.discussion-meta-info:lang(bg-BG),
-.entry-meta:lang(bg-BG),
-.entry-footer:lang(bg-BG),
-.main-navigation:lang(bg-BG),
-.no-comments:lang(bg-BG),
-.post-navigation .post-title:lang(bg-BG),
-.page-links:lang(bg-BG),
-.page-description:lang(bg-BG),
-.pagination .nav-links:lang(bg-BG),
-.sticky-post:lang(bg-BG),
-.site-title:lang(bg-BG),
-.site-info:lang(bg-BG),
-#cancel-comment-reply-link:lang(bg-BG),
-h1:lang(bg-BG),
-h2:lang(bg-BG),
-h3:lang(bg-BG),
-h4:lang(bg-BG),
-h5:lang(bg-BG),
-h6:lang(bg-BG), button:lang(bg-BG),
-input:lang(bg-BG),
-select:lang(bg-BG),
-optgroup:lang(bg-BG),
-textarea:lang(bg-BG), body:lang(bg-BG) {
-  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
-}
-.gallery-caption:lang(kk), .wp-caption-text:lang(kk), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(kk), .entry .entry-content .wp-block-file .wp-block-file__button:lang(kk), .entry .entry-content .wp-block-file:lang(kk), .entry .entry-content .wp-block-audio figcaption:lang(kk),
-.entry .entry-content .wp-block-video figcaption:lang(kk),
-.entry .entry-content .wp-block-image figcaption:lang(kk),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(kk),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(kk), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(kk),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(kk),
-.entry .entry-content .wp-block-cover-image h2:lang(kk),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(kk),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(kk),
-.entry .entry-content .wp-block-cover h2:lang(kk), .entry .entry-content .wp-block-pullquote cite:lang(kk), .entry .entry-content .has-drop-cap:lang(kk):not(:focus):first-letter, .entry .entry-content .wp-block-verse:lang(kk), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(kk), .entry .entry-content .wp-block-archives li > a:lang(kk),
-.entry .entry-content .wp-block-categories li > a:lang(kk),
-.entry .entry-content .wp-block-latest-posts li > a:lang(kk), .entry .entry-content .wp-block-button .wp-block-button__link:lang(kk), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(kk), .widget_tag_cloud .tagcloud:lang(kk), .widget_archive ul li:lang(kk),
-.widget_categories ul li:lang(kk),
-.widget_meta ul li:lang(kk),
-.widget_nav_menu ul li:lang(kk),
-.widget_pages ul li:lang(kk),
-.widget_recent_comments ul li:lang(kk),
-.widget_recent_entries ul li:lang(kk),
-.widget_rss ul li:lang(kk), .comment-form .comment-notes:lang(kk),
-.comment-form label:lang(kk), .comment-list .pingback .comment-body .comment-edit-link:lang(kk),
-.comment-list .trackback .comment-body .comment-edit-link:lang(kk), .comment-list .pingback .comment-body:lang(kk),
-.comment-list .trackback .comment-body:lang(kk), .comment-navigation .nav-previous:lang(kk),
-.comment-navigation .nav-next:lang(kk), .button:lang(kk), table:lang(kk), blockquote cite:lang(kk), .page-title:lang(kk), .author-description .author-link:lang(kk),
-.comment-metadata:lang(kk),
-.comment-reply-link:lang(kk),
-.comments-title:lang(kk),
-.comment-author .fn:lang(kk),
-.discussion-meta-info:lang(kk),
-.entry-meta:lang(kk),
-.entry-footer:lang(kk),
-.main-navigation:lang(kk),
-.no-comments:lang(kk),
-.post-navigation .post-title:lang(kk),
-.page-links:lang(kk),
-.page-description:lang(kk),
-.pagination .nav-links:lang(kk),
-.sticky-post:lang(kk),
-.site-title:lang(kk),
-.site-info:lang(kk),
-#cancel-comment-reply-link:lang(kk),
-h1:lang(kk),
-h2:lang(kk),
-h3:lang(kk),
-h4:lang(kk),
-h5:lang(kk),
-h6:lang(kk), button:lang(kk),
-input:lang(kk),
-select:lang(kk),
-optgroup:lang(kk),
-textarea:lang(kk), body:lang(kk) {
-  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
-}
-.gallery-caption:lang(mk-MK), .wp-caption-text:lang(mk-MK), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(mk-MK), .entry .entry-content .wp-block-file .wp-block-file__button:lang(mk-MK), .entry .entry-content .wp-block-file:lang(mk-MK), .entry .entry-content .wp-block-audio figcaption:lang(mk-MK),
-.entry .entry-content .wp-block-video figcaption:lang(mk-MK),
-.entry .entry-content .wp-block-image figcaption:lang(mk-MK),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(mk-MK),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(mk-MK), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(mk-MK),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(mk-MK),
-.entry .entry-content .wp-block-cover-image h2:lang(mk-MK),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(mk-MK),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(mk-MK),
-.entry .entry-content .wp-block-cover h2:lang(mk-MK), .entry .entry-content .wp-block-pullquote cite:lang(mk-MK), .entry .entry-content .has-drop-cap:lang(mk-MK):not(:focus):first-letter, .entry .entry-content .wp-block-verse:lang(mk-MK), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(mk-MK), .entry .entry-content .wp-block-archives li > a:lang(mk-MK),
-.entry .entry-content .wp-block-categories li > a:lang(mk-MK),
-.entry .entry-content .wp-block-latest-posts li > a:lang(mk-MK), .entry .entry-content .wp-block-button .wp-block-button__link:lang(mk-MK), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(mk-MK), .widget_tag_cloud .tagcloud:lang(mk-MK), .widget_archive ul li:lang(mk-MK),
-.widget_categories ul li:lang(mk-MK),
-.widget_meta ul li:lang(mk-MK),
-.widget_nav_menu ul li:lang(mk-MK),
-.widget_pages ul li:lang(mk-MK),
-.widget_recent_comments ul li:lang(mk-MK),
-.widget_recent_entries ul li:lang(mk-MK),
-.widget_rss ul li:lang(mk-MK), .comment-form .comment-notes:lang(mk-MK),
-.comment-form label:lang(mk-MK), .comment-list .pingback .comment-body .comment-edit-link:lang(mk-MK),
-.comment-list .trackback .comment-body .comment-edit-link:lang(mk-MK), .comment-list .pingback .comment-body:lang(mk-MK),
-.comment-list .trackback .comment-body:lang(mk-MK), .comment-navigation .nav-previous:lang(mk-MK),
-.comment-navigation .nav-next:lang(mk-MK), .button:lang(mk-MK), table:lang(mk-MK), blockquote cite:lang(mk-MK), .page-title:lang(mk-MK), .author-description .author-link:lang(mk-MK),
-.comment-metadata:lang(mk-MK),
-.comment-reply-link:lang(mk-MK),
-.comments-title:lang(mk-MK),
-.comment-author .fn:lang(mk-MK),
-.discussion-meta-info:lang(mk-MK),
-.entry-meta:lang(mk-MK),
-.entry-footer:lang(mk-MK),
-.main-navigation:lang(mk-MK),
-.no-comments:lang(mk-MK),
-.post-navigation .post-title:lang(mk-MK),
-.page-links:lang(mk-MK),
-.page-description:lang(mk-MK),
-.pagination .nav-links:lang(mk-MK),
-.sticky-post:lang(mk-MK),
-.site-title:lang(mk-MK),
-.site-info:lang(mk-MK),
-#cancel-comment-reply-link:lang(mk-MK),
-h1:lang(mk-MK),
-h2:lang(mk-MK),
-h3:lang(mk-MK),
-h4:lang(mk-MK),
-h5:lang(mk-MK),
-h6:lang(mk-MK), button:lang(mk-MK),
-input:lang(mk-MK),
-select:lang(mk-MK),
-optgroup:lang(mk-MK),
-textarea:lang(mk-MK), body:lang(mk-MK) {
-  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
-}
-.gallery-caption:lang(mn), .wp-caption-text:lang(mn), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(mn), .entry .entry-content .wp-block-file .wp-block-file__button:lang(mn), .entry .entry-content .wp-block-file:lang(mn), .entry .entry-content .wp-block-audio figcaption:lang(mn),
-.entry .entry-content .wp-block-video figcaption:lang(mn),
-.entry .entry-content .wp-block-image figcaption:lang(mn),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(mn),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(mn), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(mn),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(mn),
-.entry .entry-content .wp-block-cover-image h2:lang(mn),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(mn),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(mn),
-.entry .entry-content .wp-block-cover h2:lang(mn), .entry .entry-content .wp-block-pullquote cite:lang(mn), .entry .entry-content .has-drop-cap:lang(mn):not(:focus):first-letter, .entry .entry-content .wp-block-verse:lang(mn), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(mn), .entry .entry-content .wp-block-archives li > a:lang(mn),
-.entry .entry-content .wp-block-categories li > a:lang(mn),
-.entry .entry-content .wp-block-latest-posts li > a:lang(mn), .entry .entry-content .wp-block-button .wp-block-button__link:lang(mn), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(mn), .widget_tag_cloud .tagcloud:lang(mn), .widget_archive ul li:lang(mn),
-.widget_categories ul li:lang(mn),
-.widget_meta ul li:lang(mn),
-.widget_nav_menu ul li:lang(mn),
-.widget_pages ul li:lang(mn),
-.widget_recent_comments ul li:lang(mn),
-.widget_recent_entries ul li:lang(mn),
-.widget_rss ul li:lang(mn), .comment-form .comment-notes:lang(mn),
-.comment-form label:lang(mn), .comment-list .pingback .comment-body .comment-edit-link:lang(mn),
-.comment-list .trackback .comment-body .comment-edit-link:lang(mn), .comment-list .pingback .comment-body:lang(mn),
-.comment-list .trackback .comment-body:lang(mn), .comment-navigation .nav-previous:lang(mn),
-.comment-navigation .nav-next:lang(mn), .button:lang(mn), table:lang(mn), blockquote cite:lang(mn), .page-title:lang(mn), .author-description .author-link:lang(mn),
-.comment-metadata:lang(mn),
-.comment-reply-link:lang(mn),
-.comments-title:lang(mn),
-.comment-author .fn:lang(mn),
-.discussion-meta-info:lang(mn),
-.entry-meta:lang(mn),
-.entry-footer:lang(mn),
-.main-navigation:lang(mn),
-.no-comments:lang(mn),
-.post-navigation .post-title:lang(mn),
-.page-links:lang(mn),
-.page-description:lang(mn),
-.pagination .nav-links:lang(mn),
-.sticky-post:lang(mn),
-.site-title:lang(mn),
-.site-info:lang(mn),
-#cancel-comment-reply-link:lang(mn),
-h1:lang(mn),
-h2:lang(mn),
-h3:lang(mn),
-h4:lang(mn),
-h5:lang(mn),
-h6:lang(mn), button:lang(mn),
-input:lang(mn),
-select:lang(mn),
-optgroup:lang(mn),
-textarea:lang(mn), body:lang(mn) {
-  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
-}
-.gallery-caption:lang(ru-RU), .wp-caption-text:lang(ru-RU), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ru-RU), .entry .entry-content .wp-block-file .wp-block-file__button:lang(ru-RU), .entry .entry-content .wp-block-file:lang(ru-RU), .entry .entry-content .wp-block-audio figcaption:lang(ru-RU),
-.entry .entry-content .wp-block-video figcaption:lang(ru-RU),
-.entry .entry-content .wp-block-image figcaption:lang(ru-RU),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(ru-RU),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(ru-RU), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(ru-RU),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(ru-RU),
-.entry .entry-content .wp-block-cover-image h2:lang(ru-RU),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(ru-RU),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(ru-RU),
-.entry .entry-content .wp-block-cover h2:lang(ru-RU), .entry .entry-content .wp-block-pullquote cite:lang(ru-RU), .entry .entry-content .has-drop-cap:lang(ru-RU):not(:focus):first-letter, .entry .entry-content .wp-block-verse:lang(ru-RU), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ru-RU), .entry .entry-content .wp-block-archives li > a:lang(ru-RU),
-.entry .entry-content .wp-block-categories li > a:lang(ru-RU),
-.entry .entry-content .wp-block-latest-posts li > a:lang(ru-RU), .entry .entry-content .wp-block-button .wp-block-button__link:lang(ru-RU), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(ru-RU), .widget_tag_cloud .tagcloud:lang(ru-RU), .widget_archive ul li:lang(ru-RU),
-.widget_categories ul li:lang(ru-RU),
-.widget_meta ul li:lang(ru-RU),
-.widget_nav_menu ul li:lang(ru-RU),
-.widget_pages ul li:lang(ru-RU),
-.widget_recent_comments ul li:lang(ru-RU),
-.widget_recent_entries ul li:lang(ru-RU),
-.widget_rss ul li:lang(ru-RU), .comment-form .comment-notes:lang(ru-RU),
-.comment-form label:lang(ru-RU), .comment-list .pingback .comment-body .comment-edit-link:lang(ru-RU),
-.comment-list .trackback .comment-body .comment-edit-link:lang(ru-RU), .comment-list .pingback .comment-body:lang(ru-RU),
-.comment-list .trackback .comment-body:lang(ru-RU), .comment-navigation .nav-previous:lang(ru-RU),
-.comment-navigation .nav-next:lang(ru-RU), .button:lang(ru-RU), table:lang(ru-RU), blockquote cite:lang(ru-RU), .page-title:lang(ru-RU), .author-description .author-link:lang(ru-RU),
-.comment-metadata:lang(ru-RU),
-.comment-reply-link:lang(ru-RU),
-.comments-title:lang(ru-RU),
-.comment-author .fn:lang(ru-RU),
-.discussion-meta-info:lang(ru-RU),
-.entry-meta:lang(ru-RU),
-.entry-footer:lang(ru-RU),
-.main-navigation:lang(ru-RU),
-.no-comments:lang(ru-RU),
-.post-navigation .post-title:lang(ru-RU),
-.page-links:lang(ru-RU),
-.page-description:lang(ru-RU),
-.pagination .nav-links:lang(ru-RU),
-.sticky-post:lang(ru-RU),
-.site-title:lang(ru-RU),
-.site-info:lang(ru-RU),
-#cancel-comment-reply-link:lang(ru-RU),
-h1:lang(ru-RU),
-h2:lang(ru-RU),
-h3:lang(ru-RU),
-h4:lang(ru-RU),
-h5:lang(ru-RU),
-h6:lang(ru-RU), button:lang(ru-RU),
-input:lang(ru-RU),
-select:lang(ru-RU),
-optgroup:lang(ru-RU),
-textarea:lang(ru-RU), body:lang(ru-RU) {
-  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
-}
-.gallery-caption:lang(sah), .wp-caption-text:lang(sah), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(sah), .entry .entry-content .wp-block-file .wp-block-file__button:lang(sah), .entry .entry-content .wp-block-file:lang(sah), .entry .entry-content .wp-block-audio figcaption:lang(sah),
-.entry .entry-content .wp-block-video figcaption:lang(sah),
-.entry .entry-content .wp-block-image figcaption:lang(sah),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(sah),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(sah), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(sah),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(sah),
-.entry .entry-content .wp-block-cover-image h2:lang(sah),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(sah),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(sah),
-.entry .entry-content .wp-block-cover h2:lang(sah), .entry .entry-content .wp-block-pullquote cite:lang(sah), .entry .entry-content .has-drop-cap:lang(sah):not(:focus):first-letter, .entry .entry-content .wp-block-verse:lang(sah), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(sah), .entry .entry-content .wp-block-archives li > a:lang(sah),
-.entry .entry-content .wp-block-categories li > a:lang(sah),
-.entry .entry-content .wp-block-latest-posts li > a:lang(sah), .entry .entry-content .wp-block-button .wp-block-button__link:lang(sah), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(sah), .widget_tag_cloud .tagcloud:lang(sah), .widget_archive ul li:lang(sah),
-.widget_categories ul li:lang(sah),
-.widget_meta ul li:lang(sah),
-.widget_nav_menu ul li:lang(sah),
-.widget_pages ul li:lang(sah),
-.widget_recent_comments ul li:lang(sah),
-.widget_recent_entries ul li:lang(sah),
-.widget_rss ul li:lang(sah), .comment-form .comment-notes:lang(sah),
-.comment-form label:lang(sah), .comment-list .pingback .comment-body .comment-edit-link:lang(sah),
-.comment-list .trackback .comment-body .comment-edit-link:lang(sah), .comment-list .pingback .comment-body:lang(sah),
-.comment-list .trackback .comment-body:lang(sah), .comment-navigation .nav-previous:lang(sah),
-.comment-navigation .nav-next:lang(sah), .button:lang(sah), table:lang(sah), blockquote cite:lang(sah), .page-title:lang(sah), .author-description .author-link:lang(sah),
-.comment-metadata:lang(sah),
-.comment-reply-link:lang(sah),
-.comments-title:lang(sah),
-.comment-author .fn:lang(sah),
-.discussion-meta-info:lang(sah),
-.entry-meta:lang(sah),
-.entry-footer:lang(sah),
-.main-navigation:lang(sah),
-.no-comments:lang(sah),
-.post-navigation .post-title:lang(sah),
-.page-links:lang(sah),
-.page-description:lang(sah),
-.pagination .nav-links:lang(sah),
-.sticky-post:lang(sah),
-.site-title:lang(sah),
-.site-info:lang(sah),
-#cancel-comment-reply-link:lang(sah),
-h1:lang(sah),
-h2:lang(sah),
-h3:lang(sah),
-h4:lang(sah),
-h5:lang(sah),
-h6:lang(sah), button:lang(sah),
-input:lang(sah),
-select:lang(sah),
-optgroup:lang(sah),
-textarea:lang(sah), body:lang(sah) {
-  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
-}
-.gallery-caption:lang(sr-RS), .wp-caption-text:lang(sr-RS), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(sr-RS), .entry .entry-content .wp-block-file .wp-block-file__button:lang(sr-RS), .entry .entry-content .wp-block-file:lang(sr-RS), .entry .entry-content .wp-block-audio figcaption:lang(sr-RS),
-.entry .entry-content .wp-block-video figcaption:lang(sr-RS),
-.entry .entry-content .wp-block-image figcaption:lang(sr-RS),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(sr-RS),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(sr-RS), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(sr-RS),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(sr-RS),
-.entry .entry-content .wp-block-cover-image h2:lang(sr-RS),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(sr-RS),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(sr-RS),
-.entry .entry-content .wp-block-cover h2:lang(sr-RS), .entry .entry-content .wp-block-pullquote cite:lang(sr-RS), .entry .entry-content .has-drop-cap:lang(sr-RS):not(:focus):first-letter, .entry .entry-content .wp-block-verse:lang(sr-RS), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(sr-RS), .entry .entry-content .wp-block-archives li > a:lang(sr-RS),
-.entry .entry-content .wp-block-categories li > a:lang(sr-RS),
-.entry .entry-content .wp-block-latest-posts li > a:lang(sr-RS), .entry .entry-content .wp-block-button .wp-block-button__link:lang(sr-RS), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(sr-RS), .widget_tag_cloud .tagcloud:lang(sr-RS), .widget_archive ul li:lang(sr-RS),
-.widget_categories ul li:lang(sr-RS),
-.widget_meta ul li:lang(sr-RS),
-.widget_nav_menu ul li:lang(sr-RS),
-.widget_pages ul li:lang(sr-RS),
-.widget_recent_comments ul li:lang(sr-RS),
-.widget_recent_entries ul li:lang(sr-RS),
-.widget_rss ul li:lang(sr-RS), .comment-form .comment-notes:lang(sr-RS),
-.comment-form label:lang(sr-RS), .comment-list .pingback .comment-body .comment-edit-link:lang(sr-RS),
-.comment-list .trackback .comment-body .comment-edit-link:lang(sr-RS), .comment-list .pingback .comment-body:lang(sr-RS),
-.comment-list .trackback .comment-body:lang(sr-RS), .comment-navigation .nav-previous:lang(sr-RS),
-.comment-navigation .nav-next:lang(sr-RS), .button:lang(sr-RS), table:lang(sr-RS), blockquote cite:lang(sr-RS), .page-title:lang(sr-RS), .author-description .author-link:lang(sr-RS),
-.comment-metadata:lang(sr-RS),
-.comment-reply-link:lang(sr-RS),
-.comments-title:lang(sr-RS),
-.comment-author .fn:lang(sr-RS),
-.discussion-meta-info:lang(sr-RS),
-.entry-meta:lang(sr-RS),
-.entry-footer:lang(sr-RS),
-.main-navigation:lang(sr-RS),
-.no-comments:lang(sr-RS),
-.post-navigation .post-title:lang(sr-RS),
-.page-links:lang(sr-RS),
-.page-description:lang(sr-RS),
-.pagination .nav-links:lang(sr-RS),
-.sticky-post:lang(sr-RS),
-.site-title:lang(sr-RS),
-.site-info:lang(sr-RS),
-#cancel-comment-reply-link:lang(sr-RS),
-h1:lang(sr-RS),
-h2:lang(sr-RS),
-h3:lang(sr-RS),
-h4:lang(sr-RS),
-h5:lang(sr-RS),
-h6:lang(sr-RS), button:lang(sr-RS),
-input:lang(sr-RS),
-select:lang(sr-RS),
-optgroup:lang(sr-RS),
-textarea:lang(sr-RS), body:lang(sr-RS) {
-  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
-}
-.gallery-caption:lang(tt-RU), .wp-caption-text:lang(tt-RU), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(tt-RU), .entry .entry-content .wp-block-file .wp-block-file__button:lang(tt-RU), .entry .entry-content .wp-block-file:lang(tt-RU), .entry .entry-content .wp-block-audio figcaption:lang(tt-RU),
-.entry .entry-content .wp-block-video figcaption:lang(tt-RU),
-.entry .entry-content .wp-block-image figcaption:lang(tt-RU),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(tt-RU),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(tt-RU), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(tt-RU),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(tt-RU),
-.entry .entry-content .wp-block-cover-image h2:lang(tt-RU),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(tt-RU),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(tt-RU),
-.entry .entry-content .wp-block-cover h2:lang(tt-RU), .entry .entry-content .wp-block-pullquote cite:lang(tt-RU), .entry .entry-content .has-drop-cap:lang(tt-RU):not(:focus):first-letter, .entry .entry-content .wp-block-verse:lang(tt-RU), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(tt-RU), .entry .entry-content .wp-block-archives li > a:lang(tt-RU),
-.entry .entry-content .wp-block-categories li > a:lang(tt-RU),
-.entry .entry-content .wp-block-latest-posts li > a:lang(tt-RU), .entry .entry-content .wp-block-button .wp-block-button__link:lang(tt-RU), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(tt-RU), .widget_tag_cloud .tagcloud:lang(tt-RU), .widget_archive ul li:lang(tt-RU),
-.widget_categories ul li:lang(tt-RU),
-.widget_meta ul li:lang(tt-RU),
-.widget_nav_menu ul li:lang(tt-RU),
-.widget_pages ul li:lang(tt-RU),
-.widget_recent_comments ul li:lang(tt-RU),
-.widget_recent_entries ul li:lang(tt-RU),
-.widget_rss ul li:lang(tt-RU), .comment-form .comment-notes:lang(tt-RU),
-.comment-form label:lang(tt-RU), .comment-list .pingback .comment-body .comment-edit-link:lang(tt-RU),
-.comment-list .trackback .comment-body .comment-edit-link:lang(tt-RU), .comment-list .pingback .comment-body:lang(tt-RU),
-.comment-list .trackback .comment-body:lang(tt-RU), .comment-navigation .nav-previous:lang(tt-RU),
-.comment-navigation .nav-next:lang(tt-RU), .button:lang(tt-RU), table:lang(tt-RU), blockquote cite:lang(tt-RU), .page-title:lang(tt-RU), .author-description .author-link:lang(tt-RU),
-.comment-metadata:lang(tt-RU),
-.comment-reply-link:lang(tt-RU),
-.comments-title:lang(tt-RU),
-.comment-author .fn:lang(tt-RU),
-.discussion-meta-info:lang(tt-RU),
-.entry-meta:lang(tt-RU),
-.entry-footer:lang(tt-RU),
-.main-navigation:lang(tt-RU),
-.no-comments:lang(tt-RU),
-.post-navigation .post-title:lang(tt-RU),
-.page-links:lang(tt-RU),
-.page-description:lang(tt-RU),
-.pagination .nav-links:lang(tt-RU),
-.sticky-post:lang(tt-RU),
-.site-title:lang(tt-RU),
-.site-info:lang(tt-RU),
-#cancel-comment-reply-link:lang(tt-RU),
-h1:lang(tt-RU),
-h2:lang(tt-RU),
-h3:lang(tt-RU),
-h4:lang(tt-RU),
-h5:lang(tt-RU),
-h6:lang(tt-RU), button:lang(tt-RU),
-input:lang(tt-RU),
-select:lang(tt-RU),
-optgroup:lang(tt-RU),
-textarea:lang(tt-RU), body:lang(tt-RU) {
-  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
-}
-.gallery-caption:lang(uk), .wp-caption-text:lang(uk), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(uk), .entry .entry-content .wp-block-file .wp-block-file__button:lang(uk), .entry .entry-content .wp-block-file:lang(uk), .entry .entry-content .wp-block-audio figcaption:lang(uk),
-.entry .entry-content .wp-block-video figcaption:lang(uk),
-.entry .entry-content .wp-block-image figcaption:lang(uk),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(uk),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(uk), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(uk),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(uk),
-.entry .entry-content .wp-block-cover-image h2:lang(uk),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(uk),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(uk),
-.entry .entry-content .wp-block-cover h2:lang(uk), .entry .entry-content .wp-block-pullquote cite:lang(uk), .entry .entry-content .has-drop-cap:lang(uk):not(:focus):first-letter, .entry .entry-content .wp-block-verse:lang(uk), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(uk), .entry .entry-content .wp-block-archives li > a:lang(uk),
-.entry .entry-content .wp-block-categories li > a:lang(uk),
-.entry .entry-content .wp-block-latest-posts li > a:lang(uk), .entry .entry-content .wp-block-button .wp-block-button__link:lang(uk), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(uk), .widget_tag_cloud .tagcloud:lang(uk), .widget_archive ul li:lang(uk),
-.widget_categories ul li:lang(uk),
-.widget_meta ul li:lang(uk),
-.widget_nav_menu ul li:lang(uk),
-.widget_pages ul li:lang(uk),
-.widget_recent_comments ul li:lang(uk),
-.widget_recent_entries ul li:lang(uk),
-.widget_rss ul li:lang(uk), .comment-form .comment-notes:lang(uk),
-.comment-form label:lang(uk), .comment-list .pingback .comment-body .comment-edit-link:lang(uk),
-.comment-list .trackback .comment-body .comment-edit-link:lang(uk), .comment-list .pingback .comment-body:lang(uk),
-.comment-list .trackback .comment-body:lang(uk), .comment-navigation .nav-previous:lang(uk),
-.comment-navigation .nav-next:lang(uk), .button:lang(uk), table:lang(uk), blockquote cite:lang(uk), .page-title:lang(uk), .author-description .author-link:lang(uk),
-.comment-metadata:lang(uk),
-.comment-reply-link:lang(uk),
-.comments-title:lang(uk),
-.comment-author .fn:lang(uk),
-.discussion-meta-info:lang(uk),
-.entry-meta:lang(uk),
-.entry-footer:lang(uk),
-.main-navigation:lang(uk),
-.no-comments:lang(uk),
-.post-navigation .post-title:lang(uk),
-.page-links:lang(uk),
-.page-description:lang(uk),
-.pagination .nav-links:lang(uk),
-.sticky-post:lang(uk),
-.site-title:lang(uk),
-.site-info:lang(uk),
-#cancel-comment-reply-link:lang(uk),
-h1:lang(uk),
-h2:lang(uk),
-h3:lang(uk),
-h4:lang(uk),
-h5:lang(uk),
-h6:lang(uk), button:lang(uk),
-input:lang(uk),
-select:lang(uk),
-optgroup:lang(uk),
-textarea:lang(uk), body:lang(uk) {
-  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
-}
-.gallery-caption:lang(zh-HK), .wp-caption-text:lang(zh-HK), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(zh-HK), .entry .entry-content .wp-block-file .wp-block-file__button:lang(zh-HK), .entry .entry-content .wp-block-file:lang(zh-HK), .entry .entry-content .wp-block-audio figcaption:lang(zh-HK),
-.entry .entry-content .wp-block-video figcaption:lang(zh-HK),
-.entry .entry-content .wp-block-image figcaption:lang(zh-HK),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(zh-HK),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(zh-HK), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(zh-HK),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(zh-HK),
-.entry .entry-content .wp-block-cover-image h2:lang(zh-HK),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(zh-HK),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(zh-HK),
-.entry .entry-content .wp-block-cover h2:lang(zh-HK), .entry .entry-content .wp-block-pullquote cite:lang(zh-HK), .entry .entry-content .has-drop-cap:lang(zh-HK):not(:focus):first-letter, .entry .entry-content .wp-block-verse:lang(zh-HK), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(zh-HK), .entry .entry-content .wp-block-archives li > a:lang(zh-HK),
-.entry .entry-content .wp-block-categories li > a:lang(zh-HK),
-.entry .entry-content .wp-block-latest-posts li > a:lang(zh-HK), .entry .entry-content .wp-block-button .wp-block-button__link:lang(zh-HK), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(zh-HK), .widget_tag_cloud .tagcloud:lang(zh-HK), .widget_archive ul li:lang(zh-HK),
-.widget_categories ul li:lang(zh-HK),
-.widget_meta ul li:lang(zh-HK),
-.widget_nav_menu ul li:lang(zh-HK),
-.widget_pages ul li:lang(zh-HK),
-.widget_recent_comments ul li:lang(zh-HK),
-.widget_recent_entries ul li:lang(zh-HK),
-.widget_rss ul li:lang(zh-HK), .comment-form .comment-notes:lang(zh-HK),
-.comment-form label:lang(zh-HK), .comment-list .pingback .comment-body .comment-edit-link:lang(zh-HK),
-.comment-list .trackback .comment-body .comment-edit-link:lang(zh-HK), .comment-list .pingback .comment-body:lang(zh-HK),
-.comment-list .trackback .comment-body:lang(zh-HK), .comment-navigation .nav-previous:lang(zh-HK),
-.comment-navigation .nav-next:lang(zh-HK), .button:lang(zh-HK), table:lang(zh-HK), blockquote cite:lang(zh-HK), .page-title:lang(zh-HK), .author-description .author-link:lang(zh-HK),
-.comment-metadata:lang(zh-HK),
-.comment-reply-link:lang(zh-HK),
-.comments-title:lang(zh-HK),
-.comment-author .fn:lang(zh-HK),
-.discussion-meta-info:lang(zh-HK),
-.entry-meta:lang(zh-HK),
-.entry-footer:lang(zh-HK),
-.main-navigation:lang(zh-HK),
-.no-comments:lang(zh-HK),
-.post-navigation .post-title:lang(zh-HK),
-.page-links:lang(zh-HK),
-.page-description:lang(zh-HK),
-.pagination .nav-links:lang(zh-HK),
-.sticky-post:lang(zh-HK),
-.site-title:lang(zh-HK),
-.site-info:lang(zh-HK),
-#cancel-comment-reply-link:lang(zh-HK),
-h1:lang(zh-HK),
-h2:lang(zh-HK),
-h3:lang(zh-HK),
-h4:lang(zh-HK),
-h5:lang(zh-HK),
-h6:lang(zh-HK), button:lang(zh-HK),
-input:lang(zh-HK),
-select:lang(zh-HK),
-optgroup:lang(zh-HK),
-textarea:lang(zh-HK), body:lang(zh-HK) {
-  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
-}
-.gallery-caption:lang(zh-TW), .wp-caption-text:lang(zh-TW), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(zh-TW), .entry .entry-content .wp-block-file .wp-block-file__button:lang(zh-TW), .entry .entry-content .wp-block-file:lang(zh-TW), .entry .entry-content .wp-block-audio figcaption:lang(zh-TW),
-.entry .entry-content .wp-block-video figcaption:lang(zh-TW),
-.entry .entry-content .wp-block-image figcaption:lang(zh-TW),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(zh-TW),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(zh-TW), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(zh-TW),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(zh-TW),
-.entry .entry-content .wp-block-cover-image h2:lang(zh-TW),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(zh-TW),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(zh-TW),
-.entry .entry-content .wp-block-cover h2:lang(zh-TW), .entry .entry-content .wp-block-pullquote cite:lang(zh-TW), .entry .entry-content .has-drop-cap:lang(zh-TW):not(:focus):first-letter, .entry .entry-content .wp-block-verse:lang(zh-TW), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(zh-TW), .entry .entry-content .wp-block-archives li > a:lang(zh-TW),
-.entry .entry-content .wp-block-categories li > a:lang(zh-TW),
-.entry .entry-content .wp-block-latest-posts li > a:lang(zh-TW), .entry .entry-content .wp-block-button .wp-block-button__link:lang(zh-TW), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(zh-TW), .widget_tag_cloud .tagcloud:lang(zh-TW), .widget_archive ul li:lang(zh-TW),
-.widget_categories ul li:lang(zh-TW),
-.widget_meta ul li:lang(zh-TW),
-.widget_nav_menu ul li:lang(zh-TW),
-.widget_pages ul li:lang(zh-TW),
-.widget_recent_comments ul li:lang(zh-TW),
-.widget_recent_entries ul li:lang(zh-TW),
-.widget_rss ul li:lang(zh-TW), .comment-form .comment-notes:lang(zh-TW),
-.comment-form label:lang(zh-TW), .comment-list .pingback .comment-body .comment-edit-link:lang(zh-TW),
-.comment-list .trackback .comment-body .comment-edit-link:lang(zh-TW), .comment-list .pingback .comment-body:lang(zh-TW),
-.comment-list .trackback .comment-body:lang(zh-TW), .comment-navigation .nav-previous:lang(zh-TW),
-.comment-navigation .nav-next:lang(zh-TW), .button:lang(zh-TW), table:lang(zh-TW), blockquote cite:lang(zh-TW), .page-title:lang(zh-TW), .author-description .author-link:lang(zh-TW),
-.comment-metadata:lang(zh-TW),
-.comment-reply-link:lang(zh-TW),
-.comments-title:lang(zh-TW),
-.comment-author .fn:lang(zh-TW),
-.discussion-meta-info:lang(zh-TW),
-.entry-meta:lang(zh-TW),
-.entry-footer:lang(zh-TW),
-.main-navigation:lang(zh-TW),
-.no-comments:lang(zh-TW),
-.post-navigation .post-title:lang(zh-TW),
-.page-links:lang(zh-TW),
-.page-description:lang(zh-TW),
-.pagination .nav-links:lang(zh-TW),
-.sticky-post:lang(zh-TW),
-.site-title:lang(zh-TW),
-.site-info:lang(zh-TW),
-#cancel-comment-reply-link:lang(zh-TW),
-h1:lang(zh-TW),
-h2:lang(zh-TW),
-h3:lang(zh-TW),
-h4:lang(zh-TW),
-h5:lang(zh-TW),
-h6:lang(zh-TW), button:lang(zh-TW),
-input:lang(zh-TW),
-select:lang(zh-TW),
-optgroup:lang(zh-TW),
-textarea:lang(zh-TW), body:lang(zh-TW) {
-  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
-}
-.gallery-caption:lang(zh-CN), .wp-caption-text:lang(zh-CN), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(zh-CN), .entry .entry-content .wp-block-file .wp-block-file__button:lang(zh-CN), .entry .entry-content .wp-block-file:lang(zh-CN), .entry .entry-content .wp-block-audio figcaption:lang(zh-CN),
-.entry .entry-content .wp-block-video figcaption:lang(zh-CN),
-.entry .entry-content .wp-block-image figcaption:lang(zh-CN),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(zh-CN),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(zh-CN), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(zh-CN),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(zh-CN),
-.entry .entry-content .wp-block-cover-image h2:lang(zh-CN),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(zh-CN),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(zh-CN),
-.entry .entry-content .wp-block-cover h2:lang(zh-CN), .entry .entry-content .wp-block-pullquote cite:lang(zh-CN), .entry .entry-content .has-drop-cap:lang(zh-CN):not(:focus):first-letter, .entry .entry-content .wp-block-verse:lang(zh-CN), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(zh-CN), .entry .entry-content .wp-block-archives li > a:lang(zh-CN),
-.entry .entry-content .wp-block-categories li > a:lang(zh-CN),
-.entry .entry-content .wp-block-latest-posts li > a:lang(zh-CN), .entry .entry-content .wp-block-button .wp-block-button__link:lang(zh-CN), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(zh-CN), .widget_tag_cloud .tagcloud:lang(zh-CN), .widget_archive ul li:lang(zh-CN),
-.widget_categories ul li:lang(zh-CN),
-.widget_meta ul li:lang(zh-CN),
-.widget_nav_menu ul li:lang(zh-CN),
-.widget_pages ul li:lang(zh-CN),
-.widget_recent_comments ul li:lang(zh-CN),
-.widget_recent_entries ul li:lang(zh-CN),
-.widget_rss ul li:lang(zh-CN), .comment-form .comment-notes:lang(zh-CN),
-.comment-form label:lang(zh-CN), .comment-list .pingback .comment-body .comment-edit-link:lang(zh-CN),
-.comment-list .trackback .comment-body .comment-edit-link:lang(zh-CN), .comment-list .pingback .comment-body:lang(zh-CN),
-.comment-list .trackback .comment-body:lang(zh-CN), .comment-navigation .nav-previous:lang(zh-CN),
-.comment-navigation .nav-next:lang(zh-CN), .button:lang(zh-CN), table:lang(zh-CN), blockquote cite:lang(zh-CN), .page-title:lang(zh-CN), .author-description .author-link:lang(zh-CN),
-.comment-metadata:lang(zh-CN),
-.comment-reply-link:lang(zh-CN),
-.comments-title:lang(zh-CN),
-.comment-author .fn:lang(zh-CN),
-.discussion-meta-info:lang(zh-CN),
-.entry-meta:lang(zh-CN),
-.entry-footer:lang(zh-CN),
-.main-navigation:lang(zh-CN),
-.no-comments:lang(zh-CN),
-.post-navigation .post-title:lang(zh-CN),
-.page-links:lang(zh-CN),
-.page-description:lang(zh-CN),
-.pagination .nav-links:lang(zh-CN),
-.sticky-post:lang(zh-CN),
-.site-title:lang(zh-CN),
-.site-info:lang(zh-CN),
-#cancel-comment-reply-link:lang(zh-CN),
-h1:lang(zh-CN),
-h2:lang(zh-CN),
-h3:lang(zh-CN),
-h4:lang(zh-CN),
-h5:lang(zh-CN),
-h6:lang(zh-CN), button:lang(zh-CN),
-input:lang(zh-CN),
-select:lang(zh-CN),
-optgroup:lang(zh-CN),
-textarea:lang(zh-CN), body:lang(zh-CN) {
-  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
-}
-.gallery-caption:lang(bn-BD), .wp-caption-text:lang(bn-BD), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(bn-BD), .entry .entry-content .wp-block-file .wp-block-file__button:lang(bn-BD), .entry .entry-content .wp-block-file:lang(bn-BD), .entry .entry-content .wp-block-audio figcaption:lang(bn-BD),
-.entry .entry-content .wp-block-video figcaption:lang(bn-BD),
-.entry .entry-content .wp-block-image figcaption:lang(bn-BD),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(bn-BD),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(bn-BD), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(bn-BD),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(bn-BD),
-.entry .entry-content .wp-block-cover-image h2:lang(bn-BD),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(bn-BD),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(bn-BD),
-.entry .entry-content .wp-block-cover h2:lang(bn-BD), .entry .entry-content .wp-block-pullquote cite:lang(bn-BD), .entry .entry-content .has-drop-cap:lang(bn-BD):not(:focus):first-letter, .entry .entry-content .wp-block-verse:lang(bn-BD), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(bn-BD), .entry .entry-content .wp-block-archives li > a:lang(bn-BD),
-.entry .entry-content .wp-block-categories li > a:lang(bn-BD),
-.entry .entry-content .wp-block-latest-posts li > a:lang(bn-BD), .entry .entry-content .wp-block-button .wp-block-button__link:lang(bn-BD), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(bn-BD), .widget_tag_cloud .tagcloud:lang(bn-BD), .widget_archive ul li:lang(bn-BD),
-.widget_categories ul li:lang(bn-BD),
-.widget_meta ul li:lang(bn-BD),
-.widget_nav_menu ul li:lang(bn-BD),
-.widget_pages ul li:lang(bn-BD),
-.widget_recent_comments ul li:lang(bn-BD),
-.widget_recent_entries ul li:lang(bn-BD),
-.widget_rss ul li:lang(bn-BD), .comment-form .comment-notes:lang(bn-BD),
-.comment-form label:lang(bn-BD), .comment-list .pingback .comment-body .comment-edit-link:lang(bn-BD),
-.comment-list .trackback .comment-body .comment-edit-link:lang(bn-BD), .comment-list .pingback .comment-body:lang(bn-BD),
-.comment-list .trackback .comment-body:lang(bn-BD), .comment-navigation .nav-previous:lang(bn-BD),
-.comment-navigation .nav-next:lang(bn-BD), .button:lang(bn-BD), table:lang(bn-BD), blockquote cite:lang(bn-BD), .page-title:lang(bn-BD), .author-description .author-link:lang(bn-BD),
-.comment-metadata:lang(bn-BD),
-.comment-reply-link:lang(bn-BD),
-.comments-title:lang(bn-BD),
-.comment-author .fn:lang(bn-BD),
-.discussion-meta-info:lang(bn-BD),
-.entry-meta:lang(bn-BD),
-.entry-footer:lang(bn-BD),
-.main-navigation:lang(bn-BD),
-.no-comments:lang(bn-BD),
-.post-navigation .post-title:lang(bn-BD),
-.page-links:lang(bn-BD),
-.page-description:lang(bn-BD),
-.pagination .nav-links:lang(bn-BD),
-.sticky-post:lang(bn-BD),
-.site-title:lang(bn-BD),
-.site-info:lang(bn-BD),
-#cancel-comment-reply-link:lang(bn-BD),
-h1:lang(bn-BD),
-h2:lang(bn-BD),
-h3:lang(bn-BD),
-h4:lang(bn-BD),
-h5:lang(bn-BD),
-h6:lang(bn-BD), button:lang(bn-BD),
-input:lang(bn-BD),
-select:lang(bn-BD),
-optgroup:lang(bn-BD),
-textarea:lang(bn-BD), body:lang(bn-BD) {
-  font-family: Arial, sans-serif;
-}
-.gallery-caption:lang(hi-IN), .wp-caption-text:lang(hi-IN), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(hi-IN), .entry .entry-content .wp-block-file .wp-block-file__button:lang(hi-IN), .entry .entry-content .wp-block-file:lang(hi-IN), .entry .entry-content .wp-block-audio figcaption:lang(hi-IN),
-.entry .entry-content .wp-block-video figcaption:lang(hi-IN),
-.entry .entry-content .wp-block-image figcaption:lang(hi-IN),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(hi-IN),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(hi-IN), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(hi-IN),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(hi-IN),
-.entry .entry-content .wp-block-cover-image h2:lang(hi-IN),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(hi-IN),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(hi-IN),
-.entry .entry-content .wp-block-cover h2:lang(hi-IN), .entry .entry-content .wp-block-pullquote cite:lang(hi-IN), .entry .entry-content .has-drop-cap:lang(hi-IN):not(:focus):first-letter, .entry .entry-content .wp-block-verse:lang(hi-IN), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(hi-IN), .entry .entry-content .wp-block-archives li > a:lang(hi-IN),
-.entry .entry-content .wp-block-categories li > a:lang(hi-IN),
-.entry .entry-content .wp-block-latest-posts li > a:lang(hi-IN), .entry .entry-content .wp-block-button .wp-block-button__link:lang(hi-IN), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(hi-IN), .widget_tag_cloud .tagcloud:lang(hi-IN), .widget_archive ul li:lang(hi-IN),
-.widget_categories ul li:lang(hi-IN),
-.widget_meta ul li:lang(hi-IN),
-.widget_nav_menu ul li:lang(hi-IN),
-.widget_pages ul li:lang(hi-IN),
-.widget_recent_comments ul li:lang(hi-IN),
-.widget_recent_entries ul li:lang(hi-IN),
-.widget_rss ul li:lang(hi-IN), .comment-form .comment-notes:lang(hi-IN),
-.comment-form label:lang(hi-IN), .comment-list .pingback .comment-body .comment-edit-link:lang(hi-IN),
-.comment-list .trackback .comment-body .comment-edit-link:lang(hi-IN), .comment-list .pingback .comment-body:lang(hi-IN),
-.comment-list .trackback .comment-body:lang(hi-IN), .comment-navigation .nav-previous:lang(hi-IN),
-.comment-navigation .nav-next:lang(hi-IN), .button:lang(hi-IN), table:lang(hi-IN), blockquote cite:lang(hi-IN), .page-title:lang(hi-IN), .author-description .author-link:lang(hi-IN),
-.comment-metadata:lang(hi-IN),
-.comment-reply-link:lang(hi-IN),
-.comments-title:lang(hi-IN),
-.comment-author .fn:lang(hi-IN),
-.discussion-meta-info:lang(hi-IN),
-.entry-meta:lang(hi-IN),
-.entry-footer:lang(hi-IN),
-.main-navigation:lang(hi-IN),
-.no-comments:lang(hi-IN),
-.post-navigation .post-title:lang(hi-IN),
-.page-links:lang(hi-IN),
-.page-description:lang(hi-IN),
-.pagination .nav-links:lang(hi-IN),
-.sticky-post:lang(hi-IN),
-.site-title:lang(hi-IN),
-.site-info:lang(hi-IN),
-#cancel-comment-reply-link:lang(hi-IN),
-h1:lang(hi-IN),
-h2:lang(hi-IN),
-h3:lang(hi-IN),
-h4:lang(hi-IN),
-h5:lang(hi-IN),
-h6:lang(hi-IN), button:lang(hi-IN),
-input:lang(hi-IN),
-select:lang(hi-IN),
-optgroup:lang(hi-IN),
-textarea:lang(hi-IN), body:lang(hi-IN) {
-  font-family: Arial, sans-serif;
-}
-.gallery-caption:lang(mr), .wp-caption-text:lang(mr), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(mr), .entry .entry-content .wp-block-file .wp-block-file__button:lang(mr), .entry .entry-content .wp-block-file:lang(mr), .entry .entry-content .wp-block-audio figcaption:lang(mr),
-.entry .entry-content .wp-block-video figcaption:lang(mr),
-.entry .entry-content .wp-block-image figcaption:lang(mr),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(mr),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(mr), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(mr),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(mr),
-.entry .entry-content .wp-block-cover-image h2:lang(mr),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(mr),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(mr),
-.entry .entry-content .wp-block-cover h2:lang(mr), .entry .entry-content .wp-block-pullquote cite:lang(mr), .entry .entry-content .has-drop-cap:lang(mr):not(:focus):first-letter, .entry .entry-content .wp-block-verse:lang(mr), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(mr), .entry .entry-content .wp-block-archives li > a:lang(mr),
-.entry .entry-content .wp-block-categories li > a:lang(mr),
-.entry .entry-content .wp-block-latest-posts li > a:lang(mr), .entry .entry-content .wp-block-button .wp-block-button__link:lang(mr), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(mr), .widget_tag_cloud .tagcloud:lang(mr), .widget_archive ul li:lang(mr),
-.widget_categories ul li:lang(mr),
-.widget_meta ul li:lang(mr),
-.widget_nav_menu ul li:lang(mr),
-.widget_pages ul li:lang(mr),
-.widget_recent_comments ul li:lang(mr),
-.widget_recent_entries ul li:lang(mr),
-.widget_rss ul li:lang(mr), .comment-form .comment-notes:lang(mr),
-.comment-form label:lang(mr), .comment-list .pingback .comment-body .comment-edit-link:lang(mr),
-.comment-list .trackback .comment-body .comment-edit-link:lang(mr), .comment-list .pingback .comment-body:lang(mr),
-.comment-list .trackback .comment-body:lang(mr), .comment-navigation .nav-previous:lang(mr),
-.comment-navigation .nav-next:lang(mr), .button:lang(mr), table:lang(mr), blockquote cite:lang(mr), .page-title:lang(mr), .author-description .author-link:lang(mr),
-.comment-metadata:lang(mr),
-.comment-reply-link:lang(mr),
-.comments-title:lang(mr),
-.comment-author .fn:lang(mr),
-.discussion-meta-info:lang(mr),
-.entry-meta:lang(mr),
-.entry-footer:lang(mr),
-.main-navigation:lang(mr),
-.no-comments:lang(mr),
-.post-navigation .post-title:lang(mr),
-.page-links:lang(mr),
-.page-description:lang(mr),
-.pagination .nav-links:lang(mr),
-.sticky-post:lang(mr),
-.site-title:lang(mr),
-.site-info:lang(mr),
-#cancel-comment-reply-link:lang(mr),
-h1:lang(mr),
-h2:lang(mr),
-h3:lang(mr),
-h4:lang(mr),
-h5:lang(mr),
-h6:lang(mr), button:lang(mr),
-input:lang(mr),
-select:lang(mr),
-optgroup:lang(mr),
-textarea:lang(mr), body:lang(mr) {
-  font-family: Arial, sans-serif;
-}
-.gallery-caption:lang(ne-NP), .wp-caption-text:lang(ne-NP), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ne-NP), .entry .entry-content .wp-block-file .wp-block-file__button:lang(ne-NP), .entry .entry-content .wp-block-file:lang(ne-NP), .entry .entry-content .wp-block-audio figcaption:lang(ne-NP),
-.entry .entry-content .wp-block-video figcaption:lang(ne-NP),
-.entry .entry-content .wp-block-image figcaption:lang(ne-NP),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(ne-NP),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(ne-NP), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(ne-NP),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(ne-NP),
-.entry .entry-content .wp-block-cover-image h2:lang(ne-NP),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(ne-NP),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(ne-NP),
-.entry .entry-content .wp-block-cover h2:lang(ne-NP), .entry .entry-content .wp-block-pullquote cite:lang(ne-NP), .entry .entry-content .has-drop-cap:lang(ne-NP):not(:focus):first-letter, .entry .entry-content .wp-block-verse:lang(ne-NP), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ne-NP), .entry .entry-content .wp-block-archives li > a:lang(ne-NP),
-.entry .entry-content .wp-block-categories li > a:lang(ne-NP),
-.entry .entry-content .wp-block-latest-posts li > a:lang(ne-NP), .entry .entry-content .wp-block-button .wp-block-button__link:lang(ne-NP), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(ne-NP), .widget_tag_cloud .tagcloud:lang(ne-NP), .widget_archive ul li:lang(ne-NP),
-.widget_categories ul li:lang(ne-NP),
-.widget_meta ul li:lang(ne-NP),
-.widget_nav_menu ul li:lang(ne-NP),
-.widget_pages ul li:lang(ne-NP),
-.widget_recent_comments ul li:lang(ne-NP),
-.widget_recent_entries ul li:lang(ne-NP),
-.widget_rss ul li:lang(ne-NP), .comment-form .comment-notes:lang(ne-NP),
-.comment-form label:lang(ne-NP), .comment-list .pingback .comment-body .comment-edit-link:lang(ne-NP),
-.comment-list .trackback .comment-body .comment-edit-link:lang(ne-NP), .comment-list .pingback .comment-body:lang(ne-NP),
-.comment-list .trackback .comment-body:lang(ne-NP), .comment-navigation .nav-previous:lang(ne-NP),
-.comment-navigation .nav-next:lang(ne-NP), .button:lang(ne-NP), table:lang(ne-NP), blockquote cite:lang(ne-NP), .page-title:lang(ne-NP), .author-description .author-link:lang(ne-NP),
-.comment-metadata:lang(ne-NP),
-.comment-reply-link:lang(ne-NP),
-.comments-title:lang(ne-NP),
-.comment-author .fn:lang(ne-NP),
-.discussion-meta-info:lang(ne-NP),
-.entry-meta:lang(ne-NP),
-.entry-footer:lang(ne-NP),
-.main-navigation:lang(ne-NP),
-.no-comments:lang(ne-NP),
-.post-navigation .post-title:lang(ne-NP),
-.page-links:lang(ne-NP),
-.page-description:lang(ne-NP),
-.pagination .nav-links:lang(ne-NP),
-.sticky-post:lang(ne-NP),
-.site-title:lang(ne-NP),
-.site-info:lang(ne-NP),
-#cancel-comment-reply-link:lang(ne-NP),
-h1:lang(ne-NP),
-h2:lang(ne-NP),
-h3:lang(ne-NP),
-h4:lang(ne-NP),
-h5:lang(ne-NP),
-h6:lang(ne-NP), button:lang(ne-NP),
-input:lang(ne-NP),
-select:lang(ne-NP),
-optgroup:lang(ne-NP),
-textarea:lang(ne-NP), body:lang(ne-NP) {
-  font-family: Arial, sans-serif;
-}
-.gallery-caption:lang(el), .wp-caption-text:lang(el), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(el), .entry .entry-content .wp-block-file .wp-block-file__button:lang(el), .entry .entry-content .wp-block-file:lang(el), .entry .entry-content .wp-block-audio figcaption:lang(el),
-.entry .entry-content .wp-block-video figcaption:lang(el),
-.entry .entry-content .wp-block-image figcaption:lang(el),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(el),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(el), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(el),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(el),
-.entry .entry-content .wp-block-cover-image h2:lang(el),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(el),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(el),
-.entry .entry-content .wp-block-cover h2:lang(el), .entry .entry-content .wp-block-pullquote cite:lang(el), .entry .entry-content .has-drop-cap:lang(el):not(:focus):first-letter, .entry .entry-content .wp-block-verse:lang(el), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(el), .entry .entry-content .wp-block-archives li > a:lang(el),
-.entry .entry-content .wp-block-categories li > a:lang(el),
-.entry .entry-content .wp-block-latest-posts li > a:lang(el), .entry .entry-content .wp-block-button .wp-block-button__link:lang(el), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(el), .widget_tag_cloud .tagcloud:lang(el), .widget_archive ul li:lang(el),
-.widget_categories ul li:lang(el),
-.widget_meta ul li:lang(el),
-.widget_nav_menu ul li:lang(el),
-.widget_pages ul li:lang(el),
-.widget_recent_comments ul li:lang(el),
-.widget_recent_entries ul li:lang(el),
-.widget_rss ul li:lang(el), .comment-form .comment-notes:lang(el),
-.comment-form label:lang(el), .comment-list .pingback .comment-body .comment-edit-link:lang(el),
-.comment-list .trackback .comment-body .comment-edit-link:lang(el), .comment-list .pingback .comment-body:lang(el),
-.comment-list .trackback .comment-body:lang(el), .comment-navigation .nav-previous:lang(el),
-.comment-navigation .nav-next:lang(el), .button:lang(el), table:lang(el), blockquote cite:lang(el), .page-title:lang(el), .author-description .author-link:lang(el),
-.comment-metadata:lang(el),
-.comment-reply-link:lang(el),
-.comments-title:lang(el),
-.comment-author .fn:lang(el),
-.discussion-meta-info:lang(el),
-.entry-meta:lang(el),
-.entry-footer:lang(el),
-.main-navigation:lang(el),
-.no-comments:lang(el),
-.post-navigation .post-title:lang(el),
-.page-links:lang(el),
-.page-description:lang(el),
-.pagination .nav-links:lang(el),
-.sticky-post:lang(el),
-.site-title:lang(el),
-.site-info:lang(el),
-#cancel-comment-reply-link:lang(el),
-h1:lang(el),
-h2:lang(el),
-h3:lang(el),
-h4:lang(el),
-h5:lang(el),
-h6:lang(el), button:lang(el),
-input:lang(el),
-select:lang(el),
-optgroup:lang(el),
-textarea:lang(el), body:lang(el) {
-  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-}
-.gallery-caption:lang(gu), .wp-caption-text:lang(gu), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(gu), .entry .entry-content .wp-block-file .wp-block-file__button:lang(gu), .entry .entry-content .wp-block-file:lang(gu), .entry .entry-content .wp-block-audio figcaption:lang(gu),
-.entry .entry-content .wp-block-video figcaption:lang(gu),
-.entry .entry-content .wp-block-image figcaption:lang(gu),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(gu),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(gu), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(gu),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(gu),
-.entry .entry-content .wp-block-cover-image h2:lang(gu),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(gu),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(gu),
-.entry .entry-content .wp-block-cover h2:lang(gu), .entry .entry-content .wp-block-pullquote cite:lang(gu), .entry .entry-content .has-drop-cap:lang(gu):not(:focus):first-letter, .entry .entry-content .wp-block-verse:lang(gu), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(gu), .entry .entry-content .wp-block-archives li > a:lang(gu),
-.entry .entry-content .wp-block-categories li > a:lang(gu),
-.entry .entry-content .wp-block-latest-posts li > a:lang(gu), .entry .entry-content .wp-block-button .wp-block-button__link:lang(gu), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(gu), .widget_tag_cloud .tagcloud:lang(gu), .widget_archive ul li:lang(gu),
-.widget_categories ul li:lang(gu),
-.widget_meta ul li:lang(gu),
-.widget_nav_menu ul li:lang(gu),
-.widget_pages ul li:lang(gu),
-.widget_recent_comments ul li:lang(gu),
-.widget_recent_entries ul li:lang(gu),
-.widget_rss ul li:lang(gu), .comment-form .comment-notes:lang(gu),
-.comment-form label:lang(gu), .comment-list .pingback .comment-body .comment-edit-link:lang(gu),
-.comment-list .trackback .comment-body .comment-edit-link:lang(gu), .comment-list .pingback .comment-body:lang(gu),
-.comment-list .trackback .comment-body:lang(gu), .comment-navigation .nav-previous:lang(gu),
-.comment-navigation .nav-next:lang(gu), .button:lang(gu), table:lang(gu), blockquote cite:lang(gu), .page-title:lang(gu), .author-description .author-link:lang(gu),
-.comment-metadata:lang(gu),
-.comment-reply-link:lang(gu),
-.comments-title:lang(gu),
-.comment-author .fn:lang(gu),
-.discussion-meta-info:lang(gu),
-.entry-meta:lang(gu),
-.entry-footer:lang(gu),
-.main-navigation:lang(gu),
-.no-comments:lang(gu),
-.post-navigation .post-title:lang(gu),
-.page-links:lang(gu),
-.page-description:lang(gu),
-.pagination .nav-links:lang(gu),
-.sticky-post:lang(gu),
-.site-title:lang(gu),
-.site-info:lang(gu),
-#cancel-comment-reply-link:lang(gu),
-h1:lang(gu),
-h2:lang(gu),
-h3:lang(gu),
-h4:lang(gu),
-h5:lang(gu),
-h6:lang(gu), button:lang(gu),
-input:lang(gu),
-select:lang(gu),
-optgroup:lang(gu),
-textarea:lang(gu), body:lang(gu) {
-  font-family: Arial, sans-serif;
-}
-.gallery-caption:lang(he-IL), .wp-caption-text:lang(he-IL), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(he-IL), .entry .entry-content .wp-block-file .wp-block-file__button:lang(he-IL), .entry .entry-content .wp-block-file:lang(he-IL), .entry .entry-content .wp-block-audio figcaption:lang(he-IL),
-.entry .entry-content .wp-block-video figcaption:lang(he-IL),
-.entry .entry-content .wp-block-image figcaption:lang(he-IL),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(he-IL),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(he-IL), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(he-IL),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(he-IL),
-.entry .entry-content .wp-block-cover-image h2:lang(he-IL),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(he-IL),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(he-IL),
-.entry .entry-content .wp-block-cover h2:lang(he-IL), .entry .entry-content .wp-block-pullquote cite:lang(he-IL), .entry .entry-content .has-drop-cap:lang(he-IL):not(:focus):first-letter, .entry .entry-content .wp-block-verse:lang(he-IL), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(he-IL), .entry .entry-content .wp-block-archives li > a:lang(he-IL),
-.entry .entry-content .wp-block-categories li > a:lang(he-IL),
-.entry .entry-content .wp-block-latest-posts li > a:lang(he-IL), .entry .entry-content .wp-block-button .wp-block-button__link:lang(he-IL), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(he-IL), .widget_tag_cloud .tagcloud:lang(he-IL), .widget_archive ul li:lang(he-IL),
-.widget_categories ul li:lang(he-IL),
-.widget_meta ul li:lang(he-IL),
-.widget_nav_menu ul li:lang(he-IL),
-.widget_pages ul li:lang(he-IL),
-.widget_recent_comments ul li:lang(he-IL),
-.widget_recent_entries ul li:lang(he-IL),
-.widget_rss ul li:lang(he-IL), .comment-form .comment-notes:lang(he-IL),
-.comment-form label:lang(he-IL), .comment-list .pingback .comment-body .comment-edit-link:lang(he-IL),
-.comment-list .trackback .comment-body .comment-edit-link:lang(he-IL), .comment-list .pingback .comment-body:lang(he-IL),
-.comment-list .trackback .comment-body:lang(he-IL), .comment-navigation .nav-previous:lang(he-IL),
-.comment-navigation .nav-next:lang(he-IL), .button:lang(he-IL), table:lang(he-IL), blockquote cite:lang(he-IL), .page-title:lang(he-IL), .author-description .author-link:lang(he-IL),
-.comment-metadata:lang(he-IL),
-.comment-reply-link:lang(he-IL),
-.comments-title:lang(he-IL),
-.comment-author .fn:lang(he-IL),
-.discussion-meta-info:lang(he-IL),
-.entry-meta:lang(he-IL),
-.entry-footer:lang(he-IL),
-.main-navigation:lang(he-IL),
-.no-comments:lang(he-IL),
-.post-navigation .post-title:lang(he-IL),
-.page-links:lang(he-IL),
-.page-description:lang(he-IL),
-.pagination .nav-links:lang(he-IL),
-.sticky-post:lang(he-IL),
-.site-title:lang(he-IL),
-.site-info:lang(he-IL),
-#cancel-comment-reply-link:lang(he-IL),
-h1:lang(he-IL),
-h2:lang(he-IL),
-h3:lang(he-IL),
-h4:lang(he-IL),
-h5:lang(he-IL),
-h6:lang(he-IL), button:lang(he-IL),
-input:lang(he-IL),
-select:lang(he-IL),
-optgroup:lang(he-IL),
-textarea:lang(he-IL), body:lang(he-IL) {
-  font-family: "Arial Hebrew", Arial, sans-serif;
-}
-.gallery-caption:lang(ja), .wp-caption-text:lang(ja), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ja), .entry .entry-content .wp-block-file .wp-block-file__button:lang(ja), .entry .entry-content .wp-block-file:lang(ja), .entry .entry-content .wp-block-audio figcaption:lang(ja),
-.entry .entry-content .wp-block-video figcaption:lang(ja),
-.entry .entry-content .wp-block-image figcaption:lang(ja),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(ja),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(ja), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(ja),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(ja),
-.entry .entry-content .wp-block-cover-image h2:lang(ja),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(ja),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(ja),
-.entry .entry-content .wp-block-cover h2:lang(ja), .entry .entry-content .wp-block-pullquote cite:lang(ja), .entry .entry-content .has-drop-cap:lang(ja):not(:focus):first-letter, .entry .entry-content .wp-block-verse:lang(ja), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ja), .entry .entry-content .wp-block-archives li > a:lang(ja),
-.entry .entry-content .wp-block-categories li > a:lang(ja),
-.entry .entry-content .wp-block-latest-posts li > a:lang(ja), .entry .entry-content .wp-block-button .wp-block-button__link:lang(ja), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(ja), .widget_tag_cloud .tagcloud:lang(ja), .widget_archive ul li:lang(ja),
-.widget_categories ul li:lang(ja),
-.widget_meta ul li:lang(ja),
-.widget_nav_menu ul li:lang(ja),
-.widget_pages ul li:lang(ja),
-.widget_recent_comments ul li:lang(ja),
-.widget_recent_entries ul li:lang(ja),
-.widget_rss ul li:lang(ja), .comment-form .comment-notes:lang(ja),
-.comment-form label:lang(ja), .comment-list .pingback .comment-body .comment-edit-link:lang(ja),
-.comment-list .trackback .comment-body .comment-edit-link:lang(ja), .comment-list .pingback .comment-body:lang(ja),
-.comment-list .trackback .comment-body:lang(ja), .comment-navigation .nav-previous:lang(ja),
-.comment-navigation .nav-next:lang(ja), .button:lang(ja), table:lang(ja), blockquote cite:lang(ja), .page-title:lang(ja), .author-description .author-link:lang(ja),
-.comment-metadata:lang(ja),
-.comment-reply-link:lang(ja),
-.comments-title:lang(ja),
-.comment-author .fn:lang(ja),
-.discussion-meta-info:lang(ja),
-.entry-meta:lang(ja),
-.entry-footer:lang(ja),
-.main-navigation:lang(ja),
-.no-comments:lang(ja),
-.post-navigation .post-title:lang(ja),
-.page-links:lang(ja),
-.page-description:lang(ja),
-.pagination .nav-links:lang(ja),
-.sticky-post:lang(ja),
-.site-title:lang(ja),
-.site-info:lang(ja),
-#cancel-comment-reply-link:lang(ja),
-h1:lang(ja),
-h2:lang(ja),
-h3:lang(ja),
-h4:lang(ja),
-h5:lang(ja),
-h6:lang(ja), button:lang(ja),
-input:lang(ja),
-select:lang(ja),
-optgroup:lang(ja),
-textarea:lang(ja), body:lang(ja) {
-  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
-}
-.gallery-caption:lang(ko-KR), .wp-caption-text:lang(ko-KR), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ko-KR), .entry .entry-content .wp-block-file .wp-block-file__button:lang(ko-KR), .entry .entry-content .wp-block-file:lang(ko-KR), .entry .entry-content .wp-block-audio figcaption:lang(ko-KR),
-.entry .entry-content .wp-block-video figcaption:lang(ko-KR),
-.entry .entry-content .wp-block-image figcaption:lang(ko-KR),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(ko-KR),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(ko-KR), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(ko-KR),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(ko-KR),
-.entry .entry-content .wp-block-cover-image h2:lang(ko-KR),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(ko-KR),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(ko-KR),
-.entry .entry-content .wp-block-cover h2:lang(ko-KR), .entry .entry-content .wp-block-pullquote cite:lang(ko-KR), .entry .entry-content .has-drop-cap:lang(ko-KR):not(:focus):first-letter, .entry .entry-content .wp-block-verse:lang(ko-KR), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ko-KR), .entry .entry-content .wp-block-archives li > a:lang(ko-KR),
-.entry .entry-content .wp-block-categories li > a:lang(ko-KR),
-.entry .entry-content .wp-block-latest-posts li > a:lang(ko-KR), .entry .entry-content .wp-block-button .wp-block-button__link:lang(ko-KR), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(ko-KR), .widget_tag_cloud .tagcloud:lang(ko-KR), .widget_archive ul li:lang(ko-KR),
-.widget_categories ul li:lang(ko-KR),
-.widget_meta ul li:lang(ko-KR),
-.widget_nav_menu ul li:lang(ko-KR),
-.widget_pages ul li:lang(ko-KR),
-.widget_recent_comments ul li:lang(ko-KR),
-.widget_recent_entries ul li:lang(ko-KR),
-.widget_rss ul li:lang(ko-KR), .comment-form .comment-notes:lang(ko-KR),
-.comment-form label:lang(ko-KR), .comment-list .pingback .comment-body .comment-edit-link:lang(ko-KR),
-.comment-list .trackback .comment-body .comment-edit-link:lang(ko-KR), .comment-list .pingback .comment-body:lang(ko-KR),
-.comment-list .trackback .comment-body:lang(ko-KR), .comment-navigation .nav-previous:lang(ko-KR),
-.comment-navigation .nav-next:lang(ko-KR), .button:lang(ko-KR), table:lang(ko-KR), blockquote cite:lang(ko-KR), .page-title:lang(ko-KR), .author-description .author-link:lang(ko-KR),
-.comment-metadata:lang(ko-KR),
-.comment-reply-link:lang(ko-KR),
-.comments-title:lang(ko-KR),
-.comment-author .fn:lang(ko-KR),
-.discussion-meta-info:lang(ko-KR),
-.entry-meta:lang(ko-KR),
-.entry-footer:lang(ko-KR),
-.main-navigation:lang(ko-KR),
-.no-comments:lang(ko-KR),
-.post-navigation .post-title:lang(ko-KR),
-.page-links:lang(ko-KR),
-.page-description:lang(ko-KR),
-.pagination .nav-links:lang(ko-KR),
-.sticky-post:lang(ko-KR),
-.site-title:lang(ko-KR),
-.site-info:lang(ko-KR),
-#cancel-comment-reply-link:lang(ko-KR),
-h1:lang(ko-KR),
-h2:lang(ko-KR),
-h3:lang(ko-KR),
-h4:lang(ko-KR),
-h5:lang(ko-KR),
-h6:lang(ko-KR), button:lang(ko-KR),
-input:lang(ko-KR),
-select:lang(ko-KR),
-optgroup:lang(ko-KR),
-textarea:lang(ko-KR), body:lang(ko-KR) {
-  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
-}
-.gallery-caption:lang(th), .wp-caption-text:lang(th), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(th), .entry .entry-content .wp-block-file .wp-block-file__button:lang(th), .entry .entry-content .wp-block-file:lang(th), .entry .entry-content .wp-block-audio figcaption:lang(th),
-.entry .entry-content .wp-block-video figcaption:lang(th),
-.entry .entry-content .wp-block-image figcaption:lang(th),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(th),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(th), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(th),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(th),
-.entry .entry-content .wp-block-cover-image h2:lang(th),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(th),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(th),
-.entry .entry-content .wp-block-cover h2:lang(th), .entry .entry-content .wp-block-pullquote cite:lang(th), .entry .entry-content .has-drop-cap:lang(th):not(:focus):first-letter, .entry .entry-content .wp-block-verse:lang(th), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(th), .entry .entry-content .wp-block-archives li > a:lang(th),
-.entry .entry-content .wp-block-categories li > a:lang(th),
-.entry .entry-content .wp-block-latest-posts li > a:lang(th), .entry .entry-content .wp-block-button .wp-block-button__link:lang(th), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(th), .widget_tag_cloud .tagcloud:lang(th), .widget_archive ul li:lang(th),
-.widget_categories ul li:lang(th),
-.widget_meta ul li:lang(th),
-.widget_nav_menu ul li:lang(th),
-.widget_pages ul li:lang(th),
-.widget_recent_comments ul li:lang(th),
-.widget_recent_entries ul li:lang(th),
-.widget_rss ul li:lang(th), .comment-form .comment-notes:lang(th),
-.comment-form label:lang(th), .comment-list .pingback .comment-body .comment-edit-link:lang(th),
-.comment-list .trackback .comment-body .comment-edit-link:lang(th), .comment-list .pingback .comment-body:lang(th),
-.comment-list .trackback .comment-body:lang(th), .comment-navigation .nav-previous:lang(th),
-.comment-navigation .nav-next:lang(th), .button:lang(th), table:lang(th), blockquote cite:lang(th), .page-title:lang(th), .author-description .author-link:lang(th),
-.comment-metadata:lang(th),
-.comment-reply-link:lang(th),
-.comments-title:lang(th),
-.comment-author .fn:lang(th),
-.discussion-meta-info:lang(th),
-.entry-meta:lang(th),
-.entry-footer:lang(th),
-.main-navigation:lang(th),
-.no-comments:lang(th),
-.post-navigation .post-title:lang(th),
-.page-links:lang(th),
-.page-description:lang(th),
-.pagination .nav-links:lang(th),
-.sticky-post:lang(th),
-.site-title:lang(th),
-.site-info:lang(th),
-#cancel-comment-reply-link:lang(th),
-h1:lang(th),
-h2:lang(th),
-h3:lang(th),
-h4:lang(th),
-h5:lang(th),
-h6:lang(th), button:lang(th),
-input:lang(th),
-select:lang(th),
-optgroup:lang(th),
-textarea:lang(th), body:lang(th) {
-  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
-}
-.gallery-caption:lang(vi), .wp-caption-text:lang(vi), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(vi), .entry .entry-content .wp-block-file .wp-block-file__button:lang(vi), .entry .entry-content .wp-block-file:lang(vi), .entry .entry-content .wp-block-audio figcaption:lang(vi),
-.entry .entry-content .wp-block-video figcaption:lang(vi),
-.entry .entry-content .wp-block-image figcaption:lang(vi),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(vi),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(vi), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(vi),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(vi),
-.entry .entry-content .wp-block-cover-image h2:lang(vi),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(vi),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(vi),
-.entry .entry-content .wp-block-cover h2:lang(vi), .entry .entry-content .wp-block-pullquote cite:lang(vi), .entry .entry-content .has-drop-cap:lang(vi):not(:focus):first-letter, .entry .entry-content .wp-block-verse:lang(vi), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(vi), .entry .entry-content .wp-block-archives li > a:lang(vi),
-.entry .entry-content .wp-block-categories li > a:lang(vi),
-.entry .entry-content .wp-block-latest-posts li > a:lang(vi), .entry .entry-content .wp-block-button .wp-block-button__link:lang(vi), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(vi), .widget_tag_cloud .tagcloud:lang(vi), .widget_archive ul li:lang(vi),
-.widget_categories ul li:lang(vi),
-.widget_meta ul li:lang(vi),
-.widget_nav_menu ul li:lang(vi),
-.widget_pages ul li:lang(vi),
-.widget_recent_comments ul li:lang(vi),
-.widget_recent_entries ul li:lang(vi),
-.widget_rss ul li:lang(vi), .comment-form .comment-notes:lang(vi),
-.comment-form label:lang(vi), .comment-list .pingback .comment-body .comment-edit-link:lang(vi),
-.comment-list .trackback .comment-body .comment-edit-link:lang(vi), .comment-list .pingback .comment-body:lang(vi),
-.comment-list .trackback .comment-body:lang(vi), .comment-navigation .nav-previous:lang(vi),
-.comment-navigation .nav-next:lang(vi), .button:lang(vi), table:lang(vi), blockquote cite:lang(vi), .page-title:lang(vi), .author-description .author-link:lang(vi),
-.comment-metadata:lang(vi),
-.comment-reply-link:lang(vi),
-.comments-title:lang(vi),
-.comment-author .fn:lang(vi),
-.discussion-meta-info:lang(vi),
-.entry-meta:lang(vi),
-.entry-footer:lang(vi),
-.main-navigation:lang(vi),
-.no-comments:lang(vi),
-.post-navigation .post-title:lang(vi),
-.page-links:lang(vi),
-.page-description:lang(vi),
-.pagination .nav-links:lang(vi),
-.sticky-post:lang(vi),
-.site-title:lang(vi),
-.site-info:lang(vi),
-#cancel-comment-reply-link:lang(vi),
-h1:lang(vi),
-h2:lang(vi),
-h3:lang(vi),
-h4:lang(vi),
-h5:lang(vi),
-h6:lang(vi), button:lang(vi),
-input:lang(vi),
-select:lang(vi),
-optgroup:lang(vi),
-textarea:lang(vi), body:lang(vi) {
-  font-family: "Libre Franklin", sans-serif;
-}
-
 /* Normalize */
 /*! normalize.css v8.0.0 | MIT License | github.com/necolas/normalize.css */
 /* Document
@@ -2006,6 +392,101 @@ body {
   background-color: #fff;
   color: #111;
   font-family: "NonBreakingSpaceOverride", "Hoefler Text", Garamond, "Times New Roman", serif;
+}
+body:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+body:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+body:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+body:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+body:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+body:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+body:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+body:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+body:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+body:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+body:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+body:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+body:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+body:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+body:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+body:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+body:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+body:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+body:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+body:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+body:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+body:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+body:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+body:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+body:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+body:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+body:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+body:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+body:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+body:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+body:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
+body {
   font-weight: 400;
   font-size: 1em;
   line-height: 1.8;
@@ -2020,6 +501,229 @@ optgroup,
 textarea {
   color: #111;
   font-family: "NonBreakingSpaceOverride", "Hoefler Text", Garamond, "Times New Roman", serif;
+}
+button:lang(ar),
+input:lang(ar),
+select:lang(ar),
+optgroup:lang(ar),
+textarea:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+button:lang(ary),
+input:lang(ary),
+select:lang(ary),
+optgroup:lang(ary),
+textarea:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+button:lang(azb),
+input:lang(azb),
+select:lang(azb),
+optgroup:lang(azb),
+textarea:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+button:lang(ckb),
+input:lang(ckb),
+select:lang(ckb),
+optgroup:lang(ckb),
+textarea:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+button:lang(fa-IR),
+input:lang(fa-IR),
+select:lang(fa-IR),
+optgroup:lang(fa-IR),
+textarea:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+button:lang(haz),
+input:lang(haz),
+select:lang(haz),
+optgroup:lang(haz),
+textarea:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+button:lang(ps),
+input:lang(ps),
+select:lang(ps),
+optgroup:lang(ps),
+textarea:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+button:lang(be),
+input:lang(be),
+select:lang(be),
+optgroup:lang(be),
+textarea:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+button:lang(bg-BG),
+input:lang(bg-BG),
+select:lang(bg-BG),
+optgroup:lang(bg-BG),
+textarea:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+button:lang(kk),
+input:lang(kk),
+select:lang(kk),
+optgroup:lang(kk),
+textarea:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+button:lang(mk-MK),
+input:lang(mk-MK),
+select:lang(mk-MK),
+optgroup:lang(mk-MK),
+textarea:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+button:lang(mn),
+input:lang(mn),
+select:lang(mn),
+optgroup:lang(mn),
+textarea:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+button:lang(ru-RU),
+input:lang(ru-RU),
+select:lang(ru-RU),
+optgroup:lang(ru-RU),
+textarea:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+button:lang(sah),
+input:lang(sah),
+select:lang(sah),
+optgroup:lang(sah),
+textarea:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+button:lang(sr-RS),
+input:lang(sr-RS),
+select:lang(sr-RS),
+optgroup:lang(sr-RS),
+textarea:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+button:lang(tt-RU),
+input:lang(tt-RU),
+select:lang(tt-RU),
+optgroup:lang(tt-RU),
+textarea:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+button:lang(uk),
+input:lang(uk),
+select:lang(uk),
+optgroup:lang(uk),
+textarea:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+button:lang(zh-HK),
+input:lang(zh-HK),
+select:lang(zh-HK),
+optgroup:lang(zh-HK),
+textarea:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+button:lang(zh-TW),
+input:lang(zh-TW),
+select:lang(zh-TW),
+optgroup:lang(zh-TW),
+textarea:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+button:lang(zh-CN),
+input:lang(zh-CN),
+select:lang(zh-CN),
+optgroup:lang(zh-CN),
+textarea:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+button:lang(bn-BD),
+input:lang(bn-BD),
+select:lang(bn-BD),
+optgroup:lang(bn-BD),
+textarea:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+button:lang(hi-IN),
+input:lang(hi-IN),
+select:lang(hi-IN),
+optgroup:lang(hi-IN),
+textarea:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+button:lang(mr),
+input:lang(mr),
+select:lang(mr),
+optgroup:lang(mr),
+textarea:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+button:lang(ne-NP),
+input:lang(ne-NP),
+select:lang(ne-NP),
+optgroup:lang(ne-NP),
+textarea:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+button:lang(el),
+input:lang(el),
+select:lang(el),
+optgroup:lang(el),
+textarea:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+button:lang(gu),
+input:lang(gu),
+select:lang(gu),
+optgroup:lang(gu),
+textarea:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+button:lang(he-IL),
+input:lang(he-IL),
+select:lang(he-IL),
+optgroup:lang(he-IL),
+textarea:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+button:lang(ja),
+input:lang(ja),
+select:lang(ja),
+optgroup:lang(ja),
+textarea:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+button:lang(ko-KR),
+input:lang(ko-KR),
+select:lang(ko-KR),
+optgroup:lang(ko-KR),
+textarea:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+button:lang(th),
+input:lang(th),
+select:lang(th),
+optgroup:lang(th),
+textarea:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+button:lang(vi),
+input:lang(vi),
+select:lang(vi),
+optgroup:lang(vi),
+textarea:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
+button,
+input,
+select,
+optgroup,
+textarea {
   font-weight: 400;
   line-height: 1.8;
   text-rendering: optimizeLegibility;
@@ -2053,6 +757,874 @@ h5,
 h6 {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 }
+.author-description .author-link:lang(ar),
+.comment-metadata:lang(ar),
+.comment-reply-link:lang(ar),
+.comments-title:lang(ar),
+.comment-author .fn:lang(ar),
+.discussion-meta-info:lang(ar),
+.entry-meta:lang(ar),
+.entry-footer:lang(ar),
+.main-navigation:lang(ar),
+.no-comments:lang(ar),
+.not-found .page-title:lang(ar),
+.error-404 .page-title:lang(ar),
+.post-navigation .post-title:lang(ar),
+.page-links:lang(ar),
+.page-description:lang(ar),
+.pagination .nav-links:lang(ar),
+.sticky-post:lang(ar),
+.site-title:lang(ar),
+.site-info:lang(ar),
+#cancel-comment-reply-link:lang(ar),
+h1:lang(ar),
+h2:lang(ar),
+h3:lang(ar),
+h4:lang(ar),
+h5:lang(ar),
+h6:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.author-description .author-link:lang(ary),
+.comment-metadata:lang(ary),
+.comment-reply-link:lang(ary),
+.comments-title:lang(ary),
+.comment-author .fn:lang(ary),
+.discussion-meta-info:lang(ary),
+.entry-meta:lang(ary),
+.entry-footer:lang(ary),
+.main-navigation:lang(ary),
+.no-comments:lang(ary),
+.not-found .page-title:lang(ary),
+.error-404 .page-title:lang(ary),
+.post-navigation .post-title:lang(ary),
+.page-links:lang(ary),
+.page-description:lang(ary),
+.pagination .nav-links:lang(ary),
+.sticky-post:lang(ary),
+.site-title:lang(ary),
+.site-info:lang(ary),
+#cancel-comment-reply-link:lang(ary),
+h1:lang(ary),
+h2:lang(ary),
+h3:lang(ary),
+h4:lang(ary),
+h5:lang(ary),
+h6:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.author-description .author-link:lang(azb),
+.comment-metadata:lang(azb),
+.comment-reply-link:lang(azb),
+.comments-title:lang(azb),
+.comment-author .fn:lang(azb),
+.discussion-meta-info:lang(azb),
+.entry-meta:lang(azb),
+.entry-footer:lang(azb),
+.main-navigation:lang(azb),
+.no-comments:lang(azb),
+.not-found .page-title:lang(azb),
+.error-404 .page-title:lang(azb),
+.post-navigation .post-title:lang(azb),
+.page-links:lang(azb),
+.page-description:lang(azb),
+.pagination .nav-links:lang(azb),
+.sticky-post:lang(azb),
+.site-title:lang(azb),
+.site-info:lang(azb),
+#cancel-comment-reply-link:lang(azb),
+h1:lang(azb),
+h2:lang(azb),
+h3:lang(azb),
+h4:lang(azb),
+h5:lang(azb),
+h6:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.author-description .author-link:lang(ckb),
+.comment-metadata:lang(ckb),
+.comment-reply-link:lang(ckb),
+.comments-title:lang(ckb),
+.comment-author .fn:lang(ckb),
+.discussion-meta-info:lang(ckb),
+.entry-meta:lang(ckb),
+.entry-footer:lang(ckb),
+.main-navigation:lang(ckb),
+.no-comments:lang(ckb),
+.not-found .page-title:lang(ckb),
+.error-404 .page-title:lang(ckb),
+.post-navigation .post-title:lang(ckb),
+.page-links:lang(ckb),
+.page-description:lang(ckb),
+.pagination .nav-links:lang(ckb),
+.sticky-post:lang(ckb),
+.site-title:lang(ckb),
+.site-info:lang(ckb),
+#cancel-comment-reply-link:lang(ckb),
+h1:lang(ckb),
+h2:lang(ckb),
+h3:lang(ckb),
+h4:lang(ckb),
+h5:lang(ckb),
+h6:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.author-description .author-link:lang(fa-IR),
+.comment-metadata:lang(fa-IR),
+.comment-reply-link:lang(fa-IR),
+.comments-title:lang(fa-IR),
+.comment-author .fn:lang(fa-IR),
+.discussion-meta-info:lang(fa-IR),
+.entry-meta:lang(fa-IR),
+.entry-footer:lang(fa-IR),
+.main-navigation:lang(fa-IR),
+.no-comments:lang(fa-IR),
+.not-found .page-title:lang(fa-IR),
+.error-404 .page-title:lang(fa-IR),
+.post-navigation .post-title:lang(fa-IR),
+.page-links:lang(fa-IR),
+.page-description:lang(fa-IR),
+.pagination .nav-links:lang(fa-IR),
+.sticky-post:lang(fa-IR),
+.site-title:lang(fa-IR),
+.site-info:lang(fa-IR),
+#cancel-comment-reply-link:lang(fa-IR),
+h1:lang(fa-IR),
+h2:lang(fa-IR),
+h3:lang(fa-IR),
+h4:lang(fa-IR),
+h5:lang(fa-IR),
+h6:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.author-description .author-link:lang(haz),
+.comment-metadata:lang(haz),
+.comment-reply-link:lang(haz),
+.comments-title:lang(haz),
+.comment-author .fn:lang(haz),
+.discussion-meta-info:lang(haz),
+.entry-meta:lang(haz),
+.entry-footer:lang(haz),
+.main-navigation:lang(haz),
+.no-comments:lang(haz),
+.not-found .page-title:lang(haz),
+.error-404 .page-title:lang(haz),
+.post-navigation .post-title:lang(haz),
+.page-links:lang(haz),
+.page-description:lang(haz),
+.pagination .nav-links:lang(haz),
+.sticky-post:lang(haz),
+.site-title:lang(haz),
+.site-info:lang(haz),
+#cancel-comment-reply-link:lang(haz),
+h1:lang(haz),
+h2:lang(haz),
+h3:lang(haz),
+h4:lang(haz),
+h5:lang(haz),
+h6:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.author-description .author-link:lang(ps),
+.comment-metadata:lang(ps),
+.comment-reply-link:lang(ps),
+.comments-title:lang(ps),
+.comment-author .fn:lang(ps),
+.discussion-meta-info:lang(ps),
+.entry-meta:lang(ps),
+.entry-footer:lang(ps),
+.main-navigation:lang(ps),
+.no-comments:lang(ps),
+.not-found .page-title:lang(ps),
+.error-404 .page-title:lang(ps),
+.post-navigation .post-title:lang(ps),
+.page-links:lang(ps),
+.page-description:lang(ps),
+.pagination .nav-links:lang(ps),
+.sticky-post:lang(ps),
+.site-title:lang(ps),
+.site-info:lang(ps),
+#cancel-comment-reply-link:lang(ps),
+h1:lang(ps),
+h2:lang(ps),
+h3:lang(ps),
+h4:lang(ps),
+h5:lang(ps),
+h6:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.author-description .author-link:lang(be),
+.comment-metadata:lang(be),
+.comment-reply-link:lang(be),
+.comments-title:lang(be),
+.comment-author .fn:lang(be),
+.discussion-meta-info:lang(be),
+.entry-meta:lang(be),
+.entry-footer:lang(be),
+.main-navigation:lang(be),
+.no-comments:lang(be),
+.not-found .page-title:lang(be),
+.error-404 .page-title:lang(be),
+.post-navigation .post-title:lang(be),
+.page-links:lang(be),
+.page-description:lang(be),
+.pagination .nav-links:lang(be),
+.sticky-post:lang(be),
+.site-title:lang(be),
+.site-info:lang(be),
+#cancel-comment-reply-link:lang(be),
+h1:lang(be),
+h2:lang(be),
+h3:lang(be),
+h4:lang(be),
+h5:lang(be),
+h6:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.author-description .author-link:lang(bg-BG),
+.comment-metadata:lang(bg-BG),
+.comment-reply-link:lang(bg-BG),
+.comments-title:lang(bg-BG),
+.comment-author .fn:lang(bg-BG),
+.discussion-meta-info:lang(bg-BG),
+.entry-meta:lang(bg-BG),
+.entry-footer:lang(bg-BG),
+.main-navigation:lang(bg-BG),
+.no-comments:lang(bg-BG),
+.not-found .page-title:lang(bg-BG),
+.error-404 .page-title:lang(bg-BG),
+.post-navigation .post-title:lang(bg-BG),
+.page-links:lang(bg-BG),
+.page-description:lang(bg-BG),
+.pagination .nav-links:lang(bg-BG),
+.sticky-post:lang(bg-BG),
+.site-title:lang(bg-BG),
+.site-info:lang(bg-BG),
+#cancel-comment-reply-link:lang(bg-BG),
+h1:lang(bg-BG),
+h2:lang(bg-BG),
+h3:lang(bg-BG),
+h4:lang(bg-BG),
+h5:lang(bg-BG),
+h6:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.author-description .author-link:lang(kk),
+.comment-metadata:lang(kk),
+.comment-reply-link:lang(kk),
+.comments-title:lang(kk),
+.comment-author .fn:lang(kk),
+.discussion-meta-info:lang(kk),
+.entry-meta:lang(kk),
+.entry-footer:lang(kk),
+.main-navigation:lang(kk),
+.no-comments:lang(kk),
+.not-found .page-title:lang(kk),
+.error-404 .page-title:lang(kk),
+.post-navigation .post-title:lang(kk),
+.page-links:lang(kk),
+.page-description:lang(kk),
+.pagination .nav-links:lang(kk),
+.sticky-post:lang(kk),
+.site-title:lang(kk),
+.site-info:lang(kk),
+#cancel-comment-reply-link:lang(kk),
+h1:lang(kk),
+h2:lang(kk),
+h3:lang(kk),
+h4:lang(kk),
+h5:lang(kk),
+h6:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.author-description .author-link:lang(mk-MK),
+.comment-metadata:lang(mk-MK),
+.comment-reply-link:lang(mk-MK),
+.comments-title:lang(mk-MK),
+.comment-author .fn:lang(mk-MK),
+.discussion-meta-info:lang(mk-MK),
+.entry-meta:lang(mk-MK),
+.entry-footer:lang(mk-MK),
+.main-navigation:lang(mk-MK),
+.no-comments:lang(mk-MK),
+.not-found .page-title:lang(mk-MK),
+.error-404 .page-title:lang(mk-MK),
+.post-navigation .post-title:lang(mk-MK),
+.page-links:lang(mk-MK),
+.page-description:lang(mk-MK),
+.pagination .nav-links:lang(mk-MK),
+.sticky-post:lang(mk-MK),
+.site-title:lang(mk-MK),
+.site-info:lang(mk-MK),
+#cancel-comment-reply-link:lang(mk-MK),
+h1:lang(mk-MK),
+h2:lang(mk-MK),
+h3:lang(mk-MK),
+h4:lang(mk-MK),
+h5:lang(mk-MK),
+h6:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.author-description .author-link:lang(mn),
+.comment-metadata:lang(mn),
+.comment-reply-link:lang(mn),
+.comments-title:lang(mn),
+.comment-author .fn:lang(mn),
+.discussion-meta-info:lang(mn),
+.entry-meta:lang(mn),
+.entry-footer:lang(mn),
+.main-navigation:lang(mn),
+.no-comments:lang(mn),
+.not-found .page-title:lang(mn),
+.error-404 .page-title:lang(mn),
+.post-navigation .post-title:lang(mn),
+.page-links:lang(mn),
+.page-description:lang(mn),
+.pagination .nav-links:lang(mn),
+.sticky-post:lang(mn),
+.site-title:lang(mn),
+.site-info:lang(mn),
+#cancel-comment-reply-link:lang(mn),
+h1:lang(mn),
+h2:lang(mn),
+h3:lang(mn),
+h4:lang(mn),
+h5:lang(mn),
+h6:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.author-description .author-link:lang(ru-RU),
+.comment-metadata:lang(ru-RU),
+.comment-reply-link:lang(ru-RU),
+.comments-title:lang(ru-RU),
+.comment-author .fn:lang(ru-RU),
+.discussion-meta-info:lang(ru-RU),
+.entry-meta:lang(ru-RU),
+.entry-footer:lang(ru-RU),
+.main-navigation:lang(ru-RU),
+.no-comments:lang(ru-RU),
+.not-found .page-title:lang(ru-RU),
+.error-404 .page-title:lang(ru-RU),
+.post-navigation .post-title:lang(ru-RU),
+.page-links:lang(ru-RU),
+.page-description:lang(ru-RU),
+.pagination .nav-links:lang(ru-RU),
+.sticky-post:lang(ru-RU),
+.site-title:lang(ru-RU),
+.site-info:lang(ru-RU),
+#cancel-comment-reply-link:lang(ru-RU),
+h1:lang(ru-RU),
+h2:lang(ru-RU),
+h3:lang(ru-RU),
+h4:lang(ru-RU),
+h5:lang(ru-RU),
+h6:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.author-description .author-link:lang(sah),
+.comment-metadata:lang(sah),
+.comment-reply-link:lang(sah),
+.comments-title:lang(sah),
+.comment-author .fn:lang(sah),
+.discussion-meta-info:lang(sah),
+.entry-meta:lang(sah),
+.entry-footer:lang(sah),
+.main-navigation:lang(sah),
+.no-comments:lang(sah),
+.not-found .page-title:lang(sah),
+.error-404 .page-title:lang(sah),
+.post-navigation .post-title:lang(sah),
+.page-links:lang(sah),
+.page-description:lang(sah),
+.pagination .nav-links:lang(sah),
+.sticky-post:lang(sah),
+.site-title:lang(sah),
+.site-info:lang(sah),
+#cancel-comment-reply-link:lang(sah),
+h1:lang(sah),
+h2:lang(sah),
+h3:lang(sah),
+h4:lang(sah),
+h5:lang(sah),
+h6:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.author-description .author-link:lang(sr-RS),
+.comment-metadata:lang(sr-RS),
+.comment-reply-link:lang(sr-RS),
+.comments-title:lang(sr-RS),
+.comment-author .fn:lang(sr-RS),
+.discussion-meta-info:lang(sr-RS),
+.entry-meta:lang(sr-RS),
+.entry-footer:lang(sr-RS),
+.main-navigation:lang(sr-RS),
+.no-comments:lang(sr-RS),
+.not-found .page-title:lang(sr-RS),
+.error-404 .page-title:lang(sr-RS),
+.post-navigation .post-title:lang(sr-RS),
+.page-links:lang(sr-RS),
+.page-description:lang(sr-RS),
+.pagination .nav-links:lang(sr-RS),
+.sticky-post:lang(sr-RS),
+.site-title:lang(sr-RS),
+.site-info:lang(sr-RS),
+#cancel-comment-reply-link:lang(sr-RS),
+h1:lang(sr-RS),
+h2:lang(sr-RS),
+h3:lang(sr-RS),
+h4:lang(sr-RS),
+h5:lang(sr-RS),
+h6:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.author-description .author-link:lang(tt-RU),
+.comment-metadata:lang(tt-RU),
+.comment-reply-link:lang(tt-RU),
+.comments-title:lang(tt-RU),
+.comment-author .fn:lang(tt-RU),
+.discussion-meta-info:lang(tt-RU),
+.entry-meta:lang(tt-RU),
+.entry-footer:lang(tt-RU),
+.main-navigation:lang(tt-RU),
+.no-comments:lang(tt-RU),
+.not-found .page-title:lang(tt-RU),
+.error-404 .page-title:lang(tt-RU),
+.post-navigation .post-title:lang(tt-RU),
+.page-links:lang(tt-RU),
+.page-description:lang(tt-RU),
+.pagination .nav-links:lang(tt-RU),
+.sticky-post:lang(tt-RU),
+.site-title:lang(tt-RU),
+.site-info:lang(tt-RU),
+#cancel-comment-reply-link:lang(tt-RU),
+h1:lang(tt-RU),
+h2:lang(tt-RU),
+h3:lang(tt-RU),
+h4:lang(tt-RU),
+h5:lang(tt-RU),
+h6:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.author-description .author-link:lang(uk),
+.comment-metadata:lang(uk),
+.comment-reply-link:lang(uk),
+.comments-title:lang(uk),
+.comment-author .fn:lang(uk),
+.discussion-meta-info:lang(uk),
+.entry-meta:lang(uk),
+.entry-footer:lang(uk),
+.main-navigation:lang(uk),
+.no-comments:lang(uk),
+.not-found .page-title:lang(uk),
+.error-404 .page-title:lang(uk),
+.post-navigation .post-title:lang(uk),
+.page-links:lang(uk),
+.page-description:lang(uk),
+.pagination .nav-links:lang(uk),
+.sticky-post:lang(uk),
+.site-title:lang(uk),
+.site-info:lang(uk),
+#cancel-comment-reply-link:lang(uk),
+h1:lang(uk),
+h2:lang(uk),
+h3:lang(uk),
+h4:lang(uk),
+h5:lang(uk),
+h6:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.author-description .author-link:lang(zh-HK),
+.comment-metadata:lang(zh-HK),
+.comment-reply-link:lang(zh-HK),
+.comments-title:lang(zh-HK),
+.comment-author .fn:lang(zh-HK),
+.discussion-meta-info:lang(zh-HK),
+.entry-meta:lang(zh-HK),
+.entry-footer:lang(zh-HK),
+.main-navigation:lang(zh-HK),
+.no-comments:lang(zh-HK),
+.not-found .page-title:lang(zh-HK),
+.error-404 .page-title:lang(zh-HK),
+.post-navigation .post-title:lang(zh-HK),
+.page-links:lang(zh-HK),
+.page-description:lang(zh-HK),
+.pagination .nav-links:lang(zh-HK),
+.sticky-post:lang(zh-HK),
+.site-title:lang(zh-HK),
+.site-info:lang(zh-HK),
+#cancel-comment-reply-link:lang(zh-HK),
+h1:lang(zh-HK),
+h2:lang(zh-HK),
+h3:lang(zh-HK),
+h4:lang(zh-HK),
+h5:lang(zh-HK),
+h6:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.author-description .author-link:lang(zh-TW),
+.comment-metadata:lang(zh-TW),
+.comment-reply-link:lang(zh-TW),
+.comments-title:lang(zh-TW),
+.comment-author .fn:lang(zh-TW),
+.discussion-meta-info:lang(zh-TW),
+.entry-meta:lang(zh-TW),
+.entry-footer:lang(zh-TW),
+.main-navigation:lang(zh-TW),
+.no-comments:lang(zh-TW),
+.not-found .page-title:lang(zh-TW),
+.error-404 .page-title:lang(zh-TW),
+.post-navigation .post-title:lang(zh-TW),
+.page-links:lang(zh-TW),
+.page-description:lang(zh-TW),
+.pagination .nav-links:lang(zh-TW),
+.sticky-post:lang(zh-TW),
+.site-title:lang(zh-TW),
+.site-info:lang(zh-TW),
+#cancel-comment-reply-link:lang(zh-TW),
+h1:lang(zh-TW),
+h2:lang(zh-TW),
+h3:lang(zh-TW),
+h4:lang(zh-TW),
+h5:lang(zh-TW),
+h6:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.author-description .author-link:lang(zh-CN),
+.comment-metadata:lang(zh-CN),
+.comment-reply-link:lang(zh-CN),
+.comments-title:lang(zh-CN),
+.comment-author .fn:lang(zh-CN),
+.discussion-meta-info:lang(zh-CN),
+.entry-meta:lang(zh-CN),
+.entry-footer:lang(zh-CN),
+.main-navigation:lang(zh-CN),
+.no-comments:lang(zh-CN),
+.not-found .page-title:lang(zh-CN),
+.error-404 .page-title:lang(zh-CN),
+.post-navigation .post-title:lang(zh-CN),
+.page-links:lang(zh-CN),
+.page-description:lang(zh-CN),
+.pagination .nav-links:lang(zh-CN),
+.sticky-post:lang(zh-CN),
+.site-title:lang(zh-CN),
+.site-info:lang(zh-CN),
+#cancel-comment-reply-link:lang(zh-CN),
+h1:lang(zh-CN),
+h2:lang(zh-CN),
+h3:lang(zh-CN),
+h4:lang(zh-CN),
+h5:lang(zh-CN),
+h6:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.author-description .author-link:lang(bn-BD),
+.comment-metadata:lang(bn-BD),
+.comment-reply-link:lang(bn-BD),
+.comments-title:lang(bn-BD),
+.comment-author .fn:lang(bn-BD),
+.discussion-meta-info:lang(bn-BD),
+.entry-meta:lang(bn-BD),
+.entry-footer:lang(bn-BD),
+.main-navigation:lang(bn-BD),
+.no-comments:lang(bn-BD),
+.not-found .page-title:lang(bn-BD),
+.error-404 .page-title:lang(bn-BD),
+.post-navigation .post-title:lang(bn-BD),
+.page-links:lang(bn-BD),
+.page-description:lang(bn-BD),
+.pagination .nav-links:lang(bn-BD),
+.sticky-post:lang(bn-BD),
+.site-title:lang(bn-BD),
+.site-info:lang(bn-BD),
+#cancel-comment-reply-link:lang(bn-BD),
+h1:lang(bn-BD),
+h2:lang(bn-BD),
+h3:lang(bn-BD),
+h4:lang(bn-BD),
+h5:lang(bn-BD),
+h6:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+.author-description .author-link:lang(hi-IN),
+.comment-metadata:lang(hi-IN),
+.comment-reply-link:lang(hi-IN),
+.comments-title:lang(hi-IN),
+.comment-author .fn:lang(hi-IN),
+.discussion-meta-info:lang(hi-IN),
+.entry-meta:lang(hi-IN),
+.entry-footer:lang(hi-IN),
+.main-navigation:lang(hi-IN),
+.no-comments:lang(hi-IN),
+.not-found .page-title:lang(hi-IN),
+.error-404 .page-title:lang(hi-IN),
+.post-navigation .post-title:lang(hi-IN),
+.page-links:lang(hi-IN),
+.page-description:lang(hi-IN),
+.pagination .nav-links:lang(hi-IN),
+.sticky-post:lang(hi-IN),
+.site-title:lang(hi-IN),
+.site-info:lang(hi-IN),
+#cancel-comment-reply-link:lang(hi-IN),
+h1:lang(hi-IN),
+h2:lang(hi-IN),
+h3:lang(hi-IN),
+h4:lang(hi-IN),
+h5:lang(hi-IN),
+h6:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+.author-description .author-link:lang(mr),
+.comment-metadata:lang(mr),
+.comment-reply-link:lang(mr),
+.comments-title:lang(mr),
+.comment-author .fn:lang(mr),
+.discussion-meta-info:lang(mr),
+.entry-meta:lang(mr),
+.entry-footer:lang(mr),
+.main-navigation:lang(mr),
+.no-comments:lang(mr),
+.not-found .page-title:lang(mr),
+.error-404 .page-title:lang(mr),
+.post-navigation .post-title:lang(mr),
+.page-links:lang(mr),
+.page-description:lang(mr),
+.pagination .nav-links:lang(mr),
+.sticky-post:lang(mr),
+.site-title:lang(mr),
+.site-info:lang(mr),
+#cancel-comment-reply-link:lang(mr),
+h1:lang(mr),
+h2:lang(mr),
+h3:lang(mr),
+h4:lang(mr),
+h5:lang(mr),
+h6:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+.author-description .author-link:lang(ne-NP),
+.comment-metadata:lang(ne-NP),
+.comment-reply-link:lang(ne-NP),
+.comments-title:lang(ne-NP),
+.comment-author .fn:lang(ne-NP),
+.discussion-meta-info:lang(ne-NP),
+.entry-meta:lang(ne-NP),
+.entry-footer:lang(ne-NP),
+.main-navigation:lang(ne-NP),
+.no-comments:lang(ne-NP),
+.not-found .page-title:lang(ne-NP),
+.error-404 .page-title:lang(ne-NP),
+.post-navigation .post-title:lang(ne-NP),
+.page-links:lang(ne-NP),
+.page-description:lang(ne-NP),
+.pagination .nav-links:lang(ne-NP),
+.sticky-post:lang(ne-NP),
+.site-title:lang(ne-NP),
+.site-info:lang(ne-NP),
+#cancel-comment-reply-link:lang(ne-NP),
+h1:lang(ne-NP),
+h2:lang(ne-NP),
+h3:lang(ne-NP),
+h4:lang(ne-NP),
+h5:lang(ne-NP),
+h6:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+.author-description .author-link:lang(el),
+.comment-metadata:lang(el),
+.comment-reply-link:lang(el),
+.comments-title:lang(el),
+.comment-author .fn:lang(el),
+.discussion-meta-info:lang(el),
+.entry-meta:lang(el),
+.entry-footer:lang(el),
+.main-navigation:lang(el),
+.no-comments:lang(el),
+.not-found .page-title:lang(el),
+.error-404 .page-title:lang(el),
+.post-navigation .post-title:lang(el),
+.page-links:lang(el),
+.page-description:lang(el),
+.pagination .nav-links:lang(el),
+.sticky-post:lang(el),
+.site-title:lang(el),
+.site-info:lang(el),
+#cancel-comment-reply-link:lang(el),
+h1:lang(el),
+h2:lang(el),
+h3:lang(el),
+h4:lang(el),
+h5:lang(el),
+h6:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+.author-description .author-link:lang(gu),
+.comment-metadata:lang(gu),
+.comment-reply-link:lang(gu),
+.comments-title:lang(gu),
+.comment-author .fn:lang(gu),
+.discussion-meta-info:lang(gu),
+.entry-meta:lang(gu),
+.entry-footer:lang(gu),
+.main-navigation:lang(gu),
+.no-comments:lang(gu),
+.not-found .page-title:lang(gu),
+.error-404 .page-title:lang(gu),
+.post-navigation .post-title:lang(gu),
+.page-links:lang(gu),
+.page-description:lang(gu),
+.pagination .nav-links:lang(gu),
+.sticky-post:lang(gu),
+.site-title:lang(gu),
+.site-info:lang(gu),
+#cancel-comment-reply-link:lang(gu),
+h1:lang(gu),
+h2:lang(gu),
+h3:lang(gu),
+h4:lang(gu),
+h5:lang(gu),
+h6:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+.author-description .author-link:lang(he-IL),
+.comment-metadata:lang(he-IL),
+.comment-reply-link:lang(he-IL),
+.comments-title:lang(he-IL),
+.comment-author .fn:lang(he-IL),
+.discussion-meta-info:lang(he-IL),
+.entry-meta:lang(he-IL),
+.entry-footer:lang(he-IL),
+.main-navigation:lang(he-IL),
+.no-comments:lang(he-IL),
+.not-found .page-title:lang(he-IL),
+.error-404 .page-title:lang(he-IL),
+.post-navigation .post-title:lang(he-IL),
+.page-links:lang(he-IL),
+.page-description:lang(he-IL),
+.pagination .nav-links:lang(he-IL),
+.sticky-post:lang(he-IL),
+.site-title:lang(he-IL),
+.site-info:lang(he-IL),
+#cancel-comment-reply-link:lang(he-IL),
+h1:lang(he-IL),
+h2:lang(he-IL),
+h3:lang(he-IL),
+h4:lang(he-IL),
+h5:lang(he-IL),
+h6:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+.author-description .author-link:lang(ja),
+.comment-metadata:lang(ja),
+.comment-reply-link:lang(ja),
+.comments-title:lang(ja),
+.comment-author .fn:lang(ja),
+.discussion-meta-info:lang(ja),
+.entry-meta:lang(ja),
+.entry-footer:lang(ja),
+.main-navigation:lang(ja),
+.no-comments:lang(ja),
+.not-found .page-title:lang(ja),
+.error-404 .page-title:lang(ja),
+.post-navigation .post-title:lang(ja),
+.page-links:lang(ja),
+.page-description:lang(ja),
+.pagination .nav-links:lang(ja),
+.sticky-post:lang(ja),
+.site-title:lang(ja),
+.site-info:lang(ja),
+#cancel-comment-reply-link:lang(ja),
+h1:lang(ja),
+h2:lang(ja),
+h3:lang(ja),
+h4:lang(ja),
+h5:lang(ja),
+h6:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+.author-description .author-link:lang(ko-KR),
+.comment-metadata:lang(ko-KR),
+.comment-reply-link:lang(ko-KR),
+.comments-title:lang(ko-KR),
+.comment-author .fn:lang(ko-KR),
+.discussion-meta-info:lang(ko-KR),
+.entry-meta:lang(ko-KR),
+.entry-footer:lang(ko-KR),
+.main-navigation:lang(ko-KR),
+.no-comments:lang(ko-KR),
+.not-found .page-title:lang(ko-KR),
+.error-404 .page-title:lang(ko-KR),
+.post-navigation .post-title:lang(ko-KR),
+.page-links:lang(ko-KR),
+.page-description:lang(ko-KR),
+.pagination .nav-links:lang(ko-KR),
+.sticky-post:lang(ko-KR),
+.site-title:lang(ko-KR),
+.site-info:lang(ko-KR),
+#cancel-comment-reply-link:lang(ko-KR),
+h1:lang(ko-KR),
+h2:lang(ko-KR),
+h3:lang(ko-KR),
+h4:lang(ko-KR),
+h5:lang(ko-KR),
+h6:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+.author-description .author-link:lang(th),
+.comment-metadata:lang(th),
+.comment-reply-link:lang(th),
+.comments-title:lang(th),
+.comment-author .fn:lang(th),
+.discussion-meta-info:lang(th),
+.entry-meta:lang(th),
+.entry-footer:lang(th),
+.main-navigation:lang(th),
+.no-comments:lang(th),
+.not-found .page-title:lang(th),
+.error-404 .page-title:lang(th),
+.post-navigation .post-title:lang(th),
+.page-links:lang(th),
+.page-description:lang(th),
+.pagination .nav-links:lang(th),
+.sticky-post:lang(th),
+.site-title:lang(th),
+.site-info:lang(th),
+#cancel-comment-reply-link:lang(th),
+h1:lang(th),
+h2:lang(th),
+h3:lang(th),
+h4:lang(th),
+h5:lang(th),
+h6:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+.author-description .author-link:lang(vi),
+.comment-metadata:lang(vi),
+.comment-reply-link:lang(vi),
+.comments-title:lang(vi),
+.comment-author .fn:lang(vi),
+.discussion-meta-info:lang(vi),
+.entry-meta:lang(vi),
+.entry-footer:lang(vi),
+.main-navigation:lang(vi),
+.no-comments:lang(vi),
+.not-found .page-title:lang(vi),
+.error-404 .page-title:lang(vi),
+.post-navigation .post-title:lang(vi),
+.page-links:lang(vi),
+.page-description:lang(vi),
+.pagination .nav-links:lang(vi),
+.sticky-post:lang(vi),
+.site-title:lang(vi),
+.site-info:lang(vi),
+#cancel-comment-reply-link:lang(vi),
+h1:lang(vi),
+h2:lang(vi),
+h3:lang(vi),
+h4:lang(vi),
+h5:lang(vi),
+h6:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
 
 .main-navigation,
 .page-description,
@@ -2080,6 +1652,99 @@ h6 {
 
 .page-title {
   font-family: "NonBreakingSpaceOverride", "Hoefler Text", Garamond, "Times New Roman", serif;
+}
+.page-title:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.page-title:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.page-title:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.page-title:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.page-title:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.page-title:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.page-title:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.page-title:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.page-title:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.page-title:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.page-title:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.page-title:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.page-title:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.page-title:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.page-title:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.page-title:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.page-title:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.page-title:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.page-title:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.page-title:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.page-title:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+.page-title:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+.page-title:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+.page-title:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+.page-title:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+.page-title:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+.page-title:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+.page-title:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+.page-title:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+.page-title:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+.page-title:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
 }
 
 .site-branding,
@@ -2213,6 +1878,99 @@ blockquote cite {
   font-style: normal;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 }
+blockquote cite:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+blockquote cite:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+blockquote cite:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+blockquote cite:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+blockquote cite:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+blockquote cite:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+blockquote cite:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+blockquote cite:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+blockquote cite:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+blockquote cite:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+blockquote cite:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+blockquote cite:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+blockquote cite:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+blockquote cite:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+blockquote cite:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+blockquote cite:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+blockquote cite:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+blockquote cite:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+blockquote cite:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+blockquote cite:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+blockquote cite:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+blockquote cite:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+blockquote cite:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+blockquote cite:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+blockquote cite:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+blockquote cite:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+blockquote cite:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+blockquote cite:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+blockquote cite:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+blockquote cite:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+blockquote cite:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
 
 pre {
   font-size: 0.8888888889em;
@@ -2229,7 +1987,8 @@ var {
   font-family: Menlo, monaco, Consolas, Lucida Console, monospace;
 }
 
-abbr, acronym {
+abbr,
+acronym {
   border-bottom: 1px dotted #666;
   cursor: help;
 }
@@ -2281,7 +2040,7 @@ a {
 
 a:hover,
 a:active {
-  color: rgb(0, 80.5, 119);
+  color: #005177;
   outline: 0;
   text-decoration: none;
 }
@@ -2389,6 +2148,99 @@ table {
   width: 100%;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 }
+table:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+table:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+table:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+table:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+table:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+table:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+table:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+table:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+table:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+table:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+table:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+table:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+table:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+table:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+table:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+table:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+table:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+table:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+table:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+table:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+table:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+table:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+table:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+table:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+table:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+table:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+table:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+table:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+table:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+table:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+table:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
 table td,
 table th {
   padding: 0.5em;
@@ -2409,6 +2261,229 @@ input[type=submit] {
   box-sizing: border-box;
   color: #fff;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+}
+.button:lang(ar),
+button:lang(ar),
+input[type=button]:lang(ar),
+input[type=reset]:lang(ar),
+input[type=submit]:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.button:lang(ary),
+button:lang(ary),
+input[type=button]:lang(ary),
+input[type=reset]:lang(ary),
+input[type=submit]:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.button:lang(azb),
+button:lang(azb),
+input[type=button]:lang(azb),
+input[type=reset]:lang(azb),
+input[type=submit]:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.button:lang(ckb),
+button:lang(ckb),
+input[type=button]:lang(ckb),
+input[type=reset]:lang(ckb),
+input[type=submit]:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.button:lang(fa-IR),
+button:lang(fa-IR),
+input[type=button]:lang(fa-IR),
+input[type=reset]:lang(fa-IR),
+input[type=submit]:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.button:lang(haz),
+button:lang(haz),
+input[type=button]:lang(haz),
+input[type=reset]:lang(haz),
+input[type=submit]:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.button:lang(ps),
+button:lang(ps),
+input[type=button]:lang(ps),
+input[type=reset]:lang(ps),
+input[type=submit]:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.button:lang(be),
+button:lang(be),
+input[type=button]:lang(be),
+input[type=reset]:lang(be),
+input[type=submit]:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.button:lang(bg-BG),
+button:lang(bg-BG),
+input[type=button]:lang(bg-BG),
+input[type=reset]:lang(bg-BG),
+input[type=submit]:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.button:lang(kk),
+button:lang(kk),
+input[type=button]:lang(kk),
+input[type=reset]:lang(kk),
+input[type=submit]:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.button:lang(mk-MK),
+button:lang(mk-MK),
+input[type=button]:lang(mk-MK),
+input[type=reset]:lang(mk-MK),
+input[type=submit]:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.button:lang(mn),
+button:lang(mn),
+input[type=button]:lang(mn),
+input[type=reset]:lang(mn),
+input[type=submit]:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.button:lang(ru-RU),
+button:lang(ru-RU),
+input[type=button]:lang(ru-RU),
+input[type=reset]:lang(ru-RU),
+input[type=submit]:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.button:lang(sah),
+button:lang(sah),
+input[type=button]:lang(sah),
+input[type=reset]:lang(sah),
+input[type=submit]:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.button:lang(sr-RS),
+button:lang(sr-RS),
+input[type=button]:lang(sr-RS),
+input[type=reset]:lang(sr-RS),
+input[type=submit]:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.button:lang(tt-RU),
+button:lang(tt-RU),
+input[type=button]:lang(tt-RU),
+input[type=reset]:lang(tt-RU),
+input[type=submit]:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.button:lang(uk),
+button:lang(uk),
+input[type=button]:lang(uk),
+input[type=reset]:lang(uk),
+input[type=submit]:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.button:lang(zh-HK),
+button:lang(zh-HK),
+input[type=button]:lang(zh-HK),
+input[type=reset]:lang(zh-HK),
+input[type=submit]:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.button:lang(zh-TW),
+button:lang(zh-TW),
+input[type=button]:lang(zh-TW),
+input[type=reset]:lang(zh-TW),
+input[type=submit]:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.button:lang(zh-CN),
+button:lang(zh-CN),
+input[type=button]:lang(zh-CN),
+input[type=reset]:lang(zh-CN),
+input[type=submit]:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.button:lang(bn-BD),
+button:lang(bn-BD),
+input[type=button]:lang(bn-BD),
+input[type=reset]:lang(bn-BD),
+input[type=submit]:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+.button:lang(hi-IN),
+button:lang(hi-IN),
+input[type=button]:lang(hi-IN),
+input[type=reset]:lang(hi-IN),
+input[type=submit]:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+.button:lang(mr),
+button:lang(mr),
+input[type=button]:lang(mr),
+input[type=reset]:lang(mr),
+input[type=submit]:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+.button:lang(ne-NP),
+button:lang(ne-NP),
+input[type=button]:lang(ne-NP),
+input[type=reset]:lang(ne-NP),
+input[type=submit]:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+.button:lang(el),
+button:lang(el),
+input[type=button]:lang(el),
+input[type=reset]:lang(el),
+input[type=submit]:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+.button:lang(gu),
+button:lang(gu),
+input[type=button]:lang(gu),
+input[type=reset]:lang(gu),
+input[type=submit]:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+.button:lang(he-IL),
+button:lang(he-IL),
+input[type=button]:lang(he-IL),
+input[type=reset]:lang(he-IL),
+input[type=submit]:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+.button:lang(ja),
+button:lang(ja),
+input[type=button]:lang(ja),
+input[type=reset]:lang(ja),
+input[type=submit]:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+.button:lang(ko-KR),
+button:lang(ko-KR),
+input[type=button]:lang(ko-KR),
+input[type=reset]:lang(ko-KR),
+input[type=submit]:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+.button:lang(th),
+button:lang(th),
+input[type=button]:lang(th),
+input[type=reset]:lang(th),
+input[type=submit]:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+.button:lang(vi),
+button:lang(vi),
+input[type=button]:lang(vi),
+input[type=reset]:lang(vi),
+input[type=submit]:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
+.button,
+button,
+input[type=button],
+input[type=reset],
+input[type=submit] {
   font-size: 0.8888888889em;
   font-weight: 700;
   line-height: 1.2;
@@ -2517,8 +2592,9 @@ a {
 a:visited {
   color: #0073aa;
 }
-a:hover, a:active {
-  color: rgb(0, 80.5, 119);
+a:hover,
+a:active {
+  color: #005177;
   outline: 0;
   text-decoration: none;
 }
@@ -2561,7 +2637,8 @@ body.page .main-navigation {
   -webkit-appearance: none;
   -moz-appearance: none;
 }
-.main-navigation button:hover, .main-navigation button:focus {
+.main-navigation button:hover,
+.main-navigation button:focus {
   background: transparent;
 }
 .main-navigation button:focus {
@@ -2589,8 +2666,9 @@ body.page .main-navigation {
 .main-navigation .main-menu > li > a + svg {
   margin-left: 0.5rem;
 }
-.main-navigation .main-menu > li > a:hover, .main-navigation .main-menu > li > a:hover + svg {
-  color: rgb(0, 80.5, 119);
+.main-navigation .main-menu > li > a:hover,
+.main-navigation .main-menu > li > a:hover + svg {
+  color: #005177;
 }
 .main-navigation .main-menu > li.menu-item-has-children {
   display: inline-block;
@@ -2628,14 +2706,16 @@ body.page .main-navigation {
   top: -0.125rem;
   vertical-align: text-bottom;
 }
-.wp-customizer-unloading .main-navigation .main-menu > li.menu-item-has-children .submenu-expand, .main-navigation .main-menu > li.menu-item-has-children .submenu-expand.is-empty {
+.wp-customizer-unloading .main-navigation .main-menu > li.menu-item-has-children .submenu-expand,
+.main-navigation .main-menu > li.menu-item-has-children .submenu-expand.is-empty {
   display: none;
 }
 .main-navigation .main-menu > li.menu-item-has-children .submenu-expand svg {
   position: relative;
   top: 0.2rem;
 }
-.main-navigation .main-menu > li:last-child > a, .main-navigation .main-menu > li:last-child.menu-item-has-children .submenu-expand {
+.main-navigation .main-menu > li:last-child > a,
+.main-navigation .main-menu > li:last-child.menu-item-has-children .submenu-expand {
   margin-left: 0;
 }
 .main-navigation .sub-menu {
@@ -2692,15 +2772,17 @@ body.page .main-navigation {
   padding: calc(0.5 * 1rem) 1rem calc(0.5 * 1rem) calc(24px + 1rem);
   max-width: 20rem;
 }
-.main-navigation .sub-menu > li > a:hover, .main-navigation .sub-menu > li > a:focus,
+.main-navigation .sub-menu > li > a:hover,
+.main-navigation .sub-menu > li > a:focus,
 .main-navigation .sub-menu > li > .menu-item-link-return:hover,
 .main-navigation .sub-menu > li > .menu-item-link-return:focus {
-  background: rgb(0, 80.5, 119);
+  background: #005177;
 }
-.main-navigation .sub-menu > li > a:hover:after, .main-navigation .sub-menu > li > a:focus:after,
+.main-navigation .sub-menu > li > a:hover:after,
+.main-navigation .sub-menu > li > a:focus:after,
 .main-navigation .sub-menu > li > .menu-item-link-return:hover:after,
 .main-navigation .sub-menu > li > .menu-item-link-return:focus:after {
-  background: rgb(0, 80.5, 119);
+  background: #005177;
 }
 .main-navigation .sub-menu > li > .menu-item-link-return {
   width: 100%;
@@ -3079,7 +3161,8 @@ body.page .main-navigation {
   margin-bottom: -1px;
   transition: opacity 110ms ease-in-out;
 }
-.social-navigation ul.social-links-menu li a:hover, .social-navigation ul.social-links-menu li a:active {
+.social-navigation ul.social-links-menu li a:hover,
+.social-navigation ul.social-links-menu li a:active {
   color: #111;
   opacity: 0.6;
 }
@@ -3162,7 +3245,8 @@ body.page .main-navigation {
   color: #767676;
   user-select: none;
 }
-.post-navigation .nav-links a .meta-nav:before, .post-navigation .nav-links a .meta-nav:after {
+.post-navigation .nav-links a .meta-nav:before,
+.post-navigation .nav-links a .meta-nav:after {
   display: none;
   content: "—";
   width: 2em;
@@ -3173,7 +3257,7 @@ body.page .main-navigation {
   hyphens: auto;
 }
 .post-navigation .nav-links a:hover {
-  color: rgb(0, 80.5, 119);
+  color: #005177;
 }
 @media only screen and (min-width: 1168px) {
   .post-navigation .nav-links .nav-previous,
@@ -3216,21 +3300,25 @@ body.page .main-navigation {
 .pagination .nav-links > * {
   padding: calc(0.5 * 1rem);
 }
-.pagination .nav-links > *.dots, .pagination .nav-links > *.prev {
+.pagination .nav-links > *.dots,
+.pagination .nav-links > *.prev {
   padding-right: 0;
 }
-.pagination .nav-links > *.dots, .pagination .nav-links > *.next {
+.pagination .nav-links > *.dots,
+.pagination .nav-links > *.next {
   padding-left: 0;
 }
 .pagination .nav-links a:focus {
   text-decoration: underline;
   outline-offset: -1px;
 }
-.pagination .nav-links a:focus.prev, .pagination .nav-links a:focus.next {
+.pagination .nav-links a:focus.prev,
+.pagination .nav-links a:focus.next {
   text-decoration: none;
 }
 .pagination .nav-links a:focus.prev .nav-prev-text,
-.pagination .nav-links a:focus.prev .nav-next-text, .pagination .nav-links a:focus.next .nav-prev-text,
+.pagination .nav-links a:focus.prev .nav-next-text,
+.pagination .nav-links a:focus.next .nav-prev-text,
 .pagination .nav-links a:focus.next .nav-next-text {
   text-decoration: underline;
 }
@@ -3262,6 +3350,133 @@ body.page .main-navigation {
   min-width: 50%;
   width: 100%;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+}
+.comment-navigation .nav-previous:lang(ar),
+.comment-navigation .nav-next:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.comment-navigation .nav-previous:lang(ary),
+.comment-navigation .nav-next:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.comment-navigation .nav-previous:lang(azb),
+.comment-navigation .nav-next:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.comment-navigation .nav-previous:lang(ckb),
+.comment-navigation .nav-next:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.comment-navigation .nav-previous:lang(fa-IR),
+.comment-navigation .nav-next:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.comment-navigation .nav-previous:lang(haz),
+.comment-navigation .nav-next:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.comment-navigation .nav-previous:lang(ps),
+.comment-navigation .nav-next:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.comment-navigation .nav-previous:lang(be),
+.comment-navigation .nav-next:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-navigation .nav-previous:lang(bg-BG),
+.comment-navigation .nav-next:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-navigation .nav-previous:lang(kk),
+.comment-navigation .nav-next:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-navigation .nav-previous:lang(mk-MK),
+.comment-navigation .nav-next:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-navigation .nav-previous:lang(mn),
+.comment-navigation .nav-next:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-navigation .nav-previous:lang(ru-RU),
+.comment-navigation .nav-next:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-navigation .nav-previous:lang(sah),
+.comment-navigation .nav-next:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-navigation .nav-previous:lang(sr-RS),
+.comment-navigation .nav-next:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-navigation .nav-previous:lang(tt-RU),
+.comment-navigation .nav-next:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-navigation .nav-previous:lang(uk),
+.comment-navigation .nav-next:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-navigation .nav-previous:lang(zh-HK),
+.comment-navigation .nav-next:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.comment-navigation .nav-previous:lang(zh-TW),
+.comment-navigation .nav-next:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.comment-navigation .nav-previous:lang(zh-CN),
+.comment-navigation .nav-next:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.comment-navigation .nav-previous:lang(bn-BD),
+.comment-navigation .nav-next:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+.comment-navigation .nav-previous:lang(hi-IN),
+.comment-navigation .nav-next:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+.comment-navigation .nav-previous:lang(mr),
+.comment-navigation .nav-next:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+.comment-navigation .nav-previous:lang(ne-NP),
+.comment-navigation .nav-next:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+.comment-navigation .nav-previous:lang(el),
+.comment-navigation .nav-next:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+.comment-navigation .nav-previous:lang(gu),
+.comment-navigation .nav-next:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+.comment-navigation .nav-previous:lang(he-IL),
+.comment-navigation .nav-next:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+.comment-navigation .nav-previous:lang(ja),
+.comment-navigation .nav-next:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+.comment-navigation .nav-previous:lang(ko-KR),
+.comment-navigation .nav-next:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+.comment-navigation .nav-previous:lang(th),
+.comment-navigation .nav-next:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+.comment-navigation .nav-previous:lang(vi),
+.comment-navigation .nav-next:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
+.comment-navigation .nav-previous,
+.comment-navigation .nav-next {
   font-weight: bold;
 }
 .comment-navigation .nav-previous .secondary-text,
@@ -3458,7 +3673,9 @@ body.page .main-navigation {
 .site-logo .custom-logo-link .custom-logo {
   min-height: inherit;
 }
-.site-logo .custom-logo-link:hover, .site-logo .custom-logo-link:active, .site-logo .custom-logo-link:focus {
+.site-logo .custom-logo-link:hover,
+.site-logo .custom-logo-link:active,
+.site-logo .custom-logo-link:focus {
   box-shadow: 0 0 0 2px rgb(0, 0, 0);
 }
 @media only screen and (min-width: 768px) {
@@ -3476,11 +3693,12 @@ body.page .main-navigation {
 .site-title a {
   color: #111;
 }
-.site-title a:link, .site-title a:visited {
+.site-title a:link,
+.site-title a:visited {
   color: #111;
 }
 .site-title a:hover {
-  color: rgb(74.375, 74.375, 74.375);
+  color: #4a4a4a;
 }
 .featured-image .site-title {
   margin: 0;
@@ -3540,7 +3758,10 @@ body.page .main-navigation {
   color: #fff;
   transition: opacity 110ms ease-in-out;
 }
-.site-header.featured-image .main-navigation a:hover, .site-header.featured-image .main-navigation a:active, .site-header.featured-image .main-navigation a:hover + svg, .site-header.featured-image .main-navigation a:active + svg,
+.site-header.featured-image .main-navigation a:hover,
+.site-header.featured-image .main-navigation a:active,
+.site-header.featured-image .main-navigation a:hover + svg,
+.site-header.featured-image .main-navigation a:active + svg,
 .site-header.featured-image .main-navigation a + svg:hover,
 .site-header.featured-image .main-navigation a + svg:active,
 .site-header.featured-image .main-navigation a + svg:hover + svg,
@@ -3560,7 +3781,8 @@ body.page .main-navigation {
   color: #fff;
   opacity: 0.6;
 }
-.site-header.featured-image .main-navigation a:focus, .site-header.featured-image .main-navigation a:focus + svg,
+.site-header.featured-image .main-navigation a:focus,
+.site-header.featured-image .main-navigation a:focus + svg,
 .site-header.featured-image .main-navigation a + svg:focus,
 .site-header.featured-image .main-navigation a + svg:focus + svg,
 .site-header.featured-image .social-navigation a:focus,
@@ -3687,7 +3909,9 @@ body.page .main-navigation {
   background: #fff;
   box-shadow: 0 0 0 0 rgba(255, 255, 255, 0);
 }
-.site-header.featured-image .custom-logo-link:hover, .site-header.featured-image .custom-logo-link:active, .site-header.featured-image .custom-logo-link:focus {
+.site-header.featured-image .custom-logo-link:hover,
+.site-header.featured-image .custom-logo-link:active,
+.site-header.featured-image .custom-logo-link:focus {
   box-shadow: 0 0 0 2px white;
 }
 .site-header.featured-image {
@@ -3706,7 +3930,8 @@ body.page .main-navigation {
 }
 .site-header.featured-image .site-branding-container:after,
 .site-header.featured-image .site-featured-image:before,
-.site-header.featured-image .site-featured-image:after, .site-header.featured-image:after {
+.site-header.featured-image .site-featured-image:after,
+.site-header.featured-image:after {
   display: block;
   position: absolute;
   top: 0;
@@ -3861,7 +4086,7 @@ body.page .main-navigation {
   color: inherit;
 }
 .entry .entry-title a:hover {
-  color: rgb(74.375, 74.375, 74.375);
+  color: #4a4a4a;
 }
 .entry .entry-meta,
 .entry .entry-footer {
@@ -3954,7 +4179,8 @@ body.page .main-navigation {
     display: none;
   }
 }
-.image-filters-enabled .entry .post-thumbnail:before, .image-filters-enabled .entry .post-thumbnail:after {
+.image-filters-enabled .entry .post-thumbnail:before,
+.image-filters-enabled .entry .post-thumbnail:after {
   position: absolute;
   display: block;
   width: 100%;
@@ -4016,7 +4242,8 @@ body.page .main-navigation {
   text-decoration: underline;
   text-decoration-thickness: 2px;
 }
-.entry .entry-content a.button, .entry .entry-content a:hover {
+.entry .entry-content a.button,
+.entry .entry-content a:hover {
   text-decoration: none;
 }
 .entry .entry-content a.button {
@@ -4111,7 +4338,7 @@ body.page .main-navigation {
   display: inline-block;
 }
 .author-bio .author-description .author-link:hover {
-  color: rgb(0, 80.5, 119);
+  color: #005177;
   text-decoration: none;
 }
 
@@ -4270,6 +4497,133 @@ body.page .main-navigation {
 .comment-list .trackback .comment-body {
   color: #767676;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+}
+.comment-list .pingback .comment-body:lang(ar),
+.comment-list .trackback .comment-body:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.comment-list .pingback .comment-body:lang(ary),
+.comment-list .trackback .comment-body:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.comment-list .pingback .comment-body:lang(azb),
+.comment-list .trackback .comment-body:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.comment-list .pingback .comment-body:lang(ckb),
+.comment-list .trackback .comment-body:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.comment-list .pingback .comment-body:lang(fa-IR),
+.comment-list .trackback .comment-body:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.comment-list .pingback .comment-body:lang(haz),
+.comment-list .trackback .comment-body:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.comment-list .pingback .comment-body:lang(ps),
+.comment-list .trackback .comment-body:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.comment-list .pingback .comment-body:lang(be),
+.comment-list .trackback .comment-body:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-list .pingback .comment-body:lang(bg-BG),
+.comment-list .trackback .comment-body:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-list .pingback .comment-body:lang(kk),
+.comment-list .trackback .comment-body:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-list .pingback .comment-body:lang(mk-MK),
+.comment-list .trackback .comment-body:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-list .pingback .comment-body:lang(mn),
+.comment-list .trackback .comment-body:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-list .pingback .comment-body:lang(ru-RU),
+.comment-list .trackback .comment-body:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-list .pingback .comment-body:lang(sah),
+.comment-list .trackback .comment-body:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-list .pingback .comment-body:lang(sr-RS),
+.comment-list .trackback .comment-body:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-list .pingback .comment-body:lang(tt-RU),
+.comment-list .trackback .comment-body:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-list .pingback .comment-body:lang(uk),
+.comment-list .trackback .comment-body:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-list .pingback .comment-body:lang(zh-HK),
+.comment-list .trackback .comment-body:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.comment-list .pingback .comment-body:lang(zh-TW),
+.comment-list .trackback .comment-body:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.comment-list .pingback .comment-body:lang(zh-CN),
+.comment-list .trackback .comment-body:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.comment-list .pingback .comment-body:lang(bn-BD),
+.comment-list .trackback .comment-body:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+.comment-list .pingback .comment-body:lang(hi-IN),
+.comment-list .trackback .comment-body:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+.comment-list .pingback .comment-body:lang(mr),
+.comment-list .trackback .comment-body:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+.comment-list .pingback .comment-body:lang(ne-NP),
+.comment-list .trackback .comment-body:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+.comment-list .pingback .comment-body:lang(el),
+.comment-list .trackback .comment-body:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+.comment-list .pingback .comment-body:lang(gu),
+.comment-list .trackback .comment-body:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+.comment-list .pingback .comment-body:lang(he-IL),
+.comment-list .trackback .comment-body:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+.comment-list .pingback .comment-body:lang(ja),
+.comment-list .trackback .comment-body:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+.comment-list .pingback .comment-body:lang(ko-KR),
+.comment-list .trackback .comment-body:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+.comment-list .pingback .comment-body:lang(th),
+.comment-list .trackback .comment-body:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+.comment-list .pingback .comment-body:lang(vi),
+.comment-list .trackback .comment-body:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
+.comment-list .pingback .comment-body,
+.comment-list .trackback .comment-body {
   font-size: 0.7111111111em;
   font-weight: 500;
   margin-top: 1rem;
@@ -4287,6 +4641,133 @@ body.page .main-navigation {
 .comment-list .trackback .comment-body .comment-edit-link {
   color: #767676;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+}
+.comment-list .pingback .comment-body .comment-edit-link:lang(ar),
+.comment-list .trackback .comment-body .comment-edit-link:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.comment-list .pingback .comment-body .comment-edit-link:lang(ary),
+.comment-list .trackback .comment-body .comment-edit-link:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.comment-list .pingback .comment-body .comment-edit-link:lang(azb),
+.comment-list .trackback .comment-body .comment-edit-link:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.comment-list .pingback .comment-body .comment-edit-link:lang(ckb),
+.comment-list .trackback .comment-body .comment-edit-link:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.comment-list .pingback .comment-body .comment-edit-link:lang(fa-IR),
+.comment-list .trackback .comment-body .comment-edit-link:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.comment-list .pingback .comment-body .comment-edit-link:lang(haz),
+.comment-list .trackback .comment-body .comment-edit-link:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.comment-list .pingback .comment-body .comment-edit-link:lang(ps),
+.comment-list .trackback .comment-body .comment-edit-link:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.comment-list .pingback .comment-body .comment-edit-link:lang(be),
+.comment-list .trackback .comment-body .comment-edit-link:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-list .pingback .comment-body .comment-edit-link:lang(bg-BG),
+.comment-list .trackback .comment-body .comment-edit-link:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-list .pingback .comment-body .comment-edit-link:lang(kk),
+.comment-list .trackback .comment-body .comment-edit-link:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-list .pingback .comment-body .comment-edit-link:lang(mk-MK),
+.comment-list .trackback .comment-body .comment-edit-link:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-list .pingback .comment-body .comment-edit-link:lang(mn),
+.comment-list .trackback .comment-body .comment-edit-link:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-list .pingback .comment-body .comment-edit-link:lang(ru-RU),
+.comment-list .trackback .comment-body .comment-edit-link:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-list .pingback .comment-body .comment-edit-link:lang(sah),
+.comment-list .trackback .comment-body .comment-edit-link:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-list .pingback .comment-body .comment-edit-link:lang(sr-RS),
+.comment-list .trackback .comment-body .comment-edit-link:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-list .pingback .comment-body .comment-edit-link:lang(tt-RU),
+.comment-list .trackback .comment-body .comment-edit-link:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-list .pingback .comment-body .comment-edit-link:lang(uk),
+.comment-list .trackback .comment-body .comment-edit-link:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-list .pingback .comment-body .comment-edit-link:lang(zh-HK),
+.comment-list .trackback .comment-body .comment-edit-link:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.comment-list .pingback .comment-body .comment-edit-link:lang(zh-TW),
+.comment-list .trackback .comment-body .comment-edit-link:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.comment-list .pingback .comment-body .comment-edit-link:lang(zh-CN),
+.comment-list .trackback .comment-body .comment-edit-link:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.comment-list .pingback .comment-body .comment-edit-link:lang(bn-BD),
+.comment-list .trackback .comment-body .comment-edit-link:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+.comment-list .pingback .comment-body .comment-edit-link:lang(hi-IN),
+.comment-list .trackback .comment-body .comment-edit-link:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+.comment-list .pingback .comment-body .comment-edit-link:lang(mr),
+.comment-list .trackback .comment-body .comment-edit-link:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+.comment-list .pingback .comment-body .comment-edit-link:lang(ne-NP),
+.comment-list .trackback .comment-body .comment-edit-link:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+.comment-list .pingback .comment-body .comment-edit-link:lang(el),
+.comment-list .trackback .comment-body .comment-edit-link:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+.comment-list .pingback .comment-body .comment-edit-link:lang(gu),
+.comment-list .trackback .comment-body .comment-edit-link:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+.comment-list .pingback .comment-body .comment-edit-link:lang(he-IL),
+.comment-list .trackback .comment-body .comment-edit-link:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+.comment-list .pingback .comment-body .comment-edit-link:lang(ja),
+.comment-list .trackback .comment-body .comment-edit-link:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+.comment-list .pingback .comment-body .comment-edit-link:lang(ko-KR),
+.comment-list .trackback .comment-body .comment-edit-link:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+.comment-list .pingback .comment-body .comment-edit-link:lang(th),
+.comment-list .trackback .comment-body .comment-edit-link:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+.comment-list .pingback .comment-body .comment-edit-link:lang(vi),
+.comment-list .trackback .comment-body .comment-edit-link:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
+.comment-list .pingback .comment-body .comment-edit-link,
+.comment-list .trackback .comment-body .comment-edit-link {
   font-weight: 500;
 }
 
@@ -4343,14 +4824,14 @@ body.page .main-navigation {
   color: inherit;
 }
 .comment .comment-author .fn a:hover {
-  color: rgb(0, 80.5, 119);
+  color: #005177;
 }
 .comment .comment-author .post-author-badge {
   border-radius: 100%;
   display: block;
   height: 18px;
   position: absolute;
-  background: rgb(0, 142.6, 210.8);
+  background: #008fd3;
   left: calc(100% - 2.5rem);
   top: -3px;
   width: 18px;
@@ -4380,7 +4861,7 @@ body.page .main-navigation {
 }
 .comment .comment-metadata > a:hover,
 .comment .comment-metadata .comment-edit-link:hover {
-  color: rgb(0, 80.5, 119);
+  color: #005177;
   text-decoration: none;
 }
 .comment .comment-metadata > * {
@@ -4439,7 +4920,7 @@ body.page .main-navigation {
 }
 .comment-reply-link:hover,
 #cancel-comment-reply-link:hover {
-  color: rgb(0, 80.5, 119);
+  color: #005177;
 }
 
 .discussion-avatar-list {
@@ -4474,6 +4955,133 @@ body.page .main-navigation {
 .comment-form .comment-notes,
 .comment-form label {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+}
+.comment-form .comment-notes:lang(ar),
+.comment-form label:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.comment-form .comment-notes:lang(ary),
+.comment-form label:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.comment-form .comment-notes:lang(azb),
+.comment-form label:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.comment-form .comment-notes:lang(ckb),
+.comment-form label:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.comment-form .comment-notes:lang(fa-IR),
+.comment-form label:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.comment-form .comment-notes:lang(haz),
+.comment-form label:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.comment-form .comment-notes:lang(ps),
+.comment-form label:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.comment-form .comment-notes:lang(be),
+.comment-form label:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-form .comment-notes:lang(bg-BG),
+.comment-form label:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-form .comment-notes:lang(kk),
+.comment-form label:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-form .comment-notes:lang(mk-MK),
+.comment-form label:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-form .comment-notes:lang(mn),
+.comment-form label:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-form .comment-notes:lang(ru-RU),
+.comment-form label:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-form .comment-notes:lang(sah),
+.comment-form label:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-form .comment-notes:lang(sr-RS),
+.comment-form label:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-form .comment-notes:lang(tt-RU),
+.comment-form label:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-form .comment-notes:lang(uk),
+.comment-form label:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-form .comment-notes:lang(zh-HK),
+.comment-form label:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.comment-form .comment-notes:lang(zh-TW),
+.comment-form label:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.comment-form .comment-notes:lang(zh-CN),
+.comment-form label:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.comment-form .comment-notes:lang(bn-BD),
+.comment-form label:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+.comment-form .comment-notes:lang(hi-IN),
+.comment-form label:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+.comment-form .comment-notes:lang(mr),
+.comment-form label:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+.comment-form .comment-notes:lang(ne-NP),
+.comment-form label:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+.comment-form .comment-notes:lang(el),
+.comment-form label:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+.comment-form .comment-notes:lang(gu),
+.comment-form label:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+.comment-form .comment-notes:lang(he-IL),
+.comment-form label:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+.comment-form .comment-notes:lang(ja),
+.comment-form label:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+.comment-form .comment-notes:lang(ko-KR),
+.comment-form label:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+.comment-form .comment-notes:lang(th),
+.comment-form label:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+.comment-form .comment-notes:lang(vi),
+.comment-form label:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
+.comment-form .comment-notes,
+.comment-form label {
   font-size: 0.7111111111em;
   color: #767676;
 }
@@ -4639,7 +5247,7 @@ body.page .main-navigation {
   color: #0073aa;
 }
 .widget a:hover {
-  color: rgb(0, 80.5, 119);
+  color: #005177;
 }
 
 .widget_archive ul,
@@ -4663,6 +5271,325 @@ body.page .main-navigation {
 .widget_rss ul li {
   color: #767676;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+}
+.widget_archive ul li:lang(ar),
+.widget_categories ul li:lang(ar),
+.widget_meta ul li:lang(ar),
+.widget_nav_menu ul li:lang(ar),
+.widget_pages ul li:lang(ar),
+.widget_recent_comments ul li:lang(ar),
+.widget_recent_entries ul li:lang(ar),
+.widget_rss ul li:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.widget_archive ul li:lang(ary),
+.widget_categories ul li:lang(ary),
+.widget_meta ul li:lang(ary),
+.widget_nav_menu ul li:lang(ary),
+.widget_pages ul li:lang(ary),
+.widget_recent_comments ul li:lang(ary),
+.widget_recent_entries ul li:lang(ary),
+.widget_rss ul li:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.widget_archive ul li:lang(azb),
+.widget_categories ul li:lang(azb),
+.widget_meta ul li:lang(azb),
+.widget_nav_menu ul li:lang(azb),
+.widget_pages ul li:lang(azb),
+.widget_recent_comments ul li:lang(azb),
+.widget_recent_entries ul li:lang(azb),
+.widget_rss ul li:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.widget_archive ul li:lang(ckb),
+.widget_categories ul li:lang(ckb),
+.widget_meta ul li:lang(ckb),
+.widget_nav_menu ul li:lang(ckb),
+.widget_pages ul li:lang(ckb),
+.widget_recent_comments ul li:lang(ckb),
+.widget_recent_entries ul li:lang(ckb),
+.widget_rss ul li:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.widget_archive ul li:lang(fa-IR),
+.widget_categories ul li:lang(fa-IR),
+.widget_meta ul li:lang(fa-IR),
+.widget_nav_menu ul li:lang(fa-IR),
+.widget_pages ul li:lang(fa-IR),
+.widget_recent_comments ul li:lang(fa-IR),
+.widget_recent_entries ul li:lang(fa-IR),
+.widget_rss ul li:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.widget_archive ul li:lang(haz),
+.widget_categories ul li:lang(haz),
+.widget_meta ul li:lang(haz),
+.widget_nav_menu ul li:lang(haz),
+.widget_pages ul li:lang(haz),
+.widget_recent_comments ul li:lang(haz),
+.widget_recent_entries ul li:lang(haz),
+.widget_rss ul li:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.widget_archive ul li:lang(ps),
+.widget_categories ul li:lang(ps),
+.widget_meta ul li:lang(ps),
+.widget_nav_menu ul li:lang(ps),
+.widget_pages ul li:lang(ps),
+.widget_recent_comments ul li:lang(ps),
+.widget_recent_entries ul li:lang(ps),
+.widget_rss ul li:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.widget_archive ul li:lang(be),
+.widget_categories ul li:lang(be),
+.widget_meta ul li:lang(be),
+.widget_nav_menu ul li:lang(be),
+.widget_pages ul li:lang(be),
+.widget_recent_comments ul li:lang(be),
+.widget_recent_entries ul li:lang(be),
+.widget_rss ul li:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.widget_archive ul li:lang(bg-BG),
+.widget_categories ul li:lang(bg-BG),
+.widget_meta ul li:lang(bg-BG),
+.widget_nav_menu ul li:lang(bg-BG),
+.widget_pages ul li:lang(bg-BG),
+.widget_recent_comments ul li:lang(bg-BG),
+.widget_recent_entries ul li:lang(bg-BG),
+.widget_rss ul li:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.widget_archive ul li:lang(kk),
+.widget_categories ul li:lang(kk),
+.widget_meta ul li:lang(kk),
+.widget_nav_menu ul li:lang(kk),
+.widget_pages ul li:lang(kk),
+.widget_recent_comments ul li:lang(kk),
+.widget_recent_entries ul li:lang(kk),
+.widget_rss ul li:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.widget_archive ul li:lang(mk-MK),
+.widget_categories ul li:lang(mk-MK),
+.widget_meta ul li:lang(mk-MK),
+.widget_nav_menu ul li:lang(mk-MK),
+.widget_pages ul li:lang(mk-MK),
+.widget_recent_comments ul li:lang(mk-MK),
+.widget_recent_entries ul li:lang(mk-MK),
+.widget_rss ul li:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.widget_archive ul li:lang(mn),
+.widget_categories ul li:lang(mn),
+.widget_meta ul li:lang(mn),
+.widget_nav_menu ul li:lang(mn),
+.widget_pages ul li:lang(mn),
+.widget_recent_comments ul li:lang(mn),
+.widget_recent_entries ul li:lang(mn),
+.widget_rss ul li:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.widget_archive ul li:lang(ru-RU),
+.widget_categories ul li:lang(ru-RU),
+.widget_meta ul li:lang(ru-RU),
+.widget_nav_menu ul li:lang(ru-RU),
+.widget_pages ul li:lang(ru-RU),
+.widget_recent_comments ul li:lang(ru-RU),
+.widget_recent_entries ul li:lang(ru-RU),
+.widget_rss ul li:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.widget_archive ul li:lang(sah),
+.widget_categories ul li:lang(sah),
+.widget_meta ul li:lang(sah),
+.widget_nav_menu ul li:lang(sah),
+.widget_pages ul li:lang(sah),
+.widget_recent_comments ul li:lang(sah),
+.widget_recent_entries ul li:lang(sah),
+.widget_rss ul li:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.widget_archive ul li:lang(sr-RS),
+.widget_categories ul li:lang(sr-RS),
+.widget_meta ul li:lang(sr-RS),
+.widget_nav_menu ul li:lang(sr-RS),
+.widget_pages ul li:lang(sr-RS),
+.widget_recent_comments ul li:lang(sr-RS),
+.widget_recent_entries ul li:lang(sr-RS),
+.widget_rss ul li:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.widget_archive ul li:lang(tt-RU),
+.widget_categories ul li:lang(tt-RU),
+.widget_meta ul li:lang(tt-RU),
+.widget_nav_menu ul li:lang(tt-RU),
+.widget_pages ul li:lang(tt-RU),
+.widget_recent_comments ul li:lang(tt-RU),
+.widget_recent_entries ul li:lang(tt-RU),
+.widget_rss ul li:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.widget_archive ul li:lang(uk),
+.widget_categories ul li:lang(uk),
+.widget_meta ul li:lang(uk),
+.widget_nav_menu ul li:lang(uk),
+.widget_pages ul li:lang(uk),
+.widget_recent_comments ul li:lang(uk),
+.widget_recent_entries ul li:lang(uk),
+.widget_rss ul li:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.widget_archive ul li:lang(zh-HK),
+.widget_categories ul li:lang(zh-HK),
+.widget_meta ul li:lang(zh-HK),
+.widget_nav_menu ul li:lang(zh-HK),
+.widget_pages ul li:lang(zh-HK),
+.widget_recent_comments ul li:lang(zh-HK),
+.widget_recent_entries ul li:lang(zh-HK),
+.widget_rss ul li:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.widget_archive ul li:lang(zh-TW),
+.widget_categories ul li:lang(zh-TW),
+.widget_meta ul li:lang(zh-TW),
+.widget_nav_menu ul li:lang(zh-TW),
+.widget_pages ul li:lang(zh-TW),
+.widget_recent_comments ul li:lang(zh-TW),
+.widget_recent_entries ul li:lang(zh-TW),
+.widget_rss ul li:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.widget_archive ul li:lang(zh-CN),
+.widget_categories ul li:lang(zh-CN),
+.widget_meta ul li:lang(zh-CN),
+.widget_nav_menu ul li:lang(zh-CN),
+.widget_pages ul li:lang(zh-CN),
+.widget_recent_comments ul li:lang(zh-CN),
+.widget_recent_entries ul li:lang(zh-CN),
+.widget_rss ul li:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.widget_archive ul li:lang(bn-BD),
+.widget_categories ul li:lang(bn-BD),
+.widget_meta ul li:lang(bn-BD),
+.widget_nav_menu ul li:lang(bn-BD),
+.widget_pages ul li:lang(bn-BD),
+.widget_recent_comments ul li:lang(bn-BD),
+.widget_recent_entries ul li:lang(bn-BD),
+.widget_rss ul li:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+.widget_archive ul li:lang(hi-IN),
+.widget_categories ul li:lang(hi-IN),
+.widget_meta ul li:lang(hi-IN),
+.widget_nav_menu ul li:lang(hi-IN),
+.widget_pages ul li:lang(hi-IN),
+.widget_recent_comments ul li:lang(hi-IN),
+.widget_recent_entries ul li:lang(hi-IN),
+.widget_rss ul li:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+.widget_archive ul li:lang(mr),
+.widget_categories ul li:lang(mr),
+.widget_meta ul li:lang(mr),
+.widget_nav_menu ul li:lang(mr),
+.widget_pages ul li:lang(mr),
+.widget_recent_comments ul li:lang(mr),
+.widget_recent_entries ul li:lang(mr),
+.widget_rss ul li:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+.widget_archive ul li:lang(ne-NP),
+.widget_categories ul li:lang(ne-NP),
+.widget_meta ul li:lang(ne-NP),
+.widget_nav_menu ul li:lang(ne-NP),
+.widget_pages ul li:lang(ne-NP),
+.widget_recent_comments ul li:lang(ne-NP),
+.widget_recent_entries ul li:lang(ne-NP),
+.widget_rss ul li:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+.widget_archive ul li:lang(el),
+.widget_categories ul li:lang(el),
+.widget_meta ul li:lang(el),
+.widget_nav_menu ul li:lang(el),
+.widget_pages ul li:lang(el),
+.widget_recent_comments ul li:lang(el),
+.widget_recent_entries ul li:lang(el),
+.widget_rss ul li:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+.widget_archive ul li:lang(gu),
+.widget_categories ul li:lang(gu),
+.widget_meta ul li:lang(gu),
+.widget_nav_menu ul li:lang(gu),
+.widget_pages ul li:lang(gu),
+.widget_recent_comments ul li:lang(gu),
+.widget_recent_entries ul li:lang(gu),
+.widget_rss ul li:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+.widget_archive ul li:lang(he-IL),
+.widget_categories ul li:lang(he-IL),
+.widget_meta ul li:lang(he-IL),
+.widget_nav_menu ul li:lang(he-IL),
+.widget_pages ul li:lang(he-IL),
+.widget_recent_comments ul li:lang(he-IL),
+.widget_recent_entries ul li:lang(he-IL),
+.widget_rss ul li:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+.widget_archive ul li:lang(ja),
+.widget_categories ul li:lang(ja),
+.widget_meta ul li:lang(ja),
+.widget_nav_menu ul li:lang(ja),
+.widget_pages ul li:lang(ja),
+.widget_recent_comments ul li:lang(ja),
+.widget_recent_entries ul li:lang(ja),
+.widget_rss ul li:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+.widget_archive ul li:lang(ko-KR),
+.widget_categories ul li:lang(ko-KR),
+.widget_meta ul li:lang(ko-KR),
+.widget_nav_menu ul li:lang(ko-KR),
+.widget_pages ul li:lang(ko-KR),
+.widget_recent_comments ul li:lang(ko-KR),
+.widget_recent_entries ul li:lang(ko-KR),
+.widget_rss ul li:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+.widget_archive ul li:lang(th),
+.widget_categories ul li:lang(th),
+.widget_meta ul li:lang(th),
+.widget_nav_menu ul li:lang(th),
+.widget_pages ul li:lang(th),
+.widget_recent_comments ul li:lang(th),
+.widget_recent_entries ul li:lang(th),
+.widget_rss ul li:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+.widget_archive ul li:lang(vi),
+.widget_categories ul li:lang(vi),
+.widget_meta ul li:lang(vi),
+.widget_nav_menu ul li:lang(vi),
+.widget_pages ul li:lang(vi),
+.widget_recent_comments ul li:lang(vi),
+.widget_recent_entries ul li:lang(vi),
+.widget_rss ul li:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
+.widget_archive ul li,
+.widget_categories ul li,
+.widget_meta ul li,
+.widget_nav_menu ul li,
+.widget_pages ul li,
+.widget_recent_comments ul li,
+.widget_recent_entries ul li,
+.widget_rss ul li {
   font-size: calc(22px * 1.125);
   font-weight: 700;
   line-height: 1.2;
@@ -4695,6 +5622,101 @@ body.page .main-navigation {
 
 .widget_tag_cloud .tagcloud {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+}
+.widget_tag_cloud .tagcloud:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.widget_tag_cloud .tagcloud:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.widget_tag_cloud .tagcloud:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.widget_tag_cloud .tagcloud:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.widget_tag_cloud .tagcloud:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.widget_tag_cloud .tagcloud:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.widget_tag_cloud .tagcloud:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.widget_tag_cloud .tagcloud:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.widget_tag_cloud .tagcloud:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.widget_tag_cloud .tagcloud:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.widget_tag_cloud .tagcloud:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.widget_tag_cloud .tagcloud:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.widget_tag_cloud .tagcloud:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.widget_tag_cloud .tagcloud:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.widget_tag_cloud .tagcloud:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.widget_tag_cloud .tagcloud:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.widget_tag_cloud .tagcloud:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.widget_tag_cloud .tagcloud:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.widget_tag_cloud .tagcloud:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.widget_tag_cloud .tagcloud:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.widget_tag_cloud .tagcloud:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+.widget_tag_cloud .tagcloud:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+.widget_tag_cloud .tagcloud:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+.widget_tag_cloud .tagcloud:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+.widget_tag_cloud .tagcloud:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+.widget_tag_cloud .tagcloud:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+.widget_tag_cloud .tagcloud:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+.widget_tag_cloud .tagcloud:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+.widget_tag_cloud .tagcloud:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+.widget_tag_cloud .tagcloud:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+.widget_tag_cloud .tagcloud:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
+.widget_tag_cloud .tagcloud {
   font-weight: 700;
 }
 
@@ -4730,6 +5752,99 @@ body.page .main-navigation {
   display: table;
   width: 100%;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+}
+.widget_calendar .calendar_wrap .wp-calendar-nav:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.widget_calendar .calendar_wrap .wp-calendar-nav:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.widget_calendar .calendar_wrap .wp-calendar-nav:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.widget_calendar .calendar_wrap .wp-calendar-nav:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.widget_calendar .calendar_wrap .wp-calendar-nav:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.widget_calendar .calendar_wrap .wp-calendar-nav:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.widget_calendar .calendar_wrap .wp-calendar-nav:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.widget_calendar .calendar_wrap .wp-calendar-nav:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.widget_calendar .calendar_wrap .wp-calendar-nav:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.widget_calendar .calendar_wrap .wp-calendar-nav:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.widget_calendar .calendar_wrap .wp-calendar-nav:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.widget_calendar .calendar_wrap .wp-calendar-nav:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.widget_calendar .calendar_wrap .wp-calendar-nav:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.widget_calendar .calendar_wrap .wp-calendar-nav:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.widget_calendar .calendar_wrap .wp-calendar-nav:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.widget_calendar .calendar_wrap .wp-calendar-nav:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.widget_calendar .calendar_wrap .wp-calendar-nav:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.widget_calendar .calendar_wrap .wp-calendar-nav:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.widget_calendar .calendar_wrap .wp-calendar-nav:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.widget_calendar .calendar_wrap .wp-calendar-nav:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.widget_calendar .calendar_wrap .wp-calendar-nav:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+.widget_calendar .calendar_wrap .wp-calendar-nav:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+.widget_calendar .calendar_wrap .wp-calendar-nav:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+.widget_calendar .calendar_wrap .wp-calendar-nav:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+.widget_calendar .calendar_wrap .wp-calendar-nav:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+.widget_calendar .calendar_wrap .wp-calendar-nav:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+.widget_calendar .calendar_wrap .wp-calendar-nav:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+.widget_calendar .calendar_wrap .wp-calendar-nav:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+.widget_calendar .calendar_wrap .wp-calendar-nav:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+.widget_calendar .calendar_wrap .wp-calendar-nav:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+.widget_calendar .calendar_wrap .wp-calendar-nav:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
 }
 .widget_calendar .calendar_wrap .wp-calendar-nav span {
   display: table-cell;
@@ -4931,16 +6046,19 @@ body.page .main-navigation {
   display: block;
   width: 100%;
 }
-.entry .entry-content .wp-block-audio.alignleft audio, .entry .entry-content .wp-block-audio.alignright audio {
+.entry .entry-content .wp-block-audio.alignleft audio,
+.entry .entry-content .wp-block-audio.alignright audio {
   max-width: 198px;
 }
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-audio.alignleft audio, .entry .entry-content .wp-block-audio.alignright audio {
+  .entry .entry-content .wp-block-audio.alignleft audio,
+  .entry .entry-content .wp-block-audio.alignright audio {
     max-width: 384px;
   }
 }
 @media only screen and (min-width: 1379px) {
-  .entry .entry-content .wp-block-audio.alignleft audio, .entry .entry-content .wp-block-audio.alignright audio {
+  .entry .entry-content .wp-block-audio.alignleft audio,
+  .entry .entry-content .wp-block-audio.alignright audio {
     max-width: 385.44px;
   }
 }
@@ -4955,6 +6073,101 @@ body.page .main-navigation {
   border: none;
   font-size: 0.8888888889em;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+}
+.entry .entry-content .wp-block-button .wp-block-button__link:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-button .wp-block-button__link:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-button .wp-block-button__link:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-button .wp-block-button__link:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-button .wp-block-button__link:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-button .wp-block-button__link:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-button .wp-block-button__link:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-button .wp-block-button__link:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-button .wp-block-button__link:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-button .wp-block-button__link:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-button .wp-block-button__link:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-button .wp-block-button__link:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-button .wp-block-button__link:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-button .wp-block-button__link:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-button .wp-block-button__link:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-button .wp-block-button__link:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-button .wp-block-button__link:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-button .wp-block-button__link:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.entry .entry-content .wp-block-button .wp-block-button__link:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.entry .entry-content .wp-block-button .wp-block-button__link:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.entry .entry-content .wp-block-button .wp-block-button__link:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-button .wp-block-button__link:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-button .wp-block-button__link:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-button .wp-block-button__link:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-button .wp-block-button__link:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-button .wp-block-button__link:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-button .wp-block-button__link:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-button .wp-block-button__link:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+.entry .entry-content .wp-block-button .wp-block-button__link:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+.entry .entry-content .wp-block-button .wp-block-button__link:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+.entry .entry-content .wp-block-button .wp-block-button__link:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
+.entry .entry-content .wp-block-button .wp-block-button__link {
   box-sizing: border-box;
   font-weight: bold;
   text-decoration: none;
@@ -4987,15 +6200,21 @@ body.page .main-navigation {
 .entry .entry-content .wp-block-button:not(.is-style-squared) .wp-block-button__link {
   border-radius: 5px;
 }
-.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link, .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:focus, .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active {
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link,
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:focus,
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active {
   transition: all 150ms ease-in-out;
   border-width: 2px;
   border-style: solid;
 }
-.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:not(.has-background), .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:focus:not(.has-background), .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active:not(.has-background) {
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:not(.has-background),
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:focus:not(.has-background),
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active:not(.has-background) {
   background: transparent;
 }
-.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color), .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:focus:not(.has-text-color), .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active:not(.has-text-color) {
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color),
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:focus:not(.has-text-color),
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active:not(.has-text-color) {
   color: #0073aa;
   border-color: currentColor;
 }
@@ -5028,6 +6247,165 @@ body.page .main-navigation {
 .entry .entry-content .wp-block-categories li > a,
 .entry .entry-content .wp-block-latest-posts li > a {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+}
+.entry .entry-content .wp-block-archives li > a:lang(ar),
+.entry .entry-content .wp-block-categories li > a:lang(ar),
+.entry .entry-content .wp-block-latest-posts li > a:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-archives li > a:lang(ary),
+.entry .entry-content .wp-block-categories li > a:lang(ary),
+.entry .entry-content .wp-block-latest-posts li > a:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-archives li > a:lang(azb),
+.entry .entry-content .wp-block-categories li > a:lang(azb),
+.entry .entry-content .wp-block-latest-posts li > a:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-archives li > a:lang(ckb),
+.entry .entry-content .wp-block-categories li > a:lang(ckb),
+.entry .entry-content .wp-block-latest-posts li > a:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-archives li > a:lang(fa-IR),
+.entry .entry-content .wp-block-categories li > a:lang(fa-IR),
+.entry .entry-content .wp-block-latest-posts li > a:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-archives li > a:lang(haz),
+.entry .entry-content .wp-block-categories li > a:lang(haz),
+.entry .entry-content .wp-block-latest-posts li > a:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-archives li > a:lang(ps),
+.entry .entry-content .wp-block-categories li > a:lang(ps),
+.entry .entry-content .wp-block-latest-posts li > a:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-archives li > a:lang(be),
+.entry .entry-content .wp-block-categories li > a:lang(be),
+.entry .entry-content .wp-block-latest-posts li > a:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-archives li > a:lang(bg-BG),
+.entry .entry-content .wp-block-categories li > a:lang(bg-BG),
+.entry .entry-content .wp-block-latest-posts li > a:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-archives li > a:lang(kk),
+.entry .entry-content .wp-block-categories li > a:lang(kk),
+.entry .entry-content .wp-block-latest-posts li > a:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-archives li > a:lang(mk-MK),
+.entry .entry-content .wp-block-categories li > a:lang(mk-MK),
+.entry .entry-content .wp-block-latest-posts li > a:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-archives li > a:lang(mn),
+.entry .entry-content .wp-block-categories li > a:lang(mn),
+.entry .entry-content .wp-block-latest-posts li > a:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-archives li > a:lang(ru-RU),
+.entry .entry-content .wp-block-categories li > a:lang(ru-RU),
+.entry .entry-content .wp-block-latest-posts li > a:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-archives li > a:lang(sah),
+.entry .entry-content .wp-block-categories li > a:lang(sah),
+.entry .entry-content .wp-block-latest-posts li > a:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-archives li > a:lang(sr-RS),
+.entry .entry-content .wp-block-categories li > a:lang(sr-RS),
+.entry .entry-content .wp-block-latest-posts li > a:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-archives li > a:lang(tt-RU),
+.entry .entry-content .wp-block-categories li > a:lang(tt-RU),
+.entry .entry-content .wp-block-latest-posts li > a:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-archives li > a:lang(uk),
+.entry .entry-content .wp-block-categories li > a:lang(uk),
+.entry .entry-content .wp-block-latest-posts li > a:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-archives li > a:lang(zh-HK),
+.entry .entry-content .wp-block-categories li > a:lang(zh-HK),
+.entry .entry-content .wp-block-latest-posts li > a:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.entry .entry-content .wp-block-archives li > a:lang(zh-TW),
+.entry .entry-content .wp-block-categories li > a:lang(zh-TW),
+.entry .entry-content .wp-block-latest-posts li > a:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.entry .entry-content .wp-block-archives li > a:lang(zh-CN),
+.entry .entry-content .wp-block-categories li > a:lang(zh-CN),
+.entry .entry-content .wp-block-latest-posts li > a:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.entry .entry-content .wp-block-archives li > a:lang(bn-BD),
+.entry .entry-content .wp-block-categories li > a:lang(bn-BD),
+.entry .entry-content .wp-block-latest-posts li > a:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-archives li > a:lang(hi-IN),
+.entry .entry-content .wp-block-categories li > a:lang(hi-IN),
+.entry .entry-content .wp-block-latest-posts li > a:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-archives li > a:lang(mr),
+.entry .entry-content .wp-block-categories li > a:lang(mr),
+.entry .entry-content .wp-block-latest-posts li > a:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-archives li > a:lang(ne-NP),
+.entry .entry-content .wp-block-categories li > a:lang(ne-NP),
+.entry .entry-content .wp-block-latest-posts li > a:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-archives li > a:lang(el),
+.entry .entry-content .wp-block-categories li > a:lang(el),
+.entry .entry-content .wp-block-latest-posts li > a:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-archives li > a:lang(gu),
+.entry .entry-content .wp-block-categories li > a:lang(gu),
+.entry .entry-content .wp-block-latest-posts li > a:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-archives li > a:lang(he-IL),
+.entry .entry-content .wp-block-categories li > a:lang(he-IL),
+.entry .entry-content .wp-block-latest-posts li > a:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-archives li > a:lang(ja),
+.entry .entry-content .wp-block-categories li > a:lang(ja),
+.entry .entry-content .wp-block-latest-posts li > a:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+.entry .entry-content .wp-block-archives li > a:lang(ko-KR),
+.entry .entry-content .wp-block-categories li > a:lang(ko-KR),
+.entry .entry-content .wp-block-latest-posts li > a:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+.entry .entry-content .wp-block-archives li > a:lang(th),
+.entry .entry-content .wp-block-categories li > a:lang(th),
+.entry .entry-content .wp-block-latest-posts li > a:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+.entry .entry-content .wp-block-archives li > a:lang(vi),
+.entry .entry-content .wp-block-categories li > a:lang(vi),
+.entry .entry-content .wp-block-latest-posts li > a:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
+.entry .entry-content .wp-block-archives li > a,
+.entry .entry-content .wp-block-categories li > a,
+.entry .entry-content .wp-block-latest-posts li > a {
   font-size: calc(22px * 1.125);
   font-weight: bold;
   line-height: 1.2;
@@ -5055,6 +6433,101 @@ body.page .main-navigation {
 }
 .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+}
+.entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+.entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+.entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
+.entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date {
   font-size: 0.7111111111em;
   color: #767676;
   line-height: 1.2;
@@ -5067,7 +6540,8 @@ body.page .main-navigation {
 .entry .entry-content .wp-block-latest-posts li {
   padding-bottom: 0.5rem;
 }
-.entry .entry-content .wp-block-latest-posts li.menu-item-has-children, .entry .entry-content .wp-block-latest-posts li:last-child {
+.entry .entry-content .wp-block-latest-posts li.menu-item-has-children,
+.entry .entry-content .wp-block-latest-posts li:last-child {
   padding-bottom: 0;
 }
 .entry .entry-content .wp-block-latest-posts li :not(:last-child) .wp-block-latest-posts__post-excerpt {
@@ -5094,11 +6568,201 @@ body.page .main-navigation {
 }
 .entry .entry-content .wp-block-verse {
   font-family: "NonBreakingSpaceOverride", "Hoefler Text", Garamond, "Times New Roman", serif;
+}
+.entry .entry-content .wp-block-verse:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-verse:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-verse:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-verse:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-verse:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-verse:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-verse:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-verse:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-verse:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-verse:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-verse:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-verse:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-verse:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-verse:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-verse:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-verse:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-verse:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-verse:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.entry .entry-content .wp-block-verse:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.entry .entry-content .wp-block-verse:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.entry .entry-content .wp-block-verse:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-verse:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-verse:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-verse:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-verse:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-verse:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-verse:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-verse:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+.entry .entry-content .wp-block-verse:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+.entry .entry-content .wp-block-verse:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+.entry .entry-content .wp-block-verse:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
+.entry .entry-content .wp-block-verse {
   font-size: 22px;
   line-height: 1.8;
 }
 .entry .entry-content .has-drop-cap:not(:focus):first-letter {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+}
+.entry .entry-content .has-drop-cap:not(:focus):first-letter:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .has-drop-cap:not(:focus):first-letter:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .has-drop-cap:not(:focus):first-letter:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .has-drop-cap:not(:focus):first-letter:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .has-drop-cap:not(:focus):first-letter:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .has-drop-cap:not(:focus):first-letter:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .has-drop-cap:not(:focus):first-letter:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .has-drop-cap:not(:focus):first-letter:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .has-drop-cap:not(:focus):first-letter:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .has-drop-cap:not(:focus):first-letter:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .has-drop-cap:not(:focus):first-letter:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .has-drop-cap:not(:focus):first-letter:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .has-drop-cap:not(:focus):first-letter:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .has-drop-cap:not(:focus):first-letter:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .has-drop-cap:not(:focus):first-letter:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .has-drop-cap:not(:focus):first-letter:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .has-drop-cap:not(:focus):first-letter:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .has-drop-cap:not(:focus):first-letter:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.entry .entry-content .has-drop-cap:not(:focus):first-letter:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.entry .entry-content .has-drop-cap:not(:focus):first-letter:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.entry .entry-content .has-drop-cap:not(:focus):first-letter:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .has-drop-cap:not(:focus):first-letter:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .has-drop-cap:not(:focus):first-letter:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .has-drop-cap:not(:focus):first-letter:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .has-drop-cap:not(:focus):first-letter:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+.entry .entry-content .has-drop-cap:not(:focus):first-letter:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .has-drop-cap:not(:focus):first-letter:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+.entry .entry-content .has-drop-cap:not(:focus):first-letter:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+.entry .entry-content .has-drop-cap:not(:focus):first-letter:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+.entry .entry-content .has-drop-cap:not(:focus):first-letter:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+.entry .entry-content .has-drop-cap:not(:focus):first-letter:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
+.entry .entry-content .has-drop-cap:not(:focus):first-letter {
   font-size: 3.375em;
   line-height: 1;
   font-weight: bold;
@@ -5141,6 +6805,101 @@ body.page .main-navigation {
 .entry .entry-content .wp-block-pullquote cite {
   display: block;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+}
+.entry .entry-content .wp-block-pullquote cite:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-pullquote cite:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-pullquote cite:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-pullquote cite:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-pullquote cite:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-pullquote cite:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-pullquote cite:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-pullquote cite:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-pullquote cite:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-pullquote cite:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-pullquote cite:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-pullquote cite:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-pullquote cite:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-pullquote cite:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-pullquote cite:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-pullquote cite:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-pullquote cite:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-pullquote cite:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.entry .entry-content .wp-block-pullquote cite:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.entry .entry-content .wp-block-pullquote cite:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.entry .entry-content .wp-block-pullquote cite:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-pullquote cite:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-pullquote cite:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-pullquote cite:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-pullquote cite:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-pullquote cite:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-pullquote cite:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-pullquote cite:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+.entry .entry-content .wp-block-pullquote cite:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+.entry .entry-content .wp-block-pullquote cite:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+.entry .entry-content .wp-block-pullquote cite:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
+.entry .entry-content .wp-block-pullquote cite {
   line-height: 1.6;
   text-transform: none;
   color: #767676;
@@ -5150,17 +6909,20 @@ body.page .main-navigation {
    */
   font-size: calc(1rem / (1.25 * 1.125));
 }
-.entry .entry-content .wp-block-pullquote.alignleft, .entry .entry-content .wp-block-pullquote.alignright {
+.entry .entry-content .wp-block-pullquote.alignleft,
+.entry .entry-content .wp-block-pullquote.alignright {
   width: 100%;
   padding: 0;
 }
-.entry .entry-content .wp-block-pullquote.alignleft blockquote, .entry .entry-content .wp-block-pullquote.alignright blockquote {
+.entry .entry-content .wp-block-pullquote.alignleft blockquote,
+.entry .entry-content .wp-block-pullquote.alignright blockquote {
   margin: 1rem 0;
   padding: 0;
   text-align: right;
   max-width: 100%;
 }
-.entry .entry-content .wp-block-pullquote.alignleft blockquote p:first-child, .entry .entry-content .wp-block-pullquote.alignright blockquote p:first-child {
+.entry .entry-content .wp-block-pullquote.alignleft blockquote p:first-child,
+.entry .entry-content .wp-block-pullquote.alignright blockquote p:first-child {
   margin-top: 0;
 }
 .entry .entry-content .wp-block-pullquote.has-text-color cite {
@@ -5201,7 +6963,13 @@ body.page .main-navigation {
   margin-right: 1rem;
   margin-left: 1rem;
 }
-.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-text-color p, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-text-color a, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-white-color {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-text-color p,
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-text-color a,
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color,
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color,
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color,
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color,
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-white-color {
   color: inherit;
 }
 @media only screen and (min-width: 768px) {
@@ -5211,7 +6979,8 @@ body.page .main-navigation {
   }
 }
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignright, .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignleft {
+  .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignright,
+  .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignleft {
     padding: 1rem calc(2 * 1rem);
   }
 }
@@ -5221,7 +6990,8 @@ body.page .main-navigation {
     padding-left: calc(10% + 58px + 2 * 1rem);
   }
 }
-.entry .entry-content .wp-block-quote:not(.is-large), .entry .entry-content .wp-block-quote:not(.is-style-large) {
+.entry .entry-content .wp-block-quote:not(.is-large),
+.entry .entry-content .wp-block-quote:not(.is-style-large) {
   border-width: 2px;
   border-color: #0073aa;
   padding-top: 0;
@@ -5239,18 +7009,21 @@ body.page .main-navigation {
    */
   font-size: calc(1rem / (1.25 * 1.125));
 }
-.entry .entry-content .wp-block-quote.is-large, .entry .entry-content .wp-block-quote.is-style-large {
+.entry .entry-content .wp-block-quote.is-large,
+.entry .entry-content .wp-block-quote.is-style-large {
   margin: 1rem 0;
   padding: 0;
   border-right: none;
 }
-.entry .entry-content .wp-block-quote.is-large p, .entry .entry-content .wp-block-quote.is-style-large p {
+.entry .entry-content .wp-block-quote.is-large p,
+.entry .entry-content .wp-block-quote.is-style-large p {
   font-size: 1.6875em;
   line-height: 1.4;
   font-style: italic;
 }
 .entry .entry-content .wp-block-quote.is-large cite,
-.entry .entry-content .wp-block-quote.is-large footer, .entry .entry-content .wp-block-quote.is-style-large cite,
+.entry .entry-content .wp-block-quote.is-large footer,
+.entry .entry-content .wp-block-quote.is-style-large cite,
 .entry .entry-content .wp-block-quote.is-style-large footer {
   /*
    * This requires a rem-based font size calculation instead of our normal em-based one,
@@ -5259,11 +7032,13 @@ body.page .main-navigation {
   font-size: calc(1rem / (1.25 * 1.125));
 }
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-quote.is-large, .entry .entry-content .wp-block-quote.is-style-large {
+  .entry .entry-content .wp-block-quote.is-large,
+  .entry .entry-content .wp-block-quote.is-style-large {
     margin: 1rem 0;
     padding: 1rem 0;
   }
-  .entry .entry-content .wp-block-quote.is-large p, .entry .entry-content .wp-block-quote.is-style-large p {
+  .entry .entry-content .wp-block-quote.is-large p,
+  .entry .entry-content .wp-block-quote.is-style-large p {
     font-size: 1.6875em;
   }
 }
@@ -5274,12 +7049,18 @@ body.page .main-navigation {
   display: block;
 }
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-image:not(.alignwide):not(.alignfull) > img, .entry .entry-content .wp-block-image:not(.alignwide):not(.alignfull) > a > img, .entry .entry-content .wp-block-image:not(.alignwide):not(.alignfull) > img + figcaption, .entry .entry-content .wp-block-image:not(.alignwide):not(.alignfull) > a + figcaption {
+  .entry .entry-content .wp-block-image:not(.alignwide):not(.alignfull) > img,
+  .entry .entry-content .wp-block-image:not(.alignwide):not(.alignfull) > a > img,
+  .entry .entry-content .wp-block-image:not(.alignwide):not(.alignfull) > img + figcaption,
+  .entry .entry-content .wp-block-image:not(.alignwide):not(.alignfull) > a + figcaption {
     max-width: calc(66.6666666667vw - 28px);
   }
 }
 @media only screen and (min-width: 1168px) {
-  .entry .entry-content .wp-block-image:not(.alignwide):not(.alignfull) > img, .entry .entry-content .wp-block-image:not(.alignwide):not(.alignfull) > a > img, .entry .entry-content .wp-block-image:not(.alignwide):not(.alignfull) > img + figcaption, .entry .entry-content .wp-block-image:not(.alignwide):not(.alignfull) > a + figcaption {
+  .entry .entry-content .wp-block-image:not(.alignwide):not(.alignfull) > img,
+  .entry .entry-content .wp-block-image:not(.alignwide):not(.alignfull) > a > img,
+  .entry .entry-content .wp-block-image:not(.alignwide):not(.alignfull) > img + figcaption,
+  .entry .entry-content .wp-block-image:not(.alignwide):not(.alignfull) > a + figcaption {
     max-width: calc(50vw - 28px);
   }
 }
@@ -5340,6 +7121,261 @@ body.page .main-navigation {
 .entry .entry-content .wp-block-cover .wp-block-cover-text,
 .entry .entry-content .wp-block-cover h2 {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+}
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(ar),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(ar),
+.entry .entry-content .wp-block-cover-image h2:lang(ar),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(ar),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(ar),
+.entry .entry-content .wp-block-cover h2:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(ary),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(ary),
+.entry .entry-content .wp-block-cover-image h2:lang(ary),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(ary),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(ary),
+.entry .entry-content .wp-block-cover h2:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(azb),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(azb),
+.entry .entry-content .wp-block-cover-image h2:lang(azb),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(azb),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(azb),
+.entry .entry-content .wp-block-cover h2:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(ckb),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(ckb),
+.entry .entry-content .wp-block-cover-image h2:lang(ckb),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(ckb),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(ckb),
+.entry .entry-content .wp-block-cover h2:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(fa-IR),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(fa-IR),
+.entry .entry-content .wp-block-cover-image h2:lang(fa-IR),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(fa-IR),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(fa-IR),
+.entry .entry-content .wp-block-cover h2:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(haz),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(haz),
+.entry .entry-content .wp-block-cover-image h2:lang(haz),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(haz),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(haz),
+.entry .entry-content .wp-block-cover h2:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(ps),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(ps),
+.entry .entry-content .wp-block-cover-image h2:lang(ps),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(ps),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(ps),
+.entry .entry-content .wp-block-cover h2:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(be),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(be),
+.entry .entry-content .wp-block-cover-image h2:lang(be),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(be),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(be),
+.entry .entry-content .wp-block-cover h2:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(bg-BG),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(bg-BG),
+.entry .entry-content .wp-block-cover-image h2:lang(bg-BG),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(bg-BG),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(bg-BG),
+.entry .entry-content .wp-block-cover h2:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(kk),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(kk),
+.entry .entry-content .wp-block-cover-image h2:lang(kk),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(kk),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(kk),
+.entry .entry-content .wp-block-cover h2:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(mk-MK),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(mk-MK),
+.entry .entry-content .wp-block-cover-image h2:lang(mk-MK),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(mk-MK),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(mk-MK),
+.entry .entry-content .wp-block-cover h2:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(mn),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(mn),
+.entry .entry-content .wp-block-cover-image h2:lang(mn),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(mn),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(mn),
+.entry .entry-content .wp-block-cover h2:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(ru-RU),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(ru-RU),
+.entry .entry-content .wp-block-cover-image h2:lang(ru-RU),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(ru-RU),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(ru-RU),
+.entry .entry-content .wp-block-cover h2:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(sah),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(sah),
+.entry .entry-content .wp-block-cover-image h2:lang(sah),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(sah),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(sah),
+.entry .entry-content .wp-block-cover h2:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(sr-RS),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(sr-RS),
+.entry .entry-content .wp-block-cover-image h2:lang(sr-RS),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(sr-RS),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(sr-RS),
+.entry .entry-content .wp-block-cover h2:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(tt-RU),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(tt-RU),
+.entry .entry-content .wp-block-cover-image h2:lang(tt-RU),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(tt-RU),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(tt-RU),
+.entry .entry-content .wp-block-cover h2:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(uk),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(uk),
+.entry .entry-content .wp-block-cover-image h2:lang(uk),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(uk),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(uk),
+.entry .entry-content .wp-block-cover h2:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(zh-HK),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(zh-HK),
+.entry .entry-content .wp-block-cover-image h2:lang(zh-HK),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(zh-HK),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(zh-HK),
+.entry .entry-content .wp-block-cover h2:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(zh-TW),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(zh-TW),
+.entry .entry-content .wp-block-cover-image h2:lang(zh-TW),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(zh-TW),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(zh-TW),
+.entry .entry-content .wp-block-cover h2:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(zh-CN),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(zh-CN),
+.entry .entry-content .wp-block-cover-image h2:lang(zh-CN),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(zh-CN),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(zh-CN),
+.entry .entry-content .wp-block-cover h2:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(bn-BD),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(bn-BD),
+.entry .entry-content .wp-block-cover-image h2:lang(bn-BD),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(bn-BD),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(bn-BD),
+.entry .entry-content .wp-block-cover h2:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(hi-IN),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(hi-IN),
+.entry .entry-content .wp-block-cover-image h2:lang(hi-IN),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(hi-IN),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(hi-IN),
+.entry .entry-content .wp-block-cover h2:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(mr),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(mr),
+.entry .entry-content .wp-block-cover-image h2:lang(mr),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(mr),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(mr),
+.entry .entry-content .wp-block-cover h2:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(ne-NP),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(ne-NP),
+.entry .entry-content .wp-block-cover-image h2:lang(ne-NP),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(ne-NP),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(ne-NP),
+.entry .entry-content .wp-block-cover h2:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(el),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(el),
+.entry .entry-content .wp-block-cover-image h2:lang(el),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(el),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(el),
+.entry .entry-content .wp-block-cover h2:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(gu),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(gu),
+.entry .entry-content .wp-block-cover-image h2:lang(gu),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(gu),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(gu),
+.entry .entry-content .wp-block-cover h2:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(he-IL),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(he-IL),
+.entry .entry-content .wp-block-cover-image h2:lang(he-IL),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(he-IL),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(he-IL),
+.entry .entry-content .wp-block-cover h2:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(ja),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(ja),
+.entry .entry-content .wp-block-cover-image h2:lang(ja),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(ja),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(ja),
+.entry .entry-content .wp-block-cover h2:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(ko-KR),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(ko-KR),
+.entry .entry-content .wp-block-cover-image h2:lang(ko-KR),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(ko-KR),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(ko-KR),
+.entry .entry-content .wp-block-cover h2:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(th),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(th),
+.entry .entry-content .wp-block-cover-image h2:lang(th),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(th),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(th),
+.entry .entry-content .wp-block-cover h2:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(vi),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(vi),
+.entry .entry-content .wp-block-cover-image h2:lang(vi),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(vi),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(vi),
+.entry .entry-content .wp-block-cover h2:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text,
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text,
+.entry .entry-content .wp-block-cover-image h2,
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text,
+.entry .entry-content .wp-block-cover .wp-block-cover-text,
+.entry .entry-content .wp-block-cover h2 {
   font-size: 1.6875em;
   font-weight: bold;
   line-height: 1.25;
@@ -5357,13 +7393,15 @@ body.page .main-navigation {
     max-width: 100%;
   }
 }
-.entry .entry-content .wp-block-cover-image.alignleft, .entry .entry-content .wp-block-cover-image.alignright,
+.entry .entry-content .wp-block-cover-image.alignleft,
+.entry .entry-content .wp-block-cover-image.alignright,
 .entry .entry-content .wp-block-cover.alignleft,
 .entry .entry-content .wp-block-cover.alignright {
   width: 100%;
 }
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-cover-image.alignleft, .entry .entry-content .wp-block-cover-image.alignright,
+  .entry .entry-content .wp-block-cover-image.alignleft,
+  .entry .entry-content .wp-block-cover-image.alignright,
   .entry .entry-content .wp-block-cover.alignleft,
   .entry .entry-content .wp-block-cover.alignright {
     padding: 1rem calc(2 * 1rem);
@@ -5422,6 +7460,229 @@ body.page .main-navigation {
 .entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption {
   font-size: 0.7111111111em;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+}
+.entry .entry-content .wp-block-audio figcaption:lang(ar),
+.entry .entry-content .wp-block-video figcaption:lang(ar),
+.entry .entry-content .wp-block-image figcaption:lang(ar),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(ar),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-audio figcaption:lang(ary),
+.entry .entry-content .wp-block-video figcaption:lang(ary),
+.entry .entry-content .wp-block-image figcaption:lang(ary),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(ary),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-audio figcaption:lang(azb),
+.entry .entry-content .wp-block-video figcaption:lang(azb),
+.entry .entry-content .wp-block-image figcaption:lang(azb),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(azb),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-audio figcaption:lang(ckb),
+.entry .entry-content .wp-block-video figcaption:lang(ckb),
+.entry .entry-content .wp-block-image figcaption:lang(ckb),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(ckb),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-audio figcaption:lang(fa-IR),
+.entry .entry-content .wp-block-video figcaption:lang(fa-IR),
+.entry .entry-content .wp-block-image figcaption:lang(fa-IR),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(fa-IR),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-audio figcaption:lang(haz),
+.entry .entry-content .wp-block-video figcaption:lang(haz),
+.entry .entry-content .wp-block-image figcaption:lang(haz),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(haz),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-audio figcaption:lang(ps),
+.entry .entry-content .wp-block-video figcaption:lang(ps),
+.entry .entry-content .wp-block-image figcaption:lang(ps),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(ps),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-audio figcaption:lang(be),
+.entry .entry-content .wp-block-video figcaption:lang(be),
+.entry .entry-content .wp-block-image figcaption:lang(be),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(be),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-audio figcaption:lang(bg-BG),
+.entry .entry-content .wp-block-video figcaption:lang(bg-BG),
+.entry .entry-content .wp-block-image figcaption:lang(bg-BG),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(bg-BG),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-audio figcaption:lang(kk),
+.entry .entry-content .wp-block-video figcaption:lang(kk),
+.entry .entry-content .wp-block-image figcaption:lang(kk),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(kk),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-audio figcaption:lang(mk-MK),
+.entry .entry-content .wp-block-video figcaption:lang(mk-MK),
+.entry .entry-content .wp-block-image figcaption:lang(mk-MK),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(mk-MK),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-audio figcaption:lang(mn),
+.entry .entry-content .wp-block-video figcaption:lang(mn),
+.entry .entry-content .wp-block-image figcaption:lang(mn),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(mn),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-audio figcaption:lang(ru-RU),
+.entry .entry-content .wp-block-video figcaption:lang(ru-RU),
+.entry .entry-content .wp-block-image figcaption:lang(ru-RU),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(ru-RU),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-audio figcaption:lang(sah),
+.entry .entry-content .wp-block-video figcaption:lang(sah),
+.entry .entry-content .wp-block-image figcaption:lang(sah),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(sah),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-audio figcaption:lang(sr-RS),
+.entry .entry-content .wp-block-video figcaption:lang(sr-RS),
+.entry .entry-content .wp-block-image figcaption:lang(sr-RS),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(sr-RS),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-audio figcaption:lang(tt-RU),
+.entry .entry-content .wp-block-video figcaption:lang(tt-RU),
+.entry .entry-content .wp-block-image figcaption:lang(tt-RU),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(tt-RU),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-audio figcaption:lang(uk),
+.entry .entry-content .wp-block-video figcaption:lang(uk),
+.entry .entry-content .wp-block-image figcaption:lang(uk),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(uk),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-audio figcaption:lang(zh-HK),
+.entry .entry-content .wp-block-video figcaption:lang(zh-HK),
+.entry .entry-content .wp-block-image figcaption:lang(zh-HK),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(zh-HK),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.entry .entry-content .wp-block-audio figcaption:lang(zh-TW),
+.entry .entry-content .wp-block-video figcaption:lang(zh-TW),
+.entry .entry-content .wp-block-image figcaption:lang(zh-TW),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(zh-TW),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.entry .entry-content .wp-block-audio figcaption:lang(zh-CN),
+.entry .entry-content .wp-block-video figcaption:lang(zh-CN),
+.entry .entry-content .wp-block-image figcaption:lang(zh-CN),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(zh-CN),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.entry .entry-content .wp-block-audio figcaption:lang(bn-BD),
+.entry .entry-content .wp-block-video figcaption:lang(bn-BD),
+.entry .entry-content .wp-block-image figcaption:lang(bn-BD),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(bn-BD),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-audio figcaption:lang(hi-IN),
+.entry .entry-content .wp-block-video figcaption:lang(hi-IN),
+.entry .entry-content .wp-block-image figcaption:lang(hi-IN),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(hi-IN),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-audio figcaption:lang(mr),
+.entry .entry-content .wp-block-video figcaption:lang(mr),
+.entry .entry-content .wp-block-image figcaption:lang(mr),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(mr),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-audio figcaption:lang(ne-NP),
+.entry .entry-content .wp-block-video figcaption:lang(ne-NP),
+.entry .entry-content .wp-block-image figcaption:lang(ne-NP),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(ne-NP),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-audio figcaption:lang(el),
+.entry .entry-content .wp-block-video figcaption:lang(el),
+.entry .entry-content .wp-block-image figcaption:lang(el),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(el),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-audio figcaption:lang(gu),
+.entry .entry-content .wp-block-video figcaption:lang(gu),
+.entry .entry-content .wp-block-image figcaption:lang(gu),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(gu),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-audio figcaption:lang(he-IL),
+.entry .entry-content .wp-block-video figcaption:lang(he-IL),
+.entry .entry-content .wp-block-image figcaption:lang(he-IL),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(he-IL),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-audio figcaption:lang(ja),
+.entry .entry-content .wp-block-video figcaption:lang(ja),
+.entry .entry-content .wp-block-image figcaption:lang(ja),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(ja),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+.entry .entry-content .wp-block-audio figcaption:lang(ko-KR),
+.entry .entry-content .wp-block-video figcaption:lang(ko-KR),
+.entry .entry-content .wp-block-image figcaption:lang(ko-KR),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(ko-KR),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+.entry .entry-content .wp-block-audio figcaption:lang(th),
+.entry .entry-content .wp-block-video figcaption:lang(th),
+.entry .entry-content .wp-block-image figcaption:lang(th),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(th),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+.entry .entry-content .wp-block-audio figcaption:lang(vi),
+.entry .entry-content .wp-block-video figcaption:lang(vi),
+.entry .entry-content .wp-block-image figcaption:lang(vi),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(vi),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
+.entry .entry-content .wp-block-audio figcaption,
+.entry .entry-content .wp-block-video figcaption,
+.entry .entry-content .wp-block-image figcaption,
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption,
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption {
   line-height: 1.6;
   margin: 0;
   padding: 0.5rem;
@@ -5507,7 +7768,8 @@ body.page .main-navigation {
   /* Remove duplicate rule-line when a separator
    * is followed by an H1, or H2 */
 }
-.entry .entry-content .wp-block-separator + h1:before, .entry .entry-content .wp-block-separator + h2:before,
+.entry .entry-content .wp-block-separator + h1:before,
+.entry .entry-content .wp-block-separator + h2:before,
 .entry .entry-content hr + h1:before,
 .entry .entry-content hr + h2:before {
   display: none;
@@ -5522,6 +7784,99 @@ body.page .main-navigation {
 .entry .entry-content .wp-block-file {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 }
+.entry .entry-content .wp-block-file:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.entry .entry-content .wp-block-file:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.entry .entry-content .wp-block-file:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.entry .entry-content .wp-block-file:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+.entry .entry-content .wp-block-file:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+.entry .entry-content .wp-block-file:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+.entry .entry-content .wp-block-file:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
 .entry .entry-content .wp-block-file .wp-block-file__button {
   display: table;
   transition: background 150ms ease-in-out;
@@ -5530,6 +7885,101 @@ body.page .main-navigation {
   background: #0073aa;
   font-size: 22px;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+}
+.entry .entry-content .wp-block-file .wp-block-file__button:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file .wp-block-file__button:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file .wp-block-file__button:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file .wp-block-file__button:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file .wp-block-file__button:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file .wp-block-file__button:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file .wp-block-file__button:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file .wp-block-file__button:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file .wp-block-file__button:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file .wp-block-file__button:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file .wp-block-file__button:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file .wp-block-file__button:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file .wp-block-file__button:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file .wp-block-file__button:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file .wp-block-file__button:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file .wp-block-file__button:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file .wp-block-file__button:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file .wp-block-file__button:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.entry .entry-content .wp-block-file .wp-block-file__button:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.entry .entry-content .wp-block-file .wp-block-file__button:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.entry .entry-content .wp-block-file .wp-block-file__button:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file .wp-block-file__button:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file .wp-block-file__button:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file .wp-block-file__button:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file .wp-block-file__button:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file .wp-block-file__button:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file .wp-block-file__button:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file .wp-block-file__button:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+.entry .entry-content .wp-block-file .wp-block-file__button:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+.entry .entry-content .wp-block-file .wp-block-file__button:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+.entry .entry-content .wp-block-file .wp-block-file__button:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
+.entry .entry-content .wp-block-file .wp-block-file__button {
   line-height: 1.2;
   text-decoration: none;
   font-weight: bold;
@@ -5600,7 +8050,8 @@ body.page .main-navigation {
   }
 }
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-group:not(.alignfull) > .wp-block-group__inner-container > .alignfull, .entry .entry-content .wp-block-group:not(.alignfull) > .wp-block-group__inner-container > .wp-block-image > img {
+  .entry .entry-content .wp-block-group:not(.alignfull) > .wp-block-group__inner-container > .alignfull,
+  .entry .entry-content .wp-block-group:not(.alignfull) > .wp-block-group__inner-container > .wp-block-image > img {
     right: 0;
     max-width: 100%;
   }
@@ -5650,6 +8101,101 @@ body.page .main-navigation {
 }
 .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+}
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta {
   font-weight: bold;
 }
 .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta .wp-block-latest-comments__comment-date {
@@ -5734,7 +8280,7 @@ body.page .main-navigation {
 }
 .entry .entry-content .has-secondary-background-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color.has-secondary-background-color {
-  background-color: rgb(0, 80.5, 119);
+  background-color: #005177;
 }
 .entry .entry-content .has-dark-gray-background-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color.has-dark-gray-background-color {
@@ -5758,7 +8304,7 @@ body.page .main-navigation {
 .entry .entry-content .wp-block-pullquote blockquote.has-secondary-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color > p {
-  color: rgb(0, 80.5, 119);
+  color: #005177;
 }
 .entry .entry-content .has-dark-gray-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color,
@@ -5837,6 +8383,101 @@ svg {
   color: #767676;
   font-size: 0.7111111111em;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+}
+.wp-caption-text:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-caption-text:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-caption-text:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-caption-text:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-caption-text:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-caption-text:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-caption-text:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-caption-text:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-caption-text:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-caption-text:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-caption-text:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-caption-text:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-caption-text:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-caption-text:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-caption-text:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-caption-text:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-caption-text:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-caption-text:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.wp-caption-text:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.wp-caption-text:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.wp-caption-text:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+.wp-caption-text:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+.wp-caption-text:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+.wp-caption-text:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+.wp-caption-text:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+.wp-caption-text:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+.wp-caption-text:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+.wp-caption-text:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+.wp-caption-text:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+.wp-caption-text:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+.wp-caption-text:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
+.wp-caption-text {
   line-height: 1.6;
   margin: 0;
   padding: 0.5rem;
@@ -5917,6 +8558,101 @@ svg {
   display: block;
   font-size: 0.7111111111em;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+}
+.gallery-caption:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.gallery-caption:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.gallery-caption:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.gallery-caption:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.gallery-caption:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.gallery-caption:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.gallery-caption:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.gallery-caption:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.gallery-caption:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.gallery-caption:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.gallery-caption:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.gallery-caption:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.gallery-caption:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.gallery-caption:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.gallery-caption:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.gallery-caption:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.gallery-caption:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.gallery-caption:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.gallery-caption:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.gallery-caption:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.gallery-caption:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+.gallery-caption:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+.gallery-caption:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+.gallery-caption:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+.gallery-caption:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+.gallery-caption:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+.gallery-caption:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+.gallery-caption:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+.gallery-caption:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+.gallery-caption:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+.gallery-caption:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
+.gallery-caption {
   line-height: 1.6;
   margin: 0;
   padding: 0.5rem;

--- a/src/wp-content/themes/twentynineteen/style.css
+++ b/src/wp-content/themes/twentynineteen/style.css
@@ -69,1815 +69,15 @@ Colorful Bokeh by HD Wallpapers, CC0. https://stocksnap.io/photo/colorful-bokeh-
  * character instead.
  */
 @font-face {
-  font-family: 'NonBreakingSpaceOverride';
+  font-family: "NonBreakingSpaceOverride";
   src: url(data:application/font-woff2;charset=utf-8;base64,d09GMgABAAAAAAMoAA0AAAAACDQAAALTAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP0ZGVE0cGh4GYACCahEICjx3CywAATYCJANUBCAFhiEHgWwbXQfILgpsY+rQRRARwyAs6uL7pxzYhxEE+32b3aeHmifR6tklkS9hiZA0ewkqGRJE+H7/+6378ASViK/PGeavqJyOzsceKi1s3BCiQsiOdn1r/RBgIJYEgCUhbm/8/8/h4saPssnTNkkiWUBrTRtjmQSajw3Ui3pZ3LYDPD+XG2C3JA/yKAS8/rU5eNfuGqRf4eNNgV4YAlIIgxglEkWe6FYpq10+wi3g+/nUgvgPFczNrz/RsTgVm/zfbPuHZlsuQECxuyqBcQwKFBjFgKO8AqP4bAN9tFJtnM9xPcbNjeXS/x1wY/xU52f5W/X1+9cnH4YwKIaoRRAkUkj/YlAAeF/624foiIDBgBmgQBeGAyhBljUPZUm/l2dTvmpqcBDUOHdbPZWd8JsBAsGr4w8/EDn82/bUPx4eh0YNrQTBuHO2FjQEAGBwK0DeI37DpQVqdERS4gZBhpeUhWCfLFz7J99aEBgsJCHvUGAdAPp4IADDCAPCEFMGpMZ9AQpTfQtQGhLbGVBZFV8BaqNyP68oTZgHNj3M8kBPfXTTC9t90UuzYhy9ciH0grVlOcqyCytisvbsERsEYztiznR0WCrmTksJwbSNK6fd1Rvr25I9oLvctUoEbNOmXJbqgYgPXEHJ82IUsrCnpkxh23F1rfZ2zcRnJYoXtauB3VTFkFXQg3uoZYD5qE0kdjDtoDoF1h2bulGmev5HbYhbrjtohQSRI4aNOkffIcT+d3v6atpaYh3JvPoQsztCcqvaBkppDSPcQ3bw3KaCBo1f5CJWTZEgW3LjLofYg51MaVezrx8xZitYbQ9KYeoRaqQdVLwSEfrKXLK1otCWOKNdR/YwYAfon5Yk8O2MJfSD10dPGA5PIJJQMkah0ugMJiv6x4Dm7LEa8xnrRGGGLAg4sAlbsA07sAt76DOsXKO3hIjtIlpnnFrt1qW4kh6NhS83P/6HB/fl1SMAAA==) format("woff2"), url(data:application/font-woff;charset=utf-8;base64,d09GRgABAAAAAAUQAA0AAAAACDQAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAABGRlRNAAAE9AAAABwAAAAchf5yU0dERUYAAATYAAAAHAAAAB4AJwAbT1MvMgAAAaAAAABJAAAAYJAcgU5jbWFwAAACIAAAAF4AAAFqUUxBZ2dhc3AAAATQAAAACAAAAAgAAAAQZ2x5ZgAAApAAAAAyAAAAPL0n8y9oZWFkAAABMAAAADAAAAA2Fi93Z2hoZWEAAAFgAAAAHQAAACQOSgWaaG10eAAAAewAAAAzAAAAVC7TAQBsb2NhAAACgAAAABAAAAAsAOQBAm1heHAAAAGAAAAAHQAAACAAWQALbmFtZQAAAsQAAAF6AAADIYvD/Adwb3N0AAAEQAAAAI4AAADsapk2o3jaY2BkYGAA4ov5mwzj+W2+MnCzXwCKMNzgCBSB0LfbQDQ7AxuI4mBgAlEAFKQIRHjaY2BkYGD3+NvCwMDBAALsDAyMDKhAFAA3+wH3AAAAeNpjYGRgYBBl4GBgYgABEMnIABJzAPMZAAVmAGUAAAB42mNgZlJhnMDAysDCKsKygYGBYRqEZtrDYMT4D8gHSmEHjgUFOQwODAqqf9g9/rYwMLB7MNUAhRlBcsxBrMlASoGBEQAj8QtyAAAAeNrjYGBkAAGmWQwMjO8gmBnIZ2NA0ExAzNjAAFYJVn0ASBsD6VAIDZb7AtELAgANIgb9AHjaY2BgYGaAYBkGRgYQSAHyGMF8FgYPIM3HwMHAxMDGoMCwQIFLQV8hXvXP//9AcRCfAcb///h/ygPW+w/vb7olBjUHCTCyMcAFGZmABBO6AogThgZgIUsXAEDcEzcAAHjaY2BgECMCyoEgACZaAed42mNgYmRgYGBnYGNgYAZSDJqMgorCgoqCjECRXwwNrCAKSP5mAAFGBiRgyAAAi/YFBQAAeNqtkc1OwkAUhU/5M25cEhcsZick0AwlBJq6MWwgJkAgYV/KAA2lJeUn+hY+gktXvpKv4dLTMqKycGHsTZNv7px7z50ZAFd4hYHjdw1Ls4EiHjVncIFnzVnc4F1zDkWjrzmPW+NNcwGlzIRKI3fJlUyrEjZQxb3mDH2fNGfRx4vmHKqG0JzHg6E0F9DOlFBGBxUI1GEzLNT4S0aLuTtsGAEUuYcQHkyg3KmIum1bNUvKlrjbbAIleqHHnS4iSudpQcySMYtdFiXlAxzSbAwfMxK6kZoHKhbjjespMTioOPZnzI+4ucCeTVyKMVKLfeAS6vSWaTinuZwzyy/Dc7vaed+6KaV0kukdPUk6yOcctZPvvxxqksq2lEW8RvHjMEO2FCl/zy6p3NEm0R9OFSafJdldc4QVeyaaObMBO0/5cCaa6d9Ggyubxire+lEojscdjoWUR1xGOy8KD8mG2ZLO2l2paDc3A39qmU2z2W5YNv5+u79e6QfGJY/hAAB42m3NywrCMBQE0DupWp/1AYI7/6DEaLQu66Mrd35BKUWKJSlFv1+rue4cGM7shgR981qSon+ZNwUJ8iDgoYU2OvDRRQ99DDDECAHGmGCKmf80hZSx/Kik/LliFbtmN6xmt+yOjdg9GztV4tROnRwX/Bsaaw51nt4Lc7tWaZYHp/MlzKx51LZs5htNri+2AAAAAQAB//8AD3jaY2BkYGDgAWIxIGZiYARCESBmAfMYAAR6AEMAAAABAAAAANXtRbgAAAAA2AhRFAAAAADYCNuG) format("woff");
 }
-
 /* If we add the border using a regular CSS border, it won't look good on non-retina devices,
  * since its edges can look jagged due to lack of antialiasing. In this case, we are several
  * layers of box-shadow to add the border visually, which will render the border smoother. */
 /* Calculates maximum width for post content */
 /* Nested sub-menu padding: 10 levels deep */
 /* Ensure all font family declarations come with non-latin fallbacks */
-/* Build our non-latin font styles */
-body:lang(ar), button:lang(ar),
-input:lang(ar),
-select:lang(ar),
-optgroup:lang(ar),
-textarea:lang(ar), .author-description .author-link:lang(ar),
-.comment-metadata:lang(ar),
-.comment-reply-link:lang(ar),
-.comments-title:lang(ar),
-.comment-author .fn:lang(ar),
-.discussion-meta-info:lang(ar),
-.entry-meta:lang(ar),
-.entry-footer:lang(ar),
-.main-navigation:lang(ar),
-.no-comments:lang(ar),
-.not-found .page-title:lang(ar),
-.error-404 .page-title:lang(ar),
-.post-navigation .post-title:lang(ar),
-.page-links:lang(ar),
-.page-description:lang(ar),
-.pagination .nav-links:lang(ar),
-.sticky-post:lang(ar),
-.site-title:lang(ar),
-.site-info:lang(ar),
-#cancel-comment-reply-link:lang(ar),
-h1:lang(ar),
-h2:lang(ar),
-h3:lang(ar),
-h4:lang(ar),
-h5:lang(ar),
-h6:lang(ar), .page-title:lang(ar), blockquote cite:lang(ar), table:lang(ar), .button:lang(ar),
-input:lang(ar)[type="button"],
-input:lang(ar)[type="reset"],
-input:lang(ar)[type="submit"], .comment-navigation .nav-previous:lang(ar),
-.comment-navigation .nav-next:lang(ar), .comment-list .pingback .comment-body:lang(ar),
-.comment-list .trackback .comment-body:lang(ar), .comment-list .pingback .comment-body .comment-edit-link:lang(ar),
-.comment-list .trackback .comment-body .comment-edit-link:lang(ar), .comment-form .comment-notes:lang(ar),
-.comment-form label:lang(ar), .widget_archive ul li:lang(ar),
-.widget_categories ul li:lang(ar),
-.widget_meta ul li:lang(ar),
-.widget_nav_menu ul li:lang(ar),
-.widget_pages ul li:lang(ar),
-.widget_recent_comments ul li:lang(ar),
-.widget_recent_entries ul li:lang(ar),
-.widget_rss ul li:lang(ar), .widget_tag_cloud .tagcloud:lang(ar), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(ar), .entry .entry-content .wp-block-button .wp-block-button__link:lang(ar), .entry .entry-content .wp-block-archives li > a:lang(ar),
-.entry .entry-content .wp-block-categories li > a:lang(ar),
-.entry .entry-content .wp-block-latest-posts li > a:lang(ar), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ar), .entry .entry-content .wp-block-verse:lang(ar), .entry .entry-content .has-drop-cap:lang(ar):not(:focus):first-letter, .entry .entry-content .wp-block-pullquote cite:lang(ar), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(ar),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(ar),
-.entry .entry-content .wp-block-cover-image h2:lang(ar),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(ar),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(ar),
-.entry .entry-content .wp-block-cover h2:lang(ar), .entry .entry-content .wp-block-audio figcaption:lang(ar),
-.entry .entry-content .wp-block-video figcaption:lang(ar),
-.entry .entry-content .wp-block-image figcaption:lang(ar),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(ar),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(ar), .entry .entry-content .wp-block-file:lang(ar), .entry .entry-content .wp-block-file .wp-block-file__button:lang(ar), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ar), .wp-caption-text:lang(ar), .gallery-caption:lang(ar) {
-  font-family: Tahoma, Arial, sans-serif;
-}
-
-body:lang(ary), button:lang(ary),
-input:lang(ary),
-select:lang(ary),
-optgroup:lang(ary),
-textarea:lang(ary), .author-description .author-link:lang(ary),
-.comment-metadata:lang(ary),
-.comment-reply-link:lang(ary),
-.comments-title:lang(ary),
-.comment-author .fn:lang(ary),
-.discussion-meta-info:lang(ary),
-.entry-meta:lang(ary),
-.entry-footer:lang(ary),
-.main-navigation:lang(ary),
-.no-comments:lang(ary),
-.not-found .page-title:lang(ary),
-.error-404 .page-title:lang(ary),
-.post-navigation .post-title:lang(ary),
-.page-links:lang(ary),
-.page-description:lang(ary),
-.pagination .nav-links:lang(ary),
-.sticky-post:lang(ary),
-.site-title:lang(ary),
-.site-info:lang(ary),
-#cancel-comment-reply-link:lang(ary),
-h1:lang(ary),
-h2:lang(ary),
-h3:lang(ary),
-h4:lang(ary),
-h5:lang(ary),
-h6:lang(ary), .page-title:lang(ary), blockquote cite:lang(ary), table:lang(ary), .button:lang(ary),
-input:lang(ary)[type="button"],
-input:lang(ary)[type="reset"],
-input:lang(ary)[type="submit"], .comment-navigation .nav-previous:lang(ary),
-.comment-navigation .nav-next:lang(ary), .comment-list .pingback .comment-body:lang(ary),
-.comment-list .trackback .comment-body:lang(ary), .comment-list .pingback .comment-body .comment-edit-link:lang(ary),
-.comment-list .trackback .comment-body .comment-edit-link:lang(ary), .comment-form .comment-notes:lang(ary),
-.comment-form label:lang(ary), .widget_archive ul li:lang(ary),
-.widget_categories ul li:lang(ary),
-.widget_meta ul li:lang(ary),
-.widget_nav_menu ul li:lang(ary),
-.widget_pages ul li:lang(ary),
-.widget_recent_comments ul li:lang(ary),
-.widget_recent_entries ul li:lang(ary),
-.widget_rss ul li:lang(ary), .widget_tag_cloud .tagcloud:lang(ary), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(ary), .entry .entry-content .wp-block-button .wp-block-button__link:lang(ary), .entry .entry-content .wp-block-archives li > a:lang(ary),
-.entry .entry-content .wp-block-categories li > a:lang(ary),
-.entry .entry-content .wp-block-latest-posts li > a:lang(ary), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ary), .entry .entry-content .wp-block-verse:lang(ary), .entry .entry-content .has-drop-cap:lang(ary):not(:focus):first-letter, .entry .entry-content .wp-block-pullquote cite:lang(ary), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(ary),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(ary),
-.entry .entry-content .wp-block-cover-image h2:lang(ary),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(ary),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(ary),
-.entry .entry-content .wp-block-cover h2:lang(ary), .entry .entry-content .wp-block-audio figcaption:lang(ary),
-.entry .entry-content .wp-block-video figcaption:lang(ary),
-.entry .entry-content .wp-block-image figcaption:lang(ary),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(ary),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(ary), .entry .entry-content .wp-block-file:lang(ary), .entry .entry-content .wp-block-file .wp-block-file__button:lang(ary), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ary), .wp-caption-text:lang(ary), .gallery-caption:lang(ary) {
-  font-family: Tahoma, Arial, sans-serif;
-}
-
-body:lang(azb), button:lang(azb),
-input:lang(azb),
-select:lang(azb),
-optgroup:lang(azb),
-textarea:lang(azb), .author-description .author-link:lang(azb),
-.comment-metadata:lang(azb),
-.comment-reply-link:lang(azb),
-.comments-title:lang(azb),
-.comment-author .fn:lang(azb),
-.discussion-meta-info:lang(azb),
-.entry-meta:lang(azb),
-.entry-footer:lang(azb),
-.main-navigation:lang(azb),
-.no-comments:lang(azb),
-.not-found .page-title:lang(azb),
-.error-404 .page-title:lang(azb),
-.post-navigation .post-title:lang(azb),
-.page-links:lang(azb),
-.page-description:lang(azb),
-.pagination .nav-links:lang(azb),
-.sticky-post:lang(azb),
-.site-title:lang(azb),
-.site-info:lang(azb),
-#cancel-comment-reply-link:lang(azb),
-h1:lang(azb),
-h2:lang(azb),
-h3:lang(azb),
-h4:lang(azb),
-h5:lang(azb),
-h6:lang(azb), .page-title:lang(azb), blockquote cite:lang(azb), table:lang(azb), .button:lang(azb),
-input:lang(azb)[type="button"],
-input:lang(azb)[type="reset"],
-input:lang(azb)[type="submit"], .comment-navigation .nav-previous:lang(azb),
-.comment-navigation .nav-next:lang(azb), .comment-list .pingback .comment-body:lang(azb),
-.comment-list .trackback .comment-body:lang(azb), .comment-list .pingback .comment-body .comment-edit-link:lang(azb),
-.comment-list .trackback .comment-body .comment-edit-link:lang(azb), .comment-form .comment-notes:lang(azb),
-.comment-form label:lang(azb), .widget_archive ul li:lang(azb),
-.widget_categories ul li:lang(azb),
-.widget_meta ul li:lang(azb),
-.widget_nav_menu ul li:lang(azb),
-.widget_pages ul li:lang(azb),
-.widget_recent_comments ul li:lang(azb),
-.widget_recent_entries ul li:lang(azb),
-.widget_rss ul li:lang(azb), .widget_tag_cloud .tagcloud:lang(azb), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(azb), .entry .entry-content .wp-block-button .wp-block-button__link:lang(azb), .entry .entry-content .wp-block-archives li > a:lang(azb),
-.entry .entry-content .wp-block-categories li > a:lang(azb),
-.entry .entry-content .wp-block-latest-posts li > a:lang(azb), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(azb), .entry .entry-content .wp-block-verse:lang(azb), .entry .entry-content .has-drop-cap:lang(azb):not(:focus):first-letter, .entry .entry-content .wp-block-pullquote cite:lang(azb), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(azb),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(azb),
-.entry .entry-content .wp-block-cover-image h2:lang(azb),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(azb),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(azb),
-.entry .entry-content .wp-block-cover h2:lang(azb), .entry .entry-content .wp-block-audio figcaption:lang(azb),
-.entry .entry-content .wp-block-video figcaption:lang(azb),
-.entry .entry-content .wp-block-image figcaption:lang(azb),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(azb),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(azb), .entry .entry-content .wp-block-file:lang(azb), .entry .entry-content .wp-block-file .wp-block-file__button:lang(azb), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(azb), .wp-caption-text:lang(azb), .gallery-caption:lang(azb) {
-  font-family: Tahoma, Arial, sans-serif;
-}
-
-body:lang(ckb), button:lang(ckb),
-input:lang(ckb),
-select:lang(ckb),
-optgroup:lang(ckb),
-textarea:lang(ckb), .author-description .author-link:lang(ckb),
-.comment-metadata:lang(ckb),
-.comment-reply-link:lang(ckb),
-.comments-title:lang(ckb),
-.comment-author .fn:lang(ckb),
-.discussion-meta-info:lang(ckb),
-.entry-meta:lang(ckb),
-.entry-footer:lang(ckb),
-.main-navigation:lang(ckb),
-.no-comments:lang(ckb),
-.not-found .page-title:lang(ckb),
-.error-404 .page-title:lang(ckb),
-.post-navigation .post-title:lang(ckb),
-.page-links:lang(ckb),
-.page-description:lang(ckb),
-.pagination .nav-links:lang(ckb),
-.sticky-post:lang(ckb),
-.site-title:lang(ckb),
-.site-info:lang(ckb),
-#cancel-comment-reply-link:lang(ckb),
-h1:lang(ckb),
-h2:lang(ckb),
-h3:lang(ckb),
-h4:lang(ckb),
-h5:lang(ckb),
-h6:lang(ckb), .page-title:lang(ckb), blockquote cite:lang(ckb), table:lang(ckb), .button:lang(ckb),
-input:lang(ckb)[type="button"],
-input:lang(ckb)[type="reset"],
-input:lang(ckb)[type="submit"], .comment-navigation .nav-previous:lang(ckb),
-.comment-navigation .nav-next:lang(ckb), .comment-list .pingback .comment-body:lang(ckb),
-.comment-list .trackback .comment-body:lang(ckb), .comment-list .pingback .comment-body .comment-edit-link:lang(ckb),
-.comment-list .trackback .comment-body .comment-edit-link:lang(ckb), .comment-form .comment-notes:lang(ckb),
-.comment-form label:lang(ckb), .widget_archive ul li:lang(ckb),
-.widget_categories ul li:lang(ckb),
-.widget_meta ul li:lang(ckb),
-.widget_nav_menu ul li:lang(ckb),
-.widget_pages ul li:lang(ckb),
-.widget_recent_comments ul li:lang(ckb),
-.widget_recent_entries ul li:lang(ckb),
-.widget_rss ul li:lang(ckb), .widget_tag_cloud .tagcloud:lang(ckb), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(ckb), .entry .entry-content .wp-block-button .wp-block-button__link:lang(ckb), .entry .entry-content .wp-block-archives li > a:lang(ckb),
-.entry .entry-content .wp-block-categories li > a:lang(ckb),
-.entry .entry-content .wp-block-latest-posts li > a:lang(ckb), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ckb), .entry .entry-content .wp-block-verse:lang(ckb), .entry .entry-content .has-drop-cap:lang(ckb):not(:focus):first-letter, .entry .entry-content .wp-block-pullquote cite:lang(ckb), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(ckb),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(ckb),
-.entry .entry-content .wp-block-cover-image h2:lang(ckb),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(ckb),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(ckb),
-.entry .entry-content .wp-block-cover h2:lang(ckb), .entry .entry-content .wp-block-audio figcaption:lang(ckb),
-.entry .entry-content .wp-block-video figcaption:lang(ckb),
-.entry .entry-content .wp-block-image figcaption:lang(ckb),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(ckb),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(ckb), .entry .entry-content .wp-block-file:lang(ckb), .entry .entry-content .wp-block-file .wp-block-file__button:lang(ckb), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ckb), .wp-caption-text:lang(ckb), .gallery-caption:lang(ckb) {
-  font-family: Tahoma, Arial, sans-serif;
-}
-
-body:lang(fa-IR), button:lang(fa-IR),
-input:lang(fa-IR),
-select:lang(fa-IR),
-optgroup:lang(fa-IR),
-textarea:lang(fa-IR), .author-description .author-link:lang(fa-IR),
-.comment-metadata:lang(fa-IR),
-.comment-reply-link:lang(fa-IR),
-.comments-title:lang(fa-IR),
-.comment-author .fn:lang(fa-IR),
-.discussion-meta-info:lang(fa-IR),
-.entry-meta:lang(fa-IR),
-.entry-footer:lang(fa-IR),
-.main-navigation:lang(fa-IR),
-.no-comments:lang(fa-IR),
-.not-found .page-title:lang(fa-IR),
-.error-404 .page-title:lang(fa-IR),
-.post-navigation .post-title:lang(fa-IR),
-.page-links:lang(fa-IR),
-.page-description:lang(fa-IR),
-.pagination .nav-links:lang(fa-IR),
-.sticky-post:lang(fa-IR),
-.site-title:lang(fa-IR),
-.site-info:lang(fa-IR),
-#cancel-comment-reply-link:lang(fa-IR),
-h1:lang(fa-IR),
-h2:lang(fa-IR),
-h3:lang(fa-IR),
-h4:lang(fa-IR),
-h5:lang(fa-IR),
-h6:lang(fa-IR), .page-title:lang(fa-IR), blockquote cite:lang(fa-IR), table:lang(fa-IR), .button:lang(fa-IR),
-input:lang(fa-IR)[type="button"],
-input:lang(fa-IR)[type="reset"],
-input:lang(fa-IR)[type="submit"], .comment-navigation .nav-previous:lang(fa-IR),
-.comment-navigation .nav-next:lang(fa-IR), .comment-list .pingback .comment-body:lang(fa-IR),
-.comment-list .trackback .comment-body:lang(fa-IR), .comment-list .pingback .comment-body .comment-edit-link:lang(fa-IR),
-.comment-list .trackback .comment-body .comment-edit-link:lang(fa-IR), .comment-form .comment-notes:lang(fa-IR),
-.comment-form label:lang(fa-IR), .widget_archive ul li:lang(fa-IR),
-.widget_categories ul li:lang(fa-IR),
-.widget_meta ul li:lang(fa-IR),
-.widget_nav_menu ul li:lang(fa-IR),
-.widget_pages ul li:lang(fa-IR),
-.widget_recent_comments ul li:lang(fa-IR),
-.widget_recent_entries ul li:lang(fa-IR),
-.widget_rss ul li:lang(fa-IR), .widget_tag_cloud .tagcloud:lang(fa-IR), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(fa-IR), .entry .entry-content .wp-block-button .wp-block-button__link:lang(fa-IR), .entry .entry-content .wp-block-archives li > a:lang(fa-IR),
-.entry .entry-content .wp-block-categories li > a:lang(fa-IR),
-.entry .entry-content .wp-block-latest-posts li > a:lang(fa-IR), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(fa-IR), .entry .entry-content .wp-block-verse:lang(fa-IR), .entry .entry-content .has-drop-cap:lang(fa-IR):not(:focus):first-letter, .entry .entry-content .wp-block-pullquote cite:lang(fa-IR), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(fa-IR),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(fa-IR),
-.entry .entry-content .wp-block-cover-image h2:lang(fa-IR),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(fa-IR),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(fa-IR),
-.entry .entry-content .wp-block-cover h2:lang(fa-IR), .entry .entry-content .wp-block-audio figcaption:lang(fa-IR),
-.entry .entry-content .wp-block-video figcaption:lang(fa-IR),
-.entry .entry-content .wp-block-image figcaption:lang(fa-IR),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(fa-IR),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(fa-IR), .entry .entry-content .wp-block-file:lang(fa-IR), .entry .entry-content .wp-block-file .wp-block-file__button:lang(fa-IR), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(fa-IR), .wp-caption-text:lang(fa-IR), .gallery-caption:lang(fa-IR) {
-  font-family: Tahoma, Arial, sans-serif;
-}
-
-body:lang(haz), button:lang(haz),
-input:lang(haz),
-select:lang(haz),
-optgroup:lang(haz),
-textarea:lang(haz), .author-description .author-link:lang(haz),
-.comment-metadata:lang(haz),
-.comment-reply-link:lang(haz),
-.comments-title:lang(haz),
-.comment-author .fn:lang(haz),
-.discussion-meta-info:lang(haz),
-.entry-meta:lang(haz),
-.entry-footer:lang(haz),
-.main-navigation:lang(haz),
-.no-comments:lang(haz),
-.not-found .page-title:lang(haz),
-.error-404 .page-title:lang(haz),
-.post-navigation .post-title:lang(haz),
-.page-links:lang(haz),
-.page-description:lang(haz),
-.pagination .nav-links:lang(haz),
-.sticky-post:lang(haz),
-.site-title:lang(haz),
-.site-info:lang(haz),
-#cancel-comment-reply-link:lang(haz),
-h1:lang(haz),
-h2:lang(haz),
-h3:lang(haz),
-h4:lang(haz),
-h5:lang(haz),
-h6:lang(haz), .page-title:lang(haz), blockquote cite:lang(haz), table:lang(haz), .button:lang(haz),
-input:lang(haz)[type="button"],
-input:lang(haz)[type="reset"],
-input:lang(haz)[type="submit"], .comment-navigation .nav-previous:lang(haz),
-.comment-navigation .nav-next:lang(haz), .comment-list .pingback .comment-body:lang(haz),
-.comment-list .trackback .comment-body:lang(haz), .comment-list .pingback .comment-body .comment-edit-link:lang(haz),
-.comment-list .trackback .comment-body .comment-edit-link:lang(haz), .comment-form .comment-notes:lang(haz),
-.comment-form label:lang(haz), .widget_archive ul li:lang(haz),
-.widget_categories ul li:lang(haz),
-.widget_meta ul li:lang(haz),
-.widget_nav_menu ul li:lang(haz),
-.widget_pages ul li:lang(haz),
-.widget_recent_comments ul li:lang(haz),
-.widget_recent_entries ul li:lang(haz),
-.widget_rss ul li:lang(haz), .widget_tag_cloud .tagcloud:lang(haz), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(haz), .entry .entry-content .wp-block-button .wp-block-button__link:lang(haz), .entry .entry-content .wp-block-archives li > a:lang(haz),
-.entry .entry-content .wp-block-categories li > a:lang(haz),
-.entry .entry-content .wp-block-latest-posts li > a:lang(haz), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(haz), .entry .entry-content .wp-block-verse:lang(haz), .entry .entry-content .has-drop-cap:lang(haz):not(:focus):first-letter, .entry .entry-content .wp-block-pullquote cite:lang(haz), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(haz),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(haz),
-.entry .entry-content .wp-block-cover-image h2:lang(haz),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(haz),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(haz),
-.entry .entry-content .wp-block-cover h2:lang(haz), .entry .entry-content .wp-block-audio figcaption:lang(haz),
-.entry .entry-content .wp-block-video figcaption:lang(haz),
-.entry .entry-content .wp-block-image figcaption:lang(haz),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(haz),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(haz), .entry .entry-content .wp-block-file:lang(haz), .entry .entry-content .wp-block-file .wp-block-file__button:lang(haz), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(haz), .wp-caption-text:lang(haz), .gallery-caption:lang(haz) {
-  font-family: Tahoma, Arial, sans-serif;
-}
-
-body:lang(ps), button:lang(ps),
-input:lang(ps),
-select:lang(ps),
-optgroup:lang(ps),
-textarea:lang(ps), .author-description .author-link:lang(ps),
-.comment-metadata:lang(ps),
-.comment-reply-link:lang(ps),
-.comments-title:lang(ps),
-.comment-author .fn:lang(ps),
-.discussion-meta-info:lang(ps),
-.entry-meta:lang(ps),
-.entry-footer:lang(ps),
-.main-navigation:lang(ps),
-.no-comments:lang(ps),
-.not-found .page-title:lang(ps),
-.error-404 .page-title:lang(ps),
-.post-navigation .post-title:lang(ps),
-.page-links:lang(ps),
-.page-description:lang(ps),
-.pagination .nav-links:lang(ps),
-.sticky-post:lang(ps),
-.site-title:lang(ps),
-.site-info:lang(ps),
-#cancel-comment-reply-link:lang(ps),
-h1:lang(ps),
-h2:lang(ps),
-h3:lang(ps),
-h4:lang(ps),
-h5:lang(ps),
-h6:lang(ps), .page-title:lang(ps), blockquote cite:lang(ps), table:lang(ps), .button:lang(ps),
-input:lang(ps)[type="button"],
-input:lang(ps)[type="reset"],
-input:lang(ps)[type="submit"], .comment-navigation .nav-previous:lang(ps),
-.comment-navigation .nav-next:lang(ps), .comment-list .pingback .comment-body:lang(ps),
-.comment-list .trackback .comment-body:lang(ps), .comment-list .pingback .comment-body .comment-edit-link:lang(ps),
-.comment-list .trackback .comment-body .comment-edit-link:lang(ps), .comment-form .comment-notes:lang(ps),
-.comment-form label:lang(ps), .widget_archive ul li:lang(ps),
-.widget_categories ul li:lang(ps),
-.widget_meta ul li:lang(ps),
-.widget_nav_menu ul li:lang(ps),
-.widget_pages ul li:lang(ps),
-.widget_recent_comments ul li:lang(ps),
-.widget_recent_entries ul li:lang(ps),
-.widget_rss ul li:lang(ps), .widget_tag_cloud .tagcloud:lang(ps), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(ps), .entry .entry-content .wp-block-button .wp-block-button__link:lang(ps), .entry .entry-content .wp-block-archives li > a:lang(ps),
-.entry .entry-content .wp-block-categories li > a:lang(ps),
-.entry .entry-content .wp-block-latest-posts li > a:lang(ps), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ps), .entry .entry-content .wp-block-verse:lang(ps), .entry .entry-content .has-drop-cap:lang(ps):not(:focus):first-letter, .entry .entry-content .wp-block-pullquote cite:lang(ps), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(ps),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(ps),
-.entry .entry-content .wp-block-cover-image h2:lang(ps),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(ps),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(ps),
-.entry .entry-content .wp-block-cover h2:lang(ps), .entry .entry-content .wp-block-audio figcaption:lang(ps),
-.entry .entry-content .wp-block-video figcaption:lang(ps),
-.entry .entry-content .wp-block-image figcaption:lang(ps),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(ps),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(ps), .entry .entry-content .wp-block-file:lang(ps), .entry .entry-content .wp-block-file .wp-block-file__button:lang(ps), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ps), .wp-caption-text:lang(ps), .gallery-caption:lang(ps) {
-  font-family: Tahoma, Arial, sans-serif;
-}
-
-body:lang(be), button:lang(be),
-input:lang(be),
-select:lang(be),
-optgroup:lang(be),
-textarea:lang(be), .author-description .author-link:lang(be),
-.comment-metadata:lang(be),
-.comment-reply-link:lang(be),
-.comments-title:lang(be),
-.comment-author .fn:lang(be),
-.discussion-meta-info:lang(be),
-.entry-meta:lang(be),
-.entry-footer:lang(be),
-.main-navigation:lang(be),
-.no-comments:lang(be),
-.not-found .page-title:lang(be),
-.error-404 .page-title:lang(be),
-.post-navigation .post-title:lang(be),
-.page-links:lang(be),
-.page-description:lang(be),
-.pagination .nav-links:lang(be),
-.sticky-post:lang(be),
-.site-title:lang(be),
-.site-info:lang(be),
-#cancel-comment-reply-link:lang(be),
-h1:lang(be),
-h2:lang(be),
-h3:lang(be),
-h4:lang(be),
-h5:lang(be),
-h6:lang(be), .page-title:lang(be), blockquote cite:lang(be), table:lang(be), .button:lang(be),
-input:lang(be)[type="button"],
-input:lang(be)[type="reset"],
-input:lang(be)[type="submit"], .comment-navigation .nav-previous:lang(be),
-.comment-navigation .nav-next:lang(be), .comment-list .pingback .comment-body:lang(be),
-.comment-list .trackback .comment-body:lang(be), .comment-list .pingback .comment-body .comment-edit-link:lang(be),
-.comment-list .trackback .comment-body .comment-edit-link:lang(be), .comment-form .comment-notes:lang(be),
-.comment-form label:lang(be), .widget_archive ul li:lang(be),
-.widget_categories ul li:lang(be),
-.widget_meta ul li:lang(be),
-.widget_nav_menu ul li:lang(be),
-.widget_pages ul li:lang(be),
-.widget_recent_comments ul li:lang(be),
-.widget_recent_entries ul li:lang(be),
-.widget_rss ul li:lang(be), .widget_tag_cloud .tagcloud:lang(be), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(be), .entry .entry-content .wp-block-button .wp-block-button__link:lang(be), .entry .entry-content .wp-block-archives li > a:lang(be),
-.entry .entry-content .wp-block-categories li > a:lang(be),
-.entry .entry-content .wp-block-latest-posts li > a:lang(be), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(be), .entry .entry-content .wp-block-verse:lang(be), .entry .entry-content .has-drop-cap:lang(be):not(:focus):first-letter, .entry .entry-content .wp-block-pullquote cite:lang(be), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(be),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(be),
-.entry .entry-content .wp-block-cover-image h2:lang(be),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(be),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(be),
-.entry .entry-content .wp-block-cover h2:lang(be), .entry .entry-content .wp-block-audio figcaption:lang(be),
-.entry .entry-content .wp-block-video figcaption:lang(be),
-.entry .entry-content .wp-block-image figcaption:lang(be),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(be),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(be), .entry .entry-content .wp-block-file:lang(be), .entry .entry-content .wp-block-file .wp-block-file__button:lang(be), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(be), .wp-caption-text:lang(be), .gallery-caption:lang(be) {
-  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
-}
-
-body:lang(bg-BG), button:lang(bg-BG),
-input:lang(bg-BG),
-select:lang(bg-BG),
-optgroup:lang(bg-BG),
-textarea:lang(bg-BG), .author-description .author-link:lang(bg-BG),
-.comment-metadata:lang(bg-BG),
-.comment-reply-link:lang(bg-BG),
-.comments-title:lang(bg-BG),
-.comment-author .fn:lang(bg-BG),
-.discussion-meta-info:lang(bg-BG),
-.entry-meta:lang(bg-BG),
-.entry-footer:lang(bg-BG),
-.main-navigation:lang(bg-BG),
-.no-comments:lang(bg-BG),
-.not-found .page-title:lang(bg-BG),
-.error-404 .page-title:lang(bg-BG),
-.post-navigation .post-title:lang(bg-BG),
-.page-links:lang(bg-BG),
-.page-description:lang(bg-BG),
-.pagination .nav-links:lang(bg-BG),
-.sticky-post:lang(bg-BG),
-.site-title:lang(bg-BG),
-.site-info:lang(bg-BG),
-#cancel-comment-reply-link:lang(bg-BG),
-h1:lang(bg-BG),
-h2:lang(bg-BG),
-h3:lang(bg-BG),
-h4:lang(bg-BG),
-h5:lang(bg-BG),
-h6:lang(bg-BG), .page-title:lang(bg-BG), blockquote cite:lang(bg-BG), table:lang(bg-BG), .button:lang(bg-BG),
-input:lang(bg-BG)[type="button"],
-input:lang(bg-BG)[type="reset"],
-input:lang(bg-BG)[type="submit"], .comment-navigation .nav-previous:lang(bg-BG),
-.comment-navigation .nav-next:lang(bg-BG), .comment-list .pingback .comment-body:lang(bg-BG),
-.comment-list .trackback .comment-body:lang(bg-BG), .comment-list .pingback .comment-body .comment-edit-link:lang(bg-BG),
-.comment-list .trackback .comment-body .comment-edit-link:lang(bg-BG), .comment-form .comment-notes:lang(bg-BG),
-.comment-form label:lang(bg-BG), .widget_archive ul li:lang(bg-BG),
-.widget_categories ul li:lang(bg-BG),
-.widget_meta ul li:lang(bg-BG),
-.widget_nav_menu ul li:lang(bg-BG),
-.widget_pages ul li:lang(bg-BG),
-.widget_recent_comments ul li:lang(bg-BG),
-.widget_recent_entries ul li:lang(bg-BG),
-.widget_rss ul li:lang(bg-BG), .widget_tag_cloud .tagcloud:lang(bg-BG), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(bg-BG), .entry .entry-content .wp-block-button .wp-block-button__link:lang(bg-BG), .entry .entry-content .wp-block-archives li > a:lang(bg-BG),
-.entry .entry-content .wp-block-categories li > a:lang(bg-BG),
-.entry .entry-content .wp-block-latest-posts li > a:lang(bg-BG), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(bg-BG), .entry .entry-content .wp-block-verse:lang(bg-BG), .entry .entry-content .has-drop-cap:lang(bg-BG):not(:focus):first-letter, .entry .entry-content .wp-block-pullquote cite:lang(bg-BG), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(bg-BG),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(bg-BG),
-.entry .entry-content .wp-block-cover-image h2:lang(bg-BG),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(bg-BG),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(bg-BG),
-.entry .entry-content .wp-block-cover h2:lang(bg-BG), .entry .entry-content .wp-block-audio figcaption:lang(bg-BG),
-.entry .entry-content .wp-block-video figcaption:lang(bg-BG),
-.entry .entry-content .wp-block-image figcaption:lang(bg-BG),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(bg-BG),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(bg-BG), .entry .entry-content .wp-block-file:lang(bg-BG), .entry .entry-content .wp-block-file .wp-block-file__button:lang(bg-BG), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(bg-BG), .wp-caption-text:lang(bg-BG), .gallery-caption:lang(bg-BG) {
-  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
-}
-
-body:lang(kk), button:lang(kk),
-input:lang(kk),
-select:lang(kk),
-optgroup:lang(kk),
-textarea:lang(kk), .author-description .author-link:lang(kk),
-.comment-metadata:lang(kk),
-.comment-reply-link:lang(kk),
-.comments-title:lang(kk),
-.comment-author .fn:lang(kk),
-.discussion-meta-info:lang(kk),
-.entry-meta:lang(kk),
-.entry-footer:lang(kk),
-.main-navigation:lang(kk),
-.no-comments:lang(kk),
-.not-found .page-title:lang(kk),
-.error-404 .page-title:lang(kk),
-.post-navigation .post-title:lang(kk),
-.page-links:lang(kk),
-.page-description:lang(kk),
-.pagination .nav-links:lang(kk),
-.sticky-post:lang(kk),
-.site-title:lang(kk),
-.site-info:lang(kk),
-#cancel-comment-reply-link:lang(kk),
-h1:lang(kk),
-h2:lang(kk),
-h3:lang(kk),
-h4:lang(kk),
-h5:lang(kk),
-h6:lang(kk), .page-title:lang(kk), blockquote cite:lang(kk), table:lang(kk), .button:lang(kk),
-input:lang(kk)[type="button"],
-input:lang(kk)[type="reset"],
-input:lang(kk)[type="submit"], .comment-navigation .nav-previous:lang(kk),
-.comment-navigation .nav-next:lang(kk), .comment-list .pingback .comment-body:lang(kk),
-.comment-list .trackback .comment-body:lang(kk), .comment-list .pingback .comment-body .comment-edit-link:lang(kk),
-.comment-list .trackback .comment-body .comment-edit-link:lang(kk), .comment-form .comment-notes:lang(kk),
-.comment-form label:lang(kk), .widget_archive ul li:lang(kk),
-.widget_categories ul li:lang(kk),
-.widget_meta ul li:lang(kk),
-.widget_nav_menu ul li:lang(kk),
-.widget_pages ul li:lang(kk),
-.widget_recent_comments ul li:lang(kk),
-.widget_recent_entries ul li:lang(kk),
-.widget_rss ul li:lang(kk), .widget_tag_cloud .tagcloud:lang(kk), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(kk), .entry .entry-content .wp-block-button .wp-block-button__link:lang(kk), .entry .entry-content .wp-block-archives li > a:lang(kk),
-.entry .entry-content .wp-block-categories li > a:lang(kk),
-.entry .entry-content .wp-block-latest-posts li > a:lang(kk), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(kk), .entry .entry-content .wp-block-verse:lang(kk), .entry .entry-content .has-drop-cap:lang(kk):not(:focus):first-letter, .entry .entry-content .wp-block-pullquote cite:lang(kk), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(kk),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(kk),
-.entry .entry-content .wp-block-cover-image h2:lang(kk),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(kk),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(kk),
-.entry .entry-content .wp-block-cover h2:lang(kk), .entry .entry-content .wp-block-audio figcaption:lang(kk),
-.entry .entry-content .wp-block-video figcaption:lang(kk),
-.entry .entry-content .wp-block-image figcaption:lang(kk),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(kk),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(kk), .entry .entry-content .wp-block-file:lang(kk), .entry .entry-content .wp-block-file .wp-block-file__button:lang(kk), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(kk), .wp-caption-text:lang(kk), .gallery-caption:lang(kk) {
-  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
-}
-
-body:lang(mk-MK), button:lang(mk-MK),
-input:lang(mk-MK),
-select:lang(mk-MK),
-optgroup:lang(mk-MK),
-textarea:lang(mk-MK), .author-description .author-link:lang(mk-MK),
-.comment-metadata:lang(mk-MK),
-.comment-reply-link:lang(mk-MK),
-.comments-title:lang(mk-MK),
-.comment-author .fn:lang(mk-MK),
-.discussion-meta-info:lang(mk-MK),
-.entry-meta:lang(mk-MK),
-.entry-footer:lang(mk-MK),
-.main-navigation:lang(mk-MK),
-.no-comments:lang(mk-MK),
-.not-found .page-title:lang(mk-MK),
-.error-404 .page-title:lang(mk-MK),
-.post-navigation .post-title:lang(mk-MK),
-.page-links:lang(mk-MK),
-.page-description:lang(mk-MK),
-.pagination .nav-links:lang(mk-MK),
-.sticky-post:lang(mk-MK),
-.site-title:lang(mk-MK),
-.site-info:lang(mk-MK),
-#cancel-comment-reply-link:lang(mk-MK),
-h1:lang(mk-MK),
-h2:lang(mk-MK),
-h3:lang(mk-MK),
-h4:lang(mk-MK),
-h5:lang(mk-MK),
-h6:lang(mk-MK), .page-title:lang(mk-MK), blockquote cite:lang(mk-MK), table:lang(mk-MK), .button:lang(mk-MK),
-input:lang(mk-MK)[type="button"],
-input:lang(mk-MK)[type="reset"],
-input:lang(mk-MK)[type="submit"], .comment-navigation .nav-previous:lang(mk-MK),
-.comment-navigation .nav-next:lang(mk-MK), .comment-list .pingback .comment-body:lang(mk-MK),
-.comment-list .trackback .comment-body:lang(mk-MK), .comment-list .pingback .comment-body .comment-edit-link:lang(mk-MK),
-.comment-list .trackback .comment-body .comment-edit-link:lang(mk-MK), .comment-form .comment-notes:lang(mk-MK),
-.comment-form label:lang(mk-MK), .widget_archive ul li:lang(mk-MK),
-.widget_categories ul li:lang(mk-MK),
-.widget_meta ul li:lang(mk-MK),
-.widget_nav_menu ul li:lang(mk-MK),
-.widget_pages ul li:lang(mk-MK),
-.widget_recent_comments ul li:lang(mk-MK),
-.widget_recent_entries ul li:lang(mk-MK),
-.widget_rss ul li:lang(mk-MK), .widget_tag_cloud .tagcloud:lang(mk-MK), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(mk-MK), .entry .entry-content .wp-block-button .wp-block-button__link:lang(mk-MK), .entry .entry-content .wp-block-archives li > a:lang(mk-MK),
-.entry .entry-content .wp-block-categories li > a:lang(mk-MK),
-.entry .entry-content .wp-block-latest-posts li > a:lang(mk-MK), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(mk-MK), .entry .entry-content .wp-block-verse:lang(mk-MK), .entry .entry-content .has-drop-cap:lang(mk-MK):not(:focus):first-letter, .entry .entry-content .wp-block-pullquote cite:lang(mk-MK), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(mk-MK),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(mk-MK),
-.entry .entry-content .wp-block-cover-image h2:lang(mk-MK),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(mk-MK),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(mk-MK),
-.entry .entry-content .wp-block-cover h2:lang(mk-MK), .entry .entry-content .wp-block-audio figcaption:lang(mk-MK),
-.entry .entry-content .wp-block-video figcaption:lang(mk-MK),
-.entry .entry-content .wp-block-image figcaption:lang(mk-MK),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(mk-MK),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(mk-MK), .entry .entry-content .wp-block-file:lang(mk-MK), .entry .entry-content .wp-block-file .wp-block-file__button:lang(mk-MK), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(mk-MK), .wp-caption-text:lang(mk-MK), .gallery-caption:lang(mk-MK) {
-  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
-}
-
-body:lang(mn), button:lang(mn),
-input:lang(mn),
-select:lang(mn),
-optgroup:lang(mn),
-textarea:lang(mn), .author-description .author-link:lang(mn),
-.comment-metadata:lang(mn),
-.comment-reply-link:lang(mn),
-.comments-title:lang(mn),
-.comment-author .fn:lang(mn),
-.discussion-meta-info:lang(mn),
-.entry-meta:lang(mn),
-.entry-footer:lang(mn),
-.main-navigation:lang(mn),
-.no-comments:lang(mn),
-.not-found .page-title:lang(mn),
-.error-404 .page-title:lang(mn),
-.post-navigation .post-title:lang(mn),
-.page-links:lang(mn),
-.page-description:lang(mn),
-.pagination .nav-links:lang(mn),
-.sticky-post:lang(mn),
-.site-title:lang(mn),
-.site-info:lang(mn),
-#cancel-comment-reply-link:lang(mn),
-h1:lang(mn),
-h2:lang(mn),
-h3:lang(mn),
-h4:lang(mn),
-h5:lang(mn),
-h6:lang(mn), .page-title:lang(mn), blockquote cite:lang(mn), table:lang(mn), .button:lang(mn),
-input:lang(mn)[type="button"],
-input:lang(mn)[type="reset"],
-input:lang(mn)[type="submit"], .comment-navigation .nav-previous:lang(mn),
-.comment-navigation .nav-next:lang(mn), .comment-list .pingback .comment-body:lang(mn),
-.comment-list .trackback .comment-body:lang(mn), .comment-list .pingback .comment-body .comment-edit-link:lang(mn),
-.comment-list .trackback .comment-body .comment-edit-link:lang(mn), .comment-form .comment-notes:lang(mn),
-.comment-form label:lang(mn), .widget_archive ul li:lang(mn),
-.widget_categories ul li:lang(mn),
-.widget_meta ul li:lang(mn),
-.widget_nav_menu ul li:lang(mn),
-.widget_pages ul li:lang(mn),
-.widget_recent_comments ul li:lang(mn),
-.widget_recent_entries ul li:lang(mn),
-.widget_rss ul li:lang(mn), .widget_tag_cloud .tagcloud:lang(mn), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(mn), .entry .entry-content .wp-block-button .wp-block-button__link:lang(mn), .entry .entry-content .wp-block-archives li > a:lang(mn),
-.entry .entry-content .wp-block-categories li > a:lang(mn),
-.entry .entry-content .wp-block-latest-posts li > a:lang(mn), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(mn), .entry .entry-content .wp-block-verse:lang(mn), .entry .entry-content .has-drop-cap:lang(mn):not(:focus):first-letter, .entry .entry-content .wp-block-pullquote cite:lang(mn), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(mn),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(mn),
-.entry .entry-content .wp-block-cover-image h2:lang(mn),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(mn),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(mn),
-.entry .entry-content .wp-block-cover h2:lang(mn), .entry .entry-content .wp-block-audio figcaption:lang(mn),
-.entry .entry-content .wp-block-video figcaption:lang(mn),
-.entry .entry-content .wp-block-image figcaption:lang(mn),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(mn),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(mn), .entry .entry-content .wp-block-file:lang(mn), .entry .entry-content .wp-block-file .wp-block-file__button:lang(mn), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(mn), .wp-caption-text:lang(mn), .gallery-caption:lang(mn) {
-  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
-}
-
-body:lang(ru-RU), button:lang(ru-RU),
-input:lang(ru-RU),
-select:lang(ru-RU),
-optgroup:lang(ru-RU),
-textarea:lang(ru-RU), .author-description .author-link:lang(ru-RU),
-.comment-metadata:lang(ru-RU),
-.comment-reply-link:lang(ru-RU),
-.comments-title:lang(ru-RU),
-.comment-author .fn:lang(ru-RU),
-.discussion-meta-info:lang(ru-RU),
-.entry-meta:lang(ru-RU),
-.entry-footer:lang(ru-RU),
-.main-navigation:lang(ru-RU),
-.no-comments:lang(ru-RU),
-.not-found .page-title:lang(ru-RU),
-.error-404 .page-title:lang(ru-RU),
-.post-navigation .post-title:lang(ru-RU),
-.page-links:lang(ru-RU),
-.page-description:lang(ru-RU),
-.pagination .nav-links:lang(ru-RU),
-.sticky-post:lang(ru-RU),
-.site-title:lang(ru-RU),
-.site-info:lang(ru-RU),
-#cancel-comment-reply-link:lang(ru-RU),
-h1:lang(ru-RU),
-h2:lang(ru-RU),
-h3:lang(ru-RU),
-h4:lang(ru-RU),
-h5:lang(ru-RU),
-h6:lang(ru-RU), .page-title:lang(ru-RU), blockquote cite:lang(ru-RU), table:lang(ru-RU), .button:lang(ru-RU),
-input:lang(ru-RU)[type="button"],
-input:lang(ru-RU)[type="reset"],
-input:lang(ru-RU)[type="submit"], .comment-navigation .nav-previous:lang(ru-RU),
-.comment-navigation .nav-next:lang(ru-RU), .comment-list .pingback .comment-body:lang(ru-RU),
-.comment-list .trackback .comment-body:lang(ru-RU), .comment-list .pingback .comment-body .comment-edit-link:lang(ru-RU),
-.comment-list .trackback .comment-body .comment-edit-link:lang(ru-RU), .comment-form .comment-notes:lang(ru-RU),
-.comment-form label:lang(ru-RU), .widget_archive ul li:lang(ru-RU),
-.widget_categories ul li:lang(ru-RU),
-.widget_meta ul li:lang(ru-RU),
-.widget_nav_menu ul li:lang(ru-RU),
-.widget_pages ul li:lang(ru-RU),
-.widget_recent_comments ul li:lang(ru-RU),
-.widget_recent_entries ul li:lang(ru-RU),
-.widget_rss ul li:lang(ru-RU), .widget_tag_cloud .tagcloud:lang(ru-RU), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(ru-RU), .entry .entry-content .wp-block-button .wp-block-button__link:lang(ru-RU), .entry .entry-content .wp-block-archives li > a:lang(ru-RU),
-.entry .entry-content .wp-block-categories li > a:lang(ru-RU),
-.entry .entry-content .wp-block-latest-posts li > a:lang(ru-RU), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ru-RU), .entry .entry-content .wp-block-verse:lang(ru-RU), .entry .entry-content .has-drop-cap:lang(ru-RU):not(:focus):first-letter, .entry .entry-content .wp-block-pullquote cite:lang(ru-RU), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(ru-RU),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(ru-RU),
-.entry .entry-content .wp-block-cover-image h2:lang(ru-RU),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(ru-RU),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(ru-RU),
-.entry .entry-content .wp-block-cover h2:lang(ru-RU), .entry .entry-content .wp-block-audio figcaption:lang(ru-RU),
-.entry .entry-content .wp-block-video figcaption:lang(ru-RU),
-.entry .entry-content .wp-block-image figcaption:lang(ru-RU),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(ru-RU),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(ru-RU), .entry .entry-content .wp-block-file:lang(ru-RU), .entry .entry-content .wp-block-file .wp-block-file__button:lang(ru-RU), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ru-RU), .wp-caption-text:lang(ru-RU), .gallery-caption:lang(ru-RU) {
-  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
-}
-
-body:lang(sah), button:lang(sah),
-input:lang(sah),
-select:lang(sah),
-optgroup:lang(sah),
-textarea:lang(sah), .author-description .author-link:lang(sah),
-.comment-metadata:lang(sah),
-.comment-reply-link:lang(sah),
-.comments-title:lang(sah),
-.comment-author .fn:lang(sah),
-.discussion-meta-info:lang(sah),
-.entry-meta:lang(sah),
-.entry-footer:lang(sah),
-.main-navigation:lang(sah),
-.no-comments:lang(sah),
-.not-found .page-title:lang(sah),
-.error-404 .page-title:lang(sah),
-.post-navigation .post-title:lang(sah),
-.page-links:lang(sah),
-.page-description:lang(sah),
-.pagination .nav-links:lang(sah),
-.sticky-post:lang(sah),
-.site-title:lang(sah),
-.site-info:lang(sah),
-#cancel-comment-reply-link:lang(sah),
-h1:lang(sah),
-h2:lang(sah),
-h3:lang(sah),
-h4:lang(sah),
-h5:lang(sah),
-h6:lang(sah), .page-title:lang(sah), blockquote cite:lang(sah), table:lang(sah), .button:lang(sah),
-input:lang(sah)[type="button"],
-input:lang(sah)[type="reset"],
-input:lang(sah)[type="submit"], .comment-navigation .nav-previous:lang(sah),
-.comment-navigation .nav-next:lang(sah), .comment-list .pingback .comment-body:lang(sah),
-.comment-list .trackback .comment-body:lang(sah), .comment-list .pingback .comment-body .comment-edit-link:lang(sah),
-.comment-list .trackback .comment-body .comment-edit-link:lang(sah), .comment-form .comment-notes:lang(sah),
-.comment-form label:lang(sah), .widget_archive ul li:lang(sah),
-.widget_categories ul li:lang(sah),
-.widget_meta ul li:lang(sah),
-.widget_nav_menu ul li:lang(sah),
-.widget_pages ul li:lang(sah),
-.widget_recent_comments ul li:lang(sah),
-.widget_recent_entries ul li:lang(sah),
-.widget_rss ul li:lang(sah), .widget_tag_cloud .tagcloud:lang(sah), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(sah), .entry .entry-content .wp-block-button .wp-block-button__link:lang(sah), .entry .entry-content .wp-block-archives li > a:lang(sah),
-.entry .entry-content .wp-block-categories li > a:lang(sah),
-.entry .entry-content .wp-block-latest-posts li > a:lang(sah), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(sah), .entry .entry-content .wp-block-verse:lang(sah), .entry .entry-content .has-drop-cap:lang(sah):not(:focus):first-letter, .entry .entry-content .wp-block-pullquote cite:lang(sah), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(sah),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(sah),
-.entry .entry-content .wp-block-cover-image h2:lang(sah),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(sah),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(sah),
-.entry .entry-content .wp-block-cover h2:lang(sah), .entry .entry-content .wp-block-audio figcaption:lang(sah),
-.entry .entry-content .wp-block-video figcaption:lang(sah),
-.entry .entry-content .wp-block-image figcaption:lang(sah),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(sah),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(sah), .entry .entry-content .wp-block-file:lang(sah), .entry .entry-content .wp-block-file .wp-block-file__button:lang(sah), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(sah), .wp-caption-text:lang(sah), .gallery-caption:lang(sah) {
-  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
-}
-
-body:lang(sr-RS), button:lang(sr-RS),
-input:lang(sr-RS),
-select:lang(sr-RS),
-optgroup:lang(sr-RS),
-textarea:lang(sr-RS), .author-description .author-link:lang(sr-RS),
-.comment-metadata:lang(sr-RS),
-.comment-reply-link:lang(sr-RS),
-.comments-title:lang(sr-RS),
-.comment-author .fn:lang(sr-RS),
-.discussion-meta-info:lang(sr-RS),
-.entry-meta:lang(sr-RS),
-.entry-footer:lang(sr-RS),
-.main-navigation:lang(sr-RS),
-.no-comments:lang(sr-RS),
-.not-found .page-title:lang(sr-RS),
-.error-404 .page-title:lang(sr-RS),
-.post-navigation .post-title:lang(sr-RS),
-.page-links:lang(sr-RS),
-.page-description:lang(sr-RS),
-.pagination .nav-links:lang(sr-RS),
-.sticky-post:lang(sr-RS),
-.site-title:lang(sr-RS),
-.site-info:lang(sr-RS),
-#cancel-comment-reply-link:lang(sr-RS),
-h1:lang(sr-RS),
-h2:lang(sr-RS),
-h3:lang(sr-RS),
-h4:lang(sr-RS),
-h5:lang(sr-RS),
-h6:lang(sr-RS), .page-title:lang(sr-RS), blockquote cite:lang(sr-RS), table:lang(sr-RS), .button:lang(sr-RS),
-input:lang(sr-RS)[type="button"],
-input:lang(sr-RS)[type="reset"],
-input:lang(sr-RS)[type="submit"], .comment-navigation .nav-previous:lang(sr-RS),
-.comment-navigation .nav-next:lang(sr-RS), .comment-list .pingback .comment-body:lang(sr-RS),
-.comment-list .trackback .comment-body:lang(sr-RS), .comment-list .pingback .comment-body .comment-edit-link:lang(sr-RS),
-.comment-list .trackback .comment-body .comment-edit-link:lang(sr-RS), .comment-form .comment-notes:lang(sr-RS),
-.comment-form label:lang(sr-RS), .widget_archive ul li:lang(sr-RS),
-.widget_categories ul li:lang(sr-RS),
-.widget_meta ul li:lang(sr-RS),
-.widget_nav_menu ul li:lang(sr-RS),
-.widget_pages ul li:lang(sr-RS),
-.widget_recent_comments ul li:lang(sr-RS),
-.widget_recent_entries ul li:lang(sr-RS),
-.widget_rss ul li:lang(sr-RS), .widget_tag_cloud .tagcloud:lang(sr-RS), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(sr-RS), .entry .entry-content .wp-block-button .wp-block-button__link:lang(sr-RS), .entry .entry-content .wp-block-archives li > a:lang(sr-RS),
-.entry .entry-content .wp-block-categories li > a:lang(sr-RS),
-.entry .entry-content .wp-block-latest-posts li > a:lang(sr-RS), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(sr-RS), .entry .entry-content .wp-block-verse:lang(sr-RS), .entry .entry-content .has-drop-cap:lang(sr-RS):not(:focus):first-letter, .entry .entry-content .wp-block-pullquote cite:lang(sr-RS), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(sr-RS),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(sr-RS),
-.entry .entry-content .wp-block-cover-image h2:lang(sr-RS),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(sr-RS),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(sr-RS),
-.entry .entry-content .wp-block-cover h2:lang(sr-RS), .entry .entry-content .wp-block-audio figcaption:lang(sr-RS),
-.entry .entry-content .wp-block-video figcaption:lang(sr-RS),
-.entry .entry-content .wp-block-image figcaption:lang(sr-RS),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(sr-RS),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(sr-RS), .entry .entry-content .wp-block-file:lang(sr-RS), .entry .entry-content .wp-block-file .wp-block-file__button:lang(sr-RS), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(sr-RS), .wp-caption-text:lang(sr-RS), .gallery-caption:lang(sr-RS) {
-  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
-}
-
-body:lang(tt-RU), button:lang(tt-RU),
-input:lang(tt-RU),
-select:lang(tt-RU),
-optgroup:lang(tt-RU),
-textarea:lang(tt-RU), .author-description .author-link:lang(tt-RU),
-.comment-metadata:lang(tt-RU),
-.comment-reply-link:lang(tt-RU),
-.comments-title:lang(tt-RU),
-.comment-author .fn:lang(tt-RU),
-.discussion-meta-info:lang(tt-RU),
-.entry-meta:lang(tt-RU),
-.entry-footer:lang(tt-RU),
-.main-navigation:lang(tt-RU),
-.no-comments:lang(tt-RU),
-.not-found .page-title:lang(tt-RU),
-.error-404 .page-title:lang(tt-RU),
-.post-navigation .post-title:lang(tt-RU),
-.page-links:lang(tt-RU),
-.page-description:lang(tt-RU),
-.pagination .nav-links:lang(tt-RU),
-.sticky-post:lang(tt-RU),
-.site-title:lang(tt-RU),
-.site-info:lang(tt-RU),
-#cancel-comment-reply-link:lang(tt-RU),
-h1:lang(tt-RU),
-h2:lang(tt-RU),
-h3:lang(tt-RU),
-h4:lang(tt-RU),
-h5:lang(tt-RU),
-h6:lang(tt-RU), .page-title:lang(tt-RU), blockquote cite:lang(tt-RU), table:lang(tt-RU), .button:lang(tt-RU),
-input:lang(tt-RU)[type="button"],
-input:lang(tt-RU)[type="reset"],
-input:lang(tt-RU)[type="submit"], .comment-navigation .nav-previous:lang(tt-RU),
-.comment-navigation .nav-next:lang(tt-RU), .comment-list .pingback .comment-body:lang(tt-RU),
-.comment-list .trackback .comment-body:lang(tt-RU), .comment-list .pingback .comment-body .comment-edit-link:lang(tt-RU),
-.comment-list .trackback .comment-body .comment-edit-link:lang(tt-RU), .comment-form .comment-notes:lang(tt-RU),
-.comment-form label:lang(tt-RU), .widget_archive ul li:lang(tt-RU),
-.widget_categories ul li:lang(tt-RU),
-.widget_meta ul li:lang(tt-RU),
-.widget_nav_menu ul li:lang(tt-RU),
-.widget_pages ul li:lang(tt-RU),
-.widget_recent_comments ul li:lang(tt-RU),
-.widget_recent_entries ul li:lang(tt-RU),
-.widget_rss ul li:lang(tt-RU), .widget_tag_cloud .tagcloud:lang(tt-RU), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(tt-RU), .entry .entry-content .wp-block-button .wp-block-button__link:lang(tt-RU), .entry .entry-content .wp-block-archives li > a:lang(tt-RU),
-.entry .entry-content .wp-block-categories li > a:lang(tt-RU),
-.entry .entry-content .wp-block-latest-posts li > a:lang(tt-RU), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(tt-RU), .entry .entry-content .wp-block-verse:lang(tt-RU), .entry .entry-content .has-drop-cap:lang(tt-RU):not(:focus):first-letter, .entry .entry-content .wp-block-pullquote cite:lang(tt-RU), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(tt-RU),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(tt-RU),
-.entry .entry-content .wp-block-cover-image h2:lang(tt-RU),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(tt-RU),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(tt-RU),
-.entry .entry-content .wp-block-cover h2:lang(tt-RU), .entry .entry-content .wp-block-audio figcaption:lang(tt-RU),
-.entry .entry-content .wp-block-video figcaption:lang(tt-RU),
-.entry .entry-content .wp-block-image figcaption:lang(tt-RU),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(tt-RU),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(tt-RU), .entry .entry-content .wp-block-file:lang(tt-RU), .entry .entry-content .wp-block-file .wp-block-file__button:lang(tt-RU), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(tt-RU), .wp-caption-text:lang(tt-RU), .gallery-caption:lang(tt-RU) {
-  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
-}
-
-body:lang(uk), button:lang(uk),
-input:lang(uk),
-select:lang(uk),
-optgroup:lang(uk),
-textarea:lang(uk), .author-description .author-link:lang(uk),
-.comment-metadata:lang(uk),
-.comment-reply-link:lang(uk),
-.comments-title:lang(uk),
-.comment-author .fn:lang(uk),
-.discussion-meta-info:lang(uk),
-.entry-meta:lang(uk),
-.entry-footer:lang(uk),
-.main-navigation:lang(uk),
-.no-comments:lang(uk),
-.not-found .page-title:lang(uk),
-.error-404 .page-title:lang(uk),
-.post-navigation .post-title:lang(uk),
-.page-links:lang(uk),
-.page-description:lang(uk),
-.pagination .nav-links:lang(uk),
-.sticky-post:lang(uk),
-.site-title:lang(uk),
-.site-info:lang(uk),
-#cancel-comment-reply-link:lang(uk),
-h1:lang(uk),
-h2:lang(uk),
-h3:lang(uk),
-h4:lang(uk),
-h5:lang(uk),
-h6:lang(uk), .page-title:lang(uk), blockquote cite:lang(uk), table:lang(uk), .button:lang(uk),
-input:lang(uk)[type="button"],
-input:lang(uk)[type="reset"],
-input:lang(uk)[type="submit"], .comment-navigation .nav-previous:lang(uk),
-.comment-navigation .nav-next:lang(uk), .comment-list .pingback .comment-body:lang(uk),
-.comment-list .trackback .comment-body:lang(uk), .comment-list .pingback .comment-body .comment-edit-link:lang(uk),
-.comment-list .trackback .comment-body .comment-edit-link:lang(uk), .comment-form .comment-notes:lang(uk),
-.comment-form label:lang(uk), .widget_archive ul li:lang(uk),
-.widget_categories ul li:lang(uk),
-.widget_meta ul li:lang(uk),
-.widget_nav_menu ul li:lang(uk),
-.widget_pages ul li:lang(uk),
-.widget_recent_comments ul li:lang(uk),
-.widget_recent_entries ul li:lang(uk),
-.widget_rss ul li:lang(uk), .widget_tag_cloud .tagcloud:lang(uk), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(uk), .entry .entry-content .wp-block-button .wp-block-button__link:lang(uk), .entry .entry-content .wp-block-archives li > a:lang(uk),
-.entry .entry-content .wp-block-categories li > a:lang(uk),
-.entry .entry-content .wp-block-latest-posts li > a:lang(uk), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(uk), .entry .entry-content .wp-block-verse:lang(uk), .entry .entry-content .has-drop-cap:lang(uk):not(:focus):first-letter, .entry .entry-content .wp-block-pullquote cite:lang(uk), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(uk),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(uk),
-.entry .entry-content .wp-block-cover-image h2:lang(uk),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(uk),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(uk),
-.entry .entry-content .wp-block-cover h2:lang(uk), .entry .entry-content .wp-block-audio figcaption:lang(uk),
-.entry .entry-content .wp-block-video figcaption:lang(uk),
-.entry .entry-content .wp-block-image figcaption:lang(uk),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(uk),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(uk), .entry .entry-content .wp-block-file:lang(uk), .entry .entry-content .wp-block-file .wp-block-file__button:lang(uk), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(uk), .wp-caption-text:lang(uk), .gallery-caption:lang(uk) {
-  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
-}
-
-body:lang(zh-HK), button:lang(zh-HK),
-input:lang(zh-HK),
-select:lang(zh-HK),
-optgroup:lang(zh-HK),
-textarea:lang(zh-HK), .author-description .author-link:lang(zh-HK),
-.comment-metadata:lang(zh-HK),
-.comment-reply-link:lang(zh-HK),
-.comments-title:lang(zh-HK),
-.comment-author .fn:lang(zh-HK),
-.discussion-meta-info:lang(zh-HK),
-.entry-meta:lang(zh-HK),
-.entry-footer:lang(zh-HK),
-.main-navigation:lang(zh-HK),
-.no-comments:lang(zh-HK),
-.not-found .page-title:lang(zh-HK),
-.error-404 .page-title:lang(zh-HK),
-.post-navigation .post-title:lang(zh-HK),
-.page-links:lang(zh-HK),
-.page-description:lang(zh-HK),
-.pagination .nav-links:lang(zh-HK),
-.sticky-post:lang(zh-HK),
-.site-title:lang(zh-HK),
-.site-info:lang(zh-HK),
-#cancel-comment-reply-link:lang(zh-HK),
-h1:lang(zh-HK),
-h2:lang(zh-HK),
-h3:lang(zh-HK),
-h4:lang(zh-HK),
-h5:lang(zh-HK),
-h6:lang(zh-HK), .page-title:lang(zh-HK), blockquote cite:lang(zh-HK), table:lang(zh-HK), .button:lang(zh-HK),
-input:lang(zh-HK)[type="button"],
-input:lang(zh-HK)[type="reset"],
-input:lang(zh-HK)[type="submit"], .comment-navigation .nav-previous:lang(zh-HK),
-.comment-navigation .nav-next:lang(zh-HK), .comment-list .pingback .comment-body:lang(zh-HK),
-.comment-list .trackback .comment-body:lang(zh-HK), .comment-list .pingback .comment-body .comment-edit-link:lang(zh-HK),
-.comment-list .trackback .comment-body .comment-edit-link:lang(zh-HK), .comment-form .comment-notes:lang(zh-HK),
-.comment-form label:lang(zh-HK), .widget_archive ul li:lang(zh-HK),
-.widget_categories ul li:lang(zh-HK),
-.widget_meta ul li:lang(zh-HK),
-.widget_nav_menu ul li:lang(zh-HK),
-.widget_pages ul li:lang(zh-HK),
-.widget_recent_comments ul li:lang(zh-HK),
-.widget_recent_entries ul li:lang(zh-HK),
-.widget_rss ul li:lang(zh-HK), .widget_tag_cloud .tagcloud:lang(zh-HK), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(zh-HK), .entry .entry-content .wp-block-button .wp-block-button__link:lang(zh-HK), .entry .entry-content .wp-block-archives li > a:lang(zh-HK),
-.entry .entry-content .wp-block-categories li > a:lang(zh-HK),
-.entry .entry-content .wp-block-latest-posts li > a:lang(zh-HK), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(zh-HK), .entry .entry-content .wp-block-verse:lang(zh-HK), .entry .entry-content .has-drop-cap:lang(zh-HK):not(:focus):first-letter, .entry .entry-content .wp-block-pullquote cite:lang(zh-HK), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(zh-HK),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(zh-HK),
-.entry .entry-content .wp-block-cover-image h2:lang(zh-HK),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(zh-HK),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(zh-HK),
-.entry .entry-content .wp-block-cover h2:lang(zh-HK), .entry .entry-content .wp-block-audio figcaption:lang(zh-HK),
-.entry .entry-content .wp-block-video figcaption:lang(zh-HK),
-.entry .entry-content .wp-block-image figcaption:lang(zh-HK),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(zh-HK),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(zh-HK), .entry .entry-content .wp-block-file:lang(zh-HK), .entry .entry-content .wp-block-file .wp-block-file__button:lang(zh-HK), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(zh-HK), .wp-caption-text:lang(zh-HK), .gallery-caption:lang(zh-HK) {
-  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
-}
-
-body:lang(zh-TW), button:lang(zh-TW),
-input:lang(zh-TW),
-select:lang(zh-TW),
-optgroup:lang(zh-TW),
-textarea:lang(zh-TW), .author-description .author-link:lang(zh-TW),
-.comment-metadata:lang(zh-TW),
-.comment-reply-link:lang(zh-TW),
-.comments-title:lang(zh-TW),
-.comment-author .fn:lang(zh-TW),
-.discussion-meta-info:lang(zh-TW),
-.entry-meta:lang(zh-TW),
-.entry-footer:lang(zh-TW),
-.main-navigation:lang(zh-TW),
-.no-comments:lang(zh-TW),
-.not-found .page-title:lang(zh-TW),
-.error-404 .page-title:lang(zh-TW),
-.post-navigation .post-title:lang(zh-TW),
-.page-links:lang(zh-TW),
-.page-description:lang(zh-TW),
-.pagination .nav-links:lang(zh-TW),
-.sticky-post:lang(zh-TW),
-.site-title:lang(zh-TW),
-.site-info:lang(zh-TW),
-#cancel-comment-reply-link:lang(zh-TW),
-h1:lang(zh-TW),
-h2:lang(zh-TW),
-h3:lang(zh-TW),
-h4:lang(zh-TW),
-h5:lang(zh-TW),
-h6:lang(zh-TW), .page-title:lang(zh-TW), blockquote cite:lang(zh-TW), table:lang(zh-TW), .button:lang(zh-TW),
-input:lang(zh-TW)[type="button"],
-input:lang(zh-TW)[type="reset"],
-input:lang(zh-TW)[type="submit"], .comment-navigation .nav-previous:lang(zh-TW),
-.comment-navigation .nav-next:lang(zh-TW), .comment-list .pingback .comment-body:lang(zh-TW),
-.comment-list .trackback .comment-body:lang(zh-TW), .comment-list .pingback .comment-body .comment-edit-link:lang(zh-TW),
-.comment-list .trackback .comment-body .comment-edit-link:lang(zh-TW), .comment-form .comment-notes:lang(zh-TW),
-.comment-form label:lang(zh-TW), .widget_archive ul li:lang(zh-TW),
-.widget_categories ul li:lang(zh-TW),
-.widget_meta ul li:lang(zh-TW),
-.widget_nav_menu ul li:lang(zh-TW),
-.widget_pages ul li:lang(zh-TW),
-.widget_recent_comments ul li:lang(zh-TW),
-.widget_recent_entries ul li:lang(zh-TW),
-.widget_rss ul li:lang(zh-TW), .widget_tag_cloud .tagcloud:lang(zh-TW), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(zh-TW), .entry .entry-content .wp-block-button .wp-block-button__link:lang(zh-TW), .entry .entry-content .wp-block-archives li > a:lang(zh-TW),
-.entry .entry-content .wp-block-categories li > a:lang(zh-TW),
-.entry .entry-content .wp-block-latest-posts li > a:lang(zh-TW), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(zh-TW), .entry .entry-content .wp-block-verse:lang(zh-TW), .entry .entry-content .has-drop-cap:lang(zh-TW):not(:focus):first-letter, .entry .entry-content .wp-block-pullquote cite:lang(zh-TW), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(zh-TW),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(zh-TW),
-.entry .entry-content .wp-block-cover-image h2:lang(zh-TW),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(zh-TW),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(zh-TW),
-.entry .entry-content .wp-block-cover h2:lang(zh-TW), .entry .entry-content .wp-block-audio figcaption:lang(zh-TW),
-.entry .entry-content .wp-block-video figcaption:lang(zh-TW),
-.entry .entry-content .wp-block-image figcaption:lang(zh-TW),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(zh-TW),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(zh-TW), .entry .entry-content .wp-block-file:lang(zh-TW), .entry .entry-content .wp-block-file .wp-block-file__button:lang(zh-TW), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(zh-TW), .wp-caption-text:lang(zh-TW), .gallery-caption:lang(zh-TW) {
-  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
-}
-
-body:lang(zh-CN), button:lang(zh-CN),
-input:lang(zh-CN),
-select:lang(zh-CN),
-optgroup:lang(zh-CN),
-textarea:lang(zh-CN), .author-description .author-link:lang(zh-CN),
-.comment-metadata:lang(zh-CN),
-.comment-reply-link:lang(zh-CN),
-.comments-title:lang(zh-CN),
-.comment-author .fn:lang(zh-CN),
-.discussion-meta-info:lang(zh-CN),
-.entry-meta:lang(zh-CN),
-.entry-footer:lang(zh-CN),
-.main-navigation:lang(zh-CN),
-.no-comments:lang(zh-CN),
-.not-found .page-title:lang(zh-CN),
-.error-404 .page-title:lang(zh-CN),
-.post-navigation .post-title:lang(zh-CN),
-.page-links:lang(zh-CN),
-.page-description:lang(zh-CN),
-.pagination .nav-links:lang(zh-CN),
-.sticky-post:lang(zh-CN),
-.site-title:lang(zh-CN),
-.site-info:lang(zh-CN),
-#cancel-comment-reply-link:lang(zh-CN),
-h1:lang(zh-CN),
-h2:lang(zh-CN),
-h3:lang(zh-CN),
-h4:lang(zh-CN),
-h5:lang(zh-CN),
-h6:lang(zh-CN), .page-title:lang(zh-CN), blockquote cite:lang(zh-CN), table:lang(zh-CN), .button:lang(zh-CN),
-input:lang(zh-CN)[type="button"],
-input:lang(zh-CN)[type="reset"],
-input:lang(zh-CN)[type="submit"], .comment-navigation .nav-previous:lang(zh-CN),
-.comment-navigation .nav-next:lang(zh-CN), .comment-list .pingback .comment-body:lang(zh-CN),
-.comment-list .trackback .comment-body:lang(zh-CN), .comment-list .pingback .comment-body .comment-edit-link:lang(zh-CN),
-.comment-list .trackback .comment-body .comment-edit-link:lang(zh-CN), .comment-form .comment-notes:lang(zh-CN),
-.comment-form label:lang(zh-CN), .widget_archive ul li:lang(zh-CN),
-.widget_categories ul li:lang(zh-CN),
-.widget_meta ul li:lang(zh-CN),
-.widget_nav_menu ul li:lang(zh-CN),
-.widget_pages ul li:lang(zh-CN),
-.widget_recent_comments ul li:lang(zh-CN),
-.widget_recent_entries ul li:lang(zh-CN),
-.widget_rss ul li:lang(zh-CN), .widget_tag_cloud .tagcloud:lang(zh-CN), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(zh-CN), .entry .entry-content .wp-block-button .wp-block-button__link:lang(zh-CN), .entry .entry-content .wp-block-archives li > a:lang(zh-CN),
-.entry .entry-content .wp-block-categories li > a:lang(zh-CN),
-.entry .entry-content .wp-block-latest-posts li > a:lang(zh-CN), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(zh-CN), .entry .entry-content .wp-block-verse:lang(zh-CN), .entry .entry-content .has-drop-cap:lang(zh-CN):not(:focus):first-letter, .entry .entry-content .wp-block-pullquote cite:lang(zh-CN), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(zh-CN),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(zh-CN),
-.entry .entry-content .wp-block-cover-image h2:lang(zh-CN),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(zh-CN),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(zh-CN),
-.entry .entry-content .wp-block-cover h2:lang(zh-CN), .entry .entry-content .wp-block-audio figcaption:lang(zh-CN),
-.entry .entry-content .wp-block-video figcaption:lang(zh-CN),
-.entry .entry-content .wp-block-image figcaption:lang(zh-CN),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(zh-CN),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(zh-CN), .entry .entry-content .wp-block-file:lang(zh-CN), .entry .entry-content .wp-block-file .wp-block-file__button:lang(zh-CN), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(zh-CN), .wp-caption-text:lang(zh-CN), .gallery-caption:lang(zh-CN) {
-  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
-}
-
-body:lang(bn-BD), button:lang(bn-BD),
-input:lang(bn-BD),
-select:lang(bn-BD),
-optgroup:lang(bn-BD),
-textarea:lang(bn-BD), .author-description .author-link:lang(bn-BD),
-.comment-metadata:lang(bn-BD),
-.comment-reply-link:lang(bn-BD),
-.comments-title:lang(bn-BD),
-.comment-author .fn:lang(bn-BD),
-.discussion-meta-info:lang(bn-BD),
-.entry-meta:lang(bn-BD),
-.entry-footer:lang(bn-BD),
-.main-navigation:lang(bn-BD),
-.no-comments:lang(bn-BD),
-.not-found .page-title:lang(bn-BD),
-.error-404 .page-title:lang(bn-BD),
-.post-navigation .post-title:lang(bn-BD),
-.page-links:lang(bn-BD),
-.page-description:lang(bn-BD),
-.pagination .nav-links:lang(bn-BD),
-.sticky-post:lang(bn-BD),
-.site-title:lang(bn-BD),
-.site-info:lang(bn-BD),
-#cancel-comment-reply-link:lang(bn-BD),
-h1:lang(bn-BD),
-h2:lang(bn-BD),
-h3:lang(bn-BD),
-h4:lang(bn-BD),
-h5:lang(bn-BD),
-h6:lang(bn-BD), .page-title:lang(bn-BD), blockquote cite:lang(bn-BD), table:lang(bn-BD), .button:lang(bn-BD),
-input:lang(bn-BD)[type="button"],
-input:lang(bn-BD)[type="reset"],
-input:lang(bn-BD)[type="submit"], .comment-navigation .nav-previous:lang(bn-BD),
-.comment-navigation .nav-next:lang(bn-BD), .comment-list .pingback .comment-body:lang(bn-BD),
-.comment-list .trackback .comment-body:lang(bn-BD), .comment-list .pingback .comment-body .comment-edit-link:lang(bn-BD),
-.comment-list .trackback .comment-body .comment-edit-link:lang(bn-BD), .comment-form .comment-notes:lang(bn-BD),
-.comment-form label:lang(bn-BD), .widget_archive ul li:lang(bn-BD),
-.widget_categories ul li:lang(bn-BD),
-.widget_meta ul li:lang(bn-BD),
-.widget_nav_menu ul li:lang(bn-BD),
-.widget_pages ul li:lang(bn-BD),
-.widget_recent_comments ul li:lang(bn-BD),
-.widget_recent_entries ul li:lang(bn-BD),
-.widget_rss ul li:lang(bn-BD), .widget_tag_cloud .tagcloud:lang(bn-BD), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(bn-BD), .entry .entry-content .wp-block-button .wp-block-button__link:lang(bn-BD), .entry .entry-content .wp-block-archives li > a:lang(bn-BD),
-.entry .entry-content .wp-block-categories li > a:lang(bn-BD),
-.entry .entry-content .wp-block-latest-posts li > a:lang(bn-BD), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(bn-BD), .entry .entry-content .wp-block-verse:lang(bn-BD), .entry .entry-content .has-drop-cap:lang(bn-BD):not(:focus):first-letter, .entry .entry-content .wp-block-pullquote cite:lang(bn-BD), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(bn-BD),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(bn-BD),
-.entry .entry-content .wp-block-cover-image h2:lang(bn-BD),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(bn-BD),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(bn-BD),
-.entry .entry-content .wp-block-cover h2:lang(bn-BD), .entry .entry-content .wp-block-audio figcaption:lang(bn-BD),
-.entry .entry-content .wp-block-video figcaption:lang(bn-BD),
-.entry .entry-content .wp-block-image figcaption:lang(bn-BD),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(bn-BD),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(bn-BD), .entry .entry-content .wp-block-file:lang(bn-BD), .entry .entry-content .wp-block-file .wp-block-file__button:lang(bn-BD), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(bn-BD), .wp-caption-text:lang(bn-BD), .gallery-caption:lang(bn-BD) {
-  font-family: Arial, sans-serif;
-}
-
-body:lang(hi-IN), button:lang(hi-IN),
-input:lang(hi-IN),
-select:lang(hi-IN),
-optgroup:lang(hi-IN),
-textarea:lang(hi-IN), .author-description .author-link:lang(hi-IN),
-.comment-metadata:lang(hi-IN),
-.comment-reply-link:lang(hi-IN),
-.comments-title:lang(hi-IN),
-.comment-author .fn:lang(hi-IN),
-.discussion-meta-info:lang(hi-IN),
-.entry-meta:lang(hi-IN),
-.entry-footer:lang(hi-IN),
-.main-navigation:lang(hi-IN),
-.no-comments:lang(hi-IN),
-.not-found .page-title:lang(hi-IN),
-.error-404 .page-title:lang(hi-IN),
-.post-navigation .post-title:lang(hi-IN),
-.page-links:lang(hi-IN),
-.page-description:lang(hi-IN),
-.pagination .nav-links:lang(hi-IN),
-.sticky-post:lang(hi-IN),
-.site-title:lang(hi-IN),
-.site-info:lang(hi-IN),
-#cancel-comment-reply-link:lang(hi-IN),
-h1:lang(hi-IN),
-h2:lang(hi-IN),
-h3:lang(hi-IN),
-h4:lang(hi-IN),
-h5:lang(hi-IN),
-h6:lang(hi-IN), .page-title:lang(hi-IN), blockquote cite:lang(hi-IN), table:lang(hi-IN), .button:lang(hi-IN),
-input:lang(hi-IN)[type="button"],
-input:lang(hi-IN)[type="reset"],
-input:lang(hi-IN)[type="submit"], .comment-navigation .nav-previous:lang(hi-IN),
-.comment-navigation .nav-next:lang(hi-IN), .comment-list .pingback .comment-body:lang(hi-IN),
-.comment-list .trackback .comment-body:lang(hi-IN), .comment-list .pingback .comment-body .comment-edit-link:lang(hi-IN),
-.comment-list .trackback .comment-body .comment-edit-link:lang(hi-IN), .comment-form .comment-notes:lang(hi-IN),
-.comment-form label:lang(hi-IN), .widget_archive ul li:lang(hi-IN),
-.widget_categories ul li:lang(hi-IN),
-.widget_meta ul li:lang(hi-IN),
-.widget_nav_menu ul li:lang(hi-IN),
-.widget_pages ul li:lang(hi-IN),
-.widget_recent_comments ul li:lang(hi-IN),
-.widget_recent_entries ul li:lang(hi-IN),
-.widget_rss ul li:lang(hi-IN), .widget_tag_cloud .tagcloud:lang(hi-IN), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(hi-IN), .entry .entry-content .wp-block-button .wp-block-button__link:lang(hi-IN), .entry .entry-content .wp-block-archives li > a:lang(hi-IN),
-.entry .entry-content .wp-block-categories li > a:lang(hi-IN),
-.entry .entry-content .wp-block-latest-posts li > a:lang(hi-IN), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(hi-IN), .entry .entry-content .wp-block-verse:lang(hi-IN), .entry .entry-content .has-drop-cap:lang(hi-IN):not(:focus):first-letter, .entry .entry-content .wp-block-pullquote cite:lang(hi-IN), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(hi-IN),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(hi-IN),
-.entry .entry-content .wp-block-cover-image h2:lang(hi-IN),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(hi-IN),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(hi-IN),
-.entry .entry-content .wp-block-cover h2:lang(hi-IN), .entry .entry-content .wp-block-audio figcaption:lang(hi-IN),
-.entry .entry-content .wp-block-video figcaption:lang(hi-IN),
-.entry .entry-content .wp-block-image figcaption:lang(hi-IN),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(hi-IN),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(hi-IN), .entry .entry-content .wp-block-file:lang(hi-IN), .entry .entry-content .wp-block-file .wp-block-file__button:lang(hi-IN), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(hi-IN), .wp-caption-text:lang(hi-IN), .gallery-caption:lang(hi-IN) {
-  font-family: Arial, sans-serif;
-}
-
-body:lang(mr), button:lang(mr),
-input:lang(mr),
-select:lang(mr),
-optgroup:lang(mr),
-textarea:lang(mr), .author-description .author-link:lang(mr),
-.comment-metadata:lang(mr),
-.comment-reply-link:lang(mr),
-.comments-title:lang(mr),
-.comment-author .fn:lang(mr),
-.discussion-meta-info:lang(mr),
-.entry-meta:lang(mr),
-.entry-footer:lang(mr),
-.main-navigation:lang(mr),
-.no-comments:lang(mr),
-.not-found .page-title:lang(mr),
-.error-404 .page-title:lang(mr),
-.post-navigation .post-title:lang(mr),
-.page-links:lang(mr),
-.page-description:lang(mr),
-.pagination .nav-links:lang(mr),
-.sticky-post:lang(mr),
-.site-title:lang(mr),
-.site-info:lang(mr),
-#cancel-comment-reply-link:lang(mr),
-h1:lang(mr),
-h2:lang(mr),
-h3:lang(mr),
-h4:lang(mr),
-h5:lang(mr),
-h6:lang(mr), .page-title:lang(mr), blockquote cite:lang(mr), table:lang(mr), .button:lang(mr),
-input:lang(mr)[type="button"],
-input:lang(mr)[type="reset"],
-input:lang(mr)[type="submit"], .comment-navigation .nav-previous:lang(mr),
-.comment-navigation .nav-next:lang(mr), .comment-list .pingback .comment-body:lang(mr),
-.comment-list .trackback .comment-body:lang(mr), .comment-list .pingback .comment-body .comment-edit-link:lang(mr),
-.comment-list .trackback .comment-body .comment-edit-link:lang(mr), .comment-form .comment-notes:lang(mr),
-.comment-form label:lang(mr), .widget_archive ul li:lang(mr),
-.widget_categories ul li:lang(mr),
-.widget_meta ul li:lang(mr),
-.widget_nav_menu ul li:lang(mr),
-.widget_pages ul li:lang(mr),
-.widget_recent_comments ul li:lang(mr),
-.widget_recent_entries ul li:lang(mr),
-.widget_rss ul li:lang(mr), .widget_tag_cloud .tagcloud:lang(mr), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(mr), .entry .entry-content .wp-block-button .wp-block-button__link:lang(mr), .entry .entry-content .wp-block-archives li > a:lang(mr),
-.entry .entry-content .wp-block-categories li > a:lang(mr),
-.entry .entry-content .wp-block-latest-posts li > a:lang(mr), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(mr), .entry .entry-content .wp-block-verse:lang(mr), .entry .entry-content .has-drop-cap:lang(mr):not(:focus):first-letter, .entry .entry-content .wp-block-pullquote cite:lang(mr), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(mr),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(mr),
-.entry .entry-content .wp-block-cover-image h2:lang(mr),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(mr),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(mr),
-.entry .entry-content .wp-block-cover h2:lang(mr), .entry .entry-content .wp-block-audio figcaption:lang(mr),
-.entry .entry-content .wp-block-video figcaption:lang(mr),
-.entry .entry-content .wp-block-image figcaption:lang(mr),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(mr),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(mr), .entry .entry-content .wp-block-file:lang(mr), .entry .entry-content .wp-block-file .wp-block-file__button:lang(mr), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(mr), .wp-caption-text:lang(mr), .gallery-caption:lang(mr) {
-  font-family: Arial, sans-serif;
-}
-
-body:lang(ne-NP), button:lang(ne-NP),
-input:lang(ne-NP),
-select:lang(ne-NP),
-optgroup:lang(ne-NP),
-textarea:lang(ne-NP), .author-description .author-link:lang(ne-NP),
-.comment-metadata:lang(ne-NP),
-.comment-reply-link:lang(ne-NP),
-.comments-title:lang(ne-NP),
-.comment-author .fn:lang(ne-NP),
-.discussion-meta-info:lang(ne-NP),
-.entry-meta:lang(ne-NP),
-.entry-footer:lang(ne-NP),
-.main-navigation:lang(ne-NP),
-.no-comments:lang(ne-NP),
-.not-found .page-title:lang(ne-NP),
-.error-404 .page-title:lang(ne-NP),
-.post-navigation .post-title:lang(ne-NP),
-.page-links:lang(ne-NP),
-.page-description:lang(ne-NP),
-.pagination .nav-links:lang(ne-NP),
-.sticky-post:lang(ne-NP),
-.site-title:lang(ne-NP),
-.site-info:lang(ne-NP),
-#cancel-comment-reply-link:lang(ne-NP),
-h1:lang(ne-NP),
-h2:lang(ne-NP),
-h3:lang(ne-NP),
-h4:lang(ne-NP),
-h5:lang(ne-NP),
-h6:lang(ne-NP), .page-title:lang(ne-NP), blockquote cite:lang(ne-NP), table:lang(ne-NP), .button:lang(ne-NP),
-input:lang(ne-NP)[type="button"],
-input:lang(ne-NP)[type="reset"],
-input:lang(ne-NP)[type="submit"], .comment-navigation .nav-previous:lang(ne-NP),
-.comment-navigation .nav-next:lang(ne-NP), .comment-list .pingback .comment-body:lang(ne-NP),
-.comment-list .trackback .comment-body:lang(ne-NP), .comment-list .pingback .comment-body .comment-edit-link:lang(ne-NP),
-.comment-list .trackback .comment-body .comment-edit-link:lang(ne-NP), .comment-form .comment-notes:lang(ne-NP),
-.comment-form label:lang(ne-NP), .widget_archive ul li:lang(ne-NP),
-.widget_categories ul li:lang(ne-NP),
-.widget_meta ul li:lang(ne-NP),
-.widget_nav_menu ul li:lang(ne-NP),
-.widget_pages ul li:lang(ne-NP),
-.widget_recent_comments ul li:lang(ne-NP),
-.widget_recent_entries ul li:lang(ne-NP),
-.widget_rss ul li:lang(ne-NP), .widget_tag_cloud .tagcloud:lang(ne-NP), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(ne-NP), .entry .entry-content .wp-block-button .wp-block-button__link:lang(ne-NP), .entry .entry-content .wp-block-archives li > a:lang(ne-NP),
-.entry .entry-content .wp-block-categories li > a:lang(ne-NP),
-.entry .entry-content .wp-block-latest-posts li > a:lang(ne-NP), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ne-NP), .entry .entry-content .wp-block-verse:lang(ne-NP), .entry .entry-content .has-drop-cap:lang(ne-NP):not(:focus):first-letter, .entry .entry-content .wp-block-pullquote cite:lang(ne-NP), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(ne-NP),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(ne-NP),
-.entry .entry-content .wp-block-cover-image h2:lang(ne-NP),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(ne-NP),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(ne-NP),
-.entry .entry-content .wp-block-cover h2:lang(ne-NP), .entry .entry-content .wp-block-audio figcaption:lang(ne-NP),
-.entry .entry-content .wp-block-video figcaption:lang(ne-NP),
-.entry .entry-content .wp-block-image figcaption:lang(ne-NP),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(ne-NP),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(ne-NP), .entry .entry-content .wp-block-file:lang(ne-NP), .entry .entry-content .wp-block-file .wp-block-file__button:lang(ne-NP), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ne-NP), .wp-caption-text:lang(ne-NP), .gallery-caption:lang(ne-NP) {
-  font-family: Arial, sans-serif;
-}
-
-body:lang(el), button:lang(el),
-input:lang(el),
-select:lang(el),
-optgroup:lang(el),
-textarea:lang(el), .author-description .author-link:lang(el),
-.comment-metadata:lang(el),
-.comment-reply-link:lang(el),
-.comments-title:lang(el),
-.comment-author .fn:lang(el),
-.discussion-meta-info:lang(el),
-.entry-meta:lang(el),
-.entry-footer:lang(el),
-.main-navigation:lang(el),
-.no-comments:lang(el),
-.not-found .page-title:lang(el),
-.error-404 .page-title:lang(el),
-.post-navigation .post-title:lang(el),
-.page-links:lang(el),
-.page-description:lang(el),
-.pagination .nav-links:lang(el),
-.sticky-post:lang(el),
-.site-title:lang(el),
-.site-info:lang(el),
-#cancel-comment-reply-link:lang(el),
-h1:lang(el),
-h2:lang(el),
-h3:lang(el),
-h4:lang(el),
-h5:lang(el),
-h6:lang(el), .page-title:lang(el), blockquote cite:lang(el), table:lang(el), .button:lang(el),
-input:lang(el)[type="button"],
-input:lang(el)[type="reset"],
-input:lang(el)[type="submit"], .comment-navigation .nav-previous:lang(el),
-.comment-navigation .nav-next:lang(el), .comment-list .pingback .comment-body:lang(el),
-.comment-list .trackback .comment-body:lang(el), .comment-list .pingback .comment-body .comment-edit-link:lang(el),
-.comment-list .trackback .comment-body .comment-edit-link:lang(el), .comment-form .comment-notes:lang(el),
-.comment-form label:lang(el), .widget_archive ul li:lang(el),
-.widget_categories ul li:lang(el),
-.widget_meta ul li:lang(el),
-.widget_nav_menu ul li:lang(el),
-.widget_pages ul li:lang(el),
-.widget_recent_comments ul li:lang(el),
-.widget_recent_entries ul li:lang(el),
-.widget_rss ul li:lang(el), .widget_tag_cloud .tagcloud:lang(el), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(el), .entry .entry-content .wp-block-button .wp-block-button__link:lang(el), .entry .entry-content .wp-block-archives li > a:lang(el),
-.entry .entry-content .wp-block-categories li > a:lang(el),
-.entry .entry-content .wp-block-latest-posts li > a:lang(el), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(el), .entry .entry-content .wp-block-verse:lang(el), .entry .entry-content .has-drop-cap:lang(el):not(:focus):first-letter, .entry .entry-content .wp-block-pullquote cite:lang(el), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(el),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(el),
-.entry .entry-content .wp-block-cover-image h2:lang(el),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(el),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(el),
-.entry .entry-content .wp-block-cover h2:lang(el), .entry .entry-content .wp-block-audio figcaption:lang(el),
-.entry .entry-content .wp-block-video figcaption:lang(el),
-.entry .entry-content .wp-block-image figcaption:lang(el),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(el),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(el), .entry .entry-content .wp-block-file:lang(el), .entry .entry-content .wp-block-file .wp-block-file__button:lang(el), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(el), .wp-caption-text:lang(el), .gallery-caption:lang(el) {
-  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-}
-
-body:lang(gu), button:lang(gu),
-input:lang(gu),
-select:lang(gu),
-optgroup:lang(gu),
-textarea:lang(gu), .author-description .author-link:lang(gu),
-.comment-metadata:lang(gu),
-.comment-reply-link:lang(gu),
-.comments-title:lang(gu),
-.comment-author .fn:lang(gu),
-.discussion-meta-info:lang(gu),
-.entry-meta:lang(gu),
-.entry-footer:lang(gu),
-.main-navigation:lang(gu),
-.no-comments:lang(gu),
-.not-found .page-title:lang(gu),
-.error-404 .page-title:lang(gu),
-.post-navigation .post-title:lang(gu),
-.page-links:lang(gu),
-.page-description:lang(gu),
-.pagination .nav-links:lang(gu),
-.sticky-post:lang(gu),
-.site-title:lang(gu),
-.site-info:lang(gu),
-#cancel-comment-reply-link:lang(gu),
-h1:lang(gu),
-h2:lang(gu),
-h3:lang(gu),
-h4:lang(gu),
-h5:lang(gu),
-h6:lang(gu), .page-title:lang(gu), blockquote cite:lang(gu), table:lang(gu), .button:lang(gu),
-input:lang(gu)[type="button"],
-input:lang(gu)[type="reset"],
-input:lang(gu)[type="submit"], .comment-navigation .nav-previous:lang(gu),
-.comment-navigation .nav-next:lang(gu), .comment-list .pingback .comment-body:lang(gu),
-.comment-list .trackback .comment-body:lang(gu), .comment-list .pingback .comment-body .comment-edit-link:lang(gu),
-.comment-list .trackback .comment-body .comment-edit-link:lang(gu), .comment-form .comment-notes:lang(gu),
-.comment-form label:lang(gu), .widget_archive ul li:lang(gu),
-.widget_categories ul li:lang(gu),
-.widget_meta ul li:lang(gu),
-.widget_nav_menu ul li:lang(gu),
-.widget_pages ul li:lang(gu),
-.widget_recent_comments ul li:lang(gu),
-.widget_recent_entries ul li:lang(gu),
-.widget_rss ul li:lang(gu), .widget_tag_cloud .tagcloud:lang(gu), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(gu), .entry .entry-content .wp-block-button .wp-block-button__link:lang(gu), .entry .entry-content .wp-block-archives li > a:lang(gu),
-.entry .entry-content .wp-block-categories li > a:lang(gu),
-.entry .entry-content .wp-block-latest-posts li > a:lang(gu), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(gu), .entry .entry-content .wp-block-verse:lang(gu), .entry .entry-content .has-drop-cap:lang(gu):not(:focus):first-letter, .entry .entry-content .wp-block-pullquote cite:lang(gu), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(gu),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(gu),
-.entry .entry-content .wp-block-cover-image h2:lang(gu),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(gu),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(gu),
-.entry .entry-content .wp-block-cover h2:lang(gu), .entry .entry-content .wp-block-audio figcaption:lang(gu),
-.entry .entry-content .wp-block-video figcaption:lang(gu),
-.entry .entry-content .wp-block-image figcaption:lang(gu),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(gu),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(gu), .entry .entry-content .wp-block-file:lang(gu), .entry .entry-content .wp-block-file .wp-block-file__button:lang(gu), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(gu), .wp-caption-text:lang(gu), .gallery-caption:lang(gu) {
-  font-family: Arial, sans-serif;
-}
-
-body:lang(he-IL), button:lang(he-IL),
-input:lang(he-IL),
-select:lang(he-IL),
-optgroup:lang(he-IL),
-textarea:lang(he-IL), .author-description .author-link:lang(he-IL),
-.comment-metadata:lang(he-IL),
-.comment-reply-link:lang(he-IL),
-.comments-title:lang(he-IL),
-.comment-author .fn:lang(he-IL),
-.discussion-meta-info:lang(he-IL),
-.entry-meta:lang(he-IL),
-.entry-footer:lang(he-IL),
-.main-navigation:lang(he-IL),
-.no-comments:lang(he-IL),
-.not-found .page-title:lang(he-IL),
-.error-404 .page-title:lang(he-IL),
-.post-navigation .post-title:lang(he-IL),
-.page-links:lang(he-IL),
-.page-description:lang(he-IL),
-.pagination .nav-links:lang(he-IL),
-.sticky-post:lang(he-IL),
-.site-title:lang(he-IL),
-.site-info:lang(he-IL),
-#cancel-comment-reply-link:lang(he-IL),
-h1:lang(he-IL),
-h2:lang(he-IL),
-h3:lang(he-IL),
-h4:lang(he-IL),
-h5:lang(he-IL),
-h6:lang(he-IL), .page-title:lang(he-IL), blockquote cite:lang(he-IL), table:lang(he-IL), .button:lang(he-IL),
-input:lang(he-IL)[type="button"],
-input:lang(he-IL)[type="reset"],
-input:lang(he-IL)[type="submit"], .comment-navigation .nav-previous:lang(he-IL),
-.comment-navigation .nav-next:lang(he-IL), .comment-list .pingback .comment-body:lang(he-IL),
-.comment-list .trackback .comment-body:lang(he-IL), .comment-list .pingback .comment-body .comment-edit-link:lang(he-IL),
-.comment-list .trackback .comment-body .comment-edit-link:lang(he-IL), .comment-form .comment-notes:lang(he-IL),
-.comment-form label:lang(he-IL), .widget_archive ul li:lang(he-IL),
-.widget_categories ul li:lang(he-IL),
-.widget_meta ul li:lang(he-IL),
-.widget_nav_menu ul li:lang(he-IL),
-.widget_pages ul li:lang(he-IL),
-.widget_recent_comments ul li:lang(he-IL),
-.widget_recent_entries ul li:lang(he-IL),
-.widget_rss ul li:lang(he-IL), .widget_tag_cloud .tagcloud:lang(he-IL), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(he-IL), .entry .entry-content .wp-block-button .wp-block-button__link:lang(he-IL), .entry .entry-content .wp-block-archives li > a:lang(he-IL),
-.entry .entry-content .wp-block-categories li > a:lang(he-IL),
-.entry .entry-content .wp-block-latest-posts li > a:lang(he-IL), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(he-IL), .entry .entry-content .wp-block-verse:lang(he-IL), .entry .entry-content .has-drop-cap:lang(he-IL):not(:focus):first-letter, .entry .entry-content .wp-block-pullquote cite:lang(he-IL), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(he-IL),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(he-IL),
-.entry .entry-content .wp-block-cover-image h2:lang(he-IL),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(he-IL),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(he-IL),
-.entry .entry-content .wp-block-cover h2:lang(he-IL), .entry .entry-content .wp-block-audio figcaption:lang(he-IL),
-.entry .entry-content .wp-block-video figcaption:lang(he-IL),
-.entry .entry-content .wp-block-image figcaption:lang(he-IL),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(he-IL),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(he-IL), .entry .entry-content .wp-block-file:lang(he-IL), .entry .entry-content .wp-block-file .wp-block-file__button:lang(he-IL), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(he-IL), .wp-caption-text:lang(he-IL), .gallery-caption:lang(he-IL) {
-  font-family: "Arial Hebrew", Arial, sans-serif;
-}
-
-body:lang(ja), button:lang(ja),
-input:lang(ja),
-select:lang(ja),
-optgroup:lang(ja),
-textarea:lang(ja), .author-description .author-link:lang(ja),
-.comment-metadata:lang(ja),
-.comment-reply-link:lang(ja),
-.comments-title:lang(ja),
-.comment-author .fn:lang(ja),
-.discussion-meta-info:lang(ja),
-.entry-meta:lang(ja),
-.entry-footer:lang(ja),
-.main-navigation:lang(ja),
-.no-comments:lang(ja),
-.not-found .page-title:lang(ja),
-.error-404 .page-title:lang(ja),
-.post-navigation .post-title:lang(ja),
-.page-links:lang(ja),
-.page-description:lang(ja),
-.pagination .nav-links:lang(ja),
-.sticky-post:lang(ja),
-.site-title:lang(ja),
-.site-info:lang(ja),
-#cancel-comment-reply-link:lang(ja),
-h1:lang(ja),
-h2:lang(ja),
-h3:lang(ja),
-h4:lang(ja),
-h5:lang(ja),
-h6:lang(ja), .page-title:lang(ja), blockquote cite:lang(ja), table:lang(ja), .button:lang(ja),
-input:lang(ja)[type="button"],
-input:lang(ja)[type="reset"],
-input:lang(ja)[type="submit"], .comment-navigation .nav-previous:lang(ja),
-.comment-navigation .nav-next:lang(ja), .comment-list .pingback .comment-body:lang(ja),
-.comment-list .trackback .comment-body:lang(ja), .comment-list .pingback .comment-body .comment-edit-link:lang(ja),
-.comment-list .trackback .comment-body .comment-edit-link:lang(ja), .comment-form .comment-notes:lang(ja),
-.comment-form label:lang(ja), .widget_archive ul li:lang(ja),
-.widget_categories ul li:lang(ja),
-.widget_meta ul li:lang(ja),
-.widget_nav_menu ul li:lang(ja),
-.widget_pages ul li:lang(ja),
-.widget_recent_comments ul li:lang(ja),
-.widget_recent_entries ul li:lang(ja),
-.widget_rss ul li:lang(ja), .widget_tag_cloud .tagcloud:lang(ja), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(ja), .entry .entry-content .wp-block-button .wp-block-button__link:lang(ja), .entry .entry-content .wp-block-archives li > a:lang(ja),
-.entry .entry-content .wp-block-categories li > a:lang(ja),
-.entry .entry-content .wp-block-latest-posts li > a:lang(ja), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ja), .entry .entry-content .wp-block-verse:lang(ja), .entry .entry-content .has-drop-cap:lang(ja):not(:focus):first-letter, .entry .entry-content .wp-block-pullquote cite:lang(ja), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(ja),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(ja),
-.entry .entry-content .wp-block-cover-image h2:lang(ja),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(ja),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(ja),
-.entry .entry-content .wp-block-cover h2:lang(ja), .entry .entry-content .wp-block-audio figcaption:lang(ja),
-.entry .entry-content .wp-block-video figcaption:lang(ja),
-.entry .entry-content .wp-block-image figcaption:lang(ja),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(ja),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(ja), .entry .entry-content .wp-block-file:lang(ja), .entry .entry-content .wp-block-file .wp-block-file__button:lang(ja), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ja), .wp-caption-text:lang(ja), .gallery-caption:lang(ja) {
-  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
-}
-
-body:lang(ko-KR), button:lang(ko-KR),
-input:lang(ko-KR),
-select:lang(ko-KR),
-optgroup:lang(ko-KR),
-textarea:lang(ko-KR), .author-description .author-link:lang(ko-KR),
-.comment-metadata:lang(ko-KR),
-.comment-reply-link:lang(ko-KR),
-.comments-title:lang(ko-KR),
-.comment-author .fn:lang(ko-KR),
-.discussion-meta-info:lang(ko-KR),
-.entry-meta:lang(ko-KR),
-.entry-footer:lang(ko-KR),
-.main-navigation:lang(ko-KR),
-.no-comments:lang(ko-KR),
-.not-found .page-title:lang(ko-KR),
-.error-404 .page-title:lang(ko-KR),
-.post-navigation .post-title:lang(ko-KR),
-.page-links:lang(ko-KR),
-.page-description:lang(ko-KR),
-.pagination .nav-links:lang(ko-KR),
-.sticky-post:lang(ko-KR),
-.site-title:lang(ko-KR),
-.site-info:lang(ko-KR),
-#cancel-comment-reply-link:lang(ko-KR),
-h1:lang(ko-KR),
-h2:lang(ko-KR),
-h3:lang(ko-KR),
-h4:lang(ko-KR),
-h5:lang(ko-KR),
-h6:lang(ko-KR), .page-title:lang(ko-KR), blockquote cite:lang(ko-KR), table:lang(ko-KR), .button:lang(ko-KR),
-input:lang(ko-KR)[type="button"],
-input:lang(ko-KR)[type="reset"],
-input:lang(ko-KR)[type="submit"], .comment-navigation .nav-previous:lang(ko-KR),
-.comment-navigation .nav-next:lang(ko-KR), .comment-list .pingback .comment-body:lang(ko-KR),
-.comment-list .trackback .comment-body:lang(ko-KR), .comment-list .pingback .comment-body .comment-edit-link:lang(ko-KR),
-.comment-list .trackback .comment-body .comment-edit-link:lang(ko-KR), .comment-form .comment-notes:lang(ko-KR),
-.comment-form label:lang(ko-KR), .widget_archive ul li:lang(ko-KR),
-.widget_categories ul li:lang(ko-KR),
-.widget_meta ul li:lang(ko-KR),
-.widget_nav_menu ul li:lang(ko-KR),
-.widget_pages ul li:lang(ko-KR),
-.widget_recent_comments ul li:lang(ko-KR),
-.widget_recent_entries ul li:lang(ko-KR),
-.widget_rss ul li:lang(ko-KR), .widget_tag_cloud .tagcloud:lang(ko-KR), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(ko-KR), .entry .entry-content .wp-block-button .wp-block-button__link:lang(ko-KR), .entry .entry-content .wp-block-archives li > a:lang(ko-KR),
-.entry .entry-content .wp-block-categories li > a:lang(ko-KR),
-.entry .entry-content .wp-block-latest-posts li > a:lang(ko-KR), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ko-KR), .entry .entry-content .wp-block-verse:lang(ko-KR), .entry .entry-content .has-drop-cap:lang(ko-KR):not(:focus):first-letter, .entry .entry-content .wp-block-pullquote cite:lang(ko-KR), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(ko-KR),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(ko-KR),
-.entry .entry-content .wp-block-cover-image h2:lang(ko-KR),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(ko-KR),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(ko-KR),
-.entry .entry-content .wp-block-cover h2:lang(ko-KR), .entry .entry-content .wp-block-audio figcaption:lang(ko-KR),
-.entry .entry-content .wp-block-video figcaption:lang(ko-KR),
-.entry .entry-content .wp-block-image figcaption:lang(ko-KR),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(ko-KR),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(ko-KR), .entry .entry-content .wp-block-file:lang(ko-KR), .entry .entry-content .wp-block-file .wp-block-file__button:lang(ko-KR), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ko-KR), .wp-caption-text:lang(ko-KR), .gallery-caption:lang(ko-KR) {
-  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
-}
-
-body:lang(th), button:lang(th),
-input:lang(th),
-select:lang(th),
-optgroup:lang(th),
-textarea:lang(th), .author-description .author-link:lang(th),
-.comment-metadata:lang(th),
-.comment-reply-link:lang(th),
-.comments-title:lang(th),
-.comment-author .fn:lang(th),
-.discussion-meta-info:lang(th),
-.entry-meta:lang(th),
-.entry-footer:lang(th),
-.main-navigation:lang(th),
-.no-comments:lang(th),
-.not-found .page-title:lang(th),
-.error-404 .page-title:lang(th),
-.post-navigation .post-title:lang(th),
-.page-links:lang(th),
-.page-description:lang(th),
-.pagination .nav-links:lang(th),
-.sticky-post:lang(th),
-.site-title:lang(th),
-.site-info:lang(th),
-#cancel-comment-reply-link:lang(th),
-h1:lang(th),
-h2:lang(th),
-h3:lang(th),
-h4:lang(th),
-h5:lang(th),
-h6:lang(th), .page-title:lang(th), blockquote cite:lang(th), table:lang(th), .button:lang(th),
-input:lang(th)[type="button"],
-input:lang(th)[type="reset"],
-input:lang(th)[type="submit"], .comment-navigation .nav-previous:lang(th),
-.comment-navigation .nav-next:lang(th), .comment-list .pingback .comment-body:lang(th),
-.comment-list .trackback .comment-body:lang(th), .comment-list .pingback .comment-body .comment-edit-link:lang(th),
-.comment-list .trackback .comment-body .comment-edit-link:lang(th), .comment-form .comment-notes:lang(th),
-.comment-form label:lang(th), .widget_archive ul li:lang(th),
-.widget_categories ul li:lang(th),
-.widget_meta ul li:lang(th),
-.widget_nav_menu ul li:lang(th),
-.widget_pages ul li:lang(th),
-.widget_recent_comments ul li:lang(th),
-.widget_recent_entries ul li:lang(th),
-.widget_rss ul li:lang(th), .widget_tag_cloud .tagcloud:lang(th), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(th), .entry .entry-content .wp-block-button .wp-block-button__link:lang(th), .entry .entry-content .wp-block-archives li > a:lang(th),
-.entry .entry-content .wp-block-categories li > a:lang(th),
-.entry .entry-content .wp-block-latest-posts li > a:lang(th), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(th), .entry .entry-content .wp-block-verse:lang(th), .entry .entry-content .has-drop-cap:lang(th):not(:focus):first-letter, .entry .entry-content .wp-block-pullquote cite:lang(th), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(th),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(th),
-.entry .entry-content .wp-block-cover-image h2:lang(th),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(th),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(th),
-.entry .entry-content .wp-block-cover h2:lang(th), .entry .entry-content .wp-block-audio figcaption:lang(th),
-.entry .entry-content .wp-block-video figcaption:lang(th),
-.entry .entry-content .wp-block-image figcaption:lang(th),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(th),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(th), .entry .entry-content .wp-block-file:lang(th), .entry .entry-content .wp-block-file .wp-block-file__button:lang(th), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(th), .wp-caption-text:lang(th), .gallery-caption:lang(th) {
-  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
-}
-
-body:lang(vi), button:lang(vi),
-input:lang(vi),
-select:lang(vi),
-optgroup:lang(vi),
-textarea:lang(vi), .author-description .author-link:lang(vi),
-.comment-metadata:lang(vi),
-.comment-reply-link:lang(vi),
-.comments-title:lang(vi),
-.comment-author .fn:lang(vi),
-.discussion-meta-info:lang(vi),
-.entry-meta:lang(vi),
-.entry-footer:lang(vi),
-.main-navigation:lang(vi),
-.no-comments:lang(vi),
-.not-found .page-title:lang(vi),
-.error-404 .page-title:lang(vi),
-.post-navigation .post-title:lang(vi),
-.page-links:lang(vi),
-.page-description:lang(vi),
-.pagination .nav-links:lang(vi),
-.sticky-post:lang(vi),
-.site-title:lang(vi),
-.site-info:lang(vi),
-#cancel-comment-reply-link:lang(vi),
-h1:lang(vi),
-h2:lang(vi),
-h3:lang(vi),
-h4:lang(vi),
-h5:lang(vi),
-h6:lang(vi), .page-title:lang(vi), blockquote cite:lang(vi), table:lang(vi), .button:lang(vi),
-input:lang(vi)[type="button"],
-input:lang(vi)[type="reset"],
-input:lang(vi)[type="submit"], .comment-navigation .nav-previous:lang(vi),
-.comment-navigation .nav-next:lang(vi), .comment-list .pingback .comment-body:lang(vi),
-.comment-list .trackback .comment-body:lang(vi), .comment-list .pingback .comment-body .comment-edit-link:lang(vi),
-.comment-list .trackback .comment-body .comment-edit-link:lang(vi), .comment-form .comment-notes:lang(vi),
-.comment-form label:lang(vi), .widget_archive ul li:lang(vi),
-.widget_categories ul li:lang(vi),
-.widget_meta ul li:lang(vi),
-.widget_nav_menu ul li:lang(vi),
-.widget_pages ul li:lang(vi),
-.widget_recent_comments ul li:lang(vi),
-.widget_recent_entries ul li:lang(vi),
-.widget_rss ul li:lang(vi), .widget_tag_cloud .tagcloud:lang(vi), .widget_calendar .calendar_wrap .wp-calendar-nav:lang(vi), .entry .entry-content .wp-block-button .wp-block-button__link:lang(vi), .entry .entry-content .wp-block-archives li > a:lang(vi),
-.entry .entry-content .wp-block-categories li > a:lang(vi),
-.entry .entry-content .wp-block-latest-posts li > a:lang(vi), .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(vi), .entry .entry-content .wp-block-verse:lang(vi), .entry .entry-content .has-drop-cap:lang(vi):not(:focus):first-letter, .entry .entry-content .wp-block-pullquote cite:lang(vi), .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(vi),
-.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(vi),
-.entry .entry-content .wp-block-cover-image h2:lang(vi),
-.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(vi),
-.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(vi),
-.entry .entry-content .wp-block-cover h2:lang(vi), .entry .entry-content .wp-block-audio figcaption:lang(vi),
-.entry .entry-content .wp-block-video figcaption:lang(vi),
-.entry .entry-content .wp-block-image figcaption:lang(vi),
-.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(vi),
-.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(vi), .entry .entry-content .wp-block-file:lang(vi), .entry .entry-content .wp-block-file .wp-block-file__button:lang(vi), .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(vi), .wp-caption-text:lang(vi), .gallery-caption:lang(vi) {
-  font-family: "Libre Franklin", sans-serif;
-}
-
 /* Normalize */
 /*! normalize.css v8.0.0 | MIT License | github.com/necolas/normalize.css */
 /* Document
@@ -1887,10 +87,8 @@ input:lang(vi)[type="submit"], .comment-navigation .nav-previous:lang(vi),
  * 2. Prevent adjustments of font size after orientation changes in iOS.
  */
 html {
-  line-height: 1.15;
-  /* 1 */
-  -webkit-text-size-adjust: 100%;
-  /* 2 */
+  line-height: 1.15; /* 1 */
+  -webkit-text-size-adjust: 100%; /* 2 */
 }
 
 /* Sections
@@ -1918,12 +116,9 @@ h1 {
  * 2. Show the overflow in Edge and IE.
  */
 hr {
-  box-sizing: content-box;
-  /* 1 */
-  height: 0;
-  /* 1 */
-  overflow: visible;
-  /* 2 */
+  box-sizing: content-box; /* 1 */
+  height: 0; /* 1 */
+  overflow: visible; /* 2 */
 }
 
 /**
@@ -1931,10 +126,8 @@ hr {
  * 2. Correct the odd `em` font sizing in all browsers.
  */
 pre {
-  font-family: monospace, monospace;
-  /* 1 */
-  font-size: 1em;
-  /* 2 */
+  font-family: monospace, monospace; /* 1 */
+  font-size: 1em; /* 2 */
 }
 
 /* Text-level semantics
@@ -1951,12 +144,9 @@ a {
  * 2. Add the correct text decoration in Chrome, Edge, IE, Opera, and Safari.
  */
 abbr[title] {
-  border-bottom: none;
-  /* 1 */
-  text-decoration: underline;
-  /* 2 */
-  text-decoration: underline dotted;
-  /* 2 */
+  border-bottom: none; /* 1 */
+  text-decoration: underline; /* 2 */
+  text-decoration: underline dotted; /* 2 */
 }
 
 /**
@@ -1974,10 +164,8 @@ strong {
 code,
 kbd,
 samp {
-  font-family: monospace, monospace;
-  /* 1 */
-  font-size: 1em;
-  /* 2 */
+  font-family: monospace, monospace; /* 1 */
+  font-size: 1em; /* 2 */
 }
 
 /**
@@ -2027,14 +215,10 @@ input,
 optgroup,
 select,
 textarea {
-  font-family: inherit;
-  /* 1 */
-  font-size: 100%;
-  /* 1 */
-  line-height: 1.15;
-  /* 1 */
-  margin: 0;
-  /* 2 */
+  font-family: inherit; /* 1 */
+  font-size: 100%; /* 1 */
+  line-height: 1.15; /* 1 */
+  margin: 0; /* 2 */
 }
 
 /**
@@ -2042,8 +226,7 @@ textarea {
  * 1. Show the overflow in Edge.
  */
 button,
-input {
-  /* 1 */
+input { /* 1 */
   overflow: visible;
 }
 
@@ -2052,8 +235,7 @@ input {
  * 1. Remove the inheritance of text transform in Firefox.
  */
 button,
-select {
-  /* 1 */
+select { /* 1 */
   text-transform: none;
 }
 
@@ -2061,9 +243,9 @@ select {
  * Correct the inability to style clickable types in iOS and Safari.
  */
 button,
-[type="button"],
-[type="reset"],
-[type="submit"] {
+[type=button],
+[type=reset],
+[type=submit] {
   -webkit-appearance: button;
 }
 
@@ -2071,9 +253,9 @@ button,
  * Remove the inner border and padding in Firefox.
  */
 button::-moz-focus-inner,
-[type="button"]::-moz-focus-inner,
-[type="reset"]::-moz-focus-inner,
-[type="submit"]::-moz-focus-inner {
+[type=button]::-moz-focus-inner,
+[type=reset]::-moz-focus-inner,
+[type=submit]::-moz-focus-inner {
   border-style: none;
   padding: 0;
 }
@@ -2082,9 +264,9 @@ button::-moz-focus-inner,
  * Restore the focus styles unset by the previous rule.
  */
 button:-moz-focusring,
-[type="button"]:-moz-focusring,
-[type="reset"]:-moz-focusring,
-[type="submit"]:-moz-focusring {
+[type=button]:-moz-focusring,
+[type=reset]:-moz-focusring,
+[type=submit]:-moz-focusring {
   outline: 1px dotted ButtonText;
 }
 
@@ -2102,18 +284,12 @@ fieldset {
  *		`fieldset` elements in all browsers.
  */
 legend {
-  box-sizing: border-box;
-  /* 1 */
-  color: inherit;
-  /* 2 */
-  display: table;
-  /* 1 */
-  max-width: 100%;
-  /* 1 */
-  padding: 0;
-  /* 3 */
-  white-space: normal;
-  /* 1 */
+  box-sizing: border-box; /* 1 */
+  color: inherit; /* 2 */
+  display: table; /* 1 */
+  max-width: 100%; /* 1 */
+  padding: 0; /* 3 */
+  white-space: normal; /* 1 */
 }
 
 /**
@@ -2134,19 +310,17 @@ textarea {
  * 1. Add the correct box sizing in IE 10.
  * 2. Remove the padding in IE 10.
  */
-[type="checkbox"],
-[type="radio"] {
-  box-sizing: border-box;
-  /* 1 */
-  padding: 0;
-  /* 2 */
+[type=checkbox],
+[type=radio] {
+  box-sizing: border-box; /* 1 */
+  padding: 0; /* 2 */
 }
 
 /**
  * Correct the cursor style of increment and decrement buttons in Chrome.
  */
-[type="number"]::-webkit-inner-spin-button,
-[type="number"]::-webkit-outer-spin-button {
+[type=number]::-webkit-inner-spin-button,
+[type=number]::-webkit-outer-spin-button {
   height: auto;
 }
 
@@ -2154,17 +328,15 @@ textarea {
  * 1. Correct the odd appearance in Chrome and Safari.
  * 2. Correct the outline style in Safari.
  */
-[type="search"] {
-  -webkit-appearance: textfield;
-  /* 1 */
-  outline-offset: -2px;
-  /* 2 */
+[type=search] {
+  -webkit-appearance: textfield; /* 1 */
+  outline-offset: -2px; /* 2 */
 }
 
 /**
  * Remove the inner padding in Chrome and Safari on macOS.
  */
-[type="search"]::-webkit-search-decoration {
+[type=search]::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
@@ -2173,10 +345,8 @@ textarea {
  * 2. Change font properties to `inherit` in Safari.
  */
 ::-webkit-file-upload-button {
-  -webkit-appearance: button;
-  /* 1 */
-  font: inherit;
-  /* 2 */
+  -webkit-appearance: button; /* 1 */
+  font: inherit; /* 2 */
 }
 
 /* Interactive
@@ -2222,6 +392,101 @@ body {
   background-color: #fff;
   color: #111;
   font-family: "NonBreakingSpaceOverride", "Hoefler Text", Garamond, "Times New Roman", serif;
+}
+body:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+body:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+body:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+body:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+body:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+body:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+body:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+body:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+body:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+body:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+body:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+body:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+body:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+body:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+body:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+body:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+body:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+body:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+body:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+body:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+body:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+body:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+body:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+body:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+body:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+body:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+body:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+body:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+body:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+body:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+body:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
+body {
   font-weight: 400;
   font-size: 1em;
   line-height: 1.8;
@@ -2236,6 +501,229 @@ optgroup,
 textarea {
   color: #111;
   font-family: "NonBreakingSpaceOverride", "Hoefler Text", Garamond, "Times New Roman", serif;
+}
+button:lang(ar),
+input:lang(ar),
+select:lang(ar),
+optgroup:lang(ar),
+textarea:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+button:lang(ary),
+input:lang(ary),
+select:lang(ary),
+optgroup:lang(ary),
+textarea:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+button:lang(azb),
+input:lang(azb),
+select:lang(azb),
+optgroup:lang(azb),
+textarea:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+button:lang(ckb),
+input:lang(ckb),
+select:lang(ckb),
+optgroup:lang(ckb),
+textarea:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+button:lang(fa-IR),
+input:lang(fa-IR),
+select:lang(fa-IR),
+optgroup:lang(fa-IR),
+textarea:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+button:lang(haz),
+input:lang(haz),
+select:lang(haz),
+optgroup:lang(haz),
+textarea:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+button:lang(ps),
+input:lang(ps),
+select:lang(ps),
+optgroup:lang(ps),
+textarea:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+button:lang(be),
+input:lang(be),
+select:lang(be),
+optgroup:lang(be),
+textarea:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+button:lang(bg-BG),
+input:lang(bg-BG),
+select:lang(bg-BG),
+optgroup:lang(bg-BG),
+textarea:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+button:lang(kk),
+input:lang(kk),
+select:lang(kk),
+optgroup:lang(kk),
+textarea:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+button:lang(mk-MK),
+input:lang(mk-MK),
+select:lang(mk-MK),
+optgroup:lang(mk-MK),
+textarea:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+button:lang(mn),
+input:lang(mn),
+select:lang(mn),
+optgroup:lang(mn),
+textarea:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+button:lang(ru-RU),
+input:lang(ru-RU),
+select:lang(ru-RU),
+optgroup:lang(ru-RU),
+textarea:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+button:lang(sah),
+input:lang(sah),
+select:lang(sah),
+optgroup:lang(sah),
+textarea:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+button:lang(sr-RS),
+input:lang(sr-RS),
+select:lang(sr-RS),
+optgroup:lang(sr-RS),
+textarea:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+button:lang(tt-RU),
+input:lang(tt-RU),
+select:lang(tt-RU),
+optgroup:lang(tt-RU),
+textarea:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+button:lang(uk),
+input:lang(uk),
+select:lang(uk),
+optgroup:lang(uk),
+textarea:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+button:lang(zh-HK),
+input:lang(zh-HK),
+select:lang(zh-HK),
+optgroup:lang(zh-HK),
+textarea:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+button:lang(zh-TW),
+input:lang(zh-TW),
+select:lang(zh-TW),
+optgroup:lang(zh-TW),
+textarea:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+button:lang(zh-CN),
+input:lang(zh-CN),
+select:lang(zh-CN),
+optgroup:lang(zh-CN),
+textarea:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+button:lang(bn-BD),
+input:lang(bn-BD),
+select:lang(bn-BD),
+optgroup:lang(bn-BD),
+textarea:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+button:lang(hi-IN),
+input:lang(hi-IN),
+select:lang(hi-IN),
+optgroup:lang(hi-IN),
+textarea:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+button:lang(mr),
+input:lang(mr),
+select:lang(mr),
+optgroup:lang(mr),
+textarea:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+button:lang(ne-NP),
+input:lang(ne-NP),
+select:lang(ne-NP),
+optgroup:lang(ne-NP),
+textarea:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+button:lang(el),
+input:lang(el),
+select:lang(el),
+optgroup:lang(el),
+textarea:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+button:lang(gu),
+input:lang(gu),
+select:lang(gu),
+optgroup:lang(gu),
+textarea:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+button:lang(he-IL),
+input:lang(he-IL),
+select:lang(he-IL),
+optgroup:lang(he-IL),
+textarea:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+button:lang(ja),
+input:lang(ja),
+select:lang(ja),
+optgroup:lang(ja),
+textarea:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+button:lang(ko-KR),
+input:lang(ko-KR),
+select:lang(ko-KR),
+optgroup:lang(ko-KR),
+textarea:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+button:lang(th),
+input:lang(th),
+select:lang(th),
+optgroup:lang(th),
+textarea:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+button:lang(vi),
+input:lang(vi),
+select:lang(vi),
+optgroup:lang(vi),
+textarea:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
+button,
+input,
+select,
+optgroup,
+textarea {
   font-weight: 400;
   line-height: 1.8;
   text-rendering: optimizeLegibility;
@@ -2269,6 +757,874 @@ h5,
 h6 {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 }
+.author-description .author-link:lang(ar),
+.comment-metadata:lang(ar),
+.comment-reply-link:lang(ar),
+.comments-title:lang(ar),
+.comment-author .fn:lang(ar),
+.discussion-meta-info:lang(ar),
+.entry-meta:lang(ar),
+.entry-footer:lang(ar),
+.main-navigation:lang(ar),
+.no-comments:lang(ar),
+.not-found .page-title:lang(ar),
+.error-404 .page-title:lang(ar),
+.post-navigation .post-title:lang(ar),
+.page-links:lang(ar),
+.page-description:lang(ar),
+.pagination .nav-links:lang(ar),
+.sticky-post:lang(ar),
+.site-title:lang(ar),
+.site-info:lang(ar),
+#cancel-comment-reply-link:lang(ar),
+h1:lang(ar),
+h2:lang(ar),
+h3:lang(ar),
+h4:lang(ar),
+h5:lang(ar),
+h6:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.author-description .author-link:lang(ary),
+.comment-metadata:lang(ary),
+.comment-reply-link:lang(ary),
+.comments-title:lang(ary),
+.comment-author .fn:lang(ary),
+.discussion-meta-info:lang(ary),
+.entry-meta:lang(ary),
+.entry-footer:lang(ary),
+.main-navigation:lang(ary),
+.no-comments:lang(ary),
+.not-found .page-title:lang(ary),
+.error-404 .page-title:lang(ary),
+.post-navigation .post-title:lang(ary),
+.page-links:lang(ary),
+.page-description:lang(ary),
+.pagination .nav-links:lang(ary),
+.sticky-post:lang(ary),
+.site-title:lang(ary),
+.site-info:lang(ary),
+#cancel-comment-reply-link:lang(ary),
+h1:lang(ary),
+h2:lang(ary),
+h3:lang(ary),
+h4:lang(ary),
+h5:lang(ary),
+h6:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.author-description .author-link:lang(azb),
+.comment-metadata:lang(azb),
+.comment-reply-link:lang(azb),
+.comments-title:lang(azb),
+.comment-author .fn:lang(azb),
+.discussion-meta-info:lang(azb),
+.entry-meta:lang(azb),
+.entry-footer:lang(azb),
+.main-navigation:lang(azb),
+.no-comments:lang(azb),
+.not-found .page-title:lang(azb),
+.error-404 .page-title:lang(azb),
+.post-navigation .post-title:lang(azb),
+.page-links:lang(azb),
+.page-description:lang(azb),
+.pagination .nav-links:lang(azb),
+.sticky-post:lang(azb),
+.site-title:lang(azb),
+.site-info:lang(azb),
+#cancel-comment-reply-link:lang(azb),
+h1:lang(azb),
+h2:lang(azb),
+h3:lang(azb),
+h4:lang(azb),
+h5:lang(azb),
+h6:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.author-description .author-link:lang(ckb),
+.comment-metadata:lang(ckb),
+.comment-reply-link:lang(ckb),
+.comments-title:lang(ckb),
+.comment-author .fn:lang(ckb),
+.discussion-meta-info:lang(ckb),
+.entry-meta:lang(ckb),
+.entry-footer:lang(ckb),
+.main-navigation:lang(ckb),
+.no-comments:lang(ckb),
+.not-found .page-title:lang(ckb),
+.error-404 .page-title:lang(ckb),
+.post-navigation .post-title:lang(ckb),
+.page-links:lang(ckb),
+.page-description:lang(ckb),
+.pagination .nav-links:lang(ckb),
+.sticky-post:lang(ckb),
+.site-title:lang(ckb),
+.site-info:lang(ckb),
+#cancel-comment-reply-link:lang(ckb),
+h1:lang(ckb),
+h2:lang(ckb),
+h3:lang(ckb),
+h4:lang(ckb),
+h5:lang(ckb),
+h6:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.author-description .author-link:lang(fa-IR),
+.comment-metadata:lang(fa-IR),
+.comment-reply-link:lang(fa-IR),
+.comments-title:lang(fa-IR),
+.comment-author .fn:lang(fa-IR),
+.discussion-meta-info:lang(fa-IR),
+.entry-meta:lang(fa-IR),
+.entry-footer:lang(fa-IR),
+.main-navigation:lang(fa-IR),
+.no-comments:lang(fa-IR),
+.not-found .page-title:lang(fa-IR),
+.error-404 .page-title:lang(fa-IR),
+.post-navigation .post-title:lang(fa-IR),
+.page-links:lang(fa-IR),
+.page-description:lang(fa-IR),
+.pagination .nav-links:lang(fa-IR),
+.sticky-post:lang(fa-IR),
+.site-title:lang(fa-IR),
+.site-info:lang(fa-IR),
+#cancel-comment-reply-link:lang(fa-IR),
+h1:lang(fa-IR),
+h2:lang(fa-IR),
+h3:lang(fa-IR),
+h4:lang(fa-IR),
+h5:lang(fa-IR),
+h6:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.author-description .author-link:lang(haz),
+.comment-metadata:lang(haz),
+.comment-reply-link:lang(haz),
+.comments-title:lang(haz),
+.comment-author .fn:lang(haz),
+.discussion-meta-info:lang(haz),
+.entry-meta:lang(haz),
+.entry-footer:lang(haz),
+.main-navigation:lang(haz),
+.no-comments:lang(haz),
+.not-found .page-title:lang(haz),
+.error-404 .page-title:lang(haz),
+.post-navigation .post-title:lang(haz),
+.page-links:lang(haz),
+.page-description:lang(haz),
+.pagination .nav-links:lang(haz),
+.sticky-post:lang(haz),
+.site-title:lang(haz),
+.site-info:lang(haz),
+#cancel-comment-reply-link:lang(haz),
+h1:lang(haz),
+h2:lang(haz),
+h3:lang(haz),
+h4:lang(haz),
+h5:lang(haz),
+h6:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.author-description .author-link:lang(ps),
+.comment-metadata:lang(ps),
+.comment-reply-link:lang(ps),
+.comments-title:lang(ps),
+.comment-author .fn:lang(ps),
+.discussion-meta-info:lang(ps),
+.entry-meta:lang(ps),
+.entry-footer:lang(ps),
+.main-navigation:lang(ps),
+.no-comments:lang(ps),
+.not-found .page-title:lang(ps),
+.error-404 .page-title:lang(ps),
+.post-navigation .post-title:lang(ps),
+.page-links:lang(ps),
+.page-description:lang(ps),
+.pagination .nav-links:lang(ps),
+.sticky-post:lang(ps),
+.site-title:lang(ps),
+.site-info:lang(ps),
+#cancel-comment-reply-link:lang(ps),
+h1:lang(ps),
+h2:lang(ps),
+h3:lang(ps),
+h4:lang(ps),
+h5:lang(ps),
+h6:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.author-description .author-link:lang(be),
+.comment-metadata:lang(be),
+.comment-reply-link:lang(be),
+.comments-title:lang(be),
+.comment-author .fn:lang(be),
+.discussion-meta-info:lang(be),
+.entry-meta:lang(be),
+.entry-footer:lang(be),
+.main-navigation:lang(be),
+.no-comments:lang(be),
+.not-found .page-title:lang(be),
+.error-404 .page-title:lang(be),
+.post-navigation .post-title:lang(be),
+.page-links:lang(be),
+.page-description:lang(be),
+.pagination .nav-links:lang(be),
+.sticky-post:lang(be),
+.site-title:lang(be),
+.site-info:lang(be),
+#cancel-comment-reply-link:lang(be),
+h1:lang(be),
+h2:lang(be),
+h3:lang(be),
+h4:lang(be),
+h5:lang(be),
+h6:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.author-description .author-link:lang(bg-BG),
+.comment-metadata:lang(bg-BG),
+.comment-reply-link:lang(bg-BG),
+.comments-title:lang(bg-BG),
+.comment-author .fn:lang(bg-BG),
+.discussion-meta-info:lang(bg-BG),
+.entry-meta:lang(bg-BG),
+.entry-footer:lang(bg-BG),
+.main-navigation:lang(bg-BG),
+.no-comments:lang(bg-BG),
+.not-found .page-title:lang(bg-BG),
+.error-404 .page-title:lang(bg-BG),
+.post-navigation .post-title:lang(bg-BG),
+.page-links:lang(bg-BG),
+.page-description:lang(bg-BG),
+.pagination .nav-links:lang(bg-BG),
+.sticky-post:lang(bg-BG),
+.site-title:lang(bg-BG),
+.site-info:lang(bg-BG),
+#cancel-comment-reply-link:lang(bg-BG),
+h1:lang(bg-BG),
+h2:lang(bg-BG),
+h3:lang(bg-BG),
+h4:lang(bg-BG),
+h5:lang(bg-BG),
+h6:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.author-description .author-link:lang(kk),
+.comment-metadata:lang(kk),
+.comment-reply-link:lang(kk),
+.comments-title:lang(kk),
+.comment-author .fn:lang(kk),
+.discussion-meta-info:lang(kk),
+.entry-meta:lang(kk),
+.entry-footer:lang(kk),
+.main-navigation:lang(kk),
+.no-comments:lang(kk),
+.not-found .page-title:lang(kk),
+.error-404 .page-title:lang(kk),
+.post-navigation .post-title:lang(kk),
+.page-links:lang(kk),
+.page-description:lang(kk),
+.pagination .nav-links:lang(kk),
+.sticky-post:lang(kk),
+.site-title:lang(kk),
+.site-info:lang(kk),
+#cancel-comment-reply-link:lang(kk),
+h1:lang(kk),
+h2:lang(kk),
+h3:lang(kk),
+h4:lang(kk),
+h5:lang(kk),
+h6:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.author-description .author-link:lang(mk-MK),
+.comment-metadata:lang(mk-MK),
+.comment-reply-link:lang(mk-MK),
+.comments-title:lang(mk-MK),
+.comment-author .fn:lang(mk-MK),
+.discussion-meta-info:lang(mk-MK),
+.entry-meta:lang(mk-MK),
+.entry-footer:lang(mk-MK),
+.main-navigation:lang(mk-MK),
+.no-comments:lang(mk-MK),
+.not-found .page-title:lang(mk-MK),
+.error-404 .page-title:lang(mk-MK),
+.post-navigation .post-title:lang(mk-MK),
+.page-links:lang(mk-MK),
+.page-description:lang(mk-MK),
+.pagination .nav-links:lang(mk-MK),
+.sticky-post:lang(mk-MK),
+.site-title:lang(mk-MK),
+.site-info:lang(mk-MK),
+#cancel-comment-reply-link:lang(mk-MK),
+h1:lang(mk-MK),
+h2:lang(mk-MK),
+h3:lang(mk-MK),
+h4:lang(mk-MK),
+h5:lang(mk-MK),
+h6:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.author-description .author-link:lang(mn),
+.comment-metadata:lang(mn),
+.comment-reply-link:lang(mn),
+.comments-title:lang(mn),
+.comment-author .fn:lang(mn),
+.discussion-meta-info:lang(mn),
+.entry-meta:lang(mn),
+.entry-footer:lang(mn),
+.main-navigation:lang(mn),
+.no-comments:lang(mn),
+.not-found .page-title:lang(mn),
+.error-404 .page-title:lang(mn),
+.post-navigation .post-title:lang(mn),
+.page-links:lang(mn),
+.page-description:lang(mn),
+.pagination .nav-links:lang(mn),
+.sticky-post:lang(mn),
+.site-title:lang(mn),
+.site-info:lang(mn),
+#cancel-comment-reply-link:lang(mn),
+h1:lang(mn),
+h2:lang(mn),
+h3:lang(mn),
+h4:lang(mn),
+h5:lang(mn),
+h6:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.author-description .author-link:lang(ru-RU),
+.comment-metadata:lang(ru-RU),
+.comment-reply-link:lang(ru-RU),
+.comments-title:lang(ru-RU),
+.comment-author .fn:lang(ru-RU),
+.discussion-meta-info:lang(ru-RU),
+.entry-meta:lang(ru-RU),
+.entry-footer:lang(ru-RU),
+.main-navigation:lang(ru-RU),
+.no-comments:lang(ru-RU),
+.not-found .page-title:lang(ru-RU),
+.error-404 .page-title:lang(ru-RU),
+.post-navigation .post-title:lang(ru-RU),
+.page-links:lang(ru-RU),
+.page-description:lang(ru-RU),
+.pagination .nav-links:lang(ru-RU),
+.sticky-post:lang(ru-RU),
+.site-title:lang(ru-RU),
+.site-info:lang(ru-RU),
+#cancel-comment-reply-link:lang(ru-RU),
+h1:lang(ru-RU),
+h2:lang(ru-RU),
+h3:lang(ru-RU),
+h4:lang(ru-RU),
+h5:lang(ru-RU),
+h6:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.author-description .author-link:lang(sah),
+.comment-metadata:lang(sah),
+.comment-reply-link:lang(sah),
+.comments-title:lang(sah),
+.comment-author .fn:lang(sah),
+.discussion-meta-info:lang(sah),
+.entry-meta:lang(sah),
+.entry-footer:lang(sah),
+.main-navigation:lang(sah),
+.no-comments:lang(sah),
+.not-found .page-title:lang(sah),
+.error-404 .page-title:lang(sah),
+.post-navigation .post-title:lang(sah),
+.page-links:lang(sah),
+.page-description:lang(sah),
+.pagination .nav-links:lang(sah),
+.sticky-post:lang(sah),
+.site-title:lang(sah),
+.site-info:lang(sah),
+#cancel-comment-reply-link:lang(sah),
+h1:lang(sah),
+h2:lang(sah),
+h3:lang(sah),
+h4:lang(sah),
+h5:lang(sah),
+h6:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.author-description .author-link:lang(sr-RS),
+.comment-metadata:lang(sr-RS),
+.comment-reply-link:lang(sr-RS),
+.comments-title:lang(sr-RS),
+.comment-author .fn:lang(sr-RS),
+.discussion-meta-info:lang(sr-RS),
+.entry-meta:lang(sr-RS),
+.entry-footer:lang(sr-RS),
+.main-navigation:lang(sr-RS),
+.no-comments:lang(sr-RS),
+.not-found .page-title:lang(sr-RS),
+.error-404 .page-title:lang(sr-RS),
+.post-navigation .post-title:lang(sr-RS),
+.page-links:lang(sr-RS),
+.page-description:lang(sr-RS),
+.pagination .nav-links:lang(sr-RS),
+.sticky-post:lang(sr-RS),
+.site-title:lang(sr-RS),
+.site-info:lang(sr-RS),
+#cancel-comment-reply-link:lang(sr-RS),
+h1:lang(sr-RS),
+h2:lang(sr-RS),
+h3:lang(sr-RS),
+h4:lang(sr-RS),
+h5:lang(sr-RS),
+h6:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.author-description .author-link:lang(tt-RU),
+.comment-metadata:lang(tt-RU),
+.comment-reply-link:lang(tt-RU),
+.comments-title:lang(tt-RU),
+.comment-author .fn:lang(tt-RU),
+.discussion-meta-info:lang(tt-RU),
+.entry-meta:lang(tt-RU),
+.entry-footer:lang(tt-RU),
+.main-navigation:lang(tt-RU),
+.no-comments:lang(tt-RU),
+.not-found .page-title:lang(tt-RU),
+.error-404 .page-title:lang(tt-RU),
+.post-navigation .post-title:lang(tt-RU),
+.page-links:lang(tt-RU),
+.page-description:lang(tt-RU),
+.pagination .nav-links:lang(tt-RU),
+.sticky-post:lang(tt-RU),
+.site-title:lang(tt-RU),
+.site-info:lang(tt-RU),
+#cancel-comment-reply-link:lang(tt-RU),
+h1:lang(tt-RU),
+h2:lang(tt-RU),
+h3:lang(tt-RU),
+h4:lang(tt-RU),
+h5:lang(tt-RU),
+h6:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.author-description .author-link:lang(uk),
+.comment-metadata:lang(uk),
+.comment-reply-link:lang(uk),
+.comments-title:lang(uk),
+.comment-author .fn:lang(uk),
+.discussion-meta-info:lang(uk),
+.entry-meta:lang(uk),
+.entry-footer:lang(uk),
+.main-navigation:lang(uk),
+.no-comments:lang(uk),
+.not-found .page-title:lang(uk),
+.error-404 .page-title:lang(uk),
+.post-navigation .post-title:lang(uk),
+.page-links:lang(uk),
+.page-description:lang(uk),
+.pagination .nav-links:lang(uk),
+.sticky-post:lang(uk),
+.site-title:lang(uk),
+.site-info:lang(uk),
+#cancel-comment-reply-link:lang(uk),
+h1:lang(uk),
+h2:lang(uk),
+h3:lang(uk),
+h4:lang(uk),
+h5:lang(uk),
+h6:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.author-description .author-link:lang(zh-HK),
+.comment-metadata:lang(zh-HK),
+.comment-reply-link:lang(zh-HK),
+.comments-title:lang(zh-HK),
+.comment-author .fn:lang(zh-HK),
+.discussion-meta-info:lang(zh-HK),
+.entry-meta:lang(zh-HK),
+.entry-footer:lang(zh-HK),
+.main-navigation:lang(zh-HK),
+.no-comments:lang(zh-HK),
+.not-found .page-title:lang(zh-HK),
+.error-404 .page-title:lang(zh-HK),
+.post-navigation .post-title:lang(zh-HK),
+.page-links:lang(zh-HK),
+.page-description:lang(zh-HK),
+.pagination .nav-links:lang(zh-HK),
+.sticky-post:lang(zh-HK),
+.site-title:lang(zh-HK),
+.site-info:lang(zh-HK),
+#cancel-comment-reply-link:lang(zh-HK),
+h1:lang(zh-HK),
+h2:lang(zh-HK),
+h3:lang(zh-HK),
+h4:lang(zh-HK),
+h5:lang(zh-HK),
+h6:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.author-description .author-link:lang(zh-TW),
+.comment-metadata:lang(zh-TW),
+.comment-reply-link:lang(zh-TW),
+.comments-title:lang(zh-TW),
+.comment-author .fn:lang(zh-TW),
+.discussion-meta-info:lang(zh-TW),
+.entry-meta:lang(zh-TW),
+.entry-footer:lang(zh-TW),
+.main-navigation:lang(zh-TW),
+.no-comments:lang(zh-TW),
+.not-found .page-title:lang(zh-TW),
+.error-404 .page-title:lang(zh-TW),
+.post-navigation .post-title:lang(zh-TW),
+.page-links:lang(zh-TW),
+.page-description:lang(zh-TW),
+.pagination .nav-links:lang(zh-TW),
+.sticky-post:lang(zh-TW),
+.site-title:lang(zh-TW),
+.site-info:lang(zh-TW),
+#cancel-comment-reply-link:lang(zh-TW),
+h1:lang(zh-TW),
+h2:lang(zh-TW),
+h3:lang(zh-TW),
+h4:lang(zh-TW),
+h5:lang(zh-TW),
+h6:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.author-description .author-link:lang(zh-CN),
+.comment-metadata:lang(zh-CN),
+.comment-reply-link:lang(zh-CN),
+.comments-title:lang(zh-CN),
+.comment-author .fn:lang(zh-CN),
+.discussion-meta-info:lang(zh-CN),
+.entry-meta:lang(zh-CN),
+.entry-footer:lang(zh-CN),
+.main-navigation:lang(zh-CN),
+.no-comments:lang(zh-CN),
+.not-found .page-title:lang(zh-CN),
+.error-404 .page-title:lang(zh-CN),
+.post-navigation .post-title:lang(zh-CN),
+.page-links:lang(zh-CN),
+.page-description:lang(zh-CN),
+.pagination .nav-links:lang(zh-CN),
+.sticky-post:lang(zh-CN),
+.site-title:lang(zh-CN),
+.site-info:lang(zh-CN),
+#cancel-comment-reply-link:lang(zh-CN),
+h1:lang(zh-CN),
+h2:lang(zh-CN),
+h3:lang(zh-CN),
+h4:lang(zh-CN),
+h5:lang(zh-CN),
+h6:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.author-description .author-link:lang(bn-BD),
+.comment-metadata:lang(bn-BD),
+.comment-reply-link:lang(bn-BD),
+.comments-title:lang(bn-BD),
+.comment-author .fn:lang(bn-BD),
+.discussion-meta-info:lang(bn-BD),
+.entry-meta:lang(bn-BD),
+.entry-footer:lang(bn-BD),
+.main-navigation:lang(bn-BD),
+.no-comments:lang(bn-BD),
+.not-found .page-title:lang(bn-BD),
+.error-404 .page-title:lang(bn-BD),
+.post-navigation .post-title:lang(bn-BD),
+.page-links:lang(bn-BD),
+.page-description:lang(bn-BD),
+.pagination .nav-links:lang(bn-BD),
+.sticky-post:lang(bn-BD),
+.site-title:lang(bn-BD),
+.site-info:lang(bn-BD),
+#cancel-comment-reply-link:lang(bn-BD),
+h1:lang(bn-BD),
+h2:lang(bn-BD),
+h3:lang(bn-BD),
+h4:lang(bn-BD),
+h5:lang(bn-BD),
+h6:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+.author-description .author-link:lang(hi-IN),
+.comment-metadata:lang(hi-IN),
+.comment-reply-link:lang(hi-IN),
+.comments-title:lang(hi-IN),
+.comment-author .fn:lang(hi-IN),
+.discussion-meta-info:lang(hi-IN),
+.entry-meta:lang(hi-IN),
+.entry-footer:lang(hi-IN),
+.main-navigation:lang(hi-IN),
+.no-comments:lang(hi-IN),
+.not-found .page-title:lang(hi-IN),
+.error-404 .page-title:lang(hi-IN),
+.post-navigation .post-title:lang(hi-IN),
+.page-links:lang(hi-IN),
+.page-description:lang(hi-IN),
+.pagination .nav-links:lang(hi-IN),
+.sticky-post:lang(hi-IN),
+.site-title:lang(hi-IN),
+.site-info:lang(hi-IN),
+#cancel-comment-reply-link:lang(hi-IN),
+h1:lang(hi-IN),
+h2:lang(hi-IN),
+h3:lang(hi-IN),
+h4:lang(hi-IN),
+h5:lang(hi-IN),
+h6:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+.author-description .author-link:lang(mr),
+.comment-metadata:lang(mr),
+.comment-reply-link:lang(mr),
+.comments-title:lang(mr),
+.comment-author .fn:lang(mr),
+.discussion-meta-info:lang(mr),
+.entry-meta:lang(mr),
+.entry-footer:lang(mr),
+.main-navigation:lang(mr),
+.no-comments:lang(mr),
+.not-found .page-title:lang(mr),
+.error-404 .page-title:lang(mr),
+.post-navigation .post-title:lang(mr),
+.page-links:lang(mr),
+.page-description:lang(mr),
+.pagination .nav-links:lang(mr),
+.sticky-post:lang(mr),
+.site-title:lang(mr),
+.site-info:lang(mr),
+#cancel-comment-reply-link:lang(mr),
+h1:lang(mr),
+h2:lang(mr),
+h3:lang(mr),
+h4:lang(mr),
+h5:lang(mr),
+h6:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+.author-description .author-link:lang(ne-NP),
+.comment-metadata:lang(ne-NP),
+.comment-reply-link:lang(ne-NP),
+.comments-title:lang(ne-NP),
+.comment-author .fn:lang(ne-NP),
+.discussion-meta-info:lang(ne-NP),
+.entry-meta:lang(ne-NP),
+.entry-footer:lang(ne-NP),
+.main-navigation:lang(ne-NP),
+.no-comments:lang(ne-NP),
+.not-found .page-title:lang(ne-NP),
+.error-404 .page-title:lang(ne-NP),
+.post-navigation .post-title:lang(ne-NP),
+.page-links:lang(ne-NP),
+.page-description:lang(ne-NP),
+.pagination .nav-links:lang(ne-NP),
+.sticky-post:lang(ne-NP),
+.site-title:lang(ne-NP),
+.site-info:lang(ne-NP),
+#cancel-comment-reply-link:lang(ne-NP),
+h1:lang(ne-NP),
+h2:lang(ne-NP),
+h3:lang(ne-NP),
+h4:lang(ne-NP),
+h5:lang(ne-NP),
+h6:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+.author-description .author-link:lang(el),
+.comment-metadata:lang(el),
+.comment-reply-link:lang(el),
+.comments-title:lang(el),
+.comment-author .fn:lang(el),
+.discussion-meta-info:lang(el),
+.entry-meta:lang(el),
+.entry-footer:lang(el),
+.main-navigation:lang(el),
+.no-comments:lang(el),
+.not-found .page-title:lang(el),
+.error-404 .page-title:lang(el),
+.post-navigation .post-title:lang(el),
+.page-links:lang(el),
+.page-description:lang(el),
+.pagination .nav-links:lang(el),
+.sticky-post:lang(el),
+.site-title:lang(el),
+.site-info:lang(el),
+#cancel-comment-reply-link:lang(el),
+h1:lang(el),
+h2:lang(el),
+h3:lang(el),
+h4:lang(el),
+h5:lang(el),
+h6:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+.author-description .author-link:lang(gu),
+.comment-metadata:lang(gu),
+.comment-reply-link:lang(gu),
+.comments-title:lang(gu),
+.comment-author .fn:lang(gu),
+.discussion-meta-info:lang(gu),
+.entry-meta:lang(gu),
+.entry-footer:lang(gu),
+.main-navigation:lang(gu),
+.no-comments:lang(gu),
+.not-found .page-title:lang(gu),
+.error-404 .page-title:lang(gu),
+.post-navigation .post-title:lang(gu),
+.page-links:lang(gu),
+.page-description:lang(gu),
+.pagination .nav-links:lang(gu),
+.sticky-post:lang(gu),
+.site-title:lang(gu),
+.site-info:lang(gu),
+#cancel-comment-reply-link:lang(gu),
+h1:lang(gu),
+h2:lang(gu),
+h3:lang(gu),
+h4:lang(gu),
+h5:lang(gu),
+h6:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+.author-description .author-link:lang(he-IL),
+.comment-metadata:lang(he-IL),
+.comment-reply-link:lang(he-IL),
+.comments-title:lang(he-IL),
+.comment-author .fn:lang(he-IL),
+.discussion-meta-info:lang(he-IL),
+.entry-meta:lang(he-IL),
+.entry-footer:lang(he-IL),
+.main-navigation:lang(he-IL),
+.no-comments:lang(he-IL),
+.not-found .page-title:lang(he-IL),
+.error-404 .page-title:lang(he-IL),
+.post-navigation .post-title:lang(he-IL),
+.page-links:lang(he-IL),
+.page-description:lang(he-IL),
+.pagination .nav-links:lang(he-IL),
+.sticky-post:lang(he-IL),
+.site-title:lang(he-IL),
+.site-info:lang(he-IL),
+#cancel-comment-reply-link:lang(he-IL),
+h1:lang(he-IL),
+h2:lang(he-IL),
+h3:lang(he-IL),
+h4:lang(he-IL),
+h5:lang(he-IL),
+h6:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+.author-description .author-link:lang(ja),
+.comment-metadata:lang(ja),
+.comment-reply-link:lang(ja),
+.comments-title:lang(ja),
+.comment-author .fn:lang(ja),
+.discussion-meta-info:lang(ja),
+.entry-meta:lang(ja),
+.entry-footer:lang(ja),
+.main-navigation:lang(ja),
+.no-comments:lang(ja),
+.not-found .page-title:lang(ja),
+.error-404 .page-title:lang(ja),
+.post-navigation .post-title:lang(ja),
+.page-links:lang(ja),
+.page-description:lang(ja),
+.pagination .nav-links:lang(ja),
+.sticky-post:lang(ja),
+.site-title:lang(ja),
+.site-info:lang(ja),
+#cancel-comment-reply-link:lang(ja),
+h1:lang(ja),
+h2:lang(ja),
+h3:lang(ja),
+h4:lang(ja),
+h5:lang(ja),
+h6:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+.author-description .author-link:lang(ko-KR),
+.comment-metadata:lang(ko-KR),
+.comment-reply-link:lang(ko-KR),
+.comments-title:lang(ko-KR),
+.comment-author .fn:lang(ko-KR),
+.discussion-meta-info:lang(ko-KR),
+.entry-meta:lang(ko-KR),
+.entry-footer:lang(ko-KR),
+.main-navigation:lang(ko-KR),
+.no-comments:lang(ko-KR),
+.not-found .page-title:lang(ko-KR),
+.error-404 .page-title:lang(ko-KR),
+.post-navigation .post-title:lang(ko-KR),
+.page-links:lang(ko-KR),
+.page-description:lang(ko-KR),
+.pagination .nav-links:lang(ko-KR),
+.sticky-post:lang(ko-KR),
+.site-title:lang(ko-KR),
+.site-info:lang(ko-KR),
+#cancel-comment-reply-link:lang(ko-KR),
+h1:lang(ko-KR),
+h2:lang(ko-KR),
+h3:lang(ko-KR),
+h4:lang(ko-KR),
+h5:lang(ko-KR),
+h6:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+.author-description .author-link:lang(th),
+.comment-metadata:lang(th),
+.comment-reply-link:lang(th),
+.comments-title:lang(th),
+.comment-author .fn:lang(th),
+.discussion-meta-info:lang(th),
+.entry-meta:lang(th),
+.entry-footer:lang(th),
+.main-navigation:lang(th),
+.no-comments:lang(th),
+.not-found .page-title:lang(th),
+.error-404 .page-title:lang(th),
+.post-navigation .post-title:lang(th),
+.page-links:lang(th),
+.page-description:lang(th),
+.pagination .nav-links:lang(th),
+.sticky-post:lang(th),
+.site-title:lang(th),
+.site-info:lang(th),
+#cancel-comment-reply-link:lang(th),
+h1:lang(th),
+h2:lang(th),
+h3:lang(th),
+h4:lang(th),
+h5:lang(th),
+h6:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+.author-description .author-link:lang(vi),
+.comment-metadata:lang(vi),
+.comment-reply-link:lang(vi),
+.comments-title:lang(vi),
+.comment-author .fn:lang(vi),
+.discussion-meta-info:lang(vi),
+.entry-meta:lang(vi),
+.entry-footer:lang(vi),
+.main-navigation:lang(vi),
+.no-comments:lang(vi),
+.not-found .page-title:lang(vi),
+.error-404 .page-title:lang(vi),
+.post-navigation .post-title:lang(vi),
+.page-links:lang(vi),
+.page-description:lang(vi),
+.pagination .nav-links:lang(vi),
+.sticky-post:lang(vi),
+.site-title:lang(vi),
+.site-info:lang(vi),
+#cancel-comment-reply-link:lang(vi),
+h1:lang(vi),
+h2:lang(vi),
+h3:lang(vi),
+h4:lang(vi),
+h5:lang(vi),
+h6:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
 
 .main-navigation,
 .page-description,
@@ -2297,6 +1653,99 @@ h6 {
 .page-title {
   font-family: "NonBreakingSpaceOverride", "Hoefler Text", Garamond, "Times New Roman", serif;
 }
+.page-title:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.page-title:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.page-title:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.page-title:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.page-title:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.page-title:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.page-title:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.page-title:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.page-title:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.page-title:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.page-title:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.page-title:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.page-title:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.page-title:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.page-title:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.page-title:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.page-title:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.page-title:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.page-title:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.page-title:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.page-title:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+.page-title:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+.page-title:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+.page-title:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+.page-title:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+.page-title:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+.page-title:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+.page-title:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+.page-title:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+.page-title:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+.page-title:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
 
 .site-branding,
 .main-navigation ul.main-menu > li,
@@ -2309,7 +1758,6 @@ h6 {
 h1 {
   font-size: 2.25em;
 }
-
 @media only screen and (min-width: 768px) {
   h1 {
     font-size: 2.8125em;
@@ -2323,7 +1771,6 @@ h1 {
 h2 {
   font-size: 1.6875em;
 }
-
 @media only screen and (min-width: 768px) {
   .entry-title,
   .not-found .page-title,
@@ -2358,7 +1805,7 @@ h4 {
 .pagination .nav-links,
 .comment-content,
 h5 {
-  font-size: 0.88889em;
+  font-size: 0.8888888889em;
 }
 
 .entry-meta,
@@ -2373,7 +1820,7 @@ h5 {
 #cancel-comment-reply-link,
 img:after,
 h6 {
-  font-size: 0.71111em;
+  font-size: 0.7111111111em;
 }
 
 .site-title,
@@ -2427,13 +1874,106 @@ i {
 }
 
 blockquote cite {
-  font-size: 0.71111em;
+  font-size: 0.7111111111em;
   font-style: normal;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 }
+blockquote cite:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+blockquote cite:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+blockquote cite:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+blockquote cite:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+blockquote cite:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+blockquote cite:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+blockquote cite:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+blockquote cite:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+blockquote cite:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+blockquote cite:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+blockquote cite:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+blockquote cite:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+blockquote cite:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+blockquote cite:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+blockquote cite:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+blockquote cite:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+blockquote cite:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+blockquote cite:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+blockquote cite:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+blockquote cite:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+blockquote cite:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+blockquote cite:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+blockquote cite:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+blockquote cite:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+blockquote cite:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+blockquote cite:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+blockquote cite:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+blockquote cite:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+blockquote cite:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+blockquote cite:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+blockquote cite:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
 
 pre {
-  font-size: 0.88889em;
+  font-size: 0.8888888889em;
   font-family: "Courier 10 Pitch", Courier, monospace;
   line-height: 1.8;
   overflow: auto;
@@ -2443,7 +1983,7 @@ code,
 kbd,
 tt,
 var {
-  font-size: 0.88889em;
+  font-size: 0.8888888889em;
   font-family: Menlo, monaco, Consolas, Lucida Console, monospace;
 }
 
@@ -2465,11 +2005,9 @@ big {
 a {
   text-decoration: none;
 }
-
 a:hover {
   text-decoration: none;
 }
-
 a:focus {
   text-decoration: underline;
   text-decoration-thickness: 2px;
@@ -2481,11 +2019,11 @@ html {
 }
 
 ::-moz-selection {
-  background-color: #bfdcea;
+  background-color: rgb(191.25, 220, 233.75);
 }
 
 ::selection {
-  background-color: #bfdcea;
+  background-color: rgb(191.25, 220, 233.75);
 }
 
 *,
@@ -2501,7 +2039,7 @@ a {
 
 a:hover,
 a:active {
-  color: #005177;
+  color: rgb(0, 80.5, 119);
   outline: 0;
   text-decoration: none;
 }
@@ -2526,19 +2064,17 @@ h6 {
 h1:not(.site-title):before,
 h2:before {
   background: #767676;
-  content: "\020";
+  content: " ";
   display: block;
   height: 2px;
   margin: 1rem 0;
   width: 1em;
 }
-
 h1:not(.site-title).has-text-align-center:before,
 h2.has-text-align-center:before {
   margin-left: auto;
   margin-right: auto;
 }
-
 h1:not(.site-title).has-text-align-right:before,
 h2.has-text-align-right:before {
   margin-left: auto;
@@ -2558,7 +2094,6 @@ ol {
 ul {
   list-style: disc;
 }
-
 ul ul {
   list-style-type: circle;
 }
@@ -2599,11 +2134,9 @@ blockquote {
   margin-left: 0;
   padding: 0 0 0 1rem;
 }
-
 blockquote > p {
   margin: 0 0 1rem;
 }
-
 blockquote cite {
   color: #767676;
 }
@@ -2614,7 +2147,99 @@ table {
   width: 100%;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 }
-
+table:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+table:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+table:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+table:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+table:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+table:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+table:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+table:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+table:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+table:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+table:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+table:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+table:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+table:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+table:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+table:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+table:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+table:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+table:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+table:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+table:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+table:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+table:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+table:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+table:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+table:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+table:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+table:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+table:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+table:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+table:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
 table td,
 table th {
   padding: 0.5em;
@@ -2625,9 +2250,9 @@ table th {
 /* Forms */
 .button,
 button,
-input[type="button"],
-input[type="reset"],
-input[type="submit"] {
+input[type=button],
+input[type=reset],
+input[type=submit] {
   transition: background 150ms ease-in-out;
   background: #0073aa;
   border: none;
@@ -2635,7 +2260,230 @@ input[type="submit"] {
   box-sizing: border-box;
   color: #fff;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  font-size: 0.88889em;
+}
+.button:lang(ar),
+button:lang(ar),
+input[type=button]:lang(ar),
+input[type=reset]:lang(ar),
+input[type=submit]:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.button:lang(ary),
+button:lang(ary),
+input[type=button]:lang(ary),
+input[type=reset]:lang(ary),
+input[type=submit]:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.button:lang(azb),
+button:lang(azb),
+input[type=button]:lang(azb),
+input[type=reset]:lang(azb),
+input[type=submit]:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.button:lang(ckb),
+button:lang(ckb),
+input[type=button]:lang(ckb),
+input[type=reset]:lang(ckb),
+input[type=submit]:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.button:lang(fa-IR),
+button:lang(fa-IR),
+input[type=button]:lang(fa-IR),
+input[type=reset]:lang(fa-IR),
+input[type=submit]:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.button:lang(haz),
+button:lang(haz),
+input[type=button]:lang(haz),
+input[type=reset]:lang(haz),
+input[type=submit]:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.button:lang(ps),
+button:lang(ps),
+input[type=button]:lang(ps),
+input[type=reset]:lang(ps),
+input[type=submit]:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.button:lang(be),
+button:lang(be),
+input[type=button]:lang(be),
+input[type=reset]:lang(be),
+input[type=submit]:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.button:lang(bg-BG),
+button:lang(bg-BG),
+input[type=button]:lang(bg-BG),
+input[type=reset]:lang(bg-BG),
+input[type=submit]:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.button:lang(kk),
+button:lang(kk),
+input[type=button]:lang(kk),
+input[type=reset]:lang(kk),
+input[type=submit]:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.button:lang(mk-MK),
+button:lang(mk-MK),
+input[type=button]:lang(mk-MK),
+input[type=reset]:lang(mk-MK),
+input[type=submit]:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.button:lang(mn),
+button:lang(mn),
+input[type=button]:lang(mn),
+input[type=reset]:lang(mn),
+input[type=submit]:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.button:lang(ru-RU),
+button:lang(ru-RU),
+input[type=button]:lang(ru-RU),
+input[type=reset]:lang(ru-RU),
+input[type=submit]:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.button:lang(sah),
+button:lang(sah),
+input[type=button]:lang(sah),
+input[type=reset]:lang(sah),
+input[type=submit]:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.button:lang(sr-RS),
+button:lang(sr-RS),
+input[type=button]:lang(sr-RS),
+input[type=reset]:lang(sr-RS),
+input[type=submit]:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.button:lang(tt-RU),
+button:lang(tt-RU),
+input[type=button]:lang(tt-RU),
+input[type=reset]:lang(tt-RU),
+input[type=submit]:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.button:lang(uk),
+button:lang(uk),
+input[type=button]:lang(uk),
+input[type=reset]:lang(uk),
+input[type=submit]:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.button:lang(zh-HK),
+button:lang(zh-HK),
+input[type=button]:lang(zh-HK),
+input[type=reset]:lang(zh-HK),
+input[type=submit]:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.button:lang(zh-TW),
+button:lang(zh-TW),
+input[type=button]:lang(zh-TW),
+input[type=reset]:lang(zh-TW),
+input[type=submit]:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.button:lang(zh-CN),
+button:lang(zh-CN),
+input[type=button]:lang(zh-CN),
+input[type=reset]:lang(zh-CN),
+input[type=submit]:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.button:lang(bn-BD),
+button:lang(bn-BD),
+input[type=button]:lang(bn-BD),
+input[type=reset]:lang(bn-BD),
+input[type=submit]:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+.button:lang(hi-IN),
+button:lang(hi-IN),
+input[type=button]:lang(hi-IN),
+input[type=reset]:lang(hi-IN),
+input[type=submit]:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+.button:lang(mr),
+button:lang(mr),
+input[type=button]:lang(mr),
+input[type=reset]:lang(mr),
+input[type=submit]:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+.button:lang(ne-NP),
+button:lang(ne-NP),
+input[type=button]:lang(ne-NP),
+input[type=reset]:lang(ne-NP),
+input[type=submit]:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+.button:lang(el),
+button:lang(el),
+input[type=button]:lang(el),
+input[type=reset]:lang(el),
+input[type=submit]:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+.button:lang(gu),
+button:lang(gu),
+input[type=button]:lang(gu),
+input[type=reset]:lang(gu),
+input[type=submit]:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+.button:lang(he-IL),
+button:lang(he-IL),
+input[type=button]:lang(he-IL),
+input[type=reset]:lang(he-IL),
+input[type=submit]:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+.button:lang(ja),
+button:lang(ja),
+input[type=button]:lang(ja),
+input[type=reset]:lang(ja),
+input[type=submit]:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+.button:lang(ko-KR),
+button:lang(ko-KR),
+input[type=button]:lang(ko-KR),
+input[type=reset]:lang(ko-KR),
+input[type=submit]:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+.button:lang(th),
+button:lang(th),
+input[type=button]:lang(th),
+input[type=reset]:lang(th),
+input[type=submit]:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+.button:lang(vi),
+button:lang(vi),
+input[type=button]:lang(vi),
+input[type=reset]:lang(vi),
+input[type=submit]:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
+.button,
+button,
+input[type=button],
+input[type=reset],
+input[type=submit] {
+  font-size: 0.8888888889em;
   font-weight: 700;
   line-height: 1.2;
   outline: none;
@@ -2643,50 +2491,47 @@ input[type="submit"] {
   text-decoration: none;
   vertical-align: bottom;
 }
-
 .button:hover,
 button:hover,
-input[type="button"]:hover,
-input[type="reset"]:hover,
-input[type="submit"]:hover {
+input[type=button]:hover,
+input[type=reset]:hover,
+input[type=submit]:hover {
   background: #111;
   cursor: pointer;
 }
-
 .button:visited,
 button:visited,
-input[type="button"]:visited,
-input[type="reset"]:visited,
-input[type="submit"]:visited {
+input[type=button]:visited,
+input[type=reset]:visited,
+input[type=submit]:visited {
   color: #fff;
   text-decoration: none;
 }
-
 .button:focus,
 button:focus,
-input[type="button"]:focus,
-input[type="reset"]:focus,
-input[type="submit"]:focus {
+input[type=button]:focus,
+input[type=reset]:focus,
+input[type=submit]:focus {
   background: #111;
   outline: thin dotted;
   outline-offset: -4px;
 }
 
-input[type="text"],
-input[type="email"],
-input[type="url"],
-input[type="password"],
-input[type="search"],
-input[type="number"],
-input[type="tel"],
-input[type="range"],
-input[type="date"],
-input[type="month"],
-input[type="week"],
-input[type="time"],
-input[type="datetime"],
-input[type="datetime-local"],
-input[type="color"],
+input[type=text],
+input[type=email],
+input[type=url],
+input[type=password],
+input[type=search],
+input[type=number],
+input[type=tel],
+input[type=range],
+input[type=date],
+input[type=month],
+input[type=week],
+input[type=time],
+input[type=datetime],
+input[type=datetime-local],
+input[type=color],
 textarea {
   -webkit-backface-visibility: hidden;
   background: #fff;
@@ -2698,29 +2543,28 @@ textarea {
   outline-offset: 0;
   border-radius: 0;
 }
-
-input[type="text"]:focus,
-input[type="email"]:focus,
-input[type="url"]:focus,
-input[type="password"]:focus,
-input[type="search"]:focus,
-input[type="number"]:focus,
-input[type="tel"]:focus,
-input[type="range"]:focus,
-input[type="date"]:focus,
-input[type="month"]:focus,
-input[type="week"]:focus,
-input[type="time"]:focus,
-input[type="datetime"]:focus,
-input[type="datetime-local"]:focus,
-input[type="color"]:focus,
+input[type=text]:focus,
+input[type=email]:focus,
+input[type=url]:focus,
+input[type=password]:focus,
+input[type=search]:focus,
+input[type=number]:focus,
+input[type=tel]:focus,
+input[type=range]:focus,
+input[type=date]:focus,
+input[type=month]:focus,
+input[type=week]:focus,
+input[type=time]:focus,
+input[type=datetime]:focus,
+input[type=datetime-local]:focus,
+input[type=color]:focus,
 textarea:focus {
   border-color: #0073aa;
   outline: thin solid rgba(0, 115, 170, 0.15);
   outline-offset: -4px;
 }
 
-input[type="search"]::-webkit-search-decoration {
+input[type=search]::-webkit-search-decoration {
   display: none;
 }
 
@@ -2744,18 +2588,14 @@ a {
   transition: color 110ms ease-in-out;
   color: #0073aa;
 }
-
 a:visited {
   color: #0073aa;
 }
-
-a:hover,
-a:active {
-  color: #005177;
+a:hover, a:active {
+  color: rgb(0, 80.5, 119);
   outline: 0;
   text-decoration: none;
 }
-
 a:focus {
   outline: thin dotted;
   text-decoration: underline;
@@ -2769,29 +2609,16 @@ a:focus {
 .main-navigation {
   display: block;
   margin-top: 0.25rem;
-  /* Un-style buttons */
-  /*
-	 * Sub-menu styles
-	 *
-	 * :focus-within needs its own selector so other similar
-	 * selectors don’t get ignored if a browser doesn’t recognize it
-	 */
-  /**
-	 * Fade-in animation for top-level submenus
-	 */
-  /**
-	 * Off-canvas touch device styles
-	 */
 }
-
 body.page .main-navigation {
   display: block;
 }
-
 .main-navigation > div {
   display: inline;
 }
-
+.main-navigation {
+  /* Un-style buttons */
+}
 .main-navigation button {
   display: inline-block;
   border: none;
@@ -2808,74 +2635,59 @@ body.page .main-navigation {
   -webkit-appearance: none;
   -moz-appearance: none;
 }
-
 .main-navigation button:hover, .main-navigation button:focus {
   background: transparent;
 }
-
 .main-navigation button:focus {
   outline: 1px solid transparent;
   outline-offset: -4px;
 }
-
 .main-navigation button:active {
   transform: scale(0.99);
 }
-
 .main-navigation .main-menu {
   display: inline-block;
   margin: 0;
   padding: 0;
 }
-
 .main-navigation .main-menu > li {
   color: #0073aa;
   display: inline-block;
   position: relative;
 }
-
 .main-navigation .main-menu > li > a {
   font-weight: 700;
   color: #0073aa;
   margin-right: 0.5rem;
 }
-
 .main-navigation .main-menu > li > a + svg {
   margin-right: 0.5rem;
 }
-
-.main-navigation .main-menu > li > a:hover,
-.main-navigation .main-menu > li > a:hover + svg {
-  color: #005177;
+.main-navigation .main-menu > li > a:hover, .main-navigation .main-menu > li > a:hover + svg {
+  color: rgb(0, 80.5, 119);
 }
-
 .main-navigation .main-menu > li.menu-item-has-children {
   display: inline-block;
   position: inherit;
 }
-
 @media only screen and (min-width: 768px) {
   .main-navigation .main-menu > li.menu-item-has-children {
     position: relative;
   }
 }
-
 .main-navigation .main-menu > li.menu-item-has-children > a {
   margin-right: 0.125rem;
 }
-
 .main-navigation .main-menu > li.menu-item-has-children > a:after,
 .main-navigation .main-menu > li.menu-item-has-children .menu-item-has-children > a:after {
   content: "";
   display: none;
 }
-
 .main-navigation .main-menu > li.menu-item-has-children .submenu-expand {
   display: inline-block;
   margin-right: 0.25rem;
   /* Priority+ Menu */
 }
-
 .main-navigation .main-menu > li.menu-item-has-children .submenu-expand.main-menu-more-toggle {
   position: relative;
   height: 24px;
@@ -2884,28 +2696,22 @@ body.page .main-navigation {
   padding: 0;
   margin-left: 0.5rem;
 }
-
 .main-navigation .main-menu > li.menu-item-has-children .submenu-expand.main-menu-more-toggle svg {
   height: 24px;
   width: 24px;
   top: -0.125rem;
   vertical-align: text-bottom;
 }
-
 .wp-customizer-unloading .main-navigation .main-menu > li.menu-item-has-children .submenu-expand, .main-navigation .main-menu > li.menu-item-has-children .submenu-expand.is-empty {
   display: none;
 }
-
 .main-navigation .main-menu > li.menu-item-has-children .submenu-expand svg {
   position: relative;
   top: 0.2rem;
 }
-
-.main-navigation .main-menu > li:last-child > a,
-.main-navigation .main-menu > li:last-child.menu-item-has-children .submenu-expand {
+.main-navigation .main-menu > li:last-child > a, .main-navigation .main-menu > li:last-child.menu-item-has-children .submenu-expand {
   margin-right: 0;
 }
-
 .main-navigation .sub-menu {
   background-color: #0073aa;
   color: #fff;
@@ -2916,7 +2722,6 @@ body.page .main-navigation {
   left: -9999px;
   z-index: 99999;
 }
-
 @media only screen and (min-width: 768px) {
   .main-navigation .sub-menu {
     width: auto;
@@ -2925,84 +2730,79 @@ body.page .main-navigation {
     min-width: max-content;
   }
 }
-
 .main-navigation .sub-menu > li {
   display: block;
   float: none;
   position: relative;
 }
-
 .main-navigation .sub-menu > li.menu-item-has-children .submenu-expand {
   display: inline-block;
   position: absolute;
-  width: calc( 24px + 1rem);
+  width: calc(24px + 1rem);
   right: 0;
-  top: calc( .125 * 1rem);
+  top: calc(0.125 * 1rem);
   bottom: 0;
   color: white;
   line-height: 1;
-  padding: calc( .5 * 1rem);
+  padding: calc(0.5 * 1rem);
 }
-
 .main-navigation .sub-menu > li.menu-item-has-children .submenu-expand svg {
   top: 0;
 }
-
 .main-navigation .sub-menu > li.menu-item-has-children .submenu-expand {
   margin-right: 0;
 }
-
 @media only screen and (min-width: 768px) {
   .main-navigation .sub-menu > li.menu-item-has-children .menu-item-has-children > a:after {
-    content: "\203a";
+    content: "›";
   }
 }
-
 .main-navigation .sub-menu > li > a,
 .main-navigation .sub-menu > li > .menu-item-link-return {
   color: #fff;
   display: block;
   line-height: 1.2;
   text-shadow: none;
-  padding: calc( .5 * 1rem) calc( 24px + 1rem) calc( .5 * 1rem) 1rem;
+  padding: calc(0.5 * 1rem) calc(24px + 1rem) calc(0.5 * 1rem) 1rem;
   max-width: 20rem;
 }
-
 .main-navigation .sub-menu > li > a:hover, .main-navigation .sub-menu > li > a:focus,
 .main-navigation .sub-menu > li > .menu-item-link-return:hover,
 .main-navigation .sub-menu > li > .menu-item-link-return:focus {
-  background: #005177;
+  background: rgb(0, 80.5, 119);
 }
-
 .main-navigation .sub-menu > li > a:hover:after, .main-navigation .sub-menu > li > a:focus:after,
 .main-navigation .sub-menu > li > .menu-item-link-return:hover:after,
 .main-navigation .sub-menu > li > .menu-item-link-return:focus:after {
-  background: #005177;
+  background: rgb(0, 80.5, 119);
 }
-
 .main-navigation .sub-menu > li > .menu-item-link-return {
   width: 100%;
   font-size: 22px;
   font-weight: normal;
   text-align: left;
 }
-
 .main-navigation .sub-menu > li > a:empty {
   display: none;
 }
-
 .main-navigation .sub-menu > li.mobile-parent-nav-menu-item {
   display: none;
-  font-size: 0.88889em;
+  font-size: 0.8888888889em;
   font-weight: normal;
 }
-
 .main-navigation .sub-menu > li.mobile-parent-nav-menu-item svg {
   position: relative;
   top: 0.2rem;
-  margin-right: calc( .25 * 1rem);
+  margin-right: calc(0.25 * 1rem);
 }
-
+.main-navigation {
+  /*
+   * Sub-menu styles
+   *
+   * :focus-within needs its own selector so other similar
+   * selectors don’t get ignored if a browser doesn’t recognize it
+   */
+}
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu {
   display: block;
   left: 0;
@@ -3011,9 +2811,7 @@ body.page .main-navigation {
   width: auto;
   min-width: 100%;
   /* Non-mobile position */
-  /* Nested sub-menu dashes */
 }
-
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu {
   display: block;
   left: 0;
@@ -3022,9 +2820,7 @@ body.page .main-navigation {
   width: auto;
   min-width: 100%;
   /* Non-mobile position */
-  /* Nested sub-menu dashes */
 }
-
 @media only screen and (min-width: 768px) {
   .main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu {
     display: block;
@@ -3057,21 +2853,18 @@ body.page .main-navigation {
     transform: none;
   }
 }
-
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu.hidden-links {
   left: 0;
   width: 100%;
   display: table;
   position: absolute;
 }
-
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu.hidden-links {
   left: 0;
   width: 100%;
   display: table;
   position: absolute;
 }
-
 @media only screen and (min-width: 768px) {
   .main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu.hidden-links {
     right: 0;
@@ -3086,15 +2879,12 @@ body.page .main-navigation {
     width: max-content;
   }
 }
-
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .submenu-expand {
   display: none;
 }
-
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu .submenu-expand {
   display: none;
 }
-
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu {
   display: block;
   margin-top: inherit;
@@ -3104,7 +2894,6 @@ body.page .main-navigation {
   opacity: 1;
   /* Non-mobile position */
 }
-
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu .sub-menu {
   display: block;
   margin-top: inherit;
@@ -3114,7 +2903,6 @@ body.page .main-navigation {
   opacity: 1;
   /* Non-mobile position */
 }
-
 @media only screen and (min-width: 768px) {
   .main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu {
     float: none;
@@ -3125,29 +2913,30 @@ body.page .main-navigation {
     max-width: 100%;
   }
 }
-
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu {
+  /* Nested sub-menu dashes */
+}
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu {
+  /* Nested sub-menu dashes */
+}
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu {
   counter-reset: submenu;
 }
-
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu .sub-menu {
   counter-reset: submenu;
 }
-
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu > li > a::before {
   font-family: "NonBreakingSpaceOverride", "Hoefler Text", Garamond, "Times New Roman", serif;
   font-weight: normal;
   content: "– " counters(submenu, "– ", none);
   counter-increment: submenu;
 }
-
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu .sub-menu > li > a::before {
   font-family: "NonBreakingSpaceOverride", "Hoefler Text", Garamond, "Times New Roman", serif;
   font-weight: normal;
   content: "– " counters(submenu, "– ", none);
   counter-increment: submenu;
 }
-
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):hover > .sub-menu,
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus > .sub-menu,
 .main-navigation .main-menu .menu-item-has-children.is-focused:not(.off-canvas) > .sub-menu {
@@ -3158,9 +2947,7 @@ body.page .main-navigation {
   width: auto;
   min-width: 100%;
   /* Non-mobile position */
-  /* Nested sub-menu dashes */
 }
-
 @media only screen and (min-width: 768px) {
   .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):hover > .sub-menu,
   .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus > .sub-menu,
@@ -3181,7 +2968,6 @@ body.page .main-navigation {
     transform: none;
   }
 }
-
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):hover > .sub-menu.hidden-links,
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus > .sub-menu.hidden-links,
 .main-navigation .main-menu .menu-item-has-children.is-focused:not(.off-canvas) > .sub-menu.hidden-links {
@@ -3190,7 +2976,6 @@ body.page .main-navigation {
   display: table;
   position: absolute;
 }
-
 @media only screen and (min-width: 768px) {
   .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):hover > .sub-menu.hidden-links,
   .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus > .sub-menu.hidden-links,
@@ -3201,13 +2986,11 @@ body.page .main-navigation {
     width: max-content;
   }
 }
-
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):hover > .sub-menu .submenu-expand,
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus > .sub-menu .submenu-expand,
 .main-navigation .main-menu .menu-item-has-children.is-focused:not(.off-canvas) > .sub-menu .submenu-expand {
   display: none;
 }
-
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):hover > .sub-menu .sub-menu,
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus > .sub-menu .sub-menu,
 .main-navigation .main-menu .menu-item-has-children.is-focused:not(.off-canvas) > .sub-menu .sub-menu {
@@ -3219,7 +3002,6 @@ body.page .main-navigation {
   opacity: 1;
   /* Non-mobile position */
 }
-
 @media only screen and (min-width: 768px) {
   .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):hover > .sub-menu .sub-menu,
   .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus > .sub-menu .sub-menu,
@@ -3228,13 +3010,16 @@ body.page .main-navigation {
     max-width: 100%;
   }
 }
-
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):hover > .sub-menu,
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus > .sub-menu,
+.main-navigation .main-menu .menu-item-has-children.is-focused:not(.off-canvas) > .sub-menu {
+  /* Nested sub-menu dashes */
+}
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):hover > .sub-menu .sub-menu,
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus > .sub-menu .sub-menu,
 .main-navigation .main-menu .menu-item-has-children.is-focused:not(.off-canvas) > .sub-menu .sub-menu {
   counter-reset: submenu;
 }
-
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):hover > .sub-menu .sub-menu > li > a::before,
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus > .sub-menu .sub-menu > li > a::before,
 .main-navigation .main-menu .menu-item-has-children.is-focused:not(.off-canvas) > .sub-menu .sub-menu > li > a::before {
@@ -3243,38 +3028,41 @@ body.page .main-navigation {
   content: "– " counters(submenu, "– ", none);
   counter-increment: submenu;
 }
-
+.main-navigation {
+  /**
+   * Fade-in animation for top-level submenus
+   */
+}
 .main-navigation .main-menu > .menu-item-has-children:not(.off-canvas):hover > .sub-menu {
   animation: fade_in 0.1s forwards;
 }
-
+.main-navigation {
+  /**
+   * Off-canvas touch device styles
+   */
+}
 .main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu .submenu-expand .svg-icon {
   transform: rotate(270deg);
 }
-
 .main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu .sub-menu {
   opacity: 0;
   position: absolute;
   z-index: 0;
   transform: translateX(-100%);
 }
-
 .main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu li:hover,
 .main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu li:focus,
 .main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu li > a:hover,
 .main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu li > a:focus {
   background-color: transparent;
 }
-
 .main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu > li > a,
 .main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu > li > .menu-item-link-return {
   white-space: inherit;
 }
-
 .main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu:not(:has(.sub-menu.expanded-true)) {
   overflow-y: scroll;
 }
-
 .main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu.expanded-true {
   display: block;
   margin-top: 0;
@@ -3286,40 +3074,38 @@ body.page .main-navigation {
   right: 0;
   bottom: 0;
   position: fixed;
-  z-index: 100000;
-  /* Make sure appears above mobile admin bar */
+  z-index: 100000; /* Make sure appears above mobile admin bar */
   width: 100vw;
   height: 100vh;
   max-width: 100vw;
   transform: translateX(100%);
   animation: slide_in_right 0.3s forwards;
-  /* Prevent menu from being blocked by admin bar */
 }
-
 .main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu.expanded-true > .mobile-parent-nav-menu-item {
   display: block;
 }
-
+.main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu.expanded-true {
+  /* Prevent menu from being blocked by admin bar */
+}
 .admin-bar .main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu.expanded-true {
   top: 46px;
-  height: calc( 100vh - 46px);
-  /* WP core breakpoint */
+  height: calc(100vh - 46px);
 }
-
 .admin-bar .main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu.expanded-true .sub-menu.expanded-true {
   top: 0;
 }
-
+.admin-bar .main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu.expanded-true {
+  /* WP core breakpoint */
+}
 @media only screen and (min-width: 782px) {
   .admin-bar .main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu.expanded-true {
     top: 32px;
-    height: calc( 100vh - 32px);
+    height: calc(100vh - 32px);
   }
   .admin-bar .main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu.expanded-true .sub-menu.expanded-true {
     top: 0;
   }
 }
-
 .main-navigation .main-menu-more:nth-child(n+3) {
   display: none;
 }
@@ -3330,7 +3116,6 @@ body.page .main-navigation {
     transform: translateX(0%);
   }
 }
-
 @keyframes fade_in {
   from {
     opacity: 0;
@@ -3339,13 +3124,11 @@ body.page .main-navigation {
     opacity: 1;
   }
 }
-
 /* Social menu */
 .social-navigation {
   margin-top: calc(1rem / 2);
   text-align: left;
 }
-
 .social-navigation ul.social-links-menu {
   content: "";
   display: table;
@@ -3354,18 +3137,15 @@ body.page .main-navigation {
   margin: 0;
   padding: 0;
 }
-
 .social-navigation ul.social-links-menu li {
   display: inline-block;
   vertical-align: bottom;
   vertical-align: -webkit-baseline-middle;
   list-style: none;
 }
-
 .social-navigation ul.social-links-menu li:nth-child(n+2) {
   margin-left: 0.1em;
 }
-
 .social-navigation ul.social-links-menu li a {
   border-bottom: 1px solid transparent;
   display: block;
@@ -3373,25 +3153,21 @@ body.page .main-navigation {
   margin-bottom: -1px;
   transition: opacity 110ms ease-in-out;
 }
-
 .social-navigation ul.social-links-menu li a:hover, .social-navigation ul.social-links-menu li a:active {
   color: #111;
   opacity: 0.6;
 }
-
 .social-navigation ul.social-links-menu li a:focus {
   color: #111;
   opacity: 1;
   border-bottom: 1px solid #111;
 }
-
 .social-navigation ul.social-links-menu li a svg {
   display: block;
   width: 32px;
   height: 32px;
   transform: translateZ(0);
 }
-
 .social-navigation ul.social-links-menu li a svg#ui-icon-link {
   transform: rotate(-45deg);
 }
@@ -3407,16 +3183,13 @@ body.page .main-navigation {
 .footer-navigation {
   display: inline;
 }
-
 .footer-navigation > div {
   display: inline;
 }
-
 .footer-navigation .footer-menu {
   display: inline;
   padding-left: 0;
 }
-
 .footer-navigation .footer-menu li {
   display: inline;
   margin-right: 1rem;
@@ -3427,49 +3200,42 @@ body.page .main-navigation {
 --------------------------------------------------------------*/
 /* Next/Previous navigation */
 .post-navigation {
-  margin: calc(3 * 1rem) 0;
+  margin: 3rem 0;
 }
-
 @media only screen and (min-width: 768px) {
   .post-navigation {
-    margin: calc(3 * 1rem) calc(10% + 60px);
-    max-width: calc(6 * (100vw / 12));
+    margin: 3rem calc(10% + 60px);
+    max-width: 50vw;
   }
 }
-
 @media only screen and (min-width: 1168px) {
   .post-navigation {
-    margin: calc(3 * 1rem) 0;
+    margin: 3rem 0;
     max-width: 100%;
   }
 }
-
 .post-navigation .nav-links {
   margin: 0 1rem;
   max-width: 100%;
   display: flex;
   flex-direction: column;
 }
-
 @media only screen and (min-width: 768px) {
   .post-navigation .nav-links {
     margin: 0;
   }
 }
-
 @media only screen and (min-width: 1168px) {
   .post-navigation .nav-links {
     flex-direction: row;
     margin: 0 calc(10% + 60px);
-    max-width: calc(6 * (100vw / 12) - 28px);
+    max-width: calc(50vw - 28px);
   }
 }
-
 .post-navigation .nav-links a .meta-nav {
   color: #767676;
   user-select: none;
 }
-
 .post-navigation .nav-links a .meta-nav:before, .post-navigation .nav-links a .meta-nav:after {
   display: none;
   content: "—";
@@ -3477,51 +3243,41 @@ body.page .main-navigation {
   color: #767676;
   height: 1em;
 }
-
 .post-navigation .nav-links a .post-title {
   hyphens: auto;
 }
-
 .post-navigation .nav-links a:hover {
-  color: #005177;
+  color: rgb(0, 80.5, 119);
 }
-
 @media only screen and (min-width: 1168px) {
   .post-navigation .nav-links .nav-previous,
   .post-navigation .nav-links .nav-next {
     min-width: calc(50% - 2 * 1rem);
   }
 }
-
 .post-navigation .nav-links .nav-previous {
   order: 2;
 }
-
 @media only screen and (min-width: 1168px) {
   .post-navigation .nav-links .nav-previous {
     order: 1;
   }
 }
-
 .post-navigation .nav-links .nav-previous + .nav-next {
   margin-bottom: 1rem;
 }
-
 .post-navigation .nav-links .nav-previous .meta-nav:before {
   display: inline;
 }
-
 .post-navigation .nav-links .nav-next {
   order: 1;
 }
-
 @media only screen and (min-width: 1168px) {
   .post-navigation .nav-links .nav-next {
     order: 2;
     padding-left: 1rem;
   }
 }
-
 .post-navigation .nav-links .nav-next .meta-nav:after {
   display: inline;
 }
@@ -3529,41 +3285,33 @@ body.page .main-navigation {
 .pagination .nav-links {
   display: flex;
   flex-wrap: wrap;
-  padding: 0 calc(.5 * 1rem);
+  padding: 0 calc(0.5 * 1rem);
 }
-
 .pagination .nav-links > * {
-  padding: calc(.5 * 1rem);
+  padding: calc(0.5 * 1rem);
 }
-
 .pagination .nav-links > *.dots, .pagination .nav-links > *.prev {
   padding-left: 0;
 }
-
 .pagination .nav-links > *.dots, .pagination .nav-links > *.next {
   padding-right: 0;
 }
-
 .pagination .nav-links a:focus {
   text-decoration: underline;
   outline-offset: -1px;
 }
-
 .pagination .nav-links a:focus.prev, .pagination .nav-links a:focus.next {
   text-decoration: none;
 }
-
 .pagination .nav-links a:focus.prev .nav-prev-text,
 .pagination .nav-links a:focus.prev .nav-next-text, .pagination .nav-links a:focus.next .nav-prev-text,
 .pagination .nav-links a:focus.next .nav-next-text {
   text-decoration: underline;
 }
-
 .pagination .nav-links .nav-next-text,
 .pagination .nav-links .nav-prev-text {
   display: none;
 }
-
 @media only screen and (min-width: 768px) {
   .pagination .nav-links {
     margin-left: calc(10% + 60px);
@@ -3583,27 +3331,150 @@ body.page .main-navigation {
   display: flex;
   flex-direction: row;
 }
-
 .comment-navigation .nav-previous,
 .comment-navigation .nav-next {
   min-width: 50%;
   width: 100%;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+}
+.comment-navigation .nav-previous:lang(ar),
+.comment-navigation .nav-next:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.comment-navigation .nav-previous:lang(ary),
+.comment-navigation .nav-next:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.comment-navigation .nav-previous:lang(azb),
+.comment-navigation .nav-next:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.comment-navigation .nav-previous:lang(ckb),
+.comment-navigation .nav-next:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.comment-navigation .nav-previous:lang(fa-IR),
+.comment-navigation .nav-next:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.comment-navigation .nav-previous:lang(haz),
+.comment-navigation .nav-next:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.comment-navigation .nav-previous:lang(ps),
+.comment-navigation .nav-next:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.comment-navigation .nav-previous:lang(be),
+.comment-navigation .nav-next:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-navigation .nav-previous:lang(bg-BG),
+.comment-navigation .nav-next:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-navigation .nav-previous:lang(kk),
+.comment-navigation .nav-next:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-navigation .nav-previous:lang(mk-MK),
+.comment-navigation .nav-next:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-navigation .nav-previous:lang(mn),
+.comment-navigation .nav-next:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-navigation .nav-previous:lang(ru-RU),
+.comment-navigation .nav-next:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-navigation .nav-previous:lang(sah),
+.comment-navigation .nav-next:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-navigation .nav-previous:lang(sr-RS),
+.comment-navigation .nav-next:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-navigation .nav-previous:lang(tt-RU),
+.comment-navigation .nav-next:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-navigation .nav-previous:lang(uk),
+.comment-navigation .nav-next:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-navigation .nav-previous:lang(zh-HK),
+.comment-navigation .nav-next:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.comment-navigation .nav-previous:lang(zh-TW),
+.comment-navigation .nav-next:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.comment-navigation .nav-previous:lang(zh-CN),
+.comment-navigation .nav-next:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.comment-navigation .nav-previous:lang(bn-BD),
+.comment-navigation .nav-next:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+.comment-navigation .nav-previous:lang(hi-IN),
+.comment-navigation .nav-next:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+.comment-navigation .nav-previous:lang(mr),
+.comment-navigation .nav-next:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+.comment-navigation .nav-previous:lang(ne-NP),
+.comment-navigation .nav-next:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+.comment-navigation .nav-previous:lang(el),
+.comment-navigation .nav-next:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+.comment-navigation .nav-previous:lang(gu),
+.comment-navigation .nav-next:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+.comment-navigation .nav-previous:lang(he-IL),
+.comment-navigation .nav-next:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+.comment-navigation .nav-previous:lang(ja),
+.comment-navigation .nav-next:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+.comment-navigation .nav-previous:lang(ko-KR),
+.comment-navigation .nav-next:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+.comment-navigation .nav-previous:lang(th),
+.comment-navigation .nav-next:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+.comment-navigation .nav-previous:lang(vi),
+.comment-navigation .nav-next:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
+.comment-navigation .nav-previous,
+.comment-navigation .nav-next {
   font-weight: bold;
 }
-
 .comment-navigation .nav-previous .secondary-text,
 .comment-navigation .nav-next .secondary-text {
   display: none;
 }
-
 @media only screen and (min-width: 768px) {
   .comment-navigation .nav-previous .secondary-text,
   .comment-navigation .nav-next .secondary-text {
     display: inline;
   }
 }
-
 .comment-navigation .nav-previous svg,
 .comment-navigation .nav-next svg {
   vertical-align: middle;
@@ -3611,7 +3482,6 @@ body.page .main-navigation {
   margin: 0 -0.35em;
   top: -1px;
 }
-
 .comment-navigation .nav-next {
   text-align: right;
 }
@@ -3631,7 +3501,6 @@ body.page .main-navigation {
   word-wrap: normal !important;
   word-break: normal !important;
 }
-
 .screen-reader-text:focus {
   background-color: #f1f1f1;
   border-radius: 3px;
@@ -3648,8 +3517,7 @@ body.page .main-navigation {
   text-decoration: none;
   top: 5px;
   width: auto;
-  z-index: 100000;
-  /* Above WP toolbar. */
+  z-index: 100000; /* Above WP toolbar. */
 }
 
 /* Do not show the outline on the skip link target. */
@@ -3664,7 +3532,6 @@ body.page .main-navigation {
   /*rtl:ignore*/
   margin-right: 1rem;
 }
-
 @media only screen and (min-width: 768px) {
   .alignleft {
     /*rtl:ignore*/
@@ -3678,7 +3545,6 @@ body.page .main-navigation {
   /*rtl:ignore*/
   margin-left: 1rem;
 }
-
 @media only screen and (min-width: 768px) {
   .alignright {
     /*rtl:ignore*/
@@ -3737,18 +3603,15 @@ body.page .main-navigation {
 .site-header {
   padding: 1em;
 }
-
 .site-header.featured-image {
   display: flex;
   flex-direction: column;
   justify-content: space-between;
   min-height: 90vh;
 }
-
 .site-header.featured-image .site-branding-container {
   margin-bottom: auto;
 }
-
 @media only screen and (min-width: 768px) {
   .site-header {
     margin: 0;
@@ -3769,7 +3632,6 @@ body.page .main-navigation {
   position: relative;
   word-wrap: break-word;
 }
-
 @media only screen and (min-width: 768px) {
   .site-branding {
     margin: 0 calc(10% + 60px);
@@ -3779,19 +3641,17 @@ body.page .main-navigation {
 .site-logo {
   position: relative;
   z-index: 999;
-  margin-bottom: calc(.66 * 1rem);
+  margin-bottom: calc(0.66 * 1rem);
 }
-
 @media only screen and (min-width: 768px) {
   .site-logo {
     margin-bottom: 0;
     position: absolute;
-    right: calc(100% + (1.25 * 1rem));
+    right: calc(100% + 1.25 * 1rem);
     top: 4px;
     z-index: 999;
   }
 }
-
 .site-logo .custom-logo-link {
   border-radius: 100%;
   box-sizing: content-box;
@@ -3802,15 +3662,12 @@ body.page .main-navigation {
   overflow: hidden;
   transition: box-shadow 200ms ease-in-out;
 }
-
 .site-logo .custom-logo-link .custom-logo {
   min-height: inherit;
 }
-
 .site-logo .custom-logo-link:hover, .site-logo .custom-logo-link:active, .site-logo .custom-logo-link:focus {
-  box-shadow: 0 0 0 2px black;
+  box-shadow: 0 0 0 2px rgb(0, 0, 0);
 }
-
 @media only screen and (min-width: 768px) {
   .site-logo .custom-logo-link {
     width: 64px;
@@ -3822,44 +3679,38 @@ body.page .main-navigation {
   margin: auto;
   display: inline;
   color: #111;
-  /* When there is no description set, make sure navigation appears below title. */
 }
-
 .site-title a {
   color: #111;
 }
-
 .site-title a:link, .site-title a:visited {
   color: #111;
 }
-
 .site-title a:hover {
-  color: #4a4a4a;
+  color: rgb(74.375, 74.375, 74.375);
 }
-
 .featured-image .site-title {
   margin: 0;
 }
-
 @media only screen and (min-width: 768px) {
   .featured-image .site-title {
     display: inline-block;
   }
 }
-
+.site-title {
+  /* When there is no description set, make sure navigation appears below title. */
+}
 .site-title + .main-navigation {
   display: block;
 }
-
 @media only screen and (min-width: 768px) {
   .site-title {
     display: inline;
   }
 }
-
 .site-title:not(:empty) + .site-description:not(:empty):before {
-  content: "\2014";
-  margin: 0 .2em;
+  content: "—";
+  margin: 0 0.2em;
 }
 
 .site-description {
@@ -3877,24 +3728,7 @@ body.page .main-navigation {
   /* Add text shadow to text, to increase readability. */
   text-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
   /* Set white text color when featured image is set. */
-  /* add focus state to social media icons */
-  /* Entry header */
-  /* Custom Logo Link */
-  /* Make sure important elements are above pseudo elements used for effects. */
-  /* Set up image filter layer positioning */
-  /* Background & Effects */
-  /* Shared background settings between pseudo elements. */
-  background-position: center;
-  background-repeat: no-repeat;
-  background-size: cover;
-  /* The intensity of each blend mode is controlled via layer opacity. */
-  /* Second layer: screen. */
-  /* Third layer: multiply. */
-  /* When image filters are inactive, a black overlay is added. */
-  /* Fourth layer: overlay. */
-  /* Fifth layer: readability overlay */
 }
-
 .site-header.featured-image .site-branding .site-title,
 .site-header.featured-image .site-branding .site-description,
 .site-header.featured-image .main-navigation a:after,
@@ -3905,7 +3739,6 @@ body.page .main-navigation {
 .site-header.featured-image .entry-title {
   color: #fff;
 }
-
 .site-header.featured-image .main-navigation a,
 .site-header.featured-image .main-navigation a + svg,
 .site-header.featured-image .social-navigation a,
@@ -3914,10 +3747,7 @@ body.page .main-navigation {
   color: #fff;
   transition: opacity 110ms ease-in-out;
 }
-
-.site-header.featured-image .main-navigation a:hover, .site-header.featured-image .main-navigation a:active,
-.site-header.featured-image .main-navigation a:hover + svg,
-.site-header.featured-image .main-navigation a:active + svg,
+.site-header.featured-image .main-navigation a:hover, .site-header.featured-image .main-navigation a:active, .site-header.featured-image .main-navigation a:hover + svg, .site-header.featured-image .main-navigation a:active + svg,
 .site-header.featured-image .main-navigation a + svg:hover,
 .site-header.featured-image .main-navigation a + svg:active,
 .site-header.featured-image .main-navigation a + svg:hover + svg,
@@ -3937,9 +3767,7 @@ body.page .main-navigation {
   color: #fff;
   opacity: 0.6;
 }
-
-.site-header.featured-image .main-navigation a:focus,
-.site-header.featured-image .main-navigation a:focus + svg,
+.site-header.featured-image .main-navigation a:focus, .site-header.featured-image .main-navigation a:focus + svg,
 .site-header.featured-image .main-navigation a + svg:focus,
 .site-header.featured-image .main-navigation a + svg:focus + svg,
 .site-header.featured-image .social-navigation a:focus,
@@ -3950,24 +3778,26 @@ body.page .main-navigation {
 .site-header.featured-image .site-featured-image a:focus + svg {
   color: #fff;
 }
-
 .site-header.featured-image .main-navigation .sub-menu a {
   opacity: inherit;
 }
-
+.site-header.featured-image {
+  /* add focus state to social media icons */
+}
 .site-header.featured-image .social-navigation a:focus {
   color: #fff;
   opacity: 1;
   border-bottom: 1px solid #fff;
 }
-
 .site-header.featured-image .social-navigation svg,
 .site-header.featured-image .site-featured-image svg {
   /* Use -webkit- only if supporting: Chrome < 54, iOS < 9.3, Android < 4.4.4 */
   -webkit-filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.35));
   filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.35));
 }
-
+.site-header.featured-image {
+  /* Entry header */
+}
 .site-header.featured-image .site-featured-image .post-thumbnail img {
   height: auto;
   left: 50%;
@@ -3980,7 +3810,6 @@ body.page .main-navigation {
   width: auto;
   z-index: 1;
 }
-
 @supports (object-fit: cover) {
   .site-header.featured-image .site-featured-image .post-thumbnail img {
     height: 100%;
@@ -3991,72 +3820,62 @@ body.page .main-navigation {
     width: 100%;
   }
 }
-
 .image-filters-enabled .site-header.featured-image .site-featured-image .post-thumbnail img {
   /* First layer: grayscale. */
   /* When image filters are active, make it grayscale to colorize it blue. */
   filter: grayscale(100%);
 }
-
 .site-header.featured-image .site-featured-image .entry-header {
-  margin-top: calc( 4 * 1rem);
+  margin-top: calc(4 * 1rem);
   margin-bottom: 0;
   margin-left: 0;
   margin-right: 0;
-  /* Entry meta */
 }
-
 @media only screen and (min-width: 768px) {
   .site-header.featured-image .site-featured-image .entry-header {
     margin-left: calc(10% + 60px);
     margin-right: calc(10% + 60px);
   }
 }
-
 .site-header.featured-image .site-featured-image .entry-header .entry-title:before {
   background: #fff;
 }
-
+.site-header.featured-image .site-featured-image .entry-header {
+  /* Entry meta */
+}
 .site-header.featured-image .site-featured-image .entry-header .entry-meta {
   font-weight: 500;
 }
-
 .site-header.featured-image .site-featured-image .entry-header .entry-meta > span {
   margin-right: 1rem;
   display: inline-block;
 }
-
 .site-header.featured-image .site-featured-image .entry-header .entry-meta > span:last-child {
   margin-right: 0;
 }
-
 .site-header.featured-image .site-featured-image .entry-header .entry-meta a {
   transition: color 110ms ease-in-out;
   color: currentColor;
 }
-
 .site-header.featured-image .site-featured-image .entry-header .entry-meta a:hover {
   text-decoration: none;
 }
-
 .site-header.featured-image .site-featured-image .entry-header .entry-meta .svg-icon {
   position: relative;
   display: inline-block;
   vertical-align: middle;
   margin-right: 0.5em;
 }
-
 .site-header.featured-image .site-featured-image .entry-header .entry-meta .discussion-avatar-list {
   display: none;
 }
-
 @media only screen and (min-width: 768px) {
   .site-header.featured-image .site-featured-image .entry-header.has-discussion .entry-meta {
     display: flex;
     position: relative;
   }
   .site-header.featured-image .site-featured-image .entry-header.has-discussion .entry-title {
-    padding-right: calc(1 * (100vw / 12) + 1rem);
+    padding-right: calc(8.3333333333vw + 1rem);
   }
   .site-header.featured-image .site-featured-image .entry-header.has-discussion .entry-meta .comment-count {
     position: absolute;
@@ -4068,26 +3887,30 @@ body.page .main-navigation {
     bottom: 100%;
   }
 }
-
+.site-header.featured-image {
+  /* Custom Logo Link */
+}
 .site-header.featured-image .custom-logo-link {
   background: #fff;
   box-shadow: 0 0 0 0 rgba(255, 255, 255, 0);
 }
-
 .site-header.featured-image .custom-logo-link:hover, .site-header.featured-image .custom-logo-link:active, .site-header.featured-image .custom-logo-link:focus {
   box-shadow: 0 0 0 2px white;
 }
-
+.site-header.featured-image {
+  /* Make sure important elements are above pseudo elements used for effects. */
+}
 .site-header.featured-image .site-branding {
   position: relative;
   z-index: 10;
 }
-
 .site-header.featured-image .site-featured-image .entry-header {
   position: relative;
   z-index: 9;
 }
-
+.site-header.featured-image {
+  /* Set up image filter layer positioning */
+}
 .site-header.featured-image .site-branding-container:after,
 .site-header.featured-image .site-featured-image:before,
 .site-header.featured-image .site-featured-image:after, .site-header.featured-image:after {
@@ -4095,37 +3918,48 @@ body.page .main-navigation {
   position: absolute;
   top: 0;
   left: 0;
-  content: "\020";
+  content: " ";
   width: 100%;
   height: 100%;
 }
-
+.site-header.featured-image {
+  /* Background & Effects */
+  /* Shared background settings between pseudo elements. */
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: cover;
+  /* The intensity of each blend mode is controlled via layer opacity. */
+  /* Second layer: screen. */
+}
 .image-filters-enabled .site-header.featured-image .site-featured-image:before {
   background: #0073aa;
   mix-blend-mode: screen;
   opacity: 0.1;
 }
-
+.site-header.featured-image {
+  /* Third layer: multiply. */
+  /* When image filters are inactive, a black overlay is added. */
+}
 .site-header.featured-image .site-featured-image:after {
   background: #000;
   mix-blend-mode: multiply;
-  opacity: .7;
+  opacity: 0.7;
   /* When image filters are active, a blue overlay is added. */
 }
-
 .image-filters-enabled .site-header.featured-image .site-featured-image:after {
   background: #0073aa;
-  opacity: .8;
+  opacity: 0.8;
   z-index: 3;
   /* Browsers supporting mix-blend-mode don't need opacity < 1 */
 }
-
 @supports (mix-blend-mode: multiply) {
   .image-filters-enabled .site-header.featured-image .site-featured-image:after {
     opacity: 1;
   }
 }
-
+.site-header.featured-image {
+  /* Fourth layer: overlay. */
+}
 .image-filters-enabled .site-header.featured-image .site-branding-container:after {
   background: rgba(0, 0, 0, 0.35);
   mix-blend-mode: overlay;
@@ -4133,40 +3967,37 @@ body.page .main-navigation {
   z-index: 4;
   /* Browsers supporting mix-blend-mode can have a light overlay */
 }
-
 @supports (mix-blend-mode: overlay) {
   .image-filters-enabled .site-header.featured-image .site-branding-container:after {
     background: rgba(255, 255, 255, 0.35);
   }
 }
-
+.site-header.featured-image {
+  /* Fifth layer: readability overlay */
+}
 .site-header.featured-image:after {
   background: #000;
   /**
-		 * Add a transition to the readability overlay, to add a subtle
-		 * but smooth effect when resizing the screen.
-		 */
+   * Add a transition to the readability overlay, to add a subtle
+   * but smooth effect when resizing the screen.
+   */
   transition: opacity 1200ms ease-in-out;
   opacity: 0.7;
   z-index: 5;
   /* When image filters are active, a blue overlay is added. */
 }
-
 .image-filters-enabled .site-header.featured-image:after {
-  background: #000e14;
+  background: rgb(0, 13.8, 20.4);
   opacity: 0.38;
 }
-
 @media only screen and (min-width: 768px) {
   .image-filters-enabled .site-header.featured-image:after {
     opacity: 0.18;
   }
 }
-
 .site-header.featured-image ::-moz-selection {
   background: rgba(255, 255, 255, 0.17);
 }
-
 .site-header.featured-image ::selection {
   background: rgba(255, 255, 255, 0.17);
 }
@@ -4184,7 +4015,7 @@ body.page .main-navigation {
   display: inline-block;
   font-weight: bold;
   line-height: 1;
-  padding: .25rem;
+  padding: 0.25rem;
   position: absolute;
   text-transform: uppercase;
   top: -1rem;
@@ -4203,81 +4034,66 @@ body.page .main-navigation {
 .entry {
   margin-top: calc(6 * 1rem);
 }
-
 .entry:first-of-type {
   margin-top: 0;
 }
-
 .entry .entry-header {
   margin: calc(3 * 1rem) 1rem 1rem;
   position: relative;
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-header {
     margin: calc(3 * 1rem) calc(10% + 60px) 1rem;
   }
 }
-
-.entry .entry-title {
-  margin: 0;
-}
-
 .entry .entry-title:before {
   background: #767676;
-  content: "\020";
+  content: " ";
   display: block;
   height: 2px;
   margin: 1rem 0;
   width: 1em;
 }
-
 .entry .entry-title.has-text-align-center:before {
   margin-left: auto;
   margin-right: auto;
 }
-
 .entry .entry-title.has-text-align-right:before {
   margin-left: auto;
 }
-
+.entry .entry-title {
+  margin: 0;
+}
 .entry .entry-title a {
   color: inherit;
 }
-
 .entry .entry-title a:hover {
-  color: #4a4a4a;
+  color: rgb(74.375, 74.375, 74.375);
 }
-
 .entry .entry-meta,
 .entry .entry-footer {
   color: #767676;
   font-weight: 500;
 }
-
 .entry .entry-meta > span,
 .entry .entry-footer > span {
   margin-right: 1rem;
   display: inline-block;
 }
-
 .entry .entry-meta > span:last-child,
 .entry .entry-footer > span:last-child {
   margin-right: 0;
 }
-
 .entry .entry-meta a,
 .entry .entry-footer a {
   transition: color 110ms ease-in-out;
   color: currentColor;
 }
-
 .entry .entry-meta a:hover,
 .entry .entry-footer a:hover {
   text-decoration: none;
   color: #0073aa;
 }
-
 .entry .entry-meta .svg-icon,
 .entry .entry-footer .svg-icon {
   position: relative;
@@ -4285,80 +4101,66 @@ body.page .main-navigation {
   vertical-align: middle;
   margin-right: 0.5em;
 }
-
 .entry .entry-meta {
   margin: 1rem 0;
 }
-
 .entry .entry-footer {
   margin: calc(2 * 1rem) 1rem 1rem;
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-footer {
     margin: 1rem calc(10% + 60px) calc(3 * 1rem);
-    max-width: calc(8 * (100vw / 12) - 28px);
+    max-width: calc(66.6666666667vw - 28px);
   }
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-footer {
-    max-width: calc(6 * (100vw / 12) - 28px);
+    max-width: calc(50vw - 28px);
   }
 }
-
 .entry .post-thumbnail {
   margin: 1rem;
 }
-
 @media only screen and (min-width: 768px) {
   .entry .post-thumbnail {
     margin: 1rem calc(10% + 60px);
   }
 }
-
 .entry .post-thumbnail:focus {
   outline: none;
 }
-
 .entry .post-thumbnail .post-thumbnail-inner {
   display: block;
 }
-
 .entry .post-thumbnail .post-thumbnail-inner img {
   position: relative;
   display: block;
   width: 100%;
 }
-
 .image-filters-enabled .entry .post-thumbnail {
   position: relative;
   display: block;
 }
-
 .image-filters-enabled .entry .post-thumbnail .post-thumbnail-inner {
   filter: grayscale(100%);
 }
-
 .image-filters-enabled .entry .post-thumbnail .post-thumbnail-inner:after {
   background: rgba(0, 0, 0, 0.35);
   content: "";
   display: block;
   height: 100%;
-  opacity: .5;
+  opacity: 0.5;
   pointer-events: none;
   position: absolute;
   top: 0;
   width: 100%;
   z-index: 4;
 }
-
 @supports (mix-blend-mode: multiply) {
   .image-filters-enabled .entry .post-thumbnail .post-thumbnail-inner:after {
     display: none;
   }
 }
-
 .image-filters-enabled .entry .post-thumbnail:before, .image-filters-enabled .entry .post-thumbnail:after {
   position: absolute;
   display: block;
@@ -4366,37 +4168,32 @@ body.page .main-navigation {
   height: 100%;
   top: 0;
   left: 0;
-  content: "\020";
+  content: " ";
   pointer-events: none;
 }
-
 .image-filters-enabled .entry .post-thumbnail:before {
   background: #0073aa;
   mix-blend-mode: screen;
   opacity: 0.1;
   z-index: 2;
 }
-
 .image-filters-enabled .entry .post-thumbnail:after {
   background: #0073aa;
   mix-blend-mode: multiply;
-  opacity: .8;
+  opacity: 0.8;
   z-index: 3;
   /* Browsers supporting mix-blend-mode don't need opacity < 1 */
 }
-
 @supports (mix-blend-mode: multiply) {
   .image-filters-enabled .entry .post-thumbnail:after {
     opacity: 1;
   }
 }
-
 .entry .entry-content,
 .entry .entry-summary {
-  max-width: calc(100% - (2 * 1rem));
+  max-width: calc(100% - 2 * 1rem);
   margin: 0 1rem;
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content,
   .entry .entry-summary {
@@ -4405,82 +4202,67 @@ body.page .main-navigation {
     padding: 0 60px;
   }
 }
-
 .entry .entry-content p {
   word-wrap: break-word;
 }
-
 .entry .entry-content .more-link {
   transition: color 110ms ease-in-out;
   display: inline;
   color: inherit;
 }
-
 .entry .entry-content .more-link:after {
-  content: "\02192";
+  content: "→";
   display: inline-block;
   margin-left: 0.5em;
 }
-
 .entry .entry-content .more-link:hover {
   color: #0073aa;
   text-decoration: none;
 }
-
 .entry .entry-content a {
   text-decoration: underline;
   text-decoration-thickness: 2px;
 }
-
 .entry .entry-content a.button, .entry .entry-content a:hover {
   text-decoration: none;
 }
-
 .entry .entry-content a.button {
   display: inline-block;
 }
-
 .entry .entry-content a.button:hover {
   background: #111;
   color: #fff;
   cursor: pointer;
 }
-
 .entry .entry-content > iframe[style] {
   margin: 32px 0 !important;
   max-width: 100% !important;
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content > iframe[style] {
-    max-width: calc(8 * (100vw / 12) - 28px) !important;
+    max-width: calc(66.6666666667vw - 28px) !important;
   }
 }
-
 @media only screen and (min-width: 1168px) {
   .entry .entry-content > iframe[style] {
-    max-width: calc(6 * (100vw / 12) - 28px) !important;
+    max-width: calc(50vw - 28px) !important;
   }
 }
-
 .entry .entry-content .page-links a {
   margin: calc(0.5 * 1rem);
   text-decoration: none;
 }
-
 .entry .entry-content .wp-audio-shortcode {
-  max-width: calc(100vw - (2 * 1rem));
+  max-width: calc(100vw - 2 * 1rem);
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-audio-shortcode {
-    max-width: calc(8 * (100vw / 12) - 28px);
+    max-width: calc(66.6666666667vw - 28px);
   }
 }
-
 @media only screen and (min-width: 1168px) {
   .entry .entry-content .wp-audio-shortcode {
-    max-width: calc(6 * (100vw / 12) - 28px);
+    max-width: calc(50vw - 28px);
   }
 }
 
@@ -4488,66 +4270,55 @@ body.page .main-navigation {
 .author-bio {
   margin: calc(2 * 1rem) 1rem 1rem;
 }
-
 @media only screen and (min-width: 768px) {
   .author-bio {
-    max-width: calc(8 * (100vw / 12) - 28px);
+    max-width: calc(66.6666666667vw - 28px);
   }
 }
-
 @media only screen and (min-width: 1168px) {
   .author-bio {
-    max-width: calc(6 * (100vw / 12) - 28px);
+    max-width: calc(50vw - 28px);
   }
 }
-
 @media only screen and (min-width: 768px) {
   .author-bio {
     margin: calc(3 * 1rem) calc(10% + 60px);
   }
 }
-
 @media only screen and (min-width: 1168px) {
   .author-bio {
     margin: calc(3 * 1rem) calc(10% + 60px);
   }
 }
-
-.author-bio .author-title {
-  display: inline;
-}
-
 .author-bio .author-title:before {
   background: #767676;
-  content: "\020";
+  content: " ";
   display: block;
   height: 2px;
   margin: 1rem 0;
   width: 1em;
 }
-
 .author-bio .author-title.has-text-align-center:before {
   margin-left: auto;
   margin-right: auto;
 }
-
 .author-bio .author-title.has-text-align-right:before {
   margin-left: auto;
 }
-
+.author-bio .author-title {
+  display: inline;
+}
 .author-bio .author-description {
   display: inline;
   color: #767676;
   font-size: 1.125em;
   line-height: 1.2;
 }
-
 .author-bio .author-description .author-link {
   display: inline-block;
 }
-
 .author-bio .author-description .author-link:hover {
-  color: #005177;
+  color: rgb(0, 80.5, 119);
   text-decoration: none;
 }
 
@@ -4569,45 +4340,40 @@ body.page .main-navigation {
   hyphens: auto;
   margin: calc(2 * 1rem) 1rem;
   word-wrap: break-word;
-  /* Add extra margin when the comments section is located immediately after the
-	 * post itself (this happens on pages).
-	 */
 }
-
 @media only screen and (min-width: 768px) {
   .comments-area {
-    max-width: calc(8 * (100vw / 12) - 28px);
+    max-width: calc(66.6666666667vw - 28px);
   }
 }
-
 @media only screen and (min-width: 1168px) {
   .comments-area {
-    max-width: calc(6 * (100vw / 12) - 28px);
+    max-width: calc(50vw - 28px);
   }
 }
-
 @media only screen and (min-width: 768px) {
   .comments-area {
     margin: calc(3 * 1rem) calc(10% + 60px);
   }
 }
-
 .comments-area > * {
   margin-top: calc(2 * 1rem);
   margin-bottom: calc(2 * 1rem);
 }
-
 @media only screen and (min-width: 768px) {
   .comments-area > * {
     margin-top: calc(3 * 1rem);
     margin-bottom: calc(3 * 1rem);
   }
 }
-
+.comments-area {
+  /* Add extra margin when the comments section is located immediately after the
+   * post itself (this happens on pages).
+   */
+}
 .entry + .comments-area {
   margin-top: calc(3 * 1rem);
 }
-
 @media only screen and (min-width: 768px) {
   .comments-area .comments-title-wrap {
     align-items: baseline;
@@ -4615,38 +4381,32 @@ body.page .main-navigation {
     justify-content: space-between;
   }
 }
-
-.comments-area .comments-title-wrap .comments-title {
-  margin: 0;
-}
-
 .comments-area .comments-title-wrap .comments-title:before {
   background: #767676;
-  content: "\020";
+  content: " ";
   display: block;
   height: 2px;
   margin: 1rem 0;
   width: 1em;
 }
-
 .comments-area .comments-title-wrap .comments-title.has-text-align-center:before {
   margin-left: auto;
   margin-right: auto;
 }
-
 .comments-area .comments-title-wrap .comments-title.has-text-align-right:before {
   margin-left: auto;
 }
-
+.comments-area .comments-title-wrap .comments-title {
+  margin: 0;
+}
 @media only screen and (min-width: 768px) {
   .comments-area .comments-title-wrap .comments-title {
-    flex: 1 0 calc(3 * (100vw / 12));
+    flex: 1 0 25vw;
   }
 }
-
 @media only screen and (min-width: 768px) {
   .comments-area .comments-title-wrap .discussion-meta {
-    flex: 0 0 calc(2 * (100vw / 12));
+    flex: 0 0 16.6666666667vw;
     margin-left: 1rem;
   }
 }
@@ -4659,24 +4419,20 @@ body.page .main-navigation {
 #respond {
   position: relative;
 }
-
 #respond .comment-user-avatar {
   margin: 1rem 0 -1rem;
 }
-
 #respond .comment .comment-form {
   padding-left: 0;
 }
-
 #respond > small {
   display: block;
   font-size: 22px;
   position: absolute;
   left: calc(1rem + 100%);
   top: calc(-3.5 * 1rem);
-  width: calc(100vw / 12);
+  width: 8.3333333333vw;
 }
-
 #respond .comment-reply-title small {
   margin-left: 0.5em;
 }
@@ -4689,17 +4445,14 @@ body.page .main-navigation {
   display: flex;
   flex-direction: column;
 }
-
 .comment-form-flex .comments-title {
   display: none;
   margin: 0;
   order: 1;
 }
-
 .comment-form-flex #respond {
   order: 2;
 }
-
 .comment-form-flex #respond + .comments-title {
   display: block;
 }
@@ -4713,46 +4466,294 @@ body.page .main-navigation {
   list-style: none;
   padding: 0;
 }
-
 .comment-list .children {
   margin: 0;
   padding: 0 0 0 1rem;
 }
-
 .comment-list > .comment:first-child {
   margin-top: 0;
 }
-
 .comment-list .pingback .comment-body,
 .comment-list .trackback .comment-body {
   color: #767676;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  font-size: 0.71111em;
+}
+.comment-list .pingback .comment-body:lang(ar),
+.comment-list .trackback .comment-body:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.comment-list .pingback .comment-body:lang(ary),
+.comment-list .trackback .comment-body:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.comment-list .pingback .comment-body:lang(azb),
+.comment-list .trackback .comment-body:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.comment-list .pingback .comment-body:lang(ckb),
+.comment-list .trackback .comment-body:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.comment-list .pingback .comment-body:lang(fa-IR),
+.comment-list .trackback .comment-body:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.comment-list .pingback .comment-body:lang(haz),
+.comment-list .trackback .comment-body:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.comment-list .pingback .comment-body:lang(ps),
+.comment-list .trackback .comment-body:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.comment-list .pingback .comment-body:lang(be),
+.comment-list .trackback .comment-body:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-list .pingback .comment-body:lang(bg-BG),
+.comment-list .trackback .comment-body:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-list .pingback .comment-body:lang(kk),
+.comment-list .trackback .comment-body:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-list .pingback .comment-body:lang(mk-MK),
+.comment-list .trackback .comment-body:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-list .pingback .comment-body:lang(mn),
+.comment-list .trackback .comment-body:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-list .pingback .comment-body:lang(ru-RU),
+.comment-list .trackback .comment-body:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-list .pingback .comment-body:lang(sah),
+.comment-list .trackback .comment-body:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-list .pingback .comment-body:lang(sr-RS),
+.comment-list .trackback .comment-body:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-list .pingback .comment-body:lang(tt-RU),
+.comment-list .trackback .comment-body:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-list .pingback .comment-body:lang(uk),
+.comment-list .trackback .comment-body:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-list .pingback .comment-body:lang(zh-HK),
+.comment-list .trackback .comment-body:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.comment-list .pingback .comment-body:lang(zh-TW),
+.comment-list .trackback .comment-body:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.comment-list .pingback .comment-body:lang(zh-CN),
+.comment-list .trackback .comment-body:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.comment-list .pingback .comment-body:lang(bn-BD),
+.comment-list .trackback .comment-body:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+.comment-list .pingback .comment-body:lang(hi-IN),
+.comment-list .trackback .comment-body:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+.comment-list .pingback .comment-body:lang(mr),
+.comment-list .trackback .comment-body:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+.comment-list .pingback .comment-body:lang(ne-NP),
+.comment-list .trackback .comment-body:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+.comment-list .pingback .comment-body:lang(el),
+.comment-list .trackback .comment-body:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+.comment-list .pingback .comment-body:lang(gu),
+.comment-list .trackback .comment-body:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+.comment-list .pingback .comment-body:lang(he-IL),
+.comment-list .trackback .comment-body:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+.comment-list .pingback .comment-body:lang(ja),
+.comment-list .trackback .comment-body:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+.comment-list .pingback .comment-body:lang(ko-KR),
+.comment-list .trackback .comment-body:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+.comment-list .pingback .comment-body:lang(th),
+.comment-list .trackback .comment-body:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+.comment-list .pingback .comment-body:lang(vi),
+.comment-list .trackback .comment-body:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
+.comment-list .pingback .comment-body,
+.comment-list .trackback .comment-body {
+  font-size: 0.7111111111em;
   font-weight: 500;
   margin-top: 1rem;
   margin-bottom: 1rem;
 }
-
 .comment-list .pingback .comment-body a:not(.comment-edit-link),
 .comment-list .trackback .comment-body a:not(.comment-edit-link) {
   font-weight: bold;
-  font-size: 19.55556px;
+  font-size: 19.5555555556px;
   line-height: 1.5;
   padding-right: 0.5rem;
   display: block;
 }
-
 .comment-list .pingback .comment-body .comment-edit-link,
 .comment-list .trackback .comment-body .comment-edit-link {
   color: #767676;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+}
+.comment-list .pingback .comment-body .comment-edit-link:lang(ar),
+.comment-list .trackback .comment-body .comment-edit-link:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.comment-list .pingback .comment-body .comment-edit-link:lang(ary),
+.comment-list .trackback .comment-body .comment-edit-link:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.comment-list .pingback .comment-body .comment-edit-link:lang(azb),
+.comment-list .trackback .comment-body .comment-edit-link:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.comment-list .pingback .comment-body .comment-edit-link:lang(ckb),
+.comment-list .trackback .comment-body .comment-edit-link:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.comment-list .pingback .comment-body .comment-edit-link:lang(fa-IR),
+.comment-list .trackback .comment-body .comment-edit-link:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.comment-list .pingback .comment-body .comment-edit-link:lang(haz),
+.comment-list .trackback .comment-body .comment-edit-link:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.comment-list .pingback .comment-body .comment-edit-link:lang(ps),
+.comment-list .trackback .comment-body .comment-edit-link:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.comment-list .pingback .comment-body .comment-edit-link:lang(be),
+.comment-list .trackback .comment-body .comment-edit-link:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-list .pingback .comment-body .comment-edit-link:lang(bg-BG),
+.comment-list .trackback .comment-body .comment-edit-link:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-list .pingback .comment-body .comment-edit-link:lang(kk),
+.comment-list .trackback .comment-body .comment-edit-link:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-list .pingback .comment-body .comment-edit-link:lang(mk-MK),
+.comment-list .trackback .comment-body .comment-edit-link:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-list .pingback .comment-body .comment-edit-link:lang(mn),
+.comment-list .trackback .comment-body .comment-edit-link:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-list .pingback .comment-body .comment-edit-link:lang(ru-RU),
+.comment-list .trackback .comment-body .comment-edit-link:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-list .pingback .comment-body .comment-edit-link:lang(sah),
+.comment-list .trackback .comment-body .comment-edit-link:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-list .pingback .comment-body .comment-edit-link:lang(sr-RS),
+.comment-list .trackback .comment-body .comment-edit-link:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-list .pingback .comment-body .comment-edit-link:lang(tt-RU),
+.comment-list .trackback .comment-body .comment-edit-link:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-list .pingback .comment-body .comment-edit-link:lang(uk),
+.comment-list .trackback .comment-body .comment-edit-link:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-list .pingback .comment-body .comment-edit-link:lang(zh-HK),
+.comment-list .trackback .comment-body .comment-edit-link:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.comment-list .pingback .comment-body .comment-edit-link:lang(zh-TW),
+.comment-list .trackback .comment-body .comment-edit-link:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.comment-list .pingback .comment-body .comment-edit-link:lang(zh-CN),
+.comment-list .trackback .comment-body .comment-edit-link:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.comment-list .pingback .comment-body .comment-edit-link:lang(bn-BD),
+.comment-list .trackback .comment-body .comment-edit-link:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+.comment-list .pingback .comment-body .comment-edit-link:lang(hi-IN),
+.comment-list .trackback .comment-body .comment-edit-link:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+.comment-list .pingback .comment-body .comment-edit-link:lang(mr),
+.comment-list .trackback .comment-body .comment-edit-link:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+.comment-list .pingback .comment-body .comment-edit-link:lang(ne-NP),
+.comment-list .trackback .comment-body .comment-edit-link:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+.comment-list .pingback .comment-body .comment-edit-link:lang(el),
+.comment-list .trackback .comment-body .comment-edit-link:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+.comment-list .pingback .comment-body .comment-edit-link:lang(gu),
+.comment-list .trackback .comment-body .comment-edit-link:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+.comment-list .pingback .comment-body .comment-edit-link:lang(he-IL),
+.comment-list .trackback .comment-body .comment-edit-link:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+.comment-list .pingback .comment-body .comment-edit-link:lang(ja),
+.comment-list .trackback .comment-body .comment-edit-link:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+.comment-list .pingback .comment-body .comment-edit-link:lang(ko-KR),
+.comment-list .trackback .comment-body .comment-edit-link:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+.comment-list .pingback .comment-body .comment-edit-link:lang(th),
+.comment-list .trackback .comment-body .comment-edit-link:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+.comment-list .pingback .comment-body .comment-edit-link:lang(vi),
+.comment-list .trackback .comment-body .comment-edit-link:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
+.comment-list .pingback .comment-body .comment-edit-link,
+.comment-list .trackback .comment-body .comment-edit-link {
   font-weight: 500;
 }
 
 #respond + .comment-reply {
   display: none;
 }
-
 .comment-reply .comment-reply-link {
   display: inline-block;
 }
@@ -4761,10 +4762,9 @@ body.page .main-navigation {
   list-style: none;
   position: relative;
 }
-
 @media only screen and (min-width: 768px) {
   .comment {
-    padding-left: calc(.5 * (1rem + calc(100vw / 12 )));
+    padding-left: calc(0.5 * (1rem + 8.3333333333vw));
   }
   .comment.depth-1,
   .comment .children {
@@ -4774,15 +4774,12 @@ body.page .main-navigation {
     margin-left: calc(3.25 * 1rem);
   }
 }
-
 .comment .comment-body {
   margin: calc(2 * 1rem) 0 0;
 }
-
 .comment .comment-meta {
   position: relative;
 }
-
 .comment .comment-author .avatar {
   float: left;
   height: calc(2.25 * 1rem);
@@ -4790,7 +4787,6 @@ body.page .main-navigation {
   position: relative;
   width: calc(2.25 * 1rem);
 }
-
 @media only screen and (min-width: 768px) {
   .comment .comment-author .avatar {
     float: inherit;
@@ -4800,37 +4796,31 @@ body.page .main-navigation {
     right: calc(100% + 1rem);
   }
 }
-
 .comment .comment-author .fn {
   position: relative;
   display: block;
 }
-
 .comment .comment-author .fn a {
   color: inherit;
 }
-
 .comment .comment-author .fn a:hover {
-  color: #005177;
+  color: rgb(0, 80.5, 119);
 }
-
 .comment .comment-author .post-author-badge {
   border-radius: 100%;
   display: block;
   height: 18px;
   position: absolute;
-  background: #008fd3;
+  background: rgb(0, 142.6, 210.8);
   right: calc(100% - 2.5rem);
   top: -3px;
   width: 18px;
 }
-
 @media only screen and (min-width: 768px) {
   .comment .comment-author .post-author-badge {
     right: calc(100% + 0.75rem);
   }
 }
-
 .comment .comment-author .post-author-badge svg {
   width: inherit;
   height: inherit;
@@ -4838,7 +4828,6 @@ body.page .main-navigation {
   fill: white;
   transform: scale(0.875);
 }
-
 .comment .comment-metadata > a,
 .comment .comment-metadata .comment-edit-link {
   display: inline;
@@ -4846,76 +4835,61 @@ body.page .main-navigation {
   color: #767676;
   vertical-align: baseline;
 }
-
 .comment .comment-metadata > a time,
 .comment .comment-metadata .comment-edit-link time {
   vertical-align: baseline;
 }
-
 .comment .comment-metadata > a:hover,
 .comment .comment-metadata .comment-edit-link:hover {
-  color: #005177;
+  color: rgb(0, 80.5, 119);
   text-decoration: none;
 }
-
 .comment .comment-metadata > * {
   display: inline-block;
 }
-
 .comment .comment-metadata .edit-link-sep {
   color: #767676;
   margin: 0 0.2em;
   vertical-align: baseline;
 }
-
 .comment .comment-metadata .edit-link {
   color: #767676;
 }
-
 .comment .comment-metadata .edit-link svg {
   transform: scale(0.8);
   vertical-align: baseline;
   margin-right: 0.1em;
 }
-
 .comment .comment-metadata .comment-edit-link {
   position: relative;
   padding-left: 1rem;
   margin-left: -1rem;
   z-index: 1;
 }
-
 .comment .comment-metadata .comment-edit-link:hover {
   color: #0073aa;
 }
-
 .comment .comment-content {
   margin: 1rem 0;
 }
-
 @media only screen and (min-width: 1168px) {
   .comment .comment-content {
     padding-right: 1rem;
   }
 }
-
 .comment .comment-content > *:first-child {
   margin-top: 0;
 }
-
 .comment .comment-content > *:last-child {
   margin-bottom: 0;
 }
-
 .comment .comment-content blockquote {
   margin-left: 0;
 }
-
 .comment .comment-content a {
   text-decoration: underline;
   text-decoration-thickness: 2px;
 }
-
 .comment .comment-content a:hover {
   text-decoration: none;
 }
@@ -4924,10 +4898,9 @@ body.page .main-navigation {
 #cancel-comment-reply-link {
   font-weight: 500;
 }
-
 .comment-reply-link:hover,
 #cancel-comment-reply-link:hover {
-  color: #005177;
+  color: rgb(0, 80.5, 119);
 }
 
 .discussion-avatar-list {
@@ -4937,7 +4910,6 @@ body.page .main-navigation {
   margin: 0;
   padding: 0;
 }
-
 .discussion-avatar-list li {
   position: relative;
   list-style: none;
@@ -4945,7 +4917,6 @@ body.page .main-navigation {
   padding: 0;
   float: left;
 }
-
 .discussion-avatar-list .comment-user-avatar img {
   height: calc(1.5 * 1rem);
   width: calc(1.5 * 1rem);
@@ -4954,7 +4925,6 @@ body.page .main-navigation {
 .discussion-meta .discussion-meta-info {
   margin: 0;
 }
-
 .discussion-meta .discussion-meta-info .svg-icon {
   vertical-align: middle;
   fill: currentColor;
@@ -4965,14 +4935,139 @@ body.page .main-navigation {
 .comment-form .comment-notes,
 .comment-form label {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  font-size: 0.71111em;
+}
+.comment-form .comment-notes:lang(ar),
+.comment-form label:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.comment-form .comment-notes:lang(ary),
+.comment-form label:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.comment-form .comment-notes:lang(azb),
+.comment-form label:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.comment-form .comment-notes:lang(ckb),
+.comment-form label:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.comment-form .comment-notes:lang(fa-IR),
+.comment-form label:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.comment-form .comment-notes:lang(haz),
+.comment-form label:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.comment-form .comment-notes:lang(ps),
+.comment-form label:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.comment-form .comment-notes:lang(be),
+.comment-form label:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-form .comment-notes:lang(bg-BG),
+.comment-form label:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-form .comment-notes:lang(kk),
+.comment-form label:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-form .comment-notes:lang(mk-MK),
+.comment-form label:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-form .comment-notes:lang(mn),
+.comment-form label:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-form .comment-notes:lang(ru-RU),
+.comment-form label:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-form .comment-notes:lang(sah),
+.comment-form label:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-form .comment-notes:lang(sr-RS),
+.comment-form label:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-form .comment-notes:lang(tt-RU),
+.comment-form label:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-form .comment-notes:lang(uk),
+.comment-form label:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.comment-form .comment-notes:lang(zh-HK),
+.comment-form label:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.comment-form .comment-notes:lang(zh-TW),
+.comment-form label:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.comment-form .comment-notes:lang(zh-CN),
+.comment-form label:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.comment-form .comment-notes:lang(bn-BD),
+.comment-form label:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+.comment-form .comment-notes:lang(hi-IN),
+.comment-form label:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+.comment-form .comment-notes:lang(mr),
+.comment-form label:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+.comment-form .comment-notes:lang(ne-NP),
+.comment-form label:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+.comment-form .comment-notes:lang(el),
+.comment-form label:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+.comment-form .comment-notes:lang(gu),
+.comment-form label:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+.comment-form .comment-notes:lang(he-IL),
+.comment-form label:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+.comment-form .comment-notes:lang(ja),
+.comment-form label:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+.comment-form .comment-notes:lang(ko-KR),
+.comment-form label:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+.comment-form .comment-notes:lang(th),
+.comment-form label:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+.comment-form .comment-notes:lang(vi),
+.comment-form label:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
+.comment-form .comment-notes,
+.comment-form label {
+  font-size: 0.7111111111em;
   color: #767676;
 }
-
 .comment-form #wp-comment-cookies-consent {
   margin: 0 10px 0 0;
 }
-
 @media only screen and (min-width: 768px) {
   .comment-form .comment-form-author,
   .comment-form .comment-form-email {
@@ -4980,16 +5075,14 @@ body.page .main-navigation {
     float: left;
   }
 }
-
 @media only screen and (min-width: 768px) {
   .comment-form .comment-form-email {
     margin-left: 1rem;
   }
 }
-
-.comment-form input[name="author"],
-.comment-form input[name="email"],
-.comment-form input[name="url"] {
+.comment-form input[name=author],
+.comment-form input[name=email],
+.comment-form input[name=url] {
   display: block;
   width: 100%;
 }
@@ -5002,7 +5095,6 @@ body.page .main-navigation {
 .error404 .page-header {
   margin: 1rem 1rem calc(3 * 1rem);
 }
-
 @media only screen and (min-width: 768px) {
   .archive .page-header,
   .search .page-header,
@@ -5010,7 +5102,6 @@ body.page .main-navigation {
     margin: 0 calc(10% + 60px) calc(3 * 1rem);
   }
 }
-
 .archive .page-header .page-title,
 .search .page-header .page-title,
 .error404 .page-header .page-title {
@@ -5018,13 +5109,11 @@ body.page .main-navigation {
   display: inline;
   letter-spacing: normal;
 }
-
 .archive .page-header .page-title:before,
 .search .page-header .page-title:before,
 .error404 .page-header .page-title:before {
   display: none;
 }
-
 .archive .page-header .search-term,
 .archive .page-header .page-description,
 .search .page-header .search-term,
@@ -5053,20 +5142,17 @@ body.page .main-navigation {
 .no-results.not-found .page-content {
   margin: calc(3 * 1rem) 1rem;
 }
-
 @media only screen and (min-width: 768px) {
   .error-404.not-found .page-content,
   .no-results.not-found .page-content {
     margin: calc(3 * 1rem) calc(10% + 60px) calc(1rem / 2);
   }
 }
-
 .error-404.not-found .search-submit,
 .no-results.not-found .search-submit {
   vertical-align: middle;
   margin: 1rem 0;
 }
-
 .error-404.not-found .search-field,
 .no-results.not-found .search-field {
   width: 100%;
@@ -5080,19 +5166,16 @@ body.page .main-navigation {
 #colophon .site-info {
   margin: calc(2 * 1rem) 1rem;
 }
-
 @media only screen and (min-width: 768px) {
   #colophon .widget-area,
   #colophon .site-info {
     margin: calc(3 * 1rem) calc(10% + 60px);
   }
 }
-
 #colophon .widget-column {
   display: flex;
   flex-wrap: wrap;
 }
-
 #colophon .widget-column .widget {
   -webkit-hyphens: auto;
   -moz-hyphens: auto;
@@ -5101,14 +5184,12 @@ body.page .main-navigation {
   width: 100%;
   word-wrap: break-word;
 }
-
 @media only screen and (min-width: 1168px) {
   #colophon .widget-column .widget {
     margin-right: calc(3 * 1rem);
-    width: calc(50% - (3 * 1rem));
+    width: calc(50% - 3 * 1rem);
   }
 }
-
 #colophon .site-info {
   color: #767676;
   -webkit-hyphens: auto;
@@ -5117,16 +5198,13 @@ body.page .main-navigation {
   hyphens: auto;
   word-wrap: break-word;
 }
-
 #colophon .site-info a {
   color: inherit;
 }
-
 #colophon .site-info a:hover {
   text-decoration: none;
   color: #0073aa;
 }
-
 #colophon .site-info .imprint,
 #colophon .site-info .privacy-policy-link {
   margin-right: 1rem;
@@ -5135,23 +5213,21 @@ body.page .main-navigation {
 /* Widgets */
 .widget {
   margin: 0 0 1rem;
-  /* Make sure select elements fit in widgets. */
 }
-
 .widget .widget-title {
   font-size: 1.6875em;
 }
-
+.widget {
+  /* Make sure select elements fit in widgets. */
+}
 .widget select {
   max-width: 100%;
 }
-
 .widget a {
   color: #0073aa;
 }
-
 .widget a:hover {
-  color: #005177;
+  color: rgb(0, 80.5, 119);
 }
 
 .widget_archive ul,
@@ -5165,7 +5241,6 @@ body.page .main-navigation {
   padding: 0;
   list-style: none;
 }
-
 .widget_archive ul li,
 .widget_categories ul li,
 .widget_meta ul li,
@@ -5176,13 +5251,331 @@ body.page .main-navigation {
 .widget_rss ul li {
   color: #767676;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+}
+.widget_archive ul li:lang(ar),
+.widget_categories ul li:lang(ar),
+.widget_meta ul li:lang(ar),
+.widget_nav_menu ul li:lang(ar),
+.widget_pages ul li:lang(ar),
+.widget_recent_comments ul li:lang(ar),
+.widget_recent_entries ul li:lang(ar),
+.widget_rss ul li:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.widget_archive ul li:lang(ary),
+.widget_categories ul li:lang(ary),
+.widget_meta ul li:lang(ary),
+.widget_nav_menu ul li:lang(ary),
+.widget_pages ul li:lang(ary),
+.widget_recent_comments ul li:lang(ary),
+.widget_recent_entries ul li:lang(ary),
+.widget_rss ul li:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.widget_archive ul li:lang(azb),
+.widget_categories ul li:lang(azb),
+.widget_meta ul li:lang(azb),
+.widget_nav_menu ul li:lang(azb),
+.widget_pages ul li:lang(azb),
+.widget_recent_comments ul li:lang(azb),
+.widget_recent_entries ul li:lang(azb),
+.widget_rss ul li:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.widget_archive ul li:lang(ckb),
+.widget_categories ul li:lang(ckb),
+.widget_meta ul li:lang(ckb),
+.widget_nav_menu ul li:lang(ckb),
+.widget_pages ul li:lang(ckb),
+.widget_recent_comments ul li:lang(ckb),
+.widget_recent_entries ul li:lang(ckb),
+.widget_rss ul li:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.widget_archive ul li:lang(fa-IR),
+.widget_categories ul li:lang(fa-IR),
+.widget_meta ul li:lang(fa-IR),
+.widget_nav_menu ul li:lang(fa-IR),
+.widget_pages ul li:lang(fa-IR),
+.widget_recent_comments ul li:lang(fa-IR),
+.widget_recent_entries ul li:lang(fa-IR),
+.widget_rss ul li:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.widget_archive ul li:lang(haz),
+.widget_categories ul li:lang(haz),
+.widget_meta ul li:lang(haz),
+.widget_nav_menu ul li:lang(haz),
+.widget_pages ul li:lang(haz),
+.widget_recent_comments ul li:lang(haz),
+.widget_recent_entries ul li:lang(haz),
+.widget_rss ul li:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.widget_archive ul li:lang(ps),
+.widget_categories ul li:lang(ps),
+.widget_meta ul li:lang(ps),
+.widget_nav_menu ul li:lang(ps),
+.widget_pages ul li:lang(ps),
+.widget_recent_comments ul li:lang(ps),
+.widget_recent_entries ul li:lang(ps),
+.widget_rss ul li:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.widget_archive ul li:lang(be),
+.widget_categories ul li:lang(be),
+.widget_meta ul li:lang(be),
+.widget_nav_menu ul li:lang(be),
+.widget_pages ul li:lang(be),
+.widget_recent_comments ul li:lang(be),
+.widget_recent_entries ul li:lang(be),
+.widget_rss ul li:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.widget_archive ul li:lang(bg-BG),
+.widget_categories ul li:lang(bg-BG),
+.widget_meta ul li:lang(bg-BG),
+.widget_nav_menu ul li:lang(bg-BG),
+.widget_pages ul li:lang(bg-BG),
+.widget_recent_comments ul li:lang(bg-BG),
+.widget_recent_entries ul li:lang(bg-BG),
+.widget_rss ul li:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.widget_archive ul li:lang(kk),
+.widget_categories ul li:lang(kk),
+.widget_meta ul li:lang(kk),
+.widget_nav_menu ul li:lang(kk),
+.widget_pages ul li:lang(kk),
+.widget_recent_comments ul li:lang(kk),
+.widget_recent_entries ul li:lang(kk),
+.widget_rss ul li:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.widget_archive ul li:lang(mk-MK),
+.widget_categories ul li:lang(mk-MK),
+.widget_meta ul li:lang(mk-MK),
+.widget_nav_menu ul li:lang(mk-MK),
+.widget_pages ul li:lang(mk-MK),
+.widget_recent_comments ul li:lang(mk-MK),
+.widget_recent_entries ul li:lang(mk-MK),
+.widget_rss ul li:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.widget_archive ul li:lang(mn),
+.widget_categories ul li:lang(mn),
+.widget_meta ul li:lang(mn),
+.widget_nav_menu ul li:lang(mn),
+.widget_pages ul li:lang(mn),
+.widget_recent_comments ul li:lang(mn),
+.widget_recent_entries ul li:lang(mn),
+.widget_rss ul li:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.widget_archive ul li:lang(ru-RU),
+.widget_categories ul li:lang(ru-RU),
+.widget_meta ul li:lang(ru-RU),
+.widget_nav_menu ul li:lang(ru-RU),
+.widget_pages ul li:lang(ru-RU),
+.widget_recent_comments ul li:lang(ru-RU),
+.widget_recent_entries ul li:lang(ru-RU),
+.widget_rss ul li:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.widget_archive ul li:lang(sah),
+.widget_categories ul li:lang(sah),
+.widget_meta ul li:lang(sah),
+.widget_nav_menu ul li:lang(sah),
+.widget_pages ul li:lang(sah),
+.widget_recent_comments ul li:lang(sah),
+.widget_recent_entries ul li:lang(sah),
+.widget_rss ul li:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.widget_archive ul li:lang(sr-RS),
+.widget_categories ul li:lang(sr-RS),
+.widget_meta ul li:lang(sr-RS),
+.widget_nav_menu ul li:lang(sr-RS),
+.widget_pages ul li:lang(sr-RS),
+.widget_recent_comments ul li:lang(sr-RS),
+.widget_recent_entries ul li:lang(sr-RS),
+.widget_rss ul li:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.widget_archive ul li:lang(tt-RU),
+.widget_categories ul li:lang(tt-RU),
+.widget_meta ul li:lang(tt-RU),
+.widget_nav_menu ul li:lang(tt-RU),
+.widget_pages ul li:lang(tt-RU),
+.widget_recent_comments ul li:lang(tt-RU),
+.widget_recent_entries ul li:lang(tt-RU),
+.widget_rss ul li:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.widget_archive ul li:lang(uk),
+.widget_categories ul li:lang(uk),
+.widget_meta ul li:lang(uk),
+.widget_nav_menu ul li:lang(uk),
+.widget_pages ul li:lang(uk),
+.widget_recent_comments ul li:lang(uk),
+.widget_recent_entries ul li:lang(uk),
+.widget_rss ul li:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.widget_archive ul li:lang(zh-HK),
+.widget_categories ul li:lang(zh-HK),
+.widget_meta ul li:lang(zh-HK),
+.widget_nav_menu ul li:lang(zh-HK),
+.widget_pages ul li:lang(zh-HK),
+.widget_recent_comments ul li:lang(zh-HK),
+.widget_recent_entries ul li:lang(zh-HK),
+.widget_rss ul li:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.widget_archive ul li:lang(zh-TW),
+.widget_categories ul li:lang(zh-TW),
+.widget_meta ul li:lang(zh-TW),
+.widget_nav_menu ul li:lang(zh-TW),
+.widget_pages ul li:lang(zh-TW),
+.widget_recent_comments ul li:lang(zh-TW),
+.widget_recent_entries ul li:lang(zh-TW),
+.widget_rss ul li:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.widget_archive ul li:lang(zh-CN),
+.widget_categories ul li:lang(zh-CN),
+.widget_meta ul li:lang(zh-CN),
+.widget_nav_menu ul li:lang(zh-CN),
+.widget_pages ul li:lang(zh-CN),
+.widget_recent_comments ul li:lang(zh-CN),
+.widget_recent_entries ul li:lang(zh-CN),
+.widget_rss ul li:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.widget_archive ul li:lang(bn-BD),
+.widget_categories ul li:lang(bn-BD),
+.widget_meta ul li:lang(bn-BD),
+.widget_nav_menu ul li:lang(bn-BD),
+.widget_pages ul li:lang(bn-BD),
+.widget_recent_comments ul li:lang(bn-BD),
+.widget_recent_entries ul li:lang(bn-BD),
+.widget_rss ul li:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+.widget_archive ul li:lang(hi-IN),
+.widget_categories ul li:lang(hi-IN),
+.widget_meta ul li:lang(hi-IN),
+.widget_nav_menu ul li:lang(hi-IN),
+.widget_pages ul li:lang(hi-IN),
+.widget_recent_comments ul li:lang(hi-IN),
+.widget_recent_entries ul li:lang(hi-IN),
+.widget_rss ul li:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+.widget_archive ul li:lang(mr),
+.widget_categories ul li:lang(mr),
+.widget_meta ul li:lang(mr),
+.widget_nav_menu ul li:lang(mr),
+.widget_pages ul li:lang(mr),
+.widget_recent_comments ul li:lang(mr),
+.widget_recent_entries ul li:lang(mr),
+.widget_rss ul li:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+.widget_archive ul li:lang(ne-NP),
+.widget_categories ul li:lang(ne-NP),
+.widget_meta ul li:lang(ne-NP),
+.widget_nav_menu ul li:lang(ne-NP),
+.widget_pages ul li:lang(ne-NP),
+.widget_recent_comments ul li:lang(ne-NP),
+.widget_recent_entries ul li:lang(ne-NP),
+.widget_rss ul li:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+.widget_archive ul li:lang(el),
+.widget_categories ul li:lang(el),
+.widget_meta ul li:lang(el),
+.widget_nav_menu ul li:lang(el),
+.widget_pages ul li:lang(el),
+.widget_recent_comments ul li:lang(el),
+.widget_recent_entries ul li:lang(el),
+.widget_rss ul li:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+.widget_archive ul li:lang(gu),
+.widget_categories ul li:lang(gu),
+.widget_meta ul li:lang(gu),
+.widget_nav_menu ul li:lang(gu),
+.widget_pages ul li:lang(gu),
+.widget_recent_comments ul li:lang(gu),
+.widget_recent_entries ul li:lang(gu),
+.widget_rss ul li:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+.widget_archive ul li:lang(he-IL),
+.widget_categories ul li:lang(he-IL),
+.widget_meta ul li:lang(he-IL),
+.widget_nav_menu ul li:lang(he-IL),
+.widget_pages ul li:lang(he-IL),
+.widget_recent_comments ul li:lang(he-IL),
+.widget_recent_entries ul li:lang(he-IL),
+.widget_rss ul li:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+.widget_archive ul li:lang(ja),
+.widget_categories ul li:lang(ja),
+.widget_meta ul li:lang(ja),
+.widget_nav_menu ul li:lang(ja),
+.widget_pages ul li:lang(ja),
+.widget_recent_comments ul li:lang(ja),
+.widget_recent_entries ul li:lang(ja),
+.widget_rss ul li:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+.widget_archive ul li:lang(ko-KR),
+.widget_categories ul li:lang(ko-KR),
+.widget_meta ul li:lang(ko-KR),
+.widget_nav_menu ul li:lang(ko-KR),
+.widget_pages ul li:lang(ko-KR),
+.widget_recent_comments ul li:lang(ko-KR),
+.widget_recent_entries ul li:lang(ko-KR),
+.widget_rss ul li:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+.widget_archive ul li:lang(th),
+.widget_categories ul li:lang(th),
+.widget_meta ul li:lang(th),
+.widget_nav_menu ul li:lang(th),
+.widget_pages ul li:lang(th),
+.widget_recent_comments ul li:lang(th),
+.widget_recent_entries ul li:lang(th),
+.widget_rss ul li:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+.widget_archive ul li:lang(vi),
+.widget_categories ul li:lang(vi),
+.widget_meta ul li:lang(vi),
+.widget_nav_menu ul li:lang(vi),
+.widget_pages ul li:lang(vi),
+.widget_recent_comments ul li:lang(vi),
+.widget_recent_entries ul li:lang(vi),
+.widget_rss ul li:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
+.widget_archive ul li,
+.widget_categories ul li,
+.widget_meta ul li,
+.widget_nav_menu ul li,
+.widget_pages ul li,
+.widget_recent_comments ul li,
+.widget_recent_entries ul li,
+.widget_rss ul li {
   font-size: calc(22px * 1.125);
   font-weight: 700;
   line-height: 1.2;
   margin-top: 0.5rem;
   margin-bottom: 0.5rem;
 }
-
 .widget_archive ul ul,
 .widget_categories ul ul,
 .widget_meta ul ul,
@@ -5193,7 +5586,6 @@ body.page .main-navigation {
 .widget_rss ul ul {
   counter-reset: submenu;
 }
-
 .widget_archive ul ul > li > a::before,
 .widget_categories ul ul > li > a::before,
 .widget_meta ul ul > li > a::before,
@@ -5210,19 +5602,112 @@ body.page .main-navigation {
 
 .widget_tag_cloud .tagcloud {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+}
+.widget_tag_cloud .tagcloud:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.widget_tag_cloud .tagcloud:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.widget_tag_cloud .tagcloud:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.widget_tag_cloud .tagcloud:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.widget_tag_cloud .tagcloud:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.widget_tag_cloud .tagcloud:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.widget_tag_cloud .tagcloud:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.widget_tag_cloud .tagcloud:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.widget_tag_cloud .tagcloud:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.widget_tag_cloud .tagcloud:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.widget_tag_cloud .tagcloud:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.widget_tag_cloud .tagcloud:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.widget_tag_cloud .tagcloud:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.widget_tag_cloud .tagcloud:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.widget_tag_cloud .tagcloud:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.widget_tag_cloud .tagcloud:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.widget_tag_cloud .tagcloud:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.widget_tag_cloud .tagcloud:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.widget_tag_cloud .tagcloud:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.widget_tag_cloud .tagcloud:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.widget_tag_cloud .tagcloud:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+.widget_tag_cloud .tagcloud:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+.widget_tag_cloud .tagcloud:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+.widget_tag_cloud .tagcloud:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+.widget_tag_cloud .tagcloud:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+.widget_tag_cloud .tagcloud:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+.widget_tag_cloud .tagcloud:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+.widget_tag_cloud .tagcloud:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+.widget_tag_cloud .tagcloud:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+.widget_tag_cloud .tagcloud:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+.widget_tag_cloud .tagcloud:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
+.widget_tag_cloud .tagcloud {
   font-weight: 700;
 }
 
 .widget_search .search-field {
   width: 100%;
 }
-
 @media only screen and (min-width: 600px) {
   .widget_search .search-field {
     width: auto;
   }
 }
-
 .widget_search .search-submit {
   display: block;
   margin-top: 1rem;
@@ -5231,33 +5716,120 @@ body.page .main-navigation {
 .widget_calendar .calendar_wrap {
   text-align: center;
 }
-
 .widget_calendar .calendar_wrap table td,
 .widget_calendar .calendar_wrap table th {
   border: none;
 }
-
 .widget_calendar .calendar_wrap a {
   text-decoration: underline;
   text-decoration-thickness: 2px;
 }
-
 .widget_calendar .calendar_wrap .wp-calendar-table {
   margin-bottom: 0;
 }
-
 .widget_calendar .calendar_wrap .wp-calendar-nav {
   margin: 0 0 1rem;
   display: table;
   width: 100%;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 }
-
+.widget_calendar .calendar_wrap .wp-calendar-nav:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.widget_calendar .calendar_wrap .wp-calendar-nav:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.widget_calendar .calendar_wrap .wp-calendar-nav:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.widget_calendar .calendar_wrap .wp-calendar-nav:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.widget_calendar .calendar_wrap .wp-calendar-nav:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.widget_calendar .calendar_wrap .wp-calendar-nav:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.widget_calendar .calendar_wrap .wp-calendar-nav:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.widget_calendar .calendar_wrap .wp-calendar-nav:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.widget_calendar .calendar_wrap .wp-calendar-nav:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.widget_calendar .calendar_wrap .wp-calendar-nav:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.widget_calendar .calendar_wrap .wp-calendar-nav:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.widget_calendar .calendar_wrap .wp-calendar-nav:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.widget_calendar .calendar_wrap .wp-calendar-nav:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.widget_calendar .calendar_wrap .wp-calendar-nav:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.widget_calendar .calendar_wrap .wp-calendar-nav:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.widget_calendar .calendar_wrap .wp-calendar-nav:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.widget_calendar .calendar_wrap .wp-calendar-nav:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.widget_calendar .calendar_wrap .wp-calendar-nav:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.widget_calendar .calendar_wrap .wp-calendar-nav:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.widget_calendar .calendar_wrap .wp-calendar-nav:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.widget_calendar .calendar_wrap .wp-calendar-nav:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+.widget_calendar .calendar_wrap .wp-calendar-nav:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+.widget_calendar .calendar_wrap .wp-calendar-nav:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+.widget_calendar .calendar_wrap .wp-calendar-nav:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+.widget_calendar .calendar_wrap .wp-calendar-nav:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+.widget_calendar .calendar_wrap .wp-calendar-nav:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+.widget_calendar .calendar_wrap .wp-calendar-nav:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+.widget_calendar .calendar_wrap .wp-calendar-nav:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+.widget_calendar .calendar_wrap .wp-calendar-nav:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+.widget_calendar .calendar_wrap .wp-calendar-nav:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+.widget_calendar .calendar_wrap .wp-calendar-nav:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
 .widget_calendar .calendar_wrap .wp-calendar-nav span {
   display: table-cell;
   padding: 0.5em;
 }
-
 .widget_calendar .calendar_wrap .wp-calendar-nav-prev,
 .widget_calendar .calendar_wrap .wp-calendar-nav-next {
   width: 40%;
@@ -5272,25 +5844,22 @@ body.page .main-navigation {
   margin: 32px 0;
   max-width: 100%;
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content > *,
   .entry .entry-summary > *,
   .entry .entry-summary > .wp-block-group > .wp-block-group__inner-container > *,
   .entry .entry-content > .wp-block-group > .wp-block-group__inner-container > * {
-    max-width: calc(8 * (100vw / 12) - 28px);
+    max-width: calc(66.6666666667vw - 28px);
   }
 }
-
 @media only screen and (min-width: 1168px) {
   .entry .entry-content > *,
   .entry .entry-summary > *,
   .entry .entry-summary > .wp-block-group > .wp-block-group__inner-container > *,
   .entry .entry-content > .wp-block-group > .wp-block-group__inner-container > * {
-    max-width: calc(6 * (100vw / 12) - 28px);
+    max-width: calc(50vw - 28px);
   }
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content > *,
   .entry .entry-summary > *,
@@ -5299,7 +5868,6 @@ body.page .main-navigation {
     margin: 32px 0;
   }
 }
-
 .entry .entry-content > *.alignwide,
 .entry .entry-summary > *.alignwide,
 .entry .entry-summary > .wp-block-group > .wp-block-group__inner-container > *.alignwide,
@@ -5308,7 +5876,6 @@ body.page .main-navigation {
   margin-right: auto;
   clear: both;
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content > *.alignwide,
   .entry .entry-summary > *.alignwide,
@@ -5318,18 +5885,16 @@ body.page .main-navigation {
     max-width: 100%;
   }
 }
-
 .entry .entry-content > *.alignfull,
 .entry .entry-summary > *.alignfull,
 .entry .entry-summary > .wp-block-group > .wp-block-group__inner-container > *.alignfull,
 .entry .entry-content > .wp-block-group > .wp-block-group__inner-container > *.alignfull {
   position: relative;
   left: -1rem;
-  width: calc( 100% + (2 * 1rem));
-  max-width: calc( 100% + (2 * 1rem));
+  width: calc(100% + 2 * 1rem);
+  max-width: calc(100% + 2 * 1rem);
   clear: both;
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content > *.alignfull,
   .entry .entry-summary > *.alignfull,
@@ -5337,61 +5902,56 @@ body.page .main-navigation {
   .entry .entry-content > .wp-block-group > .wp-block-group__inner-container > *.alignfull {
     margin-top: calc(2 * 1rem);
     margin-bottom: calc(2 * 1rem);
-    left: calc( -12.5% - 75px);
-    width: calc( 125% + 150px);
-    max-width: calc( 125% + 150px);
+    left: calc(-12.5% - 75px);
+    width: calc(125% + 150px);
+    max-width: calc(125% + 150px);
   }
 }
-
 .entry .entry-content > *.alignleft,
 .entry .entry-summary > *.alignleft,
 .entry .entry-summary > .wp-block-group > .wp-block-group__inner-container > *.alignleft,
 .entry .entry-content > .wp-block-group > .wp-block-group__inner-container > *.alignleft {
   /*rtl:ignore*/
   float: left;
-  max-width: calc(5 * (100vw / 12));
+  max-width: 41.6666666667vw;
   margin-top: 0;
   margin-left: 0;
   /*rtl:ignore*/
   margin-right: 1rem;
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content > *.alignleft,
   .entry .entry-summary > *.alignleft,
   .entry .entry-summary > .wp-block-group > .wp-block-group__inner-container > *.alignleft,
   .entry .entry-content > .wp-block-group > .wp-block-group__inner-container > *.alignleft {
-    max-width: calc(4 * (100vw / 12));
+    max-width: 33.3333333333vw;
     /*rtl:ignore*/
     margin-right: calc(2 * 1rem);
   }
 }
-
 .entry .entry-content > *.alignright,
 .entry .entry-summary > *.alignright,
 .entry .entry-summary > .wp-block-group > .wp-block-group__inner-container > *.alignright,
 .entry .entry-content > .wp-block-group > .wp-block-group__inner-container > *.alignright {
   /*rtl:ignore*/
   float: right;
-  max-width: calc(5 * (100vw / 12));
+  max-width: 41.6666666667vw;
   margin-top: 0;
   margin-right: 0;
   /*rtl:ignore*/
   margin-left: 1rem;
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content > *.alignright,
   .entry .entry-summary > *.alignright,
   .entry .entry-summary > .wp-block-group > .wp-block-group__inner-container > *.alignright,
   .entry .entry-content > .wp-block-group > .wp-block-group__inner-container > *.alignright {
-    max-width: calc(4 * (100vw / 12));
+    max-width: 33.3333333333vw;
     margin-right: 0;
     /*rtl:ignore*/
     margin-left: calc(2 * 1rem);
   }
 }
-
 .entry .entry-content > *.aligncenter,
 .entry .entry-summary > *.aligncenter,
 .entry .entry-summary > .wp-block-group > .wp-block-group__inner-container > *.aligncenter,
@@ -5399,25 +5959,22 @@ body.page .main-navigation {
   margin-left: auto;
   margin-right: auto;
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content > *.aligncenter,
   .entry .entry-summary > *.aligncenter,
   .entry .entry-summary > .wp-block-group > .wp-block-group__inner-container > *.aligncenter,
   .entry .entry-content > .wp-block-group > .wp-block-group__inner-container > *.aligncenter {
-    max-width: calc(8 * (100vw / 12) - 28px);
+    max-width: calc(66.6666666667vw - 28px);
   }
 }
-
 @media only screen and (min-width: 1168px) {
   .entry .entry-content > *.aligncenter,
   .entry .entry-summary > *.aligncenter,
   .entry .entry-summary > .wp-block-group > .wp-block-group__inner-container > *.aligncenter,
   .entry .entry-content > .wp-block-group > .wp-block-group__inner-container > *.aligncenter {
-    max-width: calc(6 * (100vw / 12) - 28px);
+    max-width: calc(50vw - 28px);
   }
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content > *.aligncenter,
   .entry .entry-summary > *.aligncenter,
@@ -5432,7 +5989,6 @@ body.page .main-navigation {
 .entry .entry-summary > * > *:first-child {
   margin-top: 0;
 }
-
 .entry .entry-content > * > *:last-child,
 .entry .entry-summary > * > *:last-child {
   margin-bottom: 0;
@@ -5453,7 +6009,6 @@ body.page .main-navigation {
   max-width: inherit;
   padding: inherit;
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content .entry-content,
   .entry .entry-content .entry-summary,
@@ -5470,244 +6025,730 @@ body.page .main-navigation {
 .entry .entry-content p.has-background {
   padding: 20px 30px;
 }
-
 .entry .entry-content .wp-block-audio {
   width: 100%;
 }
-
 .entry .entry-content .wp-block-audio audio {
   display: block;
   width: 100%;
 }
-
-.entry .entry-content .wp-block-audio.alignleft audio,
-.entry .entry-content .wp-block-audio.alignright audio {
+.entry .entry-content .wp-block-audio.alignleft audio, .entry .entry-content .wp-block-audio.alignright audio {
   max-width: 198px;
 }
-
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-audio.alignleft audio,
-  .entry .entry-content .wp-block-audio.alignright audio {
+  .entry .entry-content .wp-block-audio.alignleft audio, .entry .entry-content .wp-block-audio.alignright audio {
     max-width: 384px;
   }
 }
-
 @media only screen and (min-width: 1379px) {
-  .entry .entry-content .wp-block-audio.alignleft audio,
-  .entry .entry-content .wp-block-audio.alignright audio {
+  .entry .entry-content .wp-block-audio.alignleft audio, .entry .entry-content .wp-block-audio.alignright audio {
     max-width: 385.44px;
   }
 }
-
 .entry .entry-content .wp-block-video video {
   width: 100%;
 }
-
 .entry .entry-content .wp-block-buttons {
   line-height: 1.2;
 }
-
 .entry .entry-content .wp-block-button .wp-block-button__link {
   transition: background 150ms ease-in-out;
   border: none;
-  font-size: 0.88889em;
+  font-size: 0.8888888889em;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+}
+.entry .entry-content .wp-block-button .wp-block-button__link:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-button .wp-block-button__link:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-button .wp-block-button__link:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-button .wp-block-button__link:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-button .wp-block-button__link:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-button .wp-block-button__link:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-button .wp-block-button__link:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-button .wp-block-button__link:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-button .wp-block-button__link:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-button .wp-block-button__link:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-button .wp-block-button__link:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-button .wp-block-button__link:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-button .wp-block-button__link:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-button .wp-block-button__link:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-button .wp-block-button__link:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-button .wp-block-button__link:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-button .wp-block-button__link:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-button .wp-block-button__link:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.entry .entry-content .wp-block-button .wp-block-button__link:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.entry .entry-content .wp-block-button .wp-block-button__link:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.entry .entry-content .wp-block-button .wp-block-button__link:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-button .wp-block-button__link:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-button .wp-block-button__link:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-button .wp-block-button__link:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-button .wp-block-button__link:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-button .wp-block-button__link:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-button .wp-block-button__link:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-button .wp-block-button__link:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+.entry .entry-content .wp-block-button .wp-block-button__link:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+.entry .entry-content .wp-block-button .wp-block-button__link:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+.entry .entry-content .wp-block-button .wp-block-button__link:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
+.entry .entry-content .wp-block-button .wp-block-button__link {
   box-sizing: border-box;
   font-weight: bold;
   text-decoration: none;
   padding: 0.76rem 1rem;
   outline: none;
 }
-
 .entry .entry-content .wp-block-button .wp-block-button__link:not(.has-background) {
   background-color: #0073aa;
 }
-
 .entry .entry-content .wp-block-button .wp-block-button__link:not(.has-text-color) {
   color: white;
 }
-
 .entry .entry-content .wp-block-button .wp-block-button__link:hover {
   color: white;
   background: #111;
   cursor: pointer;
 }
-
 .entry .entry-content .wp-block-button .wp-block-button__link:hover:not(.has-background) {
   background: #111;
 }
-
 .entry .entry-content .wp-block-button .wp-block-button__link:focus {
   color: white;
   background: #111;
   outline: thin dotted;
   outline-offset: -4px;
 }
-
 .entry .entry-content .wp-block-button .wp-block-button__link:focus:not(.has-background) {
   background: #111;
 }
-
 .entry .entry-content .wp-block-button:not(.is-style-squared) .wp-block-button__link {
   border-radius: 5px;
 }
-
-.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link,
-.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:focus,
-.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active {
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link, .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:focus, .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active {
   transition: all 150ms ease-in-out;
   border-width: 2px;
   border-style: solid;
 }
-
-.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:not(.has-background),
-.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:focus:not(.has-background),
-.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active:not(.has-background) {
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:not(.has-background), .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:focus:not(.has-background), .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active:not(.has-background) {
   background: transparent;
 }
-
-.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color),
-.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:focus:not(.has-text-color),
-.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active:not(.has-text-color) {
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color), .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:focus:not(.has-text-color), .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active:not(.has-text-color) {
   color: #0073aa;
   border-color: currentColor;
 }
-
 .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:hover {
   color: white;
   border-color: #111;
 }
-
 .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:hover:not(.has-background) {
   color: #111;
 }
-
 .entry .entry-content .wp-block-buttons.has-custom-font-size .wp-block-button__link,
 .entry .entry-content .wp-block-button.has-custom-font-size .wp-block-button__link {
   font-size: 1em;
 }
-
-.entry .entry-content .wp-block-buttons[style*="font-weight"] .wp-block-button__link,
-.entry .entry-content .wp-block-button[style*="font-weight"] .wp-block-button__link {
+.entry .entry-content .wp-block-buttons[style*=font-weight] .wp-block-button__link,
+.entry .entry-content .wp-block-button[style*=font-weight] .wp-block-button__link {
   font-weight: inherit;
 }
-
-.entry .entry-content .wp-block-buttons[style*="text-decoration"] .wp-block-button__link,
-.entry .entry-content .wp-block-button[style*="text-decoration"] .wp-block-button__link {
+.entry .entry-content .wp-block-buttons[style*=text-decoration] .wp-block-button__link,
+.entry .entry-content .wp-block-button[style*=text-decoration] .wp-block-button__link {
   text-decoration: inherit;
 }
-
 .entry .entry-content .wp-block-archives,
 .entry .entry-content .wp-block-categories,
 .entry .entry-content .wp-block-latest-posts {
   padding: 0;
   list-style: none;
 }
-
 .entry .entry-content .wp-block-archives li > a,
 .entry .entry-content .wp-block-categories li > a,
 .entry .entry-content .wp-block-latest-posts li > a {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+}
+.entry .entry-content .wp-block-archives li > a:lang(ar),
+.entry .entry-content .wp-block-categories li > a:lang(ar),
+.entry .entry-content .wp-block-latest-posts li > a:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-archives li > a:lang(ary),
+.entry .entry-content .wp-block-categories li > a:lang(ary),
+.entry .entry-content .wp-block-latest-posts li > a:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-archives li > a:lang(azb),
+.entry .entry-content .wp-block-categories li > a:lang(azb),
+.entry .entry-content .wp-block-latest-posts li > a:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-archives li > a:lang(ckb),
+.entry .entry-content .wp-block-categories li > a:lang(ckb),
+.entry .entry-content .wp-block-latest-posts li > a:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-archives li > a:lang(fa-IR),
+.entry .entry-content .wp-block-categories li > a:lang(fa-IR),
+.entry .entry-content .wp-block-latest-posts li > a:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-archives li > a:lang(haz),
+.entry .entry-content .wp-block-categories li > a:lang(haz),
+.entry .entry-content .wp-block-latest-posts li > a:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-archives li > a:lang(ps),
+.entry .entry-content .wp-block-categories li > a:lang(ps),
+.entry .entry-content .wp-block-latest-posts li > a:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-archives li > a:lang(be),
+.entry .entry-content .wp-block-categories li > a:lang(be),
+.entry .entry-content .wp-block-latest-posts li > a:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-archives li > a:lang(bg-BG),
+.entry .entry-content .wp-block-categories li > a:lang(bg-BG),
+.entry .entry-content .wp-block-latest-posts li > a:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-archives li > a:lang(kk),
+.entry .entry-content .wp-block-categories li > a:lang(kk),
+.entry .entry-content .wp-block-latest-posts li > a:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-archives li > a:lang(mk-MK),
+.entry .entry-content .wp-block-categories li > a:lang(mk-MK),
+.entry .entry-content .wp-block-latest-posts li > a:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-archives li > a:lang(mn),
+.entry .entry-content .wp-block-categories li > a:lang(mn),
+.entry .entry-content .wp-block-latest-posts li > a:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-archives li > a:lang(ru-RU),
+.entry .entry-content .wp-block-categories li > a:lang(ru-RU),
+.entry .entry-content .wp-block-latest-posts li > a:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-archives li > a:lang(sah),
+.entry .entry-content .wp-block-categories li > a:lang(sah),
+.entry .entry-content .wp-block-latest-posts li > a:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-archives li > a:lang(sr-RS),
+.entry .entry-content .wp-block-categories li > a:lang(sr-RS),
+.entry .entry-content .wp-block-latest-posts li > a:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-archives li > a:lang(tt-RU),
+.entry .entry-content .wp-block-categories li > a:lang(tt-RU),
+.entry .entry-content .wp-block-latest-posts li > a:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-archives li > a:lang(uk),
+.entry .entry-content .wp-block-categories li > a:lang(uk),
+.entry .entry-content .wp-block-latest-posts li > a:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-archives li > a:lang(zh-HK),
+.entry .entry-content .wp-block-categories li > a:lang(zh-HK),
+.entry .entry-content .wp-block-latest-posts li > a:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.entry .entry-content .wp-block-archives li > a:lang(zh-TW),
+.entry .entry-content .wp-block-categories li > a:lang(zh-TW),
+.entry .entry-content .wp-block-latest-posts li > a:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.entry .entry-content .wp-block-archives li > a:lang(zh-CN),
+.entry .entry-content .wp-block-categories li > a:lang(zh-CN),
+.entry .entry-content .wp-block-latest-posts li > a:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.entry .entry-content .wp-block-archives li > a:lang(bn-BD),
+.entry .entry-content .wp-block-categories li > a:lang(bn-BD),
+.entry .entry-content .wp-block-latest-posts li > a:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-archives li > a:lang(hi-IN),
+.entry .entry-content .wp-block-categories li > a:lang(hi-IN),
+.entry .entry-content .wp-block-latest-posts li > a:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-archives li > a:lang(mr),
+.entry .entry-content .wp-block-categories li > a:lang(mr),
+.entry .entry-content .wp-block-latest-posts li > a:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-archives li > a:lang(ne-NP),
+.entry .entry-content .wp-block-categories li > a:lang(ne-NP),
+.entry .entry-content .wp-block-latest-posts li > a:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-archives li > a:lang(el),
+.entry .entry-content .wp-block-categories li > a:lang(el),
+.entry .entry-content .wp-block-latest-posts li > a:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-archives li > a:lang(gu),
+.entry .entry-content .wp-block-categories li > a:lang(gu),
+.entry .entry-content .wp-block-latest-posts li > a:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-archives li > a:lang(he-IL),
+.entry .entry-content .wp-block-categories li > a:lang(he-IL),
+.entry .entry-content .wp-block-latest-posts li > a:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-archives li > a:lang(ja),
+.entry .entry-content .wp-block-categories li > a:lang(ja),
+.entry .entry-content .wp-block-latest-posts li > a:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+.entry .entry-content .wp-block-archives li > a:lang(ko-KR),
+.entry .entry-content .wp-block-categories li > a:lang(ko-KR),
+.entry .entry-content .wp-block-latest-posts li > a:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+.entry .entry-content .wp-block-archives li > a:lang(th),
+.entry .entry-content .wp-block-categories li > a:lang(th),
+.entry .entry-content .wp-block-latest-posts li > a:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+.entry .entry-content .wp-block-archives li > a:lang(vi),
+.entry .entry-content .wp-block-categories li > a:lang(vi),
+.entry .entry-content .wp-block-latest-posts li > a:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
+.entry .entry-content .wp-block-archives li > a,
+.entry .entry-content .wp-block-categories li > a,
+.entry .entry-content .wp-block-latest-posts li > a {
   font-size: calc(22px * 1.125);
   font-weight: bold;
   line-height: 1.2;
   text-decoration: none;
 }
-
 .entry .entry-content .wp-block-archives.aligncenter,
 .entry .entry-content .wp-block-categories.aligncenter {
   text-align: center;
 }
-
 .entry .entry-content .wp-block-categories ul {
   padding-top: 0.75rem;
 }
-
 .entry .entry-content .wp-block-categories li ul {
   list-style: none;
   padding-left: 0;
 }
-
 .entry .entry-content .wp-block-categories ul {
   counter-reset: submenu;
 }
-
 .entry .entry-content .wp-block-categories ul > li > a::before {
   font-family: "NonBreakingSpaceOverride", "Hoefler Text", Garamond, "Times New Roman", serif;
   font-weight: normal;
   content: "– " counters(submenu, "– ", none);
   counter-increment: submenu;
 }
-
 .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  font-size: 0.71111em;
+}
+.entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+.entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+.entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
+.entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-date {
+  font-size: 0.7111111111em;
   color: #767676;
   line-height: 1.2;
 }
-
 .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-full-content,
 .entry .entry-content .wp-block-latest-posts .wp-block-latest-posts__post-excerpt {
   margin-top: 1rem;
   margin-bottom: 1rem;
 }
-
 .entry .entry-content .wp-block-latest-posts li {
   padding-bottom: 0.5rem;
 }
-
 .entry .entry-content .wp-block-latest-posts li.menu-item-has-children, .entry .entry-content .wp-block-latest-posts li:last-child {
   padding-bottom: 0;
 }
-
 .entry .entry-content .wp-block-latest-posts li :not(:last-child) .wp-block-latest-posts__post-excerpt {
   padding-bottom: 0.5rem;
 }
-
 .entry .entry-content .wp-block-latest-posts.is-grid li {
   border-top: 2px solid #ccc;
   padding-top: 1rem;
   margin-bottom: 2rem;
 }
-
 .entry .entry-content .wp-block-latest-posts.is-grid li a:after {
-  content: '';
+  content: "";
 }
-
 .entry .entry-content .wp-block-latest-posts.is-grid li:last-child {
   margin-bottom: auto;
 }
-
 .entry .entry-content .wp-block-latest-posts.is-grid li:last-child a:after {
-  content: '';
+  content: "";
 }
-
 .entry .entry-content .wp-block-preformatted {
-  font-size: 0.71111em;
+  font-size: 0.7111111111em;
   line-height: 1.8;
   padding: 1rem;
 }
-
 .entry .entry-content .wp-block-verse {
   font-family: "NonBreakingSpaceOverride", "Hoefler Text", Garamond, "Times New Roman", serif;
+}
+.entry .entry-content .wp-block-verse:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-verse:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-verse:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-verse:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-verse:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-verse:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-verse:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-verse:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-verse:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-verse:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-verse:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-verse:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-verse:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-verse:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-verse:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-verse:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-verse:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-verse:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.entry .entry-content .wp-block-verse:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.entry .entry-content .wp-block-verse:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.entry .entry-content .wp-block-verse:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-verse:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-verse:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-verse:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-verse:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-verse:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-verse:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-verse:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+.entry .entry-content .wp-block-verse:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+.entry .entry-content .wp-block-verse:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+.entry .entry-content .wp-block-verse:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
+.entry .entry-content .wp-block-verse {
   font-size: 22px;
   line-height: 1.8;
 }
-
 .entry .entry-content .has-drop-cap:not(:focus):first-letter {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+}
+.entry .entry-content .has-drop-cap:not(:focus):first-letter:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .has-drop-cap:not(:focus):first-letter:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .has-drop-cap:not(:focus):first-letter:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .has-drop-cap:not(:focus):first-letter:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .has-drop-cap:not(:focus):first-letter:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .has-drop-cap:not(:focus):first-letter:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .has-drop-cap:not(:focus):first-letter:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .has-drop-cap:not(:focus):first-letter:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .has-drop-cap:not(:focus):first-letter:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .has-drop-cap:not(:focus):first-letter:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .has-drop-cap:not(:focus):first-letter:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .has-drop-cap:not(:focus):first-letter:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .has-drop-cap:not(:focus):first-letter:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .has-drop-cap:not(:focus):first-letter:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .has-drop-cap:not(:focus):first-letter:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .has-drop-cap:not(:focus):first-letter:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .has-drop-cap:not(:focus):first-letter:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .has-drop-cap:not(:focus):first-letter:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.entry .entry-content .has-drop-cap:not(:focus):first-letter:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.entry .entry-content .has-drop-cap:not(:focus):first-letter:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.entry .entry-content .has-drop-cap:not(:focus):first-letter:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .has-drop-cap:not(:focus):first-letter:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .has-drop-cap:not(:focus):first-letter:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .has-drop-cap:not(:focus):first-letter:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .has-drop-cap:not(:focus):first-letter:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+.entry .entry-content .has-drop-cap:not(:focus):first-letter:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .has-drop-cap:not(:focus):first-letter:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+.entry .entry-content .has-drop-cap:not(:focus):first-letter:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+.entry .entry-content .has-drop-cap:not(:focus):first-letter:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+.entry .entry-content .has-drop-cap:not(:focus):first-letter:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+.entry .entry-content .has-drop-cap:not(:focus):first-letter:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
+.entry .entry-content .has-drop-cap:not(:focus):first-letter {
   font-size: 3.375em;
   line-height: 1;
   font-weight: bold;
   margin: 0 0.25em 0 0;
 }
-
 @-moz-document url-prefix() {
   .entry .entry-content .has-drop-cap:not(:focus):first-letter {
     margin-top: 0.2em;
   }
 }
-
 .entry .entry-content .wp-block-pullquote {
   color: #111;
   border-color: transparent;
@@ -5715,7 +6756,6 @@ body.page .main-navigation {
   padding: 1rem;
   font-size: 1em;
 }
-
 .entry .entry-content .wp-block-pullquote blockquote {
   border: none;
   margin-top: calc(4 * 1rem);
@@ -5723,7 +6763,6 @@ body.page .main-navigation {
   margin-right: 0;
   padding-left: 0;
 }
-
 .entry .entry-content .wp-block-pullquote p {
   font-size: 1.6875em;
   font-style: italic;
@@ -5731,84 +6770,165 @@ body.page .main-navigation {
   margin-bottom: 0.5em;
   margin-top: 0.5em;
 }
-
 .entry .entry-content .wp-block-pullquote p em {
   font-style: normal;
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-pullquote p {
     font-size: 2.25em;
   }
 }
-
 .entry .entry-content .wp-block-pullquote cite {
   display: block;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+}
+.entry .entry-content .wp-block-pullquote cite:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-pullquote cite:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-pullquote cite:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-pullquote cite:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-pullquote cite:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-pullquote cite:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-pullquote cite:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-pullquote cite:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-pullquote cite:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-pullquote cite:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-pullquote cite:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-pullquote cite:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-pullquote cite:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-pullquote cite:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-pullquote cite:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-pullquote cite:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-pullquote cite:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-pullquote cite:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.entry .entry-content .wp-block-pullquote cite:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.entry .entry-content .wp-block-pullquote cite:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.entry .entry-content .wp-block-pullquote cite:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-pullquote cite:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-pullquote cite:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-pullquote cite:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-pullquote cite:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-pullquote cite:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-pullquote cite:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-pullquote cite:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+.entry .entry-content .wp-block-pullquote cite:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+.entry .entry-content .wp-block-pullquote cite:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+.entry .entry-content .wp-block-pullquote cite:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
+.entry .entry-content .wp-block-pullquote cite {
   line-height: 1.6;
   text-transform: none;
   color: #767676;
   /*
-			 * This requires a rem-based font size calculation instead of our normal em-based one,
-			 * because the cite tag sometimes gets wrapped in a p tag. This is equivalent to $font-size_xs.
-			 */
+   * This requires a rem-based font size calculation instead of our normal em-based one,
+   * because the cite tag sometimes gets wrapped in a p tag. This is equivalent to $font-size_xs.
+   */
   font-size: calc(1rem / (1.25 * 1.125));
 }
-
 .entry .entry-content .wp-block-pullquote.alignleft, .entry .entry-content .wp-block-pullquote.alignright {
   width: 100%;
   padding: 0;
 }
-
 .entry .entry-content .wp-block-pullquote.alignleft blockquote, .entry .entry-content .wp-block-pullquote.alignright blockquote {
   margin: 1rem 0;
   padding: 0;
   text-align: left;
   max-width: 100%;
 }
-
 .entry .entry-content .wp-block-pullquote.alignleft blockquote p:first-child, .entry .entry-content .wp-block-pullquote.alignright blockquote p:first-child {
   margin-top: 0;
 }
-
 .entry .entry-content .wp-block-pullquote.has-text-color cite {
   color: inherit;
 }
-
 .entry .entry-content .wp-block-pullquote.is-style-solid-color {
   background-color: #0073aa;
   padding-left: 0;
   padding-right: 0;
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-pullquote.is-style-solid-color {
     padding-left: 10%;
     padding-right: 10%;
   }
 }
-
 .entry .entry-content .wp-block-pullquote.is-style-solid-color p {
   font-size: 1.6875em;
   line-height: 1.3;
   margin-bottom: 0.5em;
   margin-top: 0.5em;
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-pullquote.is-style-solid-color p {
     font-size: 2.25em;
   }
 }
-
 .entry .entry-content .wp-block-pullquote.is-style-solid-color a {
   color: #fff;
 }
-
 .entry .entry-content .wp-block-pullquote.is-style-solid-color cite {
   color: inherit;
 }
-
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote {
   max-width: 100%;
   color: #fff;
@@ -5816,75 +6936,63 @@ body.page .main-navigation {
   margin-left: 1rem;
   margin-right: 1rem;
 }
-
-.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-text-color p,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-text-color a, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-white-color {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-text-color p, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-text-color a, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-white-color {
   color: inherit;
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote {
     margin-left: 0;
     margin-right: 0;
   }
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignright, .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignleft {
     padding: 1rem calc(2 * 1rem);
   }
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignfull {
-    padding-left: calc(10% + 58px + (2 * 1rem));
-    padding-right: calc(10% + 58px + (2 * 1rem));
+    padding-left: calc(10% + 58px + 2 * 1rem);
+    padding-right: calc(10% + 58px + 2 * 1rem);
   }
 }
-
 .entry .entry-content .wp-block-quote:not(.is-large), .entry .entry-content .wp-block-quote:not(.is-style-large) {
   border-width: 2px;
   border-color: #0073aa;
   padding-top: 0;
   padding-bottom: 0;
 }
-
 .entry .entry-content .wp-block-quote p {
   font-size: 1em;
   font-style: normal;
   line-height: 1.8;
 }
-
 .entry .entry-content .wp-block-quote cite {
   /*
-			 * This requires a rem-based font size calculation instead of our normal em-based one,
-			 * because the cite tag sometimes gets wrapped in a p tag. This is equivalent to $font-size_xs.
-			 */
+   * This requires a rem-based font size calculation instead of our normal em-based one,
+   * because the cite tag sometimes gets wrapped in a p tag. This is equivalent to $font-size_xs.
+   */
   font-size: calc(1rem / (1.25 * 1.125));
 }
-
 .entry .entry-content .wp-block-quote.is-large, .entry .entry-content .wp-block-quote.is-style-large {
   margin: 1rem 0;
   padding: 0;
   border-left: none;
 }
-
 .entry .entry-content .wp-block-quote.is-large p, .entry .entry-content .wp-block-quote.is-style-large p {
   font-size: 1.6875em;
   line-height: 1.4;
   font-style: italic;
 }
-
 .entry .entry-content .wp-block-quote.is-large cite,
 .entry .entry-content .wp-block-quote.is-large footer, .entry .entry-content .wp-block-quote.is-style-large cite,
 .entry .entry-content .wp-block-quote.is-style-large footer {
   /*
-				 * This requires a rem-based font size calculation instead of our normal em-based one,
-				 * because the cite tag sometimes gets wrapped in a p tag. This is equivalent to $font-size_xs.
-				 */
+   * This requires a rem-based font size calculation instead of our normal em-based one,
+   * because the cite tag sometimes gets wrapped in a p tag. This is equivalent to $font-size_xs.
+   */
   font-size: calc(1rem / (1.25 * 1.125));
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-quote.is-large, .entry .entry-content .wp-block-quote.is-style-large {
     margin: 1rem 0;
@@ -5894,91 +7002,72 @@ body.page .main-navigation {
     font-size: 1.6875em;
   }
 }
-
 .entry .entry-content .wp-block-image {
   max-width: 100%;
 }
-
 .entry .entry-content .wp-block-image img {
   display: block;
 }
-
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-image:not(.alignwide):not(.alignfull) > img,
-  .entry .entry-content .wp-block-image:not(.alignwide):not(.alignfull) > a > img,
-  .entry .entry-content .wp-block-image:not(.alignwide):not(.alignfull) > img + figcaption,
-  .entry .entry-content .wp-block-image:not(.alignwide):not(.alignfull) > a + figcaption {
-    max-width: calc(8 * (100vw / 12) - 28px);
+  .entry .entry-content .wp-block-image:not(.alignwide):not(.alignfull) > img, .entry .entry-content .wp-block-image:not(.alignwide):not(.alignfull) > a > img, .entry .entry-content .wp-block-image:not(.alignwide):not(.alignfull) > img + figcaption, .entry .entry-content .wp-block-image:not(.alignwide):not(.alignfull) > a + figcaption {
+    max-width: calc(66.6666666667vw - 28px);
   }
 }
-
 @media only screen and (min-width: 1168px) {
-  .entry .entry-content .wp-block-image:not(.alignwide):not(.alignfull) > img,
-  .entry .entry-content .wp-block-image:not(.alignwide):not(.alignfull) > a > img,
-  .entry .entry-content .wp-block-image:not(.alignwide):not(.alignfull) > img + figcaption,
-  .entry .entry-content .wp-block-image:not(.alignwide):not(.alignfull) > a + figcaption {
-    max-width: calc(6 * (100vw / 12) - 28px);
+  .entry .entry-content .wp-block-image:not(.alignwide):not(.alignfull) > img, .entry .entry-content .wp-block-image:not(.alignwide):not(.alignfull) > a > img, .entry .entry-content .wp-block-image:not(.alignwide):not(.alignfull) > img + figcaption, .entry .entry-content .wp-block-image:not(.alignwide):not(.alignfull) > a + figcaption {
+    max-width: calc(50vw - 28px);
   }
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-image .aligncenter {
-    max-width: calc(8 * (100vw / 12) - 28px);
+    max-width: calc(66.6666666667vw - 28px);
   }
 }
-
 @media only screen and (min-width: 1168px) {
   .entry .entry-content .wp-block-image .aligncenter {
-    max-width: calc(6 * (100vw / 12) - 28px);
+    max-width: calc(50vw - 28px);
   }
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-image .aligncenter {
     margin: 0;
-    width: calc(8 * (100vw / 12) - 28px);
+    width: calc(66.6666666667vw - 28px);
   }
   .entry .entry-content .wp-block-image .aligncenter img {
     margin: 0 auto;
   }
 }
-
 @media only screen and (min-width: 1168px) {
   .entry .entry-content .wp-block-image .aligncenter {
-    width: calc(6 * (100vw / 12) - 28px);
+    width: calc(50vw - 28px);
   }
   .entry .entry-content .wp-block-image .aligncenter img {
     margin: 0 auto;
   }
 }
-
 .entry .entry-content .wp-block-image.alignfull img {
   width: 100vw;
-  max-width: calc( 100% + (2 * 1rem));
+  max-width: calc(100% + 2 * 1rem);
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-image.alignfull img {
-    max-width: calc( 125% + 150px);
+    max-width: calc(125% + 150px);
     margin-left: auto;
     margin-right: auto;
   }
 }
-
 .entry .entry-content .wp-block-cover-image,
 .entry .entry-content .wp-block-cover {
   position: relative;
   min-height: 430px;
   padding: 1rem;
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-cover-image,
   .entry .entry-content .wp-block-cover {
     padding: 1rem 10%;
   }
 }
-
 .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text,
 .entry .entry-content .wp-block-cover-image .wp-block-cover-text,
 .entry .entry-content .wp-block-cover-image h2,
@@ -5986,13 +7075,267 @@ body.page .main-navigation {
 .entry .entry-content .wp-block-cover .wp-block-cover-text,
 .entry .entry-content .wp-block-cover h2 {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+}
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(ar),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(ar),
+.entry .entry-content .wp-block-cover-image h2:lang(ar),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(ar),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(ar),
+.entry .entry-content .wp-block-cover h2:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(ary),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(ary),
+.entry .entry-content .wp-block-cover-image h2:lang(ary),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(ary),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(ary),
+.entry .entry-content .wp-block-cover h2:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(azb),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(azb),
+.entry .entry-content .wp-block-cover-image h2:lang(azb),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(azb),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(azb),
+.entry .entry-content .wp-block-cover h2:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(ckb),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(ckb),
+.entry .entry-content .wp-block-cover-image h2:lang(ckb),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(ckb),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(ckb),
+.entry .entry-content .wp-block-cover h2:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(fa-IR),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(fa-IR),
+.entry .entry-content .wp-block-cover-image h2:lang(fa-IR),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(fa-IR),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(fa-IR),
+.entry .entry-content .wp-block-cover h2:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(haz),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(haz),
+.entry .entry-content .wp-block-cover-image h2:lang(haz),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(haz),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(haz),
+.entry .entry-content .wp-block-cover h2:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(ps),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(ps),
+.entry .entry-content .wp-block-cover-image h2:lang(ps),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(ps),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(ps),
+.entry .entry-content .wp-block-cover h2:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(be),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(be),
+.entry .entry-content .wp-block-cover-image h2:lang(be),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(be),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(be),
+.entry .entry-content .wp-block-cover h2:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(bg-BG),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(bg-BG),
+.entry .entry-content .wp-block-cover-image h2:lang(bg-BG),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(bg-BG),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(bg-BG),
+.entry .entry-content .wp-block-cover h2:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(kk),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(kk),
+.entry .entry-content .wp-block-cover-image h2:lang(kk),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(kk),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(kk),
+.entry .entry-content .wp-block-cover h2:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(mk-MK),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(mk-MK),
+.entry .entry-content .wp-block-cover-image h2:lang(mk-MK),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(mk-MK),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(mk-MK),
+.entry .entry-content .wp-block-cover h2:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(mn),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(mn),
+.entry .entry-content .wp-block-cover-image h2:lang(mn),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(mn),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(mn),
+.entry .entry-content .wp-block-cover h2:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(ru-RU),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(ru-RU),
+.entry .entry-content .wp-block-cover-image h2:lang(ru-RU),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(ru-RU),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(ru-RU),
+.entry .entry-content .wp-block-cover h2:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(sah),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(sah),
+.entry .entry-content .wp-block-cover-image h2:lang(sah),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(sah),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(sah),
+.entry .entry-content .wp-block-cover h2:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(sr-RS),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(sr-RS),
+.entry .entry-content .wp-block-cover-image h2:lang(sr-RS),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(sr-RS),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(sr-RS),
+.entry .entry-content .wp-block-cover h2:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(tt-RU),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(tt-RU),
+.entry .entry-content .wp-block-cover-image h2:lang(tt-RU),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(tt-RU),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(tt-RU),
+.entry .entry-content .wp-block-cover h2:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(uk),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(uk),
+.entry .entry-content .wp-block-cover-image h2:lang(uk),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(uk),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(uk),
+.entry .entry-content .wp-block-cover h2:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(zh-HK),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(zh-HK),
+.entry .entry-content .wp-block-cover-image h2:lang(zh-HK),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(zh-HK),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(zh-HK),
+.entry .entry-content .wp-block-cover h2:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(zh-TW),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(zh-TW),
+.entry .entry-content .wp-block-cover-image h2:lang(zh-TW),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(zh-TW),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(zh-TW),
+.entry .entry-content .wp-block-cover h2:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(zh-CN),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(zh-CN),
+.entry .entry-content .wp-block-cover-image h2:lang(zh-CN),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(zh-CN),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(zh-CN),
+.entry .entry-content .wp-block-cover h2:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(bn-BD),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(bn-BD),
+.entry .entry-content .wp-block-cover-image h2:lang(bn-BD),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(bn-BD),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(bn-BD),
+.entry .entry-content .wp-block-cover h2:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(hi-IN),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(hi-IN),
+.entry .entry-content .wp-block-cover-image h2:lang(hi-IN),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(hi-IN),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(hi-IN),
+.entry .entry-content .wp-block-cover h2:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(mr),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(mr),
+.entry .entry-content .wp-block-cover-image h2:lang(mr),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(mr),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(mr),
+.entry .entry-content .wp-block-cover h2:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(ne-NP),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(ne-NP),
+.entry .entry-content .wp-block-cover-image h2:lang(ne-NP),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(ne-NP),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(ne-NP),
+.entry .entry-content .wp-block-cover h2:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(el),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(el),
+.entry .entry-content .wp-block-cover-image h2:lang(el),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(el),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(el),
+.entry .entry-content .wp-block-cover h2:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(gu),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(gu),
+.entry .entry-content .wp-block-cover-image h2:lang(gu),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(gu),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(gu),
+.entry .entry-content .wp-block-cover h2:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(he-IL),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(he-IL),
+.entry .entry-content .wp-block-cover-image h2:lang(he-IL),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(he-IL),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(he-IL),
+.entry .entry-content .wp-block-cover h2:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(ja),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(ja),
+.entry .entry-content .wp-block-cover-image h2:lang(ja),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(ja),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(ja),
+.entry .entry-content .wp-block-cover h2:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(ko-KR),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(ko-KR),
+.entry .entry-content .wp-block-cover-image h2:lang(ko-KR),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(ko-KR),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(ko-KR),
+.entry .entry-content .wp-block-cover h2:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(th),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(th),
+.entry .entry-content .wp-block-cover-image h2:lang(th),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(th),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(th),
+.entry .entry-content .wp-block-cover h2:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text:lang(vi),
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text:lang(vi),
+.entry .entry-content .wp-block-cover-image h2:lang(vi),
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text:lang(vi),
+.entry .entry-content .wp-block-cover .wp-block-cover-text:lang(vi),
+.entry .entry-content .wp-block-cover h2:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text,
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text,
+.entry .entry-content .wp-block-cover-image h2,
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text,
+.entry .entry-content .wp-block-cover .wp-block-cover-text,
+.entry .entry-content .wp-block-cover h2 {
   font-size: 1.6875em;
   font-weight: bold;
   line-height: 1.25;
   padding: 0;
   color: #fff;
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text,
   .entry .entry-content .wp-block-cover-image .wp-block-cover-text,
@@ -6004,13 +7347,11 @@ body.page .main-navigation {
     max-width: 100%;
   }
 }
-
 .entry .entry-content .wp-block-cover-image.alignleft, .entry .entry-content .wp-block-cover-image.alignright,
 .entry .entry-content .wp-block-cover.alignleft,
 .entry .entry-content .wp-block-cover.alignright {
   width: 100%;
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-cover-image.alignleft, .entry .entry-content .wp-block-cover-image.alignright,
   .entry .entry-content .wp-block-cover.alignleft,
@@ -6018,7 +7359,6 @@ body.page .main-navigation {
     padding: 1rem calc(2 * 1rem);
   }
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-cover-image.alignfull .wp-block-cover-image-text,
   .entry .entry-content .wp-block-cover-image.alignfull .wp-block-cover-text,
@@ -6026,10 +7366,9 @@ body.page .main-navigation {
   .entry .entry-content .wp-block-cover.alignfull .wp-block-cover-image-text,
   .entry .entry-content .wp-block-cover.alignfull .wp-block-cover-text,
   .entry .entry-content .wp-block-cover.alignfull h2 {
-    max-width: calc(8 * (100vw / 12) - 28px);
+    max-width: calc(66.6666666667vw - 28px);
   }
 }
-
 @media only screen and (min-width: 1168px) {
   .entry .entry-content .wp-block-cover-image.alignfull .wp-block-cover-image-text,
   .entry .entry-content .wp-block-cover-image.alignfull .wp-block-cover-text,
@@ -6037,15 +7376,14 @@ body.page .main-navigation {
   .entry .entry-content .wp-block-cover.alignfull .wp-block-cover-image-text,
   .entry .entry-content .wp-block-cover.alignfull .wp-block-cover-text,
   .entry .entry-content .wp-block-cover.alignfull h2 {
-    max-width: calc(6 * (100vw / 12) - 28px);
+    max-width: calc(50vw - 28px);
   }
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-cover-image.alignfull,
   .entry .entry-content .wp-block-cover.alignfull {
-    padding-left: calc(10% + 58px + (2 * 1rem));
-    padding-right: calc(10% + 58px + (2 * 1rem));
+    padding-left: calc(10% + 58px + 2 * 1rem);
+    padding-right: calc(10% + 58px + 2 * 1rem);
   }
   .entry .entry-content .wp-block-cover-image.alignfull .wp-block-cover-image-text,
   .entry .entry-content .wp-block-cover-image.alignfull .wp-block-cover-text,
@@ -6056,34 +7394,252 @@ body.page .main-navigation {
     padding: 0;
   }
 }
-
 .entry .entry-content .wp-block-gallery {
   list-style-type: none;
   padding-left: 0;
 }
-
 .entry .entry-content .wp-block-gallery .blocks-gallery-image:last-child,
 .entry .entry-content .wp-block-gallery .blocks-gallery-item:last-child {
   margin-bottom: 16px;
 }
-
 .entry .entry-content .wp-block-gallery figcaption a {
   color: #fff;
 }
-
 .entry .entry-content .wp-block-audio figcaption,
 .entry .entry-content .wp-block-video figcaption,
 .entry .entry-content .wp-block-image figcaption,
 .entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption,
 .entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption {
-  font-size: 0.71111em;
+  font-size: 0.7111111111em;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+}
+.entry .entry-content .wp-block-audio figcaption:lang(ar),
+.entry .entry-content .wp-block-video figcaption:lang(ar),
+.entry .entry-content .wp-block-image figcaption:lang(ar),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(ar),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-audio figcaption:lang(ary),
+.entry .entry-content .wp-block-video figcaption:lang(ary),
+.entry .entry-content .wp-block-image figcaption:lang(ary),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(ary),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-audio figcaption:lang(azb),
+.entry .entry-content .wp-block-video figcaption:lang(azb),
+.entry .entry-content .wp-block-image figcaption:lang(azb),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(azb),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-audio figcaption:lang(ckb),
+.entry .entry-content .wp-block-video figcaption:lang(ckb),
+.entry .entry-content .wp-block-image figcaption:lang(ckb),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(ckb),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-audio figcaption:lang(fa-IR),
+.entry .entry-content .wp-block-video figcaption:lang(fa-IR),
+.entry .entry-content .wp-block-image figcaption:lang(fa-IR),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(fa-IR),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-audio figcaption:lang(haz),
+.entry .entry-content .wp-block-video figcaption:lang(haz),
+.entry .entry-content .wp-block-image figcaption:lang(haz),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(haz),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-audio figcaption:lang(ps),
+.entry .entry-content .wp-block-video figcaption:lang(ps),
+.entry .entry-content .wp-block-image figcaption:lang(ps),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(ps),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-audio figcaption:lang(be),
+.entry .entry-content .wp-block-video figcaption:lang(be),
+.entry .entry-content .wp-block-image figcaption:lang(be),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(be),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-audio figcaption:lang(bg-BG),
+.entry .entry-content .wp-block-video figcaption:lang(bg-BG),
+.entry .entry-content .wp-block-image figcaption:lang(bg-BG),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(bg-BG),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-audio figcaption:lang(kk),
+.entry .entry-content .wp-block-video figcaption:lang(kk),
+.entry .entry-content .wp-block-image figcaption:lang(kk),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(kk),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-audio figcaption:lang(mk-MK),
+.entry .entry-content .wp-block-video figcaption:lang(mk-MK),
+.entry .entry-content .wp-block-image figcaption:lang(mk-MK),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(mk-MK),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-audio figcaption:lang(mn),
+.entry .entry-content .wp-block-video figcaption:lang(mn),
+.entry .entry-content .wp-block-image figcaption:lang(mn),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(mn),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-audio figcaption:lang(ru-RU),
+.entry .entry-content .wp-block-video figcaption:lang(ru-RU),
+.entry .entry-content .wp-block-image figcaption:lang(ru-RU),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(ru-RU),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-audio figcaption:lang(sah),
+.entry .entry-content .wp-block-video figcaption:lang(sah),
+.entry .entry-content .wp-block-image figcaption:lang(sah),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(sah),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-audio figcaption:lang(sr-RS),
+.entry .entry-content .wp-block-video figcaption:lang(sr-RS),
+.entry .entry-content .wp-block-image figcaption:lang(sr-RS),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(sr-RS),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-audio figcaption:lang(tt-RU),
+.entry .entry-content .wp-block-video figcaption:lang(tt-RU),
+.entry .entry-content .wp-block-image figcaption:lang(tt-RU),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(tt-RU),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-audio figcaption:lang(uk),
+.entry .entry-content .wp-block-video figcaption:lang(uk),
+.entry .entry-content .wp-block-image figcaption:lang(uk),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(uk),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-audio figcaption:lang(zh-HK),
+.entry .entry-content .wp-block-video figcaption:lang(zh-HK),
+.entry .entry-content .wp-block-image figcaption:lang(zh-HK),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(zh-HK),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.entry .entry-content .wp-block-audio figcaption:lang(zh-TW),
+.entry .entry-content .wp-block-video figcaption:lang(zh-TW),
+.entry .entry-content .wp-block-image figcaption:lang(zh-TW),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(zh-TW),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.entry .entry-content .wp-block-audio figcaption:lang(zh-CN),
+.entry .entry-content .wp-block-video figcaption:lang(zh-CN),
+.entry .entry-content .wp-block-image figcaption:lang(zh-CN),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(zh-CN),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.entry .entry-content .wp-block-audio figcaption:lang(bn-BD),
+.entry .entry-content .wp-block-video figcaption:lang(bn-BD),
+.entry .entry-content .wp-block-image figcaption:lang(bn-BD),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(bn-BD),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-audio figcaption:lang(hi-IN),
+.entry .entry-content .wp-block-video figcaption:lang(hi-IN),
+.entry .entry-content .wp-block-image figcaption:lang(hi-IN),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(hi-IN),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-audio figcaption:lang(mr),
+.entry .entry-content .wp-block-video figcaption:lang(mr),
+.entry .entry-content .wp-block-image figcaption:lang(mr),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(mr),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-audio figcaption:lang(ne-NP),
+.entry .entry-content .wp-block-video figcaption:lang(ne-NP),
+.entry .entry-content .wp-block-image figcaption:lang(ne-NP),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(ne-NP),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-audio figcaption:lang(el),
+.entry .entry-content .wp-block-video figcaption:lang(el),
+.entry .entry-content .wp-block-image figcaption:lang(el),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(el),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-audio figcaption:lang(gu),
+.entry .entry-content .wp-block-video figcaption:lang(gu),
+.entry .entry-content .wp-block-image figcaption:lang(gu),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(gu),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-audio figcaption:lang(he-IL),
+.entry .entry-content .wp-block-video figcaption:lang(he-IL),
+.entry .entry-content .wp-block-image figcaption:lang(he-IL),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(he-IL),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-audio figcaption:lang(ja),
+.entry .entry-content .wp-block-video figcaption:lang(ja),
+.entry .entry-content .wp-block-image figcaption:lang(ja),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(ja),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+.entry .entry-content .wp-block-audio figcaption:lang(ko-KR),
+.entry .entry-content .wp-block-video figcaption:lang(ko-KR),
+.entry .entry-content .wp-block-image figcaption:lang(ko-KR),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(ko-KR),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+.entry .entry-content .wp-block-audio figcaption:lang(th),
+.entry .entry-content .wp-block-video figcaption:lang(th),
+.entry .entry-content .wp-block-image figcaption:lang(th),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(th),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+.entry .entry-content .wp-block-audio figcaption:lang(vi),
+.entry .entry-content .wp-block-video figcaption:lang(vi),
+.entry .entry-content .wp-block-image figcaption:lang(vi),
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption:lang(vi),
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
+.entry .entry-content .wp-block-audio figcaption,
+.entry .entry-content .wp-block-video figcaption,
+.entry .entry-content .wp-block-image figcaption,
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption,
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption {
   line-height: 1.6;
   margin: 0;
   padding: 0.5rem;
   text-align: center;
 }
-
 .entry .entry-content .wp-block-separator,
 .entry .entry-content hr {
   background-color: #767676;
@@ -6093,103 +7649,185 @@ body.page .main-navigation {
   margin-top: 2rem;
   max-width: 2.25em;
   text-align: left;
-  /* Remove duplicate rule-line when a separator
-		 * is followed by an H1, or H2 */
 }
-
 .entry .entry-content .wp-block-separator:not(.wp-block-separator),
 .entry .entry-content hr:not(.wp-block-separator) {
   max-width: 100%;
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-separator:not(.wp-block-separator),
   .entry .entry-content hr:not(.wp-block-separator) {
-    max-width: calc(8 * (100vw / 12) - 28px);
+    max-width: calc(66.6666666667vw - 28px);
   }
 }
-
 @media only screen and (min-width: 1168px) {
   .entry .entry-content .wp-block-separator:not(.wp-block-separator),
   .entry .entry-content hr:not(.wp-block-separator) {
-    max-width: calc(6 * (100vw / 12) - 28px);
+    max-width: calc(50vw - 28px);
   }
 }
-
 .entry .entry-content .wp-block-separator.is-style-wide,
 .entry .entry-content hr.is-style-wide {
   max-width: 100%;
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-separator.is-style-wide,
   .entry .entry-content hr.is-style-wide {
-    max-width: calc(8 * (100vw / 12) - 28px);
+    max-width: calc(66.6666666667vw - 28px);
   }
 }
-
 @media only screen and (min-width: 1168px) {
   .entry .entry-content .wp-block-separator.is-style-wide,
   .entry .entry-content hr.is-style-wide {
-    max-width: calc(6 * (100vw / 12) - 28px);
+    max-width: calc(50vw - 28px);
   }
 }
-
 .entry .entry-content .wp-block-separator.is-style-dots,
 .entry .entry-content hr.is-style-dots {
   max-width: 100%;
+}
+@media only screen and (min-width: 768px) {
+  .entry .entry-content .wp-block-separator.is-style-dots,
+  .entry .entry-content hr.is-style-dots {
+    max-width: calc(66.6666666667vw - 28px);
+  }
+}
+@media only screen and (min-width: 1168px) {
+  .entry .entry-content .wp-block-separator.is-style-dots,
+  .entry .entry-content hr.is-style-dots {
+    max-width: calc(50vw - 28px);
+  }
+}
+.entry .entry-content .wp-block-separator.is-style-dots,
+.entry .entry-content hr.is-style-dots {
   background-color: inherit;
   border: inherit;
   height: inherit;
   text-align: center;
 }
-
-@media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-separator.is-style-dots,
-  .entry .entry-content hr.is-style-dots {
-    max-width: calc(8 * (100vw / 12) - 28px);
-  }
-}
-
-@media only screen and (min-width: 1168px) {
-  .entry .entry-content .wp-block-separator.is-style-dots,
-  .entry .entry-content hr.is-style-dots {
-    max-width: calc(6 * (100vw / 12) - 28px);
-  }
-}
-
 .entry .entry-content .wp-block-separator.is-style-dots:not(.has-text-color):not(.has-background),
 .entry .entry-content hr.is-style-dots:not(.has-text-color):not(.has-background) {
   color: #767676;
 }
-
 .entry .entry-content .wp-block-separator.is-style-dots:before,
 .entry .entry-content hr.is-style-dots:before {
   font-size: 1.6875em;
-  letter-spacing: 0.88889em;
-  padding-left: 0.88889em;
+  letter-spacing: 0.8888888889em;
+  padding-left: 0.8888888889em;
 }
-
-.entry .entry-content .wp-block-separator + h1:before,
-.entry .entry-content .wp-block-separator + h2:before,
+.entry .entry-content .wp-block-separator,
+.entry .entry-content hr {
+  /* Remove duplicate rule-line when a separator
+   * is followed by an H1, or H2 */
+}
+.entry .entry-content .wp-block-separator + h1:before, .entry .entry-content .wp-block-separator + h2:before,
 .entry .entry-content hr + h1:before,
 .entry .entry-content hr + h2:before {
   display: none;
 }
-
 .entry .entry-content .wp-block-embed-twitter {
   word-break: break-word;
 }
-
 .entry .entry-content .wp-block-table th,
 .entry .entry-content .wp-block-table td {
   border-color: #767676;
 }
-
 .entry .entry-content .wp-block-file {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 }
-
+.entry .entry-content .wp-block-file:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.entry .entry-content .wp-block-file:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.entry .entry-content .wp-block-file:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.entry .entry-content .wp-block-file:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+.entry .entry-content .wp-block-file:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+.entry .entry-content .wp-block-file:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+.entry .entry-content .wp-block-file:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
 .entry .entry-content .wp-block-file .wp-block-file__button {
   display: table;
   transition: background 150ms ease-in-out;
@@ -6198,6 +7836,101 @@ body.page .main-navigation {
   background: #0073aa;
   font-size: 22px;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+}
+.entry .entry-content .wp-block-file .wp-block-file__button:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file .wp-block-file__button:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file .wp-block-file__button:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file .wp-block-file__button:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file .wp-block-file__button:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file .wp-block-file__button:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file .wp-block-file__button:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file .wp-block-file__button:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file .wp-block-file__button:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file .wp-block-file__button:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file .wp-block-file__button:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file .wp-block-file__button:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file .wp-block-file__button:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file .wp-block-file__button:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file .wp-block-file__button:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file .wp-block-file__button:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file .wp-block-file__button:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file .wp-block-file__button:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.entry .entry-content .wp-block-file .wp-block-file__button:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.entry .entry-content .wp-block-file .wp-block-file__button:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.entry .entry-content .wp-block-file .wp-block-file__button:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file .wp-block-file__button:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file .wp-block-file__button:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file .wp-block-file__button:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file .wp-block-file__button:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file .wp-block-file__button:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file .wp-block-file__button:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-file .wp-block-file__button:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+.entry .entry-content .wp-block-file .wp-block-file__button:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+.entry .entry-content .wp-block-file .wp-block-file__button:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+.entry .entry-content .wp-block-file .wp-block-file__button:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
+.entry .entry-content .wp-block-file .wp-block-file__button {
   line-height: 1.2;
   text-decoration: none;
   font-weight: bold;
@@ -6206,53 +7939,43 @@ body.page .main-navigation {
   margin-left: 0;
   margin-top: calc(0.75 * 1rem);
 }
-
 @media only screen and (min-width: 1168px) {
   .entry .entry-content .wp-block-file .wp-block-file__button {
     font-size: 22px;
     padding: 0.875rem 1.5rem;
   }
 }
-
 .entry .entry-content .wp-block-file .wp-block-file__button:hover {
   background: #111;
   cursor: pointer;
 }
-
 .entry .entry-content .wp-block-file .wp-block-file__button:focus {
   background: #111;
   outline: thin dotted;
   outline-offset: -4px;
 }
-
 .entry .entry-content .wp-block-file.aligncenter .wp-block-file__button {
   margin-left: auto;
   margin-right: auto;
 }
-
 .entry .entry-content .wp-block-file.alignright .wp-block-file__button {
   margin-left: auto;
   margin-right: 0;
 }
-
 .entry .entry-content .wp-block-code {
   border-radius: 0;
 }
-
 .entry .entry-content .wp-block-code code {
   font-size: 1.125em;
   white-space: pre-wrap;
   word-break: break-word;
 }
-
 .entry .entry-content .wp-block-columns .wp-block-column > *:first-child {
   margin-top: 0;
 }
-
 .entry .entry-content .wp-block-columns .wp-block-column > *:last-child {
   margin-bottom: 0;
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-columns .wp-block-image:not(.alignwide):not(.alignfull) > img,
   .entry .entry-content .wp-block-columns .wp-block-image:not(.alignwide):not(.alignfull) > a > img,
@@ -6261,7 +7984,6 @@ body.page .main-navigation {
     max-width: 100%;
   }
 }
-
 @media only screen and (min-width: 1168px) {
   .entry .entry-content .wp-block-columns .wp-block-image:not(.alignwide):not(.alignfull) > img,
   .entry .entry-content .wp-block-columns .wp-block-image:not(.alignwide):not(.alignfull) > a > img,
@@ -6270,7 +7992,6 @@ body.page .main-navigation {
     max-width: 100%;
   }
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-columns {
     flex-wrap: nowrap;
@@ -6279,20 +8000,16 @@ body.page .main-navigation {
     margin-left: 32px;
   }
 }
-
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-group:not(.alignfull) > .wp-block-group__inner-container > .alignfull,
-  .entry .entry-content .wp-block-group:not(.alignfull) > .wp-block-group__inner-container > .wp-block-image > img {
+  .entry .entry-content .wp-block-group:not(.alignfull) > .wp-block-group__inner-container > .alignfull, .entry .entry-content .wp-block-group:not(.alignfull) > .wp-block-group__inner-container > .wp-block-image > img {
     left: 0;
     max-width: 100%;
   }
 }
-
 .entry .entry-content .wp-block-group.alignfull > .wp-block-group__inner-container {
-  max-width: calc(100% - (2 * 1rem));
+  max-width: calc(100% - 2 * 1rem);
   margin: 0 1rem;
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-group.alignfull > .wp-block-group__inner-container {
     max-width: 80%;
@@ -6300,88 +8017,166 @@ body.page .main-navigation {
     padding: 0 60px;
   }
 }
-
 .entry .entry-content .wp-block-group.has-background {
   padding: 1rem;
   margin-top: 0;
   margin-bottom: 0;
 }
-
 .entry .entry-content .wp-block-group.has-background .wp-block-group__inner-container > *:first-child {
   margin-top: 0;
 }
-
 .entry .entry-content .wp-block-group.has-background .wp-block-group__inner-container > *:last-child {
   margin-bottom: 0;
 }
-
 .entry .entry-content .wp-block-group.has-background.alignfull {
   padding-left: 0;
   padding-right: 0;
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-group.has-background.alignfull {
     padding-top: 1rem;
     padding-bottom: 1rem;
   }
 }
-
 .entry .entry-content .wp-block-group.has-background:not(.alignfull) > .wp-block-group__inner-container > .alignfull {
   width: 100%;
   max-width: 100%;
 }
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-group.has-background:not(.alignfull) > .wp-block-group__inner-container > .alignfull {
-    width: calc( 100% + 2rem);
-    max-width: calc( 100% + 2rem);
+    width: calc(100% + 2rem);
+    max-width: calc(100% + 2rem);
     margin-left: -1rem;
   }
 }
-
 .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+}
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta {
   font-weight: bold;
 }
-
 .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta .wp-block-latest-comments__comment-date {
   font-weight: normal;
 }
-
 .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment,
 .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-date,
 .entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-excerpt p {
   font-size: inherit;
 }
-
 .entry .entry-content .wp-block-latest-comments.has-dates .wp-block-latest-comments__comment-date {
-  font-size: 0.71111em;
+  font-size: 0.7111111111em;
 }
-
 .entry .entry-content .has-small-font-size {
-  font-size: 0.88889em;
+  font-size: 0.8888888889em;
 }
-
 .entry .entry-content .has-normal-font-size {
   font-size: 1.125em;
 }
-
 .entry .entry-content .has-large-font-size {
   font-size: 1.6875em;
 }
-
 .entry .entry-content .has-huge-font-size {
   font-size: 2.25em;
 }
-
 .entry .entry-content .has-primary-background-color,
 .entry .entry-content .has-secondary-background-color,
 .entry .entry-content .has-dark-gray-background-color,
 .entry .entry-content .has-light-gray-background-color {
   color: #fff;
 }
-
 .entry .entry-content .has-primary-background-color > p,
 .entry .entry-content .has-primary-background-color > h1,
 .entry .entry-content .has-primary-background-color > h2,
@@ -6416,11 +8211,9 @@ body.page .main-navigation {
 .entry .entry-content .has-light-gray-background-color > a {
   color: #fff;
 }
-
 .entry .entry-content .has-white-background-color {
   color: #111;
 }
-
 .entry .entry-content .has-white-background-color > p,
 .entry .entry-content .has-white-background-color > h1,
 .entry .entry-content .has-white-background-color > h2,
@@ -6431,59 +8224,49 @@ body.page .main-navigation {
 .entry .entry-content .has-white-background-color > a {
   color: #111;
 }
-
 .entry .entry-content .has-primary-background-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color.has-primary-background-color {
   background-color: #0073aa;
 }
-
 .entry .entry-content .has-secondary-background-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color.has-secondary-background-color {
-  background-color: #005177;
+  background-color: rgb(0, 80.5, 119);
 }
-
 .entry .entry-content .has-dark-gray-background-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color.has-dark-gray-background-color {
   background-color: #111;
 }
-
 .entry .entry-content .has-light-gray-background-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color.has-light-gray-background-color {
   background-color: #767676;
 }
-
 .entry .entry-content .has-white-background-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color.has-white-background-color {
   background-color: #FFF;
 }
-
 .entry .entry-content .has-primary-color,
 .entry .entry-content .wp-block-pullquote blockquote.has-primary-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color > p {
   color: #0073aa;
 }
-
 .entry .entry-content .has-secondary-color,
 .entry .entry-content .wp-block-pullquote blockquote.has-secondary-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color > p {
-  color: #005177;
+  color: rgb(0, 80.5, 119);
 }
-
 .entry .entry-content .has-dark-gray-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color > p {
   color: #111;
 }
-
 .entry .entry-content .has-light-gray-color,
 .entry .entry-content .wp-block-pullquote blockquote.has-light-gray-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color > p {
   color: #767676;
 }
-
 .entry .entry-content .has-white-color,
 .entry .entry-content .wp-block-pullquote blockquote.has-white-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-white-color {
@@ -6527,22 +8310,20 @@ svg {
 .wp-caption {
   margin-bottom: calc(1.5 * 1rem);
 }
-
 @media only screen and (min-width: 768px) {
   .wp-caption.aligncenter {
     position: relative;
-    left: calc( calc(8 * (100vw / 12) - 28px) / 2);
+    left: calc(calc(66.6666666667vw - 28px) / 2);
     transform: translateX(-50%);
   }
 }
-
 @media only screen and (min-width: 1168px) {
   .wp-caption.aligncenter {
-    left: calc( calc(6 * (100vw / 12) - 28px) / 2);
+    left: calc(calc(50vw - 28px) / 2);
   }
 }
 
-.wp-caption img[class*="wp-image-"] {
+.wp-caption img[class*=wp-image-] {
   display: block;
   margin-left: auto;
   margin-right: auto;
@@ -6550,8 +8331,103 @@ svg {
 
 .wp-caption-text {
   color: #767676;
-  font-size: 0.71111em;
+  font-size: 0.7111111111em;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+}
+.wp-caption-text:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-caption-text:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-caption-text:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-caption-text:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-caption-text:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-caption-text:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-caption-text:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.wp-caption-text:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-caption-text:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-caption-text:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-caption-text:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-caption-text:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-caption-text:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-caption-text:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-caption-text:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-caption-text:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-caption-text:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.wp-caption-text:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.wp-caption-text:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.wp-caption-text:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.wp-caption-text:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+.wp-caption-text:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+.wp-caption-text:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+.wp-caption-text:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+.wp-caption-text:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+.wp-caption-text:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+.wp-caption-text:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+.wp-caption-text:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+.wp-caption-text:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+.wp-caption-text:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+.wp-caption-text:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
+.wp-caption-text {
   line-height: 1.6;
   margin: 0;
   padding: 0.5rem;
@@ -6576,79 +8452,157 @@ svg {
   vertical-align: top;
   width: 100%;
 }
-
 .gallery-columns-2 .gallery-item {
   max-width: calc((100% - 16px * 1) / 2);
 }
-
 .gallery-columns-2 .gallery-item:nth-of-type(2n+2) {
   margin-right: 0;
 }
-
 .gallery-columns-3 .gallery-item {
   max-width: calc((100% - 16px * 2) / 3);
 }
-
 .gallery-columns-3 .gallery-item:nth-of-type(3n+3) {
   margin-right: 0;
 }
-
 .gallery-columns-4 .gallery-item {
   max-width: calc((100% - 16px * 3) / 4);
 }
-
 .gallery-columns-4 .gallery-item:nth-of-type(4n+4) {
   margin-right: 0;
 }
-
 .gallery-columns-5 .gallery-item {
   max-width: calc((100% - 16px * 4) / 5);
 }
-
 .gallery-columns-5 .gallery-item:nth-of-type(5n+5) {
   margin-right: 0;
 }
-
 .gallery-columns-6 .gallery-item {
   max-width: calc((100% - 16px * 5) / 6);
 }
-
 .gallery-columns-6 .gallery-item:nth-of-type(6n+6) {
   margin-right: 0;
 }
-
 .gallery-columns-7 .gallery-item {
   max-width: calc((100% - 16px * 6) / 7);
 }
-
 .gallery-columns-7 .gallery-item:nth-of-type(7n+7) {
   margin-right: 0;
 }
-
 .gallery-columns-8 .gallery-item {
   max-width: calc((100% - 16px * 7) / 8);
 }
-
 .gallery-columns-8 .gallery-item:nth-of-type(8n+8) {
   margin-right: 0;
 }
-
 .gallery-columns-9 .gallery-item {
   max-width: calc((100% - 16px * 8) / 9);
 }
-
 .gallery-columns-9 .gallery-item:nth-of-type(9n+9) {
   margin-right: 0;
 }
-
 .gallery-item:last-of-type {
   padding-right: 0;
 }
 
 .gallery-caption {
   display: block;
-  font-size: 0.71111em;
+  font-size: 0.7111111111em;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+}
+.gallery-caption:lang(ar) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.gallery-caption:lang(ary) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.gallery-caption:lang(azb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.gallery-caption:lang(ckb) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.gallery-caption:lang(fa-IR) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.gallery-caption:lang(haz) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.gallery-caption:lang(ps) {
+  font-family: Tahoma, Arial, sans-serif;
+}
+.gallery-caption:lang(be) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.gallery-caption:lang(bg-BG) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.gallery-caption:lang(kk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.gallery-caption:lang(mk-MK) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.gallery-caption:lang(mn) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.gallery-caption:lang(ru-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.gallery-caption:lang(sah) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.gallery-caption:lang(sr-RS) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.gallery-caption:lang(tt-RU) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.gallery-caption:lang(uk) {
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
+}
+.gallery-caption:lang(zh-HK) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.gallery-caption:lang(zh-TW) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.gallery-caption:lang(zh-CN) {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
+}
+.gallery-caption:lang(bn-BD) {
+  font-family: Arial, sans-serif;
+}
+.gallery-caption:lang(hi-IN) {
+  font-family: Arial, sans-serif;
+}
+.gallery-caption:lang(mr) {
+  font-family: Arial, sans-serif;
+}
+.gallery-caption:lang(ne-NP) {
+  font-family: Arial, sans-serif;
+}
+.gallery-caption:lang(el) {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+.gallery-caption:lang(gu) {
+  font-family: Arial, sans-serif;
+}
+.gallery-caption:lang(he-IL) {
+  font-family: "Arial Hebrew", Arial, sans-serif;
+}
+.gallery-caption:lang(ja) {
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
+}
+.gallery-caption:lang(ko-KR) {
+  font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
+}
+.gallery-caption:lang(th) {
+  font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
+}
+.gallery-caption:lang(vi) {
+  font-family: "Libre Franklin", sans-serif;
+}
+.gallery-caption {
   line-height: 1.6;
   margin: 0;
   padding: 0.5rem;
@@ -6659,7 +8613,6 @@ svg {
   line-height: 0;
   box-shadow: 0 0 0 0 transparent;
 }
-
 .gallery-item > div > a:focus {
   box-shadow: 0 0 0 2px #0073aa;
 }

--- a/src/wp-content/themes/twentynineteen/style.css
+++ b/src/wp-content/themes/twentynineteen/style.css
@@ -1987,7 +1987,8 @@ var {
   font-family: Menlo, monaco, Consolas, Lucida Console, monospace;
 }
 
-abbr, acronym {
+abbr,
+acronym {
   border-bottom: 1px dotted #666;
   cursor: help;
 }
@@ -2591,7 +2592,8 @@ a {
 a:visited {
   color: #0073aa;
 }
-a:hover, a:active {
+a:hover,
+a:active {
   color: #005177;
   outline: 0;
   text-decoration: none;
@@ -2635,7 +2637,8 @@ body.page .main-navigation {
   -webkit-appearance: none;
   -moz-appearance: none;
 }
-.main-navigation button:hover, .main-navigation button:focus {
+.main-navigation button:hover,
+.main-navigation button:focus {
   background: transparent;
 }
 .main-navigation button:focus {
@@ -2663,7 +2666,8 @@ body.page .main-navigation {
 .main-navigation .main-menu > li > a + svg {
   margin-right: 0.5rem;
 }
-.main-navigation .main-menu > li > a:hover, .main-navigation .main-menu > li > a:hover + svg {
+.main-navigation .main-menu > li > a:hover,
+.main-navigation .main-menu > li > a:hover + svg {
   color: #005177;
 }
 .main-navigation .main-menu > li.menu-item-has-children {
@@ -2702,14 +2706,16 @@ body.page .main-navigation {
   top: -0.125rem;
   vertical-align: text-bottom;
 }
-.wp-customizer-unloading .main-navigation .main-menu > li.menu-item-has-children .submenu-expand, .main-navigation .main-menu > li.menu-item-has-children .submenu-expand.is-empty {
+.wp-customizer-unloading .main-navigation .main-menu > li.menu-item-has-children .submenu-expand,
+.main-navigation .main-menu > li.menu-item-has-children .submenu-expand.is-empty {
   display: none;
 }
 .main-navigation .main-menu > li.menu-item-has-children .submenu-expand svg {
   position: relative;
   top: 0.2rem;
 }
-.main-navigation .main-menu > li:last-child > a, .main-navigation .main-menu > li:last-child.menu-item-has-children .submenu-expand {
+.main-navigation .main-menu > li:last-child > a,
+.main-navigation .main-menu > li:last-child.menu-item-has-children .submenu-expand {
   margin-right: 0;
 }
 .main-navigation .sub-menu {
@@ -2766,12 +2772,14 @@ body.page .main-navigation {
   padding: calc(0.5 * 1rem) calc(24px + 1rem) calc(0.5 * 1rem) 1rem;
   max-width: 20rem;
 }
-.main-navigation .sub-menu > li > a:hover, .main-navigation .sub-menu > li > a:focus,
+.main-navigation .sub-menu > li > a:hover,
+.main-navigation .sub-menu > li > a:focus,
 .main-navigation .sub-menu > li > .menu-item-link-return:hover,
 .main-navigation .sub-menu > li > .menu-item-link-return:focus {
   background: #005177;
 }
-.main-navigation .sub-menu > li > a:hover:after, .main-navigation .sub-menu > li > a:focus:after,
+.main-navigation .sub-menu > li > a:hover:after,
+.main-navigation .sub-menu > li > a:focus:after,
 .main-navigation .sub-menu > li > .menu-item-link-return:hover:after,
 .main-navigation .sub-menu > li > .menu-item-link-return:focus:after {
   background: #005177;
@@ -3153,7 +3161,8 @@ body.page .main-navigation {
   margin-bottom: -1px;
   transition: opacity 110ms ease-in-out;
 }
-.social-navigation ul.social-links-menu li a:hover, .social-navigation ul.social-links-menu li a:active {
+.social-navigation ul.social-links-menu li a:hover,
+.social-navigation ul.social-links-menu li a:active {
   color: #111;
   opacity: 0.6;
 }
@@ -3236,7 +3245,8 @@ body.page .main-navigation {
   color: #767676;
   user-select: none;
 }
-.post-navigation .nav-links a .meta-nav:before, .post-navigation .nav-links a .meta-nav:after {
+.post-navigation .nav-links a .meta-nav:before,
+.post-navigation .nav-links a .meta-nav:after {
   display: none;
   content: "—";
   width: 2em;
@@ -3290,21 +3300,25 @@ body.page .main-navigation {
 .pagination .nav-links > * {
   padding: calc(0.5 * 1rem);
 }
-.pagination .nav-links > *.dots, .pagination .nav-links > *.prev {
+.pagination .nav-links > *.dots,
+.pagination .nav-links > *.prev {
   padding-left: 0;
 }
-.pagination .nav-links > *.dots, .pagination .nav-links > *.next {
+.pagination .nav-links > *.dots,
+.pagination .nav-links > *.next {
   padding-right: 0;
 }
 .pagination .nav-links a:focus {
   text-decoration: underline;
   outline-offset: -1px;
 }
-.pagination .nav-links a:focus.prev, .pagination .nav-links a:focus.next {
+.pagination .nav-links a:focus.prev,
+.pagination .nav-links a:focus.next {
   text-decoration: none;
 }
 .pagination .nav-links a:focus.prev .nav-prev-text,
-.pagination .nav-links a:focus.prev .nav-next-text, .pagination .nav-links a:focus.next .nav-prev-text,
+.pagination .nav-links a:focus.prev .nav-next-text,
+.pagination .nav-links a:focus.next .nav-prev-text,
 .pagination .nav-links a:focus.next .nav-next-text {
   text-decoration: underline;
 }
@@ -3665,7 +3679,9 @@ body.page .main-navigation {
 .site-logo .custom-logo-link .custom-logo {
   min-height: inherit;
 }
-.site-logo .custom-logo-link:hover, .site-logo .custom-logo-link:active, .site-logo .custom-logo-link:focus {
+.site-logo .custom-logo-link:hover,
+.site-logo .custom-logo-link:active,
+.site-logo .custom-logo-link:focus {
   box-shadow: 0 0 0 2px rgb(0, 0, 0);
 }
 @media only screen and (min-width: 768px) {
@@ -3683,7 +3699,8 @@ body.page .main-navigation {
 .site-title a {
   color: #111;
 }
-.site-title a:link, .site-title a:visited {
+.site-title a:link,
+.site-title a:visited {
   color: #111;
 }
 .site-title a:hover {
@@ -3747,7 +3764,10 @@ body.page .main-navigation {
   color: #fff;
   transition: opacity 110ms ease-in-out;
 }
-.site-header.featured-image .main-navigation a:hover, .site-header.featured-image .main-navigation a:active, .site-header.featured-image .main-navigation a:hover + svg, .site-header.featured-image .main-navigation a:active + svg,
+.site-header.featured-image .main-navigation a:hover,
+.site-header.featured-image .main-navigation a:active,
+.site-header.featured-image .main-navigation a:hover + svg,
+.site-header.featured-image .main-navigation a:active + svg,
 .site-header.featured-image .main-navigation a + svg:hover,
 .site-header.featured-image .main-navigation a + svg:active,
 .site-header.featured-image .main-navigation a + svg:hover + svg,
@@ -3767,7 +3787,8 @@ body.page .main-navigation {
   color: #fff;
   opacity: 0.6;
 }
-.site-header.featured-image .main-navigation a:focus, .site-header.featured-image .main-navigation a:focus + svg,
+.site-header.featured-image .main-navigation a:focus,
+.site-header.featured-image .main-navigation a:focus + svg,
 .site-header.featured-image .main-navigation a + svg:focus,
 .site-header.featured-image .main-navigation a + svg:focus + svg,
 .site-header.featured-image .social-navigation a:focus,
@@ -3894,7 +3915,9 @@ body.page .main-navigation {
   background: #fff;
   box-shadow: 0 0 0 0 rgba(255, 255, 255, 0);
 }
-.site-header.featured-image .custom-logo-link:hover, .site-header.featured-image .custom-logo-link:active, .site-header.featured-image .custom-logo-link:focus {
+.site-header.featured-image .custom-logo-link:hover,
+.site-header.featured-image .custom-logo-link:active,
+.site-header.featured-image .custom-logo-link:focus {
   box-shadow: 0 0 0 2px white;
 }
 .site-header.featured-image {
@@ -3913,7 +3936,8 @@ body.page .main-navigation {
 }
 .site-header.featured-image .site-branding-container:after,
 .site-header.featured-image .site-featured-image:before,
-.site-header.featured-image .site-featured-image:after, .site-header.featured-image:after {
+.site-header.featured-image .site-featured-image:after,
+.site-header.featured-image:after {
   display: block;
   position: absolute;
   top: 0;
@@ -4161,7 +4185,8 @@ body.page .main-navigation {
     display: none;
   }
 }
-.image-filters-enabled .entry .post-thumbnail:before, .image-filters-enabled .entry .post-thumbnail:after {
+.image-filters-enabled .entry .post-thumbnail:before,
+.image-filters-enabled .entry .post-thumbnail:after {
   position: absolute;
   display: block;
   width: 100%;
@@ -4223,7 +4248,8 @@ body.page .main-navigation {
   text-decoration: underline;
   text-decoration-thickness: 2px;
 }
-.entry .entry-content a.button, .entry .entry-content a:hover {
+.entry .entry-content a.button,
+.entry .entry-content a:hover {
   text-decoration: none;
 }
 .entry .entry-content a.button {
@@ -6032,16 +6058,19 @@ body.page .main-navigation {
   display: block;
   width: 100%;
 }
-.entry .entry-content .wp-block-audio.alignleft audio, .entry .entry-content .wp-block-audio.alignright audio {
+.entry .entry-content .wp-block-audio.alignleft audio,
+.entry .entry-content .wp-block-audio.alignright audio {
   max-width: 198px;
 }
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-audio.alignleft audio, .entry .entry-content .wp-block-audio.alignright audio {
+  .entry .entry-content .wp-block-audio.alignleft audio,
+  .entry .entry-content .wp-block-audio.alignright audio {
     max-width: 384px;
   }
 }
 @media only screen and (min-width: 1379px) {
-  .entry .entry-content .wp-block-audio.alignleft audio, .entry .entry-content .wp-block-audio.alignright audio {
+  .entry .entry-content .wp-block-audio.alignleft audio,
+  .entry .entry-content .wp-block-audio.alignright audio {
     max-width: 385.44px;
   }
 }
@@ -6183,15 +6212,21 @@ body.page .main-navigation {
 .entry .entry-content .wp-block-button:not(.is-style-squared) .wp-block-button__link {
   border-radius: 5px;
 }
-.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link, .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:focus, .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active {
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link,
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:focus,
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active {
   transition: all 150ms ease-in-out;
   border-width: 2px;
   border-style: solid;
 }
-.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:not(.has-background), .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:focus:not(.has-background), .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active:not(.has-background) {
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:not(.has-background),
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:focus:not(.has-background),
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active:not(.has-background) {
   background: transparent;
 }
-.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color), .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:focus:not(.has-text-color), .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active:not(.has-text-color) {
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color),
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:focus:not(.has-text-color),
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active:not(.has-text-color) {
   color: #0073aa;
   border-color: currentColor;
 }
@@ -6517,7 +6552,8 @@ body.page .main-navigation {
 .entry .entry-content .wp-block-latest-posts li {
   padding-bottom: 0.5rem;
 }
-.entry .entry-content .wp-block-latest-posts li.menu-item-has-children, .entry .entry-content .wp-block-latest-posts li:last-child {
+.entry .entry-content .wp-block-latest-posts li.menu-item-has-children,
+.entry .entry-content .wp-block-latest-posts li:last-child {
   padding-bottom: 0;
 }
 .entry .entry-content .wp-block-latest-posts li :not(:last-child) .wp-block-latest-posts__post-excerpt {
@@ -6885,17 +6921,20 @@ body.page .main-navigation {
    */
   font-size: calc(1rem / (1.25 * 1.125));
 }
-.entry .entry-content .wp-block-pullquote.alignleft, .entry .entry-content .wp-block-pullquote.alignright {
+.entry .entry-content .wp-block-pullquote.alignleft,
+.entry .entry-content .wp-block-pullquote.alignright {
   width: 100%;
   padding: 0;
 }
-.entry .entry-content .wp-block-pullquote.alignleft blockquote, .entry .entry-content .wp-block-pullquote.alignright blockquote {
+.entry .entry-content .wp-block-pullquote.alignleft blockquote,
+.entry .entry-content .wp-block-pullquote.alignright blockquote {
   margin: 1rem 0;
   padding: 0;
   text-align: left;
   max-width: 100%;
 }
-.entry .entry-content .wp-block-pullquote.alignleft blockquote p:first-child, .entry .entry-content .wp-block-pullquote.alignright blockquote p:first-child {
+.entry .entry-content .wp-block-pullquote.alignleft blockquote p:first-child,
+.entry .entry-content .wp-block-pullquote.alignright blockquote p:first-child {
   margin-top: 0;
 }
 .entry .entry-content .wp-block-pullquote.has-text-color cite {
@@ -6936,7 +6975,13 @@ body.page .main-navigation {
   margin-left: 1rem;
   margin-right: 1rem;
 }
-.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-text-color p, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-text-color a, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-white-color {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-text-color p,
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-text-color a,
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color,
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color,
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color,
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color,
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-white-color {
   color: inherit;
 }
 @media only screen and (min-width: 768px) {
@@ -6946,7 +6991,8 @@ body.page .main-navigation {
   }
 }
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignright, .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignleft {
+  .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignright,
+  .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignleft {
     padding: 1rem calc(2 * 1rem);
   }
 }
@@ -6956,7 +7002,8 @@ body.page .main-navigation {
     padding-right: calc(10% + 58px + 2 * 1rem);
   }
 }
-.entry .entry-content .wp-block-quote:not(.is-large), .entry .entry-content .wp-block-quote:not(.is-style-large) {
+.entry .entry-content .wp-block-quote:not(.is-large),
+.entry .entry-content .wp-block-quote:not(.is-style-large) {
   border-width: 2px;
   border-color: #0073aa;
   padding-top: 0;
@@ -6974,18 +7021,21 @@ body.page .main-navigation {
    */
   font-size: calc(1rem / (1.25 * 1.125));
 }
-.entry .entry-content .wp-block-quote.is-large, .entry .entry-content .wp-block-quote.is-style-large {
+.entry .entry-content .wp-block-quote.is-large,
+.entry .entry-content .wp-block-quote.is-style-large {
   margin: 1rem 0;
   padding: 0;
   border-left: none;
 }
-.entry .entry-content .wp-block-quote.is-large p, .entry .entry-content .wp-block-quote.is-style-large p {
+.entry .entry-content .wp-block-quote.is-large p,
+.entry .entry-content .wp-block-quote.is-style-large p {
   font-size: 1.6875em;
   line-height: 1.4;
   font-style: italic;
 }
 .entry .entry-content .wp-block-quote.is-large cite,
-.entry .entry-content .wp-block-quote.is-large footer, .entry .entry-content .wp-block-quote.is-style-large cite,
+.entry .entry-content .wp-block-quote.is-large footer,
+.entry .entry-content .wp-block-quote.is-style-large cite,
 .entry .entry-content .wp-block-quote.is-style-large footer {
   /*
    * This requires a rem-based font size calculation instead of our normal em-based one,
@@ -6994,11 +7044,13 @@ body.page .main-navigation {
   font-size: calc(1rem / (1.25 * 1.125));
 }
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-quote.is-large, .entry .entry-content .wp-block-quote.is-style-large {
+  .entry .entry-content .wp-block-quote.is-large,
+  .entry .entry-content .wp-block-quote.is-style-large {
     margin: 1rem 0;
     padding: 1rem 0;
   }
-  .entry .entry-content .wp-block-quote.is-large p, .entry .entry-content .wp-block-quote.is-style-large p {
+  .entry .entry-content .wp-block-quote.is-large p,
+  .entry .entry-content .wp-block-quote.is-style-large p {
     font-size: 1.6875em;
   }
 }
@@ -7009,12 +7061,18 @@ body.page .main-navigation {
   display: block;
 }
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-image:not(.alignwide):not(.alignfull) > img, .entry .entry-content .wp-block-image:not(.alignwide):not(.alignfull) > a > img, .entry .entry-content .wp-block-image:not(.alignwide):not(.alignfull) > img + figcaption, .entry .entry-content .wp-block-image:not(.alignwide):not(.alignfull) > a + figcaption {
+  .entry .entry-content .wp-block-image:not(.alignwide):not(.alignfull) > img,
+  .entry .entry-content .wp-block-image:not(.alignwide):not(.alignfull) > a > img,
+  .entry .entry-content .wp-block-image:not(.alignwide):not(.alignfull) > img + figcaption,
+  .entry .entry-content .wp-block-image:not(.alignwide):not(.alignfull) > a + figcaption {
     max-width: calc(66.6666666667vw - 28px);
   }
 }
 @media only screen and (min-width: 1168px) {
-  .entry .entry-content .wp-block-image:not(.alignwide):not(.alignfull) > img, .entry .entry-content .wp-block-image:not(.alignwide):not(.alignfull) > a > img, .entry .entry-content .wp-block-image:not(.alignwide):not(.alignfull) > img + figcaption, .entry .entry-content .wp-block-image:not(.alignwide):not(.alignfull) > a + figcaption {
+  .entry .entry-content .wp-block-image:not(.alignwide):not(.alignfull) > img,
+  .entry .entry-content .wp-block-image:not(.alignwide):not(.alignfull) > a > img,
+  .entry .entry-content .wp-block-image:not(.alignwide):not(.alignfull) > img + figcaption,
+  .entry .entry-content .wp-block-image:not(.alignwide):not(.alignfull) > a + figcaption {
     max-width: calc(50vw - 28px);
   }
 }
@@ -7347,13 +7405,15 @@ body.page .main-navigation {
     max-width: 100%;
   }
 }
-.entry .entry-content .wp-block-cover-image.alignleft, .entry .entry-content .wp-block-cover-image.alignright,
+.entry .entry-content .wp-block-cover-image.alignleft,
+.entry .entry-content .wp-block-cover-image.alignright,
 .entry .entry-content .wp-block-cover.alignleft,
 .entry .entry-content .wp-block-cover.alignright {
   width: 100%;
 }
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-cover-image.alignleft, .entry .entry-content .wp-block-cover-image.alignright,
+  .entry .entry-content .wp-block-cover-image.alignleft,
+  .entry .entry-content .wp-block-cover-image.alignright,
   .entry .entry-content .wp-block-cover.alignleft,
   .entry .entry-content .wp-block-cover.alignright {
     padding: 1rem calc(2 * 1rem);
@@ -7720,7 +7780,8 @@ body.page .main-navigation {
   /* Remove duplicate rule-line when a separator
    * is followed by an H1, or H2 */
 }
-.entry .entry-content .wp-block-separator + h1:before, .entry .entry-content .wp-block-separator + h2:before,
+.entry .entry-content .wp-block-separator + h1:before,
+.entry .entry-content .wp-block-separator + h2:before,
 .entry .entry-content hr + h1:before,
 .entry .entry-content hr + h2:before {
   display: none;
@@ -8001,7 +8062,8 @@ body.page .main-navigation {
   }
 }
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-group:not(.alignfull) > .wp-block-group__inner-container > .alignfull, .entry .entry-content .wp-block-group:not(.alignfull) > .wp-block-group__inner-container > .wp-block-image > img {
+  .entry .entry-content .wp-block-group:not(.alignfull) > .wp-block-group__inner-container > .alignfull,
+  .entry .entry-content .wp-block-group:not(.alignfull) > .wp-block-group__inner-container > .wp-block-image > img {
     left: 0;
     max-width: 100%;
   }

--- a/src/wp-content/themes/twentynineteen/style.css
+++ b/src/wp-content/themes/twentynineteen/style.css
@@ -2039,7 +2039,7 @@ a {
 
 a:hover,
 a:active {
-  color: rgb(0, 80.5, 119);
+  color: #005177;
   outline: 0;
   text-decoration: none;
 }
@@ -2592,7 +2592,7 @@ a:visited {
   color: #0073aa;
 }
 a:hover, a:active {
-  color: rgb(0, 80.5, 119);
+  color: #005177;
   outline: 0;
   text-decoration: none;
 }
@@ -2664,7 +2664,7 @@ body.page .main-navigation {
   margin-right: 0.5rem;
 }
 .main-navigation .main-menu > li > a:hover, .main-navigation .main-menu > li > a:hover + svg {
-  color: rgb(0, 80.5, 119);
+  color: #005177;
 }
 .main-navigation .main-menu > li.menu-item-has-children {
   display: inline-block;
@@ -2769,12 +2769,12 @@ body.page .main-navigation {
 .main-navigation .sub-menu > li > a:hover, .main-navigation .sub-menu > li > a:focus,
 .main-navigation .sub-menu > li > .menu-item-link-return:hover,
 .main-navigation .sub-menu > li > .menu-item-link-return:focus {
-  background: rgb(0, 80.5, 119);
+  background: #005177;
 }
 .main-navigation .sub-menu > li > a:hover:after, .main-navigation .sub-menu > li > a:focus:after,
 .main-navigation .sub-menu > li > .menu-item-link-return:hover:after,
 .main-navigation .sub-menu > li > .menu-item-link-return:focus:after {
-  background: rgb(0, 80.5, 119);
+  background: #005177;
 }
 .main-navigation .sub-menu > li > .menu-item-link-return {
   width: 100%;
@@ -3247,7 +3247,7 @@ body.page .main-navigation {
   hyphens: auto;
 }
 .post-navigation .nav-links a:hover {
-  color: rgb(0, 80.5, 119);
+  color: #005177;
 }
 @media only screen and (min-width: 1168px) {
   .post-navigation .nav-links .nav-previous,
@@ -3687,7 +3687,7 @@ body.page .main-navigation {
   color: #111;
 }
 .site-title a:hover {
-  color: rgb(74.375, 74.375, 74.375);
+  color: #4a4a4a;
 }
 .featured-image .site-title {
   margin: 0;
@@ -4068,7 +4068,7 @@ body.page .main-navigation {
   color: inherit;
 }
 .entry .entry-title a:hover {
-  color: rgb(74.375, 74.375, 74.375);
+  color: #4a4a4a;
 }
 .entry .entry-meta,
 .entry .entry-footer {
@@ -4318,7 +4318,7 @@ body.page .main-navigation {
   display: inline-block;
 }
 .author-bio .author-description .author-link:hover {
-  color: rgb(0, 80.5, 119);
+  color: #005177;
   text-decoration: none;
 }
 
@@ -4804,14 +4804,14 @@ body.page .main-navigation {
   color: inherit;
 }
 .comment .comment-author .fn a:hover {
-  color: rgb(0, 80.5, 119);
+  color: #005177;
 }
 .comment .comment-author .post-author-badge {
   border-radius: 100%;
   display: block;
   height: 18px;
   position: absolute;
-  background: rgb(0, 142.6, 210.8);
+  background: #008fd3;
   right: calc(100% - 2.5rem);
   top: -3px;
   width: 18px;
@@ -4841,7 +4841,7 @@ body.page .main-navigation {
 }
 .comment .comment-metadata > a:hover,
 .comment .comment-metadata .comment-edit-link:hover {
-  color: rgb(0, 80.5, 119);
+  color: #005177;
   text-decoration: none;
 }
 .comment .comment-metadata > * {
@@ -4900,7 +4900,7 @@ body.page .main-navigation {
 }
 .comment-reply-link:hover,
 #cancel-comment-reply-link:hover {
-  color: rgb(0, 80.5, 119);
+  color: #005177;
 }
 
 .discussion-avatar-list {
@@ -5227,7 +5227,7 @@ body.page .main-navigation {
   color: #0073aa;
 }
 .widget a:hover {
-  color: rgb(0, 80.5, 119);
+  color: #005177;
 }
 
 .widget_archive ul,
@@ -8230,7 +8230,7 @@ body.page .main-navigation {
 }
 .entry .entry-content .has-secondary-background-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color.has-secondary-background-color {
-  background-color: rgb(0, 80.5, 119);
+  background-color: #005177;
 }
 .entry .entry-content .has-dark-gray-background-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color.has-dark-gray-background-color {
@@ -8254,7 +8254,7 @@ body.page .main-navigation {
 .entry .entry-content .wp-block-pullquote blockquote.has-secondary-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color > p {
-  color: rgb(0, 80.5, 119);
+  color: #005177;
 }
 .entry .entry-content .has-dark-gray-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color,


### PR DESCRIPTION
This replaces `node-sass` with `sass` (Dart Sass).

Looking into the [issues raised on the Trac ticket](https://core.trac.wordpress.org/ticket/63013#comment:5), here is some output from Claude around each one.

> The sass output ignores five of the selectors when it creates font overrides for each non-latin language: .not-found .page-title, .error-404 .page-title, input[type="button"], input[type="reset"], and input[type="submit"]. That was difficult to notice because the compiler rearranges the lists of language selectors. 

This appears to be caused by the redundancy elimination part of Dart Sass related to the use of `@extend`.

<details>
<summary>Full output from Claude: Output ignores five of the selectors when it creates font overrides for each non-latin language</summary>

```
How the SCSS builds the non-latin overrides:

  // sass/mixins/_mixins-master.scss
  %non-latin-fonts {
    @each $lang, $font__fallback in $font__fallbacks {
      &:lang(#{$lang}) { font-family: unquote($font__fallback); }
    }
  }

  @mixin font-family($font_family: $font__body) {
    font-family: $font_family;
    @extend %non-latin-fonts;
  }

  Every selector list that calls @include font-family(...) gets @extended into the placeholder, producing one giant
  <every-selector>:lang(ar) { ... } rule per language. LibSass emitted that list verbatim. Dart Sass runs a "redundancy
  elimination" pass on extend results — if one selector in the merged list is a structural superselector of another
  (matches a superset of elements), the more specific one is dropped.

  For the .page-title cases this is provably what happened. In sass/typography/_headings.scss:

  - Lines 11/33/75/144 include .not-found .page-title and .error-404 .page-title in lists that @include font-family(...).
  - Line 54: .page-title { @include font-family($font__body); } — bare .page-title is also extended.

  So .page-title:lang(ar) is already in the merged list, and Dart Sass treats .not-found .page-title:lang(ar) and
  .error-404 .page-title:lang(ar) as redundant subselectors and drops them.

  The three input[type=...] cases come from sass/forms/_buttons.scss:

  .button, button, input[type="button"], input[type="reset"], input[type="submit"] {
    @include font-family($font__heading);
  }

  The bare button element is in the same list. Dart Sass's selector-unification math considers
  input[type="button"]:lang(ar) covered by other selectors in the merged result and trims them too — button:lang(ar) is
  the most likely cause here as the trimmer can over-eagerly treat attribute-restricted versions of an element selector as
   redundant when both end up in the same combined list.

  This is a real change in matched elements:
  - .not-found .page-title:lang(ar) is fine — .page-title:lang(ar) does match it, so the font fallback still applies via
  the kept selector. (No visual regression.)
  - input[type="button"]:lang(ar) etc. — these are only covered if you accept that button:lang(ar) covers them, but a
  <input type="submit"> is not a <button> element. So Arabic/Hebrew/etc. submit buttons would lose the non-latin font
  fallback. That is a real visual regression.

  The fix is to refactor the mixin away from @extend. Either:

  @mixin font-family($font_family: $font__body) {
    font-family: $font_family;
    @each $lang, $font__fallback in $font__fallbacks {
      &:lang(#{$lang}) { font-family: unquote($font__fallback); }
    }
  }

  This emits the same rules inline at every call site (slightly more CSS in bytes, no extend trimming, output is stable).
  Or keep @extend but split the placeholder into per-language placeholders. The inline @each is simpler and idiomatic for
  current Sass.
```

</details>

> The `#005177` blue becomes `rgb(0, 80.5, 119)`, slightly reducing its green value.

This one seems to be caused by `lighten()`/`darken()`, which have been deprecated. I've gone and hard coded the intended hex values to address this for now.

<details>
<summary>Full output from Claude: Why are hexidecimal colors output as `rgb()` and slightly different?</summary>

These come from the lighten()/darken() calls the deprecation warnings flagged in _comments.scss:240 and elsewhere. The
  math:

  - $color__link = #0073aa = rgb(0, 115, 170)
  - darken($color__link, ~8%) round-trips through HSL.
  - LibSass clamped/rounded the resulting RGB channels to integers and emitted hex.
  - Dart Sass keeps fractional precision and emits rgb(0, 80.5, 119) rather than #005177.

  Browsers accept fractional rgb() (CSS Color L4), so the rendered color is rgb(0, 80.5, 119) — half a step off the prior
  rgb(0, 81, 119). Imperceptible visually, but technically not byte-identical and slightly off from what the designer
  presumably intended (#005177).

  The right fix is the same as resolving the deprecation: replace lighten()/darken() calls with the intended literal hex
  (best — that's what the designer originally meant), or wrap with color.adjust() which is the modern API. As a stopgap
  you can wrap with round() to coerce channels back to integers.
```
</details>

> Many empty lines between rulesets are removed, but not all of them consistently. 

While annoying, this one does not require any action. It's just a formatting issue.

From Claude:
> Dart Sass's expanded formatter inserts blank lines around rule boundaries based on its own heuristics (e.g., always after @font-face, between top-level rules, but not consistently between sibling rules that came from a @for/@each loop). It does not preserve blank lines from your .scss source. There's no flag to make it match LibSass's "preserve source whitespace" behavior — this is just the formatter, and the inconsistency is baked in.

> Some comma-separated selectors share a line, where `node-sass` had given each its own line. 

Claude output:

> As noted before, this is the @extend merge grouping. Dart Sass joins selectors that came from the same extend operation with ,  on a single line and uses ,\n between groups; LibSass put every selector on its own line unconditionally. No formatter flag.

After pushing a bit further, I had it create a small PostCSS plugin to enforce this.

Trac ticket: Core-63013.

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Opus 4.7
Used for: Researching the reasons behind the differences in built files after updating.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
