### PR TITLE
 Add "multisite" as new tab on the plugin install page on multisite installations

### DIFF
--- a/src/wp-admin/includes/admin-filters.php
+++ b/src/wp-admin/includes/admin-filters.php
@@ -104,6 +104,7 @@ add_action( 'install_plugins_recommended', 'display_plugins_table' );
 add_action( 'install_plugins_new', 'display_plugins_table' );
 add_action( 'install_plugins_beta', 'display_plugins_table' );
 add_action( 'install_plugins_favorites', 'display_plugins_table' );
+add_action( 'install_plugins_multisite', 'display_plugins_table' );
 add_action( 'install_plugins_pre_plugin-information', 'install_plugin_information' );
 
 // Template hooks.

--- a/src/wp-admin/includes/class-wp-plugin-install-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugin-install-list-table.php
@@ -113,6 +113,10 @@ class WP_Plugin_Install_List_Table extends WP_List_Table {
 		$tabs['recommended'] = _x( 'Recommended', 'Plugin Installer' );
 		$tabs['favorites']   = _x( 'Favorites', 'Plugin Installer' );
 
+		if ( is_multisite() ) {
+			$tabs['multisite'] = _x( 'Multisite', 'Plugin Installer' );
+		}
+
 		if ( current_user_can( 'upload_plugins' ) ) {
 			/*
 			 * No longer a real tab. Here for filter compatibility.
@@ -129,7 +133,7 @@ class WP_Plugin_Install_List_Table extends WP_List_Table {
 		 * @since 2.7.0
 		 *
 		 * @param string[] $tabs The tabs shown on the Add Plugins screen. Defaults include
-		 *                       'featured', 'popular', 'recommended', 'favorites', and 'upload'.
+		 *                       'featured', 'popular', 'recommended', 'favorites', and 'upload' and 'multisite' (network only).
 		 */
 		$tabs = apply_filters( 'install_plugins_tabs', $tabs );
 
@@ -208,6 +212,10 @@ class WP_Plugin_Install_List_Table extends WP_List_Table {
 				add_action( 'install_plugins_favorites', 'install_plugins_favorites_form', 9, 0 );
 				break;
 
+			case 'multisite':
+				$args['tag'] = 'multisite';
+				break;
+
 			default:
 				$args = false;
 				break;
@@ -227,8 +235,10 @@ class WP_Plugin_Install_List_Table extends WP_List_Table {
 		 *  - `install_plugins_table_api_args_upload`
 		 *  - `install_plugins_table_api_args_search`
 		 *  - `install_plugins_table_api_args_beta`
+		 *  - `install_plugins_table_api_args_multisite`
 		 *
 		 * @since 3.7.0
+		 * @since 7.1.0 Added multisite filter
 		 *
 		 * @param array|false $args Plugin install API arguments.
 		 */

--- a/src/wp-admin/includes/plugin-install.php
+++ b/src/wp-admin/includes/plugin-install.php
@@ -409,6 +409,9 @@ function display_plugins_table() {
 				return;
 			}
 			break;
+		case 'install_plugins_multisite':
+			echo '<p>' . __( 'These are all plugins tagged with <code>multisite</code> from their author, this does not necessarily mean that they are optimized for multisite.' ) . '</p>';
+			break;
 	}
 	?>
 	<form id="plugin-filter" method="post">


### PR DESCRIPTION
Adds a new tab to the plugin install page if we are on a multisite installation.

Of course this is a decision of the plugin author to use this tag and it could be easily achieved with your own search, but this would require to set the dropdown to tag and type "multisite" yourself.

Offering an easy link to get all plugins tagged with "multisite" could help to find plugins that are helpful in this multisite environment.

Trac ticket: [Core-65455](https://core.trac.wordpress.org/ticket/65455)

## Use of AI Tools

None.