### PR TITLE
Comments: Exclude notes from get_page_of_comment().

### DIFF
--- a/src/wp-includes/comment.php
+++ b/src/wp-includes/comment.php
@@ -1100,14 +1100,15 @@ function get_page_of_comment( $comment_id, $args = array() ) {
 		}
 
 		$comment_args = array(
-			'type'       => $args['type'],
-			'post_id'    => $comment->comment_post_ID,
-			'fields'     => 'ids',
-			'count'      => true,
-			'status'     => 'approve',
-			'orderby'    => 'none',
-			'parent'     => 0,
-			'date_query' => array(
+			'type'         => $args['type'],
+			'type__not_in' => array( 'note' ),
+			'post_id'      => $comment->comment_post_ID,
+			'fields'       => 'ids',
+			'count'        => true,
+			'status'       => 'approve',
+			'orderby'      => 'none',
+			'parent'       => 0,
+			'date_query'   => array(
 				array(
 					'column' => "$wpdb->comments.comment_date_gmt",
 					'before' => $comment->comment_date_gmt,

--- a/tests/phpunit/tests/comment/getPageOfComment.php
+++ b/tests/phpunit/tests/comment/getPageOfComment.php
@@ -36,6 +36,38 @@ class Tests_Comment_GetPageOfComment extends WP_UnitTestCase {
 		$this->assertSame( 1, get_page_of_comment( $comment_first[0], array( 'per_page' => 10 ) ) );
 	}
 
+	/**
+	 * Ensures that internal 'note' comments are excluded from the page calculation.
+	 *
+	 * Notes share the comments table but are never displayed in the public comment
+	 * list, so they must not shift the page a regular comment appears on.
+	 *
+	 * @ticket 65642
+	 *
+	 * @covers ::get_page_of_comment
+	 */
+	public function test_notes_should_not_affect_page() {
+		$p = self::factory()->post->create();
+
+		self::factory()->comment->create_post_comments( $p, 1, array( 'comment_date' => '2013-09-14 00:00:00' ) );
+
+		// An internal note dated between the two regular comments must be ignored.
+		self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => $p,
+				'comment_type'     => 'note',
+				'comment_approved' => '1',
+				'comment_parent'   => 0,
+				'comment_date'     => '2013-09-15 00:00:00',
+			)
+		);
+
+		$comment_target = self::factory()->comment->create_post_comments( $p, 1, array( 'comment_date' => '2013-09-16 00:00:00' ) );
+
+		// Only one regular comment precedes the target, so it is on page 2.
+		$this->assertSame( 2, get_page_of_comment( $comment_target[0], array( 'per_page' => 1 ) ) );
+	}
+
 	public function test_type_pings() {
 		$p   = self::factory()->post->create();
 		$now = time();


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65642

Follow-up to the notes work in #64474.

## Summary

Internal `note` comments (the block-notes feature, 6.9) inflate the page number returned by `get_page_of_comment()`, which can send visitors to the wrong comments page via `get_comment_link()`.

`get_page_of_comment()` builds its count query with `type => 'all'` (its default). `WP_Comment_Query` deliberately does **not** exclude the `note` type when `type` is `'all'` — this was confirmed as intended behavior in #64474:

> When using the WP_Comment_Query class, it is correct behaviour that `note` comment types will be included when `type=all` is requested. However, on the comment table, the note comment type should always be excluded. — #64474

The public comment list (`comments_template()`) queries with `type => ''`, which **does** exclude notes. So the two disagree: the displayed list omits notes, but the pagination math counts them. On a post that has a note and "Break comments into pages" enabled, a note dated before a given comment shifts that comment onto a later `cpage` than the one it actually renders on.

## Reproduction

1. Settings → Discussion → enable "Break comments into pages", 1 comment per page.
2. On a post: add a regular comment, add an internal note dated after it, then add a second regular comment.
3. `get_page_of_comment()` for the second comment returns **3** instead of **2** — the note occupies a phantom page.

## Fix

Exclude notes from the count query in `get_page_of_comment()` by passing `type__not_in => array( 'note' )`, aligning the pagination calculation with the public comment display. This mirrors the fix applied to the comments list table in [61525] / #64474 (`type__not_in => 'note'` at the surface that must never show notes), rather than changing `WP_Comment_Query`'s intended `type=all` semantics.

## Testing

Added `test_notes_should_not_affect_page` to `Tests_Comment_GetPageOfComment`.

- Before the fix, it fails: `Failed asserting that 3 is identical to 2`.
- After the fix, it passes.

Full comment group is green:

```
./vendor/bin/phpunit --group comment
OK (583 tests, 1428 assertions)
```

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 4.8
Used for: Investigating the notes-exclusion surfaces, reproducing the pagination bug, implementing the fix, and writing the regression test. All changes were reviewed by me.
