### PR TITLE
Image block: remove duplicate data-wp-bind--srcset in the lightbox overlay

### DIFF
--- a/src/wp-includes/blocks/image.php
+++ b/src/wp-includes/blocks/image.php
@@ -390,7 +390,6 @@ function block_core_image_print_lightbox_overlay() {
 							data-wp-bind--style="state.imgStyles"
 							data-wp-bind--src="state.enlargedSrc"
 							data-wp-bind--srcset="state.enlargedSrcset"
-							data-wp-bind--srcset="state.enlargedSrcset"
 							sizes="100vw"
 						>
 					</figure>


### PR DESCRIPTION
The enlarged <img> in block_core_image_print_lightbox_overlay() declares data-wp-bind--srcset="state.enlargedSrcset" twice.
Removes the duplicate (no behavior change).

See #65458.

https://core.trac.wordpress.org/ticket/65458