### PR TITLE
Administration: Improve the highlight styling of newly added Quick Drafts

### DIFF
--- a/src/js/_enqueues/wp/dashboard.js
+++ b/src/js/_enqueues/wp/dashboard.js
@@ -170,9 +170,9 @@ jQuery( function($) {
  			 */
 			function highlightLatestPost () {
 				var latestPost = $('.drafts ul li').first();
-				latestPost.css('background', '#fffbe5');
+				latestPost.addClass('highlighted-draft');
 				setTimeout(function () {
-					latestPost.css('background', 'none');
+					latestPost.removeClass('highlighted-draft');
 				}, 1000);
 			}
 		} );

--- a/src/wp-admin/css/dashboard.css
+++ b/src/wp-admin/css/dashboard.css
@@ -850,6 +850,14 @@ body #dashboard-widgets .postbox form .submit {
 #dashboard_quick_press .drafts li {
 	margin-bottom: 1em;
 }
+
+/* Transient highlight applied to a newly added draft. */
+#dashboard_quick_press .drafts li.highlighted-draft {
+	margin: -6px -12px calc(1em - 6px);
+	padding: 6px 12px;
+	background: #ceb;
+}
+
 #dashboard_quick_press .drafts li time {
 	color: #646970;
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

When a new draft is created via the Quick Draft dashboard widget, the entry added to "Your Recent Drafts" is briefly highlighted for one second. This change improves that highlight's color and spacing.

### What the problem was
- The highlight used a faint yellow background (`#fffbe5`), applied inline via JavaScript.
- The yellow predates the current admin color scheme, is barely visible, and is inconsistent with other success feedback in the admin (e.g. the Recent Comments widget uses green when approving a comment or undoing a spam action).
- The highlight hugged the text with no breathing room (no padding).

### What the fix does
- Applies the highlight via a `highlighted-draft` CSS class instead of an inline style (separation of concerns; removes the odd `background: none` reset).
- Uses the success green `#ceb` already used elsewhere in the admin (`edit-comments.js`) for positive confirmations, so success feedback is visually consistent — this is the exact color referenced in the ticket.
- Makes the highlight span the full width of the widget with internal padding, matching the dashboard widget style, so it reads as a proper success row with breathing room.
- Negative margins offset the padding so surrounding drafts do not shift while the highlight is shown (no layout jank).

### Approach and why
- `#ceb` is the only existing "success" background-highlight green in core admin code and is precisely what the ticket cites for consistency. (Written as shorthand `#ceb` per the WordPress CSS Coding Standards.)
- The full-bleed band aligns with the widget's existing full-width separator (`border-top`) and `12px` content inset, keeping it on-style with the rest of the Quick Draft widget.

Trac ticket: https://core.trac.wordpress.org/ticket/65539

## Use of AI Tools

N/A
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
