### PR TITLE
AI: Catch Throwable in WP_AI_Client_Prompt_Builder so TypeErrors become WP_Error

### DIFF
--- a/src/wp-includes/ai-client/class-wp-ai-client-prompt-builder.php
+++ b/src/wp-includes/ai-client/class-wp-ai-client-prompt-builder.php
@@ -187,7 +187,7 @@ class WP_AI_Client_Prompt_Builder {
 			$this->builder = new PromptBuilder( $registry, $prompt, AiClient::getEventDispatcher() );
 		} catch ( Throwable $e ) {
 			$this->builder = new PromptBuilder( $registry, null, AiClient::getEventDispatcher() );
-			$this->error   = $this->exception_to_wp_error( $e );
+			$this->error   = $this->throwable_to_wp_error( $e );
 		}
 
 		$default_timeout = 30.0;
@@ -359,7 +359,7 @@ class WP_AI_Client_Prompt_Builder {
 
 			return $result;
 		} catch ( Throwable $e ) {
-			$this->error = $this->exception_to_wp_error( $e );
+			$this->error = $this->throwable_to_wp_error( $e );
 
 			if ( self::is_generating_method( $name ) ) {
 				return $this->error;
@@ -369,33 +369,33 @@ class WP_AI_Client_Prompt_Builder {
 	}
 
 	/**
-	 * Converts an exception into a WP_Error with a structured error code and message.
+	 * Converts a throwable into a WP_Error with a structured error code and message.
 	 *
-	 * This method maps different exception types to specific WP_Error codes and HTTP status codes.
+	 * This method maps different throwable types to specific WP_Error codes and HTTP status codes.
 	 * The presence of the status codes means these WP_Error objects can be easily used in REST API responses
 	 * or other contexts where HTTP semantics are relevant.
 	 *
 	 * @since 7.0.0
 	 *
-	 * @param Throwable $e The throwable to convert.
+	 * @param Throwable $throwable The throwable to convert.
 	 * @return WP_Error The resulting WP_Error object.
 	 */
-	private function exception_to_wp_error( Throwable $e ): WP_Error {
-		if ( $e instanceof NetworkException ) {
+	private function throwable_to_wp_error( Throwable $throwable ): WP_Error {
+		if ( $throwable instanceof NetworkException ) {
 			$error_code  = 'prompt_network_error';
 			$status_code = 503;
-		} elseif ( $e instanceof ClientException ) {
+		} elseif ( $throwable instanceof ClientException ) {
 			// `ClientException` uses HTTP status codes as exception codes, so we can rely on them.
 			$error_code  = 'prompt_client_error';
-			$status_code = $e->getCode() ? $e->getCode() : 400;
-		} elseif ( $e instanceof ServerException ) {
+			$status_code = $throwable->getCode() ? $throwable->getCode() : 400;
+		} elseif ( $throwable instanceof ServerException ) {
 			// `ServerException` uses HTTP status codes as exception codes, so we can rely on them.
 			$error_code  = 'prompt_upstream_server_error';
-			$status_code = $e->getCode() ? $e->getCode() : 500;
-		} elseif ( $e instanceof TokenLimitReachedException ) {
+			$status_code = $throwable->getCode() ? $throwable->getCode() : 500;
+		} elseif ( $throwable instanceof TokenLimitReachedException ) {
 			$error_code  = 'prompt_token_limit_reached';
 			$status_code = 400;
-		} elseif ( $e instanceof InvalidArgumentException ) {
+		} elseif ( $throwable instanceof InvalidArgumentException ) {
 			$error_code  = 'prompt_invalid_argument';
 			$status_code = 400;
 		} else {
@@ -405,10 +405,10 @@ class WP_AI_Client_Prompt_Builder {
 
 		return new WP_Error(
 			$error_code,
-			$e->getMessage(),
+			$throwable->getMessage(),
 			array(
 				'status'          => $status_code,
-				'exception_class' => get_class( $e ),
+				'exception_class' => get_class( $throwable ),
 			)
 		);
 	}

--- a/src/wp-includes/ai-client/class-wp-ai-client-prompt-builder.php
+++ b/src/wp-includes/ai-client/class-wp-ai-client-prompt-builder.php
@@ -185,7 +185,7 @@ class WP_AI_Client_Prompt_Builder {
 	public function __construct( ProviderRegistry $registry, $prompt = null ) {
 		try {
 			$this->builder = new PromptBuilder( $registry, $prompt, AiClient::getEventDispatcher() );
-		} catch ( Exception $e ) {
+		} catch ( Throwable $e ) {
 			$this->builder = new PromptBuilder( $registry, null, AiClient::getEventDispatcher() );
 			$this->error   = $this->exception_to_wp_error( $e );
 		}
@@ -358,7 +358,7 @@ class WP_AI_Client_Prompt_Builder {
 			}
 
 			return $result;
-		} catch ( Exception $e ) {
+		} catch ( Throwable $e ) {
 			$this->error = $this->exception_to_wp_error( $e );
 
 			if ( self::is_generating_method( $name ) ) {
@@ -377,10 +377,10 @@ class WP_AI_Client_Prompt_Builder {
 	 *
 	 * @since 7.0.0
 	 *
-	 * @param Exception $e The exception to convert.
+	 * @param Throwable $e The throwable to convert.
 	 * @return WP_Error The resulting WP_Error object.
 	 */
-	private function exception_to_wp_error( Exception $e ): WP_Error {
+	private function exception_to_wp_error( Throwable $e ): WP_Error {
 		if ( $e instanceof NetworkException ) {
 			$error_code  = 'prompt_network_error';
 			$status_code = 503;

--- a/tests/phpunit/tests/ai-client/wpAiClientPromptBuilder.php
+++ b/tests/phpunit/tests/ai-client/wpAiClientPromptBuilder.php
@@ -2743,18 +2743,18 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Invokes the private exception_to_wp_error method via reflection.
+	 * Invokes the private throwable_to_wp_error method via reflection.
 	 *
 	 * @param WP_AI_Client_Prompt_Builder $builder   The builder instance.
-	 * @param Throwable                   $exception The throwable to convert.
+	 * @param Throwable                   $throwable The throwable to convert.
 	 * @return WP_Error The resulting WP_Error.
 	 */
-	private function invoke_exception_to_wp_error( WP_AI_Client_Prompt_Builder $builder, Throwable $exception ): WP_Error {
+	private function invoke_throwable_to_wp_error( WP_AI_Client_Prompt_Builder $builder, Throwable $throwable ): WP_Error {
 		$reflection = new ReflectionClass( WP_AI_Client_Prompt_Builder::class );
-		$method     = $reflection->getMethod( 'exception_to_wp_error' );
+		$method     = $reflection->getMethod( 'throwable_to_wp_error' );
 		self::set_accessible( $method );
 
-		return $method->invoke( $builder, $exception );
+		return $method->invoke( $builder, $throwable );
 	}
 
 	/**
@@ -2764,7 +2764,7 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 	 */
 	public function test_exception_to_wp_error_network_exception() {
 		$builder = new WP_AI_Client_Prompt_Builder( AiClient::defaultRegistry() );
-		$error   = $this->invoke_exception_to_wp_error(
+		$error   = $this->invoke_throwable_to_wp_error(
 			$builder,
 			new NetworkException( 'Connection timed out' )
 		);
@@ -2782,7 +2782,7 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 	 */
 	public function test_exception_to_wp_error_client_exception_with_code() {
 		$builder = new WP_AI_Client_Prompt_Builder( AiClient::defaultRegistry() );
-		$error   = $this->invoke_exception_to_wp_error(
+		$error   = $this->invoke_throwable_to_wp_error(
 			$builder,
 			new ClientException( 'Unauthorized', 401 )
 		);
@@ -2800,7 +2800,7 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 	 */
 	public function test_exception_to_wp_error_client_exception_without_code() {
 		$builder = new WP_AI_Client_Prompt_Builder( AiClient::defaultRegistry() );
-		$error   = $this->invoke_exception_to_wp_error(
+		$error   = $this->invoke_throwable_to_wp_error(
 			$builder,
 			new ClientException( 'Bad request' )
 		);
@@ -2817,7 +2817,7 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 	 */
 	public function test_exception_to_wp_error_server_exception_with_code() {
 		$builder = new WP_AI_Client_Prompt_Builder( AiClient::defaultRegistry() );
-		$error   = $this->invoke_exception_to_wp_error(
+		$error   = $this->invoke_throwable_to_wp_error(
 			$builder,
 			new ServerException( 'Bad gateway', 502 )
 		);
@@ -2835,7 +2835,7 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 	 */
 	public function test_exception_to_wp_error_server_exception_without_code() {
 		$builder = new WP_AI_Client_Prompt_Builder( AiClient::defaultRegistry() );
-		$error   = $this->invoke_exception_to_wp_error(
+		$error   = $this->invoke_throwable_to_wp_error(
 			$builder,
 			new ServerException( 'Internal server error' )
 		);
@@ -2852,7 +2852,7 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 	 */
 	public function test_exception_to_wp_error_token_limit_reached_exception() {
 		$builder = new WP_AI_Client_Prompt_Builder( AiClient::defaultRegistry() );
-		$error   = $this->invoke_exception_to_wp_error(
+		$error   = $this->invoke_throwable_to_wp_error(
 			$builder,
 			new TokenLimitReachedException( 'Token limit exceeded', 4096 )
 		);
@@ -2870,7 +2870,7 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 	 */
 	public function test_exception_to_wp_error_invalid_argument_exception() {
 		$builder = new WP_AI_Client_Prompt_Builder( AiClient::defaultRegistry() );
-		$error   = $this->invoke_exception_to_wp_error(
+		$error   = $this->invoke_throwable_to_wp_error(
 			$builder,
 			new AiClientInvalidArgumentException( 'Invalid model parameter' )
 		);
@@ -2888,7 +2888,7 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 	 */
 	public function test_exception_to_wp_error_generic_exception() {
 		$builder = new WP_AI_Client_Prompt_Builder( AiClient::defaultRegistry() );
-		$error   = $this->invoke_exception_to_wp_error(
+		$error   = $this->invoke_throwable_to_wp_error(
 			$builder,
 			new Exception( 'Something went wrong' )
 		);
@@ -2909,7 +2909,7 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 	 */
 	public function test_exception_to_wp_error_type_error() {
 		$builder = new WP_AI_Client_Prompt_Builder( AiClient::defaultRegistry() );
-		$error   = $this->invoke_exception_to_wp_error(
+		$error   = $this->invoke_throwable_to_wp_error(
 			$builder,
 			new TypeError( 'Argument must be of type float' )
 		);
@@ -2955,7 +2955,7 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 	 */
 	public function test_exception_to_wp_error_error_data_structure( Exception $exception ) {
 		$builder = new WP_AI_Client_Prompt_Builder( AiClient::defaultRegistry() );
-		$error   = $this->invoke_exception_to_wp_error( $builder, $exception );
+		$error   = $this->invoke_throwable_to_wp_error( $builder, $exception );
 
 		$data = $error->get_error_data();
 		$this->assertIsArray( $data );

--- a/tests/phpunit/tests/ai-client/wpAiClientPromptBuilder.php
+++ b/tests/phpunit/tests/ai-client/wpAiClientPromptBuilder.php
@@ -2746,10 +2746,10 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 	 * Invokes the private exception_to_wp_error method via reflection.
 	 *
 	 * @param WP_AI_Client_Prompt_Builder $builder   The builder instance.
-	 * @param Exception                   $exception The exception to convert.
+	 * @param Throwable                   $exception The throwable to convert.
 	 * @return WP_Error The resulting WP_Error.
 	 */
-	private function invoke_exception_to_wp_error( WP_AI_Client_Prompt_Builder $builder, Exception $exception ): WP_Error {
+	private function invoke_exception_to_wp_error( WP_AI_Client_Prompt_Builder $builder, Throwable $exception ): WP_Error {
 		$reflection = new ReflectionClass( WP_AI_Client_Prompt_Builder::class );
 		$method     = $reflection->getMethod( 'exception_to_wp_error' );
 		self::set_accessible( $method );
@@ -2897,6 +2897,51 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 		$this->assertSame( 'Something went wrong', $error->get_error_message() );
 		$this->assertSame( 500, $error->get_error_data()['status'] );
 		$this->assertSame( 'Exception', $error->get_error_data()['exception_class'] );
+	}
+
+	/**
+	 * Tests exception_to_wp_error maps an Error (e.g. TypeError) to a generic builder error.
+	 *
+	 * A TypeError extends Error, not Exception, so this guards against the
+	 * conversion only accepting Exception instances.
+	 *
+	 * @ticket 65505
+	 */
+	public function test_exception_to_wp_error_type_error() {
+		$builder = new WP_AI_Client_Prompt_Builder( AiClient::defaultRegistry() );
+		$error   = $this->invoke_exception_to_wp_error(
+			$builder,
+			new TypeError( 'Argument must be of type float' )
+		);
+
+		$this->assertSame( 'prompt_builder_error', $error->get_error_code() );
+		$this->assertSame( 'Argument must be of type float', $error->get_error_message() );
+		$this->assertSame( 500, $error->get_error_data()['status'] );
+		$this->assertSame( 'TypeError', $error->get_error_data()['exception_class'] );
+	}
+
+	/**
+	 * Tests that a TypeError thrown by the wrapped SDK is caught and returned as a WP_Error.
+	 *
+	 * Passing an argument of the wrong type to a strict-typed SDK method throws a
+	 * TypeError (which extends Error, not Exception). The builder must catch it and
+	 * place itself in an error state instead of letting it fatal the request.
+	 *
+	 * @ticket 65505
+	 */
+	public function test_call_catches_type_error_from_invalid_argument_type() {
+		$builder = new WP_AI_Client_Prompt_Builder( $this->registry, 'Test prompt' );
+
+		// usingTemperature() expects a float; an array can never be coerced and throws a TypeError.
+		$result = $builder->using_temperature( array( 0.7 ) );
+
+		// The builder is returned (fluent interface preserved), now in an error state.
+		$this->assertInstanceOf( WP_AI_Client_Prompt_Builder::class, $result );
+
+		// A generating method now surfaces the stored WP_Error rather than fataling.
+		$error = $result->generate_text();
+		$this->assertWPError( $error );
+		$this->assertSame( 'prompt_builder_error', $error->get_error_code() );
 	}
 
 	/**


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

`WP_AI_Client_Prompt_Builder`'s contract is that any failure during a method chain puts the builder into an error state and is surfaced as a `WP_Error` from a generating method. The constructor and the `__call()` proxy enforce this with try/catch, but both only caught `Exception`.

`__call()` forwards caller arguments into the strict-typed php-ai-client SDK (`usingTemperature(float)`, `usingMaxTokens(int)`, etc. — the SDK uses `strict_types=1`). A wrong argument type throws a `TypeError`, which extends `Error`, not `Exception`. The existing catch missed it, so it escaped uncaught and fataled the request (HTTP 500) instead of returning a `WP_Error`.

### Steps to reproduce

```php
$builder = wp_ai_client_prompt( 'Write a haiku' );
// An array can never be coerced to float -> TypeError from usingTemperature().
$result = $builder->using_temperature( array( 0.7 ) )->generate_text();
// Expected: WP_Error. Before this change: uncaught TypeError -> fatal.
```
Changes

- Catch Throwable instead of Exception in the constructor and __call().
- Widen exception_to_wp_error() to accept Throwable. Its instanceof ladder already falls through to prompt_builder_error / 500 for unrecognized types, so Error/TypeError map cleanly with no other change.
- Add regression tests:
  - exception_to_wp_error() maps a TypeError to prompt_builder_error / 500.
  - End-to-end: passing an uncoercible argument type to a wrapped SDK method is caught and surfaced as a WP_Error from a generating method instead of fataling.

Testing instructions

Run the AI Client suite:

npm run test:php -- --group ai-client

181 tests, 463 assertions, all passing.

Trac ticket: https://core.trac.wordpress.org/ticket/65505

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude
Used for: Used for test cases.  Reviewed and  edited by me.
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
