### PR TITLE
Media: Only display required fields message when needed

### DIFF
--- a/src/wp-admin/includes/media.php
+++ b/src/wp-admin/includes/media.php
@@ -1678,6 +1678,18 @@ function get_media_item( $attachment_id, $args = null ) {
 		}
 	}
 
+	$has_required_field = false;
+
+	foreach ( $form_fields as $id => $field ) {
+		if ( '_' === $id[0] || ! empty( $field['tr'] ) || 'hidden' === ( $field['input'] ?? 'text' ) ) {
+			continue;
+		}
+
+		if ( ! empty( $field['required'] ) ) {
+			$has_required_field = true;
+			break;
+		}
+	}
 	$media_dims = '';
 	$meta       = wp_get_attachment_metadata( $post->ID );
 
@@ -1732,11 +1744,13 @@ function get_media_item( $attachment_id, $args = null ) {
 		</thead>
 		<tbody>
 		<tr><td colspan='2' class='imgedit-response' id='imgedit-response-$post->ID'></td></tr>\n
-		<tr><td style='display:none' colspan='2' class='image-editor' id='image-editor-$post->ID'></td></tr>\n
-		<tr><td colspan='2'><p class='media-types media-types-required-info'>" .
-			wp_required_field_message() .
-		"</p></td></tr>\n";
+		<tr><td style='display:none' colspan='2' class='image-editor' id='image-editor-$post->ID'></td></tr>\n";
 
+	if ( $has_required_field ) {
+		$item .= "		<tr><td colspan='2'><p class='media-types media-types-required-info'>" .
+			wp_required_field_message() .
+			"</p></td></tr>\n";
+	}
 	$defaults = array(
 		'input'      => 'text',
 		'required'   => false,
@@ -1978,10 +1992,10 @@ function get_compat_media_markup( $attachment_id, $args = null ) {
 		'show_in_modal' => true,
 	);
 
-	$hidden_fields = array();
+	$hidden_fields      = array();
+	$has_required_field = false;
 
 	$item = '';
-
 	foreach ( $form_fields as $id => $field ) {
 		if ( '_' === $id[0] ) {
 			continue;
@@ -2006,6 +2020,9 @@ function get_compat_media_markup( $attachment_id, $args = null ) {
 			continue;
 		}
 
+		if ( $field['required'] ) {
+			$has_required_field = true;
+		}
 		$readonly      = ! $user_can_edit && ! empty( $field['taxonomy'] ) ? " readonly='readonly' " : '';
 		$required      = $field['required'] ? ' ' . wp_required_field_indicator() : '';
 		$required_attr = $field['required'] ? ' required' : '';
@@ -2062,12 +2079,16 @@ function get_compat_media_markup( $attachment_id, $args = null ) {
 	}
 
 	if ( $item ) {
-		$item = '<p class="media-types media-types-required-info">' .
-			wp_required_field_message() .
-			'</p>' .
-			'<table class="compat-attachment-fields">' . $item . '</table>';
-	}
+		$required_fields_message = '';
 
+		if ( $has_required_field ) {
+			$required_fields_message = '<p class="media-types media-types-required-info">' .
+				wp_required_field_message() .
+				'</p>';
+		}
+
+		$item = $required_fields_message . '<table class="compat-attachment-fields">' . $item . '</table>';
+	}
 	foreach ( $hidden_fields as $hidden_field => $value ) {
 		$item .= '<input type="hidden" name="' . esc_attr( $hidden_field ) . '" value="' . esc_attr( $value ) . '" />' . "\n";
 	}

--- a/tests/phpunit/tests/admin/includesMedia.php
+++ b/tests/phpunit/tests/admin/includesMedia.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * @group admin
+ * @group media
+ *
+ * @covers ::get_media_item
+ * @covers ::get_compat_media_markup
+ */
+class Tests_Admin_IncludesMedia extends WP_UnitTestCase {
+	private static $attachment_id;
+
+	private $required = false;
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$attachment_id = $factory->post->create(
+			array(
+				'post_title'     => 'Test attachment',
+				'post_status'    => 'inherit',
+				'post_type'      => 'attachment',
+				'post_mime_type' => 'image/jpeg',
+			)
+		);
+	}
+
+	public function set_up() {
+		parent::set_up();
+
+		require_once ABSPATH . 'wp-admin/includes/media.php';
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		add_filter( 'attachment_fields_to_edit', array( $this, 'filter_attachment_fields_to_edit' ) );
+	}
+
+	public function test_get_media_item_does_not_show_required_fields_message_without_required_fields() {
+		$item = get_media_item( self::$attachment_id );
+
+		$this->assertStringNotContainsString( 'media-types-required-info', $item );
+	}
+
+	public function test_get_media_item_shows_required_fields_message_with_required_field() {
+		$this->required = true;
+
+		$item = get_media_item( self::$attachment_id );
+
+		$this->assertStringContainsString( 'media-types-required-info', $item );
+	}
+
+	public function test_get_compat_media_markup_does_not_show_required_fields_message_without_required_fields() {
+		$markup = get_compat_media_markup( self::$attachment_id );
+
+		$this->assertStringNotContainsString( 'media-types-required-info', $markup['item'] );
+	}
+
+	public function test_get_compat_media_markup_shows_required_fields_message_with_required_field() {
+		$this->required = true;
+
+		$markup = get_compat_media_markup( self::$attachment_id );
+
+		$this->assertStringContainsString( 'media-types-required-info', $markup['item'] );
+	}
+
+	public function filter_attachment_fields_to_edit() {
+		return array(
+			'test_field' => array(
+				'label'    => 'Test field',
+				'input'    => 'text',
+				'value'    => '',
+				'required' => $this->required,
+			),
+		);
+	}
+}

--- a/tests/phpunit/tests/admin/includesMedia.php
+++ b/tests/phpunit/tests/admin/includesMedia.php
@@ -18,7 +18,10 @@ class Tests_Admin_IncludesMedia extends WP_UnitTestCase {
 				'post_title'     => 'Test attachment',
 				'post_status'    => 'inherit',
 				'post_type'      => 'attachment',
-				'post_mime_type' => 'image/jpeg',
+				'post_mime_type' => 'application/pdf',
+				'meta_input'     => array(
+					'_wp_attached_file' => 'test.pdf',
+				),
 			)
 		);
 	}


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

## Trac ticket

https://core.trac.wordpress.org/ticket/54438

## Description

Only displays the required fields message in the legacy media attachment forms when at least one visible rendered field is required.

This updates both get_media_item() and get_compat_media_markup(), and adds regression tests for forms with and without required fields.

## Testing

- PHPCS passes for the changed files with warnings disabled; the full source file has three unrelated pre-existing warnings.
- PHP syntax checks pass.

Trac ticket: https://core.trac.wordpress.org/ticket/54438

## Use of AI Tools

AI assistance: Yes
Tool(s): OpenAI Codex
Model(s): GPT-5
Used for: Reviewing the Trac ticket and relevant code, helping with the initial implementation and regression-test approach, and assisting with validation and PR-description drafting. The final implementation, tests, validation results, and description were reviewed and accepted by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**