### PR TITLE
Script Loader: Keep admin jQuery blocking

### DIFF
--- a/src/wp-includes/class-wp-scripts.php
+++ b/src/wp-includes/class-wp-scripts.php
@@ -314,7 +314,10 @@ class WP_Scripts extends WP_Dependencies {
 		$strategy          = $this->get_eligible_loading_strategy( $handle );
 		$intended_strategy = (string) $this->get_data( $handle, 'strategy' );
 
-		if ( ! $this->is_delayed_strategy( $intended_strategy ) ) {
+		if (
+			! $this->is_delayed_strategy( $intended_strategy ) ||
+			! $this->is_delayed_strategy_allowed( $handle )
+		) {
 			$intended_strategy = '';
 		}
 
@@ -1022,6 +1025,24 @@ JS;
 	}
 
 	/**
+	 * Checks whether a delayed loading strategy is allowed for a script.
+	 *
+	 * @since 6.9.0
+	 *
+	 * @param string $handle The script handle.
+	 * @return bool True if a delayed strategy is allowed, otherwise false.
+	 */
+	private function is_delayed_strategy_allowed( string $handle ): bool {
+		$jquery_handles = array( 'jquery', 'jquery-core', 'jquery-migrate' );
+
+		if ( ! in_array( $handle, $jquery_handles, true ) ) {
+			return true;
+		}
+
+		return ! is_admin() && ! is_customize_preview();
+	}
+
+	/**
 	 * Checks if the provided fetchpriority is valid.
 	 *
 	 * @since 6.9.0
@@ -1045,7 +1066,7 @@ JS;
 		$intended_strategy = (string) $this->get_data( $handle, 'strategy' );
 
 		// Bail early if there is no intended strategy.
-		if ( ! $intended_strategy ) {
+		if ( ! $intended_strategy || ! $this->is_delayed_strategy_allowed( $handle ) ) {
 			return '';
 		}
 

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -1070,6 +1070,31 @@ HTML
 HTML
 				,
 			),
+			'jquery-deferred-in-admin'                     => array(
+				'set_up'          => function () {
+					set_current_screen( 'dashboard' );
+
+					$wp_scripts = wp_scripts();
+					wp_default_scripts( $wp_scripts );
+					foreach ( $wp_scripts->registered['jquery']->deps as $jquery_dep ) {
+						$wp_scripts->registered[ $jquery_dep ]->add_data( 'strategy', 'defer' );
+						$wp_scripts->registered[ $jquery_dep ]->ver = null; // Just to avoid markup changes in the test when jQuery is upgraded.
+					}
+					wp_enqueue_script(
+						'admin-functions',
+						'https://example.com/admin-functions.js',
+						array( 'jquery' ),
+						null,
+						array( 'strategy' => 'defer' )
+					);
+				},
+				'expected_markup' => <<<HTML
+<script src='http://$wp_tests_domain/wp-includes/js/jquery/jquery.js' id='jquery-core-js'></script>
+<script src='http://$wp_tests_domain/wp-includes/js/jquery/jquery-migrate.js' id='jquery-migrate-js'></script>
+<script src='https://example.com/admin-functions.js' id='admin-functions-js' defer data-wp-strategy='defer'></script>
+HTML
+				,
+			),
 			'nested-aliases'                               => array(
 				'set_up'          => function () {
 					$outer_alias_handle = 'outer-bundle-of-two';


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

## Summary
- keep delayed loading strategies from applying to core jQuery handles in admin and Customizer preview contexts
- preserve existing frontend behavior for deferred jQuery strategy requests
- add dependency-chain coverage for admin jQuery staying parser-blocking while a dependent script can still use defer

## Testing
- php -l src/wp-includes/class-wp-scripts.php
- php -l tests/phpunit/tests/dependencies/scripts.php
- php ./vendor/squizlabs/php_codesniffer/bin/phpcbf --standard=phpcs.xml.dist --cache=C:\Users\arkop\wordpress-develop\.cache\phpcs.json src/wp-includes/class-wp-scripts.php tests/phpunit/tests/dependencies/scripts.php
- php ./vendor/squizlabs/php_codesniffer/bin/phpcs --standard=phpcs.xml.dist --report=summary,source --cache=C:\Users\arkop\wordpress-develop\.cache\phpcs.json src/wp-includes/class-wp-scripts.php tests/phpunit/tests/dependencies/scripts.php
- git diff --check

Trac ticket: https://core.trac.wordpress.org/ticket/45130

## Use of AI Tools

AI assistance: Yes
Tool(s): OpenAI Codex
Model(s): GPT-5
Used for: Reviewing the Trac ticket and relevant code, helping with the initial implementation and regression-test approach, and assisting with validation and PR-description drafting. The final implementation, tests, validation results, and description were reviewed and accepted by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**