### PR TITLE
Accessibility: Display a tooltip on toggle tip buttons to expose their accessible name

### DIFF
--- a/src/js/_enqueues/wp/wp-tooltip.js
+++ b/src/js/_enqueues/wp/wp-tooltip.js
@@ -42,3 +42,60 @@
 		trigger.addEventListener( 'blur', hideTooltip );
 	});
 })();
+
+/**
+ * Add focus and hover support for the toggle tip's hint in `wp_get_toggletip()`.
+ *
+ * A toggle tip has no visible text label, so a hover/focus hint exposes the
+ * toggle button's accessible name to sighted users. The hint is suppressed while
+ * the toggle tip dialog itself is open, so the two never overlap.
+ * This script can be made obsolete when support is available for Interest Invokers.
+ */
+(() => {
+
+	const toggletips = document.querySelectorAll( '.wp-is-toggletip' );
+	let openTimeout;
+
+	toggletips.forEach( function( toggletip ) {
+		let trigger = toggletip.querySelector( 'button.wp-tooltip__toggle' );
+		let hint    = toggletip.querySelector( '.wp-tooltip__hint' );
+		let dialog  = toggletip.querySelector( 'dialog.wp-tooltip__bubble' );
+
+		if ( ! trigger || ! hint ) {
+			return;
+		}
+
+		// Show Hint Function (with delay to prevent flickering).
+		const showHint = () => {
+			clearTimeout( openTimeout );
+			openTimeout = setTimeout( () => {
+				// Don't show the hint over an open toggle tip dialog.
+				if ( dialog && dialog.matches( ':popover-open' ) ) {
+					return;
+				}
+				// Only show if it's not already open.
+				if ( ! hint.matches( ':popover-open' ) ) {
+					// pass the triggering element so implicit position anchors work.
+					hint.showPopover( { source: trigger } );
+				}
+			}, 300 );
+		};
+		// Hide Hint Function.
+		const hideHint = () => {
+			clearTimeout( openTimeout );
+			if ( hint.matches( ':popover-open' ) ) {
+				hint.hidePopover();
+			}
+		};
+
+		// Bind Hover and Focus Events.
+		trigger.addEventListener( 'mouseenter', showHint );
+		trigger.addEventListener( 'focus', showHint );
+
+		trigger.addEventListener( 'mouseleave', hideHint );
+		trigger.addEventListener( 'blur', hideHint );
+
+		// Hide the hint as soon as the toggle tip is opened.
+		trigger.addEventListener( 'click', hideHint );
+	});
+})();

--- a/src/wp-admin/css/wp-tooltip.css
+++ b/src/wp-admin/css/wp-tooltip.css
@@ -64,7 +64,8 @@
 	box-shadow: 0 3px 6px rgba(0, 0, 0, 0.08);
 }
 
-.wp-tooltip.wp-is-tooltip .wp-tooltip__bubble {
+.wp-tooltip.wp-is-tooltip .wp-tooltip__bubble,
+.wp-tooltip .wp-tooltip__hint {
 	background: #000;
 	color: #f0f0f0;
 	text-align: center;
@@ -72,7 +73,7 @@
 	line-height: 1.4;
 }
 
-.wp-tooltip:not(.wp-is-tooltip) .wp-tooltip__text {
+.wp-tooltip:not(.wp-is-tooltip) .wp-tooltip__bubble:not(.wp-tooltip__hint) .wp-tooltip__text {
 	display: block;
 	padding-inline-end: 24px;
 }
@@ -91,13 +92,14 @@
 		position-try-fallbacks: flip-block, flip-inline;
 	}
 
-	.wp-tooltip.wp-is-tooltip .wp-tooltip__bubble {
+	.wp-tooltip.wp-is-tooltip .wp-tooltip__bubble,
+	.wp-tooltip .wp-tooltip__hint {
 		margin: 0;
 	}
 
 	/* Arrow: gray border (::before) under a white fill (::after). */
-	.wp-tooltip:not(.wp-is-tooltip) .wp-tooltip__bubble::before,
-	.wp-tooltip:not(.wp-is-tooltip) .wp-tooltip__bubble::after {
+	.wp-tooltip:not(.wp-is-tooltip) .wp-tooltip__bubble:not(.wp-tooltip__hint)::before,
+	.wp-tooltip:not(.wp-is-tooltip) .wp-tooltip__bubble:not(.wp-tooltip__hint)::after {
 		content: "";
 		position: absolute;
 		top: 100%;
@@ -108,12 +110,12 @@
 		border-bottom: 0;
 	}
 
-	.wp-tooltip:not(.wp-is-tooltip) .wp-tooltip__bubble::before {
+	.wp-tooltip:not(.wp-is-tooltip) .wp-tooltip__bubble:not(.wp-tooltip__hint)::before {
 		margin-left: -8px;
 		border-top-color: #c3c4c7;
 	}
 
-	.wp-tooltip:not(.wp-is-tooltip) .wp-tooltip__bubble::after {
+	.wp-tooltip:not(.wp-is-tooltip) .wp-tooltip__bubble:not(.wp-tooltip__hint)::after {
 		margin-left: -7px;
 		border-width: 7px;
 		border-bottom: 0;

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -512,6 +512,9 @@ function wp_get_tooltip_helper( $content, $args = array() ) {
 				'<button type="button" class="wp-tooltip__toggle" popovertarget="%2$s" aria-label="%3$s" aria-haspopup="dialog">' .
 					'<span class="dashicons%4$s" aria-hidden="true"></span>' .
 				'</button>' .
+				'<span popover="hint" id="%2$s-hint" class="wp-tooltip__bubble wp-tooltip__hint" aria-hidden="true">' .
+					'<span class="wp-tooltip__text">%7$s</span>' .
+				'</span>' .
 				'<dialog popover="auto" id="%2$s" class="wp-tooltip__bubble" autofocus>' .
 					'<span id="%2$s-text" class="wp-tooltip__text">%5$s</span>' .
 					'<button type="button" class="wp-tooltip__close" popovertarget="%2$s" popovertargetaction="hide" aria-label="%6$s">' .
@@ -525,6 +528,7 @@ function wp_get_tooltip_helper( $content, $args = array() ) {
 			esc_attr( $icon ),
 			esc_html( $content ),
 			esc_attr( $args['close_label'] ),
+			esc_html( $args['label'] ),
 		);
 	}
 

--- a/tests/phpunit/tests/general/wpGetTooltip.php
+++ b/tests/phpunit/tests/general/wpGetTooltip.php
@@ -40,6 +40,9 @@ class Tests_General_wpGetTooltip extends WP_UnitTestCase {
 		$this->assertStringNotContainsString( 'class="wp-tooltip__close"', $tooltip );
 		$this->assertStringNotContainsString( 'popovertargetaction="hide"', $tooltip );
 
+		// A plain tooltip has no separate hint element.
+		$this->assertStringNotContainsString( 'wp-tooltip__hint', $tooltip );
+
 		$toggletip = wp_get_toggletip(
 			'Helpful text.',
 			array(
@@ -49,6 +52,59 @@ class Tests_General_wpGetTooltip extends WP_UnitTestCase {
 		// Ensure the toggle tip does contain a close button.
 		$this->assertStringContainsString( 'class="wp-tooltip__close"', $toggletip );
 		$this->assertStringContainsString( 'popovertargetaction="hide"', $toggletip );
+	}
+
+	/**
+	 * Tests that a toggle tip exposes its accessible name through a hint tooltip.
+	 *
+	 * With no visible text label, the toggle button's accessible name is only
+	 * available to assistive technologies via `aria-label`. A hover/focus hint
+	 * tooltip exposes that same name to sighted users, while being hidden from
+	 * assistive technologies to avoid a duplicate announcement.
+	 *
+	 * @ticket 65633
+	 */
+	public function test_wp_get_toggletip_includes_accessible_name_hint() {
+		$toggletip = wp_get_toggletip(
+			'Helpful text.',
+			array(
+				'id'    => 'my-tip',
+				'label' => 'About this field',
+			)
+		);
+
+		// The hint is a hint popover that duplicates the toggle button's label.
+		$this->assertStringContainsString(
+			'<span popover="hint" id="my-tip-hint" class="wp-tooltip__bubble wp-tooltip__hint" aria-hidden="true">',
+			$toggletip
+		);
+		$this->assertStringContainsString(
+			'<span class="wp-tooltip__text">About this field</span>',
+			$toggletip
+		);
+
+		// The toggle button still exposes the accessible name to assistive technologies.
+		$this->assertStringContainsString( 'aria-label="About this field"', $toggletip );
+	}
+
+	/**
+	 * Tests that the toggle tip hint escapes its content.
+	 *
+	 * @ticket 65633
+	 */
+	public function test_wp_get_toggletip_hint_escapes_label() {
+		$toggletip = wp_get_toggletip(
+			'Helpful text.',
+			array(
+				'label' => '<script>alert(1)</script>',
+			)
+		);
+
+		$this->assertStringContainsString(
+			'<span class="wp-tooltip__text">&lt;script&gt;',
+			$toggletip
+		);
+		$this->assertStringNotContainsString( '<span class="wp-tooltip__text"><script>', $toggletip );
 	}
 
 	/**


### PR DESCRIPTION
## Trac ticket

https://core.trac.wordpress.org/ticket/65633

## Summary

With no visible text label, a toggle tip's toggle button (from `wp_get_toggletip()`) exposes its accessible name only through `aria-label`. That name reaches assistive technologies but is invisible to sighted mouse and keyboard users, who get no on-hover or on-focus indication of what the button does.

A `tooltip` already shows a hover/focus popover surfacing its accessible name. This PR brings the same affordance to toggle tips, which was deferred as a "nice to have" in #51006.

## Changes

- `wp-includes/general-template.php` — the toggle tip markup now also outputs a hint popover carrying the button's label:
  ```html
  <span popover="hint" id="{id}-hint" class="wp-tooltip__bubble wp-tooltip__hint" aria-hidden="true">
      <span class="wp-tooltip__text">{label}</span>
  </span>
  It is aria-hidden on purpose — the button already announces its name via
  aria-label, so the hint stays purely visual and avoids a duplicate announcement.
- `js/_enqueues/wp/wp-tooltip.js` — shows the hint on mouseenter/focus and hides it on mouseleave/blur, mirroring the tooltip behaviour. The hint is suppressed while the toggle tip dialog is open, so the two never overlap.
- `wp-admin/css/wp-tooltip.css` — `.wp-tooltip__hint` reuses the tooltip bubble styling.
- `tests/phpunit/tests/general/wpGetTooltip.php` — added coverage for the hint markup, label duplication, and escaping.

Behaviour is unchanged for the tooltip type and for assistive technologies.

## Testing instructions

1. Run npm run dev so the JS/CSS rebuild.
2. Open wp-login.php and locate the ? help icon next to the "Remember Me" checkbox.
3. Hover or Tab to the icon → a small "Help" tooltip appears after ~300ms; it hides on mouse-leave/blur.
4. Click the icon → the help dialog opens and the hint disappears (no overlap). Hovering the icon while the dialog is open does not re-show the hint.
5. Inspect the toggle button: it still has aria-label="Help", and the hint is aria-hidden="true" (a screen reader announces the name once, not twice).
6. Run the tests: npm run test:php -- --filter Tests_General_wpGetTooltip.

## Screenshots

<img width="660" height="559" alt="image" src="https://github.com/user-attachments/assets/39d440c4-8f9c-40f4-9536-1324dbd656bd" />

<img width="671" height="583" alt="image" src="https://github.com/user-attachments/assets/14fef6b7-b185-4415-a14c-216cf94ff929" />


Related
- Follow-up to https://core.trac.wordpress.org/ticket/51006