### PR TITLE
Theme: Harden process_blocks_custom_css() against non-string input.

### DIFF
--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -2055,7 +2055,7 @@ class WP_Theme_JSON {
 		if ( ! is_string( $css ) ) {
 			_doing_it_wrong(
 				__METHOD__,
-			    __( 'The $css parameter must be a string.' ),
+				__( 'The $css parameter must be a string.' ),
 				'7.1.0'
 			);
 

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -2055,7 +2055,7 @@ class WP_Theme_JSON {
 		if ( ! is_string( $css ) ) {
 			_doing_it_wrong(
 				__METHOD__,
-				__( 'The $css parameter must be a string.' ),
+				__( 'The CSS parameter must be a string.' ),
 				'7.1.0'
 			);
 

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -2048,7 +2048,7 @@ class WP_Theme_JSON {
 	public static function process_blocks_custom_css( $css, $selector ) {
 		$processed_css = '';
 
-		if ( empty( $css ) ) {
+		if ( empty( $css ) || ! is_string( $css ) ) {
 			return $processed_css;
 		}
 

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -2048,7 +2048,17 @@ class WP_Theme_JSON {
 	public static function process_blocks_custom_css( $css, $selector ) {
 		$processed_css = '';
 
-		if ( empty( $css ) || ! is_string( $css ) ) {
+		if ( empty( $css ) ) {
+			return $processed_css;
+		}
+
+		if ( ! is_string( $css ) ) {
+			_doing_it_wrong(
+				__METHOD__,
+			    __( 'The $css parameter must be a string.' ),
+				'7.1.0'
+			);
+
 			return $processed_css;
 		}
 

--- a/tests/phpunit/tests/theme/wpThemeJson.php
+++ b/tests/phpunit/tests/theme/wpThemeJson.php
@@ -7108,6 +7108,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 	/**
 	 * @ticket 61165
 	 * @ticket 61769
+	 * @ticket 65608
 	 *
 	 * @dataProvider data_process_blocks_custom_css
 	 *
@@ -7181,6 +7182,56 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 					'css'      => 'color: red; margin: auto; &.one{color: blue;} & .two{color: green;} &::before{color: yellow;} & ::before{color: purple;}  &.three::before{color: orange;} & .four::before{color: skyblue;}',
 				),
 				'expected' => ':root :where(.foo, .bar){color: red; margin: auto;}:root :where(.foo.one, .bar.one){color: blue;}:root :where(.foo .two, .bar .two){color: green;}:root :where(.foo, .bar)::before{color: yellow;}:root :where(.foo, .bar) ::before{color: purple;}:root :where(.foo.three, .bar.three)::before{color: orange;}:root :where(.foo .four, .bar .four)::before{color: skyblue;}',
+			),
+			// Non-string CSS input should be handled gracefully.
+			'null css'                     => array(
+				'input'    => array(
+					'selector' => '.foo',
+					'css'      => null,
+				),
+				'expected' => '',
+			),
+			'false css'                    => array(
+				'input'    => array(
+					'selector' => '.foo',
+					'css'      => false,
+				),
+				'expected' => '',
+			),
+			'true css'                     => array(
+				'input'    => array(
+					'selector' => '.foo',
+					'css'      => true,
+				),
+				'expected' => '',
+			),
+			'integer css'                  => array(
+				'input'    => array(
+					'selector' => '.foo',
+					'css'      => 123,
+				),
+				'expected' => '',
+			),
+			'float css'                    => array(
+				'input'    => array(
+					'selector' => '.foo',
+					'css'      => 1.5,
+				),
+				'expected' => '',
+			),
+			'array css'                    => array(
+				'input'    => array(
+					'selector' => '.foo',
+					'css'      => array( 'color: red;' ),
+				),
+				'expected' => '',
+			),
+			'object css'                   => array(
+				'input'    => array(
+					'selector' => '.foo',
+					'css'      => new stdClass(),
+				),
+				'expected' => '',
 			),
 		);
 	}

--- a/tests/phpunit/tests/theme/wpThemeJson.php
+++ b/tests/phpunit/tests/theme/wpThemeJson.php
@@ -7183,7 +7183,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 				),
 				'expected' => ':root :where(.foo, .bar){color: red; margin: auto;}:root :where(.foo.one, .bar.one){color: blue;}:root :where(.foo .two, .bar .two){color: green;}:root :where(.foo, .bar)::before{color: yellow;}:root :where(.foo, .bar) ::before{color: purple;}:root :where(.foo.three, .bar.three)::before{color: orange;}:root :where(.foo .four, .bar .four)::before{color: skyblue;}',
 			),
-			// Non-string CSS input should be handled gracefully.
+			// Falsy non-string CSS is handled silently by the empty() check.
 			'null css'                     => array(
 				'input'    => array(
 					'selector' => '.foo',
@@ -7198,41 +7198,45 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 				),
 				'expected' => '',
 			),
-			'true css'                     => array(
-				'input'    => array(
-					'selector' => '.foo',
-					'css'      => true,
-				),
-				'expected' => '',
-			),
-			'integer css'                  => array(
-				'input'    => array(
-					'selector' => '.foo',
-					'css'      => 123,
-				),
-				'expected' => '',
-			),
-			'float css'                    => array(
-				'input'    => array(
-					'selector' => '.foo',
-					'css'      => 1.5,
-				),
-				'expected' => '',
-			),
-			'array css'                    => array(
-				'input'    => array(
-					'selector' => '.foo',
-					'css'      => array( 'color: red;' ),
-				),
-				'expected' => '',
-			),
-			'object css'                   => array(
-				'input'    => array(
-					'selector' => '.foo',
-					'css'      => new stdClass(),
-				),
-				'expected' => '',
-			),
+		);
+	}
+
+	/**
+	 * @ticket 65608
+	 *
+	 * @dataProvider data_process_blocks_custom_css_non_string
+	 *
+	 * @param mixed $css A non-string, non-empty CSS value.
+	 */
+	public function test_process_blocks_custom_css_triggers_doing_it_wrong_for_non_string( $css ) {
+		$this->setExpectedIncorrectUsage( 'WP_Theme_JSON::process_blocks_custom_css' );
+
+		$theme_json = new WP_Theme_JSON(
+			array(
+				'version' => WP_Theme_JSON::LATEST_SCHEMA,
+				'styles'  => array(),
+			)
+		);
+		$reflection = new ReflectionMethod( $theme_json, 'process_blocks_custom_css' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$reflection->setAccessible( true );
+		}
+
+		$this->assertSame( '', $reflection->invoke( $theme_json, $css, '.foo' ) );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_process_blocks_custom_css_non_string() {
+		return array(
+			'true'    => array( true ),
+			'integer' => array( 123 ),
+			'float'   => array( 1.5 ),
+			'array'   => array( array( 'color: red;' ) ),
+			'object'  => array( new stdClass() ),
 		);
 	}
 

--- a/tests/phpunit/tests/theme/wpThemeJson.php
+++ b/tests/phpunit/tests/theme/wpThemeJson.php
@@ -7211,18 +7211,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 	public function test_process_blocks_custom_css_triggers_doing_it_wrong_for_non_string( $css ) {
 		$this->setExpectedIncorrectUsage( 'WP_Theme_JSON::process_blocks_custom_css' );
 
-		$theme_json = new WP_Theme_JSON(
-			array(
-				'version' => WP_Theme_JSON::LATEST_SCHEMA,
-				'styles'  => array(),
-			)
-		);
-		$reflection = new ReflectionMethod( $theme_json, 'process_blocks_custom_css' );
-		if ( PHP_VERSION_ID < 80100 ) {
-			$reflection->setAccessible( true );
-		}
-
-		$this->assertSame( '', $reflection->invoke( $theme_json, $css, '.foo' ) );
+		$this->assertSame( '', WP_Theme_JSON::process_blocks_custom_css( $css, '.foo' ) );
 	}
 
 	/**


### PR DESCRIPTION
Return early when `$css` is not a string, alongside the existing `empty()` check, preventing errors when a non-string value (e.g. `null`, array) is passed to `WP_Theme_JSON::process_blocks_custom_css()`.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

## Proposed changes
* Adds an `! is_string()` guard to `WP_Theme_JSON::process_blocks_custom_css()`, so the method returns an empty string when passed a non-string `$css` value instead of attempting to process it.
* Prevents PHP warnings/fatal `TypeError`s that would otherwise occur when a non-string value (e.g. an integer, an array) reaches the string functions (`explode()`, `str_contains()`, etc.) further down the method.


## Why are these changes being made?
The existing `empty( $css )` check only short-circuits falsey values. A non-empty, non-string value (e.g. an array) passed as `$css` would still fall through to `explode( '&', $css )` and trigger a `TypeError` on PHP 8+. Guarding for `! is_string()` hardens the method against unexpected input from any caller and keeps it returning a predictable empty string. This data can come from a filter, and the method was also made public in 7.0.0 for the `custom-css block` support, so it's worth ensuring it degrades gracefully rather than fatalling on malformed input.

Trac ticket: https://core.trac.wordpress.org/ticket/65608

## Use of AI Tools
AI assistance: Yes
Tool(s): Claude Code
Model(s): Opus 4.8
Used for: Test case suggestions; implementation written by me, tests cases reviewed by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
