### PR TITLE
Block Bindings: Support innerBlocks bindings

### DIFF
--- a/src/wp-includes/block-bindings.php
+++ b/src/wp-includes/block-bindings.php
@@ -187,3 +187,635 @@ function get_block_bindings_supported_attributes( $block_type ) {
 
 	return $supported_block_attributes;
 }
+
+/*
+ * Substitutes a block's inner blocks from a bound source on the server.
+ *
+ * When a block declares an `innerBlocks` binding in its
+ * `metadata.bindings`, the bound source supplies the block's child tree as a
+ * serialized block-markup string. The filters below resolve that value before
+ * the block renders and replace the parsed block's `innerBlocks` and
+ * `innerContent`, so the frontend renders the source-supplied tree (with nested
+ * bindings resolved recursively by Core) instead of the block's own serialized
+ * children.
+ */
+
+if ( ! defined( 'WP_BLOCK_BINDINGS_INNER_BLOCKS_ANCESTRY' ) ) {
+	/**
+	 * Context key carrying the guard keys of the bound inner-block areas that are
+	 * ancestors of the block currently being rendered.
+	 *
+	 * Ancestry travels inside block context, so it is naturally scoped to the
+	 * currently-rendering subtree: it dies with the subtree and cannot leak
+	 * request-wide, and it survives third-party `render_block_data` filters that
+	 * rebuild the parsed-block array, because it lives on the `WP_Block`
+	 * instance's context rather than on the parsed block.
+	 *
+	 * @since 7.1.0
+	 */
+	define( 'WP_BLOCK_BINDINGS_INNER_BLOCKS_ANCESTRY', 'core/innerBlocksBindingAncestry' );
+}
+
+if ( ! defined( 'WP_BLOCK_BINDINGS_MAX_BOUND_DEPTH' ) ) {
+	/**
+	 * Hard cap on the nesting depth of bound inner-block areas.
+	 *
+	 * Context-carried ancestry cannot cross context boundaries (`do_blocks()`,
+	 * `core/post-template`'s per-iteration render), so a request-global depth
+	 * counter guarantees termination for cycles that cross them.
+	 *
+	 * @since 7.1.0
+	 */
+	define( 'WP_BLOCK_BINDINGS_MAX_BOUND_DEPTH', 32 );
+}
+
+/**
+ * Returns a block's `innerBlocks` binding descriptor, or null when absent/invalid.
+ *
+ * The same check gates the substitution, the top-level takeover, and the
+ * depth-counter decrement, so pairing between them is re-derived from the
+ * block's own attributes and survives parsed-block rebuilds by third-party
+ * `render_block_data` filters.
+ *
+ * @since 7.1.0
+ *
+ * @param array $parsed_block The parsed block.
+ * @return array|null The binding descriptor (with a non-empty string `source`), or null.
+ */
+function _block_bindings_get_inner_blocks_binding( $parsed_block ) {
+	$binding = $parsed_block['attrs']['metadata']['bindings']['innerBlocks'] ?? null;
+	if ( ! is_array( $binding ) || empty( $binding['source'] ) || ! is_string( $binding['source'] ) ) {
+		return null;
+	}
+	return $binding;
+}
+
+/**
+ * Builds the recursion-guard key for an `innerBlocks` binding.
+ *
+ * The key combines the source name, the binding arguments, and the resolved
+ * values of the context the source declares in `uses_context`. A nested binding
+ * is a cycle only when all three match: a context-dependent source (e.g. keyed
+ * by `postId`) legitimately appears twice when a bound area renders another post
+ * containing a block bound to the same source and args, and must not be flagged.
+ * A source with empty `uses_context` is context-independent by declaration, so
+ * the same source and args nested is a true cycle.
+ *
+ * @since 7.1.0
+ *
+ * @param string                        $source_name       The binding source name.
+ * @param array                         $source_args       The binding arguments.
+ * @param WP_Block_Bindings_Source      $source            The registered source.
+ * @param array                         $available_context The bound block's available context.
+ * @return string The guard key.
+ */
+function _block_bindings_get_binding_guard_key( $source_name, $source_args, $source, $available_context ) {
+	$context_subset = array();
+	if ( ! empty( $source->uses_context ) ) {
+		foreach ( $source->uses_context as $context_name ) {
+			if ( array_key_exists( $context_name, $available_context ) ) {
+				$context_subset[ $context_name ] = $available_context[ $context_name ];
+			}
+		}
+	}
+
+	ksort( $source_args );
+	ksort( $context_subset );
+
+	return $source_name . '|' . wp_json_encode( $source_args ) . '|' . wp_json_encode( $context_subset );
+}
+
+/**
+ * Returns (by reference) the number of bound inner-block areas currently rendering.
+ *
+ * Incremented by `_block_bindings_replace_inner_blocks()` for every
+ * block carrying an `innerBlocks` binding descriptor and decremented by
+ * `_block_bindings_close_bound_block()` once such a block has rendered.
+ * During a runaway descent no render completes, so no decrements occur and the
+ * counter grows with bound depth, guaranteeing a hard stop at
+ * `WP_BLOCK_BINDINGS_MAX_BOUND_DEPTH` even when the cycle crosses context
+ * boundaries the ancestry cannot follow.
+ *
+ * @since 7.1.0
+ *
+ * @return int The current bound-render depth.
+ */
+function &_block_bindings_bound_render_depth() {
+	static $depth = 0;
+	return $depth;
+}
+
+/**
+ * Returns the default context used when render_block() renders a top-level block.
+ *
+ * Mirrors core's context setup in render_block(): the global-post defaults plus
+ * the `render_block_context` filter. Only used as a fallback when a nested bound
+ * block's `WP_Block` instance cannot be located on its parent (top-level blocks
+ * are handled by `_block_bindings_render_top_level_bound_block()`,
+ * which applies the filter itself). This fallback is the sole remaining spot
+ * where `render_block_context` may run an extra time for a block; the branch is
+ * practically unreachable in core's render loop.
+ *
+ * @since 7.1.0
+ *
+ * @param array $parsed_block The parsed block being rendered.
+ * @return array Default block context.
+ */
+function _block_bindings_get_default_context( $parsed_block ) {
+	global $post;
+
+	$default_context = array();
+
+	if ( $post instanceof WP_Post ) {
+		$default_context = array(
+			'postId'   => $post->ID,
+			'postType' => $post->post_type,
+		);
+	}
+
+	/** This filter is documented in wp-includes/blocks.php */
+	$default_context = apply_filters( 'render_block_context', $default_context, $parsed_block, null );
+
+	return is_array( $default_context ) ? $default_context : array();
+}
+
+/**
+ * Reads a WP_Block instance's inherited available context.
+ *
+ * @since 7.1.0
+ *
+ * @param WP_Block $block The block instance.
+ * @return array The block's available context.
+ */
+function _block_bindings_get_available_context( $block ) {
+	static $get_available_context = null;
+
+	if ( ! $block instanceof WP_Block ) {
+		return array();
+	}
+
+	if ( null === $get_available_context ) {
+		/*
+		 * Sources can request context inherited through ancestors that the bound
+		 * block itself does not declare in `uses_context`. The protected
+		 * `available_context` property is the faithful source for those values.
+		 */
+		$get_available_context = Closure::bind(
+			static function ( $block_instance ) {
+				return $block_instance->available_context;
+			},
+			null,
+			WP_Block::class
+		);
+	}
+
+	$available_context = $get_available_context( $block );
+	return is_array( $available_context ) ? $available_context : array();
+}
+
+/**
+ * Finds the WP_Block instance currently being filtered inside its parent.
+ *
+ * `WP_Block_List::offsetGet()` caches the constructed instance, so the object
+ * returned here is the same object core's render loop renders — mutating its
+ * context propagates to the block's (substituted) children.
+ *
+ * @since 7.1.0
+ *
+ * @param array    $source_block The unmodified parsed block.
+ * @param WP_Block $parent_block The parent block instance.
+ * @return WP_Block|null The matching child instance, or null.
+ */
+function _block_bindings_find_inner_block_instance( $source_block, $parent_block ) {
+	if ( ! $parent_block instanceof WP_Block || empty( $parent_block->inner_blocks ) ) {
+		return null;
+	}
+
+	foreach ( $parent_block->inner_blocks as $inner_block ) {
+		if ( $inner_block instanceof WP_Block && $inner_block->parsed_block === $source_block ) {
+			return $inner_block;
+		}
+	}
+
+	return null;
+}
+
+/**
+ * Rebuilds a block's `innerContent` template around a new set of inner blocks.
+ *
+ * A block's `innerContent` is a template array that interleaves the block's own
+ * static HTML chunks (strings) with one `null` placeholder per inner block, in
+ * render order. For example `core/group` parses to
+ * `array( '<div…>', null, null, '</div>' )` (the wrapper chunks plus one `null`
+ * per child) and `core/list-item` to `array( '<li>…', null, '</li>' )`.
+ *
+ * When inner blocks are substituted from a binding source, the host block's own
+ * static chunks (its chrome, such as the `<div>`/`</div>` or `<li>`/`</li>`
+ * wrapper) must be preserved while the `null` placeholders are replaced to match
+ * the NEW inner blocks (whose count may differ from the original). This keeps the
+ * leading static chunk(s) before the first placeholder and the trailing static
+ * chunk(s) after the last placeholder, emitting exactly one `null` per new inner
+ * block in between.
+ *
+ * Edge cases:
+ *
+ * - Original template with no `null` placeholder (e.g. an empty container that
+ *   parsed to a single closed-wrapper chunk): inserts the new placeholders before
+ *   the final closing tag when one can be identified, so sourced children still
+ *   render inside the host wrapper. If no closing tag is available, the new
+ *   placeholders are appended after all existing static chunks.
+ * - Original template that is empty (no static chunks and no placeholders): falls
+ *   back to one `null` per new inner block, with no surrounding static chunks.
+ * - Zero new inner blocks (an intentionally-empty area): only the host's static
+ *   chunks remain, so the wrapper renders empty.
+ *
+ * @since 7.1.0
+ *
+ * @param array $original_inner_content The host block's existing `innerContent` template.
+ * @param int   $new_block_count        The number of substituted inner blocks.
+ * @return array The rebuilt `innerContent` template: the host's static chunks with
+ *               exactly `$new_block_count` `null` placeholders in inner-block position.
+ */
+function _block_bindings_rebuild_inner_content( $original_inner_content, $new_block_count ) {
+	if ( ! is_array( $original_inner_content ) ) {
+		$original_inner_content = array();
+	}
+
+	$placeholders = array_fill( 0, $new_block_count, null );
+
+	// Locate the original inner-block placeholders (the `null` slots).
+	$null_positions = array();
+	foreach ( $original_inner_content as $index => $chunk ) {
+		if ( null === $chunk ) {
+			$null_positions[] = $index;
+		}
+	}
+
+	/*
+	 * No placeholder to anchor on. Empty containers such as an empty Group parse
+	 * to a single closed-wrapper chunk (`<div ...></div>`), so insert the new
+	 * slots before the final closing tag when possible. This preserves the host
+	 * wrapper around source-supplied children even when the serialized fallback
+	 * originally had no children.
+	 */
+	if ( empty( $null_positions ) ) {
+		for ( $index = count( $original_inner_content ) - 1; $index >= 0; $index-- ) {
+			$chunk = $original_inner_content[ $index ];
+			if ( ! is_string( $chunk ) || ! preg_match( '#</[A-Za-z][^>]*>\s*$#', $chunk, $matches, PREG_OFFSET_CAPTURE ) ) {
+				continue;
+			}
+
+			$closing_offset = $matches[0][1];
+			$leading        = array_slice( $original_inner_content, 0, $index );
+			$before_closer  = substr( $chunk, 0, $closing_offset );
+			$after_closer   = substr( $chunk, $closing_offset );
+			if ( '' !== $before_closer ) {
+				$leading[] = $before_closer;
+			}
+
+			$trailing = array();
+			if ( '' !== $after_closer ) {
+				$trailing[] = $after_closer;
+			}
+			$trailing = array_merge( $trailing, array_slice( $original_inner_content, $index + 1 ) );
+
+			return array_merge( $leading, $placeholders, $trailing );
+		}
+
+		// No usable closing tag: keep any static chunks, then append the new slots.
+		return array_merge( array_values( $original_inner_content ), $placeholders );
+	}
+
+	$first_null = $null_positions[0];
+	$last_null  = $null_positions[ count( $null_positions ) - 1 ];
+
+	// Preserve the leading static chunks (before the first placeholder) and the
+	// trailing static chunks (after the last placeholder); replace everything in
+	// between with one placeholder per new inner block.
+	$leading  = array_slice( $original_inner_content, 0, $first_null );
+	$trailing = array_slice( $original_inner_content, $last_null + 1 );
+
+	return array_merge( $leading, $placeholders, $trailing );
+}
+
+/**
+ * Resolves a block's `innerBlocks` binding and substitutes the parsed block's
+ * inner blocks.
+ *
+ * Shared by the nested-block substitution
+ * (`_block_bindings_replace_inner_blocks()`) and the top-level takeover
+ * (`_block_bindings_render_top_level_bound_block()`). Constructs a
+ * transient `WP_Block` (so the source can read both the block's attributes and
+ * context), calls the source's `get_value()` for the `innerBlocks` attribute,
+ * and substitutes the result:
+ *
+ * - A non-empty string is parsed with `parse_blocks()` and becomes the block's
+ *   inner blocks; `innerContent` is rebuilt around the host's own static chunks
+ *   so the substituted children render IN PLACE (the host's chrome, such as a
+ *   `<div>`/`<li>` wrapper, is preserved and the children render exactly once).
+ * - An empty string `''` is an intentionally-empty area: the inner blocks are
+ *   cleared and only the host's static chunks remain, so the wrapper renders
+ *   empty (no fallback children).
+ * - `null` (absence) leaves the parsed block untouched, so the block's own
+ *   serialized children render as a fallback.
+ *
+ * Recursion guard: a source can supply markup containing another block bound to
+ * the same source (directly, or through a cycle of sources), so the substitution
+ * is skipped when the binding's guard key — source, args, and the resolved
+ * values of the context the source consumes — already appears in the
+ * currently-rendering bound ancestry, or when nesting exceeds the hard depth
+ * cap. The returned `ancestry` is non-null only when substitution actually
+ * produced children; the caller must place it under the
+ * `WP_BLOCK_BINDINGS_INNER_BLOCKS_ANCESTRY` context key of the block
+ * about to render so the substituted children inherit it.
+ *
+ * @since 7.1.0
+ *
+ * @param array $parsed_block      The parsed block carrying the binding.
+ * @param array $available_context The context available to the block.
+ * @return array {
+ *     The resolution result.
+ *
+ *     @type array      $parsed_block The parsed block, with substituted inner blocks
+ *                                    when a value resolved.
+ *     @type array|null $ancestry     The full ancestry list (ancestors plus this
+ *                                    binding's guard key) to propagate to the
+ *                                    substituted children, or null when nothing
+ *                                    needs propagating.
+ * }
+ */
+function _block_bindings_resolve_inner_blocks( $parsed_block, $available_context ) {
+	$unchanged = array(
+		'parsed_block' => $parsed_block,
+		'ancestry'     => null,
+	);
+
+	$binding = _block_bindings_get_inner_blocks_binding( $parsed_block );
+	if ( null === $binding ) {
+		return $unchanged;
+	}
+
+	$source = get_block_bindings_source( $binding['source'] );
+	if ( null === $source ) {
+		return $unchanged;
+	}
+
+	$source_args = ! empty( $binding['args'] ) && is_array( $binding['args'] ) ? $binding['args'] : array();
+	$guard_key   = _block_bindings_get_binding_guard_key( $binding['source'], $source_args, $source, $available_context );
+
+	$ancestry = $available_context[ WP_BLOCK_BINDINGS_INNER_BLOCKS_ANCESTRY ] ?? array();
+	if ( ! is_array( $ancestry ) ) {
+		$ancestry = array();
+	}
+
+	if ( in_array( $guard_key, $ancestry, true ) ) {
+		_doing_it_wrong(
+			__FUNCTION__,
+			esc_html(
+				sprintf(
+					/* translators: %s: The bound source name. */
+					__( 'The "innerBlocks" binding source "%s" supplies a block bound to itself; the nested binding is skipped to prevent infinite recursion.' ),
+					$binding['source']
+				)
+			),
+			'7.1.0'
+		);
+		return $unchanged;
+	}
+
+	/*
+	 * The depth counter (not just the ancestry length) must be checked here:
+	 * cycles crossing context boundaries (`do_blocks()`, `core/post-template`)
+	 * re-enter as top-level blocks with fresh context, so the counter is the
+	 * only state that survives them.
+	 */
+	if (
+		count( $ancestry ) >= WP_BLOCK_BINDINGS_MAX_BOUND_DEPTH ||
+		_block_bindings_bound_render_depth() >= WP_BLOCK_BINDINGS_MAX_BOUND_DEPTH
+	) {
+		_doing_it_wrong(
+			__FUNCTION__,
+			esc_html(
+				sprintf(
+					/* translators: %d: The maximum nesting depth of bound inner-block areas. */
+					__( 'Bound inner blocks are nested more than %d levels deep; the binding is skipped to prevent infinite recursion.' ),
+					WP_BLOCK_BINDINGS_MAX_BOUND_DEPTH
+				)
+			),
+			'7.1.0'
+		);
+		return $unchanged;
+	}
+
+	$block_instance = new WP_Block( $parsed_block, $available_context );
+
+	if ( ! empty( $source->uses_context ) ) {
+		foreach ( $source->uses_context as $context_name ) {
+			if ( array_key_exists( $context_name, $available_context ) ) {
+				$block_instance->context[ $context_name ] = $available_context[ $context_name ];
+			}
+		}
+	}
+
+	$source_value = $source->get_value( $source_args, $block_instance, 'innerBlocks' );
+
+	// Absence: leave the parsed block untouched so the serialized fallback renders.
+	if ( null === $source_value ) {
+		return $unchanged;
+	}
+
+	if ( ! is_string( $source_value ) ) {
+		// Surface a misuse instead of silently parsing a non-string value.
+		_doing_it_wrong(
+			__FUNCTION__,
+			esc_html(
+				sprintf(
+					/* translators: %s: The bound source name. */
+					__( 'The "innerBlocks" binding source "%s" must return a serialized block-markup string, an empty string, or null.' ),
+					$binding['source']
+				)
+			),
+			'7.1.0'
+		);
+		return $unchanged;
+	}
+
+	if ( '' === $source_value ) {
+		// Intentionally empty area: no inner blocks, but keep the host's static
+		// chunks so its wrapper renders empty (no fallback children). No children
+		// means nothing can recurse, so no ancestry needs propagating.
+		$parsed_block['innerContent'] = _block_bindings_rebuild_inner_content( $parsed_block['innerContent'] ?? array(), 0 );
+		$parsed_block['innerBlocks']  = array();
+		return array(
+			'parsed_block' => $parsed_block,
+			'ancestry'     => null,
+		);
+	}
+
+	// A non-empty string: parse it and rebuild inner content around the host's
+	// own static chunks so the substituted children render in place.
+	$parsed_block['innerBlocks']  = parse_blocks( $source_value );
+	$parsed_block['innerContent'] = _block_bindings_rebuild_inner_content(
+		$parsed_block['innerContent'] ?? array(),
+		count( $parsed_block['innerBlocks'] )
+	);
+
+	return array(
+		'parsed_block' => $parsed_block,
+		'ancestry'     => array_merge( $ancestry, array( $guard_key ) ),
+	);
+}
+
+/**
+ * Substitutes a nested block's inner blocks from its `innerBlocks` binding source.
+ *
+ * Hooked on `render_block_data`, which fires for every block (including each
+ * inner block) before it renders, with the signature
+ * `( $parsed_block, $source_block, $parent_block )`.
+ *
+ * Top-level blocks (`$parent_block === null`) only get depth accounting here;
+ * their substitution is handled by
+ * `_block_bindings_render_top_level_bound_block()`, which applies this
+ * very filter before resolving.
+ *
+ * @since 7.1.0
+ *
+ * @param array         $parsed_block The parsed block being filtered.
+ * @param array         $source_block An unmodified copy of the parsed block.
+ * @param WP_Block|null $parent_block The parent block instance, or null at the top level.
+ * @return array The parsed block, with substituted inner blocks when a value resolves.
+ */
+function _block_bindings_replace_inner_blocks( $parsed_block, $source_block, $parent_block ) {
+	if ( null === _block_bindings_get_inner_blocks_binding( $parsed_block ) ) {
+		return $parsed_block;
+	}
+
+	/*
+	 * Every block carrying the binding descriptor — any parent, any outcome —
+	 * increments the depth counter, symmetric by construction with the
+	 * decrement in `_block_bindings_close_bound_block()`, which pairs
+	 * on the same re-derivable descriptor check.
+	 */
+	$depth = &_block_bindings_bound_render_depth();
+	++$depth;
+
+	if ( ! $parent_block instanceof WP_Block ) {
+		return $parsed_block;
+	}
+
+	/*
+	 * Prefer the actual WP_Block instance being rendered so source callbacks
+	 * receive inherited context through arbitrary ancestry, even through
+	 * intermediate blocks that neither use nor provide that context.
+	 */
+	$source_instance   = _block_bindings_find_inner_block_instance( $source_block, $parent_block );
+	$available_context = $source_instance instanceof WP_Block
+		? _block_bindings_get_available_context( $source_instance )
+		: _block_bindings_get_default_context( $parsed_block );
+
+	$result = _block_bindings_resolve_inner_blocks( $parsed_block, $available_context );
+
+	/*
+	 * Propagate the bound ancestry to the substituted children by mutating the
+	 * cached instance's context: core's render loop detects the context change
+	 * against its pre-filter snapshot and rebuilds the children with it merged
+	 * into their available context. When the instance could not be located
+	 * (practically unreachable in core's loop), cycle detection for this
+	 * subtree degrades to the global depth cap.
+	 */
+	if ( null !== $result['ancestry'] && $source_instance instanceof WP_Block ) {
+		$source_instance->context[ WP_BLOCK_BINDINGS_INNER_BLOCKS_ANCESTRY ] = $result['ancestry'];
+	}
+
+	return $result['parsed_block'];
+}
+add_filter( 'render_block_data', '_block_bindings_replace_inner_blocks', 10, 3 );
+
+/**
+ * Renders a top-level block carrying an `innerBlocks` binding, replacing core's
+ * `render_block()` tail.
+ *
+ * Hooked on `pre_render_block` at `PHP_INT_MAX` so every other callback runs
+ * first (a non-null value from one of them is passed through untouched). Core's
+ * `render_block()` applies the `render_block_context` filter itself, but the
+ * substitution has to run before the block is constructed — applying the filter
+ * early AND letting core apply it again would run non-idempotent callbacks
+ * twice. Short-circuiting `render_block()` and replicating its tail here runs
+ * `render_block_data` and `render_block_context` exactly once, and resolution
+ * sees the real, post-filter context. The `render_block` and
+ * `render_block_{name}` filters still fire inside `WP_Block::render()`.
+ *
+ * @since 7.1.0
+ *
+ * @param string|null   $pre_render   The pre-rendered content, or null.
+ * @param array         $parsed_block The parsed block being rendered.
+ * @param WP_Block|null $parent_block The parent block instance, or null at the top level.
+ * @return string|null The rendered block for top-level bound blocks; otherwise `$pre_render`.
+ */
+function _block_bindings_render_top_level_bound_block( $pre_render, $parsed_block, $parent_block ) {
+	if (
+		null !== $pre_render ||
+		null !== $parent_block ||
+		null === _block_bindings_get_inner_blocks_binding( $parsed_block )
+	) {
+		return $pre_render;
+	}
+
+	global $post;
+
+	// Replicates the tail of render_block(), verified against 7.1-alpha.
+	$source_block = $parsed_block;
+
+	/** This filter is documented in wp-includes/blocks.php */
+	$parsed_block = apply_filters( 'render_block_data', $parsed_block, $source_block, null );
+
+	$context = array();
+
+	if ( $post instanceof WP_Post ) {
+		$context['postId']   = $post->ID;
+		$context['postType'] = $post->post_type;
+	}
+
+	/** This filter is documented in wp-includes/blocks.php */
+	$context = apply_filters( 'render_block_context', $context, $parsed_block, null );
+	if ( ! is_array( $context ) ) {
+		$context = array();
+	}
+
+	// The binding is re-read from the post-filter parsed block by the resolver;
+	// a descriptor removed by a `render_block_data` filter resolves to a no-op.
+	$result       = _block_bindings_resolve_inner_blocks( $parsed_block, $context );
+	$parsed_block = $result['parsed_block'];
+	if ( null !== $result['ancestry'] ) {
+		$context[ WP_BLOCK_BINDINGS_INNER_BLOCKS_ANCESTRY ] = $result['ancestry'];
+	}
+
+	$block = new WP_Block( $parsed_block, $context );
+
+	return $block->render();
+}
+add_filter( 'pre_render_block', '_block_bindings_render_top_level_bound_block', PHP_INT_MAX, 3 );
+
+/**
+ * Decrements the bound-render depth once a bound block has rendered.
+ *
+ * Companion to `_block_bindings_replace_inner_blocks()`: pairing is by
+ * the same re-derivable descriptor check on the block's own attributes (which
+ * survives parsed-block rebuilds by third-party filters), and the decrement is
+ * clamped at zero so mispaired decrements from direct `WP_Block::render()`
+ * calls cannot underflow the counter.
+ *
+ * @since 7.1.0
+ *
+ * @param string $block_content The rendered block content.
+ * @param array  $parsed_block  The parsed block.
+ * @return string The unchanged block content.
+ */
+function _block_bindings_close_bound_block( $block_content, $parsed_block ) {
+	if ( null !== _block_bindings_get_inner_blocks_binding( $parsed_block ) ) {
+		$depth = &_block_bindings_bound_render_depth();
+		$depth = max( 0, $depth - 1 );
+	}
+	return $block_content;
+}
+add_filter( 'render_block', '_block_bindings_close_bound_block', 20, 2 );

--- a/tests/phpunit/tests/block-bindings/innerBlocks.php
+++ b/tests/phpunit/tests/block-bindings/innerBlocks.php
@@ -1,0 +1,1217 @@
+<?php
+/**
+ * Tests for the Block Bindings inner-blocks substitution on `render_block_data`.
+ *
+ * @package WordPress
+ * @subpackage Blocks
+ *
+ * @group blocks
+ * @group block-bindings
+ */
+class WP_Block_Bindings_Inner_Blocks extends WP_UnitTestCase {
+
+	const SOURCE_NAME         = 'test/inner-blocks-source';
+	const CONTEXT_SOURCE_NAME = 'test/inner-blocks-context-source';
+
+	/**
+	 * Registers the block types used to host and provide context for bound inner blocks.
+	 */
+	public static function wpSetUpBeforeClass() {
+		/*
+		 * A generic container block whose render callback renders its inner blocks.
+		 * It mirrors a locally-controlled container that can carry an
+		 * `innerBlocks` binding.
+		 */
+		register_block_type(
+			'test/container',
+			array(
+				'render_callback' => static function ( $attributes, $content ) {
+					return '<div class="test-container">' . $content . '</div>';
+				},
+			)
+		);
+
+		/*
+		 * A static container block with NO render callback whose chrome lives in
+		 * its `innerContent` template (its `<div>` wrapper), mirroring blocks like
+		 * `core/group` / `core/list-item`. Used to prove the substitution preserves
+		 * the host's own static markup around the substituted inner blocks rather
+		 * than discarding it.
+		 */
+		register_block_type(
+			'test/static-container',
+			array()
+		);
+
+		/*
+		 * A provider block that mirrors `core/block`: it provides the
+		 * `pattern/overrides` context from its `content` attribute and renders
+		 * its inner blocks. Used to verify that the filter passes inherited
+		 * context to source callbacks.
+		 */
+		register_block_type(
+			'test/provider',
+			array(
+				'attributes'       => array(
+					'content' => array(
+						'type'    => 'object',
+						'default' => array(),
+					),
+				),
+				'provides_context' => array(
+					'pattern/overrides' => 'content',
+				),
+				'render_callback'  => static function ( $attributes, $content ) {
+					return '<div class="test-provider">' . $content . '</div>';
+				},
+			)
+		);
+
+		/*
+		 * A provider block that supplies the `postId` context from an attribute,
+		 * mirroring Query Loop's per-post context. Used to verify the recursion
+		 * guard keys on the context a source declares it consumes.
+		 */
+		register_block_type(
+			'test/post-provider',
+			array(
+				'attributes'       => array(
+					'postId' => array(
+						'type' => 'number',
+					),
+				),
+				'provides_context' => array(
+					'postId' => 'postId',
+				),
+				'render_callback'  => static function ( $attributes, $content ) {
+					return $content;
+				},
+			)
+		);
+	}
+
+	/**
+	 * Cleans up any block bindings sources registered during a test.
+	 */
+	public function tear_down() {
+		foreach ( get_all_registered_block_bindings_sources() as $source_name => $source_properties ) {
+			if ( str_starts_with( $source_name, 'test/' ) ) {
+				unregister_block_bindings_source( $source_name );
+			}
+		}
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Unregisters the shared block types.
+	 */
+	public static function wpTearDownAfterClass() {
+		unregister_block_type( 'test/container' );
+		unregister_block_type( 'test/static-container' );
+		unregister_block_type( 'test/provider' );
+		unregister_block_type( 'test/post-provider' );
+	}
+
+	/**
+	 * Registers a context-free inner-blocks source returning the given value.
+	 *
+	 * @param mixed $source_value The value the source returns for the `innerBlocks` attribute.
+	 */
+	private function register_inner_blocks_source( $source_value ) {
+		register_block_bindings_source(
+			self::SOURCE_NAME,
+			array(
+				'label'              => 'Inner blocks test source',
+				'get_value_callback' => static function ( $source_args, $block_instance, $attribute_name ) use ( $source_value ) {
+					if ( 'innerBlocks' === $attribute_name ) {
+						return $source_value;
+					}
+					return null;
+				},
+			)
+		);
+	}
+
+	/**
+	 * Builds a `test/container` block bound to the inner-blocks source.
+	 *
+	 * @param string $fallback_inner The serialized fallback inner blocks markup.
+	 * @return array The parsed block.
+	 */
+	private function bound_container_parsed_block( $fallback_inner = '<!-- wp:paragraph --><p>Fallback</p><!-- /wp:paragraph -->' ) {
+		$markup = '<!-- wp:test/container {"metadata":{"bindings":{"innerBlocks":{"source":"' . self::SOURCE_NAME . '"}}}} -->' .
+			$fallback_inner .
+			'<!-- /wp:test/container -->';
+		$parsed = parse_blocks( $markup );
+		return $parsed[0];
+	}
+
+	/**
+	 * A source-supplied serialized string is parsed and rendered, replacing the
+	 * block's own serialized fallback children.
+	 *
+	 * @covers ::_block_bindings_replace_inner_blocks
+	 */
+	public function test_string_value_substitutes_and_renders_inner_blocks() {
+		$this->register_inner_blocks_source(
+			'<!-- wp:paragraph --><p>Substituted child</p><!-- /wp:paragraph -->'
+		);
+
+		$parsed = $this->bound_container_parsed_block();
+		$result = render_block( $parsed );
+
+		$this->assertStringContainsString(
+			'Substituted child',
+			$result,
+			'The source-supplied inner block should be rendered.'
+		);
+		$this->assertStringNotContainsString(
+			'Fallback',
+			$result,
+			'The serialized fallback children must not be rendered when a value is supplied.'
+		);
+		$this->assertSame(
+			1,
+			substr_count( $result, 'Substituted child' ),
+			'The substituted child must be rendered exactly once (no double-render).'
+		);
+	}
+
+	/**
+	 * A `null` value is treated as absence; the block's own serialized children
+	 * render as a fallback.
+	 *
+	 * @covers ::_block_bindings_replace_inner_blocks
+	 */
+	public function test_null_value_renders_serialized_fallback() {
+		$this->register_inner_blocks_source( null );
+
+		$parsed = $this->bound_container_parsed_block();
+		$result = render_block( $parsed );
+
+		$this->assertStringContainsString(
+			'Fallback',
+			$result,
+			'The serialized fallback children should render when the source returns null.'
+		);
+	}
+
+	/**
+	 * An empty string is treated as an intentionally-empty area; no inner blocks
+	 * render and the serialized fallback is not used.
+	 *
+	 * @covers ::_block_bindings_replace_inner_blocks
+	 */
+	public function test_empty_string_renders_empty_area() {
+		$this->register_inner_blocks_source( '' );
+
+		$parsed = $this->bound_container_parsed_block();
+		$result = render_block( $parsed );
+
+		$this->assertStringNotContainsString(
+			'Fallback',
+			$result,
+			'An empty string value must not render the serialized fallback children.'
+		);
+		$this->assertSame(
+			'<div class="test-container"></div>',
+			trim( $result ),
+			'An empty string value should render an empty inner-blocks area.'
+		);
+	}
+
+	/**
+	 * A substituted inner block that itself carries a binding resolves
+	 * recursively when Core re-renders the rebuilt inner blocks.
+	 *
+	 * @covers ::_block_bindings_replace_inner_blocks
+	 */
+	public function test_substituted_inner_block_with_binding_resolves_recursively() {
+		// Source for the inner paragraph's `content` attribute.
+		register_block_bindings_source(
+			'test/recursive-content',
+			array(
+				'label'              => 'Recursive content source',
+				'get_value_callback' => static function () {
+					return 'Recursive value';
+				},
+			)
+		);
+
+		// The outer container's inner-blocks source returns a paragraph that is
+		// itself bound to the recursive content source.
+		$this->register_inner_blocks_source(
+			'<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"test/recursive-content"}}}} --><p>placeholder</p><!-- /wp:paragraph -->'
+		);
+
+		$parsed = $this->bound_container_parsed_block();
+		$result = render_block( $parsed );
+
+		$this->assertStringContainsString(
+			'Recursive value',
+			$result,
+			'A binding on a substituted inner block should resolve recursively.'
+		);
+		$this->assertStringNotContainsString(
+			'placeholder',
+			$result,
+			'The substituted inner block binding should replace its placeholder content.'
+		);
+	}
+
+	/**
+	 * A bound block that is the direct child of a context provider resolves its
+	 * override value via inherited context and renders the overridden inner blocks
+	 * instead of the fallback.
+	 *
+	 * This proves the filter surfaces `pattern/overrides` from inherited
+	 * available context, not from `$parent_block->context`.
+	 *
+	 * @covers ::_block_bindings_replace_inner_blocks
+	 */
+	public function test_nested_context_dependent_source_resolves_override() {
+		$block_name        = 'Overridable Group';
+		$override_markup   = '<!-- wp:paragraph --><p>Overridden child</p><!-- /wp:paragraph -->';
+		$attributes_seen   = array();
+		$context_value_set = array(
+			$block_name => array(
+				'innerBlocks' => $override_markup,
+			),
+		);
+
+		register_block_bindings_source(
+			self::CONTEXT_SOURCE_NAME,
+			array(
+				'label'              => 'Context-dependent inner blocks source',
+				'uses_context'       => array( 'pattern/overrides' ),
+				'get_value_callback' => static function ( $source_args, $block_instance, $attribute_name ) use ( &$attributes_seen ) {
+					if ( 'innerBlocks' !== $attribute_name ) {
+						return null;
+					}
+					// Record that metadata.name was populated on the transient instance.
+					$attributes_seen['metadata_name'] = $block_instance->attributes['metadata']['name'] ?? null;
+
+					$metadata_name = $block_instance->attributes['metadata']['name'] ?? null;
+					if ( null === $metadata_name ) {
+						return null;
+					}
+					return $block_instance->context['pattern/overrides'][ $metadata_name ]['innerBlocks'] ?? null;
+				},
+			)
+		);
+
+		// The bound container sits directly inside the provider block.
+		$inner_container = '<!-- wp:test/container {"metadata":{"name":"' . $block_name . '","bindings":{"innerBlocks":{"source":"' . self::CONTEXT_SOURCE_NAME . '"}}}} --><!-- wp:paragraph --><p>Group fallback</p><!-- /wp:paragraph --><!-- /wp:test/container -->';
+
+		$provider_markup = '<!-- wp:test/provider ' . wp_json_encode( array( 'content' => $context_value_set ) ) . ' -->' .
+			$inner_container .
+			'<!-- /wp:test/provider -->';
+
+		$parsed = parse_blocks( $provider_markup );
+		$result = render_block( $parsed[0] );
+
+		$this->assertStringContainsString(
+			'Overridden child',
+			$result,
+			'The override value must resolve and render on the frontend via inherited context.'
+		);
+		$this->assertStringNotContainsString(
+			'Group fallback',
+			$result,
+			'The bound container fallback must not render when the override resolves.'
+		);
+		$this->assertSame(
+			$block_name,
+			$attributes_seen['metadata_name'],
+			'The transient block instance must expose metadata.name to the source.'
+		);
+	}
+
+	/**
+	 * A context-dependent source must still resolve when the provider is above
+	 * an intermediate block that neither uses nor provides that context.
+	 *
+	 * @covers ::_block_bindings_replace_inner_blocks
+	 */
+	public function test_context_dependent_source_resolves_through_intermediate_block() {
+		$block_name      = 'Nested Overridable Group';
+		$override_markup = '<!-- wp:paragraph --><p>Deep overridden child</p><!-- /wp:paragraph -->';
+
+		register_block_bindings_source(
+			self::CONTEXT_SOURCE_NAME,
+			array(
+				'label'              => 'Context-dependent inner blocks source',
+				'uses_context'       => array( 'pattern/overrides' ),
+				'get_value_callback' => static function ( $source_args, $block_instance, $attribute_name ) {
+					if ( 'innerBlocks' !== $attribute_name ) {
+						return null;
+					}
+
+					$metadata_name = $block_instance->attributes['metadata']['name'] ?? null;
+					return $block_instance->context['pattern/overrides'][ $metadata_name ]['innerBlocks'] ?? null;
+				},
+			)
+		);
+
+		$bound_container = '<!-- wp:test/container {"metadata":{"name":"' . $block_name . '","bindings":{"innerBlocks":{"source":"' . self::CONTEXT_SOURCE_NAME . '"}}}} --><!-- wp:paragraph --><p>Deep fallback</p><!-- /wp:paragraph --><!-- /wp:test/container -->';
+
+		$wrapper_markup = '<!-- wp:test/container -->' .
+			$bound_container .
+			'<!-- /wp:test/container -->';
+
+		$provider_markup = '<!-- wp:test/provider ' . wp_json_encode(
+			array(
+				'content' => array(
+					$block_name => array(
+						'innerBlocks' => $override_markup,
+					),
+				),
+			)
+		) . ' -->' .
+			$wrapper_markup .
+			'<!-- /wp:test/provider -->';
+
+		$parsed = parse_blocks( $provider_markup );
+		$result = render_block( $parsed[0] );
+
+		$this->assertStringContainsString(
+			'Deep overridden child',
+			$result,
+			'The source should receive inherited context through the intermediate block.'
+		);
+		$this->assertStringNotContainsString(
+			'Deep fallback',
+			$result,
+			'The fallback must not render when the inherited context resolves.'
+		);
+	}
+
+	/**
+	 * Top-level (`$parent_block === null`), args-only source: substitution works
+	 * with no fatal when the bound block is rendered directly.
+	 *
+	 * @covers ::_block_bindings_render_top_level_bound_block
+	 */
+	public function test_top_level_context_free_source_substitutes() {
+		register_block_bindings_source(
+			self::SOURCE_NAME,
+			array(
+				'label'              => 'Args-only inner blocks source',
+				'get_value_callback' => static function ( $source_args, $block_instance, $attribute_name ) {
+					if ( 'innerBlocks' === $attribute_name && isset( $source_args['markup'] ) ) {
+						return $source_args['markup'];
+					}
+					return null;
+				},
+			)
+		);
+
+		$markup = '<!-- wp:test/container {"metadata":{"bindings":{"innerBlocks":{"source":"' . self::SOURCE_NAME . '","args":{"markup":"<!-- wp:paragraph --><p>Top level child</p><!-- /wp:paragraph -->"}}}}} --><!-- wp:paragraph --><p>Fallback</p><!-- /wp:paragraph --><!-- /wp:test/container -->';
+		$parsed = parse_blocks( $markup );
+		$result = render_block( $parsed[0] );
+
+		$this->assertStringContainsString(
+			'Top level child',
+			$result,
+			'An args-only source should resolve at the top level.'
+		);
+		$this->assertStringNotContainsString(
+			'Fallback',
+			$result,
+			'The fallback must not render when an args-only source resolves at the top level.'
+		);
+	}
+
+	/**
+	 * Top-level (`$parent_block === null`), context-dependent source: returns
+	 * `null` because no ancestry context is available, the filter falls through to
+	 * the serialized fallback, and no PHP error/warning is raised (no null
+	 * dereference of `$parent_block`).
+	 *
+	 * @covers ::_block_bindings_render_top_level_bound_block
+	 */
+	public function test_top_level_context_dependent_source_falls_back_without_error() {
+		register_block_bindings_source(
+			self::CONTEXT_SOURCE_NAME,
+			array(
+				'label'              => 'Context-dependent inner blocks source',
+				'uses_context'       => array( 'pattern/overrides' ),
+				'get_value_callback' => static function ( $source_args, $block_instance, $attribute_name ) {
+					if ( 'innerBlocks' !== $attribute_name ) {
+						return null;
+					}
+					$metadata_name = $block_instance->attributes['metadata']['name'] ?? null;
+					if ( null === $metadata_name ) {
+						return null;
+					}
+					return $block_instance->context['pattern/overrides'][ $metadata_name ]['innerBlocks'] ?? null;
+				},
+			)
+		);
+
+		$markup = '<!-- wp:test/container {"metadata":{"name":"Top Level Group","bindings":{"innerBlocks":{"source":"' . self::CONTEXT_SOURCE_NAME . '"}}}} --><!-- wp:paragraph --><p>Fallback</p><!-- /wp:paragraph --><!-- /wp:test/container -->';
+		$parsed = parse_blocks( $markup );
+
+		// Promote PHP errors/warnings/notices to exceptions for this render.
+		$caught        = null;
+		$error_handler = static function ( $errno, $errstr ) use ( &$caught ) {
+			$caught = $errstr;
+			return true;
+		};
+		set_error_handler( $error_handler );
+		try {
+			$result = render_block( $parsed[0] );
+		} finally {
+			restore_error_handler();
+		}
+
+		$this->assertNull(
+			$caught,
+			'Rendering a top-level context-dependent bound block must not raise a PHP error/warning.'
+		);
+		$this->assertStringContainsString(
+			'Fallback',
+			$result,
+			'A context-dependent source that cannot resolve at the top level must fall back to the serialized children.'
+		);
+	}
+
+	/**
+	 * Builds a `test/static-container` block bound to the inner-blocks source.
+	 *
+	 * The host has NO render callback; its `<div>` wrapper lives in the
+	 * `innerContent` template, so its rendered chrome comes from the host's own
+	 * static chunks rather than from a callback.
+	 *
+	 * @param string $fallback_inner The serialized fallback inner blocks markup.
+	 * @return array The parsed block.
+	 */
+	private function bound_static_container_parsed_block( $fallback_inner = '<!-- wp:paragraph --><p>Fallback</p><!-- /wp:paragraph -->' ) {
+		$markup = '<!-- wp:test/static-container {"metadata":{"bindings":{"innerBlocks":{"source":"' . self::SOURCE_NAME . '"}}}} -->' .
+			'<div class="static-wrapper">' . $fallback_inner . '</div>' .
+			'<!-- /wp:test/static-container -->';
+		$parsed = parse_blocks( $markup );
+		return $parsed[0];
+	}
+
+	/**
+	 * A static host whose wrapper lives in `innerContent` keeps that wrapper
+	 * around the substituted children instead of discarding it.
+	 *
+	 * @covers ::_block_bindings_rebuild_inner_content
+	 * @covers ::_block_bindings_replace_inner_blocks
+	 */
+	public function test_static_host_preserves_wrapper_around_substituted_children() {
+		$this->register_inner_blocks_source(
+			'<!-- wp:paragraph --><p>Substituted child</p><!-- /wp:paragraph -->'
+		);
+
+		$parsed = $this->bound_static_container_parsed_block();
+		$result = render_block( $parsed );
+
+		$this->assertStringContainsString(
+			'<div class="static-wrapper">',
+			$result,
+			'The host block static wrapper must be preserved around the substituted children.'
+		);
+		$this->assertStringContainsString(
+			'Substituted child',
+			$result,
+			'The source-supplied inner block should be rendered.'
+		);
+		$this->assertStringNotContainsString(
+			'Fallback',
+			$result,
+			'The serialized fallback children must not be rendered when a value is supplied.'
+		);
+		// The substituted child must sit INSIDE the preserved wrapper.
+		$this->assertMatchesRegularExpression(
+			'#<div class="static-wrapper">.*Substituted child.*</div>#s',
+			trim( $result ),
+			'The substituted child must render inside the host wrapper, not replace it.'
+		);
+	}
+
+	/**
+	 * A static host with no fallback children still keeps source-supplied
+	 * children inside its closed wrapper.
+	 *
+	 * @covers ::_block_bindings_rebuild_inner_content
+	 * @covers ::_block_bindings_replace_inner_blocks
+	 */
+	public function test_static_host_without_fallback_children_inserts_substituted_children_inside_wrapper() {
+		$this->register_inner_blocks_source(
+			'<!-- wp:paragraph --><p>Substituted child</p><!-- /wp:paragraph -->'
+		);
+
+		$parsed = $this->bound_static_container_parsed_block( '' );
+		$result = render_block( $parsed );
+
+		$this->assertMatchesRegularExpression(
+			'#^<div class="static-wrapper"><p[^>]*>Substituted child</p></div>$#',
+			trim( $result ),
+			'The substituted child must render inside the closed host wrapper.'
+		);
+	}
+
+	/**
+	 * A static host with more substituted children than the original keeps a
+	 * single surrounding wrapper with one `null` slot per new child.
+	 *
+	 * @covers ::_block_bindings_rebuild_inner_content
+	 * @covers ::_block_bindings_replace_inner_blocks
+	 */
+	public function test_static_host_wrapper_preserved_when_child_count_changes() {
+		$this->register_inner_blocks_source(
+			'<!-- wp:paragraph --><p>First</p><!-- /wp:paragraph -->' .
+			'<!-- wp:paragraph --><p>Second</p><!-- /wp:paragraph -->' .
+			'<!-- wp:paragraph --><p>Third</p><!-- /wp:paragraph -->'
+		);
+
+		// Original host has a single child; the source supplies three.
+		$parsed = $this->bound_static_container_parsed_block();
+		$result = render_block( $parsed );
+
+		$this->assertSame(
+			1,
+			substr_count( $result, '<div class="static-wrapper">' ),
+			'The host opening wrapper chunk must appear exactly once.'
+		);
+		$this->assertSame(
+			1,
+			substr_count( $result, '</div>' ),
+			'The host closing wrapper chunk must appear exactly once.'
+		);
+		foreach ( array( 'First', 'Second', 'Third' ) as $child ) {
+			$this->assertStringContainsString(
+				$child,
+				$result,
+				"The substituted child '$child' should render inside the wrapper."
+			);
+		}
+		$this->assertMatchesRegularExpression(
+			'#<div class="static-wrapper">.*First.*Second.*Third.*</div>#s',
+			trim( $result ),
+			'All substituted children must render inside the single preserved wrapper, in order.'
+		);
+	}
+
+	/**
+	 * An empty-string source on a static host keeps the host's wrapper but
+	 * renders no children inside it.
+	 *
+	 * @covers ::_block_bindings_rebuild_inner_content
+	 * @covers ::_block_bindings_replace_inner_blocks
+	 */
+	public function test_static_host_empty_string_keeps_empty_wrapper() {
+		$this->register_inner_blocks_source( '' );
+
+		$parsed = $this->bound_static_container_parsed_block();
+		$result = render_block( $parsed );
+
+		$this->assertSame(
+			'<div class="static-wrapper"></div>',
+			trim( $result ),
+			'An empty string value should keep the host wrapper and render it empty.'
+		);
+		$this->assertStringNotContainsString(
+			'Fallback',
+			$result,
+			'An empty string value must not render the serialized fallback children.'
+		);
+	}
+
+	/**
+	 * Absence (`null`) on a static host leaves the parsed block untouched, so the
+	 * host's own serialized children render inside the wrapper.
+	 *
+	 * @covers ::_block_bindings_replace_inner_blocks
+	 */
+	public function test_static_host_null_value_renders_serialized_fallback() {
+		$this->register_inner_blocks_source( null );
+
+		$parsed = $this->bound_static_container_parsed_block();
+		$result = render_block( $parsed );
+
+		$this->assertStringContainsString(
+			'<div class="static-wrapper">',
+			$result,
+			'The host wrapper should still render on the fallback path.'
+		);
+		$this->assertStringContainsString(
+			'Fallback',
+			$result,
+			'The serialized fallback children should render when the source returns null.'
+		);
+	}
+
+	/**
+	 * Unit-level coverage of the `innerContent` rebuild rule, including the
+	 * edge cases (no placeholder, empty template, zero new blocks).
+	 *
+	 * @covers ::_block_bindings_rebuild_inner_content
+	 *
+	 * @dataProvider data_rebuild_inner_content
+	 *
+	 * @param array $original  The original `innerContent` template.
+	 * @param int   $count     The number of new inner blocks.
+	 * @param array $expected  The expected rebuilt template.
+	 * @param string $message  Assertion message.
+	 */
+	public function test_rebuild_inner_content_rule( $original, $count, $expected, $message ) {
+		$this->assertSame(
+			$expected,
+			_block_bindings_rebuild_inner_content( $original, $count ),
+			$message
+		);
+	}
+
+	/**
+	 * Data provider for {@see test_rebuild_inner_content_rule}.
+	 *
+	 * @return array[] Cases of [ original, new count, expected, message ].
+	 */
+	public function data_rebuild_inner_content() {
+		return array(
+			'group wrapper, fewer/equal children' => array(
+				array( '<div>', null, null, '</div>' ),
+				1,
+				array( '<div>', null, '</div>' ),
+				'Leading/trailing chunks preserved; one null per new block.',
+			),
+			'group wrapper, more children'        => array(
+				array( '<div>', null, '</div>' ),
+				3,
+				array( '<div>', null, null, null, '</div>' ),
+				'More new blocks than original placeholders emit one null each between the wrapper chunks.',
+			),
+			'list-item wrapper, single child'     => array(
+				array( '<li>Hello', null, '</li>' ),
+				2,
+				array( '<li>Hello', null, null, '</li>' ),
+				'The list-item wrapper chunks are preserved around the new placeholders.',
+			),
+			'zero new blocks keeps only chrome'   => array(
+				array( '<div>', null, '</div>' ),
+				0,
+				array( '<div>', '</div>' ),
+				'Zero new blocks keep only the host static chunks (empty wrapper).',
+			),
+			'closed wrapper inserts new slots'    => array(
+				array( '<div></div>' ),
+				2,
+				array( '<div>', null, null, '</div>' ),
+				'A closed wrapper with no null placeholder inserts new slots before the final closing tag.',
+			),
+			'closing chunk inserts new slots'     => array(
+				array( '<div>', '</div>' ),
+				2,
+				array( '<div>', null, null, '</div>' ),
+				'A separate closing chunk with no null placeholder receives new slots before the closing tag.',
+			),
+			'no closing tag appends new slots'    => array(
+				array( '<div>' ),
+				2,
+				array( '<div>', null, null ),
+				'A template with no null placeholder and no closing tag appends the new slots after the static chunks.',
+			),
+			'empty template falls back to nulls'  => array(
+				array(),
+				2,
+				array( null, null ),
+				'An empty template falls back to one null per new block.',
+			),
+			'empty template, zero new blocks'     => array(
+				array(),
+				0,
+				array(),
+				'An empty template with zero new blocks stays empty.',
+			),
+		);
+	}
+
+	/**
+	 * A context-blind source supplying markup that contains another block bound
+	 * to the same source and args must not recurse: the nested binding is
+	 * skipped and the nested block's own serialized children render instead.
+	 *
+	 * @covers ::_block_bindings_resolve_inner_blocks
+	 * @expectedIncorrectUsage _block_bindings_resolve_inner_blocks
+	 */
+	public function test_self_referential_source_does_not_recurse() {
+		// The source's value embeds another container bound to the same source.
+		$this->register_inner_blocks_source(
+			'<!-- wp:test/container {"metadata":{"bindings":{"innerBlocks":{"source":"' . self::SOURCE_NAME . '"}}}} -->' .
+			'<!-- wp:paragraph --><p>Cycle fallback</p><!-- /wp:paragraph -->' .
+			'<!-- /wp:test/container -->'
+		);
+
+		$result = render_block( $this->bound_container_parsed_block() );
+
+		// The outer substitution ran (the fallback did not render at the top),
+		// and the nested, cyclic binding fell back to its own children exactly
+		// once — rendering terminated instead of recursing.
+		$this->assertStringContainsString(
+			'Cycle fallback',
+			$result,
+			'The nested cyclic binding must fall back to its own serialized children.'
+		);
+		$this->assertSame(
+			1,
+			substr_count( $result, 'Cycle fallback' ),
+			'The cyclic binding must render exactly once.'
+		);
+		$this->assertSame(
+			2,
+			substr_count( $result, '<div class="test-container">' ),
+			'Exactly two nested containers must render: the bound host and the one substituted level.'
+		);
+	}
+
+	/**
+	 * The recursion guard is scoped to the currently-rendering ancestry:
+	 * sequential (sibling) areas bound to the same source both substitute.
+	 *
+	 * @covers ::_block_bindings_resolve_inner_blocks
+	 */
+	public function test_sequential_bound_areas_are_not_affected_by_the_recursion_guard() {
+		$this->register_inner_blocks_source(
+			'<!-- wp:paragraph --><p>Substituted</p><!-- /wp:paragraph -->'
+		);
+
+		$first  = render_block( $this->bound_container_parsed_block() );
+		$second = render_block( $this->bound_container_parsed_block() );
+
+		$this->assertStringContainsString( 'Substituted', $first, 'The first bound area must substitute.' );
+		$this->assertStringContainsString(
+			'Substituted',
+			$second,
+			'A subsequent bound area using the same source must substitute: the guard ancestry must not outlive the first render.'
+		);
+	}
+
+	/**
+	 * Top-level context parity with core: context supplied through the standard
+	 * `render_block_context` filter (widgets, templates, plugins) reaches the
+	 * source callback, matching what core's render_block() would provide.
+	 *
+	 * @covers ::_block_bindings_render_top_level_bound_block
+	 */
+	public function test_top_level_context_resolves_through_render_block_context_filter() {
+		register_block_bindings_source(
+			self::CONTEXT_SOURCE_NAME,
+			array(
+				'label'              => 'Context-dependent inner blocks source',
+				'uses_context'       => array( 'test/filtered-context' ),
+				'get_value_callback' => static function ( $source_args, $block_instance, $attribute_name ) {
+					if ( 'innerBlocks' !== $attribute_name ) {
+						return null;
+					}
+					$value = $block_instance->context['test/filtered-context'] ?? null;
+					if ( null === $value ) {
+						return null;
+					}
+					return '<!-- wp:paragraph --><p>' . $value . '</p><!-- /wp:paragraph -->';
+				},
+			)
+		);
+
+		$add_context = static function ( $context ) {
+			$context['test/filtered-context'] = 'From the filter';
+			return $context;
+		};
+		add_filter( 'render_block_context', $add_context );
+
+		$markup = '<!-- wp:test/container {"metadata":{"bindings":{"innerBlocks":{"source":"' . self::CONTEXT_SOURCE_NAME . '"}}}} -->' .
+			'<!-- wp:paragraph --><p>Fallback</p><!-- /wp:paragraph -->' .
+			'<!-- /wp:test/container -->';
+		$parsed = parse_blocks( $markup );
+
+		try {
+			$result = render_block( $parsed[0] );
+		} finally {
+			remove_filter( 'render_block_context', $add_context );
+		}
+
+		$this->assertStringContainsString(
+			'From the filter',
+			$result,
+			'Context supplied via the render_block_context filter must reach the source at the top level.'
+		);
+		$this->assertStringNotContainsString(
+			'Fallback',
+			$result,
+			'The substituted children must replace the serialized fallback.'
+		);
+	}
+
+	/**
+	 * The recursion guard keys on the context the source declares it consumes:
+	 * a `postId`-dependent source legitimately nests the same binding under
+	 * providers supplying different `postId` values (a Query Loop rendering
+	 * other posts) and must not be flagged as a cycle.
+	 *
+	 * @covers ::_block_bindings_get_binding_guard_key
+	 * @covers ::_block_bindings_resolve_inner_blocks
+	 */
+	public function test_context_dependent_source_nested_across_posts_is_not_flagged_as_cycle() {
+		register_block_bindings_source(
+			self::CONTEXT_SOURCE_NAME,
+			array(
+				'label'              => 'Post-dependent inner blocks source',
+				'uses_context'       => array( 'postId' ),
+				'get_value_callback' => static function ( $source_args, $block_instance, $attribute_name ) {
+					if ( 'innerBlocks' !== $attribute_name ) {
+						return null;
+					}
+
+					$post_id = $block_instance->context['postId'] ?? 0;
+					if ( $post_id >= 3 ) {
+						// Terminate the descent with an intentionally-empty area.
+						return '';
+					}
+
+					$next_id = $post_id + 1;
+					return '<!-- wp:paragraph --><p>Level ' . $next_id . '</p><!-- /wp:paragraph -->' .
+						'<!-- wp:test/post-provider {"postId":' . $next_id . '} -->' .
+						'<!-- wp:test/container {"metadata":{"bindings":{"innerBlocks":{"source":"' . self::CONTEXT_SOURCE_NAME . '"}}}} -->' .
+						'<!-- wp:paragraph --><p>Guard fallback</p><!-- /wp:paragraph -->' .
+						'<!-- /wp:test/container -->' .
+						'<!-- /wp:test/post-provider -->';
+				},
+			)
+		);
+
+		$markup = '<!-- wp:test/container {"metadata":{"bindings":{"innerBlocks":{"source":"' . self::CONTEXT_SOURCE_NAME . '"}}}} -->' .
+			'<!-- wp:paragraph --><p>Guard fallback</p><!-- /wp:paragraph -->' .
+			'<!-- /wp:test/container -->';
+		$parsed = parse_blocks( $markup );
+		$result = render_block( $parsed[0] );
+
+		foreach ( array( 'Level 1', 'Level 2', 'Level 3' ) as $level ) {
+			$this->assertStringContainsString(
+				$level,
+				$result,
+				"The nested binding for '$level' must substitute: same source and args under a different postId is not a cycle."
+			);
+		}
+		$this->assertStringNotContainsString(
+			'Guard fallback',
+			$result,
+			'No level of the nested bindings may be skipped by the recursion guard.'
+		);
+	}
+
+	/**
+	 * The ancestry travels through intermediate blocks that neither use nor
+	 * provide context: a grandchild bound with an identical guard key is
+	 * skipped even when a plain container sits in between.
+	 *
+	 * @covers ::_block_bindings_resolve_inner_blocks
+	 * @expectedIncorrectUsage _block_bindings_resolve_inner_blocks
+	 */
+	public function test_cycle_through_intermediate_block_is_detected() {
+		$this->register_inner_blocks_source(
+			'<!-- wp:test/container -->' .
+			'<!-- wp:test/container {"metadata":{"bindings":{"innerBlocks":{"source":"' . self::SOURCE_NAME . '"}}}} -->' .
+			'<!-- wp:paragraph --><p>Intermediate cycle fallback</p><!-- /wp:paragraph -->' .
+			'<!-- /wp:test/container -->' .
+			'<!-- /wp:test/container -->'
+		);
+
+		$result = render_block( $this->bound_container_parsed_block() );
+
+		$this->assertStringContainsString(
+			'Intermediate cycle fallback',
+			$result,
+			'The grandchild cyclic binding must fall back to its own serialized children.'
+		);
+		$this->assertSame(
+			1,
+			substr_count( $result, 'Intermediate cycle fallback' ),
+			'The grandchild cyclic binding must render exactly once.'
+		);
+	}
+
+	/**
+	 * A `render_block_data` filter at a later priority that returns a freshly
+	 * built parsed-block array (a documented, common plugin pattern) must not
+	 * leak guard state: every subsequent area bound to the same source and args
+	 * still substitutes.
+	 *
+	 * @covers ::_block_bindings_replace_inner_blocks
+	 * @covers ::_block_bindings_close_bound_block
+	 */
+	public function test_parsed_block_rebuilt_by_later_filter_does_not_leak_guard_state() {
+		$this->register_inner_blocks_source(
+			'<!-- wp:paragraph --><p>Substituted</p><!-- /wp:paragraph -->'
+		);
+
+		$rebuild = static function ( $parsed_block ) {
+			return array_intersect_key(
+				$parsed_block,
+				array_flip( array( 'blockName', 'attrs', 'innerBlocks', 'innerContent', 'innerHTML' ) )
+			);
+		};
+		add_filter( 'render_block_data', $rebuild, 11 );
+
+		try {
+			// More renders than the depth cap proves neither the guard ancestry
+			// nor the depth counter accumulates across sequential renders.
+			for ( $i = 0; $i < 40; $i++ ) {
+				$result = render_block( $this->bound_container_parsed_block() );
+				$this->assertStringContainsString(
+					'Substituted',
+					$result,
+					"Bound area $i must substitute even when a later filter rebuilds the parsed block."
+				);
+			}
+		} finally {
+			remove_filter( 'render_block_data', $rebuild, 11 );
+		}
+	}
+
+	/**
+	 * The `render_block_context` filter runs exactly once for a top-level bound
+	 * block, and the context it injects is visible to the source's resolution.
+	 *
+	 * @covers ::_block_bindings_render_top_level_bound_block
+	 */
+	public function test_render_block_context_filter_runs_once_for_top_level_bound_block() {
+		register_block_bindings_source(
+			self::CONTEXT_SOURCE_NAME,
+			array(
+				'label'              => 'Context-dependent inner blocks source',
+				'uses_context'       => array( 'test/filtered-context' ),
+				'get_value_callback' => static function ( $source_args, $block_instance, $attribute_name ) {
+					if ( 'innerBlocks' !== $attribute_name ) {
+						return null;
+					}
+					$value = $block_instance->context['test/filtered-context'] ?? null;
+					if ( null === $value ) {
+						return null;
+					}
+					return '<!-- wp:paragraph --><p>' . $value . '</p><!-- /wp:paragraph -->';
+				},
+			)
+		);
+
+		$invocations = 0;
+		$spy         = static function ( $context, $parsed_block ) use ( &$invocations ) {
+			if ( 'context-once-top' === ( $parsed_block['attrs']['testMarker'] ?? null ) ) {
+				++$invocations;
+				$context['test/filtered-context'] = 'Injected by the spy';
+			}
+			return $context;
+		};
+		add_filter( 'render_block_context', $spy, 10, 2 );
+
+		$markup = '<!-- wp:test/container {"testMarker":"context-once-top","metadata":{"bindings":{"innerBlocks":{"source":"' . self::CONTEXT_SOURCE_NAME . '"}}}} -->' .
+			'<!-- wp:paragraph --><p>Fallback</p><!-- /wp:paragraph -->' .
+			'<!-- /wp:test/container -->';
+
+		try {
+			$result = do_blocks( $markup );
+		} finally {
+			remove_filter( 'render_block_context', $spy, 10 );
+		}
+
+		$this->assertSame(
+			1,
+			$invocations,
+			'The render_block_context filter must run exactly once for a top-level bound block.'
+		);
+		$this->assertStringContainsString(
+			'Injected by the spy',
+			$result,
+			'Context injected by the render_block_context filter must be visible to the source at the top level.'
+		);
+		$this->assertStringNotContainsString(
+			'Fallback',
+			$result,
+			'The substituted children must replace the serialized fallback.'
+		);
+	}
+
+	/**
+	 * The `render_block_context` filter runs exactly once for a bound block
+	 * nested inside another block: core's own inner-loop application, with zero
+	 * added by the substitution.
+	 *
+	 * @covers ::_block_bindings_replace_inner_blocks
+	 */
+	public function test_render_block_context_filter_runs_once_for_nested_bound_block() {
+		$this->register_inner_blocks_source(
+			'<!-- wp:paragraph --><p>Substituted</p><!-- /wp:paragraph -->'
+		);
+
+		$invocations = 0;
+		$spy         = static function ( $context, $parsed_block ) use ( &$invocations ) {
+			if ( 'context-once-nested' === ( $parsed_block['attrs']['testMarker'] ?? null ) ) {
+				++$invocations;
+			}
+			return $context;
+		};
+		add_filter( 'render_block_context', $spy, 10, 2 );
+
+		$markup = '<!-- wp:test/container -->' .
+			'<!-- wp:test/container {"testMarker":"context-once-nested","metadata":{"bindings":{"innerBlocks":{"source":"' . self::SOURCE_NAME . '"}}}} -->' .
+			'<!-- wp:paragraph --><p>Fallback</p><!-- /wp:paragraph -->' .
+			'<!-- /wp:test/container -->' .
+			'<!-- /wp:test/container -->';
+
+		try {
+			$result = do_blocks( $markup );
+		} finally {
+			remove_filter( 'render_block_context', $spy, 10 );
+		}
+
+		$this->assertSame(
+			1,
+			$invocations,
+			'The render_block_context filter must run exactly once for a nested bound block.'
+		);
+		$this->assertStringContainsString(
+			'Substituted',
+			$result,
+			'The nested bound block must substitute.'
+		);
+	}
+
+	/**
+	 * The top-level takeover preserves the filter contract of render_block():
+	 * `render_block_data` and `render_block` each fire exactly once for the
+	 * bound block.
+	 *
+	 * @covers ::_block_bindings_render_top_level_bound_block
+	 */
+	public function test_top_level_takeover_runs_data_and_render_filters_once() {
+		$this->register_inner_blocks_source(
+			'<!-- wp:paragraph --><p>Substituted child</p><!-- /wp:paragraph -->'
+		);
+
+		$data_calls   = 0;
+		$render_calls = 0;
+		$data_spy     = static function ( $parsed_block ) use ( &$data_calls ) {
+			if ( 'takeover-fidelity' === ( $parsed_block['attrs']['testMarker'] ?? null ) ) {
+				++$data_calls;
+			}
+			return $parsed_block;
+		};
+		$render_spy   = static function ( $block_content, $parsed_block ) use ( &$render_calls ) {
+			if ( 'takeover-fidelity' === ( $parsed_block['attrs']['testMarker'] ?? null ) ) {
+				++$render_calls;
+			}
+			return $block_content;
+		};
+		add_filter( 'render_block_data', $data_spy, 5 );
+		add_filter( 'render_block', $render_spy, 10, 2 );
+
+		$markup = '<!-- wp:test/container {"testMarker":"takeover-fidelity","metadata":{"bindings":{"innerBlocks":{"source":"' . self::SOURCE_NAME . '"}}}} -->' .
+			'<!-- wp:paragraph --><p>Fallback</p><!-- /wp:paragraph -->' .
+			'<!-- /wp:test/container -->';
+
+		try {
+			$result = do_blocks( $markup );
+		} finally {
+			remove_filter( 'render_block_data', $data_spy, 5 );
+			remove_filter( 'render_block', $render_spy, 10 );
+		}
+
+		$this->assertSame( 1, $data_calls, 'render_block_data must fire exactly once for a top-level bound block.' );
+		$this->assertSame( 1, $render_calls, 'render_block must fire exactly once for a top-level bound block.' );
+		$this->assertStringContainsString(
+			'Substituted child',
+			$result,
+			'The top-level bound block must substitute.'
+		);
+	}
+
+	/**
+	 * A `pre_render_block` callback registered before the takeover that returns
+	 * a non-null value wins: the takeover passes it through untouched and no
+	 * substitution occurs.
+	 *
+	 * @covers ::_block_bindings_render_top_level_bound_block
+	 */
+	public function test_earlier_pre_render_block_filter_wins_over_takeover() {
+		$this->register_inner_blocks_source(
+			'<!-- wp:paragraph --><p>Substituted child</p><!-- /wp:paragraph -->'
+		);
+
+		$short_circuit = static function ( $pre_render, $parsed_block ) {
+			if ( 'takeover-short-circuit' === ( $parsed_block['attrs']['testMarker'] ?? null ) ) {
+				return '<p>Short-circuited</p>';
+			}
+			return $pre_render;
+		};
+		add_filter( 'pre_render_block', $short_circuit, 10, 2 );
+
+		$markup = '<!-- wp:test/container {"testMarker":"takeover-short-circuit","metadata":{"bindings":{"innerBlocks":{"source":"' . self::SOURCE_NAME . '"}}}} -->' .
+			'<!-- wp:paragraph --><p>Fallback</p><!-- /wp:paragraph -->' .
+			'<!-- /wp:test/container -->';
+		$parsed = parse_blocks( $markup );
+
+		try {
+			$result = render_block( $parsed[0] );
+		} finally {
+			remove_filter( 'pre_render_block', $short_circuit, 10 );
+		}
+
+		$this->assertSame(
+			'<p>Short-circuited</p>',
+			$result,
+			'An earlier pre_render_block callback returning a value must win over the takeover.'
+		);
+		$this->assertStringNotContainsString(
+			'Substituted child',
+			$result,
+			'No substitution may occur when render_block() is short-circuited by another callback.'
+		);
+	}
+
+	/**
+	 * A cycle crossing a context boundary (`do_blocks()` inside a dynamic
+	 * block's render callback, like a template part) cannot be caught by the
+	 * context-carried ancestry; the global depth backstop must terminate it.
+	 *
+	 * @covers ::_block_bindings_bound_render_depth
+	 * @covers ::_block_bindings_resolve_inner_blocks
+	 * @expectedIncorrectUsage _block_bindings_resolve_inner_blocks
+	 */
+	public function test_depth_backstop_terminates_cycle_crossing_do_blocks() {
+		$markup = '<!-- wp:test/container {"metadata":{"bindings":{"innerBlocks":{"source":"' . self::SOURCE_NAME . '"}}}} -->' .
+			'<!-- wp:paragraph --><p>Backstop fallback</p><!-- /wp:paragraph -->' .
+			'<!-- /wp:test/container -->';
+
+		register_block_type(
+			'test/do-blocks-renderer',
+			array(
+				'render_callback' => static function () use ( $markup ) {
+					return do_blocks( $markup );
+				},
+			)
+		);
+
+		$this->register_inner_blocks_source( '<!-- wp:test/do-blocks-renderer /-->' );
+
+		$parsed = parse_blocks( $markup );
+		try {
+			$result = render_block( $parsed[0] );
+		} finally {
+			unregister_block_type( 'test/do-blocks-renderer' );
+		}
+
+		$this->assertStringContainsString(
+			'Backstop fallback',
+			$result,
+			'The capped binding must fall back to its own serialized children.'
+		);
+		$this->assertSame(
+			1,
+			substr_count( $result, 'Backstop fallback' ),
+			'Rendering must terminate at the depth cap: the fallback renders exactly once.'
+		);
+	}
+}

--- a/tests/phpunit/tests/block-bindings/listItem.php
+++ b/tests/phpunit/tests/block-bindings/listItem.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Tests for `core/list-item` with block bindings.
+ *
+ * @package WordPress
+ * @subpackage Blocks
+ *
+ * @group blocks
+ * @group block-bindings
+ */
+class WP_Block_Bindings_List_Item extends WP_UnitTestCase {
+
+	const CONTENT_SOURCE_NAME      = 'test/list-item-content';
+	const INNER_BLOCKS_SOURCE_NAME = 'test/list-item-inner-blocks';
+
+	/**
+	 * Cleans up any block bindings sources registered during a test.
+	 */
+	public function tear_down() {
+		foreach ( get_all_registered_block_bindings_sources() as $source_name => $source_properties ) {
+			if ( str_starts_with( $source_name, 'test/' ) ) {
+				unregister_block_bindings_source( $source_name );
+			}
+		}
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Registers a source supplying a List Item's `content` rich text.
+	 *
+	 * @param string $content_value The value returned for the `content` attribute.
+	 */
+	private function register_content_source( $content_value ) {
+		register_block_bindings_source(
+			self::CONTENT_SOURCE_NAME,
+			array(
+				'label'              => 'List item content source',
+				'get_value_callback' => static function ( $source_args, $block_instance, $attribute_name ) use ( $content_value ) {
+					if ( 'content' === $attribute_name ) {
+						return $content_value;
+					}
+					return null;
+				},
+			)
+		);
+	}
+
+	/**
+	 * Registers a source supplying a List Item's serialized inner blocks.
+	 *
+	 * @param mixed $inner_blocks_value The value returned for the `innerBlocks` attribute.
+	 */
+	private function register_inner_blocks_source( $inner_blocks_value ) {
+		register_block_bindings_source(
+			self::INNER_BLOCKS_SOURCE_NAME,
+			array(
+				'label'              => 'List item inner blocks source',
+				'get_value_callback' => static function ( $source_args, $block_instance, $attribute_name ) use ( $inner_blocks_value ) {
+					if ( 'innerBlocks' === $attribute_name ) {
+						return $inner_blocks_value;
+					}
+					return null;
+				},
+			)
+		);
+	}
+
+	/**
+	 * A List Item with both a bound `content` attribute and bound `innerBlocks`
+	 * renders its inner blocks exactly once.
+	 *
+	 * @covers ::_block_bindings_replace_inner_blocks
+	 */
+	public function test_content_and_inner_blocks_binding_renders_inner_blocks_once() {
+		$this->register_content_source( 'Bound item text' );
+		$this->register_inner_blocks_source(
+			'<!-- wp:list {"ordered":false} --><ul class="wp-block-list"><!-- wp:list-item --><li>Substituted nested item</li><!-- /wp:list-item --></ul><!-- /wp:list -->'
+		);
+
+		$markup = '<!-- wp:list-item {"metadata":{"bindings":{"content":{"source":"' . self::CONTENT_SOURCE_NAME . '"},"innerBlocks":{"source":"' . self::INNER_BLOCKS_SOURCE_NAME . '"}}}} -->' .
+			'<li>Original text<!-- wp:list {"ordered":false} --><ul class="wp-block-list"><!-- wp:list-item --><li>Original nested item</li><!-- /wp:list-item --></ul><!-- /wp:list --></li>' .
+			'<!-- /wp:list-item -->';
+
+		$parsed = parse_blocks( $markup );
+		$result = render_block( $parsed[0] );
+
+		$this->assertStringContainsString(
+			'Bound item text',
+			$result,
+			'The content binding should supply the list item rich text.'
+		);
+		$this->assertStringContainsString(
+			'Substituted nested item',
+			$result,
+			'The innerBlocks binding should supply the nested list.'
+		);
+		$this->assertStringNotContainsString(
+			'Original nested item',
+			$result,
+			'The original serialized inner blocks must not render when innerBlocks is bound.'
+		);
+		$this->assertSame(
+			1,
+			substr_count( $result, 'Substituted nested item' ),
+			'The bound inner blocks must render exactly once.'
+		);
+	}
+}


### PR DESCRIPTION
## What?

Backports the server-side portion of WordPress/gutenberg#79852 to WordPress Core.

This adds support for resolving a block's reserved `metadata.bindings.innerBlocks` binding on the server. A registered block bindings source can return serialized block markup for the `innerBlocks` key, and Core substitutes that parsed child tree before rendering the host block.

## Why?

Block bindings currently resolve scalar block attributes. The Gutenberg PR adds a generic mechanism for sources to own a block's child tree as well, which requires Core runtime support so frontend rendering matches the editor.

## How?

- Adds internal block-bindings helpers that resolve `innerBlocks` source values, rebuild `innerContent` around the host block's static chunks, and guard recursive source output.
- Hooks top-level and nested render paths so bound inner blocks are substituted before rendering.
- Adds PHPUnit coverage for substitution, absence vs empty values, context inheritance, recursion guards, top-level rendering, and `core/list-item` reconciliation with a bound `content` attribute.

## Testing

- `php -l src/wp-includes/block-bindings.php`
- `php -l tests/phpunit/tests/block-bindings/innerBlocks.php`
- `php -l tests/phpunit/tests/block-bindings/listItem.php`
- `git diff --check`

Full PHPUnit was not run locally in the temporary Core checkout because the Core local-env/Composer test dependencies were not installed there.
