### PR TITLE
I18N: Use `/* */` block style for translator comments

### DIFF
--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -2241,12 +2241,12 @@ class WP_Site_Health {
 				'<p>%s</p><p>%s<br>%s</p>',
 				__( 'When testing the REST API, an error was encountered:' ),
 				sprintf(
-					// translators: %s: The REST API URL.
+					/* translators: %s: The REST API URL. */
 					__( 'REST API Endpoint: %s' ),
 					$url
 				),
 				sprintf(
-					// translators: 1: The WordPress error code. 2: The WordPress error message.
+					/* translators: 1: The WordPress error code. 2: The WordPress error message. */
 					__( 'REST API Response: (%1$s) %2$s' ),
 					$r->get_error_code(),
 					$r->get_error_message()
@@ -2261,12 +2261,12 @@ class WP_Site_Health {
 				'<p>%s</p><p>%s<br>%s</p>',
 				__( 'When testing the REST API, an unexpected result was returned:' ),
 				sprintf(
-					// translators: %s: The REST API URL.
+					/* translators: %s: The REST API URL. */
 					__( 'REST API Endpoint: %s' ),
 					$url
 				),
 				sprintf(
-					// translators: 1: The WordPress error code. 2: The HTTP status code error message.
+					/* translators: 1: The WordPress error code. 2: The HTTP status code error message. */
 					__( 'REST API Response: (%1$s) %2$s' ),
 					wp_remote_retrieve_response_code( $r ),
 					wp_remote_retrieve_response_message( $r )

--- a/src/wp-admin/site-health.php
+++ b/src/wp-admin/site-health.php
@@ -39,7 +39,7 @@ $wrapper_classes = array(
 $current_tab = $_GET['tab'] ?? '';
 
 $title = sprintf(
-	// translators: %s: The currently displayed tab.
+	/* translators: %s: The currently displayed tab. */
 	__( 'Site Health - %s' ),
 	( isset( $tabs[ $current_tab ] ) ? esc_html( $tabs[ $current_tab ] ) : esc_html( reset( $tabs ) ) )
 );

--- a/src/wp-includes/abilities-api/class-wp-abilities-registry.php
+++ b/src/wp-includes/abilities-api/class-wp-abilities-registry.php
@@ -274,7 +274,7 @@ final class WP_Abilities_Registry {
 			_doing_it_wrong(
 				__METHOD__,
 				sprintf(
-					// translators: %s: init action.
+					/* translators: %s: init action. */
 					__( 'Ability API should not be initialized before the %s action has fired.' ),
 					'<code>init</code>'
 				),

--- a/src/wp-includes/abilities-api/class-wp-ability-categories-registry.php
+++ b/src/wp-includes/abilities-api/class-wp-ability-categories-registry.php
@@ -205,7 +205,7 @@ final class WP_Ability_Categories_Registry {
 			_doing_it_wrong(
 				__METHOD__,
 				sprintf(
-					// translators: %s: init action.
+					/* translators: %s: init action. */
 					__( 'Ability API should not be initialized before the %s action has fired.' ),
 					'<code>init</code>'
 				),

--- a/src/wp-includes/class-wp-icons-registry.php
+++ b/src/wp-includes/class-wp-icons-registry.php
@@ -149,7 +149,7 @@ class WP_Icons_Registry {
 				_doing_it_wrong(
 					__METHOD__,
 					sprintf(
-						// translators: %s is the name of any user-provided key
+						/* translators: %s is the name of any user-provided key */
 						__( 'Invalid icon property: "%s".' ),
 						$key
 					),

--- a/src/wp-includes/fonts/class-wp-font-collection.php
+++ b/src/wp-includes/fonts/class-wp-font-collection.php
@@ -118,7 +118,7 @@ final class WP_Font_Collection {
 		$file = file_exists( $file_or_url ) ? wp_normalize_path( realpath( $file_or_url ) ) : false;
 
 		if ( ! $url && ! $file ) {
-			// translators: %s: File path or URL to font collection JSON file.
+			/* translators: %s: File path or URL to font collection JSON file. */
 			$message = __( 'Font collection JSON file is invalid or does not exist.' );
 			_doing_it_wrong( __METHOD__, $message, '6.5.0' );
 			return new WP_Error( 'font_collection_json_missing', $message );
@@ -184,7 +184,7 @@ final class WP_Font_Collection {
 				return new WP_Error(
 					'font_collection_request_error',
 					sprintf(
-						// translators: %s: Font collection URL.
+						/* translators: %s: Font collection URL. */
 						__( 'Error fetching the font collection data from "%s".' ),
 						$url
 					)
@@ -224,7 +224,7 @@ final class WP_Font_Collection {
 		foreach ( $required_properties as $property ) {
 			if ( empty( $data[ $property ] ) ) {
 				$message = sprintf(
-					// translators: 1: Font collection slug, 2: Missing property name, e.g. "font_families".
+					/* translators: 1: Font collection slug, 2: Missing property name, e.g. "font_families". */
 					__( 'Font collection "%1$s" has missing or empty property: "%2$s".' ),
 					$this->slug,
 					$property

--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -495,7 +495,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			_doing_it_wrong(
 				__METHOD__,
 				sprintf(
-					// translators: %s: A tag name like INPUT or BR.
+					/* translators: %s: A tag name like INPUT or BR. */
 					__( 'The context element cannot be a void element, found "%s".' ),
 					$tag_name
 				),
@@ -515,7 +515,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			_doing_it_wrong(
 				__METHOD__,
 				sprintf(
-					// translators: %s: A tag name like IFRAME or TEXTAREA.
+					/* translators: %s: A tag name like IFRAME or TEXTAREA. */
 					__( 'The context element "%s" is not supported.' ),
 					$tag_name
 				),

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-icons-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-icons-controller.php
@@ -171,7 +171,7 @@ class WP_REST_Icons_Controller extends WP_REST_Controller {
 			return new WP_Error(
 				'rest_icon_not_found',
 				sprintf(
-					// translators: %s is the name of any user-provided name
+					/* translators: %s is the name of any user-provided name */
 					__( 'Icon not found: "%s".' ),
 					$name
 				),


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65518

## What

Converts the remaining `// translators:` line comments in core to the `/* translators: */` block comment style that is used consistently throughout `wp-admin` and `wp-includes` (2,636 block-style vs. 27 line-style before this change).

## Why

Per the ticket discussion, this is a coding-standards consistency change. To be clear about scope: the `// translators:` style *is* still extracted correctly by `wp i18n make-pot` / `xgettext` when the comment sits directly above the gettext call, so this is not fixing broken extraction — it is aligning the few outliers with the documented block-comment convention.

## Scope

This PR covers the **8 core-authored files** (14 occurrences):

- `wp-admin/site-health.php`
- `wp-admin/includes/class-wp-site-health.php`
- `wp-includes/abilities-api/class-wp-abilities-registry.php`
- `wp-includes/abilities-api/class-wp-ability-categories-registry.php`
- `wp-includes/class-wp-icons-registry.php`
- `wp-includes/fonts/class-wp-font-collection.php`
- `wp-includes/html-api/class-wp-html-processor.php`
- `wp-includes/rest-api/endpoints/class-wp-rest-icons-controller.php`

The `// translators:` comments in `wp-includes/blocks/*.php` are **intentionally excluded**, as those files are maintained in the Gutenberg plugin and need to be changed there first (per @sabernhardt in comment:2, +1 @mukesh27 in comment:3).

## Notes

- Pure comment-style change; no functional impact, no string changes.
- `php -l` passes on all touched files.