### PR TITLE
HTML API: Fix incorrect test assertion

### DIFF
--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -115,6 +115,7 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 			'Slash inside unquoted attribute value'      => array( '<div id=test/>', false ),
 			'Slash only unquoted attribute value'        => array( '<div attr=/>', false ),
 			'Attribute "=" with value ""'                => array( '<div =/>', true ),
+			'Attribute "=" with value "/"'               => array( '<div ==/>', false ),
 			'Self-closing flag after quoted attribute'   => array( '<div id="test"/>', true ),
 			'Self-closing flag after boolean attribute'  => array( '<div enabled/>', true ),
 			'Ignored "/" and whitespace'                 => array( '<div / >', false ),

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -114,7 +114,7 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 			'Self-closing flag after attribute'          => array( '<div id=test />', true ),
 			'Slash inside unquoted attribute value'      => array( '<div id=test/>', false ),
 			'Slash only unquoted attribute value'        => array( '<div attr=/>', false ),
-			'Attribute "=" with value ""'                => array( '<div =/>', false ),
+			'Attribute "=" with value ""'                => array( '<div =/>', true ),
 			'Self-closing flag after quoted attribute'   => array( '<div id="test"/>', true ),
 			'Self-closing flag after boolean attribute'  => array( '<div enabled/>', true ),
 			'Ignored "/" and whitespace'                 => array( '<div / >', false ),


### PR DESCRIPTION
r62595 introduced an test code that asserts the wrong behavior. Fix it.

This fixed a test that is currently failing on trunk.

Trac ticket: https://core.trac.wordpress.org/ticket/65372
Follow-up to r62595.

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
