### PR TITLE
Tests: Use `assertTrue()`/`assertFalse()` instead of `assertSame()` with boolean values.

### DIFF
--- a/tests/phpunit/tests/blocks/wpBlockType.php
+++ b/tests/phpunit/tests/blocks/wpBlockType.php
@@ -528,9 +528,9 @@ class Tests_Blocks_wpBlockType extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertSame( false, $callback_called, 'The callback should not be called before the variations are accessed.' );
+		$this->assertFalse( $callback_called, 'The callback should not be called before the variations are accessed.' );
 		$block_type->variations; // access the variations.
-		$this->assertSame( true, $callback_called, 'The callback should be called when the variations are accessed.' );
+		$this->assertTrue( $callback_called, 'The callback should be called when the variations are accessed.' );
 	}
 
 	/**
@@ -555,7 +555,7 @@ class Tests_Blocks_wpBlockType extends WP_UnitTestCase {
 
 		// If the variations are defined after registration but before first access, the callback should not override it.
 		$this->assertSameSets( $test_variations, $block_type->get_variations(), 'Variations are same as variations set' );
-		$this->assertSame( false, $callback_called, 'The callback was never called.' );
+		$this->assertFalse( $callback_called, 'The callback was never called.' );
 	}
 
 	/**
@@ -617,7 +617,7 @@ class Tests_Blocks_wpBlockType extends WP_UnitTestCase {
 
 		$obtained_variations = $block_type->variations; // access the variations.
 
-		$this->assertSame( true, $callback_called, 'The callback should be called when the variations are accessed.' );
+		$this->assertTrue( $callback_called, 'The callback should be called when the variations are accessed.' );
 		$this->assertSameSets( $obtained_variations, $expected_variations, 'The variations obtained from the callback should be filtered.' );
 	}
 

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPI-wp-bind.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPI-wp-bind.php
@@ -410,7 +410,7 @@ class Tests_WP_Interactivity_API_WP_Bind extends WP_UnitTestCase {
 	public function test_wp_bind_handles_true_value() {
 		$html    = '<div data-wp-bind--id="myPlugin::state.trueValue"></div>';
 		list($p) = $this->process_directives( $html );
-		$this->assertSame( true, $p->get_attribute( 'id' ) );
+		$this->assertTrue( $p->get_attribute( 'id' ) );
 	}
 
 	/**
@@ -423,7 +423,7 @@ class Tests_WP_Interactivity_API_WP_Bind extends WP_UnitTestCase {
 	public function test_wp_bind_ignores_unique_ids() {
 		$html    = '<div data-wp-bind--id="myPlugin::state.trueValue"></div>';
 		list($p) = $this->process_directives( $html );
-		$this->assertSame( true, $p->get_attribute( 'id' ) );
+		$this->assertTrue( $p->get_attribute( 'id' ) );
 
 		$html    = '<div data-wp-bind--id---unique-id="myPlugin::state.trueValue"></div>';
 		list($p) = $this->process_directives( $html );

--- a/tests/phpunit/tests/rest-api/rest-post-meta-fields.php
+++ b/tests/phpunit/tests/rest-api/rest-post-meta-fields.php
@@ -2348,7 +2348,7 @@ class WP_Test_REST_Post_Meta_Fields extends WP_Test_REST_TestCase {
 		$this->assertSame( 200, $response->get_status() );
 
 		$data = $response->get_data();
-		$this->assertSame( false, $data['meta']['authenticated'] );
+		$this->assertFalse( $data['meta']['authenticated'] );
 	}
 
 	/**

--- a/tests/phpunit/tests/rest-api/wpRestMenusController.php
+++ b/tests/phpunit/tests/rest-api/wpRestMenusController.php
@@ -316,7 +316,7 @@ class Tests_REST_WpRestMenusController extends WP_Test_REST_Controller_Testcase 
 		$data = $response->get_data();
 		$this->assertSame( 'New Name', $data['name'] );
 		$this->assertSame( 'New Description', $data['description'] );
-		$this->assertSame( true, $data['auto_add'] );
+		$this->assertTrue( $data['auto_add'] );
 		$this->assertSame( 'new-name', $data['slug'] );
 		$this->assertSame( 'just meta', $data['meta']['test_single_menu'] );
 		$this->assertFalse( isset( $data['meta']['test_cat_meta'] ) );


### PR DESCRIPTION
Using the dedicated boolean assertions clarifies intent and produces more descriptive failure messages.

Trac ticket: https://core.trac.wordpress.org/ticket/64894

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
