### PR TITLE
Media: Reset gallery modal state when abandoning a new gallery

### DIFF
--- a/src/js/media/views/frame/post.js
+++ b/src/js/media/views/frame/post.js
@@ -179,6 +179,7 @@ Post = Select.extend(/** @lends wp.media.view.MediaFrame.Post.prototype */{
 		Select.prototype.bindHandlers.apply( this, arguments );
 
 		this.on( 'activate', this.activate, this );
+		this.on( 'close', this.resetCreateGalleryState, this );
 
 		// Only bother checking media type counts if one of the counts is zero.
 		checkCounts = _.find( this.counts, function( type ) {
@@ -232,6 +233,30 @@ Post = Select.extend(/** @lends wp.media.view.MediaFrame.Post.prototype */{
 				this.on( region + ':render:' + handler, this[ callback ], this );
 			}, this );
 		}, this );
+	},
+
+	/**
+	 * Clears transient gallery state when a new gallery is abandoned.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @return {void}
+	 */
+	resetCreateGalleryState: function() {
+		var state = this.state(),
+			edit;
+
+		if ( ! state || ! _.contains( [ 'gallery', 'gallery-edit', 'gallery-library' ], state.get( 'id' ) ) ) {
+			return;
+		}
+
+		edit = this.state( 'gallery-edit' );
+
+		if ( edit && ! edit.get( 'editing' ) ) {
+			edit.get( 'library' ).reset();
+			this.state( 'gallery' ).get( 'selection' ).reset();
+			this.state( 'gallery-library' ).get( 'selection' ).reset();
+		}
 	},
 
 	activate: function() {

--- a/tests/qunit/index.html
+++ b/tests/qunit/index.html
@@ -162,6 +162,7 @@
 		<script src="wp-admin/js/customize-widgets.js"></script>
 		<script src="wp-admin/js/word-count.js"></script>
 		<script src="wp-admin/js/nav-menu.js"></script>
+		<script src="wp-admin/js/media/post-frame.js"></script>
 		<script src="wp-admin/js/widgets/test-media-widgets.js"></script>
 		<script src="wp-admin/js/widgets/test-media-image-widget.js"></script>
 		<script src="wp-admin/js/widgets/test-media-gallery-widget.js"></script>

--- a/tests/qunit/wp-admin/js/media/post-frame.js
+++ b/tests/qunit/wp-admin/js/media/post-frame.js
@@ -1,0 +1,37 @@
+/* global wp */
+/* jshint qunit: true */
+/* eslint-env qunit */
+
+( function() {
+	'use strict';
+
+	QUnit.module( 'Media Frame Post' );
+
+	QUnit.test( 'closing an abandoned gallery clears transient gallery state', function( assert ) {
+		var frame = wp.media({
+				frame: 'post',
+				state: 'gallery',
+				multiple: true
+			}),
+			gallery = frame.state( 'gallery' ),
+			add = frame.state( 'gallery-library' ),
+			edit = frame.state( 'gallery-edit' ),
+			attachments = [
+				wp.media.model.Attachment.create( { id: 5748901, type: 'image' } ),
+				wp.media.model.Attachment.create( { id: 5748902, type: 'image' } )
+			];
+
+		gallery.get( 'selection' ).add( attachments );
+		add.get( 'selection' ).add( attachments );
+		edit.get( 'library' ).add( attachments );
+
+		frame.setState( 'gallery-edit' );
+		frame.trigger( 'close' );
+
+		assert.equal( edit.get( 'library' ).length, 0, 'The abandoned gallery selection is cleared.' );
+		assert.equal( gallery.get( 'selection' ).length, 0, 'The create-gallery selection is cleared.' );
+		assert.equal( add.get( 'selection' ).length, 0, 'The add-to-gallery selection is cleared.' );
+
+		frame.dispose();
+	} );
+}() );


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

Media: Reset gallery modal state when abandoning a new gallery

## What?
- clear the transient `gallery-edit`, `gallery`, and `gallery-library` selections when the media modal closes during a new gallery flow
- add a QUnit regression that covers closing an abandoned gallery before insertion

## Why?
The gallery add state excludes attachments already staged in `gallery-edit`. When the modal is closed before the gallery is inserted, that staged selection leaks into the next create-gallery flow and can make the media library appear empty.

## Testing
- `php vendor/bin/phpcbf --standard=phpcs.xml.dist src/js/media/views/frame/post.js tests/qunit/wp-admin/js/media/post-frame.js`
- `php vendor/bin/phpcs --standard=phpcs.xml.dist src/js/media/views/frame/post.js tests/qunit/wp-admin/js/media/post-frame.js`
- `npm run grunt -- jshint:corejs`
- `npx playwright test --config tests/qunit/playwright.config.js`
- `npm run typecheck:js`

Trac ticket: https://core.trac.wordpress.org/ticket/57489

## Use of AI Tools

AI assistance: Yes
Tool(s): OpenAI Codex
Model(s): GPT-5
Used for: Reviewing the Trac ticket and relevant code, helping with the initial implementation and regression-test approach, and assisting with validation and PR-description drafting. The final implementation, tests, validation results, and description were reviewed and accepted by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**