### PR TITLE
Comments: Require login to comment with a registered user's email

### DIFF
--- a/src/wp-includes/comment.php
+++ b/src/wp-includes/comment.php
@@ -3853,6 +3853,26 @@ function wp_handle_comment_submission( $comment_data ) {
 		}
 	}
 
+	/*
+	 * A logged-out visitor may not comment using the email address of a
+	 * registered user. Requiring them to log in first prevents anyone from
+	 * impersonating that user. This is checked whenever an email is provided,
+	 * regardless of the 'require_name_email' option. See #10931.
+	 */
+	if ( ! $user->exists() && is_email( $comment_author_email ) && email_exists( $comment_author_email ) ) {
+		$login_url = wp_login_url( get_permalink( $comment_post_id ) );
+
+		return new WP_Error(
+			'comment_author_must_login',
+			sprintf(
+				/* translators: %s: Login URL. */
+				__( '<strong>Error:</strong> That email address belongs to a registered user. Please <a href="%s">log in</a> to comment.' ),
+				esc_url( $login_url )
+			),
+			403
+		);
+	}
+
 	$commentdata = array(
 		'comment_post_ID' => $comment_post_id,
 	);

--- a/tests/phpunit/tests/comment/wpHandleCommentSubmission.php
+++ b/tests/phpunit/tests/comment/wpHandleCommentSubmission.php
@@ -596,6 +596,71 @@ class Tests_Comment_wpHandleCommentSubmission extends WP_UnitTestCase {
 		$this->assertSame( $error, $comment->get_error_code() );
 	}
 
+	/**
+	 * A logged-out visitor must not be able to comment using the email address
+	 * of a registered user, to prevent impersonation.
+	 *
+	 * @ticket 10931
+	 */
+	public function test_submitting_comment_anonymously_with_registered_email_returns_error() {
+
+		$registered_email = get_userdata( self::$author_id )->user_email;
+
+		$data    = array(
+			'comment_post_ID' => self::$post->ID,
+			'comment'         => 'Comment',
+			'author'          => 'Impersonator',
+			'email'           => $registered_email,
+		);
+		$comment = wp_handle_comment_submission( $data );
+
+		$this->assertWPError( $comment );
+		$this->assertSame( 'comment_author_must_login', $comment->get_error_code() );
+		$this->assertSame( 403, $comment->get_error_data() );
+	}
+
+	/**
+	 * A logged-out visitor may still comment with an email that is not tied to
+	 * a registered user.
+	 *
+	 * @ticket 10931
+	 */
+	public function test_submitting_comment_anonymously_with_unregistered_email_succeeds() {
+
+		$data    = array(
+			'comment_post_ID' => self::$post->ID,
+			'comment'         => 'Comment',
+			'author'          => 'Comment Author',
+			'email'           => 'not-a-registered-user@example.org',
+		);
+		$comment = wp_handle_comment_submission( $data );
+
+		$this->assertNotWPError( $comment );
+		$this->assertInstanceOf( 'WP_Comment', $comment );
+		$this->assertSame( 'not-a-registered-user@example.org', $comment->comment_author_email );
+	}
+
+	/**
+	 * The registered-email check only targets logged-out visitors; a logged-in
+	 * user commenting under their own (registered) email must still succeed.
+	 *
+	 * @ticket 10931
+	 */
+	public function test_submitting_comment_as_logged_in_user_with_registered_email_succeeds() {
+
+		wp_set_current_user( self::$author_id );
+
+		$data    = array(
+			'comment_post_ID' => self::$post->ID,
+			'comment'         => 'Comment',
+		);
+		$comment = wp_handle_comment_submission( $data );
+
+		$this->assertNotWPError( $comment );
+		$this->assertInstanceOf( 'WP_Comment', $comment );
+		$this->assertSame( self::$author_id, (int) $comment->user_id );
+	}
+
 	public function test_submitting_comment_with_no_comment_content_returns_error() {
 
 		$error = 'require_valid_comment';


### PR DESCRIPTION
## Summary

When a logged-out visitor submits a comment using the email address of a registered user, this blocks the comment and prompts them to log in, preventing anonymous visitors from impersonating registered users.

The check is added to `wp_handle_comment_submission()`, alongside the existing name/email validation, and returns a `WP_Error` (`comment_author_must_login`, HTTP 403) whose message contains a login link that redirects back to the post after authenticating.

## Relationship to PR #8443

This is an **alternative implementation** of [PR #8443](https://github.com/WordPress/wordpress-develop/pull/8443) by @Infinite-Null, opened separately so as not to step on that contributor's work. The design goal (force login, per [comment:72](https://core.trac.wordpress.org/ticket/10931#comment:72) / [comment:73](https://core.trac.wordpress.org/ticket/10931#comment:73)) is the same; the differences are:

- **Returns a `WP_Error` instead of calling `wp_die()`.** The message is surfaced on the comment form (keeping the visitor on the page with a login link) rather than replacing the request with a 403 page.
- **Placed in `wp_handle_comment_submission()`** next to the sibling name/email checks, rather than in `wp_check_comment_data()` (which is documented to *return* an approval status, not halt the request).
- **Unit testable**, so test coverage is included (PR #8443 had its tests removed because the `wp_die()` approach could not be cleanly tested).

## Tests

`tests/phpunit/tests/comment/wpHandleCommentSubmission.php`:

- `test_submitting_comment_anonymously_with_registered_email_returns_error` — logged-out + registered email → `WP_Error` (`comment_author_must_login`, 403).
- `test_submitting_comment_anonymously_with_unregistered_email_succeeds` — logged-out + unregistered email → comment succeeds (guards against false positives).
- `test_submitting_comment_as_logged_in_user_with_registered_email_succeeds` — logged-in user commenting under their own registered email still succeeds (the check only targets logged-out visitors).

All 47 tests in the class pass; PHPCS is clean on the changed lines.

## Open question (design)

The error message states the address belongs to a registered user, which — as @johnbillion noted in [comment:56](https://core.trac.wordpress.org/ticket/10931#comment:56) — is an email-enumeration signal (though the same information is already discoverable via `wp-login.php`). This can be softened if preferred. Whether force-login is the agreed direction (vs. routing to the moderation queue) is still open on the ticket.

Trac ticket: https://core.trac.wordpress.org/ticket/10931