### PR TITLE
#64896 Correct the documentation for the `plugin` property in the `wp_get_connectors()` array

### DIFF
--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -56,9 +56,9 @@ function wp_is_connector_registered( string $id ): bool {
  *         @type string $env_var_name    Optional. Environment variable name for the API key.
  *     }
  *     @type array  $plugin         {
- *         Optional. Plugin data for install/activate UI.
+ *         Plugin data for install/activate UI.
  *
- *         @type string   $file      The plugin's main file path relative to the plugins
+ *         @type string   $file      Optional. The plugin's main file path relative to the plugins
  *                                   directory (e.g. 'my-plugin/my-plugin.php' or 'hello.php').
  *         @type callable $is_active Callback to determine whether the plugin is active. Receives no arguments and must return bool.
  *                                   Defaults to `__return_true`.
@@ -120,9 +120,9 @@ function wp_get_connector( string $id ): ?array {
  *             @type string $env_var_name    Optional. Environment variable name for the API key.
  *         }
  *         @type array       $plugin         {
- *             Optional. Plugin data for install/activate UI.
+ *             Plugin data for install/activate UI.
  *
- *             @type string   $file      The plugin's main file path relative to the plugins
+ *             @type string   $file      Optional. The plugin's main file path relative to the plugins
  *                                       directory (e.g. 'my-plugin/my-plugin.php' or 'hello.php').
  *             @type callable $is_active Callback to determine whether the plugin is active. Receives no arguments and must return bool.
  *                                       Defaults to `__return_true`.


### PR DESCRIPTION
Follow-up to https://core.trac.wordpress.org/changeset/62332

Trac ticket: https://core.trac.wordpress.org/ticket/64896