### PR TITLE
Options: Return false from get_transient() when transient timeout is missing

### DIFF
--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -1464,7 +1464,9 @@ function get_transient( $transient ) {
 				$transient_timeout = '_transient_timeout_' . $transient;
 				wp_prime_option_caches( array( $transient_option, $transient_timeout ) );
 				$timeout = get_option( $transient_timeout );
-				if ( false !== $timeout && $timeout < time() ) {
+				if ( false === $timeout ) {
+					$value = false;
+				} elseif ( $timeout < time() ) {
 					delete_option( $transient_option );
 					delete_option( $transient_timeout );
 					$value = false;
@@ -2596,7 +2598,9 @@ function get_site_transient( $transient ) {
 			wp_prime_site_option_caches( array( $transient_option, $transient_timeout ) );
 
 			$timeout = get_site_option( $transient_timeout );
-			if ( false !== $timeout && $timeout < time() ) {
+			if ( false === $timeout ) {
+				$value = false;
+			} elseif ( $timeout < time() ) {
 				delete_site_option( $transient_option );
 				delete_site_option( $transient_timeout );
 				$value = false;

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -2598,9 +2598,7 @@ function get_site_transient( $transient ) {
 			wp_prime_site_option_caches( array( $transient_option, $transient_timeout ) );
 
 			$timeout = get_site_option( $transient_timeout );
-			if ( false === $timeout ) {
-				$value = false;
-			} elseif ( $timeout < time() ) {
+			if ( false !== $timeout && $timeout < time() ) {
 				delete_site_option( $transient_option );
 				delete_site_option( $transient_timeout );
 				$value = false;

--- a/tests/phpunit/tests/option/siteTransient.php
+++ b/tests/phpunit/tests/option/siteTransient.php
@@ -155,24 +155,4 @@ class Tests_Option_SiteTransient extends WP_UnitTestCase {
 
 		$this->assertNull( $option, 'Querying option table should not return transient on multisite.' );
 	}
-
-	/**
-	 * Ensure get_site_transient() returns false when the transient timeout option is missing (broken transient).
-	 *
-	 * @ticket 33561
-	 * @group ms-excluded
-	 *
-	 * @covers ::get_site_transient
-	 */
-	public function test_get_site_transient_returns_false_when_timeout_is_missing() {
-		$key   = 'test_site_transient_broken';
-		$value = 'test_value';
-
-		set_site_transient( $key, $value, 60 * 10 );
-		$this->assertSame( $value, get_site_transient( $key ) );
-
-		delete_option( '_site_transient_timeout_' . $key );
-
-		$this->assertFalse( get_site_transient( $key ) );
-	}
 }

--- a/tests/phpunit/tests/option/siteTransient.php
+++ b/tests/phpunit/tests/option/siteTransient.php
@@ -155,4 +155,24 @@ class Tests_Option_SiteTransient extends WP_UnitTestCase {
 
 		$this->assertNull( $option, 'Querying option table should not return transient on multisite.' );
 	}
+
+	/**
+	 * Ensure get_site_transient() returns false when the transient timeout option is missing (broken transient).
+	 *
+	 * @ticket 33561
+	 * @group ms-excluded
+	 *
+	 * @covers ::get_site_transient
+	 */
+	public function test_get_site_transient_returns_false_when_timeout_is_missing() {
+		$key   = 'test_site_transient_broken';
+		$value = 'test_value';
+
+		set_site_transient( $key, $value, 60 * 10 );
+		$this->assertSame( $value, get_site_transient( $key ) );
+
+		delete_option( '_site_transient_timeout_' . $key );
+
+		$this->assertFalse( get_site_transient( $key ) );
+	}
 }

--- a/tests/phpunit/tests/option/transient.php
+++ b/tests/phpunit/tests/option/transient.php
@@ -265,4 +265,23 @@ class Tests_Option_Transient extends WP_UnitTestCase {
 		);
 		$this->assertSame( $expected, $a->get_events() );
 	}
+
+	/**
+	 * Ensure get_transient() returns false when the transient timeout option is missing (broken transient).
+	 *
+	 * @ticket 33561
+	 *
+	 * @covers ::get_transient
+	 */
+	public function test_get_transient_returns_false_when_timeout_is_missing() {
+		$key   = 'test_transient_broken';
+		$value = 'test_value';
+
+		set_transient( $key, $value, 60 * 10 );
+		$this->assertSame( $value, get_transient( $key ) );
+
+		delete_option( '_transient_timeout_' . $key );
+
+		$this->assertFalse( get_transient( $key ) );
+	}
 }


### PR DESCRIPTION

Trac ticket: [#33561](https://core.trac.wordpress.org/ticket/33561)

## Use of AI Tools

AI assistance: Yes
Tool(s): GitHub Copilot
Model(s): Gemini, Claude
Used for: Checking for potential edge cases, drafting the PR description, and assisting with local code review. The final implementation and testing were written and executed manually by me.

---

**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
