### PR TITLE
HTML API: Yield final test case

### DIFF
--- a/tests/phpunit/tests/html-api/wpHtmlProcessorWebPlatformTests.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorWebPlatformTests.php
@@ -27,20 +27,21 @@ class Tests_HtmlApi_WebPlatformTests extends WP_UnitTestCase {
 	 * Skip specific tests that may not be supported or have known issues.
 	 */
 	const SKIP_TESTS = array(
-		'noscript01/line0014' => 'Unimplemented: This parser does not add missing attributes to existing HTML or BODY tags.',
-		'tests14/line0022'    => 'Unimplemented: This parser does not add missing attributes to existing HTML or BODY tags.',
-		'tests14/line0055'    => 'Unimplemented: This parser does not add missing attributes to existing HTML or BODY tags.',
-		'tests19/line0488'    => 'Unimplemented: This parser does not add missing attributes to existing HTML or BODY tags.',
-		'tests19/line0500'    => 'Unimplemented: This parser does not add missing attributes to existing HTML or BODY tags.',
-		'tests19/line1079'    => 'Unimplemented: This parser does not add missing attributes to existing HTML or BODY tags.',
-		'tests2/line0207'     => 'Unimplemented: This parser does not add missing attributes to existing HTML or BODY tags.',
-		'tests2/line0686'     => 'Unimplemented: This parser does not add missing attributes to existing HTML or BODY tags.',
-		'tests2/line0697'     => 'Unimplemented: This parser does not add missing attributes to existing HTML or BODY tags.',
-		'tests2/line0709'     => 'Unimplemented: This parser does not add missing attributes to existing HTML or BODY tags.',
-		'webkit01/line0231'   => 'Unimplemented: This parser does not add missing attributes to existing HTML or BODY tags.',
-		'webkit02/line0692'   => 'Unimplemented: The parser does not implement the "maybe clone an option into selectedcontent" algorithm.',
-		'webkit02/line0732'   => 'Unimplemented: The parser does not implement the "maybe clone an option into selectedcontent" algorithm.',
-		'webkit02/line0748'   => 'Unimplemented: The parser does not implement the "maybe clone an option into selectedcontent" algorithm.',
+		'noscript01/line0014'              => 'Unimplemented: This parser does not add missing attributes to existing HTML or BODY tags.',
+		'tests14/line0022'                 => 'Unimplemented: This parser does not add missing attributes to existing HTML or BODY tags.',
+		'tests14/line0055'                 => 'Unimplemented: This parser does not add missing attributes to existing HTML or BODY tags.',
+		'tests19/line0488'                 => 'Unimplemented: This parser does not add missing attributes to existing HTML or BODY tags.',
+		'tests19/line0500'                 => 'Unimplemented: This parser does not add missing attributes to existing HTML or BODY tags.',
+		'tests19/line1079'                 => 'Unimplemented: This parser does not add missing attributes to existing HTML or BODY tags.',
+		'tests2/line0207'                  => 'Unimplemented: This parser does not add missing attributes to existing HTML or BODY tags.',
+		'tests2/line0686'                  => 'Unimplemented: This parser does not add missing attributes to existing HTML or BODY tags.',
+		'tests2/line0697'                  => 'Unimplemented: This parser does not add missing attributes to existing HTML or BODY tags.',
+		'tests2/line0709'                  => 'Unimplemented: This parser does not add missing attributes to existing HTML or BODY tags.',
+		'webkit01/line0231'                => 'Unimplemented: This parser does not add missing attributes to existing HTML or BODY tags.',
+		'webkit02/line0692'                => 'Unimplemented: The parser does not implement the "maybe clone an option into selectedcontent" algorithm.',
+		'webkit02/line0732'                => 'Unimplemented: The parser does not implement the "maybe clone an option into selectedcontent" algorithm.',
+		'webkit02/line0748'                => 'Unimplemented: The parser does not implement the "maybe clone an option into selectedcontent" algorithm.',
+		'processing-instructions/line0999' => 'Temporarily disabled invalid test.',
 	);
 
 	/**

--- a/tests/phpunit/tests/html-api/wpHtmlProcessorWebPlatformTests.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorWebPlatformTests.php
@@ -463,13 +463,20 @@ class Tests_HtmlApi_WebPlatformTests extends WP_UnitTestCase {
 
 		fclose( $handle );
 
-		// Return the last result when reaching the end of the file.
-		return array(
-			$test_line_number,
-			$test_context_element,
-			// Remove the trailing newline
-			substr( $test_html, 0, -1 ),
-			$test_dom,
-		);
+		// Yield the last result when reaching the end of the file.
+		if ( $state && ! $test_script_flag ) {
+			// Other tests include the blank line separating them from the next test.
+			if ( ! str_ends_with( $test_dom, "\n\n" ) ) {
+				$test_dom .= "\n";
+			}
+
+			yield array(
+				$test_line_number,
+				$test_context_element,
+				// Remove the trailing newline
+				substr( $test_html, 0, -1 ),
+				$test_dom,
+			);
+		}
 	}
 }


### PR DESCRIPTION
The web-platform-tests test suite for the HTML API (previously html5lib-tests) used return for the final case, which is not reached by iteration. The final test case in each test file was never run.

Diff with trunk: `./vendor/bin/phpunit --group=html-api-web-platform-tests`

```diff
-Tests: 1655, Assertions: 1221, Skipped: 434.
+Tests: 1707, Assertions: 1261, Failures: 1, Skipped: 446.
```

The failure is due to https://github.com/web-platform-tests/wpt/pull/61257 (an incorrect tree in WPT) and is temporarily disabled on this branch.

Trac ticket: https://core.trac.wordpress.org/ticket/64894

Follow-up to r58010.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
