### PR TITLE
#64898 Tighten the documented types in `WP_Hook`

### DIFF
--- a/src/wp-includes/class-wp-hook.php
+++ b/src/wp-includes/class-wp-hook.php
@@ -19,6 +19,9 @@
  *   function: callable,
  *   accepted_args: int,
  * }
+ *
+ * @phpstan-implements Iterator<int, array<string, Hook_Callback>>
+ * @phpstan-implements ArrayAccess<int, array<string, Hook_Callback>>
  */
 #[AllowDynamicProperties]
 final class WP_Hook implements Iterator, ArrayAccess {
@@ -482,7 +485,7 @@ final class WP_Hook implements Iterator, ArrayAccess {
 	 *
 	 * @link https://www.php.net/manual/en/arrayaccess.offsetexists.php
 	 *
-	 * @param mixed $offset An offset to check for.
+	 * @param int $offset An offset to check for.
 	 * @return bool True if the offset exists, false otherwise.
 	 */
 	#[ReturnTypeWillChange]
@@ -497,8 +500,8 @@ final class WP_Hook implements Iterator, ArrayAccess {
 	 *
 	 * @link https://www.php.net/manual/en/arrayaccess.offsetget.php
 	 *
-	 * @param mixed $offset The offset to retrieve.
-	 * @return mixed If set, the value at the specified offset, null otherwise.
+	 * @param int $offset The offset to retrieve.
+	 * @return array|null If set, the value at the specified offset, null otherwise.
 	 * @phpstan-return array<string, Hook_Callback>|null
 	 */
 	#[ReturnTypeWillChange]
@@ -513,8 +516,9 @@ final class WP_Hook implements Iterator, ArrayAccess {
 	 *
 	 * @link https://www.php.net/manual/en/arrayaccess.offsetset.php
 	 *
-	 * @param mixed $offset The offset to assign the value to.
-	 * @param mixed $value The value to set.
+	 * @param int|null $offset The offset to assign the value to.
+	 * @param array    $value The value to set.
+	 * @phpstan-param array<string, Hook_Callback> $value
 	 */
 	#[ReturnTypeWillChange]
 	public function offsetSet( $offset, $value ) {
@@ -534,7 +538,7 @@ final class WP_Hook implements Iterator, ArrayAccess {
 	 *
 	 * @link https://www.php.net/manual/en/arrayaccess.offsetunset.php
 	 *
-	 * @param mixed $offset The offset to unset.
+	 * @param int $offset The offset to unset.
 	 */
 	#[ReturnTypeWillChange]
 	public function offsetUnset( $offset ) {

--- a/src/wp-includes/class-wp-hook.php
+++ b/src/wp-includes/class-wp-hook.php
@@ -14,15 +14,21 @@
  *
  * @see Iterator
  * @see ArrayAccess
+ *
+ * @phpstan-type WP_Hook_Callback array{
+ *   function: callable,
+ *   accepted_args: int,
+ * }
  */
 #[AllowDynamicProperties]
 final class WP_Hook implements Iterator, ArrayAccess {
 
 	/**
-	 * Hook callbacks.
+	 * Hook callbacks keyed by priority.
 	 *
 	 * @since 4.7.0
 	 * @var array
+	 * @phpstan-var array<int, array<string, WP_Hook_Callback>>
 	 */
 	public $callbacks = array();
 
@@ -30,7 +36,7 @@ final class WP_Hook implements Iterator, ArrayAccess {
 	 * Priorities list.
 	 *
 	 * @since 6.4.0
-	 * @var array
+	 * @var list<int>
 	 */
 	protected $priorities = array();
 
@@ -38,7 +44,7 @@ final class WP_Hook implements Iterator, ArrayAccess {
 	 * The priority keys of actively running iterations of a hook.
 	 *
 	 * @since 4.7.0
-	 * @var array
+	 * @var array<int, list<int>>
 	 */
 	private $iterations = array();
 
@@ -46,7 +52,7 @@ final class WP_Hook implements Iterator, ArrayAccess {
 	 * The current priority of actively running iterations of a hook.
 	 *
 	 * @since 4.7.0
-	 * @var array
+	 * @var array<int, int>
 	 */
 	private $current_priority = array();
 
@@ -439,10 +445,11 @@ final class WP_Hook implements Iterator, ArrayAccess {
 	 * @since 4.7.0
 	 *
 	 * @param array $filters Filters to normalize. See documentation above for details.
-	 * @return WP_Hook[] Array of normalized filters.
+	 * @phpstan-param array<string, WP_Hook|array<int, array<WP_Hook_Callback>>> $filters
+	 * @return array<string, WP_Hook> Array of normalized filters keyed by hook name.
 	 */
 	public static function build_preinitialized_hooks( $filters ) {
-		/** @var WP_Hook[] $normalized */
+		/** @var array<string, WP_Hook> $normalized */
 		$normalized = array();
 
 		foreach ( $filters as $hook_name => $callback_groups ) {
@@ -492,6 +499,7 @@ final class WP_Hook implements Iterator, ArrayAccess {
 	 *
 	 * @param mixed $offset The offset to retrieve.
 	 * @return mixed If set, the value at the specified offset, null otherwise.
+	 * @phpstan-return array<string, WP_Hook_Callback>|null
 	 */
 	#[ReturnTypeWillChange]
 	public function offsetGet( $offset ) {
@@ -541,7 +549,8 @@ final class WP_Hook implements Iterator, ArrayAccess {
 	 *
 	 * @link https://www.php.net/manual/en/iterator.current.php
 	 *
-	 * @return array Of callbacks at current priority.
+	 * @return array|false Array of callbacks at current priority, false if there are no more elements.
+	 * @phpstan-return array<string, WP_Hook_Callback>|false
 	 */
 	#[ReturnTypeWillChange]
 	public function current() {
@@ -555,7 +564,8 @@ final class WP_Hook implements Iterator, ArrayAccess {
 	 *
 	 * @link https://www.php.net/manual/en/iterator.next.php
 	 *
-	 * @return array Of callbacks at next priority.
+	 * @return array|false Array of callbacks at next priority, false if there are no more elements.
+	 * @phpstan-return array<string, WP_Hook_Callback>|false
 	 */
 	#[ReturnTypeWillChange]
 	public function next() {
@@ -569,7 +579,7 @@ final class WP_Hook implements Iterator, ArrayAccess {
 	 *
 	 * @link https://www.php.net/manual/en/iterator.key.php
 	 *
-	 * @return mixed Returns current priority on success, or NULL on failure
+	 * @return int|null Returns current priority on success, or NULL on failure
 	 */
 	#[ReturnTypeWillChange]
 	public function key() {

--- a/src/wp-includes/class-wp-hook.php
+++ b/src/wp-includes/class-wp-hook.php
@@ -15,7 +15,7 @@
  * @see Iterator
  * @see ArrayAccess
  *
- * @phpstan-type WP_Hook_Callback array{
+ * @phpstan-type Hook_Callback array{
  *   function: callable,
  *   accepted_args: int,
  * }
@@ -28,7 +28,7 @@ final class WP_Hook implements Iterator, ArrayAccess {
 	 *
 	 * @since 4.7.0
 	 * @var array
-	 * @phpstan-var array<int, array<string, WP_Hook_Callback>>
+	 * @phpstan-var array<int, array<string, Hook_Callback>>
 	 */
 	public $callbacks = array();
 
@@ -445,7 +445,7 @@ final class WP_Hook implements Iterator, ArrayAccess {
 	 * @since 4.7.0
 	 *
 	 * @param array $filters Filters to normalize. See documentation above for details.
-	 * @phpstan-param array<string, WP_Hook|array<int, array<WP_Hook_Callback>>> $filters
+	 * @phpstan-param array<string, WP_Hook|array<int, array<Hook_Callback>>> $filters
 	 * @return array<string, WP_Hook> Array of normalized filters keyed by hook name.
 	 */
 	public static function build_preinitialized_hooks( $filters ) {
@@ -499,7 +499,7 @@ final class WP_Hook implements Iterator, ArrayAccess {
 	 *
 	 * @param mixed $offset The offset to retrieve.
 	 * @return mixed If set, the value at the specified offset, null otherwise.
-	 * @phpstan-return array<string, WP_Hook_Callback>|null
+	 * @phpstan-return array<string, Hook_Callback>|null
 	 */
 	#[ReturnTypeWillChange]
 	public function offsetGet( $offset ) {
@@ -550,7 +550,7 @@ final class WP_Hook implements Iterator, ArrayAccess {
 	 * @link https://www.php.net/manual/en/iterator.current.php
 	 *
 	 * @return array|false Array of callbacks at current priority, false if there are no more elements.
-	 * @phpstan-return array<string, WP_Hook_Callback>|false
+	 * @phpstan-return array<string, Hook_Callback>|false
 	 */
 	#[ReturnTypeWillChange]
 	public function current() {
@@ -565,7 +565,7 @@ final class WP_Hook implements Iterator, ArrayAccess {
 	 * @link https://www.php.net/manual/en/iterator.next.php
 	 *
 	 * @return array|false Array of callbacks at next priority, false if there are no more elements.
-	 * @phpstan-return array<string, WP_Hook_Callback>|false
+	 * @phpstan-return array<string, Hook_Callback>|false
 	 */
 	#[ReturnTypeWillChange]
 	public function next() {


### PR DESCRIPTION
This adds a `Hook_Callback` PHPStan type to represent the shape of a callback used internally in `WP_Hook` and used in return values of array access methods.

Also narrows a few other documented types.

Trac ticket: https://core.trac.wordpress.org/ticket/64898