### PR TITLE
Code Quality: Replace `is_double()` and `is_long()` aliases.

### DIFF
--- a/src/wp-admin/includes/class-ftp.php
+++ b/src/wp-admin/includes/class-ftp.php
@@ -278,7 +278,7 @@ class ftp_base {
 	}
 
 	function SetServer($host, $port=21, $reconnect=true) {
-		if(!is_long($port)) {
+		if(!is_int($port)) {
 	        $this->verbose=true;
     	    $this->SendMSG("Incorrect port syntax");
 			return FALSE;

--- a/src/wp-includes/IXR/class-IXR-value.php
+++ b/src/wp-includes/IXR/class-IXR-value.php
@@ -47,7 +47,7 @@ class IXR_Value {
         if (is_int($this->data)) {
             return 'int';
         }
-        if (is_double($this->data)) {
+        if (is_float($this->data)) {
             return 'double';
         }
 


### PR DESCRIPTION
The PHP 8.6 "[Deprecations for PHP 8.6](https://wiki.php.net/rfc/deprecations_php_8_6)" RFC proposes deprecating the legacy type-check aliases `is_double()`, `is_integer()`, and `is_long()` in favor of their canonical counterparts, with removal targeted for PHP 9.

Replace the two occurrences in core: 

* `is_double()` becomes `is_float()`
* `is_long()` becomes `is_int()`
 
Behavior is unchanged; the canonical functions are exact equivalents.

The remaining `is_integer()` usage lives in getID3 and has been fixed upstream; it will be picked up with the next library release.

Follow-up to [[62175](https://core.trac.wordpress.org/changeset/62175)].

Trac ticket: https://core.trac.wordpress.org/ticket/64913

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
