### PR TITLE
Improve custom fields editing flow

### DIFF
--- a/src/js/_enqueues/admin/post.js
+++ b/src/js/_enqueues/admin/post.js
@@ -689,7 +689,126 @@ jQuery( function($) {
 
 	// Custom Fields postbox.
 	if ( $('#postcustom').length ) {
-		$( '#the-list' ).wpList( {
+		var $postCustom = $( '#postcustom' ),
+			$newMeta = $postCustom.find( '#newmeta' ),
+			$addCustomFieldButton = $postCustom.find( '#add-custom-field-button' ),
+			$addCustomFieldHeading = $postCustom.find( '.custom-field-add-heading' ),
+			$addCustomFieldSubmit = $postCustom.find( '#postcustomstuff .add-custom-field' ),
+			$cancelNewMetaButton = $postCustom.find( '#newmeta-cancel' ),
+			$customFieldsNotice = $postCustom.find( '.custom-fields-notice' ),
+			$customFieldsNoticeMessage,
+			$enterNewMetaButton = $postCustom.find( '#newmeta-button' ),
+			$listTable = $postCustom.find( '#list-table' ),
+			$metaKeyInput = $postCustom.find( '#metakeyinput' ),
+			$metaKeySelect = $postCustom.find( '#metakeyselect' ),
+			$metaValue = $postCustom.find( '#metavalue' ),
+			clearNewMeta,
+			hideNewMeta,
+			resetMetaKeyInput,
+			showCustomFieldsNotice,
+			showMetaKeyInput,
+			showNewMeta;
+
+		if ( ! $customFieldsNotice.length ) {
+			$customFieldsNotice = $( '<div class="custom-fields-notice notice notice-success is-dismissible hidden"><p></p><button type="button" class="notice-dismiss"><span class="screen-reader-text"></span></button></div>' );
+			$customFieldsNotice.find( '.screen-reader-text' ).text( __( 'Dismiss this notice.' ) );
+			$postCustom.find( '#postcustomstuff' ).before( $customFieldsNotice );
+		}
+
+		$customFieldsNoticeMessage = $customFieldsNotice.find( 'p' );
+
+		showCustomFieldsNotice = function( message ) {
+			if ( ! $customFieldsNotice.length ) {
+				return;
+			}
+
+			$customFieldsNoticeMessage.text( message );
+			$customFieldsNotice.removeClass( 'hidden' );
+
+			wp.a11y.speak( message );
+		};
+
+		resetMetaKeyInput = function() {
+			if ( $metaKeySelect.length ) {
+				$metaKeySelect.prop( 'selectedIndex', 0 ).removeClass( 'hidden' );
+				$metaKeyInput.val( '' ).addClass( 'hidden' );
+				$postCustom.find( '#enternew' ).removeClass( 'hidden' );
+				$postCustom.find( '#cancelnew' ).addClass( 'hidden' );
+			}
+		};
+
+		showMetaKeyInput = function() {
+			$metaKeySelect.addClass( 'hidden' );
+			$metaKeyInput.removeClass( 'hidden' );
+			$postCustom.find( '#enternew' ).addClass( 'hidden' );
+			$postCustom.find( '#cancelnew' ).removeClass( 'hidden' );
+			$metaKeyInput.trigger( 'focus' );
+		};
+
+		clearNewMeta = function() {
+			$metaValue.val( '' );
+			resetMetaKeyInput();
+
+			if ( ! $metaKeySelect.length ) {
+				$metaKeyInput.val( '' );
+			}
+		};
+
+		showNewMeta = function( shouldFocus ) {
+			$newMeta.addClass( 'is-visible' ).show();
+			$addCustomFieldHeading.addClass( 'is-visible' );
+			$addCustomFieldSubmit.addClass( 'is-visible' );
+			$addCustomFieldButton.attr( 'aria-expanded', 'true' );
+
+			if ( false !== shouldFocus ) {
+				( $metaKeySelect.is( ':visible' ) ? $metaKeySelect : $metaKeyInput ).trigger( 'focus' );
+			}
+		};
+
+		hideNewMeta = function( shouldFocus ) {
+			clearNewMeta();
+			$newMeta.removeClass( 'is-visible' ).hide();
+			$addCustomFieldHeading.removeClass( 'is-visible' );
+			$addCustomFieldSubmit.removeClass( 'is-visible' );
+			$addCustomFieldButton.attr( 'aria-expanded', 'false' );
+
+			if ( false !== shouldFocus ) {
+				$addCustomFieldButton.trigger( 'focus' );
+			}
+		};
+
+		$addCustomFieldButton.on( 'click', function( event ) {
+			event.preventDefault();
+			showNewMeta();
+		} );
+
+		$enterNewMetaButton.on( 'click', function( event ) {
+			event.preventDefault();
+
+			if ( $metaKeyInput.hasClass( 'hidden' ) ) {
+				showMetaKeyInput();
+			} else {
+				resetMetaKeyInput();
+				$metaKeySelect.trigger( 'focus' );
+			}
+		} );
+
+		$cancelNewMetaButton.on( 'click', function( event ) {
+			event.preventDefault();
+			hideNewMeta();
+		} );
+
+		$customFieldsNotice.on( 'click', '.notice-dismiss', function() {
+			$customFieldsNotice.addClass( 'hidden' );
+		} );
+
+		if ( $listTable.hasClass( 'is-empty' ) ) {
+			showNewMeta( false );
+		}
+
+		$postCustom.find( '#the-list' ).wpList( {
+			addColor: 'none',
+			delColor: 'none',
 			/**
 			 * Add current post_ID to request to fetch custom fields
 			 *
@@ -700,7 +819,7 @@ jQuery( function($) {
 			 * @return {Object} Data modified with post_ID attached.
 			 */
 			addBefore: function( s ) {
-				s.data += '&post_id=' + $('#post_ID').val();
+				s.data += '&post_id=' + $( '#post_ID' ).val();
 				return s;
 			},
 			/**
@@ -708,8 +827,31 @@ jQuery( function($) {
 			 *
 			 * @ignore
 			 */
-			addAfter: function() {
-				$('table#list-table').show();
+			addAfter: function( returnedResponse, settings ) {
+				var message = 'newmeta' === settings.element ? __( 'Custom field added.' ) : __( 'Custom field updated.' );
+
+				if ( true === settings.parsed || ! settings.parsed || settings.parsed.errors ) {
+					return;
+				}
+
+				$listTable.removeClass( 'is-empty' ).addClass( 'has-fields' ).show();
+				showCustomFieldsNotice( message );
+
+				if ( 'newmeta' === settings.element ) {
+					hideNewMeta();
+				}
+			},
+			delAfter: function( returnedResponse, settings ) {
+				if ( ! settings.parsed || settings.parsed.errors ) {
+					return;
+				}
+
+				$postCustom.find( '#' + settings.element ).remove();
+				showCustomFieldsNotice( __( 'Custom field deleted.' ) );
+
+				if ( ! $postCustom.find( '#the-list tr.is-saved' ).length ) {
+					$listTable.removeClass( 'has-fields' ).addClass( 'is-empty' ).hide();
+				}
 			}
 		});
 	}

--- a/src/wp-admin/css/edit.css
+++ b/src/wp-admin/css/edit.css
@@ -1085,34 +1085,19 @@ form#tags-filter {
   11.1 - Custom Fields
 ------------------------------------------------------------------------------*/
 
+#postcustom .inside {
+	margin-top: 0;
+	padding: 12px;
+}
+
+.block-editor-page .edit-post-meta-boxes-area #postcustom .inside {
+	padding-right: 24px;
+	padding-left: 24px;
+}
+
 #postcustomstuff thead th {
 	padding: 5px 8px 8px;
 	background-color: #f0f0f1;
-}
-
-#postcustom #postcustomstuff .submit {
-	border: 0 none;
-	float: none;
-	padding: 0 8px 8px;
-}
-
-#postcustom #postcustomstuff .add-custom-field {
-	padding: 12px 8px 8px;
-}
-
-#side-sortables #postcustom #postcustomstuff .submit {
-	margin: 0;
-	padding: 0;
-}
-
-#side-sortables #postcustom #postcustomstuff #the-list textarea {
-	height: 85px;
-}
-
-#side-sortables #postcustom #postcustomstuff td.left input,
-#side-sortables #postcustom #postcustomstuff td.left select,
-#side-sortables #postcustomstuff #newmetaleft a {
-	margin: 3px 3px 0;
 }
 
 #postcustomstuff table {
@@ -1127,38 +1112,193 @@ form#tags-filter {
 	vertical-align: top;
 }
 
-#postcustomstuff table input,
-#postcustomstuff table select,
-#postcustomstuff table textarea {
-	width: 96%;
-	margin: 8px;
+#postcustomstuff #list-table,
+#postcustomstuff #newmeta {
+	border: 0;
+	border-spacing: 0;
+	background: transparent;
 }
 
-#side-sortables #postcustomstuff table input,
-#side-sortables #postcustomstuff table select,
-#side-sortables #postcustomstuff table textarea {
-	margin: 3px;
+#postcustomstuff #list-table tbody,
+#postcustomstuff #newmeta tbody {
+	display: block;
+}
+
+#postcustomstuff #list-table thead,
+#postcustomstuff #newmeta thead {
+	display: none;
+}
+
+#postcustomstuff .custom-field-add-heading {
+	margin: 0 0 8px;
+}
+
+.js #postcustomstuff .custom-field-add-heading {
+	display: none;
+}
+
+.js #postcustomstuff .custom-field-add-heading.is-visible {
+	display: block;
+}
+
+#postcustomstuff #list-table.has-fields ~ .custom-field-add-heading.is-visible {
+	padding-top: 16px;
+	border-top: 1px solid #dcdcde;
+}
+
+#postcustomstuff .custom-field-row,
+#postcustomstuff #newmeta tbody tr {
+	display: grid;
+	gap: 8px 12px;
+	padding: 0;
+	border-bottom: 1px solid #dcdcde;
+	background: transparent;
+}
+
+#postcustomstuff .custom-field-row {
+	grid-template-columns: minmax(160px, 24%) minmax(0, 1fr) auto;
+}
+
+#postcustomstuff #newmeta tbody tr {
+	grid-template-columns: minmax(160px, 24%) minmax(0, 1fr) auto;
+}
+
+#postcustomstuff .custom-field-row.is-saved {
+	padding: 0 0 16px;
+	border-bottom: 0;
+}
+
+#postcustom .custom-fields-notice {
+	margin: 0 0 12px;
+}
+
+#postcustom .custom-fields-notice p {
+	margin: 0.5em 0;
+}
+
+#postcustomstuff #newmeta {
+	border-bottom: 0;
+}
+
+#postcustomstuff #newmeta tbody tr {
+	border-bottom: 0;
+}
+
+#postcustomstuff #list-table.has-fields ~ #newmeta.is-visible tbody tr {
+	padding-top: 0;
+}
+
+.js #postcustomstuff #newmeta {
+	display: none;
+}
+
+.js #postcustomstuff #newmeta.is-visible {
+	display: table;
+}
+
+#postcustomstuff .custom-field-row td,
+#postcustomstuff #newmeta td {
+	display: block;
+	padding: 0;
+}
+
+#postcustomstuff .custom-field-label {
+	display: block;
+	margin: 0;
+	padding: 2px 0;
+}
+
+#postcustomstuff .custom-field-key,
+#postcustomstuff .custom-field-value-field {
+	display: block;
+	box-sizing: border-box;
+	width: 100%;
+	max-width: none;
+	margin: 0;
+}
+
+#postcustomstuff .custom-field-value-field {
+	min-height: 40px;
+}
+
+#postcustomstuff .custom-field-key.hidden {
+	display: none;
 }
 
 #postcustomstuff th.left,
 #postcustomstuff td.left {
-	width: 38%;
+	width: auto;
 }
 
-#postcustomstuff .submit input {
+#postcustomstuff .custom-field-actions,
+#postcustom #postcustomstuff .submit {
+	margin: 8px 0 0;
+	padding: 0;
+	border: 0;
+	float: none;
+}
+
+#postcustom #postcustomstuff .custom-field-row .custom-field-actions {
+	display: flex;
+	gap: 16px;
+	align-items: center;
+	align-self: start;
+	justify-content: flex-end;
+	margin: 0;
+	padding-top: 22px;
+	padding-right: 4px;
+	white-space: nowrap;
+}
+
+#postcustomstuff .custom-field-actions button,
+#postcustomstuff .custom-field-actions input {
 	margin: 0;
 	width: auto;
 }
 
-#postcustomstuff #newmetaleft a,
-#postcustomstuff #newmeta-button {
+#postcustomstuff .custom-field-enter-new {
 	display: inline-block;
-	margin: 0 8px 8px;
-	text-decoration: none;
+	margin-top: 8px;
+}
+
+#postcustomstuff .custom-field-enter-new.hidden {
+	display: none;
+}
+
+#postcustom #postcustomstuff .add-custom-field {
+	display: flex;
+}
+
+.js #postcustom #postcustomstuff .add-custom-field {
+	display: none;
+}
+
+.js #postcustom #postcustomstuff .add-custom-field.is-visible {
+	display: flex;
+}
+
+#postcustomstuff .custom-field-add-toggle {
+	margin: 0;
+}
+
+.js #postcustomstuff .custom-field-add-toggle[aria-expanded="true"] {
+	display: none;
 }
 
 .no-js #postcustomstuff #enternew {
 	display: none;
+}
+
+#side-sortables #postcustomstuff .custom-field-row,
+#side-sortables #postcustomstuff #newmeta tbody tr {
+	grid-template-columns: 1fr;
+}
+
+@media screen and (max-width: 782px) {
+	#postcustomstuff .custom-field-row,
+	#postcustomstuff #newmeta tbody tr {
+		grid-template-columns: 1fr;
+	}
 }
 
 #post-body-content .compat-attachment-fields {

--- a/src/wp-admin/includes/meta-boxes.php
+++ b/src/wp-admin/includes/meta-boxes.php
@@ -812,6 +812,12 @@ function post_trackback_meta_box( $post ) {
  */
 function post_custom_meta_box( $post ) {
 	?>
+<div id="custom-fields-notice" class="custom-fields-notice notice notice-success is-dismissible hidden">
+	<p></p>
+	<button type="button" class="notice-dismiss">
+		<span class="screen-reader-text"><?php _e( 'Dismiss this notice.' ); ?></span>
+	</button>
+</div>
 <div id="postcustomstuff">
 <div id="ajax-response"></div>
 	<?php

--- a/src/wp-admin/includes/post.php
+++ b/src/wp-admin/includes/post.php
@@ -2461,17 +2461,175 @@ function the_block_editor_meta_boxes() {
 	$enable_custom_fields = (bool) get_user_meta( get_current_user_id(), 'enable_custom_fields', true );
 
 	if ( $enable_custom_fields ) {
-		$script = "( function( $ ) {
-			if ( $('#postcustom').length ) {
-				$( '#the-list' ).wpList( {
+		$custom_field_added   = esc_js( __( 'Custom field added.' ) );
+		$custom_field_updated = esc_js( __( 'Custom field updated.' ) );
+		$custom_field_deleted = esc_js( __( 'Custom field deleted.' ) );
+		$dismiss_notice       = esc_js( __( 'Dismiss this notice.' ) );
+		$script               = "( function( $ ) {
+			function initializeCustomFields() {
+				var \$postCustom = $( '#postcustom' ).filter( ':visible' ).last();
+
+				if ( ! \$postCustom.length || \$postCustom.data( 'custom-fields-initialized' ) ) {
+					return;
+				}
+
+				\$postCustom.data( 'custom-fields-initialized', true );
+
+				var
+					\$newMeta = \$postCustom.find( '#newmeta' ),
+					\$addCustomFieldButton = \$postCustom.find( '#add-custom-field-button' ),
+					\$addCustomFieldHeading = \$postCustom.find( '.custom-field-add-heading' ),
+					\$addCustomFieldSubmit = \$postCustom.find( '#postcustomstuff .add-custom-field' ),
+					\$cancelNewMetaButton = \$postCustom.find( '#newmeta-cancel' ),
+					\$customFieldsNotice = \$postCustom.find( '.custom-fields-notice' ),
+					\$customFieldsNoticeMessage,
+					\$enterNewMetaButton = \$postCustom.find( '#newmeta-button' ),
+					\$listTable = \$postCustom.find( '#list-table' ),
+					\$metaKeyInput = \$postCustom.find( '#metakeyinput' ),
+					\$metaKeySelect = \$postCustom.find( '#metakeyselect' ),
+					\$metaValue = \$postCustom.find( '#metavalue' );
+
+				if ( ! \$customFieldsNotice.length ) {
+					\$customFieldsNotice = $( '<div class=\"custom-fields-notice notice notice-success is-dismissible hidden\"><p></p><button type=\"button\" class=\"notice-dismiss\"><span class=\"screen-reader-text\"></span></button></div>' );
+					\$customFieldsNotice.find( '.screen-reader-text' ).text( '{$dismiss_notice}' );
+					\$postCustom.find( '#postcustomstuff' ).before( \$customFieldsNotice );
+				}
+
+				\$customFieldsNoticeMessage = \$customFieldsNotice.find( 'p' );
+
+				function showCustomFieldsNotice( message ) {
+					if ( ! \$customFieldsNotice.length ) {
+						return;
+					}
+
+					\$customFieldsNoticeMessage.text( message );
+					\$customFieldsNotice.removeClass( 'hidden' );
+
+					wp.a11y.speak( message );
+				}
+
+				function resetMetaKeyInput() {
+					if ( \$metaKeySelect.length ) {
+						\$metaKeySelect.prop( 'selectedIndex', 0 ).removeClass( 'hidden' );
+						\$metaKeyInput.val( '' ).addClass( 'hidden' );
+						\$postCustom.find( '#enternew' ).removeClass( 'hidden' );
+						\$postCustom.find( '#cancelnew' ).addClass( 'hidden' );
+					}
+				}
+
+				function showMetaKeyInput() {
+					\$metaKeySelect.addClass( 'hidden' );
+					\$metaKeyInput.removeClass( 'hidden' );
+					\$postCustom.find( '#enternew' ).addClass( 'hidden' );
+					\$postCustom.find( '#cancelnew' ).removeClass( 'hidden' );
+					\$metaKeyInput.trigger( 'focus' );
+				}
+
+				function clearNewMeta() {
+					\$metaValue.val( '' );
+					resetMetaKeyInput();
+
+					if ( ! \$metaKeySelect.length ) {
+						\$metaKeyInput.val( '' );
+					}
+				}
+
+				function showNewMeta( shouldFocus ) {
+					\$newMeta.addClass( 'is-visible' ).show();
+					\$addCustomFieldHeading.addClass( 'is-visible' );
+					\$addCustomFieldSubmit.addClass( 'is-visible' );
+					\$addCustomFieldButton.attr( 'aria-expanded', 'true' );
+
+					if ( false !== shouldFocus ) {
+						( \$metaKeySelect.is( ':visible' ) ? \$metaKeySelect : \$metaKeyInput ).trigger( 'focus' );
+					}
+				}
+
+				function hideNewMeta( shouldFocus ) {
+					clearNewMeta();
+					\$newMeta.removeClass( 'is-visible' ).hide();
+					\$addCustomFieldHeading.removeClass( 'is-visible' );
+					\$addCustomFieldSubmit.removeClass( 'is-visible' );
+					\$addCustomFieldButton.attr( 'aria-expanded', 'false' );
+
+					if ( false !== shouldFocus ) {
+						\$addCustomFieldButton.trigger( 'focus' );
+					}
+				}
+
+				\$addCustomFieldButton.on( 'click', function( event ) {
+					event.preventDefault();
+					showNewMeta();
+				} );
+
+				\$enterNewMetaButton.on( 'click', function( event ) {
+					event.preventDefault();
+
+					if ( \$metaKeyInput.hasClass( 'hidden' ) ) {
+						showMetaKeyInput();
+					} else {
+						resetMetaKeyInput();
+						\$metaKeySelect.trigger( 'focus' );
+					}
+				} );
+
+				\$cancelNewMetaButton.on( 'click', function( event ) {
+					event.preventDefault();
+					hideNewMeta();
+				} );
+
+				\$customFieldsNotice.on( 'click', '.notice-dismiss', function() {
+					\$customFieldsNotice.addClass( 'hidden' );
+				} );
+
+				if ( \$listTable.hasClass( 'is-empty' ) ) {
+					showNewMeta( false );
+				}
+
+				\$postCustom.find( '#the-list' ).wpList( {
+					addColor: 'none',
+					delColor: 'none',
 					addBefore: function( s ) {
 						s.data += '&post_id=$post->ID';
 						return s;
 					},
-					addAfter: function() {
-						$('table#list-table').show();
+					addAfter: function( returnedResponse, settings ) {
+						var message = 'newmeta' === settings.element ? '$custom_field_added' : '$custom_field_updated';
+
+						if ( true === settings.parsed || ! settings.parsed || settings.parsed.errors ) {
+							return;
+						}
+
+						\$listTable.removeClass( 'is-empty' ).addClass( 'has-fields' ).show();
+						showCustomFieldsNotice( message );
+
+						if ( 'newmeta' === settings.element ) {
+							hideNewMeta();
+						}
+					},
+					delAfter: function( returnedResponse, settings ) {
+						if ( ! settings.parsed || settings.parsed.errors ) {
+							return;
+						}
+
+						\$postCustom.find( '#' + settings.element ).remove();
+						showCustomFieldsNotice( '$custom_field_deleted' );
+
+						if ( ! \$postCustom.find( '#the-list tr.is-saved' ).length ) {
+							\$listTable.removeClass( 'has-fields' ).addClass( 'is-empty' ).hide();
+						}
 					}
 				});
+			}
+
+			initializeCustomFields();
+			$( initializeCustomFields );
+
+			if ( window.MutationObserver ) {
+				new window.MutationObserver( initializeCustomFields ).observe( document.body, {
+					childList: true,
+					subtree: true
+				} );
 			}
 		} )( jQuery );";
 		wp_enqueue_script( 'wp-lists' );

--- a/src/wp-admin/includes/template.php
+++ b/src/wp-admin/includes/template.php
@@ -586,7 +586,7 @@ function list_meta( $meta ) {
 	// Exit if no meta.
 	if ( ! $meta ) {
 		echo '
-<table id="list-table" style="display: none;">
+<table id="list-table" class="custom-fields-list is-empty" style="display: none;">
 	<thead>
 	<tr>
 		<th class="left">' . _x( 'Name', 'meta name' ) . '</th>
@@ -601,7 +601,7 @@ function list_meta( $meta ) {
 	}
 	$count = 0;
 	?>
-<table id="list-table">
+<table id="list-table" class="custom-fields-list has-fields">
 	<thead>
 	<tr>
 		<th class="left"><?php _ex( 'Name', 'meta name' ); ?></th>
@@ -659,24 +659,21 @@ function _list_meta_row( $entry, &$count ) {
 
 	$delete_nonce = wp_create_nonce( 'delete-meta_' . $entry['meta_id'] );
 
-	$r .= "\n\t<tr id='meta-{$entry['meta_id']}'>";
-	$r .= "\n\t\t<td class='left'><label class='screen-reader-text' for='meta-{$entry['meta_id']}-key'>" .
-		/* translators: Hidden accessibility text. */
-		__( 'Key' ) .
-	"</label><input name='meta[{$entry['meta_id']}][key]' id='meta-{$entry['meta_id']}-key' type='text' size='20' value='{$entry['meta_key']}' />";
+	$r .= "\n\t<tr id='meta-{$entry['meta_id']}' class='custom-field-row is-saved'>";
+	$r .= "\n\t\t<td class='left custom-field-name'><label class='custom-field-label' for='meta-{$entry['meta_id']}-key'>" .
+		_x( 'Name', 'meta name' ) .
+	"</label><input class='custom-field-key regular-text' name='meta[{$entry['meta_id']}][key]' id='meta-{$entry['meta_id']}-key' type='text' size='20' value='{$entry['meta_key']}' /></td>";
 
-	$r .= "\n\t\t<div class='submit'>";
-	$r .= get_submit_button( __( 'Delete' ), 'deletemeta small', "deletemeta[{$entry['meta_id']}]", false, array( 'data-wp-lists' => "delete:the-list:meta-{$entry['meta_id']}::_ajax_nonce=$delete_nonce" ) );
-	$r .= "\n\t\t";
-	$r .= get_submit_button( __( 'Update' ), 'updatemeta small', "meta-{$entry['meta_id']}-submit", false, array( 'data-wp-lists' => "add:the-list:meta-{$entry['meta_id']}::_ajax_nonce-add-meta=$update_nonce" ) );
-	$r .= '</div>';
-	$r .= wp_nonce_field( 'change-meta', '_ajax_nonce', false, false );
+	$r .= "\n\t\t<td class='custom-field-value'><label class='custom-field-label' for='meta-{$entry['meta_id']}-value'>" .
+		__( 'Value' ) .
+	"</label><textarea class='custom-field-value-field large-text' name='meta[{$entry['meta_id']}][value]' id='meta-{$entry['meta_id']}-value' rows='1' cols='30'>{$entry['meta_value']}</textarea>";
 	$r .= '</td>';
 
-	$r .= "\n\t\t<td><label class='screen-reader-text' for='meta-{$entry['meta_id']}-value'>" .
-		/* translators: Hidden accessibility text. */
-		__( 'Value' ) .
-	"</label><textarea name='meta[{$entry['meta_id']}][value]' id='meta-{$entry['meta_id']}-value' rows='2' cols='30'>{$entry['meta_value']}</textarea></td>\n\t</tr>";
+	$r .= "\n\t\t<td class='submit custom-field-actions'>";
+	$r .= '<button type="submit" name="meta-' . $entry['meta_id'] . '-submit" id="meta-' . $entry['meta_id'] . '-submit" class="button button-secondary updatemeta custom-field-update" data-wp-lists="add:the-list:meta-' . $entry['meta_id'] . '::_ajax_nonce-add-meta=' . esc_attr( $update_nonce ) . '">' . esc_html__( 'Update' ) . '</button>';
+	$r .= '<button type="submit" name="deletemeta[' . $entry['meta_id'] . ']" id="deletemeta[' . $entry['meta_id'] . ']" class="button-link button-link-delete deletemeta custom-field-delete" value="' . esc_attr__( 'Delete' ) . '" data-wp-lists="delete:the-list:meta-' . $entry['meta_id'] . '::_ajax_nonce=' . esc_attr( $delete_nonce ) . '">' . esc_html__( 'Delete' ) . '</button>';
+	$r .= wp_nonce_field( 'change-meta', '_ajax_nonce', false, false );
+	$r .= '</td>' . "\n\t</tr>";
 	return $r;
 }
 
@@ -735,20 +732,21 @@ function meta_form( $post = null ) {
 		natcasesort( $keys );
 	}
 	?>
-<p><strong><?php _e( 'Add Custom Field:' ); ?></strong></p>
-<table id="newmeta">
+<p class="custom-field-add-heading"><strong><?php _e( 'Add new custom field' ); ?></strong></p>
+<table id="newmeta" class="custom-field-row is-new">
 <thead>
 <tr>
-<th class="left"><label for="metakeyselect"><?php _ex( 'Name', 'meta name' ); ?></label></th>
-<th><label for="metavalue"><?php _e( 'Value' ); ?></label></th>
+<th class="left"><?php _ex( 'Name', 'meta name' ); ?></th>
+<th><?php _e( 'Value' ); ?></th>
 </tr>
 </thead>
 
 <tbody>
 <tr>
-<td id="newmetaleft" class="left">
+<td id="newmetaleft" class="left custom-field-name">
+<label class="custom-field-label" for="<?php echo $keys ? 'metakeyselect' : 'metakeyinput'; ?>"><?php _ex( 'Name', 'meta name' ); ?></label>
 	<?php if ( $keys ) { ?>
-<select id="metakeyselect" name="metakeyselect">
+<select id="metakeyselect" class="custom-field-key regular-text" name="metakeyselect">
 <option value="#NONE#"><?php _e( '&mdash; Select &mdash;' ); ?></option>
 		<?php
 		foreach ( $keys as $key ) {
@@ -759,25 +757,21 @@ function meta_form( $post = null ) {
 		}
 		?>
 </select>
-<input class="hidden" type="text" id="metakeyinput" name="metakeyinput" value="" aria-label="<?php _e( 'New custom field name' ); ?>" />
-<button type="button" id="newmeta-button" class="button button-small hide-if-no-js" onclick="jQuery('#metakeyinput, #metakeyselect, #enternew, #cancelnew').toggleClass('hidden');jQuery('#metakeyinput, #metakeyselect').filter(':visible').trigger('focus');">
-<span id="enternew"><?php _e( 'Enter new' ); ?></span>
-<span id="cancelnew" class="hidden"><?php _e( 'Cancel' ); ?></span></button>
+<input class="hidden custom-field-key regular-text" type="text" id="metakeyinput" name="metakeyinput" value="" aria-label="<?php esc_attr_e( 'New custom field name' ); ?>" />
+	<button type="button" id="newmeta-button" class="button-link custom-field-enter-new hide-if-no-js">
+	<span id="enternew"><?php _e( 'Enter new' ); ?></span><span id="cancelnew" class="hidden"><?php _e( 'Use existing' ); ?></span></button>
 <?php } else { ?>
-<input type="text" id="metakeyinput" name="metakeyinput" value="" />
+<input class="custom-field-key regular-text" type="text" id="metakeyinput" name="metakeyinput" value="" />
 <?php } ?>
 </td>
-<td><textarea id="metavalue" name="metavalue" rows="2" cols="25"></textarea>
+<td class="custom-field-value"><label class="custom-field-label" for="metavalue"><?php _e( 'Value' ); ?></label><textarea id="metavalue" class="custom-field-value-field large-text" name="metavalue" rows="1" cols="25"></textarea>
 	<?php wp_nonce_field( 'add-meta', '_ajax_nonce-add-meta', false ); ?>
 </td>
-</tr>
-</tbody>
-</table>
-<div class="submit add-custom-field">
+<td class="submit add-custom-field custom-field-actions">
 	<?php
 	submit_button(
-		__( 'Add Custom Field' ),
-		'',
+		__( 'Save' ),
+		'primary',
 		'addmeta',
 		false,
 		array(
@@ -786,7 +780,14 @@ function meta_form( $post = null ) {
 		)
 	);
 	?>
-</div>
+	<button type="button" id="newmeta-cancel" class="button-link custom-field-cancel hide-if-no-js"><?php _e( 'Cancel' ); ?></button>
+</td>
+</tr>
+</tbody>
+</table>
+<button type="button" id="add-custom-field-button" class="button button-secondary custom-field-add-toggle hide-if-no-js" aria-expanded="false" aria-controls="newmeta">
+	<?php _e( 'Add new custom field' ); ?>
+</button>
 	<?php
 }
 

--- a/tests/phpunit/tests/admin/includesTemplate.php
+++ b/tests/phpunit/tests/admin/includesTemplate.php
@@ -168,6 +168,134 @@ class Tests_Admin_IncludesTemplate extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @covers ::_list_meta_row
+	 */
+	public function test_list_meta_row_outputs_modern_custom_field_controls() {
+		$count = 0;
+		$row   = _list_meta_row(
+			array(
+				'meta_id'    => 123,
+				'meta_key'   => 'event_location',
+				'meta_value' => 'Marnixstraat 234, Haarlem 3459RD, The Netherlands',
+			),
+			$count
+		);
+
+		$this->assertStringContainsString( "id='meta-123' class='custom-field-row is-saved'", $row );
+		$this->assertStringContainsString( "class='custom-field-label' for='meta-123-key'", $row );
+		$this->assertStringContainsString( '>Name</label>', $row );
+		$this->assertStringContainsString( "class='custom-field-key regular-text'", $row );
+		$this->assertStringContainsString( "class='custom-field-value-field large-text'", $row );
+		$this->assertStringContainsString( "rows='1'", $row );
+		$this->assertStringNotContainsString( 'regular-text code', $row );
+		$this->assertStringNotContainsString( 'large-text code', $row );
+		$this->assertStringContainsString( 'custom-field-delete', $row );
+		$this->assertStringContainsString( '>Delete</button>', $row );
+		$this->assertStringNotContainsString( 'dashicons-trash', $row );
+		$this->assertStringContainsString( 'custom-field-update', $row );
+		$this->assertStringContainsString( 'button button-secondary updatemeta custom-field-update', $row );
+	}
+
+	/**
+	 * @covers ::meta_form
+	 */
+	public function test_meta_form_outputs_collapsible_add_custom_field_controls() {
+		$post = self::factory()->post->create_and_get();
+
+		add_filter(
+			'postmeta_form_keys',
+			static function () {
+				return array( 'event_location' );
+			}
+		);
+
+		ob_start();
+		meta_form( $post );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'id="newmeta" class="custom-field-row is-new"', $output );
+		$this->assertStringContainsString( 'class="custom-field-label" for="metakeyselect"', $output );
+		$this->assertStringContainsString( 'class="custom-field-key regular-text"', $output );
+		$this->assertStringContainsString( 'class="hidden custom-field-key regular-text"', $output );
+		$this->assertStringContainsString( 'class="custom-field-value-field large-text"', $output );
+		$this->assertStringContainsString( 'rows="1"', $output );
+		$this->assertStringContainsString( 'id="newmeta-button"', $output );
+		$this->assertStringContainsString( 'id="enternew"', $output );
+		$this->assertStringContainsString( 'id="cancelnew"', $output );
+		$this->assertStringContainsString( 'Use existing', $output );
+		$this->assertStringContainsString( 'id="newmeta-cancel"', $output );
+		$this->assertStringContainsString( 'class="button-link custom-field-cancel hide-if-no-js"', $output );
+		$this->assertStringContainsString( 'class="button button-primary"', $output );
+		$this->assertStringNotContainsString( 'dashicons-no-alt', $output );
+		$this->assertStringContainsString( '<p class="custom-field-add-heading"><strong>Add new custom field</strong></p>', $output );
+		$this->assertStringContainsString( 'class="submit add-custom-field custom-field-actions"', $output );
+		$this->assertStringContainsString( 'Save', $output );
+		$this->assertStringNotContainsString( 'Save field', $output );
+		$this->assertStringContainsString( 'Cancel', $output );
+		$this->assertStringContainsString( 'id="add-custom-field-button" class="button button-secondary custom-field-add-toggle hide-if-no-js"', $output );
+		$this->assertStringContainsString( 'Add new custom field', $output );
+		$this->assertStringNotContainsString( 'dashicons-plus-alt2', $output );
+	}
+
+	/**
+	 * @covers ::post_custom_meta_box
+	 */
+	public function test_post_custom_meta_box_outputs_custom_fields_notice_before_fields() {
+		$post = self::factory()->post->create_and_get();
+
+		require_once ABSPATH . 'wp-admin/includes/meta-boxes.php';
+
+		wp_set_current_user( self::$editor_id );
+
+		ob_start();
+		post_custom_meta_box( $post );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'id="custom-fields-notice"', $output );
+		$this->assertStringContainsString( 'class="custom-fields-notice notice notice-success is-dismissible hidden"', $output );
+		$this->assertStringContainsString( 'class="screen-reader-text">Dismiss this notice.</span>', $output );
+		$this->assertLessThan(
+			strpos( $output, 'id="postcustomstuff"' ),
+			strpos( $output, 'id="custom-fields-notice"' )
+		);
+		$this->assertLessThan(
+			strpos( $output, 'id="list-table"' ),
+			strpos( $output, 'id="custom-fields-notice"' )
+		);
+	}
+
+	/**
+	 * @covers ::list_meta
+	 */
+	public function test_list_meta_outputs_empty_state_class_when_there_are_no_custom_fields() {
+		ob_start();
+		list_meta( array() );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'id="list-table" class="custom-fields-list is-empty"', $output );
+	}
+
+	/**
+	 * @covers ::list_meta
+	 */
+	public function test_list_meta_outputs_has_fields_class_when_there_are_custom_fields() {
+		ob_start();
+		list_meta(
+			array(
+				array(
+					'meta_id'    => 123,
+					'meta_key'   => 'event_location',
+					'meta_value' => 'Marnixstraat 234, Haarlem 3459RD, The Netherlands',
+				),
+			)
+		);
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'id="list-table" class="custom-fields-list has-fields"', $output );
+		$this->assertStringContainsString( "id='meta-123' class='custom-field-row is-saved'", $output );
+	}
+
+	/**
 	 * @ticket 50019
 	 */
 	public function test_add_meta_box_with_previously_removed_box_and_sorted_priority() {


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65553

## Summary
- Improves the Custom Fields meta box add/update/delete feedback flow.
- Adds an in-metabox success notice for AJAX add, update, and delete actions.
- Collapses the add-new custom field form when saved fields exist, while showing it by default when empty.
- Removes the yellow/red `wpList` highlight feedback for add/delete actions.
- Preserves the existing custom field names, IDs, nonces, and `data-wp-lists` behavior.

**Classic editor**
<img width="1297" height="1086" alt="Custom fields classic - before" src="https://github.com/user-attachments/assets/3e574031-fba7-4722-ab8f-6451b5f25a36" />
<img width="1138" height="2276" alt="Custom fields classic - after" src="https://github.com/user-attachments/assets/53068563-f7cb-4124-b28b-20531417b14d" />


**Gutenderg editor**
<img width="1638" height="1174" alt="Custom fields editor - before" src="https://github.com/user-attachments/assets/c9ac6c70-e9ff-4a39-b99d-3bbda7cab032" />
<img width="1641" height="1176" alt="Custom fields editor - after" src="https://github.com/user-attachments/assets/31bb9060-b22b-4924-9e0b-12095d306cf3" />


## Compatibility
This patch intentionally keeps the existing Custom Fields meta box and form submission contracts. The main compatibility surface is visual/layout CSS and additional progressive-enhancement JS.

The same behavior is initialized in both the classic editor and the block editor meta boxes area so the legacy Custom Fields meta box works consistently in both editing contexts.

## Testing
- Add a new custom field.
- Try saving without selecting or entering a field name.
- Update an existing custom field and refresh.
- Delete an existing custom field.
- Test in both the classic editor and the block editor meta boxes area.

## Local verification
- `npm run build:dev`
- `npx grunt jshint:core`
- `npm run test:php -- --filter Tests_Admin_IncludesTemplate::test_(list_meta_row_outputs_modern_custom_field_controls|meta_form_outputs_collapsible_add_custom_field_controls|post_custom_meta_box_outputs_custom_fields_notice_before_fields|list_meta_outputs_empty_state_class_when_there_are_no_custom_fields|list_meta_outputs_has_fields_class_when_there_are_custom_fields)`
- `git diff --check`

Note: PHPCS reports an existing warning in `src/wp-admin/includes/post.php:896` unrelated to this patch.