### PR TITLE
Code Modernization: Use array_any() in various places

### DIFF
--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -3833,14 +3833,7 @@ class WP_Site_Health {
 			'terms_count'    => $wpdb->terms,
 			'users_count'    => $wpdb->users,
 		);
-
-		foreach ( $threshold_map as $threshold => $table ) {
-			if ( $thresholds[ $threshold ] <= $results[ $table ]->rows ) {
-				return true;
-			}
-		}
-
-		return false;
+		return array_any( $threshold_map, fn( $table, $threshold ) => $thresholds[ $threshold ] <= $results[ $table ]->rows );
 	}
 
 	/**

--- a/src/wp-admin/includes/post.php
+++ b/src/wp-admin/includes/post.php
@@ -1980,13 +1980,8 @@ function wp_create_post_autosave( $post_data ) {
 		$post = get_post( $post_id );
 
 		// If the new autosave has the same content as the post, delete the autosave.
-		$autosave_is_different = false;
-		foreach ( array_intersect( array_keys( $new_autosave ), array_keys( _wp_post_revision_fields( $post ) ) ) as $field ) {
-			if ( normalize_whitespace( $new_autosave[ $field ] ) !== normalize_whitespace( $post->$field ) ) {
-				$autosave_is_different = true;
-				break;
-			}
-		}
+		$fields                = array_intersect( array_keys( $new_autosave ), array_keys( _wp_post_revision_fields( $post ) ) );
+		$autosave_is_different = array_any( $fields, fn( $field ) => normalize_whitespace( $new_autosave[ $field ] ) !== normalize_whitespace( $post->$field ) );
 
 		if ( ! $autosave_is_different ) {
 			wp_delete_post_revision( $old_autosave->ID );

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -1460,14 +1460,7 @@ function block_footer_area() {
  */
 function wp_is_theme_directory_ignored( $path ) {
 	$directories_to_ignore = array( '.DS_Store', '.svn', '.git', '.hg', '.bzr', 'node_modules', 'vendor' );
-
-	foreach ( $directories_to_ignore as $directory ) {
-		if ( str_starts_with( $path, $directory ) ) {
-			return true;
-		}
-	}
-
-	return false;
+	return array_any( $directories_to_ignore, fn( $directory ) => str_starts_with( $path, $directory ) );
 }
 
 /**

--- a/src/wp-includes/class-wp-block-processor.php
+++ b/src/wp-includes/class-wp-block-processor.php
@@ -1597,14 +1597,7 @@ class WP_Block_Processor {
 		if ( count( $block_type ) === 0 ) {
 			return true;
 		}
-
-		foreach ( $block_type as $block ) {
-			if ( $this->is_block_type( $block ) ) {
-				return true;
-			}
-		}
-
-		return false;
+		return array_any( $block_type, fn( $block ) => $this->is_block_type( $block ) );
 	}
 
 	/**

--- a/src/wp-includes/class-wp-scripts.php
+++ b/src/wp-includes/class-wp-scripts.php
@@ -849,13 +849,7 @@ JS;
 		if ( str_starts_with( $src, '/' . WPINC . '/js/l10n' ) ) {
 			return false;
 		}
-
-		foreach ( (array) $this->default_dirs as $test ) {
-			if ( str_starts_with( $src, $test ) ) {
-				return true;
-			}
-		}
-		return false;
+		return array_any( (array) $this->default_dirs, fn( $test ) => str_starts_with( $src, $test ) );
 	}
 
 	/**

--- a/src/wp-includes/class-wp-styles.php
+++ b/src/wp-includes/class-wp-styles.php
@@ -458,13 +458,7 @@ class WP_Styles extends WP_Dependencies {
 		if ( ! $this->default_dirs ) {
 			return true;
 		}
-
-		foreach ( (array) $this->default_dirs as $test ) {
-			if ( str_starts_with( $src, $test ) ) {
-				return true;
-			}
-		}
-		return false;
+		return array_any( (array) $this->default_dirs, fn( $test ) => str_starts_with( $src, $test ) );
 	}
 
 	/**

--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -2056,13 +2056,7 @@ function wp_kses_bad_protocol_once2( $scheme, $allowed_protocols ) {
 	$scheme = wp_kses_no_null( $scheme );
 	$scheme = strtolower( $scheme );
 
-	$allowed = false;
-	foreach ( (array) $allowed_protocols as $one_protocol ) {
-		if ( strtolower( $one_protocol ) === $scheme ) {
-			$allowed = true;
-			break;
-		}
-	}
+	$allowed = array_any( (array) $allowed_protocols, fn( $protocol ) => strtolower( $protocol ) === $scheme );
 
 	if ( $allowed ) {
 		return "$scheme:";


### PR DESCRIPTION
Replaces several `foreach` loops that iterate an array, return `true` as soon as an element matches a condition, and otherwise fall through to `false`. This is exactly what PHP 8.4's `array_any()` expresses in a single, more readable call.

Core already ships an `array_any()` polyfill in `wp-includes/compat.php` (since 6.8.0), so the change works on every supported PHP version without raising the minimum requirement.

Trac ticket: https://core.trac.wordpress.org/ticket/65519

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
