### PR TITLE
Media: Avoid GD fatal errors for oversized images

### DIFF
--- a/src/wp-includes/class-wp-image-editor-gd.php
+++ b/src/wp-includes/class-wp-image-editor-gd.php
@@ -99,22 +99,32 @@ class WP_Image_Editor_GD extends WP_Image_Editor {
 		// Set artificially high because GD uses uncompressed images in memory.
 		wp_raise_memory_limit( 'image' );
 
-		$file_contents = @file_get_contents( $this->file );
+		$size = wp_getimagesize( $this->file );
 
-		if ( ! $file_contents ) {
-			return new WP_Error( 'error_loading_image', __( 'File does not exist?' ), $this->file );
+		if ( ! $size ) {
+			return new WP_Error( 'invalid_image', __( 'Could not read image size.' ), $this->file );
+		}
+
+		if ( ! $this->has_memory_for_image( $size ) ) {
+			return new WP_Error( 'image_memory_exceeded', __( 'Image size exceeds the memory limit.' ), $this->file );
 		}
 
 		// Handle WebP and AVIF mime types explicitly, falling back to imagecreatefromstring.
 		if (
-			function_exists( 'imagecreatefromwebp' ) && ( 'image/webp' === wp_get_image_mime( $this->file ) )
+			function_exists( 'imagecreatefromwebp' ) && ( 'image/webp' === $size['mime'] )
 		) {
 			$this->image = @imagecreatefromwebp( $this->file );
 		} elseif (
-			function_exists( 'imagecreatefromavif' ) && ( 'image/avif' === wp_get_image_mime( $this->file ) )
+			function_exists( 'imagecreatefromavif' ) && ( 'image/avif' === $size['mime'] )
 		) {
 			$this->image = @imagecreatefromavif( $this->file );
 		} else {
+			$file_contents = @file_get_contents( $this->file );
+
+			if ( ! $file_contents ) {
+				return new WP_Error( 'error_loading_image', __( 'File does not exist?' ), $this->file );
+			}
+
 			$this->image = @imagecreatefromstring( $file_contents );
 		}
 
@@ -122,21 +132,51 @@ class WP_Image_Editor_GD extends WP_Image_Editor {
 			return new WP_Error( 'invalid_image', __( 'File is not an image.' ), $this->file );
 		}
 
-		$size = wp_getimagesize( $this->file );
-
-		if ( ! $size ) {
-			return new WP_Error( 'invalid_image', __( 'Could not read image size.' ), $this->file );
-		}
-
 		if ( function_exists( 'imagealphablending' ) && function_exists( 'imagesavealpha' ) ) {
 			imagealphablending( $this->image, false );
 			imagesavealpha( $this->image, true );
 		}
-
 		$this->update_size( $size[0], $size[1] );
 		$this->mime_type = $size['mime'];
 
 		return $this->set_quality();
+	}
+
+	/**
+	 * Checks whether the current memory limit can accommodate a GD image resource.
+	 *
+	 * @since 6.9.0
+	 *
+	 * @param array $size {
+	 *     Image size data from wp_getimagesize().
+	 *
+	 *     @type int $0        Image width.
+	 *     @type int $1        Image height.
+	 *     @type int $bits     Optional. Number of bits per color.
+	 *     @type int $channels Optional. Number of channels.
+	 * }
+	 * @return bool Whether there is enough memory to load the image.
+	 */
+	protected function has_memory_for_image( $size ) {
+		$memory_limit = wp_convert_hr_to_bytes( ini_get( 'memory_limit' ) );
+
+		if ( -1 === $memory_limit ) {
+			return true;
+		}
+
+		$width    = isset( $size[0] ) ? (int) $size[0] : 0;
+		$height   = isset( $size[1] ) ? (int) $size[1] : 0;
+		$bits     = isset( $size['bits'] ) ? (int) $size['bits'] : 8;
+		$channels = isset( $size['channels'] ) ? (int) $size['channels'] : 4;
+
+		if ( $width <= 0 || $height <= 0 || $bits <= 0 || $channels <= 0 ) {
+			return false;
+		}
+
+		$required_memory  = ( ( $width * $height * $bits * $channels ) / 8 + 65536 ) * 1.65;
+		$available_memory = $memory_limit - memory_get_usage( true );
+
+		return $required_memory <= $available_memory;
 	}
 
 	/**

--- a/tests/phpunit/tests/image/editorGd.php
+++ b/tests/phpunit/tests/image/editorGd.php
@@ -10,7 +10,6 @@
 require_once __DIR__ . '/base.php';
 
 class Tests_Image_Editor_GD extends WP_Image_UnitTestCase {
-
 	public $editor_engine = 'WP_Image_Editor_GD';
 
 	public function set_up() {
@@ -49,6 +48,33 @@ class Tests_Image_Editor_GD extends WP_Image_UnitTestCase {
 		$gd_image_editor = new WP_Image_Editor_GD( null );
 		$expected        = (bool) ( imagetypes() & IMG_GIF );
 		$this->assertSame( $expected, $gd_image_editor->supports_mime_type( 'image/gif' ) );
+	}
+
+	/**
+	 * Tests that images expected to exceed the memory limit are rejected.
+	 *
+	 * @ticket 23127
+	 */
+	public function test_load_rejects_images_larger_than_available_memory() {
+		if ( -1 === wp_convert_hr_to_bytes( ini_get( 'memory_limit' ) ) ) {
+			$this->markTestSkipped( 'The PHP memory limit is disabled.' );
+		}
+
+		$file      = tempnam( get_temp_dir(), 'large-image-' );
+		$ihdr_data = pack( 'NNCCCCC', 100000, 100000, 8, 2, 0, 0, 0 );
+		$png       = "\x89PNG\r\n\x1a\n"
+			. pack( 'N', 13 ) . 'IHDR' . $ihdr_data . pack( 'N', crc32( 'IHDR' . $ihdr_data ) )
+			. pack( 'N', 0 ) . 'IEND' . pack( 'N', crc32( 'IEND' ) );
+
+		file_put_contents( $file, $png );
+
+		$gd_image_editor = new WP_Image_Editor_GD( $file );
+		$loaded          = $gd_image_editor->load();
+
+		unlink( $file );
+
+		$this->assertWPError( $loaded );
+		$this->assertSame( 'image_memory_exceeded', $loaded->get_error_code() );
 	}
 
 	/**


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

This updates the GD image editor load path to read image dimensions before decoding, reject images that exceed the available PHP memory limit, and avoid reading file contents unless the fallback string decoder is needed.

Validation:
- php -l src/wp-includes/class-wp-image-editor-gd.php
- php -l tests/phpunit/tests/image/editorGd.php
- composer run format -- src/wp-includes/class-wp-image-editor-gd.php tests/phpunit/tests/image/editorGd.php
- composer run lint -- src/wp-includes/class-wp-image-editor-gd.php tests/phpunit/tests/image/editorGd.php
- git diff --check

Not run:

Trac ticket: https://core.trac.wordpress.org/ticket/23127

## Use of AI Tools

AI assistance: Yes
Tool(s): OpenAI Codex
Model(s): GPT-5
Used for: Reviewing the Trac ticket and relevant code, helping with the initial implementation and regression-test approach, and assisting with validation and PR-description drafting. The final implementation, tests, validation results, and description were reviewed and accepted by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**