### PR TITLE
Posts, Post Types: Add conditional return types to post retrieval, sanitization, and insertion functions

### DIFF
--- a/src/wp-includes/class-wp-post.php
+++ b/src/wp-includes/class-wp-post.php
@@ -218,6 +218,7 @@ final class WP_Post {
 	 *
 	 * @since 3.5.0
 	 * @var string
+	 * @phpstan-var 'raw'|'edit'|'db'|'display'|'attribute'|'js'
 	 */
 	public $filter;
 
@@ -230,6 +231,8 @@ final class WP_Post {
 	 *
 	 * @param int $post_id Post ID.
 	 * @return WP_Post|false Post object, false otherwise.
+	 *
+	 * @phpstan-param int|numeric-string $post_id
 	 */
 	public static function get_instance( $post_id ) {
 		global $wpdb;
@@ -241,7 +244,7 @@ final class WP_Post {
 
 		$_post = wp_cache_get( $post_id, 'posts' );
 
-		if ( ! $_post ) {
+		if ( ! ( $_post instanceof stdClass ) && ! ( $_post instanceof WP_Post ) ) {
 			$_post = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $wpdb->posts WHERE ID = %d LIMIT 1", $post_id ) );
 
 			if ( ! $_post ) {
@@ -249,7 +252,7 @@ final class WP_Post {
 			}
 
 			$_post = sanitize_post( $_post, 'raw' );
-			wp_cache_add( $_post->ID, $_post, 'posts' );
+			wp_cache_add( (int) $_post->ID, $_post, 'posts' );
 		} elseif ( empty( $_post->filter ) || 'raw' !== $_post->filter ) {
 			$_post = sanitize_post( $_post, 'raw' );
 		}
@@ -316,7 +319,7 @@ final class WP_Post {
 				$terms = get_the_terms( $this, 'category' );
 			}
 
-			if ( empty( $terms ) ) {
+			if ( empty( $terms ) || is_wp_error( $terms ) ) {
 				return array();
 			}
 
@@ -328,7 +331,7 @@ final class WP_Post {
 				$terms = get_the_terms( $this, 'post_tag' );
 			}
 
-			if ( empty( $terms ) ) {
+			if ( empty( $terms ) || is_wp_error( $terms ) ) {
 				return array();
 			}
 
@@ -350,12 +353,22 @@ final class WP_Post {
 	}
 
 	/**
-	 * {@Missing Summary}
+	 * Applies the provided context filter for the current post.
+	 *
+	 * If the requested filter was already applied, then it returns without any changes.
+	 *
+	 * If the 'raw' filter is supplied, then a new instance of the post is obtained and this method _may_ return false
+	 * in case the underlying post was deleted.
 	 *
 	 * @since 3.5.0
 	 *
 	 * @param string $filter Filter.
-	 * @return WP_Post
+	 * @return WP_Post|false
+	 *
+	 * @phpstan-param 'raw'|'edit'|'db'|'display'|'attribute'|'js' $filter
+	 * @phpstan-return (
+	 *     $filter is 'raw' ? WP_Post|false : WP_Post
+	 * )
 	 */
 	public function filter( $filter ) {
 		if ( $this->filter === $filter ) {
@@ -374,9 +387,10 @@ final class WP_Post {
 	 *
 	 * @since 3.5.0
 	 *
-	 * @return array Object as array.
+	 * @return array<string, mixed> Object as array.
 	 */
 	public function to_array() {
+		/** @var array<string, mixed> $post */
 		$post = get_object_vars( $this );
 
 		foreach ( array( 'ancestors', 'page_template', 'post_category', 'tags_input' ) as $key ) {

--- a/src/wp-includes/class-wp-post.php
+++ b/src/wp-includes/class-wp-post.php
@@ -319,7 +319,7 @@ final class WP_Post {
 				$terms = get_the_terms( $this, 'category' );
 			}
 
-			if ( empty( $terms ) || is_wp_error( $terms ) ) {
+			if ( empty( $terms ) || $terms instanceof WP_Error ) {
 				return array();
 			}
 
@@ -331,7 +331,7 @@ final class WP_Post {
 				$terms = get_the_terms( $this, 'post_tag' );
 			}
 
-			if ( empty( $terms ) || is_wp_error( $terms ) ) {
+			if ( empty( $terms ) || $terms instanceof WP_Error ) {
 				return array();
 			}
 

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -3946,6 +3946,10 @@ class WP_Query {
 	 *
 	 * @param string|array $query URL query string or array of query arguments.
 	 * @return WP_Post[]|int[] Array of post objects or post IDs.
+	 *
+	 * @phpstan-return (
+	 *     $query is array{ fields: 'ids', ... } ? int[] : WP_Post[]
+	 * )
 	 */
 	public function query( $query ) {
 		$this->init();

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -4469,6 +4469,7 @@ function wp_get_recent_posts( $args = array(), $output = ARRAY_A ) {
 		'suppress_filters' => true,
 	);
 
+	/** @var array{ fields: null, ... } $parsed_args */
 	$parsed_args = wp_parse_args( $args, $defaults );
 
 	$results = get_posts( $parsed_args );
@@ -4476,7 +4477,9 @@ function wp_get_recent_posts( $args = array(), $output = ARRAY_A ) {
 	// Backward compatibility. Prior to 3.1 expected posts to be returned in array.
 	if ( ARRAY_A === $output ) {
 		foreach ( $results as $key => $result ) {
-			$results[ $key ] = get_object_vars( $result );
+			/** @var array<string, mixed> $object_vars */
+			$object_vars     = get_object_vars( $result );
+			$results[ $key ] = $object_vars;
 		}
 		return $results ? $results : array();
 	}

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -4544,6 +4544,10 @@ function wp_get_recent_posts( $args = array(), $output = ARRAY_A ) {
  * @param bool  $wp_error         Optional. Whether to return a WP_Error on failure. Default false.
  * @param bool  $fire_after_hooks Optional. Whether to fire the after insert hooks. Default true.
  * @return int|WP_Error The post ID on success. The value 0 or WP_Error on failure.
+ *
+ * @phpstan-return (
+ *     $wp_error is false ? int : int|WP_Error
+ * )
  */
 function wp_insert_post( $postarr, $wp_error = false, $fire_after_hooks = true ) {
 	global $wpdb;
@@ -5269,6 +5273,10 @@ function wp_insert_post( $postarr, $wp_error = false, $fire_after_hooks = true )
  * @param bool         $wp_error         Optional. Whether to return a WP_Error on failure. Default false.
  * @param bool         $fire_after_hooks Optional. Whether to fire the after insert hooks. Default true.
  * @return int|WP_Error The post ID on success. The value 0 or WP_Error on failure.
+ *
+ * @phpstan-return (
+ *     $wp_error is false ? int : int|WP_Error
+ * )
  */
 function wp_update_post( $postarr = array(), $wp_error = false, $fire_after_hooks = true ) {
 	if ( is_object( $postarr ) ) {
@@ -6701,6 +6709,10 @@ function is_local_attachment( $url ) {
  * @param bool         $wp_error         Optional. Whether to return a WP_Error on failure. Default false.
  * @param bool         $fire_after_hooks Optional. Whether to fire the after insert hooks. Default true.
  * @return int|WP_Error The attachment ID on success. The value 0 or WP_Error on failure.
+ *
+ * @phpstan-return (
+ *     $wp_error is false ? int : int|WP_Error
+ * )
  */
 function wp_insert_attachment( $args, $file = false, $parent_post_id = 0, $wp_error = false, $fire_after_hooks = true ) {
 	$defaults = array(

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -4440,6 +4440,11 @@ function wp_get_post_terms( $post_id = 0, $taxonomy = 'post_tag', $args = array(
  *                       Default ARRAY_A.
  * @return array|false Array of recent posts, where the type of each element is determined
  *                     by the `$output` parameter. Empty array on failure.
+ *
+ * @phpstan-param 'OBJECT'|'ARRAY_A' $output
+ * @phpstan-return (
+ *     $output is 'ARRAY_A' ? array<int, array<string, mixed>> : WP_Post[]|false
+ * )
  */
 function wp_get_recent_posts( $args = array(), $output = ARRAY_A ) {
 

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -6190,6 +6190,16 @@ function get_page( $page, $output = OBJECT, $filter = 'raw' ) {
  *                                respectively. Default OBJECT.
  * @param string|array $post_type Optional. Post type or array of post types. Default 'page'.
  * @return WP_Post|array|null WP_Post (or array) on success, or null on failure.
+ *
+ * @phpstan-param 'OBJECT'|'ARRAY_A'|'ARRAY_N' $output
+ * @phpstan-param string|string[]              $post_type
+ * @phpstan-return (
+ *     $output is 'ARRAY_A' ? array<string, mixed>|null : (
+ *         $output is 'ARRAY_N' ? array<int, mixed>|null : (
+ *             WP_Post|null
+ *         )
+ *     )
+ * )
  */
 function get_page_by_path( $page_path, $output = OBJECT, $post_type = 'page' ) {
 	global $wpdb;

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -6214,7 +6214,7 @@ function get_page_by_path( $page_path, $output = OBJECT, $post_type = 'page' ) {
 		if ( '0' === $cached || 0 === $cached ) {
 			return null;
 		} else {
-			return get_post( $cached, $output );
+			return get_post( (int) $cached, $output );
 		}
 	}
 
@@ -6242,7 +6242,8 @@ function get_page_by_path( $page_path, $output = OBJECT, $post_type = 'page' ) {
 		AND post_type IN ($post_type_in_string)
 	";
 
-	$pages = $wpdb->get_results( $sql, OBJECT_K );
+	/** @var array<object{ ID: string, post_name: string, post_parent: string, post_type: string }> $pages */
+	$pages = $wpdb->get_results( $sql, OBJECT_K ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- The escaping has been applied above via esc_sql().
 
 	$revparts = array_reverse( $parts );
 
@@ -6281,7 +6282,7 @@ function get_page_by_path( $page_path, $output = OBJECT, $post_type = 'page' ) {
 	wp_cache_set_salted( $cache_key, $found_id, 'post-queries', $last_changed );
 
 	if ( $found_id ) {
-		return get_post( $found_id, $output );
+		return get_post( (int) $found_id, $output );
 	}
 
 	return null;

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -6192,6 +6192,17 @@ function get_all_page_ids() {
  * @param string      $filter Optional. How the return value should be filtered. Accepts 'raw',
  *                            'edit', 'db', 'display'. Default 'raw'.
  * @return WP_Post|array|null WP_Post or array on success, null on failure.
+ *
+ * @phpstan-param int|numeric-string|WP_Post|null $page
+ * @phpstan-param 'OBJECT'|'ARRAY_A'|'ARRAY_N' $output
+ * @phpstan-param 'raw'|'edit'|'db'|'display' $filter
+ * @phpstan-return (
+ *     $output is 'ARRAY_A' ? array<string, mixed>|null : (
+ *         $output is 'ARRAY_N' ? array<int, mixed>|null : (
+ *             WP_Post|null
+ *         )
+ *     )
+ * )
  */
 function get_page( $page, $output = OBJECT, $filter = 'raw' ) {
 	return get_post( $page, $output, $filter );

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -1110,6 +1110,17 @@ function get_extended( $post ) {
  *                                 or 'display'. Default 'raw'.
  * @return WP_Post|array|null Type corresponding to $output on success or null on failure.
  *                            When $output is OBJECT, a `WP_Post` instance is returned.
+ *
+ * @phpstan-param int|numeric-string|WP_Post|null $post
+ * @phpstan-param 'OBJECT'|'ARRAY_A'|'ARRAY_N' $output
+ * @phpstan-param 'raw'|'edit'|'db'|'display' $filter
+ * @phpstan-return (
+ *     $output is 'ARRAY_A' ? array<string, mixed>|null : (
+ *         $output is 'ARRAY_N' ? array<int, mixed>|null : (
+ *             WP_Post|null
+ *         )
+ *     )
+ * )
  */
 function get_post( $post = null, $output = OBJECT, $filter = 'raw' ) {
 	if ( empty( $post ) && isset( $GLOBALS['post'] ) ) {
@@ -1119,18 +1130,21 @@ function get_post( $post = null, $output = OBJECT, $filter = 'raw' ) {
 	if ( $post instanceof WP_Post ) {
 		$_post = $post;
 	} elseif ( is_object( $post ) ) {
+		/** @var stdClass $post */
 		if ( empty( $post->filter ) ) {
 			$_post = sanitize_post( $post, 'raw' );
 			$_post = new WP_Post( $_post );
 		} elseif ( 'raw' === $post->filter ) {
 			$_post = new WP_Post( $post );
 		} elseif ( isset( $post->ID ) ) {
-			$_post = WP_Post::get_instance( $post->ID );
+			$_post = WP_Post::get_instance( (int) $post->ID );
 		} else {
 			$_post = null;
 		}
+	} elseif ( is_numeric( $post ) ) {
+		$_post = WP_Post::get_instance( (int) $post );
 	} else {
-		$_post = WP_Post::get_instance( $post );
+		$_post = null;
 	}
 
 	if ( ! $_post ) {
@@ -1138,6 +1152,9 @@ function get_post( $post = null, $output = OBJECT, $filter = 'raw' ) {
 	}
 
 	$_post = $_post->filter( $filter );
+	if ( ! $_post ) {
+		return null;
+	}
 
 	if ( ARRAY_A === $output ) {
 		return $_post->to_array();
@@ -1202,6 +1219,13 @@ function get_post_ancestors( $post ) {
  * @param string      $context Optional. How to filter the field. Accepts 'raw', 'edit', 'db',
  *                             or 'display'. Default 'display'.
  * @return int|string|int[] The value of the post field on success, empty string on failure.
+ *
+ * @phpstan-param 'raw'|'edit'|'db'|'display' $context
+ * @phpstan-return (
+ *     $field is 'ID'|'post_parent'|'menu_order' ? int : (
+ *         $field is 'ancestors' ? non-negative-int[] : string
+ *     )
+ * )
  */
 function get_post_field( $field, $post = null, $context = 'display' ) {
 	$post = get_post( $post );
@@ -1642,6 +1666,7 @@ function get_post_type_object( $post_type ) {
  *                               element from the array needs to match; 'and' means all elements
  *                               must match; 'not' means no elements may match. Default 'and'.
  * @return string[]|WP_Post_Type[] An array of post type names or objects.
+ * @phpstan-return ( $output is 'names' ? string[] : WP_Post_Type[] )
  */
 function get_post_types( $args = array(), $output = 'names', $operator = 'and' ) {
 	global $wp_post_types;
@@ -2916,6 +2941,14 @@ function is_sticky( $post_id = 0 ) {
  *                                      'attribute', or 'js'. Default 'display'.
  * @return object|WP_Post|array The now sanitized post object or array (will be the
  *                              same type as `$post`).
+ *
+ * @phpstan-param stdClass|WP_Post|array<string, mixed> $post
+ * @phpstan-param 'raw'|'edit'|'db'|'display'|'attribute'|'js' $context
+ * @phpstan-return (
+ *     $post is WP_Post ? WP_Post : (
+ *         $post is stdClass ? stdClass : array<string, mixed>
+ *     )
+ * )
  */
 function sanitize_post( $post, $context = 'display' ) {
 	if ( is_object( $post ) ) {
@@ -2927,7 +2960,7 @@ function sanitize_post( $post, $context = 'display' ) {
 			$post->ID = 0;
 		}
 		foreach ( array_keys( get_object_vars( $post ) ) as $field ) {
-			$post->$field = sanitize_post_field( $field, $post->$field, $post->ID, $context );
+			$post->$field = sanitize_post_field( $field, $post->$field, (int) $post->ID, $context );
 		}
 		$post->filter = $context;
 	} elseif ( is_array( $post ) ) {
@@ -2939,7 +2972,7 @@ function sanitize_post( $post, $context = 'display' ) {
 			$post['ID'] = 0;
 		}
 		foreach ( array_keys( $post ) as $field ) {
-			$post[ $field ] = sanitize_post_field( $field, $post[ $field ], $post['ID'], $context );
+			$post[ $field ] = sanitize_post_field( $field, $post[ $field ], (int) $post['ID'], $context );
 		}
 		$post['filter'] = $context;
 	}
@@ -2962,6 +2995,13 @@ function sanitize_post( $post, $context = 'display' ) {
  * @param string $context Optional. How to sanitize the field. Possible values are 'raw', 'edit',
  *                        'db', 'display', 'attribute' and 'js'. Default 'display'.
  * @return mixed Sanitized value.
+ *
+ * @phpstan-param 'raw'|'edit'|'db'|'display'|'attribute'|'js' $context
+ * @phpstan-return (
+ *     $field is 'ID'|'post_parent'|'menu_order' ? int : (
+ *         $field is 'ancestors' ? non-negative-int[] : string
+ *     )
+ * )
  */
 function sanitize_post_field( $field, $value, $post_id, $context = 'display' ) {
 	$int_fields = array( 'ID', 'post_parent', 'menu_order' );
@@ -2972,7 +3012,7 @@ function sanitize_post_field( $field, $value, $post_id, $context = 'display' ) {
 	// Fields which contain arrays of integers.
 	$array_int_fields = array( 'ancestors' );
 	if ( in_array( $field, $array_int_fields, true ) ) {
-		$value = array_map( 'absint', $value );
+		$value = array_map( 'absint', (array) $value );
 		return $value;
 	}
 

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -1222,8 +1222,8 @@ function get_post_ancestors( $post ) {
  *
  * @phpstan-param 'raw'|'edit'|'db'|'display' $context
  * @phpstan-return (
- *     $field is 'ID'|'post_parent'|'menu_order' ? int : (
- *         $field is 'ancestors' ? non-negative-int[] : string
+ *     $field is 'ID'|'post_parent'|'menu_order' ? int|'' : (
+ *         $field is 'ancestors' ? non-negative-int[]|'' : string
  *     )
  * )
  */

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -2603,6 +2603,10 @@ function is_post_embeddable( $post = null ) {
  *     @type bool       $suppress_filters Whether to suppress filters. Default true.
  * }
  * @return WP_Post[]|int[] Array of post objects or post IDs.
+ *
+ * @phpstan-return (
+ *     $args is array{ fields: 'ids', ... } ? int[] : WP_Post[]
+ * )
  */
 function get_posts( $args = null ) {
 	$defaults = array(

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -986,6 +986,15 @@ function _wp_relative_upload_path( $path ) {
  *                       correspond to a WP_Post object, an associative array, or a numeric array,
  *                       respectively. Default OBJECT.
  * @return WP_Post[]|array[]|int[] Array of post objects, arrays, or IDs, depending on `$output`.
+ *
+ * @phpstan-param 'OBJECT'|'ARRAY_A'|'ARRAY_N' $output
+ * @phpstan-return (
+ *     $args is array{ fields: 'ids', ... } ? int[] : (
+ *         $output is 'ARRAY_A' ? array<int, array<string, mixed>> : (
+ *             $output is 'ARRAY_N' ? array<int, array<int, mixed>> : WP_Post[]
+ *         )
+ *     )
+ * )
  */
 function get_children( $args = '', $output = OBJECT ) {
 	$kids = array();


### PR DESCRIPTION
Adds precise, conditional PHPStan return types to the core post retrieval, sanitization, and insertion APIs, along with a small amount of behavior-preserving runtime hardening (and one genuine latent-bug fix) that these types surfaced.

## Conditional return types

Functions whose return type depends on an argument now carry a `@phpstan-return` keyed on that argument, so static analysis can narrow the result at each call site:

- **`get_post()`, `get_page()`, `get_page_by_path()`** — keyed on `$output`: `array<string, mixed>|null` for `ARRAY_A`, `array<int, mixed>|null` for `ARRAY_N`, `WP_Post|null` otherwise.
- **`get_children()`** — keyed first on `$args['fields']` (`'ids'` → `int[]`, mirroring `get_posts()`) and then on `$output`.
- **`get_posts()` and `WP_Query::query()`** — `$args` with `fields => 'ids'` → `int[]`, otherwise `WP_Post[]`.
- **`wp_get_recent_posts()`** — `ARRAY_A` → `array<int, array<string, mixed>>`, otherwise `WP_Post[]|false`.
- **`get_post_field()` / `sanitize_post_field()`** — keyed on `$field`: `int` for `ID`/`post_parent`/`menu_order`, `non-negative-int[]` for `ancestors`, `string` otherwise (`get_post_field()` additionally includes the `''` failure return).
- **`sanitize_post()`** — same type in as out (`WP_Post`, `stdClass`, or `array`).
- **`get_post_types()`** — `'names'` → `string[]`, otherwise `WP_Post_Type[]`.
- **`wp_insert_post()`, `wp_update_post()`, `wp_insert_attachment()`** — `$wp_error === false` → `int`, otherwise `int|WP_Error`.

Matching `@phpstan-param` tags were added where the analyzed return depends on a narrowed input (e.g. `$output`, `$context`, `$filter`).

## Runtime changes

Most of the diff is documentation-only, but a few small code changes were needed for the types to hold:

- **`get_post()` now null-guards the `WP_Post::filter( 'raw' )` result.** `filter( 'raw' )` calls `WP_Post::get_instance()`, which can return `false` for a since-deleted post; the previous code would then call `->to_array()` on `false`. This is a real latent fix, not just a typing change. `WP_Post::filter()` is retyped `WP_Post|false` accordingly and its missing summary docblock is filled in.
- **`WP_Post::get_instance()`** cache-hit guard uses `instanceof stdClass`/`instanceof WP_Post` (behavior-preserving vs. the old truthiness check) and casts `$_post->ID` to `int` before caching.
- **`get_post()`** routes non-numeric scalar `$post` values straight to `null` instead of issuing a pointless `WHERE ID = 0` query.
- **`sanitize_post_field()`** casts `$value` to `array` before `array_map( 'absint', ... )` for the `ancestors` field.
- **`WP_Post::get_category()` / `get_tags()`** guard against a `WP_Error` from `get_the_terms()`.
- Assorted `(int)` casts on post IDs passed to `get_post()`/`get_instance()`.

Verified with `phpstan-diff` against `trunk`: no new errors on changed lines.

Trac ticket: https://core.trac.wordpress.org/ticket/64898

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 4.8
Used for: Drafting the conditional return type annotations and the accompanying runtime hardening under my direction. I reviewed, tested, and take responsibility for all of the changes.


----

✅ Committed in r62648 (578d09b)