### PR TITLE
Use wp_rand() for multisite admin email confirmation token generation

### DIFF
--- a/src/wp-includes/ms-functions.php
+++ b/src/wp-includes/ms-functions.php
@@ -2785,7 +2785,7 @@ function update_network_option_new_admin_email( $old_value, $value ) {
 		return;
 	}
 
-	$hash            = md5( $value . time() . mt_rand() );
+	$hash            = md5( $value . time() . wp_rand() );
 	$new_admin_email = array(
 		'hash'     => $hash,
 		'newemail' => $value,


### PR DESCRIPTION
Replace `mt_rand()` with `wp_rand()` when generating the confirmation token in `update_network_option_new_admin_email()`.

This aligns multisite behavior with the security hardening previously applied to similar email-change confirmation flows in core.

## Background

The confirmation token is currently generated using:

```php
md5( $value . time() . mt_rand() );
```

While the token includes additional inputs, `mt_rand()` is not intended for security-sensitive randomness.

WordPress previously hardened similar email-change confirmation token generation by replacing `mt_rand()` with `wp_rand()` in:

* `update_option_new_admin_email()`
* `send_confirmation_on_profile_email()`

This change applies the same approach to the multisite/network equivalent function, ensuring consistency across all email-change confirmation workflows.

## Changes

```diff
- $hash = md5( $value . time() . mt_rand() );
+ $hash = md5( $value . time() . wp_rand() );
```

## Testing

* Confirmed the admin email change workflow continues to generate and validate confirmation tokens correctly.
* Verified no syntax errors.
* Verified `wp_rand()` is available when the hook executes.
* Existing token verification logic remains unchanged.
