### PR TITLE
AI: Update PHP AI Client to 1.4.0 and introduce WP_AI_Client_Embedding_Builder

### DIFF
--- a/src/wp-includes/ai-client.php
+++ b/src/wp-includes/ai-client.php
@@ -8,6 +8,7 @@
  */
 
 use WordPress\AiClient\AiClient;
+use WordPress\AiClient\Files\DTO\File;
 use WordPress\AiClient\Messages\DTO\Message;
 use WordPress\AiClient\Messages\DTO\MessagePart;
 
@@ -59,4 +60,27 @@ function wp_supports_ai(): bool {
  */
 function wp_ai_client_prompt( $prompt = null ): WP_AI_Client_Prompt_Builder {
 	return new WP_AI_Client_Prompt_Builder( AiClient::defaultRegistry(), $prompt );
+}
+
+/**
+ * Creates a new AI embedding builder using the default provider registry.
+ *
+ * This is the main entry point for generating embeddings in WordPress. It returns
+ * a fluent builder that can be used to configure and generate embedding vectors.
+ *
+ * Each input can be provided as a simple string for basic text inputs, or as more
+ * complex types. Pass multiple arguments to embed multiple inputs at once, each
+ * producing its own embedding vector.
+ *
+ * @since 7.1.0
+ *
+ * @param string|MessagePart|File|array ...$input Optional. Initial input(s) to embed.
+ *                                                A string for simple text inputs,
+ *                                                a MessagePart or File object for
+ *                                                structured content, or an array for
+ *                                                a message part array shape.
+ * @return WP_AI_Client_Embedding_Builder The embedding builder instance.
+ */
+function wp_ai_client_embedding( ...$input ): WP_AI_Client_Embedding_Builder {
+	return new WP_AI_Client_Embedding_Builder( AiClient::defaultRegistry(), array() === $input ? null : $input );
 }

--- a/src/wp-includes/ai-client/class-wp-ai-client-builder.php
+++ b/src/wp-includes/ai-client/class-wp-ai-client-builder.php
@@ -1,0 +1,380 @@
+<?php
+/**
+ * WP AI Client: WP_AI_Client_Builder class
+ *
+ * @package WordPress
+ * @subpackage AI
+ * @since 7.1.0
+ */
+
+use WordPress\AiClient\Common\Exception\InvalidArgumentException;
+use WordPress\AiClient\Common\Exception\TokenLimitReachedException;
+use WordPress\AiClient\Providers\Http\DTO\RequestOptions;
+use WordPress\AiClient\Providers\Http\Exception\ClientException;
+use WordPress\AiClient\Providers\Http\Exception\NetworkException;
+use WordPress\AiClient\Providers\Http\Exception\ServerException;
+use WordPress\AiClient\Providers\ProviderRegistry;
+
+/**
+ * Base class for fluent AI client builders, returning WP_Error on failure.
+ *
+ * This class wraps a builder from the PHP AI Client SDK and adds
+ * WordPress-specific behavior shared by all builders: WP_Error handling
+ * instead of exceptions, and snake_case method naming proxied to the SDK's
+ * camelCase methods.
+ *
+ * Only the generating methods will return a WP_Error, to not break the fluent
+ * interface. As soon as any exception is caught in a chain of method calls,
+ * the returned instance will be in an error state, and all subsequent method
+ * calls will be no-ops that just return the same error state instance. Only
+ * when a generating method is called, the WP_Error will be returned.
+ *
+ * @since 7.1.0
+ */
+abstract class WP_AI_Client_Builder {
+
+	/**
+	 * Wrapped builder instance from the PHP AI Client SDK.
+	 *
+	 * @since 7.0.0
+	 * @since 7.1.0 Moved from `WP_AI_Client_Prompt_Builder` to the `WP_AI_Client_Builder` base class.
+	 * @var object
+	 */
+	protected object $builder;
+
+	/**
+	 * WordPress error instance, if any error occurred during method calls.
+	 *
+	 * @since 7.0.0
+	 * @since 7.1.0 Moved from `WP_AI_Client_Prompt_Builder` to the `WP_AI_Client_Builder` base class.
+	 * @var WP_Error|null
+	 */
+	protected ?WP_Error $error = null;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 7.0.0
+	 * @since 7.1.0 Moved from `WP_AI_Client_Prompt_Builder` to the `WP_AI_Client_Builder` base class.
+	 *
+	 * @param ProviderRegistry $registry The provider registry for finding suitable models.
+	 * @param mixed            $input    Optional. Initial input content for the builder.
+	 *                                   See the child class for the supported types.
+	 *                                   Default null.
+	 */
+	public function __construct( ProviderRegistry $registry, $input = null ) {
+		try {
+			$this->builder = $this->create_sdk_builder( $registry, $input );
+		} catch ( Exception $e ) {
+			$this->builder = $this->create_sdk_builder( $registry, null );
+			$this->error   = $this->exception_to_wp_error( $e );
+		}
+
+		$default_timeout = 30.0;
+
+		/**
+		 * Filters the default request timeout in seconds for AI Client HTTP requests.
+		 *
+		 * @since 7.0.0
+		 *
+		 * @param float $default_timeout The default timeout in seconds.
+		 */
+		$filtered_default_timeout = apply_filters( 'wp_ai_client_default_request_timeout', $default_timeout );
+		if ( is_numeric( $filtered_default_timeout ) && (float) $filtered_default_timeout >= 0.0 ) {
+			$default_timeout = (float) $filtered_default_timeout;
+		} else {
+			_doing_it_wrong(
+				get_class( $this ) . '::__construct',
+				sprintf(
+					/* translators: %s: wp_ai_client_default_request_timeout */
+					__( 'The %s filter must return a non-negative number.' ),
+					'<code>wp_ai_client_default_request_timeout</code>'
+				),
+				'7.0.0'
+			);
+		}
+
+		$this->builder->usingRequestOptions(
+			RequestOptions::fromArray(
+				array(
+					RequestOptions::KEY_TIMEOUT => $default_timeout,
+				)
+			)
+		);
+	}
+
+	/**
+	 * Creates the wrapped builder instance from the PHP AI Client SDK.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param ProviderRegistry $registry The provider registry for finding suitable models.
+	 * @param mixed            $input    Initial input content for the builder, or null.
+	 * @return object The SDK builder instance.
+	 */
+	abstract protected function create_sdk_builder( ProviderRegistry $registry, $input ): object;
+
+	/**
+	 * Retrieves the prefix used for WP_Error codes created by this builder.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @return string The error code prefix, e.g. 'prompt' or 'embedding'.
+	 */
+	abstract protected function get_error_code_prefix(): string;
+
+	/**
+	 * Retrieves the error message to use when execution is prevented by a filter.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @return string The translated error message.
+	 */
+	abstract protected function get_prevented_error_message(): string;
+
+	/**
+	 * Checks whether execution is prevented by the builder's prevent filter.
+	 *
+	 * Child classes apply their specific filter, passing a clone of the builder
+	 * instance for read-only inspection.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @return bool Whether execution is prevented.
+	 */
+	abstract protected function is_prevented_by_filter(): bool;
+
+	/**
+	 * Retrieves the methods that generate a result from the builder.
+	 *
+	 * Structured as a map of method name to true for faster lookups.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @return array<string, bool> The generating methods map.
+	 */
+	abstract protected function get_generating_methods(): array;
+
+	/**
+	 * Retrieves the methods that check whether the builder input is supported.
+	 *
+	 * Structured as a map of method name to true for faster lookups.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @return array<string, bool> The support check methods map.
+	 */
+	abstract protected function get_support_check_methods(): array;
+
+	/**
+	 * Magic method to proxy snake_case method calls to their PHP AI Client camelCase counterparts.
+	 *
+	 * This allows WordPress developers to use snake_case naming conventions. It catches
+	 * any exceptions thrown, stores them, and returns a WP_Error when a terminate method
+	 * is called.
+	 *
+	 * @since 7.0.0
+	 * @since 7.1.0 Moved from `WP_AI_Client_Prompt_Builder` to the `WP_AI_Client_Builder` base class.
+	 *
+	 * @param string            $name      The method name in snake_case.
+	 * @param array<int, mixed> $arguments The method arguments.
+	 * @return mixed The result of the method call.
+	 */
+	public function __call( string $name, array $arguments ) {
+		/*
+		 * If an error occurred in a previous method call, either return the error for terminate methods,
+		 * or return the same instance for other methods to maintain the fluent interface.
+		 */
+		if ( null !== $this->error ) {
+			if ( $this->is_generating_method( $name ) ) {
+				return $this->error;
+			}
+			if ( $this->is_support_check_method( $name ) ) {
+				return false;
+			}
+			return $this;
+		}
+
+		// Check if execution should be prevented for support check and generating methods.
+		if ( $this->is_support_check_method( $name ) || $this->is_generating_method( $name ) ) {
+			// If AI is not supported, then there's no need to apply the filter as execution will be prevented anyway.
+			$is_ai_disabled = ! wp_supports_ai();
+			$prevent        = $is_ai_disabled;
+			if ( ! $prevent ) {
+				$prevent = $this->is_prevented_by_filter();
+			}
+
+			if ( $prevent ) {
+				// For support check methods, return false.
+				if ( $this->is_support_check_method( $name ) ) {
+					return false;
+				}
+
+				$error_message = $is_ai_disabled
+					? __( 'AI features are not supported in this environment.' )
+					: $this->get_prevented_error_message();
+
+				// For generating methods, create a WP_Error.
+				$this->error = new WP_Error(
+					$this->get_error_code_prefix() . '_prevented',
+					$error_message,
+					array(
+						'status' => 503,
+					)
+				);
+
+				if ( $this->is_generating_method( $name ) ) {
+					return $this->error;
+				}
+				return $this;
+			}
+		}
+
+		try {
+			$callable = $this->get_builder_callable( $name );
+			$result   = $callable( ...$arguments );
+
+			// If the result is the wrapped SDK builder, return the current instance to allow method chaining.
+			if ( $result instanceof $this->builder ) {
+				return $this;
+			}
+
+			return $result;
+		} catch ( Exception $e ) {
+			$this->error = $this->exception_to_wp_error( $e );
+
+			if ( $this->is_generating_method( $name ) ) {
+				return $this->error;
+			}
+			return $this;
+		}
+	}
+
+	/**
+	 * Converts an exception into a WP_Error with a structured error code and message.
+	 *
+	 * This method maps different exception types to specific WP_Error codes and HTTP status codes.
+	 * The presence of the status codes means these WP_Error objects can be easily used in REST API responses
+	 * or other contexts where HTTP semantics are relevant.
+	 *
+	 * @since 7.0.0
+	 * @since 7.1.0 Moved from `WP_AI_Client_Prompt_Builder` to the `WP_AI_Client_Builder` base class.
+	 *
+	 * @param Exception $e The exception to convert.
+	 * @return WP_Error The resulting WP_Error object.
+	 */
+	protected function exception_to_wp_error( Exception $e ): WP_Error {
+		$prefix = $this->get_error_code_prefix();
+
+		if ( $e instanceof NetworkException ) {
+			$error_code  = $prefix . '_network_error';
+			$status_code = 503;
+		} elseif ( $e instanceof ClientException ) {
+			// `ClientException` uses HTTP status codes as exception codes, so we can rely on them.
+			$error_code  = $prefix . '_client_error';
+			$status_code = $e->getCode() ? $e->getCode() : 400;
+		} elseif ( $e instanceof ServerException ) {
+			// `ServerException` uses HTTP status codes as exception codes, so we can rely on them.
+			$error_code  = $prefix . '_upstream_server_error';
+			$status_code = $e->getCode() ? $e->getCode() : 500;
+		} elseif ( $e instanceof TokenLimitReachedException ) {
+			$error_code  = $prefix . '_token_limit_reached';
+			$status_code = 400;
+		} elseif ( $e instanceof InvalidArgumentException ) {
+			$error_code  = $prefix . '_invalid_argument';
+			$status_code = 400;
+		} else {
+			$error_code  = $prefix . '_builder_error';
+			$status_code = 500;
+		}
+
+		return new WP_Error(
+			$error_code,
+			$e->getMessage(),
+			array(
+				'status'          => $status_code,
+				'exception_class' => get_class( $e ),
+			)
+		);
+	}
+
+	/**
+	 * Checks if a method name is a support check method (is_supported*).
+	 *
+	 * @since 7.0.0
+	 * @since 7.1.0 Moved from `WP_AI_Client_Prompt_Builder` to the `WP_AI_Client_Builder` base class,
+	 *              and changed from static to instance method.
+	 *
+	 * @param string $name The method name.
+	 * @return bool True if the method is a support check method, false otherwise.
+	 */
+	private function is_support_check_method( string $name ): bool {
+		$methods = $this->get_support_check_methods();
+		return isset( $methods[ $name ] );
+	}
+
+	/**
+	 * Checks if a method name is a generating method (generate_*, convert_text_to_speech*).
+	 *
+	 * @since 7.0.0
+	 * @since 7.1.0 Moved from `WP_AI_Client_Prompt_Builder` to the `WP_AI_Client_Builder` base class,
+	 *              and changed from static to instance method.
+	 *
+	 * @param string $name The method name.
+	 * @return bool True if the method is a generating method, false otherwise.
+	 */
+	private function is_generating_method( string $name ): bool {
+		$methods = $this->get_generating_methods();
+		return isset( $methods[ $name ] );
+	}
+
+	/**
+	 * Retrieves a callable for a given PHP AI Client SDK builder method name.
+	 *
+	 * @since 7.0.0
+	 * @since 7.1.0 Moved from `WP_AI_Client_Prompt_Builder` to the `WP_AI_Client_Builder` base class.
+	 *
+	 * @param string $name The method name in snake_case.
+	 * @return callable The callable for the specified method.
+	 *
+	 * @throws BadMethodCallException If the method does not exist.
+	 */
+	protected function get_builder_callable( string $name ): callable {
+		$camel_case_name = $this->snake_to_camel_case( $name );
+
+		$method = array( $this->builder, $camel_case_name );
+		if ( ! is_callable( $method ) ) {
+			throw new BadMethodCallException(
+				sprintf(
+					/* translators: 1: Method name. 2: Class name. */
+					__( 'Method %1$s does not exist on %2$s.' ),
+					$name, // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
+					get_class( $this->builder ) // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
+				)
+			);
+		}
+
+		return $method;
+	}
+
+	/**
+	 * Converts snake_case to camelCase.
+	 *
+	 * @since 7.0.0
+	 * @since 7.1.0 Moved from `WP_AI_Client_Prompt_Builder` to the `WP_AI_Client_Builder` base class.
+	 *
+	 * @param string $snake_case The snake_case string.
+	 * @return string The camelCase string.
+	 */
+	private function snake_to_camel_case( string $snake_case ): string {
+		$parts = explode( '_', $snake_case );
+
+		$camel_case  = $parts[0];
+		$parts_count = count( $parts );
+		for ( $i = 1; $i < $parts_count; $i++ ) {
+			$camel_case .= ucfirst( $parts[ $i ] );
+		}
+
+		return $camel_case;
+	}
+}

--- a/src/wp-includes/ai-client/class-wp-ai-client-builder.php
+++ b/src/wp-includes/ai-client/class-wp-ai-client-builder.php
@@ -76,10 +76,13 @@ abstract class WP_AI_Client_Builder {
 		 * Filters the default request timeout in seconds for AI Client HTTP requests.
 		 *
 		 * @since 7.0.0
+		 * @since 7.1.0 Added the `$builder_type` parameter.
 		 *
-		 * @param float $default_timeout The default timeout in seconds.
+		 * @param float  $default_timeout The default timeout in seconds.
+		 * @param string $builder_type    The class name of the builder the timeout applies to,
+		 *                                e.g. 'WP_AI_Client_Prompt_Builder' or 'WP_AI_Client_Embedding_Builder'.
 		 */
-		$filtered_default_timeout = apply_filters( 'wp_ai_client_default_request_timeout', $default_timeout );
+		$filtered_default_timeout = apply_filters( 'wp_ai_client_default_request_timeout', $default_timeout, get_class( $this ) );
 		if ( is_numeric( $filtered_default_timeout ) && (float) $filtered_default_timeout >= 0.0 ) {
 			$default_timeout = (float) $filtered_default_timeout;
 		} else {

--- a/src/wp-includes/ai-client/class-wp-ai-client-embedding-builder.php
+++ b/src/wp-includes/ai-client/class-wp-ai-client-embedding-builder.php
@@ -1,0 +1,354 @@
+<?php
+/**
+ * WP AI Client: WP_AI_Client_Embedding_Builder class
+ *
+ * @package WordPress
+ * @subpackage AI
+ * @since 7.1.0
+ */
+
+use WordPress\AiClient\AiClient;
+use WordPress\AiClient\Builders\EmbeddingBuilder;
+use WordPress\AiClient\Common\Exception\InvalidArgumentException;
+use WordPress\AiClient\Common\Exception\TokenLimitReachedException;
+use WordPress\AiClient\Providers\Http\DTO\RequestOptions;
+use WordPress\AiClient\Providers\Http\Exception\ClientException;
+use WordPress\AiClient\Providers\Http\Exception\NetworkException;
+use WordPress\AiClient\Providers\Http\Exception\ServerException;
+use WordPress\AiClient\Providers\Models\Contracts\ModelInterface;
+use WordPress\AiClient\Providers\Models\DTO\ModelConfig;
+use WordPress\AiClient\Providers\ProviderRegistry;
+use WordPress\AiClient\Results\DTO\Embedding;
+use WordPress\AiClient\Results\DTO\EmbeddingResult;
+
+/**
+ * Fluent builder for generating embeddings, returning WP_Error on failure.
+ *
+ * This class provides a fluent interface for generating embedding vectors from
+ * text or file inputs. It wraps the PHP AI Client SDK's EmbeddingBuilder and
+ * adds WordPress-specific behavior including WP_Error handling instead of
+ * exceptions and snake_case method naming.
+ *
+ * Only the generating methods will return a WP_Error, to not break the fluent
+ * interface. As soon as any exception is caught in a chain of method calls,
+ * the returned instance will be in an error state, and all subsequent method
+ * calls will be no-ops that just return the same error state instance. Only
+ * when a generating method is called, the WP_Error will be returned.
+ *
+ * @since 7.1.0
+ *
+ * @phpstan-import-type EmbeddingInput from EmbeddingBuilder
+ *
+ * @method self with_input(...$input) Adds one or more inputs to embed.
+ * @method self using_dimensions(int $dimensions) Sets the embedding dimensions.
+ * @method self using_model(ModelInterface $model) Sets the model to use for generation.
+ * @method self using_model_preference(...$preferredModels) Sets preferred models to evaluate in order.
+ * @method self using_model_config(ModelConfig $config) Sets the model configuration.
+ * @method self using_provider(string $providerIdOrClassName) Sets the provider to use for generation.
+ * @method self using_request_options(RequestOptions $options) Sets the request options for HTTP transport.
+ * @method bool is_supported() Checks whether the current inputs and configuration are supported by an available model.
+ * @method EmbeddingResult|WP_Error generate_embedding_result() Generates an embedding result from the configured inputs.
+ * @method Embedding|WP_Error generate_embedding() Generates a single embedding from the configured input.
+ * @method list<Embedding>|WP_Error generate_embeddings() Generates embeddings from the configured inputs.
+ */
+class WP_AI_Client_Embedding_Builder {
+
+	/**
+	 * Wrapped embedding builder instance from the PHP AI Client SDK.
+	 *
+	 * @since 7.1.0
+	 * @var EmbeddingBuilder
+	 */
+	private EmbeddingBuilder $builder;
+
+	/**
+	 * WordPress error instance, if any error occurred during method calls.
+	 *
+	 * @since 7.1.0
+	 * @var WP_Error|null
+	 */
+	private ?WP_Error $error = null;
+
+	/**
+	 * List of methods that generate embeddings from the inputs.
+	 *
+	 * Structured as a map for faster lookups.
+	 *
+	 * @since 7.1.0
+	 * @var array<string, bool>
+	 */
+	private static array $generating_methods = array(
+		'generate_embedding_result' => true,
+		'generate_embedding'        => true,
+		'generate_embeddings'       => true,
+	);
+
+	/**
+	 * List of methods that check whether the embedding generation is supported.
+	 *
+	 * Structured as a map for faster lookups.
+	 *
+	 * @since 7.1.0
+	 * @var array<string, bool>
+	 */
+	private static array $support_check_methods = array(
+		'is_supported' => true,
+	);
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param ProviderRegistry                         $registry The provider registry for finding suitable models.
+	 * @param EmbeddingInput|list<EmbeddingInput>|null $input    Optional. Initial input(s) to embed.
+	 *                                                           A string for simple text inputs,
+	 *                                                           a MessagePart or File object for
+	 *                                                           structured content, an array for a
+	 *                                                           message part array shape, or a list
+	 *                                                           of any of these to embed multiple
+	 *                                                           inputs. Default null.
+	 */
+	public function __construct( ProviderRegistry $registry, $input = null ) {
+		try {
+			$this->builder = new EmbeddingBuilder( $registry, $input, AiClient::getEventDispatcher() );
+		} catch ( Exception $e ) {
+			$this->builder = new EmbeddingBuilder( $registry, null, AiClient::getEventDispatcher() );
+			$this->error   = $this->exception_to_wp_error( $e );
+		}
+
+		$default_timeout = 30.0;
+
+		/** This filter is documented in wp-includes/ai-client/class-wp-ai-client-prompt-builder.php */
+		$filtered_default_timeout = apply_filters( 'wp_ai_client_default_request_timeout', $default_timeout );
+		if ( is_numeric( $filtered_default_timeout ) && (float) $filtered_default_timeout >= 0.0 ) {
+			$default_timeout = (float) $filtered_default_timeout;
+		} else {
+			_doing_it_wrong(
+				__METHOD__,
+				sprintf(
+					/* translators: %s: wp_ai_client_default_request_timeout */
+					__( 'The %s filter must return a non-negative number.' ),
+					'<code>wp_ai_client_default_request_timeout</code>'
+				),
+				'7.1.0'
+			);
+		}
+
+		$this->builder->usingRequestOptions(
+			RequestOptions::fromArray(
+				array(
+					RequestOptions::KEY_TIMEOUT => $default_timeout,
+				)
+			)
+		);
+	}
+
+	/**
+	 * Magic method to proxy snake_case method calls to their PHP AI Client camelCase counterparts.
+	 *
+	 * This allows WordPress developers to use snake_case naming conventions. It catches
+	 * any exceptions thrown, stores them, and returns a WP_Error when a terminate method
+	 * is called.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param string            $name      The method name in snake_case.
+	 * @param array<int, mixed> $arguments The method arguments.
+	 * @return mixed The result of the method call.
+	 */
+	public function __call( string $name, array $arguments ) {
+		/*
+		 * If an error occurred in a previous method call, either return the error for terminate methods,
+		 * or return the same instance for other methods to maintain the fluent interface.
+		 */
+		if ( null !== $this->error ) {
+			if ( self::is_generating_method( $name ) ) {
+				return $this->error;
+			}
+			if ( self::is_support_check_method( $name ) ) {
+				return false;
+			}
+			return $this;
+		}
+
+		// Check if the embedding generation should be prevented for is_supported and generate_* methods.
+		if ( self::is_support_check_method( $name ) || self::is_generating_method( $name ) ) {
+			// If AI is not supported, then there's no need to apply the filter as the embedding will be prevented anyway.
+			$is_ai_disabled = ! wp_supports_ai();
+			$prevent        = $is_ai_disabled;
+			if ( ! $prevent ) {
+				/**
+				 * Filters whether to prevent the embedding generation from being executed.
+				 *
+				 * @since 7.1.0
+				 *
+				 * @param bool                           $prevent Whether to prevent the embedding generation. Default false.
+				 * @param WP_AI_Client_Embedding_Builder $builder A clone of the embedding builder instance (read-only).
+				 */
+				$prevent = (bool) apply_filters( 'wp_ai_client_prevent_embedding', false, clone $this );
+			}
+
+			if ( $prevent ) {
+				// For the is_supported method, return false.
+				if ( self::is_support_check_method( $name ) ) {
+					return false;
+				}
+
+				$error_message = $is_ai_disabled
+					? __( 'AI features are not supported in this environment.' )
+					: __( 'Embedding generation was prevented by a filter.' );
+
+				// For generate_* methods, create a WP_Error.
+				$this->error = new WP_Error(
+					'embedding_prevented',
+					$error_message,
+					array(
+						'status' => 503,
+					)
+				);
+
+				if ( self::is_generating_method( $name ) ) {
+					return $this->error;
+				}
+				return $this;
+			}
+		}
+
+		try {
+			$callable = $this->get_builder_callable( $name );
+			$result   = $callable( ...$arguments );
+
+			// If the result is an EmbeddingBuilder, return the current instance to allow method chaining.
+			if ( $result instanceof EmbeddingBuilder ) {
+				return $this;
+			}
+
+			return $result;
+		} catch ( Exception $e ) {
+			$this->error = $this->exception_to_wp_error( $e );
+
+			if ( self::is_generating_method( $name ) ) {
+				return $this->error;
+			}
+			return $this;
+		}
+	}
+
+	/**
+	 * Converts an exception into a WP_Error with a structured error code and message.
+	 *
+	 * This method maps different exception types to specific WP_Error codes and HTTP status codes.
+	 * The presence of the status codes means these WP_Error objects can be easily used in REST API responses
+	 * or other contexts where HTTP semantics are relevant.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param Exception $e The exception to convert.
+	 * @return WP_Error The resulting WP_Error object.
+	 */
+	private function exception_to_wp_error( Exception $e ): WP_Error {
+		if ( $e instanceof NetworkException ) {
+			$error_code  = 'embedding_network_error';
+			$status_code = 503;
+		} elseif ( $e instanceof ClientException ) {
+			// `ClientException` uses HTTP status codes as exception codes, so we can rely on them.
+			$error_code  = 'embedding_client_error';
+			$status_code = $e->getCode() ? $e->getCode() : 400;
+		} elseif ( $e instanceof ServerException ) {
+			// `ServerException` uses HTTP status codes as exception codes, so we can rely on them.
+			$error_code  = 'embedding_upstream_server_error';
+			$status_code = $e->getCode() ? $e->getCode() : 500;
+		} elseif ( $e instanceof TokenLimitReachedException ) {
+			$error_code  = 'embedding_token_limit_reached';
+			$status_code = 400;
+		} elseif ( $e instanceof InvalidArgumentException ) {
+			$error_code  = 'embedding_invalid_argument';
+			$status_code = 400;
+		} else {
+			$error_code  = 'embedding_builder_error';
+			$status_code = 500;
+		}
+
+		return new WP_Error(
+			$error_code,
+			$e->getMessage(),
+			array(
+				'status'          => $status_code,
+				'exception_class' => get_class( $e ),
+			)
+		);
+	}
+
+	/**
+	 * Checks if a method name is a support check method (is_supported).
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param string $name The method name.
+	 * @return bool True if the method is a support check method, false otherwise.
+	 */
+	private static function is_support_check_method( string $name ): bool {
+		return isset( self::$support_check_methods[ $name ] );
+	}
+
+	/**
+	 * Checks if a method name is a generating method (generate_*).
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param string $name The method name.
+	 * @return bool True if the method is a generating method, false otherwise.
+	 */
+	private static function is_generating_method( string $name ): bool {
+		return isset( self::$generating_methods[ $name ] );
+	}
+
+	/**
+	 * Retrieves a callable for a given PHP AI Client SDK embedding builder method name.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param string $name The method name in snake_case.
+	 * @return callable The callable for the specified method.
+	 *
+	 * @throws BadMethodCallException If the method does not exist.
+	 */
+	protected function get_builder_callable( string $name ): callable {
+		$camel_case_name = $this->snake_to_camel_case( $name );
+
+		$method = array( $this->builder, $camel_case_name );
+		if ( ! is_callable( $method ) ) {
+			throw new BadMethodCallException(
+				sprintf(
+					/* translators: 1: Method name. 2: Class name. */
+					__( 'Method %1$s does not exist on %2$s.' ),
+					$name, // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
+					get_class( $this->builder ) // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
+				)
+			);
+		}
+
+		return $method;
+	}
+
+	/**
+	 * Converts snake_case to camelCase.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param string $snake_case The snake_case string.
+	 * @return string The camelCase string.
+	 */
+	private function snake_to_camel_case( string $snake_case ): string {
+		$parts = explode( '_', $snake_case );
+
+		$camel_case  = $parts[0];
+		$parts_count = count( $parts );
+		for ( $i = 1; $i < $parts_count; $i++ ) {
+			$camel_case .= ucfirst( $parts[ $i ] );
+		}
+
+		return $camel_case;
+	}
+}

--- a/src/wp-includes/ai-client/class-wp-ai-client-embedding-builder.php
+++ b/src/wp-includes/ai-client/class-wp-ai-client-embedding-builder.php
@@ -9,12 +9,7 @@
 
 use WordPress\AiClient\AiClient;
 use WordPress\AiClient\Builders\EmbeddingBuilder;
-use WordPress\AiClient\Common\Exception\InvalidArgumentException;
-use WordPress\AiClient\Common\Exception\TokenLimitReachedException;
 use WordPress\AiClient\Providers\Http\DTO\RequestOptions;
-use WordPress\AiClient\Providers\Http\Exception\ClientException;
-use WordPress\AiClient\Providers\Http\Exception\NetworkException;
-use WordPress\AiClient\Providers\Http\Exception\ServerException;
 use WordPress\AiClient\Providers\Models\Contracts\ModelInterface;
 use WordPress\AiClient\Providers\Models\DTO\ModelConfig;
 use WordPress\AiClient\Providers\ProviderRegistry;
@@ -37,6 +32,8 @@ use WordPress\AiClient\Results\DTO\EmbeddingResult;
  *
  * @since 7.1.0
  *
+ * @see WP_AI_Client_Builder
+ *
  * @phpstan-import-type EmbeddingInput from EmbeddingBuilder
  *
  * @method self with_input(...$input) Adds one or more inputs to embed.
@@ -51,23 +48,7 @@ use WordPress\AiClient\Results\DTO\EmbeddingResult;
  * @method Embedding|WP_Error generate_embedding() Generates a single embedding from the configured input.
  * @method list<Embedding>|WP_Error generate_embeddings() Generates embeddings from the configured inputs.
  */
-class WP_AI_Client_Embedding_Builder {
-
-	/**
-	 * Wrapped embedding builder instance from the PHP AI Client SDK.
-	 *
-	 * @since 7.1.0
-	 * @var EmbeddingBuilder
-	 */
-	private EmbeddingBuilder $builder;
-
-	/**
-	 * WordPress error instance, if any error occurred during method calls.
-	 *
-	 * @since 7.1.0
-	 * @var WP_Error|null
-	 */
-	private ?WP_Error $error = null;
+class WP_AI_Client_Embedding_Builder extends WP_AI_Client_Builder {
 
 	/**
 	 * List of methods that generate embeddings from the inputs.
@@ -96,259 +77,84 @@ class WP_AI_Client_Embedding_Builder {
 	);
 
 	/**
-	 * Constructor.
+	 * Creates the wrapped embedding builder instance from the PHP AI Client SDK.
 	 *
 	 * @since 7.1.0
 	 *
 	 * @param ProviderRegistry                         $registry The provider registry for finding suitable models.
-	 * @param EmbeddingInput|list<EmbeddingInput>|null $input    Optional. Initial input(s) to embed.
+	 * @param EmbeddingInput|list<EmbeddingInput>|null $input    Initial input(s) to embed, or null.
 	 *                                                           A string for simple text inputs,
 	 *                                                           a MessagePart or File object for
 	 *                                                           structured content, an array for a
 	 *                                                           message part array shape, or a list
 	 *                                                           of any of these to embed multiple
-	 *                                                           inputs. Default null.
+	 *                                                           inputs.
+	 * @return EmbeddingBuilder The SDK embedding builder instance.
 	 */
-	public function __construct( ProviderRegistry $registry, $input = null ) {
-		try {
-			$this->builder = new EmbeddingBuilder( $registry, $input, AiClient::getEventDispatcher() );
-		} catch ( Exception $e ) {
-			$this->builder = new EmbeddingBuilder( $registry, null, AiClient::getEventDispatcher() );
-			$this->error   = $this->exception_to_wp_error( $e );
-		}
-
-		$default_timeout = 30.0;
-
-		/** This filter is documented in wp-includes/ai-client/class-wp-ai-client-prompt-builder.php */
-		$filtered_default_timeout = apply_filters( 'wp_ai_client_default_request_timeout', $default_timeout );
-		if ( is_numeric( $filtered_default_timeout ) && (float) $filtered_default_timeout >= 0.0 ) {
-			$default_timeout = (float) $filtered_default_timeout;
-		} else {
-			_doing_it_wrong(
-				__METHOD__,
-				sprintf(
-					/* translators: %s: wp_ai_client_default_request_timeout */
-					__( 'The %s filter must return a non-negative number.' ),
-					'<code>wp_ai_client_default_request_timeout</code>'
-				),
-				'7.1.0'
-			);
-		}
-
-		$this->builder->usingRequestOptions(
-			RequestOptions::fromArray(
-				array(
-					RequestOptions::KEY_TIMEOUT => $default_timeout,
-				)
-			)
-		);
+	protected function create_sdk_builder( ProviderRegistry $registry, $input ): object {
+		return new EmbeddingBuilder( $registry, $input, AiClient::getEventDispatcher() );
 	}
 
 	/**
-	 * Magic method to proxy snake_case method calls to their PHP AI Client camelCase counterparts.
-	 *
-	 * This allows WordPress developers to use snake_case naming conventions. It catches
-	 * any exceptions thrown, stores them, and returns a WP_Error when a terminate method
-	 * is called.
+	 * Retrieves the prefix used for WP_Error codes created by this builder.
 	 *
 	 * @since 7.1.0
 	 *
-	 * @param string            $name      The method name in snake_case.
-	 * @param array<int, mixed> $arguments The method arguments.
-	 * @return mixed The result of the method call.
+	 * @return string The error code prefix.
 	 */
-	public function __call( string $name, array $arguments ) {
-		/*
-		 * If an error occurred in a previous method call, either return the error for terminate methods,
-		 * or return the same instance for other methods to maintain the fluent interface.
+	protected function get_error_code_prefix(): string {
+		return 'embedding';
+	}
+
+	/**
+	 * Retrieves the error message to use when the embedding generation is prevented by a filter.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @return string The translated error message.
+	 */
+	protected function get_prevented_error_message(): string {
+		return __( 'Embedding generation was prevented by a filter.' );
+	}
+
+	/**
+	 * Checks whether the embedding generation is prevented by the `wp_ai_client_prevent_embedding` filter.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @return bool Whether the embedding generation is prevented.
+	 */
+	protected function is_prevented_by_filter(): bool {
+		/**
+		 * Filters whether to prevent the embedding generation from being executed.
+		 *
+		 * @since 7.1.0
+		 *
+		 * @param bool                           $prevent Whether to prevent the embedding generation. Default false.
+		 * @param WP_AI_Client_Embedding_Builder $builder A clone of the embedding builder instance (read-only).
 		 */
-		if ( null !== $this->error ) {
-			if ( self::is_generating_method( $name ) ) {
-				return $this->error;
-			}
-			if ( self::is_support_check_method( $name ) ) {
-				return false;
-			}
-			return $this;
-		}
-
-		// Check if the embedding generation should be prevented for is_supported and generate_* methods.
-		if ( self::is_support_check_method( $name ) || self::is_generating_method( $name ) ) {
-			// If AI is not supported, then there's no need to apply the filter as the embedding will be prevented anyway.
-			$is_ai_disabled = ! wp_supports_ai();
-			$prevent        = $is_ai_disabled;
-			if ( ! $prevent ) {
-				/**
-				 * Filters whether to prevent the embedding generation from being executed.
-				 *
-				 * @since 7.1.0
-				 *
-				 * @param bool                           $prevent Whether to prevent the embedding generation. Default false.
-				 * @param WP_AI_Client_Embedding_Builder $builder A clone of the embedding builder instance (read-only).
-				 */
-				$prevent = (bool) apply_filters( 'wp_ai_client_prevent_embedding', false, clone $this );
-			}
-
-			if ( $prevent ) {
-				// For the is_supported method, return false.
-				if ( self::is_support_check_method( $name ) ) {
-					return false;
-				}
-
-				$error_message = $is_ai_disabled
-					? __( 'AI features are not supported in this environment.' )
-					: __( 'Embedding generation was prevented by a filter.' );
-
-				// For generate_* methods, create a WP_Error.
-				$this->error = new WP_Error(
-					'embedding_prevented',
-					$error_message,
-					array(
-						'status' => 503,
-					)
-				);
-
-				if ( self::is_generating_method( $name ) ) {
-					return $this->error;
-				}
-				return $this;
-			}
-		}
-
-		try {
-			$callable = $this->get_builder_callable( $name );
-			$result   = $callable( ...$arguments );
-
-			// If the result is an EmbeddingBuilder, return the current instance to allow method chaining.
-			if ( $result instanceof EmbeddingBuilder ) {
-				return $this;
-			}
-
-			return $result;
-		} catch ( Exception $e ) {
-			$this->error = $this->exception_to_wp_error( $e );
-
-			if ( self::is_generating_method( $name ) ) {
-				return $this->error;
-			}
-			return $this;
-		}
+		return (bool) apply_filters( 'wp_ai_client_prevent_embedding', false, clone $this );
 	}
 
 	/**
-	 * Converts an exception into a WP_Error with a structured error code and message.
-	 *
-	 * This method maps different exception types to specific WP_Error codes and HTTP status codes.
-	 * The presence of the status codes means these WP_Error objects can be easily used in REST API responses
-	 * or other contexts where HTTP semantics are relevant.
+	 * Retrieves the methods that generate embeddings from the inputs.
 	 *
 	 * @since 7.1.0
 	 *
-	 * @param Exception $e The exception to convert.
-	 * @return WP_Error The resulting WP_Error object.
+	 * @return array<string, bool> The generating methods map.
 	 */
-	private function exception_to_wp_error( Exception $e ): WP_Error {
-		if ( $e instanceof NetworkException ) {
-			$error_code  = 'embedding_network_error';
-			$status_code = 503;
-		} elseif ( $e instanceof ClientException ) {
-			// `ClientException` uses HTTP status codes as exception codes, so we can rely on them.
-			$error_code  = 'embedding_client_error';
-			$status_code = $e->getCode() ? $e->getCode() : 400;
-		} elseif ( $e instanceof ServerException ) {
-			// `ServerException` uses HTTP status codes as exception codes, so we can rely on them.
-			$error_code  = 'embedding_upstream_server_error';
-			$status_code = $e->getCode() ? $e->getCode() : 500;
-		} elseif ( $e instanceof TokenLimitReachedException ) {
-			$error_code  = 'embedding_token_limit_reached';
-			$status_code = 400;
-		} elseif ( $e instanceof InvalidArgumentException ) {
-			$error_code  = 'embedding_invalid_argument';
-			$status_code = 400;
-		} else {
-			$error_code  = 'embedding_builder_error';
-			$status_code = 500;
-		}
-
-		return new WP_Error(
-			$error_code,
-			$e->getMessage(),
-			array(
-				'status'          => $status_code,
-				'exception_class' => get_class( $e ),
-			)
-		);
+	protected function get_generating_methods(): array {
+		return self::$generating_methods;
 	}
 
 	/**
-	 * Checks if a method name is a support check method (is_supported).
+	 * Retrieves the methods that check whether the embedding generation is supported.
 	 *
 	 * @since 7.1.0
 	 *
-	 * @param string $name The method name.
-	 * @return bool True if the method is a support check method, false otherwise.
+	 * @return array<string, bool> The support check methods map.
 	 */
-	private static function is_support_check_method( string $name ): bool {
-		return isset( self::$support_check_methods[ $name ] );
-	}
-
-	/**
-	 * Checks if a method name is a generating method (generate_*).
-	 *
-	 * @since 7.1.0
-	 *
-	 * @param string $name The method name.
-	 * @return bool True if the method is a generating method, false otherwise.
-	 */
-	private static function is_generating_method( string $name ): bool {
-		return isset( self::$generating_methods[ $name ] );
-	}
-
-	/**
-	 * Retrieves a callable for a given PHP AI Client SDK embedding builder method name.
-	 *
-	 * @since 7.1.0
-	 *
-	 * @param string $name The method name in snake_case.
-	 * @return callable The callable for the specified method.
-	 *
-	 * @throws BadMethodCallException If the method does not exist.
-	 */
-	protected function get_builder_callable( string $name ): callable {
-		$camel_case_name = $this->snake_to_camel_case( $name );
-
-		$method = array( $this->builder, $camel_case_name );
-		if ( ! is_callable( $method ) ) {
-			throw new BadMethodCallException(
-				sprintf(
-					/* translators: 1: Method name. 2: Class name. */
-					__( 'Method %1$s does not exist on %2$s.' ),
-					$name, // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
-					get_class( $this->builder ) // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
-				)
-			);
-		}
-
-		return $method;
-	}
-
-	/**
-	 * Converts snake_case to camelCase.
-	 *
-	 * @since 7.1.0
-	 *
-	 * @param string $snake_case The snake_case string.
-	 * @return string The camelCase string.
-	 */
-	private function snake_to_camel_case( string $snake_case ): string {
-		$parts = explode( '_', $snake_case );
-
-		$camel_case  = $parts[0];
-		$parts_count = count( $parts );
-		for ( $i = 1; $i < $parts_count; $i++ ) {
-			$camel_case .= ucfirst( $parts[ $i ] );
-		}
-
-		return $camel_case;
+	protected function get_support_check_methods(): array {
+		return self::$support_check_methods;
 	}
 }

--- a/src/wp-includes/ai-client/class-wp-ai-client-prompt-builder.php
+++ b/src/wp-includes/ai-client/class-wp-ai-client-prompt-builder.php
@@ -9,8 +9,6 @@
 
 use WordPress\AiClient\AiClient;
 use WordPress\AiClient\Builders\PromptBuilder;
-use WordPress\AiClient\Common\Exception\InvalidArgumentException;
-use WordPress\AiClient\Common\Exception\TokenLimitReachedException;
 use WordPress\AiClient\Files\DTO\File;
 use WordPress\AiClient\Files\Enums\FileTypeEnum;
 use WordPress\AiClient\Files\Enums\MediaOrientationEnum;
@@ -18,9 +16,6 @@ use WordPress\AiClient\Messages\DTO\Message;
 use WordPress\AiClient\Messages\DTO\MessagePart;
 use WordPress\AiClient\Messages\Enums\ModalityEnum;
 use WordPress\AiClient\Providers\Http\DTO\RequestOptions;
-use WordPress\AiClient\Providers\Http\Exception\ClientException;
-use WordPress\AiClient\Providers\Http\Exception\NetworkException;
-use WordPress\AiClient\Providers\Http\Exception\ServerException;
 use WordPress\AiClient\Providers\Models\Contracts\ModelInterface;
 use WordPress\AiClient\Providers\Models\DTO\ModelConfig;
 use WordPress\AiClient\Providers\Models\Enums\CapabilityEnum;
@@ -46,6 +41,9 @@ use WordPress\AiClient\Tools\DTO\WebSearch;
  * when a generating method is called, the WP_Error will be returned.
  *
  * @since 7.0.0
+ * @since 7.1.0 Now extends the `WP_AI_Client_Builder` base class.
+ *
+ * @see WP_AI_Client_Builder
  *
  * @phpstan-import-type Prompt from PromptBuilder
  *
@@ -104,23 +102,7 @@ use WordPress\AiClient\Tools\DTO\WebSearch;
  * @method File|WP_Error generate_video() Generates a video from the prompt.
  * @method list<File>|WP_Error generate_videos(?int $candidateCount = null) Generates multiple videos from the prompt.
  */
-class WP_AI_Client_Prompt_Builder {
-
-	/**
-	 * Wrapped prompt builder instance from the PHP AI Client SDK.
-	 *
-	 * @since 7.0.0
-	 * @var PromptBuilder
-	 */
-	private PromptBuilder $builder;
-
-	/**
-	 * WordPress error instance, if any error occurred during method calls.
-	 *
-	 * @since 7.0.0
-	 * @var WP_Error|null
-	 */
-	private ?WP_Error $error = null;
+class WP_AI_Client_Prompt_Builder extends WP_AI_Client_Builder {
 
 	/**
 	 * List of methods that generate a result from the prompt.
@@ -167,61 +149,6 @@ class WP_AI_Client_Prompt_Builder {
 		'is_supported_for_music_generation'          => true,
 		'is_supported_for_embedding_generation'      => true,
 	);
-
-	/**
-	 * Constructor.
-	 *
-	 * @since 7.0.0
-	 *
-	 * @param ProviderRegistry $registry The provider registry for finding suitable models.
-	 * @param Prompt           $prompt   Optional. Initial prompt content.
-	 *                                   A string for simple text prompts,
-	 *                                   a MessagePart or Message object for
-	 *                                   structured content, an array for a
-	 *                                   message array shape, or a list of
-	 *                                   parts or messages for multi-turn
-	 *                                   conversations. Default null.
-	 */
-	public function __construct( ProviderRegistry $registry, $prompt = null ) {
-		try {
-			$this->builder = new PromptBuilder( $registry, $prompt, AiClient::getEventDispatcher() );
-		} catch ( Exception $e ) {
-			$this->builder = new PromptBuilder( $registry, null, AiClient::getEventDispatcher() );
-			$this->error   = $this->exception_to_wp_error( $e );
-		}
-
-		$default_timeout = 30.0;
-
-		/**
-		 * Filters the default request timeout in seconds for AI Client HTTP requests.
-		 *
-		 * @since 7.0.0
-		 *
-		 * @param float $default_timeout The default timeout in seconds.
-		 */
-		$filtered_default_timeout = apply_filters( 'wp_ai_client_default_request_timeout', $default_timeout );
-		if ( is_numeric( $filtered_default_timeout ) && (float) $filtered_default_timeout >= 0.0 ) {
-			$default_timeout = (float) $filtered_default_timeout;
-		} else {
-			_doing_it_wrong(
-				__METHOD__,
-				sprintf(
-					/* translators: %s: wp_ai_client_default_request_timeout */
-					__( 'The %s filter must return a non-negative number.' ),
-					'<code>wp_ai_client_default_request_timeout</code>'
-				),
-				'7.0.0'
-			);
-		}
-
-		$this->builder->usingRequestOptions(
-			RequestOptions::fromArray(
-				array(
-					RequestOptions::KEY_TIMEOUT => $default_timeout,
-				)
-			)
-		);
-	}
 
 	/**
 	 * Registers WordPress abilities as function declarations for the AI model.
@@ -278,210 +205,84 @@ class WP_AI_Client_Prompt_Builder {
 	}
 
 	/**
-	 * Magic method to proxy snake_case method calls to their PHP AI Client camelCase counterparts.
+	 * Creates the wrapped prompt builder instance from the PHP AI Client SDK.
 	 *
-	 * This allows WordPress developers to use snake_case naming conventions. It catches
-	 * any exceptions thrown, stores them, and returns a WP_Error when a terminate method
-	 * is called.
+	 * @since 7.1.0
 	 *
-	 * @since 7.0.0
-	 *
-	 * @param string            $name      The method name in snake_case.
-	 * @param array<int, mixed> $arguments The method arguments.
-	 * @return mixed The result of the method call.
+	 * @param ProviderRegistry $registry The provider registry for finding suitable models.
+	 * @param Prompt           $prompt   Initial prompt content, or null.
+	 *                                   A string for simple text prompts,
+	 *                                   a MessagePart or Message object for
+	 *                                   structured content, an array for a
+	 *                                   message array shape, or a list of
+	 *                                   parts or messages for multi-turn
+	 *                                   conversations.
+	 * @return PromptBuilder The SDK prompt builder instance.
 	 */
-	public function __call( string $name, array $arguments ) {
-		/*
-		 * If an error occurred in a previous method call, either return the error for terminate methods,
-		 * or return the same instance for other methods to maintain the fluent interface.
+	protected function create_sdk_builder( ProviderRegistry $registry, $prompt ): object {
+		return new PromptBuilder( $registry, $prompt, AiClient::getEventDispatcher() );
+	}
+
+	/**
+	 * Retrieves the prefix used for WP_Error codes created by this builder.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @return string The error code prefix.
+	 */
+	protected function get_error_code_prefix(): string {
+		return 'prompt';
+	}
+
+	/**
+	 * Retrieves the error message to use when the prompt is prevented by a filter.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @return string The translated error message.
+	 */
+	protected function get_prevented_error_message(): string {
+		return __( 'Prompt execution was prevented by a filter.' );
+	}
+
+	/**
+	 * Checks whether the prompt is prevented by the `wp_ai_client_prevent_prompt` filter.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @return bool Whether the prompt is prevented.
+	 */
+	protected function is_prevented_by_filter(): bool {
+		/**
+		 * Filters whether to prevent the prompt from being executed.
+		 *
+		 * @since 7.0.0
+		 *
+		 * @param bool                        $prevent Whether to prevent the prompt. Default false.
+		 * @param WP_AI_Client_Prompt_Builder $builder A clone of the prompt builder instance (read-only).
 		 */
-		if ( null !== $this->error ) {
-			if ( self::is_generating_method( $name ) ) {
-				return $this->error;
-			}
-			if ( self::is_support_check_method( $name ) ) {
-				return false;
-			}
-			return $this;
-		}
-
-		// Check if the prompt should be prevented for is_supported* and generate_*/convert_text_to_speech* methods.
-		if ( self::is_support_check_method( $name ) || self::is_generating_method( $name ) ) {
-			// If AI is not supported, then there's no need to apply the filter as the prompt will be prevented anyway.
-			$is_ai_disabled = ! wp_supports_ai();
-			$prevent        = $is_ai_disabled;
-			if ( ! $prevent ) {
-				/**
-				 * Filters whether to prevent the prompt from being executed.
-				 *
-				 * @since 7.0.0
-				 *
-				 * @param bool                        $prevent Whether to prevent the prompt. Default false.
-				 * @param WP_AI_Client_Prompt_Builder $builder A clone of the prompt builder instance (read-only).
-				 */
-				$prevent = (bool) apply_filters( 'wp_ai_client_prevent_prompt', false, clone $this );
-			}
-
-			if ( $prevent ) {
-				// For is_supported* methods, return false.
-				if ( self::is_support_check_method( $name ) ) {
-					return false;
-				}
-
-				$error_message = $is_ai_disabled
-					? __( 'AI features are not supported in this environment.' )
-					: __( 'Prompt execution was prevented by a filter.' );
-
-				// For generate_* and convert_text_to_speech* methods, create a WP_Error.
-				$this->error = new WP_Error(
-					'prompt_prevented',
-					$error_message,
-					array(
-						'status' => 503,
-					)
-				);
-
-				if ( self::is_generating_method( $name ) ) {
-					return $this->error;
-				}
-				return $this;
-			}
-		}
-
-		try {
-			$callable = $this->get_builder_callable( $name );
-			$result   = $callable( ...$arguments );
-
-			// If the result is a PromptBuilder, return the current instance to allow method chaining.
-			if ( $result instanceof PromptBuilder ) {
-				return $this;
-			}
-
-			return $result;
-		} catch ( Exception $e ) {
-			$this->error = $this->exception_to_wp_error( $e );
-
-			if ( self::is_generating_method( $name ) ) {
-				return $this->error;
-			}
-			return $this;
-		}
+		return (bool) apply_filters( 'wp_ai_client_prevent_prompt', false, clone $this );
 	}
 
 	/**
-	 * Converts an exception into a WP_Error with a structured error code and message.
+	 * Retrieves the methods that generate a result from the prompt.
 	 *
-	 * This method maps different exception types to specific WP_Error codes and HTTP status codes.
-	 * The presence of the status codes means these WP_Error objects can be easily used in REST API responses
-	 * or other contexts where HTTP semantics are relevant.
+	 * @since 7.1.0
 	 *
-	 * @since 7.0.0
-	 *
-	 * @param Exception $e The exception to convert.
-	 * @return WP_Error The resulting WP_Error object.
+	 * @return array<string, bool> The generating methods map.
 	 */
-	private function exception_to_wp_error( Exception $e ): WP_Error {
-		if ( $e instanceof NetworkException ) {
-			$error_code  = 'prompt_network_error';
-			$status_code = 503;
-		} elseif ( $e instanceof ClientException ) {
-			// `ClientException` uses HTTP status codes as exception codes, so we can rely on them.
-			$error_code  = 'prompt_client_error';
-			$status_code = $e->getCode() ? $e->getCode() : 400;
-		} elseif ( $e instanceof ServerException ) {
-			// `ServerException` uses HTTP status codes as exception codes, so we can rely on them.
-			$error_code  = 'prompt_upstream_server_error';
-			$status_code = $e->getCode() ? $e->getCode() : 500;
-		} elseif ( $e instanceof TokenLimitReachedException ) {
-			$error_code  = 'prompt_token_limit_reached';
-			$status_code = 400;
-		} elseif ( $e instanceof InvalidArgumentException ) {
-			$error_code  = 'prompt_invalid_argument';
-			$status_code = 400;
-		} else {
-			$error_code  = 'prompt_builder_error';
-			$status_code = 500;
-		}
-
-		return new WP_Error(
-			$error_code,
-			$e->getMessage(),
-			array(
-				'status'          => $status_code,
-				'exception_class' => get_class( $e ),
-			)
-		);
+	protected function get_generating_methods(): array {
+		return self::$generating_methods;
 	}
 
 	/**
-	 * Checks if a method name is a support check method (is_supported*).
+	 * Retrieves the methods that check whether the prompt is supported.
 	 *
-	 * @since 7.0.0
+	 * @since 7.1.0
 	 *
-	 * @param string $name The method name.
-	 * @return bool True if the method is a support check method, false otherwise.
+	 * @return array<string, bool> The support check methods map.
 	 */
-	private static function is_support_check_method( string $name ): bool {
-		return isset( self::$support_check_methods[ $name ] );
-	}
-
-	/**
-	 * Checks if a method name is a generating method (generate_*, convert_text_to_speech*).
-	 *
-	 * @since 7.0.0
-	 *
-	 * @param string $name The method name.
-	 * @return bool True if the method is a generating method, false otherwise.
-	 */
-	private static function is_generating_method( string $name ): bool {
-		return isset( self::$generating_methods[ $name ] );
-	}
-
-	/**
-	 * Retrieves a callable for a given PHP AI Client SDK prompt builder method name.
-	 *
-	 * @since 7.0.0
-	 *
-	 * @param string $name The method name in snake_case.
-	 * @return callable The callable for the specified method.
-	 *
-	 * @throws BadMethodCallException If the method does not exist.
-	 */
-	protected function get_builder_callable( string $name ): callable {
-		$camel_case_name = $this->snake_to_camel_case( $name );
-
-		$method = array( $this->builder, $camel_case_name );
-		if ( ! is_callable( $method ) ) {
-			throw new BadMethodCallException(
-				sprintf(
-					/* translators: 1: Method name. 2: Class name. */
-					__( 'Method %1$s does not exist on %2$s.' ),
-					$name, // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
-					get_class( $this->builder ) // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
-				)
-			);
-		}
-
-		return $method;
-	}
-
-	/**
-	 * Converts snake_case to camelCase.
-	 *
-	 * @since 7.0.0
-	 *
-	 * @param string $snake_case The snake_case string.
-	 * @return string The camelCase string.
-	 */
-	private function snake_to_camel_case( string $snake_case ): string {
-		$parts = explode( '_', $snake_case );
-
-		$camel_case  = $parts[0];
-		$parts_count = count( $parts );
-		for ( $i = 1; $i < $parts_count; $i++ ) {
-			$camel_case .= ucfirst( $parts[ $i ] );
-		}
-
-		return $camel_case;
+	protected function get_support_check_methods(): array {
+		return self::$support_check_methods;
 	}
 }

--- a/src/wp-includes/php-ai-client/src/AiClient.php
+++ b/src/wp-includes/php-ai-client/src/AiClient.php
@@ -5,6 +5,7 @@ namespace WordPress\AiClient;
 
 use WordPress\AiClientDependencies\Psr\EventDispatcher\EventDispatcherInterface;
 use WordPress\AiClientDependencies\Psr\SimpleCache\CacheInterface;
+use WordPress\AiClient\Builders\EmbeddingBuilder;
 use WordPress\AiClient\Builders\PromptBuilder;
 use WordPress\AiClient\Common\Exception\InvalidArgumentException;
 use WordPress\AiClient\Common\Exception\RuntimeException;
@@ -13,6 +14,8 @@ use WordPress\AiClient\Providers\Contracts\ProviderInterface;
 use WordPress\AiClient\Providers\Models\Contracts\ModelInterface;
 use WordPress\AiClient\Providers\Models\DTO\ModelConfig;
 use WordPress\AiClient\Providers\ProviderRegistry;
+use WordPress\AiClient\Results\DTO\Embedding;
+use WordPress\AiClient\Results\DTO\EmbeddingResult;
 use WordPress\AiClient\Results\DTO\GenerativeAiResult;
 /**
  * Main AI Client class providing both fluent and traditional APIs for AI operations.
@@ -76,6 +79,7 @@ use WordPress\AiClient\Results\DTO\GenerativeAiResult;
  * @since 0.1.0
  *
  * @phpstan-import-type Prompt from PromptBuilder
+ * @phpstan-import-type EmbeddingInput from EmbeddingBuilder
  *
  * phpcs:ignore Generic.Files.LineLength.TooLong
  */
@@ -84,7 +88,7 @@ class AiClient
     /**
      * @var string The version of the AI Client.
      */
-    public const VERSION = '1.3.1';
+    public const VERSION = '1.4.0';
     /**
      * @var ProviderRegistry|null The default provider registry instance.
      */
@@ -212,6 +216,23 @@ class AiClient
         return new PromptBuilder($registry ?? self::defaultRegistry(), $prompt, self::$eventDispatcher);
     }
     /**
+     * Creates an embedding builder for fluent embedding generation.
+     *
+     * Accepts a single input or a list of inputs; each input is embedded independently. Chain an
+     * embedding generation method such as generateEmbedding() or generateEmbeddings() to produce
+     * one vector per input.
+     *
+     * @since 1.4.0
+     *
+     * @param EmbeddingInput|list<EmbeddingInput>|null $input Optional initial input(s) to embed.
+     * @param ProviderRegistry|null $registry Optional custom registry. If null, uses default.
+     * @return EmbeddingBuilder The embedding builder instance.
+     */
+    public static function input($input = null, ?ProviderRegistry $registry = null): EmbeddingBuilder
+    {
+        return new EmbeddingBuilder($registry ?? self::defaultRegistry(), $input, self::$eventDispatcher);
+    }
+    /**
      * Generates content using a unified API that automatically detects model capabilities.
      *
      * When no model is provided, this method delegates to PromptBuilder for intelligent
@@ -335,6 +356,59 @@ class AiClient
         return self::getConfiguredPromptBuilder($prompt, $modelOrConfig, $registry)->generateVideoResult();
     }
     /**
+     * Generates embeddings using the traditional API approach.
+     *
+     * @since 1.4.0
+     *
+     * @param EmbeddingInput|list<EmbeddingInput> $input The input(s) to embed.
+     * @param ModelInterface|ModelConfig|null $modelOrConfig Optional specific model to use,
+     *                                                        or model configuration for auto-discovery,
+     *                                                        or null for defaults.
+     * @param ProviderRegistry|null $registry Optional custom registry. If null, uses default.
+     * @return EmbeddingResult The embedding result.
+     *
+     * @throws \InvalidArgumentException If the input format is invalid.
+     * @throws \RuntimeException If no suitable model is found.
+     */
+    public static function generateEmbeddingResult($input, $modelOrConfig = null, ?ProviderRegistry $registry = null): EmbeddingResult
+    {
+        self::validateModelOrConfigParameter($modelOrConfig);
+        return self::applyModelOrConfig(self::input($input, $registry), $modelOrConfig)->generateEmbeddingResult();
+    }
+    /**
+     * Generates an embedding using the traditional API approach.
+     *
+     * @since 1.4.0
+     *
+     * @param EmbeddingInput $input The input to embed.
+     * @param ModelInterface|ModelConfig|null $modelOrConfig Optional specific model to use,
+     *                                                        or model configuration for auto-discovery,
+     *                                                        or null for defaults.
+     * @param ProviderRegistry|null $registry Optional custom registry. If null, uses default.
+     * @return Embedding The generated embedding vector.
+     */
+    public static function generateEmbedding($input, $modelOrConfig = null, ?ProviderRegistry $registry = null): Embedding
+    {
+        return self::generateEmbeddingResult($input, $modelOrConfig, $registry)->getEmbedding();
+    }
+    /**
+     * Generates embeddings for a list of inputs using the traditional API approach.
+     *
+     * @since 1.4.0
+     *
+     * @param list<EmbeddingInput> $inputs The inputs to embed.
+     * @param ModelInterface|ModelConfig|null $modelOrConfig Optional specific model to use,
+     *                                                        or model configuration for auto-discovery,
+     *                                                        or null for defaults.
+     * @param ProviderRegistry|null $registry Optional custom registry. If null, uses default.
+     * @return list<Embedding> The generated embedding vectors.
+     */
+    public static function generateEmbeddings(array $inputs, $modelOrConfig = null, ?ProviderRegistry $registry = null): array
+    {
+        self::validateModelOrConfigParameter($modelOrConfig);
+        return self::applyModelOrConfig(self::input($inputs, $registry), $modelOrConfig)->generateEmbeddings();
+    }
+    /**
      * Creates a new message builder for fluent API usage.
      *
      * This method will be implemented once MessageBuilder is available.
@@ -375,7 +449,23 @@ class AiClient
      */
     private static function getConfiguredPromptBuilder($prompt, $modelOrConfig, ?ProviderRegistry $registry = null): PromptBuilder
     {
-        $builder = self::prompt($prompt, $registry);
+        return self::applyModelOrConfig(self::prompt($prompt, $registry), $modelOrConfig);
+    }
+    /**
+     * Applies a model or model configuration to a builder.
+     *
+     * Works with any builder that exposes the shared model resolution methods
+     * (see {@see \WordPress\AiClient\Builders\Traits\ModelResolutionTrait}).
+     *
+     * @template T of PromptBuilder|EmbeddingBuilder
+     *
+     * @param T $builder The builder to configure.
+     * @param ModelInterface|ModelConfig|null $modelOrConfig Specific model, model configuration,
+     *                                                        or null for default discovery.
+     * @return T The configured builder.
+     */
+    private static function applyModelOrConfig($builder, $modelOrConfig)
+    {
         if ($modelOrConfig instanceof ModelInterface) {
             $builder->usingModel($modelOrConfig);
         } elseif ($modelOrConfig instanceof ModelConfig) {

--- a/src/wp-includes/php-ai-client/src/Builders/EmbeddingBuilder.php
+++ b/src/wp-includes/php-ai-client/src/Builders/EmbeddingBuilder.php
@@ -1,0 +1,256 @@
+<?php
+
+declare (strict_types=1);
+namespace WordPress\AiClient\Builders;
+
+use WordPress\AiClientDependencies\Psr\EventDispatcher\EventDispatcherInterface;
+use WordPress\AiClient\Builders\Traits\ModelResolutionTrait;
+use WordPress\AiClient\Common\Exception\InvalidArgumentException;
+use WordPress\AiClient\Common\Exception\RuntimeException;
+use WordPress\AiClient\Events\AfterGenerateEmbeddingEvent;
+use WordPress\AiClient\Events\BeforeGenerateEmbeddingEvent;
+use WordPress\AiClient\Files\DTO\File;
+use WordPress\AiClient\Messages\DTO\MessagePart;
+use WordPress\AiClient\Providers\ModelResolver;
+use WordPress\AiClient\Providers\Models\DTO\ModelConfig;
+use WordPress\AiClient\Providers\Models\DTO\ModelRequirements;
+use WordPress\AiClient\Providers\Models\EmbeddingGeneration\Contracts\EmbeddingGenerationModelInterface;
+use WordPress\AiClient\Providers\Models\Enums\CapabilityEnum;
+use WordPress\AiClient\Providers\ProviderRegistry;
+use WordPress\AiClient\Results\DTO\Embedding;
+use WordPress\AiClient\Results\DTO\EmbeddingResult;
+/**
+ * Fluent builder for generating embeddings.
+ *
+ * Embeddings transform inputs into vector representations rather than generating a conversational
+ * response. Each input is embedded independently, and the builder produces one embedding vector per
+ * input. Model selection and configuration are shared with {@see PromptBuilder} via the
+ * {@see ModelResolutionTrait}.
+ *
+ * @since 1.4.0
+ *
+ * @phpstan-import-type MessagePartArrayShape from MessagePart
+ *
+ * @phpstan-type EmbeddingInput string|MessagePart|File|MessagePartArrayShape
+ */
+class EmbeddingBuilder
+{
+    use ModelResolutionTrait;
+    /**
+     * @var list<MessagePart> The inputs to embed.
+     */
+    protected array $inputs = [];
+    /**
+     * @var EventDispatcherInterface|null The event dispatcher for embedding lifecycle events.
+     */
+    private ?EventDispatcherInterface $eventDispatcher;
+    /**
+     * Constructor.
+     *
+     * @since 1.4.0
+     *
+     * @param ProviderRegistry $registry The provider registry for finding suitable models.
+     * @param EmbeddingInput|list<EmbeddingInput>|null $input Optional initial input(s) to embed.
+     * @param EventDispatcherInterface|null $eventDispatcher Optional event dispatcher for lifecycle events.
+     */
+    public function __construct(ProviderRegistry $registry, $input = null, ?EventDispatcherInterface $eventDispatcher = null)
+    {
+        $this->modelConfig = new ModelConfig();
+        $this->modelResolver = new ModelResolver($registry);
+        $this->eventDispatcher = $eventDispatcher;
+        if ($input === null) {
+            return;
+        }
+        if (is_array($input) && array_is_list($input)) {
+            /** @var list<EmbeddingInput> $input */
+            $this->withInput(...$input);
+            return;
+        }
+        /** @var EmbeddingInput $input */
+        $this->withInput($input);
+    }
+    /**
+     * Creates a deep clone of this builder.
+     *
+     * Clones the inputs and model configuration. Service objects (registry, event dispatcher) are
+     * intentionally NOT cloned as they are shared dependencies.
+     *
+     * @since 1.4.0
+     */
+    public function __clone()
+    {
+        $clonedInputs = [];
+        foreach ($this->inputs as $input) {
+            $clonedInputs[] = clone $input;
+        }
+        $this->inputs = $clonedInputs;
+        $this->modelConfig = clone $this->modelConfig;
+        $this->modelResolver = clone $this->modelResolver;
+        // Note: $eventDispatcher is a service object and is intentionally NOT
+        // cloned - it should be a shared reference.
+    }
+    /**
+     * Adds one or more inputs to embed.
+     *
+     * @since 1.4.0
+     *
+     * @param EmbeddingInput ...$input The inputs to embed, each treated as an independent input.
+     * @return self
+     * @throws InvalidArgumentException If no inputs are provided or an input is invalid.
+     */
+    public function withInput(...$input): self
+    {
+        if ($input === []) {
+            throw new InvalidArgumentException('At least one input must be provided.');
+        }
+        foreach ($input as $singleInput) {
+            $this->inputs[] = $this->parseInput($singleInput);
+        }
+        return $this;
+    }
+    /**
+     * Sets the embedding dimensions.
+     *
+     * @since 1.4.0
+     *
+     * @param int $dimensions The embedding dimensions.
+     * @return self
+     */
+    public function usingDimensions(int $dimensions): self
+    {
+        $this->modelConfig->setDimensions($dimensions);
+        return $this;
+    }
+    /**
+     * Checks whether the current inputs and configuration are supported by an available model.
+     *
+     * @since 1.4.0
+     *
+     * @return bool True if a suitable embedding model is available.
+     */
+    public function isSupported(): bool
+    {
+        $requirements = ModelRequirements::fromEmbeddingData($this->inputs, $this->modelConfig);
+        return $this->modelResolver->isSupported($requirements);
+    }
+    /**
+     * Generates an embedding result from the configured inputs.
+     *
+     * @since 1.4.0
+     *
+     * @return EmbeddingResult The generated embedding result.
+     * @throws InvalidArgumentException If no inputs are configured or model validation fails.
+     * @throws RuntimeException If the model doesn't support embedding generation, or returns an
+     *                          embedding count that does not match the number of inputs.
+     */
+    public function generateEmbeddingResult(): EmbeddingResult
+    {
+        if ($this->inputs === []) {
+            throw new InvalidArgumentException('Cannot generate embeddings from empty input. Add content using withInput().');
+        }
+        $capability = CapabilityEnum::embeddingGeneration();
+        $requirements = ModelRequirements::fromEmbeddingData($this->inputs, $this->modelConfig);
+        $model = $this->modelResolver->resolve($requirements, $this->modelConfig);
+        if (!$model instanceof EmbeddingGenerationModelInterface) {
+            throw new RuntimeException(sprintf('Model "%s" does not support embedding generation.', $model->metadata()->getId()));
+        }
+        $this->dispatchEvent(new BeforeGenerateEmbeddingEvent($this->inputs, $model, $capability));
+        $result = $model->generateEmbeddingResult($this->inputs);
+        // Embeddings map positionally to inputs, so the counts must match.
+        if (count($result->getEmbeddings()) !== count($this->inputs)) {
+            throw new RuntimeException(sprintf('Expected %d embedding(s) from the model, but received %d.', count($this->inputs), count($result->getEmbeddings())));
+        }
+        $this->dispatchEvent(new AfterGenerateEmbeddingEvent($this->inputs, $model, $capability, $result));
+        return $result;
+    }
+    /**
+     * Generates a single embedding from the configured input.
+     *
+     * @since 1.4.0
+     *
+     * @return Embedding The generated embedding vector.
+     * @throws InvalidArgumentException If no inputs are configured, model validation fails, or
+     *                                  multiple inputs were provided.
+     */
+    public function generateEmbedding(): Embedding
+    {
+        if (count($this->inputs) > 1) {
+            throw new InvalidArgumentException('generateEmbedding() returns a single vector; use generateEmbeddings() for multiple inputs.');
+        }
+        return $this->generateEmbeddingResult()->getEmbedding();
+    }
+    /**
+     * Generates embeddings from the configured inputs.
+     *
+     * @since 1.4.0
+     *
+     * @return list<Embedding> The generated embedding vectors.
+     * @throws InvalidArgumentException If no inputs are configured or model validation fails.
+     * @throws RuntimeException If the model doesn't support embedding generation, or returns an
+     *                          embedding count that does not match the number of inputs.
+     */
+    public function generateEmbeddings(): array
+    {
+        return $this->generateEmbeddingResult()->getEmbeddings();
+    }
+    /**
+     * Parses a single input into a message part.
+     *
+     * @since 1.4.0
+     *
+     * @param mixed $input The input to parse. Accepts a string, MessagePart, File, or
+     *                     MessagePartArrayShape.
+     * @return MessagePart The parsed message part.
+     * @throws InvalidArgumentException If the input type is not supported or is an invalid part type.
+     */
+    private function parseInput($input): MessagePart
+    {
+        if ($input instanceof MessagePart) {
+            return $this->validatePart($input);
+        }
+        if (is_string($input)) {
+            if (trim($input) === '') {
+                throw new InvalidArgumentException('Cannot create an embedding input from an empty string.');
+            }
+            return new MessagePart($input);
+        }
+        if ($input instanceof File) {
+            return new MessagePart($input);
+        }
+        if (is_array($input) && MessagePart::isArrayShape($input)) {
+            return $this->validatePart(MessagePart::fromArray($input));
+        }
+        throw new InvalidArgumentException('Embedding input must be a string, MessagePart, File, or MessagePartArrayShape.');
+    }
+    /**
+     * Validates that a message part is a valid embedding input.
+     *
+     * @since 1.4.0
+     *
+     * @param MessagePart $part The part to validate.
+     * @return MessagePart The validated part.
+     * @throws InvalidArgumentException If the part is not a text or file part.
+     */
+    private function validatePart(MessagePart $part): MessagePart
+    {
+        $type = $part->getType();
+        if (!$type->isText() && !$type->isFile()) {
+            throw new InvalidArgumentException('Embedding inputs must be text or file parts.');
+        }
+        return $part;
+    }
+    /**
+     * Dispatches an event if an event dispatcher is registered.
+     *
+     * @since 1.4.0
+     *
+     * @param object $event The event to dispatch.
+     * @return void
+     */
+    private function dispatchEvent(object $event): void
+    {
+        if ($this->eventDispatcher !== null) {
+            $this->eventDispatcher->dispatch($event);
+        }
+    }
+}

--- a/src/wp-includes/php-ai-client/src/Builders/PromptBuilder.php
+++ b/src/wp-includes/php-ai-client/src/Builders/PromptBuilder.php
@@ -4,6 +4,7 @@ declare (strict_types=1);
 namespace WordPress\AiClient\Builders;
 
 use WordPress\AiClientDependencies\Psr\EventDispatcher\EventDispatcherInterface;
+use WordPress\AiClient\Builders\Traits\ModelResolutionTrait;
 use WordPress\AiClient\Common\Exception\InvalidArgumentException;
 use WordPress\AiClient\Common\Exception\RuntimeException;
 use WordPress\AiClient\Events\AfterGenerateResultEvent;
@@ -16,11 +17,9 @@ use WordPress\AiClient\Messages\DTO\MessagePart;
 use WordPress\AiClient\Messages\DTO\UserMessage;
 use WordPress\AiClient\Messages\Enums\MessageRoleEnum;
 use WordPress\AiClient\Messages\Enums\ModalityEnum;
-use WordPress\AiClient\Providers\ApiBasedImplementation\Contracts\ApiBasedModelInterface;
-use WordPress\AiClient\Providers\Http\DTO\RequestOptions;
+use WordPress\AiClient\Providers\ModelResolver;
 use WordPress\AiClient\Providers\Models\Contracts\ModelInterface;
 use WordPress\AiClient\Providers\Models\DTO\ModelConfig;
-use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
 use WordPress\AiClient\Providers\Models\DTO\ModelRequirements;
 use WordPress\AiClient\Providers\Models\Enums\CapabilityEnum;
 use WordPress\AiClient\Providers\Models\ImageGeneration\Contracts\ImageGenerationModelInterface;
@@ -49,34 +48,11 @@ use WordPress\AiClient\Tools\DTO\WebSearch;
  */
 class PromptBuilder
 {
-    /**
-     * @var ProviderRegistry The provider registry for finding suitable models.
-     */
-    private ProviderRegistry $registry;
+    use ModelResolutionTrait;
     /**
      * @var list<Message> The messages in the conversation.
      */
     protected array $messages = [];
-    /**
-     * @var ModelInterface|null The model to use for generation.
-     */
-    protected ?ModelInterface $model = null;
-    /**
-     * @var list<string> Ordered list of preference keys to check when selecting a model.
-     */
-    protected array $modelPreferenceKeys = [];
-    /**
-     * @var string|null The provider ID or class name.
-     */
-    protected ?string $providerIdOrClassName = null;
-    /**
-     * @var ModelConfig The model configuration.
-     */
-    protected ModelConfig $modelConfig;
-    /**
-     * @var RequestOptions|null The request options for HTTP transport.
-     */
-    protected ?RequestOptions $requestOptions = null;
     /**
      * @var EventDispatcherInterface|null The event dispatcher for prompt lifecycle events.
      */
@@ -94,8 +70,8 @@ class PromptBuilder
     // phpcs:enable Generic.Files.LineLength.TooLong
     public function __construct(ProviderRegistry $registry, $prompt = null, ?EventDispatcherInterface $eventDispatcher = null)
     {
-        $this->registry = $registry;
         $this->modelConfig = new ModelConfig();
+        $this->modelResolver = new ModelResolver($registry);
         $this->eventDispatcher = $eventDispatcher;
         if ($prompt === null) {
             return;
@@ -128,12 +104,10 @@ class PromptBuilder
         $this->messages = $clonedMessages;
         // Clone model config (ModelConfig has __clone)
         $this->modelConfig = clone $this->modelConfig;
-        // Clone request options if set (contains only primitives)
-        if ($this->requestOptions !== null) {
-            $this->requestOptions = clone $this->requestOptions;
-        }
-        // Note: $registry, $model, and $eventDispatcher are service objects
-        // and are intentionally NOT cloned - they should be shared references.
+        // Clone model resolver (ModelResolver has __clone; clones request options)
+        $this->modelResolver = clone $this->modelResolver;
+        // Note: $eventDispatcher is a service object and is intentionally NOT
+        // cloned - it should be a shared reference.
     }
     /**
      * Adds text to the current message.
@@ -217,109 +191,6 @@ class PromptBuilder
     {
         // Prepend the history messages to the beginning of the messages array
         $this->messages = array_merge($messages, $this->messages);
-        return $this;
-    }
-    /**
-     * Sets the model to use for generation.
-     *
-     * The model's configuration will be merged with the builder's configuration,
-     * with the builder's configuration taking precedence for any overlapping settings.
-     *
-     * @since 0.1.0
-     *
-     * @param ModelInterface $model The model to use.
-     * @return self
-     */
-    public function usingModel(ModelInterface $model): self
-    {
-        $this->model = $model;
-        // Merge model's config with builder's config, with builder's config taking precedence
-        $modelConfigArray = $model->getConfig()->toArray();
-        $builderConfigArray = $this->modelConfig->toArray();
-        $mergedConfigArray = array_merge($modelConfigArray, $builderConfigArray);
-        $this->modelConfig = ModelConfig::fromArray($mergedConfigArray);
-        return $this;
-    }
-    /**
-     * Sets preferred models to evaluate in order.
-     *
-     * @since 0.2.0
-     *
-     * @param string|ModelInterface|array{0:string,1:string} ...$preferredModels The preferred models as model IDs,
-     * model instances, or [provider ID, model ID] tuples. For broader compatibility, it is recommended you specify
-     * only model IDs or model instances, as that will allow for different providers that expose the same model to be
-     * considered.
-     * @return self
-     *
-     * @throws InvalidArgumentException When a preferred model has an invalid type or identifier.
-     */
-    public function usingModelPreference(...$preferredModels): self
-    {
-        if ($preferredModels === []) {
-            throw new InvalidArgumentException('At least one model preference must be provided.');
-        }
-        $preferenceKeys = [];
-        foreach ($preferredModels as $preferredModel) {
-            if (is_array($preferredModel)) {
-                // [model identifier, provider ID] tuple
-                if (!array_is_list($preferredModel) || count($preferredModel) !== 2) {
-                    throw new InvalidArgumentException('Model preference tuple must contain model identifier and provider ID.');
-                }
-                [$providerId, $modelId] = $preferredModel;
-                $modelId = $this->normalizePreferenceIdentifier($modelId);
-                $providerId = $this->normalizePreferenceIdentifier($providerId, 'Model preference provider identifiers cannot be empty.');
-                $preferenceKey = $this->createProviderModelPreferenceKey($providerId, $modelId);
-            } elseif ($preferredModel instanceof ModelInterface) {
-                // Model instance
-                $modelId = $preferredModel->metadata()->getId();
-                $providerId = $preferredModel->providerMetadata()->getId();
-                $preferenceKey = $this->createProviderModelPreferenceKey($providerId, $modelId);
-            } elseif (is_string($preferredModel)) {
-                // Model ID
-                $modelId = $this->normalizePreferenceIdentifier($preferredModel);
-                $preferenceKey = $this->createModelPreferenceKey($modelId);
-            } else {
-                // Invalid type
-                throw new InvalidArgumentException('Model preferences must be model identifiers, instances of ModelInterface, ' . 'or provider/model tuples.');
-            }
-            $preferenceKeys[] = $preferenceKey;
-        }
-        $this->modelPreferenceKeys = $preferenceKeys;
-        return $this;
-    }
-    /**
-     * Sets the model configuration.
-     *
-     * Merges the provided configuration with the builder's configuration,
-     * with builder configuration taking precedence.
-     *
-     * @since 0.1.0
-     *
-     * @param ModelConfig $config The model configuration to merge.
-     * @return self
-     */
-    public function usingModelConfig(ModelConfig $config): self
-    {
-        // Convert both configs to arrays
-        $builderConfigArray = $this->modelConfig->toArray();
-        $providedConfigArray = $config->toArray();
-        // Merge arrays with builder config taking precedence
-        $mergedArray = array_merge($providedConfigArray, $builderConfigArray);
-        // Create new config from merged array
-        $this->modelConfig = ModelConfig::fromArray($mergedArray);
-        return $this;
-    }
-    /**
-     * Sets the provider to use for generation.
-     *
-     * @since 0.1.0
-     *
-     * @param string $providerIdOrClassName The provider ID or class name.
-     * @return self
-     */
-    public function usingProvider(string $providerIdOrClassName): self
-    {
-        $this->providerIdOrClassName = $providerIdOrClassName;
         return $this;
     }
     /**
@@ -466,19 +337,6 @@ class PromptBuilder
     public function usingWebSearch(WebSearch $webSearch): self
     {
         $this->modelConfig->setWebSearch($webSearch);
-        return $this;
-    }
-    /**
-     * Sets the request options for HTTP transport.
-     *
-     * @since 0.3.0
-     *
-     * @param RequestOptions $requestOptions The request options.
-     * @return self
-     */
-    public function usingRequestOptions(RequestOptions $requestOptions): self
-    {
-        $this->requestOptions = $requestOptions;
         return $this;
     }
     /**
@@ -691,8 +549,9 @@ class PromptBuilder
         // If no intended capability provided, infer from output modalities
         if ($capability === null) {
             // First try to infer from a specific model if one is set
-            if ($this->model !== null) {
-                $inferredCapability = $this->inferCapabilityFromModelInterfaces($this->model);
+            $model = $this->modelResolver->getModel();
+            if ($model !== null) {
+                $inferredCapability = $this->inferCapabilityFromModelInterfaces($model);
                 if ($inferredCapability !== null) {
                     $capability = $inferredCapability;
                 }
@@ -704,18 +563,7 @@ class PromptBuilder
         }
         // Build requirements with the specified capability
         $requirements = ModelRequirements::fromPromptData($capability, $this->messages, $this->modelConfig);
-        // If the model has been set, check if it meets the requirements
-        if ($this->model !== null) {
-            return $requirements->areMetBy($this->model->metadata());
-        }
-        try {
-            // Check if any models support these requirements
-            $models = $this->registry->findModelsMetadataForSupport($requirements);
-            return !empty($models);
-        } catch (InvalidArgumentException $e) {
-            // No models support the requirements
-            return \false;
-        }
+        return $this->modelResolver->isSupported($requirements);
     }
     /**
      * Checks if the prompt is supported for text generation.
@@ -815,8 +663,9 @@ class PromptBuilder
         // If capability is not provided, infer it
         if ($capability === null) {
             // First try to infer from a specific model if one is set
-            if ($this->model !== null) {
-                $inferredCapability = $this->inferCapabilityFromModelInterfaces($this->model);
+            $setModel = $this->modelResolver->getModel();
+            if ($setModel !== null) {
+                $inferredCapability = $this->inferCapabilityFromModelInterfaces($setModel);
                 if ($inferredCapability !== null) {
                     $capability = $inferredCapability;
                 }
@@ -1148,155 +997,7 @@ class PromptBuilder
     private function getConfiguredModel(CapabilityEnum $capability): ModelInterface
     {
         $requirements = ModelRequirements::fromPromptData($capability, $this->messages, $this->modelConfig);
-        if ($this->model !== null) {
-            // Explicit model was provided via usingModel(); just update config and bind dependencies.
-            $model = $this->model;
-            $model->setConfig($this->modelConfig);
-            $this->registry->bindModelDependencies($model);
-            $this->bindModelRequestOptions($model);
-            return $model;
-        }
-        // Retrieve the candidate models map which satisfies the requirements.
-        $candidateMap = $this->getCandidateModelsMap($requirements);
-        if (empty($candidateMap)) {
-            $message = sprintf('No models found that support %s for this prompt.', $capability->value);
-            if ($this->providerIdOrClassName !== null) {
-                $message = sprintf('No models found for provider "%s" that support %s for this prompt.', $this->providerIdOrClassName, $capability->value);
-            }
-            throw new InvalidArgumentException($message);
-        }
-        // Check if any preferred models match the candidates, in priority order.
-        if (!empty($this->modelPreferenceKeys)) {
-            // Find preferences that match available candidates, preserving preference order.
-            $matchingPreferences = array_intersect_key(array_flip($this->modelPreferenceKeys), $candidateMap);
-            if (!empty($matchingPreferences)) {
-                // Get the first matching preference key
-                $firstMatchKey = key($matchingPreferences);
-                [$providerId, $modelId] = $candidateMap[$firstMatchKey];
-                $model = $this->registry->getProviderModel($providerId, $modelId, $this->modelConfig);
-                $this->bindModelRequestOptions($model);
-                return $model;
-            }
-        }
-        // No preference matched; fall back to the first candidate discovered.
-        [$providerId, $modelId] = reset($candidateMap);
-        $model = $this->registry->getProviderModel($providerId, $modelId, $this->modelConfig);
-        $this->bindModelRequestOptions($model);
-        return $model;
-    }
-    /**
-     * Binds configured request options to the model if present and supported.
-     *
-     * Request options are only applicable to API-based models that make HTTP requests.
-     *
-     * @since 0.3.0
-     *
-     * @param ModelInterface $model The model to bind request options to.
-     * @return void
-     */
-    private function bindModelRequestOptions(ModelInterface $model): void
-    {
-        if ($this->requestOptions !== null && $model instanceof ApiBasedModelInterface) {
-            $model->setRequestOptions($this->requestOptions);
-        }
-    }
-    /**
-     * Builds a map of candidate models that satisfy the requirements for efficient lookup.
-     *
-     * @since 0.2.0
-     *
-     * @param ModelRequirements $requirements The requirements derived from the prompt.
-     * @return array<string, array{0:string,1:string}> Map of preference keys to [providerId, modelId] tuples.
-     */
-    private function getCandidateModelsMap(ModelRequirements $requirements): array
-    {
-        if ($this->providerIdOrClassName === null) {
-            // No provider locked in, gather all models across providers that meet requirements.
-            $providerModelsMetadata = $this->registry->findModelsMetadataForSupport($requirements);
-            $candidateMap = [];
-            foreach ($providerModelsMetadata as $providerModels) {
-                $providerId = $providerModels->getProvider()->getId();
-                $providerMap = $this->generateMapFromCandidates($providerId, $providerModels->getModels());
-                // Use + operator to merge, preserving keys from $candidateMap (first provider wins for model-only keys)
-                $candidateMap = $candidateMap + $providerMap;
-            }
-            return $candidateMap;
-        }
-        // Provider set, only consider models from that provider.
-        $modelsMetadata = $this->registry->findProviderModelsMetadataForSupport($this->providerIdOrClassName, $requirements);
-        // Ensure we pass the provider ID, not the class name
-        $providerId = $this->registry->getProviderId($this->providerIdOrClassName);
-        return $this->generateMapFromCandidates($providerId, $modelsMetadata);
-    }
-    /**
-     * Generates a candidate map from model metadata with both provider-specific and model-only keys.
-     *
-     * @since 0.2.0
-     *
-     * @param string $providerId The provider ID.
-     * @param list<ModelMetadata> $modelsMetadata The models metadata to map.
-     * @return array<string, array{0:string,1:string}> Map of preference keys to [providerId, modelId] tuples.
-     */
-    private function generateMapFromCandidates(string $providerId, array $modelsMetadata): array
-    {
-        $map = [];
-        foreach ($modelsMetadata as $modelMetadata) {
-            $modelId = $modelMetadata->getId();
-            // Add provider-specific key
-            $providerModelKey = $this->createProviderModelPreferenceKey($providerId, $modelId);
-            $map[$providerModelKey] = [$providerId, $modelId];
-            // Add model-only key
-            $modelKey = $this->createModelPreferenceKey($modelId);
-            $map[$modelKey] = [$providerId, $modelId];
-        }
-        return $map;
-    }
-    /**
-     * Normalizes and validates a preference identifier string.
-     *
-     * @since 0.2.0
-     *
-     * @param mixed $value The value to normalize.
-     * @param string $emptyMessage The message for empty or invalid values.
-     * @return string The normalized identifier.
-     *
-     * @throws InvalidArgumentException If the value is not a non-empty string.
-     */
-    private function normalizePreferenceIdentifier($value, string $emptyMessage = 'Model preference identifiers cannot be empty.'): string
-    {
-        if (!is_string($value)) {
-            throw new InvalidArgumentException($emptyMessage);
-        }
-        $trimmed = trim($value);
-        if ($trimmed === '') {
-            throw new InvalidArgumentException($emptyMessage);
-        }
-        return $trimmed;
-    }
-    /**
-     * Creates a preference key for a provider/model combination.
-     *
-     * @since 0.2.0
-     *
-     * @param string $providerId The provider identifier.
-     * @param string $modelId The model identifier.
-     * @return string The generated preference key.
-     */
-    private function createProviderModelPreferenceKey(string $providerId, string $modelId): string
-    {
-        return 'providerModel::' . $providerId . '::' . $modelId;
-    }
-    /**
-     * Creates a preference key for a model identifier.
-     *
-     * @since 0.2.0
-     *
-     * @param string $modelId The model identifier.
-     * @return string The generated preference key.
-     */
-    private function createModelPreferenceKey(string $modelId): string
-    {
-        return 'model::' . $modelId;
+        return $this->modelResolver->resolve($requirements, $this->modelConfig, 'prompt');
     }
     /**
      * Parses various input types into a Message with the given role.
@@ -1374,14 +1075,16 @@ class PromptBuilder
      */
     private function validateMessages(): void
     {
-        if (empty($this->messages)) {
+        // Work on a copy so reset() and end() do not change the property array's internal pointer.
+        $messages = $this->messages;
+        if (empty($messages)) {
             throw new InvalidArgumentException('Cannot generate from an empty prompt. Add content using withText() or similar methods.');
         }
-        $firstMessage = reset($this->messages);
+        $firstMessage = reset($messages);
         if (!$firstMessage->getRole()->isUser()) {
             throw new InvalidArgumentException('The first message must be from a user role, not from ' . $firstMessage->getRole()->value);
         }
-        $lastMessage = end($this->messages);
+        $lastMessage = end($messages);
         if (!$lastMessage->getRole()->isUser()) {
             throw new InvalidArgumentException('The last message must be from a user role, not from ' . $lastMessage->getRole()->value);
         }

--- a/src/wp-includes/php-ai-client/src/Builders/Traits/ModelResolutionTrait.php
+++ b/src/wp-includes/php-ai-client/src/Builders/Traits/ModelResolutionTrait.php
@@ -1,0 +1,118 @@
+<?php
+
+declare (strict_types=1);
+namespace WordPress\AiClient\Builders\Traits;
+
+use WordPress\AiClient\Common\Exception\InvalidArgumentException;
+use WordPress\AiClient\Providers\Http\DTO\RequestOptions;
+use WordPress\AiClient\Providers\ModelResolver;
+use WordPress\AiClient\Providers\Models\Contracts\ModelInterface;
+use WordPress\AiClient\Providers\Models\DTO\ModelConfig;
+/**
+ * Provides shared model selection and configuration methods for builders.
+ *
+ * Builders that generate results from a model (e.g. {@see \WordPress\AiClient\Builders\PromptBuilder}
+ * and {@see \WordPress\AiClient\Builders\EmbeddingBuilder}) use this trait to expose a consistent
+ * fluent API for choosing a model, provider, preferences, request options, and model configuration.
+ * Model selection state and logic live on the {@see ModelResolver} owned by the builder.
+ *
+ * @since 1.4.0
+ */
+trait ModelResolutionTrait
+{
+    /**
+     * @var ModelConfig The model configuration.
+     */
+    protected ModelConfig $modelConfig;
+    /**
+     * @var ModelResolver The resolver that owns model selection state and logic.
+     */
+    protected ModelResolver $modelResolver;
+    /**
+     * Sets the model to use for generation.
+     *
+     * The model's configuration will be merged with the builder's configuration,
+     * with the builder's configuration taking precedence for any overlapping settings.
+     *
+     * @since 0.1.0
+     *
+     * @param ModelInterface $model The model to use.
+     * @return self
+     */
+    public function usingModel(ModelInterface $model): self
+    {
+        $this->modelResolver->setModel($model);
+        // Merge model's config with builder's config, with builder's config taking precedence
+        $modelConfigArray = $model->getConfig()->toArray();
+        $builderConfigArray = $this->modelConfig->toArray();
+        $mergedConfigArray = array_merge($modelConfigArray, $builderConfigArray);
+        $this->modelConfig = ModelConfig::fromArray($mergedConfigArray);
+        return $this;
+    }
+    /**
+     * Sets preferred models to evaluate in order.
+     *
+     * @since 0.2.0
+     *
+     * @param string|ModelInterface|array{0:string,1:string} ...$preferredModels The preferred models as model IDs,
+     * model instances, or [provider ID, model ID] tuples. For broader compatibility, it is recommended you specify
+     * only model IDs or model instances, as that will allow for different providers that expose the same model to be
+     * considered.
+     * @return self
+     *
+     * @throws InvalidArgumentException When a preferred model has an invalid type or identifier.
+     */
+    public function usingModelPreference(...$preferredModels): self
+    {
+        $this->modelResolver->setModelPreferences(...$preferredModels);
+        return $this;
+    }
+    /**
+     * Sets the model configuration.
+     *
+     * Merges the provided configuration with the builder's configuration,
+     * with builder configuration taking precedence.
+     *
+     * @since 0.1.0
+     *
+     * @param ModelConfig $config The model configuration to merge.
+     * @return self
+     */
+    public function usingModelConfig(ModelConfig $config): self
+    {
+        // Convert both configs to arrays
+        $builderConfigArray = $this->modelConfig->toArray();
+        $providedConfigArray = $config->toArray();
+        // Merge arrays with builder config taking precedence
+        $mergedArray = array_merge($providedConfigArray, $builderConfigArray);
+        // Create new config from merged array
+        $this->modelConfig = ModelConfig::fromArray($mergedArray);
+        return $this;
+    }
+    /**
+     * Sets the provider to use for generation.
+     *
+     * @since 0.1.0
+     *
+     * @param string $providerIdOrClassName The provider ID or class name.
+     * @return self
+     */
+    public function usingProvider(string $providerIdOrClassName): self
+    {
+        $this->modelResolver->setProvider($providerIdOrClassName);
+        return $this;
+    }
+    /**
+     * Sets the request options for HTTP transport.
+     *
+     * @since 0.3.0
+     *
+     * @param RequestOptions $requestOptions The request options.
+     * @return self
+     */
+    public function usingRequestOptions(RequestOptions $requestOptions): self
+    {
+        $this->modelResolver->setRequestOptions($requestOptions);
+        return $this;
+    }
+}

--- a/src/wp-includes/php-ai-client/src/Events/AfterGenerateEmbeddingEvent.php
+++ b/src/wp-includes/php-ai-client/src/Events/AfterGenerateEmbeddingEvent.php
@@ -1,0 +1,108 @@
+<?php
+
+declare (strict_types=1);
+namespace WordPress\AiClient\Events;
+
+use WordPress\AiClient\Messages\DTO\MessagePart;
+use WordPress\AiClient\Providers\Models\Contracts\ModelInterface;
+use WordPress\AiClient\Providers\Models\Enums\CapabilityEnum;
+use WordPress\AiClient\Results\DTO\EmbeddingResult;
+/**
+ * Event dispatched after embeddings have been generated.
+ *
+ * @since 1.4.0
+ */
+class AfterGenerateEmbeddingEvent
+{
+    /**
+     * @var list<MessagePart> The inputs that were sent to the model.
+     */
+    private array $inputs;
+    /**
+     * @var ModelInterface The model that generated embeddings.
+     */
+    private ModelInterface $model;
+    /**
+     * @var CapabilityEnum The capability that was used for generation.
+     */
+    private CapabilityEnum $capability;
+    /**
+     * @var EmbeddingResult The result from the model.
+     */
+    private EmbeddingResult $result;
+    /**
+     * Constructor.
+     *
+     * @since 1.4.0
+     *
+     * @param list<MessagePart> $inputs The inputs that were sent to the model.
+     * @param ModelInterface    $model The model that generated embeddings.
+     * @param CapabilityEnum    $capability The capability that was used for generation.
+     * @param EmbeddingResult   $result The result from the model.
+     */
+    public function __construct(array $inputs, ModelInterface $model, CapabilityEnum $capability, EmbeddingResult $result)
+    {
+        $this->inputs = $inputs;
+        $this->model = $model;
+        $this->capability = $capability;
+        $this->result = $result;
+    }
+    /**
+     * Gets the inputs that were sent to the model.
+     *
+     * @since 1.4.0
+     *
+     * @return list<MessagePart> The inputs.
+     */
+    public function getInputs(): array
+    {
+        return $this->inputs;
+    }
+    /**
+     * Gets the model that generated embeddings.
+     *
+     * @since 1.4.0
+     *
+     * @return ModelInterface The model.
+     */
+    public function getModel(): ModelInterface
+    {
+        return $this->model;
+    }
+    /**
+     * Gets the capability that was used for generation.
+     *
+     * @since 1.4.0
+     *
+     * @return CapabilityEnum The capability.
+     */
+    public function getCapability(): CapabilityEnum
+    {
+        return $this->capability;
+    }
+    /**
+     * Gets the result from the model.
+     *
+     * @since 1.4.0
+     *
+     * @return EmbeddingResult The result.
+     */
+    public function getResult(): EmbeddingResult
+    {
+        return $this->result;
+    }
+    /**
+     * Performs a deep clone of the event.
+     *
+     * @since 1.4.0
+     */
+    public function __clone()
+    {
+        $clonedInputs = [];
+        foreach ($this->inputs as $input) {
+            $clonedInputs[] = clone $input;
+        }
+        $this->inputs = $clonedInputs;
+        $this->result = clone $this->result;
+    }
+}

--- a/src/wp-includes/php-ai-client/src/Events/BeforeGenerateEmbeddingEvent.php
+++ b/src/wp-includes/php-ai-client/src/Events/BeforeGenerateEmbeddingEvent.php
@@ -1,0 +1,89 @@
+<?php
+
+declare (strict_types=1);
+namespace WordPress\AiClient\Events;
+
+use WordPress\AiClient\Messages\DTO\MessagePart;
+use WordPress\AiClient\Providers\Models\Contracts\ModelInterface;
+use WordPress\AiClient\Providers\Models\Enums\CapabilityEnum;
+/**
+ * Event dispatched before inputs are sent to an embedding generation model.
+ *
+ * @since 1.4.0
+ */
+class BeforeGenerateEmbeddingEvent
+{
+    /**
+     * @var list<MessagePart> The inputs to be sent to the model.
+     */
+    private array $inputs;
+    /**
+     * @var ModelInterface The model that will generate embeddings.
+     */
+    private ModelInterface $model;
+    /**
+     * @var CapabilityEnum The capability being used for generation.
+     */
+    private CapabilityEnum $capability;
+    /**
+     * Constructor.
+     *
+     * @since 1.4.0
+     *
+     * @param list<MessagePart> $inputs The inputs to be sent to the model.
+     * @param ModelInterface    $model The model that will generate embeddings.
+     * @param CapabilityEnum    $capability The capability being used for generation.
+     */
+    public function __construct(array $inputs, ModelInterface $model, CapabilityEnum $capability)
+    {
+        $this->inputs = $inputs;
+        $this->model = $model;
+        $this->capability = $capability;
+    }
+    /**
+     * Gets the inputs to be sent to the model.
+     *
+     * @since 1.4.0
+     *
+     * @return list<MessagePart> The inputs.
+     */
+    public function getInputs(): array
+    {
+        return $this->inputs;
+    }
+    /**
+     * Gets the model that will generate embeddings.
+     *
+     * @since 1.4.0
+     *
+     * @return ModelInterface The model.
+     */
+    public function getModel(): ModelInterface
+    {
+        return $this->model;
+    }
+    /**
+     * Gets the capability being used for generation.
+     *
+     * @since 1.4.0
+     *
+     * @return CapabilityEnum The capability.
+     */
+    public function getCapability(): CapabilityEnum
+    {
+        return $this->capability;
+    }
+    /**
+     * Performs a deep clone of the event.
+     *
+     * @since 1.4.0
+     */
+    public function __clone()
+    {
+        $clonedInputs = [];
+        foreach ($this->inputs as $input) {
+            $clonedInputs[] = clone $input;
+        }
+        $this->inputs = $clonedInputs;
+    }
+}

--- a/src/wp-includes/php-ai-client/src/Files/Enums/MediaOrientationEnum.php
+++ b/src/wp-includes/php-ai-client/src/Files/Enums/MediaOrientationEnum.php
@@ -5,7 +5,7 @@ namespace WordPress\AiClient\Files\Enums;
 
 use WordPress\AiClient\Common\AbstractEnum;
 /**
- * Represents the type of file storage.
+ * Represents the media orientation.
  *
  * @method static self square() Returns the square orientation
  * @method static self landscape() Returns the landscape orientation.

--- a/src/wp-includes/php-ai-client/src/Messages/Util/ModalityCombinationsUtil.php
+++ b/src/wp-includes/php-ai-client/src/Messages/Util/ModalityCombinationsUtil.php
@@ -1,0 +1,48 @@
+<?php
+
+declare (strict_types=1);
+namespace WordPress\AiClient\Messages\Util;
+
+use WordPress\AiClient\Messages\Enums\ModalityEnum;
+/**
+ * Utility class for building modality combinations.
+ *
+ * @since 1.4.0
+ */
+class ModalityCombinationsUtil
+{
+    /**
+     * Builds all modality combinations that always include the required modalities
+     * with every possible subset of the optional modalities.
+     *
+     * Uses binary representation to enumerate all 2^n subsets of the optional
+     * modalities. Each subset is merged with the required modalities to form one
+     * complete combination. Modality lists are unordered, so only unique
+     * combinations (not permutations) are produced.
+     *
+     * @since 1.4.0
+     *
+     * @param list<ModalityEnum> $required Required modalities included in every combination.
+     * @param list<ModalityEnum> $optional Optional modalities to generate subsets from.
+     * @return list<list<ModalityEnum>> List of modality combinations, each containing
+     *                                  all required modalities plus a unique subset of
+     *                                  the optional modalities.
+     */
+    public static function buildCombinations(array $required, array $optional): array
+    {
+        $combinations = [];
+        $count = count($optional);
+        $subsetCount = 1 << $count;
+        // 2^count.
+        for ($i = 0; $i < $subsetCount; $i++) {
+            $combo = $required;
+            for ($j = 0; $j < $count; $j++) {
+                if ($i & 1 << $j) {
+                    $combo[] = $optional[$j];
+                }
+            }
+            $combinations[] = $combo;
+        }
+        return $combinations;
+    }
+}

--- a/src/wp-includes/php-ai-client/src/Providers/ModelResolver.php
+++ b/src/wp-includes/php-ai-client/src/Providers/ModelResolver.php
@@ -1,0 +1,372 @@
+<?php
+
+declare (strict_types=1);
+namespace WordPress\AiClient\Providers;
+
+use WordPress\AiClient\Common\Exception\InvalidArgumentException;
+use WordPress\AiClient\Providers\ApiBasedImplementation\Contracts\ApiBasedModelInterface;
+use WordPress\AiClient\Providers\Http\DTO\RequestOptions;
+use WordPress\AiClient\Providers\Models\Contracts\ModelInterface;
+use WordPress\AiClient\Providers\Models\DTO\ModelConfig;
+use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
+use WordPress\AiClient\Providers\Models\DTO\ModelRequirements;
+/**
+ * Resolves the concrete AI model to use based on selection preferences.
+ *
+ * This class owns all model-selection state and logic: an explicitly set model,
+ * ordered model preferences, a provider constraint, and HTTP request options. It
+ * is shared between the builders (via the model resolution trait) so that model
+ * selection behaves identically regardless of what is being generated.
+ *
+ * @since 1.4.0
+ */
+class ModelResolver
+{
+    /**
+     * @var ProviderRegistry The provider registry for finding suitable models.
+     */
+    private \WordPress\AiClient\Providers\ProviderRegistry $registry;
+    /**
+     * @var ModelInterface|null The model to use for generation.
+     */
+    private ?ModelInterface $model = null;
+    /**
+     * @var list<string> Ordered list of preference keys to check when selecting a model.
+     */
+    private array $modelPreferenceKeys = [];
+    /**
+     * @var string|null The provider ID or class name.
+     */
+    private ?string $providerIdOrClassName = null;
+    /**
+     * @var RequestOptions|null The request options for HTTP transport.
+     */
+    private ?RequestOptions $requestOptions = null;
+    /**
+     * Constructor.
+     *
+     * @since 1.4.0
+     *
+     * @param ProviderRegistry $registry The provider registry for finding suitable models.
+     */
+    public function __construct(\WordPress\AiClient\Providers\ProviderRegistry $registry)
+    {
+        $this->registry = $registry;
+    }
+    /**
+     * Creates a deep clone of this resolver.
+     *
+     * Clones the request options (which contain only primitives). The registry and
+     * explicitly set model are service objects and are intentionally NOT cloned, as
+     * they should be shared references.
+     *
+     * @since 1.4.0
+     */
+    public function __clone()
+    {
+        if ($this->requestOptions !== null) {
+            $this->requestOptions = clone $this->requestOptions;
+        }
+    }
+    /**
+     * Sets the model to use for generation.
+     *
+     * @since 1.4.0
+     *
+     * @param ModelInterface $model The model to use.
+     * @return void
+     */
+    public function setModel(ModelInterface $model): void
+    {
+        $this->model = $model;
+    }
+    /**
+     * Gets the explicitly set model, if any.
+     *
+     * @since 1.4.0
+     *
+     * @return ModelInterface|null The explicitly set model, or null if none was set.
+     */
+    public function getModel(): ?ModelInterface
+    {
+        return $this->model;
+    }
+    /**
+     * Sets preferred models to evaluate in order.
+     *
+     * @since 1.4.0
+     *
+     * @param string|ModelInterface|array{0:string,1:string} ...$preferredModels The preferred models as model IDs,
+     * model instances, or [provider ID, model ID] tuples. For broader compatibility, it is recommended you specify
+     * only model IDs or model instances, as that will allow for different providers that expose the same model to be
+     * considered.
+     * @return void
+     *
+     * @throws InvalidArgumentException When a preferred model has an invalid type or identifier.
+     */
+    public function setModelPreferences(...$preferredModels): void
+    {
+        if ($preferredModels === []) {
+            throw new InvalidArgumentException('At least one model preference must be provided.');
+        }
+        $preferenceKeys = [];
+        foreach ($preferredModels as $preferredModel) {
+            if (is_array($preferredModel)) {
+                // [model identifier, provider ID] tuple
+                if (!array_is_list($preferredModel) || count($preferredModel) !== 2) {
+                    throw new InvalidArgumentException('Model preference tuple must contain model identifier and provider ID.');
+                }
+                [$providerId, $modelId] = $preferredModel;
+                $modelId = $this->normalizePreferenceIdentifier($modelId);
+                $providerId = $this->normalizePreferenceIdentifier($providerId, 'Model preference provider identifiers cannot be empty.');
+                $preferenceKey = $this->createProviderModelPreferenceKey($providerId, $modelId);
+            } elseif ($preferredModel instanceof ModelInterface) {
+                // Model instance
+                $modelId = $preferredModel->metadata()->getId();
+                $providerId = $preferredModel->providerMetadata()->getId();
+                $preferenceKey = $this->createProviderModelPreferenceKey($providerId, $modelId);
+            } elseif (is_string($preferredModel)) {
+                // Model ID
+                $modelId = $this->normalizePreferenceIdentifier($preferredModel);
+                $preferenceKey = $this->createModelPreferenceKey($modelId);
+            } else {
+                // Invalid type
+                throw new InvalidArgumentException('Model preferences must be model identifiers, instances of ModelInterface, ' . 'or provider/model tuples.');
+            }
+            $preferenceKeys[] = $preferenceKey;
+        }
+        $this->modelPreferenceKeys = $preferenceKeys;
+    }
+    /**
+     * Sets the provider to use for generation.
+     *
+     * @since 1.4.0
+     *
+     * @param string $providerIdOrClassName The provider ID or class name.
+     * @return void
+     */
+    public function setProvider(string $providerIdOrClassName): void
+    {
+        $this->providerIdOrClassName = $providerIdOrClassName;
+    }
+    /**
+     * Sets the request options for HTTP transport.
+     *
+     * @since 1.4.0
+     *
+     * @param RequestOptions $requestOptions The request options.
+     * @return void
+     */
+    public function setRequestOptions(RequestOptions $requestOptions): void
+    {
+        $this->requestOptions = $requestOptions;
+    }
+    /**
+     * Resolves the model to use for the given requirements.
+     *
+     * If a model has been explicitly set, updates its config, binds dependencies,
+     * and returns it. Otherwise, finds a suitable model based on the requirements,
+     * honoring any configured model preferences and provider constraint.
+     *
+     * @since 1.4.0
+     *
+     * @param ModelRequirements $requirements The requirements the model must satisfy.
+     * @param ModelConfig $modelConfig The model configuration to apply.
+     * @param string|null $subject Optional caller-specific subject for failure messages.
+     * @return ModelInterface The model to use.
+     * @throws InvalidArgumentException If no suitable model is found or set model doesn't meet requirements.
+     */
+    public function resolve(ModelRequirements $requirements, ModelConfig $modelConfig, ?string $subject = null): ModelInterface
+    {
+        if ($this->model !== null) {
+            // Explicit model was provided via setModel(); just update config and bind dependencies.
+            $model = $this->model;
+            $model->setConfig($modelConfig);
+            $this->registry->bindModelDependencies($model);
+            $this->bindModelRequestOptions($model);
+            return $model;
+        }
+        // Retrieve the candidate models map which satisfies the requirements.
+        $candidateMap = $this->getCandidateModelsMap($requirements);
+        if (empty($candidateMap)) {
+            // The primary capability is always the first required capability (see
+            // ModelRequirements::fromPromptData()/fromEmbeddingData()).
+            $requiredCapabilities = $requirements->getRequiredCapabilities();
+            $primaryCapability = reset($requiredCapabilities);
+            if ($primaryCapability === \false) {
+                $message = 'No models found that meet the requested requirements.';
+                if ($this->providerIdOrClassName !== null) {
+                    $message = sprintf('No models found for provider "%s" that meet the requested requirements.', $this->providerIdOrClassName);
+                }
+                throw new InvalidArgumentException($message);
+            }
+            $capabilityValue = $primaryCapability->value;
+            $message = sprintf('No models found that support %s.', $capabilityValue);
+            if ($subject !== null) {
+                $message = sprintf('No models found that support %s for this %s.', $capabilityValue, $subject);
+            }
+            if ($this->providerIdOrClassName !== null) {
+                $message = sprintf('No models found for provider "%s" that support %s.', $this->providerIdOrClassName, $capabilityValue);
+                if ($subject !== null) {
+                    $message = sprintf('No models found for provider "%s" that support %s for this %s.', $this->providerIdOrClassName, $capabilityValue, $subject);
+                }
+            }
+            throw new InvalidArgumentException($message);
+        }
+        // Check if any preferred models match the candidates, in priority order.
+        if (!empty($this->modelPreferenceKeys)) {
+            // Find preferences that match available candidates, preserving preference order.
+            $matchingPreferences = array_intersect_key(array_flip($this->modelPreferenceKeys), $candidateMap);
+            if (!empty($matchingPreferences)) {
+                // Get the first matching preference key
+                $firstMatchKey = key($matchingPreferences);
+                [$providerId, $modelId] = $candidateMap[$firstMatchKey];
+                $model = $this->registry->getProviderModel($providerId, $modelId, $modelConfig);
+                $this->bindModelRequestOptions($model);
+                return $model;
+            }
+        }
+        // No preference matched; fall back to the first candidate discovered.
+        [$providerId, $modelId] = reset($candidateMap);
+        $model = $this->registry->getProviderModel($providerId, $modelId, $modelConfig);
+        $this->bindModelRequestOptions($model);
+        return $model;
+    }
+    /**
+     * Checks whether any model can satisfy the given requirements.
+     *
+     * @since 1.4.0
+     *
+     * @param ModelRequirements $requirements The requirements to check support for.
+     * @return bool True if the set model or any registered model meets the requirements.
+     */
+    public function isSupported(ModelRequirements $requirements): bool
+    {
+        // If the model has been set, check if it meets the requirements
+        if ($this->model !== null) {
+            return $requirements->areMetBy($this->model->metadata());
+        }
+        try {
+            // Check if any models support these requirements
+            $models = $this->registry->findModelsMetadataForSupport($requirements);
+            return !empty($models);
+        } catch (InvalidArgumentException $e) {
+            // No models support the requirements
+            return \false;
+        }
+    }
+    /**
+     * Binds configured request options to the model if present and supported.
+     *
+     * Request options are only applicable to API-based models that make HTTP requests.
+     *
+     * @since 1.4.0
+     *
+     * @param ModelInterface $model The model to bind request options to.
+     * @return void
+     */
+    private function bindModelRequestOptions(ModelInterface $model): void
+    {
+        if ($this->requestOptions !== null && $model instanceof ApiBasedModelInterface) {
+            $model->setRequestOptions($this->requestOptions);
+        }
+    }
+    /**
+     * Builds a map of candidate models that satisfy the requirements for efficient lookup.
+     *
+     * @since 1.4.0
+     *
+     * @param ModelRequirements $requirements The requirements derived from the prompt.
+     * @return array<string, array{0:string,1:string}> Map of preference keys to [providerId, modelId] tuples.
+     */
+    private function getCandidateModelsMap(ModelRequirements $requirements): array
+    {
+        if ($this->providerIdOrClassName === null) {
+            // No provider locked in, gather all models across providers that meet requirements.
+            $providerModelsMetadata = $this->registry->findModelsMetadataForSupport($requirements);
+            $candidateMap = [];
+            foreach ($providerModelsMetadata as $providerModels) {
+                $providerId = $providerModels->getProvider()->getId();
+                $providerMap = $this->generateMapFromCandidates($providerId, $providerModels->getModels());
+                // Use + operator to merge, preserving keys from $candidateMap (first provider wins for model-only keys)
+                $candidateMap = $candidateMap + $providerMap;
+            }
+            return $candidateMap;
+        }
+        // Provider set, only consider models from that provider.
+        $modelsMetadata = $this->registry->findProviderModelsMetadataForSupport($this->providerIdOrClassName, $requirements);
+        // Ensure we pass the provider ID, not the class name
+        $providerId = $this->registry->getProviderId($this->providerIdOrClassName);
+        return $this->generateMapFromCandidates($providerId, $modelsMetadata);
+    }
+    /**
+     * Generates a candidate map from model metadata with both provider-specific and model-only keys.
+     *
+     * @since 1.4.0
+     *
+     * @param string $providerId The provider ID.
+     * @param list<ModelMetadata> $modelsMetadata The models metadata to map.
+     * @return array<string, array{0:string,1:string}> Map of preference keys to [providerId, modelId] tuples.
+     */
+    private function generateMapFromCandidates(string $providerId, array $modelsMetadata): array
+    {
+        $map = [];
+        foreach ($modelsMetadata as $modelMetadata) {
+            $modelId = $modelMetadata->getId();
+            // Add provider-specific key
+            $providerModelKey = $this->createProviderModelPreferenceKey($providerId, $modelId);
+            $map[$providerModelKey] = [$providerId, $modelId];
+            // Add model-only key
+            $modelKey = $this->createModelPreferenceKey($modelId);
+            $map[$modelKey] = [$providerId, $modelId];
+        }
+        return $map;
+    }
+    /**
+     * Normalizes and validates a preference identifier string.
+     *
+     * @since 1.4.0
+     *
+     * @param mixed $value The value to normalize.
+     * @param string $emptyMessage The message for empty or invalid values.
+     * @return string The normalized identifier.
+     *
+     * @throws InvalidArgumentException If the value is not a non-empty string.
+     */
+    private function normalizePreferenceIdentifier($value, string $emptyMessage = 'Model preference identifiers cannot be empty.'): string
+    {
+        if (!is_string($value)) {
+            throw new InvalidArgumentException($emptyMessage);
+        }
+        $trimmed = trim($value);
+        if ($trimmed === '') {
+            throw new InvalidArgumentException($emptyMessage);
+        }
+        return $trimmed;
+    }
+    /**
+     * Creates a preference key for a provider/model combination.
+     *
+     * @since 1.4.0
+     *
+     * @param string $providerId The provider identifier.
+     * @param string $modelId The model identifier.
+     * @return string The generated preference key.
+     */
+    private function createProviderModelPreferenceKey(string $providerId, string $modelId): string
+    {
+        return 'providerModel::' . $providerId . '::' . $modelId;
+    }
+    /**
+     * Creates a preference key for a model identifier.
+     *
+     * @since 1.4.0
+     *
+     * @param string $modelId The model identifier.
+     * @return string The generated preference key.
+     */
+    private function createModelPreferenceKey(string $modelId): string
+    {
+        return 'model::' . $modelId;
+    }
+}

--- a/src/wp-includes/php-ai-client/src/Providers/Models/DTO/ModelConfig.php
+++ b/src/wp-includes/php-ai-client/src/Providers/Models/DTO/ModelConfig.php
@@ -43,6 +43,7 @@ use WordPress\AiClient\Tools\DTO\WebSearch;
  *     outputMediaOrientation?: string,
  *     outputMediaAspectRatio?: string,
  *     outputSpeechVoice?: string,
+ *     dimensions?: int,
  *     customOptions?: array<string, mixed>
  * }
  *
@@ -70,6 +71,7 @@ class ModelConfig extends AbstractDataTransferObject
     public const KEY_OUTPUT_MEDIA_ORIENTATION = 'outputMediaOrientation';
     public const KEY_OUTPUT_MEDIA_ASPECT_RATIO = 'outputMediaAspectRatio';
     public const KEY_OUTPUT_SPEECH_VOICE = 'outputSpeechVoice';
+    public const KEY_DIMENSIONS = 'dimensions';
     public const KEY_CUSTOM_OPTIONS = 'customOptions';
     /*
      * Note: This key is not an actual model config key, but specified here for convenience.
@@ -157,6 +159,10 @@ class ModelConfig extends AbstractDataTransferObject
      * @var string|null Output speech voice.
      */
     protected ?string $outputSpeechVoice = null;
+    /**
+     * @var int|null Embedding vector dimensions.
+     */
+    protected ?int $dimensions = null;
     /**
      * @var array<string, mixed> Custom provider-specific options.
      */
@@ -683,6 +689,31 @@ class ModelConfig extends AbstractDataTransferObject
         return $this->outputSpeechVoice;
     }
     /**
+     * Sets the embedding dimensions.
+     *
+     * @since 1.4.0
+     *
+     * @param int $dimensions The embedding dimensions.
+     */
+    public function setDimensions(int $dimensions): void
+    {
+        if ($dimensions < 1) {
+            throw new InvalidArgumentException('Dimensions must be greater than zero.');
+        }
+        $this->dimensions = $dimensions;
+    }
+    /**
+     * Gets the embedding dimensions.
+     *
+     * @since 1.4.0
+     *
+     * @return int|null The embedding dimensions.
+     */
+    public function getDimensions(): ?int
+    {
+        return $this->dimensions;
+    }
+    /**
      * Sets a single custom option.
      *
      * @since 0.1.0
@@ -723,7 +754,7 @@ class ModelConfig extends AbstractDataTransferObject
      */
     public static function getJsonSchema(): array
     {
-        return ['type' => 'object', 'properties' => [self::KEY_OUTPUT_MODALITIES => ['type' => 'array', 'items' => ['type' => 'string', 'enum' => ModalityEnum::getValues()], 'description' => 'Output modalities for the model.'], self::KEY_SYSTEM_INSTRUCTION => ['type' => 'string', 'description' => 'System instruction for the model.'], self::KEY_CANDIDATE_COUNT => ['type' => 'integer', 'minimum' => 1, 'description' => 'Number of response candidates to generate.'], self::KEY_MAX_TOKENS => ['type' => 'integer', 'minimum' => 1, 'description' => 'Maximum number of tokens to generate.'], self::KEY_TEMPERATURE => ['type' => 'number', 'minimum' => 0.0, 'maximum' => 2.0, 'description' => 'Temperature for randomness.'], self::KEY_TOP_P => ['type' => 'number', 'minimum' => 0.0, 'maximum' => 1.0, 'description' => 'Top-p nucleus sampling parameter.'], self::KEY_TOP_K => ['type' => 'integer', 'minimum' => 1, 'description' => 'Top-k sampling parameter.'], self::KEY_STOP_SEQUENCES => ['type' => 'array', 'items' => ['type' => 'string'], 'description' => 'Stop sequences.'], self::KEY_PRESENCE_PENALTY => ['type' => 'number', 'description' => 'Presence penalty for reducing repetition.'], self::KEY_FREQUENCY_PENALTY => ['type' => 'number', 'description' => 'Frequency penalty for reducing repetition.'], self::KEY_LOGPROBS => ['type' => 'boolean', 'description' => 'Whether to return log probabilities.'], self::KEY_TOP_LOGPROBS => ['type' => 'integer', 'minimum' => 1, 'description' => 'Number of top log probabilities to return.'], self::KEY_FUNCTION_DECLARATIONS => ['type' => 'array', 'items' => FunctionDeclaration::getJsonSchema(), 'description' => 'Function declarations available to the model.'], self::KEY_WEB_SEARCH => WebSearch::getJsonSchema(), self::KEY_OUTPUT_FILE_TYPE => ['type' => 'string', 'enum' => FileTypeEnum::getValues(), 'description' => 'Output file type.'], self::KEY_OUTPUT_MIME_TYPE => ['type' => 'string', 'description' => 'Output MIME type.'], self::KEY_OUTPUT_SCHEMA => ['type' => 'object', 'additionalProperties' => \true, 'description' => 'Output schema (JSON schema).'], self::KEY_OUTPUT_MEDIA_ORIENTATION => ['type' => 'string', 'enum' => MediaOrientationEnum::getValues(), 'description' => 'Output media orientation.'], self::KEY_OUTPUT_MEDIA_ASPECT_RATIO => ['type' => 'string', 'pattern' => '^\d+:\d+$', 'description' => 'Output media aspect ratio.'], self::KEY_OUTPUT_SPEECH_VOICE => ['type' => 'string', 'description' => 'Output speech voice.'], self::KEY_CUSTOM_OPTIONS => ['type' => 'object', 'additionalProperties' => \true, 'description' => 'Custom provider-specific options.']], 'additionalProperties' => \false];
+        return ['type' => 'object', 'properties' => [self::KEY_OUTPUT_MODALITIES => ['type' => 'array', 'items' => ['type' => 'string', 'enum' => ModalityEnum::getValues()], 'description' => 'Output modalities for the model.'], self::KEY_SYSTEM_INSTRUCTION => ['type' => 'string', 'description' => 'System instruction for the model.'], self::KEY_CANDIDATE_COUNT => ['type' => 'integer', 'minimum' => 1, 'description' => 'Number of response candidates to generate.'], self::KEY_MAX_TOKENS => ['type' => 'integer', 'minimum' => 1, 'description' => 'Maximum number of tokens to generate.'], self::KEY_TEMPERATURE => ['type' => 'number', 'minimum' => 0.0, 'maximum' => 2.0, 'description' => 'Temperature for randomness.'], self::KEY_TOP_P => ['type' => 'number', 'minimum' => 0.0, 'maximum' => 1.0, 'description' => 'Top-p nucleus sampling parameter.'], self::KEY_TOP_K => ['type' => 'integer', 'minimum' => 1, 'description' => 'Top-k sampling parameter.'], self::KEY_STOP_SEQUENCES => ['type' => 'array', 'items' => ['type' => 'string'], 'description' => 'Stop sequences.'], self::KEY_PRESENCE_PENALTY => ['type' => 'number', 'description' => 'Presence penalty for reducing repetition.'], self::KEY_FREQUENCY_PENALTY => ['type' => 'number', 'description' => 'Frequency penalty for reducing repetition.'], self::KEY_LOGPROBS => ['type' => 'boolean', 'description' => 'Whether to return log probabilities.'], self::KEY_TOP_LOGPROBS => ['type' => 'integer', 'minimum' => 1, 'description' => 'Number of top log probabilities to return.'], self::KEY_FUNCTION_DECLARATIONS => ['type' => 'array', 'items' => FunctionDeclaration::getJsonSchema(), 'description' => 'Function declarations available to the model.'], self::KEY_WEB_SEARCH => WebSearch::getJsonSchema(), self::KEY_OUTPUT_FILE_TYPE => ['type' => 'string', 'enum' => FileTypeEnum::getValues(), 'description' => 'Output file type.'], self::KEY_OUTPUT_MIME_TYPE => ['type' => 'string', 'description' => 'Output MIME type.'], self::KEY_OUTPUT_SCHEMA => ['type' => 'object', 'additionalProperties' => \true, 'description' => 'Output schema (JSON schema).'], self::KEY_OUTPUT_MEDIA_ORIENTATION => ['type' => 'string', 'enum' => MediaOrientationEnum::getValues(), 'description' => 'Output media orientation.'], self::KEY_OUTPUT_MEDIA_ASPECT_RATIO => ['type' => 'string', 'pattern' => '^\d+:\d+$', 'description' => 'Output media aspect ratio.'], self::KEY_OUTPUT_SPEECH_VOICE => ['type' => 'string', 'description' => 'Output speech voice.'], self::KEY_DIMENSIONS => ['type' => 'integer', 'minimum' => 1, 'description' => 'Embedding vector dimensions.'], self::KEY_CUSTOM_OPTIONS => ['type' => 'object', 'additionalProperties' => \true, 'description' => 'Custom provider-specific options.']], 'additionalProperties' => \false];
     }
     /**
      * {@inheritDoc}
@@ -799,6 +830,9 @@ class ModelConfig extends AbstractDataTransferObject
         if ($this->outputSpeechVoice !== null) {
             $data[self::KEY_OUTPUT_SPEECH_VOICE] = $this->outputSpeechVoice;
         }
+        if ($this->dimensions !== null) {
+            $data[self::KEY_DIMENSIONS] = $this->dimensions;
+        }
         if (!empty($this->customOptions)) {
             $data[self::KEY_CUSTOM_OPTIONS] = $this->customOptions;
         }
@@ -873,6 +907,9 @@ class ModelConfig extends AbstractDataTransferObject
         }
         if (isset($array[self::KEY_OUTPUT_SPEECH_VOICE])) {
             $config->setOutputSpeechVoice($array[self::KEY_OUTPUT_SPEECH_VOICE]);
+        }
+        if (isset($array[self::KEY_DIMENSIONS])) {
+            $config->setDimensions($array[self::KEY_DIMENSIONS]);
         }
         if (isset($array[self::KEY_CUSTOM_OPTIONS])) {
             $config->setCustomOptions($array[self::KEY_CUSTOM_OPTIONS]);

--- a/src/wp-includes/php-ai-client/src/Providers/Models/DTO/ModelRequirements.php
+++ b/src/wp-includes/php-ai-client/src/Providers/Models/DTO/ModelRequirements.php
@@ -6,6 +6,7 @@ namespace WordPress\AiClient\Providers\Models\DTO;
 use WordPress\AiClient\Common\AbstractDataTransferObject;
 use WordPress\AiClient\Common\Exception\InvalidArgumentException;
 use WordPress\AiClient\Messages\DTO\Message;
+use WordPress\AiClient\Messages\DTO\MessagePart;
 use WordPress\AiClient\Messages\Enums\ModalityEnum;
 use WordPress\AiClient\Providers\Models\Enums\CapabilityEnum;
 use WordPress\AiClient\Providers\Models\Enums\OptionEnum;
@@ -143,24 +144,9 @@ class ModelRequirements extends AbstractDataTransferObject
         $hasFunctionMessageParts = \false;
         foreach ($messages as $message) {
             foreach ($message->getParts() as $part) {
-                // Check for text input
-                if ($part->getType()->isText()) {
-                    $inputModalities[] = ModalityEnum::text();
-                }
-                // Check for file inputs
-                if ($part->getType()->isFile()) {
-                    $file = $part->getFile();
-                    if ($file !== null) {
-                        if ($file->isImage()) {
-                            $inputModalities[] = ModalityEnum::image();
-                        } elseif ($file->isAudio()) {
-                            $inputModalities[] = ModalityEnum::audio();
-                        } elseif ($file->isVideo()) {
-                            $inputModalities[] = ModalityEnum::video();
-                        } elseif ($file->isDocument() || $file->isText()) {
-                            $inputModalities[] = ModalityEnum::document();
-                        }
-                    }
+                $modality = self::inputModalityForPart($part);
+                if ($modality !== null) {
+                    $inputModalities[] = $modality;
                 }
                 // Check for function calls/responses (these might require special capabilities)
                 if ($part->getType()->isFunctionCall() || $part->getType()->isFunctionResponse()) {
@@ -182,6 +168,72 @@ class ModelRequirements extends AbstractDataTransferObject
         }
         // Step 6: Return new ModelRequirements
         return new self($capabilities, $requiredOptions);
+    }
+    /**
+     * Creates ModelRequirements from embedding input data and model configuration.
+     *
+     * Unlike {@see self::fromPromptData()}, embedding inputs are independent items rather than a
+     * conversation, so no chat history capability is inferred. Each input contributes its input
+     * modality (text or file) to the requirements.
+     *
+     * @since 1.4.0
+     *
+     * @param list<MessagePart> $inputs The embedding inputs.
+     * @param ModelConfig $modelConfig The model configuration.
+     * @return self The created requirements.
+     */
+    public static function fromEmbeddingData(array $inputs, \WordPress\AiClient\Providers\Models\DTO\ModelConfig $modelConfig): self
+    {
+        $capabilities = [CapabilityEnum::embeddingGeneration()];
+        $inputModalities = [];
+        // Analyze each input to determine required input modalities. Function call/response parts
+        // are not valid embedding inputs and are rejected before reaching this point.
+        foreach ($inputs as $part) {
+            $modality = self::inputModalityForPart($part);
+            if ($modality !== null) {
+                $inputModalities[] = $modality;
+            }
+        }
+        // Convert ModelConfig to RequiredOptions
+        $requiredOptions = self::toRequiredOptions($modelConfig);
+        // Add input modalities if we have any inputs
+        if (!empty($inputModalities)) {
+            // Remove duplicates
+            $inputModalities = array_unique($inputModalities, \SORT_REGULAR);
+            $requiredOptions = self::includeInRequiredOptions($requiredOptions, new \WordPress\AiClient\Providers\Models\DTO\RequiredOption(OptionEnum::inputModalities(), array_values($inputModalities)));
+        }
+        return new self($capabilities, $requiredOptions);
+    }
+    /**
+     * Determines the input modality contributed by a message part, if any.
+     *
+     * @since 1.4.0
+     *
+     * @param MessagePart $part The message part to analyze.
+     * @return ModalityEnum|null The input modality, or null if the part contributes none.
+     */
+    private static function inputModalityForPart(MessagePart $part): ?ModalityEnum
+    {
+        // Check for text input
+        if ($part->getType()->isText()) {
+            return ModalityEnum::text();
+        }
+        // Check for file inputs
+        if ($part->getType()->isFile()) {
+            $file = $part->getFile();
+            if ($file !== null) {
+                if ($file->isImage()) {
+                    return ModalityEnum::image();
+                } elseif ($file->isAudio()) {
+                    return ModalityEnum::audio();
+                } elseif ($file->isVideo()) {
+                    return ModalityEnum::video();
+                } elseif ($file->isDocument() || $file->isText()) {
+                    return ModalityEnum::document();
+                }
+            }
+        }
+        return null;
     }
     /**
      * Converts ModelConfig to an array of RequiredOptions.
@@ -252,6 +304,9 @@ class ModelRequirements extends AbstractDataTransferObject
         }
         if ($modelConfig->getOutputMediaAspectRatio() !== null) {
             $requiredOptions[] = new \WordPress\AiClient\Providers\Models\DTO\RequiredOption(OptionEnum::outputMediaAspectRatio(), $modelConfig->getOutputMediaAspectRatio());
+        }
+        if ($modelConfig->getDimensions() !== null) {
+            $requiredOptions[] = new \WordPress\AiClient\Providers\Models\DTO\RequiredOption(OptionEnum::dimensions(), $modelConfig->getDimensions());
         }
         // Add custom options as individual RequiredOptions
         foreach ($modelConfig->getCustomOptions() as $key => $value) {

--- a/src/wp-includes/php-ai-client/src/Providers/Models/EmbeddingGeneration/Contracts/EmbeddingGenerationModelInterface.php
+++ b/src/wp-includes/php-ai-client/src/Providers/Models/EmbeddingGeneration/Contracts/EmbeddingGenerationModelInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+declare (strict_types=1);
+namespace WordPress\AiClient\Providers\Models\EmbeddingGeneration\Contracts;
+
+use WordPress\AiClient\Messages\DTO\MessagePart;
+use WordPress\AiClient\Results\DTO\EmbeddingResult;
+/**
+ * Interface for models that support embedding generation.
+ *
+ * @since 1.4.0
+ */
+interface EmbeddingGenerationModelInterface
+{
+    /**
+     * Generates embeddings from one or more inputs.
+     *
+     * @since 1.4.0
+     *
+     * @param list<MessagePart> $inputs The inputs to embed, one embedding generated per input.
+     * @return EmbeddingResult Result containing one embedding per input, in input order.
+     */
+    public function generateEmbeddingResult(array $inputs): EmbeddingResult;
+}

--- a/src/wp-includes/php-ai-client/src/Providers/Models/Enums/OptionEnum.php
+++ b/src/wp-includes/php-ai-client/src/Providers/Models/Enums/OptionEnum.php
@@ -19,6 +19,7 @@ use WordPress\AiClient\Providers\Models\DTO\ModelConfig;
  * Dynamically loaded from ModelConfig KEY_* constants:
  * @method static self candidateCount() Creates an instance for CANDIDATE_COUNT option.
  * @method static self customOptions() Creates an instance for CUSTOM_OPTIONS option.
+ * @method static self dimensions() Creates an instance for DIMENSIONS option.
  * @method static self frequencyPenalty() Creates an instance for FREQUENCY_PENALTY option.
  * @method static self functionDeclarations() Creates an instance for FUNCTION_DECLARATIONS option.
  * @method static self logprobs() Creates an instance for LOGPROBS option.
@@ -40,6 +41,7 @@ use WordPress\AiClient\Providers\Models\DTO\ModelConfig;
  * @method static self webSearch() Creates an instance for WEB_SEARCH option.
  * @method bool isCandidateCount() Checks if the option is CANDIDATE_COUNT.
  * @method bool isCustomOptions() Checks if the option is CUSTOM_OPTIONS.
+ * @method bool isDimensions() Checks if the option is DIMENSIONS.
  * @method bool isFrequencyPenalty() Checks if the option is FREQUENCY_PENALTY.
  * @method bool isFunctionDeclarations() Checks if the option is FUNCTION_DECLARATIONS.
  * @method bool isLogprobs() Checks if the option is LOGPROBS.

--- a/src/wp-includes/php-ai-client/src/Results/DTO/Embedding.php
+++ b/src/wp-includes/php-ai-client/src/Results/DTO/Embedding.php
@@ -1,0 +1,168 @@
+<?php
+
+declare (strict_types=1);
+namespace WordPress\AiClient\Results\DTO;
+
+use ArrayIterator;
+use Countable;
+use IteratorAggregate;
+use JsonSerializable;
+use Traversable;
+use WordPress\AiClient\Common\Exception\InvalidArgumentException;
+/**
+ * Represents a single generated embedding vector.
+ *
+ * @since 1.4.0
+ *
+ * @phpstan-type EmbeddingList list<float|int>
+ *
+ * @implements IteratorAggregate<int, float|int>
+ */
+final class Embedding implements Countable, IteratorAggregate, JsonSerializable
+{
+    /**
+     * @var EmbeddingList
+     */
+    private array $values;
+    /**
+     * @var int The vector dimension count.
+     */
+    private int $dimensions;
+    /**
+     * Constructor.
+     *
+     * @since 1.4.0
+     *
+     * @param EmbeddingList $values The embedding vector values.
+     * @param int $dimensions The vector dimension count.
+     */
+    public function __construct(array $values, int $dimensions)
+    {
+        if ($dimensions < 1) {
+            throw new InvalidArgumentException('Embedding dimensions must be greater than zero');
+        }
+        if (!self::isEmbeddingList($values)) {
+            if (!array_is_list($values)) {
+                throw new InvalidArgumentException('Embedding values must be a list array.');
+            }
+            throw new InvalidArgumentException('Embedding values must be integers or floats.');
+        }
+        if (count($values) !== $dimensions) {
+            throw new InvalidArgumentException('Embedding vector length must match dimensions.');
+        }
+        $this->values = $values;
+        $this->dimensions = $dimensions;
+    }
+    /**
+     * Checks whether the value is a list of integers or floats.
+     *
+     * @since 1.4.0
+     *
+     * @param mixed $values The value to check.
+     * @return bool True if the value is an embedding list.
+     *
+     * @phpstan-assert-if-true EmbeddingList $values
+     */
+    private static function isEmbeddingList($values): bool
+    {
+        if (!is_array($values) || !array_is_list($values)) {
+            return \false;
+        }
+        foreach ($values as $value) {
+            if (!is_int($value) && !is_float($value)) {
+                return \false;
+            }
+        }
+        return \true;
+    }
+    /**
+     * Gets the vector values.
+     *
+     * @since 1.4.0
+     *
+     * @return EmbeddingList The embedding vector values.
+     */
+    public function getValues(): array
+    {
+        return $this->values;
+    }
+    /**
+     * Gets the vector dimension count.
+     *
+     * @since 1.4.0
+     *
+     * @return int The vector dimension count.
+     */
+    public function getDimensions(): int
+    {
+        return $this->dimensions;
+    }
+    /**
+     * Gets the number of vector values.
+     *
+     * @since 1.4.0
+     *
+     * @return int The number of vector values.
+     */
+    public function count(): int
+    {
+        return $this->dimensions;
+    }
+    /**
+     * Gets an iterator for the vector values.
+     *
+     * @since 1.4.0
+     *
+     * @return Traversable<int, float|int> The vector value iterator.
+     */
+    public function getIterator(): Traversable
+    {
+        return new ArrayIterator($this->values);
+    }
+    /**
+     * Gets the JSON schema for embedding vectors.
+     *
+     * @since 1.4.0
+     *
+     * @return array<string, mixed> The JSON schema.
+     */
+    public static function getJsonSchema(): array
+    {
+        return ['type' => 'array', 'items' => ['type' => 'number'], 'description' => 'Generated embedding vector values.'];
+    }
+    /**
+     * Converts the embedding to an array.
+     *
+     * @since 1.4.0
+     *
+     * @return EmbeddingList The embedding vector values.
+     */
+    public function toArray(): array
+    {
+        return $this->values;
+    }
+    /**
+     * Creates an embedding from an array.
+     *
+     * @since 1.4.0
+     *
+     * @param EmbeddingList $array The embedding vector values.
+     * @param int $dimensions The vector dimension count.
+     * @return self The embedding instance.
+     */
+    public static function fromArray(array $array, int $dimensions): self
+    {
+        return new self($array, $dimensions);
+    }
+    /**
+     * Converts the embedding to a JSON-serializable value.
+     *
+     * @since 1.4.0
+     *
+     * @return EmbeddingList The embedding vector values.
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+}

--- a/src/wp-includes/php-ai-client/src/Results/DTO/EmbeddingResult.php
+++ b/src/wp-includes/php-ai-client/src/Results/DTO/EmbeddingResult.php
@@ -1,0 +1,225 @@
+<?php
+
+declare (strict_types=1);
+namespace WordPress\AiClient\Results\DTO;
+
+use WordPress\AiClient\Common\AbstractDataTransferObject;
+use WordPress\AiClient\Common\Exception\InvalidArgumentException;
+use WordPress\AiClient\Providers\DTO\ProviderMetadata;
+use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
+use WordPress\AiClient\Results\Contracts\ResultInterface;
+/**
+ * Represents the result of an embedding generation operation.
+ *
+ * @since 1.4.0
+ *
+ * @phpstan-import-type TokenUsageArrayShape from TokenUsage
+ * @phpstan-import-type ProviderMetadataArrayShape from ProviderMetadata
+ * @phpstan-import-type ModelMetadataArrayShape from ModelMetadata
+ * @phpstan-import-type EmbeddingList from Embedding
+ *
+ * @phpstan-type EmbeddingResultArrayShape array{
+ *     id: string,
+ *     embeddings: list<EmbeddingList>,
+ *     dimensions: int,
+ *     tokenUsage: TokenUsageArrayShape,
+ *     providerMetadata: ProviderMetadataArrayShape,
+ *     modelMetadata: ModelMetadataArrayShape,
+ *     additionalData?: array<string, mixed>
+ * }
+ *
+ * @extends AbstractDataTransferObject<EmbeddingResultArrayShape>
+ */
+class EmbeddingResult extends AbstractDataTransferObject implements ResultInterface
+{
+    public const KEY_ID = 'id';
+    public const KEY_EMBEDDINGS = 'embeddings';
+    public const KEY_DIMENSIONS = 'dimensions';
+    public const KEY_TOKEN_USAGE = 'tokenUsage';
+    public const KEY_PROVIDER_METADATA = 'providerMetadata';
+    public const KEY_MODEL_METADATA = 'modelMetadata';
+    public const KEY_ADDITIONAL_DATA = 'additionalData';
+    /**
+     * @var string Unique identifier for this result.
+     */
+    private string $id;
+    /**
+     * @var list<Embedding>
+     */
+    private array $embeddings;
+    /**
+     * @var int The vector dimension count.
+     */
+    private int $dimensions;
+    /**
+     * @var TokenUsage Token usage statistics.
+     */
+    private \WordPress\AiClient\Results\DTO\TokenUsage $tokenUsage;
+    /**
+     * @var ProviderMetadata Provider metadata.
+     */
+    private ProviderMetadata $providerMetadata;
+    /**
+     * @var ModelMetadata Model metadata.
+     */
+    private ModelMetadata $modelMetadata;
+    /**
+     * @var array<string, mixed>
+     */
+    private array $additionalData;
+    /**
+     * Constructor.
+     *
+     * @since 1.4.0
+     *
+     * @param string $id Unique identifier for this result.
+     * @param list<Embedding|EmbeddingList> $embeddings The generated embedding vectors.
+     * @param int $dimensions The vector dimension count.
+     * @param TokenUsage $tokenUsage Token usage statistics.
+     * @param ProviderMetadata $providerMetadata Provider metadata.
+     * @param ModelMetadata $modelMetadata Model metadata.
+     * @param array<string, mixed> $additionalData Additional data.
+     */
+    public function __construct(string $id, array $embeddings, int $dimensions, \WordPress\AiClient\Results\DTO\TokenUsage $tokenUsage, ProviderMetadata $providerMetadata, ModelMetadata $modelMetadata, array $additionalData = [])
+    {
+        if (empty($embeddings)) {
+            throw new InvalidArgumentException('At least one embedding must be provided');
+        }
+        if ($dimensions < 1) {
+            throw new InvalidArgumentException('Embedding dimensions must be greater than zero');
+        }
+        $normalizedEmbeddings = [];
+        foreach ($embeddings as $embedding) {
+            if (!$embedding instanceof \WordPress\AiClient\Results\DTO\Embedding) {
+                $embedding = new \WordPress\AiClient\Results\DTO\Embedding($embedding, $dimensions);
+            } elseif ($embedding->getDimensions() !== $dimensions) {
+                throw new InvalidArgumentException('Embedding vector length must match dimensions.');
+            }
+            $normalizedEmbeddings[] = $embedding;
+        }
+        $this->id = $id;
+        $this->embeddings = $normalizedEmbeddings;
+        $this->dimensions = $dimensions;
+        $this->tokenUsage = $tokenUsage;
+        $this->providerMetadata = $providerMetadata;
+        $this->modelMetadata = $modelMetadata;
+        $this->additionalData = $additionalData;
+    }
+    /**
+     * {@inheritDoc}
+     *
+     * @since 1.4.0
+     */
+    public function getId(): string
+    {
+        return $this->id;
+    }
+    /**
+     * Gets the generated embedding vectors.
+     *
+     * @since 1.4.0
+     *
+     * @return list<Embedding> The embeddings.
+     */
+    public function getEmbeddings(): array
+    {
+        return $this->embeddings;
+    }
+    /**
+     * Gets the first generated embedding vector.
+     *
+     * @since 1.4.0
+     *
+     * @return Embedding The first embedding.
+     */
+    public function getEmbedding(): \WordPress\AiClient\Results\DTO\Embedding
+    {
+        return $this->embeddings[0];
+    }
+    /**
+     * Gets the vector dimension count.
+     *
+     * @since 1.4.0
+     *
+     * @return int The vector dimension count.
+     */
+    public function getDimensions(): int
+    {
+        return $this->dimensions;
+    }
+    /**
+     * {@inheritDoc}
+     *
+     * @since 1.4.0
+     */
+    public function getTokenUsage(): \WordPress\AiClient\Results\DTO\TokenUsage
+    {
+        return $this->tokenUsage;
+    }
+    /**
+     * {@inheritDoc}
+     *
+     * @since 1.4.0
+     */
+    public function getProviderMetadata(): ProviderMetadata
+    {
+        return $this->providerMetadata;
+    }
+    /**
+     * {@inheritDoc}
+     *
+     * @since 1.4.0
+     */
+    public function getModelMetadata(): ModelMetadata
+    {
+        return $this->modelMetadata;
+    }
+    /**
+     * {@inheritDoc}
+     *
+     * @since 1.4.0
+     */
+    public function getAdditionalData(): array
+    {
+        return $this->additionalData;
+    }
+    /**
+     * Gets the JSON schema for embedding results.
+     *
+     * @since 1.4.0
+     *
+     * @return array<string, mixed> The JSON schema.
+     */
+    public static function getJsonSchema(): array
+    {
+        return ['type' => 'object', 'properties' => [self::KEY_ID => ['type' => 'string', 'description' => 'Unique identifier for this result.'], self::KEY_EMBEDDINGS => ['type' => 'array', 'items' => \WordPress\AiClient\Results\DTO\Embedding::getJsonSchema(), 'description' => 'Generated embedding vectors.'], self::KEY_DIMENSIONS => ['type' => 'integer', 'minimum' => 1, 'description' => 'Embedding vector dimensions.'], self::KEY_TOKEN_USAGE => \WordPress\AiClient\Results\DTO\TokenUsage::getJsonSchema(), self::KEY_PROVIDER_METADATA => ProviderMetadata::getJsonSchema(), self::KEY_MODEL_METADATA => ModelMetadata::getJsonSchema(), self::KEY_ADDITIONAL_DATA => ['type' => 'object', 'additionalProperties' => \true, 'description' => 'Additional provider-specific data.']], 'required' => [self::KEY_ID, self::KEY_EMBEDDINGS, self::KEY_DIMENSIONS, self::KEY_TOKEN_USAGE, self::KEY_PROVIDER_METADATA, self::KEY_MODEL_METADATA]];
+    }
+    /**
+     * Converts the embedding result to an array.
+     *
+     * @since 1.4.0
+     *
+     * @return EmbeddingResultArrayShape The embedding result array.
+     */
+    public function toArray(): array
+    {
+        $data = [self::KEY_ID => $this->id, self::KEY_EMBEDDINGS => array_map(static fn(\WordPress\AiClient\Results\DTO\Embedding $embedding): array => $embedding->toArray(), $this->embeddings), self::KEY_DIMENSIONS => $this->dimensions, self::KEY_TOKEN_USAGE => $this->tokenUsage->toArray(), self::KEY_PROVIDER_METADATA => $this->providerMetadata->toArray(), self::KEY_MODEL_METADATA => $this->modelMetadata->toArray()];
+        if (!empty($this->additionalData)) {
+            $data[self::KEY_ADDITIONAL_DATA] = $this->additionalData;
+        }
+        return $data;
+    }
+    /**
+     * Creates an embedding result from an array.
+     *
+     * @since 1.4.0
+     *
+     * @param EmbeddingResultArrayShape $array The embedding result array.
+     * @return self The embedding result instance.
+     */
+    public static function fromArray(array $array): self
+    {
+        static::validateFromArrayData($array, [self::KEY_ID, self::KEY_EMBEDDINGS, self::KEY_DIMENSIONS, self::KEY_TOKEN_USAGE, self::KEY_PROVIDER_METADATA, self::KEY_MODEL_METADATA]);
+        return new self($array[self::KEY_ID], $array[self::KEY_EMBEDDINGS], $array[self::KEY_DIMENSIONS], \WordPress\AiClient\Results\DTO\TokenUsage::fromArray($array[self::KEY_TOKEN_USAGE]), ProviderMetadata::fromArray($array[self::KEY_PROVIDER_METADATA]), ModelMetadata::fromArray($array[self::KEY_MODEL_METADATA]), $array[self::KEY_ADDITIONAL_DATA] ?? []);
+    }
+}

--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -296,6 +296,7 @@ require ABSPATH . WPINC . '/ai-client/adapters/class-wp-ai-client-discovery-stra
 require ABSPATH . WPINC . '/ai-client/adapters/class-wp-ai-client-event-dispatcher.php';
 require ABSPATH . WPINC . '/ai-client/class-wp-ai-client-ability-function-resolver.php';
 require ABSPATH . WPINC . '/ai-client/class-wp-ai-client-prompt-builder.php';
+require ABSPATH . WPINC . '/ai-client/class-wp-ai-client-embedding-builder.php';
 require ABSPATH . WPINC . '/ai-client.php';
 require ABSPATH . WPINC . '/class-wp-connector-registry.php';
 require ABSPATH . WPINC . '/connectors.php';

--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -295,6 +295,7 @@ require ABSPATH . WPINC . '/ai-client/adapters/class-wp-ai-client-cache.php';
 require ABSPATH . WPINC . '/ai-client/adapters/class-wp-ai-client-discovery-strategy.php';
 require ABSPATH . WPINC . '/ai-client/adapters/class-wp-ai-client-event-dispatcher.php';
 require ABSPATH . WPINC . '/ai-client/class-wp-ai-client-ability-function-resolver.php';
+require ABSPATH . WPINC . '/ai-client/class-wp-ai-client-builder.php';
 require ABSPATH . WPINC . '/ai-client/class-wp-ai-client-prompt-builder.php';
 require ABSPATH . WPINC . '/ai-client/class-wp-ai-client-embedding-builder.php';
 require ABSPATH . WPINC . '/ai-client.php';

--- a/tests/phpunit/tests/ai-client/wpAiClientEmbedding.php
+++ b/tests/phpunit/tests/ai-client/wpAiClientEmbedding.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Tests for wp_ai_client_embedding().
+ *
+ * @group ai-client
+ * @covers ::wp_ai_client_embedding
+ */
+
+use WordPress\AiClient\Messages\DTO\MessagePart;
+
+class Tests_AI_Client_Embedding extends WP_UnitTestCase {
+
+	/**
+	 * Gets the inputs stored on the wrapped SDK embedding builder.
+	 *
+	 * @param WP_AI_Client_Embedding_Builder $builder The WordPress embedding builder instance.
+	 * @return array The wrapped builder's inputs.
+	 */
+	private function get_wrapped_builder_inputs( WP_AI_Client_Embedding_Builder $builder ): array {
+		$reflection_class = new ReflectionClass( WP_AI_Client_Embedding_Builder::class );
+		$builder_property = $reflection_class->getProperty( 'builder' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$builder_property->setAccessible( true );
+		}
+		$wrapped_builder = $builder_property->getValue( $builder );
+
+		$reflection_class2 = new ReflectionClass( get_class( $wrapped_builder ) );
+		$inputs_property   = $reflection_class2->getProperty( 'inputs' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$inputs_property->setAccessible( true );
+		}
+
+		return $inputs_property->getValue( $wrapped_builder );
+	}
+
+	/**
+	 * Test that wp_ai_client_embedding() returns a WP_AI_Client_Embedding_Builder instance.
+	 *
+	 * @ticket 64591
+	 */
+	public function test_returns_embedding_builder_instance() {
+		$builder = wp_ai_client_embedding();
+
+		$this->assertInstanceOf( WP_AI_Client_Embedding_Builder::class, $builder );
+	}
+
+	/**
+	 * Test that successive calls return independent builder instances.
+	 *
+	 * @ticket 64591
+	 */
+	public function test_returns_independent_instances() {
+		$builder1 = wp_ai_client_embedding( 'First' );
+		$builder2 = wp_ai_client_embedding( 'Second' );
+
+		$this->assertNotSame( $builder1, $builder2 );
+	}
+
+	/**
+	 * Test that calling with no arguments creates a builder without inputs or an error state.
+	 *
+	 * @ticket 64591
+	 */
+	public function test_no_arguments_creates_builder_without_inputs() {
+		$builder = wp_ai_client_embedding();
+
+		$this->assertSame( array(), $this->get_wrapped_builder_inputs( $builder ) );
+	}
+
+	/**
+	 * Test that a single argument becomes a single input.
+	 *
+	 * @ticket 64591
+	 */
+	public function test_single_argument_becomes_single_input() {
+		$builder = wp_ai_client_embedding( 'Test input' );
+
+		$inputs = $this->get_wrapped_builder_inputs( $builder );
+
+		$this->assertCount( 1, $inputs );
+		$this->assertInstanceOf( MessagePart::class, $inputs[0] );
+	}
+
+	/**
+	 * Test that multiple variadic arguments each become an independent input.
+	 *
+	 * @ticket 64591
+	 */
+	public function test_variadic_arguments_become_independent_inputs() {
+		$builder = wp_ai_client_embedding( 'First', 'Second', 'Third' );
+
+		$inputs = $this->get_wrapped_builder_inputs( $builder );
+
+		$this->assertCount( 3, $inputs );
+		$this->assertContainsOnlyInstancesOf( MessagePart::class, $inputs );
+	}
+}

--- a/tests/phpunit/tests/ai-client/wpAiClientEmbeddingBuilder.php
+++ b/tests/phpunit/tests/ai-client/wpAiClientEmbeddingBuilder.php
@@ -1,0 +1,694 @@
+<?php
+/**
+ * Tests for the WP_AI_Client_Embedding_Builder class.
+ *
+ * @group ai-client
+ *
+ * @coversDefaultClass WP_AI_Client_Embedding_Builder
+ */
+
+use WordPress\AiClient\AiClient;
+use WordPress\AiClient\Common\Exception\InvalidArgumentException as AiClientInvalidArgumentException;
+use WordPress\AiClient\Common\Exception\TokenLimitReachedException;
+use WordPress\AiClient\Messages\DTO\MessagePart;
+use WordPress\AiClient\Providers\DTO\ProviderMetadata;
+use WordPress\AiClient\Providers\Enums\ProviderTypeEnum;
+use WordPress\AiClient\Providers\Http\DTO\RequestOptions;
+use WordPress\AiClient\Providers\Http\Exception\ClientException;
+use WordPress\AiClient\Providers\Http\Exception\NetworkException;
+use WordPress\AiClient\Providers\Http\Exception\ServerException;
+use WordPress\AiClient\Providers\Models\Contracts\ModelInterface;
+use WordPress\AiClient\Providers\Models\DTO\ModelConfig;
+use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
+use WordPress\AiClient\Providers\Models\DTO\SupportedOption;
+use WordPress\AiClient\Providers\Models\EmbeddingGeneration\Contracts\EmbeddingGenerationModelInterface;
+use WordPress\AiClient\Providers\Models\Enums\CapabilityEnum;
+use WordPress\AiClient\Providers\Models\Enums\OptionEnum;
+use WordPress\AiClient\Providers\ProviderRegistry;
+use WordPress\AiClient\Results\DTO\Embedding;
+use WordPress\AiClient\Results\DTO\EmbeddingResult;
+use WordPress\AiClient\Results\DTO\TokenUsage;
+
+class Tests_AI_Client_EmbeddingBuilder extends WP_UnitTestCase {
+
+	/**
+	 * @var ProviderRegistry
+	 */
+	private ProviderRegistry $registry;
+
+	/**
+	 * Set up before each test.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->registry = $this->createMock( ProviderRegistry::class );
+	}
+
+	/**
+	 * Makes a reflector accessible on PHP versions that require it.
+	 *
+	 * Since PHP 8.1 all reflection-accessed members are accessible by default,
+	 * and PHP 8.5 deprecates the setAccessible() call.
+	 *
+	 * @param ReflectionProperty|ReflectionMethod $reflector The reflector to make accessible.
+	 */
+	private static function set_accessible( $reflector ) {
+		if ( PHP_VERSION_ID < 80100 ) {
+			$reflector->setAccessible( true );
+		}
+	}
+
+	/**
+	 * Gets the value of a protected or private property from the wrapped embedding builder.
+	 *
+	 * Model selection state (e.g. `model`, `requestOptions`) lives on the builder's
+	 * ModelResolver, so properties not found on the wrapped builder are looked up there.
+	 *
+	 * @param WP_AI_Client_Embedding_Builder $builder  The WordPress embedding builder instance.
+	 * @param string                         $property Property to get value for.
+	 * @return mixed The property value.
+	 */
+	private function get_wrapped_builder_property_value( WP_AI_Client_Embedding_Builder $builder, string $property ) {
+		$reflection_class = new ReflectionClass( WP_AI_Client_Embedding_Builder::class );
+		$builder_property = $reflection_class->getProperty( 'builder' );
+		self::set_accessible( $builder_property );
+		$wrapped_builder = $builder_property->getValue( $builder );
+
+		$reflection_class2 = new ReflectionClass( get_class( $wrapped_builder ) );
+		if ( ! $reflection_class2->hasProperty( $property ) ) {
+			$resolver_property = $reflection_class2->getProperty( 'modelResolver' );
+			self::set_accessible( $resolver_property );
+			$wrapped_builder = $resolver_property->getValue( $wrapped_builder );
+
+			$reflection_class2 = new ReflectionClass( get_class( $wrapped_builder ) );
+		}
+
+		$the_property = $reflection_class2->getProperty( $property );
+		self::set_accessible( $the_property );
+
+		return $the_property->getValue( $wrapped_builder );
+	}
+
+	/**
+	 * Invokes the protected exception_to_wp_error() method on a builder.
+	 *
+	 * @param WP_AI_Client_Embedding_Builder $builder   The builder to invoke the method on.
+	 * @param Exception                      $exception The exception to convert.
+	 * @return WP_Error The resulting WP_Error.
+	 */
+	private function invoke_exception_to_wp_error( WP_AI_Client_Embedding_Builder $builder, Exception $exception ): WP_Error {
+		$reflection = new ReflectionClass( WP_AI_Client_Embedding_Builder::class );
+		$method     = $reflection->getMethod( 'exception_to_wp_error' );
+		self::set_accessible( $method );
+
+		return $method->invoke( $builder, $exception );
+	}
+
+	/**
+	 * Creates a test model metadata instance for embedding generation.
+	 *
+	 * @return ModelMetadata
+	 */
+	private function create_test_embedding_model_metadata(): ModelMetadata {
+		return new ModelMetadata(
+			'test-embedding-model',
+			'Test Embedding Model',
+			array( CapabilityEnum::embeddingGeneration() ),
+			array( new SupportedOption( OptionEnum::inputModalities() ) )
+		);
+	}
+
+	/**
+	 * Creates a test EmbeddingResult with the given number of embeddings.
+	 *
+	 * @param int $count      The number of embeddings in the result.
+	 * @param int $dimensions Optional. The dimensions of each embedding. Default 3.
+	 * @return EmbeddingResult
+	 */
+	private function create_test_embedding_result( int $count, int $dimensions = 3 ): EmbeddingResult {
+		$embeddings = array();
+		for ( $i = 0; $i < $count; $i++ ) {
+			$embeddings[] = new Embedding( array_fill( 0, $dimensions, 0.1 * ( $i + 1 ) ), $dimensions );
+		}
+
+		return new EmbeddingResult(
+			'test-embedding-result',
+			$embeddings,
+			$dimensions,
+			new TokenUsage( 10, 0, 10 ),
+			new ProviderMetadata( 'mock', 'Mock Provider', ProviderTypeEnum::cloud() ),
+			$this->create_test_embedding_model_metadata()
+		);
+	}
+
+	/**
+	 * Creates a mock embedding generation model using an anonymous class.
+	 *
+	 * @param EmbeddingResult    $result   The result to return from generation.
+	 * @param ModelMetadata|null $metadata Optional metadata.
+	 * @return ModelInterface&EmbeddingGenerationModelInterface The mock model.
+	 */
+	private function create_mock_embedding_model(
+		EmbeddingResult $result,
+		?ModelMetadata $metadata = null
+	): ModelInterface {
+		$metadata = $metadata ?? $this->create_test_embedding_model_metadata();
+
+		$provider_metadata = new ProviderMetadata(
+			'mock',
+			'Mock Provider',
+			ProviderTypeEnum::cloud()
+		);
+
+		return new class( $metadata, $provider_metadata, $result ) implements ModelInterface, EmbeddingGenerationModelInterface {
+
+			private ModelMetadata $metadata;
+			private ProviderMetadata $provider_metadata;
+			private EmbeddingResult $result;
+			private ModelConfig $config;
+
+			public function __construct(
+				ModelMetadata $metadata,
+				ProviderMetadata $provider_metadata,
+				EmbeddingResult $result
+			) {
+				$this->metadata          = $metadata;
+				$this->provider_metadata = $provider_metadata;
+				$this->result            = $result;
+				$this->config            = new ModelConfig();
+			}
+
+			public function metadata(): ModelMetadata {
+				return $this->metadata;
+			}
+
+			public function providerMetadata(): ProviderMetadata {
+				return $this->provider_metadata;
+			}
+
+			public function setConfig( ModelConfig $config ): void {
+				$this->config = $config;
+			}
+
+			public function getConfig(): ModelConfig {
+				return $this->config;
+			}
+
+			public function generateEmbeddingResult( array $inputs ): EmbeddingResult { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter
+				return $this->result;
+			}
+		};
+	}
+
+	/**
+	 * Test that WP_AI_Client_Embedding_Builder can be instantiated.
+	 *
+	 * @ticket 64591
+	 */
+	public function test_instantiation() {
+		$builder = new WP_AI_Client_Embedding_Builder( AiClient::defaultRegistry() );
+
+		$this->assertInstanceOf( WP_AI_Client_Embedding_Builder::class, $builder );
+	}
+
+	/**
+	 * Test that WP_AI_Client_Embedding_Builder can be instantiated with initial input.
+	 *
+	 * @ticket 64591
+	 */
+	public function test_instantiation_with_input() {
+		$builder = new WP_AI_Client_Embedding_Builder( AiClient::defaultRegistry(), 'Test input' );
+
+		$this->assertInstanceOf( WP_AI_Client_Embedding_Builder::class, $builder );
+	}
+
+	/**
+	 * Test that the constructor parses a single string input into one message part.
+	 *
+	 * @ticket 64591
+	 */
+	public function test_constructor_with_string_input() {
+		$builder = new WP_AI_Client_Embedding_Builder( $this->registry, 'Test input' );
+
+		$inputs = $this->get_wrapped_builder_property_value( $builder, 'inputs' );
+
+		$this->assertCount( 1, $inputs );
+		$this->assertInstanceOf( MessagePart::class, $inputs[0] );
+	}
+
+	/**
+	 * Test that the constructor parses a list of inputs into one message part each.
+	 *
+	 * @ticket 64591
+	 */
+	public function test_constructor_with_input_list() {
+		$builder = new WP_AI_Client_Embedding_Builder( $this->registry, array( 'First', 'Second' ) );
+
+		$inputs = $this->get_wrapped_builder_property_value( $builder, 'inputs' );
+
+		$this->assertCount( 2, $inputs );
+		$this->assertContainsOnlyInstancesOf( MessagePart::class, $inputs );
+	}
+
+	/**
+	 * Test that the constructor sets the default request timeout.
+	 *
+	 * @ticket 64591
+	 */
+	public function test_constructor_sets_default_request_timeout() {
+		$builder = new WP_AI_Client_Embedding_Builder( AiClient::defaultRegistry() );
+
+		/** @var RequestOptions $request_options */
+		$request_options = $this->get_wrapped_builder_property_value( $builder, 'requestOptions' );
+
+		$this->assertInstanceOf( RequestOptions::class, $request_options );
+		$this->assertSame( 30.0, $request_options->getTimeout() );
+	}
+
+	/**
+	 * Test that the request timeout filter receives the embedding builder type.
+	 *
+	 * @ticket 64591
+	 */
+	public function test_request_timeout_filter_receives_builder_type() {
+		$received_builder_type = null;
+
+		add_filter(
+			'wp_ai_client_default_request_timeout',
+			static function ( $default_timeout, $builder_type ) use ( &$received_builder_type ) {
+				$received_builder_type = $builder_type;
+				return $default_timeout;
+			},
+			10,
+			2
+		);
+
+		new WP_AI_Client_Embedding_Builder( AiClient::defaultRegistry() );
+
+		$this->assertSame( WP_AI_Client_Embedding_Builder::class, $received_builder_type );
+	}
+
+	/**
+	 * Test that the constructor allows overriding the default request timeout.
+	 *
+	 * @ticket 64591
+	 */
+	public function test_constructor_allows_overriding_request_timeout() {
+		add_filter(
+			'wp_ai_client_default_request_timeout',
+			static function () {
+				return 45.5;
+			}
+		);
+
+		$builder = new WP_AI_Client_Embedding_Builder( AiClient::defaultRegistry() );
+
+		/** @var RequestOptions $request_options */
+		$request_options = $this->get_wrapped_builder_property_value( $builder, 'requestOptions' );
+
+		$this->assertSame( 45.5, $request_options->getTimeout() );
+	}
+
+	/**
+	 * Test that the constructor rejects an invalid request timeout, reporting the concrete class name.
+	 *
+	 * @ticket 64591
+	 *
+	 * @expectedIncorrectUsage WP_AI_Client_Embedding_Builder::__construct
+	 */
+	public function test_constructor_disallows_overriding_with_invalid_request_timeout() {
+		add_filter( 'wp_ai_client_default_request_timeout', '__return_null' );
+
+		$builder = new WP_AI_Client_Embedding_Builder( AiClient::defaultRegistry() );
+
+		/** @var RequestOptions $request_options */
+		$request_options = $this->get_wrapped_builder_property_value( $builder, 'requestOptions' );
+
+		$this->assertSame( 30.0, $request_options->getTimeout() );
+	}
+
+	/**
+	 * Test that fluent methods return the wrapper instance for method chaining.
+	 *
+	 * @ticket 64591
+	 */
+	public function test_method_chaining_returns_wrapper() {
+		$builder = new WP_AI_Client_Embedding_Builder( $this->registry );
+
+		$result = $builder->with_input( 'Test input' );
+		$this->assertSame( $builder, $result, 'with_input() should return the wrapper instance' );
+
+		$result = $builder->using_dimensions( 256 );
+		$this->assertSame( $builder, $result, 'using_dimensions() should return the wrapper instance' );
+	}
+
+	/**
+	 * Test that with_input() appends inputs to the wrapped builder.
+	 *
+	 * @ticket 64591
+	 */
+	public function test_with_input_appends_inputs() {
+		$builder = new WP_AI_Client_Embedding_Builder( $this->registry, 'First' );
+		$builder->with_input( 'Second', 'Third' );
+
+		$inputs = $this->get_wrapped_builder_property_value( $builder, 'inputs' );
+
+		$this->assertCount( 3, $inputs );
+		$this->assertContainsOnlyInstancesOf( MessagePart::class, $inputs );
+	}
+
+	/**
+	 * Test that using_dimensions() sets the dimensions on the model configuration.
+	 *
+	 * @ticket 64591
+	 */
+	public function test_using_dimensions_sets_model_config() {
+		$builder = new WP_AI_Client_Embedding_Builder( $this->registry );
+		$builder->using_dimensions( 256 );
+
+		/** @var ModelConfig $config */
+		$config = $this->get_wrapped_builder_property_value( $builder, 'modelConfig' );
+
+		$this->assertSame( 256, $config->getDimensions() );
+	}
+
+	/**
+	 * Test that the wrapper passes the AiClient event dispatcher to the wrapped builder.
+	 *
+	 * @ticket 64591
+	 */
+	public function test_passes_ai_client_event_dispatcher_to_wrapped_builder() {
+		$builder = new WP_AI_Client_Embedding_Builder( $this->registry );
+
+		$dispatcher = $this->get_wrapped_builder_property_value( $builder, 'eventDispatcher' );
+
+		$this->assertSame( AiClient::getEventDispatcher(), $dispatcher );
+	}
+
+	/**
+	 * Test that calling a nonexistent method puts the builder in an error state.
+	 *
+	 * @ticket 64591
+	 */
+	public function test_invalid_method_returns_wp_error() {
+		$builder = new WP_AI_Client_Embedding_Builder( $this->registry );
+
+		$builder->nonexistent_method();
+		$result = $builder->generate_embeddings();
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'embedding_builder_error', $result->get_error_code() );
+	}
+
+	/**
+	 * Test that once in error state, subsequent fluent calls return the same instance.
+	 *
+	 * @ticket 64591
+	 */
+	public function test_error_state_fluent_calls_return_same_instance() {
+		$builder = new WP_AI_Client_Embedding_Builder( $this->registry );
+
+		// Trigger an error state by calling a nonexistent method.
+		$builder->nonexistent_method();
+
+		$result = $builder->with_input( 'Test' );
+		$this->assertSame( $builder, $result, 'Fluent method should return same instance when in error state' );
+
+		$result = $builder->using_dimensions( 256 );
+		$this->assertSame( $builder, $result, 'Fluent method should return same instance when in error state' );
+	}
+
+	/**
+	 * Test that is_supported() returns false when in error state.
+	 *
+	 * @ticket 64591
+	 */
+	public function test_support_check_method_returns_false_in_error_state() {
+		$builder = new WP_AI_Client_Embedding_Builder( $this->registry );
+
+		// Trigger an error state by calling a nonexistent method.
+		$builder->nonexistent_method();
+
+		$this->assertFalse( $builder->is_supported(), 'is_supported should return false when in error state' );
+	}
+
+	/**
+	 * Test that an invalid constructor input puts the builder in an error state.
+	 *
+	 * @ticket 64591
+	 */
+	public function test_constructor_with_invalid_input_enters_error_state() {
+		$builder = new WP_AI_Client_Embedding_Builder( $this->registry, '' );
+
+		$result = $builder->generate_embeddings();
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'embedding_invalid_argument', $result->get_error_code() );
+	}
+
+	/**
+	 * Test that generating without any inputs returns a WP_Error.
+	 *
+	 * @ticket 64591
+	 */
+	public function test_generate_embeddings_without_input_returns_wp_error() {
+		$builder = new WP_AI_Client_Embedding_Builder( $this->registry );
+
+		$result = $builder->generate_embeddings();
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'embedding_invalid_argument', $result->get_error_code() );
+	}
+
+	/**
+	 * Test that is_supported() returns false when AI is not supported.
+	 *
+	 * @ticket 64591
+	 */
+	public function test_is_supported_returns_false_when_ai_not_supported() {
+		add_filter( 'wp_supports_ai', '__return_false' );
+
+		$builder = new WP_AI_Client_Embedding_Builder( AiClient::defaultRegistry(), 'Test input' );
+
+		$this->assertFalse( $builder->is_supported() );
+	}
+
+	/**
+	 * Test that is_supported() returns false when the prevent embedding filter returns true.
+	 *
+	 * @ticket 64591
+	 */
+	public function test_is_supported_returns_false_when_filter_prevents_embedding() {
+		add_filter( 'wp_ai_client_prevent_embedding', '__return_true' );
+
+		$builder = new WP_AI_Client_Embedding_Builder( AiClient::defaultRegistry(), 'Test input' );
+
+		$this->assertFalse( $builder->is_supported() );
+	}
+
+	/**
+	 * Test that is_supported() returns true for a model with the embedding generation capability.
+	 *
+	 * @ticket 64591
+	 */
+	public function test_is_supported_with_capable_model() {
+		$model   = $this->create_mock_embedding_model( $this->create_test_embedding_result( 1 ) );
+		$builder = new WP_AI_Client_Embedding_Builder( $this->registry, 'Test input' );
+
+		$this->assertTrue( $builder->using_model( $model )->is_supported() );
+	}
+
+	/**
+	 * Test that generating returns a WP_Error when the prevent embedding filter returns true.
+	 *
+	 * @ticket 64591
+	 */
+	public function test_generate_embeddings_returns_wp_error_when_filter_prevents_embedding() {
+		add_filter( 'wp_ai_client_prevent_embedding', '__return_true' );
+
+		$builder = new WP_AI_Client_Embedding_Builder( AiClient::defaultRegistry(), 'Test input' );
+
+		$result = $builder->generate_embeddings();
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'embedding_prevented', $result->get_error_code() );
+		$this->assertSame( 'Embedding generation was prevented by a filter.', $result->get_error_message() );
+		$this->assertSame( 503, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * Test that generating returns a WP_Error when AI is not supported.
+	 *
+	 * @ticket 64591
+	 */
+	public function test_generate_embeddings_returns_wp_error_when_ai_not_supported() {
+		add_filter( 'wp_supports_ai', '__return_false' );
+
+		$builder = new WP_AI_Client_Embedding_Builder( AiClient::defaultRegistry(), 'Test input' );
+
+		$result = $builder->generate_embeddings();
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'embedding_prevented', $result->get_error_code() );
+		$this->assertSame( 'AI features are not supported in this environment.', $result->get_error_message() );
+	}
+
+	/**
+	 * Test that the prevent embedding filter receives a clone of the builder instance.
+	 *
+	 * @ticket 64591
+	 */
+	public function test_prevent_embedding_filter_receives_cloned_builder_instance() {
+		$captured_builder = null;
+
+		add_filter(
+			'wp_ai_client_prevent_embedding',
+			static function ( $prevent, $builder ) use ( &$captured_builder ) {
+				$captured_builder = $builder;
+				return $prevent;
+			},
+			10,
+			2
+		);
+
+		$builder = new WP_AI_Client_Embedding_Builder( AiClient::defaultRegistry(), 'Test input' );
+
+		// Test with is_supported().
+		$builder->is_supported();
+		$this->assertNotSame( $builder, $captured_builder, 'Filter should receive a clone, not the same instance' );
+		$this->assertInstanceOf( WP_AI_Client_Embedding_Builder::class, $captured_builder );
+
+		// Reset and test with generate_embeddings().
+		$captured_builder = null;
+		$builder2         = new WP_AI_Client_Embedding_Builder( AiClient::defaultRegistry(), 'Test input' );
+		$builder2->generate_embeddings();
+		$this->assertNotSame( $builder2, $captured_builder, 'Filter should receive a clone, not the same instance' );
+		$this->assertInstanceOf( WP_AI_Client_Embedding_Builder::class, $captured_builder );
+	}
+
+	/**
+	 * Test that generate_embedding_result() returns the result from the model.
+	 *
+	 * @ticket 64591
+	 */
+	public function test_generate_embedding_result() {
+		$result = $this->create_test_embedding_result( 1 );
+		$model  = $this->create_mock_embedding_model( $result );
+
+		$builder = new WP_AI_Client_Embedding_Builder( $this->registry, 'Test input' );
+		$builder->using_model( $model );
+
+		$actual_result = $builder->generate_embedding_result();
+
+		$this->assertSame( $result, $actual_result );
+	}
+
+	/**
+	 * Test that generate_embedding() returns a single embedding.
+	 *
+	 * @ticket 64591
+	 */
+	public function test_generate_embedding() {
+		$result = $this->create_test_embedding_result( 1 );
+		$model  = $this->create_mock_embedding_model( $result );
+
+		$builder = new WP_AI_Client_Embedding_Builder( $this->registry, 'Test input' );
+		$builder->using_model( $model );
+
+		$embedding = $builder->generate_embedding();
+
+		$this->assertInstanceOf( Embedding::class, $embedding );
+		$this->assertSame( $result->getEmbedding(), $embedding );
+	}
+
+	/**
+	 * Test that generate_embeddings() returns one embedding per input.
+	 *
+	 * @ticket 64591
+	 */
+	public function test_generate_embeddings() {
+		$result = $this->create_test_embedding_result( 2 );
+		$model  = $this->create_mock_embedding_model( $result );
+
+		$builder = new WP_AI_Client_Embedding_Builder( $this->registry, array( 'First', 'Second' ) );
+		$builder->using_model( $model );
+
+		$embeddings = $builder->generate_embeddings();
+
+		$this->assertIsArray( $embeddings );
+		$this->assertCount( 2, $embeddings );
+		$this->assertSame( $result->getEmbeddings(), $embeddings );
+	}
+
+	/**
+	 * Test that generate_embedding() returns a WP_Error when multiple inputs are configured.
+	 *
+	 * @ticket 64591
+	 */
+	public function test_generate_embedding_returns_wp_error_with_multiple_inputs() {
+		$builder = new WP_AI_Client_Embedding_Builder( $this->registry, array( 'First', 'Second' ) );
+
+		$result = $builder->generate_embedding();
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'embedding_invalid_argument', $result->get_error_code() );
+	}
+
+	/**
+	 * Test that a mismatched embedding count from the model results in a WP_Error.
+	 *
+	 * @ticket 64591
+	 */
+	public function test_generate_embeddings_returns_wp_error_on_count_mismatch() {
+		$result = $this->create_test_embedding_result( 1 );
+		$model  = $this->create_mock_embedding_model( $result );
+
+		$builder = new WP_AI_Client_Embedding_Builder( $this->registry, array( 'First', 'Second' ) );
+		$builder->using_model( $model );
+
+		$error = $builder->generate_embeddings();
+
+		$this->assertWPError( $error );
+		$this->assertSame( 'embedding_builder_error', $error->get_error_code() );
+	}
+
+	/**
+	 * Test that exception_to_wp_error() maps exceptions to embedding-prefixed error codes.
+	 *
+	 * @ticket 64591
+	 *
+	 * @dataProvider data_exception_to_wp_error_mapping
+	 *
+	 * @param Exception $exception       The exception to convert.
+	 * @param string    $expected_code   The expected WP_Error code.
+	 * @param int       $expected_status The expected HTTP status in the error data.
+	 */
+	public function test_exception_to_wp_error_mapping( Exception $exception, string $expected_code, int $expected_status ) {
+		$builder = new WP_AI_Client_Embedding_Builder( AiClient::defaultRegistry() );
+		$error   = $this->invoke_exception_to_wp_error( $builder, $exception );
+
+		$this->assertSame( $expected_code, $error->get_error_code() );
+		$this->assertSame( $exception->getMessage(), $error->get_error_message() );
+		$this->assertSame( $expected_status, $error->get_error_data()['status'] );
+		$this->assertSame( get_class( $exception ), $error->get_error_data()['exception_class'] );
+	}
+
+	/**
+	 * Data provider for {@see self::test_exception_to_wp_error_mapping()}.
+	 *
+	 * @return array<string, array{0: Exception, 1: string, 2: int}>
+	 */
+	public static function data_exception_to_wp_error_mapping(): array {
+		return array(
+			'NetworkException'             => array( new NetworkException( 'network error' ), 'embedding_network_error', 503 ),
+			'ClientException with code'    => array( new ClientException( 'unauthorized', 401 ), 'embedding_client_error', 401 ),
+			'ClientException without code' => array( new ClientException( 'bad request' ), 'embedding_client_error', 400 ),
+			'ServerException with code'    => array( new ServerException( 'bad gateway', 502 ), 'embedding_upstream_server_error', 502 ),
+			'ServerException without code' => array( new ServerException( 'server error' ), 'embedding_upstream_server_error', 500 ),
+			'TokenLimitReachedException'   => array( new TokenLimitReachedException( 'token limit' ), 'embedding_token_limit_reached', 400 ),
+			'InvalidArgumentException'     => array( new AiClientInvalidArgumentException( 'invalid arg' ), 'embedding_invalid_argument', 400 ),
+			'generic Exception'            => array( new Exception( 'generic' ), 'embedding_builder_error', 500 ),
+		);
+	}
+}

--- a/tests/phpunit/tests/ai-client/wpAiClientPromptBuilder.php
+++ b/tests/phpunit/tests/ai-client/wpAiClientPromptBuilder.php
@@ -96,6 +96,10 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 	/**
 	 * Gets the value of a protected or private property from the wrapped prompt builder.
 	 *
+	 * Since PHP AI Client 1.4.0, model selection state (e.g. `model`, `registry`,
+	 * `providerIdOrClassName`, `requestOptions`) lives on the builder's ModelResolver,
+	 * so properties not found on the wrapped builder are looked up there.
+	 *
 	 * @param WP_AI_Client_Prompt_Builder $builder  The WordPress prompt builder instance.
 	 * @param string                      $property Property to get value for.
 	 * @return mixed The property value.
@@ -107,7 +111,15 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 		$wrapped_builder = $builder_property->getValue( $builder );
 
 		$reflection_class2 = new ReflectionClass( get_class( $wrapped_builder ) );
-		$the_property      = $reflection_class2->getProperty( $property );
+		if ( ! $reflection_class2->hasProperty( $property ) ) {
+			$resolver_property = $reflection_class2->getProperty( 'modelResolver' );
+			self::set_accessible( $resolver_property );
+			$wrapped_builder = $resolver_property->getValue( $wrapped_builder );
+
+			$reflection_class2 = new ReflectionClass( get_class( $wrapped_builder ) );
+		}
+
+		$the_property = $reflection_class2->getProperty( $property );
 		self::set_accessible( $the_property );
 
 		return $the_property->getValue( $wrapped_builder );
@@ -376,15 +388,7 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 		$registry       = AiClient::defaultRegistry();
 		$prompt_builder = new WP_AI_Client_Prompt_Builder( $registry );
 
-		$reflection_class = new ReflectionClass( WP_AI_Client_Prompt_Builder::class );
-		$builder_property = $reflection_class->getProperty( 'builder' );
-		self::set_accessible( $builder_property );
-		$wrapped_builder = $builder_property->getValue( $prompt_builder );
-
-		$wrapped_builder_reflection = new ReflectionClass( get_class( $wrapped_builder ) );
-		$registry_property          = $wrapped_builder_reflection->getProperty( 'registry' );
-		self::set_accessible( $registry_property );
-		$this->assertSame( $registry, $registry_property->getValue( $wrapped_builder ), 'Wrapped builder should have the same registry' );
+		$this->assertSame( $registry, $this->get_wrapped_prompt_builder_property_value( $prompt_builder, 'registry' ), 'Wrapped builder should have the same registry' );
 	}
 
 	/**

--- a/tests/phpunit/tests/ai-client/wpAiClientPromptBuilder.php
+++ b/tests/phpunit/tests/ai-client/wpAiClientPromptBuilder.php
@@ -204,6 +204,29 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that the request timeout filter receives the builder type.
+	 *
+	 * @ticket 64591
+	 */
+	public function test_request_timeout_filter_receives_builder_type() {
+		$received_builder_type = null;
+
+		add_filter(
+			'wp_ai_client_default_request_timeout',
+			static function ( $default_timeout, $builder_type ) use ( &$received_builder_type ) {
+				$received_builder_type = $builder_type;
+				return $default_timeout;
+			},
+			10,
+			2
+		);
+
+		new WP_AI_Client_Prompt_Builder( AiClient::defaultRegistry() );
+
+		$this->assertSame( WP_AI_Client_Prompt_Builder::class, $received_builder_type );
+	}
+
+	/**
 	 * Test that the constructor allows overriding the default request timeout with a valid value.
 	 *
 	 * @ticket 64591


### PR DESCRIPTION
Trac: https://core.trac.wordpress.org/ticket/65638

## What

Updates the bundled PHP AI Client library to [1.4.0](https://github.com/WordPress/php-ai-client/releases/tag/1.4.0) and introduces embedding generation support in core.

### Library update

Regenerated `src/wp-includes/php-ai-client/` via `bash tools/php-ai-client/installer.sh --version=1.4.0`. The headline feature of 1.4.0 is embedding generation: a new `EmbeddingBuilder`, embedding lifecycle events, `Embedding`/`EmbeddingResult` DTOs, and a shared `ModelResolver`. See the [1.4.0 release notes](https://github.com/WordPress/php-ai-client/releases/tag/1.4.0) for a full list of changes.

### New: `WP_AI_Client_Embedding_Builder`

A WordPress wrapper around the SDK's new `EmbeddingBuilder`, following the exact pattern established by `WP_AI_Client_Prompt_Builder`:

- snake_case method naming proxied to the SDK's camelCase methods via `__call()`.
- `WP_Error` handling instead of exceptions: non-generating methods never throw; once an error occurs the instance enters an error state that preserves the fluent interface, and the `WP_Error` is returned from the generating methods (`generate_embedding_result()`, `generate_embedding()`, `generate_embeddings()`).
- Respects `wp_supports_ai()` and the existing `wp_ai_client_default_request_timeout` filter.
- Adds a `wp_ai_client_prevent_embedding` filter, analogous to `wp_ai_client_prevent_prompt`.
- Error codes use an `embedding_*` prefix (e.g. `embedding_network_error`, `embedding_invalid_argument`) with HTTP status codes for REST-friendly errors.

Also introduces the variadic `wp_ai_client_embedding()` entry point, analogous to `wp_ai_client_prompt()`:

```php
$embeddings = wp_ai_client_embedding( 'first input', 'second input' )->generate_embeddings();
```

## Testing

- `php -l` and PHPCS pass on all changed files.
- Autoloader smoke test: `WordPress\AiClient\AiClient` resolves after the update.
- Verified via reflection that all 11 proxied snake_case methods map to existing `EmbeddingBuilder` methods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Shared base class: `WP_AI_Client_Builder`

Since the prompt and embedding builders share nearly all of their machinery, it now lives in an abstract `WP_AI_Client_Builder` base class: the snake_case `__call()` proxying, `WP_Error` error-state handling, exception-to-`WP_Error` conversion, and default request timeout setup. Child classes supply the SDK builder, error code prefix, prevent filter, and method maps via abstract methods. No behavior changes for `WP_AI_Client_Prompt_Builder` — error codes, filter names, and `_doing_it_wrong()` notices (which report the concrete class name) are identical to 7.0.

### Test updates

PHP AI Client 1.4.0 moved model selection state (`model`, `registry`, `providerIdOrClassName`, `requestOptions`) from the SDK `PromptBuilder` onto its new `ModelResolver`; the test reflection helper now follows properties there.

Dedicated tests were added for `WP_AI_Client_Embedding_Builder` and `wp_ai_client_embedding()`, covering the wrapper behavior (not the SDK): constructor input parsing, timeout filter handling, fluent proxying and error-state semantics, the `wp_supports_ai()` / `wp_ai_client_prevent_embedding` gates, exception-to-`WP_Error` mapping, and generation via a mock embedding model. The full `ai-client` group passes: 298 tests, 747 assertions.

