### PR TITLE
Comments: Allow changing a comment's parent from the Edit Comment screen

### DIFF
--- a/src/js/_enqueues/admin/comment.js
+++ b/src/js/_enqueues/admin/comment.js
@@ -102,7 +102,7 @@ jQuery( function($) {
 
 	var $commentparentdiv = $( '#comment-parent-div' ),
 		$commentparentdisplay = $( '#comment-parent-display' ),
-		commentparent = $commentparentdisplay.html(),
+		originalcommentparentdisplay = $commentparentdisplay.html(),
 		$editcommentparent = $commentparentdiv.siblings( 'a.edit-comment-parent' );
 
 	/**
@@ -141,7 +141,7 @@ jQuery( function($) {
 		$editcommentparent.show().trigger( 'focus' );
 		$commentparentdiv.slideUp( 'fast' );
 		$( '#comment_parent' ).val( $( '#hidden_comment_parent' ).val() );
-		$commentparentdisplay.html( commentparent );
+		$commentparentdisplay.html( originalcommentparentdisplay );
 		event.preventDefault();
 	});
 
@@ -161,9 +161,13 @@ jQuery( function($) {
 
 		event.preventDefault();
 
-		$commentparentdisplay
-			.text( wp.i18n.__( 'In reply to:' ) + ' ' )
-			.append( $( '<b />' ).text( parentLabel ) );
+		$commentparentdisplay.html(
+			wp.i18n.sprintf(
+				/* translators: %s: Parent comment author. */
+				wp.i18n.__( 'In reply to: %s' ),
+				$( '<b />' ).text( parentLabel ).prop( 'outerHTML' )
+			)
+		);
 
 		// Move focus back to the Edit link.
 		$editcommentparent.show().trigger( 'focus' );

--- a/src/js/_enqueues/admin/comment.js
+++ b/src/js/_enqueues/admin/comment.js
@@ -99,4 +99,74 @@ jQuery( function($) {
 		$edittimestamp.show().trigger( 'focus' );
 		$timestampdiv.slideUp( 'fast' );
 	});
+
+	var $commentparentdiv = $( '#comment-parent-div' ),
+		$commentparentdisplay = $( '#comment-parent-display' ),
+		commentparent = $commentparentdisplay.html(),
+		$editcommentparent = $commentparentdiv.siblings( 'a.edit-comment-parent' );
+
+	/**
+	 * Adds event that opens the parent comment form if the form is hidden.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @listens $editcommentparent:click
+	 *
+	 * @param {Event} event The event object.
+	 * @return {void}
+	 */
+	$editcommentparent.on( 'click', function( event ) {
+		if ( $commentparentdiv.is( ':hidden' ) ) {
+			// Slide down the form and set focus on the parent field.
+			$commentparentdiv.slideDown( 'fast', function() {
+				$( '#comment_parent' ).trigger( 'focus' );
+			} );
+			$(this).hide();
+		}
+		event.preventDefault();
+	});
+
+	/**
+	 * Resets the parent comment value when the cancel button is clicked.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @listens .cancel-comment-parent:click
+	 *
+	 * @param {Event} event The event object.
+	 * @return {void}
+	 */
+	$commentparentdiv.find( '.cancel-comment-parent' ).on( 'click', function( event ) {
+		// Move focus back to the Edit link.
+		$editcommentparent.show().trigger( 'focus' );
+		$commentparentdiv.slideUp( 'fast' );
+		$( '#comment_parent' ).val( $( '#hidden_comment_parent' ).val() );
+		$commentparentdisplay.html( commentparent );
+		event.preventDefault();
+	});
+
+	/**
+	 * Updates the parent comment display when the ok button is clicked.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @listens .save-comment-parent:click
+	 *
+	 * @param {Event} event The event object.
+	 * @return {void}
+	 */
+	$commentparentdiv.find( '.save-comment-parent' ).on( 'click', function( event ) {
+		var $selected = $( '#comment_parent option:selected' ),
+			parentLabel = $selected.data( 'author' ) || $selected.text();
+
+		event.preventDefault();
+
+		$commentparentdisplay
+			.text( wp.i18n.__( 'In reply to:' ) + ' ' )
+			.append( $( '<b />' ).text( parentLabel ) );
+
+		// Move focus back to the Edit link.
+		$editcommentparent.show().trigger( 'focus' );
+		$commentparentdiv.slideUp( 'fast' );
+	});
 });

--- a/src/js/_enqueues/admin/comment.js
+++ b/src/js/_enqueues/admin/comment.js
@@ -157,13 +157,16 @@ jQuery( function($) {
 	 */
 	$commentparentdiv.find( '.save-comment-parent' ).on( 'click', function( event ) {
 		var $selected = $( '#comment_parent option:selected' ),
-			parentLabel = $selected.data( 'author' ) || $selected.text();
+			parentLabel = '0' === $selected.val() ?
+				/* translators: Displayed when a comment has no parent. */
+				wp.i18n.__( 'None' ) :
+				$selected.data( 'author' ) || $selected.text();
 
 		event.preventDefault();
 
 		$commentparentdisplay.html(
 			wp.i18n.sprintf(
-				/* translators: %s: Parent comment author. */
+				/* translators: %s: Parent comment link, or 'None'. */
 				wp.i18n.__( 'In reply to: %s' ),
 				$( '<b />' ).text( parentLabel ).prop( 'outerHTML' )
 			)

--- a/src/wp-admin/css/edit.css
+++ b/src/wp-admin/css/edit.css
@@ -554,6 +554,16 @@ form#tags-filter {
 	line-height: 1.76923076;
 }
 
+#comment-parent-div {
+	padding-top: 5px;
+	/* Fieldsets cannot shrink below their content by default, allow it so the select cannot cause overflow. */
+	min-width: 0;
+}
+
+#comment-parent-div select {
+	width: 100%;
+}
+
 #timestampdiv p {
 	margin: 8px 0 6px;
 }

--- a/src/wp-admin/edit-form-comment.php
+++ b/src/wp-admin/edit-form-comment.php
@@ -207,9 +207,11 @@ if ( $comment->comment_parent ) {
 	$parent = get_comment( $comment->comment_parent );
 
 	if ( $parent ) {
-		$parent_link    = esc_url( get_comment_link( $parent ) );
-		$name           = get_comment_author( $parent );
-		$parent_display = '<a href="' . $parent_link . '">' . $name . '</a>';
+		$parent_display = sprintf(
+			'<a href="%s">%s</a>',
+			esc_url( get_comment_link( $parent ) ),
+			esc_html( get_comment_author( $parent ) )
+		);
 	}
 }
 
@@ -231,7 +233,7 @@ foreach ( $post_comments as $post_comment ) {
 }
 
 $comment_descendants = array();
-$comment_queue       = array( $comment->comment_ID );
+$comment_queue       = array( (int) $comment->comment_ID );
 
 while ( $comment_queue ) {
 	$descendant_parent = array_shift( $comment_queue );
@@ -276,7 +278,7 @@ printf(
 	foreach ( $post_comments as $post_comment ) {
 		$post_comment_id = (int) $post_comment->comment_ID;
 
-		if ( $post_comment_id === $comment->comment_ID || isset( $comment_descendants[ $post_comment_id ] ) ) {
+		if ( $post_comment_id === (int) $comment->comment_ID || isset( $comment_descendants[ $post_comment_id ] ) ) {
 			continue;
 		}
 
@@ -292,7 +294,7 @@ printf(
 		);
 
 		printf(
-			"\t<option value=\"%d\" data-author=\"%s\"%s>%s</option>\n",
+			"\t<option value='%d' data-author='%s'%s>%s</option>\n",
 			$post_comment_id,
 			esc_attr( get_comment_author( $post_comment ) ),
 			selected( $post_comment_id, (int) $comment->comment_parent, false ),
@@ -301,7 +303,7 @@ printf(
 	}
 
 	// The current parent may not be listed, e.g. a pingback or a comment no longer publicly visible.
-	if ( $comment->comment_parent && ! $current_parent_listed && $parent ) {
+	if ( $comment->comment_parent && ! $current_parent_listed && isset( $parent ) ) {
 		$option_label = sprintf(
 			/* translators: 1: Comment author, 2: Comment excerpt. */
 			__( '%1$s: %2$s' ),
@@ -310,7 +312,7 @@ printf(
 		);
 
 		printf(
-			"\t<option value=\"%d\" data-author=\"%s\" selected=\"selected\">%s</option>\n",
+			"\t<option value='%d' data-author='%s' selected>%s</option>\n",
 			(int) $comment->comment_parent,
 			esc_attr( get_comment_author( $parent ) ),
 			esc_html( $option_label )

--- a/src/wp-admin/edit-form-comment.php
+++ b/src/wp-admin/edit-form-comment.php
@@ -215,34 +215,67 @@ if ( $comment->comment_parent ) {
 	}
 }
 
-$post_comments = get_comments(
-	array(
-		'post_id' => $comment->comment_post_ID,
-		'type'    => 'comment',
-		'status'  => 'all',
-		'orderby' => 'comment_date_gmt',
-		'order'   => 'ASC',
-	)
-);
+// The parent can only be changed when threaded comments are enabled.
+$comment_threading_enabled = get_option( 'thread_comments' );
 
-// Group comments by parent to find this comment's descendants, which cannot become its parent.
-$comments_by_parent = array();
+if ( $comment_threading_enabled ) {
+	$max_thread_depth = (int) get_option( 'thread_comments_depth' );
 
-foreach ( $post_comments as $post_comment ) {
-	$comments_by_parent[ (int) $post_comment->comment_parent ][] = (int) $post_comment->comment_ID;
-}
+	// Limit the number of comments to keep memory usage and the size of the dropdown reasonable on busy posts.
+	$post_comments = get_comments(
+		array(
+			'post_id' => $comment->comment_post_ID,
+			'type'    => 'comment',
+			'status'  => array( 'approve', 'hold' ),
+			'orderby' => 'comment_date_gmt',
+			'order'   => 'DESC',
+			'number'  => 100,
+		)
+	);
 
-$comment_descendants = array();
-$comment_queue       = array( (int) $comment->comment_ID );
+	// Restore chronological order for display.
+	$post_comments = array_reverse( $post_comments );
 
-while ( $comment_queue ) {
-	$descendant_parent = array_shift( $comment_queue );
+	$post_comments_by_id = array();
 
-	if ( isset( $comments_by_parent[ $descendant_parent ] ) ) {
-		foreach ( $comments_by_parent[ $descendant_parent ] as $descendant_id ) {
-			$comment_descendants[ $descendant_id ] = true;
-			$comment_queue[]                       = $descendant_id;
+	foreach ( $post_comments as $post_comment ) {
+		$post_comments_by_id[ (int) $post_comment->comment_ID ] = $post_comment;
+	}
+
+	// Group comments by parent to find this comment's descendants, which cannot become its parent.
+	$comments_by_parent = array();
+
+	foreach ( $post_comments as $post_comment ) {
+		$comments_by_parent[ (int) $post_comment->comment_parent ][] = (int) $post_comment->comment_ID;
+	}
+
+	$comment_descendants = array();
+	$comment_queue       = array( (int) $comment->comment_ID );
+
+	while ( $comment_queue ) {
+		$descendant_parent = array_shift( $comment_queue );
+
+		if ( isset( $comments_by_parent[ $descendant_parent ] ) ) {
+			foreach ( $comments_by_parent[ $descendant_parent ] as $descendant_id ) {
+				$comment_descendants[ $descendant_id ] = true;
+				$comment_queue[]                       = $descendant_id;
+			}
 		}
+	}
+
+	// Compute each comment's depth, since comments at the maximum threading depth cannot become a parent.
+	$comment_depths = array();
+
+	foreach ( $post_comments as $post_comment ) {
+		$depth       = 1;
+		$ancestor_id = (int) $post_comment->comment_parent;
+
+		while ( $ancestor_id && isset( $post_comments_by_id[ $ancestor_id ] ) ) {
+			++$depth;
+			$ancestor_id = (int) $post_comments_by_id[ $ancestor_id ]->comment_parent;
+		}
+
+		$comment_depths[ (int) $post_comment->comment_ID ] = $depth;
 	}
 }
 ?>
@@ -256,6 +289,7 @@ printf(
 );
 ?>
 </span>
+<?php if ( $comment_threading_enabled ) : ?>
 <a href="#edit_comment_parent" class="edit-comment-parent hide-if-no-js"><span aria-hidden="true"><?php _e( 'Edit' ); ?></span> <span class="screen-reader-text">
 	<?php
 	/* translators: Hidden accessibility text. */
@@ -271,7 +305,12 @@ printf(
 </legend>
 <label for="comment_parent"><?php _e( 'Parent comment' ); ?></label>
 <select name="comment_parent" id="comment_parent">
-	<option value="0"<?php selected( 0, (int) $comment->comment_parent ); ?>><?php _e( 'None (top-level comment)' ); ?></option>
+	<option value="0"<?php selected( 0, (int) $comment->comment_parent ); ?>>
+		<?php
+		/* translators: Option in the parent comment dropdown, meaning the comment has no parent. */
+		_e( 'None (top-level comment)' );
+		?>
+	</option>
 	<?php
 	$current_parent_listed = false;
 
@@ -279,6 +318,11 @@ printf(
 		$post_comment_id = (int) $post_comment->comment_ID;
 
 		if ( $post_comment_id === (int) $comment->comment_ID || isset( $comment_descendants[ $post_comment_id ] ) ) {
+			continue;
+		}
+
+		// Comments already at the maximum threading depth cannot become a parent.
+		if ( $max_thread_depth && $comment_depths[ $post_comment_id ] >= $max_thread_depth ) {
 			continue;
 		}
 
@@ -326,6 +370,7 @@ printf(
 <a href="#edit_comment_parent" class="cancel-comment-parent hide-if-no-js button-cancel"><?php _e( 'Cancel' ); ?></a>
 </p>
 </fieldset>
+<?php endif; ?>
 </div>
 
 <?php

--- a/src/wp-admin/edit-form-comment.php
+++ b/src/wp-admin/edit-form-comment.php
@@ -334,7 +334,7 @@ printf(
 			/* translators: 1: Comment author, 2: Comment excerpt. */
 			__( '%1$s: %2$s' ),
 			get_comment_author( $post_comment ),
-			get_comment_excerpt( $post_comment )
+			wp_html_excerpt( get_comment_excerpt( $post_comment ), 50, '…' )
 		);
 
 		printf(
@@ -352,7 +352,7 @@ printf(
 			/* translators: 1: Comment author, 2: Comment excerpt. */
 			__( '%1$s: %2$s' ),
 			get_comment_author( $parent ),
-			get_comment_excerpt( $parent )
+			wp_html_excerpt( get_comment_excerpt( $parent ), 50, '…' )
 		);
 
 		printf(

--- a/src/wp-admin/edit-form-comment.php
+++ b/src/wp-admin/edit-form-comment.php
@@ -249,18 +249,28 @@ if ( $comment_threading_enabled ) {
 		$comments_by_parent[ (int) $post_comment->comment_parent ][] = (int) $post_comment->comment_ID;
 	}
 
-	$comment_descendants = array();
-	$comment_queue       = array( (int) $comment->comment_ID );
+	// Walk the descendants level by level, which also gives the height of the subtree that moves with the comment.
+	$comment_descendants    = array();
+	$comment_subtree_height = 1;
+	$comment_level          = array( (int) $comment->comment_ID );
 
-	while ( $comment_queue ) {
-		$descendant_parent = array_shift( $comment_queue );
+	while ( $comment_level ) {
+		$next_level = array();
 
-		if ( isset( $comments_by_parent[ $descendant_parent ] ) ) {
-			foreach ( $comments_by_parent[ $descendant_parent ] as $descendant_id ) {
-				$comment_descendants[ $descendant_id ] = true;
-				$comment_queue[]                       = $descendant_id;
+		foreach ( $comment_level as $level_comment_id ) {
+			if ( isset( $comments_by_parent[ $level_comment_id ] ) ) {
+				foreach ( $comments_by_parent[ $level_comment_id ] as $descendant_id ) {
+					$comment_descendants[ $descendant_id ] = true;
+					$next_level[]                          = $descendant_id;
+				}
 			}
 		}
+
+		if ( $next_level ) {
+			++$comment_subtree_height;
+		}
+
+		$comment_level = $next_level;
 	}
 
 	// Compute each comment's depth, since comments at the maximum threading depth cannot become a parent.
@@ -321,8 +331,8 @@ printf(
 			continue;
 		}
 
-		// Comments already at the maximum threading depth cannot become a parent.
-		if ( $max_thread_depth && $comment_depths[ $post_comment_id ] >= $max_thread_depth ) {
+		// The comment and the replies that move with it must stay within the maximum threading depth.
+		if ( $max_thread_depth && $comment_depths[ $post_comment_id ] + $comment_subtree_height > $max_thread_depth ) {
 			continue;
 		}
 

--- a/src/wp-admin/edit-form-comment.php
+++ b/src/wp-admin/edit-form-comment.php
@@ -201,25 +201,130 @@ if ( current_user_can( 'edit_post', $post_id ) ) {
 </div>
 
 <?php
-if ( $comment->comment_parent ) :
+$parent_display = __( 'None' );
+
+if ( $comment->comment_parent ) {
 	$parent = get_comment( $comment->comment_parent );
-	if ( $parent ) :
-		$parent_link = esc_url( get_comment_link( $parent ) );
-		$name        = get_comment_author( $parent );
-		?>
-	<div class="misc-pub-section misc-pub-reply-to">
-		<?php
-		printf(
-			/* translators: %s: Comment link. */
-			__( 'In reply to: %s' ),
-			'<b><a href="' . $parent_link . '">' . $name . '</a></b>'
-		);
-		?>
-	</div>
-		<?php
-endif;
-endif;
+
+	if ( $parent ) {
+		$parent_link    = esc_url( get_comment_link( $parent ) );
+		$name           = get_comment_author( $parent );
+		$parent_display = '<a href="' . $parent_link . '">' . $name . '</a>';
+	}
+}
+
+$post_comments = get_comments(
+	array(
+		'post_id' => $comment->comment_post_ID,
+		'type'    => 'comment',
+		'status'  => 'all',
+		'orderby' => 'comment_date_gmt',
+		'order'   => 'ASC',
+	)
+);
+
+// Group comments by parent to find this comment's descendants, which cannot become its parent.
+$comments_by_parent = array();
+
+foreach ( $post_comments as $post_comment ) {
+	$comments_by_parent[ (int) $post_comment->comment_parent ][] = (int) $post_comment->comment_ID;
+}
+
+$comment_descendants = array();
+$comment_queue       = array( $comment->comment_ID );
+
+while ( $comment_queue ) {
+	$descendant_parent = array_shift( $comment_queue );
+
+	if ( isset( $comments_by_parent[ $descendant_parent ] ) ) {
+		foreach ( $comments_by_parent[ $descendant_parent ] as $descendant_id ) {
+			$comment_descendants[ $descendant_id ] = true;
+			$comment_queue[]                       = $descendant_id;
+		}
+	}
+}
 ?>
+<div class="misc-pub-section misc-pub-reply-to">
+<span id="comment-parent-display">
+<?php
+printf(
+	/* translators: %s: Parent comment link, or 'None'. */
+	__( 'In reply to: %s' ),
+	'<b>' . $parent_display . '</b>'
+);
+?>
+</span>
+<a href="#edit_comment_parent" class="edit-comment-parent hide-if-no-js"><span aria-hidden="true"><?php _e( 'Edit' ); ?></span> <span class="screen-reader-text">
+	<?php
+	/* translators: Hidden accessibility text. */
+	_e( 'Edit parent comment' );
+	?>
+</span></a>
+<fieldset id="comment-parent-div" class="hide-if-js">
+<legend class="screen-reader-text">
+	<?php
+	/* translators: Hidden accessibility text. */
+	_e( 'Parent comment' );
+	?>
+</legend>
+<label for="comment_parent"><?php _e( 'Parent comment' ); ?></label>
+<select name="comment_parent" id="comment_parent">
+	<option value="0"<?php selected( 0, (int) $comment->comment_parent ); ?>><?php _e( 'None (top-level comment)' ); ?></option>
+	<?php
+	$current_parent_listed = false;
+
+	foreach ( $post_comments as $post_comment ) {
+		$post_comment_id = (int) $post_comment->comment_ID;
+
+		if ( $post_comment_id === $comment->comment_ID || isset( $comment_descendants[ $post_comment_id ] ) ) {
+			continue;
+		}
+
+		if ( $post_comment_id === (int) $comment->comment_parent ) {
+			$current_parent_listed = true;
+		}
+
+		$option_label = sprintf(
+			/* translators: 1: Comment author, 2: Comment excerpt. */
+			__( '%1$s: %2$s' ),
+			get_comment_author( $post_comment ),
+			get_comment_excerpt( $post_comment )
+		);
+
+		printf(
+			"\t<option value=\"%d\" data-author=\"%s\"%s>%s</option>\n",
+			$post_comment_id,
+			esc_attr( get_comment_author( $post_comment ) ),
+			selected( $post_comment_id, (int) $comment->comment_parent, false ),
+			esc_html( $option_label )
+		);
+	}
+
+	// The current parent may not be listed, e.g. a pingback or a comment no longer publicly visible.
+	if ( $comment->comment_parent && ! $current_parent_listed && $parent ) {
+		$option_label = sprintf(
+			/* translators: 1: Comment author, 2: Comment excerpt. */
+			__( '%1$s: %2$s' ),
+			get_comment_author( $parent ),
+			get_comment_excerpt( $parent )
+		);
+
+		printf(
+			"\t<option value=\"%d\" data-author=\"%s\" selected=\"selected\">%s</option>\n",
+			(int) $comment->comment_parent,
+			esc_attr( get_comment_author( $parent ) ),
+			esc_html( $option_label )
+		);
+	}
+	?>
+</select>
+<input type="hidden" id="hidden_comment_parent" value="<?php echo esc_attr( $comment->comment_parent ); ?>" />
+<p>
+<a href="#edit_comment_parent" class="save-comment-parent hide-if-no-js button"><?php _e( 'OK' ); ?></a>
+<a href="#edit_comment_parent" class="cancel-comment-parent hide-if-no-js button-cancel"><?php _e( 'Cancel' ); ?></a>
+</p>
+</fieldset>
+</div>
 
 <?php
 	/**

--- a/src/wp-admin/edit-form-comment.php
+++ b/src/wp-admin/edit-form-comment.php
@@ -236,16 +236,12 @@ if ( $comment_threading_enabled ) {
 	// Restore chronological order for display.
 	$post_comments = array_reverse( $post_comments );
 
+	// Index the comments by ID and by parent, to compute depths and find descendants.
 	$post_comments_by_id = array();
+	$comments_by_parent  = array();
 
 	foreach ( $post_comments as $post_comment ) {
-		$post_comments_by_id[ (int) $post_comment->comment_ID ] = $post_comment;
-	}
-
-	// Group comments by parent to find this comment's descendants, which cannot become its parent.
-	$comments_by_parent = array();
-
-	foreach ( $post_comments as $post_comment ) {
+		$post_comments_by_id[ (int) $post_comment->comment_ID ]      = $post_comment;
 		$comments_by_parent[ (int) $post_comment->comment_parent ][] = (int) $post_comment->comment_ID;
 	}
 

--- a/src/wp-admin/includes/comment.php
+++ b/src/wp-admin/includes/comment.php
@@ -124,8 +124,41 @@ function edit_comment() {
 
 			$max_thread_depth = (int) get_option( 'thread_comments_depth' );
 
-			if ( $max_thread_depth && $parent_depth >= $max_thread_depth ) {
-				return new WP_Error( 'comment_parent_invalid', __( 'The parent comment is already at the maximum threading depth.' ) );
+			if ( $max_thread_depth ) {
+				if ( $parent_depth >= $max_thread_depth ) {
+					return new WP_Error( 'comment_parent_invalid', __( 'The parent comment is already at the maximum threading depth.' ) );
+				}
+
+				// The comment's replies move with it, so the whole subtree must stay within the maximum depth.
+				$subtree_height = 1;
+				$subtree_ids    = array( $comment_id => true );
+				$level_ids      = array( $comment_id );
+
+				while ( $level_ids && $parent_depth + $subtree_height <= $max_thread_depth ) {
+					$level_ids = get_comments(
+						array(
+							'parent__in' => $level_ids,
+							'fields'     => 'ids',
+							'status'     => 'any',
+							'orderby'    => 'none',
+						)
+					);
+
+					// Guard against a comment appearing twice, e.g. a loop in existing data.
+					$level_ids = array_diff( array_map( 'intval', $level_ids ), array_keys( $subtree_ids ) );
+
+					foreach ( $level_ids as $level_id ) {
+						$subtree_ids[ $level_id ] = true;
+					}
+
+					if ( $level_ids ) {
+						++$subtree_height;
+					}
+				}
+
+				if ( $parent_depth + $subtree_height > $max_thread_depth ) {
+					return new WP_Error( 'comment_parent_invalid', __( 'The replies to this comment would exceed the maximum threading depth.' ) );
+				}
 			}
 		}
 	}

--- a/src/wp-admin/includes/comment.php
+++ b/src/wp-admin/includes/comment.php
@@ -46,6 +46,7 @@ function comment_exists( $comment_author, $comment_date, $timezone = 'blog' ) {
  *
  * @since 2.0.0
  * @since 5.5.0 A return value was added.
+ * @since 7.1.0 The comment parent can be updated via `$_POST['comment_parent']`.
  *
  * @return int|WP_Error The value 1 if the comment was updated, 0 if not updated.
  *                      A WP_Error object on failure.
@@ -72,6 +73,43 @@ function edit_comment() {
 	}
 	if ( isset( $_POST['comment_ID'] ) ) {
 		$_POST['comment_ID'] = (int) $_POST['comment_ID'];
+	}
+
+	if ( isset( $_POST['comment_parent'] ) ) {
+		$comment_id     = (int) $_POST['comment_ID'];
+		$comment_parent = (int) $_POST['comment_parent'];
+
+		$_POST['comment_parent'] = $comment_parent;
+
+		$comment = get_comment( $comment_id );
+
+		if ( $comment && $comment_parent !== (int) $comment->comment_parent ) {
+			if ( $comment_parent === $comment_id ) {
+				return new WP_Error( 'comment_parent_invalid', __( 'A comment cannot be a reply to itself.' ) );
+			}
+
+			if ( $comment_parent ) {
+				$parent = get_comment( $comment_parent );
+
+				if ( ! $parent || (int) $parent->comment_post_ID !== (int) $comment->comment_post_ID ) {
+					return new WP_Error( 'comment_parent_invalid', __( 'The parent must be another comment on the same post.' ) );
+				}
+
+				// Walk up the new parent's ancestors to prevent creating a threading loop.
+				$ancestors = array();
+				$ancestor  = $parent;
+
+				while ( $ancestor && $ancestor->comment_parent && ! isset( $ancestors[ $ancestor->comment_ID ] ) ) {
+					if ( (int) $ancestor->comment_parent === $comment_id ) {
+						return new WP_Error( 'comment_parent_invalid', __( 'A comment cannot be a reply to one of its own replies.' ) );
+					}
+
+					$ancestors[ $ancestor->comment_ID ] = true;
+
+					$ancestor = get_comment( $ancestor->comment_parent );
+				}
+			}
+		}
 	}
 
 	foreach ( array( 'aa', 'mm', 'jj', 'hh', 'mn' ) as $timeunit ) {

--- a/src/wp-admin/includes/comment.php
+++ b/src/wp-admin/includes/comment.php
@@ -94,16 +94,14 @@ function edit_comment() {
 
 			$parent = get_comment( $comment_parent );
 
-			if ( ! $parent || (int) $parent->comment_post_ID !== (int) $comment->comment_post_ID ) {
-				return new WP_Error( 'comment_parent_invalid', __( 'The parent must be another comment on the same post.' ) );
-			}
-
-			if ( $parent->comment_type !== $comment->comment_type ) {
-				return new WP_Error( 'comment_parent_invalid', __( 'The parent must be a comment of the same type.' ) );
-			}
-
-			if ( in_array( wp_get_comment_status( $parent ), array( 'spam', 'trash' ), true ) ) {
-				return new WP_Error( 'comment_parent_invalid', __( 'The parent cannot be a comment in the Trash or marked as spam.' ) );
+			// The parent must be a comment of the same type, on the same post, and not in the Trash or marked as spam.
+			if (
+				! $parent
+				|| (int) $parent->comment_post_ID !== (int) $comment->comment_post_ID
+				|| $parent->comment_type !== $comment->comment_type
+				|| in_array( wp_get_comment_status( $parent ), array( 'spam', 'trash' ), true )
+			) {
+				return new WP_Error( 'comment_parent_invalid', __( 'Invalid parent comment.' ) );
 			}
 
 			// Walk up the new parent's ancestors to prevent creating a threading loop.
@@ -125,13 +123,13 @@ function edit_comment() {
 			$max_thread_depth = (int) get_option( 'thread_comments_depth' );
 
 			if ( $max_thread_depth ) {
-				if ( $parent_depth >= $max_thread_depth ) {
-					return new WP_Error( 'comment_parent_invalid', __( 'The parent comment is already at the maximum threading depth.' ) );
-				}
-
-				// The comment's replies move with it, so the whole subtree must stay within the maximum depth.
+				/*
+				 * The comment's replies move with it, so the whole subtree must stay within
+				 * the maximum depth. Measure its height one level of replies at a time,
+				 * stopping as soon as the subtree cannot fit, which also bounds the loop
+				 * should the stored comment hierarchy contain a cycle.
+				 */
 				$subtree_height = 1;
-				$subtree_ids    = array( $comment_id => true );
 				$level_ids      = array( $comment_id );
 
 				while ( $level_ids && $parent_depth + $subtree_height <= $max_thread_depth ) {
@@ -144,20 +142,13 @@ function edit_comment() {
 						)
 					);
 
-					// Guard against a comment appearing twice, e.g. a loop in existing data.
-					$level_ids = array_diff( array_map( 'intval', $level_ids ), array_keys( $subtree_ids ) );
-
-					foreach ( $level_ids as $level_id ) {
-						$subtree_ids[ $level_id ] = true;
-					}
-
 					if ( $level_ids ) {
 						++$subtree_height;
 					}
 				}
 
 				if ( $parent_depth + $subtree_height > $max_thread_depth ) {
-					return new WP_Error( 'comment_parent_invalid', __( 'The replies to this comment would exceed the maximum threading depth.' ) );
+					return new WP_Error( 'comment_parent_invalid', __( 'The comment cannot be moved there because it or its replies would exceed the maximum threading depth.' ) );
 				}
 			}
 		}

--- a/src/wp-admin/includes/comment.php
+++ b/src/wp-admin/includes/comment.php
@@ -83,31 +83,49 @@ function edit_comment() {
 
 		$comment = get_comment( $comment_id );
 
-		if ( $comment && $comment_parent !== (int) $comment->comment_parent ) {
+		if ( $comment && $comment_parent && $comment_parent !== (int) $comment->comment_parent ) {
+			if ( ! get_option( 'thread_comments' ) ) {
+				return new WP_Error( 'comment_parent_invalid', __( 'The comment parent cannot be changed because threaded comments are disabled.' ) );
+			}
+
 			if ( $comment_parent === $comment_id ) {
 				return new WP_Error( 'comment_parent_invalid', __( 'A comment cannot be a reply to itself.' ) );
 			}
 
-			if ( $comment_parent ) {
-				$parent = get_comment( $comment_parent );
+			$parent = get_comment( $comment_parent );
 
-				if ( ! $parent || (int) $parent->comment_post_ID !== (int) $comment->comment_post_ID ) {
-					return new WP_Error( 'comment_parent_invalid', __( 'The parent must be another comment on the same post.' ) );
+			if ( ! $parent || (int) $parent->comment_post_ID !== (int) $comment->comment_post_ID ) {
+				return new WP_Error( 'comment_parent_invalid', __( 'The parent must be another comment on the same post.' ) );
+			}
+
+			if ( $parent->comment_type !== $comment->comment_type ) {
+				return new WP_Error( 'comment_parent_invalid', __( 'The parent must be a comment of the same type.' ) );
+			}
+
+			if ( in_array( wp_get_comment_status( $parent ), array( 'spam', 'trash' ), true ) ) {
+				return new WP_Error( 'comment_parent_invalid', __( 'The parent cannot be a comment in the Trash or marked as spam.' ) );
+			}
+
+			// Walk up the new parent's ancestors to prevent creating a threading loop.
+			$ancestors    = array();
+			$ancestor     = $parent;
+			$parent_depth = 1;
+
+			while ( $ancestor && $ancestor->comment_parent && ! isset( $ancestors[ $ancestor->comment_ID ] ) ) {
+				if ( (int) $ancestor->comment_parent === $comment_id ) {
+					return new WP_Error( 'comment_parent_invalid', __( 'A comment cannot be a reply to one of its own replies.' ) );
 				}
 
-				// Walk up the new parent's ancestors to prevent creating a threading loop.
-				$ancestors = array();
-				$ancestor  = $parent;
+				$ancestors[ $ancestor->comment_ID ] = true;
+				++$parent_depth;
 
-				while ( $ancestor && $ancestor->comment_parent && ! isset( $ancestors[ $ancestor->comment_ID ] ) ) {
-					if ( (int) $ancestor->comment_parent === $comment_id ) {
-						return new WP_Error( 'comment_parent_invalid', __( 'A comment cannot be a reply to one of its own replies.' ) );
-					}
+				$ancestor = get_comment( $ancestor->comment_parent );
+			}
 
-					$ancestors[ $ancestor->comment_ID ] = true;
+			$max_thread_depth = (int) get_option( 'thread_comments_depth' );
 
-					$ancestor = get_comment( $ancestor->comment_parent );
-				}
+			if ( $max_thread_depth && $parent_depth >= $max_thread_depth ) {
+				return new WP_Error( 'comment_parent_invalid', __( 'The parent comment is already at the maximum threading depth.' ) );
 			}
 		}
 	}

--- a/tests/phpunit/tests/admin/EditFormComment_Test.php
+++ b/tests/phpunit/tests/admin/EditFormComment_Test.php
@@ -132,27 +132,6 @@ class Admin_EditFormComment_Test extends WP_UnitTestCase {
 	/**
 	 * @ticket 65570
 	 */
-	public function test_should_exclude_parents_at_maximum_threading_depth() {
-		update_option( 'thread_comments_depth', 2 );
-
-		$top_id     = self::factory()->comment->create( array( 'comment_post_ID' => self::$post_id ) );
-		$deep_id    = self::factory()->comment->create(
-			array(
-				'comment_post_ID' => self::$post_id,
-				'comment_parent'  => $top_id,
-			)
-		);
-		$comment_id = self::factory()->comment->create( array( 'comment_post_ID' => self::$post_id ) );
-
-		$dropdown = $this->get_parent_dropdown( $comment_id );
-
-		$this->assertStringContainsString( "value='{$top_id}'", $dropdown, 'A top-level comment should be listed.' );
-		$this->assertStringNotContainsString( "value='{$deep_id}'", $dropdown, 'A comment at the maximum depth should not be listed.' );
-	}
-
-	/**
-	 * @ticket 65570
-	 */
 	public function test_should_account_for_replies_when_excluding_deep_parents() {
 		update_option( 'thread_comments_depth', 3 );
 

--- a/tests/phpunit/tests/admin/EditFormComment_Test.php
+++ b/tests/phpunit/tests/admin/EditFormComment_Test.php
@@ -1,0 +1,202 @@
+<?php
+
+/**
+ * Tests for the parent comment selector on the Edit Comment screen.
+ *
+ * @group admin
+ * @group comment
+ */
+class Admin_EditFormComment_Test extends WP_UnitTestCase {
+
+	/**
+	 * Admin user ID.
+	 */
+	public static int $admin_id;
+
+	/**
+	 * Post ID to add comments to.
+	 */
+	public static int $post_id;
+
+	/**
+	 * Create the user and post for the tests.
+	 *
+	 * @param WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$admin_id = $factory->user->create( array( 'role' => 'administrator' ) );
+		self::$post_id  = $factory->post->create();
+	}
+
+	public function set_up() {
+		parent::set_up();
+
+		wp_set_current_user( self::$admin_id );
+	}
+
+	/**
+	 * Renders the Edit Comment form for a comment and returns the output.
+	 *
+	 * @param int $comment_id Comment ID.
+	 * @return string The rendered form.
+	 */
+	private function render_edit_form( $comment_id ) {
+		global $comment;
+
+		$comment = get_comment_to_edit( $comment_id );
+		$action  = 'editcomment';
+
+		set_current_screen( 'comment' );
+
+		ob_start();
+		require ABSPATH . 'wp-admin/edit-form-comment.php';
+		$output = ob_get_clean();
+
+		unset( $GLOBALS['comment'] );
+
+		return $output;
+	}
+
+	/**
+	 * Returns the parent comment dropdown markup from the rendered form.
+	 *
+	 * @param int $comment_id Comment ID.
+	 * @return string The dropdown markup, or an empty string if not rendered.
+	 */
+	private function get_parent_dropdown( $comment_id ) {
+		$output = $this->render_edit_form( $comment_id );
+
+		if ( ! preg_match( '|<select name="comment_parent"[^>]*>.*?</select>|s', $output, $matches ) ) {
+			return '';
+		}
+
+		return $matches[0];
+	}
+
+	/**
+	 * @ticket 65570
+	 */
+	public function test_should_list_valid_parents_and_exclude_invalid_ones() {
+		$top_id     = self::factory()->comment->create( array( 'comment_post_ID' => self::$post_id ) );
+		$reply_id   = self::factory()->comment->create(
+			array(
+				'comment_post_ID' => self::$post_id,
+				'comment_parent'  => $top_id,
+			)
+		);
+		$spam_id    = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => self::$post_id,
+				'comment_approved' => 'spam',
+			)
+		);
+		$trash_id   = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => self::$post_id,
+				'comment_approved' => 'trash',
+			)
+		);
+		$comment_id = self::factory()->comment->create( array( 'comment_post_ID' => self::$post_id ) );
+		$child_id   = self::factory()->comment->create(
+			array(
+				'comment_post_ID' => self::$post_id,
+				'comment_parent'  => $comment_id,
+			)
+		);
+
+		$dropdown = $this->get_parent_dropdown( $comment_id );
+
+		$this->assertStringContainsString( 'value="0"', $dropdown, 'The "None" option should be listed.' );
+		$this->assertStringContainsString( "value='{$top_id}'", $dropdown, 'A top-level comment should be listed.' );
+		$this->assertStringContainsString( "value='{$reply_id}'", $dropdown, 'A nested comment should be listed.' );
+		$this->assertStringNotContainsString( "value='{$comment_id}'", $dropdown, 'The comment being edited should not be listed.' );
+		$this->assertStringNotContainsString( "value='{$child_id}'", $dropdown, 'A reply to the comment being edited should not be listed.' );
+		$this->assertStringNotContainsString( "value='{$spam_id}'", $dropdown, 'A spam comment should not be listed.' );
+		$this->assertStringNotContainsString( "value='{$trash_id}'", $dropdown, 'A trashed comment should not be listed.' );
+	}
+
+	/**
+	 * @ticket 65570
+	 */
+	public function test_should_not_render_parent_selector_when_comment_threading_is_disabled() {
+		update_option( 'thread_comments', 0 );
+
+		$comment_id = self::factory()->comment->create( array( 'comment_post_ID' => self::$post_id ) );
+
+		$output = $this->render_edit_form( $comment_id );
+
+		$this->assertStringContainsString( 'id="comment-parent-display"', $output, 'The parent should still be displayed.' );
+		$this->assertStringNotContainsString( 'name="comment_parent"', $output, 'The parent selector should not be rendered.' );
+	}
+
+	/**
+	 * @ticket 65570
+	 */
+	public function test_should_exclude_parents_at_maximum_threading_depth() {
+		update_option( 'thread_comments_depth', 2 );
+
+		$top_id     = self::factory()->comment->create( array( 'comment_post_ID' => self::$post_id ) );
+		$deep_id    = self::factory()->comment->create(
+			array(
+				'comment_post_ID' => self::$post_id,
+				'comment_parent'  => $top_id,
+			)
+		);
+		$comment_id = self::factory()->comment->create( array( 'comment_post_ID' => self::$post_id ) );
+
+		$dropdown = $this->get_parent_dropdown( $comment_id );
+
+		$this->assertStringContainsString( "value='{$top_id}'", $dropdown, 'A top-level comment should be listed.' );
+		$this->assertStringNotContainsString( "value='{$deep_id}'", $dropdown, 'A comment at the maximum depth should not be listed.' );
+	}
+
+	/**
+	 * @ticket 65570
+	 */
+	public function test_should_account_for_replies_when_excluding_deep_parents() {
+		update_option( 'thread_comments_depth', 3 );
+
+		$top_id     = self::factory()->comment->create( array( 'comment_post_ID' => self::$post_id ) );
+		$mid_id     = self::factory()->comment->create(
+			array(
+				'comment_post_ID' => self::$post_id,
+				'comment_parent'  => $top_id,
+			)
+		);
+		$comment_id = self::factory()->comment->create( array( 'comment_post_ID' => self::$post_id ) );
+		self::factory()->comment->create(
+			array(
+				'comment_post_ID' => self::$post_id,
+				'comment_parent'  => $comment_id,
+			)
+		);
+
+		$dropdown = $this->get_parent_dropdown( $comment_id );
+
+		$this->assertStringContainsString( "value='{$top_id}'", $dropdown, 'A parent leaving room for the reply should be listed.' );
+		$this->assertStringNotContainsString( "value='{$mid_id}'", $dropdown, 'A parent whose depth plus the replies would exceed the maximum should not be listed.' );
+	}
+
+	/**
+	 * @ticket 65570
+	 */
+	public function test_should_list_current_parent_even_when_it_is_not_a_valid_option() {
+		$spam_parent_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => self::$post_id,
+				'comment_approved' => 'spam',
+			)
+		);
+		$comment_id     = self::factory()->comment->create(
+			array(
+				'comment_post_ID' => self::$post_id,
+				'comment_parent'  => $spam_parent_id,
+			)
+		);
+
+		$dropdown = $this->get_parent_dropdown( $comment_id );
+
+		$this->assertStringContainsString( "value='{$spam_parent_id}'", $dropdown, 'The current parent should be listed.' );
+		$this->assertStringContainsString( ' selected>', $dropdown, 'The current parent should be selected.' );
+	}
+}

--- a/tests/phpunit/tests/admin/includes/comment/EditComment_Test.php
+++ b/tests/phpunit/tests/admin/includes/comment/EditComment_Test.php
@@ -1,0 +1,199 @@
+<?php
+
+/**
+ * @group admin
+ * @group comment
+ *
+ * @covers ::edit_comment
+ */
+class Admin_Includes_Comment_EditComment_Test extends WP_UnitTestCase {
+
+	/**
+	 * Admin user ID.
+	 *
+	 * @var int
+	 */
+	public static $admin_id;
+
+	/**
+	 * Post ID to add comments to.
+	 *
+	 * @var int
+	 */
+	public static $post_id;
+
+	/**
+	 * Another post ID, to test cross-post re-parenting.
+	 *
+	 * @var int
+	 */
+	public static $other_post_id;
+
+	/**
+	 * Create the user and posts for the tests.
+	 *
+	 * @param WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$admin_id      = $factory->user->create( array( 'role' => 'administrator' ) );
+		self::$post_id       = $factory->post->create();
+		self::$other_post_id = $factory->post->create();
+	}
+
+	public function set_up() {
+		parent::set_up();
+
+		wp_set_current_user( self::$admin_id );
+	}
+
+	public function tear_down() {
+		$_POST = array();
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Calls edit_comment() with a comment ID and a new parent, as submitted from the Edit Comment screen.
+	 *
+	 * @param int $comment_id     Comment ID.
+	 * @param int $comment_parent New parent comment ID.
+	 * @return int|WP_Error The edit_comment() return value.
+	 */
+	private function update_comment_parent( $comment_id, $comment_parent ) {
+		$_POST = array(
+			'comment_ID'     => $comment_id,
+			'comment_parent' => $comment_parent,
+		);
+
+		return edit_comment();
+	}
+
+	/**
+	 * @ticket 65570
+	 */
+	public function test_should_update_comment_parent() {
+		$parent_id  = self::factory()->comment->create( array( 'comment_post_ID' => self::$post_id ) );
+		$comment_id = self::factory()->comment->create( array( 'comment_post_ID' => self::$post_id ) );
+
+		$result = $this->update_comment_parent( $comment_id, $parent_id );
+
+		$this->assertSame( 1, $result );
+		$this->assertSame( (string) $parent_id, get_comment( $comment_id )->comment_parent );
+	}
+
+	/**
+	 * @ticket 65570
+	 */
+	public function test_should_allow_clearing_comment_parent() {
+		$parent_id  = self::factory()->comment->create( array( 'comment_post_ID' => self::$post_id ) );
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID' => self::$post_id,
+				'comment_parent'  => $parent_id,
+			)
+		);
+
+		$result = $this->update_comment_parent( $comment_id, 0 );
+
+		$this->assertSame( 1, $result );
+		$this->assertSame( '0', get_comment( $comment_id )->comment_parent );
+	}
+
+	/**
+	 * @ticket 65570
+	 */
+	public function test_should_reject_parent_on_a_different_post() {
+		$parent_id  = self::factory()->comment->create( array( 'comment_post_ID' => self::$other_post_id ) );
+		$comment_id = self::factory()->comment->create( array( 'comment_post_ID' => self::$post_id ) );
+
+		$result = $this->update_comment_parent( $comment_id, $parent_id );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'comment_parent_invalid', $result->get_error_code() );
+		$this->assertSame( '0', get_comment( $comment_id )->comment_parent );
+	}
+
+	/**
+	 * @ticket 65570
+	 */
+	public function test_should_reject_nonexistent_parent() {
+		$comment_id = self::factory()->comment->create( array( 'comment_post_ID' => self::$post_id ) );
+
+		$result = $this->update_comment_parent( $comment_id, $comment_id + 1000 );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'comment_parent_invalid', $result->get_error_code() );
+	}
+
+	/**
+	 * @ticket 65570
+	 */
+	public function test_should_reject_comment_as_its_own_parent() {
+		$comment_id = self::factory()->comment->create( array( 'comment_post_ID' => self::$post_id ) );
+
+		$result = $this->update_comment_parent( $comment_id, $comment_id );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'comment_parent_invalid', $result->get_error_code() );
+	}
+
+	/**
+	 * @ticket 65570
+	 */
+	public function test_should_reject_child_as_parent() {
+		$comment_id = self::factory()->comment->create( array( 'comment_post_ID' => self::$post_id ) );
+		$child_id   = self::factory()->comment->create(
+			array(
+				'comment_post_ID' => self::$post_id,
+				'comment_parent'  => $comment_id,
+			)
+		);
+
+		$result = $this->update_comment_parent( $comment_id, $child_id );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'comment_parent_invalid', $result->get_error_code() );
+	}
+
+	/**
+	 * @ticket 65570
+	 */
+	public function test_should_reject_descendant_as_parent() {
+		$comment_id    = self::factory()->comment->create( array( 'comment_post_ID' => self::$post_id ) );
+		$child_id      = self::factory()->comment->create(
+			array(
+				'comment_post_ID' => self::$post_id,
+				'comment_parent'  => $comment_id,
+			)
+		);
+		$grandchild_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID' => self::$post_id,
+				'comment_parent'  => $child_id,
+			)
+		);
+
+		$result = $this->update_comment_parent( $comment_id, $grandchild_id );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'comment_parent_invalid', $result->get_error_code() );
+	}
+
+	/**
+	 * @ticket 65570
+	 */
+	public function test_should_allow_resubmitting_unchanged_parent() {
+		$parent_id  = self::factory()->comment->create( array( 'comment_post_ID' => self::$post_id ) );
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID' => self::$post_id,
+				'comment_parent'  => $parent_id,
+			)
+		);
+
+		$result = $this->update_comment_parent( $comment_id, $parent_id );
+
+		$this->assertNotWPError( $result );
+		$this->assertSame( (string) $parent_id, get_comment( $comment_id )->comment_parent );
+	}
+}

--- a/tests/phpunit/tests/admin/includes/comment/EditComment_Test.php
+++ b/tests/phpunit/tests/admin/includes/comment/EditComment_Test.php
@@ -10,24 +10,18 @@ class Admin_Includes_Comment_EditComment_Test extends WP_UnitTestCase {
 
 	/**
 	 * Admin user ID.
-	 *
-	 * @var int
 	 */
-	public static $admin_id;
+	public static int $admin_id;
 
 	/**
 	 * Post ID to add comments to.
-	 *
-	 * @var int
 	 */
-	public static $post_id;
+	public static int $post_id;
 
 	/**
 	 * Another post ID, to test cross-post re-parenting.
-	 *
-	 * @var int
 	 */
-	public static $other_post_id;
+	public static int $other_post_id;
 
 	/**
 	 * Create the user and posts for the tests.

--- a/tests/phpunit/tests/admin/includes/comment/EditComment_Test.php
+++ b/tests/phpunit/tests/admin/includes/comment/EditComment_Test.php
@@ -252,6 +252,57 @@ class Admin_Includes_Comment_EditComment_Test extends WP_UnitTestCase {
 	/**
 	 * @ticket 65570
 	 */
+	public function test_should_reject_parent_when_replies_would_exceed_maximum_threading_depth() {
+		update_option( 'thread_comments_depth', 3 );
+
+		$top_id     = self::factory()->comment->create( array( 'comment_post_ID' => self::$post_id ) );
+		$mid_id     = self::factory()->comment->create(
+			array(
+				'comment_post_ID' => self::$post_id,
+				'comment_parent'  => $top_id,
+			)
+		);
+		$comment_id = self::factory()->comment->create( array( 'comment_post_ID' => self::$post_id ) );
+		self::factory()->comment->create(
+			array(
+				'comment_post_ID' => self::$post_id,
+				'comment_parent'  => $comment_id,
+			)
+		);
+
+		// The comment itself would be at depth 3, but its reply would end up at depth 4.
+		$result = $this->update_comment_parent( $comment_id, $mid_id );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'comment_parent_invalid', $result->get_error_code() );
+		$this->assertSame( '0', get_comment( $comment_id )->comment_parent );
+	}
+
+	/**
+	 * @ticket 65570
+	 */
+	public function test_should_allow_moving_comment_with_replies_within_maximum_threading_depth() {
+		update_option( 'thread_comments_depth', 3 );
+
+		$top_id     = self::factory()->comment->create( array( 'comment_post_ID' => self::$post_id ) );
+		$comment_id = self::factory()->comment->create( array( 'comment_post_ID' => self::$post_id ) );
+		self::factory()->comment->create(
+			array(
+				'comment_post_ID' => self::$post_id,
+				'comment_parent'  => $comment_id,
+			)
+		);
+
+		// The comment ends up at depth 2 and its reply at depth 3, the maximum.
+		$result = $this->update_comment_parent( $comment_id, $top_id );
+
+		$this->assertSame( 1, $result );
+		$this->assertSame( (string) $top_id, get_comment( $comment_id )->comment_parent );
+	}
+
+	/**
+	 * @ticket 65570
+	 */
 	public function test_should_reject_parent_of_a_different_comment_type() {
 		$parent_id  = self::factory()->comment->create(
 			array(

--- a/tests/phpunit/tests/admin/includes/comment/EditComment_Test.php
+++ b/tests/phpunit/tests/admin/includes/comment/EditComment_Test.php
@@ -190,4 +190,116 @@ class Admin_Includes_Comment_EditComment_Test extends WP_UnitTestCase {
 		$this->assertNotWPError( $result );
 		$this->assertSame( (string) $parent_id, get_comment( $comment_id )->comment_parent );
 	}
+
+	/**
+	 * @ticket 65570
+	 */
+	public function test_should_reject_new_parent_when_comment_threading_is_disabled() {
+		update_option( 'thread_comments', 0 );
+
+		$parent_id  = self::factory()->comment->create( array( 'comment_post_ID' => self::$post_id ) );
+		$comment_id = self::factory()->comment->create( array( 'comment_post_ID' => self::$post_id ) );
+
+		$result = $this->update_comment_parent( $comment_id, $parent_id );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'comment_parent_invalid', $result->get_error_code() );
+		$this->assertSame( '0', get_comment( $comment_id )->comment_parent );
+	}
+
+	/**
+	 * @ticket 65570
+	 */
+	public function test_should_allow_clearing_parent_when_comment_threading_is_disabled() {
+		update_option( 'thread_comments', 0 );
+
+		$parent_id  = self::factory()->comment->create( array( 'comment_post_ID' => self::$post_id ) );
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID' => self::$post_id,
+				'comment_parent'  => $parent_id,
+			)
+		);
+
+		$result = $this->update_comment_parent( $comment_id, 0 );
+
+		$this->assertSame( 1, $result );
+		$this->assertSame( '0', get_comment( $comment_id )->comment_parent );
+	}
+
+	/**
+	 * @ticket 65570
+	 */
+	public function test_should_reject_parent_at_maximum_threading_depth() {
+		update_option( 'thread_comments_depth', 2 );
+
+		$top_id     = self::factory()->comment->create( array( 'comment_post_ID' => self::$post_id ) );
+		$child_id   = self::factory()->comment->create(
+			array(
+				'comment_post_ID' => self::$post_id,
+				'comment_parent'  => $top_id,
+			)
+		);
+		$comment_id = self::factory()->comment->create( array( 'comment_post_ID' => self::$post_id ) );
+
+		$result = $this->update_comment_parent( $comment_id, $child_id );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'comment_parent_invalid', $result->get_error_code() );
+		$this->assertSame( '0', get_comment( $comment_id )->comment_parent );
+	}
+
+	/**
+	 * @ticket 65570
+	 */
+	public function test_should_reject_parent_of_a_different_comment_type() {
+		$parent_id  = self::factory()->comment->create(
+			array(
+				'comment_post_ID' => self::$post_id,
+				'comment_type'    => 'pingback',
+			)
+		);
+		$comment_id = self::factory()->comment->create( array( 'comment_post_ID' => self::$post_id ) );
+
+		$result = $this->update_comment_parent( $comment_id, $parent_id );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'comment_parent_invalid', $result->get_error_code() );
+		$this->assertSame( '0', get_comment( $comment_id )->comment_parent );
+	}
+
+	/**
+	 * @ticket 65570
+	 *
+	 * @dataProvider data_should_reject_spam_or_trashed_parent
+	 *
+	 * @param string $comment_approved The parent's comment_approved value.
+	 */
+	public function test_should_reject_spam_or_trashed_parent( $comment_approved ) {
+		$parent_id  = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => self::$post_id,
+				'comment_approved' => $comment_approved,
+			)
+		);
+		$comment_id = self::factory()->comment->create( array( 'comment_post_ID' => self::$post_id ) );
+
+		$result = $this->update_comment_parent( $comment_id, $parent_id );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'comment_parent_invalid', $result->get_error_code() );
+		$this->assertSame( '0', get_comment( $comment_id )->comment_parent );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_should_reject_spam_or_trashed_parent() {
+		return array(
+			'a spam parent'    => array( 'spam' ),
+			'a trashed parent' => array( 'trash' ),
+		);
+	}
 }


### PR DESCRIPTION
There is currently no way to re-parent a comment (change `comment_parent`) through the admin UI, even though the data layer fully supports it (`wp_update_comment()` lists `comment_parent` among its updatable fields, and the REST API accepts `parent` on update).

This PR adds an editable "In reply to" control to the Edit Comment screen:

- The "In reply to" line in the Save box is now always displayed (showing "None" for top-level comments), with an Edit toggle following the exact pattern of the "Submitted on" (timestamp) control above it.
- The picker is a `<select>` of the other comments on the same post, each option labeled with the comment author and a trimmed excerpt (via `get_comment_excerpt()`). The comment being edited and its descendants are excluded from the list, so a threading loop cannot even be selected. If the current parent would not otherwise be listed (e.g. a pingback, or a comment no longer publicly visible), it is appended as a selected option so saving without touching the field never re-parents the comment.
- `edit_comment()` now reads `comment_parent` from the submitted form and validates it before handing off to `wp_update_comment()`: the parent must be another comment on the same post, and cannot be the comment itself or one of its descendants. Invalid values return a `WP_Error`, surfaced the same way as other comment update failures. The quick-edit AJAX path is unaffected, as its form does not submit `comment_parent`.
- Without JavaScript, the fieldset is simply visible and submits with the form, same as the timestamp control.

Note on UI scope: the UI is intentionally kept minimal for now (a plain `select`). The Edit Comment screen is a non-React admin screen, so advanced UI components (custom searchable selects/comboboxes) are hard to do well there without pulling in significant machinery. The plain select matches the existing core precedent for picking a parent (`wp_dropdown_pages()` in Page Attributes) and can be revisited later.

### Screenshots

| Picker open | After choosing a parent |
| --- | --- |
| ![Edit Comment Save box with the parent comment select open](https://raw.githubusercontent.com/youknowriad/wordpress-develop/assets-65570/parent-picker-open.png) | ![Edit Comment Save box showing the updated In reply to author](https://raw.githubusercontent.com/youknowriad/wordpress-develop/assets-65570/parent-picker-after-save.png) |

### Testing instructions

1. On a post with a few (threaded) comments, go to Comments and click Edit on one of them.
2. In the Save box, click Edit next to "In reply to:".
3. Pick another comment — note the edited comment itself and its own replies are not offered — and click OK, then Update.
4. Verify the comment is re-parented on the front end.

New PHPUnit tests cover the `edit_comment()` validation (re-parenting, clearing to top-level, and rejecting cross-post, nonexistent, self, child, and descendant parents): `tests/phpunit/tests/admin/includes/comment/EditComment_Test.php`.

Trac ticket: https://core.trac.wordpress.org/ticket/65570

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Fable 5
Used for: Implementation, tests, and screenshots were authored with AI assistance, directed and reviewed by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
