### PR TITLE
Docs: Correct the documented default for `$format` in get_next_post_link() and next_post_link()

### DIFF
--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -2291,7 +2291,7 @@ function previous_post_link( $format = '&laquo; %link', $link = '%title', $in_sa
  *
  * @since 3.7.0
  *
- * @param string       $format         Optional. Link anchor format. Default '&laquo; %link'.
+ * @param string       $format         Optional. Link anchor format. Default '%link &raquo;'.
  * @param string       $link           Optional. Link permalink format. Default '%title'.
  * @param bool         $in_same_term   Optional. Whether link should be in the same taxonomy term.
  *                                     Default false.
@@ -2311,7 +2311,7 @@ function get_next_post_link( $format = '%link &raquo;', $link = '%title', $in_sa
  *
  * @see get_next_post_link()
  *
- * @param string       $format         Optional. Link anchor format. Default '&laquo; %link'.
+ * @param string       $format         Optional. Link anchor format. Default '%link &raquo;'.
  * @param string       $link           Optional. Link permalink format. Default '%title'.
  * @param bool         $in_same_term   Optional. Whether link should be in the same taxonomy term.
  *                                     Default false.


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65541

## Description

The `@param` DocBlock for `$format` in `get_next_post_link()` documents the default as `'&laquo; %link'`, but the actual signature default is `'%link &raquo;'`. The `'&laquo; %link'` value is the default for the *previous*-post functions (`get_previous_post_link()` / `previous_post_link()`) and was copied onto the next-post functions. The same mismatch is present in `next_post_link()` (its signature default is likewise `'%link &raquo;'`).

For context: the `$format` signature default was originally corrected in [25965] (#25743). The `Default '...'.` notations were added later in [37254] (4.6.0), which copied the previous-post value onto the next-post DocBlocks — so the documentation again contradicts the signature.

## Change

Update the `@param $format` DocBlocks of `get_next_post_link()` and `next_post_link()` to read `Default '%link &raquo;'.` so they match their signatures. Documentation only — no functional change. The previous-post functions are already correct and are left unchanged.

Verified against `trunk`; `phpcs` reports no new issues on the changed lines.

## Use of AI Tools

AI assistance: Yes (Claude). Used to locate the discrepancy, verify it against the source and changeset history, and draft this description. The change was reviewed and verified before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
