### PR TITLE
Docs: Correct the `$data_object` type in `Walker_Nav_Menu::start_el()`

### DIFF
--- a/src/wp-includes/class-walker-nav-menu.php
+++ b/src/wp-includes/class-walker-nav-menu.php
@@ -148,7 +148,7 @@ class Walker_Nav_Menu extends Walker {
 	 * @see Walker::start_el()
 	 *
 	 * @param string   $output            Used to append additional content (passed by reference).
-	 * @param WP_Post  $data_object       Menu item data object.
+	 * @param object   $data_object       Menu item data object.
 	 * @param int      $depth             Depth of menu item. Used for padding.
 	 * @param stdClass $args              An object of wp_nav_menu() arguments.
 	 * @param int      $current_object_id Optional. ID of the current menu item. Default 0.


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/57428

## Description

The inline docs for `Walker_Nav_Menu::start_el()` document the `$data_object` parameter as a `WP_Post` object. This is inaccurate: the menu item passed to the method is a decorated object produced by `wp_setup_nav_menu_item()`, which carries properties such as `$title`, `$url`, `$xfn`, `$target`, etc. that do not exist on a standard `WP_Post`.

The type was changed from `object` to `WP_Post` in [38559], but the underlying value is not a plain `WP_Post`.

## Fix

Document `$data_object` as `object`, which:

- matches the parent `Walker::start_el()`, whose `@param` is `object $data_object` (the [5.9.0] rename was explicitly done "to match parent class");
- matches `wp_setup_nav_menu_item()`, which documents the decorated menu item as `object`;
- accurately reflects that the object carries menu-item properties not present on `WP_Post`.

This is a documentation-only change with no behavioral impact. `phpcs` passes on the modified file.

## Notes for reviewers

Scope is intentionally limited to `start_el()` per the ticket. A few filter docblocks in the same file (e.g. `nav_menu_item_args`, `nav_menu_css_class`) describe the same menu-item object as `WP_Post`; happy to align those in this PR or a follow-up if preferred.