### PR TITLE
General: Do not return values from constructors for PHP 8.6 compatibility

### DIFF
--- a/src/wp-includes/class-pop3.php
+++ b/src/wp-includes/class-pop3.php
@@ -64,7 +64,6 @@ class POP3 {
                 set_time_limit($timeout);
             }
         }
-        return true;
     }
 
 	/**

--- a/src/wp-includes/pomo/streams.php
+++ b/src/wp-includes/pomo/streams.php
@@ -314,7 +314,7 @@ if ( ! class_exists( 'POMO_CachedFileReader', false ) ) :
 			parent::__construct();
 			$this->_str = file_get_contents( $filename );
 			if ( false === $this->_str ) {
-				return false;
+				return;
 			}
 			$this->_pos = 0;
 		}


### PR DESCRIPTION
## Trac ticket

Fixes https://core.trac.wordpress.org/ticket/65637

## Problem

PHP 8.6 introduces a deprecation from the [Constructor/Destructor Return Values RFC](https://wiki.php.net/rfc/constructor-return-value) (see also https://php.watch/r/188). Returning a value from `__construct()` or `__destruct()` now emits:

Deprecated: Returning a value from a constructor is deprecated in /path/to/wp-includes/pomo/streams.php on line 317

A constructor's return value is always discarded by PHP — `new Foo()` evaluates to the object, never to whatever the constructor returned — so these statements were dead code and are safe to remove.

## Changes

- `streams.php` — `return false;` → `return;`. The return was an early bail when `file_get_contents()` fails; the bare `return;` preserves that control flow exactly. (The skipped `$this->_pos = 0;` is redundant anyway, as the parent `POMO_StringReader::__construct()` already sets it to `0`.)
- `class-pop3.php` — `return true;` removed. It was the constructor's final statement, so nothing is skipped.

No behavioral change: the returned values were never observable by callers.

## Testing instructions

Requires PHP 8.6. Using the official Docker RC image:

```bash
# Before this change (from a clean checkout) — two deprecations
docker run --rm -v "$PWD":/wp -w /wp php:8.6-rc-cli php -r '
  define("ABSPATH", "/wp/src/");
  require "src/wp-includes/pomo/streams.php";
  new POMO_CachedFileReader("/nonexistent.mo");
  require "src/wp-includes/class-pop3.php";
  new POP3();
'
```

## Usage of AI

Claude Code Opus 4.8 used to scan instances throughout the codebase