### PR TITLE
Allow deleting an active plugin in one step from the Plugins screen

### DIFF
--- a/src/js/_enqueues/wp/updates.js
+++ b/src/js/_enqueues/wp/updates.js
@@ -2715,7 +2715,13 @@
 			var $pluginRow = $( event.target ).parents( 'tr' ),
 				confirmMessage;
 
-			if ( $pluginRow.hasClass( 'is-uninstallable' ) ) {
+			if ( $pluginRow.hasClass( 'active' ) ) {
+				confirmMessage = sprintf(
+					/* translators: %s: Plugin name. */
+					__( 'You are about to delete %s.\n\nThis plugin is active and will be deactivated before deletion.\n\nAre you sure you want to proceed?' ),
+					$pluginRow.find( '.plugin-title strong' ).text()
+				);
+			} else if ( $pluginRow.hasClass( 'is-uninstallable' ) ) {
 				confirmMessage = sprintf(
 					/* translators: %s: Plugin name. */
 					__( 'Are you sure you want to delete %s and its data?' ),
@@ -2842,9 +2848,22 @@
 					break;
 
 				case 'delete-selected':
-					var confirmMessage = 'plugin' === type ?
-						__( 'Are you sure you want to delete the selected plugins and their data?' ) :
-						__( 'Caution: These themes may be active on other sites in the network. Are you sure you want to proceed?' );
+					var confirmMessage;
+					if ( 'plugin' === type ) {
+						var hasActivePlugins = false;
+						$bulkActionForm.find( 'input[name="checked[]"]:checked' ).each( function() {
+							if ( $( this ).parents( 'tr' ).hasClass( 'active' ) ) {
+								hasActivePlugins = true;
+							}
+						} );
+
+						confirmMessage = __( 'Are you sure you want to delete the selected plugins and their data?' );
+						if ( hasActivePlugins ) {
+							confirmMessage += '\n\n' + __( 'Note: Active plugins will be deactivated before deletion.' );
+						}
+					} else {
+						confirmMessage = __( 'Caution: These themes may be active on other sites in the network. Are you sure you want to proceed?' );
+					}
 
 					if ( ! window.confirm( confirmMessage ) ) {
 						event.preventDefault();

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -4752,9 +4752,8 @@ function wp_ajax_delete_plugin() {
 	$status['plugin']     = $plugin;
 	$status['pluginName'] = $plugin_data['Name'];
 
-	if ( is_plugin_active( $plugin ) ) {
-		$status['errorMessage'] = __( 'You cannot delete a plugin while it is active on the main site.' );
-		wp_send_json_error( $status );
+	if ( is_network_admin() ? is_plugin_active_for_network( $plugin ) : is_plugin_active( $plugin ) ) {
+		deactivate_plugins( $plugin, false, is_network_admin() );
 	}
 
 	// Check filesystem credentials. `delete_plugins()` will bail otherwise.

--- a/src/wp-admin/includes/class-wp-plugins-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugins-list-table.php
@@ -680,7 +680,7 @@ class WP_Plugins_List_Table extends WP_List_Table {
 				$actions['update-selected'] = __( 'Update' );
 			}
 
-			if ( current_user_can( 'delete_plugins' ) && ( 'active' !== $status ) ) {
+			if ( current_user_can( 'delete_plugins' ) ) {
 				$actions['delete-selected'] = __( 'Delete' );
 			}
 
@@ -942,29 +942,29 @@ class WP_Plugins_List_Table extends WP_List_Table {
 							);
 						}
 					}
+				}
 
-					if ( current_user_can( 'delete_plugins' ) && ! is_plugin_active( $plugin_file ) ) {
-						if ( $has_dependents && ! $has_circular_dependency ) {
-							$actions['delete'] = __( 'Delete' ) .
-								'<span class="screen-reader-text">' .
-								__( 'You cannot delete this plugin as other plugins require it.' ) .
-								'</span>';
-						} else {
-							$delete_url = 'plugins.php?action=delete-selected' .
-								'&amp;checked[]=' . urlencode( $plugin_file ) .
-								'&amp;plugin_status=' . $context .
-								'&amp;paged=' . $page .
-								'&amp;s=' . $s;
+				if ( current_user_can( 'delete_plugins' ) ) {
+					if ( $has_dependents && ! $has_circular_dependency ) {
+						$actions['delete'] = __( 'Delete' ) .
+							'<span class="screen-reader-text">' .
+							__( 'You cannot delete this plugin as other plugins require it.' ) .
+							'</span>';
+					} else {
+						$delete_url = 'plugins.php?action=delete-selected' .
+							'&amp;checked[]=' . urlencode( $plugin_file ) .
+							'&amp;plugin_status=' . $context .
+							'&amp;paged=' . $page .
+							'&amp;s=' . $s;
 
-							$actions['delete'] = sprintf(
-								'<a href="%s" id="delete-%s" class="delete" aria-label="%s">%s</a>',
-								wp_nonce_url( $delete_url, 'bulk-plugins' ),
-								esc_attr( $plugin_id_attr ),
-								/* translators: %s: Plugin name. */
-								esc_attr( sprintf( _x( 'Delete %s', 'plugin' ), $plugin_data['Name'] ) ),
-								__( 'Delete' )
-							);
-						}
+						$actions['delete'] = sprintf(
+							'<a href="%s" id="delete-%s" class="delete" aria-label="%s">%s</a>',
+							wp_nonce_url( $delete_url, 'bulk-plugins' ),
+							esc_attr( $plugin_id_attr ),
+							/* translators: %s: Plugin name. */
+							esc_attr( sprintf( _x( 'Delete %s', 'plugin' ), $plugin_data['Name'] ) ),
+							__( 'Delete' )
+						);
 					}
 				}
 			} else {
@@ -1048,31 +1048,31 @@ class WP_Plugins_List_Table extends WP_List_Table {
 							);
 						}
 					}
-
-					if ( ! is_multisite() && current_user_can( 'delete_plugins' ) ) {
-						if ( $has_dependents && ! $has_circular_dependency ) {
-							$actions['delete'] = __( 'Delete' ) .
-								'<span class="screen-reader-text">' .
-								__( 'You cannot delete this plugin as other plugins require it.' ) .
-								'</span>';
-						} else {
-							$delete_url = 'plugins.php?action=delete-selected' .
-								'&amp;checked[]=' . urlencode( $plugin_file ) .
-								'&amp;plugin_status=' . $context .
-								'&amp;paged=' . $page .
-								'&amp;s=' . $s;
-
-							$actions['delete'] = sprintf(
-								'<a href="%s" id="delete-%s" class="delete" aria-label="%s">%s</a>',
-								wp_nonce_url( $delete_url, 'bulk-plugins' ),
-								esc_attr( $plugin_id_attr ),
-								/* translators: %s: Plugin name. */
-								esc_attr( sprintf( _x( 'Delete %s', 'plugin' ), $plugin_data['Name'] ) ),
-								__( 'Delete' )
-							);
-						}
-					}
 				} // End if $is_active.
+
+				if ( ! is_multisite() && current_user_can( 'delete_plugins' ) ) {
+					if ( $has_dependents && ! $has_circular_dependency ) {
+						$actions['delete'] = __( 'Delete' ) .
+							'<span class="screen-reader-text">' .
+							__( 'You cannot delete this plugin as other plugins require it.' ) .
+							'</span>';
+					} else {
+						$delete_url = 'plugins.php?action=delete-selected' .
+							'&amp;checked[]=' . urlencode( $plugin_file ) .
+							'&amp;plugin_status=' . $context .
+							'&amp;paged=' . $page .
+							'&amp;s=' . $s;
+
+						$actions['delete'] = sprintf(
+							'<a href="%s" id="delete-%s" class="delete" aria-label="%s">%s</a>',
+							wp_nonce_url( $delete_url, 'bulk-plugins' ),
+							esc_attr( $plugin_id_attr ),
+							/* translators: %s: Plugin name. */
+							esc_attr( sprintf( _x( 'Delete %s', 'plugin' ), $plugin_data['Name'] ) ),
+							__( 'Delete' )
+						);
+					}
+				}
 			} // End if $screen->in_admin( 'network' ).
 		} // End if $context.
 

--- a/src/wp-admin/plugins.php
+++ b/src/wp-admin/plugins.php
@@ -280,12 +280,6 @@ if ( $action ) {
 				exit;
 			}
 
-			$plugins = array_filter( $plugins, 'is_plugin_inactive' ); // Do not allow to delete activated plugins.
-			if ( empty( $plugins ) ) {
-				wp_redirect( self_admin_url( "plugins.php?error=true&main=true&plugin_status=$status&paged=$page&s=$s" ) );
-				exit;
-			}
-
 			// Bail on all if any paths are invalid.
 			// validate_file() returns truthy for invalid files.
 			$invalid_plugin_files = array_filter( $plugins, 'validate_file' );
@@ -373,14 +367,21 @@ if ( $action ) {
 
 						$data_to_delete = false;
 
-						foreach ( $plugin_info as $plugin ) {
+						foreach ( $plugin_info as $plugin_file => $plugin ) {
+							$is_active = is_network_admin() ? is_plugin_active_for_network( $plugin_file ) : is_plugin_active( $plugin_file );
+
+							$active_notice = '';
+							if ( $is_active ) {
+								$active_notice = ' <strong>' . __( '(is active and will be deactivated)' ) . '</strong>';
+							}
+
 							if ( $plugin['is_uninstallable'] ) {
 								/* translators: 1: Plugin name, 2: Plugin author. */
-								echo '<li>', sprintf( __( '%1$s by %2$s (will also <strong>delete its data</strong>)' ), '<strong>' . $plugin['Name'] . '</strong>', '<em>' . $plugin['AuthorName'] . '</em>' ), '</li>';
+								echo '<li>', sprintf( __( '%1$s by %2$s (will also <strong>delete its data</strong>)' ), '<strong>' . $plugin['Name'] . '</strong>', '<em>' . $plugin['AuthorName'] . '</em>' ), $active_notice, '</li>';
 								$data_to_delete = true;
 							} else {
 								/* translators: 1: Plugin name, 2: Plugin author. */
-								echo '<li>', sprintf( _x( '%1$s by %2$s', 'plugin' ), '<strong>' . $plugin['Name'] . '</strong>', '<em>' . $plugin['AuthorName'] ) . '</em>', '</li>';
+								echo '<li>', sprintf( _x( '%1$s by %2$s', 'plugin' ), '<strong>' . $plugin['Name'] . '</strong>', '<em>' . $plugin['AuthorName'] ) . '</em>', $active_notice, '</li>';
 							}
 						}
 
@@ -426,6 +427,18 @@ if ( $action ) {
 			} else {
 				$plugins_to_delete = count( $plugins );
 			} // End if verify-delete.
+
+			// Deactivate active plugins before deleting them.
+			$active_plugins = array();
+			foreach ( $plugins as $plugin ) {
+				if ( is_network_admin() ? is_plugin_active_for_network( $plugin ) : is_plugin_active( $plugin ) ) {
+					$active_plugins[] = $plugin;
+				}
+			}
+
+			if ( ! empty( $active_plugins ) ) {
+				deactivate_plugins( $active_plugins, false, is_network_admin() );
+			}
 
 			$delete_result = delete_plugins( $plugins );
 


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

### Description
This PR is a prototype implementation for the proposal outlined in Trac #65430. It aims to keep the safety of the current safeguard while dropping the UI friction by allowing active plugins to be deleted in a single step.

### Changes
- **`src/wp-admin/includes/class-wp-plugins-list-table.php`**: Updated to render the "Delete" link and allow bulk deletion selection for active plugins.
- **`src/wp-admin/plugins.php`**: Updated the `delete-selected` action to intercept active plugins and safely run `deactivate_plugins()` prior to the existing uninstall/delete routines.
- **`src/wp-admin/includes/ajax-actions.php` & `src/js/_enqueues/wp/updates.js`**: Enhanced the AJAX deletion handlers and confirmation prompts to explicitly inform the user when an active plugin is being removed.


Trac ticket: https://core.trac.wordpress.org/ticket/65430

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

AI assistance: Yes
Tool(s): Antigravity
Model(s): Gemini
Used for: Reviewing the existing implementation and suggesting the changes. Final decisions and edits were made by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
