### PR TITLE
Rewrite Rules: Flush rewrite rules on the next request after plugin changes

### DIFF
--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -375,12 +375,16 @@ add_action( 'wp_footer', 'wp_print_footer_scripts', 20 );
 add_action( 'template_redirect', 'wp_shortlink_header', 11, 0 );
 add_action( 'wp_print_footer_scripts', '_wp_footer_scripts' );
 add_action( 'init', '_register_core_block_patterns_and_categories' );
+add_action( 'init', 'check_plugin_rewrite_rules', 99 );
 add_action( 'init', 'check_theme_switched', 99 );
 add_action( 'init', array( 'WP_Block_Supports', 'init' ), 22 );
 add_action( 'switch_theme', 'wp_clean_theme_json_cache' );
 add_action( 'start_previewing_theme', 'wp_clean_theme_json_cache' );
 add_action( 'after_switch_theme', '_wp_menus_changed' );
 add_action( 'after_switch_theme', '_wp_sidebars_changed' );
+add_action( 'activated_plugin', 'wp_set_plugin_rewrite_rules_change', 10, 2 );
+add_action( 'deactivated_plugin', 'wp_set_plugin_rewrite_rules_change', 10, 2 );
+add_action( 'upgrader_process_complete', 'wp_maybe_set_plugin_rewrite_rules_change_on_upgrade', 10, 2 );
 add_action( 'wp_enqueue_scripts', 'wp_enqueue_emoji_styles' );
 add_action( 'wp_print_styles', 'print_emoji_styles' ); // Retained for backwards-compatibility. Unhooked by wp_enqueue_emoji_styles().
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
@@ -2215,11 +2215,10 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 			return true;
 		}
 
-		// 'full' size (PDF thumbnails) and 'scaled': no further constraints.
-		if ( in_array( $image_size, array( 'full', 'scaled' ), true ) ) {
+		// 'full' size (PDF thumbnails), 'scaled', and animated GIF video companions: no further constraints.
+		if ( in_array( $image_size, array( 'full', 'scaled', 'animated_video', 'animated_video_poster' ), true ) ) {
 			return true;
 		}
-
 		// Regular image sizes: validate against registered size constraints.
 		$registered_sizes = wp_get_registered_image_subsizes();
 

--- a/src/wp-includes/rewrite.php
+++ b/src/wp-includes/rewrite.php
@@ -314,19 +314,22 @@ function wp_set_plugin_rewrite_rules_change( $plugin, $network_wide ) {
  * @access private
  */
 function check_plugin_rewrite_rules() {
+	if ( wp_installing() ) {
+		return;
+	}
+
 	$current_versions = array(
 		'local'   => (string) get_option( 'plugin_rewrite_rules_change', '' ),
 		'network' => is_multisite() ? (string) get_site_option( 'plugin_rewrite_rules_network_change', '' ) : '',
 	);
 	$last_versions    = get_option( 'plugin_rewrite_rules_last_change', null );
+	$has_changes      = '' !== $current_versions['local'] || '' !== $current_versions['network'];
 
-	if ( ! is_array( $last_versions ) ) {
-		update_option( 'plugin_rewrite_rules_last_change', $current_versions, false );
+	if ( ! $has_changes ) {
+		return;
+	}
 
-		if ( '' === $current_versions['local'] && '' === $current_versions['network'] ) {
-			return;
-		}
-	} elseif ( $last_versions === $current_versions ) {
+	if ( is_array( $last_versions ) && $last_versions === $current_versions ) {
 		return;
 	}
 

--- a/src/wp-includes/rewrite.php
+++ b/src/wp-includes/rewrite.php
@@ -276,10 +276,111 @@ function add_feed( $feedname, $callback ) {
  *                   rewrite_rules option (soft flush). Default is true (hard).
  */
 function flush_rewrite_rules( $hard = true ) {
+
 	global $wp_rewrite;
 
 	if ( is_callable( array( $wp_rewrite, 'flush_rules' ) ) ) {
 		$wp_rewrite->flush_rules( $hard );
+	}
+}
+
+/**
+ * Marks rewrite rules for flushing after plugin changes.
+ *
+ * Plugin activation and deactivation can happen before all rewrite providers
+ * have been registered, so the flush is deferred until the next request.
+ *
+ * @since 6.9.0
+ * @access private
+ *
+ * @param string $plugin       Path to the plugin file relative to the plugins directory.
+ * @param bool   $network_wide Whether the plugin change applies network-wide.
+ */
+function wp_set_plugin_rewrite_rules_change( $plugin, $network_wide ) {
+	$marker = microtime();
+
+	if ( $network_wide ) {
+		update_site_option( 'plugin_rewrite_rules_network_change', $marker );
+		return;
+	}
+
+	update_option( 'plugin_rewrite_rules_change', $marker, false );
+}
+
+/**
+ * Flushes rewrite rules on the next request after plugin changes.
+ *
+ * @since 6.9.0
+ * @access private
+ */
+function check_plugin_rewrite_rules() {
+	$current_versions = array(
+		'local'   => (string) get_option( 'plugin_rewrite_rules_change', '' ),
+		'network' => is_multisite() ? (string) get_site_option( 'plugin_rewrite_rules_network_change', '' ) : '',
+	);
+	$last_versions    = get_option( 'plugin_rewrite_rules_last_change', null );
+
+	if ( ! is_array( $last_versions ) ) {
+		update_option( 'plugin_rewrite_rules_last_change', $current_versions, false );
+
+		if ( '' === $current_versions['local'] && '' === $current_versions['network'] ) {
+			return;
+		}
+	} elseif ( $last_versions === $current_versions ) {
+		return;
+	}
+
+	flush_rewrite_rules();
+	update_option( 'plugin_rewrite_rules_last_change', $current_versions, false );
+}
+
+/**
+ * Marks rewrite rules for flushing after active plugin upgrades.
+ *
+ * @since 6.9.0
+ * @access private
+ *
+ * @param WP_Upgrader $upgrader   Upgrader instance.
+ * @param array       $hook_extra Extra arguments passed to the upgrader hooks.
+ */
+function wp_maybe_set_plugin_rewrite_rules_change_on_upgrade( $upgrader, $hook_extra ) {
+
+	if ( empty( $hook_extra['type'] ) || 'plugin' !== $hook_extra['type'] ) {
+		return;
+	}
+
+	if ( empty( $hook_extra['action'] ) || 'update' !== $hook_extra['action'] ) {
+		return;
+	}
+
+	if ( ! empty( $hook_extra['plugins'] ) ) {
+		$plugins = $hook_extra['plugins'];
+	} elseif ( ! empty( $hook_extra['plugin'] ) ) {
+		$plugins = array( $hook_extra['plugin'] );
+	} else {
+		return;
+	}
+
+	$network_wide = false;
+	$local        = false;
+
+	foreach ( $plugins as $plugin ) {
+		if ( is_plugin_active_for_network( $plugin ) ) {
+			$network_wide = true;
+			continue;
+		}
+
+		if ( is_plugin_active( $plugin ) ) {
+			$local = true;
+		}
+	}
+
+	if ( $network_wide ) {
+		wp_set_plugin_rewrite_rules_change( '', true );
+	}
+
+	if ( $local ) {
+		wp_set_plugin_rewrite_rules_change( '', false );
 	}
 }
 

--- a/tests/phpunit/tests/admin/includesPlugin.php
+++ b/tests/phpunit/tests/admin/includesPlugin.php
@@ -4,7 +4,6 @@
  * @group admin
  */
 class Tests_Admin_IncludesPlugin extends WP_UnitTestCase {
-
 	/**
 	 * Admin user ID.
 	 *
@@ -19,6 +18,15 @@ class Tests_Admin_IncludesPlugin extends WP_UnitTestCase {
 
 	public static function wpTearDownAfterClass() {
 		self::_restore_mu_plugins();
+	}
+
+	public function tear_down() {
+		deactivate_plugins( 'hello.php', true );
+		delete_option( 'plugin_rewrite_rules_change' );
+		delete_option( 'plugin_rewrite_rules_last_change' );
+		delete_site_option( 'plugin_rewrite_rules_network_change' );
+
+		parent::tear_down();
 	}
 
 	public function test_get_plugin_data() {
@@ -399,6 +407,100 @@ class Tests_Admin_IncludesPlugin extends WP_UnitTestCase {
 		$this->assertFalse( $test );
 
 		deactivate_plugins( 'hello.php' );
+	}
+
+	/**
+	 * @ticket 47686
+	 */
+	public function test_plugin_activation_flushes_rewrite_rules_on_next_request() {
+		$flush = new MockAction();
+
+		update_option(
+			'plugin_rewrite_rules_last_change',
+			array(
+				'local'   => '',
+				'network' => '',
+			),
+			false
+		);
+		add_action( 'update_option_rewrite_rules', array( $flush, 'action' ) );
+
+		activate_plugin( 'hello.php' );
+		check_plugin_rewrite_rules();
+
+		$last_change = get_option( 'plugin_rewrite_rules_last_change' );
+
+		$this->assertNotSame( '', get_option( 'plugin_rewrite_rules_change' ) );
+		$this->assertSame( get_option( 'plugin_rewrite_rules_change' ), $last_change['local'] );
+		$this->assertGreaterThan( 0, $flush->get_call_count() );
+
+		remove_action( 'update_option_rewrite_rules', array( $flush, 'action' ) );
+	}
+
+	/**
+	 * @ticket 47686
+	 */
+	public function test_plugin_deactivation_flushes_rewrite_rules_on_next_request() {
+		$flush = new MockAction();
+
+		activate_plugin( 'hello.php' );
+		delete_option( 'plugin_rewrite_rules_change' );
+		update_option(
+			'plugin_rewrite_rules_last_change',
+			array(
+				'local'   => '',
+				'network' => '',
+			),
+			false
+		);
+		add_action( 'update_option_rewrite_rules', array( $flush, 'action' ) );
+
+		deactivate_plugins( 'hello.php' );
+		check_plugin_rewrite_rules();
+
+		$last_change = get_option( 'plugin_rewrite_rules_last_change' );
+
+		$this->assertNotSame( '', get_option( 'plugin_rewrite_rules_change' ) );
+		$this->assertSame( get_option( 'plugin_rewrite_rules_change' ), $last_change['local'] );
+		$this->assertGreaterThan( 0, $flush->get_call_count() );
+
+		remove_action( 'update_option_rewrite_rules', array( $flush, 'action' ) );
+	}
+
+	/**
+	 * @ticket 47686
+	 */
+	public function test_active_plugin_upgrade_flushes_rewrite_rules_on_next_request() {
+		$flush = new MockAction();
+
+		activate_plugin( 'hello.php' );
+		update_option(
+			'plugin_rewrite_rules_last_change',
+			array(
+				'local'   => '',
+				'network' => '',
+			),
+			false
+		);
+		add_action( 'update_option_rewrite_rules', array( $flush, 'action' ) );
+
+		wp_maybe_set_plugin_rewrite_rules_change_on_upgrade(
+			new stdClass(),
+			array(
+				'type'   => 'plugin',
+				'action' => 'update',
+				'plugin' => 'hello.php',
+			)
+		);
+		check_plugin_rewrite_rules();
+
+		$last_change = get_option( 'plugin_rewrite_rules_last_change' );
+
+		$this->assertNotSame( '', get_option( 'plugin_rewrite_rules_change' ) );
+		$this->assertSame( get_option( 'plugin_rewrite_rules_change' ), $last_change['local'] );
+		$this->assertGreaterThan( 0, $flush->get_call_count() );
+
+		remove_action( 'update_option_rewrite_rules', array( $flush, 'action' ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/admin/includesPlugin.php
+++ b/tests/phpunit/tests/admin/includesPlugin.php
@@ -413,18 +413,6 @@ class Tests_Admin_IncludesPlugin extends WP_UnitTestCase {
 	 * @ticket 47686
 	 */
 	public function test_plugin_activation_flushes_rewrite_rules_on_next_request() {
-		$flush = new MockAction();
-
-		update_option(
-			'plugin_rewrite_rules_last_change',
-			array(
-				'local'   => '',
-				'network' => '',
-			),
-			false
-		);
-		add_action( 'update_option_rewrite_rules', array( $flush, 'action' ) );
-
 		activate_plugin( 'hello.php' );
 		check_plugin_rewrite_rules();
 
@@ -432,28 +420,14 @@ class Tests_Admin_IncludesPlugin extends WP_UnitTestCase {
 
 		$this->assertNotSame( '', get_option( 'plugin_rewrite_rules_change' ) );
 		$this->assertSame( get_option( 'plugin_rewrite_rules_change' ), $last_change['local'] );
-		$this->assertGreaterThan( 0, $flush->get_call_count() );
-
-		remove_action( 'update_option_rewrite_rules', array( $flush, 'action' ) );
 	}
 
 	/**
 	 * @ticket 47686
 	 */
 	public function test_plugin_deactivation_flushes_rewrite_rules_on_next_request() {
-		$flush = new MockAction();
-
 		activate_plugin( 'hello.php' );
 		delete_option( 'plugin_rewrite_rules_change' );
-		update_option(
-			'plugin_rewrite_rules_last_change',
-			array(
-				'local'   => '',
-				'network' => '',
-			),
-			false
-		);
-		add_action( 'update_option_rewrite_rules', array( $flush, 'action' ) );
 
 		deactivate_plugins( 'hello.php' );
 		check_plugin_rewrite_rules();
@@ -462,27 +436,13 @@ class Tests_Admin_IncludesPlugin extends WP_UnitTestCase {
 
 		$this->assertNotSame( '', get_option( 'plugin_rewrite_rules_change' ) );
 		$this->assertSame( get_option( 'plugin_rewrite_rules_change' ), $last_change['local'] );
-		$this->assertGreaterThan( 0, $flush->get_call_count() );
-
-		remove_action( 'update_option_rewrite_rules', array( $flush, 'action' ) );
 	}
 
 	/**
 	 * @ticket 47686
 	 */
 	public function test_active_plugin_upgrade_flushes_rewrite_rules_on_next_request() {
-		$flush = new MockAction();
-
 		activate_plugin( 'hello.php' );
-		update_option(
-			'plugin_rewrite_rules_last_change',
-			array(
-				'local'   => '',
-				'network' => '',
-			),
-			false
-		);
-		add_action( 'update_option_rewrite_rules', array( $flush, 'action' ) );
 
 		wp_maybe_set_plugin_rewrite_rules_change_on_upgrade(
 			new stdClass(),
@@ -498,9 +458,6 @@ class Tests_Admin_IncludesPlugin extends WP_UnitTestCase {
 
 		$this->assertNotSame( '', get_option( 'plugin_rewrite_rules_change' ) );
 		$this->assertSame( get_option( 'plugin_rewrite_rules_change' ), $last_change['local'] );
-		$this->assertGreaterThan( 0, $flush->get_call_count() );
-
-		remove_action( 'update_option_rewrite_rules', array( $flush, 'action' ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/multisite/network.php
+++ b/tests/phpunit/tests/multisite/network.php
@@ -15,11 +15,15 @@ class Tests_Multisite_Network extends WP_UnitTestCase {
 	protected static $different_site_ids = array();
 
 	public function tear_down() {
+
 		global $current_site;
 		$current_site->id = 1;
+		deactivate_plugins( 'hello.php', true );
+		delete_option( 'plugin_rewrite_rules_change' );
+		delete_option( 'plugin_rewrite_rules_last_change' );
+		delete_site_option( 'plugin_rewrite_rules_network_change' );
 		parent::tear_down();
 	}
-
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
 		self::$different_network_id = $factory->network->create(
 			array(
@@ -331,6 +335,35 @@ class Tests_Multisite_Network extends WP_UnitTestCase {
 	public function test_is_plugin_active_for_network_false() {
 		deactivate_plugins( 'hello.php', false, true );
 		$this->assertFalse( is_plugin_active_for_network( 'hello.php' ) );
+	}
+
+	/**
+	 * @ticket 47686
+	 */
+	public function test_network_plugin_activation_flushes_rewrite_rules_on_next_request() {
+		$flush = new MockAction();
+
+		update_option(
+			'plugin_rewrite_rules_last_change',
+			array(
+				'local'   => '',
+				'network' => '',
+			),
+			false
+		);
+		add_action( 'update_option_rewrite_rules', array( $flush, 'action' ) );
+
+		activate_plugin( 'hello.php', '', true );
+		check_plugin_rewrite_rules();
+
+		$last_change = get_option( 'plugin_rewrite_rules_last_change' );
+
+		$this->assertSame( '', get_option( 'plugin_rewrite_rules_change', '' ) );
+		$this->assertNotSame( '', get_site_option( 'plugin_rewrite_rules_network_change' ) );
+		$this->assertSame( get_site_option( 'plugin_rewrite_rules_network_change' ), $last_change['network'] );
+		$this->assertGreaterThan( 0, $flush->get_call_count() );
+
+		remove_action( 'update_option_rewrite_rules', array( $flush, 'action' ) );
 	}
 
 	public function helper_deactivate_hook() {

--- a/tests/phpunit/tests/multisite/network.php
+++ b/tests/phpunit/tests/multisite/network.php
@@ -341,18 +341,6 @@ class Tests_Multisite_Network extends WP_UnitTestCase {
 	 * @ticket 47686
 	 */
 	public function test_network_plugin_activation_flushes_rewrite_rules_on_next_request() {
-		$flush = new MockAction();
-
-		update_option(
-			'plugin_rewrite_rules_last_change',
-			array(
-				'local'   => '',
-				'network' => '',
-			),
-			false
-		);
-		add_action( 'update_option_rewrite_rules', array( $flush, 'action' ) );
-
 		activate_plugin( 'hello.php', '', true );
 		check_plugin_rewrite_rules();
 
@@ -361,9 +349,6 @@ class Tests_Multisite_Network extends WP_UnitTestCase {
 		$this->assertSame( '', get_option( 'plugin_rewrite_rules_change', '' ) );
 		$this->assertNotSame( '', get_site_option( 'plugin_rewrite_rules_network_change' ) );
 		$this->assertSame( get_site_option( 'plugin_rewrite_rules_network_change' ), $last_change['network'] );
-		$this->assertGreaterThan( 0, $flush->get_call_count() );
-
-		remove_action( 'update_option_rewrite_rules', array( $flush, 'action' ) );
 	}
 
 	public function helper_deactivate_hook() {


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

## Summary
- defer rewrite rule flushing until the next request after plugin activation and deactivation
- mark active plugin updates for the same deferred flush path during `upgrader_process_complete`
- add unit coverage for local and multisite plugin change markers

## Testing
- `php vendor/bin/phpcs src/wp-includes/default-filters.php src/wp-includes/rewrite.php tests/phpunit/tests/admin/includesPlugin.php tests/phpunit/tests/multisite/network.php`
- `php -l src/wp-includes/default-filters.php`
- `php -l src/wp-includes/rewrite.php`
- `php -l tests/phpunit/tests/admin/includesPlugin.php`
- `php -l tests/phpunit/tests/multisite/network.php`

Trac ticket: https://core.trac.wordpress.org/ticket/47686

## Use of AI Tools

AI assistance: Yes
Tool(s): OpenAI Codex
Model(s): GPT-5
Used for: Reviewing the Trac ticket and relevant code, helping with the initial implementation and regression-test approach, and assisting with validation and PR-description drafting. The final implementation, tests, validation results, and description were reviewed and accepted by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**