### PR TITLE
Block Supports: Guard test for element hover styles with a missing hover selector.

### DIFF
--- a/tests/phpunit/tests/block-supports/wpRenderElementsSupportStyles.php
+++ b/tests/phpunit/tests/block-supports/wpRenderElementsSupportStyles.php
@@ -194,12 +194,13 @@ class Tests_Block_Supports_WpRenderElementsSupportStyles extends WP_UnitTestCase
 						':hover' => array( 'color' => $color_styles ),
 					),
 				),
+
 				/*
 				 * Only the base button rule should be emitted. The button element
 				 * type has no `hover_selector`, so the `:hover` object must be
 				 * ignored rather than triggering an undefined array key warning.
 				 */
-				'expected_styles' => '/^.wp-elements-[a-f0-9]{32} .wp-element-button, .wp-elements-[a-f0-9]{32} .wp-block-button__link' . $color_css_rules . '$/',
+				'expected_styles' => '/^.wp-elements-\d+ .wp-element-button, .wp-elements-\d+ .wp-block-button__link' . $color_css_rules . '$/',
 			),
 			'link element styles are applied'            => array(
 				'color_settings'  => array( 'link' => true ),

--- a/tests/phpunit/tests/block-supports/wpRenderElementsSupportStyles.php
+++ b/tests/phpunit/tests/block-supports/wpRenderElementsSupportStyles.php
@@ -22,6 +22,7 @@ class Tests_Block_Supports_WpRenderElementsSupportStyles extends WP_UnitTestCase
 	 *
 	 * @ticket 59555
 	 * @ticket 60557
+	 * @ticket 65538
 	 *
 	 * @covers ::wp_render_elements_support_styles
 	 *
@@ -184,6 +185,21 @@ class Tests_Block_Supports_WpRenderElementsSupportStyles extends WP_UnitTestCase
 					'button' => array( 'color' => $color_styles ),
 				),
 				'expected_styles' => '/^.wp-elements-\d+ .wp-element-button, .wp-elements-\d+ .wp-block-button__link' . $color_css_rules . '$/',
+			),
+			'button hover styles are skipped without a hover selector' => array(
+				'color_settings'  => array( 'button' => true ),
+				'elements_styles' => array(
+					'button' => array(
+						'color'  => $color_styles,
+						':hover' => array( 'color' => $color_styles ),
+					),
+				),
+				/*
+				 * Only the base button rule should be emitted. The button element
+				 * type has no `hover_selector`, so the `:hover` object must be
+				 * ignored rather than triggering an undefined array key warning.
+				 */
+				'expected_styles' => '/^.wp-elements-[a-f0-9]{32} .wp-element-button, .wp-elements-[a-f0-9]{32} .wp-block-button__link' . $color_css_rules . '$/',
 			),
 			'link element styles are applied'            => array(
 				'color_settings'  => array( 'link' => true ),


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65538

## What?

Backports regression test added in Gutenberg PR https://github.com/WordPress/gutenberg/pull/79511.

Core already has a fix protecting against undefined array index that https://github.com/WordPress/gutenberg/pull/79511 addresses.

## Why?

Protect against regressions around hover selectors for elements.

## How?

Adds test for an element containing hover styles while not defining a hover CSS selector.

## Testing Instructions

1. The updated `Tests_Block_Supports_WpRenderElementsSupportStyles` should pass.