### PR TITLE
HTTP API: Add Link preload header to internal redirects in wp_redirect

### DIFF
--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -1608,6 +1608,10 @@ if ( ! function_exists( 'wp_is_internal_url' ) ) :
 			return true;
 		}
 
+		if ( ! is_blog_installed() ) {
+			return false;
+		}
+
 		$site_url = site_url();
 
 		return substr( $url, 0, strlen( $site_url ) ) === $site_url;

--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -2445,7 +2445,7 @@ if ( ! function_exists( 'wp_new_user_notification' ) ) :
 
 		$switched_locale = switch_to_user_locale( $user_id );
 
-		$message  = __( 'To set your password, visit the following address:' ) . "\r\n\r\n";
+		$message = __( 'To set your password, visit the following address:' ) . "\r\n\r\n";
 
 		/*
 		 * Since some user login names end in a period, this could produce ambiguous URLs that

--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -1535,6 +1535,8 @@ if ( ! function_exists( 'wp_redirect' ) ) :
 			header( "X-Redirect-By: $x_redirect_by" );
 		}
 
+		wp_add_preload_header( $location );
+
 		header( "Location: $location", true, $status );
 
 		return true;
@@ -1589,6 +1591,77 @@ if ( ! function_exists( 'wp_sanitize_redirect' ) ) :
 	 */
 	function _wp_sanitize_utf8_in_redirect( $matches ) {
 		return urlencode( $matches[0] );
+	}
+endif;
+
+if ( ! function_exists( 'wp_is_internal_url' ) ) :
+	/**
+	 * Checks whether a URL is internal to the site.
+	 *
+	 * @since 6.9.0
+	 *
+	 * @param string $url The URL to check.
+	 * @return bool True if the URL is relative or matches the site URL, false otherwise.
+	 */
+	function wp_is_internal_url( $url ) {
+		if ( '/' === substr( $url, 0, 1 ) ) {
+			return true;
+		}
+
+		$site_url = site_url();
+
+		return substr( $url, 0, strlen( $site_url ) ) === $site_url;
+	}
+endif;
+
+if ( ! function_exists( 'wp_create_preload_header' ) ) :
+	/**
+	 * Creates a preload Link header string for the given URL.
+	 *
+	 * @since 6.9.0
+	 *
+	 * @param string $url  The URL to preload.
+	 * @param string $type Optional. The preload type. Default 'document'.
+	 * @return string The Link header string, or an empty string if not applicable.
+	 */
+	function wp_create_preload_header( $url, $type = 'document' ) {
+		if ( ! wp_is_internal_url( $url ) ) {
+			return '';
+		}
+
+		$parts = parse_url( $url );
+		$path  = isset( $parts['path'] ) ? $parts['path'] : '';
+
+		if ( '/' !== substr( $path, -1 ) &&
+			'.php' !== substr( $path, -4 ) &&
+			'.html' !== substr( $path, -5 ) ) {
+			return '';
+		}
+
+		$link = $path;
+		if ( isset( $parts['query'] ) ) {
+			$link .= '?' . $parts['query'];
+		}
+
+		return "Link: <{$link}>; rel=preload; as={$type}";
+	}
+endif;
+
+if ( ! function_exists( 'wp_add_preload_header' ) ) :
+	/**
+	 * Sends a preload Link header for the given URL if it is an internal URL.
+	 *
+	 * @since 6.9.0
+	 *
+	 * @param string $url  The URL to preload.
+	 * @param string $type Optional. The preload type. Default 'document'.
+	 */
+	function wp_add_preload_header( $url, $type = 'document' ) {
+		$header = wp_create_preload_header( $url, $type );
+
+		if ( $header ) {
+			header( $header, false );
+		}
 	}
 endif;
 

--- a/tests/phpunit/tests/formatting/redirect.php
+++ b/tests/phpunit/tests/formatting/redirect.php
@@ -260,4 +260,53 @@ class Tests_Formatting_Redirect extends WP_UnitTestCase {
 			),
 		);
 	}
+
+	/**
+	 * @ticket 39695
+	 *
+	 * @dataProvider data_wp_create_preload_header
+	 *
+	 * @covers ::wp_create_preload_header
+	 *
+	 * @param string $url      The URL to preload.
+	 * @param string $expected Expected header string.
+	 */
+	public function test_wp_create_preload_header( $url, $expected ) {
+		$this->assertSame( $expected, wp_create_preload_header( $url ) );
+	}
+
+	/**
+	 * Data provider for test_wp_create_preload_header().
+	 *
+	 * @return array[]
+	 */
+	public function data_wp_create_preload_header() {
+		return array(
+			'relative path ending in slash'    => array(
+				'/wp-admin/',
+				'Link: </wp-admin/>; rel=preload; as=document',
+			),
+			'relative path ending in .php'     => array(
+				'/wp-login.php',
+				'Link: </wp-login.php>; rel=preload; as=document',
+			),
+			'relative path with query string'  => array(
+				'/wp-login.php?redirect_to=%2Fwp-admin%2F&reauth=1',
+				'Link: </wp-login.php?redirect_to=%2Fwp-admin%2F&reauth=1>; rel=preload; as=document',
+			),
+			'same-site absolute URL'           => array(
+				site_url( '/wp-login.php' ),
+				'Link: </wp-login.php>; rel=preload; as=document',
+			),
+			'external URL returns empty string' => array(
+				'https://external.example.com/wp-login.php',
+				'',
+			),
+			'non-document extension returns empty string' => array(
+				'/wp-content/uploads/file.zip',
+				'',
+			),
+		);
+	}
+
 }

--- a/tests/phpunit/tests/formatting/redirect.php
+++ b/tests/phpunit/tests/formatting/redirect.php
@@ -282,23 +282,23 @@ class Tests_Formatting_Redirect extends WP_UnitTestCase {
 	 */
 	public function data_wp_create_preload_header() {
 		return array(
-			'relative path ending in slash'    => array(
+			'relative path ending in slash'               => array(
 				'/wp-admin/',
 				'Link: </wp-admin/>; rel=preload; as=document',
 			),
-			'relative path ending in .php'     => array(
+			'relative path ending in .php'                => array(
 				'/wp-login.php',
 				'Link: </wp-login.php>; rel=preload; as=document',
 			),
-			'relative path with query string'  => array(
+			'relative path with query string'             => array(
 				'/wp-login.php?redirect_to=%2Fwp-admin%2F&reauth=1',
 				'Link: </wp-login.php?redirect_to=%2Fwp-admin%2F&reauth=1>; rel=preload; as=document',
 			),
-			'same-site absolute URL'           => array(
+			'same-site absolute URL'                      => array(
 				site_url( '/wp-login.php' ),
 				'Link: </wp-login.php>; rel=preload; as=document',
 			),
-			'external URL returns empty string' => array(
+			'external URL returns empty string'           => array(
 				'https://external.example.com/wp-login.php',
 				'',
 			),
@@ -308,5 +308,4 @@ class Tests_Formatting_Redirect extends WP_UnitTestCase {
 			),
 		);
 	}
-
 }

--- a/tests/phpunit/tests/pluggable/signatures.php
+++ b/tests/phpunit/tests/pluggable/signatures.php
@@ -180,6 +180,15 @@ class Tests_Pluggable_Signatures extends WP_UnitTestCase {
 			),
 			'wp_sanitize_redirect'            => array( 'location' ),
 			'_wp_sanitize_utf8_in_redirect'   => array( 'matches' ),
+			'wp_is_internal_url'              => array( 'url' ),
+			'wp_create_preload_header'        => array(
+				'url',
+				'type' => 'document',
+			),
+			'wp_add_preload_header'           => array(
+				'url',
+				'type' => 'document',
+			),
 			'wp_safe_redirect'                => array(
 				'location',
 				'status'        => 302,


### PR DESCRIPTION

Trac ticket: [#39695](https://core.trac.wordpress.org/ticket/39695)

## Use of AI Tools

AI assistance: Yes
Tool(s): GitHub Copilot
Model(s): Gemini, Claude
Used for: Checking for potential edge cases, drafting the PR description, and assisting with local code review. The final implementation and testing were written and executed manually by me.

---

**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
