### PR TITLE
Media: Only count attachments from the mirrored query collection

### DIFF
--- a/src/js/media/models/attachments.js
+++ b/src/js/media/models/attachments.js
@@ -204,7 +204,7 @@ var Attachments = Backbone.Collection.extend(/** @lends wp.media.model.Attachmen
 	 * Start observing another attachments collection change events
 	 * and replicate them on this collection.
 	 *
-	 * @param {wp.media.model.Attachments} The attachments collection to observe.
+	 * @param {wp.media.model.Attachments} attachments The attachments collection to observe.
 	 * @return {wp.media.model.Attachments} Returns itself to allow chaining.
 	 */
 	observe: function( attachments ) {
@@ -212,9 +212,19 @@ var Attachments = Backbone.Collection.extend(/** @lends wp.media.model.Attachmen
 		this.observers.push( attachments );
 
 		attachments.on( 'add change remove', this._validateHandler, this );
-		attachments.on( 'add', this._addToTotalAttachments, this );
-		attachments.on( 'remove', this._removeFromTotalAttachments, this );
 		attachments.on( 'reset', this._validateAllHandler, this );
+
+		/*
+		 * Only track the total number of attachments for the mirrored query
+		 * collection. Other observed collections, such as the selection, must
+		 * not change the count, otherwise an uploaded attachment that is also
+		 * added to the selection is counted more than once. See ticket #65513.
+		 */
+		if ( attachments === this.mirroring ) {
+			attachments.on( 'add', this._addToTotalAttachments, this );
+			attachments.on( 'remove', this._removeFromTotalAttachments, this );
+		}
+
 		this.validateAll( attachments );
 		return this;
 	},
@@ -239,7 +249,7 @@ var Attachments = Backbone.Collection.extend(/** @lends wp.media.model.Attachmen
 		return this;
 	},
 	/**
-	 * Update total attachment count when items are added to a collection.
+	 * Update total attachment count when items are removed from a collection.
 	 *
 	 * @access private
 	 *


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

Fixes the Media Library tab reporting "Showing 1 of 2 media items" after uploading the first image into an empty library through the Featured Image modal.

What the problem was:
- `wp.media.model.Attachments.observe()` bound the total-attachments counters (`_addToTotalAttachments`/`_removeFromTotalAttachments`) to every observed collection.
- The Featured Image state additionally observes the selection (`library.observe( this.get('selection') )`). With `autoSelect`, an uploaded image is added both to the mirrored query and to the selection, so it was counted twice — total became 2 for a single item.

What the fix does:
- Restricts the total-count handlers to the mirrored query collection, so the count reflects only the items in the library itself.
- Also corrects two JSDoc issues in the touched code (a missing `@param` name on `observe()` and a copy/paste description on `_removeFromTotalAttachments()`).

Approach and why:
- The count is meant to track the library (query) total. Other observed collections such as the selection should never change it; gating the bindings on `attachments === this.mirroring` is the minimal, correct expression of that intent and also resolves the same latent double-count in replace-image, gallery-edit, and collection-edit.

Trac ticket: https://core.trac.wordpress.org/ticket/65513

## Use of AI Tools
AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 4.8
Used for: Ticket analysis, live reproduction, root-cause investigation and verification. All changes were reviewed, validated against the codebase, and are taken responsibility for by me (Khokan Sardar).
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
