### PR TITLE
Users: Only set initial focus on the password field on the reset password form

### DIFF
--- a/src/js/_enqueues/admin/user-profile.js
+++ b/src/js/_enqueues/admin/user-profile.js
@@ -59,11 +59,6 @@
 
 		// Once zxcvbn loads, passwords strength is known.
 		$( '#pw-weak-text-label' ).text( __( 'Confirm use of weak password' ) );
-
-		// Only focus the password field on the reset password form.
-		if ( $pass1.closest( '#resetpassform' ).length ) {
-			$( $pass1 ).trigger( 'focus' );
-		}
 	}
 
 	function bindPass1() {

--- a/src/js/_enqueues/admin/user-profile.js
+++ b/src/js/_enqueues/admin/user-profile.js
@@ -60,8 +60,8 @@
 		// Once zxcvbn loads, passwords strength is known.
 		$( '#pw-weak-text-label' ).text( __( 'Confirm use of weak password' ) );
 
-		// Focus the password field if not the install screen.
-		if ( 'mailserver_pass' !== $pass1.prop('id' ) && ! $('#weblog_title').length ) {
+		// Only focus the password field on the reset password form.
+		if ( $pass1.closest( '#resetpassform' ).length ) {
 			$( $pass1 ).trigger( 'focus' );
 		}
 	}


### PR DESCRIPTION
## Ticket

https://core.trac.wordpress.org/ticket/65630

## Description

Setting initial focus on a specific control only makes sense when there is a single, well-defined task for the user. On the **Add New User** screen, focus is currently placed on the password field in the middle of the form, skipping the Username, Email, and Name fields. This disrupts the native tab order and hurts discoverability for keyboard and screen reader users.

## Cause

In `src/js/_enqueues/admin/user-profile.js`, the password field is focused whenever `generatePassword()` runs, which happens on every screen where the field carries `data-reveal="1"` — the `wp-login.php` reset password form, `install.php`, and `user-new.php` (Add New User).

The existing guard is a blocklist that only excludes the mailserver (`#mailserver_pass`) and install (`#weblog_title`) screens, so Add New User slips through and steals focus. The behavior was originally introduced in [52193](https://core.trac.wordpress.org/changeset/52193) and was only ever intended for the reset password field on `wp-login.php`; the shared selector caused it to leak onto other pages.

## Testing

- Add New User (`wp-admin`/`user-new.php`): focus is no longer forced onto the password field; tab order starts at the top of the form.
- Reset password (`wp-login.php`): password field still receives focus as intended.
- Unaffected screens verified: `install.php`, `options-writing.php` (`#mailserver_pass`), `setup-config.php` (`#pwd`, not matched by `$pass1`).

## Screenshots

Before

https://github.com/user-attachments/assets/f05ce9bf-5d98-435a-bd03-517ad6da4913

After 

https://github.com/user-attachments/assets/39911c72-899d-485c-8c03-422ce4968c7e

