### PR TITLE
Provide mechanism for host to change default Speculative Loading eagerness and mode

### DIFF
--- a/src/wp-includes/class-wp-speculation-rules.php
+++ b/src/wp-includes/class-wp-speculation-rules.php
@@ -259,24 +259,30 @@ final class WP_Speculation_Rules implements JsonSerializable {
 	 * Checks whether the given speculation rules mode is valid.
 	 *
 	 * @since 6.8.0
+	 * @since 7.1.0 The $mode param now allows mixed and not just string.
 	 *
-	 * @param string $mode Speculation rules mode.
+	 * @param mixed $mode Speculation rules mode.
 	 * @return bool True if valid, false otherwise.
+	 *
+	 * @phpstan-assert-if-true 'prefetch'|'prerender' $mode
 	 */
-	public static function is_valid_mode( string $mode ): bool {
-		return isset( self::$mode_allowlist[ $mode ] );
+	public static function is_valid_mode( $mode ): bool {
+		return is_string( $mode ) && isset( self::$mode_allowlist[ $mode ] );
 	}
 
 	/**
 	 * Checks whether the given speculation rules eagerness is valid.
 	 *
 	 * @since 6.8.0
+	 * @since 7.1.0 The $eagerness param now allows mixed and not just string.
 	 *
-	 * @param string $eagerness Speculation rules eagerness.
+	 * @param mixed $eagerness Speculation rules eagerness.
 	 * @return bool True if valid, false otherwise.
+	 *
+	 * @phpstan-assert-if-true 'conservative'|'moderate'|'eager'|'immediate' $eagerness
 	 */
-	public static function is_valid_eagerness( string $eagerness ): bool {
-		return isset( self::$eagerness_allowlist[ $eagerness ] );
+	public static function is_valid_eagerness( $eagerness ): bool {
+		return is_string( $eagerness ) && isset( self::$eagerness_allowlist[ $eagerness ] );
 	}
 
 	/**

--- a/src/wp-includes/speculative-loading.php
+++ b/src/wp-includes/speculative-loading.php
@@ -61,7 +61,6 @@ function wp_get_speculation_rules_configuration(): ?array {
 	// Sanitize the configuration and replace 'auto' with current defaults.
 	if (
 		isset( $_ENV['WP_SPECULATIVE_LOADING_DEFAULT_MODE'] ) &&
-		is_string( $_ENV['WP_SPECULATIVE_LOADING_DEFAULT_MODE'] ) &&
 		WP_Speculation_Rules::is_valid_mode( $_ENV['WP_SPECULATIVE_LOADING_DEFAULT_MODE'] )
 	) {
 		$default_mode = $_ENV['WP_SPECULATIVE_LOADING_DEFAULT_MODE'];
@@ -70,7 +69,6 @@ function wp_get_speculation_rules_configuration(): ?array {
 	}
 	if (
 		isset( $_ENV['WP_SPECULATIVE_LOADING_DEFAULT_EAGERNESS'] ) &&
-		is_string( $_ENV['WP_SPECULATIVE_LOADING_DEFAULT_EAGERNESS'] ) &&
 		WP_Speculation_Rules::is_valid_eagerness( $_ENV['WP_SPECULATIVE_LOADING_DEFAULT_EAGERNESS'] )
 	) {
 		$default_eagerness = $_ENV['WP_SPECULATIVE_LOADING_DEFAULT_EAGERNESS'];

--- a/src/wp-includes/speculative-loading.php
+++ b/src/wp-includes/speculative-loading.php
@@ -11,6 +11,8 @@
  * Returns the speculation rules configuration.
  *
  * @since 6.8.0
+ * @since 7.1.0 Environment variables `WP_SPECULATIVE_LOADING_DEFAULT_MODE` and `WP_SPECULATIVE_LOADING_DEFAULT_EAGERNESS`
+ *              now can specify the default mode and eagerness, respectively.
  *
  * @return array<string, string>|null Associative array with 'mode' and 'eagerness' keys, or null if speculative
  *                                    loading is disabled.

--- a/src/wp-includes/speculative-loading.php
+++ b/src/wp-includes/speculative-loading.php
@@ -59,8 +59,24 @@ function wp_get_speculation_rules_configuration(): ?array {
 	}
 
 	// Sanitize the configuration and replace 'auto' with current defaults.
-	$default_mode      = 'prefetch';
-	$default_eagerness = 'conservative';
+	if (
+		isset( $_ENV['WP_SPECULATIVE_LOADING_DEFAULT_MODE'] ) &&
+		is_string( $_ENV['WP_SPECULATIVE_LOADING_DEFAULT_MODE'] ) &&
+		WP_Speculation_Rules::is_valid_mode( $_ENV['WP_SPECULATIVE_LOADING_DEFAULT_MODE'] )
+	) {
+		$default_mode = $_ENV['WP_SPECULATIVE_LOADING_DEFAULT_MODE'];
+	} else {
+		$default_mode = 'prefetch';
+	}
+	if (
+		isset( $_ENV['WP_SPECULATIVE_LOADING_DEFAULT_EAGERNESS'] ) &&
+		is_string( $_ENV['WP_SPECULATIVE_LOADING_DEFAULT_EAGERNESS'] ) &&
+		WP_Speculation_Rules::is_valid_eagerness( $_ENV['WP_SPECULATIVE_LOADING_DEFAULT_EAGERNESS'] )
+	) {
+		$default_eagerness = $_ENV['WP_SPECULATIVE_LOADING_DEFAULT_EAGERNESS'];
+	} else {
+		$default_eagerness = 'conservative';
+	}
 	if ( ! is_array( $config ) ) {
 		return array(
 			'mode'      => $default_mode,

--- a/src/wp-includes/speculative-loading.php
+++ b/src/wp-includes/speculative-loading.php
@@ -14,6 +14,10 @@
  *
  * @return array<string, string>|null Associative array with 'mode' and 'eagerness' keys, or null if speculative
  *                                    loading is disabled.
+ * @phpstan-return array{
+ *     mode: 'prefetch'|'prerender',
+ *     eagerness: 'conservative'|'moderate'|'eager'|'immediate',
+ * }|null
  */
 function wp_get_speculation_rules_configuration(): ?array {
 	// By default, speculative loading is only enabled for sites with pretty permalinks when no user is logged in.

--- a/src/wp-includes/speculative-loading.php
+++ b/src/wp-includes/speculative-loading.php
@@ -170,6 +170,7 @@ function wp_get_speculation_rules(): ?WP_Speculation_Rules {
 	 * @param string   $mode               Mode used to apply speculative loading. Either 'prefetch' or 'prerender'.
 	 */
 	$href_exclude_paths = (array) apply_filters( 'wp_speculation_rules_href_exclude_paths', array(), $mode );
+	$href_exclude_paths = array_filter( $href_exclude_paths, 'is_string' );
 
 	// Ensure that:
 	// 1. There are no duplicates.

--- a/src/wp-includes/speculative-loading.php
+++ b/src/wp-includes/speculative-loading.php
@@ -11,14 +11,16 @@
  * Returns the speculation rules configuration.
  *
  * @since 6.8.0
- * @since 7.1.0 Environment variables `WP_SPECULATIVE_LOADING_DEFAULT_MODE` and `WP_SPECULATIVE_LOADING_DEFAULT_EAGERNESS`
- *              now can specify the default mode and eagerness, respectively.
+ * @since 7.1.0 The `WP_SPECULATIVE_LOADING_DEFAULT_MODE` and `WP_SPECULATIVE_LOADING_DEFAULT_EAGERNESS` constants and
+ *              environment variables can now specify the default mode and eagerness, respectively.
+ *
+ * @see wp_get_speculation_rules_default_configuration()
  *
  * @return array<string, string>|null Associative array with 'mode' and 'eagerness' keys, or null if speculative
  *                                    loading is disabled.
  * @phpstan-return array{
  *     mode: 'prefetch'|'prerender',
- *     eagerness: 'conservative'|'moderate'|'eager'|'immediate',
+ *     eagerness: 'conservative'|'moderate'|'eager',
  * }|null
  */
 function wp_get_speculation_rules_configuration(): ?array {
@@ -65,22 +67,10 @@ function wp_get_speculation_rules_configuration(): ?array {
 	}
 
 	// Sanitize the configuration and replace 'auto' with current defaults.
-	if (
-		isset( $_ENV['WP_SPECULATIVE_LOADING_DEFAULT_MODE'] ) &&
-		WP_Speculation_Rules::is_valid_mode( $_ENV['WP_SPECULATIVE_LOADING_DEFAULT_MODE'] )
-	) {
-		$default_mode = $_ENV['WP_SPECULATIVE_LOADING_DEFAULT_MODE'];
-	} else {
-		$default_mode = 'prefetch';
-	}
-	if (
-		isset( $_ENV['WP_SPECULATIVE_LOADING_DEFAULT_EAGERNESS'] ) &&
-		WP_Speculation_Rules::is_valid_eagerness( $_ENV['WP_SPECULATIVE_LOADING_DEFAULT_EAGERNESS'] )
-	) {
-		$default_eagerness = $_ENV['WP_SPECULATIVE_LOADING_DEFAULT_EAGERNESS'];
-	} else {
-		$default_eagerness = 'conservative';
-	}
+	$defaults          = wp_get_speculation_rules_default_configuration();
+	$default_mode      = $defaults['mode'];
+	$default_eagerness = $defaults['eagerness'];
+
 	if ( ! is_array( $config ) ) {
 		return array(
 			'mode'      => $default_mode,
@@ -108,6 +98,83 @@ function wp_get_speculation_rules_configuration(): ?array {
 		'mode'      => $config['mode'],
 		'eagerness' => $config['eagerness'],
 	);
+}
+
+/**
+ * Returns the default speculation rules configuration that the value 'auto' resolves to.
+ *
+ * WordPress Core defaults to a mode of 'prefetch' and an eagerness of 'conservative'. Hosting providers can override
+ * either default by way of the `WP_SPECULATIVE_LOADING_DEFAULT_MODE` and `WP_SPECULATIVE_LOADING_DEFAULT_EAGERNESS`
+ * constants or environment variables. This only changes what the 'auto' value resolves to, so a plugin which supplies
+ * an explicit mode or eagerness via the {@see 'wp_speculation_rules_configuration'} filter continues to take
+ * precedence.
+ *
+ * Note that an eagerness of 'immediate' is not permitted as a default, since WordPress does not allow it for the
+ * document-level rules that it generates.
+ *
+ * @since 7.1.0
+ * @access private
+ *
+ * @return array<string, string> Associative array with 'mode' and 'eagerness' keys.
+ * @phpstan-return array{
+ *     mode: 'prefetch'|'prerender',
+ *     eagerness: 'conservative'|'moderate'|'eager',
+ * }
+ */
+function wp_get_speculation_rules_default_configuration(): array {
+	$default_mode = 'prefetch';
+	$mode         = wp_get_speculative_loading_override( 'WP_SPECULATIVE_LOADING_DEFAULT_MODE' );
+	if ( WP_Speculation_Rules::is_valid_mode( $mode ) ) {
+		$default_mode = $mode;
+	}
+
+	$default_eagerness = 'conservative';
+	$eagerness         = wp_get_speculative_loading_override( 'WP_SPECULATIVE_LOADING_DEFAULT_EAGERNESS' );
+	if (
+		WP_Speculation_Rules::is_valid_eagerness( $eagerness ) &&
+		// 'immediate' is a valid eagerness, but for safety WordPress does not allow it for document-level rules.
+		'immediate' !== $eagerness
+	) {
+		$default_eagerness = $eagerness;
+	}
+
+	return array(
+		'mode'      => $default_mode,
+		'eagerness' => $default_eagerness,
+	);
+}
+
+/**
+ * Returns the value of a speculative loading override, as supplied by a constant or an environment variable.
+ *
+ * The constant takes precedence over the environment variable, consistent with {@see wp_get_environment_type()}.
+ *
+ * @since 7.1.0
+ * @access private
+ *
+ * @param string $name Name of the constant and environment variable to look up.
+ * @return string|null The override value, or null if neither is set.
+ */
+function wp_get_speculative_loading_override( string $name ): ?string {
+	$value = null;
+
+	// Check if the environment variable has been set, if `getenv` is available on the system.
+	if ( function_exists( 'getenv' ) ) {
+		$has_env = getenv( $name );
+		if ( false !== $has_env ) {
+			$value = $has_env;
+		}
+	}
+
+	// Fetch the value from a constant, which overrides the environment variable.
+	if ( defined( $name ) ) {
+		$has_constant = constant( $name );
+		if ( is_string( $has_constant ) ) {
+			$value = $has_constant;
+		}
+	}
+
+	return $value;
 }
 
 /**

--- a/tests/phpunit/tests/speculative-loading/wpGetSpeculationRules.php
+++ b/tests/phpunit/tests/speculative-loading/wpGetSpeculationRules.php
@@ -21,8 +21,19 @@ class Tests_Speculative_Loading_wpGetSpeculationRules extends WP_UnitTestCase {
 		'eagerness' => 'conservative',
 	);
 
-	public function set_up() {
+	/**
+	 * Stores the original speculative loading env values for cleanup.
+	 *
+	 * @var array<string, string|false>
+	 */
+	private array $original_env = array();
+
+	public function set_up(): void {
 		parent::set_up();
+
+		foreach ( array( 'WP_SPECULATIVE_LOADING_DEFAULT_MODE', 'WP_SPECULATIVE_LOADING_DEFAULT_EAGERNESS' ) as $name ) {
+			$this->original_env[ $name ] = getenv( $name );
+		}
 
 		add_filter(
 			'template_directory_uri',
@@ -42,8 +53,13 @@ class Tests_Speculative_Loading_wpGetSpeculationRules extends WP_UnitTestCase {
 	}
 
 	public function tear_down(): void {
-		putenv( 'WP_SPECULATIVE_LOADING_DEFAULT_MODE' );
-		putenv( 'WP_SPECULATIVE_LOADING_DEFAULT_EAGERNESS' );
+		foreach ( $this->original_env as $name => $value ) {
+			if ( false === $value ) {
+				putenv( $name );
+			} else {
+				putenv( "{$name}={$value}" );
+			}
+		}
 
 		parent::tear_down();
 	}

--- a/tests/phpunit/tests/speculative-loading/wpGetSpeculationRules.php
+++ b/tests/phpunit/tests/speculative-loading/wpGetSpeculationRules.php
@@ -41,6 +41,13 @@ class Tests_Speculative_Loading_wpGetSpeculationRules extends WP_UnitTestCase {
 		update_option( 'permalink_structure', '/%year%/%monthnum%/%day%/%postname%/' );
 	}
 
+	public function tear_down(): void {
+		putenv( 'WP_SPECULATIVE_LOADING_DEFAULT_MODE' );
+		putenv( 'WP_SPECULATIVE_LOADING_DEFAULT_EAGERNESS' );
+
+		parent::tear_down();
+	}
+
 	/**
 	 * Tests speculation rules output with prefetch for the different eagerness levels.
 	 *
@@ -557,5 +564,44 @@ class Tests_Speculative_Loading_wpGetSpeculationRules extends WP_UnitTestCase {
 		$this->assertSame( 'conservative', $rules['prefetch'][0]['eagerness'] );
 		$this->assertSame( 'moderate', $rules['prerender'][0]['eagerness'] );
 		$this->assertSame( 'eager', $rules['prerender'][1]['eagerness'] );
+	}
+
+	/**
+	 * Tests that an overridden default eagerness is applied to the main document-level rule.
+	 *
+	 * @ticket 65624
+	 */
+	public function test_wp_get_speculation_rules_with_overridden_default_eagerness(): void {
+		putenv( 'WP_SPECULATIVE_LOADING_DEFAULT_EAGERNESS=moderate' );
+
+		$rules = wp_get_speculation_rules();
+		$this->assertInstanceOf( WP_Speculation_Rules::class, $rules );
+
+		$rules = $rules->jsonSerialize();
+
+		$this->assertArrayHasKey( 'prefetch', $rules );
+		$this->assertCount( 1, $rules['prefetch'] );
+		$this->assertSame( 'moderate', $rules['prefetch'][0]['eagerness'] );
+	}
+
+	/**
+	 * Tests that an eagerness of 'immediate' cannot be forced as the default.
+	 *
+	 * WordPress does not allow 'immediate' for the document-level rules it generates, so allowing it as a default
+	 * would cause the main rule to be rejected, leaving no speculation rules at all.
+	 *
+	 * @ticket 65624
+	 */
+	public function test_wp_get_speculation_rules_with_immediate_default_eagerness(): void {
+		putenv( 'WP_SPECULATIVE_LOADING_DEFAULT_EAGERNESS=immediate' );
+
+		$rules = wp_get_speculation_rules();
+		$this->assertInstanceOf( WP_Speculation_Rules::class, $rules );
+
+		$rules = $rules->jsonSerialize();
+
+		$this->assertArrayHasKey( 'prefetch', $rules );
+		$this->assertCount( 1, $rules['prefetch'] );
+		$this->assertSame( 'conservative', $rules['prefetch'][0]['eagerness'] );
 	}
 }

--- a/tests/phpunit/tests/speculative-loading/wpGetSpeculationRulesConfiguration.php
+++ b/tests/phpunit/tests/speculative-loading/wpGetSpeculationRulesConfiguration.php
@@ -18,6 +18,13 @@ class Tests_Speculative_Loading_wpGetSpeculationRulesConfiguration extends WP_Un
 		update_option( 'permalink_structure', '/%year%/%monthnum%/%day%/%postname%/' );
 	}
 
+	public function tear_down(): void {
+		putenv( 'WP_SPECULATIVE_LOADING_DEFAULT_MODE' );
+		putenv( 'WP_SPECULATIVE_LOADING_DEFAULT_EAGERNESS' );
+
+		parent::tear_down();
+	}
+
 	/**
 	 * Tests that the default configuration is the expected value.
 	 *
@@ -263,5 +270,64 @@ class Tests_Speculative_Loading_wpGetSpeculationRulesConfiguration extends WP_Un
 				),
 			),
 		);
+	}
+
+	/**
+	 * Tests that an overridden default is what the 'auto' value resolves to.
+	 *
+	 * @ticket 65624
+	 */
+	public function test_wp_get_speculation_rules_configuration_with_overridden_default(): void {
+		putenv( 'WP_SPECULATIVE_LOADING_DEFAULT_EAGERNESS=moderate' );
+
+		$this->assertSame(
+			array(
+				'mode'      => 'prefetch',
+				'eagerness' => 'moderate',
+			),
+			wp_get_speculation_rules_configuration()
+		);
+	}
+
+	/**
+	 * Tests that an explicit eagerness from the filter takes precedence over an overridden default.
+	 *
+	 * This ensures a plugin such as Speculative Loading continues to win over a hosting provider's default.
+	 *
+	 * @ticket 65624
+	 */
+	public function test_wp_get_speculation_rules_configuration_filter_beats_overridden_default(): void {
+		putenv( 'WP_SPECULATIVE_LOADING_DEFAULT_EAGERNESS=moderate' );
+
+		add_filter(
+			'wp_speculation_rules_configuration',
+			static function () {
+				return array(
+					'mode'      => 'auto',
+					'eagerness' => 'conservative',
+				);
+			}
+		);
+
+		$this->assertSame(
+			array(
+				'mode'      => 'prefetch',
+				'eagerness' => 'conservative',
+			),
+			wp_get_speculation_rules_configuration()
+		);
+	}
+
+	/**
+	 * Tests that speculative loading remains disabled when a default is overridden.
+	 *
+	 * @ticket 65624
+	 */
+	public function test_wp_get_speculation_rules_configuration_with_overridden_default_while_disabled(): void {
+		putenv( 'WP_SPECULATIVE_LOADING_DEFAULT_EAGERNESS=moderate' );
+
+		add_filter( 'wp_speculation_rules_configuration', '__return_null' );
+
+		$this->assertNull( wp_get_speculation_rules_configuration() );
 	}
 }

--- a/tests/phpunit/tests/speculative-loading/wpGetSpeculationRulesConfiguration.php
+++ b/tests/phpunit/tests/speculative-loading/wpGetSpeculationRulesConfiguration.php
@@ -12,15 +12,31 @@
  */
 class Tests_Speculative_Loading_wpGetSpeculationRulesConfiguration extends WP_UnitTestCase {
 
-	public function set_up() {
+	/**
+	 * Stores the original speculative loading env values for cleanup.
+	 *
+	 * @var array<string, string|false>
+	 */
+	private array $original_env = array();
+
+	public function set_up(): void {
 		parent::set_up();
+
+		foreach ( array( 'WP_SPECULATIVE_LOADING_DEFAULT_MODE', 'WP_SPECULATIVE_LOADING_DEFAULT_EAGERNESS' ) as $name ) {
+			$this->original_env[ $name ] = getenv( $name );
+		}
 
 		update_option( 'permalink_structure', '/%year%/%monthnum%/%day%/%postname%/' );
 	}
 
 	public function tear_down(): void {
-		putenv( 'WP_SPECULATIVE_LOADING_DEFAULT_MODE' );
-		putenv( 'WP_SPECULATIVE_LOADING_DEFAULT_EAGERNESS' );
+		foreach ( $this->original_env as $name => $value ) {
+			if ( false === $value ) {
+				putenv( $name );
+			} else {
+				putenv( "{$name}={$value}" );
+			}
+		}
 
 		parent::tear_down();
 	}

--- a/tests/phpunit/tests/speculative-loading/wpGetSpeculationRulesDefaultConfiguration.php
+++ b/tests/phpunit/tests/speculative-loading/wpGetSpeculationRulesDefaultConfiguration.php
@@ -12,9 +12,29 @@
  */
 class Tests_Speculative_Loading_wpGetSpeculationRulesDefaultConfiguration extends WP_UnitTestCase {
 
+	/**
+	 * Stores the original speculative loading env values for cleanup.
+	 *
+	 * @var array<string, string|false>
+	 */
+	private array $original_env = array();
+
+	public function set_up(): void {
+		parent::set_up();
+
+		foreach ( array( 'WP_SPECULATIVE_LOADING_DEFAULT_MODE', 'WP_SPECULATIVE_LOADING_DEFAULT_EAGERNESS' ) as $name ) {
+			$this->original_env[ $name ] = getenv( $name );
+		}
+	}
+
 	public function tear_down(): void {
-		putenv( 'WP_SPECULATIVE_LOADING_DEFAULT_MODE' );
-		putenv( 'WP_SPECULATIVE_LOADING_DEFAULT_EAGERNESS' );
+		foreach ( $this->original_env as $name => $value ) {
+			if ( false === $value ) {
+				putenv( $name );
+			} else {
+				putenv( "{$name}={$value}" );
+			}
+		}
 
 		parent::tear_down();
 	}

--- a/tests/phpunit/tests/speculative-loading/wpGetSpeculationRulesDefaultConfiguration.php
+++ b/tests/phpunit/tests/speculative-loading/wpGetSpeculationRulesDefaultConfiguration.php
@@ -1,0 +1,231 @@
+<?php
+/**
+ * Tests for the wp_get_speculation_rules_default_configuration() function.
+ *
+ * @package WordPress
+ * @subpackage Speculative Loading
+ */
+
+/**
+ * @group speculative-loading
+ * @covers ::wp_get_speculation_rules_default_configuration
+ */
+class Tests_Speculative_Loading_wpGetSpeculationRulesDefaultConfiguration extends WP_UnitTestCase {
+
+	public function tear_down(): void {
+		putenv( 'WP_SPECULATIVE_LOADING_DEFAULT_MODE' );
+		putenv( 'WP_SPECULATIVE_LOADING_DEFAULT_EAGERNESS' );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Tests that WordPress Core defaults to a conservative prefetch.
+	 *
+	 * @ticket 65624
+	 */
+	public function test_core_defaults(): void {
+		$this->assertSame(
+			array(
+				'mode'      => 'prefetch',
+				'eagerness' => 'conservative',
+			),
+			wp_get_speculation_rules_default_configuration()
+		);
+	}
+
+	/**
+	 * Tests that the defaults can be overridden by environment variables.
+	 *
+	 * @ticket 65624
+	 * @dataProvider data_environment_variables
+	 *
+	 * @param string|null           $mode      Value for the mode environment variable, or null to leave it unset.
+	 * @param string|null           $eagerness Value for the eagerness environment variable, or null to leave it unset.
+	 * @param array<string, string> $expected  Expected default configuration.
+	 */
+	public function test_environment_variables( ?string $mode, ?string $eagerness, array $expected ): void {
+		if ( null !== $mode ) {
+			putenv( "WP_SPECULATIVE_LOADING_DEFAULT_MODE={$mode}" );
+		}
+		if ( null !== $eagerness ) {
+			putenv( "WP_SPECULATIVE_LOADING_DEFAULT_EAGERNESS={$eagerness}" );
+		}
+
+		$this->assertSame( $expected, wp_get_speculation_rules_default_configuration() );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array<string, array{
+	 *     0: string|null,
+	 *     1: string|null,
+	 *     2: array{
+	 *         mode: string,
+	 *         eagerness: string,
+	 *     },
+	 * }> Test parameters, keyed by test case name. Each entry consists of the value for the mode environment
+	 *    variable, the value for the eagerness environment variable, and the expected default configuration. A
+	 *    `null` environment variable value means the variable is left unset.
+	 */
+	public static function data_environment_variables(): array {
+		return array(
+			'moderate eagerness'            => array(
+				null,
+				'moderate',
+				array(
+					'mode'      => 'prefetch',
+					'eagerness' => 'moderate',
+				),
+			),
+			'eager eagerness'               => array(
+				null,
+				'eager',
+				array(
+					'mode'      => 'prefetch',
+					'eagerness' => 'eager',
+				),
+			),
+			'prerender mode'                => array(
+				'prerender',
+				null,
+				array(
+					'mode'      => 'prerender',
+					'eagerness' => 'conservative',
+				),
+			),
+			'both mode and eagerness'       => array(
+				'prerender',
+				'moderate',
+				array(
+					'mode'      => 'prerender',
+					'eagerness' => 'moderate',
+				),
+			),
+			/*
+			 * 'immediate' is a valid eagerness, but for safety WordPress does not allow it for document-level rules,
+			 * so it must not be usable as the default either.
+			 */
+			'immediate eagerness'           => array(
+				null,
+				'immediate',
+				array(
+					'mode'      => 'prefetch',
+					'eagerness' => 'conservative',
+				),
+			),
+			'invalid mode'                  => array(
+				'invalid',
+				null,
+				array(
+					'mode'      => 'prefetch',
+					'eagerness' => 'conservative',
+				),
+			),
+			'invalid eagerness'             => array(
+				null,
+				'invalid',
+				array(
+					'mode'      => 'prefetch',
+					'eagerness' => 'conservative',
+				),
+			),
+			'empty string'                  => array(
+				'',
+				'',
+				array(
+					'mode'      => 'prefetch',
+					'eagerness' => 'conservative',
+				),
+			),
+			'invalid mode, valid eagerness' => array(
+				'invalid',
+				'moderate',
+				array(
+					'mode'      => 'prefetch',
+					'eagerness' => 'moderate',
+				),
+			),
+			'valid mode, invalid eagerness' => array(
+				'prerender',
+				'invalid',
+				array(
+					'mode'      => 'prerender',
+					'eagerness' => 'conservative',
+				),
+			),
+			'wrong case is not normalized'  => array(
+				'PREFETCH',
+				'MODERATE',
+				array(
+					'mode'      => 'prefetch',
+					'eagerness' => 'conservative',
+				),
+			),
+			'auto is not a valid env value' => array(
+				'auto',
+				'auto',
+				array(
+					'mode'      => 'prefetch',
+					'eagerness' => 'conservative',
+				),
+			),
+		);
+	}
+
+	/**
+	 * Tests that the defaults can be overridden by constants.
+	 *
+	 * @ticket 65624
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_constants(): void {
+		define( 'WP_SPECULATIVE_LOADING_DEFAULT_MODE', 'prerender' );
+		define( 'WP_SPECULATIVE_LOADING_DEFAULT_EAGERNESS', 'moderate' );
+
+		$this->assertSame(
+			array(
+				'mode'      => 'prerender',
+				'eagerness' => 'moderate',
+			),
+			wp_get_speculation_rules_default_configuration()
+		);
+	}
+
+	/**
+	 * Tests that a constant takes precedence over an environment variable.
+	 *
+	 * @ticket 65624
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_constant_overrides_environment_variable(): void {
+		putenv( 'WP_SPECULATIVE_LOADING_DEFAULT_EAGERNESS=eager' );
+		define( 'WP_SPECULATIVE_LOADING_DEFAULT_EAGERNESS', 'moderate' );
+
+		$config = wp_get_speculation_rules_default_configuration();
+
+		$this->assertSame( 'moderate', $config['eagerness'] );
+	}
+
+	/**
+	 * Tests that an invalid constant falls back to the Core default rather than to the environment variable.
+	 *
+	 * @ticket 65624
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_invalid_constant_falls_back_to_core_default(): void {
+		putenv( 'WP_SPECULATIVE_LOADING_DEFAULT_EAGERNESS=eager' );
+		define( 'WP_SPECULATIVE_LOADING_DEFAULT_EAGERNESS', 'invalid' );
+
+		$config = wp_get_speculation_rules_default_configuration();
+
+		$this->assertSame( 'conservative', $config['eagerness'] );
+	}
+}


### PR DESCRIPTION
Provides a mechanism for hosting providers to change the default speculative loading `mode` and `eagerness` that the `auto` value resolves to, without having to ship an mu-plugin.

This is the first step proposed in [comment:26](https://core.trac.wordpress.org/ticket/64066#comment:26) of Core-64066: give hosts an opt-in so they can enable a `moderate` default and report back on the resulting TTFB/LCP improvements and the increase in server load from wasted speculations. If that data is favorable, a later change can consider using the page cache and persistent object cache Site Health results as the heuristic for defaulting to `moderate`, with these overrides then serving as the opt-out.

## Approach

Two overrides are introduced, each settable as either an environment variable or a constant:

* `WP_SPECULATIVE_LOADING_DEFAULT_MODE` — `prefetch` (default) or `prerender`.
* `WP_SPECULATIVE_LOADING_DEFAULT_EAGERNESS` — `conservative` (default), `moderate`, or `eager`.

Resolution follows `wp_get_environment_type()`: the environment variable is read with `getenv()`, and a constant of the same name takes precedence over it. Supporting the constant means a host can set this from `wp-config.php`, which is how hosts already inject `WP_CACHE` and friends. An invalid or unrecognized value falls back to the Core default.

These only change what `auto` resolves to. A plugin that supplies an explicit `mode` or `eagerness` through the `wp_speculation_rules_configuration` filter still takes precedence over a host's default, so the Speculative Loading plugin continues to win.

An `eagerness` of `immediate` is deliberately not accepted, since WordPress does not permit it for the document-level rules it generates — `WP_Speculation_Rules::add_rule()` rejects such a rule, which would leave the site with no speculation rules at all.

Also widens `WP_Speculation_Rules::is_valid_mode()` and `::is_valid_eagerness()` to accept `mixed` rather than `string`. Both are validation methods, so accepting an arbitrary value and returning `false` is the more useful contract; it also hardens the filter path, where a plugin returning e.g. an array for `mode` would previously have caused a `TypeError`.

## Testing instructions

1. Confirm the default output is unchanged: view the source of a front-end page as a logged-out user with pretty permalinks enabled, and observe the speculation rules script with `"eagerness": "conservative"` and a `prefetch` rule.
2. Set the environment variable for your web server (or add `define( 'WP_SPECULATIVE_LOADING_DEFAULT_EAGERNESS', 'moderate' );` to `wp-config.php`).
3. Reload and observe the rules now use `"eagerness": "moderate"`.
4. Set the value to something invalid (e.g. `bogus`, or `immediate`) and confirm the rules fall back to `conservative` and that speculation rules are still output.
5. With the override still set to `moderate`, add a filter returning an explicit `'eagerness' => 'conservative'` and confirm the filter wins.

Unit tests cover the environment variable and constant handling, the precedence of the constant over the environment variable, invalid/empty values, the rejection of `immediate`, and that an explicit filter value still beats a host default:

```
npm run test:php -- --group=speculative-loading
```

Trac ticket: https://core.trac.wordpress.org/ticket/65624

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 4.8
Used for: Reviewing the initial implementation, which surfaced two defects that I have since fixed — the overrides were originally read from `$_ENV`, which is not populated under the `variables_order` value that PHP's shipped `php.ini` files use, so they were silently ignored on a stock install; and `immediate` was accepted as a default eagerness, which caused the main document-level rule to be rejected and left the page with no speculation rules. Also used to draft the accompanying unit tests. I have reviewed and take responsibility for all of the above.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
