### PR TITLE
Tests: Remove duplicated array keys in test data.

### DIFF
--- a/tests/phpunit/tests/blocks/wpBlock.php
+++ b/tests/phpunit/tests/blocks/wpBlock.php
@@ -1301,7 +1301,6 @@ HTML
 				'post_type'    => 'post',
 				'order'        => 'DESC',
 				'orderby'      => 'date',
-				'post__not_in' => array(),
 				'tax_query'    => array(),
 				'post__not_in' => array( $sticky_post_id ),
 			),

--- a/tests/phpunit/tests/blocks/wpBlock.php
+++ b/tests/phpunit/tests/blocks/wpBlock.php
@@ -1301,8 +1301,8 @@ HTML
 				'post_type'    => 'post',
 				'order'        => 'DESC',
 				'orderby'      => 'date',
-				'tax_query'    => array(),
 				'post__not_in' => array( $sticky_post_id ),
+				'tax_query'    => array(),
 			),
 			$query_args
 		);

--- a/tests/phpunit/tests/functions.php
+++ b/tests/phpunit/tests/functions.php
@@ -457,16 +457,7 @@ class Tests_Functions extends WP_UnitTestCase {
 
 			$this->assertSame( "$url?foo=1", add_query_arg( 'foo', '1', $url ) );
 			$this->assertSame( "$url?foo=1", add_query_arg( array( 'foo' => '1' ), $url ) );
-			$this->assertSame(
-				"$url?foo=2",
-				add_query_arg(
-					array(
-						'foo' => '1',
-						'foo' => '2',
-					),
-					$url
-				)
-			);
+			$this->assertSame( "$url?foo=2", add_query_arg( array( 'foo' => '2' ), $url ) );
 			$this->assertSame(
 				"$url?foo=1&bar=2",
 				add_query_arg(
@@ -482,15 +473,7 @@ class Tests_Functions extends WP_UnitTestCase {
 
 			$this->assertSame( "$url?foo=1", add_query_arg( 'foo', '1' ) );
 			$this->assertSame( "$url?foo=1", add_query_arg( array( 'foo' => '1' ) ) );
-			$this->assertSame(
-				"$url?foo=2",
-				add_query_arg(
-					array(
-						'foo' => '1',
-						'foo' => '2',
-					)
-				)
-			);
+			$this->assertSame( "$url?foo=2", add_query_arg( array( 'foo' => '2' ) ) );
 			$this->assertSame(
 				"$url?foo=1&bar=2",
 				add_query_arg(
@@ -508,16 +491,7 @@ class Tests_Functions extends WP_UnitTestCase {
 
 			$this->assertSame( "$url?foo=1#frag", add_query_arg( 'foo', '1', $frag_url ) );
 			$this->assertSame( "$url?foo=1#frag", add_query_arg( array( 'foo' => '1' ), $frag_url ) );
-			$this->assertSame(
-				"$url?foo=2#frag",
-				add_query_arg(
-					array(
-						'foo' => '1',
-						'foo' => '2',
-					),
-					$frag_url
-				)
-			);
+			$this->assertSame( "$url?foo=2#frag", add_query_arg( array( 'foo' => '2' ), $frag_url ) );
 			$this->assertSame(
 				"$url?foo=1&bar=2#frag",
 				add_query_arg(
@@ -533,15 +507,7 @@ class Tests_Functions extends WP_UnitTestCase {
 
 			$this->assertSame( "$url?foo=1#frag", add_query_arg( 'foo', '1' ) );
 			$this->assertSame( "$url?foo=1#frag", add_query_arg( array( 'foo' => '1' ) ) );
-			$this->assertSame(
-				"$url?foo=2#frag",
-				add_query_arg(
-					array(
-						'foo' => '1',
-						'foo' => '2',
-					)
-				)
-			);
+			$this->assertSame( "$url?foo=2#frag", add_query_arg( array( 'foo' => '2' ) ) );
 			$this->assertSame(
 				"$url?foo=1&bar=2#frag",
 				add_query_arg(
@@ -570,16 +536,7 @@ class Tests_Functions extends WP_UnitTestCase {
 
 			$this->assertSame( "$url&foo=1", add_query_arg( 'foo', '1', $url ) );
 			$this->assertSame( "$url&foo=1", add_query_arg( array( 'foo' => '1' ), $url ) );
-			$this->assertSame(
-				"$url&foo=2",
-				add_query_arg(
-					array(
-						'foo' => '1',
-						'foo' => '2',
-					),
-					$url
-				)
-			);
+			$this->assertSame( "$url&foo=2", add_query_arg( array( 'foo' => '2' ), $url ) );
 			$this->assertSame(
 				"$url&foo=1&bar=2",
 				add_query_arg(
@@ -595,15 +552,7 @@ class Tests_Functions extends WP_UnitTestCase {
 
 			$this->assertSame( "$url&foo=1", add_query_arg( 'foo', '1' ) );
 			$this->assertSame( "$url&foo=1", add_query_arg( array( 'foo' => '1' ) ) );
-			$this->assertSame(
-				"$url&foo=2",
-				add_query_arg(
-					array(
-						'foo' => '1',
-						'foo' => '2',
-					)
-				)
-			);
+			$this->assertSame( "$url&foo=2", add_query_arg( array( 'foo' => '2' ) ) );
 			$this->assertSame(
 				"$url&foo=1&bar=2",
 				add_query_arg(

--- a/tests/phpunit/tests/query/cacheResults.php
+++ b/tests/phpunit/tests/query/cacheResults.php
@@ -1213,7 +1213,6 @@ class Test_Query_CacheResults extends WP_UnitTestCase {
 		$posts1 = $query1->query( $args );
 
 		$args           = array(
-			'cache_results'          => true,
 			'fields'                 => 'ids',
 			'suppress_filters'       => true,
 			'cache_results'          => true,


### PR DESCRIPTION
Removes redundant array entries that were silently overwritten by a later key with the same name.

Trac ticket: https://core.trac.wordpress.org/ticket/64894

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
