### PR TITLE
HTML API: processing instructions in head noscript

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -2090,13 +2090,14 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 
 			/*
 			 * > A comment token
-			 * >
+			 * > A processing instruction token
 			 * > A start tag whose tag name is one of: "basefont", "bgsound",
 			 * > "link", "meta", "noframes", "style"
 			 */
 			case '#comment':
 			case '#funky-comment':
 			case '#presumptuous-tag':
+			case '#processing-instruction':
 			case '+BASEFONT':
 			case '+BGSOUND':
 			case '+LINK':

--- a/tests/phpunit/data/web-platform-tests/README.md
+++ b/tests/phpunit/data/web-platform-tests/README.md
@@ -7,7 +7,7 @@ The current tests can be found on GitHub at
 [`web-platform-tests/wpt/html/syntax/parsing/resources`](https://github.com/web-platform-tests/wpt/tree/master/html/syntax/parsing/resources).
 
 The version of the WPT files was taken from the git commit with
-SHA [`f4c2ec1d071ccbae305f7aea4e883b5bd0f5c0df`](https://github.com/web-platform-tests/wpt/commit/f4c2ec1d071ccbae305f7aea4e883b5bd0f5c0df).
+SHA [`e0d8cc13ecda5b72946a8df5428ffcb620540819`](https://github.com/web-platform-tests/wpt/commit/e0d8cc13ecda5b72946a8df5428ffcb620540819).
 
 ## Updating
 

--- a/tests/phpunit/data/web-platform-tests/html_syntax_parsing_resources/processing-instructions.dat
+++ b/tests/phpunit/data/web-platform-tests/html_syntax_parsing_resources/processing-instructions.dat
@@ -986,3 +986,23 @@ there=1?>
 |     <title>
 |       "<?something>"
 
+#data
+<noscript><?pi>
+#script-off
+#document
+| <html>
+|   <head>
+|     <noscript>
+|       <?pi ?>
+|   <body>
+
+#data
+<template><?pi>
+#document
+| <html>
+|   <head>
+|   <body>
+|     <template>
+|       content
+|         <?pi ?>
+


### PR DESCRIPTION
The HTML spec updates to introduce HTML processing instructions (PI) overlooked a few insertion modes. PI were added to those modes in https://github.com/whatwg/html/pull/12653. Update the HTML API accordingly.

Update Web Platform Tests with additional tests for these conditions: https://github.com/web-platform-tests/wpt/pull/61120

Trac ticket: https://core.trac.wordpress.org/ticket/65582

Follow-up to: r62687.

<!--

## Use of AI Tools

You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
