### PR TITLE
Build/Test Tools: Honor `@global` tags on `global` statement docblocks in PHPStan analysis

### DIFF
--- a/tests/phpstan/GlobalDocBlockVisitor.php
+++ b/tests/phpstan/GlobalDocBlockVisitor.php
@@ -26,6 +26,12 @@ use PhpParser\NodeVisitorAbstract;
  * visitor closes the gap so PHPStan can use the existing core annotations
  * without each `global` statement needing its own redundant `@var`.
  *
+ * `@global` tags in a docblock attached directly to a `global` statement are
+ * honored as well, and take precedence over the enclosing function's tags.
+ * This makes `@global` sufficient for file-scope `global` statements (e.g. in
+ * templates included into another scope), which have no enclosing function
+ * docblock at all.
+ *
  * Functions that do not document a global, or that import a global the
  * function docblock does not list, are left untouched and continue to
  * resolve as `mixed` — preserving PHPStan's safety guarantees.
@@ -73,11 +79,25 @@ final class GlobalDocBlockVisitor extends NodeVisitorAbstract {
 			return null;
 		}
 
-		if ( ! ( $node instanceof Node\Stmt\Global_ ) || $this->stack === array() ) {
+		if ( ! ( $node instanceof Node\Stmt\Global_ ) ) {
 			return null;
 		}
 
-		$map = $this->stack[ count( $this->stack ) - 1 ];
+		$map = $this->stack !== array() ? $this->stack[ count( $this->stack ) - 1 ] : array();
+
+		$existing      = $node->getDocComment();
+		$existing_text = $existing !== null ? $existing->getText() : '';
+
+		/*
+		 * Also honor `@global` tags on the docblock attached directly to the
+		 * `global` statement itself. This covers file-scope statements (which
+		 * have no enclosing function docblock) and takes precedence over the
+		 * enclosing function's tags for the same variable.
+		 */
+		if ( $existing_text !== '' ) {
+			$map = array_merge( $map, $this->parse_global_tags( $existing_text ) );
+		}
+
 		if ( $map === array() ) {
 			return null;
 		}
@@ -87,9 +107,7 @@ final class GlobalDocBlockVisitor extends NodeVisitorAbstract {
 		 * statement so we can leave them alone but still inject `@var` lines for
 		 * the remaining variables in a multi-variable `global $a, $b;` statement.
 		 */
-		$existing       = $node->getDocComment();
-		$existing_text  = $existing !== null ? $existing->getText() : '';
-		$already_typed  = array();
+		$already_typed = array();
 		if ( $existing_text !== '' && preg_match_all( '/@(?:phpstan-)?var\s+[^\n]*?\$(\w+)/', $existing_text, $existing_matches ) > 0 ) {
 			$already_typed = array_flip( $existing_matches[1] );
 		}


### PR DESCRIPTION
The `GlobalDocBlockVisitor` PHPStan extension (introduced in [9e0b63d872](https://github.com/WordPress/wordpress-develop/commit/9e0b63d872)) only read `@global` tags from the enclosing function's docblock, and skipped `global` statements outside any function entirely. As a result, file-scope `global` statements (e.g. in admin templates like `wp-admin/edit-form-comment.php` that are included into another scope) required a redundant `@var` tag in addition to `@global` for PHPStan to resolve the variable's type:

```php
/**
 * @global WP_Comment $comment Global comment object.
 * @var WP_Comment $comment
 */
global $comment;
```

With this change, `@global` tags in a docblock attached directly to a `global` statement are honored as well, so the `@var` tag above is no longer needed. Statement-level tags take precedence over the enclosing function's tags for the same variable, and handwritten `@var` annotations continue to win over synthetic ones.

Verified by running PHPStan against `src/wp-admin/edit-form-comment.php` with the redundant `@var` removed: all `Cannot access property ... on mixed` errors for `$comment` are resolved by the `@global` tag alone.

Trac ticket: https://core.trac.wordpress.org/ticket/64898

## Todo

- [x] Do a before/after comparison of all level 10 errors to see the impact.

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Fable 5
Used for: Diagnosing the visitor's file-scope gap and implementing the fix; reviewed, tested, and verified by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

----

✅  Committed in r62642 (f062fd6fd29335a193da73cf6ffafcc71ce9e154)
