### PR TITLE
Media: Update big image size threshold to consider registered image widths

### DIFF
--- a/src/wp-admin/includes/image.php
+++ b/src/wp-admin/includes/image.php
@@ -282,7 +282,12 @@ function wp_create_image_subsizes( $file, $attachment_id ) {
 	 * @param string $file          Full path to the uploaded image file.
 	 * @param int    $attachment_id Attachment post ID.
 	 */
-	$threshold = (int) apply_filters( 'big_image_size_threshold', 2560, $imagesize, $file, $attachment_id );
+	$threshold = max(
+		2560,
+		...wp_list_pluck( wp_get_registered_image_subsizes(), 'width' )
+	);
+
+	$threshold = (int) apply_filters( 'big_image_size_threshold', $threshold, $imagesize, $file, $attachment_id );
 
 	/*
 	 * If the original image's dimensions are over the threshold,

--- a/src/wp-admin/includes/image.php
+++ b/src/wp-admin/includes/image.php
@@ -282,10 +282,7 @@ function wp_create_image_subsizes( $file, $attachment_id ) {
 	 * @param string $file          Full path to the uploaded image file.
 	 * @param int    $attachment_id Attachment post ID.
 	 */
-	$threshold = max(
-		2560,
-		...wp_list_pluck( wp_get_registered_image_subsizes(), 'width' )
-	);
+	$threshold = max( array_merge( array( 2560 ), wp_list_pluck( wp_get_registered_image_subsizes(), 'width' ) ) );
 
 	$threshold = (int) apply_filters( 'big_image_size_threshold', $threshold, $imagesize, $file, $attachment_id );
 

--- a/tests/phpunit/tests/media/wpGenerateAttachmentMetadata.php
+++ b/tests/phpunit/tests/media/wpGenerateAttachmentMetadata.php
@@ -8,7 +8,17 @@
  */
 class Tests_Media_wpGenerateAttachmentMetadata extends WP_UnitTestCase {
 
+	private $backup_additional_image_sizes;
+
+	public function set_up(): void {
+		parent::set_up();
+
+		$this->backup_additional_image_sizes = wp_get_additional_image_sizes();
+	}
+
 	public function tear_down() {
+		$GLOBALS['_wp_additional_image_sizes'] = $this->backup_additional_image_sizes;
+
 		$this->remove_added_uploads();
 
 		parent::tear_down();
@@ -99,6 +109,34 @@ class Tests_Media_wpGenerateAttachmentMetadata extends WP_UnitTestCase {
 		$metadata = wp_get_attachment_metadata( $attachment );
 
 		// Check that the full sized image with `-scaled` is created for the PNG.
+		$this->assertStringContainsString( '-scaled.png', basename( $metadata['file'] ) );
+	}
+
+	/**
+	 * Checks that the big image threshold considers registered image widths.
+	 *
+	 * @ticket 48489
+	 */
+	public function test_wp_generate_attachment_metadata_big_image_threshold_considers_registered_image_widths() {
+		add_image_size( 'test-size-width-threshold', 3000, 100, true );
+
+		$attachment = $this->factory->attachment->create_upload_object( DIR_TESTDATA . '/images/png-tests/test-image-large.png' );
+		$metadata   = wp_get_attachment_metadata( $attachment );
+
+		$this->assertStringNotContainsString( '-scaled.png', basename( $metadata['file'] ) );
+	}
+
+	/**
+	 * Checks that the big image threshold ignores registered image heights.
+	 *
+	 * @ticket 48489
+	 */
+	public function test_wp_generate_attachment_metadata_big_image_threshold_ignores_registered_image_heights() {
+		add_image_size( 'test-size-height-threshold', 100, 9999, true );
+
+		$attachment = $this->factory->attachment->create_upload_object( DIR_TESTDATA . '/images/png-tests/test-image-large.png' );
+		$metadata   = wp_get_attachment_metadata( $attachment );
+
 		$this->assertStringContainsString( '-scaled.png', basename( $metadata['file'] ) );
 	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

…

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->

This updates the default big_image_size_threshold calculation in wp_create_image_subsizes() so it accounts for registered image subsize widths before scaling large uploads. Instead of always starting from 2560, core now uses the larger of 2560 and the widest registered image size, while still ignoring height-only 9999 style definitions that are commonly used to mean “unbounded height.”
It also adds focused PHPUnit coverage to verify both behaviors: wide registered sizes prevent unnecessary -scaled generation, and height-only large values do not inflate the threshold.`n`n## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**

Trac ticket: https://core.trac.wordpress.org/ticket/48489

## Use of AI Tools

AI assistance: Yes
Tool(s): OpenAI Codex
Model(s): GPT-5
Used for: Reviewing the Trac ticket and relevant code, helping with the initial implementation and regression-test approach, and assisting with validation and PR-description drafting. The final implementation, tests, validation results, and description were reviewed and accepted by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**