### PR TITLE
Formatting: Fix make_clickable() handling of existing links with spaces

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -3205,7 +3205,7 @@ function make_clickable( $text ) {
 	}
 
 	// Cleanup of accidental links within links.
-	return preg_replace( '#(<a([ \r\n\t]+[^>]+?>|>))<a [^>]+?>([^>]+?)</a></a>#i', '$1$3</a>', $r );
+	return preg_replace( '#(<a([ \r\n\t]+[^>]+?>|>))<a [^>]+?>([^>]+?)</a>([^<]*)</a>#i', '$1$3$4</a>', $r );
 }
 
 /**

--- a/tests/phpunit/tests/formatting/makeClickable.php
+++ b/tests/phpunit/tests/formatting/makeClickable.php
@@ -528,4 +528,22 @@ class Tests_Formatting_MakeClickable extends WP_UnitTestCase {
 			),
 		);
 	}
+
+	public function test_make_clickable_does_not_break_existing_link_with_spaces() {
+		$text = '<a href="https://codex.wordpress.org/Roles and Capabilities">https://codex.wordpress.org/Roles and Capabilities</a>';
+
+		$this->assertSame(
+			$text,
+			make_clickable( $text )
+		);
+	}
+
+	public function test_make_clickable_does_not_break_existing_truncated_link() {
+		$text = '<p><a href="https://search.google.com/structured-data/testing-tool#url=">https://search.google.com/s...</a>';
+
+		$this->assertSame(
+			$text,
+			make_clickable( $text )
+		);
+	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

## Description

Fix an issue in `make_clickable()` where existing links containing URLs with spaces or truncated URLs are incorrectly processed and result in nested anchor tags.

For example, the following input:

```
<a href="https://codex.wordpress.org/Roles and Capabilities">https://codex.wordpress.org/Roles and Capabilities</a>
```
was incorrectly converted to:
```
<a href="https://codex.wordpress.org/Roles and Capabilities">
	<a href="https://codex.wordpress.org/Roles" rel="nofollow">
		https://codex.wordpress.org/Roles
	</a>
	and Capabilities
</a>
```

Trac ticket: https://core.trac.wordpress.org/ticket/45702

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:
-->
AI assistance: Yes
Tool(s): Claude
Model(s): Opus 4.7
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
