### PR TITLE
Tests: Fix duplicate data set key in data_sanitize_key()

### DIFF
--- a/tests/phpunit/tests/formatting/sanitizeKey.php
+++ b/tests/phpunit/tests/formatting/sanitizeKey.php
@@ -33,7 +33,7 @@ class Tests_Formatting_SanitizeKey extends WP_UnitTestCase {
 				'key'      => 'howdy,admin',
 				'expected' => 'howdyadmin',
 			),
-			'a lowercase key with commas'    => array(
+			'an uppercase key with commas'   => array(
 				'key'      => 'HOWDY,ADMIN',
 				'expected' => 'howdyadmin',
 			),


### PR DESCRIPTION
## Description

`Tests_Formatting_SanitizeKey::data_sanitize_key()` declared two data sets with the same key `'a lowercase key with commas'`. Since PHP keeps only the last value for a duplicate array key, the first case (`howdy,admin`) was silently discarded and never ran.

On top of that, the second case is mislabeled: its input is `HOWDY,ADMIN`, i.e. uppercase, not lowercase. Together with the following `'a mixed case key with commas'` case, the clear intent is to cover lowercase / uppercase / mixed input.

This renames the second case to `'an uppercase key with commas'`, fixing both the duplicate key and the inaccurate label, and restoring the dropped lowercase case.

The duplicate key was introduced in [[52292](https://core.trac.wordpress.org/changeset/52292)].

## Testing instructions
Run the affected tests:
`npm run test:php -- --filter Tests_Formatting_SanitizeKey tests/phpunit/tests/formatting/sanitizeKey.php`

All cases pass, and the data provider now contributes the lowercase, uppercase, and mixed-case scenarios instead of dropping the lowercase one.

Trac ticket: https://core.trac.wordpress.org/ticket/64894

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
