### PR TITLE
Rewrite: Escape feed names in generate_rewrite_rules() to prevent regex breakage

### DIFF
--- a/src/wp-includes/class-wp-rewrite.php
+++ b/src/wp-includes/class-wp-rewrite.php
@@ -874,8 +874,8 @@ class WP_Rewrite {
 	public function generate_rewrite_rules( $permalink_structure, $ep_mask = EP_NONE, $paged = true, $feed = true, $forcomments = false, $walk_dirs = true, $endpoints = true ) {
 		// Build a regex to match the feed section of URLs, something like (feed|atom|rss|rss2)/?
 		$feedregex2 = array();
-		foreach ( $this->feeds as $feed ) {
-			$feedregex2[] = preg_quote( $feed, '#' );
+		foreach ( $this->feeds as $feed_name ) {
+			$feedregex2[] = preg_quote( $feed_name, '#' );
 		}
 		$feedregex2 = '(' . implode( '|', $feedregex2 ) . ')/?$';
 

--- a/src/wp-includes/class-wp-rewrite.php
+++ b/src/wp-includes/class-wp-rewrite.php
@@ -873,11 +873,11 @@ class WP_Rewrite {
 	 */
 	public function generate_rewrite_rules( $permalink_structure, $ep_mask = EP_NONE, $paged = true, $feed = true, $forcomments = false, $walk_dirs = true, $endpoints = true ) {
 		// Build a regex to match the feed section of URLs, something like (feed|atom|rss|rss2)/?
-		$feedregex2 = '';
-		foreach ( (array) $this->feeds as $feed_name ) {
-			$feedregex2 .= $feed_name . '|';
+		$feedregex2 = array();
+		foreach ( $this->feeds as $feed ) {
+			$feedregex2[] = preg_quote( $feed, '#' );
 		}
-		$feedregex2 = '(' . trim( $feedregex2, '|' ) . ')/?$';
+		$feedregex2 = '(' . implode( '|', $feedregex2 ) . ')/?$';
 
 		/*
 		 * $feedregex is identical but with /feed/ added on as well, so URLs like <permalink>/feed/atom

--- a/tests/phpunit/tests/rewrite/addFeed.php
+++ b/tests/phpunit/tests/rewrite/addFeed.php
@@ -41,6 +41,13 @@ class Tests_Rewrite_AddFeed extends WP_UnitTestCase {
 		foreach ( array_keys( $rules ) as $pattern ) {
 			if ( str_contains( $pattern, $expected_pattern ) ) {
 				$found = true;
+
+				// Confirm the full rewrite rule pattern is a syntactically valid regex.
+				$this->assertNotFalse(
+					preg_match( '#' . $pattern . '#', '' ),
+					sprintf( 'The rewrite rule pattern "%s" is not a valid regular expression.', $pattern )
+				);
+
 				break;
 			}
 		}
@@ -50,8 +57,9 @@ class Tests_Rewrite_AddFeed extends WP_UnitTestCase {
 
 	public function data_add_feed_is_escaped_in_rules() {
 		return array(
-			array( 'test[json]', 'test\[json\]' ),
-			array( 'json', 'json' ),
+			'plain name'          => array( 'json', 'json' ),
+			'character class'     => array( 'test[json]', 'test\[json\]' ),
+			'quantifier chars'    => array( 'test???', 'test\?\?\?' ),
 		);
 	}
 }

--- a/tests/phpunit/tests/rewrite/addFeed.php
+++ b/tests/phpunit/tests/rewrite/addFeed.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * @group rewrite
+ *
+ * @covers ::add_feed
+ */
+class Tests_Rewrite_AddFeed extends WP_UnitTestCase {
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->set_permalink_structure( '/%postname%/' );
+	}
+
+	public function tear_down() {
+		global $wp_rewrite;
+		$wp_rewrite->init();
+		parent::tear_down();
+	}
+
+	/**
+	 * Tests that a feed name is properly escaped in the generated rewrite rules regex pattern.
+	 *
+	 * @ticket 43571
+	 *
+	 * @dataProvider data_add_feed_is_escaped_in_rules
+	 *
+	 * @param string $feed_name        The feed name to add.
+	 * @param string $expected_pattern The expected escaped pattern.
+	 */
+	public function test_add_feed_is_escaped_in_rules( $feed_name, $expected_pattern ) {
+		global $wp_rewrite;
+
+		add_feed( $feed_name, '__return_false' );
+		flush_rewrite_rules();
+
+		$rules = $wp_rewrite->rewrite_rules();
+
+		$found = false;
+		foreach ( array_keys( $rules ) as $pattern ) {
+			if ( str_contains( $pattern, $expected_pattern ) ) {
+				$found = true;
+				break;
+			}
+		}
+
+		$this->assertTrue( $found, 'Expected to find a rewrite rule with the feed name properly escaped.' );
+	}
+
+	public function data_add_feed_is_escaped_in_rules() {
+		return array(
+			array( 'test[json]', 'test\[json\]' ),
+			array( 'json', 'json' ),
+		);
+	}
+}


### PR DESCRIPTION
Trac ticket: [#43571](https://core.trac.wordpress.org/ticket/43571)

## Use of AI Tools

AI assistance: Yes
Tool(s): GitHub Copilot
Model(s): Gemini, Claude
Used for: Checking for potential edge cases, drafting the PR description, and assisting with local code review. The final implementation and testing were written and executed manually by me.

---

**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
