### PR TITLE
Add aria-describedby to post link with hierarchy info

### DIFF
--- a/src/wp-admin/includes/class-wp-posts-list-table.php
+++ b/src/wp-admin/includes/class-wp-posts-list-table.php
@@ -1143,7 +1143,7 @@ class WP_Posts_List_Table extends WP_List_Table {
 
 		if ( $can_edit_post && 'trash' !== $post->post_status ) {
 			printf(
-				'%2$s<a class="row-title" href="%1$s" aria-describedby="post_hierarchy_%4$s">%3$s</a>%4$s',
+				'%2$s<a class="row-title" href="%1$s" aria-describedby="post_hierarchy_%5$s">%3$s</a>%4$s',
 				get_edit_post_link( $post->ID ),
 				$pad,
 				$title,

--- a/src/wp-admin/includes/class-wp-posts-list-table.php
+++ b/src/wp-admin/includes/class-wp-posts-list-table.php
@@ -1133,8 +1133,10 @@ class WP_Posts_List_Table extends WP_List_Table {
 
 		$pad = str_repeat( '<span class="aria-hidden">&#8212;</span> ', $this->current_level );
 		$described = '<span id="post_hierarchy_' . $post->ID . '" class="hidden">';
-		if ( isset( $parent_name ) ) {
-			$described .= sprintf( __( 'Child of %s' ), $parent_name );
+		if ( 0 !== $post->post_parent ) {
+			$parent       = get_post( $post->post_parent );
+			$parent_title = apply_filters( 'the_title', $parent->post_title, $parent->ID );
+			$described   .= sprintf( __( 'Child of %s' ), esc_html( $parent_title ) );
 		}
 		$described .= '</span>';
 		echo '<strong>';

--- a/src/wp-admin/includes/class-wp-posts-list-table.php
+++ b/src/wp-admin/includes/class-wp-posts-list-table.php
@@ -1131,17 +1131,23 @@ class WP_Posts_List_Table extends WP_List_Table {
 			echo '<div class="locked-info"><span class="locked-avatar">' . $locked_avatar . '</span> <span class="locked-text">' . $locked_text . "</span></div>\n";
 		}
 
-		$pad = str_repeat( '&#8212; ', $this->current_level );
+		$pad = str_repeat( '<span class="aria-hidden">&#8212;</span> ', $this->current_level );
+		$described = '<span id="post_hierarchy_' . $post->ID . '" class="hidden">';
+		if ( $parent_name ) {
+			$described .= sprintf( __( 'Child of %s' ), $parent_name );
+		}
+		$described .= '</span>';
 		echo '<strong>';
 
 		$title = _draft_or_post_title();
 
 		if ( $can_edit_post && 'trash' !== $post->post_status ) {
 			printf(
-				'<a class="row-title" href="%s">%s%s</a>',
+				'%2$s<a class="row-title" href="%1$s" aria-describedby="post_hierarchy_%1$s">%3$s</a>%4$s',
 				get_edit_post_link( $post->ID ),
 				$pad,
-				$title
+				$title,
+				$described
 			);
 		} else {
 			printf(

--- a/src/wp-admin/includes/class-wp-posts-list-table.php
+++ b/src/wp-admin/includes/class-wp-posts-list-table.php
@@ -1143,11 +1143,12 @@ class WP_Posts_List_Table extends WP_List_Table {
 
 		if ( $can_edit_post && 'trash' !== $post->post_status ) {
 			printf(
-				'%2$s<a class="row-title" href="%1$s" aria-describedby="post_hierarchy_%1$s">%3$s</a>%4$s',
+				'%2$s<a class="row-title" href="%1$s" aria-describedby="post_hierarchy_%4$s">%3$s</a>%4$s',
 				get_edit_post_link( $post->ID ),
 				$pad,
 				$title,
-				$described
+				$described,
+				$post->ID
 			);
 		} else {
 			printf(

--- a/src/wp-admin/includes/class-wp-posts-list-table.php
+++ b/src/wp-admin/includes/class-wp-posts-list-table.php
@@ -1133,7 +1133,7 @@ class WP_Posts_List_Table extends WP_List_Table {
 
 		$pad = str_repeat( '<span class="aria-hidden">&#8212;</span> ', $this->current_level );
 		$described = '<span id="post_hierarchy_' . $post->ID . '" class="hidden">';
-		if ( $parent_name ) {
+		if ( isset( $parent_name ) ) {
 			$described .= sprintf( __( 'Child of %s' ), $parent_name );
 		}
 		$described .= '</span>';


### PR DESCRIPTION
Conveys the immediate parent, if assigned. Moves dash characters out of the link so they don't impact naming.

Alternate fix using `aria-describedby`

<!--
Hi there! Thanks for contributing to WordPress!

<!-- Insert a description of your changes here -->

Trac ticket: [64932](https://core.trac.wordpress.org/ticket/64932)

## Use of AI Tools

AI assistance: no.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
