### PR TITLE
Normalize rich text block attribute schemas for REST validation

### DIFF
--- a/src/wp-includes/class-wp-block-type.php
+++ b/src/wp-includes/class-wp-block-type.php
@@ -501,6 +501,8 @@ class WP_Block_Type {
 			return $attributes;
 		}
 
+		$attribute_schemas = $this->get_attributes_for_rest_schema();
+
 		foreach ( $attributes as $attribute_name => $value ) {
 			// If the attribute is not defined by the block type, it cannot be
 			// validated.
@@ -508,7 +510,7 @@ class WP_Block_Type {
 				continue;
 			}
 
-			$schema = $this->attributes[ $attribute_name ];
+			$schema = $attribute_schemas[ $attribute_name ];
 
 			// Validate value by JSON schema. An invalid value should revert to
 			// its default, if one exists. This occurs by virtue of the missing
@@ -588,6 +590,25 @@ class WP_Block_Type {
 		return is_array( $this->attributes ) ?
 			$this->attributes :
 			array();
+	}
+
+	/**
+	 * Gets block attributes normalized for REST schema validation.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @return array Block attributes with REST-compatible types.
+	 */
+	public function get_attributes_for_rest_schema() {
+		$attributes = $this->get_attributes();
+
+		foreach ( $attributes as $attribute_name => $attribute_schema ) {
+			if ( isset( $attribute_schema['type'] ) && 'rich-text' === $attribute_schema['type'] ) {
+				$attributes[ $attribute_name ]['type'] = 'string';
+			}
+		}
+
+		return $attributes;
 	}
 
 	/**

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-block-renderer-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-block-renderer-controller.php
@@ -64,7 +64,7 @@ class WP_REST_Block_Renderer_Controller extends WP_REST_Controller {
 
 								$schema = array(
 									'type'                 => 'object',
-									'properties'           => $block->get_attributes(),
+									'properties'           => $block->get_attributes_for_rest_schema(),
 									'additionalProperties' => false,
 								);
 
@@ -80,7 +80,7 @@ class WP_REST_Block_Renderer_Controller extends WP_REST_Controller {
 
 								$schema = array(
 									'type'                 => 'object',
-									'properties'           => $block->get_attributes(),
+									'properties'           => $block->get_attributes_for_rest_schema(),
 									'additionalProperties' => false,
 								);
 

--- a/tests/phpunit/tests/rest-api/rest-block-renderer-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-block-renderer-controller.php
@@ -171,6 +171,9 @@ class REST_Block_Renderer_Controller_Test extends WP_Test_REST_Controller_Testca
 							'type' => 'integer',
 						),
 					),
+					'rich_text'   => array(
+						'type' => 'rich-text',
+					),
 				),
 				'render_callback' => array( $this, 'render_test_block' ),
 			)
@@ -418,6 +421,35 @@ class REST_Block_Renderer_Controller_Test extends WP_Test_REST_Controller_Testca
 		$this->assertEqualSetsWithIndex(
 			json_decode( $block_type->render( $attributes ), true ),
 			json_decode( $data['rendered'], true )
+		);
+	}
+
+	/**
+	 * Tests rendering a block with a rich text attribute.
+	 *
+	 * @covers WP_REST_Block_Renderer_Controller::register_routes
+	 */
+	public function test_get_item_with_rich_text_attribute() {
+		wp_set_current_user( self::$user_id );
+
+		$request = new WP_REST_Request( 'GET', self::$rest_api_route . self::$block_name );
+		$request->set_param( 'context', 'edit' );
+		$request->set_param(
+			'attributes',
+			array(
+				'some_string' => 'some_value',
+				'rich_text' => '<strong>Example</strong>',
+			)
+		);
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame(
+			array(
+				'some_string' => 'some_value',
+				'rich_text' => '<strong>Example</strong>',
+			),
+			json_decode( $response->get_data()['rendered'], true )
 		);
 	}
 


### PR DESCRIPTION
## Summary
- map block-only `rich-text` attributes to the REST-compatible `string` type at validation boundaries
- use the normalized schema for renderer-route validation, sanitization, and block render preparation
- add a renderer regression test that preserves rich-text markup

## Testing
- `php -l src/wp-includes/class-wp-block-type.php`
- `php -l src/wp-includes/rest-api/endpoints/class-wp-rest-block-renderer-controller.php`
- `php -l tests/phpunit/tests/rest-api/rest-block-renderer-controller.php`
- PHPUnit dependencies are not installed in this worktree.