### PR TITLE
Tests: Use `assertContainsOnlyInstancesOf()` instead of looping over collections.

### DIFF
--- a/tests/phpunit/tests/post/getPages.php
+++ b/tests/phpunit/tests/post/getPages.php
@@ -55,18 +55,14 @@ class Tests_Post_GetPages extends WP_UnitTestCase {
 		$time1 = wp_cache_get( 'last_changed', 'posts' );
 		$this->assertNotEmpty( $time1 );
 		$num_queries = get_num_queries();
-		foreach ( $pages as $page ) {
-			$this->assertInstanceOf( 'WP_Post', $page );
-		}
+		$this->assertContainsOnlyInstancesOf( 'WP_Post', $pages );
 
 		// Again. num_queries and last_changed should remain the same.
 		$pages = get_pages();
 		$this->assertCount( 3, $pages );
 		$this->assertSame( $time1, wp_cache_get( 'last_changed', 'posts' ) );
 		$this->assertSame( $num_queries, get_num_queries() );
-		foreach ( $pages as $page ) {
-			$this->assertInstanceOf( 'WP_Post', $page );
-		}
+		$this->assertContainsOnlyInstancesOf( 'WP_Post', $pages );
 
 		// Again with different args. last_changed should not increment because of
 		// different args to get_pages(). num_queries should bump by 1.
@@ -74,9 +70,7 @@ class Tests_Post_GetPages extends WP_UnitTestCase {
 		$this->assertCount( 2, $pages );
 		$this->assertSame( $time1, wp_cache_get( 'last_changed', 'posts' ) );
 		$this->assertSame( $num_queries + 1, get_num_queries() );
-		foreach ( $pages as $page ) {
-			$this->assertInstanceOf( 'WP_Post', $page );
-		}
+		$this->assertContainsOnlyInstancesOf( 'WP_Post', $pages );
 
 		$num_queries = get_num_queries();
 
@@ -85,18 +79,14 @@ class Tests_Post_GetPages extends WP_UnitTestCase {
 		$this->assertCount( 2, $pages );
 		$this->assertSame( $time1, wp_cache_get( 'last_changed', 'posts' ) );
 		$this->assertSame( $num_queries, get_num_queries() );
-		foreach ( $pages as $page ) {
-			$this->assertInstanceOf( 'WP_Post', $page );
-		}
+		$this->assertContainsOnlyInstancesOf( 'WP_Post', $pages );
 
 		// Do the first query again. The interim queries should not affect it.
 		$pages = get_pages();
 		$this->assertCount( 3, $pages );
 		$this->assertSame( $time1, wp_cache_get( 'last_changed', 'posts' ) );
 		$this->assertSame( $num_queries, get_num_queries() );
-		foreach ( $pages as $page ) {
-			$this->assertInstanceOf( 'WP_Post', $page );
-		}
+		$this->assertContainsOnlyInstancesOf( 'WP_Post', $pages );
 
 		// Force last_changed to increment.
 		clean_post_cache( $pages[0]->ID );
@@ -109,9 +99,7 @@ class Tests_Post_GetPages extends WP_UnitTestCase {
 		$this->assertCount( 2, $pages );
 		$this->assertSame( $time2, wp_cache_get( 'last_changed', 'posts' ) );
 		$this->assertSame( $num_queries + 1, get_num_queries() );
-		foreach ( $pages as $page ) {
-			$this->assertInstanceOf( 'WP_Post', $page );
-		}
+		$this->assertContainsOnlyInstancesOf( 'WP_Post', $pages );
 
 		$last_changed = wp_cache_get( 'last_changed', 'posts' );
 
@@ -129,9 +117,7 @@ class Tests_Post_GetPages extends WP_UnitTestCase {
 		$this->assertCount( 2, $pages );
 		$this->assertSame( $last_changed, wp_cache_get( 'last_changed', 'posts' ) );
 		$this->assertSame( $num_queries + 1, get_num_queries() );
-		foreach ( $pages as $page ) {
-			$this->assertInstanceOf( 'WP_Post', $page );
-		}
+		$this->assertContainsOnlyInstancesOf( 'WP_Post', $pages );
 	}
 
 	/**

--- a/tests/phpunit/tests/post/wpPostType.php
+++ b/tests/phpunit/tests/post/wpPostType.php
@@ -9,9 +9,7 @@ class Tests_Post_WP_Post_Type extends WP_UnitTestCase {
 
 		$this->assertNotEmpty( $wp_post_types );
 
-		foreach ( $wp_post_types as $post_type ) {
-			$this->assertInstanceOf( 'WP_Post_Type', $post_type );
-		}
+		$this->assertContainsOnlyInstancesOf( 'WP_Post_Type', $wp_post_types );
 	}
 
 	public function test_add_supports_defaults() {

--- a/tests/phpunit/tests/term/getTerms.php
+++ b/tests/phpunit/tests/term/getTerms.php
@@ -2876,9 +2876,7 @@ class Tests_Term_getTerms extends WP_UnitTestCase {
 
 		$this->assertNotEmpty( $found );
 
-		foreach ( $found as $term ) {
-			$this->assertInstanceOf( 'WP_Term', $term );
-		}
+		$this->assertContainsOnlyInstancesOf( 'WP_Term', $found );
 	}
 
 	/**
@@ -2914,9 +2912,7 @@ class Tests_Term_getTerms extends WP_UnitTestCase {
 
 		$this->assertNotEmpty( $found );
 
-		foreach ( $found as $term ) {
-			$this->assertInstanceOf( 'WP_Term', $term );
-		}
+		$this->assertContainsOnlyInstancesOf( 'WP_Term', $found );
 	}
 
 	/**

--- a/tests/phpunit/tests/term/wpGetObjectTerms.php
+++ b/tests/phpunit/tests/term/wpGetObjectTerms.php
@@ -781,9 +781,7 @@ class Tests_Term_WpGetObjectTerms extends WP_UnitTestCase {
 		);
 
 		$this->assertNotEmpty( $found );
-		foreach ( $found as $f ) {
-			$this->assertInstanceOf( 'WP_Term', $f );
-		}
+		$this->assertContainsOnlyInstancesOf( 'WP_Term', $found );
 	}
 
 	/**
@@ -804,9 +802,7 @@ class Tests_Term_WpGetObjectTerms extends WP_UnitTestCase {
 		);
 
 		$this->assertNotEmpty( $found );
-		foreach ( $found as $f ) {
-			$this->assertInstanceOf( 'WP_Term', $f );
-		}
+		$this->assertContainsOnlyInstancesOf( 'WP_Term', $found );
 	}
 
 	/**

--- a/tests/phpunit/tests/term/wpTaxonomy.php
+++ b/tests/phpunit/tests/term/wpTaxonomy.php
@@ -9,9 +9,7 @@ class Tests_WP_Taxonomy extends WP_UnitTestCase {
 
 		$this->assertNotEmpty( $wp_taxonomies );
 
-		foreach ( $wp_taxonomies as $taxonomy ) {
-			$this->assertInstanceOf( 'WP_Taxonomy', $taxonomy );
-		}
+		$this->assertContainsOnlyInstancesOf( 'WP_Taxonomy', $wp_taxonomies );
 	}
 
 	public function test_does_not_add_query_var_if_not_public() {

--- a/tests/phpunit/tests/user/query.php
+++ b/tests/phpunit/tests/user/query.php
@@ -138,9 +138,7 @@ class Tests_User_Query extends WP_UnitTestCase {
 
 		// +1 for the default user created during installation.
 		$this->assertCount( 13, $users );
-		foreach ( $users as $user ) {
-			$this->assertInstanceOf( 'WP_User', $user );
-		}
+		$this->assertContainsOnlyInstancesOf( 'WP_User', $users );
 
 		$users = new WP_User_Query(
 			array(
@@ -150,9 +148,7 @@ class Tests_User_Query extends WP_UnitTestCase {
 		);
 		$users = $users->get_results();
 		$this->assertCount( 13, $users );
-		foreach ( $users as $user ) {
-			$this->assertInstanceOf( 'WP_User', $user );
-		}
+		$this->assertContainsOnlyInstancesOf( 'WP_User', $users );
 	}
 
 	/**
@@ -1416,9 +1412,7 @@ class Tests_User_Query extends WP_UnitTestCase {
 
 		$this->assertCount( 2, $users );
 
-		foreach ( $users as $user ) {
-			$this->assertInstanceOf( 'WP_User', $user );
-		}
+		$this->assertContainsOnlyInstancesOf( 'WP_User', $users );
 	}
 
 	/**
@@ -1430,9 +1424,7 @@ class Tests_User_Query extends WP_UnitTestCase {
 
 		// +1 for the default user created during installation.
 		$this->assertCount( 8, $users );
-		foreach ( $users as $user ) {
-			$this->assertInstanceOf( 'WP_User', $user );
-		}
+		$this->assertContainsOnlyInstancesOf( 'WP_User', $users );
 	}
 
 	/**


### PR DESCRIPTION
✅  Committed in r62751 (8b7872f97950e32d4fcf84bf738f059f69620bb1)

----

Replace `foreach` loops calling `assertInstanceOf()` on each element with a single `assertContainsOnlyInstancesOf()` assertion. This clarifies intent, reduces boilerplate, and produces more descriptive failure messages.

Docs: https://docs.phpunit.de/en/13.2/assertions.html#assertcontainsonlyinstancesof

Trac ticket: https://core.trac.wordpress.org/ticket/64894

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
