### PR TITLE
Password protected form: Add wp-element-button class to the submit input

### DIFF
--- a/src/wp-includes/post-template.php
+++ b/src/wp-includes/post-template.php
@@ -1772,6 +1772,7 @@ function prepend_attachment( $content ) {
  * Retrieves protected post password form content.
  *
  * @since 1.0.0
+ * @since 7.2.0 Added Button block classes to the submit button for block themes.
  *
  * @param int|WP_Post $post Optional. Post ID or WP_Post object. Default is global $post.
  * @return string HTML content for password form for password-protected post.
@@ -1784,6 +1785,7 @@ function get_the_password_form( $post = 0 ) {
 	$aria                  = '';
 	$class                 = '';
 	$redirect_field        = '';
+	$button_class          = '';
 
 	// If the referrer is the same as the current request, the user has entered an invalid password.
 	if ( ! empty( $post->ID ) && wp_get_raw_referer() === get_permalink( $post->ID ) && isset( $_COOKIE[ 'wp-postpass_' . COOKIEHASH ] ) ) {
@@ -1809,9 +1811,16 @@ function get_the_password_form( $post = 0 ) {
 		);
 	}
 
+	if ( wp_is_block_theme() ) {
+		$button_class = ' class="wp-block-button__link ' . wp_theme_get_element_class_name( 'button' ) . '"';
+		if ( wp_style_is( 'wp-block-button', 'registered' ) ) {
+			wp_enqueue_style( 'wp-block-button' );
+		}
+	}
+
 	$output = '<form action="' . esc_url( site_url( 'wp-login.php?action=postpass', 'login_post' ) ) . '" class="post-password-form' . $class . '" method="post">' . $redirect_field . $invalid_password_html . '
 	<p>' . __( 'This content is password-protected. To view it, please enter the password below.' ) . '</p>
-	<p><label for="' . $field_id . '">' . __( 'Password:' ) . ' <input name="post_password" id="' . $field_id . '" type="password" spellcheck="false" required size="20"' . $aria . ' /></label> <input type="submit" name="Submit" value="' . esc_attr_x( 'Enter', 'post password form' ) . '" /></p></form>
+	<p><label for="' . $field_id . '">' . __( 'Password:' ) . ' <input name="post_password" id="' . $field_id . '" type="password" spellcheck="false" required size="20"' . $aria . ' /></label> <input type="submit" name="Submit" ' . $button_class . ' value="' . esc_attr_x( 'Enter', 'post password form' ) . '" /></p></form>
 	';
 
 	/**


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/65567

Updates get_the_password_form() to print the wp-element-button classes on the submit input, if the current theme is a block theme.

A similar solution is already used for the submit button on the comments block:
https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-includes/blocks/comments.php#L113

This way, the button uses the same styling as the button block. It allows styling the button using theme.json or the global styles interface in the Site Editor.

It enqueues the button block stylesheet, so that the CSS is applied even if there is no other button block on the page. 
If the style has been unregistered for any reason, it is not enqueued.

### Testing Instructions
Activate a block theme that styles button, like Twenty Twenty-Four.
Create a new post. Password protect it.
View the post on the front. Confirm that the classes are present on the submit button and that the style matches the button block.

Props, see https://github.com/WordPress/gutenberg/pull/76627#issuecomment-4102828758


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
