### PR TITLE
Ajax: Sanitize dashboard widget AJAX request parameters.

### DIFF
--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -420,12 +420,19 @@ function wp_ajax_get_community_events() {
 function wp_ajax_dashboard_widgets() {
 	require_once ABSPATH . 'wp-admin/includes/dashboard.php';
 
-	$pagenow = $_GET['pagenow'];
+	$pagenow = isset( $_GET['pagenow'] )
+		? sanitize_key( wp_unslash( $_GET['pagenow'] ) )
+		: '';
+
 	if ( 'dashboard-user' === $pagenow || 'dashboard-network' === $pagenow || 'dashboard' === $pagenow ) {
 		set_current_screen( $pagenow );
 	}
 
-	switch ( $_GET['widget'] ) {
+	$widget = isset( $_GET['widget'] )
+		? sanitize_key( wp_unslash( $_GET['widget'] ) )
+		: '';
+
+	switch ( $widget ) {
 		case 'dashboard_primary':
 			wp_dashboard_primary();
 			break;


### PR DESCRIPTION
## Summary

This PR sanitizes the pagenow and widget request parameters in
`wp_ajax_dashboard_widgets()`.

Change log:

- Add Sanitize `$_GET['pagenow']` using `sanitize_key( wp_unslash() )`.
- Sanitize `$_GET['widget']` using `sanitize_key( wp_unslash() )`.
- Replace direct use of `$_GET['widget']` with the sanitized local variable.

Testing

- Applied the patch.
- Verified Dashboard widgets continue to load correctly.
- Tested valid and invalid values for `pagenow` and `widget`.
- Confirmed no regressions were observed.

Trac ticket: https://core.trac.wordpress.org/ticket/65054

Fixes #65054.