### PR TITLE
Editor: Add hook to disable the Font Library

### DIFF
--- a/src/wp-admin/font-library.php
+++ b/src/wp-admin/font-library.php
@@ -10,6 +10,14 @@
 /** WordPress Administration Bootstrap */
 require_once __DIR__ . '/admin.php';
 
+if ( ! wp_is_font_library_enabled() ) {
+	wp_die(
+		'<h1>' . __( 'Font Library is not available.' ) . '</h1>' .
+		'<p>' . __( 'The Font Library has been disabled on this site.' ) . '</p>',
+		403
+	);
+}
+
 if ( ! current_user_can( 'edit_theme_options' ) ) {
 	wp_die(
 		'<h1>' . __( 'You need a higher level of permission.' ) . '</h1>' .

--- a/src/wp-admin/menu.php
+++ b/src/wp-admin/menu.php
@@ -237,7 +237,9 @@ if ( wp_is_block_theme() ) {
 }
 
 // Font Library menu item.
-$submenu['themes.php'][9] = array( __( 'Fonts' ), 'edit_theme_options', 'font-library.php' );
+if ( wp_is_font_library_enabled() ) {
+	$submenu['themes.php'][9] = array( __( 'Fonts' ), 'edit_theme_options', 'font-library.php' );
+}
 
 $customize_url = add_query_arg( 'return', urlencode( remove_query_arg( wp_removable_query_args(), wp_unslash( $_SERVER['REQUEST_URI'] ) ) ), 'customize.php' );
 

--- a/src/wp-includes/fonts.php
+++ b/src/wp-includes/fonts.php
@@ -110,6 +110,30 @@ function wp_unregister_font_collection( string $slug ) {
 }
 
 /**
+ * Determines whether the Font Library is enabled.
+ *
+ * The Font Library lets users with the `edit_theme_options` capability install
+ * and manage fonts from the admin interface. Returning false from the
+ * {@see 'wp_is_font_library_enabled'} filter removes the Font Library admin
+ * menu item and screen, which is useful for sites where fonts are managed by
+ * the theme and the feature is not needed in the interface.
+ *
+ * @since 7.1.0
+ *
+ * @return bool True if the Font Library is enabled, false otherwise.
+ */
+function wp_is_font_library_enabled() {
+	/**
+	 * Filters whether the Font Library is enabled.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param bool $enabled Whether the Font Library is enabled. Default true.
+	 */
+	return (bool) apply_filters( 'wp_is_font_library_enabled', true );
+}
+
+/**
  * Retrieves font uploads directory information.
  *
  * Same as wp_font_dir() but "light weight" as it doesn't attempt to create the font uploads directory.

--- a/tests/phpunit/tests/fonts/font-library/wpIsFontLibraryEnabled.php
+++ b/tests/phpunit/tests/fonts/font-library/wpIsFontLibraryEnabled.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Test wp_is_font_library_enabled().
+ *
+ * @package WordPress
+ * @subpackage Font Library
+ *
+ * @group fonts
+ * @group font-library
+ *
+ * @covers ::wp_is_font_library_enabled
+ */
+class Tests_Fonts_WpIsFontLibraryEnabled extends WP_UnitTestCase {
+
+	/**
+	 * @ticket 65550
+	 */
+	public function test_is_enabled_by_default() {
+		$this->assertTrue( wp_is_font_library_enabled() );
+	}
+
+	/**
+	 * @ticket 65550
+	 */
+	public function test_can_be_disabled_via_filter() {
+		add_filter( 'wp_is_font_library_enabled', '__return_false' );
+
+		$this->assertFalse( wp_is_font_library_enabled() );
+	}
+
+	/**
+	 * @ticket 65550
+	 */
+	public function test_filtered_value_is_cast_to_boolean() {
+		add_filter( 'wp_is_font_library_enabled', '__return_zero' );
+
+		$this->assertFalse( wp_is_font_library_enabled() );
+	}
+}


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

Adds a developer hook to disable the Font Library, allowing sites to remove the feature from the admin interface. Useful for sites where fonts are managed by the theme and the ability to install fonts from the UI is not needed.

What the problem was:
- The Font Library (admin menu item + standalone admin screen, new in 7.0) is only gated by the `edit_theme_options` capability, which is shared with many unrelated features and cannot be repurposed to switch the feature off.
- There was no way for a developer to remove the Font Library from the interface for managers who hold admin rights but should not install fonts.

What the fix does:
- Introduces `wp_is_font_library_enabled()` and the `wp_is_font_library_enabled` filter (default `true`).
- When the filter returns `false`, the "Fonts" admin submenu item is not registered and the Font Library admin screen (`font-library.php`) returns a 403.
- Adds unit tests covering the default value, disabling via filter, and boolean casting of the filtered value.

Trac ticket: https://core.trac.wordpress.org/ticket/65550

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 4.8
Used for: Ticket analysis and tests cases. All changes were reviewed, validated against the codebase, and are taken responsibility for by me.
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
