### PR TITLE
Introduce bounded content-length processing for draft excerpts in `wp_dashboard_recent_drafts()`

### DIFF
--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -669,6 +669,15 @@ function wp_dashboard_recent_drafts( $drafts = false ) {
 	/* translators: Maximum number of words used in a preview of a draft on the dashboard. */
 	$draft_length = (int) _x( '10', 'draft_length' );
 
+	/**
+	 * Filters the maximum number of words used in a preview of a draft on the dashboard.
+	 *
+	 * @since 7.0.1
+	 *
+	 * @param int $draft_length Maximum number of words used in a preview.
+	 */
+	$draft_length = (int) apply_filters( 'dashboard_recent_drafts_word_length', $draft_length );
+
 	$drafts = array_slice( $drafts, 0, 3 );
 	foreach ( $drafts as $draft ) {
 		$url   = get_edit_post_link( $draft->ID );


### PR DESCRIPTION

Trac ticket: https://core.trac.wordpress.org/ticket/25616

This PR introduces the `dashboard_recent_drafts_word_length` filter to the "Recent Drafts" dashboard widget. 

Previously, the draft preview length was implicitly hardcoded to 10 words via the `_x('10', 'draft_length')` translation context. This severely limited content spacing. It also provided no intuitive way for theme/plugin developers to easily customize this layout. 

The new filter behaves similarly to the standard `excerpt_length` filter, allowing developers to cleanly and safely adjust the draft preview length for their specific site's needs.
