### PR TITLE
#58987: Unify "Don't load directly" guards to use exit;

### DIFF
--- a/src/wp-admin/admin-footer.php
+++ b/src/wp-admin/admin-footer.php
@@ -8,7 +8,7 @@
 
 // Don't load directly.
 if ( ! defined( 'ABSPATH' ) ) {
-	die( '-1' );
+	exit;
 }
 
 /**

--- a/src/wp-admin/admin-functions.php
+++ b/src/wp-admin/admin-functions.php
@@ -11,7 +11,7 @@
 
 // Don't load directly.
 if ( ! defined( 'ABSPATH' ) ) {
-	die( '-1' );
+	exit;
 }
 
 _deprecated_file( basename( __FILE__ ), '2.5.0', 'wp-admin/includes/admin.php' );

--- a/src/wp-admin/admin-header.php
+++ b/src/wp-admin/admin-header.php
@@ -8,7 +8,7 @@
 
 // Don't load directly.
 if ( ! defined( 'ABSPATH' ) ) {
-	die( '-1' );
+	exit;
 }
 
 header( 'Content-Type: ' . get_option( 'html_type' ) . '; charset=' . get_option( 'blog_charset' ) );

--- a/src/wp-admin/custom-background.php
+++ b/src/wp-admin/custom-background.php
@@ -11,7 +11,7 @@
 
 // Don't load directly.
 if ( ! defined( 'ABSPATH' ) ) {
-	die( '-1' );
+	exit;
 }
 
 _deprecated_file( basename( __FILE__ ), '5.3.0', 'wp-admin/includes/class-custom-background.php' );

--- a/src/wp-admin/custom-header.php
+++ b/src/wp-admin/custom-header.php
@@ -11,7 +11,7 @@
 
 // Don't load directly.
 if ( ! defined( 'ABSPATH' ) ) {
-	die( '-1' );
+	exit;
 }
 
 _deprecated_file( basename( __FILE__ ), '5.3.0', 'wp-admin/includes/class-custom-image-header.php' );

--- a/src/wp-admin/edit-form-advanced.php
+++ b/src/wp-admin/edit-form-advanced.php
@@ -8,7 +8,7 @@
 
 // Don't load directly.
 if ( ! defined( 'ABSPATH' ) ) {
-	die( '-1' );
+	exit;
 }
 
 /**

--- a/src/wp-admin/edit-form-blocks.php
+++ b/src/wp-admin/edit-form-blocks.php
@@ -10,7 +10,7 @@
 
 // Don't load directly.
 if ( ! defined( 'ABSPATH' ) ) {
-	die( '-1' );
+	exit;
 }
 
 /**

--- a/src/wp-admin/edit-form-comment.php
+++ b/src/wp-admin/edit-form-comment.php
@@ -8,7 +8,7 @@
 
 // Don't load directly.
 if ( ! defined( 'ABSPATH' ) ) {
-	die( '-1' );
+	exit;
 }
 
 /**

--- a/src/wp-admin/edit-link-form.php
+++ b/src/wp-admin/edit-link-form.php
@@ -8,7 +8,7 @@
 
 // Don't load directly.
 if ( ! defined( 'ABSPATH' ) ) {
-	die( '-1' );
+	exit;
 }
 
 if ( ! empty( $link_id ) ) {

--- a/src/wp-admin/edit-tag-form.php
+++ b/src/wp-admin/edit-tag-form.php
@@ -8,7 +8,7 @@
 
 // Don't load directly.
 if ( ! defined( 'ABSPATH' ) ) {
-	die( '-1' );
+	exit;
 }
 
 // Back compat hooks.

--- a/src/wp-admin/link-parse-opml.php
+++ b/src/wp-admin/link-parse-opml.php
@@ -6,8 +6,9 @@
  * @subpackage Administration
  */
 
+// Don't load directly.
 if ( ! defined( 'ABSPATH' ) ) {
-	die();
+	exit;
 }
 
 /**

--- a/src/wp-admin/menu-header.php
+++ b/src/wp-admin/menu-header.php
@@ -8,7 +8,7 @@
 
 // Don't load directly.
 if ( ! defined( 'ABSPATH' ) ) {
-	die( '-1' );
+	exit;
 }
 
 /**

--- a/src/wp-admin/menu.php
+++ b/src/wp-admin/menu.php
@@ -8,7 +8,7 @@
 
 // Don't load directly.
 if ( ! defined( 'ABSPATH' ) ) {
-	die( '-1' );
+	exit;
 }
 
 /**

--- a/src/wp-admin/network/menu.php
+++ b/src/wp-admin/network/menu.php
@@ -9,7 +9,7 @@
 
 // Don't load directly.
 if ( ! defined( 'ABSPATH' ) ) {
-	die( '-1' );
+	exit;
 }
 
 /* translators: Network menu item. */

--- a/src/wp-admin/options-head.php
+++ b/src/wp-admin/options-head.php
@@ -10,7 +10,7 @@
 
 // Don't load directly.
 if ( ! defined( 'ABSPATH' ) ) {
-	die( '-1' );
+	exit;
 }
 
 $action = ! empty( $_REQUEST['action'] ) ? sanitize_text_field( $_REQUEST['action'] ) : '';

--- a/src/wp-admin/site-health-info.php
+++ b/src/wp-admin/site-health-info.php
@@ -6,8 +6,9 @@
  * @subpackage Administration
  */
 
+// Don't load directly.
 if ( ! defined( 'ABSPATH' ) ) {
-	die();
+	exit;
 }
 
 if ( ! class_exists( 'WP_Debug_Data' ) ) {

--- a/src/wp-admin/user/menu.php
+++ b/src/wp-admin/user/menu.php
@@ -9,7 +9,7 @@
 
 // Don't load directly.
 if ( ! defined( 'ABSPATH' ) ) {
-	die( '-1' );
+	exit;
 }
 
 $menu[2] = array( __( 'Dashboard' ), 'exist', 'index.php', '', 'menu-top menu-top-first menu-icon-dashboard', 'menu-dashboard', 'dashicons-dashboard' );

--- a/src/wp-admin/widgets-form-blocks.php
+++ b/src/wp-admin/widgets-form-blocks.php
@@ -8,7 +8,7 @@
 
 // Don't load directly.
 if ( ! defined( 'ABSPATH' ) ) {
-	die( '-1' );
+	exit;
 }
 
 // Flag that we're loading the block editor.

--- a/src/wp-admin/widgets-form.php
+++ b/src/wp-admin/widgets-form.php
@@ -8,7 +8,7 @@
 
 // Don't load directly.
 if ( ! defined( 'ABSPATH' ) ) {
-	die( '-1' );
+	exit;
 }
 
 $widgets_access = get_user_setting( 'widgets_access' );

--- a/src/wp-content/plugins/hello.php
+++ b/src/wp-content/plugins/hello.php
@@ -13,9 +13,9 @@ Author URI: http://ma.tt/
 Text Domain: hello-dolly
 */
 
-// Do not load directly.
+// Don't load directly.
 if ( ! defined( 'ABSPATH' ) ) {
-	die();
+	exit;
 }
 
 function hello_dolly_get_lyric() {

--- a/src/wp-includes/blocks/index.php
+++ b/src/wp-includes/blocks/index.php
@@ -7,7 +7,7 @@
 
 // Don't load directly.
 if ( ! defined( 'ABSPATH' ) ) {
-	die( '-1' );
+	exit;
 }
 
 define( 'BLOCKS_PATH', ABSPATH . WPINC . '/blocks/' );

--- a/src/wp-includes/class-IXR.php
+++ b/src/wp-includes/class-IXR.php
@@ -41,7 +41,7 @@
 
 // Don't load directly.
 if ( ! defined( 'ABSPATH' ) ) {
-	die( '-1' );
+	exit;
 }
 
 require_once ABSPATH . WPINC . '/IXR/class-IXR-server.php';

--- a/src/wp-includes/class-wp-customize-control.php
+++ b/src/wp-includes/class-wp-customize-control.php
@@ -9,7 +9,7 @@
 
 // Don't load directly.
 if ( ! defined( 'ABSPATH' ) ) {
-	die( '-1' );
+	exit;
 }
 
 /**

--- a/src/wp-includes/class-wp-customize-panel.php
+++ b/src/wp-includes/class-wp-customize-panel.php
@@ -9,7 +9,7 @@
 
 // Don't load directly.
 if ( ! defined( 'ABSPATH' ) ) {
-	die( '-1' );
+	exit;
 }
 
 /**

--- a/src/wp-includes/class-wp-customize-setting.php
+++ b/src/wp-includes/class-wp-customize-setting.php
@@ -9,7 +9,7 @@
 
 // Don't load directly.
 if ( ! defined( 'ABSPATH' ) ) {
-	die( '-1' );
+	exit;
 }
 
 /**

--- a/src/wp-includes/class-wp-http.php
+++ b/src/wp-includes/class-wp-http.php
@@ -9,7 +9,7 @@
 
 // Don't load directly.
 if ( ! defined( 'ABSPATH' ) ) {
-	die( '-1' );
+	exit;
 }
 
 if ( ! class_exists( 'WpOrg\Requests\Autoload' ) ) {

--- a/src/wp-includes/class-wp-simplepie-sanitize-kses.php
+++ b/src/wp-includes/class-wp-simplepie-sanitize-kses.php
@@ -9,7 +9,7 @@
 
 // Don't load directly.
 if ( ! defined( 'ABSPATH' ) ) {
-	die( '-1' );
+	exit;
 }
 
 /**

--- a/src/wp-includes/class-wp-text-diff-renderer-table.php
+++ b/src/wp-includes/class-wp-text-diff-renderer-table.php
@@ -9,7 +9,7 @@
 
 // Don't load directly.
 if ( ! defined( 'ABSPATH' ) ) {
-	die( '-1' );
+	exit;
 }
 
 /**

--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -25,7 +25,7 @@
 
 // Don't load directly.
 if ( ! defined( 'ABSPATH' ) ) {
-	die( '-1' );
+	exit;
 }
 
 // Strip, trim, kses, special chars for string saves.

--- a/src/wp-includes/default-widgets.php
+++ b/src/wp-includes/default-widgets.php
@@ -9,7 +9,7 @@
 
 // Don't load directly.
 if ( ! defined( 'ABSPATH' ) ) {
-	die( '-1' );
+	exit;
 }
 
 /** WP_Widget_Pages class */

--- a/src/wp-includes/feed-atom.php
+++ b/src/wp-includes/feed-atom.php
@@ -7,7 +7,7 @@
 
 // Don't load directly.
 if ( ! defined( 'ABSPATH' ) ) {
-	die( '-1' );
+	exit;
 }
 
 header( 'Content-Type: ' . feed_content_type( 'atom' ) . '; charset=' . get_option( 'blog_charset' ), true );

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -7,7 +7,7 @@
 
 // Don't load directly.
 if ( ! defined( 'ABSPATH' ) ) {
-	die( '-1' );
+	exit;
 }
 
 require ABSPATH . WPINC . '/option.php';

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -8,7 +8,7 @@
 
 // Don't load directly.
 if ( ! defined( 'ABSPATH' ) ) {
-	die( '-1' );
+	exit;
 }
 
 /**

--- a/src/wp-includes/ms-blogs.php
+++ b/src/wp-includes/ms-blogs.php
@@ -10,7 +10,7 @@
 
 // Don't load directly.
 if ( ! defined( 'ABSPATH' ) ) {
-	die( '-1' );
+	exit;
 }
 
 require_once ABSPATH . WPINC . '/ms-site.php';

--- a/src/wp-includes/ms-settings.php
+++ b/src/wp-includes/ms-settings.php
@@ -12,7 +12,7 @@
 
 // Don't load directly.
 if ( ! defined( 'ABSPATH' ) ) {
-	die( '-1' );
+	exit;
 }
 
 /**

--- a/src/wp-includes/nav-menu-template.php
+++ b/src/wp-includes/nav-menu-template.php
@@ -9,7 +9,7 @@
 
 // Don't load directly.
 if ( ! defined( 'ABSPATH' ) ) {
-	die( '-1' );
+	exit;
 }
 
 /** Walker_Nav_Menu class */

--- a/src/wp-includes/rss-functions.php
+++ b/src/wp-includes/rss-functions.php
@@ -6,8 +6,9 @@
  * @deprecated 2.1.0
  */
 
+// Don't load directly.
 if ( ! defined( 'ABSPATH' ) ) {
-	exit();
+	exit;
 }
 
 _deprecated_file( basename( __FILE__ ), '2.1.0', WPINC . '/rss.php' );

--- a/src/wp-includes/update.php
+++ b/src/wp-includes/update.php
@@ -8,7 +8,7 @@
 
 // Don't load directly.
 if ( ! defined( 'ABSPATH' ) ) {
-	die( '-1' );
+	exit;
 }
 
 /**

--- a/src/wp-includes/vars.php
+++ b/src/wp-includes/vars.php
@@ -17,7 +17,7 @@
 
 // Don't load directly.
 if ( ! defined( 'ABSPATH' ) ) {
-	die( '-1' );
+	exit;
 }
 
 global $pagenow,

--- a/src/wp-includes/wp-diff.php
+++ b/src/wp-includes/wp-diff.php
@@ -10,7 +10,7 @@
 
 // Don't load directly.
 if ( ! defined( 'ABSPATH' ) ) {
-	die( '-1' );
+	exit;
 }
 
 if ( ! class_exists( 'Text_Diff', false ) ) {


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->
Unifies all "Don't load directly" file guards across `src/` to use a consistent
canonical form as recommended by the WordPress Plugin Developer Handbook
(https://developer.wordpress.org/plugins/plugin-basics/best-practices/#avoiding-direct-file-access):

```php
// Don't load directly.
if ( ! defined( 'ABSPATH' ) ) {
	exit;
}
```

Previously, files used three different patterns inconsistently:
- `die( '-1' );` (36 files) — the `-1` has no meaningful effect in a direct file-access context where no JavaScript AJAX handler is present to interpret it
- `die();` (3 files, some also missing the comment or using "Do not load directly.")
- `exit()` (1 file, missing the comment)

This patch normalises all 40 affected files to `exit;` (bare, without parentheses,
matching the documented best practice) and ensures the `// Don't load directly.`
comment is present and consistently worded in every case.

Not changed:
- `pluggable.php:1449` — `die( '-1' )` inside a function body as an intentional AJAX response value
- `wp-includes/assets/icon-library-manifest.php` — auto-generated from a Gutenberg package source; must be fixed upstream
- Files where `ABSPATH` is *defined* (not guarded against), e.g. `wp-load.php`, `load-scripts.php`
- All other `die()` / `exit()` calls that are genuine program logic, not file guards

Trac ticket: https://core.trac.wordpress.org/ticket/58987

## Use of AI Tools
AI assistance: Yes
Tool(s): GitHub Copilot
Model(s): Claude Sonnet 4.8
Used for: Identifying all affected files, generating the batch edits, and verifying no functional die()/exit() calls were touched. All changes were reviewed and approved by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**