### PR TITLE
Docs: Use richer `numeric-string` type for DB-backed class properties

### DIFF
--- a/src/wp-includes/class-wp-comment.php
+++ b/src/wp-includes/class-wp-comment.php
@@ -22,6 +22,7 @@ final class WP_Comment {
 	 *
 	 * @since 4.4.0
 	 * @var string
+	 * @phpstan-var numeric-string
 	 */
 	public $comment_ID;
 
@@ -32,6 +33,7 @@ final class WP_Comment {
 	 *
 	 * @since 4.4.0
 	 * @var string
+	 * @phpstan-var numeric-string
 	 */
 	public $comment_post_ID = '0';
 
@@ -98,6 +100,7 @@ final class WP_Comment {
 	 *
 	 * @since 4.4.0
 	 * @var string
+	 * @phpstan-var numeric-string
 	 */
 	public $comment_karma = '0';
 
@@ -133,6 +136,7 @@ final class WP_Comment {
 	 *
 	 * @since 4.4.0
 	 * @var string
+	 * @phpstan-var numeric-string
 	 */
 	public $comment_parent = '0';
 
@@ -143,6 +147,7 @@ final class WP_Comment {
 	 *
 	 * @since 4.4.0
 	 * @var string
+	 * @phpstan-var numeric-string
 	 */
 	public $user_id = '0';
 

--- a/src/wp-includes/class-wp-network.php
+++ b/src/wp-includes/class-wp-network.php
@@ -61,6 +61,7 @@ class WP_Network {
 	 *
 	 * @since 4.4.0
 	 * @var string
+	 * @phpstan-var numeric-string
 	 */
 	private $blog_id = '0';
 

--- a/src/wp-includes/class-wp-network.php
+++ b/src/wp-includes/class-wp-network.php
@@ -18,8 +18,11 @@
  *
  * @since 4.4.0
  *
- * @property int $id
- * @property int $site_id
+ * @property int    $id
+ * @property string $blog_id
+ * @property int    $site_id
+ *
+ * @phpstan-property numeric-string $blog_id
  */
 #[AllowDynamicProperties]
 class WP_Network {

--- a/src/wp-includes/class-wp-site.php
+++ b/src/wp-includes/class-wp-site.php
@@ -34,6 +34,7 @@ final class WP_Site {
 	 *
 	 * @since 4.5.0
 	 * @var string
+	 * @phpstan-var numeric-string
 	 */
 	public $blog_id;
 
@@ -63,6 +64,7 @@ final class WP_Site {
 	 *
 	 * @since 4.5.0
 	 * @var string
+	 * @phpstan-var numeric-string
 	 */
 	public $site_id = '0';
 
@@ -89,6 +91,7 @@ final class WP_Site {
 	 *
 	 * @since 4.5.0
 	 * @var string
+	 * @phpstan-var numeric-string
 	 */
 	public $public = '1';
 
@@ -99,6 +102,7 @@ final class WP_Site {
 	 *
 	 * @since 4.5.0
 	 * @var string
+	 * @phpstan-var numeric-string
 	 */
 	public $archived = '0';
 
@@ -112,6 +116,7 @@ final class WP_Site {
 	 *
 	 * @since 4.5.0
 	 * @var string
+	 * @phpstan-var numeric-string
 	 */
 	public $mature = '0';
 
@@ -122,6 +127,7 @@ final class WP_Site {
 	 *
 	 * @since 4.5.0
 	 * @var string
+	 * @phpstan-var numeric-string
 	 */
 	public $spam = '0';
 
@@ -132,6 +138,7 @@ final class WP_Site {
 	 *
 	 * @since 4.5.0
 	 * @var string
+	 * @phpstan-var numeric-string
 	 */
 	public $deleted = '0';
 
@@ -142,6 +149,7 @@ final class WP_Site {
 	 *
 	 * @since 4.5.0
 	 * @var string
+	 * @phpstan-var numeric-string
 	 */
 	public $lang_id = '0';
 

--- a/src/wp-includes/class-wp-site.php
+++ b/src/wp-includes/class-wp-site.php
@@ -15,12 +15,14 @@
  *
  * @since 4.5.0
  *
- * @property int    $id
- * @property int    $network_id
- * @property string $blogname
- * @property string $siteurl
- * @property int    $post_count
- * @property string $home
+ * @property int              $id
+ * @property int              $network_id
+ * @property string           $blogname
+ * @property string           $siteurl
+ * @property int|string|false $post_count
+ * @property string           $home
+ *
+ * @phpstan-property int|numeric-string|false $post_count
  */
 #[AllowDynamicProperties]
 final class WP_Site {

--- a/src/wp-includes/class-wp-user.php
+++ b/src/wp-includes/class-wp-user.php
@@ -14,29 +14,32 @@
  * @since 6.8.0 The `user_pass` property is now hashed using bcrypt by default instead of phpass.
  *              Existing passwords may still be hashed using phpass.
  *
- * @property string $nickname
- * @property string $description
- * @property string $user_description
- * @property string $first_name
- * @property string $user_firstname
- * @property string $last_name
- * @property string $user_lastname
- * @property string $user_login
- * @property string $user_pass
- * @property string $user_nicename
- * @property string $user_email
- * @property string $user_url
- * @property string $user_registered
- * @property string $user_activation_key
- * @property string $user_status
- * @property int    $user_level
- * @property string $display_name
- * @property string $spam
- * @property string $deleted
- * @property string $locale
- * @property string $rich_editing
- * @property string $syntax_highlighting
- * @property string $use_ssl
+ * @property string     $nickname
+ * @property string     $description
+ * @property string     $user_description
+ * @property string     $first_name
+ * @property string     $user_firstname
+ * @property string     $last_name
+ * @property string     $user_lastname
+ * @property string     $user_login
+ * @property string     $user_pass
+ * @property string     $user_nicename
+ * @property string     $user_email
+ * @property string     $user_url
+ * @property string     $user_registered
+ * @property string     $user_activation_key
+ * @property string     $user_status
+ * @property int|string $user_level
+ * @property string     $display_name
+ * @property string     $spam
+ * @property string     $deleted
+ * @property string     $locale
+ * @property string     $rich_editing
+ * @property string     $syntax_highlighting
+ * @property string     $use_ssl
+ *
+ * @phpstan-property numeric-string        $user_status
+ * @phpstan-property int|numeric-string|'' $user_level
  */
 #[AllowDynamicProperties]
 class WP_User {


### PR DESCRIPTION
Follow-up to r62437 / be80802 (for Core-44723) which corrected the type of `WP_User_Request::$user_id` and added `numeric-string` as a richer PHPStan type to `WP_Post::$post_author` and `WP_Post::$comment_count`. This PR extends the same treatment to the remaining DB-backed class properties which are documented as `string` but always hold numeric strings, and corrects the documented types of a few magic properties along the way:

- **`WP_Comment`**: Adds `@phpstan-var numeric-string` to `$comment_ID`, `$comment_post_ID`, `$comment_karma`, `$comment_parent`, and `$user_id`. (`$comment_approved` is intentionally excluded since it can also be `spam`, `trash`, or `post-trashed`.)
- **`WP_Site`**: Adds `@phpstan-var numeric-string` to `$blog_id`, `$site_id`, `$public`, `$archived`, `$mature`, `$spam`, `$deleted`, and `$lang_id`.
- **`WP_Network`**: Adds `@phpstan-var numeric-string` to the private `$blog_id` property, and documents the corresponding magic `$blog_id` property (exposed via `__get()`, which returns `(string) $this->get_main_site_id()`) with an `@property` tag and an `@phpstan-property numeric-string` refinement, as it was previously missing from the class-level tags.
- **`WP_Site::$post_count`** (magic): Corrects the type from `int` to `int|string|false` (`int|numeric-string|false` for PHPStan). The value is lazy-loaded via `get_option( 'post_count' )` in `WP_Site::get_details()`, so despite `update_posts_count()` storing an integer, it is a numeric string once read back from the database, and `false` when the option is not set (new sites with no published posts — see `Tests_Multisite_Site_Details::test_site_details_cached_including_false_values()`). The integer can also be returned within the same request via the options cache and can persist in the `site-details` object cache.
- **`WP_User::$user_status`** (magic): Adds an `@phpstan-property numeric-string` refinement. The value comes raw off the `wp_users` row, where the column always exists.
- **`WP_User::$user_level`** (magic): Corrects the type from `int` to `int|string` (`int|numeric-string|''` for PHPStan). The value resolves through `get_user_meta( ..., 'wp_user_level', true )`, which returns a numeric string, or an empty string when the metadata is absent (e.g. a multisite user with no role on the site). It is an integer only after `WP_User::update_user_level_from_caps()` has assigned one to the instance in the same request, such as via `WP_User::set_role()` during `wp_insert_user()`. (`$spam`/`$deleted` are left as plain `string` since on single site they fall through to user meta and return `''`.)

`WP_Post` and `WP_Term` integer-like fields are not touched because they are actually cast to `int` during hydration (`WP_Post::get_instance()`/`sanitize_term()`).

Existing core call sites are unaffected: nothing in core reads the magic `WP_Site::$post_count`, and the `WP_User::$user_level` readers either cast to `(int)` (`wp_set_current_user()`) or use loose comparisons in `deprecated.php`.

Trac tickets: https://core.trac.wordpress.org/ticket/64898, https://core.trac.wordpress.org/ticket/64896

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Fable 5
Used for: Auditing core for remaining DB-backed properties missing `numeric-string` types, tracing the runtime types of the magic properties, authoring the docblock changes and commit messages, and verifying with PHPCS/PHPStan. All changes were reviewed and directed by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

----

✅  Committed in 0ee8e28 (r62640).