### PR TITLE
Update maintenance mode message wording

### DIFF
--- a/src/wp-includes/load.php
+++ b/src/wp-includes/load.php
@@ -414,7 +414,7 @@ function wp_maintenance() {
 	header( 'Retry-After: 600' );
 
 	wp_die(
-		__( 'Briefly unavailable for scheduled maintenance. Check back in a minute.' ),
+		__( 'Briefly unavailable for scheduled maintenance. Check back shortly.' ),
 		__( 'Maintenance' ),
 		503
 	);


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/35530

## Summary
- Updates the default maintenance-mode message from “Check back in a minute.” to “Check back shortly.”

## Why
The default maintenance response sends `Retry-After: 600`, and `wp_is_maintenance_mode()` can continue blocking normal boot while the timestamped `.maintenance` lockfile is less than 10 minutes old. In normal successful updates the interruption is usually much shorter, but in common interrupted-update cases “in a minute” can be objectively misleading.

“Shortly” keeps the message concise without promising a specific duration.

## Testing
- `php -l src/wp-includes/load.php`
