### PR TITLE
Plugins: Match translated plugin data in the Installed Plugins search

### DIFF
--- a/src/wp-admin/includes/class-wp-plugins-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugins-list-table.php
@@ -393,7 +393,8 @@ class WP_Plugins_List_Table extends WP_List_Table {
 	public function _search_callback( $plugin, $plugin_file = '' ) {
 		global $s;
 
-		$term = urldecode( $s );
+		// Lowercase the term so the search stays case-insensitive.
+		$term = strtolower( urldecode( $s ) );
 
 		/*
 		 * Search the original (untranslated) plugin data as well as the translated
@@ -407,7 +408,7 @@ class WP_Plugins_List_Table extends WP_List_Table {
 
 		foreach ( $plugin_data_sets as $plugin_data ) {
 			foreach ( $plugin_data as $value ) {
-				if ( is_string( $value ) && false !== stripos( strip_tags( $value ), $term ) ) {
+				if ( is_string( $value ) && str_contains( strtolower( strip_tags( $value ) ), $term ) ) {
 					return true;
 				}
 			}

--- a/src/wp-admin/includes/class-wp-plugins-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugins-list-table.php
@@ -306,7 +306,7 @@ class WP_Plugins_List_Table extends WP_List_Table {
 
 		if ( strlen( $s ) ) {
 			$status            = 'search';
-			$plugins['search'] = array_filter( $plugins['all'], array( $this, '_search_callback' ) );
+			$plugins['search'] = array_filter( $plugins['all'], array( $this, '_search_callback' ), ARRAY_FILTER_USE_BOTH );
 		}
 
 		/**
@@ -382,15 +382,34 @@ class WP_Plugins_List_Table extends WP_List_Table {
 	 *
 	 * @global string $s URL encoded search term.
 	 *
-	 * @param array<string, mixed> $plugin Plugin data array to check against the search term.
+	 * @param array<string, mixed> $plugin      Plugin data array to check against the search term.
+	 * @param string               $plugin_file Optional. Plugin file path relative to the plugins
+	 *                                          directory. When provided, the plugin's translated data
+	 *                                          is also searched so that the search matches the
+	 *                                          translated name, description, and author shown in the
+	 *                                          list table. Default empty string.
 	 * @return bool True if the plugin matches the search term, false otherwise.
 	 */
-	public function _search_callback( $plugin ) {
+	public function _search_callback( $plugin, $plugin_file = '' ) {
 		global $s;
 
-		foreach ( $plugin as $value ) {
-			if ( is_string( $value ) && false !== stripos( strip_tags( $value ), urldecode( $s ) ) ) {
-				return true;
+		$term = urldecode( $s );
+
+		/*
+		 * Search the original (untranslated) plugin data as well as the translated
+		 * data shown in the list table, so searches match either the value in the
+		 * plugin's file header or the localized value displayed to the user.
+		 */
+		$plugin_data_sets = array( $plugin );
+		if ( '' !== $plugin_file ) {
+			$plugin_data_sets[] = _get_plugin_data_markup_translate( $plugin_file, $plugin, false, true );
+		}
+
+		foreach ( $plugin_data_sets as $plugin_data ) {
+			foreach ( $plugin_data as $value ) {
+				if ( is_string( $value ) && false !== stripos( strip_tags( $value ), $term ) ) {
+					return true;
+				}
 			}
 		}
 

--- a/tests/phpunit/tests/admin/wpPluginsListTable.php
+++ b/tests/phpunit/tests/admin/wpPluginsListTable.php
@@ -436,9 +436,12 @@ class Tests_Admin_wpPluginsListTable extends WP_UnitTestCase {
 	 */
 	public function data_search_terms_against_translatable_plugin() {
 		return array(
-			'original (untranslated) name' => array( 'Fake Translated Plugin', true ),
-			'translated name'              => array( 'Wtyczka', true ),
-			'unrelated term'               => array( 'NoSuchPluginNameHere', false ),
+			'original (untranslated) name'     => array( 'Fake Translated Plugin', true ),
+			'translated name'                  => array( 'Wtyczka', true ),
+			'original name, different case'    => array( 'fake translated plugin', true ),
+			'translated name, different case'  => array( 'wtyczka', true ),
+			'translated name, upper case'      => array( 'WTYCZKA', true ),
+			'unrelated term'                   => array( 'NoSuchPluginNameHere', false ),
 		);
 	}
 

--- a/tests/phpunit/tests/admin/wpPluginsListTable.php
+++ b/tests/phpunit/tests/admin/wpPluginsListTable.php
@@ -337,4 +337,152 @@ class Tests_Admin_wpPluginsListTable extends WP_UnitTestCase {
 
 		return $plugins_list;
 	}
+
+	/**
+	 * Tests that the Installed Plugins search matches the translated plugin
+	 * data shown in the list table, not only the original (untranslated) headers.
+	 *
+	 * The list table displays translated plugin names, but the search used to
+	 * filter against the raw plugin headers only, so searching by the displayed
+	 * (translated) name returned no results.
+	 *
+	 * @ticket 64188
+	 *
+	 * @covers WP_Plugins_List_Table::prepare_items
+	 * @covers WP_Plugins_List_Table::_search_callback
+	 */
+	public function test_search_matches_translated_plugin_data() {
+		global $status, $s;
+
+		wp_set_current_user( self::$admin_id );
+
+		$old_status = $status;
+		$status     = 'all';
+
+		// The search term only appears in the translated name, not the raw header.
+		$s = 'Wtyczka';
+
+		add_filter( 'all_plugins', array( $this, 'inject_translatable_plugin' ) );
+		add_filter( 'gettext', array( $this, 'filter_translate_plugin_name' ), 10, 3 );
+
+		$this->table->prepare_items();
+		$items = $this->table->items;
+
+		remove_filter( 'gettext', array( $this, 'filter_translate_plugin_name' ), 10 );
+		remove_filter( 'all_plugins', array( $this, 'inject_translatable_plugin' ) );
+
+		$status = $old_status;
+
+		$this->assertArrayHasKey(
+			'fake-translated-plugin/fake-translated-plugin.php',
+			$items,
+			'The plugin should be found when searching by its translated name.'
+		);
+	}
+
+	/**
+	 * Tests that the Installed Plugins search still matches the original
+	 * (untranslated) plugin headers, and does not match unrelated terms.
+	 *
+	 * @ticket 64188
+	 *
+	 * @covers WP_Plugins_List_Table::prepare_items
+	 * @covers WP_Plugins_List_Table::_search_callback
+	 *
+	 * @dataProvider data_search_terms_against_translatable_plugin
+	 *
+	 * @param string $search_term The value of the `$s` search global.
+	 * @param bool   $should_match Whether the injected plugin should be in the results.
+	 */
+	public function test_search_against_original_plugin_data( $search_term, $should_match ) {
+		global $status, $s;
+
+		wp_set_current_user( self::$admin_id );
+
+		$old_status = $status;
+		$status     = 'all';
+		$s          = $search_term;
+
+		add_filter( 'all_plugins', array( $this, 'inject_translatable_plugin' ) );
+		add_filter( 'gettext', array( $this, 'filter_translate_plugin_name' ), 10, 3 );
+
+		$this->table->prepare_items();
+		$items = $this->table->items;
+
+		remove_filter( 'gettext', array( $this, 'filter_translate_plugin_name' ), 10 );
+		remove_filter( 'all_plugins', array( $this, 'inject_translatable_plugin' ) );
+
+		$status = $old_status;
+
+		if ( $should_match ) {
+			$this->assertArrayHasKey(
+				'fake-translated-plugin/fake-translated-plugin.php',
+				$items,
+				"The plugin should be found when searching for '{$search_term}'."
+			);
+		} else {
+			$this->assertArrayNotHasKey(
+				'fake-translated-plugin/fake-translated-plugin.php',
+				$items,
+				"The plugin should not be found when searching for '{$search_term}'."
+			);
+		}
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_search_terms_against_translatable_plugin() {
+		return array(
+			'original (untranslated) name' => array( 'Fake Translated Plugin', true ),
+			'translated name'              => array( 'Wtyczka', true ),
+			'unrelated term'               => array( 'NoSuchPluginNameHere', false ),
+		);
+	}
+
+	/**
+	 * Injects a plugin whose translated name differs from its file header name.
+	 *
+	 * Used as a callback for the 'all_plugins' hook.
+	 *
+	 * @param array $all_plugins Array of plugin data keyed by plugin file.
+	 * @return array
+	 */
+	public function inject_translatable_plugin( $all_plugins ) {
+		$all_plugins['fake-translated-plugin/fake-translated-plugin.php'] = array(
+			'Name'        => 'Fake Translated Plugin',
+			'PluginURI'   => 'https://wordpress.org/',
+			'Version'     => '1.0.0',
+			'Description' => 'A fake plugin for testing translated search.',
+			'Author'      => 'WordPress',
+			'AuthorURI'   => 'https://wordpress.org/',
+			'TextDomain'  => 'fake-translated-plugin',
+			'DomainPath'  => '',
+			'Network'     => false,
+			'Title'       => 'Fake Translated Plugin',
+			'AuthorName'  => 'WordPress',
+		);
+
+		return $all_plugins;
+	}
+
+	/**
+	 * Simulates a translation of the fake plugin's name, as a loaded .mo file would.
+	 *
+	 * Used as a callback for the 'gettext' hook.
+	 *
+	 * @param string $translation Translated text.
+	 * @param string $text        Text to translate.
+	 * @param string $domain      Text domain.
+	 * @return string
+	 */
+	public function filter_translate_plugin_name( $translation, $text, $domain ) {
+		if ( 'fake-translated-plugin' === $domain && 'Fake Translated Plugin' === $text ) {
+			return 'Wtyczka testowa';
+		}
+
+		return $translation;
+	}
 }

--- a/tests/phpunit/tests/admin/wpPluginsListTable.php
+++ b/tests/phpunit/tests/admin/wpPluginsListTable.php
@@ -436,12 +436,12 @@ class Tests_Admin_wpPluginsListTable extends WP_UnitTestCase {
 	 */
 	public function data_search_terms_against_translatable_plugin() {
 		return array(
-			'original (untranslated) name'     => array( 'Fake Translated Plugin', true ),
-			'translated name'                  => array( 'Wtyczka', true ),
-			'original name, different case'    => array( 'fake translated plugin', true ),
-			'translated name, different case'  => array( 'wtyczka', true ),
-			'translated name, upper case'      => array( 'WTYCZKA', true ),
-			'unrelated term'                   => array( 'NoSuchPluginNameHere', false ),
+			'original (untranslated) name'    => array( 'Fake Translated Plugin', true ),
+			'translated name'                 => array( 'Wtyczka', true ),
+			'original name, different case'   => array( 'fake translated plugin', true ),
+			'translated name, different case' => array( 'wtyczka', true ),
+			'translated name, upper case'     => array( 'WTYCZKA', true ),
+			'unrelated term'                  => array( 'NoSuchPluginNameHere', false ),
 		);
 	}
 


### PR DESCRIPTION
## Summary

Make the **Installed Plugins** search (`Plugins → Installed Plugins`) match the **translated** plugin name, description, and author that are shown in the list — not only the original (untranslated) values from the plugin file headers.

Trac ticket: https://core.trac.wordpress.org/ticket/64188

## Problem

When WordPress runs in a non-English locale, the Installed Plugins list table displays translated plugin names (from the plugin's `.mo` files). However, the search box only matched against the **raw, untranslated** plugin headers. Searching for a plugin by the name shown in the list returned _no results_.

This is also inconsistent with the **Add Plugins** screen, whose search already matches translated names.

In `WP_Plugins_List_Table::prepare_items()` the search runs against the raw `get_plugins()` data:

```php
$plugins['search'] = array_filter( $plugins['all'], array( $this, '_search_callback' ) );
```

…while the data is only passed through `_get_plugin_data_markup_translate()` for **display** afterwards:

```php
$this->items[ $plugin_file ] = _get_plugin_data_markup_translate( $plugin_file, $plugin_data, false, true );
```

So the user sees translated names but searches against untranslated strings.

## Solution

- Pass the plugin file path into `_search_callback()` using `ARRAY_FILTER_USE_BOTH`.
- In `_search_callback()`, in addition to the original header values, also match against the translated plugin data returned by `_get_plugin_data_markup_translate()`.
- The original (untranslated) values are still searched, so finding a plugin by its English/original name continues to work. The second parameter is optional, preserving backward compatibility for any external callers.

The extra translation work only runs while a search is active.

## Testing instructions

Reproduction via WordPress Playground (provided on the ticket):
`https://playground.wordpress.net/?language=de_DE&url=%2Fwp-admin%2Fplugins.php%3Fs%3Dnicht`

Manual:
1. Install a plugin that ships translations for its name (e.g. **Event Organiser**).
2. Set Site Language to a locale with that translation (e.g. Polish) in `Settings → General`.
3. Go to `Plugins → Installed Plugins`. The plugin shows its translated name.
4. Search for the **translated** name.
   - Before: 0 results.
   - After: the plugin is found. Searching by the original name still works too.

Automated:
```
phpunit tests/phpunit/tests/admin/wpPluginsListTable.php
```
New regression tests cover search by translated name, search by original (untranslated) name, and a non-matching term. The translated-name test fails on trunk and passes with this change.

## Use of AI Tools

- **AI assistance:** Yes
- **Tool(s):** Claude Code
- **Model(s):** Claude Opus 4.8
- **Used for:** Root-cause analysis, drafting the fix and the PHPUnit regression tests. All changes were reviewed, reproduced live in the `wordpress-develop` Docker environment (before/after), and verified against PHPUnit and PHPCS by me.
