### PR TITLE
Fonts API: Replace `_doing_it_wrong()` with `wp_trigger_error()` in `WP_Font_Face`

### DIFF
--- a/src/wp-includes/fonts/class-wp-font-face.php
+++ b/src/wp-includes/fonts/class-wp-font-face.php
@@ -137,22 +137,18 @@ class WP_Font_Face {
 
 		// Check the font-family.
 		if ( empty( $font_face['font-family'] ) || ! is_string( $font_face['font-family'] ) ) {
-			// @todo replace with `wp_trigger_error()`.
-			_doing_it_wrong(
+			wp_trigger_error(
 				__METHOD__,
-				__( 'Font font-family must be a non-empty string.' ),
-				'6.4.0'
+				__( 'Font font-family must be a non-empty string.' )
 			);
 			return false;
 		}
 
 		// Make sure that local fonts have 'src' defined.
 		if ( empty( $font_face['src'] ) || ( ! is_string( $font_face['src'] ) && ! is_array( $font_face['src'] ) ) ) {
-			// @todo replace with `wp_trigger_error()`.
-			_doing_it_wrong(
+			wp_trigger_error(
 				__METHOD__,
-				__( 'Font src must be a non-empty string or an array of strings.' ),
-				'6.4.0'
+				__( 'Font src must be a non-empty string or an array of strings.' )
 			);
 			return false;
 		}
@@ -160,11 +156,9 @@ class WP_Font_Face {
 		// Validate the 'src' property.
 		foreach ( (array) $font_face['src'] as $src ) {
 			if ( empty( $src ) || ! is_string( $src ) ) {
-				// @todo replace with `wp_trigger_error()`.
-				_doing_it_wrong(
+				wp_trigger_error(
 					__METHOD__,
-					__( 'Each font src must be a non-empty string.' ),
-					'6.4.0'
+					__( 'Each font src must be a non-empty string.' )
 				);
 				return false;
 			}
@@ -172,11 +166,9 @@ class WP_Font_Face {
 
 		// Check the font-weight.
 		if ( ! is_string( $font_face['font-weight'] ) && ! is_int( $font_face['font-weight'] ) ) {
-			// @todo replace with `wp_trigger_error()`.
-			_doing_it_wrong(
+			wp_trigger_error(
 				__METHOD__,
-				__( 'Font font-weight must be a properly formatted string or integer.' ),
-				'6.4.0'
+				__( 'Font font-weight must be a properly formatted string or integer.' )
 			);
 			return false;
 		}


### PR DESCRIPTION
## Summary

Replaces four instances of `_doing_it_wrong()` with `wp_trigger_error()` in `WP_Font_Face::validate_font_face_declarations()`.

### Root Cause / Context

In [`src/wp-includes/fonts/class-wp-font-face.php`](https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-includes/fonts/class-wp-font-face.php), `_doing_it_wrong()` is currently used to trigger notices when invalid font face properties are encountered (e.g., missing or invalid `font-family`, `src`, or `font-weight`).

Above each of these occurrences is an inline comment:
`// @todo replace with wp_trigger_error().`

`wp_trigger_error()` was introduced in WordPress 6.4.0 (the same version `WP_Font_Face` was introduced). The new function is the modernized, preferred API for triggering developer notices in core. However, the initial `@todo` comments remained unresolved.

### Solution

- Replaced the four `_doing_it_wrong()` calls with `wp_trigger_error()` inside the `WP_Font_Face::validate_font_face_declarations()` method.
- Removed the inline `// @todo replace with wp_trigger_error().` comments.
- Omitted the 3rd argument since `wp_trigger_error()` defaults to `E_USER_NOTICE`, which accurately mirrors the exact error level behavior previously provided by `_doing_it_wrong()`.

## Testing

1. **Set up a local WordPress dev environment** (e.g. using `wp-env`, Local, or Docker).
2. **Enable `WP_DEBUG`** in your `wp-config.php`:
   ```php
   define( 'WP_DEBUG', true );
   ```
3. **Trigger an invalid font face declaration** by adding this code snippet to a `mu-plugins` file or your theme's `functions.php`:
   ```php
   add_action( 'init', function() {
       $font_face = new WP_Font_Face();
       
       // Pass an array of arrays to trigger the validation
       $font_face->generate_and_print( array(
           array(
               array(
                   'font-family' => '', 
                   'src'         => ''
               )
           )
       ) );
   } );
   ```
4. **Verify the PHP Notice**:
   Load any page on the frontend or backend. You should see a standard PHP notice generated by `wp_trigger_error()` in your `debug.log`:
   `Notice: WP_Font_Face::validate_font_face_declarations(): Font font-family must be a non-empty string.`
   The behavior should match exactly how it functioned prior to the patch, just utilizing the modern Core API.
5. **Run the PHPUnit tests for the class**:
   ```bash
   npm run test:php -- --filter WP_Font_Face
   ```

---

Trac Ticket: https://core.trac.wordpress.org/ticket/65475

---

| Test Case | Expected / Result | Status |
|---|---|---|
| `validate_font_face_declarations` with invalid properties | Triggers standard notice via `wp_trigger_error()` rather than `_doing_it_wrong()` | ✅ Passed |
| PHPUnit tests for `WP_Font_Face` | All tests pass successfully | ✅ Passed |
| PHPCS Linting (`composer lint src/wp-includes/fonts/class-wp-font-face.php`) | No syntax or coding standards errors | ✅ Passed |


## Use of AI Tools: 

None Used 


