### PR TITLE
perf: Do not perform unnecessary query in wp-embed

### DIFF
--- a/src/wp-includes/class-wp-embed.php
+++ b/src/wp-includes/class-wp-embed.php
@@ -251,7 +251,7 @@ class WP_Embed {
 		$cache      = '';
 		$cache_time = 0;
 
-		$cached_post_id = $this->find_oembed_post_id( $key_suffix );
+		$cached_post_id = 0;
 
 		if ( $post_id ) {
 			$cache      = get_post_meta( $post_id, $cachekey, true );
@@ -260,11 +260,14 @@ class WP_Embed {
 			if ( ! $cache_time ) {
 				$cache_time = 0;
 			}
-		} elseif ( $cached_post_id ) {
-			$cached_post = get_post( $cached_post_id );
+		} else {
+			$cached_post_id = $this->find_oembed_post_id( $key_suffix );
+			if ( $cached_post_id ) {
+				$cached_post = get_post( $cached_post_id );
 
-			$cache      = $cached_post->post_content;
-			$cache_time = strtotime( $cached_post->post_modified_gmt );
+				$cache      = $cached_post->post_content;
+				$cache_time = strtotime( $cached_post->post_modified_gmt );
+			}
 		}
 
 		$cached_recently = ( time() - $cache_time ) < $ttl;


### PR DESCRIPTION
Do not perform unnecessary oembed_cache post query when the cached oembed has already been found in post meta

[Trac ticket: #65587](https://core.trac.wordpress.org/ticket/65587)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
