### PR TITLE
Fonts: Fix font-family source in font face resolver and add tests

### DIFF
--- a/src/wp-includes/fonts/class-wp-font-face-resolver.php
+++ b/src/wp-includes/fonts/class-wp-font-face-resolver.php
@@ -87,12 +87,12 @@ class WP_Font_Face_Resolver {
 					continue;
 				}
 
-				// Skip if "fontFamily" is not defined.
-				if ( empty( $definition['fontFamily'] ) ) {
+				// Skip if "fontFamily" is not defined in the font face variation.
+				if ( empty( $definition['fontFace'][0]['fontFamily'] ) ) {
 					continue;
 				}
 
-				$font_family_name = static::maybe_parse_name_from_comma_separated_list( $definition['fontFamily'] );
+				$font_family_name = static::maybe_parse_name_from_comma_separated_list( $definition['fontFace'][0]['fontFamily'] );
 
 				// Skip if no font family is defined.
 				if ( empty( $font_family_name ) ) {

--- a/tests/phpunit/tests/fonts/font-face/wpFontFaceResolver/getFontsFromThemeJson.php
+++ b/tests/phpunit/tests/fonts/font-face/wpFontFaceResolver/getFontsFromThemeJson.php
@@ -144,6 +144,8 @@ class Tests_Fonts_WPFontFaceResolver_GetFontsFromThemeJson extends WP_Font_Face_
 	/**
 	 * @dataProvider data_should_get_font_family_name
 	 *
+	 * @ticket 59911
+	 *
 	 * @param array  $fonts         Fonts to test.
 	 * @param string $expected_name Expected font-family name.
 	 */
@@ -252,6 +254,107 @@ class Tests_Fonts_WPFontFaceResolver_GetFontsFromThemeJson extends WP_Font_Face_
 				),
 				'expected_name' => 'DM Sans',
 			),
+			'CSS variable in preset, real name in fontFace' => array(
+				'fonts'         => array(
+					array(
+						'fontFamily' => 'var(--font-primary)',
+						'name'       => 'Primary (Inter)',
+						'slug'       => 'primary',
+						'fontFace'   => array(
+							array(
+								'fontFamily' => 'Inter',
+								'fontStyle'  => 'normal',
+								'fontWeight' => '400',
+								'src'        => array(
+									'file:./assets/fonts/dm-sans/DMSans-Regular.woff2',
+								),
+							),
+						),
+					),
+				),
+				'expected_name' => 'Inter',
+			),
+			'multi-font stack in preset, single font in fontFace' => array(
+				'fonts'         => array(
+					array(
+						'fontFamily' => 'CustomEllipsisFont, DesignerFont, serif',
+						'name'       => 'DesignerFont',
+						'slug'       => 'headings',
+						'fontFace'   => array(
+							array(
+								'fontFamily' => 'DesignerFont',
+								'fontStyle'  => 'normal',
+								'fontWeight' => '400',
+								'src'        => array(
+									'file:./assets/fonts/dm-sans/DMSans-Regular.woff2',
+								),
+							),
+						),
+					),
+				),
+				'expected_name' => 'DesignerFont',
+			),
+			'preset fontFamily omitted, fontFace fontFamily defined' => array(
+				'fonts'         => array(
+					array(
+						'name'     => 'Halcom Variable',
+						'slug'     => 'halcom',
+						'fontFace' => array(
+							array(
+								'fontFamily' => 'Halcom Variable',
+								'fontStyle'  => 'normal',
+								'fontWeight' => '500 700',
+								'src'        => array(
+									'file:./assets/fonts/dm-sans/DMSans-Regular.woff2',
+								),
+							),
+						),
+					),
+				),
+				'expected_name' => 'Halcom Variable',
+			),
 		);
+	}
+
+	/**
+	 * Ensures the generated font-family does not use the preset fontFamily value.
+	 *
+	 * @ticket 59911
+	 */
+	public function test_should_not_use_preset_font_family_in_font_face() {
+		switch_theme( static::FONTS_THEME );
+
+		$replace_fonts = static function ( $theme_json_data ) {
+			$data = $theme_json_data->get_data();
+
+			$data['settings']['typography']['fontFamilies']['theme'] = array(
+				array(
+					'fontFamily' => 'var(--font-primary)',
+					'name'       => 'Primary (Inter)',
+					'slug'       => 'primary',
+					'fontFace'   => array(
+						array(
+							'fontFamily' => 'Inter',
+							'fontStyle'  => 'normal',
+							'fontWeight' => '400',
+							'src'        => array(
+								'file:./assets/fonts/dm-sans/DMSans-Regular.woff2',
+							),
+						),
+					),
+				),
+			);
+
+			return new WP_Theme_JSON_Data( $data );
+		};
+
+		add_filter( 'wp_theme_json_data_theme', $replace_fonts );
+		$fonts = WP_Font_Face_Resolver::get_fonts_from_theme_json();
+		remove_filter( 'wp_theme_json_data_theme', $replace_fonts );
+
+		$fonts = array_merge( array(), ...array_map( 'array_values', $fonts ) );
+
+		$this->assertSame( 'Inter', $fonts[0]['font-family'] );
+		$this->assertNotSame( 'var(--font-primary)', $fonts[0]['font-family'] );
 	}
 }


### PR DESCRIPTION
Use fontFace fontFamily instead of the preset fontFamily when generating @font-face rules. Adds PHPUnit coverage for CSS variable presets, multi-font stacks, and missing preset fontFamily values.

Fixes Trac ticket: https://core.trac.wordpress.org/ticket/59911.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

`WP_Font_Face_Resolver::parse_settings()` currently uses the preset `fontFamily` value when generating `@font-face` rules. This breaks valid theme.json setups where the preset value is a CSS variable or a multi-font stack, while the actual font name is declared in `fontFace[].fontFamily`.

This change uses `fontFace[0]['fontFamily']` as the source for the generated `@font-face` `font-family` value, matching the intent of the theme.json schema and the approach in https://github.com/WordPress/wordpress-develop/pull/7473.

PHPUnit tests cover:
- CSS variable presets (`var(--font-primary)` → `Inter`)
- Multi-font stacks in the preset (`CustomEllipsisFont, DesignerFont, serif` → `DesignerFont`)
- Presets without `fontFamily` but with `fontFace.fontFamily`

## Test plan

- [ ] `npm run test:php -- tests/phpunit/tests/fonts/font-face/wpFontFaceResolver/getFontsFromThemeJson.php`
- [ ] `npm run test:php -- --group fontface`
- [ ] Manual: verify `@font-face` output with a theme.json preset using `fontFamily: "var(--font-primary)"` and `fontFace.fontFamily: "Inter"`

Trac ticket: https://core.trac.wordpress.org/ticket/59911

## Use of AI Tools

AI assistance: Yes
Tool(s): Cursor
Model(s): Composer
Used for: Test case design, PR description drafting, and implementation review. The fix logic follows https://github.com/WordPress/wordpress-develop/pull/7473 by webmandesign. Final code was reviewed by the contributor.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**