### PR TITLE
Code Quality: Improve PHPStan type coverage for `WP_Post`

### DIFF
--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -1739,14 +1739,14 @@ function inject_ignored_hooked_blocks_metadata_attributes( $changes, $deprecated
 	// Required for the WP_Block_Template. Update the post object with the current time.
 	$post->post_modified = current_time( 'mysql' );
 
-	// If the post_author is empty, set it to the current user. Normalize to a
-	// string in either case, since it may arrive as an int (e.g. from a REST
-	// controller) and the resulting object is passed to new WP_Post().
-	$post->post_author = (string) (
-		empty( $post->post_author )
-			? get_current_user_id()
-			: (int) $post->post_author
-	);
+	// If the post_author is empty, set it to the current user. If it arrived as
+	// an int (e.g. from a REST controller), normalize it to a string, since the
+	// resulting object is passed to new WP_Post().
+	if ( empty( $post->post_author ) ) {
+		$post->post_author = (string) get_current_user_id();
+	} elseif ( is_int( $post->post_author ) ) {
+		$post->post_author = (string) $post->post_author;
+	}
 
 	if ( 'wp_template_part' === $post->post_type && ! isset( $terms['wp_template_part_area'] ) ) {
 		$area_terms                     = get_the_terms( $changes->ID, 'wp_template_part_area' );

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -1739,10 +1739,14 @@ function inject_ignored_hooked_blocks_metadata_attributes( $changes, $deprecated
 	// Required for the WP_Block_Template. Update the post object with the current time.
 	$post->post_modified = current_time( 'mysql' );
 
-	// If the post_author is empty, set it to the current user.
-	if ( empty( $post->post_author ) ) {
-		$post->post_author = (string) get_current_user_id();
-	}
+	// If the post_author is empty, set it to the current user. Normalize to a
+	// string in either case, since it may arrive as an int (e.g. from a REST
+	// controller) and the resulting object is passed to new WP_Post().
+	$post->post_author = (string) (
+		empty( $post->post_author )
+			? get_current_user_id()
+			: (int) $post->post_author
+	);
 
 	if ( 'wp_template_part' === $post->post_type && ! isset( $terms['wp_template_part_area'] ) ) {
 		$area_terms                     = get_the_terms( $changes->ID, 'wp_template_part_area' );

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -1741,7 +1741,7 @@ function inject_ignored_hooked_blocks_metadata_attributes( $changes, $deprecated
 
 	// If the post_author is empty, set it to the current user.
 	if ( empty( $post->post_author ) ) {
-		$post->post_author = get_current_user_id();
+		$post->post_author = (string) get_current_user_id();
 	}
 
 	if ( 'wp_template_part' === $post->post_type && ! isset( $terms['wp_template_part_area'] ) ) {

--- a/src/wp-includes/class-wp-post.php
+++ b/src/wp-includes/class-wp-post.php
@@ -42,7 +42,7 @@
  *     post_type: string,
  *     post_mime_type: string,
  *     comment_count: numeric-string,
- *     filter: string,
+ *     filter: 'raw'|'edit'|'db'|'display'|'attribute'|'js'|'sample'|null,
  *     ancestors: int[],
  *     page_template: string,
  *     post_category: int[],
@@ -255,7 +255,8 @@ final class WP_Post {
 	 * Does not correspond to a DB field.
 	 *
 	 * @since 3.5.0
-	 * @var string
+	 * @var string|null
+	 * @phpstan-var 'raw'|'edit'|'db'|'display'|'attribute'|'js'|'sample'|null
 	 */
 	public $filter;
 

--- a/src/wp-includes/class-wp-post.php
+++ b/src/wp-includes/class-wp-post.php
@@ -14,9 +14,9 @@
  *
  * @property string $page_template
  *
- * @property-read int[]    $ancestors
- * @property-read int[]    $post_category
- * @property-read string[] $tags_input
+ * @property-read list<non-negative-int> $ancestors
+ * @property-read list<non-negative-int> $post_category
+ * @property-read list<non-empty-string> $tags_input
  *
  * @phpstan-type Data_Array array{
  *     ID: non-negative-int,
@@ -26,9 +26,9 @@
  *     post_content: string,
  *     post_title: string,
  *     post_excerpt: string,
- *     post_status: string,
- *     comment_status: string,
- *     ping_status: string,
+ *     post_status: non-empty-string,
+ *     comment_status: non-empty-string,
+ *     ping_status: non-empty-string,
  *     post_password: string,
  *     post_name: string,
  *     to_ping: string,
@@ -39,14 +39,14 @@
  *     post_parent: non-negative-int,
  *     guid: string,
  *     menu_order: int,
- *     post_type: string,
+ *     post_type: non-empty-string,
  *     post_mime_type: string,
  *     comment_count: numeric-string,
  *     filter: 'raw'|'edit'|'db'|'display'|'attribute'|'js'|'sample'|null,
- *     ancestors: int[],
+ *     ancestors: list<non-negative-int>,
  *     page_template: string,
- *     post_category: int[],
- *     tags_input: string[],
+ *     post_category: list<non-negative-int>,
+ *     tags_input: list<non-empty-string>,
  *     ...
  * }
  */
@@ -120,6 +120,7 @@ final class WP_Post {
 	 *
 	 * @since 3.5.0
 	 * @var string
+	 * @phpstan-var non-empty-string
 	 */
 	public $post_status = 'publish';
 
@@ -128,6 +129,7 @@ final class WP_Post {
 	 *
 	 * @since 3.5.0
 	 * @var string
+	 * @phpstan-var non-empty-string
 	 */
 	public $comment_status = 'open';
 
@@ -136,6 +138,7 @@ final class WP_Post {
 	 *
 	 * @since 3.5.0
 	 * @var string
+	 * @phpstan-var non-empty-string
 	 */
 	public $ping_status = 'open';
 
@@ -227,6 +230,7 @@ final class WP_Post {
 	 *
 	 * @since 3.5.0
 	 * @var string
+	 * @phpstan-var non-empty-string
 	 */
 	public $post_type = 'post';
 

--- a/src/wp-includes/class-wp-post.php
+++ b/src/wp-includes/class-wp-post.php
@@ -258,6 +258,8 @@ final class WP_Post {
 	 *
 	 * Does not correspond to a DB field.
 	 *
+	 * The 'sample' value is set exclusively by {@see get_sample_permalink()} and is read during permalink previewing.
+	 *
 	 * @since 3.5.0
 	 * @var string|null
 	 * @phpstan-var 'raw'|'edit'|'db'|'display'|'attribute'|'js'|'sample'|null

--- a/src/wp-includes/class-wp-post.php
+++ b/src/wp-includes/class-wp-post.php
@@ -20,9 +20,9 @@
  *
  * @phpstan-type Data_Array array{
  *     ID: non-negative-int,
- *     post_author: numeric-string,
- *     post_date: non-empty-string,
- *     post_date_gmt: non-empty-string,
+ *     post_author: numeric-string|'',
+ *     post_date: string,
+ *     post_date_gmt: string,
  *     post_content: string,
  *     post_title: string,
  *     post_excerpt: string,
@@ -33,8 +33,8 @@
  *     post_name: string,
  *     to_ping: string,
  *     pinged: string,
- *     post_modified: non-empty-string,
- *     post_modified_gmt: non-empty-string,
+ *     post_modified: string,
+ *     post_modified_gmt: string,
  *     post_content_filtered: string,
  *     post_parent: non-negative-int,
  *     guid: string,
@@ -65,11 +65,12 @@ final class WP_Post {
 	/**
 	 * ID of post author.
 	 *
-	 * A numeric string, for compatibility reasons.
+	 * A numeric string, for compatibility reasons. May be an empty string for a
+	 * default post that has not yet been assigned an author.
 	 *
 	 * @since 3.5.0
 	 * @var string
-	 * @phpstan-var numeric-string
+	 * @phpstan-var numeric-string|''
 	 */
 	public $post_author = '0';
 
@@ -78,7 +79,6 @@ final class WP_Post {
 	 *
 	 * @since 3.5.0
 	 * @var string
-	 * @phpstan-var non-empty-string
 	 */
 	public $post_date = '0000-00-00 00:00:00';
 
@@ -87,7 +87,6 @@ final class WP_Post {
 	 *
 	 * @since 3.5.0
 	 * @var string
-	 * @phpstan-var non-empty-string
 	 */
 	public $post_date_gmt = '0000-00-00 00:00:00';
 
@@ -179,7 +178,6 @@ final class WP_Post {
 	 *
 	 * @since 3.5.0
 	 * @var string
-	 * @phpstan-var non-empty-string
 	 */
 	public $post_modified = '0000-00-00 00:00:00';
 
@@ -188,7 +186,6 @@ final class WP_Post {
 	 *
 	 * @since 3.5.0
 	 * @var string
-	 * @phpstan-var non-empty-string
 	 */
 	public $post_modified_gmt = '0000-00-00 00:00:00';
 

--- a/src/wp-includes/class-wp-post.php
+++ b/src/wp-includes/class-wp-post.php
@@ -17,6 +17,38 @@
  * @property-read int[]    $ancestors
  * @property-read int[]    $post_category
  * @property-read string[] $tags_input
+ *
+ * @phpstan-type Data_Array array{
+ *     ID: non-negative-int,
+ *     post_author: numeric-string,
+ *     post_date: non-empty-string,
+ *     post_date_gmt: non-empty-string,
+ *     post_content: string,
+ *     post_title: string,
+ *     post_excerpt: string,
+ *     post_status: string,
+ *     comment_status: string,
+ *     ping_status: string,
+ *     post_password: string,
+ *     post_name: string,
+ *     to_ping: string,
+ *     pinged: string,
+ *     post_modified: non-empty-string,
+ *     post_modified_gmt: non-empty-string,
+ *     post_content_filtered: string,
+ *     post_parent: non-negative-int,
+ *     guid: string,
+ *     menu_order: int,
+ *     post_type: string,
+ *     post_mime_type: string,
+ *     comment_count: numeric-string,
+ *     filter: string,
+ *     ancestors: int[],
+ *     page_template: string,
+ *     post_category: int[],
+ *     tags_input: string[],
+ *     ...
+ * }
  */
 #[AllowDynamicProperties]
 final class WP_Post {
@@ -26,6 +58,7 @@ final class WP_Post {
 	 *
 	 * @since 3.5.0
 	 * @var int
+	 * @phpstan-var non-negative-int
 	 */
 	public $ID;
 
@@ -45,6 +78,7 @@ final class WP_Post {
 	 *
 	 * @since 3.5.0
 	 * @var string
+	 * @phpstan-var non-empty-string
 	 */
 	public $post_date = '0000-00-00 00:00:00';
 
@@ -53,6 +87,7 @@ final class WP_Post {
 	 *
 	 * @since 3.5.0
 	 * @var string
+	 * @phpstan-var non-empty-string
 	 */
 	public $post_date_gmt = '0000-00-00 00:00:00';
 
@@ -141,6 +176,7 @@ final class WP_Post {
 	 *
 	 * @since 3.5.0
 	 * @var string
+	 * @phpstan-var non-empty-string
 	 */
 	public $post_modified = '0000-00-00 00:00:00';
 
@@ -149,6 +185,7 @@ final class WP_Post {
 	 *
 	 * @since 3.5.0
 	 * @var string
+	 * @phpstan-var non-empty-string
 	 */
 	public $post_modified_gmt = '0000-00-00 00:00:00';
 
@@ -165,6 +202,7 @@ final class WP_Post {
 	 *
 	 * @since 3.5.0
 	 * @var int
+	 * @phpstan-var non-negative-int
 	 */
 	public $post_parent = 0;
 
@@ -218,7 +256,6 @@ final class WP_Post {
 	 *
 	 * @since 3.5.0
 	 * @var string
-	 * @phpstan-var 'raw'|'edit'|'db'|'display'|'attribute'|'js'
 	 */
 	public $filter;
 
@@ -389,10 +426,9 @@ final class WP_Post {
 	 *
 	 * @return array<string, mixed> Object as array.
 	 *
-	 * @phpstan-return non-empty-array<string, mixed>
+	 * @phpstan-return Data_Array
 	 */
 	public function to_array() {
-		/** @var non-empty-array<string, mixed> $post */
 		$post = get_object_vars( $this );
 
 		foreach ( array( 'ancestors', 'page_template', 'post_category', 'tags_input' ) as $key ) {
@@ -401,6 +437,7 @@ final class WP_Post {
 			}
 		}
 
+		/** @var Data_Array $post */
 		return $post;
 	}
 }

--- a/src/wp-includes/customize/class-wp-customize-nav-menu-item-setting.php
+++ b/src/wp-includes/customize/class-wp-customize-nav-menu-item-setting.php
@@ -625,7 +625,7 @@ class WP_Customize_Nav_Menu_Item_Setting extends WP_Customize_Setting {
 		$post        = new WP_Post( (object) $item );
 
 		if ( empty( $post->post_author ) ) {
-			$post->post_author = get_current_user_id();
+			$post->post_author = (string) get_current_user_id();
 		}
 
 		if ( ! isset( $post->type_label ) ) {

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -3010,8 +3010,8 @@ function sanitize_post( $post, $context = 'display' ) {
  * @param string $field   The Post Object field name.
  * @param mixed  $value   The Post Object value.
  * @param int    $post_id Post ID.
- * @param string $context Optional. How to sanitize the field. Possible values are 'raw', 'edit',
- *                        'db', 'display', 'attribute' and 'js'. Default 'display'.
+ * @param string $context Optional. How to sanitize the field. Possible values are 'raw', 'edit', 'db', 'display',
+ *                        'attribute' and 'js'. The 'sample' value is used for permalink previewing. Default 'display'.
  * @return mixed Sanitized value.
  *
  * @phpstan-param 'raw'|'edit'|'db'|'display'|'attribute'|'js'|'sample' $context

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -1185,6 +1185,7 @@ function get_post( $post = null, $output = OBJECT, $filter = 'raw' ) {
  *
  * @param int|WP_Post $post Post ID or post object.
  * @return int[] Array of ancestor IDs or empty array if there are none.
+ * @phpstan-return list<non-negative-int>
  */
 function get_post_ancestors( $post ) {
 	$post = get_post( $post );
@@ -6149,11 +6150,11 @@ function get_to_ping( $post ) {
 function trackback_url_list( $tb_list, $post_id ) {
 	if ( ! empty( $tb_list ) ) {
 		// Get post data.
-		$postdata = get_post( $post_id, ARRAY_A );
-
-		if ( ! $postdata ) {
+		$post = get_post( $post_id );
+		if ( ! $post ) {
 			return;
 		}
+		$postdata = $post->to_array();
 
 		// Form an excerpt.
 		$excerpt = strip_tags( $postdata['post_excerpt'] ? $postdata['post_excerpt'] : $postdata['post_content'] );

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -3287,7 +3287,8 @@ function sanitize_post_field( $field, $value, $post_id, $context = 'display' ) {
 			 * @param int    $post_id Post ID.
 			 * @param string $context Context for how to sanitize the field.
 			 *                        Accepts 'raw', 'edit', 'db', 'display',
-			 *                        'attribute', or 'js'. Default 'display'.
+			 *                        'attribute', or 'js'. The 'sample' value is
+			 *                        used for permalink previewing. Default 'display'.
 			 */
 			$value = apply_filters( "{$field}", $value, $post_id, $context );
 		} else {
@@ -3314,7 +3315,8 @@ function sanitize_post_field( $field, $value, $post_id, $context = 'display' ) {
 			 * @param int    $post_id Post ID
 			 * @param string $context Context for how to sanitize the field.
 			 *                        Accepts 'raw', 'edit', 'db', 'display',
-			 *                        'attribute', or 'js'. Default 'display'.
+			 *                        'attribute', or 'js'. The 'sample' value is
+			 *                        used for permalink previewing. Default 'display'.
 			 */
 			$value = apply_filters( "post_{$field}", $value, $post_id, $context );
 		}

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -3002,7 +3002,8 @@ function sanitize_post( $post, $context = 'display' ) {
  *
  * Possible context values are:  'raw', 'edit', 'db', 'display', 'attribute' and
  * 'js'. The 'display' context is used by default. 'attribute' and 'js' contexts
- * are treated like 'display' when calling filters.
+ * are treated like 'display' when calling filters. The 'sample' value is used
+ * for permalink previewing.
  *
  * @since 2.3.0
  * @since 4.4.0 Like `sanitize_post()`, `$context` defaults to 'display'.

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -3014,7 +3014,7 @@ function sanitize_post( $post, $context = 'display' ) {
  *                        'db', 'display', 'attribute' and 'js'. Default 'display'.
  * @return mixed Sanitized value.
  *
- * @phpstan-param 'raw'|'edit'|'db'|'display'|'attribute'|'js' $context
+ * @phpstan-param 'raw'|'edit'|'db'|'display'|'attribute'|'js'|'sample' $context
  * @phpstan-return (
  *     $field is 'ID'|'post_parent'|'menu_order' ? int : (
  *         $field is 'ancestors' ? non-negative-int[] : string

--- a/tests/phpunit/tests/customize/nav-menu-item-setting.php
+++ b/tests/phpunit/tests/customize/nav-menu-item-setting.php
@@ -950,7 +950,7 @@ class Test_WP_Customize_Nav_Menu_Item_Setting extends WP_UnitTestCase {
 		$this->assertSame( $post_value['title'], $nav_menu_item->post_title );
 		$this->assertSame( 123, $nav_menu_item->ID );
 		$this->assertSame( 123, $nav_menu_item->db_id );
-		$this->assertSame( wp_get_current_user()->ID, $nav_menu_item->post_author );
+		$this->assertSame( (string) wp_get_current_user()->ID, $nav_menu_item->post_author );
 		$this->assertObjectHasProperty( 'type_label', $nav_menu_item );
 		$expected = apply_filters( 'nav_menu_attr_title', wp_unslash( apply_filters( 'excerpt_save_pre', wp_slash( $post_value['attr_title'] ) ) ) );
 		$this->assertSame( $expected, $nav_menu_item->attr_title );


### PR DESCRIPTION
✅  Committed in r62717 (068b5782ef6bc9778edf2af7b929109580a5a279)

----
Improves PHPStan static-analysis coverage for `WP_Post`, tightening the types of its array form and properties to what the code actually guarantees.

## Changes

- **`WP_Post::to_array()`** — adds a `Data_Array` `@phpstan-type` shape describing every key it returns, used as the method's `@phpstan-return`. The shape is open (`...`) because `WP_Post` is `#[AllowDynamicProperties]` and instances routinely carry extra columns, so sealing it would produce false "offset does not exist" errors. This doesn't have a lot of value at the moment other than to calls to `WP_Post::to_array()`, but once https://github.com/phpstan/phpstan/issues/9164 lands then this will become much more useful as `get_post()` will be able to import the type and return it for calls to `get_post( ..., ARRAY_A )`.
- **Refined value types**, only where the value set is genuinely constrained:
  - `ID`, `post_parent` → `non-negative-int` (never negative; `0` is valid for unsaved objects, so deliberately not `positive-int`).
  - `comment_count` → `numeric-string`.
  - `post_author` → `numeric-string|''` (a user ID, or an empty string for a default post that has not yet been assigned an author, e.g. from `get_default_post_to_edit()`). The `''` is kept in the type rather than narrowed away so `(int)` casts stay meaningful without excluding that real state.
  - `post_status`, `comment_status`, `ping_status`, `post_type` → `non-empty-string`. Each is a `NOT NULL` column that always holds a non-empty slug, but the type is left **open** (not an enum) so custom statuses/types registered via `register_post_status()` / `register_post_type()` remain valid.
  - The always-present magic keys become precise lists: `ancestors` and `post_category` are `list<non-negative-int>` (from `get_post_ancestors()` and `wp_list_pluck( …, 'term_id' )`), and `tags_input` is `list<non-empty-string>` (`wp_list_pluck( …, 'name' )`). `WP_Post::__isset()` returns `true` for all four magic keys, so `to_array()` always appends them.
  - Fields that can legitimately be empty stay `string`: `post_content`, `post_title`, `post_excerpt`, `post_name`, `post_password`, `guid`, `to_ping`, `pinged`, `post_content_filtered`, `post_mime_type`, `page_template`, and the datetime fields `post_date`, `post_date_gmt`, `post_modified`, `post_modified_gmt`. The datetimes are `NOT NULL` in the DB, but `get_default_post_to_edit()` constructs a `WP_Post` with empty date strings, so `non-empty-string` would be inaccurate (and there is no finer type for a possibly-empty datetime string). `menu_order` stays `int` since it can be negative.
- **`WP_Post::$filter`** — corrected to `string|null` / the six sanitize contexts plus `'sample'` plus `null`. It had been mistyped (as `string`, then as the six contexts), both of which wrongly excluded `null` (a `WP_Post` built from a raw row has no `filter` until sanitized, and core relies on this via `isset()`/`empty()` checks) and `'sample'` (assigned by `get_sample_permalink()` since [8526] / WP 2.7.1 to keep the mutated object out of the cache). `sanitize_post_field()`'s `$context` is widened to accept `'sample'` accordingly — it already handles it at runtime, falling through to the `display` branch.
- **`get_post_ancestors()`** → `list<non-negative-int>` return type.
- **`trackback_url_list()`** — fetches the `WP_Post` and calls `to_array()` so the accessed keys are known, guarding against a `null` post.
- **`WP_Customize_Nav_Menu_Item_Setting`** and **`inject_ignored_hooked_blocks_metadata_attributes()`** — cast the `int` from `get_current_user_id()` to `string` when defaulting `post_author` on an object passed to `new WP_Post()`, so it stays a `numeric-string`.

## Follow-up

> [!WARNING]
> `get_default_post_to_edit()` (`wp-admin/includes/post.php`) sets `$post->post_category = get_option( 'default_category' )`, which assigns a **scalar** term ID where an array of category IDs is expected, and writes to the `@property-read` `post_category` magic property (it only works because `$post` is a `stdClass` there, so the write creates a dynamic property that shadows the getter). This is a pre-existing inconsistency, out of scope for this PR, and should be addressed in a follow-up.

## PHPStan impact (level 10)

Net **−8** errors (24 fixed, 16 "introduced").

The 16 "introduced" are **not regressions**. They are pre-existing latent errors at distant call sites (e.g. `esc_attr( $post->ID )`, `isset( $post->ID )`) that PHPStan now prints with the sharper `int<0, max>` type instead of `int` — each has a byte-identical counterpart on `trunk` at the same line, so a message-based diff counts one re-worded error as one fixed + one introduced. None of those sites is in a file this PR edits.

Trac ticket: https://core.trac.wordpress.org/ticket/64898

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 4.8
Used for: Static-analysis-driven iteration and drafting the PHPDoc/type annotations. Every change was reviewed, verified against PHPStan (level 10) and PHPCS, and edited by me; I take responsibility for the result.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
