### PR TITLE
HTML API: Ensure attribute removals do not create self-closing tags

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -2798,8 +2798,11 @@ class WP_HTML_Tag_Processor {
 
 		$enqueued_text = $this->lexical_updates[ $comparable_name ]->text;
 
-		// Removed attributes erase the entire span.
-		if ( '' === $enqueued_text ) {
+		/*
+		 * Removed attributes erase the entire span, unless a space is needed
+		 * to prevent a preceding slash from becoming a self-closing flag.
+		 */
+		if ( '' === $enqueued_text || ' ' === $enqueued_text ) {
 			return null;
 		}
 
@@ -4745,19 +4748,49 @@ class WP_HTML_Tag_Processor {
 		 *
 		 *    Result: <div />
 		 */
+		$attribute_token = $this->attributes[ $name ];
+		$replacement     = (
+			$attribute_token->start > 0 &&
+			'/' === $this->html[ $attribute_token->start - 1 ]
+		) ? ' ' : '';
+
 		$this->lexical_updates[ $name ] = new WP_HTML_Text_Replacement(
-			$this->attributes[ $name ]->start,
-			$this->attributes[ $name ]->length,
-			''
+			$attribute_token->start,
+			$attribute_token->length,
+			$replacement
 		);
 
+		$duplicate_attributes       = $this->duplicate_attributes[ $name ] ?? array();
+		$duplicates_already_removed = false;
+
+		/*
+		 * Duplicate removals are always enqueued as a batch. If the first is
+		 * already present, all are present, and none should be enqueued again.
+		 */
+		if ( count( $duplicate_attributes ) > 0 ) {
+			$first_duplicate = $duplicate_attributes[0];
+			foreach ( $this->lexical_updates as $update ) {
+				if ( $first_duplicate->start === $update->start && $first_duplicate->length === $update->length ) {
+					$duplicates_already_removed = true;
+					break;
+				}
+			}
+		}
+
 		// Removes any duplicated attributes if they were also present.
-		foreach ( $this->duplicate_attributes[ $name ] ?? array() as $attribute_token ) {
-			$this->lexical_updates[] = new WP_HTML_Text_Replacement(
-				$attribute_token->start,
-				$attribute_token->length,
-				''
-			);
+		if ( ! $duplicates_already_removed ) {
+			foreach ( $duplicate_attributes as $attribute_token ) {
+				$replacement = (
+					$attribute_token->start > 0 &&
+					'/' === $this->html[ $attribute_token->start - 1 ]
+				) ? ' ' : '';
+
+				$this->lexical_updates[] = new WP_HTML_Text_Replacement(
+					$attribute_token->start,
+					$attribute_token->length,
+					$replacement
+				);
+			}
 		}
 
 		return true;

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -4749,10 +4749,7 @@ class WP_HTML_Tag_Processor {
 		 *    Result: <div />
 		 */
 		$attribute_token = $this->attributes[ $name ];
-		$replacement     = (
-			$attribute_token->start > 0 &&
-			'/' === $this->html[ $attribute_token->start - 1 ]
-		) ? ' ' : '';
+		$replacement     = '/' === $this->html[ $attribute_token->start - 1 ] ? ' ' : '';
 
 		$this->lexical_updates[ $name ] = new WP_HTML_Text_Replacement(
 			$attribute_token->start,
@@ -4780,10 +4777,7 @@ class WP_HTML_Tag_Processor {
 		// Removes any duplicated attributes if they were also present.
 		if ( ! $duplicates_already_removed ) {
 			foreach ( $duplicate_attributes as $attribute_token ) {
-				$replacement = (
-					$attribute_token->start > 0 &&
-					'/' === $this->html[ $attribute_token->start - 1 ]
-				) ? ' ' : '';
+				$replacement = '/' === $this->html[ $attribute_token->start - 1 ] ? ' ' : '';
 
 				$this->lexical_updates[] = new WP_HTML_Text_Replacement(
 					$attribute_token->start,

--- a/tests/phpunit/tests/html-api/wpHtmlProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessor.php
@@ -609,6 +609,60 @@ class Tests_HtmlApi_WpHtmlProcessor extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Ensures that removing attributes preserves foreign-content tree semantics.
+	 *
+	 * @ticket 65372
+	 *
+	 * @covers ::remove_attribute
+	 *
+	 * @dataProvider data_remove_attribute_preserves_foreign_content_tree
+	 *
+	 * @param string $html                           HTML containing the attribute to remove.
+	 * @param string $tag_name                       Foreign element tag name to modify.
+	 * @param bool   $expected_has_self_closing_flag Expected self-closing flag state.
+	 * @param bool   $expected_expects_closer        Expected closer expectation.
+	 * @param array  $expected_text_breadcrumbs      Expected breadcrumbs for the following text.
+	 */
+	public function test_remove_attribute_preserves_foreign_content_tree( $html, $tag_name, $expected_has_self_closing_flag, $expected_expects_closer, $expected_text_breadcrumbs ) {
+		$processor = WP_HTML_Processor::create_fragment( $html );
+		$this->assertTrue( $processor->next_tag( $tag_name ), "Failed to find the {$tag_name} tag: check test setup." );
+		$this->assertTrue( $processor->remove_attribute( 'attr' ), 'Could not remove the target attribute.' );
+
+		$processor = WP_HTML_Processor::create_fragment( $processor->get_updated_html() );
+		$this->assertTrue( $processor->next_tag( $tag_name ), "Failed to find the updated {$tag_name} tag." );
+		$this->assertNull( $processor->get_attribute( 'attr' ), 'The updated tag retained the removed attribute.' );
+		$this->assertSame( $expected_has_self_closing_flag, $processor->has_self_closing_flag(), 'Removing the attribute changed the self-closing flag state.' );
+		$this->assertSame( $expected_expects_closer, $processor->expects_closer(), 'Removing the attribute changed the closer expectation.' );
+
+		$this->assertTrue( $processor->next_token(), 'Failed to find text following the updated tag.' );
+		$this->assertSame( $expected_text_breadcrumbs, $processor->get_breadcrumbs(), 'Removing the attribute changed the text node ancestry.' );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public static function data_remove_attribute_preserves_foreign_content_tree() {
+		return array(
+			'SVG element without self-closing flag' => array(
+				'<svg><g /attr>inside</g></svg>',
+				'G',
+				false,
+				true,
+				array( 'HTML', 'BODY', 'SVG', 'G', '#text' ),
+			),
+			'MathML element with self-closing flag' => array(
+				'<math><mi /attr/>outside</math>',
+				'MI',
+				true,
+				false,
+				array( 'HTML', 'BODY', 'MATH', '#text' ),
+			),
+		);
+	}
+
+	/**
 	 * Ensures that expects_closer works for void-like elements in foreign content.
 	 *
 	 * For example, `<svg><input>text` creates an `svg:input` that contains a text node.

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor-bookmark.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor-bookmark.php
@@ -188,16 +188,17 @@ HTML;
 	 * @covers WP_HTML_Tag_Processor::seek
 	 * @covers WP_HTML_Tag_Processor::set_bookmark
 	 */
-	public function test_repeated_slash_adjacent_duplicate_removal_does_not_break_following_bookmark() {
-		$processor = new WP_HTML_Tag_Processor( '<svg><g attr /attr></g><path id=x></path></svg>' );
-		$this->assertTrue( $processor->next_tag( 'g' ), 'Could not find the G tag: check test setup.' );
-		$this->assertTrue( $processor->set_bookmark( 'g' ), 'Could not bookmark the G tag.' );
+	public function test_repeated_duplicate_attribute_removal_does_not_break_following_bookmark() {
+		$processor = new WP_HTML_Tag_Processor( '<div a a></div><path id=x></path>' );
+		$this->assertTrue( $processor->next_tag( 'div' ), 'Could not find the DIV tag: check test setup.' );
+		$this->assertTrue( $processor->set_bookmark( 'div' ), 'Could not bookmark the DIV tag.' );
 		$this->assertTrue( $processor->next_tag( 'path' ), 'Could not find the PATH tag: check test setup.' );
 		$this->assertTrue( $processor->set_bookmark( 'path' ), 'Could not bookmark the PATH tag.' );
 
-		$this->assertTrue( $processor->seek( 'g' ), 'Could not seek back to the G tag.' );
-		$processor->remove_attribute( 'attr' );
-		$processor->remove_attribute( 'attr' );
+		$this->assertTrue( $processor->seek( 'div' ), 'Could not seek back to the DIV tag.' );
+		$this->assertTrue( $processor->remove_attribute( 'a' ), 'Could not remove the duplicated attribute.' );
+		$this->assertTrue( $processor->remove_attribute( 'a' ), 'Could not remove the duplicated attribute again.' );
+		$this->assertNull( $processor->get_attribute( 'a' ), 'The duplicated attribute was not removed.' );
 		$processor->get_updated_html();
 
 		$this->assertTrue( $processor->seek( 'path' ), 'Could not seek to the PATH tag after removing the attributes.' );

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor-bookmark.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor-bookmark.php
@@ -182,6 +182,30 @@ HTML;
 	}
 
 	/**
+	 * @ticket 65372
+	 *
+	 * @covers WP_HTML_Tag_Processor::remove_attribute
+	 * @covers WP_HTML_Tag_Processor::seek
+	 * @covers WP_HTML_Tag_Processor::set_bookmark
+	 */
+	public function test_repeated_slash_adjacent_duplicate_removal_does_not_break_following_bookmark() {
+		$processor = new WP_HTML_Tag_Processor( '<svg><g attr /attr></g><path id=x></path></svg>' );
+		$this->assertTrue( $processor->next_tag( 'g' ), 'Could not find the G tag: check test setup.' );
+		$this->assertTrue( $processor->set_bookmark( 'g' ), 'Could not bookmark the G tag.' );
+		$this->assertTrue( $processor->next_tag( 'path' ), 'Could not find the PATH tag: check test setup.' );
+		$this->assertTrue( $processor->set_bookmark( 'path' ), 'Could not bookmark the PATH tag.' );
+
+		$this->assertTrue( $processor->seek( 'g' ), 'Could not seek back to the G tag.' );
+		$processor->remove_attribute( 'attr' );
+		$processor->remove_attribute( 'attr' );
+		$processor->get_updated_html();
+
+		$this->assertTrue( $processor->seek( 'path' ), 'Could not seek to the PATH tag after removing the attributes.' );
+		$this->assertSame( 'PATH', $processor->get_tag(), 'The PATH bookmark no longer points to its tag.' );
+		$this->assertSame( 'x', $processor->get_attribute( 'id' ), 'The PATH bookmark points to the wrong tag.' );
+	}
+
+	/**
 	 * @ticket 56299
 	 *
 	 * @covers WP_HTML_Tag_Processor::seek

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -1333,6 +1333,17 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @covers WP_HTML_Tag_Processor::remove_attribute
+	 */
+	public function test_remove_attribute_does_not_create_a_self_closing_flag() {
+		$processor = new WP_HTML_Tag_Processor( '<svg><g /attr>ok' );
+		$processor->next_tag( 'g' );
+		$processor->remove_attribute( 'attr' );
+
+		$this->assertSame( '<svg><g / >ok', $processor->get_updated_html() );
+	}
+
+	/**
 	 * @ticket 58119
 	 *
 	 * @since 6.3.2 Removes all duplicated attributes as expected.

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -1334,13 +1334,36 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @covers WP_HTML_Tag_Processor::remove_attribute
+	 *
+	 * @dataProvider data_remove_attribute_does_not_create_a_self_closing_flag
+	 *
+	 * @param string $html          HTML containing the attribute to remove.
+	 * @param int    $removal_count Number of times to remove the attribute.
+	 * @param string $expected      Expected HTML after removing the attribute.
 	 */
-	public function test_remove_attribute_does_not_create_a_self_closing_flag() {
-		$processor = new WP_HTML_Tag_Processor( '<svg><g /attr>ok' );
+	public function test_remove_attribute_does_not_create_a_self_closing_flag( $html, $removal_count, $expected ) {
+		$processor = new WP_HTML_Tag_Processor( $html );
 		$processor->next_tag( 'g' );
-		$processor->remove_attribute( 'attr' );
 
-		$this->assertSame( '<svg><g / >ok', $processor->get_updated_html() );
+		for ( $i = 0; $i < $removal_count; $i++ ) {
+			$processor->remove_attribute( 'attr' );
+			$this->assertNull( $processor->get_attribute( 'attr' ) );
+		}
+
+		$this->assertSame( $expected, $processor->get_updated_html() );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public static function data_remove_attribute_does_not_create_a_self_closing_flag() {
+		return array(
+			'Attribute preceded by a slash'           => array( '<svg><g /attr>ok', 1, '<svg><g / >ok' ),
+			'Duplicate attribute preceded by a slash' => array( '<svg><g attr /attr>ok', 1, '<svg><g  / >ok' ),
+			'Duplicate attribute removed twice'       => array( '<svg><g attr /attr>ok', 2, '<svg><g  / >ok' ),
+		);
 	}
 
 	/**

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -1333,17 +1333,21 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 65372
+	 *
 	 * @covers WP_HTML_Tag_Processor::remove_attribute
 	 *
-	 * @dataProvider data_remove_attribute_does_not_create_a_self_closing_flag
+	 * @dataProvider data_remove_attribute_preserves_self_closing_flag_state
 	 *
-	 * @param string $html          HTML containing the attribute to remove.
-	 * @param int    $removal_count Number of times to remove the attribute.
-	 * @param string $expected      Expected HTML after removing the attribute.
+	 * @param string $html                           HTML containing the attribute to remove.
+	 * @param int    $removal_count                  Number of times to remove the attribute.
+	 * @param string $expected                       Expected HTML after removing the attribute.
+	 * @param bool   $expected_has_self_closing_flag Expected self-closing flag state.
 	 */
-	public function test_remove_attribute_does_not_create_a_self_closing_flag( $html, $removal_count, $expected ) {
+	public function test_remove_attribute_preserves_self_closing_flag_state( $html, $removal_count, $expected, $expected_has_self_closing_flag ) {
 		$processor = new WP_HTML_Tag_Processor( $html );
 		$processor->next_tag( 'g' );
+		$this->assertSame( $expected_has_self_closing_flag, $processor->has_self_closing_flag(), 'Test setup has the wrong self-closing flag state.' );
 
 		for ( $i = 0; $i < $removal_count; $i++ ) {
 			$processor->remove_attribute( 'attr' );
@@ -1351,6 +1355,7 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 		}
 
 		$this->assertSame( $expected, $processor->get_updated_html() );
+		$this->assertSame( $expected_has_self_closing_flag, $processor->has_self_closing_flag(), 'Removing the attribute changed the self-closing flag state.' );
 	}
 
 	/**
@@ -1358,11 +1363,11 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 	 *
 	 * @return array[]
 	 */
-	public static function data_remove_attribute_does_not_create_a_self_closing_flag() {
+	public static function data_remove_attribute_preserves_self_closing_flag_state() {
 		return array(
-			'Attribute preceded by a slash'           => array( '<svg><g /attr>ok', 1, '<svg><g / >ok' ),
-			'Duplicate attribute preceded by a slash' => array( '<svg><g attr /attr>ok', 1, '<svg><g  / >ok' ),
-			'Duplicate attribute removed twice'       => array( '<svg><g attr /attr>ok', 2, '<svg><g  / >ok' ),
+			'Attribute preceded by a slash'      => array( '<svg><g /attr>ok', 1, '<svg><g / >ok', false ),
+			'Attribute before self-closing flag' => array( '<svg><g /attr/>ok', 1, '<svg><g / />ok', true ),
+			'Duplicate attribute removed twice'  => array( '<svg><g attr /attr>ok', 2, '<svg><g  / >ok', false ),
 		);
 	}
 


### PR DESCRIPTION
Removing an attribute could accidentally change tag semantics. For example, removing attr from `<svg><g /attr>ok` produced `<svg><g />ok`, producing a self-closing flag on the `g` tag that was not present before.



Trac ticket: https://core.trac.wordpress.org/ticket/65967

Alternative to #12368.

## Use of AI Tools

AI assistance: Yes
Tool(s): Codex
Model(s): GPT-5
Used for: Diagnosis, tests, implementation, adversarial review, and verification. All generated changes were reviewed before submission.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
