### PR TITLE
Customize: Remove unreachable `return` statements in `WP_Customize_Manager`.

### DIFF
--- a/src/wp-includes/class-wp-customize-manager.php
+++ b/src/wp-includes/class-wp-customize-manager.php
@@ -1936,7 +1936,6 @@ final class WP_Customize_Manager {
 					'<code>customize_messenger_channel<code>'
 				)
 			);
-			return;
 		}
 
 		$this->prepare_controls();
@@ -3166,7 +3165,6 @@ final class WP_Customize_Manager {
 					'code'    => 'non_existent_changeset',
 				)
 			);
-			return;
 		}
 
 		if ( ! current_user_can( get_post_type_object( 'customize_changeset' )->cap->delete_post, $changeset_post_id ) ) {
@@ -3197,7 +3195,6 @@ final class WP_Customize_Manager {
 					'code'    => 'changeset_already_trashed',
 				)
 			);
-			return;
 		}
 
 		$r = $this->trash_changeset_post( $changeset_post_id );


### PR DESCRIPTION
✅  Committed in r62763 (d6b46699b2d4d81390af8bb0cdb03ff7fd31c583)

----

Both `wp_send_json_error()` and `WP_Customize_Manager::wp_die()` are documented with `@return never` and always terminate execution, so a subsequent `return` statement is never reached.

This also makes the class more consistent, as other `wp_send_json_error()` calls in the same class, e.g. for `invalid_nonce` and `changeset_locked` in `handle_changeset_trash_request()`, are already not followed by a `return` statement.

Follow-up to [62704]

Trac ticket: https://core.trac.wordpress.org/ticket/64898

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
