### PR TITLE
Tests: Use null coalescing operator over `isset()` checks.

### DIFF
--- a/tests/phpunit/includes/object-cache.php
+++ b/tests/phpunit/includes/object-cache.php
@@ -2364,11 +2364,7 @@ class WP_Object_Cache {
 	public function get_from_runtime_cache( $key, $group ) {
 		$derived_key = $this->buildKey( $key, $group );
 
-		if ( isset( $this->cache[ $derived_key ] ) ) {
-			return $this->cache[ $derived_key ];
-		}
-
-		return false;
+		return $this->cache[ $derived_key ] ?? false;
 	}
 
 	/**

--- a/tests/phpunit/tests/fonts/font-face/wp-font-face-tests-dataset.php
+++ b/tests/phpunit/tests/fonts/font-face/wp-font-face-tests-dataset.php
@@ -308,11 +308,7 @@ CSS
 			);
 		}
 
-		if ( isset( $data[ $key ] ) ) {
-			return $data[ $key ];
-		}
-
-		return $data;
+		return $data[ $key ] ?? $data;
 	}
 
 	public static function get_custom_font_families( $key = '' ) {
@@ -397,11 +393,7 @@ CSS
 			);
 		}
 
-		if ( isset( $data[ $key ] ) ) {
-			return $data[ $key ];
-		}
-
-		return $data;
+		return $data[ $key ] ?? $data;
 	}
 
 	public static function get_custom_style_variations( $key = '' ) {
@@ -488,10 +480,6 @@ CSS;
 			);
 		}
 
-		if ( isset( $data[ $key ] ) ) {
-			return $data[ $key ];
-		}
-
-		return $data;
+		return $data[ $key ] ?? $data;
 	}
 }


### PR DESCRIPTION
Replace verbose `isset()`-and-return blocks with the `??` operator in the object cache helper and font-face test dataset.

Trac ticket: https://core.trac.wordpress.org/ticket/64894

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
