### PR TITLE
HTML API: Add class_list_from_string() helper to tokenize decoded class names.

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -1202,29 +1202,58 @@ class WP_HTML_Tag_Processor {
 			return;
 		}
 
+		yield from self::class_list_from_string( $class, self::QUIRKS_MODE === $this->compat_mode );
+	}
+
+	/**
+	 * Generator for a foreach loop to step through each class name in a decoded class attribute value.
+	 *
+	 * Unlike WP_HTML_Tag_Processor::class_list(), this method does not decode HTML character
+	 * references. It is intended for values that have already been decoded, such as class names
+	 * stored in block attributes or other non-HTML sources, so callers do not need to construct
+	 * an HTML tag and encode the value merely to tokenize it.
+	 *
+	 * The provided string is tokenized according to the HTML specification's set of ASCII
+	 * whitespace "space characters" (space, tab, form feed, carriage return, and newline).
+	 * Duplicate class names are yielded only once.
+	 *
+	 * Example:
+	 *
+	 *     foreach ( WP_HTML_Tag_Processor::class_list_from_string( ' foo  bar foo ' ) as $class_name ) {
+	 *         echo "{$class_name} ";
+	 *     }
+	 *     // Outputs: "foo bar "
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param string $class_attribute  Decoded class attribute value to tokenize.
+	 * @param bool   $case_insensitive Optional. Whether to normalize class names to lower-case,
+	 *                                 as in HTML quirks mode. Default false.
+	 * @return Generator<int, non-empty-string>
+	 */
+	public static function class_list_from_string( string $class_attribute, bool $case_insensitive = false ) {
 		$seen = array();
 
-		$is_quirks = self::QUIRKS_MODE === $this->compat_mode;
-
-		$at = 0;
-		while ( $at < strlen( $class ) ) {
+		$at     = 0;
+		$length = strlen( $class_attribute );
+		while ( $at < $length ) {
 			// Skip past any initial boundary characters.
-			$at += strspn( $class, " \t\f\r\n", $at );
-			if ( $at >= strlen( $class ) ) {
+			$at += strspn( $class_attribute, " \t\f\r\n", $at );
+			if ( $at >= $length ) {
 				return;
 			}
 
 			// Find the byte length until the next boundary.
-			$length = strcspn( $class, " \t\f\r\n", $at );
-			if ( 0 === $length ) {
+			$name_length = strcspn( $class_attribute, " \t\f\r\n", $at );
+			if ( 0 === $name_length ) {
 				return;
 			}
 
-			$name = substr( $class, $at, $length );
-			if ( $is_quirks ) {
+			$name = substr( $class_attribute, $at, $name_length );
+			if ( $case_insensitive ) {
 				$name = strtolower( $name );
 			}
-			$at += $length;
+			$at += $name_length;
 
 			/*
 			 * It's expected that the number of class names for a given tag is relatively small.

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -2433,6 +2433,88 @@ HTML;
 	}
 
 	/**
+	 * Ensures class_list_from_string() tokenizes a decoded class attribute value.
+	 *
+	 * @ticket 65466
+	 *
+	 * @covers WP_HTML_Tag_Processor::class_list_from_string
+	 *
+	 * @dataProvider data_class_list_from_string
+	 *
+	 * @param string   $class_attribute  Decoded class attribute value to tokenize.
+	 * @param bool     $case_insensitive Whether to normalize class names to lower-case.
+	 * @param string[] $expected         Expected list of class names.
+	 */
+	public function test_class_list_from_string( string $class_attribute, bool $case_insensitive, array $expected ) {
+		$this->assertSame(
+			$expected,
+			iterator_to_array( WP_HTML_Tag_Processor::class_list_from_string( $class_attribute, $case_insensitive ) )
+		);
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public static function data_class_list_from_string() {
+		return array(
+			'Empty string'                     => array( '', false, array() ),
+			'Only whitespace'                  => array( " \t\f\r\n", false, array() ),
+			'Single class'                     => array( 'foo', false, array( 'foo' ) ),
+			'Multiple classes in order'        => array( 'one two three', false, array( 'one', 'two', 'three' ) ),
+			'Leading and trailing whitespace'  => array( '  foo bar  ', false, array( 'foo', 'bar' ) ),
+			'Mixed HTML whitespace separators' => array( "a\tb\fc\rd\ne", false, array( 'a', 'b', 'c', 'd', 'e' ) ),
+			'Collapses repeated whitespace'    => array( 'foo    bar', false, array( 'foo', 'bar' ) ),
+			'Skips duplicate class names'      => array( 'foo bar foo', false, array( 'foo', 'bar' ) ),
+			'Case-sensitive by default'        => array( 'Foo foo FOO', false, array( 'Foo', 'foo', 'FOO' ) ),
+			'Case-insensitive normalizes'      => array( 'Foo foo FOO', true, array( 'foo' ) ),
+		);
+	}
+
+	/**
+	 * Ensures class_list_from_string() does not decode HTML character references.
+	 *
+	 * This distinguishes it from class_list(), which operates on an HTML attribute value
+	 * and decodes character references. The standalone helper treats its input as already
+	 * decoded, so entity-like sequences are preserved verbatim.
+	 *
+	 * @ticket 65466
+	 *
+	 * @covers WP_HTML_Tag_Processor::class_list_from_string
+	 */
+	public function test_class_list_from_string_does_not_decode_character_references() {
+		$found_classes = iterator_to_array(
+			WP_HTML_Tag_Processor::class_list_from_string( '&lt;egg&gt; &#x6f;ne' )
+		);
+
+		$this->assertSame(
+			array( '&lt;egg&gt;', '&#x6f;ne' ),
+			$found_classes,
+			'Character references should be preserved verbatim rather than decoded.'
+		);
+	}
+
+	/**
+	 * Ensures class_list_from_string() and class_list() agree for decoded input.
+	 *
+	 * @ticket 65466
+	 *
+	 * @covers WP_HTML_Tag_Processor::class_list
+	 * @covers WP_HTML_Tag_Processor::class_list_from_string
+	 */
+	public function test_class_list_delegates_to_class_list_from_string() {
+		$processor = new WP_HTML_Tag_Processor( '<div class="one two one three">' );
+		$processor->next_tag();
+
+		$this->assertSame(
+			iterator_to_array( $processor->class_list() ),
+			iterator_to_array( WP_HTML_Tag_Processor::class_list_from_string( 'one two one three' ) ),
+			'class_list() should tokenize decoded values identically to class_list_from_string().'
+		);
+	}
+
+	/**
 	 * Ensures that the tag processor matches class names with null bytes correctly.
 	 *
 	 * @ticket 61531


### PR DESCRIPTION
The HTML API's `WP_HTML_Tag_Processor::class_list()` can tokenize class names according to the HTML specification, but it only operates on a matched tag's `class` attribute. To reuse that logic on a plain, already-decoded string (for example, class names stored in block attributes or other non-HTML sources), callers currently have to construct a throwaway HTML element and HTML-encode the value first:

```php
$processor = new WP_HTML_Tag_Processor(
    sprintf( '<div class="%s"></div>', esc_attr( $class_names ) )
);
$processor->next_tag();
foreach ( $processor->class_list() as $class_name ) {
    // ...
}
```

This PR introduces a static helper, `WP_HTML_Tag_Processor::class_list_from_string()`, that tokenizes an already-decoded class attribute value directly.

**What it does:**

- Splits on the HTML specification's ASCII whitespace "space characters" (space, tab, form feed, carriage return, newline).
- Yields each unique class name once (duplicates are skipped), matching `class_list()` semantics.
- **Does not** decode HTML character references — the input is treated as already decoded, which is the key distinction from `class_list()` and directly addresses the concern raised on the ticket about applying HTML decoding to non-HTML data.
- Is case-sensitive by default, with an optional `$case_insensitive` flag for quirks-mode-style normalization.

`class_list()` is refactored to delegate its tokenization to the new helper via `yield from`, so there is no behavior change to the existing method — it simply becomes the HTML-aware wrapper (fetch the decoded attribute, decide quirks mode) around the shared tokenizer.

**Testing:**

Adds unit tests in `tests/phpunit/tests/html-api/wpHtmlTagProcessor.php` covering tokenization, whitespace handling, deduplication, the case-sensitive/insensitive flag, verification that character references are *not* decoded, and parity between `class_list()` and `class_list_from_string()` for decoded input.

Trac ticket: https://core.trac.wordpress.org/ticket/65466

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 4.7
Used for:  Implementing `class_list_from_string()`, refactoring `class_list()`, writing the unit tests, and PR Description. All changes were reviewed by me.


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
