### PR TITLE
Interactivity API: Use `str_starts_with()` instead of `substr()` comparison in `WP_Interactivity_API`.

### DIFF
--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -790,7 +790,7 @@ final class WP_Interactivity_API {
 		$remaining = substr( $name, $suffix_index );
 
 		// If remaining starts with '---' but not '----', it's a unique_id
-		if ( '---' === substr( $remaining, 0, 3 ) && '-' !== ( $remaining[3] ?? '' ) ) {
+		if ( str_starts_with( $remaining, '---' ) && '-' !== ( $remaining[3] ?? '' ) ) {
 			return array(
 				'prefix'    => $prefix,
 				'suffix'    => null,

--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -790,7 +790,7 @@ final class WP_Interactivity_API {
 		$remaining = substr( $name, $suffix_index );
 
 		// If remaining starts with '---' but not '----', it's a unique_id
-		if ( str_starts_with( $remaining, '---' ) && '-' !== ( $remaining[3] ?? '' ) ) {
+		if ( str_starts_with( $remaining, '---' ) && ! str_starts_with( $remaining, '----' ) ) {
 			return array(
 				'prefix'    => $prefix,
 				'suffix'    => null,


### PR DESCRIPTION
The `str_starts_with()` function was introduced in PHP 8.0 and a polyfill is available in WordPress Core, making the intent of the check clearer than comparing the result of `substr()` against the prefix string.

Follow-up to [61020]

Trac ticket: https://core.trac.wordpress.org/ticket/65620

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
