### PR TITLE
Code Quality: Add never return types to functions that always terminate

### DIFF
--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -1621,7 +1621,7 @@ function wp_ajax_add_meta() {
 	$post    = get_post( $post_id );
 
 	if ( isset( $_POST['metakeyselect'] ) || isset( $_POST['metakeyinput'] ) ) {
-		if ( ! current_user_can( 'edit_post', $post_id ) ) {
+		if ( ! $post || ! current_user_can( 'edit_post', $post_id ) ) {
 			wp_die( -1 );
 		}
 
@@ -2106,6 +2106,9 @@ function wp_ajax_inline_save() {
 	$data = &$_POST;
 
 	$post = get_post( $post_id, ARRAY_A );
+	if ( ! $post ) {
+		wp_die();
+	}
 
 	// Since it's coming from the database.
 	$post = wp_slash( $post );
@@ -3134,6 +3137,9 @@ function wp_ajax_save_attachment() {
 
 	$changes = $_REQUEST['changes'];
 	$post    = get_post( $id, ARRAY_A );
+	if ( ! $post ) {
+		wp_send_json_error();
+	}
 
 	if ( 'attachment' !== $post['post_type'] ) {
 		wp_send_json_error();
@@ -3225,6 +3231,9 @@ function wp_ajax_save_attachment_compat() {
 	}
 
 	$post = get_post( $id, ARRAY_A );
+	if ( ! $post ) {
+		wp_send_json_error();
+	}
 
 	if ( 'attachment' !== $post['post_type'] ) {
 		wp_send_json_error();

--- a/src/wp-admin/includes/class-custom-background.php
+++ b/src/wp-admin/includes/class-custom-background.php
@@ -569,6 +569,8 @@ class Custom_Background {
 	 * Media Manager.
 	 *
 	 * @since 4.1.0
+	 *
+	 * @return never
 	 */
 	public function ajax_background_add() {
 		check_ajax_referer( 'background-add', 'nonce' );
@@ -612,6 +614,8 @@ class Custom_Background {
 	/**
 	 * @since 3.4.0
 	 * @deprecated 3.5.0
+	 *
+	 * @return never
 	 */
 	public function wp_set_background_image() {
 		check_ajax_referer( 'custom-background' );

--- a/src/wp-admin/includes/class-custom-image-header.php
+++ b/src/wp-admin/includes/class-custom-image-header.php
@@ -1383,6 +1383,8 @@ endif;
 	 * new object. Returns JSON-encoded object details.
 	 *
 	 * @since 3.9.0
+	 *
+	 * @return never
 	 */
 	public function ajax_header_crop() {
 		check_ajax_referer( 'image_editor-' . $_POST['id'], 'nonce' );
@@ -1452,6 +1454,8 @@ endif;
 	 * Media Manager, even if s/he doesn't save that change.
 	 *
 	 * @since 3.9.0
+	 *
+	 * @return never
 	 */
 	public function ajax_header_add() {
 		check_ajax_referer( 'header-add', 'nonce' );
@@ -1480,6 +1484,8 @@ endif;
 	 * choice in the Customizer's Header tool.
 	 *
 	 * @since 3.9.0
+	 *
+	 * @return never
 	 */
 	public function ajax_header_remove() {
 		check_ajax_referer( 'header-remove', 'nonce' );

--- a/src/wp-admin/includes/class-wp-importer.php
+++ b/src/wp-admin/includes/class-wp-importer.php
@@ -298,8 +298,11 @@ class WP_Importer {
  *
  * @param string $param    The parameter name to retrieve.
  * @param bool   $required Optional. Whether the parameter is required. Default false.
- * @return string|true|null|never The parameter value or true if found, null otherwise.
- *                                The function exits when a required parameter is missing.
+ * @return string|true|null The parameter value, or true if the parameter was supplied
+ *                          without a value, or null if it was not supplied at all.
+ *                          Never returns when `$required` is true and the parameter
+ *                          is missing, as the function exits instead.
+ * @phpstan-return ( $required is true ? string|true : string|true|null )
  */
 function get_cli_args( $param, $required = false ) {
 	$args = $_SERVER['argv'];

--- a/src/wp-admin/includes/class-wp-list-table.php
+++ b/src/wp-admin/includes/class-wp-list-table.php
@@ -1843,6 +1843,8 @@ class WP_List_Table {
 	 * Handles an incoming ajax request (called from admin-ajax.php)
 	 *
 	 * @since 3.1.0
+	 *
+	 * @return never
 	 */
 	public function ajax_response() {
 		$this->prepare_items();

--- a/src/wp-admin/includes/comment.php
+++ b/src/wp-admin/includes/comment.php
@@ -294,6 +294,7 @@ function enqueue_comment_hotkeys_js() {
  * @since 2.5.0
  *
  * @param string $msg Error Message. Assumed to contain HTML and be sanitized.
+ * @return never
  */
 function comment_footer_die( $msg ) {
 	echo "<div class='wrap'><p>$msg</p></div>";

--- a/src/wp-admin/includes/post.php
+++ b/src/wp-admin/includes/post.php
@@ -2183,6 +2183,7 @@ function wp_autosave( $post_data ) {
  * @since 2.7.0
  *
  * @param int $post_id Optional. Post ID.
+ * @return never
  */
 function redirect_post( $post_id = 0 ) {
 	if ( isset( $_POST['save'] ) || isset( $_POST['publish'] ) ) {

--- a/src/wp-admin/includes/theme-install.php
+++ b/src/wp-admin/includes/theme-install.php
@@ -251,6 +251,7 @@ function display_themes() {
  * @since 2.8.0
  *
  * @global WP_Theme_Install_List_Table $wp_list_table
+ * @return never
  */
 function install_theme_information() {
 	global $wp_list_table;

--- a/src/wp-admin/includes/theme-install.php
+++ b/src/wp-admin/includes/theme-install.php
@@ -251,6 +251,7 @@ function display_themes() {
  * @since 2.8.0
  *
  * @global WP_Theme_Install_List_Table $wp_list_table
+ *
  * @return never
  */
 function install_theme_information() {

--- a/src/wp-admin/network.php
+++ b/src/wp-admin/network.php
@@ -39,7 +39,7 @@ foreach ( $wpdb->tables( 'ms_global' ) as $table => $prefixed_table ) {
 
 if ( ! network_domain_check() && ( ! defined( 'WP_ALLOW_MULTISITE' ) || ! WP_ALLOW_MULTISITE ) ) {
 	wp_die(
-		printf(
+		sprintf(
 			/* translators: 1: WP_ALLOW_MULTISITE, 2: wp-config.php */
 			__( 'You must define the %1$s constant as true in your %2$s file to allow creation of a Network.' ),
 			'<code>WP_ALLOW_MULTISITE</code>',

--- a/src/wp-includes/canonical.php
+++ b/src/wp-includes/canonical.php
@@ -38,6 +38,7 @@
  *                              figure if redirect is needed.
  * @param bool   $do_redirect   Optional. Redirect to the new URL.
  * @return string|null The string of the URL, if redirect needed. Never returns if a redirect occurs, depending on $do_redirect.
+ * @phpstan-return ( $do_redirect is true ? null : string|null )
  */
 function redirect_canonical( $requested_url = null, $do_redirect = true ) {
 	global $wp_rewrite, $is_IIS, $wp_query, $wpdb, $wp;

--- a/src/wp-includes/class-wp-ajax-response.php
+++ b/src/wp-includes/class-wp-ajax-response.php
@@ -148,6 +148,8 @@ class WP_Ajax_Response {
 	 * Sets the content type header to text/xml.
 	 *
 	 * @since 2.1.0
+	 *
+	 * @return never
 	 */
 	public function send() {
 		header( 'Content-Type: text/xml; charset=' . get_option( 'blog_charset' ) );

--- a/src/wp-includes/class-wp-customize-manager.php
+++ b/src/wp-includes/class-wp-customize-manager.php
@@ -447,6 +447,7 @@ final class WP_Customize_Manager {
 	 *
 	 * @param string|WP_Error $ajax_message Ajax return.
 	 * @param string          $message      Optional. UI message.
+	 * @return never
 	 */
 	protected function wp_die( $ajax_message, $message = null ) {
 		if ( $this->doing_ajax() ) {
@@ -2427,6 +2428,8 @@ final class WP_Customize_Manager {
 	 *
 	 * @since 3.4.0
 	 * @since 4.7.0 The semantics of this method have changed to update a changeset, optionally to also change the status and other attributes.
+	 *
+	 * @return never
 	 */
 	public function save() {
 		if ( ! is_user_logged_in() ) {
@@ -3386,6 +3389,8 @@ final class WP_Customize_Manager {
 	 * Removes changeset lock when take over request is sent via Ajax.
 	 *
 	 * @since 4.9.0
+	 *
+	 * @return never
 	 */
 	public function handle_override_changeset_lock_request() {
 		if ( ! $this->is_preview() ) {
@@ -3685,6 +3690,8 @@ final class WP_Customize_Manager {
 	 * Refreshes nonces for the current preview.
 	 *
 	 * @since 4.2.0
+	 *
+	 * @return never
 	 */
 	public function refresh_nonces() {
 		if ( ! $this->is_preview() ) {
@@ -3698,6 +3705,8 @@ final class WP_Customize_Manager {
 	 * Deletes a given auto-draft changeset or the autosave revision for a given changeset or delete changeset lock.
 	 *
 	 * @since 4.9.0
+	 *
+	 * @return never
 	 */
 	public function handle_dismiss_autosave_or_lock_request() {
 		// Calls to dismiss_user_auto_draft_changesets() and wp_get_post_autosave() require non-zero get_current_user_id().
@@ -5824,6 +5833,8 @@ final class WP_Customize_Manager {
 	 * Loads themes into the theme browsing/installation UI.
 	 *
 	 * @since 4.9.0
+	 *
+	 * @return never
 	 */
 	public function handle_load_themes_request() {
 		check_ajax_referer( 'switch_themes', 'nonce' );

--- a/src/wp-includes/class-wp-customize-nav-menus.php
+++ b/src/wp-includes/class-wp-customize-nav-menus.php
@@ -88,6 +88,8 @@ final class WP_Customize_Nav_Menus {
 	 * Ajax handler for loading available menu items.
 	 *
 	 * @since 4.3.0
+	 *
+	 * @return never
 	 */
 	public function ajax_load_available_items() {
 		check_ajax_referer( 'customize-menus', 'customize-menus-nonce' );
@@ -313,6 +315,8 @@ final class WP_Customize_Nav_Menus {
 	 * Ajax handler for searching available menu items.
 	 *
 	 * @since 4.3.0
+	 *
+	 * @return never
 	 */
 	public function ajax_search_available_items() {
 		check_ajax_referer( 'customize-menus', 'customize-menus-nonce' );
@@ -995,6 +999,8 @@ final class WP_Customize_Nav_Menus {
 	 * Ajax handler for adding a new auto-draft post.
 	 *
 	 * @since 4.7.0
+	 *
+	 * @return never
 	 */
 	public function ajax_insert_auto_draft_post() {
 		if ( ! check_ajax_referer( 'customize-menus', 'customize-menus-nonce', false ) ) {

--- a/src/wp-includes/class-wp-customize-widgets.php
+++ b/src/wp-includes/class-wp-customize-widgets.php
@@ -1697,6 +1697,8 @@ final class WP_Customize_Widgets {
 	 * @since 3.9.0
 	 *
 	 * @see wp_ajax_save_widget()
+	 *
+	 * @return never
 	 */
 	public function wp_ajax_update_widget() {
 

--- a/src/wp-includes/class-wp-plugin-dependencies.php
+++ b/src/wp-includes/class-wp-plugin-dependencies.php
@@ -433,6 +433,8 @@ class WP_Plugin_Dependencies {
 	 * Checks plugin dependencies after a plugin is installed via AJAX.
 	 *
 	 * @since 6.5.0
+	 *
+	 * @return never
 	 */
 	public static function check_plugin_dependencies_during_ajax() {
 		check_ajax_referer( 'updates' );

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -3777,13 +3777,13 @@ function wp_nonce_ays( $action ) {
  *
  * @global WP_Query $wp_query WordPress Query object.
  *
- * @param string|WP_Error  $message Optional. Error message. If this is a WP_Error object,
- *                                  and not an Ajax or XML-RPC request, the error's messages are used.
- *                                  Default empty string.
- * @param string|int       $title   Optional. Error title. If `$message` is a `WP_Error` object,
- *                                  error data with the key 'title' may be used to specify the title.
- *                                  If `$title` is an integer, then it is treated as the response code.
- *                                  Default empty string.
+ * @param string|WP_Error|int $message Optional. Error message. If this is a WP_Error object,
+ *                                     and not an Ajax or XML-RPC request, the error's messages are used.
+ *                                     Default empty string.
+ * @param string|int          $title   Optional. Error title. If `$message` is a `WP_Error` object,
+ *                                     error data with the key 'title' may be used to specify the title.
+ *                                     If `$title` is an integer, then it is treated as the response code.
+ *                                     Default empty string.
  * @param string|array|int $args {
  *     Optional. Arguments to control behavior. If `$args` is an integer, then it is treated
  *     as the response code. Default empty array.
@@ -3804,6 +3804,7 @@ function wp_nonce_ays( $action ) {
  * }
  * @return void Never returns if `$args['exit']` is true (the default), otherwise returns void.
  *
+ * @phpstan-param string|WP_Error|int<-1, 1> $message
  * @phpstan-return ( $args is array{exit: false} ? void : never )
  */
 function wp_die( $message = '', $title = '', $args = array() ) {

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -1747,6 +1747,8 @@ function do_robots() {
  * Displays the favicon.ico file content.
  *
  * @since 5.4.0
+ *
+ * @return never
  */
 function do_favicon() {
 	/**
@@ -3712,7 +3714,6 @@ function get_allowed_mime_types( $user = null ) {
  * @since 2.0.4
  *
  * @param string $action The nonce action.
- *
  * @return never
  */
 function wp_nonce_ays( $action ) {
@@ -3803,7 +3804,6 @@ function wp_nonce_ays( $action ) {
  *     @type bool   $exit           Whether to exit the process after completion. Default true.
  * }
  * @return void Never returns if `$args['exit']` is true (the default), otherwise returns void.
- *
  * @phpstan-param string|WP_Error|int<-1, 1> $message
  * @phpstan-return ( $args is array{exit: false} ? void : never )
  */
@@ -3892,7 +3892,6 @@ function wp_die( $message = '', $title = '', $args = array() ) {
  * @param string|WP_Error $message Error message or WP_Error object.
  * @param string          $title   Optional. Error title. Default empty string.
  * @param string|array    $args    Optional. Arguments to control behavior. Default empty array.
- *
  * @phpstan-return ( $args is array{exit: false} ? void : never )
  */
 function _default_wp_die_handler( $message, $title = '', $args = array() ) {
@@ -4096,7 +4095,6 @@ function _default_wp_die_handler( $message, $title = '', $args = array() ) {
  * @param string       $message Error message.
  * @param string       $title   Optional. Error title (unused). Default empty string.
  * @param string|array $args    Optional. Arguments to control behavior. Default empty array.
- *
  * @phpstan-return ( $args is array{exit: false} ? void : never )
  */
 function _ajax_wp_die_handler( $message, $title = '', $args = array() ) {
@@ -4140,7 +4138,6 @@ function _ajax_wp_die_handler( $message, $title = '', $args = array() ) {
  * @param string       $message Error message.
  * @param string       $title   Optional. Error title. Default empty string.
  * @param string|array $args    Optional. Arguments to control behavior. Default empty array.
- *
  * @phpstan-return ( $args is array{exit: false} ? void : never )
  */
 function _json_wp_die_handler( $message, $title = '', $args = array() ) {
@@ -4184,7 +4181,6 @@ function _json_wp_die_handler( $message, $title = '', $args = array() ) {
  * @param string       $message Error message.
  * @param string       $title   Optional. Error title. Default empty string.
  * @param string|array $args    Optional. Arguments to control behavior. Default empty array.
- *
  * @phpstan-return ( $args is array{exit: false} ? void : never )
  */
 function _jsonp_wp_die_handler( $message, $title = '', $args = array() ) {
@@ -4234,7 +4230,6 @@ function _jsonp_wp_die_handler( $message, $title = '', $args = array() ) {
  * @param string       $message Error message.
  * @param string       $title   Optional. Error title. Default empty string.
  * @param string|array $args    Optional. Arguments to control behavior. Default empty array.
- *
  * @phpstan-return ( $args is array{exit: false} ? void : never )
  */
 function _xmlrpc_wp_die_handler( $message, $title = '', $args = array() ) {
@@ -4266,7 +4261,6 @@ function _xmlrpc_wp_die_handler( $message, $title = '', $args = array() ) {
  * @param string       $message Error message.
  * @param string       $title   Optional. Error title. Default empty string.
  * @param string|array $args    Optional. Arguments to control behavior. Default empty array.
- *
  * @phpstan-return ( $args is array{exit: false} ? void : never )
  */
 function _xml_wp_die_handler( $message, $title = '', $args = array() ) {
@@ -4313,7 +4307,6 @@ EOD;
  * @param string       $message Optional. Response to print. Default empty string.
  * @param string       $title   Optional. Error title (unused). Default empty string.
  * @param string|array $args    Optional. Arguments to control behavior. Default empty array.
- *
  * @phpstan-return ( $args is array{exit: false} ? void : never )
  */
 function _scalar_wp_die_handler( $message = '', $title = '', $args = array() ) {
@@ -4579,7 +4572,6 @@ function _wp_json_prepare_data( $value ) {
  *                           then print and die.
  * @param int   $status_code Optional. The HTTP status code to output. Default null.
  * @param int   $flags       Optional. Options to be passed to json_encode(). Default 0.
- *
  * @return never
  */
 function wp_send_json( $response, $status_code = null, $flags = 0 ) {
@@ -4628,7 +4620,6 @@ function wp_send_json( $response, $status_code = null, $flags = 0 ) {
  * @param mixed $value       Optional. Data to encode as JSON, then print and die. Default null.
  * @param int   $status_code Optional. The HTTP status code to output. Default null.
  * @param int   $flags       Optional. Options to be passed to json_encode(). Default 0.
- *
  * @return never
  */
 function wp_send_json_success( $value = null, $status_code = null, $flags = 0 ) {
@@ -4657,7 +4648,6 @@ function wp_send_json_success( $value = null, $status_code = null, $flags = 0 ) 
  * @param mixed $value       Optional. Data to encode as JSON, then print and die. Default null.
  * @param int   $status_code Optional. The HTTP status code to output. Default null.
  * @param int   $flags       Optional. Options to be passed to json_encode(). Default 0.
- *
  * @return never
  */
 function wp_send_json_error( $value = null, $status_code = null, $flags = 0 ) {

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -3804,7 +3804,7 @@ function wp_nonce_ays( $action ) {
  *     @type bool   $exit           Whether to exit the process after completion. Default true.
  * }
  * @return void Never returns if `$args['exit']` is true (the default), otherwise returns void.
- * @phpstan-param string|WP_Error|int<-1, 1> $message
+ * @phpstan-param string|WP_Error|int<-1, max> $message
  * @phpstan-return ( $args is array{exit: false} ? void : never )
  */
 function wp_die( $message = '', $title = '', $args = array() ) {

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -3891,6 +3891,8 @@ function wp_die( $message = '', $title = '', $args = array() ) {
  * @param string|WP_Error $message Error message or WP_Error object.
  * @param string          $title   Optional. Error title. Default empty string.
  * @param string|array    $args    Optional. Arguments to control behavior. Default empty array.
+ *
+ * @phpstan-return ( $args is array{exit: false} ? void : never )
  */
 function _default_wp_die_handler( $message, $title = '', $args = array() ) {
 	list( $message, $title, $parsed_args ) = _wp_die_process_input( $message, $title, $args );
@@ -4093,6 +4095,8 @@ function _default_wp_die_handler( $message, $title = '', $args = array() ) {
  * @param string       $message Error message.
  * @param string       $title   Optional. Error title (unused). Default empty string.
  * @param string|array $args    Optional. Arguments to control behavior. Default empty array.
+ *
+ * @phpstan-return ( $args is array{exit: false} ? void : never )
  */
 function _ajax_wp_die_handler( $message, $title = '', $args = array() ) {
 	// Set default 'response' to 200 for Ajax requests.
@@ -4135,6 +4139,8 @@ function _ajax_wp_die_handler( $message, $title = '', $args = array() ) {
  * @param string       $message Error message.
  * @param string       $title   Optional. Error title. Default empty string.
  * @param string|array $args    Optional. Arguments to control behavior. Default empty array.
+ *
+ * @phpstan-return ( $args is array{exit: false} ? void : never )
  */
 function _json_wp_die_handler( $message, $title = '', $args = array() ) {
 	list( $message, $title, $parsed_args ) = _wp_die_process_input( $message, $title, $args );
@@ -4177,6 +4183,8 @@ function _json_wp_die_handler( $message, $title = '', $args = array() ) {
  * @param string       $message Error message.
  * @param string       $title   Optional. Error title. Default empty string.
  * @param string|array $args    Optional. Arguments to control behavior. Default empty array.
+ *
+ * @phpstan-return ( $args is array{exit: false} ? void : never )
  */
 function _jsonp_wp_die_handler( $message, $title = '', $args = array() ) {
 	list( $message, $title, $parsed_args ) = _wp_die_process_input( $message, $title, $args );
@@ -4225,6 +4233,8 @@ function _jsonp_wp_die_handler( $message, $title = '', $args = array() ) {
  * @param string       $message Error message.
  * @param string       $title   Optional. Error title. Default empty string.
  * @param string|array $args    Optional. Arguments to control behavior. Default empty array.
+ *
+ * @phpstan-return ( $args is array{exit: false} ? void : never )
  */
 function _xmlrpc_wp_die_handler( $message, $title = '', $args = array() ) {
 	global $wp_xmlrpc_server;
@@ -4255,6 +4265,8 @@ function _xmlrpc_wp_die_handler( $message, $title = '', $args = array() ) {
  * @param string       $message Error message.
  * @param string       $title   Optional. Error title. Default empty string.
  * @param string|array $args    Optional. Arguments to control behavior. Default empty array.
+ *
+ * @phpstan-return ( $args is array{exit: false} ? void : never )
  */
 function _xml_wp_die_handler( $message, $title = '', $args = array() ) {
 	list( $message, $title, $parsed_args ) = _wp_die_process_input( $message, $title, $args );
@@ -4300,6 +4312,8 @@ EOD;
  * @param string       $message Optional. Response to print. Default empty string.
  * @param string       $title   Optional. Error title (unused). Default empty string.
  * @param string|array $args    Optional. Arguments to control behavior. Default empty array.
+ *
+ * @phpstan-return ( $args is array{exit: false} ? void : never )
  */
 function _scalar_wp_die_handler( $message = '', $title = '', $args = array() ) {
 	list( $message, $title, $parsed_args ) = _wp_die_process_input( $message, $title, $args );

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -3712,6 +3712,8 @@ function get_allowed_mime_types( $user = null ) {
  * @since 2.0.4
  *
  * @param string $action The nonce action.
+ *
+ * @return never
  */
 function wp_nonce_ays( $action ) {
 	// Default title and response code.

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -4562,6 +4562,8 @@ function _wp_json_prepare_data( $value ) {
  *                           then print and die.
  * @param int   $status_code Optional. The HTTP status code to output. Default null.
  * @param int   $flags       Optional. Options to be passed to json_encode(). Default 0.
+ *
+ * @return never
  */
 function wp_send_json( $response, $status_code = null, $flags = 0 ) {
 	if ( wp_is_serving_rest_request() ) {
@@ -4609,6 +4611,8 @@ function wp_send_json( $response, $status_code = null, $flags = 0 ) {
  * @param mixed $value       Optional. Data to encode as JSON, then print and die. Default null.
  * @param int   $status_code Optional. The HTTP status code to output. Default null.
  * @param int   $flags       Optional. Options to be passed to json_encode(). Default 0.
+ *
+ * @return never
  */
 function wp_send_json_success( $value = null, $status_code = null, $flags = 0 ) {
 	$response = array( 'success' => true );
@@ -4636,6 +4640,8 @@ function wp_send_json_success( $value = null, $status_code = null, $flags = 0 ) 
  * @param mixed $value       Optional. Data to encode as JSON, then print and die. Default null.
  * @param int   $status_code Optional. The HTTP status code to output. Default null.
  * @param int   $flags       Optional. Options to be passed to json_encode(). Default 0.
+ *
+ * @return never
  */
 function wp_send_json_error( $value = null, $status_code = null, $flags = 0 ) {
 	$response = array( 'success' => false );

--- a/src/wp-includes/ms-deprecated.php
+++ b/src/wp-includes/ms-deprecated.php
@@ -85,6 +85,8 @@ if ( !function_exists( 'graceful_fail' ) ) :
  * @since MU (3.0.0)
  * @deprecated 3.0.0 Use wp_die()
  * @see wp_die()
+ *
+ * @return never
  */
 function graceful_fail( $message ) {
 	_deprecated_function( __FUNCTION__, '3.0.0', 'wp_die()' );
@@ -268,6 +270,7 @@ function get_most_active_blogs( $num = 10, $display = true ) {
  * @see wp_redirect()
  *
  * @param string $url Optional. Redirect URL. Default empty.
+ * @return never
  */
 function wpmu_admin_do_redirect( $url = '' ) {
 	_deprecated_function( __FUNCTION__, '3.3.0', 'wp_redirect()' );

--- a/src/wp-includes/ms-load.php
+++ b/src/wp-includes/ms-load.php
@@ -465,6 +465,7 @@ function ms_load_current_site_and_network( $domain, $path, $subdomain = false ) 
  *
  * @param string $domain The requested domain for the error to reference.
  * @param string $path   The requested path for the error to reference.
+ * @return never
  */
 function ms_not_installed( $domain, $path ) {
 	global $wpdb;

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -559,6 +559,8 @@ function wp_set_option_autoload( $option, $autoload ) {
  * @since 2.2.0
  *
  * @param string $option Option name.
+ * @return void Never returns if `$option` is protected, as the function dies in that case.
+ * @phpstan-return ( $option is 'alloptions'|'notoptions' ? never : void )
  */
 function wp_protect_special_option( $option ) {
 	if ( 'alloptions' === $option || 'notoptions' === $option ) {

--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -1367,7 +1367,9 @@ if ( ! function_exists( 'check_admin_referer' ) ) :
 	 * @param string     $query_arg Optional. Key to check for nonce in `$_REQUEST`. Default '_wpnonce'.
 	 * @return int|false 1 if the nonce is valid and generated between 0-12 hours ago,
 	 *                   2 if the nonce is valid and generated between 12-24 hours ago.
-	 *                   False if the nonce is invalid.
+	 *                   False if the nonce is invalid. Only possible when `$action` is -1,
+	 *                   as the function otherwise exits rather than returning false.
+	 * @phpstan-return ( $action is -1 ? int|false : int )
 	 */
 	function check_admin_referer( $action = -1, $query_arg = '_wpnonce' ) {
 		if ( -1 === $action ) {
@@ -1412,7 +1414,9 @@ if ( ! function_exists( 'check_ajax_referer' ) ) :
 	 *                                Default true.
 	 * @return int|false 1 if the nonce is valid and generated between 0-12 hours ago,
 	 *                   2 if the nonce is valid and generated between 12-24 hours ago.
-	 *                   False if the nonce is invalid.
+	 *                   False if the nonce is invalid. Only possible when `$stop` is false,
+	 *                   as the function otherwise exits rather than returning false.
+	 * @phpstan-return ( $stop is true ? int : int|false )
 	 */
 	function check_ajax_referer( $action = -1, $query_arg = false, $stop = true ) {
 		if ( -1 === $action ) {

--- a/src/wp-includes/sitemaps/class-wp-sitemaps-stylesheet.php
+++ b/src/wp-includes/sitemaps/class-wp-sitemaps-stylesheet.php
@@ -20,6 +20,7 @@ class WP_Sitemaps_Stylesheet {
 	 * Renders the XSL stylesheet depending on whether it's the sitemap index or not.
 	 *
 	 * @param string $type Stylesheet type. Either 'sitemap' or 'index'.
+	 * @return never
 	 */
 	public function render_stylesheet( $type ) {
 		header( 'Content-Type: application/xml; charset=UTF-8' );

--- a/src/wp-trackback.php
+++ b/src/wp-trackback.php
@@ -26,6 +26,9 @@ wp_set_current_user( 0 );
  * @param int|bool $error         Whether there was an error.
  *                                Default '0'. Accepts '0' or '1', true or false.
  * @param string   $error_message Error message if an error occurred. Default empty string.
+ * @return void Never returns if `$error` is truthy, as the function dies after
+ *              sending the error response.
+ * @phpstan-return ( $error is 1|true ? never : void )
  */
 function trackback_response( $error = 0, $error_message = '' ) {
 	header( 'Content-Type: text/xml; charset=' . get_option( 'blog_charset' ) );


### PR DESCRIPTION
✅  Committed in r62703 (7c6ea919178ba6c4db88bce71573f66c78a0999e), r62704 (1e521e729346f21354ae2b28d33c2b23601648d6), r62705 (0d59cc4)

----

Teaches static analysis that certain functions never come back, so it knows the code following a call to them is unreachable — and, where returning depends on a parameter, describes each case exactly instead of over-widening to the union of both.

Native `never` is PHP 8.1+, so all type work here is PHPDoc-only. Aside from two bug fixes noted at the end, there are no behavioral changes.

`wp_die()` itself is already typed `( $args is array{exit: false} ? void : never )` on trunk. This branch extends that idea outward to the functions built on top of it, then uses the result.

## 1. `@return never` on functions that always terminate (30)

The core primitives first, since almost everything else depends on them: `wp_send_json()`, `wp_send_json_success()`, `wp_send_json_error()`, `wp_nonce_ays()`, `do_favicon()`, and `WP_Ajax_Response::send()`.

Then the rest: six `WP_Customize_Manager` methods (`wp_die()`, `save()`, `refresh_nonces()` and three request handlers), three `WP_Customize_Nav_Menus` Ajax methods, `WP_Customize_Widgets::wp_ajax_update_widget()`, two `Custom_Background` and three `Custom_Image_Header` Ajax methods, `WP_List_Table::ajax_response()`, `comment_footer_die()`, `redirect_post()`, `install_theme_information()`, `WP_Plugin_Dependencies::check_plugin_dependencies_during_ajax()`, `graceful_fail()`, `wpmu_admin_do_redirect()`, `ms_not_installed()`, and `WP_Sitemaps_Stylesheet::render_stylesheet()`.

Candidates were found by walking the AST of every non-third-party file under `src/` and keeping only declarations that contain no `return` statement in their own scope *and* terminate on every branch. Each survivor was then independently confirmed by PHPStan, which reports `return.never` when a `@return never` is wrong — both for an explicit `return` and for falling off the end.

Deliberately **excluded**:

- **The `wp_ajax_*` handlers in `ajax-actions.php`.** They do always terminate, but nothing calls them directly, so the annotation would buy no call-site narrowing.
- **`IXR_Server::error()`/`output()`/`serve()`.** IXR is vendored third-party code, and `wp_xmlrpc_server` extends `IXR_Server` while overriding `error()` with a method that *can* return. Since `never` is a bottom type, annotating the parent would break return-type covariance.
- **`WP_List_Table::get_columns()`/`prepare_items()`/`ajax_user_can()` and `WP_Widget::widget()`.** These `die()` with a "must be overridden in a subclass" message, but they are abstract by convention — subclasses return real values.

## 2. Conditional return types (13)

**The seven `wp_die()` handlers** — `_default_wp_die_handler()`, `_ajax_wp_die_handler()`, `_json_wp_die_handler()`, `_jsonp_wp_die_handler()`, `_xmlrpc_wp_die_handler()`, `_xml_wp_die_handler()` and `_scalar_wp_die_handler()` — each gain the same conditional `wp_die()` already carries:

```
@phpstan-return ( $args is array{exit: false} ? void : never )
```

**Six more functions terminate on one path and return on another**, with a parameter deciding which:

| Function | Conditional type | Why |
|---|---|---|
| `trackback_response()` | `($error is 1\|true ? never : void)` | Dies after emitting the error response when `$error` is truthy. |
| `wp_protect_special_option()` | `($option is 'alloptions'\|'notoptions' ? never : void)` | Dies for the protected option names. |
| `redirect_canonical()` | `($do_redirect is true ? null : string\|null)` | With `$do_redirect` true it either exits or returns `null`; the `string` is unreachable. Only the recursive `redirect_canonical( $url, false )` call can produce one. |
| `check_admin_referer()` | `($action is -1 ? int\|false : int)` | `false` is only reachable in the deprecated no-action case. Callers passing a real action get an `int` or do not come back at all. |
| `check_ajax_referer()` | `($stop is true ? int : int\|false)` | Same, keyed on `$stop`, which defaults to true. |
| `get_cli_args()` | `($required is true ? string\|true : string\|true\|null)` | With `$required` true the function exits rather than returning `null`. |

`redirect_canonical()`'s `@return` already *said in prose* "Never returns if a redirect occurs, depending on `$do_redirect`" — this just encodes it.

`never` is claimed only for parameter values where termination is certain. Over-declaring `void` where the function actually dies merely loses precision at the call site; claiming `never` where the function can return would be unsound and would mark live code unreachable.

`get_cli_args()` also declared `@return string|true|null|never`. `never` is the bottom type, so in a union it is absorbed and said nothing; the exit is now described in prose instead.

## 3. `wp_die()` PHPDoc

`$message` has always accepted an `int` — the legacy Ajax protocol responds with `-1` (not permitted), `0` (failure) and `1` (success), and `check_ajax_referer()` dies with `-1` — but the type was documented as `string|WP_Error`. Now `string|WP_Error|int`, with the `@param` block realigned.

The PHPStan range is `int<-1, max>` rather than `int<-1, 1>`: core also calls `wp_die( time() )` in six places in `ajax-actions.php`, sending a Unix timestamp as the response body. `-1` is the only negative value passed anywhere in core.

## 4. Short-circuits in `ajax-actions.php`

With `wp_die()` and `wp_send_json_error()` typed as terminating, PHPStan can see where `get_post()` may return `null` and the result is dereferenced anyway. Four handlers gained a guard:

- **`wp_ajax_add_meta()`** — folded `! $post` into the existing capability check. `$post` is only dereferenced in the *add* branch (`$post->post_status`, `$post->post_type`); the *update* branch finds the row by `meta_id` and never touches it, so guarding earlier would have broken a working path.
- **`wp_ajax_inline_save()`** — `wp_die()` before `$post['post_content']`.
- **`wp_ajax_save_attachment()`** and **`wp_ajax_save_attachment_compat()`** — `wp_send_json_error()` before `$post['post_type']`, matching the failure idiom immediately below in each.

All four sit behind `current_user_can( 'edit_post', … )`, which already returns false for a nonexistent post (`map_meta_cap()` maps it to `do_not_allow`), so these are unreachable in practice today. They are defensive narrowing that also covers the delete-between-check-and-fetch race. This is what unlocks the 190 fixed errors in this file.

## 5. Two bug fixes

**`src/wp-admin/network.php`** built its "You must define the `WP_ALLOW_MULTISITE` constant" notice with `printf()` instead of `sprintf()`. `printf()` writes to the output buffer immediately and returns a byte count, so the message was emitted bare — ahead of `wp_die()`'s own markup — and `wp_die()` then rendered the integer byte count as its message body. Every other `wp_die()` call in core uses `sprintf()`; this was the only outlier. Surfaced by PHPStan once `wp_die()` had a precise `$message` type.

**`wp_ajax_save_attachment()`/`_compat()` and friends** — see §4; the missing null guards were real, if currently unreachable.

## PHPStan impact

Both passes run on a **cold result cache**. This matters: a warm cache can serve a stale result for a file whose PHPDoc the branch edited and silently drop findings on exactly the code under review, which is a correctness problem rather than merely a staleness one.

| Metric | Value |
|---|---|
| Errors on `trunk` | 33,128 |
| Errors on this branch | 32,859 |
| **Net change** | **−269** |
| Errors fixed | **308** |
| Errors introduced | **39** |
| Reconciliation | ✓ (308 − 39 = 269) |

**Fixed, by identifier:** 211 `argument.type`, 37 `missingType.return`, 20 `property.nonObject`, 15 `offsetAccess.nonOffsetAccessible`, 8 `offsetAccess.notFound`, 4 `binaryOp.invalid`, 4 `variable.undefined`, 4 `offsetAccess.invalidOffset`, 3 `foreach.nonIterable`, 1 `missingType.iterableValue`, 1 `assign.propertyType`.

**Most-improved files:** `ajax-actions.php` (190), `privacy-tools.php` (39), `functions.php` (12), `class-wp-customize-nav-menus.php` (11), then `comment.php`, `class-wp-customize-manager.php` and `class-wp-customize-selective-refresh.php` at 10 each.

### The 39 "introduced" errors are not 39 regressions

- **~15 are the same errors re-worded.** On trunk, `src/wp-admin/comment.php:304` reads *"Cannot access property `$comment_post_ID` on `array|WP_Comment|null`"*; on this branch it reads *"…on `array|WP_Comment`"*. Because `wp_die()` after `if ( ! $comment )` is now `never`, the null branch is correctly pruned — the type gets strictly **better**. A diff keyed on message text counts an improved message as one fixed plus one introduced. The underlying `array|WP_Comment` complaint is pre-existing, from `get_comment( $id, ARRAY_A )`.

- **10 are genuinely unreachable code**, correctly identified:

  ```
  src/wp-admin/includes/ajax-actions.php:          98, 2711, 2856
  src/wp-admin/post.php:                           128, 248
  src/wp-includes/class-wp-customize-manager.php:  1939, 3169, 3200
  src/wp-includes/pluggable.php:                   1396
  src/wp-includes/sitemaps/class-wp-sitemaps.php:  187
  ```

  For example `ajax-actions.php:98` is `$wp_list_table->ajax_response(); wp_die( 0 );` — `ajax_response()` already ends in `wp_die()`, so the trailing `wp_die( 0 )` can never run. Likewise `post.php:128` is `redirect_post( $post_id ); exit;`. These are harmless belt-and-braces terminators rather than bugs, so they are left alone here and can be cleaned up separately.

- **3 are in `canonical.php`** — the nested `lowercase_octets()` helper inside `redirect_canonical()`, now reachable for analysis.

- **The remainder** is latent looseness at `wp_die()` call sites (`mixed`, `string|false`, `string|null` passed as `$message`) that the newly-precise signature makes visible.

Trac ticket: https://core.trac.wordpress.org/ticket/64898

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 4.8
Used for: Substantially authored by AI. The AI wrote an AST-based analyzer to find every function under `src/` whose control-flow paths all terminate, applied the annotations, and verified each against PHPStan — including negative controls proving PHPStan rejects a wrong `@return never`, and `PHPStan\dumpType` probes proving each conditional type resolves as intended. It also found the `network.php` `printf()`/`sprintf()` bug. I have reviewed and take responsibility for all of it; the exclusion decisions (Ajax handlers, IXR, the "must be overridden" stubs) and the `int<-1, max>` range were settled in review.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
