### PR TITLE
Admin bar: correctly preview changes to site title and icon

### DIFF
--- a/src/js/_enqueues/admin/site-icon.js
+++ b/src/js/_enqueues/admin/site-icon.js
@@ -14,6 +14,8 @@
 		$appIconPreview = $( '#app-icon-preview' ),
 		$hiddenDataField = $( '#site_icon_hidden_field' ),
 		$removeButton = $( '#js-remove-site-icon' ),
+		$adminBarSiteName = $( '#wp-admin-bar-site-name' ),
+		$adminBarSiteNameLink = $adminBarSiteName.children( 'a' ).first(),
 		frame;
 
 	/**
@@ -194,6 +196,19 @@
 			'url(' + attributes.url + ')'
 		);
 
+		// Replace the site icon in the admin bar.
+		$adminBarSiteNameLink.children( 'img.site-icon' ).remove();
+		$( '<img />' )
+			.attr( {
+				class: 'site-icon',
+				src: attributes.url,
+				alt: '',
+				width: 20,
+				height: 20,
+			} )
+			.prependTo( $adminBarSiteNameLink );
+		$adminBarSiteName.addClass( 'has-site-icon' );
+
 		// If the choose button is not in the update state, swap the classes.
 		if ( $chooseButton.attr( 'data-state' ) !== '1' ) {
 			$chooseButton.attr( {
@@ -224,6 +239,10 @@
 			src: '',
 			alt: '',
 		} );
+
+		// Remove the site icon from the admin bar.
+		$adminBarSiteNameLink.children( 'img.site-icon' ).remove();
+		$adminBarSiteName.removeClass( 'has-site-icon' );
 
 		/**
 		 * Resets state to the button, for correct visual style and state.

--- a/src/wp-admin/includes/options.php
+++ b/src/wp-admin/includes/options.php
@@ -40,14 +40,15 @@ function options_general_add_js() {
 			homeURL = ( <?php echo wp_json_encode( get_home_url(), JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ); ?> || '' ).replace( /^(https?:\/\/)?(www\.)?/, '' );
 
 		$( '#blogname' ).on( 'input', function() {
-			var title = $.trim( $( this ).val() ) || homeURL;
+			var title = $.trim( $( this ).val() ) || homeURL,
+				$siteIcon = $siteName.children();
 
 			// Truncate to 40 characters.
 			if ( 40 < title.length ) {
 				title = title.substring( 0, 40 ) + '\u2026';
 			}
 
-			$siteName.text( title );
+			$siteName.text( title ).prepend( $siteIcon );
 			$siteIconPreview.text( title );
 		});
 


### PR DESCRIPTION

Trac ticket: https://core.trac.wordpress.org/ticket/65606

A follow-up to https://github.com/WordPress/wordpress-develop/pull/11781. This PR improves the site title/icon update logic in Settings -> General, when the form is not saved yet.

Previously, only site title is live-previewed (but removes site icon accidentally; see the video in the linked Trac ticket). This PR fixes that, and also live-preview the site icon changes, so that addition/change/removal to the site icon is also live-previewed in the admin bar.

See the following video:

https://github.com/user-attachments/assets/7383ed8f-0803-44c4-9459-418675cebb66

## Testing Instructions

1. Go to Settings -> General
2. Try to update site title, or add / change / remove site icon. Verify that the change is immediately live-previewed in the admin bar,

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Opus 4.8
Used for: code generation and brainstorming


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
