### PR TITLE
Code Quality: Add PHPStan types for `wp_insert_term()`, `wp_update_term()`, and `wp_delete_term()`

### DIFF
--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -2634,6 +2634,7 @@ function wp_insert_term( $term, $taxonomy, $args = array() ) {
 		do_action( 'edited_terms', $term_id, $taxonomy );
 	}
 
+	/** @var numeric-string|null $tt_id */
 	$tt_id = $wpdb->get_var( $wpdb->prepare( "SELECT tt.term_taxonomy_id FROM $wpdb->term_taxonomy AS tt INNER JOIN $wpdb->terms AS t ON tt.term_id = t.term_id WHERE tt.taxonomy = %s AND t.term_id = %d", $taxonomy, $term_id ) );
 
 	if ( ! empty( $tt_id ) ) {

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -3242,7 +3242,7 @@ function wp_unique_term_slug( $slug, $term ) {
  * }
  * @return array|WP_Error An array containing the `term_id` and `term_taxonomy_id`,
  *                        WP_Error otherwise.
- * @phpstan-param string|array{
+ * @phpstan-param array{
  *     alias_of?: string,
  *     description?: string,
  *     parent?: non-negative-int,

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -2048,6 +2048,10 @@ function wp_delete_object_term_relationships( $object_id, $taxonomies ) {
  * @return bool|int|WP_Error True on success, false if term does not exist. Zero on attempted
  *                           deletion of default Category. WP_Error if the taxonomy does not exist.
  * @phpstan-param non-empty-string $taxonomy
+ * @phpstan-param string|array{
+ *     default?: int|numeric-string,
+ *     force_default?: bool,
+ * } $args
  * @phpstan-return bool|WP_Error|0
  */
 function wp_delete_term( $term, $taxonomy, $args = array() ) {

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -2049,7 +2049,7 @@ function wp_delete_object_term_relationships( $object_id, $taxonomies ) {
  *                           deletion of default Category. WP_Error if the taxonomy does not exist.
  * @phpstan-param non-empty-string $taxonomy
  * @phpstan-param string|array{
- *     default?: int|numeric-string,
+ *     default?: positive-int,
  *     force_default?: bool,
  * } $args
  * @phpstan-return bool|WP_Error|0
@@ -2446,7 +2446,7 @@ function wp_get_object_terms( $object_ids, $taxonomies, $args = array() ) {
  * @phpstan-param string|array{
  *     alias_of?: string,
  *     description?: string|null,
- *     parent?: int|numeric-string,
+ *     parent?: non-negative-int,
  *     slug?: string|null,
  *     ...
  * } $args

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -2443,7 +2443,7 @@ function wp_get_object_terms( $object_ids, $taxonomies, $args = array() ) {
  *     alias_of?: string,
  *     description?: string|null,
  *     parent?: int|numeric-string,
- *     slug?: string,
+ *     slug?: string|null,
  *     ...
  * } $args
  * @phpstan-return array{

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -3247,7 +3247,7 @@ function wp_unique_term_slug( $slug, $term ) {
  *     alias_of?: string,
  *     description?: string,
  *     parent?: non-negative-int,
- *     slug?: string,
+ *     slug?: string|null,
  *     ...
  * } $args
  * @phpstan-return array{

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -2441,8 +2441,8 @@ function wp_get_object_terms( $object_ids, $taxonomies, $args = array() ) {
  * }
  * @phpstan-param string|array{
  *     alias_of?: string,
- *     description?: string,
- *     parent?: non-negative-int,
+ *     description?: string|null,
+ *     parent?: int|numeric-string,
  *     slug?: string,
  *     ...
  * } $args

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -3246,7 +3246,7 @@ function wp_unique_term_slug( $slug, $term ) {
  * @phpstan-param array{
  *     alias_of?: string,
  *     description?: string,
- *     parent?: int|numeric-string,
+ *     parent?: non-negative-int,
  *     slug?: string|null,
  *     ...
  * } $args

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -3246,7 +3246,7 @@ function wp_unique_term_slug( $slug, $term ) {
  * @phpstan-param array{
  *     alias_of?: string,
  *     description?: string,
- *     parent?: non-negative-int,
+ *     parent?: int|numeric-string,
  *     slug?: string|null,
  *     ...
  * } $args

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -2437,6 +2437,16 @@ function wp_get_object_terms( $object_ids, $taxonomies, $args = array() ) {
  *     @type int        $term_id          The new term ID.
  *     @type int|string $term_taxonomy_id The new term taxonomy ID. Can be a numeric string.
  * }
+ * @phpstan-param string|array{
+ *     alias_of?: string,
+ *     description?: string,
+ *     parent?: non-negative-int,
+ *     slug?: string,
+ * } $args
+ * @phpstan-return array{
+ *     term_id: int,
+ *     term_taxonomy_id: int|numeric-string,
+ * }|WP_Error
  */
 function wp_insert_term( $term, $taxonomy, $args = array() ) {
 	global $wpdb;
@@ -3218,7 +3228,7 @@ function wp_unique_term_slug( $slug, $term ) {
  *
  * @param int          $term_id  The ID of the term.
  * @param string       $taxonomy The taxonomy of the term.
- * @param array        $args {
+ * @param array|string $args {
  *     Optional. Array of arguments for updating a term.
  *
  *     @type string $alias_of    Slug of the term to make this term an alias of.
@@ -3229,6 +3239,16 @@ function wp_unique_term_slug( $slug, $term ) {
  * }
  * @return array|WP_Error An array containing the `term_id` and `term_taxonomy_id`,
  *                        WP_Error otherwise.
+ * @phpstan-param string|array{
+ *     alias_of?: string,
+ *     description?: string,
+ *     parent?: non-negative-int,
+ *     slug?: string,
+ * } $args
+ * @phpstan-return array{
+ *     term_id: int,
+ *     term_taxonomy_id: int,
+ * }|WP_Error
  */
 function wp_update_term( $term_id, $taxonomy, $args = array() ) {
 	global $wpdb;

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -2047,6 +2047,8 @@ function wp_delete_object_term_relationships( $object_id, $taxonomies ) {
  * }
  * @return bool|int|WP_Error True on success, false if term does not exist. Zero on attempted
  *                           deletion of default Category. WP_Error if the taxonomy does not exist.
+ * @phpstan-param non-empty-string $taxonomy
+ * @phpstan-return bool|WP_Error|0
  */
 function wp_delete_term( $term, $taxonomy, $args = array() ) {
 	global $wpdb;

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -3232,7 +3232,7 @@ function wp_unique_term_slug( $slug, $term ) {
  *
  * @param int          $term_id  The ID of the term.
  * @param string       $taxonomy The taxonomy of the term.
- * @param array|string $args {
+ * @param array        $args {
  *     Optional. Array of arguments for updating a term.
  *
  *     @type string $alias_of    Slug of the term to make this term an alias of.

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -2444,6 +2444,7 @@ function wp_get_object_terms( $object_ids, $taxonomies, $args = array() ) {
  *     description?: string,
  *     parent?: non-negative-int,
  *     slug?: string,
+ *     ...
  * } $args
  * @phpstan-return array{
  *     term_id: int,
@@ -3247,6 +3248,7 @@ function wp_unique_term_slug( $slug, $term ) {
  *     description?: string,
  *     parent?: non-negative-int,
  *     slug?: string,
+ *     ...
  * } $args
  * @phpstan-return array{
  *     term_id: int,


### PR DESCRIPTION
✅  Committed in r62682 (0527680ee2fbe6a66affc26807e3ed4602f3397b)

----

Adds PHPStan array shapes and narrowed parameter/return types to `wp_insert_term()`, `wp_update_term()`, and `wp_delete_term()` in `src/wp-includes/taxonomy.php`. This removes the `missingType.iterableValue` errors reported for each function's `$args` parameter and return type at PHPStan level 10.

The types describe the contract these functions are *intended* to be called with, rather than what unguarded callers happen to pass today. Notably:

<!--- **`wp_update_term()`'s `@phpstan-param` omits the `string` alternative** that `wp_insert_term()` and `wp_delete_term()` have. Those two pass `$args` through `wp_parse_args()` before touching it, so a query string is accepted; `wp_update_term()` instead runs `array_merge( $term, $args )` first, which would raise a `TypeError` on a string. Its `@param` has always documented `array` alone, and the new shape matches that.-->
- **`parent` is typed `non-negative-int`.** `sanitize_term_field()` puts `parent` in `$int_fields` and silently clamps a negative value to `0`, reparenting the term to the root. A `numeric-string` alternative would be redundant: for `wp_insert_term()` a query string matches the `string` branch of the union, so the array shape only ever constrains callers passing an actual array, where an `int` is what should be supplied; and `wp_update_term()` has no `string` branch at all.
- **`wp_delete_term()`'s `default` is typed `positive-int`**, since `0` is discarded by the subsequent `term_exists()` check.
- **The `$args` shapes for `wp_insert_term()` and `wp_update_term()` are unsealed** (`...`), because `$args` is forwarded to the `pre_insert_term`, `wp_insert_term_data`, `wp_insert_term_duplicate_term_check`, `create_term`, `wp_update_term_data`, and `edit_term` hooks, where plugins legitimately read arbitrary keys. `wp_delete_term()`'s shape is sealed, as its `$args` is consumed locally and never passed to a hook.
- **`description` is `string|null` for `wp_insert_term()` but `string` for `wp_update_term()`.** This asymmetry is deliberate: `wp_insert_term()` explicitly coerces a null description (`// Coerce null description to strings, to avoid database errors.`), while `wp_update_term()` has no such coercion.
- `wp_delete_term()`'s return is narrowed to `bool|WP_Error|0`, verified against all six return paths. This relies on the `term_exists()` conditional return type added in r62680.

These annotations surface new `argument.type` errors at several core call sites that pass `$_POST` or otherwise unvalidated data directly into these functions (`wp-admin/edit-tags.php`, `wp-admin/includes/ajax-actions.php`, `wp-includes/nav-menu.php`, `class-wp-rest-terms-controller.php`, `class-wp-xmlrpc-server.php`). These are pre-existing latent issues that the types now make visible, and are left to be addressed separately.

The two `term_id: mixed` return errors that remain inside `wp_insert_term()` and `wp_update_term()` stem from `apply_filters()` being typed as returning `mixed`, and are addressed in a separate pull request. See https://github.com/WordPress/wordpress-develop/pull/12022.

Trac ticket: https://core.trac.wordpress.org/ticket/64898

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 4.8
Used for: Reviewing the annotations against the function bodies and every core call site by diffing PHPStan level 10 output before and after; identifying that `wp_update_term()` cannot accept a query string, the null `description`/`slug` values, the unsealed-shape requirement, and the redundant `numeric-string` alternatives; and authoring the final `non-negative-int`/`positive-int` narrowings. All changes were reviewed, tested, and are owned by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
