### PR TITLE
Plugins: Expose author-scoped plugin search from the installed plugins screen

### DIFF
--- a/src/wp-admin/includes/class-wp-plugins-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugins-list-table.php
@@ -1292,6 +1292,21 @@ class WP_Plugins_List_Table extends WP_List_Table {
 						);
 					}
 
+					if ( ! empty( $plugin_data['AuthorName'] ) && current_user_can( 'install_plugins' ) ) {
+						$plugin_meta[] = sprintf(
+							'<a href="%s" aria-label="%s">%s</a>',
+							esc_url(
+								network_admin_url(
+									'plugin-install.php?tab=search&s=' . urlencode( $plugin_data['AuthorName'] )
+								)
+							),
+							/* translators: %s: Plugin author name. */
+							esc_attr( sprintf( __( 'Search for more plugins by %s' ), $plugin_data['AuthorName'] ) ),
+							/* translators: %s: Plugin author name. */
+							sprintf( __( 'View more plugins by %s' ), $plugin_data['AuthorName'] )
+						);
+					}
+
 					/**
 					 * Filters the array of row meta for each plugin in the Plugins list table.
 					 *

--- a/src/wp-admin/includes/class-wp-plugins-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugins-list-table.php
@@ -1293,7 +1293,7 @@ class WP_Plugins_List_Table extends WP_List_Table {
 					}
 
 					if ( ! empty( $plugin_data['AuthorName'] ) && isset( $plugin_data['slug'] ) && current_user_can( 'install_plugins' ) ) {
-						$author_name = wp_strip_all_tags( $plugin_data['AuthorName'] );
+						$author_name   = wp_strip_all_tags( $plugin_data['AuthorName'] );
 						$plugin_meta[] = sprintf(
 							'<a href="%s" aria-label="%s">%s</a>',
 							esc_url(

--- a/src/wp-admin/includes/class-wp-plugins-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugins-list-table.php
@@ -1292,18 +1292,19 @@ class WP_Plugins_List_Table extends WP_List_Table {
 						);
 					}
 
-					if ( ! empty( $plugin_data['AuthorName'] ) && current_user_can( 'install_plugins' ) ) {
+					if ( ! empty( $plugin_data['AuthorName'] ) && isset( $plugin_data['slug'] ) && current_user_can( 'install_plugins' ) ) {
+						$author_name = wp_strip_all_tags( $plugin_data['AuthorName'] );
 						$plugin_meta[] = sprintf(
 							'<a href="%s" aria-label="%s">%s</a>',
 							esc_url(
 								network_admin_url(
-									'plugin-install.php?tab=search&s=' . urlencode( $plugin_data['AuthorName'] )
+									'plugin-install.php?tab=search&s=' . urlencode( $author_name )
 								)
 							),
 							/* translators: %s: Plugin author name. */
-							esc_attr( sprintf( __( 'Search for more plugins by %s' ), $plugin_data['AuthorName'] ) ),
+							esc_attr( sprintf( __( 'Search for more plugins by %s' ), $author_name ) ),
 							/* translators: %s: Plugin author name. */
-							sprintf( __( 'View more plugins by %s' ), $plugin_data['AuthorName'] )
+							esc_html( sprintf( __( 'View more plugins by %s' ), $author_name ) )
 						);
 					}
 


### PR DESCRIPTION

Trac ticket: https://core.trac.wordpress.org/ticket/65459


This PR adds a "View more plugins by {Author}" link to the row meta on the Installed Plugins screen.

It appends a "View more plugins by [Author]" link to the plugin metadata row (alongside "Version" and "View details"). When clicked, this link directs the user to the "Add Plugins" screen, pre-filtered for the selected author.

Instead of aggregating multiple authors into a single "Trusted Authors" tab (which introduces severe N+1 query performance bottlenecks with the WordPress.org API), this context-aware link utilizes the existing author search functionality (`?tab=search&s=[AuthorName]`). 

`AuthorName` is passed through `wp_strip_all_tags()` before interpolation, producing a clean search term in the URL and consistent output across the `aria-label` and visible text. The block is guarded by `current_user_can( 'install_plugins' )`, consistent with the adjacent Details link, and is inserted before `apply_filters( 'plugin_row_meta', ... )` so third-party code retains full control over its presence.
