### PR TITLE
#57271 Return true when the existing stored cron array value already matches the new value

### DIFF
--- a/src/wp-includes/cron.php
+++ b/src/wp-includes/cron.php
@@ -1282,6 +1282,7 @@ function _get_cron_array() {
  * @since 2.1.0
  * @since 5.1.0 Return value modified to outcome of update_option().
  * @since 5.7.0 The `$wp_error` parameter was added.
+ * @since x.y.z Now returns true when the existing stored cron array value already matches the new value.
  *
  * @access private
  *
@@ -1300,6 +1301,15 @@ function _set_cron_array( $cron, $wp_error = false ) {
 	$cron['version'] = 2;
 
 	$result = update_option( 'cron', $cron, true );
+
+	if ( ! $result ) {
+		// If the cron array already matches the new value, then treat it as a success.
+		$stored = get_option( 'cron' );
+
+		if ( maybe_serialize( $stored ) === maybe_serialize( $cron ) ) {
+			$result = true;
+		}
+	}
 
 	if ( $wp_error && ! $result ) {
 		return new WP_Error(

--- a/tests/phpunit/tests/cron/setCronArray.php
+++ b/tests/phpunit/tests/cron/setCronArray.php
@@ -85,15 +85,21 @@ class Tests_Cron_setCronArray extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that `_set_cron_array()` returns `false` when the cron option was not updated.
+	 * Tests that `_set_cron_array()` returns true when the cron option already holds the desired value.
 	 *
-	 * @dataProvider data_set_cron_array_returns_false_when_not_updated
+	 * @ticket 38903
+	 * @ticket 57271
+	 *
+	 * @dataProvider data_set_cron_array_returns_true_when_option_already_holds_intended_value
 	 *
 	 * @param array $input    Cron array.
 	 * @param mixed $wp_error Value to use for $wp_error.
 	 */
-	public function test_set_cron_array_returns_false_when_not_updated( $input, $wp_error ) {
-		$this->assertFalse( _set_cron_array( $input ) );
+	public function test_set_cron_array_returns_true_when_option_already_holds_intended_value( $input, $wp_error ) {
+		// Store the cron array so that the next call to `_set_cron_array()` will not update it.
+		_set_cron_array( $input, $wp_error );
+
+		$this->assertTrue( _set_cron_array( $input, $wp_error ) );
 	}
 
 	/**
@@ -101,7 +107,7 @@ class Tests_Cron_setCronArray extends WP_UnitTestCase {
 	 *
 	 * @return array
 	 */
-	public function data_set_cron_array_returns_false_when_not_updated() {
+	public function data_set_cron_array_returns_true_when_option_already_holds_intended_value() {
 		return array(
 			'empty array' => array(
 				'input'    => array(),
@@ -117,6 +123,22 @@ class Tests_Cron_setCronArray extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that `_set_cron_array()` returns false when the cron option was not updated and `$wp_error` is truthy.
+	 *
+	 * @ticket 38903
+	 * @ticket 57271
+	 *
+	 * @dataProvider data_set_cron_array_returns_WP_Error_when_not_updated
+	 *
+	 * @param array $input Cron array.
+	 */
+	public function test_set_cron_array_returns_false_when_not_updated( $input ) {
+		$this->force_update_option_cron_failure();
+
+		$this->assertFalse( _set_cron_array( $input ) );
+	}
+
+	/**
 	 * Tests that `_set_cron_array()` returns a WP_Error object when the cron option was not updated and `$wp_error` is truthy.
 	 *
 	 * @dataProvider data_set_cron_array_returns_WP_Error_when_not_updated
@@ -125,6 +147,8 @@ class Tests_Cron_setCronArray extends WP_UnitTestCase {
 	 * @param mixed $wp_error Value to use for $wp_error.
 	 */
 	public function test_set_cron_array_returns_WP_Error_when_not_updated( $input, $wp_error ) {
+		$this->force_update_option_cron_failure();
+
 		$result = _set_cron_array( $input, $wp_error );
 		$this->assertWPError( $result, 'Return value is not an instance of WP_Error.' );
 		$this->assertSame( 'could_not_set', $result->get_error_code(), 'WP_Error error code does not match expected code.' );
@@ -147,6 +171,39 @@ class Tests_Cron_setCronArray extends WP_UnitTestCase {
 				),
 				'wp_error' => 1,
 			),
+		);
+	}
+
+	/**
+	 * Forces `update_option( 'cron', ... )` to report no change by keeping the
+	 * existing value, simulating a failure to persist a genuinely new value.
+	 */
+	private function force_update_option_cron_failure() {
+		// Store a cron array that differs from the value under test, so the
+		// "already stored the identical value" short-circuit does not fire.
+		update_option(
+			'cron',
+			array(
+				'version' => 2,
+				time()    => array(
+					'hookname' => array(
+						'event key' => array(
+							'schedule' => 'schedule',
+							'args'     => 'args',
+							'interval' => 'interval',
+						),
+					),
+				),
+			)
+		);
+
+		// Force update_option() to report no change by keeping the existing
+		// value, simulating a failure to persist a genuinely new value.
+		add_filter(
+			'pre_update_option_cron',
+			static fn ( $value, $old_value ) => $old_value,
+			10,
+			2
 		);
 	}
 


### PR DESCRIPTION
This PR proposes changing the return value of `_set_cron_array()` to true when updating the cron array option fails but its value already matches the desired value.

This is _a speculative change_. I don't know whether many/any of the reported instances of the "The cron event list could not be saved" error in the ticket are actually caused by the cron array having already been updated to the expected value (for example, via a concurrent process).

Is this a good idea? I think so. Does it paper over an underlying issue? I don't think it does. Feedback welcome.

Trac ticket: https://core.trac.wordpress.org/ticket/57271

## Use of AI Tools

AI assistance: No

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
