### PR TITLE
REST API: Reject non-string custom CSS in the global styles controller

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-global-styles-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-global-styles-controller.php
@@ -673,13 +673,22 @@ class WP_REST_Global_Styles_Controller extends WP_REST_Posts_Controller {
 	 * @since 7.0.0 Only restricts contents which risk prematurely closing the STYLE element,
 	 *              either through a STYLE end tag or a prefix of one which might become a
 	 *              full end tag when combined with the contents of other styles.
+	 * @since 7.1.0 Rejects non-string values with a WP_Error instead of a fatal error.
 	 *
 	 * @see WP_Customize_Custom_CSS_Setting::validate()
 	 *
-	 * @param string $css CSS to validate.
+	 * @param mixed $css CSS to validate.
 	 * @return true|WP_Error True if the input was validated, otherwise WP_Error.
 	 */
 	protected function validate_custom_css( $css ) {
+		if ( ! is_string( $css ) ) {
+			return new WP_Error(
+				'rest_custom_css_invalid_type',
+				__( 'CSS must be a string.' ),
+				array( 'status' => 400 )
+			);
+		}
+
 		$length = strlen( $css );
 		for (
 			$at = strcspn( $css, '<' );

--- a/tests/phpunit/tests/rest-api/rest-global-styles-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-global-styles-controller.php
@@ -668,6 +668,25 @@ class WP_REST_Global_Styles_Controller_Test extends WP_Test_REST_Controller_Test
 	}
 
 	/**
+	 * @covers WP_REST_Global_Styles_Controller::update_item
+	 * @ticket 65640
+	 */
+	public function test_update_item_non_string_styles_css() {
+		wp_set_current_user( self::$admin_id );
+		if ( is_multisite() ) {
+			grant_super_admin( self::$admin_id );
+		}
+		$request = new WP_REST_Request( 'PUT', '/wp/v2/global-styles/' . self::$global_styles_id );
+		$request->set_body_params(
+			array(
+				'styles' => array( 'css' => array( 'body { color: red; }' ) ),
+			)
+		);
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertErrorResponse( 'rest_custom_css_invalid_type', $response, 400 );
+	}
+
+	/**
 	 * Tests the submission of a custom block style variation that was defined
 	 * within a theme style variation and wouldn't be registered at the time
 	 * of saving via the API.
@@ -944,6 +963,44 @@ CSS;
 			'truncated "</sty"'          => array( '</sty', 'The CSS must not end in "&lt;/sty".' ),
 			'truncated "</STYL"'         => array( '</STYL', 'The CSS must not end in "&lt;/STYL".' ),
 			'truncated "</stYle"'        => array( '</stYle', 'The CSS must not end in "&lt;/stYle".' ),
+		);
+	}
+
+	/**
+	 * @covers WP_REST_Global_Styles_Controller::validate_custom_css
+	 * @ticket 65640
+	 *
+	 * @dataProvider data_custom_css_non_string
+	 *
+	 * @param mixed $custom_css Non-string value to validate.
+	 */
+	public function test_validate_custom_css_non_string( $custom_css ) {
+		$controller = new WP_REST_Global_Styles_Controller();
+		$validate   = Closure::bind(
+			function ( $css ) {
+				return $this->validate_custom_css( $css );
+			},
+			$controller,
+			$controller
+		);
+
+		$result = $validate( $custom_css );
+		$this->assertWPError( $result );
+		$this->assertSame( 'rest_custom_css_invalid_type', $result->get_error_code() );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array<string, mixed[]>
+	 */
+	public static function data_custom_css_non_string(): array {
+		return array(
+			'array'   => array( array( 'body { color: red; }' ) ),
+			'integer' => array( 123 ),
+			'boolean' => array( true ),
+			'null'    => array( null ),
+			'object'  => array( new stdClass() ),
 		);
 	}
 }


### PR DESCRIPTION
`styles.css` has no type constraint in the global styles request schema, so a REST consumer can PUT an array (or any non-string value). That value reaches `strlen()` in `validate_custom_css()` and throws an uncaught `TypeError` on PHP 8+.

Guard `validate_custom_css()` against non-string input, returning a `rest_custom_css_invalid_type` `WP_Error` with a 400 status instead of a fatal.

Adds a controller test that PUTs `styles.css` as an array and asserts the 400 response, plus unit tests covering array, integer, boolean, null, and object values.

Backports https://github.com/WordPress/gutenberg/pull/80338

Trac ticket: https://core.trac.wordpress.org/ticket/65640
