### PR TITLE
Formatting: Prevent wpautop() from splitting anchors around block elements

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -444,7 +444,9 @@ function _wptexturize_pushpop_element( $text, &$stack, $disabled_elements ) {
  * @return string Text which has been converted into correct paragraph tags.
  */
 function wpautop( $text, $br = true ) {
-	$pre_tags = array();
+	$pre_tags                 = array();
+	$has_block_anchor         = false;
+	$block_anchor_placeholder = '';
 
 	if ( '' === trim( $text ) ) {
 		return '';
@@ -485,6 +487,29 @@ function wpautop( $text, $br = true ) {
 	$text = preg_replace( '|<br\s*/?>\s*<br\s*/?>|', "\n\n", $text );
 
 	$allblocks = '(?:table|thead|tfoot|caption|col|colgroup|tbody|tr|td|th|div|dl|dd|dt|ul|ol|li|pre|form|map|area|blockquote|address|style|p|h[1-6]|hr|fieldset|legend|section|article|aside|hgroup|header|footer|nav|figure|figcaption|details|menu|summary)';
+
+	/*
+	 * Anchors can contain block-level elements. Replace their tags with temporary
+	 * block-level placeholders so the paragraph cleanup does not split the anchor.
+	 */
+	if ( str_contains( $text, '<a' ) ) {
+		$block_anchor_placeholder = 'wp-autop-block-anchor';
+
+		while ( str_contains( $text, '<' . $block_anchor_placeholder ) ) {
+			$block_anchor_placeholder .= '-';
+		}
+
+		$text             = preg_replace(
+			'~<a(\b[^>]*)>(?=\s*<' . $allblocks . '[\s/>])(.*?)(</a>)~s',
+			'<' . $block_anchor_placeholder . '$1>$2</' . $block_anchor_placeholder . '>',
+			$text
+		);
+		$has_block_anchor = str_contains( $text, '<' . $block_anchor_placeholder );
+
+		if ( $has_block_anchor ) {
+			$allblocks = substr( $allblocks, 0, -1 ) . '|' . $block_anchor_placeholder . ')';
+		}
+	}
 
 	// Add a double line break above block-level opening tags.
 	$text = preg_replace( '!(<' . $allblocks . '[\s/>])!', "\n\n$1", $text );
@@ -563,6 +588,13 @@ function wpautop( $text, $br = true ) {
 	$text = preg_replace( '|<p><blockquote([^>]*)>|i', '<blockquote$1><p>', $text );
 	$text = str_replace( '</blockquote></p>', '</p></blockquote>', $text );
 
+	// Move paragraphs inside anchors that contain block-level elements.
+	if ( $has_block_anchor ) {
+		$text = preg_replace( '|<p>(<' . $block_anchor_placeholder . '[^>]*>)|', '$1<p>', $text );
+		$text = preg_replace( '|(</' . $block_anchor_placeholder . '>)</p>|', '</p>$1', $text );
+		$text = preg_replace( '|<p>\s*</p>|', '', $text );
+	}
+
 	// If an opening or closing block element tag is preceded by an opening <p> tag, remove it.
 	$text = preg_replace( '!<p>\s*(</?' . $allblocks . '[^>]*>)!', '$1', $text );
 
@@ -599,6 +631,11 @@ function wpautop( $text, $br = true ) {
 	// Restore newlines in all elements.
 	if ( str_contains( $text, '<!-- wpnl -->' ) ) {
 		$text = str_replace( array( ' <!-- wpnl --> ', '<!-- wpnl -->' ), "\n", $text );
+	}
+
+	// Restore anchors that contain block-level elements.
+	if ( $has_block_anchor ) {
+		$text = str_replace( array( '<' . $block_anchor_placeholder, '</' . $block_anchor_placeholder . '>' ), array( '<a', '</a>' ), $text );
 	}
 
 	return $text;

--- a/tests/phpunit/tests/formatting/wpAutop.php
+++ b/tests/phpunit/tests/formatting/wpAutop.php
@@ -491,6 +491,21 @@ Paragraph two.';
 	}
 
 	/**
+	 * @ticket 40202
+	 */
+	public function test_that_wpautop_does_not_split_anchors_containing_block_elements() {
+		$content  = '<a href="document.htm"><div>Text</div></a>';
+		$expected = "<a href=\"document.htm\">\n<div>Text</div>\n</a>";
+
+		$this->assertSame( $expected, trim( wpautop( $content ) ) );
+
+		$content  = '<a href="document.htm"><div>First</div><section>Second</section></a>';
+		$expected = "<a href=\"document.htm\">\n<div>First</div>\n<section>Second</section>\n</a>";
+
+		$this->assertSame( $expected, trim( wpautop( $content ) ) );
+	}
+
+	/**
 	 * Do not allow newlines within HTML elements to become mangled.
 	 *
 	 * @ticket 33106


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

Prevents wpautop() from generating invalid markup when an anchor wraps one or more block-level elements. The affected anchors are temporarily treated as block containers during paragraph cleanup, then restored without changing normal inline anchors. The placeholder name is selected to avoid collisions with existing content.`n`n## Testing

- npm run test:php -- --group 40202
- npm run test:php -- --filter Tests_Formatting_wpAutop
- PHPCBF on the changed files
- PHPCS on the changed files

## Use of AI Tools

AI assistance: Yes
Tool(s): OpenAI Codex
Model(s): GPT-5
Used for: Ticket analysis, implementation, test coverage, validation, and pull request drafting; the final changes were reviewed and validated by the contributor.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**

Trac ticket: https://core.trac.wordpress.org/ticket/40202

## Use of AI Tools

AI assistance: Yes
Tool(s): OpenAI Codex
Model(s): GPT-5
Used for: Reviewing the Trac ticket and relevant code, helping with the initial implementation and regression-test approach, and assisting with validation and PR-description drafting. The final implementation, tests, validation results, and description were reviewed and accepted by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**