### PR TITLE
Formatting: Reject leading, trailing, and consecutive dots in the email local part

### DIFF
--- a/src/wp-includes/class-wp-email-address.php
+++ b/src/wp-includes/class-wp-email-address.php
@@ -34,27 +34,53 @@
  */
 final class WP_Email_Address {
 	/**
-	 * Regex for the local part when Unicode is not enabled.
+	 * Pattern for a single ASCII local-part atom (no dot).
 	 *
-	 * Matches the character set from the WHATWG email specification:
+	 * Matches the character set from the WHATWG email specification, minus the
+	 * dot, which the dot-atom structure handles as a separator:
 	 * https://html.spec.whatwg.org/multipage/input.html#email-state-(type=email)
 	 *
 	 * @since 7.1.0
 	 * @var string
 	 */
-	const LOCAL_PART_ASCII_REGEX = '/^[a-zA-Z0-9.!#$%&\'*+\/=?^_`{|}~-]+$/';
+	const LOCAL_PART_ATOM_ASCII = '[a-zA-Z0-9!#$%&\'*+\/=?^_`{|}~-]+';
 
 	/**
-	 * Regex for the local part when Unicode is enabled.
+	 * Pattern for a single Unicode local-part atom (no dot).
 	 *
-	 * Extends the WHATWG character set to allow Unicode letters and numbers,
-	 * and applies the same grapheme-cluster structure used for domain labels:
-	 * each cluster must open with a non-combining character.
+	 * Extends the ASCII atom to allow Unicode letters and numbers, with the same
+	 * grapheme-cluster structure used for domain labels: each cluster must open
+	 * with a non-combining character, followed by zero or more combining marks.
 	 *
 	 * @since 7.1.0
 	 * @var string
 	 */
-	const LOCAL_PART_UNICODE_REGEX = '/^([\p{L}\p{N}.!#$%&\'*+\/=?^_`{|}~-]\p{M}*)+$/u';
+	const LOCAL_PART_ATOM_UNICODE = '(?:[\p{L}\p{N}!#$%&\'*+\/=?^_`{|}~-]\p{M}*)+';
+
+	/**
+	 * Regex for the local part when Unicode is not enabled.
+	 *
+	 * Assembled from {@see self::LOCAL_PART_ATOM_ASCII} as a dot-atom: one atom,
+	 * then zero or more dot-separated atoms. A leading dot, trailing dot, or two
+	 * consecutive dots are rejected, matching the stricter RFC 5321/5322 syntax
+	 * and PHP's FILTER_VALIDATE_EMAIL, because such addresses are undeliverable.
+	 *
+	 * @since 7.1.0
+	 * @var string
+	 */
+	const LOCAL_PART_ASCII_REGEX = '/^' . self::LOCAL_PART_ATOM_ASCII . '(?:\.' . self::LOCAL_PART_ATOM_ASCII . ')*$/';
+
+	/**
+	 * Regex for the local part when Unicode is enabled.
+	 *
+	 * Assembled from {@see self::LOCAL_PART_ATOM_UNICODE} as a dot-atom: one atom,
+	 * then zero or more dot-separated atoms. As with the ASCII variant, a leading
+	 * dot, trailing dot, or two consecutive dots are rejected.
+	 *
+	 * @since 7.1.0
+	 * @var string
+	 */
+	const LOCAL_PART_UNICODE_REGEX = '/^' . self::LOCAL_PART_ATOM_UNICODE . '(?:\.' . self::LOCAL_PART_ATOM_UNICODE . ')*$/u';
 
 	/**
 	 * Pattern for a single ASCII domain label (no dot).

--- a/tests/phpunit/tests/formatting/antispambot.php
+++ b/tests/phpunit/tests/formatting/antispambot.php
@@ -30,16 +30,16 @@ class Tests_Formatting_Antispambot extends WP_UnitTestCase {
 	 */
 	public function data_returns_valid_utf8() {
 		return array(
-			'plain'                => array( 'bob@example.com' ),
-			'plain with ip'        => array( 'ace@204.32.222.14' ),
-			'deep subdomain'       => array( 'kevin@many.subdomains.make.a.happy.man.edu' ),
-			'short address'        => array( 'a@b.co' ),
-			'ascii@nonascii'       => array( 'info@grå.org' ),
-			'nonascii@nonascii'    => array( 'grå@grå.org' ),
-			'decomposed unicode'   => array( "gr\u{0061}\u{030a}blå@grå.org" ),
-			'weird but legal dots' => array( '..@example.com' ),
-			'umlauts'              => array( 'bücher@gmx.de' ),
-			'three-byte UTF-8'     => array( "\u{FFFD}@who.knows.com" ),
+			'plain'              => array( 'bob@example.com' ),
+			'plain with ip'      => array( 'ace@204.32.222.14' ),
+			'deep subdomain'     => array( 'kevin@many.subdomains.make.a.happy.man.edu' ),
+			'short address'      => array( 'a@b.co' ),
+			'ascii@nonascii'     => array( 'info@grå.org' ),
+			'nonascii@nonascii'  => array( 'grå@grå.org' ),
+			'decomposed unicode' => array( "gr\u{0061}\u{030a}blå@grå.org" ),
+			'consecutive dots'   => array( '..@example.com' ),
+			'umlauts'            => array( 'bücher@gmx.de' ),
+			'three-byte UTF-8'   => array( "\u{FFFD}@who.knows.com" ),
 		);
 	}
 

--- a/tests/phpunit/tests/formatting/isEmail.php
+++ b/tests/phpunit/tests/formatting/isEmail.php
@@ -42,7 +42,6 @@ class Tests_Formatting_IsEmail extends WP_UnitTestCase {
 			'info@grå.org',
 			'grå@grå.org',
 			"gr\u{0061}\u{030a}blå@grå.org",
-			'..@example.com',
 		);
 
 		foreach ( $valid_emails as $email ) {
@@ -54,6 +53,7 @@ class Tests_Formatting_IsEmail extends WP_UnitTestCase {
 	 * Ensures that unrecognized email addresses are rejected.
 	 *
 	 * @ticket 31992
+	 * @ticket 55821
 	 *
 	 * @dataProvider data_invalid_email_provider
 	 *
@@ -120,6 +120,17 @@ class Tests_Formatting_IsEmail extends WP_UnitTestCase {
 			 */
 			"a\x80b@example.com",  // invalid UTF-8 in local part.
 			"abc@\x80.org",        // invalid UTF-8 in domain subdomain.
+
+			/*
+			 * The local part is a dot-atom: dots may only separate non-empty
+			 * atoms. Leading dots, trailing dots, and consecutive dots are
+			 * invalid per RFC 5321/5322 and PHP's FILTER_VALIDATE_EMAIL, so
+			 * such addresses are undeliverable and best rejected. See #55821.
+			 */
+			'abc..def@xyz.com', // consecutive dots in local part.
+			'.abc@xyz.com',     // leading dot in local part.
+			'abc.@xyz.com',     // trailing dot in local part.
+			'..@example.com',   // only dots in local part.
 		);
 
 		foreach ( $invalid_emails as $email ) {

--- a/tests/phpunit/tests/wp-email-address/wpEmailAddress.php
+++ b/tests/phpunit/tests/wp-email-address/wpEmailAddress.php
@@ -216,6 +216,40 @@ class Tests_WpEmailAddress extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that the local part is treated as a dot-atom, rejecting leading,
+	 * trailing, and consecutive dots.
+	 *
+	 * These addresses are invalid per the stricter RFC 5321/5322 syntax and
+	 * PHP's FILTER_VALIDATE_EMAIL, so WordPress cannot deliver mail to them.
+	 *
+	 * @ticket 55821
+	 *
+	 * @dataProvider data_invalid_local_part_dots
+	 * @covers WP_Email_Address::from_string
+	 *
+	 * @param string $address The invalid email address string.
+	 */
+	public function test_from_string_rejects_invalid_local_part_dots( $address ) {
+		$this->assertNull( WP_Email_Address::from_string( $address, 'unicode' ), 'Should reject in Unicode mode.' );
+		$this->assertNull( WP_Email_Address::from_string( $address, 'ascii' ), 'Should reject in ASCII mode.' );
+	}
+
+	/**
+	 * Data provider for local parts with invalid dot placement.
+	 *
+	 * @return array[]
+	 */
+	public function data_invalid_local_part_dots() {
+		return array(
+			'consecutive dots in local part' => array( 'abc..def@example.com' ),
+			'leading dot in local part'      => array( '.abc@example.com' ),
+			'trailing dot in local part'     => array( 'abc.@example.com' ),
+			'only dots in local part'        => array( '..@example.com' ),
+			'single dot as local part'       => array( '.@example.com' ),
+		);
+	}
+
+	/**
 	 * Data provider for several tests.
 	 *
 	 * @return array[]


### PR DESCRIPTION
## Description

`is_email( 'abc..def@xyz.com' )` returns the address as valid, even though the local part contains consecutive dots. PHP's `filter_var( …, FILTER_VALIDATE_EMAIL )` rejects it, and so does every SMTP server, because the address is undeliverable. The same applies to a leading dot (`.abc@xyz.com`) and a trailing dot (`abc.@xyz.com`).

Since [62225]/#31992, `is_email()` delegates to `WP_Email_Address::from_string()`, whose local-part patterns are derived from the WHATWG `<input type=email>` character set. That set places `.` in the character class with no positional constraint (`[…]+`), so any arrangement of dots passes. The domain side already validates correctly (each label must be bookended by an alphanumeric), so this only affected the local part.

This PR restructures the local part as a proper **dot-atom**, mirroring the existing domain-label design already in the class: a dot may only separate non-empty atoms. Leading, trailing, and consecutive dots are now rejected, while all previously valid addresses — including the intended Unicode addresses from #31992 (`grå@grå.org`) — continue to validate.

## Why reject these

This change is not a departure from #31992 — it implements a decision that ticket's discussion already reached. While reviewing test cases on #31992, [@agulbra noted](https://core.trac.wordpress.org/ticket/31992#comment:40):

> `to..to@couc.ou` and `to.@couc.ou` are invalid according to RFC 5321, therefore WordPress cannot send mail to them. Rejecting these is a good idea.

and [@peteresnick — the author of RFC 5322 — confirmed](https://core.trac.wordpress.org/ticket/31992#comment:43):

> Also invalid according to 5322 section 3 (the more restrictive) syntax.

The WHATWG character set was adopted as the *basis* for the allowed characters, but the agreed intent was to be at least as strict as the syntaxes used to *generate* and *deliver* mail, which forbid empty atoms in the local part. The shipped regex used the WHATWG `[…]+` shorthand verbatim and did not enforce that structure; this PR closes that gap.

## Implementation

- Add `LOCAL_PART_ATOM_ASCII` and `LOCAL_PART_ATOM_UNICODE` constants (the previous local-part character sets, minus the dot).
- Assemble `LOCAL_PART_ASCII_REGEX` / `LOCAL_PART_UNICODE_REGEX` as `atom (?:\. atom)*`, the same dot-separated structure already used by `DOMAIN_ASCII_REGEX` / `DOMAIN_UNICODE_REGEX`.

## Testing instructions

1. Apply the patch.
2. Confirm the following now return `false`:
   ```php
   is_email( 'abc..def@xyz.com' ); // consecutive dots
   is_email( '.abc@xyz.com' );     // leading dot
   is_email( 'abc.@xyz.com' );     // trailing dot
   ```
3. Confirm normal addresses still validate:
   ```php
   is_email( 'bob@example.com' );
   is_email( 'bill+ted@example.com' );
   is_email( 'a.b.c@example.com' ); 
   is_email( 'grå@grå.org' );
   ```
4. Or run the test suite:
   ```bash
   npm run test:php -- --group 55821
   npm run test:php -- --filter 'IsEmail|EmailAddress|Antispambot|SanitizeEmail'
   ```

### Unit tests

- **tests/formatting/isEmail.php**: Moved `..@example.com` from the valid provider to the invalid provider, added the leading/trailing/consecutive-dot cases, and tagged the test with `@ticket 55821`.
- **tests/wp-email-address/wpEmailAddress.php**: New `@ticket 55821` test asserting rejection in both unicode and ascii modes.
- **tests/formatting/antispambot.php**: Relabeled a now-inaccurate data-set key (`antispambot()` is obfuscation-only; behavior unchanged).

Trac ticket: https://core.trac.wordpress.org/ticket/55821

## Use of AI Tools

AI assistance: Yes — used to investigate the regression, cross-reference the #31992 discussion, draft the fix, and write the tests. All changes were reviewed and verified by me.

