### PR TITLE
HTML API: Do not inject redundant newlines in foreign content PRE, TEXTAREA

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -3793,6 +3793,17 @@ class WP_HTML_Tag_Processor {
 	 */
 	public function set_modifiable_text( string $plaintext_content ): bool {
 		if ( self::STATE_TEXT_NODE === $this->parser_state ) {
+			/*
+			 * HTML ignores a single leading newline in this context. If a leading newline
+			 * is intended, preserve it by adding an extra newline.
+			 */
+			if (
+				$this->skip_newline_at === $this->token_starts_at &&
+				1 === strspn( $plaintext_content, "\n\r", 0, 1 )
+			) {
+				$plaintext_content = "\n{$plaintext_content}";
+			}
+
 			$this->lexical_updates['modifiable text'] = new WP_HTML_Text_Replacement(
 				$this->text_starts_at,
 				$this->text_length,

--- a/tests/phpunit/tests/html-api/wpHtmlProcessorModifiableText.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorModifiableText.php
@@ -70,6 +70,102 @@ class Tests_HtmlApi_WpHtmlProcessorModifiableText extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Ensures that text node updates preserve a leading newline where the HTML parser
+	 * ignores one newline after the opening tag.
+	 *
+	 * @ticket 64609
+	 *
+	 * @dataProvider data_modifiable_text_ignores_leading_newline_text_nodes
+	 *
+	 * @param string $tag_name      Expected tag name.
+	 * @param string $set_text      Text to set.
+	 * @param string $expected_html Expected HTML output.
+	 */
+	public function test_modifiable_text_preserves_ignored_leading_newline_in_text_nodes( string $tag_name, string $set_text, string $expected_html ): void {
+		$html      = "<{$tag_name}>initial</{$tag_name}>";
+		$processor = WP_HTML_Processor::create_fragment( $html );
+		$this->assertNotNull( $processor, 'Failed to create a processor.' );
+		$this->assertTrue( $processor->next_tag( $tag_name ), 'Failed to find target tag.' );
+		$this->assertTrue( $processor->next_token(), 'Failed to find text node.' );
+		$this->assertSame( '#text', $processor->get_token_name(), 'Should have found a text node.' );
+
+		$this->assertTrue( $processor->set_modifiable_text( $set_text ) );
+		$expected_text = strtr(
+			$set_text,
+			array(
+				"\r\n" => "\n",
+				"\r"   => "\n",
+			)
+		);
+		$this->assertSame(
+			$expected_text,
+			$processor->get_modifiable_text(),
+			'Should have preserved the leading newline when reading the updated text.'
+		);
+
+		$updated_html = $processor->get_updated_html();
+		$this->assertEqualHTML(
+			$expected_html,
+			$updated_html,
+			'<body>',
+			'Should have preserved the leading newline in the serialized HTML.'
+		);
+
+		$processor = WP_HTML_Processor::create_fragment( $updated_html );
+		$this->assertNotNull( $processor, 'Failed to reprocess updated HTML.' );
+		$this->assertTrue( $processor->next_tag( $tag_name ), 'Failed to find target tag after update.' );
+		$roundtrip_text = '';
+		while ( $processor->next_token() && '#text' === $processor->get_token_name() ) {
+			$roundtrip_text .= $processor->get_modifiable_text();
+		}
+		$this->assertSame(
+			$expected_text,
+			$roundtrip_text,
+			'Should have preserved the leading newline after reprocessing the updated HTML.'
+		);
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array<string, array{0: string, 1: string, 2: string}>
+	 */
+	public static function data_modifiable_text_ignores_leading_newline_text_nodes(): array {
+		return array(
+			'PRE leading newline'                       => array(
+				'PRE',
+				"\nAFTER NEWLINE",
+				"<pre>\n\nAFTER NEWLINE</pre>",
+			),
+			'PRE leading carriage return'               => array(
+				'PRE',
+				"\rAFTER CR",
+				"<pre>\n\nAFTER CR</pre>",
+			),
+			'PRE leading carriage return + newline'     => array(
+				'PRE',
+				"\r\nAFTER CRLF",
+				"<pre>\n\nAFTER CRLF</pre>",
+			),
+			'LISTING leading newline'                   => array(
+				'LISTING',
+				"\nAFTER NEWLINE",
+				"<listing>\n\nAFTER NEWLINE</listing>",
+			),
+			'LISTING leading carriage return'           => array(
+				'LISTING',
+				"\rAFTER CR",
+				"<listing>\n\nAFTER CR</listing>",
+			),
+			'LISTING leading carriage return + newline' => array(
+				'LISTING',
+				"\r\nAFTER CRLF",
+				"<listing>\n\nAFTER CRLF</listing>",
+			),
+		);
+	}
+
+	/**
 	 * Ensures that `set_modifiable_text()` returns false for elements that are not special "atomic" elements.
 	 *
 	 * This includes atomic-like foreign elements (`<svg><textarea>`) as well as arbitrary HTML

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessorModifiableText.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessorModifiableText.php
@@ -666,6 +666,100 @@ HTML;
 	}
 
 	/**
+	 * Ensures that text node updates preserve a leading newline where the HTML parser
+	 * ignores one newline after the opening tag.
+	 *
+	 * @ticket 64609
+	 *
+	 * @dataProvider data_modifiable_text_ignores_leading_newline_text_nodes
+	 *
+	 * @param string $tag_name      Expected tag name.
+	 * @param string $set_text      Text to set.
+	 * @param string $expected_html Expected HTML output.
+	 */
+	public function test_modifiable_text_preserves_ignored_leading_newline_in_text_nodes( string $tag_name, string $set_text, string $expected_html ): void {
+		$html      = "<{$tag_name}>initial</{$tag_name}>";
+		$processor = new WP_HTML_Tag_Processor( $html );
+		$this->assertTrue( $processor->next_tag( $tag_name ), 'Failed to find target tag.' );
+		$this->assertTrue( $processor->next_token(), 'Failed to find text node.' );
+		$this->assertSame( '#text', $processor->get_token_name(), 'Should have found a text node.' );
+
+		$this->assertTrue( $processor->set_modifiable_text( $set_text ) );
+		$expected_text = strtr(
+			$set_text,
+			array(
+				"\r\n" => "\n",
+				"\r"   => "\n",
+			)
+		);
+		$this->assertSame(
+			$expected_text,
+			$processor->get_modifiable_text(),
+			'Should have preserved the leading newline when reading the updated text.'
+		);
+
+		$updated_html = $processor->get_updated_html();
+		$this->assertEqualHTML(
+			$expected_html,
+			$updated_html,
+			'<body>',
+			'Should have preserved the leading newline in the serialized HTML.'
+		);
+
+		$processor = new WP_HTML_Tag_Processor( $updated_html );
+		$this->assertTrue( $processor->next_tag( $tag_name ), 'Failed to find target tag after update.' );
+		$roundtrip_text = '';
+		while ( $processor->next_token() && '#text' === $processor->get_token_name() ) {
+			$roundtrip_text .= $processor->get_modifiable_text();
+		}
+		$this->assertSame(
+			$expected_text,
+			$roundtrip_text,
+			'Should have preserved the leading newline after reprocessing the updated HTML.'
+		);
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array<string, array{0: string, 1: string, 2: string}>
+	 */
+	public static function data_modifiable_text_ignores_leading_newline_text_nodes(): array {
+		return array(
+			'PRE leading newline'                       => array(
+				'PRE',
+				"\nAFTER NEWLINE",
+				"<pre>\n\nAFTER NEWLINE</pre>",
+			),
+			'PRE leading carriage return'               => array(
+				'PRE',
+				"\rAFTER CR",
+				"<pre>\n\nAFTER CR</pre>",
+			),
+			'PRE leading carriage return + newline'     => array(
+				'PRE',
+				"\r\nAFTER CRLF",
+				"<pre>\n\nAFTER CRLF</pre>",
+			),
+			'LISTING leading newline'                   => array(
+				'LISTING',
+				"\nAFTER NEWLINE",
+				"<listing>\n\nAFTER NEWLINE</listing>",
+			),
+			'LISTING leading carriage return'           => array(
+				'LISTING',
+				"\rAFTER CR",
+				"<listing>\n\nAFTER CR</listing>",
+			),
+			'LISTING leading carriage return + newline' => array(
+				'LISTING',
+				"\r\nAFTER CRLF",
+				"<listing>\n\nAFTER CRLF</listing>",
+			),
+		);
+	}
+
+	/**
 	 * Ensures that `set_modifiable_text()` returns false for elements that are
 	 * not special "atomic" elements.
 	 *


### PR DESCRIPTION


Trac ticket: https://core.trac.wordpress.org/ticket/65372
Follow-up to r61754.

## Use of AI Tools


AI assistance: Yes
Tool(s): Codex GPT-5.5
Used for: Fuzz testing, initial implementation, review and feedback.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
