### PR TITLE
Block Style Variations: Simplify block style variation selector regex

### DIFF
--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -5662,11 +5662,22 @@ class WP_Theme_JSON {
 		$selector_parts = static::split_selector_list( $block_selector );
 		$result         = array();
 
+		/*
+		 * Append the variation class to each selector's ancestor: the first
+		 * run of characters before any combinator (whitespace) or pseudo-class
+		 * (`:`). Only the first match is replaced.
+		 *
+		 * Examples ("custom" variation):
+		 * - `.wp-block`              => `.wp-block.is-style-custom`
+		 * - `.wp-block .inner`       => `.wp-block.is-style-custom .inner`
+		 * - `.wp-block:where(.a .b)` => `.wp-block.is-style-custom:where(.a .b)`
+		 * - `:where(.outer .inner)`  => `:where(.outer.is-style-custom .inner)`
+		 */
 		foreach ( $selector_parts as $part ) {
 			$result[] = preg_replace_callback(
-				'/((?::\([^)]+\))?\s*)([^\s:]+)/',
+				'/[^\s:]+/',
 				function ( $matches ) use ( $variation_class ) {
-					return $matches[1] . $matches[2] . $variation_class;
+					return $matches[0] . $variation_class;
 				},
 				$part,
 				$limit


### PR DESCRIPTION
## What?

Backports Gutenberg PR https://github.com/WordPress/gutenberg/pull/79924 to Core, tidying up the regex used to add a block style variation's class (e.g. `.is-style-custom`) to a block's selector in `WP_Theme_JSON`.

Trac ticket: https://core.trac.wordpress.org/ticket/65588

## Why?

The regex is hard to follow and its first capture group is effectively dead. It only matches a literal `:(...)`, which isn't valid selector syntax (functional pseudo-classes like `:is()` and `:where()` always have a name between the colon and the parenthesis), so `$matches[1]` is always empty. The second group does all the work, so dropping the dead group gives identical output and is much easier to follow.

## How?

- Simplifies the pattern from `/((?::\([^)]+\))?\s*)([^\s:]+)/` to `/[^\s:]+/` and adds a comment with worked examples.
- Keeps the replacement callback rather than switching to backreferences, so the variation name is always treated as a literal (no chance of `$`/`\` being interpreted).

The `:is` selector-list test case from the Gutenberg change already exists in Core's suite (`tests/phpunit/tests/theme/wpThemeJson.php`), so no test change was needed here.

## Testing Instructions

This is a behaviour-preserving change, so the output should be identical to `trunk`.

1. Confirm the `test_get_block_style_variation_selector` PHP tests pass