### PR TITLE
Admin: Keep `#wpfooter` visible on mobile viewports for accessibility.

### DIFF
--- a/src/wp-admin/css/admin-menu.css
+++ b/src/wp-admin/css/admin-menu.css
@@ -671,6 +671,10 @@ li#wp-admin-bar-menu-toggle {
 		padding-left: 10px;
 	}
 
+	.auto-fold #wpfooter {
+		margin-left: 0;
+	}
+
 	.sticky-menu #adminmenuwrap {
 		position: relative;
 		z-index: auto;

--- a/src/wp-admin/css/admin-menu.css
+++ b/src/wp-admin/css/admin-menu.css
@@ -665,14 +665,14 @@ li#wp-admin-bar-menu-toggle {
 }
 
 @media screen and (max-width: 782px) {
-	.auto-fold #wpcontent {
+	.auto-fold #wpcontent,
+	.auto-fold #wpfooter {
 		position: relative;
 		margin-left: 0;
-		padding-left: 10px;
 	}
 
-	.auto-fold #wpfooter {
-		margin-left: 0;
+	.auto-fold #wpcontent {
+		padding-left: 10px;
 	}
 
 	.sticky-menu #adminmenuwrap {

--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -4220,9 +4220,6 @@ img {
 		margin-bottom: 0;
 	}
 
-	#wpfooter {
-		margin-left: 0;
-	}
 
 	#comments-form .checkforspam {
 		display: none;

--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -4221,7 +4221,7 @@ img {
 	}
 
 	#wpfooter {
-		display: none;
+		margin-left: 0;
 	}
 
 	#comments-form .checkforspam {


### PR DESCRIPTION

Trac ticket: https://core.trac.wordpress.org/ticket/65488

Currently, `#wpfooter` is intentionally hidden on viewports `max-width: 782px` using `display: none;`. However, when users with low vision zoom their browser to 200% or more on a desktop, the browser effectively reduces the CSS viewport width, triggering this mobile media query and hiding the footer. This is a failure of **WCAG 1.4.10 Reflow (Level AA)** as they lose access to important links, plugin additions, and version information.

This PR removes the `display: none;` rule inside the `782px` media query in `common.css`. To ensure the footer aligns correctly on mobile without overlapping the collapsed side menu, a `margin-left: 0;` rule is applied to `.auto-fold #wpfooter` in `admin-menu.css`.

Hiding core semantic elements based purely on screen size creates unnecessary barriers for users relying on browser zoom, violating Level AA accessibility guidelines.

### Before


https://github.com/user-attachments/assets/c1c81607-1d38-42a0-a07f-f06295051cc5



### After


https://github.com/user-attachments/assets/391efea3-4412-424e-bf9e-0d8d11d6b229




