### PR TITLE
Update README.md: Correct git pull command syntax for upstream branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ You can get started using the local development environment with these steps:
 1. Then clone the forked repository to your computer using `git clone https://github.com/<your-username>/wordpress-develop.git`.
 1. Navigate into the directory for the cloned repository using `cd wordpress-develop`.
 1. Add the origin repo as an `upstream` remote via `git remote add upstream https://github.com/WordPress/wordpress-develop.git`.
-1. Then you can keep your branches up to date via `git pull --ff upstream/trunk`, for example.
+1. Then you can keep your branches up to date via `git pull --ff upstream trunk`, for example.
 
 Alternatively, if you have the [GitHub CLI](https://cli.github.com/) installed, you can simply run `gh repo fork WordPress/wordpress-develop --clone --remote` ([docs](https://cli.github.com/manual/gh_repo_fork)). This command will:
 1. Fork the repository to your account (use the `--org` flag to clone into an organization).


### PR DESCRIPTION
Fix the documented `git pull` command used for syncing with the upstream repository.

The README currently shows:

```bash
git pull --ff upstream/trunk
```

This PR updates it to:

```bash
git pull --ff upstream trunk
```

This matches Git's expected syntax (`git pull <remote> <branch>`) and avoids the fatal error encountered during the initial repository setup.

**Fixes :** https://core.trac.wordpress.org/ticket/65540

## Use of AI Tools

AI assistance: Yes

Tool(s): ChatGPT

Model(s): GPT-5.5

Used for: Assisted in drafting the Trac ticket and Pull Request description. I verified the issue, tested the command locally, and prepared the final documentation change myself.
