### PR TITLE
Users: Do not send an email change notification when there was no previous address

### DIFF
--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -2782,7 +2782,15 @@ function wp_update_user( $userdata ) {
 		$send_password_change_email = apply_filters( 'send_password_change_email', true, $user, $userdata );
 	}
 
-	if ( isset( $userdata['user_email'] ) && $user['user_email'] !== $userdata['user_email'] ) {
+	/*
+	 * Only notify of an email change when there is a previous address to notify.
+	 * The change notification is sent to the old address, so when a user had no
+	 * email set (for example an account created during an import), there is no
+	 * recipient and the notification would be sent to an empty address.
+	 */
+	if ( isset( $userdata['user_email'] ) && '' !== $user['user_email']
+		&& $user['user_email'] !== $userdata['user_email']
+	) {
 		/**
 		 * Filters whether to send the email change email.
 		 *

--- a/tests/phpunit/tests/user.php
+++ b/tests/phpunit/tests/user.php
@@ -1709,6 +1709,48 @@ class Tests_User extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Ensures no email change notification is triggered when the account had no previous address.
+	 *
+	 * The notification is addressed to the old email, so an account that never had
+	 * an address (for example one created during a content import) has no recipient,
+	 * and the notification would otherwise be sent to an empty address.
+	 *
+	 * @ticket 47618
+	 *
+	 * @covers ::wp_update_user
+	 */
+	public function test_email_change_email_not_triggered_when_old_email_is_empty() {
+		global $wpdb;
+
+		$user_id = self::factory()->user->create();
+
+		// Blank the address to reproduce an account imported without an email.
+		$wpdb->update( $wpdb->users, array( 'user_email' => '' ), array( 'ID' => $user_id ) );
+		clean_user_cache( $user_id );
+
+		$this->assertSame( '', get_userdata( $user_id )->user_email, 'The account should start with no email address.' );
+
+		$change_email_triggered = false;
+		add_filter(
+			'send_email_change_email',
+			static function ( $send ) use ( &$change_email_triggered ) {
+				$change_email_triggered = true;
+				return $send;
+			}
+		);
+
+		$update = wp_update_user(
+			array(
+				'ID'         => $user_id,
+				'user_email' => 'new@example.com',
+			)
+		);
+
+		$this->assertSame( $user_id, $update, 'The email address should have been updated.' );
+		$this->assertFalse( $change_email_triggered, 'The email change notification should not be triggered when there is no previous address.' );
+	}
+
+	/**
 	 * Testing wp_new_user_notification email statuses.
 	 *
 	 * @dataProvider data_wp_new_user_notifications


### PR DESCRIPTION
The email change notification is addressed to the user's **old** email address, so that the previous owner of the address learns it was changed. When an account has no previous address (the case in the ticket is a user created during a content import, where the importer never set one), there is nobody at the old address to notify, and the notification is instead sent to an empty recipient. Email loggers show it as a message with an empty `To:` field.

This adds an empty-address guard so the notification is only prepared when there was a prior address to send it to. The change is one condition on the existing `if` that gates the `send_email_change_email` filter, so the filter and everything downstream simply don't run when the old address is empty.

I kept the patch scoped to the email-change case from the ticket. The password-change notification a few lines above has the same shape (it is sent to the user's current address, which would also be empty for one of these imported accounts), so it may be worth the same guard, but I left it out to keep this change to what the ticket describes. Happy to fold it in if you'd prefer to cover both here.

The regression test creates a user, blanks their address to reproduce the imported-account state, then updates the email and asserts the `send_email_change_email` filter is never reached. By construction it fails without the guard (the old condition fires the filter, which would send to the empty address) and passes with it.

One disclosure on verification: this box has no Docker/`wp-env`, so I could not run the full PHPUnit suite locally. I verified the guard logic with a standalone harness and wrote the committed test to the PHPUnit harness with `@ticket 47618`; I'd appreciate a CI run confirming it.

Trac ticket: https://core.trac.wordpress.org/ticket/47618

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 4.8
Used for: Helping locate the affected code path and draft the regression test. I reviewed, tested, and take responsibility for the final code.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
