### PR TITLE
Tests: Move test_http_response_code_constants to getStatusHeaderDesc.php

### DIFF
--- a/tests/phpunit/tests/functions/getStatusHeaderDesc.php
+++ b/tests/phpunit/tests/functions/getStatusHeaderDesc.php
@@ -41,4 +41,19 @@ class Tests_Functions_GetStatusHeaderDesc extends WP_UnitTestCase {
 			array( 'random', '' ),
 		);
 	}
+
+	/**
+	 * @ticket 35426
+	 */
+	public function test_http_response_code_constants() {
+		global $wp_header_to_desc;
+
+		$ref       = new ReflectionClass( 'WP_Http' );
+		$constants = $ref->getConstants();
+
+		// This primes the `$wp_header_to_desc` global:
+		get_status_header_desc( 200 );
+
+		$this->assertSame( array_keys( $wp_header_to_desc ), array_values( $constants ) );
+	}
 }

--- a/tests/phpunit/tests/http/http.php
+++ b/tests/phpunit/tests/http/http.php
@@ -278,23 +278,6 @@ class Tests_HTTP_HTTP extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @ticket 35426
-	 *
-	 * @covers ::get_status_header_desc
-	 */
-	public function test_http_response_code_constants() {
-		global $wp_header_to_desc;
-
-		$ref       = new ReflectionClass( 'WP_Http' );
-		$constants = $ref->getConstants();
-
-		// This primes the `$wp_header_to_desc` global:
-		get_status_header_desc( 200 );
-
-		$this->assertSame( array_keys( $wp_header_to_desc ), array_values( $constants ) );
-	}
-
-	/**
 	 * @ticket 37768
 	 *
 	 * @covers WP_Http::normalize_cookies


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

Moves test_http_response_code_constants() from the HTTP API test file into the test class for get_status_header_desc(), so all tests for that function live in one place.

What the problem was:
- test_http_response_code_constants() exercises get_status_header_desc() but was located in tests/phpunit/tests/http/http.php (Tests_HTTP_HTTP).

What the fix does:
- Moves the test method into Tests_Functions_GetStatusHeaderDesc (tests/phpunit/tests/functions/getStatusHeaderDesc.php).
- Drops the redundant method-level @covers ::get_status_header_desc, as the class-level docblock already declares it.

Approach and why:
- Test body is unchanged; this only relocates it to the canonical file for the function under test, improving discoverability and grouping.

Trac ticket: https://core.trac.wordpress.org/ticket/65527

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 4.8
Used for: Ticket analysis and tests. All changes were reviewed, validated against the codebase, and are taken responsibility for by me.
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
