### PR TITLE
Block link-local addresses in wp_http_validate_url()

### DIFF
--- a/src/wp-includes/http.php
+++ b/src/wp-includes/http.php
@@ -548,6 +548,9 @@ function send_origin_headers() {
  *
  * - `http://192.168.0.1/caniload.php` - IP address from LAN network.
  *   This can be changed with the {@see 'http_request_host_is_external'} filter.
+ * - `http://169.254.169.254/latest/meta-data/` - Link-local address (169.254.0.0/16),
+ *   which includes cloud instance metadata endpoints.
+ *   This can be changed with the {@see 'http_request_host_is_external'} filter.
  * - `http://198.143.164.252:81/caniload.php` - By default, only ports 80, 443, and 8080 are allowed.
  *   This can be changed with the {@see 'http_allowed_safe_ports'} filter.
  *
@@ -598,6 +601,7 @@ function wp_http_validate_url( $url ) {
 			if ( 127 === $parts[0] || 10 === $parts[0] || 0 === $parts[0]
 				|| ( 172 === $parts[0] && 16 <= $parts[1] && 31 >= $parts[1] )
 				|| ( 192 === $parts[0] && 168 === $parts[1] )
+				|| ( 169 === $parts[0] && 254 === $parts[1] )
 			) {
 				// If host appears local, reject unless specifically allowed.
 				/**

--- a/tests/phpunit/tests/http/http.php
+++ b/tests/phpunit/tests/http/http.php
@@ -555,6 +555,14 @@ class Tests_HTTP_HTTP extends WP_UnitTestCase {
 				'url'           => 'http://192.168.0.1/caniload.php',
 				'external_host' => false,
 			),
+			'a link-local address (RFC 3927)'              => array(
+				'url'           => 'http://169.254.1.1/caniload.php',
+				'external_host' => false,
+			),
+			'the cloud metadata endpoint (link-local)'     => array(
+				'url'           => 'http://169.254.169.254/latest/meta-data/iam/security-credentials/',
+				'external_host' => false,
+			),
 			'a port not considered safe by default'        => array(
 				'url' => 'https://example.com:81/caniload.php',
 			),


### PR DESCRIPTION
`wp_http_validate_url()` is the validation layer used by WordPress's safe HTTP API (`wp_safe_remote_get()`, `wp_safe_remote_post()`, and related functions) to prevent requests to internal network destinations.

While the existing implementation blocks loopback and RFC1918 private address ranges, it does not reject the IPv4 link-local range (`169.254.0.0/16`).

This allows URLs resolving to addresses such as `169.254.169.254` (commonly used by cloud metadata services) to pass validation.

## Changes

* Add validation logic to reject addresses in the `169.254.0.0/16` link-local range.
* Update the function documentation to include the newly blocked range.
* Add regression tests covering:

  * `169.254.169.254`
  * `169.254.1.1`

## Impact

The link-local range is reserved for local network communication and should not be reachable through APIs intended to protect against SSRF.

Blocking this range aligns its handling with other reserved internal address ranges already denied by `wp_http_validate_url()` and prevents requests to cloud metadata endpoints from bypassing existing SSRF protections.