### PR TITLE
Tests: Add tests for term slug generation with duplicate names

### DIFF
--- a/tests/phpunit/tests/term/wpInsertTerm.php
+++ b/tests/phpunit/tests/term/wpInsertTerm.php
@@ -907,6 +907,77 @@ class Tests_Term_WpInsertTerm extends WP_UnitTestCase {
 		$this->assertSame( 'invalid_term_name', $term->get_error_code() );
 	}
 
+	/**
+	 * @ticket 31270
+	 */
+	public function test_wp_insert_term_root_level_term_with_same_name_as_child_should_get_clean_slug() {
+		register_taxonomy( 'wptests_tax', 'post', array( 'hierarchical' => true ) );
+
+		$t1 = self::factory()->term->create(
+			array(
+				'name'     => 'Foo',
+				'taxonomy' => 'wptests_tax',
+			)
+		);
+
+		self::factory()->term->create(
+			array(
+				'name'     => 'Bar',
+				'slug'     => 'foo-bar',
+				'parent'   => $t1,
+				'taxonomy' => 'wptests_tax',
+			)
+		);
+
+		$t3 = wp_insert_term( 'Bar', 'wptests_tax' );
+
+		$this->assertNotWPError( $t3 );
+		$t3_term = get_term( $t3['term_id'], 'wptests_tax' );
+		$this->assertSame( 'bar', $t3_term->slug );
+	}
+
+	/**
+	 * @ticket 31270
+	 */
+	public function test_wp_insert_term_child_term_with_same_name_as_another_child_under_different_parent_should_get_clean_slug() {
+		register_taxonomy( 'wptests_tax', 'post', array( 'hierarchical' => true ) );
+
+		$t1 = self::factory()->term->create(
+			array(
+				'name'     => 'Parent One',
+				'taxonomy' => 'wptests_tax',
+			)
+		);
+
+		$t2 = self::factory()->term->create(
+			array(
+				'name'     => 'Parent Two',
+				'taxonomy' => 'wptests_tax',
+			)
+		);
+
+		self::factory()->term->create(
+			array(
+				'name'     => 'Child',
+				'slug'     => 'parent-one-child',
+				'parent'   => $t1,
+				'taxonomy' => 'wptests_tax',
+			)
+		);
+
+		$t4 = wp_insert_term(
+			'Child',
+			'wptests_tax',
+			array(
+				'parent' => $t2,
+			)
+		);
+
+		$this->assertNotWPError( $t4 );
+		$t4_term = get_term( $t4['term_id'], 'wptests_tax' );
+		$this->assertSame( 'child', $t4_term->slug );
+	}
+
 	/** Helpers */
 
 	public function deleted_term_cb( $term, $tt_id, $taxonomy, $deleted_term, $object_ids ) {


### PR DESCRIPTION
The originally reported bug (incorrect slug prefixes for same-named terms at different hierarchy levels) was already silently fixed in a previous refactoring of wp_insert_term().

This PR formally closes the ticket by adding two focused unit tests to verify the correct behavior and prevent future regressions.

Trac ticket: [#31270](https://core.trac.wordpress.org/ticket/31270)

## Use of AI Tools

AI assistance: Yes
Tool(s): GitHub Copilot
Model(s): Gemini, Claude
Used for: Checking for potential edge cases, drafting the PR description, and assisting with local code review. The final implementation and testing were written and executed manually by me.

---

**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
