### PR TITLE
Attachments REST API: Apply unapplied EXIF orientation before image edits

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
@@ -1064,6 +1064,9 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 			);
 		}
 
+		// Apply any unapplied EXIF orientation so edits run in the upright frame the client previewed.
+		$image_editor->maybe_exif_rotate();
+
 		foreach ( $modifiers as $modifier ) {
 			$args = $modifier['args'];
 			switch ( $modifier['type'] ) {

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
@@ -959,6 +959,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 	 *
 	 * @since 5.5.0
 	 * @since 6.9.0 Adds flips capability and editable fields for the newly-created attachment post.
+	 * @since 7.1.0 Applies EXIF orientation correction before image modifications.
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_REST_Response|WP_Error Response object on success, WP_Error object on failure.

--- a/tests/phpunit/tests/rest-api/rest-attachments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-attachments-controller.php
@@ -3042,6 +3042,89 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 	}
 
 	/**
+	 * @ticket 65618
+	 * @requires function imagejpeg
+	 */
+	public function test_edit_image_returns_error_if_no_image_editor() {
+		wp_set_current_user( self::$superadmin_id );
+		$attachment = self::factory()->attachment->create_upload_object( self::$test_file );
+
+		add_filter( 'wp_image_editors', '__return_empty_array' );
+
+		$request = new WP_REST_Request( 'POST', "/wp/v2/media/{$attachment}/edit" );
+		$request->set_body_params(
+			array(
+				'rotation' => 60,
+				'src'      => wp_get_attachment_image_url( $attachment, 'full' ),
+			)
+		);
+		$response = rest_do_request( $request );
+		$this->assertErrorResponse( 'rest_unknown_image_file_type', $response, 500 );
+	}
+
+	/**
+	 * @ticket 65618
+	 * @requires function imagejpeg
+	 */
+	public function test_edit_image_applies_unbaked_exif_orientation_before_edits() {
+		wp_set_current_user( self::$superadmin_id );
+		$attachment = self::factory()->attachment->create_upload_object( self::$test_file );
+
+		$this->setup_mock_editor();
+		add_filter(
+			'wp_image_maybe_exif_rotate',
+			static function () {
+				return 6;
+			}
+		);
+		WP_Image_Editor_Mock::$edit_return['rotate'] = new WP_Error();
+
+		$request = new WP_REST_Request( 'POST', "/wp/v2/media/{$attachment}/edit" );
+		$request->set_body_params(
+			array(
+				'rotation' => 60,
+				'src'      => wp_get_attachment_image_url( $attachment, 'full' ),
+			)
+		);
+		$response = rest_do_request( $request );
+		$this->assertErrorResponse( 'rest_image_rotation_failed', $response, 500 );
+
+		// The EXIF orientation correction (orientation 6 => rotate 270) must run before the requested edit.
+		$this->assertSame( array( array( 270 ), array( -60 ) ), WP_Image_Editor_Mock::$spy['rotate'] );
+	}
+
+	/**
+	 * @ticket 65618
+	 * @requires extension exif
+	 * @requires function imagejpeg
+	 */
+	public function test_edit_image_rotate_with_unbaked_exif_orientation() {
+		wp_set_current_user( self::$superadmin_id );
+		$attachment = self::factory()->attachment->create_upload_object( DIR_TESTDATA . '/images/test-image-rotated-90ccw.jpg' );
+
+		$request = new WP_REST_Request( 'POST', "/wp/v2/media/{$attachment}/edit" );
+		$request->set_body_params(
+			array(
+				'rotation' => 90,
+				'src'      => wp_get_attachment_image_url( $attachment, 'full' ),
+			)
+		);
+		$response = rest_do_request( $request );
+		$item     = $response->get_data();
+
+		$this->assertSame( 201, $response->get_status() );
+
+		/*
+		 * The original file is 1200x1800 raw pixels with an unapplied EXIF orientation of 6,
+		 * so clients preview it upright as 1800x1200. Rotating that upright frame 90 degrees
+		 * must produce 1200x1800. Without the orientation correction the edit rotates the raw
+		 * pixels instead and produces 1800x1200.
+		 */
+		$this->assertSame( 1200, $item['media_details']['width'] );
+		$this->assertSame( 1800, $item['media_details']['height'] );
+	}
+
+	/**
 	 * @ticket 44405
 	 * @requires function imagejpeg
 	 */


### PR DESCRIPTION
A PR to backport https://github.com/WordPress/gutenberg/pull/80144

## What

Fixes image edits (rotate, crop, flip) landing in the wrong frame for photos whose EXIF orientation tag was never applied to their pixels, most visibly iPhone JPEGs. Rotating such a photo in the media editor modal or the Image block cropper previously appeared to do nothing.

## Manual testing


1. Upload a JPEG with an EXIF orientation tag, for example a portrait photo taken on an iPhone 
2. Open it in the media editor modal, rotate it 90°, and save.
3. Confirm the saved image is actually rotated. Before this change it looked identical to the original.
4. Repeat with a crop: crop a distinctive corner and confirm the saved crop matches the region you framed.
5. Edit the saved (already upright) copy again and rotate once more. Confirm it rotates exactly once, with no double rotation.
6. Check for regressions on regular images

Trac ticket: https://core.trac.wordpress.org/ticket/65618

## Use of AI Tools

Unit tests.