### PR TITLE
Formatting: Convert non-breaking spaces to hyphens in all contexts in sanitize_title_with_dashes()

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -2296,11 +2296,16 @@ function sanitize_title_with_dashes( $title, $raw_title = '', $context = 'displa
 
 	$title = strtolower( $title );
 
+	// Convert non-breaking space to a hyphen in all contexts, otherwise the
+	// surrounding words are merged when the HTML entity is later stripped.
+	$title = str_replace( '%c2%a0', '-', $title );
+	$title = str_replace( array( '&nbsp;', '&#160;' ), '-', $title );
+
 	if ( 'save' === $context ) {
-		// Convert &nbsp, non-breaking hyphen, &ndash, and &mdash to hyphens.
-		$title = str_replace( array( '%c2%a0', '%e2%80%91', '%e2%80%93', '%e2%80%94' ), '-', $title );
-		// Convert &nbsp, non-breaking hyphen, &ndash, and &mdash HTML entities to hyphens.
-		$title = str_replace( array( '&nbsp;', '&#8209;', '&#160;', '&ndash;', '&#8211;', '&mdash;', '&#8212;' ), '-', $title );
+		// Convert non-breaking hyphen, &ndash, and &mdash to hyphens.
+		$title = str_replace( array( '%e2%80%91', '%e2%80%93', '%e2%80%94' ), '-', $title );
+		// Convert non-breaking hyphen, &ndash, and &mdash HTML entities to hyphens.
+		$title = str_replace( array( '&#8209;', '&ndash;', '&#8211;', '&mdash;', '&#8212;' ), '-', $title );
 		// Convert forward slash to hyphen.
 		$title = str_replace( '/', '-', $title );
 

--- a/tests/phpunit/tests/formatting/sanitizeTitleWithDashes.php
+++ b/tests/phpunit/tests/formatting/sanitizeTitleWithDashes.php
@@ -72,6 +72,18 @@ class Tests_Formatting_SanitizeTitleWithDashes extends WP_UnitTestCase {
 		$this->assertSame( 'dont-break-the-space', sanitize_title_with_dashes( "don't&nbsp;break&#160;the&nbsp;space", '', 'save' ) );
 	}
 
+	/**
+	 * Non-breaking spaces must become a hyphen in the default (display) context
+	 * too, otherwise the surrounding words are merged when the entity is stripped.
+	 *
+	 * @ticket 31790
+	 */
+	public function test_replaces_nbsp_in_display_context() {
+		$this->assertSame( 'foo-bar', sanitize_title_with_dashes( "foo\xc2\xa0bar" ) );
+		$this->assertSame( 'foo-bar', sanitize_title_with_dashes( 'foo&nbsp;bar' ) );
+		$this->assertSame( 'foo-bar', sanitize_title_with_dashes( 'foo&#160;bar' ) );
+	}
+
 	public function test_replaces_ndash_mdash() {
 		$this->assertSame( 'do-the-dash', sanitize_title_with_dashes( 'Do – the Dash', '', 'save' ) );
 		$this->assertSame( 'do-the-dash', sanitize_title_with_dashes( 'Do the — Dash', '', 'save' ) );


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/31790

## Problem

`sanitize_title_with_dashes()` only converted non-breaking spaces (`%c2%a0`, `&nbsp;`, `&#160;`) to hyphens in the `save` context. In the default `display` context:

- the `&nbsp;` / `&#160;` HTML entity was later stripped as generic HTML, **merging the surrounding words** (`foo&nbsp;bar` → `foobar`);
- the UTF-8 form was left as the literal `foo%c2%a0bar`.

This surfaces on content imported from platforms that insert non-breaking spaces into titles (e.g. "no widow" helpers).

## Change

Move the non-breaking space replacement above the context branch so it runs in **all** contexts, before the blanket entity removal. `&ndash;`, `&mdash;`, and the non-breaking hyphen remain `save`-only (unchanged).

## Testing

Added `test_replaces_nbsp_in_display_context` covering the UTF-8 char and both entities in the default context. Full `sanitizeTitleWithDashes` suite passes (95 tests), plus `sanitizeTitle` (2 tests).

Before:
```
nbsp entity   display:[foobar]        save:[foo-bar]
utf8 nbsp     display:[foo%c2%a0bar]  save:[foo-bar]
```
After:
```
nbsp entity   display:[foo-bar]  save:[foo-bar]
utf8 nbsp     display:[foo-bar]  save:[foo-bar]
```