### PR TITLE
Posts, Post Types: Improve static analysis types for post retrieval functions

### DIFF
--- a/src/wp-includes/class-wp-post.php
+++ b/src/wp-includes/class-wp-post.php
@@ -388,9 +388,11 @@ final class WP_Post {
 	 * @since 3.5.0
 	 *
 	 * @return array<string, mixed> Object as array.
+	 *
+	 * @phpstan-return non-empty-array<string, mixed>
 	 */
 	public function to_array() {
-		/** @var array<string, mixed> $post */
+		/** @var non-empty-array<string, mixed> $post */
 		$post = get_object_vars( $this );
 
 		foreach ( array( 'ancestors', 'page_template', 'post_category', 'tags_input' ) as $key ) {

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -990,8 +990,8 @@ function _wp_relative_upload_path( $path ) {
  * @phpstan-param 'OBJECT'|'ARRAY_A'|'ARRAY_N' $output
  * @phpstan-return (
  *     $args is array{ fields: 'ids', ... } ? int[] : (
- *         $output is 'ARRAY_A' ? array<int, array<string, mixed>> : (
- *             $output is 'ARRAY_N' ? array<int, array<int, mixed>> : WP_Post[]
+ *         $output is 'ARRAY_A' ? array<int, non-empty-array<string, mixed>> : (
+ *             $output is 'ARRAY_N' ? array<int, non-empty-array<int, mixed>> : WP_Post[]
  *         )
  *     )
  * )
@@ -1040,13 +1040,17 @@ function get_children( $args = '', $output = OBJECT ) {
 	} elseif ( ARRAY_A === $output ) {
 		$weeuns = array();
 		foreach ( (array) $kids as $kid ) {
-			$weeuns[ $kid->ID ] = get_object_vars( $kids[ $kid->ID ] );
+			/** @var non-empty-array<string, mixed> $vars */
+			$vars               = get_object_vars( $kids[ $kid->ID ] );
+			$weeuns[ $kid->ID ] = $vars;
 		}
 		return $weeuns;
 	} elseif ( ARRAY_N === $output ) {
 		$babes = array();
 		foreach ( (array) $kids as $kid ) {
-			$babes[ $kid->ID ] = array_values( get_object_vars( $kids[ $kid->ID ] ) );
+			/** @var non-empty-array<string, mixed> $vars */
+			$vars              = get_object_vars( $kids[ $kid->ID ] );
+			$babes[ $kid->ID ] = array_values( $vars );
 		}
 		return $babes;
 	} else {
@@ -1124,8 +1128,8 @@ function get_extended( $post ) {
  * @phpstan-param 'OBJECT'|'ARRAY_A'|'ARRAY_N' $output
  * @phpstan-param 'raw'|'edit'|'db'|'display' $filter
  * @phpstan-return (
- *     $output is 'ARRAY_A' ? array<string, mixed>|null : (
- *         $output is 'ARRAY_N' ? array<int, mixed>|null : (
+ *     $output is 'ARRAY_A' ? non-empty-array<string, mixed>|null : (
+ *         $output is 'ARRAY_N' ? non-empty-array<int, mixed>|null : (
  *             WP_Post|null
  *         )
  *     )
@@ -4452,7 +4456,7 @@ function wp_get_post_terms( $post_id = 0, $taxonomy = 'post_tag', $args = array(
  *
  * @phpstan-param 'OBJECT'|'ARRAY_A' $output
  * @phpstan-return (
- *     $output is 'ARRAY_A' ? array<int, array<string, mixed>> : WP_Post[]|false
+ *     $output is 'ARRAY_A' ? array<int, non-empty-array<string, mixed>> : WP_Post[]|false
  * )
  */
 function wp_get_recent_posts( $args = array(), $output = ARRAY_A ) {
@@ -4485,12 +4489,13 @@ function wp_get_recent_posts( $args = array(), $output = ARRAY_A ) {
 
 	// Backward compatibility. Prior to 3.1 expected posts to be returned in array.
 	if ( ARRAY_A === $output ) {
+		$posts = array();
 		foreach ( $results as $key => $result ) {
-			/** @var array<string, mixed> $object_vars */
-			$object_vars     = get_object_vars( $result );
-			$results[ $key ] = $object_vars;
+			/** @var non-empty-array<string, mixed> $object_vars */
+			$object_vars   = get_object_vars( $result );
+			$posts[ $key ] = $object_vars;
 		}
-		return $results ? $results : array();
+		return $posts;
 	}
 
 	return $results ? $results : false;
@@ -6146,6 +6151,10 @@ function trackback_url_list( $tb_list, $post_id ) {
 		// Get post data.
 		$postdata = get_post( $post_id, ARRAY_A );
 
+		if ( ! $postdata ) {
+			return;
+		}
+
 		// Form an excerpt.
 		$excerpt = strip_tags( $postdata['post_excerpt'] ? $postdata['post_excerpt'] : $postdata['post_content'] );
 
@@ -6206,8 +6215,8 @@ function get_all_page_ids() {
  * @phpstan-param 'OBJECT'|'ARRAY_A'|'ARRAY_N' $output
  * @phpstan-param 'raw'|'edit'|'db'|'display' $filter
  * @phpstan-return (
- *     $output is 'ARRAY_A' ? array<string, mixed>|null : (
- *         $output is 'ARRAY_N' ? array<int, mixed>|null : (
+ *     $output is 'ARRAY_A' ? non-empty-array<string, mixed>|null : (
+ *         $output is 'ARRAY_N' ? non-empty-array<int, mixed>|null : (
  *             WP_Post|null
  *         )
  *     )
@@ -6234,8 +6243,8 @@ function get_page( $page, $output = OBJECT, $filter = 'raw' ) {
  * @phpstan-param 'OBJECT'|'ARRAY_A'|'ARRAY_N' $output
  * @phpstan-param string|string[]              $post_type
  * @phpstan-return (
- *     $output is 'ARRAY_A' ? array<string, mixed>|null : (
- *         $output is 'ARRAY_N' ? array<int, mixed>|null : (
+ *     $output is 'ARRAY_A' ? non-empty-array<string, mixed>|null : (
+ *         $output is 'ARRAY_N' ? non-empty-array<int, mixed>|null : (
  *             WP_Post|null
  *         )
  *     )

--- a/src/wp-includes/revision.php
+++ b/src/wp-includes/revision.php
@@ -423,6 +423,17 @@ function wp_save_revisioned_meta_fields( $revision_id, $post_id ) {
  *                            respectively. Default OBJECT.
  * @param string      $filter Optional sanitization filter. See sanitize_post(). Default 'raw'.
  * @return WP_Post|array|null WP_Post (or array) on success, or null on failure.
+ *
+ * @phpstan-param int|WP_Post $post
+ * @phpstan-param 'OBJECT'|'ARRAY_A'|'ARRAY_N' $output
+ * @phpstan-param 'raw'|'edit'|'db'|'display' $filter
+ * @phpstan-return (
+ *     $output is 'ARRAY_A' ? non-empty-array<string, mixed>|null : (
+ *         $output is 'ARRAY_N' ? non-empty-array<int, mixed>|null : (
+ *             WP_Post|null
+ *         )
+ *     )
+ * )
  */
 function wp_get_post_revision( &$post, $output = OBJECT, $filter = 'raw' ) {
 	$revision = get_post( $post, OBJECT, $filter );
@@ -438,10 +449,13 @@ function wp_get_post_revision( &$post, $output = OBJECT, $filter = 'raw' ) {
 	if ( OBJECT === $output ) {
 		return $revision;
 	} elseif ( ARRAY_A === $output ) {
+		/** @var non-empty-array<string, mixed> $_revision */
 		$_revision = get_object_vars( $revision );
 		return $_revision;
 	} elseif ( ARRAY_N === $output ) {
-		$_revision = array_values( get_object_vars( $revision ) );
+		/** @var non-empty-array<string, mixed> $vars */
+		$vars      = get_object_vars( $revision );
+		$_revision = array_values( $vars );
 		return $_revision;
 	}
 


### PR DESCRIPTION
✅  Committed in r62694 (99fc1444bdf3b6481eb72f4f93af154dd201e436)

----
This improves the static analysis types for the post retrieval functions, so that the type of the returned value can be determined from the requested `$output`.

## Conditional return types

The `@phpstan-return` types of `get_post()`, `get_page()`, `get_page_by_path()`, `get_children()`, and `wp_get_recent_posts()` are narrowed so that the `ARRAY_A` and `ARRAY_N` outputs are typed as `non-empty-array`. This is consistent with `WP_Post::to_array()`, which always returns at least the object's declared properties and therefore can never return an empty array.

`wp_get_post_revision()` previously had no conditional return type at all, so its return value was seen as `WP_Post|array|null` regardless of the requested `$output`. Describing it precisely resolves 30 pre-existing PHPStan errors in its callers — mostly `Cannot access property $ID on array|WP_Post` — across `wp_restore_post_revision()`, `wp_delete_post_revision()`, `wp_xmlrpc_server::wp_restoreRevision()`, and `wp-admin/revision.php`.

Note that `non-empty-array` is a PHPStan-specific type which phpDocumentor does not understand, so the plain `@return` tag for `WP_Post::to_array()` continues to use `array<string, mixed>`, with the narrower type supplied via `@phpstan-return`.

## Behavior changes

Two small runtime changes were needed to support the above:

* **`trackback_url_list()`** now bails when `get_post()` returns `null`. Previously, calling it with an invalid post ID would fall through to `$postdata['post_excerpt']`, emitting "Trying to access array offset on value of type null" warnings.
* **`wp_get_recent_posts()`** now collects its `ARRAY_A` output in a separate `$posts` variable rather than overwriting the `WP_Post` objects in `$results` in place. Reassigning array values over the elements of `$results` left the variable holding a mix of `WP_Post` objects and arrays partway through the loop, so static analysis could only ever infer `array<WP_Post|array<string, mixed>>` for it. Building up a dedicated variable guarantees that everything it contains is an array. The returned value is unchanged.

## A note on `list<>`

It may be tempting to type these array returns as `list<…>` rather than `array<int, …>`, but that would not be sound. The `the_posts`, `posts_results`, and `posts_pre_query` filters allow plugins to return arbitrary arrays — an `array_filter()` in a `the_posts` callback is enough to produce a sparse numeric array — and core never re-indexes the result. `array<int, …>` is therefore the honest type. (`get_children()` is keyed by post ID in any case.)

## Testing instructions

No behavior change is expected beyond the removal of the PHP warnings noted above. The existing tests pass:

```
npm run test:php -- tests/phpunit/tests/post.php
npm run test:php -- tests/phpunit/tests/post/revisions.php
```

Static analysis was verified to introduce no new errors on the changed files (and to fix 30 existing ones).

Trac ticket: https://core.trac.wordpress.org/ticket/64898

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 4.8
Used for: Reviewing the change for correctness and consistency, extending it to `wp_get_post_revision()` and `WP_Post::to_array()`, verifying with PHPStan/PHPCS/PHPUnit, and drafting the commit message and this description. All changes were reviewed and edited by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
