### PR TITLE
Themes: register bundled theme root with custom content dirs

### DIFF
--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -401,6 +401,28 @@ function get_theme_roots() {
 }
 
 /**
+ * Registers the default theme directory roots.
+ *
+ * This includes the active content directory's themes root and the bundled core
+ * themes root when they differ, allowing bundled themes to remain available when
+ * `WP_CONTENT_DIR` points somewhere else.
+ *
+ * @since 7.1.0
+ *
+ * @global string[] $wp_theme_directories
+ */
+function wp_register_default_theme_directories() {
+	$theme_root         = get_theme_root();
+	$bundled_theme_root = ABSPATH . 'wp-content/themes';
+
+	if ( untrailingslashit( $bundled_theme_root ) !== untrailingslashit( $theme_root ) ) {
+		register_theme_directory( $bundled_theme_root );
+	}
+
+	register_theme_directory( $theme_root );
+}
+
+/**
  * Registers a directory that contains themes.
  *
  * @since 2.9.0

--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -559,9 +559,8 @@ create_initial_post_types();
 
 wp_start_scraping_edited_file_errors();
 
-// Register the default theme directory root.
-register_theme_directory( get_theme_root() );
-
+// Register the default theme directory roots.
+wp_register_default_theme_directories();
 if ( ! is_multisite() && wp_is_fatal_error_handler_enabled() ) {
 	// Handle users requesting a recovery mode link and initiating recovery mode.
 	wp_recovery_mode()->initialize();

--- a/tests/phpunit/tests/theme/themeDir.php
+++ b/tests/phpunit/tests/theme/themeDir.php
@@ -280,8 +280,8 @@ class Tests_Theme_ThemeDir extends WP_UnitTestCase {
 	 * @ticket 28662
 	 */
 	public function test_theme_dir_slashes() {
-		$size = count( $GLOBALS['wp_theme_directories'] );
 
+		$size = count( $GLOBALS['wp_theme_directories'] );
 		@mkdir( WP_CONTENT_DIR . '/themes/foo' );
 		@mkdir( WP_CONTENT_DIR . '/themes/foo-themes' );
 
@@ -318,5 +318,35 @@ class Tests_Theme_ThemeDir extends WP_UnitTestCase {
 
 		rmdir( WP_CONTENT_DIR . '/themes/foo' );
 		rmdir( WP_CONTENT_DIR . '/themes/foo-themes' );
+	}
+
+	public function test_wp_register_default_theme_directories_registers_bundled_and_filtered_roots() {
+		$GLOBALS['wp_theme_directories'] = array();
+
+		wp_register_default_theme_directories();
+
+		$this->assertSame(
+			array(
+				untrailingslashit( ABSPATH . 'wp-content/themes' ),
+				self::THEME_ROOT,
+			),
+			$GLOBALS['wp_theme_directories']
+		);
+	}
+
+	public function test_wp_register_default_theme_directories_does_not_duplicate_bundled_root() {
+		remove_filter( 'theme_root', array( $this, 'filter_theme_root' ) );
+		$GLOBALS['wp_theme_directories'] = array();
+
+		wp_register_default_theme_directories();
+
+		$this->assertSame(
+			array(
+				untrailingslashit( ABSPATH . 'wp-content/themes' ),
+			),
+			$GLOBALS['wp_theme_directories']
+		);
+
+		add_filter( 'theme_root', array( $this, 'filter_theme_root' ) );
 	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

## Summary
- register both the bundled core theme root and the active content theme root during bootstrap
- keep the active content theme root registered last so it still wins on conflicts
- add focused tests for the dual-root and no-duplicate cases

## Testing
- php vendor/bin/phpcs --standard=phpcs.xml.dist src/wp-includes/theme.php src/wp-settings.php tests/phpunit/tests/theme/themeDir.php
- standalone reproduction with WP_CONTENT_DIR moved outside ABSPATH now registers both roots and finds bundled themes

Trac ticket: https://core.trac.wordpress.org/ticket/24143

## Use of AI Tools

AI assistance: Yes
Tool(s): OpenAI Codex
Model(s): GPT-5
Used for: Reviewing the Trac ticket and relevant code, helping with the initial implementation and regression-test approach, and assisting with validation and PR-description drafting. The final implementation, tests, validation results, and description were reviewed and accepted by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**