### PR TITLE
Add `old_slug_redirect_status` filter to allow customizable HTTP redirect codes

### DIFF
--- a/src/wp-includes/query.php
+++ b/src/wp-includes/query.php
@@ -1137,7 +1137,20 @@ function wp_old_slug_redirect() {
 			return;
 		}
 
-		wp_redirect( $link, 301 ); // Permanent redirect.
+		/**
+		 * Filters the old slug redirect status.
+		 *
+		 * @since 7.0.1
+		 *
+		 * @param int $status The HTTP response status code to use. Default 301.
+		 * @param int $id     The redirect post ID.
+		 */
+		$status = apply_filters( 'old_slug_redirect_status', 301, $id );
+		if ( ! $status ) {
+			return;
+		}
+
+		wp_redirect( $link, $status );
 		exit;
 	}
 }


### PR DESCRIPTION

Trac ticket: https://core.trac.wordpress.org/ticket/52737

This PR addresses Trac Ticket #52737 by introducing the `old_slug_redirect_status` filter. Previously, `wp_old_slug_redirect()` hardcoded the redirect status to `301`, preventing developers from issuing temporary redirects (302) or other custom HTTP status codes when a post's slug changes.

- Introduced the `old_slug_redirect_status` filter in `src/wp-includes/query.php`.
- Passed the `$id` (Post ID) as the second parameter to allow conditional redirects based on post properties.

Example - 
```php
// Example: Use 302 for WooCommerce products only
add_filter( 'old_slug_redirect_status', function( $status, $post_id ) {
    if ( get_post_type( $post_id ) === 'product' ) return 302;
    return $status;
}, 10, 2 );
```

- Allowed returning a falsy value to entirely abort the redirect.

