### PR TITLE
Posts, Post Types: Show modified date for pending/draft posts in the list table Date column

### DIFF
--- a/src/wp-admin/includes/class-wp-posts-list-table.php
+++ b/src/wp-admin/includes/class-wp-posts-list-table.php
@@ -1193,7 +1193,8 @@ class WP_Posts_List_Table extends WP_List_Table {
 		if ( '0000-00-00 00:00:00' === $post->post_date ) {
 			$t_time    = __( 'Unpublished' );
 			$time_diff = 0;
-		} else {
+		} elseif ( 'publish' === $post->post_status || 'future' === $post->post_status ) {
+			// For published and scheduled posts, show the publication date and time.
 			$t_time = sprintf(
 				/* translators: 1: Post date, 2: Post time. */
 				__( '%1$s at %2$s' ),
@@ -1204,6 +1205,24 @@ class WP_Posts_List_Table extends WP_List_Table {
 			);
 
 			$time      = get_post_timestamp( $post );
+			$time_diff = time() - $time;
+		} else {
+			/*
+			 * For all other statuses (draft, pending, etc.), the "Last Modified"
+			 * label is shown below, so display the modified date and time to match.
+			 * This avoids showing a future scheduled date labeled as "Last Modified",
+			 * for example when a pending post has a future publication date.
+			 */
+			$t_time = sprintf(
+				/* translators: 1: Post modified date, 2: Post modified time. */
+				__( '%1$s at %2$s' ),
+				/* translators: Post modified date format. See https://www.php.net/manual/datetime.format.php */
+				get_the_modified_time( __( 'Y/m/d' ), $post ),
+				/* translators: Post modified time format. See https://www.php.net/manual/datetime.format.php */
+				get_the_modified_time( __( 'g:i a' ), $post )
+			);
+
+			$time      = get_post_timestamp( $post, 'modified' );
 			$time_diff = time() - $time;
 		}
 

--- a/tests/phpunit/tests/admin/wpPostsListTable.php
+++ b/tests/phpunit/tests/admin/wpPostsListTable.php
@@ -330,4 +330,111 @@ class Tests_Admin_wpPostsListTable extends WP_UnitTestCase {
 
 		$this->assertSame( $expected, $actual );
 	}
+
+	/**
+	 * Ensures the Date column shows the modified date (not the future
+	 * publication date) for a pending post scheduled in the future.
+	 *
+	 * @ticket 40860
+	 *
+	 * @covers WP_Posts_List_Table::column_date
+	 */
+	public function test_column_date_shows_modified_date_for_pending_scheduled_post() {
+		global $mode;
+
+		$mode  = 'list';
+		$table = _get_list_table( 'WP_Posts_List_Table', array( 'screen' => 'edit-post' ) );
+
+		$future_gmt = gmdate( 'Y-m-d H:i:s', time() + WEEK_IN_SECONDS );
+		$now        = current_time( 'mysql' );
+		$now_gmt    = current_time( 'mysql', true );
+
+		$post_id = self::factory()->post->create(
+			array(
+				'post_status'   => 'pending',
+				'post_date'     => get_date_from_gmt( $future_gmt ),
+				'post_date_gmt' => $future_gmt,
+			)
+		);
+
+		// Force a modified date in the past (now), distinct from the future post_date.
+		global $wpdb;
+		$wpdb->update(
+			$wpdb->posts,
+			array(
+				'post_modified'     => $now,
+				'post_modified_gmt' => $now_gmt,
+			),
+			array( 'ID' => $post_id )
+		);
+		clean_post_cache( $post_id );
+
+		$post = get_post( $post_id );
+
+		ob_start();
+		$table->column_date( $post );
+		$output = ob_get_clean();
+
+		$modified_date = get_the_modified_time( __( 'Y/m/d' ), $post );
+		$future_date   = get_the_time( __( 'Y/m/d' ), $post );
+
+		$this->assertStringContainsString( 'Last Modified', $output, 'A pending post should display the "Last Modified" status.' );
+		$this->assertStringContainsString( $modified_date, $output, 'The Date column should display the post modified date.' );
+		$this->assertStringNotContainsString( $future_date, $output, 'The Date column should not display the future publication date for a pending post.' );
+	}
+
+	/**
+	 * Ensures the Date column still shows the publication date for
+	 * published and scheduled posts.
+	 *
+	 * @ticket 40860
+	 *
+	 * @covers WP_Posts_List_Table::column_date
+	 *
+	 * @dataProvider data_column_date_uses_publication_date_for_published_and_scheduled
+	 *
+	 * @param string $post_status   The post status to test.
+	 * @param string $expected_text The status label expected in the output.
+	 */
+	public function test_column_date_uses_publication_date_for_published_and_scheduled( $post_status, $expected_text ) {
+		global $mode;
+
+		$mode  = 'list';
+		$table = _get_list_table( 'WP_Posts_List_Table', array( 'screen' => 'edit-post' ) );
+
+		if ( 'future' === $post_status ) {
+			$date_gmt = gmdate( 'Y-m-d H:i:s', time() + DAY_IN_SECONDS );
+		} else {
+			$date_gmt = gmdate( 'Y-m-d H:i:s', time() - DAY_IN_SECONDS );
+		}
+
+		$post_id = self::factory()->post->create(
+			array(
+				'post_status'   => $post_status,
+				'post_date'     => get_date_from_gmt( $date_gmt ),
+				'post_date_gmt' => $date_gmt,
+			)
+		);
+
+		$post = get_post( $post_id );
+
+		ob_start();
+		$table->column_date( $post );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( $expected_text, $output, 'The Date column should display the expected status label.' );
+		$this->assertStringContainsString( get_the_time( __( 'Y/m/d' ), $post ), $output, 'The Date column should display the publication date.' );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_column_date_uses_publication_date_for_published_and_scheduled() {
+		return array(
+			'published post' => array( 'publish', 'Published' ),
+			'scheduled post' => array( 'future', 'Scheduled' ),
+		);
+	}
 }


### PR DESCRIPTION
## Summary

Fixes [#40860](https://core.trac.wordpress.org/ticket/40860).

The Posts list table Date column labels non-published posts as **"Last Modified"** but displays the `post_date` instead of the modified date. For a **pending or draft post with a future publication date**, this results in a *future* date being shown under a "Last Modified" label — which is incorrect and confusing.

### Reproduction
1. Create a new post
2. Schedule it for a date in the future
3. Set its status to *Pending Review*
4. Save, then return to the Posts list
5. The Date column shows the future date labeled **"Last Modified"**

Verified on the local Docker environment:
```
post_date (future): 2026-06-27   post_modified (now): 2026-06-20
BEFORE: Last Modified 2026/06/27 at 11:00 pm   (wrong — future date)
AFTER:  Last Modified 2026/06/20 at 11:00 pm   (correct — actual modified date)
```

## The fix

In `WP_Posts_List_Table::column_date()`, for statuses other than `publish` and `future`, display the **modified** date/time (via `get_the_modified_time()` and `get_post_timestamp( $post, 'modified' )`) so the date shown matches the "Last Modified" label. Published and scheduled posts continue to show the publication date as before.

## Testing

Adds unit tests to `Tests_Admin_wpPostsListTable`:
- `test_column_date_shows_modified_date_for_pending_scheduled_post` — asserts the modified date (not the future publication date) is shown for a pending+scheduled post. Fails without the fix, passes with it.
- `test_column_date_uses_publication_date_for_published_and_scheduled` (data provider: published, scheduled) — asserts published/scheduled posts still show the publication date and correct label.

```bash
npm run test:php -- --filter test_column_date
```
```
✔ Column date shows modified date for pending scheduled post
✔ Column date uses publication date for published and scheduled with data set "published post"
✔ Column date uses publication date for published and scheduled with data set "scheduled post"
OK (3 tests, 7 assertions)
```

- PHP lint: clean
- PHPCS: no new errors/warnings on the changed lines

This builds on the approach proposed in the earlier patch on the ticket, adding unit test coverage (the ticket previously had `has-test-info` but no automated tests).

Trac ticket: https://core.trac.wordpress.org/ticket/40860