### PR TITLE
Toolbar: Unhook the toolbar when the admin bar is disabled.

### DIFF
--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -1403,6 +1403,9 @@ function wp_enqueue_admin_bar_bump_styles() {
  * from a function hooked to the {@see 'init'} action.
  *
  * @since 3.1.0
+ * @since 7.1.0 Disabling the admin bar after it has been initialized now also
+ *              unhooks its rendering actions and dequeues its assets. Re-enabling
+ *              it restores them.
  *
  * @global bool $show_admin_bar
  *
@@ -1411,6 +1414,30 @@ function wp_enqueue_admin_bar_bump_styles() {
 function show_admin_bar( $show ) {
 	global $show_admin_bar;
 	$show_admin_bar = (bool) $show;
+
+	if ( false === $show_admin_bar ) {
+		remove_action( 'wp_head', 'wp_admin_bar_header' );
+		remove_action( 'admin_head', 'wp_admin_bar_header' );
+		remove_action( 'wp_head', '_admin_bar_bump_cb' );
+
+		remove_action( 'wp_enqueue_scripts', 'wp_enqueue_admin_bar_bump_styles' );
+		remove_action( 'wp_enqueue_scripts', 'wp_enqueue_admin_bar_header_styles' );
+		remove_action( 'admin_enqueue_scripts', 'wp_enqueue_admin_bar_header_styles' );
+
+		wp_dequeue_script( 'admin-bar' );
+		wp_dequeue_style( 'admin-bar' );
+	} elseif ( did_action( 'admin_bar_init' ) ) {
+		add_action( 'wp_head', 'wp_admin_bar_header' );
+		add_action( 'admin_head', 'wp_admin_bar_header' );
+		add_action( 'wp_head', '_admin_bar_bump_cb' );
+
+		add_action( 'wp_enqueue_scripts', 'wp_enqueue_admin_bar_bump_styles' );
+		add_action( 'wp_enqueue_scripts', 'wp_enqueue_admin_bar_header_styles' );
+		add_action( 'admin_enqueue_scripts', 'wp_enqueue_admin_bar_header_styles' );
+
+		wp_enqueue_script( 'admin-bar' );
+		wp_enqueue_style( 'admin-bar' );
+	}
 }
 
 /**

--- a/tests/phpunit/tests/adminbar.php
+++ b/tests/phpunit/tests/adminbar.php
@@ -932,4 +932,82 @@ class Tests_AdminBar extends WP_UnitTestCase {
 		$this->assertTrue( isset( $admin_bar->menu ), 'WP_Admin_Bar::$menu should be set.' );
 		$this->assertSame( array(), $admin_bar->menu, 'WP_Admin_Bar::$menu should be equal to an empty array.' );
 	}
+
+	/**
+	 * Ensures disabling the admin bar after it has been initialized unhooks the
+	 * toolbar's rendering actions and dequeues its assets.
+	 *
+	 * @ticket 28569
+	 *
+	 * @covers ::show_admin_bar
+	 */
+	public function test_show_admin_bar_false_after_init_unhooks_toolbar() {
+		wp_set_current_user( self::$admin_id );
+
+		// Enable and initialize the admin bar, as happens on 'template_redirect'.
+		show_admin_bar( true );
+		_wp_admin_bar_init();
+
+		// The toolbar's rendering actions are hooked and its assets are enqueued.
+		$this->assertSame( 10, has_action( 'wp_head', 'wp_admin_bar_header' ), 'wp_admin_bar_header should be hooked to wp_head after init.' );
+		$this->assertSame( 10, has_action( 'wp_head', '_admin_bar_bump_cb' ), '_admin_bar_bump_cb should be hooked to wp_head after init.' );
+		$this->assertTrue( wp_style_is( 'admin-bar', 'enqueued' ), 'The admin-bar stylesheet should be enqueued after init.' );
+		$this->assertTrue( wp_script_is( 'admin-bar', 'enqueued' ), 'The admin-bar script should be enqueued after init.' );
+
+		// Disabling the admin bar should remove the actions and dequeue the assets.
+		show_admin_bar( false );
+
+		$this->assertFalse( has_action( 'wp_head', 'wp_admin_bar_header' ), 'wp_admin_bar_header should be unhooked from wp_head.' );
+		$this->assertFalse( has_action( 'admin_head', 'wp_admin_bar_header' ), 'wp_admin_bar_header should be unhooked from admin_head.' );
+		$this->assertFalse( has_action( 'wp_head', '_admin_bar_bump_cb' ), '_admin_bar_bump_cb should be unhooked from wp_head.' );
+		$this->assertFalse( has_action( 'wp_enqueue_scripts', 'wp_enqueue_admin_bar_bump_styles' ), 'wp_enqueue_admin_bar_bump_styles should be unhooked from wp_enqueue_scripts.' );
+		$this->assertFalse( has_action( 'wp_enqueue_scripts', 'wp_enqueue_admin_bar_header_styles' ), 'wp_enqueue_admin_bar_header_styles should be unhooked from wp_enqueue_scripts.' );
+		$this->assertFalse( has_action( 'admin_enqueue_scripts', 'wp_enqueue_admin_bar_header_styles' ), 'wp_enqueue_admin_bar_header_styles should be unhooked from admin_enqueue_scripts.' );
+		$this->assertFalse( wp_style_is( 'admin-bar', 'enqueued' ), 'The admin-bar stylesheet should be dequeued.' );
+		$this->assertFalse( wp_script_is( 'admin-bar', 'enqueued' ), 'The admin-bar script should be dequeued.' );
+	}
+
+	/**
+	 * Ensures re-enabling the admin bar after it was disabled restores the
+	 * toolbar's rendering actions and re-enqueues its assets.
+	 *
+	 * @ticket 28569
+	 *
+	 * @covers ::show_admin_bar
+	 */
+	public function test_show_admin_bar_true_after_init_restores_toolbar() {
+		wp_set_current_user( self::$admin_id );
+
+		show_admin_bar( true );
+		_wp_admin_bar_init();
+
+		show_admin_bar( false );
+		show_admin_bar( true );
+
+		$this->assertSame( 10, has_action( 'wp_head', 'wp_admin_bar_header' ), 'wp_admin_bar_header should be re-hooked to wp_head.' );
+		$this->assertSame( 10, has_action( 'admin_head', 'wp_admin_bar_header' ), 'wp_admin_bar_header should be re-hooked to admin_head.' );
+		$this->assertSame( 10, has_action( 'wp_head', '_admin_bar_bump_cb' ), '_admin_bar_bump_cb should be re-hooked to wp_head.' );
+		$this->assertSame( 10, has_action( 'wp_enqueue_scripts', 'wp_enqueue_admin_bar_bump_styles' ), 'wp_enqueue_admin_bar_bump_styles should be re-hooked to wp_enqueue_scripts.' );
+		$this->assertSame( 10, has_action( 'wp_enqueue_scripts', 'wp_enqueue_admin_bar_header_styles' ), 'wp_enqueue_admin_bar_header_styles should be re-hooked to wp_enqueue_scripts.' );
+		$this->assertSame( 10, has_action( 'admin_enqueue_scripts', 'wp_enqueue_admin_bar_header_styles' ), 'wp_enqueue_admin_bar_header_styles should be re-hooked to admin_enqueue_scripts.' );
+		$this->assertTrue( wp_style_is( 'admin-bar', 'enqueued' ), 'The admin-bar stylesheet should be re-enqueued.' );
+		$this->assertTrue( wp_script_is( 'admin-bar', 'enqueued' ), 'The admin-bar script should be re-enqueued.' );
+	}
+
+	/**
+	 * Ensures toggling the admin bar before it is initialized does not prematurely
+	 * hook the toolbar's rendering actions.
+	 *
+	 * @ticket 28569
+	 *
+	 * @covers ::show_admin_bar
+	 */
+	public function test_show_admin_bar_true_before_init_does_not_add_actions() {
+		unset( $GLOBALS['show_admin_bar'] );
+
+		show_admin_bar( true );
+
+		$this->assertFalse( has_action( 'wp_head', 'wp_admin_bar_header' ), 'wp_admin_bar_header should not be hooked before the admin bar is initialized.' );
+		$this->assertFalse( has_action( 'wp_head', '_admin_bar_bump_cb' ), '_admin_bar_bump_cb should not be hooked before the admin bar is initialized.' );
+	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

Makes `show_admin_bar( false )` fully dehook the toolbar when it is called after the admin bar has already been initialized.

What the problem was:
- `show_admin_bar( false )` only set the `$show_admin_bar` global to false.
- When called after `_wp_admin_bar_init()` has run (e.g. right before `get_header()`), the actions registered by `WP_Admin_Bar::initialize()` stayed hooked and the `admin-bar` assets stayed enqueued.
- Result: `_admin_bar_bump_cb` still added the `margin-top: 32px` body offset and the admin bar CSS/JS still loaded, even though no toolbar rendered.

What the fix does:
- When disabling, `show_admin_bar()` now removes `wp_admin_bar_header`, `_admin_bar_bump_cb`, and the enqueue-style callbacks, and dequeues the `admin-bar` script and style.
- When re-enabling after `admin_bar_init` has fired, those actions and assets are restored so toggling stays symmetric.

Approach and why:
- Follows the approach in the ticket description and PR #12402, which a committer was ready to land for 7.1.
- The `did_action( 'admin_bar_init' )` guard keeps the common early call ("immediately upon plugin load", per the docblock) a pure setter, so no hooks are added before the toolbar is initialized.
- Kept the enable/disable path symmetric per @joedolson's request in the ticket for a more thorough toggle (see #65091).

Testing instructions:
1. As a logged-in admin on the front end, add to a theme's functions.php: `add_action( 'template_redirect', function () { show_admin_bar( false ); }, 20 );`
2. Before the patch: view the front end — the page still has a ~32px top margin and loads the admin-bar stylesheet even though no toolbar shows.
3. After the patch: the top margin is gone and the admin-bar assets are no longer enqueued.
4. Edge cases: calling `show_admin_bar( true )` again after disabling restores the toolbar; calling `show_admin_bar( false )` early (before init) remains a harmless no-op.
5. Run the tests: `npm run test:php -- --filter show_admin_bar tests/phpunit/tests/adminbar.php`

Trac ticket: https://core.trac.wordpress.org/ticket/28569

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 4.8
Used for: Ticket analysis and implementation tests cases. All changes were reviewed, validated against the codebase, and are taken responsibility for by me.
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
