### PR TITLE
Use `@` symbol prefix for responsive style states

### DIFF
--- a/src/wp-includes/block-supports/states.php
+++ b/src/wp-includes/block-supports/states.php
@@ -4,7 +4,7 @@
  *
  * Generates scoped CSS for per-instance state styles declared in block attributes,
  * including pseudo-states (e.g., `style[':hover']`) and responsive states
- * (e.g., `style['mobile']` and `style['mobile'][':hover']`).
+ * (e.g., `style['@mobile']` and `style['@mobile'][':hover']`).
  *
  * @package WordPress
  * @since 7.1.0

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -653,8 +653,8 @@ class WP_Theme_JSON {
 	 * @var array
 	 */
 	const RESPONSIVE_BREAKPOINTS = array(
-		'mobile' => '@media (width <= 480px)',
-		'tablet' => '@media (480px < width <= 782px)',
+		'@mobile' => '@media (width <= 480px)',
+		'@tablet' => '@media (480px < width <= 782px)',
 	);
 
 	/**
@@ -1072,7 +1072,7 @@ class WP_Theme_JSON {
 		 * e.g.
 		 * - top level elements: `$schema['styles']['elements']['link'][':hover']`.
 		 * - block level elements: `$schema['styles']['blocks']['core/button']['elements']['link'][':hover']`.
-		 * - block responsive elements: `$schema['styles']['blocks']['core/button']['tablet']['elements']['link'][':hover']`.
+		 * - block responsive elements: `$schema['styles']['blocks']['core/button']['@tablet']['elements']['link'][':hover']`.
 		 */
 		foreach ( $valid_element_names as $element ) {
 			$schema_styles_elements[ $element ] = $styles_non_top_level;

--- a/tests/phpunit/tests/block-supports/states.php
+++ b/tests/phpunit/tests/block-supports/states.php
@@ -940,7 +940,7 @@ class Tests_Block_Supports_States extends WP_UnitTestCase {
 			'blockName' => 'test/responsive-root-state',
 			'attrs'     => array(
 				'style' => array(
-					'mobile' => array(
+					'@mobile' => array(
 						'color' => array(
 							'text' => '#ff0000',
 						),
@@ -979,7 +979,7 @@ class Tests_Block_Supports_States extends WP_UnitTestCase {
 			'blockName' => 'core/group',
 			'attrs'     => array(
 				'style' => array(
-					'mobile' => array(
+					'@mobile' => array(
 						'elements' => array(
 							'link' => array(
 								'color' => array(
@@ -1025,7 +1025,7 @@ class Tests_Block_Supports_States extends WP_UnitTestCase {
 			'blockName' => 'core/button',
 			'attrs'     => array(
 				'style' => array(
-					'mobile' => array(
+					'@mobile' => array(
 						':hover' => array(
 							'color' => array(
 								'background' => '#ff00d0',
@@ -1091,7 +1091,7 @@ class Tests_Block_Supports_States extends WP_UnitTestCase {
 						'type' => 'default',
 					),
 					'style'  => array(
-						'mobile' => array(
+						'@mobile' => array(
 							'spacing' => array(
 								'blockGap' => '12px',
 							),
@@ -1156,7 +1156,7 @@ class Tests_Block_Supports_States extends WP_UnitTestCase {
 						'type' => 'flex',
 					),
 					'style'  => array(
-						'mobile' => array(
+						'@mobile' => array(
 							'spacing' => array(
 								'blockGap' => '12px',
 							),
@@ -1210,7 +1210,7 @@ class Tests_Block_Supports_States extends WP_UnitTestCase {
 					'type' => 'grid',
 				),
 				'style'  => array(
-					'mobile' => array(
+					'@mobile' => array(
 						'layout' => array(
 							'minimumColumnWidth' => '8rem',
 						),
@@ -1260,7 +1260,7 @@ class Tests_Block_Supports_States extends WP_UnitTestCase {
 					'type' => 'grid',
 				),
 				'style'  => array(
-					'mobile' => array(
+					'@mobile' => array(
 						'layout' => array(
 							'columnCount' => 3,
 						),
@@ -1317,7 +1317,7 @@ class Tests_Block_Supports_States extends WP_UnitTestCase {
 			array(
 				'attrs' => array(
 					'style' => array(
-						'mobile' => array(
+						'@mobile' => array(
 							'layout' => array(
 								'columnCount' => 3,
 							),
@@ -1331,7 +1331,7 @@ class Tests_Block_Supports_States extends WP_UnitTestCase {
 			array(
 				'attrs' => array(
 					'style' => array(
-						'mobile' => array(
+						'@mobile' => array(
 							'layout' => array(
 								'columnCount' => 4,
 							),
@@ -1403,7 +1403,7 @@ class Tests_Block_Supports_States extends WP_UnitTestCase {
 						'type' => 'grid',
 					),
 					'style'  => array(
-						'mobile' => array(
+						'@mobile' => array(
 							'layout'  => array(
 								'columnCount' => 3,
 							),
@@ -1469,7 +1469,7 @@ class Tests_Block_Supports_States extends WP_UnitTestCase {
 						'minimumColumnWidth' => '12rem',
 					),
 					'style'  => array(
-						'tablet' => array(
+						'@tablet' => array(
 							'spacing' => array(
 								'blockGap' => '12px',
 							),
@@ -1518,7 +1518,7 @@ class Tests_Block_Supports_States extends WP_UnitTestCase {
 			'innerContent' => array( '<p>Some text.</p>' ),
 			'attrs'        => array(
 				'style' => array(
-					'mobile' => array(
+					'@mobile' => array(
 						'layout' => array(
 							'columnSpan' => '2',
 						),
@@ -1581,7 +1581,7 @@ class Tests_Block_Supports_States extends WP_UnitTestCase {
 					'type' => 'grid',
 				),
 				'style'  => array(
-					'mobile' => array(
+					'@mobile' => array(
 						'layout' => array(
 							'columnCount' => 3,
 						),

--- a/tests/phpunit/tests/theme/wpThemeJson.php
+++ b/tests/phpunit/tests/theme/wpThemeJson.php
@@ -3196,7 +3196,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 						'core/group' => array(
 							'elements' => array(
 								'link' => array(
-									'color'  => array(
+									'color'   => array(
 										'text' => 'var:preset|color|dark-gray',
 									),
 									'@mobile' => array(
@@ -3224,7 +3224,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 					'core/group' => array(
 						'elements' => array(
 							'link' => array(
-								'color'  => array(
+								'color'   => array(
 									'text' => 'var(--wp--preset--color--dark-gray)',
 								),
 								'@mobile' => array(

--- a/tests/phpunit/tests/theme/wpThemeJson.php
+++ b/tests/phpunit/tests/theme/wpThemeJson.php
@@ -957,7 +957,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 				'styles'  => array(
 					'blocks' => array(
 						'test/responsive-feature' => array(
-							'mobile' => array(
+							'@mobile' => array(
 								'color' => array(
 									'text' => 'red',
 								),
@@ -979,7 +979,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 
 		$mobile_metadata = array(
 			'name'        => 'test/responsive-feature',
-			'path'        => array( 'styles', 'blocks', 'test/responsive-feature', 'mobile' ),
+			'path'        => array( 'styles', 'blocks', 'test/responsive-feature', '@mobile' ),
 			'selector'    => '.wp-block-test-responsive-feature',
 			'selectors'   => array(
 				'color' => '.wp-block-test-responsive-feature .color-target',
@@ -1020,7 +1020,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 							'spacing' => array(
 								'blockGap' => '5rem',
 							),
-							'mobile'  => array(
+							'@mobile' => array(
 								'spacing' => array(
 									'blockGap' => '2rem',
 								),
@@ -1040,7 +1040,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 
 		$mobile_metadata = array(
 			'name'        => 'core/group',
-			'path'        => array( 'styles', 'blocks', 'core/group', 'mobile' ),
+			'path'        => array( 'styles', 'blocks', 'core/group', '@mobile' ),
 			'selector'    => '.wp-block-group',
 			'css'         => '.wp-block-group',
 			'media_query' => '@media (width <= 480px)',
@@ -1080,7 +1080,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 									),
 								),
 							),
-							'mobile'   => array(
+							'@mobile'  => array(
 								'elements' => array(
 									'link' => array(
 										'color'  => array(
@@ -1109,7 +1109,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 		);
 
 		$mobile_link_node = array(
-			'path'        => array( 'styles', 'blocks', 'core/group', 'mobile', 'elements', 'link' ),
+			'path'        => array( 'styles', 'blocks', 'core/group', '@mobile', 'elements', 'link' ),
 			'selector'    => $link_selector,
 			'media_query' => '@media (width <= 480px)',
 		);
@@ -1120,7 +1120,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 		);
 
 		$mobile_hover_node = array(
-			'path'        => array( 'styles', 'blocks', 'core/group', 'mobile', 'elements', 'link' ),
+			'path'        => array( 'styles', 'blocks', 'core/group', '@mobile', 'elements', 'link' ),
 			'selector'    => $link_selector . ':hover',
 			'media_query' => '@media (width <= 480px)',
 		);
@@ -1174,7 +1174,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 									'spacing' => array(
 										'blockGap' => '5rem',
 									),
-									'mobile'  => array(
+									'@mobile' => array(
 										'spacing' => array(
 											'blockGap' => '2rem',
 										),
@@ -1230,7 +1230,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 				'styles'  => array(
 					'blocks' => array(
 						'test/tablet-only' => array(
-							'tablet' => array(
+							'@tablet' => array(
 								'color' => array(
 									'text' => 'purple',
 								),
@@ -1243,7 +1243,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 
 		$tablet_metadata = array(
 			'name'        => 'test/tablet-only',
-			'path'        => array( 'styles', 'blocks', 'test/tablet-only', 'tablet' ),
+			'path'        => array( 'styles', 'blocks', 'test/tablet-only', '@tablet' ),
 			'selector'    => '.wp-block-test-tablet-only',
 			'media_query' => '@media (480px < width <= 782px)',
 		);
@@ -3199,12 +3199,12 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 									'color'  => array(
 										'text' => 'var:preset|color|dark-gray',
 									),
-									'mobile' => array(
+									'@mobile' => array(
 										'color' => array(
 											'text' => 'var:preset|color|dark-pink',
 										),
 									),
-									'tablet' => array(
+									'@tablet' => array(
 										'color' => array(
 											'text' => 'var:preset|color|dark-red',
 										),
@@ -3227,12 +3227,12 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 								'color'  => array(
 									'text' => 'var(--wp--preset--color--dark-gray)',
 								),
-								'mobile' => array(
+								'@mobile' => array(
 									'color' => array(
 										'text' => 'var(--wp--preset--color--dark-pink)',
 									),
 								),
-								'tablet' => array(
+								'@tablet' => array(
 									'color' => array(
 										'text' => 'var(--wp--preset--color--dark-red)',
 									),
@@ -3259,7 +3259,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 				'styles'  => array(
 					'blocks' => array(
 						'core/group' => array(
-							'mobile' => array(
+							'@mobile' => array(
 								'elements' => array(
 									'link' => array(
 										'color' => array(
@@ -3279,7 +3279,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 			'styles'  => array(
 				'blocks' => array(
 					'core/group' => array(
-						'mobile' => array(
+						'@mobile' => array(
 							'elements' => array(
 								'link' => array(
 									'color' => array(


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65503
Backport for Gutenberg PR: https://github.com/WordPress/gutenberg/pull/79210

Updates the property keys for responsive style states to include an `@` prefix:
- `tablet` becomes `@tablet`
- `mobile` becomes `@mobile`

This is to avoid the future possibility of property name clashes.

No backwards compatibility is required in WordPress core since responsive style states have not been shipped in any WordPress version. This is a pure rename.

## Use of AI Tools

AI assistance: Yes
Tool(s): Codex / OpenCode
Model(s): GPT-5.5
Used for: All code changes, reviewed by me.

---

**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
