### PR TITLE
Update GitHub CLI fork command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ You can get started using the local development environment with these steps:
 1. Add the origin repo as an `upstream` remote via `git remote add upstream https://github.com/WordPress/wordpress-develop.git`.
 1. Then you can keep your branches up to date via `git pull --ff upstream/trunk`, for example.
 
-Alternatively, if you have the [GitHub CLI](https://cli.github.com/) installed, you can simply run `gh repo fork WordPress/wordpress-develop --clone --remote` ([docs](https://cli.github.com/manual/gh_repo_fork)). This command will:
+Alternatively, if you have the [GitHub CLI](https://cli.github.com/) installed, you can simply run `gh repo fork WordPress/wordpress-develop --clone` ([docs](https://cli.github.com/manual/gh_repo_fork)). This command will:
 1. Fork the repository to your account (use the `--org` flag to clone into an organization).
 1. Clone the repository to your machine. 
 1. Add `WordPress/wordpress-develop` as `upstream` and set it to the default `remote` repository


### PR DESCRIPTION
This PR updates the GitHub CLI example used when forking the `wordpress-develop` repository.

### Current command

```bash
gh repo fork WordPress/wordpress-develop --clone --remote
```

### Updated command

```bash
gh repo fork WordPress/wordpress-develop --clone
```

### Why?

While following the contributor documentation for the first time, I encountered the following error when running the documented command with GitHub CLI **2.94.0**:

```text
the `--remote` flag is unsupported when a repository argument is provided
```

Running the command without `--remote` successfully:

* Forked the repository.
* Cloned it locally.
* Added the upstream remote as described in the documentation.

This update aligns the documentation with the current behavior of the GitHub CLI and helps prevent confusion for new contributors.

**Fixes:** https://core.trac.wordpress.org/ticket/65542

## Use of AI Tools

**AI assistance:** Yes

**Tool(s):** ChatGPT

**Model(s):** GPT-5.5

**Used for:** Drafting the Trac ticket and pull request description. I verified the issue, tested the commands locally, and reviewed the final content before submission.
