### PR TITLE
Always use a visible label and icon for the language switcher

### DIFF
--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -664,6 +664,7 @@ code {
 
 /* Dashicon for language options on General Settings and Profile screens */
 .form-table th label[for="locale"] .dashicons,
+.form-table th label[for="site-language"] .dashicons,
 .form-table th label[for="WPLANG"] .dashicons {
 	margin-left: 5px;
 }

--- a/src/wp-admin/css/login.css
+++ b/src/wp-admin/css/login.css
@@ -447,7 +447,8 @@ input::-ms-reveal {
 }
 
 .language-switcher label {
-	margin-right: 0.25em;
+	display: block;
+	margin-bottom: 0.5em;
 }
 
 .language-switcher label .dashicons {

--- a/src/wp-admin/css/login.css
+++ b/src/wp-admin/css/login.css
@@ -446,12 +446,18 @@ input::-ms-reveal {
 	text-align: center;
 }
 
+.language-switcher form {
+	display: inline-block;
+}
+
 .language-switcher label {
 	display: block;
 	margin-bottom: 0.5em;
+	text-align: left;
 }
 
 .language-switcher label .dashicons {
+	margin-left: 0.5em;
 	width: auto;
 	height: auto;
 }

--- a/src/wp-admin/network/site-new.php
+++ b/src/wp-admin/network/site-new.php
@@ -248,7 +248,7 @@ if ( ! empty( $messages ) ) {
 		if ( ! empty( $languages ) || ! empty( $translations ) ) :
 			?>
 			<tr class="form-field form-required">
-				<th scope="row"><label for="site-language"><?php _e( 'Site Language' ); ?> <span class="dashicons dashicons-translation" aria-hidden="true"></span></label></th>
+				<th scope="row"><label for="site-language"><?php _e( 'Site Language' ); ?><span class="dashicons dashicons-translation" aria-hidden="true"></span></label></th>
 				<td>
 					<?php
 					// Network default.

--- a/src/wp-admin/network/site-new.php
+++ b/src/wp-admin/network/site-new.php
@@ -248,7 +248,7 @@ if ( ! empty( $messages ) ) {
 		if ( ! empty( $languages ) || ! empty( $translations ) ) :
 			?>
 			<tr class="form-field form-required">
-				<th scope="row"><label for="site-language"><?php _e( 'Site Language' ); ?></label></th>
+				<th scope="row"><label for="site-language"><?php _e( 'Site Language' ); ?> <span class="dashicons dashicons-translation" aria-hidden="true"></span></label></th>
 				<td>
 					<?php
 					// Network default.

--- a/src/wp-login.php
+++ b/src/wp-login.php
@@ -378,12 +378,7 @@ function login_footer( $input_id = '' ) {
 
 					<label for="language-switcher-locales">
 						<span class="dashicons dashicons-translation" aria-hidden="true"></span>
-						<span class="screen-reader-text">
-							<?php
-							/* translators: Hidden accessibility text. */
-							_e( 'Language' );
-							?>
-						</span>
+						<?php _e( 'Language' ); ?>
 					</label>
 
 					<?php

--- a/src/wp-login.php
+++ b/src/wp-login.php
@@ -377,8 +377,7 @@ function login_footer( $input_id = '' ) {
 				<form id="language-switcher" method="get">
 
 					<label for="language-switcher-locales">
-						<span class="dashicons dashicons-translation" aria-hidden="true"></span>
-						<?php _e( 'Language' ); ?>
+						<?php _e( 'Language' ); ?><span class="dashicons dashicons-translation" aria-hidden="true"></span>
 					</label>
 
 					<?php

--- a/src/wp-signup.php
+++ b/src/wp-signup.php
@@ -125,9 +125,9 @@ function show_blog_form( $blogname = '', $blog_title = '', $errors = '' ) {
 	$current_network = get_network();
 	// Site name.
 	if ( ! is_subdomain_install() ) {
-		echo '<label for="blogname">' . __( 'Site Name (subdirectory only):' ) . '</label>';
+		echo '<label for="blogname">' . __( 'Site Name (subdirectory only)' ) . '</label>';
 	} else {
-		echo '<label for="blogname">' . __( 'Site Domain (subdomain only):' ) . '</label>';
+		echo '<label for="blogname">' . __( 'Site Domain (subdomain only)' ) . '</label>';
 	}
 
 	$errmsg_blogname      = $errors->get_error_message( 'blogname' );
@@ -161,7 +161,7 @@ function show_blog_form( $blogname = '', $blog_title = '', $errors = '' ) {
 
 	// Site Title.
 	?>
-	<label for="blog_title"><?php _e( 'Site Title:' ); ?></label>
+	<label for="blog_title"><?php _e( 'Site Title' ); ?></label>
 	<?php
 	$errmsg_blog_title      = $errors->get_error_message( 'blog_title' );
 	$errmsg_blog_title_aria = '';
@@ -179,7 +179,7 @@ function show_blog_form( $blogname = '', $blog_title = '', $errors = '' ) {
 	if ( ! empty( $languages ) ) :
 		?>
 		<p>
-			<label for="site-language"><?php _e( 'Site Language:' ); ?> <span class="dashicons dashicons-translation" aria-hidden="true"></span></label>
+			<label for="site-language"><?php _e( 'Site Language' ); ?><span class="dashicons dashicons-translation" aria-hidden="true"></span></label>
 			<?php
 			// Network default.
 			$lang = get_site_option( 'WPLANG' );
@@ -278,7 +278,7 @@ function show_user_form( $user_name = '', $user_email = '', $errors = '' ) {
 	}
 
 	// Username.
-	echo '<label for="user_name">' . __( 'Username:' ) . '</label>';
+	echo '<label for="user_name">' . __( 'Username' ) . '</label>';
 	$errmsg_username      = $errors->get_error_message( 'user_name' );
 	$errmsg_username_aria = '';
 	if ( $errmsg_username ) {
@@ -291,7 +291,7 @@ function show_user_form( $user_name = '', $user_email = '', $errors = '' ) {
 
 	<?php
 	// Email address.
-	echo '<label for="user_email">' . __( 'Email&nbsp;Address:' ) . '</label>';
+	echo '<label for="user_email">' . __( 'Email&nbsp;Address' ) . '</label>';
 	$errmsg_email      = $errors->get_error_message( 'user_email' );
 	$errmsg_email_aria = '';
 	if ( $errmsg_email ) {

--- a/src/wp-signup.php
+++ b/src/wp-signup.php
@@ -78,13 +78,13 @@ function wpmu_signup_stylesheet() {
 		.mu_register input[type="email"],
 			.mu_register #user_name { direction: ltr; }
 		.mu_register #site-language { display: block; }
+		.mu_register label[for="site-language"] { display: inline-flex; align-items: center; }
 		.mu_register label[for="site-language"] .dashicons { margin-left: 0.5em; }
 		.mu_register .prefix_address,
 			.mu_register .suffix_address { font-size: 18px; display: inline-block; direction: ltr; }
 		.mu_register label,
 			.mu_register legend,
 			.mu_register .label-heading { font-weight: 600; font-size: 15px; display: block; margin: 10px 0; }
-		.mu_register label[for="site-language"] { display: inline-flex; align-items: center; }
 		.mu_register legend + p,
 			.mu_register input + p { margin-top: 0; }
 		.mu_register label.checkbox { display: inline; }

--- a/src/wp-signup.php
+++ b/src/wp-signup.php
@@ -78,6 +78,7 @@ function wpmu_signup_stylesheet() {
 		.mu_register input[type="email"],
 			.mu_register #user_name { direction: ltr; }
 		.mu_register #site-language { display: block; }
+		.mu_register label[for="site-language"] .dashicons { margin-left: 0.5em; }
 		.mu_register .prefix_address,
 			.mu_register .suffix_address { font-size: 18px; display: inline-block; direction: ltr; }
 		.mu_register label,
@@ -91,6 +92,7 @@ function wpmu_signup_stylesheet() {
 		.mu_register .signup-options .wp-signup-radio-button { display: block; }
 		.mu_register .privacy-intro .wp-signup-radio-button { margin-right: 0.5em; }
 		.rtl .mu_register .wp-signup-blogname { direction: ltr; text-align: right; }
+		.rtl .mu_register label[for="site-language"] .dashicons { margin-right: 0.5em; margin-left: 0; }
 	</style>
 	<?php
 }

--- a/src/wp-signup.php
+++ b/src/wp-signup.php
@@ -84,6 +84,7 @@ function wpmu_signup_stylesheet() {
 		.mu_register label,
 			.mu_register legend,
 			.mu_register .label-heading { font-weight: 600; font-size: 15px; display: block; margin: 10px 0; }
+		.mu_register label[for="site-language"] { display: inline-flex; align-items: center; }
 		.mu_register legend + p,
 			.mu_register input + p { margin-top: 0; }
 		.mu_register label.checkbox { display: inline; }

--- a/src/wp-signup.php
+++ b/src/wp-signup.php
@@ -179,7 +179,7 @@ function show_blog_form( $blogname = '', $blog_title = '', $errors = '' ) {
 	if ( ! empty( $languages ) ) :
 		?>
 		<p>
-			<label for="site-language"><?php _e( 'Site Language:' ); ?></label>
+			<label for="site-language"><?php _e( 'Site Language:' ); ?> <span class="dashicons dashicons-translation" aria-hidden="true"></span></label>
 			<?php
 			// Network default.
 			$lang = get_site_option( 'WPLANG' );


### PR DESCRIPTION

Trac ticket: https://core.trac.wordpress.org/ticket/65464

This PR addresses inconsistencies with the language switcher UI. 

Specifically, it:
1. Removes the `screen-reader-text` class from the language switcher label in `wp-login.php` to ensure the text is visibly displayed.
2. Appends the missing `dashicons-translation` span to the language labels in `wp-signup.php` and `wp-admin/network/site-new.php` for Multisite consistency.

This reduces cognitive load and ensures a standardized user experience across settings and authentication screens. 



| Scenario | Before | After |
|----------|--------|-------|
| **wp-login** | <img width="1125" alt="before_login" src="https://github.com/user-attachments/assets/efa16a8a-2af8-4690-81c9-bb65f47ac7ad" /> | <img width="1125" alt="after_login" src="https://github.com/user-attachments/assets/d6af727b-14e3-478c-92b4-2602c49cbfc4" /> |
| **site-new** | <img width="1125" alt="before_site_new" src="https://github.com/user-attachments/assets/40b2097c-09b4-499d-a3a0-37fb63de25dc" /> | <img width="1125" alt="after_site_new" src="https://github.com/user-attachments/assets/4bc176db-8692-4de0-bab1-3a953d2ab491" /> |
| **wp-signup** | <img width="1125" alt="before_wp_signup" src="https://github.com/user-attachments/assets/7abc1be1-7630-42f5-adc4-fe9b6e4b870c" /> | <img width="1125" alt="after_wp_signup" src="https://github.com/user-attachments/assets/b6f979e7-2131-4600-b7d7-73437c52f729" /> |