### PR TITLE
Style Engine: Preserve important state declarations

### DIFF
--- a/src/wp-includes/block-supports/states.php
+++ b/src/wp-includes/block-supports/states.php
@@ -122,12 +122,13 @@ function wp_get_state_declarations_with_background_resets( $declarations ) {
 
 	/*
 	 * When the state sets a solid background-color but no gradient of its own,
-	 * emit `background-image: unset !important` to clear any gradient (whether
-	 * stored as the `background` shorthand or as `background-image`) that was
-	 * applied to the default / normal state via an inline style attribute.
+	 * emit `background-image: unset` to clear any gradient (whether stored as
+	 * the `background` shorthand or as `background-image`) that was applied to
+	 * the default / normal state via an inline style attribute. The declaration
+	 * is marked important when the state rule is registered with the style engine.
 	 */
 	if ( $has_background_color && ! $has_background && ! $has_background_image ) {
-		$declarations['background-image'] = 'unset !important';
+		$declarations['background-image'] = 'unset';
 	}
 
 	return $declarations;
@@ -677,21 +678,44 @@ function wp_render_block_states_support( $block_content, $block ) {
 	 */
 	$style_rules = array();
 	foreach ( $css_rules as $rule ) {
-		$declarations = $rule['declarations'];
-		foreach ( $declarations as $property => $value ) {
-			$declarations[ $property ] = is_string( $value ) && str_contains( $value, '!important' )
-				? $value
-				: $value . ' !important';
+		$declarations                 = $rule['declarations'];
+		$important_declaration_values = wp_get_state_declarations_with_background_resets( $declarations );
+		$important_declarations       = new WP_Style_Engine_CSS_Declarations();
+		foreach ( $important_declaration_values as $property => $value ) {
+			$important_declarations->add_declaration(
+				$property,
+				$value,
+				array(
+					'important' => true,
+				)
+			);
 		}
-		$declarations = wp_get_state_declarations_with_fallback_border_styles( $declarations );
-		$declarations = wp_get_state_declarations_with_background_resets( $declarations );
-		$style_rule   = array(
-			'selector'     => wp_build_state_selector(
-				".$unique_class",
-				$rule['selector'],
-				$rule['state']
-			),
-			'declarations' => $declarations,
+		$selector   = wp_build_state_selector(
+			".$unique_class",
+			$rule['selector'],
+			$rule['state']
+		);
+		$style_rule = array(
+			'selector'     => $selector,
+			'declarations' => $important_declarations,
+		);
+		if ( ! empty( $rule['rules_group'] ) ) {
+			$style_rule['rules_group'] = $rule['rules_group'];
+		}
+		$style_rules[] = $style_rule;
+
+		$fallback_declarations = wp_get_state_declarations_with_fallback_border_styles( $declarations );
+		foreach ( array_keys( $declarations ) as $property ) {
+			unset( $fallback_declarations[ $property ] );
+		}
+
+		if ( empty( $fallback_declarations ) ) {
+			continue;
+		}
+
+		$style_rule = array(
+			'selector'     => $selector,
+			'declarations' => $fallback_declarations,
 		);
 		if ( ! empty( $rule['rules_group'] ) ) {
 			$style_rule['rules_group'] = $rule['rules_group'];

--- a/src/wp-includes/block-supports/states.php
+++ b/src/wp-includes/block-supports/states.php
@@ -690,19 +690,19 @@ function wp_render_block_states_support( $block_content, $block ) {
 				)
 			);
 		}
-		$selector   = wp_build_state_selector(
+		$selector             = wp_build_state_selector(
 			".$unique_class",
 			$rule['selector'],
 			$rule['state']
 		);
-		$style_rule = array(
+		$important_style_rule = array(
 			'selector'     => $selector,
 			'declarations' => $important_declarations,
 		);
 		if ( ! empty( $rule['rules_group'] ) ) {
-			$style_rule['rules_group'] = $rule['rules_group'];
+			$important_style_rule['rules_group'] = $rule['rules_group'];
 		}
-		$style_rules[] = $style_rule;
+		$style_rules[] = $important_style_rule;
 
 		$fallback_declarations = wp_get_state_declarations_with_fallback_border_styles( $declarations );
 		foreach ( array_keys( $declarations ) as $property ) {
@@ -713,14 +713,14 @@ function wp_render_block_states_support( $block_content, $block ) {
 			continue;
 		}
 
-		$style_rule = array(
+		$fallback_style_rule = array(
 			'selector'     => $selector,
 			'declarations' => $fallback_declarations,
 		);
 		if ( ! empty( $rule['rules_group'] ) ) {
-			$style_rule['rules_group'] = $rule['rules_group'];
+			$fallback_style_rule['rules_group'] = $rule['rules_group'];
 		}
-		$style_rules[] = $style_rule;
+		$style_rules[] = $fallback_style_rule;
 	}
 
 	wp_style_engine_get_stylesheet_from_css_rules(

--- a/src/wp-includes/style-engine.php
+++ b/src/wp-includes/style-engine.php
@@ -114,7 +114,7 @@ function wp_style_engine_get_styles( $block_styles, $options = array() ) {
  *
  * @since 6.1.0
  * @since 6.6.0 Added support for `$rules_group` in the `$css_rules` array.
- * @since 7.1.0 The `declarations` value also accepts a WP_Style_Engine_CSS_Declarations object.
+ * @since 7.1.0 Extended `declarations` in `$css_rules` array to accept `WP_Style_Engine_CSS_Declarations` object.
  *
  * @param array $css_rules {
  *     Required. A collection of CSS rules.

--- a/src/wp-includes/style-engine.php
+++ b/src/wp-includes/style-engine.php
@@ -114,16 +114,18 @@ function wp_style_engine_get_styles( $block_styles, $options = array() ) {
  *
  * @since 6.1.0
  * @since 6.6.0 Added support for `$rules_group` in the `$css_rules` array.
+ * @since 7.1.0 The `declarations` value also accepts a WP_Style_Engine_CSS_Declarations object.
  *
  * @param array $css_rules {
  *     Required. A collection of CSS rules.
  *
  *     @type array ...$0 {
- *         @type string   $rules_group  A parent CSS selector in the case of nested CSS,
- *                                      or a CSS nested @rule, such as `@media (min-width: 80rem)` or `@layer module`.
- *         @type string   $selector     A CSS selector.
- *         @type string[] $declarations An associative array of CSS definitions,
- *                                      e.g. `array( "$property" => "$value", "$property" => "$value" )`.
+ *         @type string                                    $rules_group  A parent CSS selector in the case of nested CSS,
+ *                                                                       or a CSS nested @rule, such as `@media (min-width: 80rem)` or `@layer module`.
+ *         @type string                                    $selector     A CSS selector.
+ *         @type string[]|WP_Style_Engine_CSS_Declarations $declarations An associative array of CSS definitions,
+ *                                                                       e.g. `array( "$property" => "$value", "$property" => "$value" )`,
+ *                                                                       or a WP_Style_Engine_CSS_Declarations object.
  *     }
  * }
  * @param array $options {
@@ -153,16 +155,21 @@ function wp_style_engine_get_stylesheet_from_css_rules( $css_rules, $options = a
 
 	$css_rule_objects = array();
 	foreach ( $css_rules as $css_rule ) {
-		if ( empty( $css_rule['selector'] ) || empty( $css_rule['declarations'] ) || ! is_array( $css_rule['declarations'] ) ) {
+		$declarations = $css_rule['declarations'] ?? null;
+		if (
+			empty( $css_rule['selector'] ) ||
+			empty( $declarations ) ||
+			( ! is_array( $declarations ) && ! $declarations instanceof WP_Style_Engine_CSS_Declarations )
+		) {
 			continue;
 		}
 
 		$rules_group = $css_rule['rules_group'] ?? null;
 		if ( ! empty( $options['context'] ) ) {
-			WP_Style_Engine::store_css_rule( $options['context'], $css_rule['selector'], $css_rule['declarations'], $rules_group );
+			WP_Style_Engine::store_css_rule( $options['context'], $css_rule['selector'], $declarations, $rules_group );
 		}
 
-		$css_rule_objects[] = new WP_Style_Engine_CSS_Rule( $css_rule['selector'], $css_rule['declarations'], $rules_group );
+		$css_rule_objects[] = new WP_Style_Engine_CSS_Rule( $css_rule['selector'], $declarations, $rules_group );
 	}
 
 	if ( empty( $css_rule_objects ) ) {

--- a/src/wp-includes/style-engine/class-wp-style-engine-css-declarations.php
+++ b/src/wp-includes/style-engine/class-wp-style-engine-css-declarations.php
@@ -27,6 +27,15 @@ class WP_Style_Engine_CSS_Declarations {
 	protected $declarations = array();
 
 	/**
+	 * CSS declaration options keyed by property name.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @var array
+	 */
+	protected $declaration_options = array();
+
+	/**
 	 * Constructor for this object.
 	 *
 	 * If a `$declarations` array is passed, it will be used to populate
@@ -46,12 +55,18 @@ class WP_Style_Engine_CSS_Declarations {
 	 * Adds a single declaration.
 	 *
 	 * @since 6.1.0
+	 * @since 7.1.0 Added the `$options` parameter.
 	 *
 	 * @param string $property The CSS property.
 	 * @param string $value    The CSS value.
+	 * @param array  $options  {
+	 *     Optional. An array of options. Default empty array.
+	 *
+	 *     @type bool $important Whether to output the declaration with !important. Default false.
+	 * }
 	 * @return WP_Style_Engine_CSS_Declarations Returns the object to allow chaining methods.
 	 */
-	public function add_declaration( $property, $value ) {
+	public function add_declaration( $property, $value, $options = array() ) {
 		// Sanitizes the property.
 		$property = $this->sanitize_property( $property );
 		// Bails early if the property is empty.
@@ -70,8 +85,21 @@ class WP_Style_Engine_CSS_Declarations {
 			return $this;
 		}
 
+		$options = wp_parse_args(
+			$options,
+			array(
+				'important' => false,
+			)
+		);
+		$options = array_filter( $options );
+
 		// Adds the declaration property/value pair.
 		$this->declarations[ $property ] = $value;
+		if ( $options ) {
+			$this->declaration_options[ $property ] = $options;
+		} else {
+			unset( $this->declaration_options[ $property ] );
+		}
 
 		return $this;
 	}
@@ -86,6 +114,7 @@ class WP_Style_Engine_CSS_Declarations {
 	 */
 	public function remove_declaration( $property ) {
 		unset( $this->declarations[ $property ] );
+		unset( $this->declaration_options[ $property ] );
 		return $this;
 	}
 
@@ -131,20 +160,50 @@ class WP_Style_Engine_CSS_Declarations {
 	}
 
 	/**
+	 * Gets declaration options keyed by property name.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @return array Declaration options keyed by property name.
+	 */
+	public function get_declaration_options() {
+		return $this->declaration_options;
+	}
+
+	/**
 	 * Filters a CSS property + value pair.
 	 *
 	 * @since 6.1.0
+	 * @since 7.1.0 Added the `$options` parameter.
 	 *
 	 * @param string $property The CSS property.
 	 * @param string $value    The value to be filtered.
 	 * @param string $spacer   Optional. The spacer between the colon and the value.
 	 *                         Default empty string.
+	 * @param array  $options  {
+	 *     Optional. An array of options. Default empty array.
+	 *
+	 *     @type bool $important Whether to output the declaration with !important. Default false.
+	 * }
 	 * @return string The filtered declaration or an empty string.
 	 */
-	protected static function filter_declaration( $property, $value, $spacer = '' ) {
+	protected static function filter_declaration( $property, $value, $spacer = '', $options = array() ) {
 		$filtered_value = wp_strip_all_tags( $value, true );
 		if ( '' !== $filtered_value ) {
-			return safecss_filter_attr( "{$property}:{$spacer}{$filtered_value}" );
+			$options = wp_parse_args(
+				$options,
+				array(
+					'important' => false,
+				)
+			);
+
+			$filtered_declaration = safecss_filter_attr( "{$property}:{$spacer}{$filtered_value}" );
+
+			if ( ! empty( $options['important'] ) && '' !== $filtered_declaration && ! str_contains( $filtered_declaration, ';' ) ) {
+				return "$filtered_declaration !important";
+			}
+
+			return $filtered_declaration;
 		}
 		return '';
 	}
@@ -169,7 +228,7 @@ class WP_Style_Engine_CSS_Declarations {
 		$spacer              = $should_prettify ? ' ' : '';
 
 		foreach ( $declarations_array as $property => $value ) {
-			$filtered_declaration = static::filter_declaration( $property, $value, $spacer );
+			$filtered_declaration = static::filter_declaration( $property, $value, $spacer, $this->declaration_options[ $property ] ?? array() );
 			if ( $filtered_declaration ) {
 				$declarations_output .= "{$indent}{$filtered_declaration};$suffix";
 			}

--- a/src/wp-includes/style-engine/class-wp-style-engine-css-declarations.php
+++ b/src/wp-includes/style-engine/class-wp-style-engine-css-declarations.php
@@ -199,7 +199,8 @@ class WP_Style_Engine_CSS_Declarations {
 
 			$filtered_declaration = safecss_filter_attr( "{$property}:{$spacer}{$filtered_value}" );
 
-			if ( ! empty( $options['important'] ) && '' !== $filtered_declaration && ! str_contains( $filtered_declaration, ';' ) ) {
+			// Only append !important in the presence of an option value and when sanitization returns a single declaration.
+			if ( true === $options['important'] && '' !== $filtered_declaration && ! str_contains( $filtered_declaration, ';' ) ) {
 				return "$filtered_declaration !important";
 			}
 

--- a/src/wp-includes/style-engine/class-wp-style-engine-css-rule.php
+++ b/src/wp-includes/style-engine/class-wp-style-engine-css-rule.php
@@ -81,7 +81,7 @@ class WP_Style_Engine_CSS_Rule {
 	 * Sets the declarations.
 	 *
 	 * @since 6.1.0
-	 * @since 7.1.0 Preserves declaration options when declarations are provided as a WP_Style_Engine_CSS_Declarations object.
+	 * @since 7.1.0 Preserves declaration options when declarations are provided as a `WP_Style_Engine_CSS_Declarations` object.
 	 *
 	 * @param string[]|WP_Style_Engine_CSS_Declarations $declarations An array of declarations (property => value pairs),
 	 *                                                                or a WP_Style_Engine_CSS_Declarations object.

--- a/src/wp-includes/style-engine/class-wp-style-engine-css-rule.php
+++ b/src/wp-includes/style-engine/class-wp-style-engine-css-rule.php
@@ -81,6 +81,7 @@ class WP_Style_Engine_CSS_Rule {
 	 * Sets the declarations.
 	 *
 	 * @since 6.1.0
+	 * @since 7.1.0 Preserves declaration options when declarations are provided as a WP_Style_Engine_CSS_Declarations object.
 	 *
 	 * @param string[]|WP_Style_Engine_CSS_Declarations $declarations An array of declarations (property => value pairs),
 	 *                                                                or a WP_Style_Engine_CSS_Declarations object.
@@ -89,15 +90,23 @@ class WP_Style_Engine_CSS_Rule {
 	public function add_declarations( $declarations ) {
 		$is_declarations_object = ! is_array( $declarations );
 		$declarations_array     = $is_declarations_object ? $declarations->get_declarations() : $declarations;
+		$declaration_options    = $is_declarations_object ? $declarations->get_declaration_options() : array();
 
 		if ( null === $this->declarations ) {
 			if ( $is_declarations_object ) {
 				$this->declarations = $declarations;
 				return $this;
 			}
-			$this->declarations = new WP_Style_Engine_CSS_Declarations( $declarations_array );
+			$this->declarations = new WP_Style_Engine_CSS_Declarations();
 		}
-		$this->declarations->add_declarations( $declarations_array );
+
+		foreach ( $declarations_array as $property => $value ) {
+			$this->declarations->add_declaration(
+				$property,
+				$value,
+				$declaration_options[ $property ] ?? array()
+			);
+		}
 
 		return $this;
 	}

--- a/src/wp-includes/style-engine/class-wp-style-engine-processor.php
+++ b/src/wp-includes/style-engine/class-wp-style-engine-processor.php
@@ -154,6 +154,7 @@ class WP_Style_Engine_Processor {
 			$declarations        = $rule->get_declarations()->get_declarations();
 			$declaration_options = $rule->get_declarations()->get_declaration_options();
 			ksort( $declarations );
+			// Declaration options are keyed by property and are part of the rule identity.
 			ksort( $declaration_options );
 			foreach ( $declaration_options as $property => $options ) {
 				if ( is_array( $options ) ) {

--- a/src/wp-includes/style-engine/class-wp-style-engine-processor.php
+++ b/src/wp-includes/style-engine/class-wp-style-engine-processor.php
@@ -151,9 +151,22 @@ class WP_Style_Engine_Processor {
 		// Build an array of selectors along with the JSON-ified styles to make comparisons easier.
 		$selectors_json = array();
 		foreach ( $this->css_rules as $rule ) {
-			$declarations = $rule->get_declarations()->get_declarations();
+			$declarations        = $rule->get_declarations()->get_declarations();
+			$declaration_options = $rule->get_declarations()->get_declaration_options();
 			ksort( $declarations );
-			$selectors_json[ $rule->get_selector() ] = wp_json_encode( $declarations );
+			ksort( $declaration_options );
+			foreach ( $declaration_options as $property => $options ) {
+				if ( is_array( $options ) ) {
+					ksort( $options );
+					$declaration_options[ $property ] = $options;
+				}
+			}
+			$selectors_json[ $rule->get_selector() ] = wp_json_encode(
+				array(
+					'declarations'        => $declarations,
+					'declaration_options' => $declaration_options,
+				)
+			);
 		}
 
 		// Combine selectors that have the same styles.

--- a/src/wp-includes/style-engine/class-wp-style-engine.php
+++ b/src/wp-includes/style-engine/class-wp-style-engine.php
@@ -425,15 +425,18 @@ final class WP_Style_Engine {
 	 *
 	 * @since 6.1.0
 	 * @since 6.6.0 Added the `$rules_group` parameter.
+	 * @since 7.1.0 The `$css_declarations` parameter also accepts a WP_Style_Engine_CSS_Declarations object.
 	 *
-	 * @param string   $store_name       A valid store key.
-	 * @param string   $css_selector     When a selector is passed, the function will return
-	 *                                   a full CSS rule `$selector { ...rules }`
-	 *                                   otherwise a concatenated string of properties and values.
-	 * @param string[] $css_declarations An associative array of CSS definitions,
-	 *                                   e.g. `array( "$property" => "$value", "$property" => "$value" )`.
-	 * @param string $rules_group        Optional. A parent CSS selector in the case of nested CSS, or a CSS nested @rule,
-	 *                                   such as `@media (min-width: 80rem)` or `@layer module`.
+	 * @param string                                    $store_name       A valid store key.
+	 * @param string                                    $css_selector     When a selector is passed, the function will return
+	 *                                                                    a full CSS rule `$selector { ...rules }`
+	 *                                                                    otherwise a concatenated string of properties and values.
+	 * @param string[]|WP_Style_Engine_CSS_Declarations $css_declarations An associative array of CSS definitions,
+	 *                                                                    e.g. `array( "$property" => "$value", "$property" => "$value" )`,
+	 *                                                                    or a WP_Style_Engine_CSS_Declarations object.
+	 * @param string                                    $rules_group      Optional. A parent CSS selector in the case of nested CSS,
+	 *                                                                    or a CSS nested @rule, such as `@media (min-width: 80rem)`
+	 *                                                                    or `@layer module`.
 	 */
 	public static function store_css_rule( $store_name, $css_selector, $css_declarations, $rules_group = '' ) {
 		if ( empty( $store_name ) || empty( $css_selector ) || empty( $css_declarations ) ) {

--- a/src/wp-includes/style-engine/class-wp-style-engine.php
+++ b/src/wp-includes/style-engine/class-wp-style-engine.php
@@ -425,7 +425,7 @@ final class WP_Style_Engine {
 	 *
 	 * @since 6.1.0
 	 * @since 6.6.0 Added the `$rules_group` parameter.
-	 * @since 7.1.0 The `$css_declarations` parameter also accepts a WP_Style_Engine_CSS_Declarations object.
+	 * @since 7.1.0 Extended `$css_declarations` parameter to accept `WP_Style_Engine_CSS_Declarations` object.
 	 *
 	 * @param string                                    $store_name       A valid store key.
 	 * @param string                                    $css_selector     When a selector is passed, the function will return

--- a/tests/phpunit/tests/block-supports/states.php
+++ b/tests/phpunit/tests/block-supports/states.php
@@ -141,6 +141,7 @@ class Tests_Block_Supports_States extends WP_UnitTestCase {
 	 *
 	 * @covers ::wp_get_state_declarations_with_background_resets
 	 *
+	 * @ticket 65561
 	 * @ticket 65239
 	 */
 	public function test_adds_background_image_reset_for_solid_background_color() {
@@ -153,7 +154,7 @@ class Tests_Block_Supports_States extends WP_UnitTestCase {
 		$this->assertSame(
 			array(
 				'background-color' => '#ff0000 !important',
-				'background-image' => 'unset !important',
+				'background-image' => 'unset',
 			),
 			$actual
 		);
@@ -1002,6 +1003,46 @@ class Tests_Block_Supports_States extends WP_UnitTestCase {
 
 		$this->assertStringContainsString(
 			'@media (width <= 480px){.' . $matches[0] . '{text-align:right !important;}}',
+			$actual_stylesheet
+		);
+	}
+
+	/**
+	 * Tests that a responsive background gradient generates media-query scoped CSS.
+	 *
+	 * @covers ::wp_render_block_states_support
+	 *
+	 * @ticket 65561
+	 * @ticket 65239
+	 */
+	public function test_responsive_background_gradient_generates_media_query_scoped_css() {
+		$this->ensure_block_registered( 'core/group' );
+
+		$block_content = '<div class="wp-block-group">Hello</div>';
+		$block         = array(
+			'blockName' => 'core/group',
+			'attrs'     => array(
+				'style' => array(
+					'@tablet' => array(
+						'background' => array(
+							'backgroundImage' => 'linear-gradient(135deg,rgb(119,255,112) 0%,rgb(253,254,215) 99%)',
+						),
+					),
+				),
+			),
+		);
+
+		$actual = wp_render_block_states_support( $block_content, $block );
+
+		$this->assertMatchesRegularExpression(
+			'/^<div class="wp-block-group (wp-states-[a-f0-9]{8})">Hello<\/div>$/',
+			$actual
+		);
+		preg_match( '/wp-states-[a-f0-9]{8}/', $actual, $matches );
+		$actual_stylesheet = wp_style_engine_get_stylesheet_from_context( 'block-supports', array( 'prettify' => false ) );
+
+		$this->assertStringContainsString(
+			'@media (480px < width <= 782px){.' . $matches[0] . '{background-image:linear-gradient(135deg,rgb(119,255,112) 0%,rgb(253,254,215) 99%) !important;}}',
 			$actual_stylesheet
 		);
 	}

--- a/tests/phpunit/tests/block-supports/states.php
+++ b/tests/phpunit/tests/block-supports/states.php
@@ -1013,7 +1013,6 @@ class Tests_Block_Supports_States extends WP_UnitTestCase {
 	 * @covers ::wp_render_block_states_support
 	 *
 	 * @ticket 65561
-	 * @ticket 65239
 	 */
 	public function test_responsive_background_gradient_generates_media_query_scoped_css() {
 		$this->ensure_block_registered( 'core/group' );

--- a/tests/phpunit/tests/block-supports/states.php
+++ b/tests/phpunit/tests/block-supports/states.php
@@ -1024,7 +1024,7 @@ class Tests_Block_Supports_States extends WP_UnitTestCase {
 				'style' => array(
 					'@tablet' => array(
 						'background' => array(
-							'backgroundImage' => 'linear-gradient(135deg,rgb(119,255,112) 0%,rgb(253,254,215) 99%)',
+							'gradient' => 'linear-gradient(135deg,rgb(119,255,112) 0%,rgb(253,254,215) 99%)',
 						),
 					),
 				),

--- a/tests/phpunit/tests/style-engine/styleEngine.php
+++ b/tests/phpunit/tests/style-engine/styleEngine.php
@@ -794,6 +794,35 @@ class Tests_wpStyleEngine extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests returning a generated stylesheet with important declarations.
+	 *
+	 * @covers ::wp_style_engine_get_stylesheet_from_css_rules
+	 * @covers WP_Style_Engine::compile_stylesheet_from_css_rules
+	 *
+	 * @ticket 65561
+	 */
+	public function test_should_return_stylesheet_with_important_declarations() {
+		$declarations = new WP_Style_Engine_CSS_Declarations();
+		$declarations->add_declaration(
+			'background-image',
+			'linear-gradient(135deg,rgb(119,255,112) 0%,rgb(253,254,215) 99%)',
+			array(
+				'important' => true,
+			)
+		);
+		$css_rules = array(
+			array(
+				'selector'     => '.responsive-state',
+				'declarations' => $declarations,
+			),
+		);
+
+		$compiled_stylesheet = wp_style_engine_get_stylesheet_from_css_rules( $css_rules, array( 'prettify' => false ) );
+
+		$this->assertSame( '.responsive-state{background-image:linear-gradient(135deg,rgb(119,255,112) 0%,rgb(253,254,215) 99%) !important;}', $compiled_stylesheet );
+	}
+
+	/**
 	 * Tests that incoming styles are deduped and merged.
 	 *
 	 * @ticket 58811

--- a/tests/phpunit/tests/style-engine/wpStyleEngineCssDeclarations.php
+++ b/tests/phpunit/tests/style-engine/wpStyleEngineCssDeclarations.php
@@ -173,6 +173,72 @@ class Tests_Style_Engine_wpStyleEngineCSSDeclarations extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that important declarations are added after CSS sanitization.
+	 *
+	 * @covers ::get_declarations_string
+	 * @covers ::filter_declaration
+	 *
+	 * @ticket 65561
+	 */
+	public function test_should_add_important_after_sanitizing_declarations() {
+		$css_declarations = new WP_Style_Engine_CSS_Declarations();
+		$css_declarations->add_declaration(
+			'background-image',
+			'linear-gradient(135deg,rgb(119,255,112) 0%,rgb(253,254,215) 99%)',
+			array(
+				'important' => true,
+			)
+		);
+
+		$this->assertSame(
+			'background-image:linear-gradient(135deg,rgb(119,255,112) 0%,rgb(253,254,215) 99%) !important;',
+			$css_declarations->get_declarations_string()
+		);
+	}
+
+	/**
+	 * Tests that declaration options are stored and cleared with their declarations.
+	 *
+	 * @covers ::add_declaration
+	 * @covers ::remove_declaration
+	 * @covers ::get_declaration_options
+	 *
+	 * @ticket 65561
+	 */
+	public function test_should_store_declaration_options_by_property() {
+		$css_declarations = new WP_Style_Engine_CSS_Declarations();
+		$css_declarations->add_declaration(
+			'background-image',
+			'linear-gradient(135deg,rgb(119,255,112) 0%,rgb(253,254,215) 99%)',
+			array(
+				'important' => true,
+			)
+		);
+
+		$this->assertSame(
+			array(
+				'background-image' => array(
+					'important' => true,
+				),
+			),
+			$css_declarations->get_declaration_options()
+		);
+
+		$css_declarations->add_declaration( 'background-image', 'url("https://wordpress.org")' );
+		$this->assertSame( array(), $css_declarations->get_declaration_options() );
+
+		$css_declarations->add_declaration(
+			'background-image',
+			'linear-gradient(135deg,rgb(119,255,112) 0%,rgb(253,254,215) 99%)',
+			array(
+				'important' => true,
+			)
+		);
+		$css_declarations->remove_declaration( 'background-image' );
+		$this->assertSame( array(), $css_declarations->get_declaration_options() );
+	}
+
+	/**
 	 * Tests that CSS declarations are compiled into a CSS declarations block string.
 	 *
 	 * @ticket 56467

--- a/tests/phpunit/tests/style-engine/wpStyleEngineProcessor.php
+++ b/tests/phpunit/tests/style-engine/wpStyleEngineProcessor.php
@@ -353,6 +353,45 @@ class Tests_Style_Engine_wpStyleEngineProcessor extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that CSS rules with different declaration options are not combined.
+	 *
+	 * @covers ::get_css
+	 *
+	 * @ticket 65561
+	 */
+	public function test_should_not_combine_css_rules_with_different_declaration_options() {
+		$important_declarations = new WP_Style_Engine_CSS_Declarations();
+		$important_declarations->add_declaration(
+			'color',
+			'red',
+			array(
+				'important' => true,
+			)
+		);
+
+		$important_rule = new WP_Style_Engine_CSS_Rule( '.important-rule', $important_declarations );
+		$regular_rule   = new WP_Style_Engine_CSS_Rule(
+			'.regular-rule',
+			array(
+				'color' => 'red',
+			)
+		);
+
+		$processor = new WP_Style_Engine_Processor();
+		$processor->add_rules( array( $important_rule, $regular_rule ) );
+
+		$this->assertSame(
+			'.important-rule{color:red !important;}.regular-rule{color:red;}',
+			$processor->get_css(
+				array(
+					'prettify' => false,
+					'optimize' => true,
+				)
+			)
+		);
+	}
+
+	/**
 	 * Tests that incoming CSS rules are optimized and merged with existing CSS rules.
 	 *
 	 * @ticket 58811

--- a/tests/phpunit/tests/style-engine/wpStyleEngineProcessor.php
+++ b/tests/phpunit/tests/style-engine/wpStyleEngineProcessor.php
@@ -415,4 +415,45 @@ class Tests_Style_Engine_wpStyleEngineProcessor extends WP_UnitTestCase {
 			'Return value of get_css() does not match expectations when combining 4 CSS rules'
 		);
 	}
+
+	/**
+	 * Tests that rules with different declaration options are not combined.
+	 *
+	 * @covers ::get_css
+	 *
+	 * @ticket 65561
+	 */
+	public function test_should_not_combine_rules_with_different_declaration_options() {
+		$important_declarations = new WP_Style_Engine_CSS_Declarations();
+		$important_declarations->add_declaration(
+			'color',
+			'red',
+			array(
+				'important' => true,
+			)
+		);
+
+		$processor = new WP_Style_Engine_Processor();
+		$processor->add_rules(
+			array(
+				new WP_Style_Engine_CSS_Rule( '.important-rule', $important_declarations ),
+				new WP_Style_Engine_CSS_Rule(
+					'.standard-rule',
+					array(
+						'color' => 'red',
+					)
+				),
+			)
+		);
+
+		$this->assertSame(
+			'.important-rule{color:red !important;}.standard-rule{color:red;}',
+			$processor->get_css(
+				array(
+					'prettify' => false,
+					'optimize' => true,
+				)
+			)
+		);
+	}
 }

--- a/tests/phpunit/tests/style-engine/wpStyleEngineProcessor.php
+++ b/tests/phpunit/tests/style-engine/wpStyleEngineProcessor.php
@@ -415,45 +415,4 @@ class Tests_Style_Engine_wpStyleEngineProcessor extends WP_UnitTestCase {
 			'Return value of get_css() does not match expectations when combining 4 CSS rules'
 		);
 	}
-
-	/**
-	 * Tests that rules with different declaration options are not combined.
-	 *
-	 * @covers ::get_css
-	 *
-	 * @ticket 65561
-	 */
-	public function test_should_not_combine_rules_with_different_declaration_options() {
-		$important_declarations = new WP_Style_Engine_CSS_Declarations();
-		$important_declarations->add_declaration(
-			'color',
-			'red',
-			array(
-				'important' => true,
-			)
-		);
-
-		$processor = new WP_Style_Engine_Processor();
-		$processor->add_rules(
-			array(
-				new WP_Style_Engine_CSS_Rule( '.important-rule', $important_declarations ),
-				new WP_Style_Engine_CSS_Rule(
-					'.standard-rule',
-					array(
-						'color' => 'red',
-					)
-				),
-			)
-		);
-
-		$this->assertSame(
-			'.important-rule{color:red !important;}.standard-rule{color:red;}',
-			$processor->get_css(
-				array(
-					'prettify' => false,
-					'optimize' => true,
-				)
-			)
-		);
-	}
 }


### PR DESCRIPTION
> [!IMPORTANT]
> This PR has a dependency on https://github.com/WordPress/wordpress-develop/pull/11384


Backport of https://github.com/WordPress/gutenberg/pull/79568


## What

State styles currently append !important directly to CSS values before Style Engine sanitization. For gradient values, this can cause safecss_filter_attr() to reject otherwise valid declarations, so responsive/state gradient CSS may not be emitted.

## How
Store !important as declaration metadata in the Style Engine, preserve it through rule generation and optimization, and append it only after sanitization.

Trac ticket: https://core.trac.wordpress.org/ticket/65561

## Use of AI Tools



AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.5
Used for: Initial architectural discussion. Unit test scaffolding.
