### PR TITLE
HTTP: Preserve non-default port in get_allowed_http_origins()

### DIFF
--- a/src/wp-includes/http.php
+++ b/src/wp-includes/http.php
@@ -449,13 +449,28 @@ function get_allowed_http_origins() {
 	$admin_origin = parse_url( admin_url() );
 	$home_origin  = parse_url( home_url() );
 
-	// @todo Preserve port?
+	/*
+	 * Preserve a non-default port so that origins served on a custom port
+	 * (for example `http://example.com:8080`) are matched against the browser's
+	 * `Origin` request header. The default HTTP and HTTPS ports (80 and 443) are
+	 * omitted because browsers leave them out of the `Origin` header.
+	 */
+	$admin_host = $admin_origin['host'];
+	if ( isset( $admin_origin['port'] ) && 80 !== $admin_origin['port'] && 443 !== $admin_origin['port'] ) {
+		$admin_host .= ':' . $admin_origin['port'];
+	}
+
+	$home_host = $home_origin['host'];
+	if ( isset( $home_origin['port'] ) && 80 !== $home_origin['port'] && 443 !== $home_origin['port'] ) {
+		$home_host .= ':' . $home_origin['port'];
+	}
+
 	$allowed_origins = array_unique(
 		array(
-			'http://' . $admin_origin['host'],
-			'https://' . $admin_origin['host'],
-			'http://' . $home_origin['host'],
-			'https://' . $home_origin['host'],
+			'http://' . $admin_host,
+			'https://' . $admin_host,
+			'http://' . $home_host,
+			'https://' . $home_host,
 		)
 	);
 

--- a/tests/phpunit/tests/http/getAllowedHttpOrigins.php
+++ b/tests/phpunit/tests/http/getAllowedHttpOrigins.php
@@ -1,0 +1,121 @@
+<?php
+
+/**
+ * Tests for get_allowed_http_origins().
+ *
+ * @group http
+ *
+ * @covers ::get_allowed_http_origins
+ */
+class Tests_HTTP_GetAllowedHttpOrigins extends WP_UnitTestCase {
+
+	/**
+	 * Backup of the `home` option.
+	 *
+	 * @var string
+	 */
+	private $original_home;
+
+	/**
+	 * Backup of the `siteurl` option.
+	 *
+	 * @var string
+	 */
+	private $original_siteurl;
+
+	public function set_up() {
+		parent::set_up();
+		$this->original_home    = get_option( 'home' );
+		$this->original_siteurl = get_option( 'siteurl' );
+	}
+
+	public function tear_down() {
+		update_option( 'home', $this->original_home );
+		update_option( 'siteurl', $this->original_siteurl );
+		parent::tear_down();
+	}
+
+	/**
+	 * A non-default port must be preserved so that an origin served on a custom
+	 * port (for example a local or staging install) is matched.
+	 *
+	 * @ticket 65522
+	 */
+	public function test_non_default_port_is_preserved() {
+		update_option( 'home', 'http://example.com:8080' );
+		update_option( 'siteurl', 'http://example.com:8080' );
+
+		$origins = get_allowed_http_origins();
+
+		$this->assertContains( 'http://example.com:8080', $origins );
+		$this->assertContains( 'https://example.com:8080', $origins );
+		$this->assertNotContains( 'http://example.com', $origins );
+	}
+
+	/**
+	 * A URL without a port must not gain a port suffix.
+	 *
+	 * @ticket 65522
+	 */
+	public function test_url_without_port_has_no_port_suffix() {
+		update_option( 'home', 'http://example.com' );
+		update_option( 'siteurl', 'http://example.com' );
+
+		$origins = get_allowed_http_origins();
+
+		$this->assertContains( 'http://example.com', $origins );
+		$this->assertContains( 'https://example.com', $origins );
+		$this->assertNotContains( 'http://example.com:80', $origins );
+	}
+
+	/**
+	 * The default HTTP and HTTPS ports must be omitted, because browsers leave
+	 * them out of the `Origin` request header. An explicit `:80` (or `:443`) in
+	 * the site URL must therefore still produce a port-less origin so the check
+	 * matches the value the browser actually sends.
+	 *
+	 * @ticket 65522
+	 *
+	 * @dataProvider data_default_ports
+	 *
+	 * @param string $url The site URL with an explicit default port.
+	 */
+	public function test_default_ports_are_omitted( $url ) {
+		update_option( 'home', $url );
+		update_option( 'siteurl', $url );
+
+		$origins = get_allowed_http_origins();
+
+		$this->assertContains( 'http://example.com', $origins, 'A port-less HTTP origin should be present.' );
+		$this->assertContains( 'https://example.com', $origins, 'A port-less HTTPS origin should be present.' );
+		$this->assertNotContains( 'http://example.com:80', $origins, 'The default HTTP port should be omitted.' );
+		$this->assertNotContains( 'https://example.com:443', $origins, 'The default HTTPS port should be omitted.' );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_default_ports() {
+		return array(
+			'explicit default HTTP port'  => array( 'http://example.com:80' ),
+			'explicit default HTTPS port' => array( 'https://example.com:443' ),
+		);
+	}
+
+	/**
+	 * A custom port on the site URL must make a matching origin allowed.
+	 *
+	 * @ticket 65522
+	 *
+	 * @covers ::is_allowed_http_origin
+	 */
+	public function test_is_allowed_http_origin_matches_custom_port() {
+		update_option( 'home', 'http://example.com:8080' );
+		update_option( 'siteurl', 'http://example.com:8080' );
+
+		$this->assertSame( 'http://example.com:8080', is_allowed_http_origin( 'http://example.com:8080' ) );
+		$this->assertSame( '', is_allowed_http_origin( 'http://example.com' ), 'A port-less origin should not match a custom-port site.' );
+	}
+}


### PR DESCRIPTION
## Summary

Preserve a non-default port in `get_allowed_http_origins()` so that sites served on a custom port (for example `http://example.com:8080`, or a local `http://localhost:8889`) are matched against the browser `Origin` request header.

Trac ticket: https://core.trac.wordpress.org/ticket/65522

## Problem

`get_allowed_http_origins()` built the allowed origin list from the **host** of `admin_url()` and `home_url()` only, discarding the port (there was even a `// @todo Preserve port?` note in core):

```php
$admin_origin = parse_url( admin_url() );
// @todo Preserve port?
$allowed_origins = array_unique( array(
    'http://' . $admin_origin['host'],
    ...
) );
```

For a site on `http://localhost:8889`, this returns `http://localhost` / `https://localhost`. The browser sends `Origin: http://localhost:8889`, which is not in the list, so the cross-origin request is rejected.

## Solution

Append the port when it is present and non-default. The default HTTP and HTTPS ports (80 and 443) are intentionally omitted, because browsers leave them out of the `Origin` header — so an explicit `:80`/`:443` in the site URL still produces a port-less origin that matches the request.

## Relationship to #12287

There is an existing PR, #12287, which also appends the port. This PR improves on it in one important way: #12287 appends the port **unconditionally**, including the default ports. For a site whose `siteurl` is stored as `http://example.com:80`, #12287 produces only `http://example.com:80` and no port-less variant. Since the browser sends `Origin: http://example.com` (port 80 omitted), that case is **broken** by #12287 — it would reject a request that currently works on trunk. This PR omits the default ports, so both the custom-port case and the explicit-default-port case are correct. The included tests cover the default-port case explicitly.

## Testing

Verified on a local install served at `http://localhost:8889`:

```php
// Before: array( 'http://localhost', 'https://localhost' )
// After:  array( 'http://localhost:8889', 'https://localhost:8889' )
get_allowed_http_origins();
```

Automated:

```
phpunit tests/phpunit/tests/http/getAllowedHttpOrigins.php
```

New tests cover a custom port, a port-less URL, the explicit default-port case (`:80`/`:443`), and `is_allowed_http_origin()` matching a custom-port origin.

## Use of AI Tools

- **AI assistance:** Yes
- **Tool(s):** Claude Code
- **Model(s):** Claude Opus 4.8
- **Used for:** Reproducing the issue (on a local `:8889` install), identifying the default-port edge case missed by the existing PR, and drafting the change and PHPUnit tests. All changes were reviewed, reproduced in the `wordpress-develop` Docker environment, and verified with PHPUnit and PHPCS by me.
