### PR TITLE
Administration: Remove unused font-weight tokens

### DIFF
--- a/src/wp-admin/css/colors/_tokens.scss
+++ b/src/wp-admin/css/colors/_tokens.scss
@@ -171,11 +171,6 @@ $line-height-xs: 16px;  // xs
 $line-height-s: 20px;   // s - Most UI elements
 $line-height-m: 24px;   // m - Body large
 
-// Font Weights
-$font-weight-regular: 400;  // Regular - Body text
-$font-weight-medium: 500;   // Medium - Headings, buttons
-
-
 // --------------------------------------------------------------------------
 // Elevation (Box Shadows)
 // --------------------------------------------------------------------------


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/pull/80093

Removes the unused `$font-weight-regular` and `$font-weight-medium` Sass variables from the admin color scheme tokens. Neither variable has a consumer, so this does not change generated CSS or runtime styling.

Trac ticket: https://core.trac.wordpress.org/ticket/65629

## Testing Instructions

1. Run `npm run grunt -- colors --dev`.
2. Confirm the admin color schemes compile successfully.
3. Confirm no generated CSS files change.

## Use of AI Tools

AI assistance: Yes  
Tool(s): OpenAI Codex  
Model(s): GPT-5  
Used for: Repository research, implementation, verification, and PR preparation.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
