### PR TITLE
Site Health: Fix incorrect persistent object cache documentation link anchor.

### DIFF
--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -2578,7 +2578,7 @@ class WP_Site_Health {
 		$action_url = apply_filters(
 			'site_status_persistent_object_cache_url',
 			/* translators: Localized Support reference. */
-			__( 'https://developer.wordpress.org/advanced-administration/performance/optimization/#persistent-object-cache' )
+			__( 'https://developer.wordpress.org/advanced-administration/performance/optimization/#object-caching' )
 		);
 
 		$result = array(


### PR DESCRIPTION
### Description
This PR addresses [Trac Ticket #65477](https://core.trac.wordpress.org/ticket/65477) by fixing a broken anchor link in the Site Health tool.

The "Learn more about persistent object caching" link previously directed users to `https://developer.wordpress.org/advanced-administration/performance/optimization/#persistent-object-cache`. This anchor is incorrect and does not work. 

This update changes the anchor to the correct one: `#object-caching`.

### Testing Instructions
1. Navigate to **Tools > Site Health** in your WordPress admin dashboard.
2. If your local environment is not using a persistent object cache, you should see the recommended improvement: "You should use a persistent object cache".
3. Click the link "Learn more about persistent object caching."
4. Verify that the link correctly redirects to the specific `#object-caching` section on the Advanced Administration documentation page.