### PR TITLE
KSES: Allow CSS anchor positioning in safecss_filter_attr()

### DIFF
--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -2553,6 +2553,8 @@ function kses_init() {
  * @since 6.5.0 Added support for `background-repeat`.
  * @since 6.6.0 Added support for `grid-column`, `grid-row`, and `container-type`.
  * @since 6.9.0 Added support for `white-space`.
+ * @since 7.1.0 Added support for CSS anchor positioning properties and the
+ *              `anchor()` and `anchor-size()` functions.
  *
  * @param string $css        A string of CSS rules, decoded from an HTML `style` attribute.
  * @param string $deprecated Not used.
@@ -2734,6 +2736,16 @@ function safecss_filter_attr( $css, $deprecated = '' ) {
 			'aspect-ratio',
 			'container-type',
 
+			// CSS anchor positioning.
+			'anchor-name',
+			'anchor-scope',
+			'position-anchor',
+			'position-area',
+			'position-try',
+			'position-try-fallbacks',
+			'position-try-order',
+			'position-visibility',
+
 			'fill',
 			'fill-opacity',
 			'fill-rule',
@@ -2913,7 +2925,7 @@ function safecss_filter_attr( $css, $deprecated = '' ) {
 			 * Nested functions and parentheses are also removed, so long as the parentheses are balanced.
 			 */
 			$css_test_string = preg_replace(
-				'/\b(?:var|calc|min|max|minmax|clamp|repeat)(\((?:[^()]|(?1))*\))/',
+				'/\b(?:var|calc|min|max|minmax|clamp|repeat|anchor-size|anchor)(\((?:[^()]|(?1))*\))/',
 				'',
 				$css_test_string
 			);

--- a/tests/phpunit/tests/kses.php
+++ b/tests/phpunit/tests/kses.php
@@ -1001,6 +1001,7 @@ EOF;
 	 * @ticket 60132
 	 * @ticket 64414
 	 * @ticket 65457
+	 * @ticket 64972
 	 *
 	 * @dataProvider data_safecss_filter_attr
 	 *
@@ -1510,6 +1511,31 @@ EOF;
 			array(
 				'css'      => 'text-anchor: middle',
 				'expected' => 'text-anchor: middle',
+			),
+			// CSS anchor positioning properties are allowed.
+			array(
+				'css'      => 'anchor-name: --tooltip;anchor-scope: all;position-anchor: --tooltip;position-area: top;position-try: flip-block;position-try-fallbacks: --fallback;position-try-order: most-height;position-visibility: anchors-visible',
+				'expected' => 'anchor-name: --tooltip;anchor-scope: all;position-anchor: --tooltip;position-area: top;position-try: flip-block;position-try-fallbacks: --fallback;position-try-order: most-height;position-visibility: anchors-visible',
+			),
+			// The `anchor()` function is allowed in inset properties.
+			array(
+				'css'      => 'top: anchor(--tooltip bottom)',
+				'expected' => 'top: anchor(--tooltip bottom)',
+			),
+			// The `anchor-size()` function is allowed in sizing properties.
+			array(
+				'css'      => 'width: anchor-size(--tooltip width)',
+				'expected' => 'width: anchor-size(--tooltip width)',
+			),
+			// The `anchor-size()` function is allowed when nested in another function.
+			array(
+				'css'      => 'margin-left: calc(anchor-size(width) / 2)',
+				'expected' => 'margin-left: calc(anchor-size(width) / 2)',
+			),
+			// Allowing `anchor()` must not allow other, unknown functions.
+			array(
+				'css'      => 'width: expression(alert(1))',
+				'expected' => '',
 			),
 		);
 	}


### PR DESCRIPTION
## Summary

Allow CSS [anchor positioning](https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Anchor_positioning) in `safecss_filter_attr()` so it is no longer stripped from `style` attributes filtered through KSES.

Trac ticket: https://core.trac.wordpress.org/ticket/64972

## Problem

On trunk, every anchor positioning declaration is stripped:

```php
safecss_filter_attr( 'anchor-name: --tooltip' );        // ''
safecss_filter_attr( 'position-anchor: --tooltip' );    // ''
safecss_filter_attr( 'top: anchor(--tooltip bottom)' ); // ''
safecss_filter_attr( 'width: anchor-size(--tooltip width)' ); // ''
```

This is two separate gaps:

1. The anchor positioning **properties** are not in the `safe_style_css` allowlist.
2. The **`anchor()` and `anchor-size()` functions** are not in the allowlist of CSS functions. `safecss_filter_attr()` rejects any declaration whose value still contains a function call after the known functions (`var`, `calc`, `min`, `max`, `minmax`, `clamp`, `repeat`) are removed.

## Why a properties-only fix is not enough

There is an existing PR, #11419, which adds the anchor positioning **properties** only. That is necessary but not sufficient: anchor positioning is driven by the `anchor()` and `anchor-size()` functions used in standard inset and sizing properties (e.g. `top: anchor(--tooltip bottom)`, `width: anchor-size(--tooltip width)`). Because those functions are not allowlisted, such declarations are still stripped, so the feature remains unusable after #11419, and its test only exercises simple values such as `position-area: top` so the gap is not caught.

This PR is a superset of #11419: it adds the same properties **and** the `anchor()` / `anchor-size()` functions, with tests that cover the function usage.

## Changes

- Add the anchor positioning properties to the `safe_style_css` allowlist: `anchor-name`, `anchor-scope`, `position-anchor`, `position-area`, `position-try`, `position-try-fallbacks`, `position-try-order`, `position-visibility`.
- Add `anchor` and `anchor-size` to the allowed CSS functions, handled the same way as the existing `var()`/`calc()`/`clamp()` allowlist. Unknown functions such as `expression()` are still stripped, so sanitization is not weakened.
- Update the `@since` docblock.
- Add regression tests covering the properties, the `anchor()`/`anchor-size()` functions (including nesting inside `calc()`), and that an unknown function is still rejected.

## Testing instructions

```
phpunit --filter Tests_Kses tests/phpunit/tests/kses.php
```

Or manually:

```php
// Before this change all of these return ''. After, each is preserved:
safecss_filter_attr( 'anchor-name: --tooltip' );
safecss_filter_attr( 'top: anchor(--tooltip bottom)' );
safecss_filter_attr( 'width: anchor-size(--tooltip width)' );
safecss_filter_attr( 'margin-left: calc(anchor-size(width) / 2)' );
// Still stripped (sanitization preserved):
safecss_filter_attr( 'width: expression(alert(1))' ); // ''
```

## Relationship to #11419

This supersedes #11419, which only allowlists the properties. If preferred, the property list here could instead be merged into #11419 and this PR reduced to the function allowlist — happy to coordinate either way.

## Use of AI Tools

- **AI assistance:** Yes
- **Tool(s):** Claude Code
- **Model(s):** Claude Opus 4.8
- **Used for:** Root-cause analysis (identifying the function-allowlist gap missed by the properties-only patch), drafting the change and the PHPUnit tests. All changes were reviewed, reproduced against trunk in the `wordpress-develop` Docker environment, and verified with PHPUnit and PHPCS by me.
