### PR TITLE
WP_Term_Query misses descendants when intermediate children are filtered

### DIFF
--- a/src/wp-includes/class-wp-term-query.php
+++ b/src/wp-includes/class-wp-term-query.php
@@ -829,7 +829,8 @@ class WP_Term_Query {
 			foreach ( $taxonomies as $_tax ) {
 				$children = _get_term_hierarchy( $_tax );
 				if ( ! empty( $children ) ) {
-					$term_objects = _get_term_children( $child_of, $term_objects, $_tax );
+					$ancestors    = array();
+					$term_objects = _get_term_children( $child_of, $term_objects, $_tax, $ancestors, $hierarchical );
 				}
 			}
 		}

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -3969,7 +3969,7 @@ function _get_term_hierarchy( $taxonomy ) {
  *                          with 1 as value. Default empty array.
  * @return array|WP_Error The subset of $terms that are descendants of $term_id.
  */
-function _get_term_children( $term_id, $terms, $taxonomy, &$ancestors = array() ) {
+function _get_term_children( $term_id, $terms, $taxonomy, &$ancestors = array(), $hierarchical = true ) {
 	$empty_array = array();
 	if ( empty( $terms ) ) {
 		return $empty_array;
@@ -3988,35 +3988,54 @@ function _get_term_children( $term_id, $terms, $taxonomy, &$ancestors = array() 
 		$ancestors[ $term_id ] = 1;
 	}
 
-	foreach ( (array) $terms as $term ) {
-		$use_id = false;
-		if ( ! is_object( $term ) ) {
-			$term = get_term( $term, $taxonomy );
-			if ( is_wp_error( $term ) ) {
-				return $term;
+	if ( is_array( $terms ) && isset( $terms['_normalized_terms_by_id'] ) ) {
+		$terms_by_id = $terms['_normalized_terms_by_id'];
+	} else {
+		$terms_by_id = array();
+		foreach ( (array) $terms as $term ) {
+			$use_id = false;
+			if ( ! is_object( $term ) ) {
+				$term = get_term( $term, $taxonomy );
+				if ( is_wp_error( $term ) ) {
+					return $term;
+				}
+				$use_id = true;
 			}
-			$use_id = true;
-		}
 
+			$term_id_key                   = (int) $term->term_id;
+			$terms_by_id[ $term_id_key ][] = array(
+				'term'   => $term,
+				'use_id' => $use_id,
+			);
+		}
+	}
+
+	foreach ( (array) $has_children[ $term_id ] as $child_id ) {
 		// Don't recurse if we've already identified the term as a child - this indicates a loop.
-		if ( isset( $ancestors[ $term->term_id ] ) ) {
+		if ( isset( $ancestors[ $child_id ] ) ) {
 			continue;
 		}
 
-		if ( (int) $term->parent === $term_id ) {
-			if ( $use_id ) {
-				$term_list[] = $term->term_id;
-			} else {
-				$term_list[] = $term;
+		$ancestors[ $child_id ] = 1;
+
+		$child_in_terms = isset( $terms_by_id[ $child_id ] );
+
+		if ( $child_in_terms ) {
+			foreach ( $terms_by_id[ $child_id ] as $matched ) {
+				if ( $matched['use_id'] ) {
+					$term_list[] = $matched['term']->term_id;
+				} else {
+					$term_list[] = $matched['term'];
+				}
 			}
+		}
 
-			if ( ! isset( $has_children[ $term->term_id ] ) ) {
-				continue;
+		// Recurse if hierarchical is true, or if the child is in the terms set.
+		if ( ( $hierarchical || $child_in_terms ) && isset( $has_children[ $child_id ] ) ) {
+			$children = _get_term_children( $child_id, array( '_normalized_terms_by_id' => $terms_by_id ), $taxonomy, $ancestors, $hierarchical );
+			if ( is_wp_error( $children ) ) {
+				return $children;
 			}
-
-			$ancestors[ $term->term_id ] = 1;
-
-			$children = _get_term_children( $term->term_id, $terms, $taxonomy, $ancestors );
 			if ( $children ) {
 				$term_list = array_merge( $term_list, $children );
 			}

--- a/tests/phpunit/tests/term/getTerms.php
+++ b/tests/phpunit/tests/term/getTerms.php
@@ -1285,7 +1285,12 @@ class Tests_Term_getTerms extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertSameSets( array( $laval ), $terms );
+		/**
+		 * Dorval is also expected here as a childless descendant of Quebec.
+		 * Previously, Dorval was improperly excluded because the recursion broke
+		 * when the intermediate parent Montreal was excluded by the childless filter.
+		 */
+		$this->assertSameSets( array( $laval, $dorval ), $terms );
 	}
 
 	/**
@@ -3562,5 +3567,36 @@ class Tests_Term_getTerms extends WP_UnitTestCase {
 		}
 
 		wp_cache_delete( 'last_changed', 'terms' );
+	}
+
+	/**
+	 * @ticket 52904
+	 */
+	public function test_get_terms_child_of_with_name__like_filter() {
+		$parent     = self::factory()->category->create( array( 'name' => 'Parent' ) );
+		$child      = self::factory()->category->create(
+			array(
+				'parent' => $parent,
+				'name'   => 'Child',
+			)
+		);
+		$grandchild = self::factory()->category->create(
+			array(
+				'parent' => $child,
+				'name'   => 'Grandchild',
+			)
+		);
+
+		$terms = get_terms(
+			'category',
+			array(
+				'child_of'   => $parent,
+				'name__like' => 'Grandchild',
+				'hide_empty' => false,
+				'fields'     => 'ids',
+			)
+		);
+
+		$this->assertSameSets( array( $grandchild ), $terms );
 	}
 }


### PR DESCRIPTION
This PR fixes a bug in `WP_Term_Query` where querying a hierarchical taxonomy using `child_of` alongside filters (such as `name__like` or `childless`) could incorrectly exclude deep descendants. Specifically, if an intermediate parent term was filtered out of the results, the recursion in `_get_term_children()` would break, dropping any valid grandchildren beneath that parent.

Trac ticket: https://core.trac.wordpress.org/ticket/52904

### 2) What Changed?

- Added a `$hierarchical` parameter to the `_get_term_children()` function signature to control traversal behavior.
- Passed the `$hierarchical` parameter from `class-wp-term-query.php` appropriately when invoking the method.
- Replaced the $O(C x T)$ nested iteration loop inside `_get_term_children()` with an optimized $O(T + H)$ lookup-map algorithm.
- Updated the traversal to use the complete topology tree fetched via `_get_term_hierarchy()`, rather than restricting traversal to only the pre-filtered `$terms` array.
- Added a new unit test `test_get_terms_child_of_with_name__like_filter` explicitly reproducing the bug, and updated the existing `childless` unit test to correctly expect the missing grandchild.

### 3) How does this solve the issues?

- By utilizing the full taxonomy hierarchy tree during traversal and leveraging the `$hierarchical` parameter, we ensure that the function always traverses down the entire tree hierarchy from the ancestor. 
- Even if an intermediate parent term does not match the initial filter (and is therefore excluded from the final returned terms), the recursion now continues descending into its children. 
- This guarantees that any descendants deeper in the tree that *do* match the query constraints are successfully identified and returned.


## Use of AI Tools

AI assistance: Yes
Tool(s): GitHub Copilot.
Model(s): GPT-4o
Used for: To review and add suitable tests for the modified patch.

---