### PR TITLE
General: Bump the pinned hash for Gutenberg to `e73c3c4`

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"url": "https://develop.svn.wordpress.org/trunk"
 	},
 	"gutenberg": {
-		"sha": "2872d71cde528d82675f14862a1b84e2b8abbaea",
+		"sha": "e73c3c481db0650183f092af157f6e42efe9ee2d",
 		"ghcrRepo": "WordPress/gutenberg/gutenberg-wp-develop-build"
 	},
 	"engines": {

--- a/src/wp-includes/assets/script-loader-packages.php
+++ b/src/wp-includes/assets/script-loader-packages.php
@@ -104,7 +104,7 @@
 			'wp-url',
 			'wp-warning'
 		),
-		'version' => '71e7b84529c697129ad2'
+		'version' => '99803447584b3d7644e9'
 	),
 	'block-library.js' => array(
 		'dependencies' => array(
@@ -150,7 +150,7 @@
 				'import' => 'dynamic'
 			)
 		),
-		'version' => '055223542466f9623198'
+		'version' => 'c9f222767e6c1a5ce0f0'
 	),
 	'block-serialization-default-parser.js' => array(
 		'dependencies' => array(
@@ -446,7 +446,7 @@
 				'import' => 'static'
 			)
 		),
-		'version' => '9c810e308a711a2bcdf2'
+		'version' => 'a37c6fdd10740408f19d'
 	),
 	'edit-widgets.js' => array(
 		'dependencies' => array(
@@ -537,7 +537,7 @@
 				'import' => 'static'
 			)
 		),
-		'version' => 'a2f8d72b2257e8f87177'
+		'version' => '0a609157ffb795abc542'
 	),
 	'element.js' => array(
 		'dependencies' => array(
@@ -657,7 +657,7 @@
 			'wp-url',
 			'wp-warning'
 		),
-		'version' => 'd8c18297580c50b16352'
+		'version' => 'cdee5bad0dbdf854a8de'
 	),
 	'notices.js' => array(
 		'dependencies' => array(

--- a/src/wp-includes/assets/script-modules-packages.php
+++ b/src/wp-includes/assets/script-modules-packages.php
@@ -211,7 +211,7 @@
 				'import' => 'static'
 			)
 		),
-		'version' => '1e8b284f8ef6746e1032'
+		'version' => 'fb445bf351657f44f1d0'
 	),
 	'core-abilities/index.js' => array(
 		'dependencies' => array(
@@ -224,7 +224,7 @@
 				'import' => 'static'
 			)
 		),
-		'version' => 'ed8d088084da397754c1'
+		'version' => '012760fd849397dd0031'
 	),
 	'dashboard-init/index.js' => array(
 		'dependencies' => array(
@@ -382,9 +382,9 @@
 			),
 			array(
 				'id' => '@wordpress/core-abilities',
-				'import' => 'static'
+				'import' => 'dynamic'
 			)
 		),
-		'version' => '29988b33dda5ec9dc56b'
+		'version' => '9e09ede3195f2f51bc49'
 	)
 );

--- a/src/wp-includes/blocks/blocks-json.php
+++ b/src/wp-includes/blocks/blocks-json.php
@@ -3179,9 +3179,11 @@
 			),
 			'html' => false,
 			'color' => array(
-				'background' => true,
-				'text' => true,
-				'__experimentalSkipSerialization' => true
+				'__experimentalSkipSerialization' => true,
+				'__experimentalDefaultControls' => array(
+					'background' => true,
+					'text' => true
+				)
 			),
 			'interactivity' => array(
 				'clientNavigation' => true
@@ -7942,7 +7944,8 @@
 				'padding' => '.wp-block-tab-list button'
 			)
 		),
-		'style' => 'wp-block-tab-list'
+		'style' => 'wp-block-tab-list',
+		'editorStyle' => 'wp-block-tab-list-editor'
 	),
 	'tab-panel' => array(
 		'$schema' => 'https://schemas.wp.org/trunk/block.json',

--- a/src/wp-includes/blocks/icon/block.json
+++ b/src/wp-includes/blocks/icon/block.json
@@ -33,9 +33,11 @@
 		"align": [ "left", "center", "right" ],
 		"html": false,
 		"color": {
-			"background": true,
-			"text": true,
-			"__experimentalSkipSerialization": true
+			"__experimentalSkipSerialization": true,
+			"__experimentalDefaultControls": {
+				"background": true,
+				"text": true
+			}
 		},
 		"interactivity": {
 			"clientNavigation": true

--- a/src/wp-includes/blocks/tab-list/block.json
+++ b/src/wp-includes/blocks/tab-list/block.json
@@ -77,5 +77,6 @@
 			"padding": ".wp-block-tab-list button"
 		}
 	},
-	"style": "wp-block-tab-list"
+	"style": "wp-block-tab-list",
+	"editorStyle": "wp-block-tab-list-editor"
 }


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65529

This ticket is for syncing the changes between `2872d71cde528d82675f14862a1b84e2b8abbaea` into `wordpress-develop` (`e73c3c481db0650183f092af157f6e42efe9ee2d`).

Diff: https://github.com/WordPress/gutenberg/compare/2872d71cde528d82675f14862a1b84e2b8abbaea...e73c3c481db0650183f092af157f6e42efe9ee2d

- Icon block: Show text and background color controls by default. (https://github.com/WordPress/gutenberg/pull/80251)
- fix: set dataviews popover hover text color (https://github.com/WordPress/gutenberg/pull/80105)
- DataViews: Fix the unintended gap between `list` layout items when `groupBy` is set (https://github.com/WordPress/gutenberg/pull/80254)
- DataViews: Fix the `list` layout ignoring some settings when `groupBy` is set (https://github.com/WordPress/gutenberg/pull/80255)
- DataViews: Add shift-click range selection (https://github.com/WordPress/gutenberg/pull/80046)
- Responsive Editing: support editing pattern styles (https://github.com/WordPress/gutenberg/pull/80233)
- Tab List: Add toolbar buttons to reorder tabs (https://github.com/WordPress/gutenberg/pull/80107)
- Hide color controls for Navigation and Social Icons when viewport states are active (https://github.com/WordPress/gutenberg/pull/80289)
- Icons: Fix collection unregister not removing icons after core added its own registry (https://github.com/WordPress/gutenberg/pull/80292)
- Notes: increase contrast between avatar border colors (https://github.com/WordPress/gutenberg/pull/80285)
- Playlist: Fix track insertion (https://github.com/WordPress/gutenberg/pull/80200)
- Fix: Allow icon labels to wrap with word breaks and no ellipsis (https://github.com/WordPress/gutenberg/pull/80309)
- Core Abilities: Restore the ready promise and lazy-load via dynamic import (https://github.com/WordPress/gutenberg/pull/79155)

## Use of AI Tools

None