### PR TITLE
Code Modernization: Use array_all() in various places.

### DIFF
--- a/src/wp-includes/class-wp-user.php
+++ b/src/wp-includes/class-wp-user.php
@@ -827,13 +827,7 @@ class WP_User {
 		unset( $capabilities['do_not_allow'] );
 
 		// Must have ALL requested caps.
-		foreach ( (array) $caps as $cap ) {
-			if ( empty( $capabilities[ $cap ] ) ) {
-				return false;
-			}
-		}
-
-		return true;
+		return array_all( (array) $caps, fn( $cap ) => ! empty( $capabilities[ $cap ] ) );
 	}
 
 	/**

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -5317,14 +5317,7 @@ function wp_is_numeric_array( $data ): bool {
 	if ( ! is_array( $data ) ) {
 		return false;
 	}
-
-	foreach ( $data as $key => $value ) {
-		if ( is_string( $key ) ) {
-			return false;
-		}
-	}
-
-	return true;
+	return array_all( $data, fn( $value, $key ) => ! is_string( $key ) );
 }
 
 /**

--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -2090,14 +2090,10 @@ function rest_are_values_equal( $value1, $value2 ) {
 		if ( count( $value1 ) !== count( $value2 ) ) {
 			return false;
 		}
-
-		foreach ( $value1 as $index => $value ) {
-			if ( ! array_key_exists( $index, $value2 ) || ! rest_are_values_equal( $value, $value2[ $index ] ) ) {
-				return false;
-			}
-		}
-
-		return true;
+		return array_all(
+			$value1,
+			fn( $value, $index ) => array_key_exists( $index, $value2 ) && rest_are_values_equal( $value, $value2[ $index ] )
+		);
 	}
 
 	if ( is_int( $value1 ) && is_float( $value2 )


### PR DESCRIPTION
Replaces several `foreach` loops that iterate an array, return `false` as soon as an element fails a condition, and otherwise fall through to `true`. This is exactly what PHP 8.4's `array_all()` expresses in a single, more readable call.

Core already ships an `array_all()` polyfill in `wp-includes/compat.php` (since 6.8.0), so the change works on every supported PHP version without raising the minimum requirement.

Trac ticket: https://core.trac.wordpress.org/ticket/65519

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
