### PR TITLE
Fix selected state for placeholder options in wp_dropdown_pages()

### DIFF
--- a/src/wp-includes/post-template.php
+++ b/src/wp-includes/post-template.php
@@ -1230,10 +1230,10 @@ function wp_dropdown_pages( $args = '' ) {
 
 		$output = "<select name='" . esc_attr( $parsed_args['name'] ) . "'" . $class . " id='" . esc_attr( $parsed_args['id'] ) . "'>\n";
 		if ( $parsed_args['show_option_no_change'] ) {
-			$output .= "\t<option value=\"-1\">" . $parsed_args['show_option_no_change'] . "</option>\n";
+			$output .= "\t<option value=\"-1\"" . selected( '-1', $parsed_args['selected'], false ) . '>' . $parsed_args['show_option_no_change'] . "</option>\n";
 		}
 		if ( $parsed_args['show_option_none'] ) {
-			$output .= "\t<option value=\"" . esc_attr( $parsed_args['option_none_value'] ) . '">' . $parsed_args['show_option_none'] . "</option>\n";
+			$output .= "\t<option value=\"" . esc_attr( $parsed_args['option_none_value'] ) . '"' . selected( $parsed_args['option_none_value'], $parsed_args['selected'], false ) . '>' . $parsed_args['show_option_none'] . "</option>\n";
 		}
 		$output .= walk_page_dropdown_tree( $pages, $parsed_args['depth'], $parsed_args );
 		$output .= "</select>\n";

--- a/tests/phpunit/tests/post/wpDropdownPages.php
+++ b/tests/phpunit/tests/post/wpDropdownPages.php
@@ -219,4 +219,53 @@ NO;
 
 		$this->assertMatchesRegularExpression( '/<select[^>]+class=\'bar\'/', $found );
 	}
+
+	/**
+	 * Tests that the 'show_option_none' option can be selected.
+	 *
+	 * @ticket 65510
+	 */
+	public function test_wp_dropdown_pages_show_option_none_is_selected() {
+		self::factory()->post->create(
+			array(
+				'post_type' => 'page',
+				'post_name' => 'foo',
+			)
+		);
+
+		$found = wp_dropdown_pages(
+			array(
+				'echo'              => 0,
+				'show_option_none'  => 'None',
+				'option_none_value' => 'none_value',
+				'selected'          => 'none_value',
+			)
+		);
+
+		$this->assertStringContainsString( '<option value="none_value" selected=\'selected\'>None</option>', $found );
+	}
+
+	/**
+	 * Tests that the 'show_option_no_change' option can be selected.
+	 *
+	 * @ticket 65510
+	 */
+	public function test_wp_dropdown_pages_show_option_no_change_is_selected() {
+		self::factory()->post->create(
+			array(
+				'post_type' => 'page',
+				'post_name' => 'foo',
+			)
+		);
+
+		$found = wp_dropdown_pages(
+			array(
+				'echo'                  => 0,
+				'show_option_no_change' => 'No Change',
+				'selected'              => '-1',
+			)
+		);
+
+		$this->assertStringContainsString( '<option value="-1" selected=\'selected\'>No Change</option>', $found );
+	}
 }


### PR DESCRIPTION
This PR fixes an issue in the `wp_dropdown_pages()` function where the `show_option_none` and `show_option_no_change` placeholder options would lose their selected state upon page reload. When a developer passed their respective values into the `selected` argument, the dropdown would incorrectly default to the first position instead of marking the chosen placeholder as selected.

Trac ticket: https://core.trac.wordpress.org/ticket/65510

### What Changed?
* Modified the core function `wp_dropdown_pages()` within `src/wp-includes/post-template.php` to include the `selected()` helper function on both the `show_option_none` and `show_option_no_change` HTML `<option>` tags.
* Added corresponding PHPUnit tests in `tests/phpunit/tests/post/wpDropdownPages.php` to verify that both placeholder options correctly reflect their selected states when their exact values are passed to the arguments array.