### PR TITLE
KSES: Add tabindex to the list of allowed global attributes.

### DIFF
--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -2960,7 +2960,7 @@ function safecss_filter_attr( $css, $deprecated = '' ) {
  * @since 6.0.0 Added `dir`, `lang`, and `xml:lang` to global attributes.
  * @since 6.3.0 Added `aria-controls`, `aria-current`, and `aria-expanded` attributes.
  * @since 6.4.0 Added `aria-live` and `hidden` attributes.
- * @since 7.1.0 Added the `tabindex` attribute.
+ * @since 7.1.0 Added `tabindex` attribute.
  *
  * @access private
  * @ignore

--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -2960,6 +2960,7 @@ function safecss_filter_attr( $css, $deprecated = '' ) {
  * @since 6.0.0 Added `dir`, `lang`, and `xml:lang` to global attributes.
  * @since 6.3.0 Added `aria-controls`, `aria-current`, and `aria-expanded` attributes.
  * @since 6.4.0 Added `aria-live` and `hidden` attributes.
+ * @since 7.1.0 Added the `tabindex` attribute.
  *
  * @access private
  * @ignore
@@ -2985,6 +2986,7 @@ function _wp_add_global_attributes( $value ) {
 		'id'               => true,
 		'lang'             => true,
 		'style'            => true,
+		'tabindex'         => true,
 		'title'            => true,
 		'role'             => true,
 		'xml:lang'         => true,

--- a/tests/phpunit/tests/kses.php
+++ b/tests/phpunit/tests/kses.php
@@ -497,6 +497,7 @@ EOF;
 			$this->assertTrue( $tag['id'] );
 			$this->assertTrue( $tag['lang'] );
 			$this->assertTrue( $tag['style'] );
+			$this->assertTrue( $tag['tabindex'] );
 			$this->assertTrue( $tag['title'] );
 			$this->assertTrue( $tag['xml:lang'] );
 		}


### PR DESCRIPTION
- Trac ticket: https://core.trac.wordpress.org/ticket/65619#ticket
- Related Gutenberg PR: https://github.com/WordPress/gutenberg/pull/80163#discussion_r3568900135

## Use of AI Tools

The AI implemented it, and then I reviewed everything myself.