### PR TITLE
Add Automed Tests to enforce `-src` on the wp-version.

### DIFF
--- a/tests/phpunit/tests/basic.php
+++ b/tests/phpunit/tests/basic.php
@@ -136,4 +136,47 @@ class Tests_Basic extends WP_UnitTestCase {
 
 		$this->assertSame( $version, $composer_json['version'], "composer.json's version needs to be updated to $version." );
 	}
+
+	/**
+	 * Test the src wp_version always ends with '-src'.
+	 *
+	 * @coversNothing
+	 */
+	public function test_src_wp_version_ends_with_src() {
+		$version_file = dirname( ABSPATH ) . '/src/wp-includes/version.php';
+
+		$src_wp_version = $this->get_wp_version_from_file( $version_file );
+
+		$this->assertStringEndsWith( '-src', $src_wp_version, 'The src wp_version must end with -src.' );
+	}
+
+	/**
+	 * Test the build wp_version never ends with '-src'.
+	 *
+	 * @coversNothing
+	 */
+	public function test_build_wp_version_does_not_end_with_src() {
+		$version_file = dirname( ABSPATH ) . '/build/wp-includes/version.php';
+
+		if ( ! file_exists( $version_file ) ) {
+			$this->markTestSkipped( 'The build directory does not exist.' );
+		}
+
+		$build_wp_version = $this->get_wp_version_from_file( $version_file );
+
+		$this->assertStringEndsNotWith( '-src', $build_wp_version, 'The build wp_version must not end with -src.' );
+	}
+
+	/**
+	 * Includes a version.php file in an isolated scope and returns its $wp_version.
+	 *
+	 * @param string $file Path to a version.php file.
+	 * @return string The value of $wp_version defined in the file.
+	 */
+	private function get_wp_version_from_file( $file ) {
+		$wp_version = '';
+		include $file;
+
+		return $wp_version;
+	}
 }


### PR DESCRIPTION
Follow-up to: r62676, r62677.

Trac Ticket: https://core.trac.wordpress.org/ticket/64894

AI assistance: Yes
Tool(s): Claude Code
Model(s): Sonnet 5
Used for: Initial code skeleton, final implementation was reviewed and modified by me