### PR TITLE
Block Supports: Improve handling of block class name to avoid fatal

### DIFF
--- a/src/wp-includes/block-supports/block-style-variations.php
+++ b/src/wp-includes/block-supports/block-style-variations.php
@@ -223,11 +223,16 @@ function wp_render_block_style_variation_class_name( $block_content, $block ) {
 		return $block_content;
 	}
 
+	$block_class_name = $block['attrs']['className'];
+	if ( ! is_string( $block_class_name ) ) {
+		return $block_content;
+	}
+
 	/*
 	 * Matches a class prefixed by `is-style`, followed by the
 	 * variation slug, then `--`, and finally an instance number.
 	 */
-	preg_match( '/\bis-style-(\S+?--\d+)\b/', $block['attrs']['className'], $matches );
+	preg_match( '/\bis-style-(\S+?--\d+)\b/', $block_class_name, $matches );
 
 	if ( empty( $matches ) ) {
 		return $block_content;

--- a/src/wp-includes/block-supports/layout.php
+++ b/src/wp-includes/block-supports/layout.php
@@ -1160,7 +1160,9 @@ function wp_render_layout_support_flag( $block_content, $block ) {
 		// Check if the block has an active style variation with a blockGap value.
 		// Only check the registry if the className contains a variation class to avoid unnecessary lookups.
 		$variation_block_gap_value = null;
-		$block_class_name          = $block['attrs']['className'] ?? '';
+		$block_class_name          = is_string( $block['attrs']['className'] ?? null )
+			? $block['attrs']['className']
+			: '';
 		if ( $block_class_name && str_contains( $block_class_name, 'is-style-' ) && $block_name ) {
 			$styles_registry   = WP_Block_Styles_Registry::get_instance();
 			$registered_styles = $styles_registry->get_registered_styles_for_block( $block_name );

--- a/tests/phpunit/tests/block-supports/block-style-variations.php
+++ b/tests/phpunit/tests/block-supports/block-style-variations.php
@@ -320,4 +320,47 @@ class Tests_Block_Supports_BlockStyleVariations extends WP_UnitTestCase {
 
 		$this->assertSameSetsWithIndex( $expected, $variation_data, 'Variation data with resolved ref values does not match' );
 	}
+
+	/**
+	 * Tests that a non-string `className` attribute does not cause a fatal
+	 * error and the block content is returned unmodified.
+	 *
+	 * @covers ::wp_render_block_style_variation_class_name
+	 */
+	public function test_block_style_variation_class_name_with_non_string_class_name() {
+		$block = array(
+			'blockName' => 'core/paragraph',
+			'attrs'     => array(
+				'className' => array( '0', '1' ),
+			),
+		);
+
+		$block_content = "<p class=\"0 1\">Test</p>\n";
+
+		$this->assertSame(
+			$block_content,
+			wp_render_block_style_variation_class_name( $block_content, $block ),
+			'Block content should be returned unchanged when className is not a string'
+		);
+	}
+
+	/**
+	 * Tests to ensure that there are no references to an undefined array key
+	 * if `className` is not assigned.
+	 *
+	 * @covers ::wp_render_block_style_variation_class_name
+	 */
+	public function test_block_style_variation_class_name_with_missing_class_name() {
+		$block = array(
+			'blockName' => 'core/paragraph',
+			'attrs'     => array(),
+		);
+
+		$block_content = "<p>Test</p>\n";
+
+		$this->assertSame(
+			$block_content,
+			wp_render_block_style_variation_class_name( $block_content, $block )
+		);
+	}
 }

--- a/tests/phpunit/tests/block-supports/layout.php
+++ b/tests/phpunit/tests/block-supports/layout.php
@@ -1053,4 +1053,29 @@ class Tests_Block_Supports_Layout extends WP_UnitTestCase {
 			),
 		);
 	}
+
+	/**
+	 * Tests that a non-string `className` attribute does not cause a fatal
+	 * when checking for style variation layout styles.
+	 *
+	 * @covers ::wp_render_layout_support_flag
+	 */
+	public function test_layout_support_flag_with_non_string_class_name() {
+		$block_content = '<div class="wp-block-group 0 1"></div>';
+		$block         = array(
+			'blockName' => 'core/group',
+			'attrs'     => array(
+				'className' => array( '0', '1' ),
+				'layout'    => array(
+					'type' => 'constrained',
+				),
+			),
+		);
+
+		$this->assertSame(
+			'<div class="wp-block-group 0 1 is-layout-constrained wp-block-group-is-layout-constrained"></div>',
+			wp_render_layout_support_flag( $block_content, $block ),
+			'Layout support should render the expected markup when className is not a string'
+		);
+	}
 }


### PR DESCRIPTION
Backport for https://github.com/WordPress/gutenberg/pull/80214/
Core trac ticket: https://core.trac.wordpress.org/ticket/65625

## What?

Adds defensive guards to block classname attribute handling to avoid fatal errors for corrupted block content.

This is similar to the issue fixed in https://github.com/WordPress/gutenberg/pull/78841.

## Why?

Fixes fatal errors that can occur when operating on specific corrupted block content.

While this should be rare in practice because blocks don't normally emit this markup, because the logic is operating on raw block attributes, it needs to be especially defensive about the values that it works with.

## How?

Adds additional `is_string` checks before operating on the `className` attribute as if it were a string.

## Testing instructions

* See https://github.com/WordPress/gutenberg/pull/80214
* Verify all tests pass. 