### PR TITLE
filter page list overlay styles through safecss_filter_attr

### DIFF
--- a/src/wp-includes/blocks/page-list.php
+++ b/src/wp-includes/blocks/page-list.php
@@ -219,7 +219,7 @@ function block_core_page_list_render_nested_page_list( $submenu_visibility, $sho
 		if ( ( ( 0 < $depth && ! $is_nested ) || $is_nested ) && isset( $colors['overlay_css_classes'], $colors['overlay_inline_styles'] ) ) {
 			$css_class .= ' ' . trim( implode( ' ', $colors['overlay_css_classes'] ) );
 			if ( '' !== $colors['overlay_inline_styles'] ) {
-				$style_attribute = sprintf( ' style="%s"', esc_attr( $colors['overlay_inline_styles'] ) );
+				$style_attribute = sprintf( ' style="%s"', esc_attr( safecss_filter_attr( $colors['overlay_inline_styles'] ) ) );
 			}
 		}
 


### PR DESCRIPTION
Repro: add a Navigation block with a Page List inside it and give the Navigation a custom overlay color carrying extra declarations, e.g. set `customOverlayBackgroundColor` to `red;behavior:url(#default#time2);background:url(javascript:alert(1))`. The submenu `<li>` renders that whole string verbatim in its `style` attribute for every front-end visitor.

Cause: `block_core_page_list_render_nested_page_list()` emits the overlay style with `esc_attr()` alone. The overlay colors arrive as plain Navigation context strings, so they never pass through the style engine, `get_block_wrapper_attributes()`, or KSES, and the CSS property allowlist is skipped.

Fix: wrap the value in `safecss_filter_attr()` before `esc_attr()`, matching how the Navigation block renders these same overlay colors.

Trac ticket: _none yet; happy to open one to track this._

## Use of AI Tools

<!-- -->
