### PR TITLE
Media: Allow removing the srcset attribute in wp_get_attachment_image()

### DIFF
--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -1153,8 +1153,12 @@ function wp_get_attachment_image( $attachment_id, $size = 'thumbnail', $icon = f
 			unset( $attr['fetchpriority'] );
 		}
 
-		// Generate 'srcset' and 'sizes' if not already present.
-		if ( empty( $attr['srcset'] ) ) {
+		// If srcset is set to false, it should be omitted.
+		if ( isset( $attr['srcset'] ) && false === $attr['srcset'] ) {
+			unset( $attr['srcset'] );
+			unset( $attr['sizes'] );
+		} elseif ( empty( $attr['srcset'] ) ) {
+			// Generate 'srcset' and 'sizes' if not already present and srcset is not set to false.
 			$image_meta = wp_get_attachment_metadata( $attachment_id );
 
 			if ( is_array( $image_meta ) ) {
@@ -1169,6 +1173,12 @@ function wp_get_attachment_image( $attachment_id, $size = 'thumbnail', $icon = f
 						$attr['sizes'] = $sizes;
 					}
 				}
+			}
+
+			// If after trying to generate it, it's still empty, omit it.
+			if ( empty( $attr['srcset'] ) ) {
+				unset( $attr['srcset'] );
+				unset( $attr['sizes'] );
 			}
 		}
 

--- a/tests/phpunit/tests/media/wpGetAttachmentImage.php
+++ b/tests/phpunit/tests/media/wpGetAttachmentImage.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * @group media
+ */
+class Tests_Media_WpGetAttachmentImage extends WP_UnitTestCase {
+
+	/**
+	 * @ticket 43070
+	 */
+	public function test_wp_get_attachment_image_should_not_include_sizes_when_srcset_is_disabled() {
+		$file          = DIR_TESTDATA . '/images/canola.jpg';
+		$attachment_id = $this->factory->attachment->create_upload_object( $file, 0 );
+
+		$html = wp_get_attachment_image( $attachment_id, 'thumbnail', false, array( 'srcset' => false ) );
+
+		wp_delete_attachment( $attachment_id, true );
+
+		$this->assertStringNotContainsString( 'srcset=', $html, 'The srcset attribute should not be rendered.' );
+		$this->assertStringNotContainsString( 'sizes=', $html, 'The sizes attribute should not be rendered when srcset is absent.' );
+	}
+}


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->
This PR enhances the wp_get_attachment_image() function by allowing developers to explicitly remove the srcset (and sizes) attributes from the generated image tag. This is achieved by setting the respective attribute value to false in the function call.
Includes a PHPUnit test to cover this new behavior.

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->
https://core.trac.wordpress.org/ticket/43070
## Use of AI Tools
AI assistance: Yes
Tool(s): Gemini
Model(s): Gemini 3.5 Flash
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
