### PR TITLE
Media: Add a user preference for Media Library infinite scrolling

### DIFF
--- a/src/wp-admin/includes/user.php
+++ b/src/wp-admin/includes/user.php
@@ -132,10 +132,11 @@ function edit_user( $user_id = 0 ) {
 	}
 
 	if ( $update ) {
-		$user->rich_editing         = isset( $_POST['rich_editing'] ) && 'false' === $_POST['rich_editing'] ? 'false' : 'true';
-		$user->syntax_highlighting  = isset( $_POST['syntax_highlighting'] ) && 'false' === $_POST['syntax_highlighting'] ? 'false' : 'true';
-		$user->admin_color          = isset( $_POST['admin_color'] ) ? sanitize_text_field( $_POST['admin_color'] ) : 'modern';
-		$user->show_admin_bar_front = isset( $_POST['admin_bar_front'] ) ? 'true' : 'false';
+		$user->rich_editing                     = isset( $_POST['rich_editing'] ) && 'false' === $_POST['rich_editing'] ? 'false' : 'true';
+		$user->syntax_highlighting              = isset( $_POST['syntax_highlighting'] ) && 'false' === $_POST['syntax_highlighting'] ? 'false' : 'true';
+		$user->media_library_infinite_scrolling = isset( $_POST['media_library_infinite_scrolling'] ) && 'false' === $_POST['media_library_infinite_scrolling'] ? 'false' : 'true';
+		$user->admin_color                      = isset( $_POST['admin_color'] ) ? sanitize_text_field( $_POST['admin_color'] ) : 'modern';
+		$user->show_admin_bar_front             = isset( $_POST['admin_bar_front'] ) ? 'true' : 'false';
 	}
 
 	$user->comment_shortcuts = isset( $_POST['comment_shortcuts'] ) && 'true' === $_POST['comment_shortcuts'] ? 'true' : '';

--- a/src/wp-admin/includes/user.php
+++ b/src/wp-admin/includes/user.php
@@ -132,11 +132,11 @@ function edit_user( $user_id = 0 ) {
 	}
 
 	if ( $update ) {
-		$user->rich_editing                     = isset( $_POST['rich_editing'] ) && 'false' === $_POST['rich_editing'] ? 'false' : 'true';
-		$user->syntax_highlighting              = isset( $_POST['syntax_highlighting'] ) && 'false' === $_POST['syntax_highlighting'] ? 'false' : 'true';
-		$user->media_library_infinite_scrolling = isset( $_POST['media_library_infinite_scrolling'] ) && 'false' === $_POST['media_library_infinite_scrolling'] ? 'false' : 'true';
-		$user->admin_color                      = isset( $_POST['admin_color'] ) ? sanitize_text_field( $_POST['admin_color'] ) : 'modern';
-		$user->show_admin_bar_front             = isset( $_POST['admin_bar_front'] ) ? 'true' : 'false';
+		$user->rich_editing         = isset( $_POST['rich_editing'] ) && 'false' === $_POST['rich_editing'] ? 'false' : 'true';
+		$user->syntax_highlighting  = isset( $_POST['syntax_highlighting'] ) && 'false' === $_POST['syntax_highlighting'] ? 'false' : 'true';
+		$user->infinite_scrolling   = isset( $_POST['infinite_scrolling'] ) && 'false' === $_POST['infinite_scrolling'] ? 'false' : 'true';
+		$user->admin_color          = isset( $_POST['admin_color'] ) ? sanitize_text_field( $_POST['admin_color'] ) : 'modern';
+		$user->show_admin_bar_front = isset( $_POST['admin_bar_front'] ) ? 'true' : 'false';
 	}
 
 	$user->comment_shortcuts = isset( $_POST['comment_shortcuts'] ) && 'true' === $_POST['comment_shortcuts'] ? 'true' : '';

--- a/src/wp-admin/user-edit.php
+++ b/src/wp-admin/user-edit.php
@@ -376,6 +376,15 @@ switch ( $action ) {
 						</td>
 					</tr>
 
+					<tr class="user-media-library-infinite-scrolling-wrap">
+						<th scope="row"><?php _e( 'Infinite Scrolling' ); ?></th>
+						<td>
+							<label for="media_library_infinite_scrolling"><input name="media_library_infinite_scrolling" type="checkbox" id="media_library_infinite_scrolling" value="false" <?php checked( 'false', $profile_user->media_library_infinite_scrolling ); ?> />
+								<?php _e( 'Disable infinite scrolling in the media library' ); ?>
+							</label>
+						</td>
+					</tr>
+
 					<?php
 					$languages                = get_available_languages();
 					$can_install_translations = current_user_can( 'install_languages' ) && wp_can_install_language_pack();

--- a/src/wp-admin/user-edit.php
+++ b/src/wp-admin/user-edit.php
@@ -377,10 +377,10 @@ switch ( $action ) {
 					</tr>
 
 					<?php if ( user_can( $profile_user, 'upload_files' ) ) : ?>
-					<tr class="user-media-library-infinite-scrolling-wrap">
+					<tr class="user-infinite-scrolling-wrap">
 						<th scope="row"><?php _e( 'Infinite Scrolling' ); ?></th>
 						<td>
-							<label for="media_library_infinite_scrolling"><input name="media_library_infinite_scrolling" type="checkbox" id="media_library_infinite_scrolling" value="false" <?php checked( 'false', $profile_user->media_library_infinite_scrolling ); ?> />
+							<label for="infinite_scrolling"><input name="infinite_scrolling" type="checkbox" id="infinite_scrolling" value="false" <?php checked( 'false', $profile_user->infinite_scrolling ); ?> />
 								<?php _e( 'Disable infinite scrolling in the Media Library grid view' ); ?>
 							</label>
 						</td>

--- a/src/wp-admin/user-edit.php
+++ b/src/wp-admin/user-edit.php
@@ -381,7 +381,7 @@ switch ( $action ) {
 						<th scope="row"><?php _e( 'Infinite Scrolling' ); ?></th>
 						<td>
 							<label for="media_library_infinite_scrolling"><input name="media_library_infinite_scrolling" type="checkbox" id="media_library_infinite_scrolling" value="false" <?php checked( 'false', $profile_user->media_library_infinite_scrolling ); ?> />
-								<?php _e( 'Disable infinite scrolling in the media library' ); ?>
+								<?php _e( 'Disable infinite scrolling in the Media Library grid view' ); ?>
 							</label>
 						</td>
 					</tr>

--- a/src/wp-admin/user-edit.php
+++ b/src/wp-admin/user-edit.php
@@ -376,6 +376,7 @@ switch ( $action ) {
 						</td>
 					</tr>
 
+					<?php if ( user_can( $profile_user, 'upload_files' ) ) : ?>
 					<tr class="user-media-library-infinite-scrolling-wrap">
 						<th scope="row"><?php _e( 'Infinite Scrolling' ); ?></th>
 						<td>
@@ -384,6 +385,7 @@ switch ( $action ) {
 							</label>
 						</td>
 					</tr>
+					<?php endif; ?>
 
 					<?php
 					$languages                = get_available_languages();

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -5043,7 +5043,7 @@ function wp_enqueue_media( $args = array() ) {
 	$infinite_scrolling = true;
 
 	// A user can opt out of infinite scrolling via their profile's personal options.
-	if ( 'false' === get_user_option( 'media_library_infinite_scrolling' ) ) {
+	if ( 'false' === get_user_option( 'infinite_scrolling' ) ) {
 		$infinite_scrolling = false;
 	}
 

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -5040,14 +5040,25 @@ function wp_enqueue_media( $args = array() ) {
 		);
 	}
 
+	$infinite_scrolling = true;
+
+	// A user can opt out of infinite scrolling via their profile's personal options.
+	if ( 'false' === get_user_option( 'media_library_infinite_scrolling' ) ) {
+		$infinite_scrolling = false;
+	}
+
 	/**
-	 * Filters whether the Media Library grid has infinite scrolling. Default `false`.
+	 * Filters whether the Media Library grid has infinite scrolling. Default `true`.
+	 *
+	 * This setting respects the current user's "Infinite Scrolling" personal
+	 * option, but a filter callback takes precedence over that preference.
 	 *
 	 * @since 5.8.0
+	 * @since 7.1.0 Changed default to `true` and introduced per-user opt-out of infinite scrolling.
 	 *
-	 * @param bool $infinite Whether the Media Library grid has infinite scrolling.
+	 * @param bool $infinite_scrolling Whether the Media Library grid has infinite scrolling.
 	 */
-	$infinite_scrolling = apply_filters( 'media_library_infinite_scrolling', false );
+	$infinite_scrolling = apply_filters( 'media_library_infinite_scrolling', $infinite_scrolling );
 
 	$settings = array(
 		'tabs'              => $tabs,

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -2245,7 +2245,7 @@ function wp_insert_user( $userdata ) {
 				'description',
 				'rich_editing',
 				'syntax_highlighting',
-				'media_library_infinite_scrolling',
+				'infinite_scrolling',
 				'comment_shortcuts',
 				'admin_color',
 				'use_ssl',
@@ -2510,7 +2510,7 @@ function wp_insert_user( $userdata ) {
 
 	$meta['syntax_highlighting'] = empty( $userdata['syntax_highlighting'] ) ? 'true' : $userdata['syntax_highlighting'];
 
-	$meta['media_library_infinite_scrolling'] = empty( $userdata['media_library_infinite_scrolling'] ) ? 'true' : $userdata['media_library_infinite_scrolling'];
+	$meta['infinite_scrolling'] = empty( $userdata['infinite_scrolling'] ) ? 'true' : $userdata['infinite_scrolling'];
 
 	$meta['comment_shortcuts'] = empty( $userdata['comment_shortcuts'] ) || 'false' === $userdata['comment_shortcuts'] ? 'false' : 'true';
 
@@ -3022,7 +3022,7 @@ function wp_create_user(
  * @return string[] List of user keys to be populated in wp_update_user().
  */
 function _get_additional_user_keys( $user ) {
-	$keys = array( 'first_name', 'last_name', 'nickname', 'description', 'rich_editing', 'syntax_highlighting', 'media_library_infinite_scrolling', 'comment_shortcuts', 'admin_color', 'use_ssl', 'show_admin_bar_front', 'locale' );
+	$keys = array( 'first_name', 'last_name', 'nickname', 'description', 'rich_editing', 'syntax_highlighting', 'infinite_scrolling', 'comment_shortcuts', 'admin_color', 'use_ssl', 'show_admin_bar_front', 'locale' );
 	return array_merge( $keys, array_keys( wp_get_user_contact_methods( $user ) ) );
 }
 

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -2245,6 +2245,7 @@ function wp_insert_user( $userdata ) {
 				'description',
 				'rich_editing',
 				'syntax_highlighting',
+				'media_library_infinite_scrolling',
 				'comment_shortcuts',
 				'admin_color',
 				'use_ssl',
@@ -2508,6 +2509,8 @@ function wp_insert_user( $userdata ) {
 	$meta['rich_editing'] = empty( $userdata['rich_editing'] ) ? 'true' : $userdata['rich_editing'];
 
 	$meta['syntax_highlighting'] = empty( $userdata['syntax_highlighting'] ) ? 'true' : $userdata['syntax_highlighting'];
+
+	$meta['media_library_infinite_scrolling'] = empty( $userdata['media_library_infinite_scrolling'] ) ? 'true' : $userdata['media_library_infinite_scrolling'];
 
 	$meta['comment_shortcuts'] = empty( $userdata['comment_shortcuts'] ) || 'false' === $userdata['comment_shortcuts'] ? 'false' : 'true';
 
@@ -3019,7 +3022,7 @@ function wp_create_user(
  * @return string[] List of user keys to be populated in wp_update_user().
  */
 function _get_additional_user_keys( $user ) {
-	$keys = array( 'first_name', 'last_name', 'nickname', 'description', 'rich_editing', 'syntax_highlighting', 'comment_shortcuts', 'admin_color', 'use_ssl', 'show_admin_bar_front', 'locale' );
+	$keys = array( 'first_name', 'last_name', 'nickname', 'description', 'rich_editing', 'syntax_highlighting', 'media_library_infinite_scrolling', 'comment_shortcuts', 'admin_color', 'use_ssl', 'show_admin_bar_front', 'locale' );
 	return array_merge( $keys, array_keys( wp_get_user_contact_methods( $user ) ) );
 }
 

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -109,6 +109,69 @@ CAP;
 		$this->assertSame( 'img_caption_shortcode', $shortcode_tags['wp_caption'] );
 	}
 
+	/**
+	 * Tests the precedence rules for the Media Library infinite scrolling setting.
+	 *
+	 * Infinite scrolling is enabled by default. A user can opt out via the
+	 * `media_library_infinite_scrolling` personal option, and the
+	 * `media_library_infinite_scrolling` filter takes precedence over both.
+	 *
+	 * @ticket 65564
+	 *
+	 * @covers ::wp_enqueue_media
+	 */
+	public function test_wp_enqueue_media_infinite_scrolling_precedence() {
+		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user_id );
+
+		// Default: no user preference and no filter, infinite scrolling is enabled.
+		$this->assertSame(
+			1,
+			$this->get_media_infinite_scrolling_setting(),
+			'Infinite scrolling should be enabled by default.'
+		);
+
+		// User preference: disabling it via the personal option turns it off.
+		update_user_meta( $user_id, 'media_library_infinite_scrolling', 'false' );
+		$this->assertSame(
+			0,
+			$this->get_media_infinite_scrolling_setting(),
+			'The user preference should disable infinite scrolling.'
+		);
+
+		// Filter precedence: a filter overrides the user preference.
+		add_filter( 'media_library_infinite_scrolling', '__return_true' );
+		$this->assertSame(
+			1,
+			$this->get_media_infinite_scrolling_setting(),
+			'The filter should take precedence over the user preference.'
+		);
+	}
+
+	/**
+	 * Helper that runs wp_enqueue_media() and returns the computed
+	 * `infiniteScrolling` media view setting.
+	 *
+	 * @return int The infiniteScrolling setting: 1 when enabled, 0 when disabled.
+	 */
+	private function get_media_infinite_scrolling_setting() {
+		// wp_enqueue_media() only runs once per request; reset the guard so it
+		// can be invoked again for each scenario.
+		unset( $GLOBALS['wp_actions']['wp_enqueue_media'] );
+
+		$infinite_scrolling = null;
+		$capture            = static function ( $settings ) use ( &$infinite_scrolling ) {
+			$infinite_scrolling = $settings['infiniteScrolling'];
+			return $settings;
+		};
+
+		add_filter( 'media_view_settings', $capture );
+		wp_enqueue_media();
+		remove_filter( 'media_view_settings', $capture );
+
+		return $infinite_scrolling;
+	}
+
 	public function test_img_caption_shortcode_with_empty_params() {
 		$result = img_caption_shortcode( array() );
 		$this->assertSame( '', $result );

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -113,7 +113,7 @@ CAP;
 	 * Tests the precedence rules for the Media Library infinite scrolling setting.
 	 *
 	 * Infinite scrolling is enabled by default. A user can opt out via the
-	 * `media_library_infinite_scrolling` personal option, and the
+	 * `infinite_scrolling` personal option, and the
 	 * `media_library_infinite_scrolling` filter takes precedence over both.
 	 *
 	 * @ticket 65564
@@ -132,7 +132,7 @@ CAP;
 		);
 
 		// User preference: disabling it via the personal option turns it off.
-		update_user_meta( $user_id, 'media_library_infinite_scrolling', 'false' );
+		update_user_meta( $user_id, 'infinite_scrolling', 'false' );
 		$this->assertSame(
 			0,
 			$this->get_media_infinite_scrolling_setting(),

--- a/tests/phpunit/tests/user.php
+++ b/tests/phpunit/tests/user.php
@@ -433,18 +433,18 @@ class Tests_User extends WP_UnitTestCase {
 
 		// Test update of fields in _get_additional_user_keys().
 		$user_data = array(
-			'ID'                               => self::$author_id,
-			'use_ssl'                          => 1,
-			'show_admin_bar_front'             => 1,
-			'rich_editing'                     => 1,
-			'syntax_highlighting'              => 1,
-			'media_library_infinite_scrolling' => 'false', // See #65564.
-			'first_name'                       => 'first',
-			'last_name'                        => 'last',
-			'nickname'                         => 'nick',
-			'comment_shortcuts'                => 'true',
-			'admin_color'                      => 'classic',
-			'description'                      => 'describe',
+			'ID'                   => self::$author_id,
+			'use_ssl'              => 1,
+			'show_admin_bar_front' => 1,
+			'rich_editing'         => 1,
+			'syntax_highlighting'  => 1,
+			'infinite_scrolling'   => 'false', // See #65564.
+			'first_name'           => 'first',
+			'last_name'            => 'last',
+			'nickname'             => 'nick',
+			'comment_shortcuts'    => 'true',
+			'admin_color'          => 'classic',
+			'description'          => 'describe',
 		);
 		wp_update_user( $user_data );
 

--- a/tests/phpunit/tests/user.php
+++ b/tests/phpunit/tests/user.php
@@ -433,17 +433,18 @@ class Tests_User extends WP_UnitTestCase {
 
 		// Test update of fields in _get_additional_user_keys().
 		$user_data = array(
-			'ID'                   => self::$author_id,
-			'use_ssl'              => 1,
-			'show_admin_bar_front' => 1,
-			'rich_editing'         => 1,
-			'syntax_highlighting'  => 1,
-			'first_name'           => 'first',
-			'last_name'            => 'last',
-			'nickname'             => 'nick',
-			'comment_shortcuts'    => 'true',
-			'admin_color'          => 'classic',
-			'description'          => 'describe',
+			'ID'                               => self::$author_id,
+			'use_ssl'                          => 1,
+			'show_admin_bar_front'             => 1,
+			'rich_editing'                     => 1,
+			'syntax_highlighting'              => 1,
+			'media_library_infinite_scrolling' => 'false', // See #65564.
+			'first_name'                       => 'first',
+			'last_name'                        => 'last',
+			'nickname'                         => 'nick',
+			'comment_shortcuts'                => 'true',
+			'admin_color'                      => 'classic',
+			'description'                      => 'describe',
 		);
 		wp_update_user( $user_data );
 


### PR DESCRIPTION
## Trac ticket

Fixes https://core.trac.wordpress.org/ticket/65564

## Summary

- Defaults the `media_library_infinite_scrolling` filter to `true`.
- Adds an **Infinite Scrolling** personal option on the profile screen, with a checkbox labeled _"Disable infinite scrolling in the media library"_ (unchecked by default).
- The user preference takes precedence over the default.
- The `media_library_infinite_scrolling` filter takes precedence over the user preference.

So the resolution order is: **filter → user preference → default (`true`)**.

## Screenshot

The new option appears in the profile's Personal Options, between _Toolbar_ and _Language_:

<img width="558" height="202" alt="Screenshot 2026-07-03 at 15 52 32" src="https://github.com/user-attachments/assets/3be7dbfa-6bac-49c3-8a11-ecf4ac792702" />


## Implementation notes

- `wp_enqueue_media()` now derives the default from the current user's `media_library_infinite_scrolling` option via `get_user_option()` before applying the filter, so a hooked filter still wins.
- The new option is wired through the same plumbing as `syntax_highlighting` — the profile form field (`user-edit.php`), the save handler (`wp-admin/includes/user.php`), and persistence in `wp_insert_user()` / `_get_additional_user_keys()` (`wp-includes/user.php`).

## Manual Testing

### Setup:
- Make sure the Media Library has enough items to paginate — upload ~80 images so there's more than one "page" of attachments. Without this, there's nothing to load and the difference isn't visible.

### Default behavior — infinite scrolling is ON

1. With no filter and no preference set, scroll to the bottom of the media grid.
2. ✅ Expected: more attachments load automatically as you scroll; there is no "Load more" button.

### The new profile option exists and is off by default

3. Go to Users → Profile (or edit another user) and find Personal Options.
4. ✅ Expected: an Infinite Scrolling row (between Toolbar and Language) with a checkbox labeled "Disable infinite scrolling in the media library", unchecked by default.

### The user preference disables infinite scrolling

5. Check the box and click Update Profile.
6. Reload Media → Library (grid view) and scroll to the bottom.
7. ✅ Expected: scrolling no longer auto-loads; a "Load more" button appears instead.
8. Uncheck the box, save, reload the grid.
9. ✅ Expected: auto-load-on-scroll behavior returns.

### The filter takes precedence over the preference

10. With the preference checked (disabled), add this to a mu-plugin or theme functions.php:
`add_filter( 'media_library_infinite_scrolling', '__return_true' );`
11. Reload the media grid.
12. ✅ Expected: infinite scrolling is ON again (auto-loads on scroll), proving the filter overrides the user preference.
13. Swap it for __return_false while the preference is unchecked:
`add_filter( 'media_library_infinite_scrolling', '__return_false' );`
14. ✅ Expected: infinite scrolling is OFF ("Load more" button), confirming the filter wins in both directions.

## Automated testing:
- `Tests_User::test_update_user` — extended to cover persistence of the new user option.
- `Tests_Media::test_wp_enqueue_media_infinite_scrolling_precedence` — new test covering the default, the user preference, and filter precedence.

Both pass, and PHPCS reports no new violations.

## AI usage

I used Claude Opus 4.8 for exploring, validating, and testing.