### PR TITLE
Script Loader: Prevent strict mode leaking into concatenated scripts

### DIFF
--- a/src/wp-admin/load-scripts.php
+++ b/src/wp-admin/load-scripts.php
@@ -45,7 +45,22 @@ require ABSPATH . WPINC . '/script-loader.php';
 require ABSPATH . WPINC . '/version.php';
 
 $expires_offset = 31536000; // 1 year.
-$out            = '';
+
+/*
+ * Begin the concatenated output with an empty statement.
+ *
+ * The concatenated files are appended one after another, so a "use strict"
+ * directive at the very top of the first bundled script (for example the
+ * one shipped in wp-includes/js/dist/hooks.js) would be treated as the
+ * directive prologue for the entire file. That would force every legacy,
+ * non-strict script bundled afterwards (such as ThickBox) to run in strict
+ * mode, where implicit global assignments throw a ReferenceError.
+ *
+ * Prepending an empty statement ensures any later "use strict" string is no
+ * longer the first statement, so it is evaluated as a harmless expression
+ * rather than enabling strict mode for the whole concatenated file.
+ */
+$out = ";\n";
 
 $wp_scripts = new WP_Scripts();
 wp_default_scripts( $wp_scripts );


### PR DESCRIPTION
Fixes the WordPress 7.0 regression where ThickBox modals fail to open (e.g. "View details" on the Plugins screen), with the console error `ReferenceError: imgLoader is not defined`.

What the problem was:
- Since the esbuild build switch (changeset 22294 / commit 22294af4ed), wp-includes/js/dist/hooks.js begins with a top-level `"use strict";`.
- load-scripts.php concatenates requested scripts head-to-tail with `wp-hooks` first, so that directive becomes the directive prologue for the entire concatenated file, forcing strict mode on every script after it.
- Legacy non-strict scripts like ThickBox assign implicit globals (`imgLoader`, `imgPreloader`, `TB_WIDTH`, `ajaxContentW`, ...), which throw ReferenceError in strict mode and abort the modal.

What the fix does:
- Begins the concatenated output with an empty statement (`$out = ";\n";`), so a leading `"use strict";` is no longer the first statement and is evaluated as a harmless expression instead of enabling strict mode for the whole file.

Approach and why:
- The root cause is strict-mode contamination at the concatenation layer, not a single thickbox.js variable. Fixing only `imgLoader` would move the crash to the next implicit global on the same code path and leave every other bundled legacy script exposed.
- This one-line change restores the pre-7.0 behaviour (concatenated admin scripts ran in sloppy mode) and fixes all affected scripts at once.
- It is a no-op when CONCATENATE_SCRIPTS is disabled, since files are then served standalone; that path already runs hooks.js in strict mode, confirming no shipped script relies on strict mode for correctness.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/65515

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 4.8
Used for: Ticket analysis, regression bisection and root-cause verification. All changes were reviewed, validated against the codebase and verified with runtime reproduction, and are taken responsibility for by me.
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
