### PR TITLE
REST API: Exempt animated GIF video companions from sideload dimension validation

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
@@ -2220,6 +2220,15 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 			return true;
 		}
 
+		/*
+		 * 'animated_video_poster' companion: a static poster image for the
+		 * converted video. It is a real image (so it has positive dimensions)
+		 * but is not a registered sub-size, so it has no dimension constraint.
+		 */
+		if ( 'animated_video_poster' === $image_size ) {
+			return true;
+		}
+
 		// Regular image sizes: validate against registered size constraints.
 		$registered_sizes = wp_get_registered_image_subsizes();
 
@@ -2367,16 +2376,19 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 		$image_size = $request['image_size'];
 
 		/*
-		 * Validate raster sub-sizes before storing them. Companion files are
-		 * exempt: their dimensions are neither validated nor recorded, and the
-		 * file may not be readable by wp_getimagesize() at all. This applies to
-		 * source-format originals (e.g. a HEIC or JXL kept next to its JPEG
-		 * derivative) and to the converted-video companions of an animated GIF
-		 * (the MP4/WebM and its static first-frame poster).
+		 * Validate raster sub-sizes before storing them. Two companion sizes
+		 * are exempt because wp_getimagesize() may not be able to read the
+		 * file at all: the 'animated_video' companion of an animated GIF is a
+		 * video (MP4/WebM), and a source-format original (e.g. a HEIC or JXL
+		 * kept next to its JPEG derivative) may be an unreadable format. Their
+		 * dimensions are neither validated nor recorded. The
+		 * 'animated_video_poster' companion is a real image, so it is still
+		 * read and rejected if unreadable; validate_image_dimensions() skips
+		 * only the registered-size constraint for it.
 		 */
-		$companion_sizes = array( self::IMAGE_SIZE_SOURCE_ORIGINAL, 'animated_video', 'animated_video_poster' );
+		$skip_dimension_read = in_array( $image_size, array( self::IMAGE_SIZE_SOURCE_ORIGINAL, 'animated_video' ), true );
 
-		if ( ! in_array( $image_size, $companion_sizes, true ) ) {
+		if ( ! $skip_dimension_read ) {
 			/*
 			 * Read the dimensions up front. A file whose dimensions cannot be
 			 * read is corrupted or an unsupported format and must be rejected

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
@@ -2367,12 +2367,16 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 		$image_size = $request['image_size'];
 
 		/*
-		 * Validate raster sub-sizes before storing them. Source-format companion
-		 * originals (e.g. a HEIC or JXL kept next to its JPEG derivative) are
+		 * Validate raster sub-sizes before storing them. Companion files are
 		 * exempt: their dimensions are neither validated nor recorded, and the
-		 * source format may not be readable by wp_getimagesize() at all.
+		 * file may not be readable by wp_getimagesize() at all. This applies to
+		 * source-format originals (e.g. a HEIC or JXL kept next to its JPEG
+		 * derivative) and to the converted-video companions of an animated GIF
+		 * (the MP4/WebM and its static first-frame poster).
 		 */
-		if ( self::IMAGE_SIZE_SOURCE_ORIGINAL !== $image_size ) {
+		$companion_sizes = array( self::IMAGE_SIZE_SOURCE_ORIGINAL, 'animated_video', 'animated_video_poster' );
+
+		if ( ! in_array( $image_size, $companion_sizes, true ) ) {
 			/*
 			 * Read the dimensions up front. A file whose dimensions cannot be
 			 * read is corrupted or an unsupported format and must be rejected


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65549

## What

Fixes the PHPUnit failure on trunk introduced by the combination of [62619] and [62623]:

```
1) WP_Test_REST_Attachments_Controller::test_sideload_animated_video_companions_write_metadata
Sideloading animated_video should succeed.
Failed asserting that 400 is identical to 200.
```

Failing run: https://github.com/WordPress/wordpress-develop/actions/runs/28562019769/attempts/2

## Why the failure only appeared on trunk

This is a semantic conflict between two individually green commits:

- [62619] (#64798) added dimension validation to the sideload endpoint: every scalar `image_size` other than `_source_original` is now checked against `wp_get_registered_image_subsizes()` and rejected with `rest_upload_unknown_size` (400) when not registered.
- [62623] (#65549, PR #12005) added the `animated_video` / `animated_video_poster` companion sizes. The PR branch last merged trunk at 19:11 UTC on July 1, before [62619] landed at 21:32 UTC, so its CI ran against a trunk without dimension validation and passed.

Once both were on trunk, sideloading a companion hit the new validation: `animated_video` is not a registered sub-size, so the request returns 400.

Beyond the test, the real feature flow was broken too: the actual companion is an MP4/WebM video, and `wp_getimagesize()` cannot read it, which would fail with `rest_upload_invalid_image` even before the unknown-size check.

## Fix

In `sideload_item()`, skip the `wp_getimagesize()` read and all dimension checks for the `animated_video` companion (like the existing `_source_original` exemption), since a video is not image-readable. The `animated_video_poster` companion is a real image, so it keeps the readability and positive-dimension checks; `validate_image_dimensions()` skips only the registered-size constraint for it.

## Testing

- `tests/phpunit/tests/rest-api/rest-attachments-controller.php --filter test_sideload_animated_video_companions_write_metadata` passes.
- The full `restattachments` group passes locally.

## Parity with Gutenberg

The exemption semantics match the Gutenberg polyfill in [GB PR #79603](https://github.com/WordPress/gutenberg/pull/79603) (`Gutenberg_REST_Attachments_Controller`):

- `animated_video` (MP4/WebM) and `_source_original`: skip the `wp_getimagesize()` read and all dimension checks - the file may not be image-readable at all.
- `animated_video_poster`: still read via `wp_getimagesize()` and rejected if unreadable (it is a real image); only the registered-size constraint is skipped.

## Commit message

```
Media: Fix sideload validation for animated GIF video companions.

Update the dimension validation introduced in [62619] so sideloading the `animated_video` and `animated_video_poster` companion sizes added in [62623] work as expected.  

Follow-up to [62619], [62623].

Props mukesh27.
See #65549, #64798.
```
