### PR TITLE
Coding Standards: Use `array_first()/array_last()` to get the first/last array element.

### DIFF
--- a/src/wp-includes/l10n.php
+++ b/src/wp-includes/l10n.php
@@ -1270,7 +1270,7 @@ function _load_script_textdomain_from_src( string $handle, string $src, string $
 		 */
 
 		$theme_dir = array_last( explode( '/', $theme_root ) );
-		$dirname   = $theme_dir[0] === $relative[0] ? 'themes' : 'plugins';
+		$dirname   = $theme_dir === $relative[0] ? 'themes' : 'plugins';
 
 		$languages_path = WP_LANG_DIR . '/' . $dirname;
 

--- a/src/wp-includes/l10n.php
+++ b/src/wp-includes/l10n.php
@@ -1269,7 +1269,7 @@ function _load_script_textdomain_from_src( string $handle, string $src, string $
 		 * See https://core.trac.wordpress.org/ticket/60891 and https://core.trac.wordpress.org/ticket/62016.
 		 */
 
-		$theme_dir = array_slice( explode( '/', $theme_root ), -1 );
+		$theme_dir = array_last( explode( '/', $theme_root ) );
 		$dirname   = $theme_dir[0] === $relative[0] ? 'themes' : 'plugins';
 
 		$languages_path = WP_LANG_DIR . '/' . $dirname;

--- a/tests/phpunit/tests/abilities-api/wpGetAbilities.php
+++ b/tests/phpunit/tests/abilities-api/wpGetAbilities.php
@@ -573,13 +573,13 @@ class Tests_Abilities_API_WpGetAbilities extends WP_UnitTestCase {
 		$result = wp_get_abilities(
 			array(
 				'namespace'       => 'test',
-				'result_callback' => static function ( array $abilities ): array {
+				'result_callback' => static function ( array $abilities ) {
 					return array_first( $abilities );
 				},
 			)
 		);
 
-		$this->assertCount( 1, $result );
+		$this->assertNotEmpty( $result );
 	}
 
 	// -------------------------------------------------------------------------
@@ -597,7 +597,7 @@ class Tests_Abilities_API_WpGetAbilities extends WP_UnitTestCase {
 		$this->register_test_ability( 'test/ability-one' );
 		$this->register_test_ability( 'test/ability-two' );
 
-		$filter = static function ( array $abilities ): array {
+		$filter = static function ( array $abilities ) {
 			return array_first( $abilities );
 		};
 
@@ -605,7 +605,7 @@ class Tests_Abilities_API_WpGetAbilities extends WP_UnitTestCase {
 		$result = wp_get_abilities( array( 'namespace' => 'test' ) );
 		remove_filter( 'wp_get_abilities_result', $filter );
 
-		$this->assertCount( 1, $result );
+		$this->assertNotEmpty( $result );
 	}
 
 	/**

--- a/tests/phpunit/tests/abilities-api/wpGetAbilities.php
+++ b/tests/phpunit/tests/abilities-api/wpGetAbilities.php
@@ -574,7 +574,7 @@ class Tests_Abilities_API_WpGetAbilities extends WP_UnitTestCase {
 			array(
 				'namespace'       => 'test',
 				'result_callback' => static function ( array $abilities ): array {
-					return array_slice( $abilities, 0, 1 );
+					return array_first( $abilities );
 				},
 			)
 		);
@@ -598,7 +598,7 @@ class Tests_Abilities_API_WpGetAbilities extends WP_UnitTestCase {
 		$this->register_test_ability( 'test/ability-two' );
 
 		$filter = static function ( array $abilities ): array {
-			return array_slice( $abilities, 0, 1 );
+			return array_first( $abilities );
 		};
 
 		add_filter( 'wp_get_abilities_result', $filter );

--- a/tests/phpunit/tests/feed/atom.php
+++ b/tests/phpunit/tests/feed/atom.php
@@ -281,16 +281,14 @@ class Tests_Feed_Atom extends WP_UnitTestCase {
 
 		$this->assertNotEmpty( $entries );
 
-		foreach ( $entries as $key => $entry ) {
-			$links = xml_find( $entries[ $key ]['child'], 'link' );
-			$i     = 0;
-			foreach ( (array) $links as $link ) {
-				if ( 'enclosure' === $link['attributes']['rel'] ) {
-					$this->assertSame( $enclosures[ $i ]['expected']['href'], $link['attributes']['href'] );
-					$this->assertEquals( $enclosures[ $i ]['expected']['length'], $link['attributes']['length'] );
-					$this->assertSame( $enclosures[ $i ]['expected']['type'], $link['attributes']['type'] );
-					++$i;
-				}
+		$links = xml_find( $entries['child'], 'link' );
+		$i     = 0;
+		foreach ( (array) $links as $link ) {
+			if ( 'enclosure' === $link['attributes']['rel'] ) {
+				$this->assertSame( $enclosures[ $i ]['expected']['href'], $link['attributes']['href'] );
+				$this->assertEquals( $enclosures[ $i ]['expected']['length'], $link['attributes']['length'] );
+				$this->assertSame( $enclosures[ $i ]['expected']['type'], $link['attributes']['type'] );
+				++$i;
 			}
 		}
 	}

--- a/tests/phpunit/tests/feed/atom.php
+++ b/tests/phpunit/tests/feed/atom.php
@@ -277,7 +277,7 @@ class Tests_Feed_Atom extends WP_UnitTestCase {
 		$feed    = $this->do_atom();
 		$xml     = xml_to_array( $feed );
 		$entries = xml_find( $xml, 'feed', 'entry' );
-		$entries = array_slice( $entries, 0, 1 );
+		$entries = array_first( $entries );
 
 		$this->assertNotEmpty( $entries );
 

--- a/tests/phpunit/tests/rest-api/rest-posts-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-posts-controller.php
@@ -1592,7 +1592,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$this->assertCount( 0, $response->get_data() );
 
 		$this->assertCount( 1, $this->posts_clauses );
-		$this->posts_clauses = array_slice( $this->posts_clauses, 0, 1 );
+		$this->posts_clauses = array_first( $this->posts_clauses );
 
 		$this->assertPostsWhere( " AND {posts}.ID IN (0) AND {posts}.post_type = 'post' AND (({posts}.post_status = 'publish'))" );
 
@@ -1623,7 +1623,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$this->assertCount( 0, $response->get_data() );
 
 		$this->assertCount( 1, $this->posts_clauses );
-		$this->posts_clauses = array_slice( $this->posts_clauses, 0, 1 );
+		$this->posts_clauses = array_first( $this->posts_clauses );
 
 		$this->assertPostsWhere( " AND {posts}.ID IN (0) AND {posts}.post_type = 'post' AND (({posts}.post_status = 'publish'))" );
 	}
@@ -1641,7 +1641,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$this->assertCount( 0, $response->get_data() );
 
 		$this->assertCount( 1, $this->posts_clauses );
-		$this->posts_clauses = array_slice( $this->posts_clauses, 0, 1 );
+		$this->posts_clauses = array_first( $this->posts_clauses );
 
 		$this->assertPostsWhere( " AND {posts}.ID IN (0) AND {posts}.post_type = 'post' AND (({posts}.post_status = 'publish'))" );
 	}

--- a/tests/phpunit/tests/rest-api/rest-posts-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-posts-controller.php
@@ -1592,7 +1592,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$this->assertCount( 0, $response->get_data() );
 
 		$this->assertCount( 1, $this->posts_clauses );
-		$this->posts_clauses = array_first( $this->posts_clauses );
+		$this->posts_clauses = array_slice( $this->posts_clauses, 0, 1 );
 
 		$this->assertPostsWhere( " AND {posts}.ID IN (0) AND {posts}.post_type = 'post' AND (({posts}.post_status = 'publish'))" );
 
@@ -1623,7 +1623,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$this->assertCount( 0, $response->get_data() );
 
 		$this->assertCount( 1, $this->posts_clauses );
-		$this->posts_clauses = array_first( $this->posts_clauses );
+		$this->posts_clauses = array_slice( $this->posts_clauses, 0, 1 );
 
 		$this->assertPostsWhere( " AND {posts}.ID IN (0) AND {posts}.post_type = 'post' AND (({posts}.post_status = 'publish'))" );
 	}
@@ -1641,7 +1641,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$this->assertCount( 0, $response->get_data() );
 
 		$this->assertCount( 1, $this->posts_clauses );
-		$this->posts_clauses = array_first( $this->posts_clauses );
+		$this->posts_clauses = array_slice( $this->posts_clauses, 0, 1 );
 
 		$this->assertPostsWhere( " AND {posts}.ID IN (0) AND {posts}.post_type = 'post' AND (({posts}.post_status = 'publish'))" );
 	}


### PR DESCRIPTION

Trac link: https://core.trac.wordpress.org/ticket/65598


Replace array_values( ... )[0] and array_slice( ..., 0, 1 )[0] constructs with the array_first() function (added in PHP 8.5, polyfilled in compat.php) for improved readability.