### PR TITLE
Build/Test Tools: Update the sinon dependency to version 22.0.0.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -84,7 +84,7 @@
 				"qunit": "~2.25.0",
 				"react-refresh": "0.14.0",
 				"sass": "1.98.0",
-				"sinon": "16.1.3",
+				"sinon": "22.0.0",
 				"sinon-test": "~3.1.6",
 				"source-map-loader": "5.0.0",
 				"terser-webpack-plugin": "5.4.0",
@@ -4683,30 +4683,25 @@
 			}
 		},
 		"node_modules/@sinonjs/samsam": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.0.tgz",
-			"integrity": "sha512-Bp8KUVlLp8ibJZrnvq2foVhP0IVX2CIprMJPK0vqGqgrDa0OHVKeZyBykqskkrdxV6yKBPmGasO8LVjAKR3Gew==",
+			"version": "10.0.2",
+			"resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-10.0.2.tgz",
+			"integrity": "sha512-8lVwD1Df1BmzoaOLhMcGGcz/Jyr5QY2KSB75/YK1QgKzoabTeLdIVyhXNZK9ojfSKSdirbXqdbsXXqP9/Ve8+A==",
 			"dev": true,
+			"license": "BSD-3-Clause",
 			"dependencies": {
-				"@sinonjs/commons": "^2.0.0",
-				"lodash.get": "^4.4.2",
-				"type-detect": "^4.0.8"
+				"@sinonjs/commons": "^3.0.1",
+				"type-detect": "^4.1.0"
 			}
 		},
-		"node_modules/@sinonjs/samsam/node_modules/@sinonjs/commons": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
-			"integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
+		"node_modules/@sinonjs/samsam/node_modules/type-detect": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+			"integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
 			"dev": true,
-			"dependencies": {
-				"type-detect": "4.0.8"
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
 			}
-		},
-		"node_modules/@sinonjs/text-encoding": {
-			"version": "0.7.2",
-			"resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
-			"integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
-			"dev": true
 		},
 		"node_modules/@standard-schema/spec": {
 			"version": "1.0.0",
@@ -22701,12 +22696,6 @@
 				"node": ">=4.0"
 			}
 		},
-		"node_modules/just-extend": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/just-extend/-/just-extend-6.2.0.tgz",
-			"integrity": "sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==",
-			"dev": true
-		},
 		"node_modules/keyv": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/keyv/-/keyv-3.0.0.tgz",
@@ -23254,12 +23243,6 @@
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
 			"integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
-			"dev": true
-		},
-		"node_modules/lodash.get": {
-			"version": "4.4.2",
-			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-			"integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
 			"dev": true
 		},
 		"node_modules/lodash.isplainobject": {
@@ -24482,29 +24465,6 @@
 			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
 			"dev": true,
 			"optional": true
-		},
-		"node_modules/nise": {
-			"version": "5.1.9",
-			"resolved": "https://registry.npmjs.org/nise/-/nise-5.1.9.tgz",
-			"integrity": "sha512-qOnoujW4SV6e40dYxJOb3uvuoPHtmLzIk4TFo+j0jPJoC+5Z9xja5qH5JZobEPsa8+YYphMrOSwnrshEhG2qww==",
-			"dev": true,
-			"dependencies": {
-				"@sinonjs/commons": "^3.0.0",
-				"@sinonjs/fake-timers": "^11.2.2",
-				"@sinonjs/text-encoding": "^0.7.2",
-				"just-extend": "^6.2.0",
-				"path-to-regexp": "^6.2.1"
-			}
-		},
-		"node_modules/nise/node_modules/@sinonjs/fake-timers": {
-			"version": "11.3.1",
-			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.3.1.tgz",
-			"integrity": "sha512-EVJO7nW5M/F5Tur0Rf2z/QoMo+1Ia963RiMtapiQrEWvY0iBUvADo8Beegwjpnle5BHkyHuoxSTW3jF43H1XRA==",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"@sinonjs/commons": "^3.0.1"
-			}
 		},
 		"node_modules/no-case": {
 			"version": "3.0.4",
@@ -26082,13 +26042,6 @@
 			"engines": {
 				"node": ">=16 || 14 >=14.17"
 			}
-		},
-		"node_modules/path-to-regexp": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
-			"integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/path-type": {
 			"version": "4.0.0",
@@ -29306,17 +29259,16 @@
 			"dev": true
 		},
 		"node_modules/sinon": {
-			"version": "16.1.3",
-			"resolved": "https://registry.npmjs.org/sinon/-/sinon-16.1.3.tgz",
-			"integrity": "sha512-mjnWWeyxcAf9nC0bXcPmiDut+oE8HYridTNzBbF98AYVLmWwGRp2ISEpyhYflG1ifILT+eNn3BmKUJPxjXUPlA==",
+			"version": "22.0.0",
+			"resolved": "https://registry.npmjs.org/sinon/-/sinon-22.0.0.tgz",
+			"integrity": "sha512-sq/6DpdXOrLyfbKlXLg/Usc7xu8YXPeLkOFZRvA3bNUSA2lhbrZ06yuXbH1fkzBPCbz9O10+7hznzUsjaYNm0Q==",
 			"dev": true,
+			"license": "BSD-3-Clause",
 			"dependencies": {
-				"@sinonjs/commons": "^3.0.0",
-				"@sinonjs/fake-timers": "^10.3.0",
-				"@sinonjs/samsam": "^8.0.0",
-				"diff": "^5.1.0",
-				"nise": "^5.1.4",
-				"supports-color": "^7.2.0"
+				"@sinonjs/commons": "^3.0.1",
+				"@sinonjs/fake-timers": "^15.4.0",
+				"@sinonjs/samsam": "^10.0.2",
+				"diff": "^9.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -29332,25 +29284,24 @@
 				"sinon": ">= 2.x"
 			}
 		},
-		"node_modules/sinon/node_modules/has-flag": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+		"node_modules/sinon/node_modules/@sinonjs/fake-timers": {
+			"version": "15.4.0",
+			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.4.0.tgz",
+			"integrity": "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==",
 			"dev": true,
-			"engines": {
-				"node": ">=8"
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@sinonjs/commons": "^3.0.1"
 			}
 		},
-		"node_modules/sinon/node_modules/supports-color": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+		"node_modules/sinon/node_modules/diff": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+			"integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
 			"dev": true,
-			"dependencies": {
-				"has-flag": "^4.0.0"
-			},
+			"license": "BSD-3-Clause",
 			"engines": {
-				"node": ">=8"
+				"node": ">=0.3.1"
 			}
 		},
 		"node_modules/sirv": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
 		"qunit": "~2.25.0",
 		"react-refresh": "0.14.0",
 		"sass": "1.98.0",
-		"sinon": "16.1.3",
+		"sinon": "22.0.0",
 		"sinon-test": "~3.1.6",
 		"source-map-loader": "5.0.0",
 		"terser-webpack-plugin": "5.4.0",

--- a/tests/qunit/wp-admin/js/dashboard.js
+++ b/tests/qunit/wp-admin/js/dashboard.js
@@ -144,22 +144,41 @@ jQuery( document ).ready( function () {
 		QUnit.module( 'communityEvents.getTimeZone', function() {
 			QUnit.test( 'modern browsers should return a time zone name', function( assert ) {
 				// Simulate a modern browser.
-				var stub = sinon.stub( Intl.DateTimeFormat.prototype, 'resolvedOptions' );
-				stub.returns( { timeZone: 'America/Chicago' } );
+				//
+				// `getTimeZone()` builds a fresh `Intl.DateTimeFormat()` instance, so the
+				// constructor is replaced to control `resolvedOptions()`. Stubbing the
+				// prototype method is no longer sufficient, because `@sinonjs/fake-timers`
+				// (bundled with sinon) mirrors `Intl` inside the sandbox and the freshly
+				// constructed instance bypasses the prototype-level stub.
+				sinon.replace( Intl, 'DateTimeFormat', function() {
+					return {
+						resolvedOptions: function() {
+							return { timeZone: 'America/Chicago' };
+						}
+					};
+				} );
 
 				var actual = getTimeZone( startDate );
 
-				stub.restore();
-
 				assert.strictEqual( actual, 'America/Chicago' );
+
+				sinon.restore();
 			} );
 
 			QUnit.test( 'older browsers should fallback to a raw UTC offset', function( assert ) {
-				// Simulate IE11.
-				var resolvedOptionsStub = sinon.stub( Intl.DateTimeFormat.prototype, 'resolvedOptions' );
+				// Simulate IE11, which declares the `timeZone` property but leaves it undefined.
+				//
+				// The constructor is replaced rather than its prototype method, because
+				// `@sinonjs/fake-timers` (bundled with sinon) mirrors `Intl` inside the sandbox
+				// and a freshly constructed instance bypasses a prototype-level stub.
+				sinon.replace( Intl, 'DateTimeFormat', function() {
+					return {
+						resolvedOptions: function() {
+							return { timeZone: undefined };
+						}
+					};
+				} );
 				var getTimezoneOffsetStub = sinon.stub( Date.prototype, 'getTimezoneOffset' );
-
-				resolvedOptionsStub.returns( { timeZone: undefined } );
 
 				getTimezoneOffsetStub.returns( 300 );
 				var actual = getTimeZone( startDate );
@@ -173,8 +192,7 @@ jQuery( document ).ready( function () {
 				actual = getTimeZone( startDate );
 				assert.strictEqual( actual, 300, 'positive offset' ); // Intentionally opposite, see `getTimeZone()`.
 
-				resolvedOptionsStub.restore();
-				getTimezoneOffsetStub.restore();
+				sinon.restore();
 			} );
 		} );
 


### PR DESCRIPTION
This updates the `sinon` development dependency from 16.1.3 to the latest 22.0.0, as requested on the ticket, and regenerates `package-lock.json`. `sinon-test` and `qunit` are left unchanged, and the lockfile changes are confined to the `sinon` dependency subtree.

The bump surfaces the timezone test failures noted on the ticket. The `communityEvents.getTimeZone` tests in `tests/qunit/wp-admin/js/dashboard.js` stubbed `Intl.DateTimeFormat.prototype.resolvedOptions`, but `getTimeZone()` reads from a freshly constructed `Intl.DateTimeFormat()` instance. From sinon 17 onwards, the bundled `@sinonjs/fake-timers` mirrors `Intl` inside the sandbox, so a newly constructed instance no longer resolves to the prototype-level stub.

The tests are updated to replace the `Intl.DateTimeFormat` constructor via `sinon.replace()` (the ticket's suggested `sinon.stub( Intl, 'DateTimeFormat' )` throws against the mirrored `Intl`), and to restore the sandbox at the end of each test to match the convention used elsewhere in the file. No production code is changed.

Testing: `npm run grunt qunit:compiled` reports 535/535 passing (0 failed) on both `compiled.html` and `index.html`. Before the change, the four documented `getTimeZone` assertions fail.

Trac ticket: https://core.trac.wordpress.org/ticket/64228

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 4.8
Used for: Analysing the sinon major-version breaking changes and the `@sinonjs/fake-timers` `Intl` mirroring behaviour, drafting the dependency update and the test adjustments, and running the QUnit suite. All changes were reviewed, tested, and are owned by me.

---
This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.
