### PR TITLE
XML-RPC: Fix argument parsing for blogger.getUsersBlogs in Multisite

### DIFF
--- a/src/wp-includes/class-wp-xmlrpc-server.php
+++ b/src/wp-includes/class-wp-xmlrpc-server.php
@@ -4892,6 +4892,7 @@ class wp_xmlrpc_server extends IXR_Server {
 		$domain = $current_blog->domain;
 		$path   = $current_blog->path . 'xmlrpc.php';
 
+		array_shift( $args );
 		$blogs = $this->wp_getUsersBlogs( $args );
 		if ( $blogs instanceof IXR_Error ) {
 			return $blogs;

--- a/tests/phpunit/tests/xmlrpc/blogger/getUsersBlogs.php
+++ b/tests/phpunit/tests/xmlrpc/blogger/getUsersBlogs.php
@@ -11,13 +11,13 @@ class Tests_XMLRPC_blogger_getUsersBlogs extends WP_XMLRPC_UnitTestCase {
 	 */
 	public function test_multisite_argument_parsing() {
 		$subscriber_id = $this->make_user_by_role( 'subscriber' );
-		
+
 		$result = $this->myxmlrpcserver->blogger_getUsersBlogs( array( 1, 'subscriber', 'subscriber' ) );
 
 		$this->assertNotIXRError( $result );
 		$this->assertIsArray( $result );
 		$this->assertNotEmpty( $result );
-		
+
 		$blog = $result[0];
 		$this->assertArrayHasKey( 'url', $blog );
 		$this->assertArrayHasKey( 'blogid', $blog );

--- a/tests/phpunit/tests/xmlrpc/blogger/getUsersBlogs.php
+++ b/tests/phpunit/tests/xmlrpc/blogger/getUsersBlogs.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * @group xmlrpc
+ * @group user
+ */
+class Tests_XMLRPC_blogger_getUsersBlogs extends WP_XMLRPC_UnitTestCase {
+
+	/**
+	 * @ticket 65536
+	 */
+	public function test_multisite_argument_parsing() {
+		$subscriber_id = $this->make_user_by_role( 'subscriber' );
+		
+		$result = $this->myxmlrpcserver->blogger_getUsersBlogs( array( 1, 'subscriber', 'subscriber' ) );
+
+		$this->assertNotIXRError( $result );
+		$this->assertIsArray( $result );
+		$this->assertNotEmpty( $result );
+		
+		$blog = $result[0];
+		$this->assertArrayHasKey( 'url', $blog );
+		$this->assertArrayHasKey( 'blogid', $blog );
+		$this->assertArrayHasKey( 'blogName', $blog );
+	}
+}


### PR DESCRIPTION
Trac ticket:  [#65536](https://core.trac.wordpress.org/ticket/65536)
