### PR TITLE
Add On This Day Query Loop variation

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -2695,6 +2695,125 @@ function wp_migrate_old_typography_shape( $metadata ) {
 }
 
 /**
+ * Builds the date query for the On This Day Query Loop variation.
+ *
+ * @since 7.1.0
+ *
+ * @param DateTimeInterface|null $date Optional. Date to build the clause for. Default current date.
+ * @return array Date query clause.
+ */
+function _wp_get_on_this_day_query_date_query( $date = null ) {
+	if ( null === $date ) {
+		$date = current_datetime();
+	}
+
+	$year       = (int) $date->format( 'Y' );
+	$month      = (int) $date->format( 'm' );
+	$day        = (int) $date->format( 'd' );
+	$day_clause = array(
+		'month' => $month,
+		'day'   => $day,
+	);
+
+	if ( 2 === $month && 28 === $day && ! $date->format( 'L' ) ) {
+		$day_clause = array(
+			'relation' => 'OR',
+			$day_clause,
+			array(
+				'month' => 2,
+				'day'   => 29,
+			),
+		);
+	}
+
+	return array(
+		'relation' => 'AND',
+		array(
+			'before' => array( 'year' => $year ),
+		),
+		$day_clause,
+	);
+}
+
+/**
+ * Applies the On This Day date query to an existing WP_Query argument array.
+ *
+ * @since 7.1.0
+ *
+ * @param array $query WP_Query arguments.
+ * @return array Filtered WP_Query arguments.
+ */
+function _wp_apply_on_this_day_query_args( $query ) {
+	$on_this_day_date_query = _wp_get_on_this_day_query_date_query();
+
+	if ( ! empty( $query['date_query'] ) ) {
+		$query['date_query'] = array(
+			'relation' => 'AND',
+			$query['date_query'],
+			$on_this_day_date_query,
+		);
+	} else {
+		$query['date_query'] = $on_this_day_date_query;
+	}
+
+	$query['post_status']         = 'publish';
+	$query['ignore_sticky_posts'] = true;
+
+	return $query;
+}
+
+/**
+ * Filters Query Loop block arguments for the On This Day variation.
+ *
+ * @since 7.1.0
+ *
+ * @param array    $query WP_Query arguments.
+ * @param WP_Block $block Block instance.
+ * @return array Filtered WP_Query arguments.
+ */
+function _wp_filter_on_this_day_query_loop_block_query_vars( $query, $block ) {
+	if ( empty( $block->context['query']['onThisDay'] ) ) {
+		return $query;
+	}
+
+	return _wp_apply_on_this_day_query_args( $query );
+}
+
+/**
+ * Filters REST API post query arguments for the On This Day Query Loop variation preview.
+ *
+ * @since 7.1.0
+ *
+ * @param array           $args    WP_Query arguments.
+ * @param WP_REST_Request $request Request object.
+ * @return array Filtered WP_Query arguments.
+ */
+function _wp_filter_on_this_day_rest_post_query( $args, $request ) {
+	if ( ! wp_validate_boolean( $request['onThisDay'] ?? false ) ) {
+		return $args;
+	}
+
+	return _wp_apply_on_this_day_query_args( $args );
+}
+
+/**
+ * Adds the On This Day query parameter to REST API post collection parameters.
+ *
+ * @since 7.1.0
+ *
+ * @param array $query_params JSON Schema-formatted collection parameters.
+ * @return array Filtered collection parameters.
+ */
+function _wp_register_on_this_day_rest_post_collection_param( $query_params ) {
+	$query_params['onThisDay'] = array(
+		'description' => __( 'Limit results to posts published on this calendar day in previous years.' ),
+		'type'        => 'boolean',
+	);
+
+	return $query_params;
+}
+
+/**
  * Helper function that constructs a WP_Query args array from
  * a `Query` block properties.
  *

--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -645,6 +645,10 @@ add_action( 'enqueue_block_editor_assets', 'wp_enqueue_block_editor_script_modul
 add_action( 'enqueue_block_editor_assets', 'wp_enqueue_global_styles_css_custom_properties' );
 add_action( 'enqueue_block_editor_assets', '_wp_enqueue_auto_register_blocks' );
 add_action( 'enqueue_block_editor_assets', 'wp_declare_classic_block_necessary' );
+add_action( 'enqueue_block_editor_assets', '_wp_enqueue_on_this_day_query_loop_variation' );
+add_filter( 'query_loop_block_query_vars', '_wp_filter_on_this_day_query_loop_block_query_vars', 10, 2 );
+add_filter( 'rest_post_query', '_wp_filter_on_this_day_rest_post_query', 10, 2 );
+add_filter( 'rest_post_collection_params', '_wp_register_on_this_day_rest_post_collection_param' );
 add_action( 'wp_print_scripts', 'wp_just_in_time_script_localization' );
 add_filter( 'print_scripts_array', 'wp_prototype_before_jquery' );
 add_action( 'customize_controls_print_styles', 'wp_resource_hints', 1 );

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2944,6 +2944,102 @@ function wp_enqueue_editor_format_library_assets() {
 }
 
 /**
+ * Enqueues the On This Day Query Loop variation in the block editor.
+ *
+ * @since 7.1.0
+ */
+function _wp_enqueue_on_this_day_query_loop_variation() {
+	$variation = array(
+		'name'            => 'core/on-this-day',
+		'title'           => __( 'On This Day' ),
+		'description'     => __( 'Display posts published on this calendar day in previous years.' ),
+		'icon'            => 'calendar',
+		'scope'           => array( 'inserter', 'transform' ),
+		'isActive'        => array( 'namespace' ),
+		'allowedControls' => array(
+			'perPage',
+			'offset',
+			'pages',
+			'order',
+			'sticky',
+			'taxQuery',
+			'author',
+			'search',
+			'parents',
+			'format',
+		),
+		'attributes'      => array(
+			'namespace' => 'core/on-this-day',
+			'query'     => array(
+				'perPage'   => 10,
+				'pages'     => 0,
+				'offset'    => 0,
+				'postType'  => 'post',
+				'order'     => 'desc',
+				'orderBy'   => 'date',
+				'author'    => '',
+				'search'    => '',
+				'exclude'   => array(),
+				'sticky'    => 'ignore',
+				'inherit'   => false,
+				'taxQuery'  => null,
+				'parents'   => array(),
+				'format'    => array(),
+				'onThisDay' => true,
+			),
+		),
+		'innerBlocks'     => array(
+			array(
+				'core/post-template',
+				array(),
+				array(
+					array(
+						'core/post-title',
+						array(
+							'isLink' => true,
+						),
+					),
+					array( 'core/post-date' ),
+					array( 'core/post-excerpt' ),
+				),
+			),
+			array(
+				'core/query-pagination',
+				array(),
+				array(
+					array( 'core/query-pagination-previous' ),
+					array( 'core/query-pagination-numbers' ),
+					array( 'core/query-pagination-next' ),
+				),
+			),
+			array(
+				'core/query-no-results',
+				array(),
+				array(
+					array(
+						'core/paragraph',
+						array(
+							'content' => __( 'No posts found from this day in previous years.' ),
+						),
+					),
+				),
+			),
+		),
+	);
+
+	wp_register_script( 'wp-on-this-day-query-loop-variation', false, array( 'wp-blocks' ), true, array( 'in_footer' => true ) );
+	wp_add_inline_script(
+		'wp-on-this-day-query-loop-variation',
+		sprintf(
+			'wp.blocks.registerBlockVariation( %s, %s );',
+			wp_json_encode( 'core/query', JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ),
+			wp_json_encode( $variation, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES )
+		)
+	);
+	wp_enqueue_script( 'wp-on-this-day-query-loop-variation' );
+}
+
+/**
  * Formats `<script>` loader tags.
  *
  * It is possible to inject attributes in the `<script>` tag via the {@see 'wp_script_attributes'} filter.

--- a/tests/phpunit/tests/blocks/wpBlock.php
+++ b/tests/phpunit/tests/blocks/wpBlock.php
@@ -1402,6 +1402,122 @@ HTML
 		);
 	}
 
+	public function test_enqueue_on_this_day_query_loop_variation() {
+		$handle = 'wp-on-this-day-query-loop-variation';
+
+		_wp_enqueue_on_this_day_query_loop_variation();
+
+		$after = wp_scripts()->get_data( $handle, 'after' );
+
+		$this->assertTrue( wp_script_is( $handle, 'enqueued' ) );
+		$this->assertIsArray( $after );
+		$this->assertStringContainsString( 'wp.blocks.registerBlockVariation( "core/query"', implode( "\n", $after ) );
+		$this->assertStringContainsString( '"name":"core/on-this-day"', implode( "\n", $after ) );
+		$this->assertStringContainsString( '"onThisDay":true', implode( "\n", $after ) );
+	}
+
+	public function test_get_on_this_day_query_date_query() {
+		$date  = new DateTimeImmutable( '2026-06-29 12:00:00', wp_timezone() );
+		$query = _wp_get_on_this_day_query_date_query( $date );
+
+		$this->assertSame(
+			array(
+				'relation' => 'AND',
+				array(
+					'before' => array( 'year' => 2026 ),
+				),
+				array(
+					'month' => 6,
+					'day'   => 29,
+				),
+			),
+			$query
+		);
+	}
+
+	public function test_get_on_this_day_query_date_query_includes_february_29_on_february_28_in_non_leap_year() {
+		$date  = new DateTimeImmutable( '2023-02-28 12:00:00', wp_timezone() );
+		$query = _wp_get_on_this_day_query_date_query( $date );
+
+		$this->assertSame(
+			array(
+				'relation' => 'AND',
+				array(
+					'before' => array( 'year' => 2023 ),
+				),
+				array(
+					'relation' => 'OR',
+					array(
+						'month' => 2,
+						'day'   => 28,
+					),
+					array(
+						'month' => 2,
+						'day'   => 29,
+					),
+				),
+			),
+			$query
+		);
+	}
+
+	public function test_get_on_this_day_query_date_query_does_not_include_february_29_on_february_28_in_leap_year() {
+		$date  = new DateTimeImmutable( '2024-02-28 12:00:00', wp_timezone() );
+		$query = _wp_get_on_this_day_query_date_query( $date );
+
+		$this->assertSame(
+			array(
+				'relation' => 'AND',
+				array(
+					'before' => array( 'year' => 2024 ),
+				),
+				array(
+					'month' => 2,
+					'day'   => 28,
+				),
+			),
+			$query
+		);
+	}
+
+	public function test_build_query_vars_from_on_this_day_query_loop_block() {
+		$this->registry->register(
+			'core/example',
+			array( 'uses_context' => array( 'query' ) )
+		);
+
+		$parsed_blocks = parse_blocks( '<!-- wp:example {"ok":true} -->a<!-- wp:example /-->b<!-- /wp:example -->' );
+		$parsed_block  = $parsed_blocks[0];
+		$context       = array(
+			'query' => array(
+				'onThisDay' => true,
+			),
+		);
+		$block         = new WP_Block( $parsed_block, $context, $this->registry );
+		$query         = build_query_vars_from_query_block( $block, 1 );
+
+		$this->assertSame( _wp_get_on_this_day_query_date_query(), $query['date_query'] );
+		$this->assertSame( 'publish', $query['post_status'] );
+		$this->assertTrue( $query['ignore_sticky_posts'] );
+	}
+
+	public function test_on_this_day_rest_post_query_filter() {
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
+		$request->set_param( 'onThisDay', true );
+
+		$query = _wp_filter_on_this_day_rest_post_query( array(), $request );
+
+		$this->assertSame( _wp_get_on_this_day_query_date_query(), $query['date_query'] );
+		$this->assertSame( 'publish', $query['post_status'] );
+		$this->assertTrue( $query['ignore_sticky_posts'] );
+	}
+
+	public function test_on_this_day_rest_post_collection_param() {
+		$query_params = _wp_register_on_this_day_rest_post_collection_param( array() );
+
+		$this->assertSame( 'boolean', $query_params['onThisDay']['type'] );
+	}
+
 	/**
 	 * @ticket 52991
 	 */


### PR DESCRIPTION
## Summary
- add an On This Day variation for the Query Loop block
- apply the previous-years date query on front-end rendering and REST editor previews
- include leap-year handling for February 29 posts on February 28 in non-leap years

## Testing
- `php -l src/wp-includes/blocks.php`
- `php -l src/wp-includes/default-filters.php`
- `php -l src/wp-includes/script-loader.php`
- `php -l tests/phpunit/tests/blocks/wpBlock.php`
- `/Users/omaralshaker/Work.nosync/Automattic/wordpress-develop/vendor/bin/phpcs --standard=phpcs.xml.dist --report=summary src/wp-includes/blocks.php src/wp-includes/default-filters.php src/wp-includes/script-loader.php tests/phpunit/tests/blocks/wpBlock.php`
- `NODE_PATH=/Users/omaralshaker/Work.nosync/Automattic/wordpress-develop/node_modules node ./tools/local-env/scripts/docker.js run --rm -v /Users/omaralshaker/Work.nosync/Automattic/wordpress-develop/vendor:/var/www/vendor:ro -v /Users/omaralshaker/Work.nosync/Automattic/wordpress-develop/wp-tests-config.php:/var/www/wp-tests-config.php:ro php ./vendor/bin/phpunit --filter Tests_Blocks_wpBlock tests/phpunit/tests/blocks/wpBlock.php`
