### PR TITLE
REST API: Avoid undefined property warning when creating a post with a slug

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -741,7 +741,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			 */
 			$prepared_post->post_name = wp_unique_post_slug(
 				$prepared_post->post_name,
-				$prepared_post->id,
+				! empty( $prepared_post->ID ) ? $prepared_post->ID : 0,
 				'publish',
 				$prepared_post->post_type,
 				$prepared_post->post_parent

--- a/tests/phpunit/tests/rest-api/rest-posts-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-posts-controller.php
@@ -2526,6 +2526,52 @@ Shankle pork chop prosciutto ribeye ham hock pastrami. T-bone shank brisket baco
 		$this->check_create_post_response( $response );
 	}
 
+	/**
+	 * Ensures creating a draft/pending post with an explicit slug does not emit
+	 * "Undefined property: stdClass::$id" (PHP 8+) from wp_unique_post_slug().
+	 *
+	 * @ticket XXXXX
+	 *
+	 * @covers WP_REST_Posts_Controller::create_item
+	 */
+	public function test_create_draft_with_slug_does_not_emit_undefined_property_warning() {
+		wp_set_current_user( self::$editor_id );
+
+		$caught = array();
+		set_error_handler(
+			static function ( $errno, $errstr ) use ( &$caught ) {
+				$caught[] = $errstr;
+				return true;
+			},
+			E_WARNING | E_NOTICE | E_DEPRECATED
+		);
+
+		try {
+			$request = new WP_REST_Request( 'POST', '/wp/v2/posts' );
+			$request->set_body_params(
+				array(
+					'title'  => 'Draft with explicit slug',
+					'status' => 'draft',
+					'slug'   => 'draft-with-explicit-slug',
+				)
+			);
+			$response = rest_get_server()->dispatch( $request );
+		} finally {
+			restore_error_handler();
+		}
+
+		$this->assertSame( 201, $response->get_status() );
+		$this->assertSame( 'draft-with-explicit-slug', $response->get_data()['slug'] );
+
+		foreach ( $caught as $message ) {
+			$this->assertStringNotContainsString(
+				'Undefined property: stdClass::$id',
+				$message,
+				'Creating a draft with a slug should not emit an undefined property warning.'
+			);
+		}
+	}
+
 	public function data_post_dates() {
 		$all_statuses = array(
 			'draft',


### PR DESCRIPTION
## Trac ticket
<!-- TODO: file the Trac ticket and paste its URL here, then replace @ticket XXXXX in the test. -->
Trac ticket: https://core.trac.wordpress.org/ticket/XXXXX

## Problem
`WP_REST_Posts_Controller::create_item()` passes `$prepared_post->id` (lowercase) to
`wp_unique_post_slug()`:

```php
$prepared_post->post_name = wp_unique_post_slug(
    $prepared_post->post_name,
    $prepared_post->id, // lowercase — never set on this object
    'publish',
    $prepared_post->post_type,
    $prepared_post->post_parent
);
```

`$prepared_post` is a fresh `stdClass` from `prepare_item_for_database()`, which only ever assigns
`$prepared_post->ID` (uppercase), and only on the update path. On create, neither `id` nor `ID` is
set, so `$prepared_post->id` is an undefined property. Every other reference to the id in this file
already uses `->ID`.

- PHP < 8: silent `E_NOTICE`, coerced to `null` → `0` (the correct value for a new post).
- **PHP 8.0+: `E_WARNING` "Undefined property: stdClass::$id"** on every matching request.

This fires on `POST /wp/v2/posts` when the request includes a `slug` and a `draft`/`pending` status
(common from the block editor), and is noisy in error loggers such as Sentry.

## Fix
Pass the post ID defensively — `0` for a brand-new post — matching the `! empty( $prepared_post->ID )`
guard already used elsewhere in the controller:

```php
! empty( $prepared_post->ID ) ? $prepared_post->ID : 0,
```

## Testing
Adds `test_create_draft_with_slug_does_not_emit_undefined_property_warning()` to
`tests/phpunit/tests/rest-api/rest-posts-controller.php`, which creates a draft with an explicit slug
and asserts (a) a 201 with the expected unique slug and (b) no `Undefined property: stdClass::$id`
warning is emitted during dispatch.
