### PR TITLE
Coding Standards: Use `in_array()` instead of `array_search()` for existence checks.

### DIFF
--- a/src/wp-admin/nav-menus.php
+++ b/src/wp-admin/nav-menus.php
@@ -1179,7 +1179,7 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 
 									if ( ! isset( $auto_add['auto_add'] ) ) {
 										$auto_add = false;
-									} elseif ( false !== array_search( $nav_menu_selected_id, $auto_add['auto_add'], true ) ) {
+									} elseif ( in_array( $nav_menu_selected_id, $auto_add['auto_add'], true ) ) {
 										$auto_add = true;
 									} else {
 										$auto_add = false;

--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -1863,7 +1863,7 @@ function wp_kses_check_attr_val( $value, $vless, $checkname, $checkvalue ) {
 			 * has one of the given values.
 			 */
 
-			if ( false === array_search( strtolower( $value ), $checkvalue, true ) ) {
+			if ( ! in_array( strtolower( $value ), $checkvalue, true ) ) {
 				$ok = false;
 			}
 			break;

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -3679,7 +3679,7 @@ function wp_match_mime_types( $wildcard_mime_types, $real_mime_types ) {
 		foreach ( $patterns as $type => $pattern ) {
 			foreach ( (array) $real_mime_types as $real ) {
 				if ( preg_match( "#$pattern#", $real )
-					&& ( empty( $matches[ $type ] ) || false === array_search( $real, $matches[ $type ], true ) )
+					&& ( empty( $matches[ $type ] ) || ! in_array( $real, $matches[ $type ], true ) )
 				) {
 					$matches[ $type ][] = $real;
 				}

--- a/tests/phpunit/includes/object-cache.php
+++ b/tests/phpunit/includes/object-cache.php
@@ -2171,7 +2171,7 @@ class WP_Object_Cache {
 			$group = 'default';
 		}
 
-		if ( false !== array_search( $group, $this->global_groups, true ) ) {
+		if ( in_array( $group, $this->global_groups, true ) ) {
 			$prefix = $this->global_prefix;
 		} else {
 			$prefix = $this->blog_prefix;


### PR DESCRIPTION
## Description

Several places in core use `array_search()` purely to determine whether a value exists in an array, comparing the result against `false`. In these cases the returned key/position is never used, so `in_array()` expresses the intent more clearly and avoids computing a return value that is discarded.

This PR replaces those existence-only `array_search()` calls with `in_array()`. The strict (`true`) comparison flag is preserved in every case, so there is no change in behavior.

## Scope

Only existence-only checks were touched. All other `array_search()` calls in core were reviewed and left unchanged because they use the returned key/position (e.g. `unset( $arr[ array_search( ... ) ] )`, `array_splice( ..., array_search( ... ), 1 )`). Bundled third-party libraries (getID3, PHPMailer, Requests, etc.) are intentionally excluded.

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
