### PR TITLE
Posts: Add $wp_error support to edit_post()

### DIFF
--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -1645,7 +1645,7 @@ function wp_ajax_add_meta() {
 				gmdate( __( 'g:i a' ), $now )
 			);
 
-			$post_id = edit_post( $post_data );
+			$post_id = edit_post( $post_data, true );
 
 			if ( $post_id ) {
 				if ( is_wp_error( $post_id ) ) {
@@ -2157,7 +2157,7 @@ function wp_ajax_inline_save() {
 	}
 
 	// Update the post.
-	edit_post();
+	edit_post( null, true );
 
 	$wp_list_table = _get_list_table( 'WP_Posts_List_Table', array( 'screen' => $_POST['screen'] ) );
 
@@ -2891,7 +2891,7 @@ function wp_ajax_wp_fullscreen_save_post() {
 
 	check_ajax_referer( 'update-post_' . $post_id, '_wpnonce' );
 
-	$post_id = edit_post();
+	$post_id = edit_post( null, true );
 
 	if ( is_wp_error( $post_id ) ) {
 		wp_send_json_error();

--- a/src/wp-admin/includes/post.php
+++ b/src/wp-admin/includes/post.php
@@ -250,9 +250,11 @@ function _wp_get_allowed_postdata( $post_data = null ) {
  *
  * @param array|null $post_data Optional. The array of post data to process.
  *                              Defaults to the `$_POST` superglobal.
- * @return int Post ID.
+ * @param bool       $wp_error  Optional. Whether to return a WP_Error on failure.
+ *                              Default false.
+ * @return int|WP_Error Post ID on success, WP_Error on failure.
  */
-function edit_post( $post_data = null ) {
+function edit_post( $post_data = null, $wp_error = false ) {
 	global $wpdb;
 
 	if ( empty( $post_data ) ) {
@@ -279,8 +281,14 @@ function edit_post( $post_data = null ) {
 	$ptype = get_post_type_object( $post_data['post_type'] );
 	if ( ! current_user_can( 'edit_post', $post_id ) ) {
 		if ( 'page' === $post_data['post_type'] ) {
+			if ( $wp_error ) {
+				return new WP_Error( 'edit_page_not_allowed', __( 'Sorry, you are not allowed to edit this page.' ) );
+			}
 			wp_die( __( 'Sorry, you are not allowed to edit this page.' ) );
 		} else {
+			if ( $wp_error ) {
+				return new WP_Error( 'edit_post_not_allowed', __( 'Sorry, you are not allowed to edit this post.' ) );
+			}
 			wp_die( __( 'Sorry, you are not allowed to edit this post.' ) );
 		}
 	}
@@ -319,6 +327,9 @@ function edit_post( $post_data = null ) {
 
 	$post_data = _wp_translate_postdata( true, $post_data );
 	if ( is_wp_error( $post_data ) ) {
+		if ( $wp_error ) {
+			return $post_data;
+		}
 		wp_die( $post_data->get_error_message() );
 	}
 	$translated = _wp_get_allowed_postdata( $post_data );
@@ -446,10 +457,10 @@ function edit_post( $post_data = null ) {
 
 	update_post_meta( $post_id, '_edit_last', get_current_user_id() );
 
-	$success = wp_update_post( $translated );
+	$success = wp_update_post( $translated, $wp_error );
 
 	// If the save failed, see if we can confidence check the main fields and try again.
-	if ( ! $success && is_callable( array( $wpdb, 'strip_invalid_text_for_column' ) ) ) {
+	if ( ( ! $success || is_wp_error( $success ) ) && is_callable( array( $wpdb, 'strip_invalid_text_for_column' ) ) ) {
 		$fields = array( 'post_title', 'post_content', 'post_excerpt' );
 
 		foreach ( $fields as $field ) {
@@ -458,7 +469,11 @@ function edit_post( $post_data = null ) {
 			}
 		}
 
-		wp_update_post( $translated );
+		$success = wp_update_post( $translated, $wp_error );
+	}
+
+	if ( is_wp_error( $success ) ) {
+		return $success;
 	}
 
 	// Now that we have an ID we can fix any attachment anchor hrefs.
@@ -2091,7 +2106,7 @@ function post_preview() {
 	if ( ! wp_check_post_lock( $post->ID ) && get_current_user_id() === (int) $post->post_author
 		&& ( 'draft' === $post->post_status || 'auto-draft' === $post->post_status )
 	) {
-		$saved_post_id = edit_post();
+		$saved_post_id = edit_post( null, true );
 	} else {
 		$is_autosave = true;
 
@@ -2167,7 +2182,7 @@ function wp_autosave( $post_data ) {
 		&& ( 'auto-draft' === $post->post_status || 'draft' === $post->post_status )
 	) {
 		// Drafts and auto-drafts are just overwritten by autosave for the same user if the post is not locked.
-		return edit_post( wp_slash( $post_data ) );
+		return edit_post( wp_slash( $post_data ), true );
 	} else {
 		/*
 		 * Non-drafts or other users' drafts are not overwritten.

--- a/src/wp-admin/includes/post.php
+++ b/src/wp-admin/includes/post.php
@@ -476,6 +476,12 @@ function edit_post( $post_data = null, $wp_error = false ) {
 		return $success;
 	}
 
+	if ( 0 === $success ) {
+		if ( $wp_error ) {
+			return new WP_Error( 'edit_post_failed', __( 'Could not update post.' ) );
+		}
+	}
+
 	// Now that we have an ID we can fix any attachment anchor hrefs.
 	_fix_attachment_links( $post_id );
 
@@ -2147,8 +2153,8 @@ function post_preview() {
  * @since 3.9.0
  *
  * @param array $post_data Associative array of the submitted post data.
- * @return mixed The value 0 or WP_Error on failure. The saved post ID on success.
- *               The ID can be the draft post_id or the autosave revision post_id.
+ * @return int|WP_Error The saved post ID on success, WP_Error on failure.
+ *                      The ID can be the draft post_id or the autosave revision post_id.
  */
 function wp_autosave( $post_data ) {
 	// Back-compat.

--- a/tests/phpunit/tests/admin/includesPost.php
+++ b/tests/phpunit/tests/admin/includesPost.php
@@ -1371,4 +1371,114 @@ class Tests_Admin_IncludesPost extends WP_UnitTestCase {
 		$this->assertNotEmpty( $response['wp-refresh-metabox-loader-nonces']['replace']['_wpnonce'] );
 		$this->assertNotEmpty( $response['wp-refresh-metabox-loader-nonces']['replace']['metabox_loader_nonce'] );
 	}
+
+	/**
+	 * Tests that edit_post() returns a WP_Error instead of wp_die() when $wp_error is true.
+	 *
+	 * @ticket 65548
+	 *
+	 * @covers ::edit_post
+	 */
+	public function test_edit_post_returns_wp_error_on_permission_failure() {
+		wp_set_current_user( self::$contributor_id );
+
+		$post      = self::factory()->post->create_and_get( array( 'post_author' => self::$admin_id ) );
+		$post_data = array(
+			'post_title' => 'Test',
+			'content'    => 'Test content',
+			'post_type'  => 'post',
+			'post_ID'    => $post->ID,
+		);
+
+		$result = edit_post( $post_data, true );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'edit_post_not_allowed', $result->get_error_code() );
+	}
+
+	/**
+	 * Tests that edit_post() returns a WP_Error for page post type when $wp_error is true.
+	 *
+	 * @ticket 65548
+	 *
+	 * @covers ::edit_post
+	 */
+	public function test_edit_post_returns_wp_error_on_page_permission_failure() {
+		wp_set_current_user( self::$contributor_id );
+
+		$post      = self::factory()->post->create_and_get(
+			array(
+				'post_author' => self::$admin_id,
+				'post_type'   => 'page',
+			)
+		);
+		$post_data = array(
+			'post_title' => 'Test',
+			'content'    => 'Test content',
+			'post_type'  => 'page',
+			'post_ID'    => $post->ID,
+		);
+
+		$result = edit_post( $post_data, true );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'edit_page_not_allowed', $result->get_error_code() );
+	}
+
+	/**
+	 * Tests that edit_post() calls wp_die() on permission failure when $wp_error is false (default).
+	 *
+	 * @ticket 65548
+	 *
+	 * @covers ::edit_post
+	 */
+	public function test_edit_post_calls_wp_die_on_permission_failure() {
+		wp_set_current_user( self::$contributor_id );
+
+		$post      = self::factory()->post->create_and_get( array( 'post_author' => self::$admin_id ) );
+		$post_data = array(
+			'post_title' => 'Test',
+			'content'    => 'Test content',
+			'post_type'  => 'post',
+			'post_ID'    => $post->ID,
+		);
+
+		$this->expectException( 'WPDieException' );
+		edit_post( $post_data );
+	}
+
+	/**
+	 * Tests that edit_post() returns a WP_Error from _wp_translate_postdata() when $wp_error is true.
+	 *
+	 * @ticket 65548
+	 *
+	 * @covers ::edit_post
+	 */
+	public function test_edit_post_returns_wp_error_on_translate_postdata_failure() {
+		wp_set_current_user( self::$contributor_id );
+
+		// Create a post owned by the contributor.
+		$post = self::factory()->post->create_and_get(
+			array(
+				'post_author' => self::$contributor_id,
+				'post_status' => 'draft',
+			)
+		);
+
+		// Set post_author to another user to trigger edit_others_posts failure in _wp_translate_postdata().
+		$post_data = array(
+			'post_title'   => 'Test',
+			'content'      => 'Test content',
+			'post_type'    => 'post',
+			'post_status'  => 'draft',
+			'post_author'  => self::$editor_id,
+			'post_ID'      => $post->ID,
+			'saveasdraft'  => true,
+		);
+
+		$result = edit_post( $post_data, true );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'edit_others_posts', $result->get_error_code() );
+	}
 }

--- a/tests/phpunit/tests/admin/includesPost.php
+++ b/tests/phpunit/tests/admin/includesPost.php
@@ -1467,13 +1467,13 @@ class Tests_Admin_IncludesPost extends WP_UnitTestCase {
 
 		// Set post_author to another user to trigger edit_others_posts failure in _wp_translate_postdata().
 		$post_data = array(
-			'post_title'   => 'Test',
-			'content'      => 'Test content',
-			'post_type'    => 'post',
-			'post_status'  => 'draft',
-			'post_author'  => self::$editor_id,
-			'post_ID'      => $post->ID,
-			'saveasdraft'  => true,
+			'post_title'  => 'Test',
+			'content'     => 'Test content',
+			'post_type'   => 'post',
+			'post_status' => 'draft',
+			'post_author' => self::$editor_id,
+			'post_ID'     => $post->ID,
+			'saveasdraft' => true,
 		);
 
 		$result = edit_post( $post_data, true );


### PR DESCRIPTION
This PR introduces a `$wp_error` parameter to `edit_post()`, allowing it to return a `WP_Error` on failure instead of always calling `wp_die()`. It also updates all callers that previously performed unreachable `is_wp_error()` checks on the return value, making those code paths functional. Includes tests and edge-case handling for the 0 return from `wp_update_post()`.

Trac ticket: https://core.trac.wordpress.org/ticket/65548

## What Changes?

- Added a $wp_error parameter (default false) to edit_post() in src/wp-admin/includes/post.php
- When $wp_error is true, the function returns WP_Error instead of calling wp_die() in three failure paths:
- Permission check (edit_post_not_allowed / edit_page_not_allowed)
- _wp_translate_postdata() validation failure
- wp_update_post() save failure (including a WP_Error passthrough and a 0 === $success edge case)
- Passed $wp_error through to both wp_update_post() calls and expanded the fallback retry condition to handle WP_Error returns
- Updated post_preview(), wp_autosave(), wp_ajax_add_meta(), wp_ajax_inline_save(), and wp_ajax_wp_fullscreen_save_post() to pass $wp_error = true
- Added 4 PHPUnit tests covering permission failure for posts and pages, wp_die backward compatibility, and the _wp_translate_postdata error path

## Why?
- `edit_post()` historically either returned the post ID or killed execution with `wp_die()`. 
- However, at least three callers checked its return value with `is_wp_error()` - a pointless operation since the function could never return one. 
- This technical debt is addressed by following the same `$wp_error pattern` used by `wp_insert_post()`, `wp_update_post()`, and many other core functions, making `edit_post()` consistent with the rest of the API while preserving full backward compatibility.

## Use of AI Tools

AI assistance: Yes
Tool(s): Antigravity
Model(s): Gemini 3.1 Pro
Used for: Addition of relevant tests for verification of currently implemented patch.