### PR TITLE
Allow `application/json` uploads when fileinfo detects them as `text/plain`

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -3247,6 +3247,7 @@ function wp_check_filetype_and_ext( $file, $filename, $mimes = null ) {
 					'text/richtext',
 					'text/tsv',
 					'text/vtt',
+					'application/json',
 				),
 				true
 			)

--- a/tests/phpunit/data/uploads/test.json
+++ b/tests/phpunit/data/uploads/test.json
@@ -1,0 +1,1 @@
+"just a string"

--- a/tests/phpunit/tests/functions.php
+++ b/tests/phpunit/tests/functions.php
@@ -1840,6 +1840,32 @@ class Tests_Functions extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 54193
+	 * @group ms-excluded
+	 * @requires extension fileinfo
+	 */
+	public function test_wp_check_filetype_and_ext_with_filtered_json() {
+		$file     = DIR_TESTDATA . '/uploads/test.json';
+		$filename = 'test.json';
+
+		$expected = array(
+			'ext'             => 'json',
+			'type'            => 'application/json',
+			'proper_filename' => false,
+		);
+
+		add_filter(
+			'upload_mimes',
+			static function ( $mimes ) {
+				$mimes['json'] = 'application/json';
+				return $mimes;
+			}
+		);
+
+		$this->assertSame( $expected, wp_check_filetype_and_ext( $file, $filename ) );
+	}
+
+	/**
 	 * @ticket 39550
 	 * @group ms-excluded
 	 * @requires extension fileinfo


### PR DESCRIPTION

Trac ticket: https://core.trac.wordpress.org/ticket/54193

When the PHP `fileinfo` extension is active, it occasionally misidentifies uploaded `.json` files (especially those with simple string structures) as `text/plain`. Because `application/json` was not included in the fallback list of safe plain-text types in `wp_check_filetype_and_ext()`, these uploads were being falsely rejected. 

This PR resolves the issue by adding `application/json` to the array of allowed types when the real MIME type is detected as `text/plain`. Since JSON is inherently a plain-text format, this is a secure, non-breaking fix that allows users to seamlessly upload JSON files, even on server environments with older `libmagic` definitions.
