### PR TITLE
Abilities API: Allow registration after init

### DIFF
--- a/src/wp-includes/abilities-api.php
+++ b/src/wp-includes/abilities-api.php
@@ -19,12 +19,10 @@
  *
  * ## Working with Abilities
  *
- * Register abilities on the `wp_abilities_api_init` action hook. The hook fires
- * once, when the abilities registry is first initialized (on or after the `init`
- * action), which guarantees the ability is available to every discovery surface
- * from the start. Registration is also supported at any later point in the
- * request - for example from code that initializes on `rest_api_init`, or in
- * long-running runtimes that load plugin code after WordPress has booted.
+ * Register abilities on the `wp_abilities_api_init` action hook, the recommended
+ * deterministic registration point. Registration after the `init` action has
+ * fired is also supported. Callers registering afterward are responsible for
+ * doing so before relevant discovery, snapshot, or use.
  * Attempting to register an ability before the `init` action has fired will
  * fail and trigger a `_doing_it_wrong()` notice.
 
@@ -77,9 +75,8 @@
  *
  * ## Best Practices
  *
- *  - Prefer registering abilities on the `wp_abilities_api_init` hook, so they
- *    are available to all discovery surfaces from the moment the registry
- *    initializes.
+ *  - Register abilities on the `wp_abilities_api_init` hook, the recommended
+ *    deterministic registration point.
  *  - Use namespaced ability names to prevent conflicts.
  *  - Implement robust permission checks in permission callbacks.
  *  - Provide an `input_schema` to ensure data integrity and document expected inputs.
@@ -97,8 +94,9 @@ declare( strict_types = 1 );
 /**
  * Registers a new ability using the Abilities API. It requires three steps:
  *
- *  1. Hook into the `wp_abilities_api_init` action (recommended), or call at
- *     any later point after the `init` action has fired.
+ *  1. Hook into the `wp_abilities_api_init` action, the recommended deterministic
+ *     registration point. Callers registering after `init` must do so before
+ *     relevant discovery, snapshot, or use.
  *  2. Call `wp_register_ability()` with a namespaced name and configuration.
  *  3. Provide execute and permission callbacks.
  *
@@ -228,9 +226,9 @@ declare( strict_types = 1 );
  * This allows abilities to be invoked via HTTP requests to the WordPress REST API.
  *
  * @since 6.9.0
- * @since 7.1.0 Registration is supported at any point after the `init` action has
- *              fired; the `wp_abilities_api_init` action is no longer the only
- *              registration window.
+ * @since 7.1.0 Registration after the `init` action has fired is supported.
+ *              Callers registering afterward must do so before relevant discovery,
+ *              snapshot, or use.
  *
  * @see WP_Abilities_Registry::register()
  * @see wp_register_ability_category()
@@ -610,7 +608,9 @@ function _wp_get_abilities_match_meta( array $meta, array $conditions ): bool {
  * that reference them.
  *
  * Register ability categories on the `wp_abilities_api_categories_init` action
- * hook (recommended), or at any later point after the `init` action has fired.
+ * hook, the recommended deterministic registration point. Registration after
+ * the `init` action has fired is also supported. Callers registering afterward
+ * are responsible for doing so before relevant discovery, snapshot, or use.
  * Attempting to register an ability category before `init` will fail and
  * trigger a `_doing_it_wrong()` notice.
  *
@@ -628,9 +628,9 @@ function _wp_get_abilities_match_meta( array $meta, array $conditions ): bool {
  *     add_action( 'wp_abilities_api_categories_init', 'my_plugin_register_categories' );
  *
  * @since 6.9.0
- * @since 7.1.0 Registration is supported at any point after the `init` action has
- *              fired; the `wp_abilities_api_categories_init` action is no longer
- *              the only registration window.
+ * @since 7.1.0 Registration after the `init` action has fired is supported.
+ *              Callers registering afterward must do so before relevant discovery,
+ *              snapshot, or use.
  *
  * @see WP_Ability_Categories_Registry::register()
  * @see wp_register_ability()

--- a/src/wp-includes/abilities-api.php
+++ b/src/wp-includes/abilities-api.php
@@ -19,9 +19,14 @@
  *
  * ## Working with Abilities
  *
- * Abilities must be registered on the `wp_abilities_api_init` action hook.
- * Attempting to register an ability outside of this hook will fail and
- * trigger a `_doing_it_wrong()` notice.
+ * Register abilities on the `wp_abilities_api_init` action hook. The hook fires
+ * once, when the abilities registry is first initialized (on or after the `init`
+ * action), which guarantees the ability is available to every discovery surface
+ * from the start. Registration is also supported at any later point in the
+ * request - for example from code that initializes on `rest_api_init`, or in
+ * long-running runtimes that load plugin code after WordPress has booted.
+ * Attempting to register an ability before the `init` action has fired will
+ * fail and trigger a `_doing_it_wrong()` notice.
 
  * Example:
  *
@@ -72,7 +77,9 @@
  *
  * ## Best Practices
  *
- *  - Always register abilities on the `wp_abilities_api_init` hook.
+ *  - Prefer registering abilities on the `wp_abilities_api_init` hook, so they
+ *    are available to all discovery surfaces from the moment the registry
+ *    initializes.
  *  - Use namespaced ability names to prevent conflicts.
  *  - Implement robust permission checks in permission callbacks.
  *  - Provide an `input_schema` to ensure data integrity and document expected inputs.
@@ -90,7 +97,8 @@ declare( strict_types = 1 );
 /**
  * Registers a new ability using the Abilities API. It requires three steps:
  *
- *  1. Hook into the `wp_abilities_api_init` action.
+ *  1. Hook into the `wp_abilities_api_init` action (recommended), or call at
+ *     any later point after the `init` action has fired.
  *  2. Call `wp_register_ability()` with a namespaced name and configuration.
  *  3. Provide execute and permission callbacks.
  *
@@ -220,6 +228,9 @@ declare( strict_types = 1 );
  * This allows abilities to be invoked via HTTP requests to the WordPress REST API.
  *
  * @since 6.9.0
+ * @since 7.1.0 Registration is supported at any point after the `init` action has
+ *              fired; the `wp_abilities_api_init` action is no longer the only
+ *              registration window.
  *
  * @see WP_Abilities_Registry::register()
  * @see wp_register_ability_category()
@@ -276,16 +287,16 @@ declare( strict_types = 1 );
  * @return WP_Ability|null The registered ability instance on success, `null` on failure.
  */
 function wp_register_ability( string $name, array $args ): ?WP_Ability {
-	if ( ! doing_action( 'wp_abilities_api_init' ) ) {
+	if ( ! did_action( 'init' ) ) {
 		_doing_it_wrong(
 			__FUNCTION__,
 			sprintf(
-				/* translators: 1: wp_abilities_api_init, 2: string value of the ability name. */
-				__( 'Abilities must be registered on the %1$s action. The ability %2$s was not registered.' ),
-				'<code>wp_abilities_api_init</code>',
+				/* translators: 1: init, 2: string value of the ability name. */
+				__( 'Abilities cannot be registered before the %1$s action has fired. The ability %2$s was not registered.' ),
+				'<code>init</code>',
 				'<code>' . esc_html( $name ) . '</code>'
 			),
-			'6.9.0'
+			'7.1.0'
 		);
 		return null;
 	}
@@ -598,7 +609,10 @@ function _wp_get_abilities_match_meta( array $meta, array $conditions ): bool {
  * discoverability and management. Ability categories must be registered before abilities
  * that reference them.
  *
- * Ability categories must be registered on the `wp_abilities_api_categories_init` action hook.
+ * Register ability categories on the `wp_abilities_api_categories_init` action
+ * hook (recommended), or at any later point after the `init` action has fired.
+ * Attempting to register an ability category before `init` will fail and
+ * trigger a `_doing_it_wrong()` notice.
  *
  * Example:
  *
@@ -614,6 +628,9 @@ function _wp_get_abilities_match_meta( array $meta, array $conditions ): bool {
  *     add_action( 'wp_abilities_api_categories_init', 'my_plugin_register_categories' );
  *
  * @since 6.9.0
+ * @since 7.1.0 Registration is supported at any point after the `init` action has
+ *              fired; the `wp_abilities_api_categories_init` action is no longer
+ *              the only registration window.
  *
  * @see WP_Ability_Categories_Registry::register()
  * @see wp_register_ability()
@@ -631,16 +648,16 @@ function _wp_get_abilities_match_meta( array $meta, array $conditions ): bool {
  * @return WP_Ability_Category|null The registered ability category instance on success, `null` on failure.
  */
 function wp_register_ability_category( string $slug, array $args ): ?WP_Ability_Category {
-	if ( ! doing_action( 'wp_abilities_api_categories_init' ) ) {
+	if ( ! did_action( 'init' ) ) {
 		_doing_it_wrong(
 			__FUNCTION__,
 			sprintf(
-				/* translators: 1: wp_abilities_api_categories_init, 2: ability category slug. */
-				__( 'Ability categories must be registered on the %1$s action. The ability category %2$s was not registered.' ),
-				'<code>wp_abilities_api_categories_init</code>',
+				/* translators: 1: init, 2: ability category slug. */
+				__( 'Ability categories cannot be registered before the %1$s action has fired. The ability category %2$s was not registered.' ),
+				'<code>init</code>',
 				'<code>' . esc_html( $slug ) . '</code>'
 			),
-			'6.9.0'
+			'7.1.0'
 		);
 		return null;
 	}

--- a/tests/phpunit/tests/abilities-api/wpRegisterAbility.php
+++ b/tests/phpunit/tests/abilities-api/wpRegisterAbility.php
@@ -129,26 +129,32 @@ class Test_Abilities_API_WpRegisterAbility extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests registering an ability when `wp_abilities_api_init` action has not fired.
+	 * Tests registering an ability outside the `wp_abilities_api_init` action.
 	 *
-	 * @ticket 64098
+	 * Late registration is supported: once the `init` action has fired, an
+	 * ability can be registered at any point in the request, and it must be
+	 * discoverable through the regular retrieval functions.
 	 *
-	 * @expectedIncorrectUsage wp_register_ability
+	 * @ticket 65583
 	 */
-	public function test_register_ability_no_abilities_api_init_action(): void {
+	public function test_register_ability_after_abilities_api_init_action(): void {
 		$this->assertFalse( doing_action( 'wp_abilities_api_init' ) );
 
 		$result = wp_register_ability( self::$test_ability_name, self::$test_ability_args );
 
-		$this->assertNull( $result );
+		$this->assertInstanceOf( WP_Ability::class, $result );
+		$this->assertTrue( wp_has_ability( self::$test_ability_name ) );
+		$this->assertSame( $result, wp_get_ability( self::$test_ability_name ) );
+		$this->assertArrayHasKey( self::$test_ability_name, wp_get_abilities() );
 	}
 
 	/**
 	 * Tests registering an ability when `init` action has not fired.
 	 *
 	 * @ticket 64098
+	 * @ticket 65583
 	 *
-	 * @expectedIncorrectUsage WP_Abilities_Registry::get_instance
+	 * @expectedIncorrectUsage wp_register_ability
 	 */
 	public function test_register_ability_no_init_action(): void {
 		global $wp_actions;
@@ -158,8 +164,6 @@ class Test_Abilities_API_WpRegisterAbility extends WP_UnitTestCase {
 
 		// Reset the action count to simulate it not being fired.
 		unset( $wp_actions['init'] );
-
-		$this->simulate_doing_wp_abilities_init_action();
 
 		$result = wp_register_ability( self::$test_ability_name, self::$test_ability_args );
 

--- a/tests/phpunit/tests/abilities-api/wpRegisterAbility.php
+++ b/tests/phpunit/tests/abilities-api/wpRegisterAbility.php
@@ -129,11 +129,10 @@ class Test_Abilities_API_WpRegisterAbility extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests registering an ability outside the `wp_abilities_api_init` action.
+	 * Tests registering an ability after the `wp_abilities_api_init` action.
 	 *
-	 * Late registration is supported: once the `init` action has fired, an
-	 * ability can be registered at any point in the request, and it must be
-	 * discoverable through the regular retrieval functions.
+	 * Registration after `init` is supported. Callers registering afterward are
+	 * responsible for doing so before relevant discovery, snapshot, or use.
 	 *
 	 * @ticket 65583
 	 */

--- a/tests/phpunit/tests/abilities-api/wpRegisterAbilityCategory.php
+++ b/tests/phpunit/tests/abilities-api/wpRegisterAbilityCategory.php
@@ -54,13 +54,14 @@ class Tests_Abilities_API_WpRegisterAbilityCategory extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test registering ability category before `wp_abilities_api_categories_init` hook.
+	 * Test registering an ability category outside the `wp_abilities_api_categories_init` hook.
 	 *
-	 * @ticket 64098
+	 * Late registration is supported: once the `init` action has fired, an
+	 * ability category can be registered at any point in the request.
 	 *
-	 * @expectedIncorrectUsage wp_register_ability_category
+	 * @ticket 65583
 	 */
-	public function test_register_category_before_init_hook(): void {
+	public function test_register_category_after_categories_init_hook(): void {
 		$this->assertFalse( doing_action( 'wp_abilities_api_categories_init' ) );
 
 		$result = wp_register_ability_category(
@@ -68,15 +69,17 @@ class Tests_Abilities_API_WpRegisterAbilityCategory extends WP_UnitTestCase {
 			self::$test_ability_category_args
 		);
 
-		$this->assertNull( $result );
+		$this->assertInstanceOf( WP_Ability_Category::class, $result );
+		$this->assertTrue( wp_has_ability_category( self::$test_ability_category_name ) );
 	}
 
 	/**
 	 * Tests registering an ability category when `init` action has not fired.
 	 *
 	 * @ticket 64098
+	 * @ticket 65583
 	 *
-	 * @expectedIncorrectUsage WP_Ability_Categories_Registry::get_instance
+	 * @expectedIncorrectUsage wp_register_ability_category
 	 */
 	public function test_register_ability_category_no_init_action(): void {
 		global $wp_actions;
@@ -86,8 +89,6 @@ class Tests_Abilities_API_WpRegisterAbilityCategory extends WP_UnitTestCase {
 
 		// Reset the action count to simulate it not being fired.
 		unset( $wp_actions['init'] );
-
-		$this->simulate_doing_wp_ability_categories_init_action();
 
 		$result = wp_register_ability_category(
 			self::$test_ability_category_name,

--- a/tests/phpunit/tests/abilities-api/wpRegisterAbilityCategory.php
+++ b/tests/phpunit/tests/abilities-api/wpRegisterAbilityCategory.php
@@ -54,10 +54,10 @@ class Tests_Abilities_API_WpRegisterAbilityCategory extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test registering an ability category outside the `wp_abilities_api_categories_init` hook.
+	 * Tests registering an ability category after the `wp_abilities_api_categories_init` action.
 	 *
-	 * Late registration is supported: once the `init` action has fired, an
-	 * ability category can be registered at any point in the request.
+	 * Registration after `init` is supported. Callers registering afterward are
+	 * responsible for doing so before relevant discovery, snapshot, or use.
 	 *
 	 * @ticket 65583
 	 */


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65583

## What

Allows Abilities API registration through `wp_register_ability()` and `wp_register_ability_category()` after the `init` action has fired.

The `wp_abilities_api_init` and `wp_abilities_api_categories_init` hooks remain the recommended deterministic registration points. Callers registering afterward are responsible for doing so before relevant discovery, snapshot, or use. The public wrappers continue to reject genuinely too-early registration before `init`.

## Why

The public wrapper currently treats the Abilities API action as the only valid registration window, even though the underlying registry supports later registration. This makes registration timing stricter than other WordPress registration APIs and pushes consumers that load later toward direct registry calls.

This timing contract was explicitly debated during the original Core merge:

- Aaron Jorbin noted that registration problems are commonly caused by registering too early rather than too late, and recommended `did_action()` unless a concrete reason required `doing_action()`: https://github.com/WordPress/wordpress-develop/pull/9410#discussion_r2444533238
- The original merge used `did_action()`, allowing registration after initialization.
- A follow-up deliberately changed the check to `doing_action()` based on concerns that arbitrary timing might cause less obvious downstream problems: https://github.com/WordPress/wordpress-develop/pull/10452

This PR revisits that trade-off. It does not claim that downstream consumers are unable to attach registration callbacks earlier. Instead, it follows the block-registration model: provide a recommended deterministic hook while allowing extenders to register later when they do so before the relevant consumer runs.

Existing implementations have independently added post-hook registration paths through the registry:

- Data Machine: https://github.com/Extra-Chill/data-machine/blob/main/inc/Abilities/AgentAbilities.php#L62-L82
- Agents API: https://github.com/Automattic/agents-api/blob/main/src/Runtime/register-runtime-package-run-ability.php#L149-L165
- Static Site Importer: https://github.com/Automattic/static-site-importer/blob/main/includes/abilities.php#L420-L429

Core also permits `wp_unregister_ability()` and `wp_unregister_ability_category()` at any time after registration, so completion of the registration hooks does not make the registry immutable: https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-includes/abilities-api.php#L301-L330

## Compatibility

This changes the public registration lifecycle. Code registering on the recommended Abilities API hooks continues to work unchanged, and registration before `init` remains rejected. Code that inspects or snapshots abilities must still run after the registrations it expects to observe.

## Tests

Adds coverage that:

- abilities can be registered after `wp_abilities_api_init` and remain discoverable via `wp_has_ability()`, `wp_get_ability()`, and `wp_get_abilities()`;
- ability categories can be registered after `wp_abilities_api_categories_init`;
- pre-`init` registration still fails with `_doing_it_wrong()`.

### How to test

1. Run `npm install`.
2. Run `npm run env:start`.
3. Run `npm run test:php -- --group abilities-api`.
4. Confirm the Abilities API test group passes, including post-`init` ability and category registration and pre-`init` rejection.
5. Run `npm run env:stop`.

Local verification:

- `php -l src/wp-includes/abilities-api.php`
- `php -l tests/phpunit/tests/abilities-api/wpRegisterAbility.php`
- `php -l tests/phpunit/tests/abilities-api/wpRegisterAbilityCategory.php`
- `vendor/bin/phpcs --standard=phpcs.xml.dist src/wp-includes/abilities-api.php tests/phpunit/tests/abilities-api/wpRegisterAbility.php tests/phpunit/tests/abilities-api/wpRegisterAbilityCategory.php`
- `git diff --check`

Focused PHPUnit was not run locally because this checkout does not have `wp-tests-config.php` configured. The GitHub test matrix exercises the affected suites.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode via Homeboy
- **Model(s):** OpenAI GPT 5.5 (initial patch), openai/gpt-5.6-terra (lifecycle review revision)
- **Used for:** Drafted the implementation, tests, documentation revision, and PR text from the public Core discussions and source-code investigation; the submitter reviewed and remains responsible for the change.