### PR TITLE
Site Health: Update debug mode description for development environments

### DIFF
--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -1405,7 +1405,7 @@ class WP_Site_Health {
 			),
 			'description' => sprintf(
 				'<p>%s</p>',
-				__( 'Debug mode is often enabled to gather more details about an error or site failure, but may contain sensitive information which should not be available on a publicly available website.' )
+				__( 'Debug mode is often enabled to gather more details about an error or site failure, but may contain sensitive information which should not be available on a public website.' )
 			),
 			'actions'     => sprintf(
 				'<p><a href="%s" target="_blank">%s<span class="screen-reader-text"> %s</span><span aria-hidden="true" class="dashicons dashicons-external"></span></a></p>',
@@ -1439,11 +1439,6 @@ class WP_Site_Health {
 
 				$result['status'] = 'critical';
 
-				// On development environments, set the status to recommended.
-				if ( $this->is_development_environment() ) {
-					$result['status'] = 'recommended';
-				}
-
 				$result['description'] .= sprintf(
 					'<p>%s</p>',
 					sprintf(
@@ -1453,6 +1448,24 @@ class WP_Site_Health {
 						'<code>WP_DEBUG</code>'
 					)
 				);
+
+				// On development environments, set the status to recommended, display an appropriate label, and complete the description.
+				if ( $this->is_development_environment() ) {
+					$result['label']        = __( 'Your site is set to display errors in a development environment' );
+					$result['status']       = 'recommended';
+					$result['description'] .= sprintf(
+						'<p>%s</p>',
+						__( 'Since the site is currently using the development environment, this should be fine. If these values are manually defined in the wp-config.php file, remember to disable these before the website goes live.' )
+					);
+				}
+			} elseif ( defined( 'WP_DEBUG_LOG' ) && WP_DEBUG_LOG ) {
+				if ( $this->is_development_environment() ) {
+					$result['status']       = 'recommended';
+					$result['description'] .= sprintf(
+						'<p>%s</p>',
+						__( 'Since the site is currently using the development environment, this should be fine. If these values are manually defined in the wp-config.php file, remember to disable these before the website goes live.' )
+					);
+				}
 			}
 		}
 


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->
This PR updates the get_test_is_in_debug_mode Site Health test by modifying both the label and the description; the updated text now explicitly specifies that displaying errors is the expected behavior when working in a development environment.
Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->
https://core.trac.wordpress.org/ticket/51230
## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
