### PR TITLE
General: Align `_mb_substr()` with native `mb_substr()` for out-of-range offsets

### DIFF
--- a/src/wp-includes/compat.php
+++ b/src/wp-includes/compat.php
@@ -298,7 +298,14 @@ function _mb_substr( $str, $start, $length = null, $encoding = null ) {
 
 	// The solution below works only for UTF-8; treat all other encodings as byte streams.
 	if ( ! _is_utf8_charset( $encoding ?? get_option( 'blog_charset' ) ) ) {
-		return is_null( $length ) ? substr( $str, $start ) : substr( $str, $start, $length );
+		$result = is_null( $length ) ? substr( $str, $start ) : substr( $str, $start, $length );
+
+		/*
+		 * For an out-of-range start, substr() returns false on PHP < 8.0 but an
+		 * empty string on PHP >= 8.0. mb_substr() always returns an empty string,
+		 * so normalize to match its behavior across all supported PHP versions.
+		 */
+		return false === $result ? '' : $result;
 	}
 
 	$total_length = ( $start < 0 || $length < 0 )

--- a/tests/phpunit/tests/compat/mbSubstr.php
+++ b/tests/phpunit/tests/compat/mbSubstr.php
@@ -46,18 +46,18 @@ class Tests_Compat_mbSubstr extends WP_UnitTestCase {
 	 */
 	public function data_utf8_substrings() {
 		return array(
-			'баба'           => array( 'баба', 0, 3 ),
-			'баба'           => array( 'баба', 0, -1 ),
-			'баба'           => array( 'баба', 1, null ),
-			'баба'           => array( 'баба', -3, null ),
-			'баба'           => array( 'баба', -3, 2 ),
-			'баба'           => array( 'баба', -2, 1 ),
-			'баба'           => array( 'баба', 30, 1 ),
-			'баба'           => array( 'баба', 15, -30 ),
-			'баба'           => array( 'баба', -5, -5 ),
-			'баба'           => array( 'баба', 5, -3 ),
-			'баба'           => array( 'баба', -3, 5 ),
-			'I am your баба' => array( 'I am your баба', 0, 11 ),
+			'positive start, positive length'              => array( 'баба', 0, 3 ),
+			'positive start, negative length'              => array( 'баба', 0, -1 ),
+			'positive start, null length'                  => array( 'баба', 1, null ),
+			'negative start, null length'                  => array( 'баба', -3, null ),
+			'negative start, positive length'              => array( 'баба', -3, 2 ),
+			'negative start near end, positive length'     => array( 'баба', -2, 1 ),
+			'start beyond length, positive length'         => array( 'баба', 30, 1 ),
+			'start beyond length, large negative length'   => array( 'баба', 15, -30 ),
+			'negative start beyond start, negative length' => array( 'баба', -5, -5 ),
+			'start beyond length, negative length'         => array( 'баба', 5, -3 ),
+			'negative start, length beyond end'            => array( 'баба', -3, 5 ),
+			'multibyte character in longer string'         => array( 'I am your баба', 0, 11 ),
 		);
 	}
 


### PR DESCRIPTION
## Description

`_mb_substr()` is WordPress' polyfill for `mb_substr()`. In its non-UTF-8 (byte-stream) path it delegates to `substr()`, which returns `false` for a start offset beyond the string length on PHP < 8.0 (PHP >= 8.0 returns `''`). Native `mb_substr()` returns an empty string for that case on **all** PHP versions, so on a pre-8.0 site without the `mbstring` extension, `mb_substr()` (resolved to this polyfill) returned `false` instead of `''`.

This PR normalizes the non-UTF-8 path to return an empty string, so the polyfill matches native `mb_substr()` on every supported PHP version. The UTF-8 path is unaffected (it already returns `''`).

### How this was found

The bug was surfaced by a test data provider issue. `Tests_Compat_mbSubstr::data_utf8_substrings()` declared every data set with the same array key `'баба'`. Since PHP keeps only the last value for a duplicate array key, all but the final entry were silently discarded — only 2 of the 12 intended cases actually ran in `test_mb_substr()` and `test_8bit_mb_substr()`.

Replacing the duplicated keys with unique, descriptive ones (e.g. `negative start, positive length`, `start beyond length, large negative length`) restored all cases. Two `test_8bit_mb_substr()` cases with an out-of-range start (`('баба', 30, 1)` and `('баба', 15, -30)`) then failed on PHP 7.4, exposing the `_mb_substr()` behavior above.

The duplicate keys were introduced in [[60969](https://core.trac.wordpress.org/changeset/60969)].

## Testing instructions

Run the affected tests:
`npm run test:php -- --filter Tests_Compat_mbSubstr tests/phpunit/tests/compat/mbSubstr.php`
- **Before**: 23 tests (the data provider contributed only 2 distinct cases per test method).
- **Now**: 43 tests (12 distinct cases per test method), passing on all supported PHP versions including 7.4.

Trac ticket: https://core.trac.wordpress.org/ticket/64894

---

**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**