### PR TITLE
Admin: Use absolute URLs in admin menu links

### DIFF
--- a/src/wp-admin/menu-header.php
+++ b/src/wp-admin/menu-header.php
@@ -55,6 +55,24 @@ $submenu_file = apply_filters( 'submenu_file', $submenu_file, $parent_file );
 get_admin_page_parent();
 
 /**
+ * Returns an absolute URL for an admin menu item.
+ *
+ * @since 6.9.0
+ * @access private
+ *
+ * @param string $path The admin menu item path.
+ * @return string The escaped absolute admin menu item URL.
+ */
+function _wp_admin_menu_url( $path ) {
+
+	if ( preg_match( '#^[a-z][a-z0-9+.-]*:#i', $path ) || str_starts_with( $path, '//' ) ) {
+		return esc_url( $path );
+	}
+
+	return esc_url( self_admin_url( $path ) );
+}
+
+/**
  * Display menu.
  *
  * @access private
@@ -170,9 +188,11 @@ function _wp_menu_output( $menu, $submenu, $submenu_as_parent = true ) {
 					&& ! file_exists( ABSPATH . "/wp-admin/$menu_file" ) )
 			) {
 				$admin_is_parent = true;
-				echo "<a href='admin.php?page={$submenu_items[0][2]}'$class $aria_attributes><div class='wp-menu-image$img_class'$img_style aria-hidden='true'>$img</div><div class='wp-menu-name'>$title</div></a>";
+				$menu_url        = _wp_admin_menu_url( add_query_arg( 'page', $submenu_items[0][2], 'admin.php' ) );
+				echo "<a href='$menu_url'$class $aria_attributes><div class='wp-menu-image$img_class'$img_style aria-hidden='true'>$img</div><div class='wp-menu-name'>$title</div></a>";
 			} else {
-				echo "\n\t<a href='{$submenu_items[0][2]}'$class $aria_attributes><div class='wp-menu-image$img_class'$img_style aria-hidden='true'>$img</div><div class='wp-menu-name'>$title</div></a>";
+				$menu_url = _wp_admin_menu_url( $submenu_items[0][2] );
+				echo "\n\t<a href='$menu_url'$class $aria_attributes><div class='wp-menu-image$img_class'$img_style aria-hidden='true'>$img</div><div class='wp-menu-name'>$title</div></a>";
 			}
 		} elseif ( ! empty( $item[2] ) && current_user_can( $item[1] ) ) {
 			$menu_hook = get_plugin_page_hook( $item[2], 'admin.php' );
@@ -189,12 +209,13 @@ function _wp_menu_output( $menu, $submenu, $submenu_as_parent = true ) {
 					&& ! file_exists( ABSPATH . "/wp-admin/$menu_file" ) )
 			) {
 				$admin_is_parent = true;
-				echo "\n\t<a href='admin.php?page={$item[2]}'$class $aria_attributes><div class='wp-menu-image$img_class'$img_style aria-hidden='true'>$img</div><div class='wp-menu-name'>{$item[0]}</div></a>";
+				$menu_url        = _wp_admin_menu_url( add_query_arg( 'page', $item[2], 'admin.php' ) );
+				echo "\n\t<a href='$menu_url'$class $aria_attributes><div class='wp-menu-image$img_class'$img_style aria-hidden='true'>$img</div><div class='wp-menu-name'>{$item[0]}</div></a>";
 			} else {
-				echo "\n\t<a href='{$item[2]}'$class $aria_attributes><div class='wp-menu-image$img_class'$img_style aria-hidden='true'>$img</div><div class='wp-menu-name'>{$item[0]}</div></a>";
+				$menu_url = _wp_admin_menu_url( $item[2] );
+				echo "\n\t<a href='$menu_url'$class $aria_attributes><div class='wp-menu-image$img_class'$img_style aria-hidden='true'>$img</div><div class='wp-menu-name'>{$item[0]}</div></a>";
 			}
 		}
-
 		if ( ! empty( $submenu_items ) ) {
 			echo "\n\t<ul class='wp-submenu wp-submenu-wrap'>";
 			echo "<li class='wp-submenu-head' aria-hidden='true'>{$item[0]}</li>";
@@ -270,10 +291,11 @@ function _wp_menu_output( $menu, $submenu, $submenu_as_parent = true ) {
 						$sub_item_url = add_query_arg( array( 'page' => $sub_item[2] ), 'admin.php' );
 					}
 
-					$sub_item_url = esc_url( $sub_item_url );
+					$sub_item_url = _wp_admin_menu_url( $sub_item_url );
 					echo "<li$class><a href='$sub_item_url'$class$aria_attributes>$title</a></li>";
 				} else {
-					echo "<li$class><a href='{$sub_item[2]}'$class$aria_attributes>$title</a></li>";
+					$sub_item_url = _wp_admin_menu_url( $sub_item[2] );
+					echo "<li$class><a href='$sub_item_url'$class$aria_attributes>$title</a></li>";
 				}
 			}
 			echo '</ul>';

--- a/tests/phpunit/tests/admin/menuHeader.php
+++ b/tests/phpunit/tests/admin/menuHeader.php
@@ -5,26 +5,10 @@
 class Tests_Admin_MenuHeader extends WP_UnitTestCase {
 
 	/**
-	 * Admin user ID.
-	 *
-	 * @var int
-	 */
-	public static $admin_id;
-
-	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
-		self::$admin_id = $factory->user->create( array( 'role' => 'administrator' ) );
-	}
-
-	public static function wpTearDownAfterClass() {
-		self::delete_user( self::$admin_id );
-	}
-
-	/**
 	 * @ticket 56302
 	 */
 	public function test_wp_menu_output_uses_absolute_top_level_url() {
-		wp_set_current_user( self::$admin_id );
-		update_option( 'siteurl', 'http://example.com' );
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
 
 		$menu = array(
 			array( 'Dashboard', 'read', 'index.php', 'Dashboard', 'menu-top', 'menu-dashboard', 'dashicons-dashboard' ),
@@ -32,15 +16,14 @@ class Tests_Admin_MenuHeader extends WP_UnitTestCase {
 
 		$actual = $this->render_admin_menu( $menu, array() );
 
-		$this->assertStringContainsString( "href='http://example.com/wp-admin/index.php'", $actual );
+		$this->assertStringContainsString( "href='" . admin_url( 'index.php' ) . "'", $actual );
 	}
 
 	/**
 	 * @ticket 56302
 	 */
 	public function test_wp_menu_output_uses_absolute_submenu_parent_url() {
-		wp_set_current_user( self::$admin_id );
-		update_option( 'siteurl', 'http://example.com' );
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
 
 		$menu    = array(
 			array( 'Tools', 'read', 'tools.php', 'Tools', 'menu-top', 'menu-tools', 'dashicons-admin-tools' ),
@@ -53,15 +36,14 @@ class Tests_Admin_MenuHeader extends WP_UnitTestCase {
 
 		$actual = $this->render_admin_menu( $menu, $submenu );
 
-		$this->assertStringContainsString( "href='http://example.com/wp-admin/tools.php'", $actual );
+		$this->assertStringContainsString( "href='" . admin_url( 'tools.php' ) . "'", $actual );
 	}
 
 	/**
 	 * @ticket 56302
 	 */
 	public function test_wp_menu_output_uses_absolute_submenu_urls() {
-		wp_set_current_user( self::$admin_id );
-		update_option( 'siteurl', 'http://example.com' );
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
 
 		$menu    = array(
 			array( 'Posts', 'read', 'edit.php', 'Posts', 'menu-top', 'menu-posts', 'dashicons-admin-post' ),
@@ -75,16 +57,15 @@ class Tests_Admin_MenuHeader extends WP_UnitTestCase {
 
 		$actual = $this->render_admin_menu( $menu, $submenu );
 
-		$this->assertStringContainsString( "href='http://example.com/wp-admin/edit.php'", $actual );
-		$this->assertStringContainsString( "href='http://example.com/wp-admin/post-new.php?post_type=post'", $actual );
+		$this->assertStringContainsString( "href='" . admin_url( 'edit.php' ) . "'", $actual );
+		$this->assertStringContainsString( "href='" . admin_url( 'post-new.php?post_type=post' ) . "'", $actual );
 	}
 
 	/**
 	 * @ticket 56302
 	 */
 	public function test_wp_menu_output_uses_absolute_plugin_page_url() {
-		wp_set_current_user( self::$admin_id );
-		update_option( 'siteurl', 'http://example.com' );
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
 
 		add_menu_page( 'Test Page', 'Test Page', 'read', 'test-page', '__return_null' );
 
@@ -92,15 +73,14 @@ class Tests_Admin_MenuHeader extends WP_UnitTestCase {
 
 		$actual = $this->render_admin_menu( $menu, array(), false );
 
-		$this->assertStringContainsString( "href='http://example.com/wp-admin/admin.php?page=test-page'", $actual );
+		$this->assertStringContainsString( "href='" . admin_url( 'admin.php?page=test-page' ) . "'", $actual );
 	}
 
 	/**
 	 * @ticket 56302
 	 */
 	public function test_wp_menu_output_preserves_external_urls() {
-		wp_set_current_user( self::$admin_id );
-		update_option( 'siteurl', 'http://example.com' );
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
 
 		$menu = array(
 			array( 'External', 'read', 'https://wordpress.org/news/', 'External', 'menu-top', 'menu-external', 'dashicons-admin-site' ),
@@ -116,6 +96,8 @@ class Tests_Admin_MenuHeader extends WP_UnitTestCase {
 
 		global $self, $parent_file, $submenu_file, $plugin_page, $typenow;
 
+		$globals = $this->backup_globals( array( 'self', 'parent_file', 'submenu_file', 'plugin_page', 'typenow' ) );
+
 		$self         = 'index.php';
 		$parent_file  = '';
 		$submenu_file = '';
@@ -123,8 +105,12 @@ class Tests_Admin_MenuHeader extends WP_UnitTestCase {
 		$typenow      = '';
 
 		ob_start();
-		_wp_menu_output( $menu, $submenu, $submenu_as_parent );
-		return ob_get_clean();
+		try {
+			_wp_menu_output( $menu, $submenu, $submenu_as_parent );
+			return ob_get_clean();
+		} finally {
+			$this->restore_globals( $globals );
+		}
 	}
 
 	private function require_menu_header() {
@@ -134,6 +120,9 @@ class Tests_Admin_MenuHeader extends WP_UnitTestCase {
 
 		global $menu, $submenu, $parent_file, $submenu_file;
 
+		$globals  = $this->backup_globals( array( 'menu', 'submenu', 'parent_file', 'submenu_file' ) );
+		$php_self = isset( $_SERVER['PHP_SELF'] ) ? $_SERVER['PHP_SELF'] : null;
+
 		$menu         = array();
 		$submenu      = array();
 		$parent_file  = '';
@@ -142,7 +131,40 @@ class Tests_Admin_MenuHeader extends WP_UnitTestCase {
 		$_SERVER['PHP_SELF'] = '/wp-admin/index.php';
 
 		ob_start();
-		require ABSPATH . 'wp-admin/menu-header.php';
-		ob_end_clean();
+		try {
+			require ABSPATH . 'wp-admin/menu-header.php';
+			ob_end_clean();
+		} finally {
+			$this->restore_globals( $globals );
+
+			if ( null === $php_self ) {
+				unset( $_SERVER['PHP_SELF'] );
+			} else {
+				$_SERVER['PHP_SELF'] = $php_self;
+			}
+		}
+	}
+
+	private function backup_globals( $names ) {
+		$globals = array();
+
+		foreach ( $names as $name ) {
+			$globals[ $name ] = array(
+				'exists' => array_key_exists( $name, $GLOBALS ),
+				'value'  => array_key_exists( $name, $GLOBALS ) ? $GLOBALS[ $name ] : null,
+			);
+		}
+
+		return $globals;
+	}
+
+	private function restore_globals( $globals ) {
+		foreach ( $globals as $name => $global ) {
+			if ( $global['exists'] ) {
+				$GLOBALS[ $name ] = $global['value'];
+			} else {
+				unset( $GLOBALS[ $name ] );
+			}
+		}
 	}
 }

--- a/tests/phpunit/tests/admin/menuHeader.php
+++ b/tests/phpunit/tests/admin/menuHeader.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * @group admin
+ */
+class Tests_Admin_MenuHeader extends WP_UnitTestCase {
+
+	/**
+	 * Admin user ID.
+	 *
+	 * @var int
+	 */
+	public static $admin_id;
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$admin_id = $factory->user->create( array( 'role' => 'administrator' ) );
+	}
+
+	public static function wpTearDownAfterClass() {
+		self::delete_user( self::$admin_id );
+	}
+
+	/**
+	 * @ticket 56302
+	 */
+	public function test_wp_menu_output_uses_absolute_top_level_url() {
+		wp_set_current_user( self::$admin_id );
+		update_option( 'siteurl', 'http://example.com' );
+
+		$menu = array(
+			array( 'Dashboard', 'read', 'index.php', 'Dashboard', 'menu-top', 'menu-dashboard', 'dashicons-dashboard' ),
+		);
+
+		$actual = $this->render_admin_menu( $menu, array() );
+
+		$this->assertStringContainsString( "href='http://example.com/wp-admin/index.php'", $actual );
+	}
+
+	/**
+	 * @ticket 56302
+	 */
+	public function test_wp_menu_output_uses_absolute_submenu_parent_url() {
+		wp_set_current_user( self::$admin_id );
+		update_option( 'siteurl', 'http://example.com' );
+
+		$menu    = array(
+			array( 'Tools', 'read', 'tools.php', 'Tools', 'menu-top', 'menu-tools', 'dashicons-admin-tools' ),
+		);
+		$submenu = array(
+			'tools.php' => array(
+				array( 'Available Tools', 'read', 'tools.php', 'Available Tools' ),
+			),
+		);
+
+		$actual = $this->render_admin_menu( $menu, $submenu );
+
+		$this->assertStringContainsString( "href='http://example.com/wp-admin/tools.php'", $actual );
+	}
+
+	/**
+	 * @ticket 56302
+	 */
+	public function test_wp_menu_output_uses_absolute_submenu_urls() {
+		wp_set_current_user( self::$admin_id );
+		update_option( 'siteurl', 'http://example.com' );
+
+		$menu    = array(
+			array( 'Posts', 'read', 'edit.php', 'Posts', 'menu-top', 'menu-posts', 'dashicons-admin-post' ),
+		);
+		$submenu = array(
+			'edit.php' => array(
+				array( 'All Posts', 'read', 'edit.php', 'All Posts' ),
+				array( 'Add New', 'read', 'post-new.php?post_type=post', 'Add New' ),
+			),
+		);
+
+		$actual = $this->render_admin_menu( $menu, $submenu );
+
+		$this->assertStringContainsString( "href='http://example.com/wp-admin/edit.php'", $actual );
+		$this->assertStringContainsString( "href='http://example.com/wp-admin/post-new.php?post_type=post'", $actual );
+	}
+
+	/**
+	 * @ticket 56302
+	 */
+	public function test_wp_menu_output_uses_absolute_plugin_page_url() {
+		wp_set_current_user( self::$admin_id );
+		update_option( 'siteurl', 'http://example.com' );
+
+		add_menu_page( 'Test Page', 'Test Page', 'read', 'test-page', '__return_null' );
+
+		global $menu;
+
+		$actual = $this->render_admin_menu( $menu, array(), false );
+
+		$this->assertStringContainsString( "href='http://example.com/wp-admin/admin.php?page=test-page'", $actual );
+	}
+
+	/**
+	 * @ticket 56302
+	 */
+	public function test_wp_menu_output_preserves_external_urls() {
+		wp_set_current_user( self::$admin_id );
+		update_option( 'siteurl', 'http://example.com' );
+
+		$menu = array(
+			array( 'External', 'read', 'https://wordpress.org/news/', 'External', 'menu-top', 'menu-external', 'dashicons-admin-site' ),
+		);
+
+		$actual = $this->render_admin_menu( $menu, array() );
+
+		$this->assertStringContainsString( "href='https://wordpress.org/news/'", $actual );
+	}
+
+	private function render_admin_menu( $menu, $submenu, $submenu_as_parent = true ) {
+		$this->require_menu_header();
+
+		global $self, $parent_file, $submenu_file, $plugin_page, $typenow;
+
+		$self         = 'index.php';
+		$parent_file  = '';
+		$submenu_file = '';
+		$plugin_page  = null;
+		$typenow      = '';
+
+		ob_start();
+		_wp_menu_output( $menu, $submenu, $submenu_as_parent );
+		return ob_get_clean();
+	}
+
+	private function require_menu_header() {
+		if ( function_exists( '_wp_menu_output' ) ) {
+			return;
+		}
+
+		global $menu, $submenu, $parent_file, $submenu_file;
+
+		$menu         = array();
+		$submenu      = array();
+		$parent_file  = '';
+		$submenu_file = '';
+
+		$_SERVER['PHP_SELF'] = '/wp-admin/index.php';
+
+		ob_start();
+		require ABSPATH . 'wp-admin/menu-header.php';
+		ob_end_clean();
+	}
+}


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

This updates admin menu rendering so generated menu item href values use absolute URLs in the current admin context, while preserving already absolute/external URLs.

Validation:
- php -l src\\wp-admin\\menu-header.php
- php -l tests\\phpunit\\tests\\admin\\menuHeader.php
- php vendor\\squizlabs\\php_codesniffer\\bin\\phpcbf --standard=phpcs.xml.dist src\\wp-admin\\menu-header.php tests\\phpunit\\tests\\admin\\menuHeader.php
- php vendor\\squizlabs\\php_codesniffer\\bin\\phpcs --standard=phpcs.xml.dist src\\wp-admin\\menu-header.php tests\\phpunit\\tests\\admin\\menuHeader.php
- git diff --check`n`nTrac ticket: https://core.trac.wordpress.org/ticket/56302

## Use of AI Tools

AI assistance: Yes
Tool(s): OpenAI Codex
Model(s): GPT-5
Used for: Reviewing the Trac ticket and relevant code, helping with the initial implementation and regression-test approach, and assisting with validation and PR-description drafting. The final implementation, tests, validation results, and description were reviewed and accepted by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**