### PR TITLE
Block Bindings: Enable native List Item content binding

### DIFF
--- a/src/wp-includes/block-bindings.php
+++ b/src/wp-includes/block-bindings.php
@@ -134,6 +134,7 @@ function get_block_bindings_source( string $source_name ) {
  * Retrieves the list of block attributes supported by block bindings.
  *
  * @since 6.9.0
+ * @since 7.1.0 Added support for the List Item block.
  *
  * @param string $block_type The block type whose supported attributes are being retrieved.
  * @return array The list of block attributes that are supported by block bindings.
@@ -142,6 +143,7 @@ function get_block_bindings_supported_attributes( $block_type ) {
 	$block_bindings_supported_attributes = array(
 		'core/paragraph'          => array( 'content' ),
 		'core/heading'            => array( 'content' ),
+		'core/list-item'          => array( 'content' ),
 		'core/image'              => array( 'id', 'url', 'title', 'alt', 'caption' ),
 		'core/button'             => array( 'url', 'text', 'linkTarget', 'rel' ),
 		'core/post-date'          => array( 'datetime' ),

--- a/tests/phpunit/tests/block-bindings/render.php
+++ b/tests/phpunit/tests/block-bindings/render.php
@@ -122,6 +122,16 @@ HTML
 				,
 				'<p>test source value</p>',
 			),
+			'list item block' => array(
+				'content',
+				<<<HTML
+<!-- wp:list-item -->
+<li>This should not appear</li>
+<!-- /wp:list-item -->
+HTML
+				,
+				'<li>test source value</li>',
+			),
 		);
 	}
 


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65406

Adds `core/list-item` to the block attributes supported by block bindings, so a List Item's `content` rich text can be bound.

**Clean enablement — no render changes.** Lands first. Tests cover the basic (non-nested) List Item binding, which needs no render-side change.

A List Item that contains a nested List keeps both inside the same `<li>`; preserving that nested list when `content` is bound is the inner-block fix in **#12113** (stacked on this PR).

The fix can live for different blocks rather than the list-item. That's why I'm committing in a different PR for project hygiene.

- Gutenberg counterpart: WordPress/gutenberg#78947
- Supersedes #12084 by @sauliusv.