### PR TITLE
REST API: Remove redundant `parent_post_type` property from template autosaves controller

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-template-autosaves-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-template-autosaves-controller.php
@@ -16,14 +16,6 @@
  */
 class WP_REST_Template_Autosaves_Controller extends WP_REST_Autosaves_Controller {
 	/**
-	 * Parent post type.
-	 *
-	 * @since 6.4.0
-	 * @var string
-	 */
-	private $parent_post_type;
-
-	/**
 	 * Parent post controller.
 	 *
 	 * @since 6.4.0
@@ -56,7 +48,6 @@ class WP_REST_Template_Autosaves_Controller extends WP_REST_Autosaves_Controller
 	 */
 	public function __construct( $parent_post_type ) {
 		parent::__construct( $parent_post_type );
-		$this->parent_post_type = $parent_post_type;
 		$post_type_object       = get_post_type_object( $parent_post_type );
 		$parent_controller      = $post_type_object->get_rest_controller();
 


### PR DESCRIPTION
The `WP_REST_Template_Autosaves_Controller` class redeclared a private `$parent_post_type` property and assigned it in its constructor. Both were dead code. The parent class `WP_REST_Autosaves_Controller` already declares and sets this property, and because it is declared `private`, the child class's copy could never be accessed by the parent's methods, nor was it ever read anywhere within the child class itself. The result was confusing property shadowing without any functional purpose.

This change removes the duplicate property declaration and the corresponding assignment in the constructor. Since the property was never read in the child class and was effectively a separate, unused storage slot, there is no change in runtime behavior.

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
