### PR TITLE
HTML API: Respect namespace in open element lookup

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-open-elements.php
+++ b/src/wp-includes/html-api/class-wp-html-open-elements.php
@@ -128,16 +128,16 @@ class WP_HTML_Open_Elements {
 	}
 
 	/**
-	 * Reports if a node of a given name is in the stack of open elements.
+	 * Reports if an HTML element of a given name is on the stack of open elements.
 	 *
 	 * @since 6.7.0
 	 *
-	 * @param string $node_name Name of node for which to check.
+	 * @param string $node_name Name of HTML element for which to check.
 	 * @return bool Whether a node of the given name is in the stack of open elements.
 	 */
 	public function contains( string $node_name ): bool {
 		foreach ( $this->walk_up() as $item ) {
-			if ( $node_name === $item->node_name ) {
+			if ( 'html' === $item->namespace && $node_name === $item->node_name ) {
 				return true;
 			}
 		}

--- a/tests/phpunit/tests/html-api/wpHtmlProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessor.php
@@ -643,6 +643,26 @@ class Tests_HtmlApi_WpHtmlProcessor extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Ensures foreign TEMPLATE elements do not satisfy HTML template handling.
+	 *
+	 * @ticket 65372
+	 */
+	public function test_unmatched_template_closer_after_mathml_template_is_ignored() {
+		$processor = WP_HTML_Processor::create_fragment( '<math><template><mi><c></template>here' );
+
+		$this->assertTrue( $processor->next_tag( 'C' ), 'Failed to find C tag.' );
+		$this->assertTrue( $processor->next_token(), 'Failed to advance past the C tag.' );
+
+		// Closing HTML </template> tag should be ignored, advancing to "here" text without modifying breadcrumbs.
+		$this->assertSame( '#text', $processor->get_token_type(), 'Failed to reach text node.' );
+		$this->assertSame( 'here', $processor->get_modifiable_text() );
+		$this->assertSame(
+			array( 'HTML', 'BODY', 'MATH', 'TEMPLATE', 'MI', 'C', '#text' ),
+			$processor->get_breadcrumbs(),
+		);
+	}
+
+	/**
 	 * Ensures that the tag processor is case sensitive when removing CSS classes in no-quirks mode.
 	 *
 	 * @ticket 61531


### PR DESCRIPTION
Ensure foreign content elements do not match HTML elements on the stack of open element checks.

A closing HTML tag could close non-matching foreign content elements producing breadcrumgbs in some documents.

Trac ticket: https://core.trac.wordpress.org/ticket/65372

## Use of AI Tools



AI assistance: Yes
Tool(s): Codex
Model(s): GPT-5.5
Used for: Fuzzing, diagnosis, fix implementation.


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
