### PR TITLE
Fix rich-text block attribute validation

### DIFF
--- a/src/wp-includes/class-wp-block-type.php
+++ b/src/wp-includes/class-wp-block-type.php
@@ -510,6 +510,20 @@ class WP_Block_Type {
 
 			$schema = $this->attributes[ $attribute_name ];
 
+			// Block metadata supports "rich-text" for editor attributes, but
+			// REST validation expects a valid JSON Schema type.
+			if ( isset( $schema['type'] ) ) {
+				if ( 'rich-text' === $schema['type'] ) {
+					$schema['type'] = 'string';
+				} elseif ( is_array( $schema['type'] ) ) {
+					foreach ( $schema['type'] as $type_index => $type ) {
+						if ( 'rich-text' === $type ) {
+							$schema['type'][ $type_index ] = 'string';
+						}
+					}
+				}
+			}
+
 			// Validate value by JSON schema. An invalid value should revert to
 			// its default, if one exists. This occurs by virtue of the missing
 			// attributes loop immediately following. If there is not a default

--- a/tests/phpunit/tests/blocks/wpBlockType.php
+++ b/tests/phpunit/tests/blocks/wpBlockType.php
@@ -255,6 +255,61 @@ class Tests_Blocks_wpBlockType extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 61406
+	 */
+	public function test_prepare_attributes_validates_rich_text_attributes_as_strings() {
+		$doing_it_wrong = array();
+		$callback       = static function ( $function_name ) use ( &$doing_it_wrong ) {
+			if ( 'rest_validate_value_from_schema' === $function_name ) {
+				$doing_it_wrong[] = $function_name;
+			}
+		};
+
+		add_action( 'doing_it_wrong_run', $callback );
+
+		try {
+			$block_type = new WP_Block_Type(
+				'core/fake',
+				array(
+					'attributes' => array(
+						'content'         => array(
+							'type' => 'rich-text',
+						),
+						'caption'         => array(
+							'type'    => 'rich-text',
+							'default' => 'Default caption',
+						),
+						'nullableContent' => array(
+							'type' => array( 'rich-text', 'null' ),
+						),
+					),
+				)
+			);
+
+			$prepared_attributes = $block_type->prepare_attributes_for_render(
+				array(
+					'content'         => '<strong>include</strong>',
+					'caption'         => 5,
+					'nullableContent' => 'nullable include',
+				)
+			);
+		} finally {
+			remove_action( 'doing_it_wrong_run', $callback );
+		}
+
+		$this->assertSame( '<strong>include</strong>', $prepared_attributes['content'] );
+		$this->assertSame( 'Default caption', $prepared_attributes['caption'] );
+		$this->assertSame( 'nullable include', $prepared_attributes['nullableContent'] );
+		$this->assertSame(
+			array(),
+			$doing_it_wrong,
+			'rest_validate_value_from_schema() should not emit _doing_it_wrong() for rich-text attributes.'
+		);
+		$this->assertSame( 'rich-text', $block_type->attributes['content']['type'] );
+		$this->assertSame( array( 'rich-text', 'null' ), $block_type->attributes['nullableContent']['type'] );
+	}
+
+	/**
 	 * @ticket 45145
 	 */
 	public function test_prepare_attributes_none_defined() {


### PR DESCRIPTION
Maps `rich-text` block attribute schemas to `string` only for render-time REST validation, so `WP_Block_Type::prepare_attributes_for_render()` can validate those attributes without mutating registered block metadata.

This keeps non-string rich-text values rejected through the existing string validation path and preserves the registered `rich-text` schema after validation.

Trac ticket: https://core.trac.wordpress.org/ticket/61406

## Use of AI Tools

AI assistance: Yes
Tool(s): OpenAI Codex
Model(s): GPT-5
Used for: Implementing the patch, adding focused PHPUnit coverage, running validation commands, and preparing this PR.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
