### PR TITLE
Media: Use rotated image dimensions in wp_get_missing_image_subsizes() when original image orientation differs

### DIFF
--- a/src/wp-admin/includes/image.php
+++ b/src/wp-admin/includes/image.php
@@ -97,16 +97,26 @@ function wp_get_missing_image_subsizes( $attachment_id ) {
 		return $registered_sizes;
 	}
 
-	// Use the originally uploaded image dimensions as full_width and full_height.
+	// Use the originally uploaded image dimensions as full_width and full_height,
+	// but only if the image has not been rotated (i.e. aspect ratios match).
 	if ( ! empty( $image_meta['original_image'] ) ) {
 		$image_file = wp_get_original_image_path( $attachment_id );
 		$imagesize  = wp_getimagesize( $image_file );
+
+		if ( ! empty( $imagesize ) ) {
+			$rotated_ratio  = ( $image_meta['height'] > 0 ) ? $image_meta['width'] / $image_meta['height'] : 0;
+			$original_ratio = ( $imagesize[1] > 0 ) ? $imagesize[0] / $imagesize[1] : 0;
+
+			// If ratios match the image was not rotated; use original dimensions
+			// as they may allow additional sub-sizes to be generated.
+			if ( abs( $rotated_ratio - $original_ratio ) < 0.01 ) {
+				$full_width  = $imagesize[0];
+				$full_height = $imagesize[1];
+			}
+		}
 	}
 
-	if ( ! empty( $imagesize ) ) {
-		$full_width  = $imagesize[0];
-		$full_height = $imagesize[1];
-	} else {
+	if ( empty( $full_width ) ) {
 		$full_width  = (int) $image_meta['width'];
 		$full_height = (int) $image_meta['height'];
 	}


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->
Prevent wp_get_missing_image_subsizes() from reporting incorrect missing subsizes for rotated images by using the processed image dimensions when the original and processed image aspect ratios differ, while preserving the existing behavior for non-rotated images.

Trac ticket: https://core.trac.wordpress.org/ticket/58611

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:
-->

AI assistance: Yes
Tool(s): Claude
Model(s): Opus 4.7
Used for: Initial code skeleton; final implementation and tests were reviewed and edited by me.


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
