### PR TITLE
Editor: Simplify plugin name fallback in entity view-config.php

### DIFF
--- a/src/wp-includes/view-config.php
+++ b/src/wp-includes/view-config.php
@@ -660,11 +660,7 @@ function _wp_get_entity_view_config_post_type_wp_template( $config ) {
 				if ( '' === $plugin_name ) {
 					$plugins         = get_plugins();
 					$plugin_basename = plugin_basename( sanitize_text_field( $template->theme . '.php' ) );
-					if ( isset( $plugins[ $plugin_basename ] ) && isset( $plugins[ $plugin_basename ]['Name'] ) ) {
-						$plugin_name = $plugins[ $plugin_basename ]['Name'];
-					} else {
-						$plugin_name = $template->plugin ?? $template->theme;
-					}
+					$plugin_name     = $plugins[ $plugin_basename ]['Name'] ?? $template->plugin ?? $template->theme;
 				}
 				$author_text = $plugin_name;
 				break;


### PR DESCRIPTION
Simplifies the plugin name resolution in by replacing the nested `isset()` checks with a null coalescing chain.

No functional change — the fallback order is preserved: plugin's registered `Name`, then the template's `plugin` attribute, then the `theme` attribute.

Follow-up to [[62547](https://core.trac.wordpress.org/changeset/62547)]

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
