### PR TITLE
REST API: Use array_first() in widget types controller.

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-widget-types-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-widget-types-controller.php
@@ -504,7 +504,7 @@ class WP_REST_Widget_Types_Controller extends WP_REST_Controller {
 			isset( $request['form_data'][ "widget-$id" ] ) &&
 			is_array( $request['form_data'][ "widget-$id" ] )
 		) {
-			$new_instance = array_values( $request['form_data'][ "widget-$id" ] )[0];
+			$new_instance = array_first( $request['form_data'][ "widget-$id" ] );
 			$old_instance = $instance;
 
 			$instance = $widget_object->update( $new_instance, $old_instance );


### PR DESCRIPTION
Replace `array_values( ... )[0]` with `array_first()` when retrieving the new widget instance from the submitted form data. This is more readable and avoids creating an intermediate array just to grab the first element.

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
