### PR TITLE
Administration: Improve dashboard meta box control visuals

### DIFF
--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -2196,6 +2196,7 @@ html.wp-toolbar {
 /* one column on the dash */
 @media only screen and (max-width: 799px) {
 	#wpbody-content .metabox-holder .postbox-container .empty-container {
+		border: 0;
 		outline: none;
 		height: 0;
 		min-height: 0;
@@ -2235,6 +2236,12 @@ html.wp-toolbar {
 
 .postbox-header .handle-actions {
 	flex-shrink: 0;
+	padding-right: 8px;
+}
+
+.rtl .postbox-header .handle-actions {
+	padding-right: 0;
+	padding-left: 8px;
 }
 
 /* Post box order and toggle buttons. */
@@ -3343,8 +3350,8 @@ img {
 .postbox .handle-order-higher:focus,
 .postbox .handle-order-lower:focus,
 .postbox .handlediv:focus {
-	box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus, 1.5px) var(--wp-admin-theme-color);
-	border-radius: 50%;
+	border-radius: 2px;
+	box-shadow: 0 0 0 var(--wp-admin-border-width-focus, 1.5px) var(--wp-admin-theme-color, #3858e9);
 	/* Only visible in Windows High Contrast mode */
 	outline: 2px solid transparent;
 }

--- a/src/wp-admin/css/dashboard.css
+++ b/src/wp-admin/css/dashboard.css
@@ -67,11 +67,10 @@
 }
 
 #dashboard-widgets .postbox-container .empty-container {
-	outline: 2px dashed rgb(0, 0, 0, 0.15);
-	outline-offset: -2px;
+	box-sizing: border-box;
+	border: 1px dashed #c3c4c7;
 	border-radius: 8px;
 	height: 250px;
-	margin: 4px;
 }
 
 /* Only highlight drop zones when dragging. */
@@ -82,7 +81,7 @@
 }
 
 .is-dragging-metaboxes #dashboard-widgets .postbox-container .empty-container {
-	background: rgb(0, 0, 0, 0.01);
+	background: rgb(var(--wp-admin-theme-color--rgb), 0.04);
 }
 
 #dashboard-widgets .postbox-container .empty-container:after {
@@ -1288,6 +1287,7 @@ a.rsswidget {
 	}
 
 	#dashboard-widgets .meta-box-sortables.empty-container {
+		border: 0;
 		margin-bottom: 0;
 	}
 }


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/50699
Follow-up to: https://github.com/WordPress/wordpress-develop/pull/12180

## Summary
- Adds right-side spacing to shared postbox header actions, with RTL support.
- Updates shared postbox header action buttons, including the move and collapse controls, to use the standard wp-admin focus ring treatment.
- Refines dashboard-specific empty drop areas to use a 1px dashed border and align with the existing subtle theme-color drag highlight used for meta box drop zones.

**Before**
<img width="2016" height="664" alt="image" src="https://github.com/user-attachments/assets/167cb1ed-e683-4d97-ab41-2ad7cb5620fc" />
<img width="1730" height="590" alt="image" src="https://github.com/user-attachments/assets/ca79cbe0-0547-438c-9049-8498c36fec95" />
<img width="984" height="334" alt="image" src="https://github.com/user-attachments/assets/069e6a5d-8bc7-4f47-8b0a-aa6fca96f946" />

**After**
<img width="1998" height="646" alt="image" src="https://github.com/user-attachments/assets/f455a316-664d-43dc-a25f-ab4d339c8938" />
<img width="1542" height="550" alt="image" src="https://github.com/user-attachments/assets/ae189998-6fa2-4e66-b38b-6cf3d93aa734" />
<img width="924" height="380" alt="image" src="https://github.com/user-attachments/assets/52d8f079-71e2-4327-815b-9ef1047f23dd" />

## Scope
The postbox header action spacing and action-button focus styles live in `common.css`, so they apply to postbox controls generally. The drag highlight is a general meta box drop-zone pattern; this PR only changes the dashboard empty drop area because that is the dashboard-specific part that needed the visual cleanup.

## Context
This extracts small visual improvements from the broader meta box reordering behavior work so the behavior PR can remain focused on the Screen Options toggle and reordering logic.

## Testing
- git diff --check
- `npm exec -- grunt build:css`
- PostCSS safe-parser check for `src/wp-admin/css/common.css` and `src/wp-admin/css/dashboard.css`
- Focused declaration assertion for the new spacing, RTL, shared focus, border, and drag-fill CSS
- Playwright check on the local classic WooCommerce product editor confirming the collapse and move buttons compute to the same focus `border-radius` and `box-shadow`
