### PR TITLE
Update view config for DataViews/DataForm in the server

### DIFF
--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -819,7 +819,7 @@ add_filter( 'rest_pre_insert_wp_template', 'inject_ignored_hooked_blocks_metadat
 add_filter( 'rest_pre_insert_wp_template_part', 'inject_ignored_hooked_blocks_metadata_attributes' );
 
 // View Config API.
-foreach ( array( 'page', 'post', 'wp_block', 'wp_template_part', 'wp_template' ) as $post_type ) {
+foreach ( array( 'page', 'wp_block', 'wp_template_part', 'wp_template' ) as $post_type ) {
 	add_filter(
 		"get_entity_view_config_postType_{$post_type}",
 		"_wp_get_entity_view_config_post_type_{$post_type}",

--- a/src/wp-includes/view-config.php
+++ b/src/wp-includes/view-config.php
@@ -11,6 +11,88 @@
  */
 
 /**
+ * Builds the default `form` configuration shared by every post type entity.
+ *
+ * This is the single `form` consumed today; it is a sensible default for `post`,
+ * `page`, and custom post types alike rather than being tailored per type.
+ *
+ * It is intentionally NOT gated by `supports`. The registered fields are the
+ * single source of truth for what applies: each field is registered for a post
+ * type based on its `supports` (and related flags such as `theme_supports`), and
+ * the editor drops any form field whose definition is absent or whose `isVisible`
+ * returns `false`.
+ *
+ * @since 7.1.0
+ *
+ * @return array The default form configuration.
+ */
+function _wp_get_default_post_type_form() {
+	return array(
+		'layout' => array( 'type' => 'panel' ),
+		'fields' => array(
+			array(
+				'id'     => 'featured_media',
+				'layout' => array(
+					'type'          => 'regular',
+					'labelPosition' => 'none',
+				),
+			),
+			array(
+				'id'     => 'post-content-info',
+				'layout' => array(
+					'type'          => 'regular',
+					'labelPosition' => 'none',
+				),
+			),
+			array(
+				'id'     => 'excerpt',
+				'layout' => array(
+					'type'          => 'panel',
+					'labelPosition' => 'top',
+				),
+			),
+			array(
+				'id'       => 'status',
+				'label'    => __( 'Status' ),
+				'children' => array(
+					array(
+						'id'     => 'status',
+						'layout' => array(
+							'type'          => 'regular',
+							'labelPosition' => 'none',
+						),
+					),
+					'scheduled_date',
+					'password',
+					'sticky',
+				),
+			),
+			'date',
+			'slug',
+			'author',
+			'template',
+			array(
+				'id'       => 'discussion',
+				'label'    => __( 'Discussion' ),
+				'children' => array(
+					array(
+						'id'     => 'comment_status',
+						'layout' => array(
+							'type'          => 'regular',
+							'labelPosition' => 'none',
+						),
+					),
+					'ping_status',
+				),
+			),
+			'parent',
+			'format',
+			'revisions',
+		),
+	);
+}
+
+/**
  * Returns the view configuration for the given entity.
  *
  * Builds the default configuration shared by all entities and then exposes it
@@ -65,7 +147,7 @@ function wp_get_entity_view_config( $kind, $name ) {
 		'default_view'    => $default_view,
 		'default_layouts' => $default_layouts,
 		'view_list'       => $view_list,
-		'form'            => array(),
+		'form'            => 'postType' === $kind ? _wp_get_default_post_type_form() : array(),
 	);
 
 	/**
@@ -238,148 +320,6 @@ function _wp_get_entity_view_config_post_type_page( $config ) {
 					),
 				),
 			),
-		),
-	);
-
-	$config['form'] = array(
-		'layout' => array( 'type' => 'panel' ),
-		'fields' => array(
-			array(
-				'id'     => 'featured_media',
-				'layout' => array(
-					'type'          => 'regular',
-					'labelPosition' => 'none',
-				),
-			),
-			array(
-				'id'     => 'post-content-info',
-				'layout' => array(
-					'type'          => 'regular',
-					'labelPosition' => 'none',
-				),
-			),
-			array(
-				'id'     => 'excerpt',
-				'layout' => array(
-					'type'          => 'panel',
-					'labelPosition' => 'top',
-				),
-			),
-			array(
-				'id'       => 'status',
-				'label'    => __( 'Status' ),
-				'children' => array(
-					array(
-						'id'     => 'status',
-						'layout' => array(
-							'type'          => 'regular',
-							'labelPosition' => 'none',
-						),
-					),
-					'scheduled_date',
-					'password',
-					'sticky',
-				),
-			),
-			'date',
-			'slug',
-			'author',
-			'template',
-			array(
-				'id'       => 'discussion',
-				'label'    => __( 'Discussion' ),
-				'children' => array(
-					array(
-						'id'     => 'comment_status',
-						'layout' => array(
-							'type'          => 'regular',
-							'labelPosition' => 'none',
-						),
-					),
-					'ping_status',
-				),
-			),
-			'parent',
-			'format',
-			'revisions',
-		),
-	);
-
-	return $config;
-}
-
-/**
- * Provides the view configuration for the `post` post type.
- *
- * @since 7.1.0
- *
- * @param array $config {
- *     The view configuration for the entity.
- * }
- * @return array The filtered view configuration.
- */
-function _wp_get_entity_view_config_post_type_post( $config ) {
-	$config['form'] = array(
-		'layout' => array( 'type' => 'panel' ),
-		'fields' => array(
-			array(
-				'id'     => 'featured_media',
-				'layout' => array(
-					'type'          => 'regular',
-					'labelPosition' => 'none',
-				),
-			),
-			array(
-				'id'     => 'post-content-info',
-				'layout' => array(
-					'type'          => 'regular',
-					'labelPosition' => 'none',
-				),
-			),
-			array(
-				'id'     => 'excerpt',
-				'layout' => array(
-					'type'          => 'panel',
-					'labelPosition' => 'top',
-				),
-			),
-			array(
-				'id'       => 'status',
-				'label'    => __( 'Status' ),
-				'children' => array(
-					array(
-						'id'     => 'status',
-						'layout' => array(
-							'type'          => 'regular',
-							'labelPosition' => 'none',
-						),
-					),
-					'scheduled_date',
-					'password',
-					'sticky',
-				),
-			),
-			'date',
-			'slug',
-			'author',
-			'template',
-			array(
-				'id'       => 'discussion',
-				'label'    => __( 'Discussion' ),
-				'children' => array(
-					array(
-						'id'     => 'comment_status',
-						'layout' => array(
-							'type'          => 'regular',
-							'labelPosition' => 'none',
-						),
-					),
-					'ping_status',
-				),
-			),
-			'parent',
-			'format',
-			'revisions',
 		),
 	);
 

--- a/src/wp-includes/view-config.php
+++ b/src/wp-includes/view-config.php
@@ -11,10 +11,11 @@
  */
 
 /**
- * Builds the default `form` configuration shared by every post type entity.
+ * Builds the default `form` configuration for post types that don't provide their own.
  *
- * This is the single `form` consumed today; it is a sensible default for `post`,
- * `page`, and custom post types alike rather than being tailored per type.
+ * It is a sensible default for `post`, `page`, and custom post types alike rather
+ * than being tailored per type. Post types that need a different shape can replace
+ * it entirely with a dedicated `form` through their own filter callback.
  *
  * It is intentionally NOT gated by `supports`. The registered fields are the
  * single source of truth for what applies: each field is registered for a post

--- a/src/wp-includes/view-config.php
+++ b/src/wp-includes/view-config.php
@@ -490,13 +490,7 @@ function _wp_get_entity_view_config_post_type_wp_block( $config ) {
 					'labelPosition' => 'none',
 				),
 			),
-			array(
-				'id'     => 'sync-status',
-				'layout' => array(
-					'type'          => 'regular',
-					'labelPosition' => 'side',
-				),
-			),
+			'sync-status',
 			'revisions',
 		),
 	);

--- a/src/wp-includes/view-config.php
+++ b/src/wp-includes/view-config.php
@@ -473,6 +473,34 @@ function _wp_get_entity_view_config_post_type_wp_block( $config ) {
 
 	$config['view_list'] = $view_list;
 
+	$config['form'] = array(
+		'layout' => array( 'type' => 'panel' ),
+		'fields' => array(
+			array(
+				'id'     => 'excerpt',
+				'layout' => array(
+					'type'          => 'panel',
+					'labelPosition' => 'top',
+				),
+			),
+			array(
+				'id'     => 'post-content-info',
+				'layout' => array(
+					'type'          => 'regular',
+					'labelPosition' => 'none',
+				),
+			),
+			array(
+				'id'     => 'sync-status',
+				'layout' => array(
+					'type'          => 'regular',
+					'labelPosition' => 'side',
+				),
+			),
+			'revisions',
+		),
+	);
+
 	return $config;
 }
 

--- a/tests/phpunit/tests/rest-api/rest-view-config-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-view-config-controller.php
@@ -302,6 +302,52 @@ class WP_REST_View_Config_Controller_Test extends WP_Test_REST_TestCase {
 	}
 
 	/**
+	 * The pattern form config exposes the fields shown in the pattern summary.
+	 *
+	 * @ticket 65516
+	 *
+	 * @covers WP_REST_View_Config_Controller::get_items
+	 */
+	public function test_wp_block_config_includes_pattern_summary_form() {
+		wp_set_current_user( self::$editor_id );
+
+		$response = $this->dispatch_request( 'postType', 'wp_block' );
+		$data     = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame(
+			array(
+				'layout' => array( 'type' => 'panel' ),
+				'fields' => array(
+					array(
+						'id'     => 'excerpt',
+						'layout' => array(
+							'type'          => 'panel',
+							'labelPosition' => 'top',
+						),
+					),
+					array(
+						'id'     => 'post-content-info',
+						'layout' => array(
+							'type'          => 'regular',
+							'labelPosition' => 'none',
+						),
+					),
+					array(
+						'id'     => 'sync-status',
+						'layout' => array(
+							'type'          => 'regular',
+							'labelPosition' => 'side',
+						),
+					),
+					'revisions',
+				),
+			),
+			$data['form']
+		);
+	}
+
+	/**
 	 * Empty object-typed config values serialize as JSON objects ({}), not arrays ([]).
 	 *
 	 * @covers ::get_items

--- a/tests/phpunit/tests/rest-api/rest-view-config-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-view-config-controller.php
@@ -302,52 +302,6 @@ class WP_REST_View_Config_Controller_Test extends WP_Test_REST_TestCase {
 	}
 
 	/**
-	 * The pattern form config exposes the fields shown in the pattern summary.
-	 *
-	 * @ticket 65516
-	 *
-	 * @covers WP_REST_View_Config_Controller::get_items
-	 */
-	public function test_wp_block_config_includes_pattern_summary_form() {
-		wp_set_current_user( self::$editor_id );
-
-		$response = $this->dispatch_request( 'postType', 'wp_block' );
-		$data     = $response->get_data();
-
-		$this->assertSame( 200, $response->get_status() );
-		$this->assertSame(
-			array(
-				'layout' => array( 'type' => 'panel' ),
-				'fields' => array(
-					array(
-						'id'     => 'excerpt',
-						'layout' => array(
-							'type'          => 'panel',
-							'labelPosition' => 'top',
-						),
-					),
-					array(
-						'id'     => 'post-content-info',
-						'layout' => array(
-							'type'          => 'regular',
-							'labelPosition' => 'none',
-						),
-					),
-					array(
-						'id'     => 'sync-status',
-						'layout' => array(
-							'type'          => 'regular',
-							'labelPosition' => 'side',
-						),
-					),
-					'revisions',
-				),
-			),
-			$data['form']
-		);
-	}
-
-	/**
 	 * Empty object-typed config values serialize as JSON objects ({}), not arrays ([]).
 	 *
 	 * @covers ::get_items


### PR DESCRIPTION
## What?
This is a follow-up to WordPress/wordpress-develop#11272  and will port the changes in view config from:

- Add a better default for post types form in view config. GB PR: https://github.com/WordPress/gutenberg/pull/79625
- Add pattern (`wp_block`) `form` config. GB PR: https://github.com/WordPress/gutenberg/pull/79452





## Testing
Verify unit tests are passing.

Trac ticket: https://core.trac.wordpress.org/ticket/65552