### PR TITLE
AI: Skip non-ability function calls in execute_abilities()

### DIFF
--- a/src/wp-includes/ai-client/class-wp-ai-client-ability-function-resolver.php
+++ b/src/wp-includes/ai-client/class-wp-ai-client-ability-function-resolver.php
@@ -190,7 +190,7 @@ class WP_AI_Client_Ability_Function_Resolver {
 		foreach ( $message->getParts() as $part ) {
 			if ( $part->getType()->isFunctionCall() ) {
 				$function_call = $part->getFunctionCall();
-				if ( $function_call instanceof FunctionCall ) {
+				if ( $function_call instanceof FunctionCall && $this->is_ability_call( $function_call ) ) {
 					$function_response = $this->execute_ability( $function_call );
 					$response_parts[]  = new MessagePart( $function_response );
 				}

--- a/tests/phpunit/tests/ai-client/wpAiClientAbilityFunctionResolver.php
+++ b/tests/phpunit/tests/ai-client/wpAiClientAbilityFunctionResolver.php
@@ -667,6 +667,54 @@ class Tests_AI_Client_AbilityFunctionResolver extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test execute_abilities ignores non-ability function calls.
+	 *
+	 * A message may contain function calls for tools handled elsewhere (not
+	 * prefixed with `wpab__`). Those must be left untouched rather than answered
+	 * with a spurious `invalid_ability_call` error response, matching the parts
+	 * that has_ability_calls() reports.
+	 *
+	 * @ticket 65504
+	 */
+	public function test_execute_abilities_ignores_non_ability_function_calls() {
+		$resolver = new WP_AI_Client_Ability_Function_Resolver( 'wpaiclienttests/simple' );
+
+		$ability_call = new FunctionCall(
+			'call-ability',
+			'wpab__wpaiclienttests__simple',
+			array()
+		);
+
+		$other_call = new FunctionCall(
+			'call-other',
+			'some_other_tool',
+			array()
+		);
+
+		$message = new ModelMessage(
+			array(
+				new MessagePart( $ability_call ),
+				new MessagePart( $other_call ),
+			)
+		);
+
+		$result = $resolver->execute_abilities( $message );
+
+		$this->assertInstanceOf( UserMessage::class, $result );
+		$parts = $result->getParts();
+		// Only the ability call should produce a response; the other tool is left alone.
+		$this->assertCount( 1, $parts );
+
+		$response = $parts[0]->getFunctionResponse();
+		$this->assertInstanceOf( FunctionResponse::class, $response );
+		$this->assertSame( 'wpab__wpaiclienttests__simple', $response->getName() );
+		$data = $response->getResponse();
+		$this->assertArrayNotHasKey( 'code', $data );
+		$this->assertArrayHasKey( 'success', $data );
+		$this->assertTrue( $data['success'] );
+	}
+
+	/**
 	 * Test execute_abilities with ability that has parameters.
 	 *
 	 * @ticket 64591


### PR DESCRIPTION
`WP_AI_Client_Ability_Function_Resolver::execute_abilities()` ran `execute_ability()` on every function-call part in a message. Unlike its sibling `has_ability_calls()`, it did not check `is_ability_call()` first, so a function call for a tool handled elsewhere (anything not prefixed `wpab__`) was answered with a fabricated `invalid_ability_call` error response. Because providers expect one response per function call, that spurious response was attributed to the other tool and the real tool never ran.

Add the `is_ability_call()` guard so `execute_abilities()` processes the same parts that `has_ability_calls()` reports, and add a regression test covering a mixed ability / non-ability message.

Fixes #65504.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/65504

## Use of AI Tools

N/A
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
