### PR TITLE
Taxonomy: Add a search_columns argument to WP_Term_Query.

### DIFF
--- a/src/wp-includes/class-wp-term-query.php
+++ b/src/wp-includes/class-wp-term-query.php
@@ -92,6 +92,7 @@ class WP_Term_Query {
 	 * @since 5.1.0 Introduced the 'meta_compare_key' parameter.
 	 * @since 5.3.0 Introduced the 'meta_type_key' parameter.
 	 * @since 6.4.0 Introduced the 'cache_results' parameter.
+	 * @since 7.1.0 Introduced the 'search_columns' parameter.
 	 *
 	 * @param string|array $query {
 	 *     Optional. Array or query string of term query parameters. Default empty.
@@ -158,6 +159,9 @@ class WP_Term_Query {
 	 *                                                   (even if `$hide_empty` is set to true). Default true.
 	 *     @type string          $search                 Search criteria to match terms. Will be SQL-formatted with
 	 *                                                   wildcards before and after. Default empty.
+	 *     @type string[]        $search_columns         Array of column names to be searched. Accepts 'name',
+	 *                                                   'slug' and 'description'. An empty array searches
+	 *                                                   'name' and 'slug'. Default empty array.
 	 *     @type string          $name__like             Retrieve terms with criteria by which a term is LIKE
 	 *                                                   `$name__like`. Default empty.
 	 *     @type string          $description__like      Retrieve terms where the description is LIKE
@@ -211,6 +215,7 @@ class WP_Term_Query {
 			'term_taxonomy_id'       => '',
 			'hierarchical'           => true,
 			'search'                 => '',
+			'search_columns'         => array(),
 			'name__like'             => '',
 			'description__like'      => '',
 			'pad_counts'             => false,
@@ -638,7 +643,7 @@ class WP_Term_Query {
 		}
 
 		if ( ! empty( $args['search'] ) ) {
-			$this->sql_clauses['where']['search'] = $this->get_search_sql( $args['search'] );
+			$this->sql_clauses['where']['search'] = $this->get_search_sql( $args['search'], $this->query_vars['search_columns'] );
 		}
 
 		// Meta query support.
@@ -1096,18 +1101,62 @@ class WP_Term_Query {
 	 * Used internally to generate a SQL string related to the 'search' parameter.
 	 *
 	 * @since 4.6.0
+	 * @since 7.1.0 Introduced the `$search_columns` parameter.
 	 *
 	 * @global wpdb $wpdb WordPress database abstraction object.
 	 *
-	 * @param string $search Search string.
+	 * @param string   $search         Search string.
+	 * @param string[] $search_columns Optional. Array of column names to be searched. Accepts 'name',
+	 *                                 'slug' and 'description'. An empty array searches 'name' and 'slug'.
+	 *                                 Default empty array.
 	 * @return string Search SQL.
 	 */
-	protected function get_search_sql( $search ) {
+	protected function get_search_sql( $search, $search_columns = array() ) {
 		global $wpdb;
 
 		$like = '%' . $wpdb->esc_like( $search ) . '%';
 
-		return $wpdb->prepare( '((t.name LIKE %s) OR (t.slug LIKE %s))', $like, $like );
+		$default_search_columns = array( 'name', 'slug' );
+		$search_columns         = ! empty( $search_columns ) ? $search_columns : $default_search_columns;
+		if ( ! is_array( $search_columns ) ) {
+			$search_columns = array( $search_columns );
+		}
+
+		/**
+		 * Filters the columns to search in a WP_Term_Query search.
+		 *
+		 * The default columns depend on the `$search_columns` argument passed to WP_Term_Query.
+		 * If no `$search_columns` are specified, both 'name' and 'slug' are searched.
+		 * The supported columns are 'name', 'slug' and 'description'.
+		 *
+		 * @since 7.1.0
+		 *
+		 * @param string[]      $search_columns Array of column names to be searched.
+		 * @param string        $search         Text being searched.
+		 * @param WP_Term_Query $query          The current WP_Term_Query instance.
+		 */
+		$search_columns = (array) apply_filters( 'term_search_columns', $search_columns, $search, $this );
+
+		// Use only supported search columns.
+		$search_columns = array_intersect( $search_columns, array( 'name', 'slug', 'description' ) );
+		if ( empty( $search_columns ) ) {
+			$search_columns = $default_search_columns;
+		}
+
+		$column_map = array(
+			'name'        => 't.name',
+			'slug'        => 't.slug',
+			'description' => 'tt.description',
+		);
+
+		$search_parts = array();
+		foreach ( $search_columns as $search_column ) {
+			// The column name comes from the internal $column_map and is not user input.
+			$column         = $column_map[ $search_column ];
+			$search_parts[] = $wpdb->prepare( "({$column} LIKE %s)", $like ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		}
+
+		return '(' . implode( ' OR ', $search_parts ) . ')';
 	}
 
 	/**

--- a/tests/phpunit/tests/term/query.php
+++ b/tests/phpunit/tests/term/query.php
@@ -1207,4 +1207,94 @@ class Tests_Term_Query extends WP_UnitTestCase {
 
 		$this->assertSame( ltrim( $q->request ), $q->request, 'The query has leading whitespace' );
 	}
+
+	/**
+	 * @ticket 32824
+	 */
+	public function test_search_defaults_unchanged_without_search_columns() {
+		register_taxonomy( 'wptests_tax', 'post' );
+
+		$term_id = self::factory()->term->create(
+			array(
+				'taxonomy'    => 'wptests_tax',
+				'name'        => 'Alpha',
+				'slug'        => 'alpha',
+				'description' => 'Matchable description text',
+			)
+		);
+
+		$q = new WP_Term_Query(
+			array(
+				'taxonomy'   => 'wptests_tax',
+				'hide_empty' => false,
+				'fields'     => 'ids',
+				'search'     => 'Matchable',
+			)
+		);
+
+		$this->assertNotContains( $term_id, $q->terms );
+	}
+
+	/**
+	 * @ticket 32824
+	 */
+	public function test_search_columns_can_include_description() {
+		register_taxonomy( 'wptests_tax', 'post' );
+
+		$term_id = self::factory()->term->create(
+			array(
+				'taxonomy'    => 'wptests_tax',
+				'name'        => 'Alpha',
+				'slug'        => 'alpha',
+				'description' => 'Matchable description text',
+			)
+		);
+
+		$q = new WP_Term_Query(
+			array(
+				'taxonomy'       => 'wptests_tax',
+				'hide_empty'     => false,
+				'fields'         => 'ids',
+				'search'         => 'Matchable',
+				'search_columns' => array( 'description' ),
+			)
+		);
+
+		$this->assertSameSets( array( $term_id ), $q->terms );
+	}
+
+	/**
+	 * @ticket 32824
+	 */
+	public function test_term_search_columns_filter_can_alter_columns() {
+		register_taxonomy( 'wptests_tax', 'post' );
+
+		$term_id = self::factory()->term->create(
+			array(
+				'taxonomy'    => 'wptests_tax',
+				'name'        => 'Alpha',
+				'slug'        => 'alpha',
+				'description' => 'Matchable description text',
+			)
+		);
+
+		$filter = static function () {
+			return array( 'description' );
+		};
+
+		add_filter( 'term_search_columns', $filter );
+
+		$q = new WP_Term_Query(
+			array(
+				'taxonomy'   => 'wptests_tax',
+				'hide_empty' => false,
+				'fields'     => 'ids',
+				'search'     => 'Matchable',
+			)
+		);
+
+		remove_filter( 'term_search_columns', $filter );
+
+		$this->assertSameSets( array( $term_id ), $q->terms );
+	}
 }


### PR DESCRIPTION
`WP_Query` supports a `search_columns` argument and a `post_search_columns` filter, but `WP_Term_Query` has no equivalent: term search is a hard-coded `name`/`slug` `LIKE` with no way to also search the description or otherwise adjust the searched columns. This reconciles that inconsistency between post and term search.

Changes to `WP_Term_Query`:
- Adds a `search_columns` query argument accepting `name`, `slug`, and `description`.
- Adds a `term_search_columns` filter that mirrors `WP_Query`'s `post_search_columns` (same `( $columns, $search_term, $query )` signature).

Default behaviour is unchanged: when `search_columns` is not provided, only `name` and `slug` are searched, and the generated SQL is identical to before. Because the default query is untouched, there is no additional cost for existing searches — the wider column set is strictly opt-in. (This is intended to address the performance concern raised earlier on the ticket: there is no change to default search behaviour.)

New unit tests in `tests/phpunit/tests/term/query.php` cover: defaults unchanged (description is not searched by default), opting into `description`, and the `term_search_columns` filter. The `Tests_Term_Query` suite passes (45/45) and the change is WPCS-clean.

Note on the single `phpcs:ignore`: the `WordPress.DB.PreparedSQL.InterpolatedNotPrepared` annotation follows the established core idiom (e.g. `WP_Meta_Query` and `WP_Query`) — the interpolated column name comes only from an internal whitelist (`array_intersect` against `name`/`slug`/`description`), never from user input, and all values are still passed through `$wpdb->prepare()`.

Trac ticket: https://core.trac.wordpress.org/ticket/32824

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 4.8
Used for: Analysing the `WP_Query` vs `WP_Term_Query` search implementations and the ticket history, drafting the implementation and unit tests, and running PHPUnit and PHPCS. All changes were reviewed, tested, and are owned by me.

---
This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.
