### PR TITLE
Code Modernization: Use `array_any()` in `WP_REST_Comments_Controller`.

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
@@ -2055,11 +2055,6 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 		if ( ! is_array( $supports['editor'] ) ) {
 			return false;
 		}
-		foreach ( $supports['editor'] as $item ) {
-			if ( ! empty( $item['notes'] ) ) {
-				return true;
-			}
-		}
-		return false;
+		return array_any( $supports['editor'], fn( $item ) => ! empty( $item['notes'] ) );
 	}
 }


### PR DESCRIPTION
It replaces a `foreach` loop in `check_post_type_supports_notes()` that iterates the editor supports, returns `true` as soon as an element has non-empty notes, and otherwise falls through to `false`. 

That is exactly what PHP 8.4's `array_any()` expresses in a single, more readable call. WordPress core includes a polyfill for `array_any()` on PHP < 8.4 as of WordPress 6.8, so the change works on every supported PHP version without raising the minimum requirement.

Follow-up to [59783], [62550] , [62553]

Trac ticket: https://core.trac.wordpress.org/ticket/65519

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
