### PR TITLE
Connectors: add application password authentication

### DIFF
--- a/src/wp-includes/class-wp-connector-registry.php
+++ b/src/wp-includes/class-wp-connector-registry.php
@@ -71,7 +71,7 @@ final class WP_Connector_Registry {
 	 * Validates the provided arguments and stores the connector in the registry.
 	 * For connectors with `api_key` or `application_password` authentication, a
 	 * `setting_name` can be provided explicitly. When omitted, setting names are
-	 * automatically generated using the pattern `connectors_{$type}_{$id}_{$credential}`,
+	 * automatically generated using the pattern `connectors_{$type}_{$id}_{$method}`,
 	 * with hyphens in the type and ID normalized to underscores. These setting
 	 * names are used for Settings API registration and REST API exposure.
 	 *

--- a/src/wp-includes/class-wp-connector-registry.php
+++ b/src/wp-includes/class-wp-connector-registry.php
@@ -205,12 +205,12 @@ final class WP_Connector_Registry {
 		}
 
 		if ( empty( $args['authentication']['method'] ) || ! in_array( $args['authentication']['method'], array( 'api_key', 'application_password', 'none' ), true ) ) {
-			_doing_it_wrong(
-				__METHOD__,
-				/* translators: %s: Connector ID. */
+				_doing_it_wrong(
+					__METHOD__,
+					/* translators: %s: Connector ID. */
 					sprintf( __( 'Connector "%s" authentication method must be "api_key", "application_password", or "none".' ), esc_html( $id ) ),
-				'7.0.0'
-			);
+					'7.0.0'
+				);
 			return null;
 		}
 

--- a/src/wp-includes/class-wp-connector-registry.php
+++ b/src/wp-includes/class-wp-connector-registry.php
@@ -102,7 +102,7 @@ final class WP_Connector_Registry {
 	 *                                       or application-password credentials. When
 	 *                                       omitted, auto-generated as
 	 *                                       `connectors_{$type}_{$id}_api_key` for API
-	 *                                       keys and `connectors_{$type}_{$id}_credentials`
+	 *                                       keys and `connectors_{$type}_{$id}_application_password`
 	 *                                       for application passwords.
 	 *                                       Must be a non-empty string when provided.
 	 *         @type string $constant_name   Optional. PHP constant name for the API key
@@ -246,7 +246,7 @@ final class WP_Connector_Registry {
 				}
 				$connector['authentication']['setting_name'] = $args['authentication']['setting_name'];
 			} else {
-				$setting_suffix                              = 'api_key' === $args['authentication']['method'] ? 'api_key' : 'credentials';
+				$setting_suffix                              = $args['authentication']['method'];
 				$connector['authentication']['setting_name'] = str_replace( '-', '_', "connectors_{$connector['type']}_{$id}_{$setting_suffix}" );
 			}
 

--- a/src/wp-includes/class-wp-connector-registry.php
+++ b/src/wp-includes/class-wp-connector-registry.php
@@ -214,6 +214,24 @@ final class WP_Connector_Registry {
 			return null;
 		}
 
+		if ( 'application_password' !== $args['authentication']['method'] ) {
+			foreach ( array( 'username_setting_name', 'application_password_setting_name' ) as $setting_name_key ) {
+				if ( array_key_exists( $setting_name_key, $args['authentication'] ) ) {
+					_doing_it_wrong(
+						__METHOD__,
+						sprintf(
+							/* translators: 1: Connector ID, 2: Authentication setting name key. */
+							__( 'Connector "%1$s" authentication %2$s can only be provided when authentication method is "application_password".' ),
+							esc_html( $id ),
+							esc_html( $setting_name_key )
+						),
+						'7.0.0'
+					);
+					return null;
+				}
+			}
+		}
+
 		if ( 'ai_provider' === $args['type'] && ! wp_supports_ai() ) {
 			// No need for a `doing_it_wrong` as AI support is disabled intentionally.
 			return null;

--- a/src/wp-includes/class-wp-connector-registry.php
+++ b/src/wp-includes/class-wp-connector-registry.php
@@ -280,12 +280,20 @@ final class WP_Connector_Registry {
 		}
 
 		if ( 'application_password' === $args['authentication']['method'] ) {
-			$setting_names = array(
-				'username_setting_name'             => 'username',
-				'application_password_setting_name' => 'application_password',
+			$default_setting_names = array(
+				'username_setting_name'             => str_replace(
+					'-',
+					'_',
+					"connectors_{$connector['type']}_{$id}_username"
+				),
+				'application_password_setting_name' => str_replace(
+					'-',
+					'_',
+					"connectors_{$connector['type']}_{$id}_application_password"
+				),
 			);
 
-			foreach ( $setting_names as $setting_name_key => $setting_name_suffix ) {
+			foreach ( $default_setting_names as $setting_name_key => $default_setting_name ) {
 				if ( isset( $args['authentication'][ $setting_name_key ] ) ) {
 					if ( ! is_string( $args['authentication'][ $setting_name_key ] ) || '' === $args['authentication'][ $setting_name_key ] ) {
 						_doing_it_wrong(
@@ -302,7 +310,7 @@ final class WP_Connector_Registry {
 					}
 					$connector['authentication'][ $setting_name_key ] = $args['authentication'][ $setting_name_key ];
 				} else {
-					$connector['authentication'][ $setting_name_key ] = str_replace( '-', '_', "connectors_{$connector['type']}_{$id}_{$setting_name_suffix}" );
+					$connector['authentication'][ $setting_name_key ] = $default_setting_name;
 				}
 			}
 		}

--- a/src/wp-includes/class-wp-connector-registry.php
+++ b/src/wp-includes/class-wp-connector-registry.php
@@ -33,9 +33,11 @@
  *     logo_url?: non-empty-string,
  *     type: non-empty-string,
  *     authentication: array{
- *         method: 'api_key'|'none',
+ *         method: 'api_key'|'application_password'|'none',
  *         credentials_url?: non-empty-string,
  *         setting_name?: non-empty-string,
+ *         username_setting_name?: non-empty-string,
+ *         application_password_setting_name?: non-empty-string,
  *         constant_name?: non-empty-string,
  *         env_var_name?: non-empty-string
  *     },
@@ -70,11 +72,12 @@ final class WP_Connector_Registry {
 	 *
 	 * Validates the provided arguments and stores the connector in the registry.
 	 * For connectors with `api_key` authentication, a `setting_name` can be provided
-	 * explicitly. If omitted, one is automatically generated using the pattern
-	 * `connectors_{$type}_{$id}_api_key`, with hyphens in the type and ID normalized
-	 * to underscores (e.g., connector type `spam_filtering` with ID `my_plugin` produces
-	 * `connectors_spam_filtering_my_plugin_api_key`). This setting name is used for the
-	 * Settings API registration and REST API exposure.
+	 * explicitly. For connectors with `application_password` authentication,
+	 * `username_setting_name` and `application_password_setting_name` can be provided.
+	 * When omitted, setting names are automatically generated using the pattern
+	 * `connectors_{$type}_{$id}_{$credential}`, with hyphens in the type and ID
+	 * normalized to underscores. These setting names are used for Settings API
+	 * registration and REST API exposure.
 	 *
 	 * Registering a connector with an ID that is already registered will trigger a
 	 * `_doing_it_wrong()` notice and return `null`. To override an existing connector,
@@ -96,12 +99,19 @@ final class WP_Connector_Registry {
 	 *     @type array  $authentication {
 	 *         Required. Authentication configuration.
 	 *
-	 *         @type string $method          Required. The authentication method: 'api_key' or 'none'.
+	 *         @type string $method          Required. The authentication method: 'api_key',
+	 *                                       'application_password', or 'none'.
 	 *         @type string $credentials_url Optional. URL where users can obtain API credentials.
 	 *         @type string $setting_name    Optional. The setting name for the API key.
 	 *                                       When omitted, auto-generated as
 	 *                                       `connectors_{$type}_{$id}_api_key`.
 	 *                                       Must be a non-empty string when provided.
+	 *         @type string $username_setting_name Optional. The setting name for the username used
+	 *                                       with application password authentication. When omitted,
+	 *                                       auto-generated as `connectors_{$type}_{$id}_username`.
+	 *         @type string $application_password_setting_name Optional. The setting name for the
+	 *                                       application password. When omitted, auto-generated as
+	 *                                       `connectors_{$type}_{$id}_application_password`.
 	 *         @type string $constant_name   Optional. PHP constant name for the API key
 	 *                                       (e.g. 'ANTHROPIC_API_KEY'). Only checked when provided.
 	 *         @type string $env_var_name    Optional. Environment variable name for the API key
@@ -126,9 +136,11 @@ final class WP_Connector_Registry {
 	 *     logo_url?: non-empty-string,
 	 *     type: non-empty-string,
 	 *     authentication: array{
-	 *         method: 'api_key'|'none',
+	 *         method: 'api_key'|'application_password'|'none',
 	 *         credentials_url?: non-empty-string,
 	 *         setting_name?: non-empty-string,
+	 *         username_setting_name?: non-empty-string,
+	 *         application_password_setting_name?: non-empty-string,
 	 *         constant_name?: non-empty-string,
 	 *         env_var_name?: non-empty-string
 	 *     },
@@ -192,11 +204,11 @@ final class WP_Connector_Registry {
 			return null;
 		}
 
-		if ( empty( $args['authentication']['method'] ) || ! in_array( $args['authentication']['method'], array( 'api_key', 'none' ), true ) ) {
+		if ( empty( $args['authentication']['method'] ) || ! in_array( $args['authentication']['method'], array( 'api_key', 'application_password', 'none' ), true ) ) {
 			_doing_it_wrong(
 				__METHOD__,
 				/* translators: %s: Connector ID. */
-				sprintf( __( 'Connector "%s" authentication method must be "api_key" or "none".' ), esc_html( $id ) ),
+					sprintf( __( 'Connector "%s" authentication method must be "api_key", "application_password", or "none".' ), esc_html( $id ) ),
 				'7.0.0'
 			);
 			return null;
@@ -220,10 +232,13 @@ final class WP_Connector_Registry {
 			$connector['logo_url'] = $args['logo_url'];
 		}
 
-		if ( 'api_key' === $args['authentication']['method'] ) {
+		if ( in_array( $args['authentication']['method'], array( 'api_key', 'application_password' ), true ) ) {
 			if ( ! empty( $args['authentication']['credentials_url'] ) && is_string( $args['authentication']['credentials_url'] ) ) {
 				$connector['authentication']['credentials_url'] = $args['authentication']['credentials_url'];
 			}
+		}
+
+		if ( 'api_key' === $args['authentication']['method'] ) {
 			if ( isset( $args['authentication']['setting_name'] ) ) {
 				if ( ! is_string( $args['authentication']['setting_name'] ) || '' === $args['authentication']['setting_name'] ) {
 					_doing_it_wrong(
@@ -261,6 +276,34 @@ final class WP_Connector_Registry {
 					return null;
 				}
 				$connector['authentication']['env_var_name'] = $args['authentication']['env_var_name'];
+			}
+		}
+
+		if ( 'application_password' === $args['authentication']['method'] ) {
+			$setting_names = array(
+				'username_setting_name'             => 'username',
+				'application_password_setting_name' => 'application_password',
+			);
+
+			foreach ( $setting_names as $setting_name_key => $setting_name_suffix ) {
+				if ( isset( $args['authentication'][ $setting_name_key ] ) ) {
+					if ( ! is_string( $args['authentication'][ $setting_name_key ] ) || '' === $args['authentication'][ $setting_name_key ] ) {
+						_doing_it_wrong(
+							__METHOD__,
+							sprintf(
+								/* translators: 1: Connector ID, 2: Authentication setting name key. */
+								__( 'Connector "%1$s" authentication %2$s must be a non-empty string.' ),
+								esc_html( $id ),
+								esc_html( $setting_name_key )
+							),
+							'7.0.0'
+						);
+						return null;
+					}
+					$connector['authentication'][ $setting_name_key ] = $args['authentication'][ $setting_name_key ];
+				} else {
+					$connector['authentication'][ $setting_name_key ] = str_replace( '-', '_', "connectors_{$connector['type']}_{$id}_{$setting_name_suffix}" );
+				}
 			}
 		}
 

--- a/src/wp-includes/class-wp-connector-registry.php
+++ b/src/wp-includes/class-wp-connector-registry.php
@@ -106,9 +106,13 @@ final class WP_Connector_Registry {
 	 *                                       for application passwords.
 	 *                                       Must be a non-empty string when provided.
 	 *         @type string $constant_name   Optional. PHP constant name for the API key
-	 *                                       (e.g. 'ANTHROPIC_API_KEY'). Only checked when provided.
+	 *                                       (e.g. 'ANTHROPIC_API_KEY') or for application-password
+	 *                                       credentials in `username:password` format. Only checked
+	 *                                       when provided.
 	 *         @type string $env_var_name    Optional. Environment variable name for the API key
-	 *                                       (e.g. 'ANTHROPIC_API_KEY'). Only checked when provided.
+	 *                                       (e.g. 'ANTHROPIC_API_KEY') or for application-password
+	 *                                       credentials in `username:password` format. Only checked
+	 *                                       when provided.
 	 *     }
 	 *     @type array  $plugin         {
 	 *         Optional. Plugin data for install/activate UI.
@@ -263,7 +267,7 @@ final class WP_Connector_Registry {
 			}
 		}
 
-		if ( 'api_key' === $args['authentication']['method'] ) {
+		if ( in_array( $args['authentication']['method'], array( 'api_key', 'application_password' ), true ) ) {
 			if ( isset( $args['authentication']['constant_name'] ) ) {
 				if ( ! is_string( $args['authentication']['constant_name'] ) || '' === $args['authentication']['constant_name'] ) {
 					_doing_it_wrong(

--- a/src/wp-includes/class-wp-connector-registry.php
+++ b/src/wp-includes/class-wp-connector-registry.php
@@ -36,8 +36,6 @@
  *         method: 'api_key'|'application_password'|'none',
  *         credentials_url?: non-empty-string,
  *         setting_name?: non-empty-string,
- *         username_setting_name?: non-empty-string,
- *         application_password_setting_name?: non-empty-string,
  *         constant_name?: non-empty-string,
  *         env_var_name?: non-empty-string
  *     },
@@ -71,13 +69,11 @@ final class WP_Connector_Registry {
 	 * Registers a new connector.
 	 *
 	 * Validates the provided arguments and stores the connector in the registry.
-	 * For connectors with `api_key` authentication, a `setting_name` can be provided
-	 * explicitly. For connectors with `application_password` authentication,
-	 * `username_setting_name` and `application_password_setting_name` can be provided.
-	 * When omitted, setting names are automatically generated using the pattern
-	 * `connectors_{$type}_{$id}_{$credential}`, with hyphens in the type and ID
-	 * normalized to underscores. These setting names are used for Settings API
-	 * registration and REST API exposure.
+	 * For connectors with `api_key` or `application_password` authentication, a
+	 * `setting_name` can be provided explicitly. When omitted, setting names are
+	 * automatically generated using the pattern `connectors_{$type}_{$id}_{$credential}`,
+	 * with hyphens in the type and ID normalized to underscores. These setting
+	 * names are used for Settings API registration and REST API exposure.
 	 *
 	 * Registering a connector with an ID that is already registered will trigger a
 	 * `_doing_it_wrong()` notice and return `null`. To override an existing connector,
@@ -102,16 +98,13 @@ final class WP_Connector_Registry {
 	 *         @type string $method          Required. The authentication method: 'api_key',
 	 *                                       'application_password', or 'none'.
 	 *         @type string $credentials_url Optional. URL where users can obtain API credentials.
-	 *         @type string $setting_name    Optional. The setting name for the API key.
-	 *                                       When omitted, auto-generated as
-	 *                                       `connectors_{$type}_{$id}_api_key`.
+	 *         @type string $setting_name    Optional. The setting name for the API key
+	 *                                       or application-password credentials. When
+	 *                                       omitted, auto-generated as
+	 *                                       `connectors_{$type}_{$id}_api_key` for API
+	 *                                       keys and `connectors_{$type}_{$id}_credentials`
+	 *                                       for application passwords.
 	 *                                       Must be a non-empty string when provided.
-	 *         @type string $username_setting_name Optional. The setting name for the username used
-	 *                                       with application password authentication. When omitted,
-	 *                                       auto-generated as `connectors_{$type}_{$id}_username`.
-	 *         @type string $application_password_setting_name Optional. The setting name for the
-	 *                                       application password. When omitted, auto-generated as
-	 *                                       `connectors_{$type}_{$id}_application_password`.
 	 *         @type string $constant_name   Optional. PHP constant name for the API key
 	 *                                       (e.g. 'ANTHROPIC_API_KEY'). Only checked when provided.
 	 *         @type string $env_var_name    Optional. Environment variable name for the API key
@@ -139,8 +132,6 @@ final class WP_Connector_Registry {
 	 *         method: 'api_key'|'application_password'|'none',
 	 *         credentials_url?: non-empty-string,
 	 *         setting_name?: non-empty-string,
-	 *         username_setting_name?: non-empty-string,
-	 *         application_password_setting_name?: non-empty-string,
 	 *         constant_name?: non-empty-string,
 	 *         env_var_name?: non-empty-string
 	 *     },
@@ -214,21 +205,19 @@ final class WP_Connector_Registry {
 			return null;
 		}
 
-		if ( 'application_password' !== $args['authentication']['method'] ) {
-			foreach ( array( 'username_setting_name', 'application_password_setting_name' ) as $setting_name_key ) {
-				if ( array_key_exists( $setting_name_key, $args['authentication'] ) ) {
-					_doing_it_wrong(
-						__METHOD__,
-						sprintf(
-							/* translators: 1: Connector ID, 2: Authentication setting name key. */
-							__( 'Connector "%1$s" authentication %2$s can only be provided when authentication method is "application_password".' ),
-							esc_html( $id ),
-							esc_html( $setting_name_key )
-						),
-						'7.0.0'
-					);
-					return null;
-				}
+		foreach ( array( 'username_setting_name', 'application_password_setting_name' ) as $setting_name_key ) {
+			if ( array_key_exists( $setting_name_key, $args['authentication'] ) ) {
+				_doing_it_wrong(
+					__METHOD__,
+					sprintf(
+						/* translators: 1: Connector ID, 2: Authentication setting name key. */
+						__( 'Connector "%1$s" authentication %2$s is not supported. Use setting_name instead.' ),
+						esc_html( $id ),
+						esc_html( $setting_name_key )
+					),
+					'7.0.0'
+				);
+				return null;
 			}
 		}
 
@@ -256,7 +245,7 @@ final class WP_Connector_Registry {
 			}
 		}
 
-		if ( 'api_key' === $args['authentication']['method'] ) {
+		if ( in_array( $args['authentication']['method'], array( 'api_key', 'application_password' ), true ) ) {
 			if ( isset( $args['authentication']['setting_name'] ) ) {
 				if ( ! is_string( $args['authentication']['setting_name'] ) || '' === $args['authentication']['setting_name'] ) {
 					_doing_it_wrong(
@@ -269,8 +258,12 @@ final class WP_Connector_Registry {
 				}
 				$connector['authentication']['setting_name'] = $args['authentication']['setting_name'];
 			} else {
-				$connector['authentication']['setting_name'] = str_replace( '-', '_', "connectors_{$connector['type']}_{$id}_api_key" );
+				$setting_suffix                              = 'api_key' === $args['authentication']['method'] ? 'api_key' : 'credentials';
+				$connector['authentication']['setting_name'] = str_replace( '-', '_', "connectors_{$connector['type']}_{$id}_{$setting_suffix}" );
 			}
+		}
+
+		if ( 'api_key' === $args['authentication']['method'] ) {
 			if ( isset( $args['authentication']['constant_name'] ) ) {
 				if ( ! is_string( $args['authentication']['constant_name'] ) || '' === $args['authentication']['constant_name'] ) {
 					_doing_it_wrong(
@@ -294,42 +287,6 @@ final class WP_Connector_Registry {
 					return null;
 				}
 				$connector['authentication']['env_var_name'] = $args['authentication']['env_var_name'];
-			}
-		}
-
-		if ( 'application_password' === $args['authentication']['method'] ) {
-			$default_setting_names = array(
-				'username_setting_name'             => str_replace(
-					'-',
-					'_',
-					"connectors_{$connector['type']}_{$id}_username"
-				),
-				'application_password_setting_name' => str_replace(
-					'-',
-					'_',
-					"connectors_{$connector['type']}_{$id}_application_password"
-				),
-			);
-
-			foreach ( $default_setting_names as $setting_name_key => $default_setting_name ) {
-				if ( isset( $args['authentication'][ $setting_name_key ] ) ) {
-					if ( ! is_string( $args['authentication'][ $setting_name_key ] ) || '' === $args['authentication'][ $setting_name_key ] ) {
-						_doing_it_wrong(
-							__METHOD__,
-							sprintf(
-								/* translators: 1: Connector ID, 2: Authentication setting name key. */
-								__( 'Connector "%1$s" authentication %2$s must be a non-empty string.' ),
-								esc_html( $id ),
-								esc_html( $setting_name_key )
-							),
-							'7.0.0'
-						);
-						return null;
-					}
-					$connector['authentication'][ $setting_name_key ] = $args['authentication'][ $setting_name_key ];
-				} else {
-					$connector['authentication'][ $setting_name_key ] = $default_setting_name;
-				}
 			}
 		}
 

--- a/src/wp-includes/class-wp-connector-registry.php
+++ b/src/wp-includes/class-wp-connector-registry.php
@@ -246,8 +246,7 @@ final class WP_Connector_Registry {
 				}
 				$connector['authentication']['setting_name'] = $args['authentication']['setting_name'];
 			} else {
-				$setting_suffix                              = $args['authentication']['method'];
-				$connector['authentication']['setting_name'] = str_replace( '-', '_', "connectors_{$connector['type']}_{$id}_{$setting_suffix}" );
+				$connector['authentication']['setting_name'] = str_replace( '-', '_', "connectors_{$connector['type']}_{$id}_{$args['authentication']['method']}" );
 			}
 
 			if ( isset( $args['authentication']['constant_name'] ) ) {

--- a/src/wp-includes/class-wp-connector-registry.php
+++ b/src/wp-includes/class-wp-connector-registry.php
@@ -200,29 +200,13 @@ final class WP_Connector_Registry {
 		}
 
 		if ( empty( $args['authentication']['method'] ) || ! in_array( $args['authentication']['method'], array( 'api_key', 'application_password', 'none' ), true ) ) {
-				_doing_it_wrong(
-					__METHOD__,
-					/* translators: %s: Connector ID. */
-					sprintf( __( 'Connector "%s" authentication method must be "api_key", "application_password", or "none".' ), esc_html( $id ) ),
-					'7.0.0'
-				);
+			_doing_it_wrong(
+				__METHOD__,
+				/* translators: %s: Connector ID. */
+				sprintf( __( 'Connector "%s" authentication method must be "api_key", "application_password", or "none".' ), esc_html( $id ) ),
+				'7.0.0'
+			);
 			return null;
-		}
-
-		foreach ( array( 'username_setting_name', 'application_password_setting_name' ) as $setting_name_key ) {
-			if ( array_key_exists( $setting_name_key, $args['authentication'] ) ) {
-				_doing_it_wrong(
-					__METHOD__,
-					sprintf(
-						/* translators: 1: Connector ID, 2: Authentication setting name key. */
-						__( 'Connector "%1$s" authentication %2$s is not supported. Use setting_name instead.' ),
-						esc_html( $id ),
-						esc_html( $setting_name_key )
-					),
-					'7.0.0'
-				);
-				return null;
-			}
 		}
 
 		if ( 'ai_provider' === $args['type'] && ! wp_supports_ai() ) {
@@ -243,13 +227,13 @@ final class WP_Connector_Registry {
 			$connector['logo_url'] = $args['logo_url'];
 		}
 
-		if ( in_array( $args['authentication']['method'], array( 'api_key', 'application_password' ), true ) ) {
+		$requires_credentials = in_array( $args['authentication']['method'], array( 'api_key', 'application_password' ), true );
+
+		if ( $requires_credentials ) {
 			if ( ! empty( $args['authentication']['credentials_url'] ) && is_string( $args['authentication']['credentials_url'] ) ) {
 				$connector['authentication']['credentials_url'] = $args['authentication']['credentials_url'];
 			}
-		}
 
-		if ( in_array( $args['authentication']['method'], array( 'api_key', 'application_password' ), true ) ) {
 			if ( isset( $args['authentication']['setting_name'] ) ) {
 				if ( ! is_string( $args['authentication']['setting_name'] ) || '' === $args['authentication']['setting_name'] ) {
 					_doing_it_wrong(
@@ -265,9 +249,7 @@ final class WP_Connector_Registry {
 				$setting_suffix                              = 'api_key' === $args['authentication']['method'] ? 'api_key' : 'credentials';
 				$connector['authentication']['setting_name'] = str_replace( '-', '_', "connectors_{$connector['type']}_{$id}_{$setting_suffix}" );
 			}
-		}
 
-		if ( in_array( $args['authentication']['method'], array( 'api_key', 'application_password' ), true ) ) {
 			if ( isset( $args['authentication']['constant_name'] ) ) {
 				if ( ! is_string( $args['authentication']['constant_name'] ) || '' === $args['authentication']['constant_name'] ) {
 					_doing_it_wrong(

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -482,8 +482,10 @@ function _wp_connectors_get_api_key_source( string $setting_name, string $env_va
  */
 function _wp_connectors_parse_application_password_credentials( string $value ): array {
 	$separator = strpos( $value, ':' );
-	$username  = false === $separator ? '' : substr( $value, 0, $separator );
-	$password  = false === $separator ? '' : substr( $value, $separator + 1 );
+	// Trim so surrounding whitespace or a trailing newline (common when the
+	// value comes from a file or `.env`) does not become part of the credentials.
+	$username  = false === $separator ? '' : trim( substr( $value, 0, $separator ) );
+	$password  = false === $separator ? '' : trim( substr( $value, $separator + 1 ) );
 
 	if ( '' === $username || '' === $password ) {
 		return array(

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -47,11 +47,16 @@ function wp_is_connector_registered( string $id ): bool {
  *     @type array  $authentication {
  *         Authentication configuration. When method is 'api_key', includes
  *         credentials_url, setting_name, and optionally constant_name and
- *         env_var_name. When 'none', only method is present.
+ *         env_var_name. When method is 'application_password', includes
+ *         credentials_url, username_setting_name, and
+ *         application_password_setting_name. When 'none', only method is present.
  *
- *         @type string $method          The authentication method: 'api_key' or 'none'.
+ *         @type string $method          The authentication method: 'api_key',
+ *                                       'application_password', or 'none'.
  *         @type string $credentials_url Optional. URL where users can obtain API credentials.
  *         @type string $setting_name    Optional. The setting name for the API key.
+ *         @type string $username_setting_name Optional. The setting name for the username.
+ *         @type string $application_password_setting_name Optional. The setting name for the application password.
  *         @type string $constant_name   Optional. PHP constant name for the API key.
  *         @type string $env_var_name    Optional. Environment variable name for the API key.
  *     }
@@ -70,9 +75,11 @@ function wp_is_connector_registered( string $id ): bool {
  *     logo_url?: non-empty-string,
  *     type: non-empty-string,
  *     authentication: array{
- *         method: 'api_key'|'none',
+ *         method: 'api_key'|'application_password'|'none',
  *         credentials_url?: non-empty-string,
  *         setting_name?: non-empty-string,
+ *         username_setting_name?: non-empty-string,
+ *         application_password_setting_name?: non-empty-string,
  *         constant_name?: non-empty-string,
  *         env_var_name?: non-empty-string
  *     },
@@ -111,11 +118,16 @@ function wp_get_connector( string $id ): ?array {
  *         @type array       $authentication {
  *             Authentication configuration. When method is 'api_key', includes
  *             credentials_url, setting_name, and optionally constant_name and
- *             env_var_name. When 'none', only method is present.
+ *             env_var_name. When method is 'application_password', includes
+ *             credentials_url, username_setting_name, and
+ *             application_password_setting_name. When 'none', only method is present.
  *
- *             @type string $method          The authentication method: 'api_key' or 'none'.
+ *             @type string $method          The authentication method: 'api_key',
+ *                                           'application_password', or 'none'.
  *             @type string $credentials_url Optional. URL where users can obtain API credentials.
  *             @type string $setting_name    Optional. The setting name for the API key.
+ *             @type string $username_setting_name Optional. The setting name for the username.
+ *             @type string $application_password_setting_name Optional. The setting name for the application password.
  *             @type string $constant_name   Optional. PHP constant name for the API key.
  *             @type string $env_var_name    Optional. Environment variable name for the API key.
  *         }
@@ -135,9 +147,11 @@ function wp_get_connector( string $id ): ?array {
  *     logo_url?: non-empty-string,
  *     type: non-empty-string,
  *     authentication: array{
- *         method: 'api_key'|'none',
+ *         method: 'api_key'|'application_password'|'none',
  *         credentials_url?: non-empty-string,
  *         setting_name?: non-empty-string,
+ *         username_setting_name?: non-empty-string,
+ *         application_password_setting_name?: non-empty-string,
  *         constant_name?: non-empty-string,
  *         env_var_name?: non-empty-string
  *     },
@@ -503,7 +517,7 @@ function _wp_connectors_is_ai_api_key_valid( string $key, string $provider_id ):
 }
 
 /**
- * Masks and validates connector API keys in REST responses.
+ * Masks and validates connector credentials in REST responses.
  *
  * On every `/wp/v2/settings` response, masks connector API key values so raw
  * keys are never exposed via the REST API.
@@ -533,6 +547,15 @@ function _wp_connectors_rest_settings_dispatch( WP_REST_Response $response, WP_R
 
 	foreach ( wp_get_connectors() as $connector_id => $connector_data ) {
 		$auth = $connector_data['authentication'];
+
+		if ( 'application_password' === $auth['method'] && ! empty( $auth['application_password_setting_name'] ) ) {
+			$setting_name = $auth['application_password_setting_name'];
+			if ( array_key_exists( $setting_name, $data ) && is_string( $data[ $setting_name ] ) && '' !== $data[ $setting_name ] ) {
+				$data[ $setting_name ] = _wp_connectors_mask_api_key( $data[ $setting_name ] );
+			}
+			continue;
+		}
+
 		if ( 'api_key' !== $auth['method'] || empty( $auth['setting_name'] ) ) {
 			continue;
 		}
@@ -576,12 +599,7 @@ function _wp_register_default_connector_settings(): void {
 
 	foreach ( wp_get_connectors() as $connector_data ) {
 		$auth = $connector_data['authentication'];
-		if ( 'api_key' !== $auth['method'] || empty( $auth['setting_name'] ) ) {
-			continue;
-		}
-
-		// Skip if the setting is already registered (e.g. by an owning plugin).
-		if ( isset( $registered_settings[ $auth['setting_name'] ] ) ) {
+		if ( 'api_key' !== $auth['method'] && 'application_password' !== $auth['method'] ) {
 			continue;
 		}
 
@@ -593,10 +611,9 @@ function _wp_register_default_connector_settings(): void {
 			continue;
 		}
 
-		register_setting(
-			'connectors',
-			$auth['setting_name'],
-			array(
+		$settings = array();
+		if ( 'api_key' === $auth['method'] && ! empty( $auth['setting_name'] ) ) {
+			$settings[ $auth['setting_name'] ] = array(
 				'type'              => 'string',
 				'label'             => sprintf(
 					/* translators: %s: Connector name. */
@@ -611,8 +628,49 @@ function _wp_register_default_connector_settings(): void {
 				'default'           => '',
 				'show_in_rest'      => true,
 				'sanitize_callback' => 'sanitize_text_field',
-			)
-		);
+			);
+		} elseif ( 'application_password' === $auth['method'] && ! empty( $auth['username_setting_name'] ) && ! empty( $auth['application_password_setting_name'] ) ) {
+			$settings[ $auth['username_setting_name'] ] = array(
+				'type'              => 'string',
+				'label'             => sprintf(
+					/* translators: %s: Connector name. */
+					__( '%s Username' ),
+					$connector_data['name']
+				),
+				'description'       => sprintf(
+					/* translators: %s: Connector name. */
+					__( 'Username for the %s connector.' ),
+					$connector_data['name']
+				),
+				'default'           => '',
+				'show_in_rest'      => true,
+				'sanitize_callback' => 'sanitize_text_field',
+			);
+			$settings[ $auth['application_password_setting_name'] ] = array(
+				'type'              => 'string',
+				'label'             => sprintf(
+					/* translators: %s: Connector name. */
+					__( '%s Application Password' ),
+					$connector_data['name']
+				),
+				'description'       => sprintf(
+					/* translators: %s: Connector name. */
+					__( 'Application password for the %s connector.' ),
+					$connector_data['name']
+				),
+				'default'           => '',
+				'show_in_rest'      => true,
+				'sanitize_callback' => 'sanitize_text_field',
+			);
+		}
+
+		foreach ( $settings as $setting_name => $setting_args ) {
+			// Skip settings already registered by the connector's owning plugin.
+			if ( isset( $registered_settings[ $setting_name ] ) ) {
+				continue;
+			}
+			register_setting( 'connectors', $setting_name, $setting_args );
+		}
 	}
 }
 add_action( 'init', '_wp_register_default_connector_settings', 20 );
@@ -698,6 +756,16 @@ function _wp_connectors_get_connector_script_module_data( array $data ): array {
 			} else {
 				$auth_out['isConnected'] = 'none' !== $key_source;
 			}
+		} elseif ( 'application_password' === $auth['method'] ) {
+			$username_setting_name             = $auth['username_setting_name'] ?? '';
+			$application_password_setting_name = $auth['application_password_setting_name'] ?? '';
+			$username                          = get_option( $username_setting_name, '' );
+			$application_password              = get_option( $application_password_setting_name, '' );
+
+			$auth_out['usernameSettingName']             = $username_setting_name;
+			$auth_out['applicationPasswordSettingName'] = $application_password_setting_name;
+			$auth_out['credentialsUrl']                 = $auth['credentials_url'] ?? null;
+			$auth_out['isConnected']                    = is_string( $username ) && '' !== $username && is_string( $application_password ) && '' !== $application_password;
 		}
 
 		$connector_out = array(

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -45,17 +45,17 @@ function wp_is_connector_registered( string $id ): bool {
  *     @type string $logo_url       Optional. URL to the connector's logo image.
  *     @type string $type           The connector type, e.g. 'ai_provider'.
  *     @type array  $authentication {
- *         Authentication configuration. When method is 'api_key', includes
- *         credentials_url, setting_name, and optionally constant_name and
- *         env_var_name. When method is 'application_password', includes
- *         credentials_url and setting_name. When 'none', only method is present.
+ *         Authentication configuration. When method is 'api_key' or
+ *         'application_password', includes credentials_url, setting_name, and
+ *         optionally constant_name and env_var_name. When 'none', only method
+ *         is present.
  *
  *         @type string $method          The authentication method: 'api_key',
  *                                       'application_password', or 'none'.
  *         @type string $credentials_url Optional. URL where users can obtain API credentials.
  *         @type string $setting_name    Optional. The setting name for the API key or application-password credentials.
- *         @type string $constant_name   Optional. PHP constant name for the API key.
- *         @type string $env_var_name    Optional. Environment variable name for the API key.
+ *         @type string $constant_name   Optional. PHP constant name for the API key or application-password credentials.
+ *         @type string $env_var_name    Optional. Environment variable name for the API key or application-password credentials.
  *     }
  *     @type array  $plugin         {
  *         Optional. Plugin data for install/activate UI.
@@ -111,17 +111,17 @@ function wp_get_connector( string $id ): ?array {
  *         @type string      $logo_url       Optional. URL to the connector's logo image.
  *         @type string      $type           The connector type, e.g. 'ai_provider'.
  *         @type array       $authentication {
- *             Authentication configuration. When method is 'api_key', includes
- *             credentials_url, setting_name, and optionally constant_name and
- *             env_var_name. When method is 'application_password', includes
- *             credentials_url and setting_name. When 'none', only method is present.
+ *             Authentication configuration. When method is 'api_key' or
+ *             'application_password', includes credentials_url, setting_name,
+ *             and optionally constant_name and env_var_name. When 'none', only
+ *             method is present.
  *
  *             @type string $method          The authentication method: 'api_key',
  *                                           'application_password', or 'none'.
  *             @type string $credentials_url Optional. URL where users can obtain API credentials.
  *             @type string $setting_name    Optional. The setting name for the API key or application-password credentials.
- *             @type string $constant_name   Optional. PHP constant name for the API key.
- *             @type string $env_var_name    Optional. Environment variable name for the API key.
+ *             @type string $constant_name   Optional. PHP constant name for the API key or application-password credentials.
+ *             @type string $env_var_name    Optional. Environment variable name for the API key or application-password credentials.
  *         }
  *         @type array       $plugin         {
  *             Optional. Plugin data for install/activate UI.
@@ -468,6 +468,90 @@ function _wp_connectors_get_api_key_source( string $setting_name, string $env_va
 }
 
 /**
+ * Parses a `username:password` credentials string.
+ *
+ * Splits on the first colon, matching the HTTP Basic authentication
+ * userinfo format, so passwords may contain colons.
+ *
+ * @since 7.0.0
+ * @access private
+ *
+ * @param string $value The raw credentials string.
+ * @return array{username: string, password: string} Parsed credentials. Both values
+ *                                                   are empty when the string is malformed.
+ */
+function _wp_connectors_parse_application_password_credentials( string $value ): array {
+	$separator = strpos( $value, ':' );
+	$username  = false === $separator ? '' : substr( $value, 0, $separator );
+	$password  = false === $separator ? '' : substr( $value, $separator + 1 );
+
+	if ( '' === $username || '' === $password ) {
+		return array(
+			'username' => '',
+			'password' => '',
+		);
+	}
+
+	return array(
+		'username' => $username,
+		'password' => $password,
+	);
+}
+
+/**
+ * Resolves application-password credentials for a connector.
+ *
+ * Checks in order: environment variable, PHP constant, database. The
+ * environment variable and constant are only checked when their respective
+ * names are provided, and must contain the credentials as a single
+ * `username:password` string. A non-empty environment variable or constant
+ * claims the source even when malformed, in which case the resolved
+ * credentials are empty.
+ *
+ * @since 7.0.0
+ * @access private
+ *
+ * @param array $auth The connector's authentication configuration.
+ * @return array{username: string, password: string, source: string} Resolved credentials and
+ *                                                                   their source: 'env', 'constant',
+ *                                                                   'database', or 'none'.
+ */
+function _wp_connectors_get_application_password_credentials( array $auth ): array {
+	// Check environment variable first.
+	$env_var_name = $auth['env_var_name'] ?? '';
+	if ( '' !== $env_var_name ) {
+		$env_value = getenv( $env_var_name );
+		if ( false !== $env_value && '' !== $env_value ) {
+			$credentials           = _wp_connectors_parse_application_password_credentials( $env_value );
+			$credentials['source'] = 'env';
+			return $credentials;
+		}
+	}
+
+	// Check PHP constant.
+	$constant_name = $auth['constant_name'] ?? '';
+	if ( '' !== $constant_name && defined( $constant_name ) ) {
+		$const_value = constant( $constant_name );
+		if ( is_string( $const_value ) && '' !== $const_value ) {
+			$credentials           = _wp_connectors_parse_application_password_credentials( $const_value );
+			$credentials['source'] = 'constant';
+			return $credentials;
+		}
+	}
+
+	// Check database.
+	$stored   = get_option( $auth['setting_name'] ?? '', array() );
+	$username = is_array( $stored ) && isset( $stored['username'] ) && is_string( $stored['username'] ) ? $stored['username'] : '';
+	$password = is_array( $stored ) && isset( $stored['password'] ) && is_string( $stored['password'] ) ? $stored['password'] : '';
+
+	return array(
+		'username' => $username,
+		'password' => $password,
+		'source'   => '' !== $username || '' !== $password ? 'database' : 'none',
+	);
+}
+
+/**
  * Checks whether an API key is valid for a given provider.
  *
  * @since 7.0.0
@@ -795,14 +879,12 @@ function _wp_connectors_get_connector_script_module_data( array $data ): array {
 				$auth_out['isConnected'] = 'none' !== $key_source;
 			}
 		} elseif ( 'application_password' === $auth['method'] ) {
-			$setting_name = $auth['setting_name'] ?? '';
-			$credentials  = get_option( $setting_name, array() );
-			$username     = is_array( $credentials ) ? ( $credentials['username'] ?? '' ) : '';
-			$password     = is_array( $credentials ) ? ( $credentials['password'] ?? '' ) : '';
+			$credentials = _wp_connectors_get_application_password_credentials( $auth );
 
-			$auth_out['settingName']    = $setting_name;
+			$auth_out['settingName']    = $auth['setting_name'] ?? '';
 			$auth_out['credentialsUrl'] = $auth['credentials_url'] ?? null;
-			$auth_out['isConnected']    = is_string( $username ) && '' !== $username && is_string( $password ) && '' !== $password;
+			$auth_out['keySource']      = $credentials['source'];
+			$auth_out['isConnected']    = '' !== $credentials['username'] && '' !== $credentials['password'];
 		}
 
 		$connector_out = array(

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -437,6 +437,18 @@ function _wp_connectors_mask_api_key( string $key ): string {
 }
 
 /**
+ * Masks an application password without revealing any characters.
+ *
+ * @since 7.0.0
+ * @access private
+ *
+ * @return string The masked application password.
+ */
+function _wp_connectors_mask_application_password(): string {
+	return str_repeat( "\u{2022}", 16 );
+}
+
+/**
  * Determines the source of an API key for a given connector.
  *
  * Checks in order: environment variable, PHP constant, database.
@@ -552,7 +564,7 @@ function _wp_connectors_rest_settings_dispatch( WP_REST_Response $response, WP_R
 		if ( 'application_password' === $auth['method'] && ! empty( $auth['application_password_setting_name'] ) ) {
 			$setting_name = $auth['application_password_setting_name'];
 			if ( array_key_exists( $setting_name, $data ) && is_string( $data[ $setting_name ] ) && '' !== $data[ $setting_name ] ) {
-				$data[ $setting_name ] = _wp_connectors_mask_api_key( $data[ $setting_name ] );
+				$data[ $setting_name ] = _wp_connectors_mask_application_password();
 			}
 			continue;
 		}

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -509,6 +509,13 @@ function _wp_connectors_is_ai_api_key_valid( string $key, string $provider_id ):
 /**
  * Sanitizes stored application-password credentials for a connector.
  *
+ * Credential fields that are missing or not strings keep their currently
+ * stored values, so partial updates cannot silently clear a stored secret.
+ * A password matching the mask that `_wp_connectors_rest_settings_dispatch()`
+ * places in REST responses also keeps the stored password, so a masked
+ * settings response can be submitted back to the endpoint unchanged.
+ * Pass an empty string to clear a field.
+ *
  * @since 7.0.0
  * @access private
  *
@@ -520,10 +527,27 @@ function _wp_connectors_sanitize_application_password_credentials( $value ): arr
 		$value = array();
 	}
 
-	return array(
-		'username' => isset( $value['username'] ) && is_string( $value['username'] ) ? sanitize_text_field( $value['username'] ) : '',
-		'password' => isset( $value['password'] ) && is_string( $value['password'] ) ? sanitize_text_field( $value['password'] ) : '',
-	);
+	$option = str_replace( 'sanitize_option_', '', (string) current_filter() );
+	$stored = get_option( $option );
+	if ( ! is_array( $stored ) ) {
+		$stored = array();
+	}
+
+	$credentials = array();
+	foreach ( array( 'username', 'password' ) as $field ) {
+		if ( isset( $value[ $field ] ) && is_string( $value[ $field ] ) ) {
+			$credentials[ $field ] = sanitize_text_field( $value[ $field ] );
+		} else {
+			$credentials[ $field ] = isset( $stored[ $field ] ) && is_string( $stored[ $field ] ) ? $stored[ $field ] : '';
+		}
+	}
+
+	// A masked password means a client resubmitted a masked REST response.
+	if ( str_repeat( "\u{2022}", 16 ) === $credentials['password'] ) {
+		$credentials['password'] = isset( $stored['password'] ) && is_string( $stored['password'] ) ? $stored['password'] : '';
+	}
+
+	return $credentials;
 }
 
 /**

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -630,7 +630,7 @@ function _wp_register_default_connector_settings(): void {
 				'sanitize_callback' => 'sanitize_text_field',
 			);
 		} elseif ( 'application_password' === $auth['method'] && ! empty( $auth['username_setting_name'] ) && ! empty( $auth['application_password_setting_name'] ) ) {
-			$settings[ $auth['username_setting_name'] ] = array(
+			$settings[ $auth['username_setting_name'] ]             = array(
 				'type'              => 'string',
 				'label'             => sprintf(
 					/* translators: %s: Connector name. */
@@ -762,7 +762,7 @@ function _wp_connectors_get_connector_script_module_data( array $data ): array {
 			$username                          = get_option( $username_setting_name, '' );
 			$application_password              = get_option( $application_password_setting_name, '' );
 
-			$auth_out['usernameSettingName']             = $username_setting_name;
+			$auth_out['usernameSettingName']            = $username_setting_name;
 			$auth_out['applicationPasswordSettingName'] = $application_password_setting_name;
 			$auth_out['credentialsUrl']                 = $auth['credentials_url'] ?? null;
 			$auth_out['isConnected']                    = is_string( $username ) && '' !== $username && is_string( $application_password ) && '' !== $application_password;

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -480,7 +480,7 @@ function _wp_connectors_get_api_key_source( string $setting_name, string $env_va
  * @return array{username: string, password: string} Parsed credentials. Both values
  *                                                   are empty when the string is malformed.
  */
-function _wp_connectors_parse_application_password_credentials( string $value ): array {
+function wp_connectors_parse_application_password_credentials( string $value ): array {
 	$separator = strpos( $value, ':' );
 	// Trim so surrounding whitespace or a trailing newline (common when the
 	// value comes from a file or `.env`) does not become part of the credentials.
@@ -519,13 +519,13 @@ function _wp_connectors_parse_application_password_credentials( string $value ):
  *                                                                   their source: 'env', 'constant',
  *                                                                   'database', or 'none'.
  */
-function _wp_connectors_get_application_password_credentials( array $auth ): array {
+function wp_connectors_get_application_password_credentials( array $auth ): array {
 	// Check environment variable first.
 	$env_var_name = $auth['env_var_name'] ?? '';
 	if ( '' !== $env_var_name ) {
 		$env_value = getenv( $env_var_name );
 		if ( false !== $env_value && '' !== $env_value ) {
-			$credentials = _wp_connectors_parse_application_password_credentials( $env_value );
+			$credentials = wp_connectors_parse_application_password_credentials( $env_value );
 			if ( '' !== $credentials['username'] && '' !== $credentials['password'] ) {
 				$credentials['source'] = 'env';
 				return $credentials;
@@ -536,7 +536,7 @@ function _wp_connectors_get_application_password_credentials( array $auth ): arr
 				sprintf(
 					/* translators: %s: Environment variable name. */
 					__( 'The %s environment variable must contain application password credentials in "username:password" format.' ),
-					$env_var_name
+					esc_html( $env_var_name )
 				),
 				'7.1.0'
 			);
@@ -548,7 +548,7 @@ function _wp_connectors_get_application_password_credentials( array $auth ): arr
 	if ( '' !== $constant_name && defined( $constant_name ) ) {
 		$const_value = constant( $constant_name );
 		if ( is_string( $const_value ) && '' !== $const_value ) {
-			$credentials = _wp_connectors_parse_application_password_credentials( $const_value );
+			$credentials = wp_connectors_parse_application_password_credentials( $const_value );
 			if ( '' !== $credentials['username'] && '' !== $credentials['password'] ) {
 				$credentials['source'] = 'constant';
 				return $credentials;
@@ -559,7 +559,7 @@ function _wp_connectors_get_application_password_credentials( array $auth ): arr
 				sprintf(
 					/* translators: %s: PHP constant name. */
 					__( 'The %s constant must contain application password credentials in "username:password" format.' ),
-					$constant_name
+					esc_html( $constant_name )
 				),
 				'7.1.0'
 			);
@@ -638,7 +638,7 @@ function _wp_connectors_is_ai_api_key_valid( string $key, string $provider_id ):
  *                       `sanitize_option_{$option}` filter name when omitted.
  * @return array{username: string, password: string} Sanitized credentials.
  */
-function _wp_connectors_sanitize_application_password_credentials( $value, string $option = '' ): array {
+function wp_connectors_sanitize_application_password_credentials( $value, string $option = '' ): array {
 	if ( ! is_array( $value ) ) {
 		$value = array();
 	}
@@ -836,7 +836,7 @@ function _wp_register_default_connector_settings(): void {
 						),
 					),
 					'sanitize_callback' => static function ( $value ) use ( $setting_name ) {
-						return _wp_connectors_sanitize_application_password_credentials( $value, $setting_name );
+						return wp_connectors_sanitize_application_password_credentials( $value, $setting_name );
 					},
 				)
 			);
@@ -927,7 +927,7 @@ function _wp_connectors_get_connector_script_module_data( array $data ): array {
 				$auth_out['isConnected'] = 'none' !== $key_source;
 			}
 		} elseif ( 'application_password' === $auth['method'] ) {
-			$credentials = _wp_connectors_get_application_password_credentials( $auth );
+			$credentials = wp_connectors_get_application_password_credentials( $auth );
 
 			$auth_out['settingName']    = $auth['setting_name'] ?? '';
 			$auth_out['credentialsUrl'] = $auth['credentials_url'] ?? null;

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -437,18 +437,6 @@ function _wp_connectors_mask_api_key( string $key ): string {
 }
 
 /**
- * Masks an application password without revealing any characters.
- *
- * @since 7.0.0
- * @access private
- *
- * @return string The masked application password.
- */
-function _wp_connectors_mask_application_password(): string {
-	return str_repeat( "\u{2022}", 16 );
-}
-
-/**
  * Determines the source of an API key for a given connector.
  *
  * Checks in order: environment variable, PHP constant, database.
@@ -564,7 +552,7 @@ function _wp_connectors_rest_settings_dispatch( WP_REST_Response $response, WP_R
 		if ( 'application_password' === $auth['method'] && ! empty( $auth['application_password_setting_name'] ) ) {
 			$setting_name = $auth['application_password_setting_name'];
 			if ( array_key_exists( $setting_name, $data ) && is_string( $data[ $setting_name ] ) && '' !== $data[ $setting_name ] ) {
-				$data[ $setting_name ] = _wp_connectors_mask_application_password();
+				$data[ $setting_name ] = str_repeat( "\u{2022}", 16 );
 			}
 			continue;
 		}

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -519,11 +519,12 @@ function _wp_connectors_is_ai_api_key_valid( string $key, string $provider_id ):
 /**
  * Masks and validates connector credentials in REST responses.
  *
- * On every `/wp/v2/settings` response, masks connector API key values so raw
- * keys are never exposed via the REST API.
+ * On every `/wp/v2/settings` response, masks connector API key and application
+ * password values so raw credentials are never exposed via the REST API.
  *
- * On POST or PUT requests, validates each updated key against the provider
- * before masking. If validation fails, the key is reverted to an empty string.
+ * On POST or PUT requests, validates each updated AI provider API key before
+ * masking. If validation fails, the key is reverted to an empty string.
+ * Application password values are masked but not validated.
  *
  * @since 7.0.0
  * @access private

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -505,8 +505,9 @@ function _wp_connectors_parse_application_password_credentials( string $value ):
  * environment variable and constant are only checked when their respective
  * names are provided, and must contain the credentials as a single
  * `username:password` string. A non-empty environment variable or constant
- * claims the source even when malformed, in which case the resolved
- * credentials are empty.
+ * that cannot be parsed as `username:password` is reported with
+ * `_doing_it_wrong()` and ignored, so resolution falls through to the next
+ * source.
  *
  * @since 7.1.0
  * @access private
@@ -522,9 +523,21 @@ function _wp_connectors_get_application_password_credentials( array $auth ): arr
 	if ( '' !== $env_var_name ) {
 		$env_value = getenv( $env_var_name );
 		if ( false !== $env_value && '' !== $env_value ) {
-			$credentials           = _wp_connectors_parse_application_password_credentials( $env_value );
-			$credentials['source'] = 'env';
-			return $credentials;
+			$credentials = _wp_connectors_parse_application_password_credentials( $env_value );
+			if ( '' !== $credentials['username'] && '' !== $credentials['password'] ) {
+				$credentials['source'] = 'env';
+				return $credentials;
+			}
+
+			_doing_it_wrong(
+				__FUNCTION__,
+				sprintf(
+					/* translators: %s: Environment variable name. */
+					__( 'The %s environment variable must contain application password credentials in "username:password" format.' ),
+					$env_var_name
+				),
+				'7.1.0'
+			);
 		}
 	}
 
@@ -533,9 +546,21 @@ function _wp_connectors_get_application_password_credentials( array $auth ): arr
 	if ( '' !== $constant_name && defined( $constant_name ) ) {
 		$const_value = constant( $constant_name );
 		if ( is_string( $const_value ) && '' !== $const_value ) {
-			$credentials           = _wp_connectors_parse_application_password_credentials( $const_value );
-			$credentials['source'] = 'constant';
-			return $credentials;
+			$credentials = _wp_connectors_parse_application_password_credentials( $const_value );
+			if ( '' !== $credentials['username'] && '' !== $credentials['password'] ) {
+				$credentials['source'] = 'constant';
+				return $credentials;
+			}
+
+			_doing_it_wrong(
+				__FUNCTION__,
+				sprintf(
+					/* translators: %s: PHP constant name. */
+					__( 'The %s constant must contain application password credentials in "username:password" format.' ),
+					$constant_name
+				),
+				'7.1.0'
+			);
 		}
 	}
 

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -48,15 +48,12 @@ function wp_is_connector_registered( string $id ): bool {
  *         Authentication configuration. When method is 'api_key', includes
  *         credentials_url, setting_name, and optionally constant_name and
  *         env_var_name. When method is 'application_password', includes
- *         credentials_url, username_setting_name, and
- *         application_password_setting_name. When 'none', only method is present.
+ *         credentials_url and setting_name. When 'none', only method is present.
  *
  *         @type string $method          The authentication method: 'api_key',
  *                                       'application_password', or 'none'.
  *         @type string $credentials_url Optional. URL where users can obtain API credentials.
- *         @type string $setting_name    Optional. The setting name for the API key.
- *         @type string $username_setting_name Optional. The setting name for the username.
- *         @type string $application_password_setting_name Optional. The setting name for the application password.
+ *         @type string $setting_name    Optional. The setting name for the API key or application-password credentials.
  *         @type string $constant_name   Optional. PHP constant name for the API key.
  *         @type string $env_var_name    Optional. Environment variable name for the API key.
  *     }
@@ -78,8 +75,6 @@ function wp_is_connector_registered( string $id ): bool {
  *         method: 'api_key'|'application_password'|'none',
  *         credentials_url?: non-empty-string,
  *         setting_name?: non-empty-string,
- *         username_setting_name?: non-empty-string,
- *         application_password_setting_name?: non-empty-string,
  *         constant_name?: non-empty-string,
  *         env_var_name?: non-empty-string
  *     },
@@ -119,15 +114,12 @@ function wp_get_connector( string $id ): ?array {
  *             Authentication configuration. When method is 'api_key', includes
  *             credentials_url, setting_name, and optionally constant_name and
  *             env_var_name. When method is 'application_password', includes
- *             credentials_url, username_setting_name, and
- *             application_password_setting_name. When 'none', only method is present.
+ *             credentials_url and setting_name. When 'none', only method is present.
  *
  *             @type string $method          The authentication method: 'api_key',
  *                                           'application_password', or 'none'.
  *             @type string $credentials_url Optional. URL where users can obtain API credentials.
- *             @type string $setting_name    Optional. The setting name for the API key.
- *             @type string $username_setting_name Optional. The setting name for the username.
- *             @type string $application_password_setting_name Optional. The setting name for the application password.
+ *             @type string $setting_name    Optional. The setting name for the API key or application-password credentials.
  *             @type string $constant_name   Optional. PHP constant name for the API key.
  *             @type string $env_var_name    Optional. Environment variable name for the API key.
  *         }
@@ -150,8 +142,6 @@ function wp_get_connector( string $id ): ?array {
  *         method: 'api_key'|'application_password'|'none',
  *         credentials_url?: non-empty-string,
  *         setting_name?: non-empty-string,
- *         username_setting_name?: non-empty-string,
- *         application_password_setting_name?: non-empty-string,
  *         constant_name?: non-empty-string,
  *         env_var_name?: non-empty-string
  *     },
@@ -517,6 +507,26 @@ function _wp_connectors_is_ai_api_key_valid( string $key, string $provider_id ):
 }
 
 /**
+ * Sanitizes stored application-password credentials for a connector.
+ *
+ * @since 7.0.0
+ * @access private
+ *
+ * @param mixed $value The submitted setting value.
+ * @return array{username: string, password: string} Sanitized credentials.
+ */
+function _wp_connectors_sanitize_application_password_credentials( $value ): array {
+	if ( ! is_array( $value ) ) {
+		$value = array();
+	}
+
+	return array(
+		'username' => isset( $value['username'] ) && is_string( $value['username'] ) ? sanitize_text_field( $value['username'] ) : '',
+		'password' => isset( $value['password'] ) && is_string( $value['password'] ) ? sanitize_text_field( $value['password'] ) : '',
+	);
+}
+
+/**
  * Masks and validates connector credentials in REST responses.
  *
  * On every `/wp/v2/settings` response, masks connector API key and application
@@ -549,10 +559,13 @@ function _wp_connectors_rest_settings_dispatch( WP_REST_Response $response, WP_R
 	foreach ( wp_get_connectors() as $connector_id => $connector_data ) {
 		$auth = $connector_data['authentication'];
 
-		if ( 'application_password' === $auth['method'] && ! empty( $auth['application_password_setting_name'] ) ) {
-			$setting_name = $auth['application_password_setting_name'];
-			if ( array_key_exists( $setting_name, $data ) && is_string( $data[ $setting_name ] ) && '' !== $data[ $setting_name ] ) {
-				$data[ $setting_name ] = str_repeat( "\u{2022}", 16 );
+		if ( 'application_password' === $auth['method'] && ! empty( $auth['setting_name'] ) ) {
+			$setting_name = $auth['setting_name'];
+			if ( array_key_exists( $setting_name, $data ) && is_array( $data[ $setting_name ] ) ) {
+				$password = $data[ $setting_name ]['password'] ?? '';
+				if ( is_string( $password ) && '' !== $password ) {
+					$data[ $setting_name ]['password'] = str_repeat( "\u{2022}", 16 );
+				}
 			}
 			continue;
 		}
@@ -630,38 +643,38 @@ function _wp_register_default_connector_settings(): void {
 				'show_in_rest'      => true,
 				'sanitize_callback' => 'sanitize_text_field',
 			);
-		} elseif ( 'application_password' === $auth['method'] && ! empty( $auth['username_setting_name'] ) && ! empty( $auth['application_password_setting_name'] ) ) {
-			$settings[ $auth['username_setting_name'] ]             = array(
-				'type'              => 'string',
+		} elseif ( 'application_password' === $auth['method'] && ! empty( $auth['setting_name'] ) ) {
+			$settings[ $auth['setting_name'] ] = array(
+				'type'              => 'object',
 				'label'             => sprintf(
 					/* translators: %s: Connector name. */
-					__( '%s Username' ),
+					__( '%s Credentials' ),
 					$connector_data['name']
 				),
 				'description'       => sprintf(
 					/* translators: %s: Connector name. */
-					__( 'Username for the %s connector.' ),
+					__( 'Application password credentials for the %s connector.' ),
 					$connector_data['name']
 				),
-				'default'           => '',
-				'show_in_rest'      => true,
-				'sanitize_callback' => 'sanitize_text_field',
-			);
-			$settings[ $auth['application_password_setting_name'] ] = array(
-				'type'              => 'string',
-				'label'             => sprintf(
-					/* translators: %s: Connector name. */
-					__( '%s Application Password' ),
-					$connector_data['name']
+				'default'           => array(
+					'username' => '',
+					'password' => '',
 				),
-				'description'       => sprintf(
-					/* translators: %s: Connector name. */
-					__( 'Application password for the %s connector.' ),
-					$connector_data['name']
+				'show_in_rest'      => array(
+					'schema' => array(
+						'type'                 => 'object',
+						'properties'           => array(
+							'username' => array(
+								'type' => 'string',
+							),
+							'password' => array(
+								'type' => 'string',
+							),
+						),
+						'additionalProperties' => false,
+					),
 				),
-				'default'           => '',
-				'show_in_rest'      => true,
-				'sanitize_callback' => 'sanitize_text_field',
+				'sanitize_callback' => '_wp_connectors_sanitize_application_password_credentials',
 			);
 		}
 
@@ -758,15 +771,14 @@ function _wp_connectors_get_connector_script_module_data( array $data ): array {
 				$auth_out['isConnected'] = 'none' !== $key_source;
 			}
 		} elseif ( 'application_password' === $auth['method'] ) {
-			$username_setting_name             = $auth['username_setting_name'] ?? '';
-			$application_password_setting_name = $auth['application_password_setting_name'] ?? '';
-			$username                          = get_option( $username_setting_name, '' );
-			$application_password              = get_option( $application_password_setting_name, '' );
+			$setting_name = $auth['setting_name'] ?? '';
+			$credentials  = get_option( $setting_name, array() );
+			$username     = is_array( $credentials ) ? ( $credentials['username'] ?? '' ) : '';
+			$password     = is_array( $credentials ) ? ( $credentials['password'] ?? '' ) : '';
 
-			$auth_out['usernameSettingName']            = $username_setting_name;
-			$auth_out['applicationPasswordSettingName'] = $application_password_setting_name;
-			$auth_out['credentialsUrl']                 = $auth['credentials_url'] ?? null;
-			$auth_out['isConnected']                    = is_string( $username ) && '' !== $username && is_string( $application_password ) && '' !== $application_password;
+			$auth_out['settingName']    = $setting_name;
+			$auth_out['credentialsUrl'] = $auth['credentials_url'] ?? null;
+			$auth_out['isConnected']    = is_string( $username ) && '' !== $username && is_string( $password ) && '' !== $password;
 		}
 
 		$connector_out = array(

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -473,7 +473,7 @@ function _wp_connectors_get_api_key_source( string $setting_name, string $env_va
  * Splits on the first colon, matching the HTTP Basic authentication
  * userinfo format, so passwords may contain colons.
  *
- * @since 7.0.0
+ * @since 7.1.0
  * @access private
  *
  * @param string $value The raw credentials string.
@@ -508,7 +508,7 @@ function _wp_connectors_parse_application_password_credentials( string $value ):
  * claims the source even when malformed, in which case the resolved
  * credentials are empty.
  *
- * @since 7.0.0
+ * @since 7.1.0
  * @access private
  *
  * @param array $auth The connector's authentication configuration.
@@ -547,7 +547,7 @@ function _wp_connectors_get_application_password_credentials( array $auth ): arr
 	return array(
 		'username' => $username,
 		'password' => $password,
-		'source'   => '' !== $username || '' !== $password ? 'database' : 'none',
+		'source'   => '' !== $username && '' !== $password ? 'database' : 'none',
 	);
 }
 
@@ -599,8 +599,10 @@ function _wp_connectors_is_ai_api_key_valid( string $key, string $provider_id ):
  * places in REST responses also keeps the stored password, so a masked
  * settings response can be submitted back to the endpoint unchanged.
  * Pass an empty string to clear a field.
+ * If the sanitized username is empty, both fields are discarded so partial
+ * credentials cannot leave an orphaned secret.
  *
- * @since 7.0.0
+ * @since 7.1.0
  * @access private
  *
  * @param mixed $value The submitted setting value.
@@ -631,14 +633,21 @@ function _wp_connectors_sanitize_application_password_credentials( $value ): arr
 		$credentials['password'] = isset( $stored['password'] ) && is_string( $stored['password'] ) ? $stored['password'] : '';
 	}
 
+	if ( '' === $credentials['username'] ) {
+		return array(
+			'username' => '',
+			'password' => '',
+		);
+	}
+
 	return $credentials;
 }
 
 /**
  * Masks and validates connector credentials in REST responses.
  *
- * On every `/wp/v2/settings` response, masks connector API key and application
- * password values so raw credentials are never exposed via the REST API.
+ * On every `/wp/v2/settings` response, masks connector API key values and the
+ * password field of default application-password credential objects.
  *
  * On POST or PUT requests, validates each updated AI provider API key before
  * masking. If validation fails, the key is reverted to an empty string.
@@ -725,6 +734,11 @@ function _wp_register_default_connector_settings(): void {
 			continue;
 		}
 
+		if ( empty( $auth['setting_name'] ) || isset( $registered_settings[ $auth['setting_name'] ] ) ) {
+			continue;
+		}
+		$setting_name = $auth['setting_name'];
+
 		if ( ! isset( $connector_data['plugin']['is_active'] ) || ! is_callable( $connector_data['plugin']['is_active'] ) ) {
 			continue;
 		}
@@ -733,65 +747,64 @@ function _wp_register_default_connector_settings(): void {
 			continue;
 		}
 
-		$settings = array();
-		if ( 'api_key' === $auth['method'] && ! empty( $auth['setting_name'] ) ) {
-			$settings[ $auth['setting_name'] ] = array(
-				'type'              => 'string',
-				'label'             => sprintf(
-					/* translators: %s: Connector name. */
-					__( '%s API Key' ),
-					$connector_data['name']
-				),
-				'description'       => sprintf(
-					/* translators: %s: Connector name. */
-					__( 'API key for the %s connector.' ),
-					$connector_data['name']
-				),
-				'default'           => '',
-				'show_in_rest'      => true,
-				'sanitize_callback' => 'sanitize_text_field',
-			);
-		} elseif ( 'application_password' === $auth['method'] && ! empty( $auth['setting_name'] ) ) {
-			$settings[ $auth['setting_name'] ] = array(
-				'type'              => 'object',
-				'label'             => sprintf(
-					/* translators: %s: Connector name. */
-					__( '%s Credentials' ),
-					$connector_data['name']
-				),
-				'description'       => sprintf(
-					/* translators: %s: Connector name. */
-					__( 'Application password credentials for the %s connector.' ),
-					$connector_data['name']
-				),
-				'default'           => array(
-					'username' => '',
-					'password' => '',
-				),
-				'show_in_rest'      => array(
-					'schema' => array(
-						'type'                 => 'object',
-						'properties'           => array(
-							'username' => array(
-								'type' => 'string',
-							),
-							'password' => array(
-								'type' => 'string',
-							),
-						),
-						'additionalProperties' => false,
+		if ( 'api_key' === $auth['method'] ) {
+			register_setting(
+				'connectors',
+				$setting_name,
+				array(
+					'type'              => 'string',
+					'label'             => sprintf(
+						/* translators: %s: Connector name. */
+						__( '%s API Key' ),
+						$connector_data['name']
 					),
-				),
-				'sanitize_callback' => '_wp_connectors_sanitize_application_password_credentials',
+					'description'       => sprintf(
+						/* translators: %s: Connector name. */
+						__( 'API key for the %s connector.' ),
+						$connector_data['name']
+					),
+					'default'           => '',
+					'show_in_rest'      => true,
+					'sanitize_callback' => 'sanitize_text_field',
+				)
 			);
-		}
-
-		foreach ( $settings as $setting_name => $setting_args ) {
-			// Skip settings already registered by the connector's owning plugin.
-			if ( isset( $registered_settings[ $setting_name ] ) ) {
-				continue;
-			}
-			register_setting( 'connectors', $setting_name, $setting_args );
+		} elseif ( 'application_password' === $auth['method'] ) {
+			register_setting(
+				'connectors',
+				$setting_name,
+				array(
+					'type'              => 'object',
+					'label'             => sprintf(
+						/* translators: %s: Connector name. */
+						__( '%s Credentials' ),
+						$connector_data['name']
+					),
+					'description'       => sprintf(
+						/* translators: %s: Connector name. */
+						__( 'Application password credentials for the %s connector.' ),
+						$connector_data['name']
+					),
+					'default'           => array(
+						'username' => '',
+						'password' => '',
+					),
+					'show_in_rest'      => array(
+						'schema' => array(
+							'type'                 => 'object',
+							'properties'           => array(
+								'username' => array(
+									'type' => 'string',
+								),
+								'password' => array(
+									'type' => 'string',
+								),
+							),
+							'additionalProperties' => false,
+						),
+					),
+					'sanitize_callback' => '_wp_connectors_sanitize_application_password_credentials',
+				)
+			);
 		}
 	}
 }

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -484,8 +484,8 @@ function _wp_connectors_parse_application_password_credentials( string $value ):
 	$separator = strpos( $value, ':' );
 	// Trim so surrounding whitespace or a trailing newline (common when the
 	// value comes from a file or `.env`) does not become part of the credentials.
-	$username  = false === $separator ? '' : trim( substr( $value, 0, $separator ) );
-	$password  = false === $separator ? '' : trim( substr( $value, $separator + 1 ) );
+	$username = false === $separator ? '' : trim( substr( $value, 0, $separator ) );
+	$password = false === $separator ? '' : trim( substr( $value, $separator + 1 ) );
 
 	if ( '' === $username || '' === $password ) {
 		return array(

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -605,15 +605,21 @@ function _wp_connectors_is_ai_api_key_valid( string $key, string $provider_id ):
  * @since 7.1.0
  * @access private
  *
- * @param mixed $value The submitted setting value.
+ * @param mixed  $value  The submitted setting value.
+ * @param string $option The option name being sanitized. Passed explicitly by the
+ *                       registered sanitize callback; falls back to the current
+ *                       `sanitize_option_{$option}` filter name when omitted.
  * @return array{username: string, password: string} Sanitized credentials.
  */
-function _wp_connectors_sanitize_application_password_credentials( $value ): array {
+function _wp_connectors_sanitize_application_password_credentials( $value, string $option = '' ): array {
 	if ( ! is_array( $value ) ) {
 		$value = array();
 	}
 
-	$option = str_replace( 'sanitize_option_', '', (string) current_filter() );
+	if ( '' === $option ) {
+		$option = str_replace( 'sanitize_option_', '', (string) current_filter() );
+	}
+
 	$stored = get_option( $option );
 	if ( ! is_array( $stored ) ) {
 		$stored = array();
@@ -802,7 +808,9 @@ function _wp_register_default_connector_settings(): void {
 							'additionalProperties' => false,
 						),
 					),
-					'sanitize_callback' => '_wp_connectors_sanitize_application_password_credentials',
+					'sanitize_callback' => static function ( $value ) use ( $setting_name ) {
+						return _wp_connectors_sanitize_application_password_credentials( $value, $setting_name );
+					},
 				)
 			);
 		}

--- a/tests/phpunit/tests/connectors/wpConnectorRegistry.php
+++ b/tests/phpunit/tests/connectors/wpConnectorRegistry.php
@@ -130,7 +130,7 @@ class Tests_Connectors_WpConnectorRegistry extends WP_UnitTestCase {
 	/**
 	 * @ticket 64850
 	 */
-	public function test_register_generates_application_password_setting_name() {
+	public function test_register_generates_credentials_setting_name() {
 		$args                   = self::$default_args;
 		$args['authentication'] = array(
 			'method'          => 'application_password',
@@ -147,7 +147,7 @@ class Tests_Connectors_WpConnectorRegistry extends WP_UnitTestCase {
 	/**
 	 * @ticket 64850
 	 */
-	public function test_register_uses_custom_application_password_setting_name() {
+	public function test_register_uses_custom_credentials_setting_name() {
 		$args                   = self::$default_args;
 		$args['authentication'] = array(
 			'method'       => 'application_password',
@@ -206,75 +206,6 @@ class Tests_Connectors_WpConnectorRegistry extends WP_UnitTestCase {
 		return array(
 			'constant name'             => array( 'constant_name' ),
 			'environment variable name' => array( 'env_var_name' ),
-		);
-	}
-
-	/**
-	 * @ticket 64850
-	 *
-	 * @dataProvider data_application_password_setting_names
-	 *
-	 * @param string $setting_name_key Authentication setting name key.
-	 */
-	public function test_register_rejects_application_password_setting_names( string $setting_name_key ) {
-		$this->setExpectedIncorrectUsage( 'WP_Connector_Registry::register' );
-
-		$args                   = self::$default_args;
-		$args['authentication'] = array(
-			'method'          => 'application_password',
-			$setting_name_key => 'remote_site_credential',
-		);
-
-		$result = $this->registry->register( 'remote-site', $args );
-
-		$this->assertNull( $result );
-	}
-
-	/**
-	 * Data provider for unsupported application password setting names.
-	 *
-	 * @return array<string, array{string}> Test cases.
-	 */
-	public function data_application_password_setting_names(): array {
-		return array(
-			'username setting name'             => array( 'username_setting_name' ),
-			'application password setting name' => array( 'application_password_setting_name' ),
-		);
-	}
-
-	/**
-	 * @ticket 64850
-	 *
-	 * @dataProvider data_application_password_setting_names_for_other_auth_methods
-	 *
-	 * @param string $method           Authentication method.
-	 * @param string $setting_name_key Authentication setting name key.
-	 */
-	public function test_register_rejects_application_password_setting_names_for_other_auth_methods( string $method, string $setting_name_key ) {
-		$this->setExpectedIncorrectUsage( 'WP_Connector_Registry::register' );
-
-		$args                   = self::$default_args;
-		$args['authentication'] = array(
-			'method'          => $method,
-			$setting_name_key => 'remote_site_credential',
-		);
-
-		$result = $this->registry->register( 'remote-site', $args );
-
-		$this->assertNull( $result );
-	}
-
-	/**
-	 * Data provider for application-password setting names with other auth methods.
-	 *
-	 * @return array<string, array{string, string}> Test cases.
-	 */
-	public function data_application_password_setting_names_for_other_auth_methods(): array {
-		return array(
-			'api_key with username setting name'          => array( 'api_key', 'username_setting_name' ),
-			'api_key with application password setting name' => array( 'api_key', 'application_password_setting_name' ),
-			'none with username setting name'             => array( 'none', 'username_setting_name' ),
-			'none with application password setting name' => array( 'none', 'application_password_setting_name' ),
 		);
 	}
 

--- a/tests/phpunit/tests/connectors/wpConnectorRegistry.php
+++ b/tests/phpunit/tests/connectors/wpConnectorRegistry.php
@@ -227,10 +227,10 @@ class Tests_Connectors_WpConnectorRegistry extends WP_UnitTestCase {
 	 */
 	public function data_application_password_setting_names_for_other_auth_methods(): array {
 		return array(
-			'api_key with username setting name'             => array( 'api_key', 'username_setting_name' ),
+			'api_key with username setting name'          => array( 'api_key', 'username_setting_name' ),
 			'api_key with application password setting name' => array( 'api_key', 'application_password_setting_name' ),
-			'none with username setting name'                => array( 'none', 'username_setting_name' ),
-			'none with application password setting name'    => array( 'none', 'application_password_setting_name' ),
+			'none with username setting name'             => array( 'none', 'username_setting_name' ),
+			'none with application password setting name' => array( 'none', 'application_password_setting_name' ),
 		);
 	}
 

--- a/tests/phpunit/tests/connectors/wpConnectorRegistry.php
+++ b/tests/phpunit/tests/connectors/wpConnectorRegistry.php
@@ -161,6 +161,56 @@ class Tests_Connectors_WpConnectorRegistry extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 64850
+	 */
+	public function test_register_accepts_application_password_constant_and_env_names() {
+		$args                   = self::$default_args;
+		$args['authentication'] = array(
+			'method'        => 'application_password',
+			'constant_name' => 'REMOTE_SITE_CREDENTIALS',
+			'env_var_name'  => 'REMOTE_SITE_CREDENTIALS',
+		);
+
+		$result = $this->registry->register( 'remote-site', $args );
+
+		$this->assertSame( 'REMOTE_SITE_CREDENTIALS', $result['authentication']['constant_name'] );
+		$this->assertSame( 'REMOTE_SITE_CREDENTIALS', $result['authentication']['env_var_name'] );
+	}
+
+	/**
+	 * @ticket 64850
+	 *
+	 * @dataProvider data_application_password_external_name_keys
+	 *
+	 * @param string $name_key Authentication argument key.
+	 */
+	public function test_register_rejects_empty_application_password_external_names( string $name_key ) {
+		$this->setExpectedIncorrectUsage( 'WP_Connector_Registry::register' );
+
+		$args                   = self::$default_args;
+		$args['authentication'] = array(
+			'method'  => 'application_password',
+			$name_key => '',
+		);
+
+		$result = $this->registry->register( 'remote-site', $args );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * Data provider for application-password constant and environment variable name keys.
+	 *
+	 * @return array<string, array{string}> Test cases.
+	 */
+	public function data_application_password_external_name_keys(): array {
+		return array(
+			'constant name'             => array( 'constant_name' ),
+			'environment variable name' => array( 'env_var_name' ),
+		);
+	}
+
+	/**
+	 * @ticket 64850
 	 *
 	 * @dataProvider data_application_password_setting_names
 	 *

--- a/tests/phpunit/tests/connectors/wpConnectorRegistry.php
+++ b/tests/phpunit/tests/connectors/wpConnectorRegistry.php
@@ -141,7 +141,7 @@ class Tests_Connectors_WpConnectorRegistry extends WP_UnitTestCase {
 
 		$this->assertSame( 'application_password', $result['authentication']['method'] );
 		$this->assertSame( 'https://example.com/profile.php', $result['authentication']['credentials_url'] );
-		$this->assertSame( 'connectors_test_type_remote_site_credentials', $result['authentication']['setting_name'] );
+		$this->assertSame( 'connectors_test_type_remote_site_application_password', $result['authentication']['setting_name'] );
 	}
 
 	/**

--- a/tests/phpunit/tests/connectors/wpConnectorRegistry.php
+++ b/tests/phpunit/tests/connectors/wpConnectorRegistry.php
@@ -130,7 +130,7 @@ class Tests_Connectors_WpConnectorRegistry extends WP_UnitTestCase {
 	/**
 	 * @ticket 64850
 	 */
-	public function test_register_generates_application_password_setting_names() {
+	public function test_register_generates_application_password_setting_name() {
 		$args                   = self::$default_args;
 		$args['authentication'] = array(
 			'method'          => 'application_password',
@@ -141,42 +141,38 @@ class Tests_Connectors_WpConnectorRegistry extends WP_UnitTestCase {
 
 		$this->assertSame( 'application_password', $result['authentication']['method'] );
 		$this->assertSame( 'https://example.com/profile.php', $result['authentication']['credentials_url'] );
-		$this->assertSame( 'connectors_test_type_remote_site_username', $result['authentication']['username_setting_name'] );
-		$this->assertSame( 'connectors_test_type_remote_site_application_password', $result['authentication']['application_password_setting_name'] );
+		$this->assertSame( 'connectors_test_type_remote_site_credentials', $result['authentication']['setting_name'] );
 	}
 
 	/**
 	 * @ticket 64850
 	 */
-	public function test_register_uses_custom_application_password_setting_names() {
+	public function test_register_uses_custom_application_password_setting_name() {
 		$args                   = self::$default_args;
 		$args['authentication'] = array(
-			'method'                            => 'application_password',
-			'username_setting_name'             => 'remote_site_username',
-			'application_password_setting_name' => 'remote_site_application_password',
+			'method'       => 'application_password',
+			'setting_name' => 'remote_site_credentials',
 		);
 
 		$result = $this->registry->register( 'remote-site', $args );
 
-		$this->assertSame( 'remote_site_username', $result['authentication']['username_setting_name'] );
-		$this->assertSame( 'remote_site_application_password', $result['authentication']['application_password_setting_name'] );
+		$this->assertSame( 'remote_site_credentials', $result['authentication']['setting_name'] );
 	}
 
 	/**
 	 * @ticket 64850
 	 *
-	 * @dataProvider data_invalid_application_password_setting_names
+	 * @dataProvider data_application_password_setting_names
 	 *
 	 * @param string $setting_name_key Authentication setting name key.
-	 * @param mixed  $value            Invalid setting name value.
 	 */
-	public function test_register_rejects_invalid_application_password_setting_names( string $setting_name_key, $value ) {
+	public function test_register_rejects_application_password_setting_names( string $setting_name_key ) {
 		$this->setExpectedIncorrectUsage( 'WP_Connector_Registry::register' );
 
 		$args                   = self::$default_args;
 		$args['authentication'] = array(
 			'method'          => 'application_password',
-			$setting_name_key => $value,
+			$setting_name_key => 'remote_site_credential',
 		);
 
 		$result = $this->registry->register( 'remote-site', $args );
@@ -185,16 +181,14 @@ class Tests_Connectors_WpConnectorRegistry extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Data provider for invalid application password setting names.
+	 * Data provider for unsupported application password setting names.
 	 *
-	 * @return array<string, array{string, mixed}> Test cases.
+	 * @return array<string, array{string}> Test cases.
 	 */
-	public function data_invalid_application_password_setting_names(): array {
+	public function data_application_password_setting_names(): array {
 		return array(
-			'empty username setting name'      => array( 'username_setting_name', '' ),
-			'non-string username setting name' => array( 'username_setting_name', 123 ),
-			'empty password setting name'      => array( 'application_password_setting_name', '' ),
-			'non-string password setting name' => array( 'application_password_setting_name', 123 ),
+			'username setting name'             => array( 'username_setting_name' ),
+			'application password setting name' => array( 'application_password_setting_name' ),
 		);
 	}
 

--- a/tests/phpunit/tests/connectors/wpConnectorRegistry.php
+++ b/tests/phpunit/tests/connectors/wpConnectorRegistry.php
@@ -131,7 +131,7 @@ class Tests_Connectors_WpConnectorRegistry extends WP_UnitTestCase {
 	 * @ticket 64850
 	 */
 	public function test_register_generates_application_password_setting_names() {
-		$args = self::$default_args;
+		$args                   = self::$default_args;
 		$args['authentication'] = array(
 			'method'          => 'application_password',
 			'credentials_url' => 'https://example.com/profile.php',
@@ -149,7 +149,7 @@ class Tests_Connectors_WpConnectorRegistry extends WP_UnitTestCase {
 	 * @ticket 64850
 	 */
 	public function test_register_uses_custom_application_password_setting_names() {
-		$args = self::$default_args;
+		$args                   = self::$default_args;
 		$args['authentication'] = array(
 			'method'                            => 'application_password',
 			'username_setting_name'             => 'remote_site_username',
@@ -173,9 +173,9 @@ class Tests_Connectors_WpConnectorRegistry extends WP_UnitTestCase {
 	public function test_register_rejects_invalid_application_password_setting_names( string $setting_name_key, $value ) {
 		$this->setExpectedIncorrectUsage( 'WP_Connector_Registry::register' );
 
-		$args = self::$default_args;
+		$args                   = self::$default_args;
 		$args['authentication'] = array(
-			'method'           => 'application_password',
+			'method'          => 'application_password',
 			$setting_name_key => $value,
 		);
 
@@ -191,10 +191,10 @@ class Tests_Connectors_WpConnectorRegistry extends WP_UnitTestCase {
 	 */
 	public function data_invalid_application_password_setting_names(): array {
 		return array(
-			'empty username setting name'          => array( 'username_setting_name', '' ),
-			'non-string username setting name'     => array( 'username_setting_name', 123 ),
-			'empty password setting name'          => array( 'application_password_setting_name', '' ),
-			'non-string password setting name'     => array( 'application_password_setting_name', 123 ),
+			'empty username setting name'      => array( 'username_setting_name', '' ),
+			'non-string username setting name' => array( 'username_setting_name', 123 ),
+			'empty password setting name'      => array( 'application_password_setting_name', '' ),
+			'non-string password setting name' => array( 'application_password_setting_name', 123 ),
 		);
 	}
 

--- a/tests/phpunit/tests/connectors/wpConnectorRegistry.php
+++ b/tests/phpunit/tests/connectors/wpConnectorRegistry.php
@@ -199,6 +199,42 @@ class Tests_Connectors_WpConnectorRegistry extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 64850
+	 *
+	 * @dataProvider data_application_password_setting_names_for_other_auth_methods
+	 *
+	 * @param string $method           Authentication method.
+	 * @param string $setting_name_key Authentication setting name key.
+	 */
+	public function test_register_rejects_application_password_setting_names_for_other_auth_methods( string $method, string $setting_name_key ) {
+		$this->setExpectedIncorrectUsage( 'WP_Connector_Registry::register' );
+
+		$args                   = self::$default_args;
+		$args['authentication'] = array(
+			'method'          => $method,
+			$setting_name_key => 'remote_site_credential',
+		);
+
+		$result = $this->registry->register( 'remote-site', $args );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * Data provider for application-password setting names with other auth methods.
+	 *
+	 * @return array<string, array{string, string}> Test cases.
+	 */
+	public function data_application_password_setting_names_for_other_auth_methods(): array {
+		return array(
+			'api_key with username setting name'             => array( 'api_key', 'username_setting_name' ),
+			'api_key with application password setting name' => array( 'api_key', 'application_password_setting_name' ),
+			'none with username setting name'                => array( 'none', 'username_setting_name' ),
+			'none with application password setting name'    => array( 'none', 'application_password_setting_name' ),
+		);
+	}
+
+	/**
 	 * @ticket 64957
 	 */
 	public function test_register_stores_constant_name_when_provided() {

--- a/tests/phpunit/tests/connectors/wpConnectorRegistry.php
+++ b/tests/phpunit/tests/connectors/wpConnectorRegistry.php
@@ -128,6 +128,77 @@ class Tests_Connectors_WpConnectorRegistry extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 64850
+	 */
+	public function test_register_generates_application_password_setting_names() {
+		$args = self::$default_args;
+		$args['authentication'] = array(
+			'method'          => 'application_password',
+			'credentials_url' => 'https://example.com/profile.php',
+		);
+
+		$result = $this->registry->register( 'remote-site', $args );
+
+		$this->assertSame( 'application_password', $result['authentication']['method'] );
+		$this->assertSame( 'https://example.com/profile.php', $result['authentication']['credentials_url'] );
+		$this->assertSame( 'connectors_test_type_remote_site_username', $result['authentication']['username_setting_name'] );
+		$this->assertSame( 'connectors_test_type_remote_site_application_password', $result['authentication']['application_password_setting_name'] );
+	}
+
+	/**
+	 * @ticket 64850
+	 */
+	public function test_register_uses_custom_application_password_setting_names() {
+		$args = self::$default_args;
+		$args['authentication'] = array(
+			'method'                            => 'application_password',
+			'username_setting_name'             => 'remote_site_username',
+			'application_password_setting_name' => 'remote_site_application_password',
+		);
+
+		$result = $this->registry->register( 'remote-site', $args );
+
+		$this->assertSame( 'remote_site_username', $result['authentication']['username_setting_name'] );
+		$this->assertSame( 'remote_site_application_password', $result['authentication']['application_password_setting_name'] );
+	}
+
+	/**
+	 * @ticket 64850
+	 *
+	 * @dataProvider data_invalid_application_password_setting_names
+	 *
+	 * @param string $setting_name_key Authentication setting name key.
+	 * @param mixed  $value            Invalid setting name value.
+	 */
+	public function test_register_rejects_invalid_application_password_setting_names( string $setting_name_key, $value ) {
+		$this->setExpectedIncorrectUsage( 'WP_Connector_Registry::register' );
+
+		$args = self::$default_args;
+		$args['authentication'] = array(
+			'method'           => 'application_password',
+			$setting_name_key => $value,
+		);
+
+		$result = $this->registry->register( 'remote-site', $args );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * Data provider for invalid application password setting names.
+	 *
+	 * @return array<string, array{string, mixed}> Test cases.
+	 */
+	public function data_invalid_application_password_setting_names(): array {
+		return array(
+			'empty username setting name'          => array( 'username_setting_name', '' ),
+			'non-string username setting name'     => array( 'username_setting_name', 123 ),
+			'empty password setting name'          => array( 'application_password_setting_name', '' ),
+			'non-string password setting name'     => array( 'application_password_setting_name', 123 ),
+		);
+	}
+
+	/**
 	 * @ticket 64957
 	 */
 	public function test_register_stores_constant_name_when_provided() {

--- a/tests/phpunit/tests/connectors/wpConnectorsGetConnectorScriptModuleData.php
+++ b/tests/phpunit/tests/connectors/wpConnectorsGetConnectorScriptModuleData.php
@@ -9,6 +9,7 @@ class Tests_Connectors_WpConnectorsGetConnectorScriptModuleData extends WP_UnitT
 
 	const CONNECTOR_ID             = 'wp_test_application_password_connector';
 	const CREDENTIALS_SETTING_NAME = 'connectors_test_remote_credentials';
+	const CREDENTIALS_ENV_VAR_NAME = 'WP_TESTS_CONNECTOR_REMOTE_CREDENTIALS';
 
 	/**
 	 * Registers an application password connector before each test.
@@ -16,23 +17,11 @@ class Tests_Connectors_WpConnectorsGetConnectorScriptModuleData extends WP_UnitT
 	public function set_up(): void {
 		parent::set_up();
 
-		WP_Connector_Registry::get_instance()->register(
-			self::CONNECTOR_ID,
-			array(
-				'name'           => 'Test Remote WordPress Connector',
-				'description'    => 'Connect to a remote WordPress site.',
-				'type'           => 'content_source',
-				'authentication' => array(
-					'method'          => 'application_password',
-					'credentials_url' => 'https://example.com/profile.php',
-					'setting_name'    => self::CREDENTIALS_SETTING_NAME,
-				),
-			)
-		);
+		$this->register_connector( array() );
 	}
 
 	/**
-	 * Removes the connector and its settings after each test.
+	 * Removes the connector, its settings, and environment overrides after each test.
 	 */
 	public function tear_down(): void {
 		$registry = WP_Connector_Registry::get_instance();
@@ -41,8 +30,38 @@ class Tests_Connectors_WpConnectorsGetConnectorScriptModuleData extends WP_UnitT
 		}
 
 		delete_option( self::CREDENTIALS_SETTING_NAME );
+		putenv( self::CREDENTIALS_ENV_VAR_NAME );
 
 		parent::tear_down();
+	}
+
+	/**
+	 * Registers the test connector with extra authentication arguments.
+	 *
+	 * @param array $auth_extra Extra authentication arguments to merge in.
+	 */
+	private function register_connector( array $auth_extra ): void {
+		$registry = WP_Connector_Registry::get_instance();
+		if ( $registry->is_registered( self::CONNECTOR_ID ) ) {
+			$registry->unregister( self::CONNECTOR_ID );
+		}
+
+		$registry->register(
+			self::CONNECTOR_ID,
+			array(
+				'name'           => 'Test Remote WordPress Connector',
+				'description'    => 'Connect to a remote WordPress site.',
+				'type'           => 'content_source',
+				'authentication' => array_merge(
+					array(
+						'method'          => 'application_password',
+						'credentials_url' => 'https://example.com/profile.php',
+						'setting_name'    => self::CREDENTIALS_SETTING_NAME,
+					),
+					$auth_extra
+				),
+			)
+		);
 	}
 
 	/**
@@ -63,6 +82,7 @@ class Tests_Connectors_WpConnectorsGetConnectorScriptModuleData extends WP_UnitT
 		$this->assertSame( 'application_password', $auth['method'] );
 		$this->assertSame( self::CREDENTIALS_SETTING_NAME, $auth['settingName'] );
 		$this->assertSame( 'https://example.com/profile.php', $auth['credentialsUrl'] );
+		$this->assertSame( 'database', $auth['keySource'] );
 		$this->assertTrue( $auth['isConnected'] );
 		$this->assertArrayNotHasKey( 'username', $auth );
 		$this->assertArrayNotHasKey( 'applicationPassword', $auth );
@@ -84,5 +104,91 @@ class Tests_Connectors_WpConnectorsGetConnectorScriptModuleData extends WP_UnitT
 		$data = _wp_connectors_get_connector_script_module_data( array() );
 
 		$this->assertFalse( $data['connectors'][ self::CONNECTOR_ID ]['authentication']['isConnected'] );
+	}
+
+	/**
+	 * @ticket 64850
+	 */
+	public function test_environment_variable_credentials_mark_connector_connected(): void {
+		$this->register_connector( array( 'env_var_name' => self::CREDENTIALS_ENV_VAR_NAME ) );
+		putenv( self::CREDENTIALS_ENV_VAR_NAME . '=remote-user:abcd efgh ijkl mnop 1234' );
+
+		$data = _wp_connectors_get_connector_script_module_data( array() );
+		$auth = $data['connectors'][ self::CONNECTOR_ID ]['authentication'];
+
+		$this->assertSame( 'env', $auth['keySource'] );
+		$this->assertTrue( $auth['isConnected'] );
+		$this->assertArrayNotHasKey( 'username', $auth );
+		$this->assertArrayNotHasKey( 'password', $auth );
+	}
+
+	/**
+	 * @ticket 64850
+	 */
+	public function test_constant_credentials_mark_connector_connected(): void {
+		if ( ! defined( 'WP_TESTS_CONNECTOR_REMOTE_CREDENTIALS_CONSTANT' ) ) {
+			define( 'WP_TESTS_CONNECTOR_REMOTE_CREDENTIALS_CONSTANT', 'remote-user:abcd efgh ijkl mnop 1234' );
+		}
+		$this->register_connector( array( 'constant_name' => 'WP_TESTS_CONNECTOR_REMOTE_CREDENTIALS_CONSTANT' ) );
+
+		$data = _wp_connectors_get_connector_script_module_data( array() );
+		$auth = $data['connectors'][ self::CONNECTOR_ID ]['authentication'];
+
+		$this->assertSame( 'constant', $auth['keySource'] );
+		$this->assertTrue( $auth['isConnected'] );
+	}
+
+	/**
+	 * @ticket 64850
+	 */
+	public function test_environment_variable_takes_precedence_over_database(): void {
+		$this->register_connector( array( 'env_var_name' => self::CREDENTIALS_ENV_VAR_NAME ) );
+		putenv( self::CREDENTIALS_ENV_VAR_NAME . '=env-user:env-password' );
+		update_option(
+			self::CREDENTIALS_SETTING_NAME,
+			array(
+				'username' => 'db-user',
+				'password' => 'db-password',
+			)
+		);
+
+		$data = _wp_connectors_get_connector_script_module_data( array() );
+
+		$this->assertSame( 'env', $data['connectors'][ self::CONNECTOR_ID ]['authentication']['keySource'] );
+	}
+
+	/**
+	 * @ticket 64850
+	 */
+	public function test_malformed_environment_variable_credentials_are_not_connected(): void {
+		$this->register_connector( array( 'env_var_name' => self::CREDENTIALS_ENV_VAR_NAME ) );
+		putenv( self::CREDENTIALS_ENV_VAR_NAME . '=missing-a-separator' );
+		update_option(
+			self::CREDENTIALS_SETTING_NAME,
+			array(
+				'username' => 'db-user',
+				'password' => 'db-password',
+			)
+		);
+
+		$data = _wp_connectors_get_connector_script_module_data( array() );
+		$auth = $data['connectors'][ self::CONNECTOR_ID ]['authentication'];
+
+		$this->assertSame( 'env', $auth['keySource'] );
+		$this->assertFalse( $auth['isConnected'] );
+	}
+
+	/**
+	 * @ticket 64850
+	 */
+	public function test_environment_variable_password_may_contain_colons(): void {
+		$this->register_connector( array( 'env_var_name' => self::CREDENTIALS_ENV_VAR_NAME ) );
+		putenv( self::CREDENTIALS_ENV_VAR_NAME . '=remote-user:pass:with:colons' );
+
+		$data = _wp_connectors_get_connector_script_module_data( array() );
+		$auth = $data['connectors'][ self::CONNECTOR_ID ]['authentication'];
+
+		$this->assertSame( 'env', $auth['keySource'] );
+		$this->assertTrue( $auth['isConnected'] );
 	}
 }

--- a/tests/phpunit/tests/connectors/wpConnectorsGetConnectorScriptModuleData.php
+++ b/tests/phpunit/tests/connectors/wpConnectorsGetConnectorScriptModuleData.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Tests for _wp_connectors_get_connector_script_module_data().
+ *
+ * @group connectors
+ * @covers ::_wp_connectors_get_connector_script_module_data
+ */
+class Tests_Connectors_WpConnectorsGetConnectorScriptModuleData extends WP_UnitTestCase {
+
+	const CONNECTOR_ID = 'wp_test_application_password_connector';
+	const USERNAME_SETTING_NAME = 'connectors_test_remote_username';
+	const APPLICATION_PASSWORD_SETTING_NAME = 'connectors_test_remote_application_password';
+
+	/**
+	 * Registers an application password connector before each test.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		WP_Connector_Registry::get_instance()->register(
+			self::CONNECTOR_ID,
+			array(
+				'name'           => 'Test Remote WordPress Connector',
+				'description'    => 'Connect to a remote WordPress site.',
+				'type'           => 'content_source',
+				'authentication' => array(
+					'method'                            => 'application_password',
+					'credentials_url'                   => 'https://example.com/profile.php',
+					'username_setting_name'             => self::USERNAME_SETTING_NAME,
+					'application_password_setting_name' => self::APPLICATION_PASSWORD_SETTING_NAME,
+				),
+			)
+		);
+	}
+
+	/**
+	 * Removes the connector and its settings after each test.
+	 */
+	public function tear_down(): void {
+		$registry = WP_Connector_Registry::get_instance();
+		if ( null !== $registry && $registry->is_registered( self::CONNECTOR_ID ) ) {
+			$registry->unregister( self::CONNECTOR_ID );
+		}
+
+		delete_option( self::USERNAME_SETTING_NAME );
+		delete_option( self::APPLICATION_PASSWORD_SETTING_NAME );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * @ticket 64850
+	 */
+	public function test_exposes_application_password_metadata_without_credentials(): void {
+		update_option( self::USERNAME_SETTING_NAME, 'remote-user' );
+		update_option( self::APPLICATION_PASSWORD_SETTING_NAME, 'abcd efgh ijkl mnop 1234' );
+
+		$data = _wp_connectors_get_connector_script_module_data( array() );
+		$auth = $data['connectors'][ self::CONNECTOR_ID ]['authentication'];
+
+		$this->assertSame( 'application_password', $auth['method'] );
+		$this->assertSame( self::USERNAME_SETTING_NAME, $auth['usernameSettingName'] );
+		$this->assertSame( self::APPLICATION_PASSWORD_SETTING_NAME, $auth['applicationPasswordSettingName'] );
+		$this->assertSame( 'https://example.com/profile.php', $auth['credentialsUrl'] );
+		$this->assertTrue( $auth['isConnected'] );
+		$this->assertArrayNotHasKey( 'username', $auth );
+		$this->assertArrayNotHasKey( 'applicationPassword', $auth );
+	}
+
+	/**
+	 * @ticket 64850
+	 */
+	public function test_is_not_connected_when_one_credential_is_missing(): void {
+		update_option( self::USERNAME_SETTING_NAME, 'remote-user' );
+
+		$data = _wp_connectors_get_connector_script_module_data( array() );
+
+		$this->assertFalse( $data['connectors'][ self::CONNECTOR_ID ]['authentication']['isConnected'] );
+	}
+}

--- a/tests/phpunit/tests/connectors/wpConnectorsGetConnectorScriptModuleData.php
+++ b/tests/phpunit/tests/connectors/wpConnectorsGetConnectorScriptModuleData.php
@@ -161,7 +161,7 @@ class Tests_Connectors_WpConnectorsGetConnectorScriptModuleData extends WP_UnitT
 	 * @ticket 64850
 	 */
 	public function test_malformed_environment_variable_credentials_fall_back_to_database(): void {
-		$this->setExpectedIncorrectUsage( '_wp_connectors_get_application_password_credentials' );
+		$this->setExpectedIncorrectUsage( 'wp_connectors_get_application_password_credentials' );
 
 		$this->register_connector( array( 'env_var_name' => self::CREDENTIALS_ENV_VAR_NAME ) );
 		putenv( self::CREDENTIALS_ENV_VAR_NAME . '=missing-a-separator' );
@@ -184,7 +184,7 @@ class Tests_Connectors_WpConnectorsGetConnectorScriptModuleData extends WP_UnitT
 	 * @ticket 64850
 	 */
 	public function test_malformed_environment_variable_credentials_without_fallback_are_not_connected(): void {
-		$this->setExpectedIncorrectUsage( '_wp_connectors_get_application_password_credentials' );
+		$this->setExpectedIncorrectUsage( 'wp_connectors_get_application_password_credentials' );
 
 		$this->register_connector( array( 'env_var_name' => self::CREDENTIALS_ENV_VAR_NAME ) );
 		putenv( self::CREDENTIALS_ENV_VAR_NAME . '=missing-a-separator' );

--- a/tests/phpunit/tests/connectors/wpConnectorsGetConnectorScriptModuleData.php
+++ b/tests/phpunit/tests/connectors/wpConnectorsGetConnectorScriptModuleData.php
@@ -7,9 +7,8 @@
  */
 class Tests_Connectors_WpConnectorsGetConnectorScriptModuleData extends WP_UnitTestCase {
 
-	const CONNECTOR_ID                      = 'wp_test_application_password_connector';
-	const USERNAME_SETTING_NAME             = 'connectors_test_remote_username';
-	const APPLICATION_PASSWORD_SETTING_NAME = 'connectors_test_remote_application_password';
+	const CONNECTOR_ID             = 'wp_test_application_password_connector';
+	const CREDENTIALS_SETTING_NAME = 'connectors_test_remote_credentials';
 
 	/**
 	 * Registers an application password connector before each test.
@@ -24,10 +23,9 @@ class Tests_Connectors_WpConnectorsGetConnectorScriptModuleData extends WP_UnitT
 				'description'    => 'Connect to a remote WordPress site.',
 				'type'           => 'content_source',
 				'authentication' => array(
-					'method'                            => 'application_password',
-					'credentials_url'                   => 'https://example.com/profile.php',
-					'username_setting_name'             => self::USERNAME_SETTING_NAME,
-					'application_password_setting_name' => self::APPLICATION_PASSWORD_SETTING_NAME,
+					'method'          => 'application_password',
+					'credentials_url' => 'https://example.com/profile.php',
+					'setting_name'    => self::CREDENTIALS_SETTING_NAME,
 				),
 			)
 		);
@@ -42,8 +40,7 @@ class Tests_Connectors_WpConnectorsGetConnectorScriptModuleData extends WP_UnitT
 			$registry->unregister( self::CONNECTOR_ID );
 		}
 
-		delete_option( self::USERNAME_SETTING_NAME );
-		delete_option( self::APPLICATION_PASSWORD_SETTING_NAME );
+		delete_option( self::CREDENTIALS_SETTING_NAME );
 
 		parent::tear_down();
 	}
@@ -52,26 +49,37 @@ class Tests_Connectors_WpConnectorsGetConnectorScriptModuleData extends WP_UnitT
 	 * @ticket 64850
 	 */
 	public function test_exposes_application_password_metadata_without_credentials(): void {
-		update_option( self::USERNAME_SETTING_NAME, 'remote-user' );
-		update_option( self::APPLICATION_PASSWORD_SETTING_NAME, 'abcd efgh ijkl mnop 1234' );
+		update_option(
+			self::CREDENTIALS_SETTING_NAME,
+			array(
+				'username' => 'remote-user',
+				'password' => 'abcd efgh ijkl mnop 1234',
+			)
+		);
 
 		$data = _wp_connectors_get_connector_script_module_data( array() );
 		$auth = $data['connectors'][ self::CONNECTOR_ID ]['authentication'];
 
 		$this->assertSame( 'application_password', $auth['method'] );
-		$this->assertSame( self::USERNAME_SETTING_NAME, $auth['usernameSettingName'] );
-		$this->assertSame( self::APPLICATION_PASSWORD_SETTING_NAME, $auth['applicationPasswordSettingName'] );
+		$this->assertSame( self::CREDENTIALS_SETTING_NAME, $auth['settingName'] );
 		$this->assertSame( 'https://example.com/profile.php', $auth['credentialsUrl'] );
 		$this->assertTrue( $auth['isConnected'] );
 		$this->assertArrayNotHasKey( 'username', $auth );
 		$this->assertArrayNotHasKey( 'applicationPassword', $auth );
+		$this->assertArrayNotHasKey( 'password', $auth );
 	}
 
 	/**
 	 * @ticket 64850
 	 */
 	public function test_is_not_connected_when_one_credential_is_missing(): void {
-		update_option( self::USERNAME_SETTING_NAME, 'remote-user' );
+		update_option(
+			self::CREDENTIALS_SETTING_NAME,
+			array(
+				'username' => 'remote-user',
+				'password' => '',
+			)
+		);
 
 		$data = _wp_connectors_get_connector_script_module_data( array() );
 

--- a/tests/phpunit/tests/connectors/wpConnectorsGetConnectorScriptModuleData.php
+++ b/tests/phpunit/tests/connectors/wpConnectorsGetConnectorScriptModuleData.php
@@ -7,8 +7,8 @@
  */
 class Tests_Connectors_WpConnectorsGetConnectorScriptModuleData extends WP_UnitTestCase {
 
-	const CONNECTOR_ID = 'wp_test_application_password_connector';
-	const USERNAME_SETTING_NAME = 'connectors_test_remote_username';
+	const CONNECTOR_ID                      = 'wp_test_application_password_connector';
+	const USERNAME_SETTING_NAME             = 'connectors_test_remote_username';
 	const APPLICATION_PASSWORD_SETTING_NAME = 'connectors_test_remote_application_password';
 
 	/**

--- a/tests/phpunit/tests/connectors/wpConnectorsGetConnectorScriptModuleData.php
+++ b/tests/phpunit/tests/connectors/wpConnectorsGetConnectorScriptModuleData.php
@@ -160,7 +160,9 @@ class Tests_Connectors_WpConnectorsGetConnectorScriptModuleData extends WP_UnitT
 	/**
 	 * @ticket 64850
 	 */
-	public function test_malformed_environment_variable_credentials_are_not_connected(): void {
+	public function test_malformed_environment_variable_credentials_fall_back_to_database(): void {
+		$this->setExpectedIncorrectUsage( '_wp_connectors_get_application_password_credentials' );
+
 		$this->register_connector( array( 'env_var_name' => self::CREDENTIALS_ENV_VAR_NAME ) );
 		putenv( self::CREDENTIALS_ENV_VAR_NAME . '=missing-a-separator' );
 		update_option(
@@ -174,7 +176,23 @@ class Tests_Connectors_WpConnectorsGetConnectorScriptModuleData extends WP_UnitT
 		$data = _wp_connectors_get_connector_script_module_data( array() );
 		$auth = $data['connectors'][ self::CONNECTOR_ID ]['authentication'];
 
-		$this->assertSame( 'env', $auth['keySource'] );
+		$this->assertSame( 'database', $auth['keySource'] );
+		$this->assertTrue( $auth['isConnected'] );
+	}
+
+	/**
+	 * @ticket 64850
+	 */
+	public function test_malformed_environment_variable_credentials_without_fallback_are_not_connected(): void {
+		$this->setExpectedIncorrectUsage( '_wp_connectors_get_application_password_credentials' );
+
+		$this->register_connector( array( 'env_var_name' => self::CREDENTIALS_ENV_VAR_NAME ) );
+		putenv( self::CREDENTIALS_ENV_VAR_NAME . '=missing-a-separator' );
+
+		$data = _wp_connectors_get_connector_script_module_data( array() );
+		$auth = $data['connectors'][ self::CONNECTOR_ID ]['authentication'];
+
+		$this->assertSame( 'none', $auth['keySource'] );
 		$this->assertFalse( $auth['isConnected'] );
 	}
 

--- a/tests/phpunit/tests/connectors/wpConnectorsGetConnectorSettings.php
+++ b/tests/phpunit/tests/connectors/wpConnectorsGetConnectorSettings.php
@@ -61,7 +61,38 @@ class Tests_Connectors_WpGetConnectors extends WP_UnitTestCase {
 			$this->assertArrayHasKey( 'authentication', $connector_data, "Connector '{$connector_id}' is missing 'authentication'." );
 			$this->assertIsArray( $connector_data['authentication'], "Connector '{$connector_id}' authentication should be an array." );
 			$this->assertArrayHasKey( 'method', $connector_data['authentication'], "Connector '{$connector_id}' authentication is missing 'method'." );
-			$this->assertContains( $connector_data['authentication']['method'], array( 'api_key', 'none' ), "Connector '{$connector_id}' has unexpected authentication method." );
+			$this->assertContains( $connector_data['authentication']['method'], array( 'api_key', 'application_password', 'none' ), "Connector '{$connector_id}' has unexpected authentication method." );
+		}
+	}
+
+	/**
+	 * @ticket 64850
+	 */
+	public function test_application_password_connector_has_setting_names(): void {
+		$connector_id = 'remote-site';
+
+		WP_Connector_Registry::get_instance()->register(
+			$connector_id,
+			array(
+				'name'           => 'Remote Site',
+				'description'    => 'Connects to a remote WordPress site.',
+				'type'           => 'content_source',
+				'authentication' => array(
+					'method' => 'application_password',
+				),
+			)
+		);
+
+		try {
+			$connector = wp_get_connectors()[ $connector_id ];
+
+			$this->assertSame( 'application_password', $connector['authentication']['method'] );
+			$this->assertSame( 'connectors_content_source_remote_site_username', $connector['authentication']['username_setting_name'] );
+			$this->assertSame( 'connectors_content_source_remote_site_application_password', $connector['authentication']['application_password_setting_name'] );
+		} finally {
+			if ( wp_is_connector_registered( $connector_id ) ) {
+				WP_Connector_Registry::get_instance()->unregister( $connector_id );
+			}
 		}
 	}
 

--- a/tests/phpunit/tests/connectors/wpConnectorsGetConnectorSettings.php
+++ b/tests/phpunit/tests/connectors/wpConnectorsGetConnectorSettings.php
@@ -87,7 +87,7 @@ class Tests_Connectors_WpGetConnectors extends WP_UnitTestCase {
 			$connector = wp_get_connectors()[ $connector_id ];
 
 			$this->assertSame( 'application_password', $connector['authentication']['method'] );
-			$this->assertSame( 'connectors_content_source_remote_site_credentials', $connector['authentication']['setting_name'] );
+			$this->assertSame( 'connectors_content_source_remote_site_application_password', $connector['authentication']['setting_name'] );
 		} finally {
 			if ( wp_is_connector_registered( $connector_id ) ) {
 				WP_Connector_Registry::get_instance()->unregister( $connector_id );

--- a/tests/phpunit/tests/connectors/wpConnectorsGetConnectorSettings.php
+++ b/tests/phpunit/tests/connectors/wpConnectorsGetConnectorSettings.php
@@ -68,7 +68,7 @@ class Tests_Connectors_WpGetConnectors extends WP_UnitTestCase {
 	/**
 	 * @ticket 64850
 	 */
-	public function test_application_password_connector_has_setting_names(): void {
+	public function test_application_password_connector_has_setting_name(): void {
 		$connector_id = 'remote-site';
 
 		WP_Connector_Registry::get_instance()->register(
@@ -87,8 +87,7 @@ class Tests_Connectors_WpGetConnectors extends WP_UnitTestCase {
 			$connector = wp_get_connectors()[ $connector_id ];
 
 			$this->assertSame( 'application_password', $connector['authentication']['method'] );
-			$this->assertSame( 'connectors_content_source_remote_site_username', $connector['authentication']['username_setting_name'] );
-			$this->assertSame( 'connectors_content_source_remote_site_application_password', $connector['authentication']['application_password_setting_name'] );
+			$this->assertSame( 'connectors_content_source_remote_site_credentials', $connector['authentication']['setting_name'] );
 		} finally {
 			if ( wp_is_connector_registered( $connector_id ) ) {
 				WP_Connector_Registry::get_instance()->unregister( $connector_id );

--- a/tests/phpunit/tests/connectors/wpConnectorsRestSettingsDispatch.php
+++ b/tests/phpunit/tests/connectors/wpConnectorsRestSettingsDispatch.php
@@ -4,7 +4,6 @@
  *
  * @group connectors
  * @covers ::_wp_connectors_rest_settings_dispatch
- * @covers ::_wp_connectors_mask_application_password
  */
 class Tests_Connectors_WpConnectorsRestSettingsDispatch extends WP_UnitTestCase {
 

--- a/tests/phpunit/tests/connectors/wpConnectorsRestSettingsDispatch.php
+++ b/tests/phpunit/tests/connectors/wpConnectorsRestSettingsDispatch.php
@@ -7,9 +7,8 @@
  */
 class Tests_Connectors_WpConnectorsRestSettingsDispatch extends WP_UnitTestCase {
 
-	const CONNECTOR_ID                      = 'wp_test_application_password_connector';
-	const USERNAME_SETTING_NAME             = 'connectors_test_remote_username';
-	const APPLICATION_PASSWORD_SETTING_NAME = 'connectors_test_remote_application_password';
+	const CONNECTOR_ID             = 'wp_test_application_password_connector';
+	const CREDENTIALS_SETTING_NAME = 'connectors_test_remote_credentials';
 
 	/**
 	 * Registers an application password connector before each test.
@@ -23,9 +22,8 @@ class Tests_Connectors_WpConnectorsRestSettingsDispatch extends WP_UnitTestCase 
 				'name'           => 'Test Remote WordPress Connector',
 				'type'           => 'content_source',
 				'authentication' => array(
-					'method'                            => 'application_password',
-					'username_setting_name'             => self::USERNAME_SETTING_NAME,
-					'application_password_setting_name' => self::APPLICATION_PASSWORD_SETTING_NAME,
+					'method'       => 'application_password',
+					'setting_name' => self::CREDENTIALS_SETTING_NAME,
 				),
 			)
 		);
@@ -50,8 +48,10 @@ class Tests_Connectors_WpConnectorsRestSettingsDispatch extends WP_UnitTestCase 
 		$application_password = 'abcd efgh ijkl mnop 1234';
 		$response             = new WP_REST_Response(
 			array(
-				self::USERNAME_SETTING_NAME             => 'remote-user',
-				self::APPLICATION_PASSWORD_SETTING_NAME => $application_password,
+				self::CREDENTIALS_SETTING_NAME => array(
+					'username' => 'remote-user',
+					'password' => $application_password,
+				),
 			)
 		);
 		$request              = new WP_REST_Request( 'GET', '/wp/v2/settings' );
@@ -59,8 +59,8 @@ class Tests_Connectors_WpConnectorsRestSettingsDispatch extends WP_UnitTestCase 
 		$result = _wp_connectors_rest_settings_dispatch( $response, rest_get_server(), $request );
 		$data   = $result->get_data();
 
-		$this->assertSame( 'remote-user', $data[ self::USERNAME_SETTING_NAME ] );
-		$this->assertSame( str_repeat( "\u{2022}", 16 ), $data[ self::APPLICATION_PASSWORD_SETTING_NAME ] );
-		$this->assertNotSame( $application_password, $data[ self::APPLICATION_PASSWORD_SETTING_NAME ] );
+		$this->assertSame( 'remote-user', $data[ self::CREDENTIALS_SETTING_NAME ]['username'] );
+		$this->assertSame( str_repeat( "\u{2022}", 16 ), $data[ self::CREDENTIALS_SETTING_NAME ]['password'] );
+		$this->assertNotSame( $application_password, $data[ self::CREDENTIALS_SETTING_NAME ]['password'] );
 	}
 }

--- a/tests/phpunit/tests/connectors/wpConnectorsRestSettingsDispatch.php
+++ b/tests/phpunit/tests/connectors/wpConnectorsRestSettingsDispatch.php
@@ -4,6 +4,7 @@
  *
  * @group connectors
  * @covers ::_wp_connectors_rest_settings_dispatch
+ * @covers ::_wp_connectors_mask_application_password
  */
 class Tests_Connectors_WpConnectorsRestSettingsDispatch extends WP_UnitTestCase {
 
@@ -60,7 +61,7 @@ class Tests_Connectors_WpConnectorsRestSettingsDispatch extends WP_UnitTestCase 
 		$data   = $result->get_data();
 
 		$this->assertSame( 'remote-user', $data[ self::USERNAME_SETTING_NAME ] );
-		$this->assertSame( _wp_connectors_mask_api_key( $application_password ), $data[ self::APPLICATION_PASSWORD_SETTING_NAME ] );
+		$this->assertSame( str_repeat( "\u{2022}", 16 ), $data[ self::APPLICATION_PASSWORD_SETTING_NAME ] );
 		$this->assertNotSame( $application_password, $data[ self::APPLICATION_PASSWORD_SETTING_NAME ] );
 	}
 }

--- a/tests/phpunit/tests/connectors/wpConnectorsRestSettingsDispatch.php
+++ b/tests/phpunit/tests/connectors/wpConnectorsRestSettingsDispatch.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Tests for _wp_connectors_rest_settings_dispatch().
+ *
+ * @group connectors
+ * @covers ::_wp_connectors_rest_settings_dispatch
+ */
+class Tests_Connectors_WpConnectorsRestSettingsDispatch extends WP_UnitTestCase {
+
+	const CONNECTOR_ID = 'wp_test_application_password_connector';
+	const USERNAME_SETTING_NAME = 'connectors_test_remote_username';
+	const APPLICATION_PASSWORD_SETTING_NAME = 'connectors_test_remote_application_password';
+
+	/**
+	 * Registers an application password connector before each test.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		WP_Connector_Registry::get_instance()->register(
+			self::CONNECTOR_ID,
+			array(
+				'name'           => 'Test Remote WordPress Connector',
+				'type'           => 'content_source',
+				'authentication' => array(
+					'method'                            => 'application_password',
+					'username_setting_name'             => self::USERNAME_SETTING_NAME,
+					'application_password_setting_name' => self::APPLICATION_PASSWORD_SETTING_NAME,
+				),
+			)
+		);
+	}
+
+	/**
+	 * Removes the test connector after each test.
+	 */
+	public function tear_down(): void {
+		$registry = WP_Connector_Registry::get_instance();
+		if ( null !== $registry && $registry->is_registered( self::CONNECTOR_ID ) ) {
+			$registry->unregister( self::CONNECTOR_ID );
+		}
+
+		parent::tear_down();
+	}
+
+	/**
+	 * @ticket 64850
+	 */
+	public function test_masks_application_password_but_not_username(): void {
+		$application_password = 'abcd efgh ijkl mnop 1234';
+		$response             = new WP_REST_Response(
+			array(
+				self::USERNAME_SETTING_NAME             => 'remote-user',
+				self::APPLICATION_PASSWORD_SETTING_NAME => $application_password,
+			)
+		);
+		$request              = new WP_REST_Request( 'GET', '/wp/v2/settings' );
+
+		$result = _wp_connectors_rest_settings_dispatch( $response, rest_get_server(), $request );
+		$data   = $result->get_data();
+
+		$this->assertSame( 'remote-user', $data[ self::USERNAME_SETTING_NAME ] );
+		$this->assertSame( _wp_connectors_mask_api_key( $application_password ), $data[ self::APPLICATION_PASSWORD_SETTING_NAME ] );
+		$this->assertNotSame( $application_password, $data[ self::APPLICATION_PASSWORD_SETTING_NAME ] );
+	}
+}

--- a/tests/phpunit/tests/connectors/wpConnectorsRestSettingsDispatch.php
+++ b/tests/phpunit/tests/connectors/wpConnectorsRestSettingsDispatch.php
@@ -7,8 +7,8 @@
  */
 class Tests_Connectors_WpConnectorsRestSettingsDispatch extends WP_UnitTestCase {
 
-	const CONNECTOR_ID = 'wp_test_application_password_connector';
-	const USERNAME_SETTING_NAME = 'connectors_test_remote_username';
+	const CONNECTOR_ID                      = 'wp_test_application_password_connector';
+	const USERNAME_SETTING_NAME             = 'connectors_test_remote_username';
 	const APPLICATION_PASSWORD_SETTING_NAME = 'connectors_test_remote_application_password';
 
 	/**

--- a/tests/phpunit/tests/connectors/wpConnectorsSanitizeApplicationPasswordCredentials.php
+++ b/tests/phpunit/tests/connectors/wpConnectorsSanitizeApplicationPasswordCredentials.php
@@ -1,9 +1,9 @@
 <?php
 /**
- * Tests for _wp_connectors_sanitize_application_password_credentials().
+ * Tests for wp_connectors_sanitize_application_password_credentials().
  *
  * @group connectors
- * @covers ::_wp_connectors_sanitize_application_password_credentials
+ * @covers ::wp_connectors_sanitize_application_password_credentials
  */
 class Tests_Connectors_WpConnectorsSanitizeApplicationPasswordCredentials extends WP_UnitTestCase {
 

--- a/tests/phpunit/tests/connectors/wpConnectorsSanitizeApplicationPasswordCredentials.php
+++ b/tests/phpunit/tests/connectors/wpConnectorsSanitizeApplicationPasswordCredentials.php
@@ -105,6 +105,27 @@ class Tests_Connectors_WpConnectorsSanitizeApplicationPasswordCredentials extend
 	/**
 	 * @ticket 64850
 	 */
+	public function test_empty_sanitized_username_discards_submitted_password(): void {
+		update_option(
+			self::CREDENTIALS_SETTING_NAME,
+			array(
+				'username' => '%ab',
+				'password' => 'abcd efgh ijkl mnop 1234',
+			)
+		);
+
+		$this->assertSame(
+			array(
+				'username' => '',
+				'password' => '',
+			),
+			get_option( self::CREDENTIALS_SETTING_NAME )
+		);
+	}
+
+	/**
+	 * @ticket 64850
+	 */
 	public function test_missing_fields_preserve_stored_credentials(): void {
 		update_option(
 			self::CREDENTIALS_SETTING_NAME,

--- a/tests/phpunit/tests/connectors/wpConnectorsSanitizeApplicationPasswordCredentials.php
+++ b/tests/phpunit/tests/connectors/wpConnectorsSanitizeApplicationPasswordCredentials.php
@@ -1,0 +1,350 @@
+<?php
+/**
+ * Tests for _wp_connectors_sanitize_application_password_credentials().
+ *
+ * @group connectors
+ * @covers ::_wp_connectors_sanitize_application_password_credentials
+ */
+class Tests_Connectors_WpConnectorsSanitizeApplicationPasswordCredentials extends WP_UnitTestCase {
+
+	const CONNECTOR_ID             = 'wp_test_application_password_connector';
+	const CREDENTIALS_SETTING_NAME = 'connectors_test_remote_credentials';
+
+	/**
+	 * Administrator user ID.
+	 *
+	 * @var int
+	 */
+	private static $administrator_id;
+
+	/**
+	 * Snapshot of registered settings before each test.
+	 *
+	 * @var array
+	 */
+	private array $original_registered_settings = array();
+
+	/**
+	 * Creates an administrator for REST settings requests.
+	 *
+	 * @param WP_UnitTest_Factory $factory Test factory.
+	 */
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$administrator_id = $factory->user->create( array( 'role' => 'administrator' ) );
+	}
+
+	/**
+	 * Removes the administrator.
+	 */
+	public static function wpTearDownAfterClass() {
+		self::delete_user( self::$administrator_id );
+	}
+
+	/**
+	 * Registers an application password connector and its credentials setting before each test.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		global $wp_registered_settings;
+		$this->original_registered_settings = is_array( $wp_registered_settings ) ? $wp_registered_settings : array();
+
+		WP_Connector_Registry::get_instance()->register(
+			self::CONNECTOR_ID,
+			array(
+				'name'           => 'Test Remote WordPress Connector',
+				'type'           => 'content_source',
+				'authentication' => array(
+					'method'       => 'application_password',
+					'setting_name' => self::CREDENTIALS_SETTING_NAME,
+				),
+			)
+		);
+
+		_wp_register_default_connector_settings();
+	}
+
+	/**
+	 * Removes the test connector, its option, and restores registered settings.
+	 */
+	public function tear_down(): void {
+		$registry = WP_Connector_Registry::get_instance();
+		if ( null !== $registry && $registry->is_registered( self::CONNECTOR_ID ) ) {
+			$registry->unregister( self::CONNECTOR_ID );
+		}
+
+		delete_option( self::CREDENTIALS_SETTING_NAME );
+
+		global $wp_registered_settings;
+		$wp_registered_settings = $this->original_registered_settings;
+
+		parent::tear_down();
+	}
+
+	/**
+	 * @ticket 64850
+	 */
+	public function test_sanitizes_submitted_credentials(): void {
+		update_option(
+			self::CREDENTIALS_SETTING_NAME,
+			array(
+				'username' => "  remote-user\t",
+				'password' => 'abcd efgh ijkl mnop 1234',
+			)
+		);
+
+		$this->assertSame(
+			array(
+				'username' => 'remote-user',
+				'password' => 'abcd efgh ijkl mnop 1234',
+			),
+			get_option( self::CREDENTIALS_SETTING_NAME )
+		);
+	}
+
+	/**
+	 * @ticket 64850
+	 */
+	public function test_missing_fields_preserve_stored_credentials(): void {
+		update_option(
+			self::CREDENTIALS_SETTING_NAME,
+			array(
+				'username' => 'remote-user',
+				'password' => 'abcd efgh ijkl mnop 1234',
+			)
+		);
+
+		update_option( self::CREDENTIALS_SETTING_NAME, array( 'username' => 'renamed-user' ) );
+
+		$this->assertSame(
+			array(
+				'username' => 'renamed-user',
+				'password' => 'abcd efgh ijkl mnop 1234',
+			),
+			get_option( self::CREDENTIALS_SETTING_NAME )
+		);
+	}
+
+	/**
+	 * @ticket 64850
+	 */
+	public function test_masked_password_preserves_stored_password(): void {
+		update_option(
+			self::CREDENTIALS_SETTING_NAME,
+			array(
+				'username' => 'remote-user',
+				'password' => 'abcd efgh ijkl mnop 1234',
+			)
+		);
+
+		update_option(
+			self::CREDENTIALS_SETTING_NAME,
+			array(
+				'username' => 'remote-user',
+				'password' => str_repeat( "\u{2022}", 16 ),
+			)
+		);
+
+		$this->assertSame(
+			array(
+				'username' => 'remote-user',
+				'password' => 'abcd efgh ijkl mnop 1234',
+			),
+			get_option( self::CREDENTIALS_SETTING_NAME )
+		);
+	}
+
+	/**
+	 * @ticket 64850
+	 */
+	public function test_non_array_value_preserves_stored_credentials(): void {
+		update_option(
+			self::CREDENTIALS_SETTING_NAME,
+			array(
+				'username' => 'remote-user',
+				'password' => 'abcd efgh ijkl mnop 1234',
+			)
+		);
+
+		update_option( self::CREDENTIALS_SETTING_NAME, 'garbage' );
+
+		$this->assertSame(
+			array(
+				'username' => 'remote-user',
+				'password' => 'abcd efgh ijkl mnop 1234',
+			),
+			get_option( self::CREDENTIALS_SETTING_NAME )
+		);
+	}
+
+	/**
+	 * @ticket 64850
+	 */
+	public function test_non_string_fields_preserve_stored_credentials(): void {
+		update_option(
+			self::CREDENTIALS_SETTING_NAME,
+			array(
+				'username' => 'remote-user',
+				'password' => 'abcd efgh ijkl mnop 1234',
+			)
+		);
+
+		update_option(
+			self::CREDENTIALS_SETTING_NAME,
+			array(
+				'username' => 123,
+				'password' => array( 'not-a-string' ),
+			)
+		);
+
+		$this->assertSame(
+			array(
+				'username' => 'remote-user',
+				'password' => 'abcd efgh ijkl mnop 1234',
+			),
+			get_option( self::CREDENTIALS_SETTING_NAME )
+		);
+	}
+
+	/**
+	 * @ticket 64850
+	 */
+	public function test_empty_strings_clear_stored_credentials(): void {
+		update_option(
+			self::CREDENTIALS_SETTING_NAME,
+			array(
+				'username' => 'remote-user',
+				'password' => 'abcd efgh ijkl mnop 1234',
+			)
+		);
+
+		update_option(
+			self::CREDENTIALS_SETTING_NAME,
+			array(
+				'username' => '',
+				'password' => '',
+			)
+		);
+
+		$this->assertSame(
+			array(
+				'username' => '',
+				'password' => '',
+			),
+			get_option( self::CREDENTIALS_SETTING_NAME )
+		);
+	}
+
+	/**
+	 * @ticket 64850
+	 */
+	public function test_rest_round_trip_of_masked_response_preserves_stored_password(): void {
+		wp_set_current_user( self::$administrator_id );
+
+		update_option(
+			self::CREDENTIALS_SETTING_NAME,
+			array(
+				'username' => 'remote-user',
+				'password' => 'abcd efgh ijkl mnop 1234',
+			)
+		);
+
+		$get_request  = new WP_REST_Request( 'GET', '/wp/v2/settings' );
+		$get_response = $this->dispatch_settings_request( $get_request );
+		$credentials  = $get_response->get_data()[ self::CREDENTIALS_SETTING_NAME ];
+
+		$this->assertSame( str_repeat( "\u{2022}", 16 ), $credentials['password'] );
+
+		// Submit the masked response back, as a read-modify-write client would.
+		$post_request = new WP_REST_Request( 'POST', '/wp/v2/settings' );
+		$post_request->set_param( self::CREDENTIALS_SETTING_NAME, $credentials );
+		$post_response = $this->dispatch_settings_request( $post_request );
+
+		$this->assertSame( 200, $post_response->get_status() );
+		$this->assertSame(
+			array(
+				'username' => 'remote-user',
+				'password' => 'abcd efgh ijkl mnop 1234',
+			),
+			get_option( self::CREDENTIALS_SETTING_NAME )
+		);
+		$this->assertSame(
+			str_repeat( "\u{2022}", 16 ),
+			$post_response->get_data()[ self::CREDENTIALS_SETTING_NAME ]['password']
+		);
+	}
+
+	/**
+	 * @ticket 64850
+	 */
+	public function test_rest_partial_username_update_preserves_stored_password(): void {
+		wp_set_current_user( self::$administrator_id );
+
+		update_option(
+			self::CREDENTIALS_SETTING_NAME,
+			array(
+				'username' => 'remote-user',
+				'password' => 'abcd efgh ijkl mnop 1234',
+			)
+		);
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/settings' );
+		$request->set_param( self::CREDENTIALS_SETTING_NAME, array( 'username' => 'renamed-user' ) );
+		$response = $this->dispatch_settings_request( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame(
+			array(
+				'username' => 'renamed-user',
+				'password' => 'abcd efgh ijkl mnop 1234',
+			),
+			get_option( self::CREDENTIALS_SETTING_NAME )
+		);
+	}
+
+	/**
+	 * @ticket 64850
+	 */
+	public function test_rest_empty_strings_clear_stored_credentials(): void {
+		wp_set_current_user( self::$administrator_id );
+
+		update_option(
+			self::CREDENTIALS_SETTING_NAME,
+			array(
+				'username' => 'remote-user',
+				'password' => 'abcd efgh ijkl mnop 1234',
+			)
+		);
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/settings' );
+		$request->set_param(
+			self::CREDENTIALS_SETTING_NAME,
+			array(
+				'username' => '',
+				'password' => '',
+			)
+		);
+		$response = $this->dispatch_settings_request( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame(
+			array(
+				'username' => '',
+				'password' => '',
+			),
+			get_option( self::CREDENTIALS_SETTING_NAME )
+		);
+	}
+
+	/**
+	 * Dispatches a settings REST request and applies the `rest_post_dispatch`
+	 * filter, mirroring how WP_REST_Server::serve_request() produces responses.
+	 *
+	 * @param WP_REST_Request $request The request to dispatch.
+	 * @return WP_REST_Response The filtered response.
+	 */
+	private function dispatch_settings_request( WP_REST_Request $request ): WP_REST_Response {
+		$response = rest_do_request( $request );
+		return apply_filters( 'rest_post_dispatch', rest_ensure_response( $response ), rest_get_server(), $request );
+	}
+}

--- a/tests/phpunit/tests/connectors/wpRegisterDefaultConnectorSettings.php
+++ b/tests/phpunit/tests/connectors/wpRegisterDefaultConnectorSettings.php
@@ -10,6 +10,8 @@ class Tests_Connectors_WpRegisterDefaultConnectorSettings extends WP_UnitTestCas
 
 	const CONNECTOR_ID = 'wp_test_non_ai_connector';
 	const SETTING_NAME = 'connectors_test_non_ai_api_key';
+	const USERNAME_SETTING_NAME = 'connectors_test_non_ai_username';
+	const APPLICATION_PASSWORD_SETTING_NAME = 'connectors_test_non_ai_application_password';
 
 	/**
 	 * Snapshot of registered settings before each test.
@@ -97,5 +99,34 @@ class Tests_Connectors_WpRegisterDefaultConnectorSettings extends WP_UnitTestCas
 		_wp_register_default_connector_settings();
 
 		$this->assertArrayHasKey( self::SETTING_NAME, get_registered_settings() );
+	}
+
+	/**
+	 * @ticket 64850
+	 */
+	public function test_application_password_connector_registers_both_settings(): void {
+		WP_Connector_Registry::get_instance()->register(
+			self::CONNECTOR_ID,
+			array(
+				'name'           => 'Test Remote WordPress Connector',
+				'description'    => '',
+				'type'           => 'content_source',
+				'authentication' => array(
+					'method'                            => 'application_password',
+					'username_setting_name'             => self::USERNAME_SETTING_NAME,
+					'application_password_setting_name' => self::APPLICATION_PASSWORD_SETTING_NAME,
+				),
+			)
+		);
+
+		_wp_register_default_connector_settings();
+
+		$registered_settings = get_registered_settings();
+		$this->assertArrayHasKey( self::USERNAME_SETTING_NAME, $registered_settings );
+		$this->assertArrayHasKey( self::APPLICATION_PASSWORD_SETTING_NAME, $registered_settings );
+		$this->assertSame( 'Test Remote WordPress Connector Username', $registered_settings[ self::USERNAME_SETTING_NAME ]['label'] );
+		$this->assertSame( 'Test Remote WordPress Connector Application Password', $registered_settings[ self::APPLICATION_PASSWORD_SETTING_NAME ]['label'] );
+		$this->assertTrue( $registered_settings[ self::USERNAME_SETTING_NAME ]['show_in_rest'] );
+		$this->assertTrue( $registered_settings[ self::APPLICATION_PASSWORD_SETTING_NAME ]['show_in_rest'] );
 	}
 }

--- a/tests/phpunit/tests/connectors/wpRegisterDefaultConnectorSettings.php
+++ b/tests/phpunit/tests/connectors/wpRegisterDefaultConnectorSettings.php
@@ -180,6 +180,45 @@ class Tests_Connectors_WpRegisterDefaultConnectorSettings extends WP_UnitTestCas
 			),
 			$registered_settings[ self::CREDENTIALS_SETTING_NAME ]['default']
 		);
-		$this->assertFalse( $registered_settings[ self::CREDENTIALS_SETTING_NAME ]['show_in_rest'] );
+			$this->assertFalse( $registered_settings[ self::CREDENTIALS_SETTING_NAME ]['show_in_rest'] );
+	}
+
+	/**
+	 * @ticket 64850
+	 */
+	public function test_already_registered_setting_skips_before_is_active_callback(): void {
+		$is_active_called = false;
+
+		register_setting(
+			'connectors',
+			self::CREDENTIALS_SETTING_NAME,
+			array(
+				'type'         => 'object',
+				'show_in_rest' => false,
+			)
+		);
+
+		WP_Connector_Registry::get_instance()->register(
+			self::CONNECTOR_ID,
+			array(
+				'name'           => 'Test Remote WordPress Connector',
+				'description'    => '',
+				'type'           => 'content_source',
+				'authentication' => array(
+					'method'       => 'application_password',
+					'setting_name' => self::CREDENTIALS_SETTING_NAME,
+				),
+				'plugin'         => array(
+					'is_active' => static function () use ( &$is_active_called ): bool {
+						$is_active_called = true;
+						return true;
+					},
+				),
+			)
+		);
+
+		_wp_register_default_connector_settings();
+
+		$this->assertFalse( $is_active_called );
 	}
 }

--- a/tests/phpunit/tests/connectors/wpRegisterDefaultConnectorSettings.php
+++ b/tests/phpunit/tests/connectors/wpRegisterDefaultConnectorSettings.php
@@ -183,7 +183,7 @@ class Tests_Connectors_WpRegisterDefaultConnectorSettings extends WP_UnitTestCas
 	 */
 	public function data_application_password_settings(): array {
 		return array(
-			'username setting already registered'             => array(
+			'username setting already registered' => array(
 				self::USERNAME_SETTING_NAME,
 				self::APPLICATION_PASSWORD_SETTING_NAME,
 			),

--- a/tests/phpunit/tests/connectors/wpRegisterDefaultConnectorSettings.php
+++ b/tests/phpunit/tests/connectors/wpRegisterDefaultConnectorSettings.php
@@ -27,7 +27,7 @@ class Tests_Connectors_WpRegisterDefaultConnectorSettings extends WP_UnitTestCas
 		parent::set_up();
 
 		global $wp_registered_settings;
-		$this->original_registered_settings = $wp_registered_settings;
+		$this->original_registered_settings = is_array( $wp_registered_settings ) ? $wp_registered_settings : array();
 	}
 
 	/**
@@ -128,5 +128,69 @@ class Tests_Connectors_WpRegisterDefaultConnectorSettings extends WP_UnitTestCas
 		$this->assertSame( 'Test Remote WordPress Connector Application Password', $registered_settings[ self::APPLICATION_PASSWORD_SETTING_NAME ]['label'] );
 		$this->assertTrue( $registered_settings[ self::USERNAME_SETTING_NAME ]['show_in_rest'] );
 		$this->assertTrue( $registered_settings[ self::APPLICATION_PASSWORD_SETTING_NAME ]['show_in_rest'] );
+	}
+
+	/**
+	 * @ticket 64850
+	 *
+	 * @dataProvider data_application_password_settings
+	 *
+	 * @param string $pre_registered_setting_name Setting name registered by the connector plugin.
+	 * @param string $other_setting_name          Setting name registered by Core.
+	 */
+	public function test_application_password_connector_skips_already_registered_settings( string $pre_registered_setting_name, string $other_setting_name ): void {
+		register_setting(
+			'connectors',
+			$pre_registered_setting_name,
+			array(
+				'type'              => 'string',
+				'label'             => 'Plugin-owned setting',
+				'description'       => 'Registered by the connector plugin.',
+				'default'           => 'plugin-default',
+				'show_in_rest'      => false,
+				'sanitize_callback' => 'sanitize_text_field',
+			)
+		);
+
+		WP_Connector_Registry::get_instance()->register(
+			self::CONNECTOR_ID,
+			array(
+				'name'           => 'Test Remote WordPress Connector',
+				'description'    => '',
+				'type'           => 'content_source',
+				'authentication' => array(
+					'method'                            => 'application_password',
+					'username_setting_name'             => self::USERNAME_SETTING_NAME,
+					'application_password_setting_name' => self::APPLICATION_PASSWORD_SETTING_NAME,
+				),
+			)
+		);
+
+		_wp_register_default_connector_settings();
+
+		$registered_settings = get_registered_settings();
+		$this->assertArrayHasKey( $pre_registered_setting_name, $registered_settings );
+		$this->assertArrayHasKey( $other_setting_name, $registered_settings );
+		$this->assertSame( 'Plugin-owned setting', $registered_settings[ $pre_registered_setting_name ]['label'] );
+		$this->assertSame( 'plugin-default', $registered_settings[ $pre_registered_setting_name ]['default'] );
+		$this->assertFalse( $registered_settings[ $pre_registered_setting_name ]['show_in_rest'] );
+	}
+
+	/**
+	 * Data provider for application-password settings.
+	 *
+	 * @return array<string, array{string, string}> Test cases.
+	 */
+	public function data_application_password_settings(): array {
+		return array(
+			'username setting already registered'             => array(
+				self::USERNAME_SETTING_NAME,
+				self::APPLICATION_PASSWORD_SETTING_NAME,
+			),
+			'application password setting already registered' => array(
+				self::APPLICATION_PASSWORD_SETTING_NAME,
+				self::USERNAME_SETTING_NAME,
+			),
+		);
 	}
 }

--- a/tests/phpunit/tests/connectors/wpRegisterDefaultConnectorSettings.php
+++ b/tests/phpunit/tests/connectors/wpRegisterDefaultConnectorSettings.php
@@ -151,7 +151,7 @@ class Tests_Connectors_WpRegisterDefaultConnectorSettings extends WP_UnitTestCas
 					'password' => '',
 				),
 				'show_in_rest'      => false,
-				'sanitize_callback' => '_wp_connectors_sanitize_application_password_credentials',
+				'sanitize_callback' => 'wp_connectors_sanitize_application_password_credentials',
 			)
 		);
 

--- a/tests/phpunit/tests/connectors/wpRegisterDefaultConnectorSettings.php
+++ b/tests/phpunit/tests/connectors/wpRegisterDefaultConnectorSettings.php
@@ -8,10 +8,9 @@
  */
 class Tests_Connectors_WpRegisterDefaultConnectorSettings extends WP_UnitTestCase {
 
-	const CONNECTOR_ID                      = 'wp_test_non_ai_connector';
-	const SETTING_NAME                      = 'connectors_test_non_ai_api_key';
-	const USERNAME_SETTING_NAME             = 'connectors_test_non_ai_username';
-	const APPLICATION_PASSWORD_SETTING_NAME = 'connectors_test_non_ai_application_password';
+	const CONNECTOR_ID             = 'wp_test_non_ai_connector';
+	const SETTING_NAME             = 'connectors_test_non_ai_api_key';
+	const CREDENTIALS_SETTING_NAME = 'connectors_test_non_ai_credentials';
 
 	/**
 	 * Snapshot of registered settings before each test.
@@ -104,7 +103,7 @@ class Tests_Connectors_WpRegisterDefaultConnectorSettings extends WP_UnitTestCas
 	/**
 	 * @ticket 64850
 	 */
-	public function test_application_password_connector_registers_both_settings(): void {
+	public function test_application_password_connector_registers_credentials_setting(): void {
 		WP_Connector_Registry::get_instance()->register(
 			self::CONNECTOR_ID,
 			array(
@@ -112,9 +111,8 @@ class Tests_Connectors_WpRegisterDefaultConnectorSettings extends WP_UnitTestCas
 				'description'    => '',
 				'type'           => 'content_source',
 				'authentication' => array(
-					'method'                            => 'application_password',
-					'username_setting_name'             => self::USERNAME_SETTING_NAME,
-					'application_password_setting_name' => self::APPLICATION_PASSWORD_SETTING_NAME,
+					'method'       => 'application_password',
+					'setting_name' => self::CREDENTIALS_SETTING_NAME,
 				),
 			)
 		);
@@ -122,33 +120,38 @@ class Tests_Connectors_WpRegisterDefaultConnectorSettings extends WP_UnitTestCas
 		_wp_register_default_connector_settings();
 
 		$registered_settings = get_registered_settings();
-		$this->assertArrayHasKey( self::USERNAME_SETTING_NAME, $registered_settings );
-		$this->assertArrayHasKey( self::APPLICATION_PASSWORD_SETTING_NAME, $registered_settings );
-		$this->assertSame( 'Test Remote WordPress Connector Username', $registered_settings[ self::USERNAME_SETTING_NAME ]['label'] );
-		$this->assertSame( 'Test Remote WordPress Connector Application Password', $registered_settings[ self::APPLICATION_PASSWORD_SETTING_NAME ]['label'] );
-		$this->assertTrue( $registered_settings[ self::USERNAME_SETTING_NAME ]['show_in_rest'] );
-		$this->assertTrue( $registered_settings[ self::APPLICATION_PASSWORD_SETTING_NAME ]['show_in_rest'] );
+		$this->assertArrayHasKey( self::CREDENTIALS_SETTING_NAME, $registered_settings );
+		$this->assertSame( 'object', $registered_settings[ self::CREDENTIALS_SETTING_NAME ]['type'] );
+		$this->assertSame( 'Test Remote WordPress Connector Credentials', $registered_settings[ self::CREDENTIALS_SETTING_NAME ]['label'] );
+		$this->assertSame(
+			array(
+				'username' => '',
+				'password' => '',
+			),
+			$registered_settings[ self::CREDENTIALS_SETTING_NAME ]['default']
+		);
+		$this->assertSame( 'object', $registered_settings[ self::CREDENTIALS_SETTING_NAME ]['show_in_rest']['schema']['type'] );
+		$this->assertArrayHasKey( 'username', $registered_settings[ self::CREDENTIALS_SETTING_NAME ]['show_in_rest']['schema']['properties'] );
+		$this->assertArrayHasKey( 'password', $registered_settings[ self::CREDENTIALS_SETTING_NAME ]['show_in_rest']['schema']['properties'] );
 	}
 
 	/**
 	 * @ticket 64850
-	 *
-	 * @dataProvider data_application_password_settings
-	 *
-	 * @param string $pre_registered_setting_name Setting name registered by the connector plugin.
-	 * @param string $other_setting_name          Setting name registered by Core.
 	 */
-	public function test_application_password_connector_skips_already_registered_settings( string $pre_registered_setting_name, string $other_setting_name ): void {
+	public function test_application_password_connector_skips_already_registered_setting(): void {
 		register_setting(
 			'connectors',
-			$pre_registered_setting_name,
+			self::CREDENTIALS_SETTING_NAME,
 			array(
-				'type'              => 'string',
+				'type'              => 'object',
 				'label'             => 'Plugin-owned setting',
 				'description'       => 'Registered by the connector plugin.',
-				'default'           => 'plugin-default',
+				'default'           => array(
+					'username' => 'plugin-default',
+					'password' => '',
+				),
 				'show_in_rest'      => false,
-				'sanitize_callback' => 'sanitize_text_field',
+				'sanitize_callback' => '_wp_connectors_sanitize_application_password_credentials',
 			)
 		);
 
@@ -159,9 +162,8 @@ class Tests_Connectors_WpRegisterDefaultConnectorSettings extends WP_UnitTestCas
 				'description'    => '',
 				'type'           => 'content_source',
 				'authentication' => array(
-					'method'                            => 'application_password',
-					'username_setting_name'             => self::USERNAME_SETTING_NAME,
-					'application_password_setting_name' => self::APPLICATION_PASSWORD_SETTING_NAME,
+					'method'       => 'application_password',
+					'setting_name' => self::CREDENTIALS_SETTING_NAME,
 				),
 			)
 		);
@@ -169,28 +171,15 @@ class Tests_Connectors_WpRegisterDefaultConnectorSettings extends WP_UnitTestCas
 		_wp_register_default_connector_settings();
 
 		$registered_settings = get_registered_settings();
-		$this->assertArrayHasKey( $pre_registered_setting_name, $registered_settings );
-		$this->assertArrayHasKey( $other_setting_name, $registered_settings );
-		$this->assertSame( 'Plugin-owned setting', $registered_settings[ $pre_registered_setting_name ]['label'] );
-		$this->assertSame( 'plugin-default', $registered_settings[ $pre_registered_setting_name ]['default'] );
-		$this->assertFalse( $registered_settings[ $pre_registered_setting_name ]['show_in_rest'] );
-	}
-
-	/**
-	 * Data provider for application-password settings.
-	 *
-	 * @return array<string, array{string, string}> Test cases.
-	 */
-	public function data_application_password_settings(): array {
-		return array(
-			'username setting already registered' => array(
-				self::USERNAME_SETTING_NAME,
-				self::APPLICATION_PASSWORD_SETTING_NAME,
+		$this->assertArrayHasKey( self::CREDENTIALS_SETTING_NAME, $registered_settings );
+		$this->assertSame( 'Plugin-owned setting', $registered_settings[ self::CREDENTIALS_SETTING_NAME ]['label'] );
+		$this->assertSame(
+			array(
+				'username' => 'plugin-default',
+				'password' => '',
 			),
-			'application password setting already registered' => array(
-				self::APPLICATION_PASSWORD_SETTING_NAME,
-				self::USERNAME_SETTING_NAME,
-			),
+			$registered_settings[ self::CREDENTIALS_SETTING_NAME ]['default']
 		);
+		$this->assertFalse( $registered_settings[ self::CREDENTIALS_SETTING_NAME ]['show_in_rest'] );
 	}
 }

--- a/tests/phpunit/tests/connectors/wpRegisterDefaultConnectorSettings.php
+++ b/tests/phpunit/tests/connectors/wpRegisterDefaultConnectorSettings.php
@@ -8,9 +8,9 @@
  */
 class Tests_Connectors_WpRegisterDefaultConnectorSettings extends WP_UnitTestCase {
 
-	const CONNECTOR_ID = 'wp_test_non_ai_connector';
-	const SETTING_NAME = 'connectors_test_non_ai_api_key';
-	const USERNAME_SETTING_NAME = 'connectors_test_non_ai_username';
+	const CONNECTOR_ID                      = 'wp_test_non_ai_connector';
+	const SETTING_NAME                      = 'connectors_test_non_ai_api_key';
+	const USERNAME_SETTING_NAME             = 'connectors_test_non_ai_username';
 	const APPLICATION_PASSWORD_SETTING_NAME = 'connectors_test_non_ai_application_password';
 
 	/**


### PR DESCRIPTION


## What?
- Adds an application_password connector authentication method with generated username and application-password setting names.
- Registers both settings, masks only the application password in REST responses, and exposes non-secret connection metadata to the admin UI.
- Adds registry, Settings API, REST masking, and script-module tests.

## Testing
- php ./vendor/bin/phpunit --group connectors
- Targeted PHPCS for the changed Core files
- Verified end to end with WordPress/gutenberg#79403 by pointing WP_ENV_CORE at this checkout

- Verified this test connector saved correctly:
```
add_action(
	'wp_connectors_init',
	static function ( WP_Connector_Registry $registry ) {
		$registry->register(
			'test-remote-wordpress',
			array(
				'name'           => 'Test Remote WordPress',
				'description'    => 'Connect to example.com as a remote WordPress site.',
				'type'           => 'content_source',
				'authentication' => array(
					'method'          => 'application_password',
					'credentials_url' => 'https://example.com/wp-admin/profile.php',
				),
			)
		);
	}
);
````


Companion UI: https://github.com/WordPress/gutenberg/pull/79403
Trac: https://core.trac.wordpress.org/ticket/64850