### PR TITLE
Abilities API: Add `public` meta flag to control ability exposure defaults

### DIFF
--- a/src/wp-includes/abilities-api.php
+++ b/src/wp-includes/abilities-api.php
@@ -264,9 +264,13 @@ declare( strict_types = 1 );
  *             @type bool|null $idempotent  Optional. If true, calling the ability repeatedly with the same arguments
  *                                          will have no additional effect on its environment.
  *         }
+ *         @type bool                     $public       Optional. Whether the ability is intended to be publicly
+ *                                                      available to clients. When true, channel-specific exposure
+ *                                                      flags such as `$show_in_rest` default to true. An explicitly
+ *                                                      set channel flag always takes precedence.
  *         @type bool                     $show_in_rest Optional. Whether to expose this ability in the REST API.
  *                                                      When true, the ability can be invoked via HTTP requests.
- *                                                      Default false.
+ *                                                      Default is the value of `$public` when set, false otherwise.
  *     }
  *     @type string               $ability_class       Optional. Fully-qualified custom class name to instantiate
  *                                                     instead of the default `WP_Ability` class. The custom class

--- a/src/wp-includes/abilities-api/class-wp-abilities-registry.php
+++ b/src/wp-includes/abilities-api/class-wp-abilities-registry.php
@@ -71,7 +71,12 @@ final class WP_Abilities_Registry {
 	 *             @type bool|null $idempotent  Optional. If true, calling the ability repeatedly with the same arguments
 	 *                                          will have no additional effect on its environment.
 	 *         }
-	 *         @type bool                     $show_in_rest Optional. Whether to expose this ability in the REST API. Default false.
+	 *         @type bool                     $public       Optional. Whether the ability is intended to be publicly
+	 *                                                      available to clients. When true, channel-specific exposure
+	 *                                                      flags such as `$show_in_rest` default to true. An explicitly
+	 *                                                      set channel flag always takes precedence.
+	 *         @type bool                     $show_in_rest Optional. Whether to expose this ability in the REST API.
+	 *                                                      Default is the value of `$public` when set, false otherwise.
 	 *     }
 	 *     @type string               $ability_class         Optional. Custom class to instantiate instead of WP_Ability.
 	 * }
@@ -120,7 +125,11 @@ final class WP_Abilities_Registry {
 		 *         Optional. Additional metadata for the ability.
 		 *
 		 *         @type array<string, bool|string> $annotations  Optional. Annotation metadata for the ability.
-		 *         @type bool                       $show_in_rest Optional. Whether to expose this ability in the REST API. Default false.
+		 *         @type bool                       $public       Optional. Whether the ability is intended to be
+		 *                                                        publicly available to clients. Seeds the default for
+		 *                                                        channel-specific exposure flags like `$show_in_rest`.
+		 *         @type bool                       $show_in_rest Optional. Whether to expose this ability in the REST API.
+		 *                                                        Default is the value of `$public` when set, false otherwise.
 		 *     }
 		 *     @type string               $ability_class         Optional. Custom class to instantiate instead of WP_Ability.
 		 * }

--- a/src/wp-includes/abilities-api/class-wp-ability.php
+++ b/src/wp-includes/abilities-api/class-wp-ability.php
@@ -160,7 +160,12 @@ class WP_Ability {
 	 *             @type bool|null $idempotent  Optional. If true, calling the ability repeatedly with the same arguments
 	 *                                          will have no additional effect on its environment.
 	 *         }
-	 *         @type bool                     $show_in_rest Optional. Whether to expose this ability in the REST API. Default false.
+	 *         @type bool                     $public       Optional. Whether the ability is intended to be publicly
+	 *                                                      available to clients. When true, channel-specific exposure
+	 *                                                      flags such as `$show_in_rest` default to true. An explicitly
+	 *                                                      set channel flag always takes precedence.
+	 *         @type bool                     $show_in_rest Optional. Whether to expose this ability in the REST API.
+	 *                                                      Default is the value of `$public` when set, false otherwise.
 	 *     }
 	 * }
 	 */
@@ -224,7 +229,12 @@ class WP_Ability {
 	 *             @type bool|null $idempotent  Optional. If true, calling the ability repeatedly with the same arguments
 	 *                                          will have no additional effect on its environment.
 	 *         }
-	 *         @type bool                     $show_in_rest Optional. Whether to expose this ability in the REST API. Default false.
+	 *         @type bool                     $public       Optional. Whether the ability is intended to be publicly
+	 *                                                      available to clients. When true, channel-specific exposure
+	 *                                                      flags such as `$show_in_rest` default to true. An explicitly
+	 *                                                      set channel flag always takes precedence.
+	 *         @type bool                     $show_in_rest Optional. Whether to expose this ability in the REST API.
+	 *                                                      Default is the value of `$public` when set, false otherwise.
 	 *     }
 	 * }
 	 * @return array<string, mixed> {
@@ -252,7 +262,9 @@ class WP_Ability {
 	 *             @type bool|null $idempotent  If true, calling the ability repeatedly with the same arguments
 	 *                                          will have no additional effect on its environment.
 	 *         }
-	 *         @type bool                     $show_in_rest Whether to expose this ability in the REST API. Default false.
+	 *         @type bool                     $public       Whether the ability is intended to be publicly available
+	 *                                                      to clients. Only present when provided during registration.
+	 *         @type bool                     $show_in_rest Whether to expose this ability in the REST API.
 	 *     }
 	 * }
 	 * @throws InvalidArgumentException if an argument is invalid.
@@ -322,14 +334,27 @@ class WP_Ability {
 			);
 		}
 
+		if ( isset( $args['meta']['public'] ) && ! is_bool( $args['meta']['public'] ) ) {
+			throw new InvalidArgumentException(
+				__( 'The ability meta should provide a valid `public` boolean.' )
+			);
+		}
+
 		// Set defaults for optional meta.
-		$args['meta']                = wp_parse_args(
+		$args['meta'] = wp_parse_args(
 			$args['meta'] ?? array(),
 			array(
-				'annotations'  => static::$default_annotations,
-				'show_in_rest' => self::DEFAULT_SHOW_IN_REST,
+				'annotations' => static::$default_annotations,
 			)
 		);
+
+		/*
+		 * Resolve `show_in_rest` from most specific to least specific: an explicit
+		 * `show_in_rest` value wins, then the high-level `public` flag seeds the
+		 * default, then the built-in default applies.
+		 */
+		$args['meta']['show_in_rest'] = $args['meta']['show_in_rest'] ?? $args['meta']['public'] ?? self::DEFAULT_SHOW_IN_REST;
+
 		$args['meta']['annotations'] = wp_parse_args(
 			$args['meta']['annotations'],
 			static::$default_annotations

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-abilities-v1-list-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-abilities-v1-list-controller.php
@@ -312,6 +312,10 @@ class WP_REST_Abilities_V1_List_Controller extends WP_REST_Controller {
 							),
 							'additionalProperties' => true,
 						),
+						'public'      => array(
+							'description' => __( 'Whether the ability author intends the ability to be publicly available to clients. Only present when set by the ability author.' ),
+							'type'        => 'boolean',
+						),
 					),
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,

--- a/tests/phpunit/tests/abilities-api/wpAbilitiesRegistry.php
+++ b/tests/phpunit/tests/abilities-api/wpAbilitiesRegistry.php
@@ -358,7 +358,6 @@ class Tests_Abilities_API_WpAbilitiesRegistry extends WP_UnitTestCase {
 		$this->assertNull( $result );
 	}
 
-
 	/**
 	 * Should reject ability registration with invalid `annotations` type.
 	 *
@@ -405,6 +404,23 @@ class Tests_Abilities_API_WpAbilitiesRegistry extends WP_UnitTestCase {
 	 */
 	public function test_register_invalid_show_in_rest_type() {
 		self::$test_ability_args['meta']['show_in_rest'] = 5;
+
+		$result = $this->registry->register( self::$test_ability_name, self::$test_ability_args );
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * Should reject ability registration with invalid public type.
+	 *
+	 * @ticket 65568
+	 *
+	 * @covers WP_Abilities_Registry::register
+	 * @covers WP_Ability::prepare_properties
+	 *
+	 * @expectedIncorrectUsage WP_Abilities_Registry::register
+	 */
+	public function test_register_invalid_public_type() {
+		self::$test_ability_args['meta']['public'] = 5;
 
 		$result = $this->registry->register( self::$test_ability_name, self::$test_ability_args );
 		$this->assertNull( $result );

--- a/tests/phpunit/tests/abilities-api/wpAbility.php
+++ b/tests/phpunit/tests/abilities-api/wpAbility.php
@@ -263,6 +263,95 @@ class Tests_Abilities_API_WpAbility extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that `public` metadata seeds `show_in_rest` to true when it is not set explicitly.
+	 *
+	 * @ticket 65568
+	 */
+	public function test_meta_public_true_defaults_show_in_rest_to_true() {
+		$args    = array_merge(
+			self::$test_ability_properties,
+			array(
+				'meta' => array(
+					'public' => true,
+				),
+			)
+		);
+		$ability = new WP_Ability( self::$test_ability_name, $args );
+
+		$this->assertTrue(
+			$ability->get_meta_item( 'show_in_rest' ),
+			'`show_in_rest` metadata should default to the `public` value.'
+		);
+		$this->assertTrue(
+			$ability->get_meta_item( 'public' ),
+			'`public` metadata should be stored as provided.'
+		);
+	}
+
+	/**
+	 * Tests that an explicit `show_in_rest` value of false wins over `public` set to true.
+	 *
+	 * @ticket 65568
+	 */
+	public function test_meta_explicit_show_in_rest_false_wins_over_public_true() {
+		$args    = array_merge(
+			self::$test_ability_properties,
+			array(
+				'meta' => array(
+					'public'       => true,
+					'show_in_rest' => false,
+				),
+			)
+		);
+		$ability = new WP_Ability( self::$test_ability_name, $args );
+
+		$this->assertFalse(
+			$ability->get_meta_item( 'show_in_rest' ),
+			'An explicit `show_in_rest` value of false should win over `public` set to true.'
+		);
+	}
+
+	/**
+	 * Tests that `public` metadata is not added to the stored meta when not provided.
+	 *
+	 * @ticket 65568
+	 */
+	public function test_meta_public_is_not_defaulted_when_unset() {
+		$ability = new WP_Ability( self::$test_ability_name, self::$test_ability_properties );
+
+		$this->assertArrayNotHasKey(
+			'public',
+			$ability->get_meta(),
+			'`public` metadata should only be present when provided during registration.'
+		);
+		$this->assertFalse(
+			$ability->get_meta_item( 'show_in_rest' ),
+			'`show_in_rest` metadata should still default to false.'
+		);
+	}
+
+	/**
+	 * Tests that invalid `public` value throws an exception.
+	 *
+	 * @ticket 65568
+	 */
+	public function test_meta_public_throws_exception_for_non_boolean() {
+		$args = array_merge(
+			self::$test_ability_properties,
+			array(
+				'meta' => array(
+					'public' => 5,
+				),
+			)
+		);
+
+		$this->expectException( InvalidArgumentException::class );
+		$this->expectExceptionMessage( 'The ability meta should provide a valid `public` boolean.' );
+
+		new WP_Ability( self::$test_ability_name, $args );
+	}
+
+	/**
 	 * Data provider for testing the execution of the ability.
 	 *
 	 * @return array<string, array{0: array, 1: callable, 2: mixed, 3: mixed}> Data sets with different configurations.

--- a/tests/phpunit/tests/rest-api/wpRestAbilitiesV1ListController.php
+++ b/tests/phpunit/tests/rest-api/wpRestAbilitiesV1ListController.php
@@ -415,6 +415,66 @@ class Tests_REST_API_WpRestAbilitiesV1ListController extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that an ability with only the `public` meta flag is exposed in REST.
+	 *
+	 * @ticket 65568
+	 */
+	public function test_get_item_public_meta_exposes_in_rest(): void {
+		$this->register_test_ability(
+			'test/public-ability',
+			array(
+				'label'               => 'Public Ability',
+				'description'         => 'Exposed in REST via the public meta flag.',
+				'category'            => 'general',
+				'execute_callback'    => '__return_true',
+				'permission_callback' => '__return_true',
+				'meta'                => array(
+					'public' => true,
+				),
+			)
+		);
+
+		$request  = new WP_REST_Request( 'GET', '/wp-abilities/v1/abilities/test/public-ability' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertTrue( $data['meta']['public'] );
+		$this->assertTrue( $data['meta']['show_in_rest'] );
+	}
+
+	/**
+	 * Test that an explicit `show_in_rest` value of false hides an ability even when `public` is true.
+	 *
+	 * @ticket 65568
+	 */
+	public function test_get_item_public_true_show_in_rest_false_is_hidden(): void {
+		$this->register_test_ability(
+			'test/public-optout',
+			array(
+				'label'               => 'Public Opt-out',
+				'description'         => 'Opts out of REST exposure despite the public meta flag.',
+				'category'            => 'general',
+				'execute_callback'    => '__return_true',
+				'permission_callback' => '__return_true',
+				'meta'                => array(
+					'public'       => true,
+					'show_in_rest' => false,
+				),
+			)
+		);
+
+		$request  = new WP_REST_Request( 'GET', '/wp-abilities/v1/abilities/test/public-optout' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 404, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertSame( 'rest_ability_not_found', $data['code'] );
+	}
+
+	/**
 	 * Test permission check for listing abilities.
 	 *
 	 * @ticket 64098
@@ -620,6 +680,22 @@ class Tests_REST_API_WpRestAbilitiesV1ListController extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'output_schema', $properties );
 		$this->assertArrayHasKey( 'meta', $properties );
 		$this->assertArrayHasKey( 'category', $properties );
+	}
+
+	/**
+	 * Test that the item schema declares the `public` meta property.
+	 *
+	 * @ticket 65568
+	 */
+	public function test_get_schema_meta_declares_public(): void {
+		$request  = new WP_REST_Request( 'OPTIONS', '/wp-abilities/v1/abilities' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$meta_properties = $data['schema']['properties']['meta']['properties'];
+
+		$this->assertArrayHasKey( 'public', $meta_properties );
+		$this->assertSame( 'boolean', $meta_properties['public']['type'] );
 	}
 
 	/**

--- a/tests/phpunit/tests/rest-api/wpRestAbilitiesV1RunController.php
+++ b/tests/phpunit/tests/rest-api/wpRestAbilitiesV1RunController.php
@@ -651,6 +651,35 @@ class Tests_REST_API_WpRestAbilitiesV1RunController extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test running an ability exposed in REST via the `public` meta flag.
+	 *
+	 * @ticket 65568
+	 */
+	public function test_run_public_meta_ability_is_executable(): void {
+		$this->register_test_ability(
+			'test/public-ability',
+			array(
+				'label'               => 'Public Ability',
+				'description'         => 'Exposed in REST via the public meta flag.',
+				'category'            => 'general',
+				'execute_callback'    => '__return_true',
+				'permission_callback' => '__return_true',
+				'meta'                => array(
+					'public' => true,
+				),
+			)
+		);
+
+		$request = new WP_REST_Request( 'POST', '/wp-abilities/v1/abilities/test/public-ability/run' );
+		$request->set_header( 'Content-Type', 'application/json' );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertTrue( $response->get_data() );
+	}
+
+	/**
 	 * Test handling of null is a valid return value.
 	 *
 	 * @ticket 64098


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

Introduce a `public` flag in ability metadata as a single high-level control over client exposure. When set, `public` seeds the default for `show_in_rest` via null coalescing:
`show_in_rest = meta'show_in_rest' ?? meta'public' ?? false`

An explicit `show_in_rest: false` always wins over `public: true`, preserving per-channel opt-out. The `public` key stays in stored metadata so other channels (MCP, AI agents) can read it via the `wp_register_ability_args` filter.

**Testing:**  `npm run test:php -- --group abilities-api --filter 'public'`

Trac ticket: https://core.trac.wordpress.org/ticket/65568

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
