### PR TITLE
61557 / admin nav-menu / Moving the Delete Entire Menu link in the toolbar to the right

### DIFF
--- a/src/wp-admin/css/nav-menus.css
+++ b/src/wp-admin/css/nav-menus.css
@@ -850,6 +850,7 @@ body.menu-max-depth-11 { min-width: 1280px !important; }
 	padding: 10px 0;
 	display: flex;
 	align-items: center;
+	justify-content: space-between;
 }
 
 .nav-menus-php .major-publishing-actions > * {


### PR DESCRIPTION
Related to : https://core.trac.wordpress.org/ticket/61557

styles(admin-nav-menus): space out action buttons while preserving "Delete"

<img width="1124" height="653" alt="Capture d’écran 2026-07-07 à 08 02 48" src="https://github.com/user-attachments/assets/0ec54305-3dc5-49d3-aef5-3aef22ab24e7" />

