### PR TITLE
Refactor wp_parse_url to use WHATWG URL parser

### DIFF
--- a/src/wp-includes/compat.php
+++ b/src/wp-includes/compat.php
@@ -384,10 +384,3 @@ if ( ! defined( 'IMAGETYPE_WEBP' ) ) {
 if ( ! defined( 'IMG_WEBP' ) ) {
 	define( 'IMG_WEBP', IMAGETYPE_WEBP ); // phpcs:ignore PHPCompatibility.Constants.NewConstants.imagetype_webpFound
 }
-
-// Set WP_PARSE_URL_USE_WHATWG constant is available in PHP 8.5 or later.
-if ( class_exists( 'Uri\\WhatWg\\Url', false ) ) {
-	define( 'WP_PARSE_URL_USE_WHATWG', true );
-} else {
-	define( 'WP_PARSE_URL_USE_WHATWG', false );
-}

--- a/src/wp-includes/compat.php
+++ b/src/wp-includes/compat.php
@@ -384,3 +384,10 @@ if ( ! defined( 'IMAGETYPE_WEBP' ) ) {
 if ( ! defined( 'IMG_WEBP' ) ) {
 	define( 'IMG_WEBP', IMAGETYPE_WEBP ); // phpcs:ignore PHPCompatibility.Constants.NewConstants.imagetype_webpFound
 }
+
+// Set WP_PARSE_URL_USE_WHATWG constant is available in PHP 8.5 or later.
+if ( class_exists( 'Uri\\WhatWg\\Url', false ) ) {
+	define( 'WP_PARSE_URL_USE_WHATWG', true );
+} else {
+	define( 'WP_PARSE_URL_USE_WHATWG', false );
+}

--- a/src/wp-includes/http.php
+++ b/src/wp-includes/http.php
@@ -641,6 +641,100 @@ function ms_allowed_http_request_hosts( $is_external, $host ) {
 }
 
 /**
+ * Parses URL components using PHP's WHATWG URL parser.
+ *
+ * @since 7.1.0
+ * @access private
+ *
+ * @param string $url URL to parse.
+ * @return array|false Array of URL components, or false on failure.
+ */
+function _wp_parse_url_components_whatwg( $url ) {
+	$parsed = \Uri\WhatWg\Url::parse( $url );
+
+	if ( null === $parsed ) {
+		return false;
+	}
+
+	$parts = array();
+
+	$scheme = $parsed->getScheme();
+	if ( null !== $scheme ) {
+		$parts['scheme'] = $scheme;
+	}
+
+	$host = $parsed->getAsciiHost();
+	if ( null !== $host ) {
+		$parts['host'] = $host;
+	}
+
+	$port = $parsed->getPort();
+	if ( null !== $port ) {
+		$parts['port'] = $port;
+	}
+
+	$user = $parsed->getUsername();
+	if ( null !== $user && '' !== $user ) {
+		$parts['user'] = $user;
+	}
+
+	$pass = $parsed->getPassword();
+	if ( null !== $pass && '' !== $pass ) {
+		$parts['pass'] = $pass;
+	}
+
+	$path = $parsed->getPath();
+
+	/*
+	 * WHATWG URLs normalize an empty path on special URLs to "/".
+	 * parse_url( 'https://example.com' ) does not return a path.
+	 */
+	if ( '' !== $path && ! ( '/' === $path && ! preg_match( '#^[a-z][a-z0-9+.-]*://[^/?#]+/#i', $url ) ) ) {
+		$parts['path'] = $path;
+	}
+
+	$query = $parsed->getQuery();
+	if ( null !== $query ) {
+		$parts['query'] = $query;
+	}
+
+	$fragment = $parsed->getFragment();
+	if ( null !== $fragment ) {
+		$parts['fragment'] = $fragment;
+	}
+
+	return $parts;
+}
+
+if ( class_exists( 'Uri\\WhatWg\\Url', false ) ) {
+	/**
+	 * Parses URL components.
+	 *
+	 * @since 7.1.0
+	 * @access private
+	 *
+	 * @param string $url URL to parse.
+	 * @return array|false Array of URL components, or false on failure.
+	 */
+	function _wp_parse_url_components( $url ) {
+		return _wp_parse_url_components_whatwg( $url );
+	}
+} else {
+	/**
+	 * Parses URL components.
+	 *
+	 * @since 7.1.0
+	 * @access private
+	 *
+	 * @param string $url URL to parse.
+	 * @return array|false Array of URL components, or false on failure.
+	 */
+	function _wp_parse_url_components( $url ) {
+		return parse_url( $url );
+	}
+}
+
+/**
  * A wrapper for PHP's parse_url() function that handles consistency in the return
  * values across PHP versions.
  *
@@ -654,6 +748,7 @@ function ms_allowed_http_request_hosts( $is_external, $host ) {
  *
  * @since 4.4.0
  * @since 4.7.0 The `$component` parameter was added for parity with PHP's `parse_url()`.
+ * @since 7.1.0 Use helper function to utilize PHP's WHATWG URL parser if available (PHP 8.5+)
  *
  * @link https://www.php.net/manual/en/function.parse-url.php
  *
@@ -666,88 +761,30 @@ function ms_allowed_http_request_hosts( $is_external, $host ) {
  *               doesn't exist in the given URL; a string or - in the case of
  *               PHP_URL_PORT - integer when it does. See parse_url()'s return values.
  */
-if ( class_exists( 'Uri\\WhatWg\\Url', false ) ) {
+function wp_parse_url( $url, $component = -1 ) {
+	$to_unset = array();
+	$url      = (string) $url;
 
-	// WHATWG implementation (PHP 8.5+).
-	function wp_parse_url( $url, $component = -1 ) {
-
-		$to_unset = array();
-		$url      = (string) $url;
-
-		if ( str_starts_with( $url, '//' ) ) {
-			$to_unset[] = 'scheme';
-			$url        = 'placeholder:' . $url;
-		} elseif ( str_starts_with( $url, '/' ) ) {
-			$to_unset[] = 'scheme';
-			$to_unset[] = 'host';
-			$url        = 'placeholder://placeholder' . $url;
-		}
-
-		$parsed = \Uri\WhatWg\Url::parse( $url );
-
-		// Parsing failure.
-		if ( null === $parsed ) {
-			return false;
-		}
-
-		$parts = array();
-
-		foreach (
-			array(
-				'scheme'   => $parsed->getScheme(),
-				'host'     => $parsed->getAsciiHost(),
-				'port'     => $parsed->getPort(),
-				'user'     => $parsed->getUsername(),
-				'pass'     => $parsed->getPassword(),
-				'path'     => $parsed->getPath(),
-				'query'    => $parsed->getQuery(),
-				'fragment' => $parsed->getFragment(),
-			)
-			as $key => $value
-		) {
-			if ( null !== $value && '' !== $value ) {
-				$parts[ $key ] = $value;
-			}
-		}
-
-		// Remove the placeholder values.
-		foreach ( $to_unset as $key ) {
-			unset( $parts[ $key ] );
-		}
-
-		return _get_component_from_parsed_url_array( $parts, $component );
+	if ( str_starts_with( $url, '//' ) ) {
+		$to_unset[] = 'scheme';
+		$url        = 'placeholder:' . $url;
+	} elseif ( str_starts_with( $url, '/' ) ) {
+		$to_unset[] = 'scheme';
+		$to_unset[] = 'host';
+		$url        = 'placeholder://placeholder' . $url;
 	}
-} else {
 
-	// Legacy parse_url implementation.
-	function wp_parse_url( $url, $component = -1 ) {
+	$parts = _wp_parse_url_components( $url );
 
-		$to_unset = array();
-		$url      = (string) $url;
-
-		if ( str_starts_with( $url, '//' ) ) {
-			$to_unset[] = 'scheme';
-			$url        = 'placeholder:' . $url;
-		} elseif ( str_starts_with( $url, '/' ) ) {
-			$to_unset[] = 'scheme';
-			$to_unset[] = 'host';
-			$url        = 'placeholder://placeholder' . $url;
-		}
-
-		$parts = parse_url( $url );
-
-		if ( false === $parts ) {
-			// Parsing failure.
-			return $parts;
-		}
-
-		// Remove the placeholder values.
-		foreach ( $to_unset as $key ) {
-			unset( $parts[ $key ] );
-		}
-
-		return _get_component_from_parsed_url_array( $parts, $component );
+	if ( false === $parts ) {
+		return false;
 	}
+
+	foreach ( $to_unset as $key ) {
+		unset( $parts[ $key ] );
+	}
+
+	return _get_component_from_parsed_url_array( $parts, $component );
 }
 
 /**

--- a/src/wp-includes/http.php
+++ b/src/wp-includes/http.php
@@ -670,20 +670,74 @@ function wp_parse_url( $url, $component = -1 ) {
 	$to_unset = array();
 	$url      = (string) $url;
 
-	if ( '//' === substr( $url, 0, 2 ) ) {
+	if ( str_starts_with( $url, '//' ) ) {
 		$to_unset[] = 'scheme';
 		$url        = 'placeholder:' . $url;
-	} elseif ( '/' === substr( $url, 0, 1 ) ) {
+	} elseif ( str_starts_with( $url, '/' ) ) {
 		$to_unset[] = 'scheme';
 		$to_unset[] = 'host';
 		$url        = 'placeholder://placeholder' . $url;
 	}
 
-	$parts = parse_url( $url );
+	/*
+	 * PHP 8.5+: Prefer the WHATWG URL parser.
+	 */
+	if ( class_exists( 'Uri\\WhatWg\\Url' ) ) {
+		$parsed = \Uri\WhatWg\Url::parse( $url );
 
-	if ( false === $parts ) {
 		// Parsing failure.
-		return $parts;
+		if ( null === $parsed ) {
+			return false;
+		}
+
+		$parts = array();
+
+		$scheme = $parsed->getScheme();
+		if ( null !== $scheme ) {
+			$parts['scheme'] = $scheme;
+		}
+
+		$host = $parsed->getAsciiHost();
+		if ( null !== $host ) {
+			$parts['host'] = $host;
+		}
+
+		$port = $parsed->getPort();
+		if ( null !== $port ) {
+			$parts['port'] = $port;
+		}
+
+		$user = $parsed->getUsername();
+		if ( null !== $user ) {
+			$parts['user'] = $user;
+		}
+
+		$pass = $parsed->getPassword();
+		if ( null !== $pass ) {
+			$parts['pass'] = $pass;
+		}
+
+		$path = $parsed->getPath();
+		if ( '' !== $path ) {
+			$parts['path'] = $path;
+		}
+
+		$query = $parsed->getQuery();
+		if ( null !== $query ) {
+			$parts['query'] = $query;
+		}
+
+		$fragment = $parsed->getFragment();
+		if ( null !== $fragment ) {
+			$parts['fragment'] = $fragment;
+		}
+	} else {
+		$parts = parse_url( $url );
+
+		// Parsing failure.
+		if ( false === $parts ) {
+			return false;
+		}
 	}
 
 	// Remove the placeholder values.

--- a/src/wp-includes/http.php
+++ b/src/wp-includes/http.php
@@ -679,10 +679,7 @@ function wp_parse_url( $url, $component = -1 ) {
 		$url        = 'placeholder://placeholder' . $url;
 	}
 
-	/*
-	 * PHP 8.5+: Prefer the WHATWG URL parser.
-	 */
-	if ( class_exists( 'Uri\\WhatWg\\Url' ) ) {
+	if ( WP_PARSE_URL_USE_WHATWG ) {
 		$parsed = \Uri\WhatWg\Url::parse( $url );
 
 		// Parsing failure.
@@ -692,48 +689,26 @@ function wp_parse_url( $url, $component = -1 ) {
 
 		$parts = array();
 
-		$scheme = $parsed->getScheme();
-		if ( null !== $scheme ) {
-			$parts['scheme'] = $scheme;
-		}
-
-		$host = $parsed->getAsciiHost();
-		if ( null !== $host ) {
-			$parts['host'] = $host;
-		}
-
-		$port = $parsed->getPort();
-		if ( null !== $port ) {
-			$parts['port'] = $port;
-		}
-
-		$user = $parsed->getUsername();
-		if ( null !== $user ) {
-			$parts['user'] = $user;
-		}
-
-		$pass = $parsed->getPassword();
-		if ( null !== $pass ) {
-			$parts['pass'] = $pass;
-		}
-
-		$path = $parsed->getPath();
-		if ( '' !== $path ) {
-			$parts['path'] = $path;
-		}
-
-		$query = $parsed->getQuery();
-		if ( null !== $query ) {
-			$parts['query'] = $query;
-		}
-
-		$fragment = $parsed->getFragment();
-		if ( null !== $fragment ) {
-			$parts['fragment'] = $fragment;
+		foreach (
+			array(
+				'scheme'   => $parsed->getScheme(),
+				'host'     => $parsed->getAsciiHost(),
+				'port'     => $parsed->getPort(),
+				'user'     => $parsed->getUsername(),
+				'pass'     => $parsed->getPassword(),
+				'path'     => $parsed->getPath(),
+				'query'    => $parsed->getQuery(),
+				'fragment' => $parsed->getFragment(),
+			)
+			as $key => $value
+		) {
+			if ( null !== $value && '' !== $value ) {
+				$parts[ $key ] = $value;
+			}
 		}
 	} else {
 		$parts = parse_url( $url );
-
+		
 		// Parsing failure.
 		if ( false === $parts ) {
 			return false;

--- a/src/wp-includes/http.php
+++ b/src/wp-includes/http.php
@@ -666,20 +666,23 @@ function ms_allowed_http_request_hosts( $is_external, $host ) {
  *               doesn't exist in the given URL; a string or - in the case of
  *               PHP_URL_PORT - integer when it does. See parse_url()'s return values.
  */
-function wp_parse_url( $url, $component = -1 ) {
-	$to_unset = array();
-	$url      = (string) $url;
+if ( class_exists( 'Uri\\WhatWg\\Url', false ) ) {
 
-	if ( str_starts_with( $url, '//' ) ) {
-		$to_unset[] = 'scheme';
-		$url        = 'placeholder:' . $url;
-	} elseif ( str_starts_with( $url, '/' ) ) {
-		$to_unset[] = 'scheme';
-		$to_unset[] = 'host';
-		$url        = 'placeholder://placeholder' . $url;
-	}
+	// WHATWG implementation (PHP 8.5+).
+	function wp_parse_url( $url, $component = -1 ) {
 
-	if ( WP_PARSE_URL_USE_WHATWG ) {
+		$to_unset = array();
+		$url      = (string) $url;
+
+		if ( str_starts_with( $url, '//' ) ) {
+			$to_unset[] = 'scheme';
+			$url        = 'placeholder:' . $url;
+		} elseif ( str_starts_with( $url, '/' ) ) {
+			$to_unset[] = 'scheme';
+			$to_unset[] = 'host';
+			$url        = 'placeholder://placeholder' . $url;
+		}
+
 		$parsed = \Uri\WhatWg\Url::parse( $url );
 
 		// Parsing failure.
@@ -706,21 +709,45 @@ function wp_parse_url( $url, $component = -1 ) {
 				$parts[ $key ] = $value;
 			}
 		}
-	} else {
-		$parts = parse_url( $url );
-		
-		// Parsing failure.
-		if ( false === $parts ) {
-			return false;
+
+		// Remove the placeholder values.
+		foreach ( $to_unset as $key ) {
+			unset( $parts[ $key ] );
 		}
-	}
 
-	// Remove the placeholder values.
-	foreach ( $to_unset as $key ) {
-		unset( $parts[ $key ] );
+		return _get_component_from_parsed_url_array( $parts, $component );
 	}
+} else {
 
-	return _get_component_from_parsed_url_array( $parts, $component );
+	// Legacy parse_url implementation.
+	function wp_parse_url( $url, $component = -1 ) {
+
+		$to_unset = array();
+		$url      = (string) $url;
+
+		if ( str_starts_with( $url, '//' ) ) {
+			$to_unset[] = 'scheme';
+			$url        = 'placeholder:' . $url;
+		} elseif ( str_starts_with( $url, '/' ) ) {
+			$to_unset[] = 'scheme';
+			$to_unset[] = 'host';
+			$url        = 'placeholder://placeholder' . $url;
+		}
+
+		$parts = parse_url( $url );
+
+		if ( false === $parts ) {
+			// Parsing failure.
+			return $parts;
+		}
+
+		// Remove the placeholder values.
+		foreach ( $to_unset as $key ) {
+			unset( $parts[ $key ] );
+		}
+
+		return _get_component_from_parsed_url_array( $parts, $component );
+	}
 }
 
 /**


### PR DESCRIPTION
Refactor wp_parse_url to use WHATWG URL parser introduced in PHP 8.5. 

Trac ticket: https://core.trac.wordpress.org/ticket/65448
Trac ticket: Core-65448

## Use of AI Tools

AI assistance: Yes
Tool(s): Codex
Model(s): GPT-5.5 (Medium)
Used for: Implementation - reviewed and edited by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
