### PR TITLE
Build/Test Tools: Support multiple built file change patches

### DIFF
--- a/.github/workflows/commit-built-file-changes.yml
+++ b/.github/workflows/commit-built-file-changes.yml
@@ -44,7 +44,8 @@ jobs:
       # generated below, so `GITHUB_TOKEN` only needs read access to the triggering workflow's artifacts.
       actions: read # Required to list and download the artifact uploaded by the triggering workflow run.
     steps:
-      - name: Download artifact
+      - name: Download artifacts
+        id: download-artifacts
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
@@ -54,43 +55,48 @@ jobs:
                run_id: process.env.RUN_ID,
             } );
 
-            const matchArtifact = artifacts.data.artifacts.filter( ( artifact ) => {
-              return artifact.name === 'pr-built-file-changes'
-            } )[0];
+            // Patches are uploaded with the `pr-built-file-changes` prefix. A single triggering
+            // workflow run can produce more than one (for example, one per default theme).
+            const matchArtifacts = artifacts.data.artifacts.filter( ( artifact ) => {
+              return artifact.name.startsWith( 'pr-built-file-changes' );
+            } );
 
-            if ( ! matchArtifact ) {
-              core.info( 'No artifact found!' );
+            if ( matchArtifacts.length === 0 ) {
+              core.info( 'No artifacts found!' );
+              core.setOutput( 'artifacts-found', 'false' );
               return;
             }
 
-            const download = await github.rest.actions.downloadArtifact( {
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               artifact_id: matchArtifact.id,
-               archive_format: 'zip',
-            } );
-
             const fs = require( 'fs' );
-            fs.writeFileSync( '${{ github.workspace }}/pr-built-file-changes.zip', Buffer.from( download.data ) )
+            const path = require( 'path' );
+            const downloadDir = path.join( process.env.GITHUB_WORKSPACE, 'built-file-changes' );
+            fs.mkdirSync( downloadDir, { recursive: true } );
+
+            for ( const artifact of matchArtifacts ) {
+              const download = await github.rest.actions.downloadArtifact( {
+                 owner: context.repo.owner,
+                 repo: context.repo.repo,
+                 artifact_id: artifact.id,
+                 archive_format: 'zip',
+              } );
+
+              fs.writeFileSync( path.join( downloadDir, `${ artifact.name }.zip` ), Buffer.from( download.data ) );
+            }
+
+            core.setOutput( 'artifacts-found', 'true' );
         env:
           RUN_ID: ${{ github.event.workflow_run.id }}
 
-      - name: Check for artifact
-        id: artifact-check
+      - name: Unzip the artifacts containing the PR data
+        if: ${{ steps.download-artifacts.outputs.artifacts-found == 'true' }}
         run: |
-          if [ -f "pr-built-file-changes.zip" ]; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Unzip the artifact containing the PR data
-        if: ${{ steps.artifact-check.outputs.exists == 'true' }}
-        run: unzip pr-built-file-changes.zip
+          for zip in built-file-changes/*.zip; do
+            unzip "${zip}" -d "${zip%.zip}"
+          done
 
       - name: Generate Installation Token
         id: generate_token
-        if: ${{ steps.artifact-check.outputs.exists == 'true' }}
+        if: ${{ steps.download-artifacts.outputs.artifacts-found == 'true' }}
         env:
           GH_APP_ID: ${{ vars.GH_PR_BUILT_FILES_APP_ID }}
           GH_APP_PRIVATE_KEY: ${{ secrets.GH_PR_BUILT_FILES_PRIVATE_KEY }}
@@ -121,7 +127,7 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        if: ${{ steps.artifact-check.outputs.exists == 'true' }}
+        if: ${{ steps.download-artifacts.outputs.artifacts-found == 'true' }}
         with:
           repository: ${{ github.event.workflow_run.head_repository.full_name }}
           ref: ${{ github.event.workflow_run.head_branch }}
@@ -130,18 +136,21 @@ jobs:
           token: ${{ steps.generate_token.outputs.access-token }}
           persist-credentials: true
 
-      - name: Apply patch
-        if: ${{ steps.artifact-check.outputs.exists == 'true' }}
+      - name: Apply patches
+        if: ${{ steps.download-artifacts.outputs.artifacts-found == 'true' }}
         working-directory: 'pr-repo'
-        run: git apply "$GITHUB_WORKSPACE/changes.diff"
+        run: |
+          for patch in "${GITHUB_WORKSPACE}"/built-file-changes/*/changes.diff; do
+            git apply "${patch}"
+          done
 
       - name: Display changes to versioned files
-        if: ${{ steps.artifact-check.outputs.exists == 'true' }}
+        if: ${{ steps.download-artifacts.outputs.artifacts-found == 'true' }}
         working-directory: 'pr-repo'
         run: git diff
 
       - name: Configure git user name and email
-        if: ${{ steps.artifact-check.outputs.exists == 'true' }}
+        if: ${{ steps.download-artifacts.outputs.artifacts-found == 'true' }}
         working-directory: 'pr-repo'
         env:
           GH_APP_ID: ${{ vars.GH_PR_BUILT_FILES_APP_ID }}
@@ -150,17 +159,17 @@ jobs:
           git config user.email "${GH_APP_ID}+wordpress-develop-pr-bot[bot]@users.noreply.github.com"
 
       - name: Stage changes
-        if: ${{ steps.artifact-check.outputs.exists == 'true' }}
+        if: ${{ steps.download-artifacts.outputs.artifacts-found == 'true' }}
         working-directory: 'pr-repo'
         run: git add .
 
       - name: Commit changes
-        if: ${{ steps.artifact-check.outputs.exists == 'true' }}
+        if: ${{ steps.download-artifacts.outputs.artifacts-found == 'true' }}
         working-directory: 'pr-repo'
         run: |
           git commit -m "Automation: Updating built files with changes."
 
       - name: Push changes
-        if: ${{ steps.artifact-check.outputs.exists == 'true' }}
+        if: ${{ steps.download-artifacts.outputs.artifacts-found == 'true' }}
         working-directory: 'pr-repo'
         run: git push

--- a/.github/workflows/test-and-zip-default-themes.yml
+++ b/.github/workflows/test-and-zip-default-themes.yml
@@ -179,7 +179,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ steps.built-file-check.outputs.uncommitted_changes == 'true' }}
         with:
-          name: pr-built-file-changes
+          name: pr-built-file-changes-${{ matrix.theme }}
           path: src/wp-content/themes/${{ matrix.theme }}/changes.diff
 
       - name: Ensure version-controlled files are not modified or deleted


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

Fixes the theme testing workflow failing when more than one default theme has uncommitted changes to built files.

What the problem was:
- The `test-build-scripts` matrix in `test-and-zip-default-themes.yml` uploaded every theme's patch under the same artifact name (`pr-built-file-changes`).
- `actions/upload-artifact` rejects duplicate artifact names within a single workflow run, so any run with two or more affected themes failed.
- `commit-built-file-changes.yml` only ever matched and processed the first artifact named exactly `pr-built-file-changes`, so multiple theme patches could not be handled.

What the fix does:
- Gives each theme a unique artifact name: `pr-built-file-changes-<theme>`.
- Updates the "Commit Built File Changes" workflow to download, unzip, and apply every artifact sharing the `pr-built-file-changes` prefix, instead of only the first match.
- Leaves `reusable-check-built-files.yml` unchanged; its single `pr-built-file-changes` artifact is still matched by the same prefix.

Approach and why:
- A shared prefix lets one consumer workflow handle both the single main-build patch and the per-theme patches without special-casing either trigger. Each patch is extracted to its own directory so the `changes.diff` files do not collide, then applied in sequence.


Trac ticket: https://core.trac.wordpress.org/ticket/65496

## Use of AI Tools
AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 4.8
Used for: Ticket analysis, and tests cases. All changes were reviewed, validated against the codebase, and are taken responsibility for by me.

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
