### PR TITLE
Block Supports: Ensure that custom CSS is output after the block library styles.

### DIFF
--- a/src/wp-includes/block-supports/custom-css.php
+++ b/src/wp-includes/block-supports/custom-css.php
@@ -68,9 +68,9 @@ function wp_render_custom_css_support_styles( $parsed_block ) {
 	$processed_css = WP_Theme_JSON::process_blocks_custom_css( $custom_css, $selector );
 
 	if ( ! empty( $processed_css ) ) {
-		/*
+		/**
 		 * Reuse one handle so identical custom CSS is enqueued only once via
-		 * wp_unique_id_from_values(). Explicitly declare the `wp-block-library`
+		 * {@see wp_unique_id_from_values()}. Explicitly declare the `wp-block-library`
 		 * dependency so `global-styles` is guaranteed to print after it, preventing
 		 * block default styles from unintentionally overriding global styles.
 		 */

--- a/src/wp-includes/block-supports/custom-css.php
+++ b/src/wp-includes/block-supports/custom-css.php
@@ -68,15 +68,15 @@ function wp_render_custom_css_support_styles( $parsed_block ) {
 	$processed_css = WP_Theme_JSON::process_blocks_custom_css( $custom_css, $selector );
 
 	if ( ! empty( $processed_css ) ) {
-		/**
-		 * Skip CSS that has already been added. Blocks with identical attributes
-		 * share the same class name and processed CSS via {@see wp_unique_id_from_values()},
-		 * so the same style would otherwise be enqueued more than once (e.g. inside
-		 * a Query Loop or when blocks share identical custom CSS).
+		/*
+		 * Reuse one handle so identical custom CSS is enqueued only once via
+		 * wp_unique_id_from_values(). Explicitly declare the `wp-block-library`
+		 * dependency so `global-styles` is guaranteed to print after it, preventing
+		 * block default styles from unintentionally overriding global styles.
 		 */
 		$handle = 'wp-block-custom-css';
 		if ( ! wp_style_is( $handle, 'registered' ) ) {
-			wp_register_style( $handle, false, array( 'global-styles' ) );
+			wp_register_style( $handle, false, array( 'wp-block-library', 'global-styles' ) );
 		}
 		$after_styles = wp_styles()->get_data( $handle, 'after' );
 		if ( ! is_array( $after_styles ) ) {


### PR DESCRIPTION
Ports https://github.com/WordPress/gutenberg/pull/80062.

Trac ticket: https://core.trac.wordpress.org/ticket/65602

## Use of AI Tools

I had the AI implement the code, and then I reviewed it myself.