### PR TITLE
Abilities API: Avoid _doing_it_wrong() on REST lookups of unknown abilities.

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-abilities-v1-categories-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-abilities-v1-categories-controller.php
@@ -142,7 +142,7 @@ class WP_REST_Abilities_V1_Categories_Controller extends WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function get_item( $request ) {
-		$category = wp_get_ability_category( $request['slug'] );
+		$category = wp_has_ability_category( $request['slug'] ) ? wp_get_ability_category( $request['slug'] ) : null;
 		if ( ! $category ) {
 			return new WP_Error(
 				'rest_ability_category_not_found',

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-abilities-v1-list-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-abilities-v1-list-controller.php
@@ -156,7 +156,7 @@ class WP_REST_Abilities_V1_List_Controller extends WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function get_item( $request ) {
-		$ability = wp_get_ability( $request['name'] );
+		$ability = wp_has_ability( $request['name'] ) ? wp_get_ability( $request['name'] ) : null;
 		if ( ! $ability || ! $ability->get_meta_item( 'show_in_rest' ) ) {
 			return new WP_Error(
 				'rest_ability_not_found',

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-abilities-v1-run-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-abilities-v1-run-controller.php
@@ -80,7 +80,7 @@ class WP_REST_Abilities_V1_Run_Controller extends WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function execute_ability( $request ) {
-		$ability = wp_get_ability( $request['name'] );
+		$ability = wp_has_ability( $request['name'] ) ? wp_get_ability( $request['name'] ) : null;
 		if ( ! $ability ) {
 			return new WP_Error(
 				'rest_ability_not_found',
@@ -141,7 +141,7 @@ class WP_REST_Abilities_V1_Run_Controller extends WP_REST_Controller {
 	 * @return true|WP_Error True if the request has execution permission, WP_Error object otherwise.
 	 */
 	public function check_ability_permissions( $request ) {
-		$ability = wp_get_ability( $request['name'] );
+		$ability = wp_has_ability( $request['name'] ) ? wp_get_ability( $request['name'] ) : null;
 		if ( ! $ability || ! $ability->get_meta_item( 'show_in_rest' ) ) {
 			return new WP_Error(
 				'rest_ability_not_found',
@@ -239,7 +239,7 @@ class WP_REST_Abilities_V1_Run_Controller extends WP_REST_Controller {
 	 * @return mixed Coerced input, or the raw input when it cannot be safely coerced.
 	 */
 	public function sanitize_input_for_ability( $input, $request ) {
-		$ability = wp_get_ability( $request['name'] );
+		$ability = wp_has_ability( $request['name'] ) ? wp_get_ability( $request['name'] ) : null;
 		if ( ! $ability instanceof WP_Ability ) {
 			return $input;
 		}

--- a/tests/phpunit/tests/rest-api/wpRestAbilitiesV1CategoriesController.php
+++ b/tests/phpunit/tests/rest-api/wpRestAbilitiesV1CategoriesController.php
@@ -219,8 +219,7 @@ class Tests_REST_API_WpRestAbilitiesV1CategoriesController extends WP_UnitTestCa
 	 * Test getting a non-existent ability category returns 404.
 	 *
 	 * @ticket 64098
-	 *
-	 * @expectedIncorrectUsage WP_Ability_Categories_Registry::get_registered
+	 * @ticket 65644
 	 */
 	public function test_get_item_not_found(): void {
 		$request  = new WP_REST_Request( 'GET', '/wp-abilities/v1/categories/non-existent' );

--- a/tests/phpunit/tests/rest-api/wpRestAbilitiesV1ListController.php
+++ b/tests/phpunit/tests/rest-api/wpRestAbilitiesV1ListController.php
@@ -386,8 +386,7 @@ class Tests_REST_API_WpRestAbilitiesV1ListController extends WP_UnitTestCase {
 	 * Test getting a non-existent ability returns 404.
 	 *
 	 * @ticket 64098
-	 *
-	 * @expectedIncorrectUsage WP_Abilities_Registry::get_registered
+	 * @ticket 65644
 	 */
 	public function test_get_item_not_found(): void {
 		$request  = new WP_REST_Request( 'GET', '/wp-abilities/v1/abilities/non/existent' );
@@ -768,8 +767,7 @@ class Tests_REST_API_WpRestAbilitiesV1ListController extends WP_UnitTestCase {
 	 * Test extremely long ability names.
 	 *
 	 * @ticket 64098
-	 *
-	 * @expectedIncorrectUsage WP_Abilities_Registry::get_registered
+	 * @ticket 65644
 	 */
 	public function test_extremely_long_ability_names(): void {
 		// Create a very long but valid ability name

--- a/tests/phpunit/tests/rest-api/wpRestAbilitiesV1RunController.php
+++ b/tests/phpunit/tests/rest-api/wpRestAbilitiesV1RunController.php
@@ -716,8 +716,7 @@ class Tests_REST_API_WpRestAbilitiesV1RunController extends WP_UnitTestCase {
 	 * Test non-existent ability returns 404.
 	 *
 	 * @ticket 64098
-	 *
-	 * @expectedIncorrectUsage WP_Abilities_Registry::get_registered
+	 * @ticket 65644
 	 */
 	public function test_execute_non_existent_ability(): void {
 		$request = new WP_REST_Request( 'POST', '/wp-abilities/v1/abilities/non/existent/run' );


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65644

## Summary

The Abilities REST controllers resolve an ability (or category) from the name/slug in the request URL and return a 404 when it does not exist — calling `wp_get_ability()` / `wp_get_ability_category()` directly:

```php
$ability = wp_get_ability( $request['name'] );
if ( ! $ability ) {
    return new WP_Error( 'rest_ability_not_found', __( 'Ability not found.' ), array( 'status' => 404 ) );
}
```

Those functions delegate to `WP_Abilities_Registry::get_registered()` / `WP_Ability_Categories_Registry::get_registered()`, which deliberately call `_doing_it_wrong()` for an unknown name to flag developer misuse. Because the name is **client-controlled**, a routine 404 for a non-existent ability fires `_doing_it_wrong()` on every such request — including via the run endpoint's `permission_callback`, so unauthenticated requests trigger it too.

Core's `rest_api_default_filters()` suppresses the `trigger_error()` output during REST requests (see #64260), but the `doing_it_wrong_run` action still fires, so the notice surfaces in **Query Monitor**, in `doing_it_wrong_run` listeners / logging plugins, and in the test suite — the not-found REST controller tests currently carried `@expectedIncorrectUsage`. Existence-probing a public endpoint should not emit a developer "doing it wrong" warning.

## Reproduction

`POST /wp-json/wp-abilities/v1/abilities/non/existent/run` returns the expected 404, but (surfaced via Query Monitor / the `doing_it_wrong_run` action) `_doing_it_wrong()` fires:

> `WP_Abilities_Registry::get_registered` was called incorrectly. Ability "non/existent" not found.

See the before/after screenshots on the Trac ticket.

## Fix

Guard each REST lookup with the non-warning existence helper before calling the getter:

```php
$ability = wp_has_ability( $request['name'] ) ? wp_get_ability( $request['name'] ) : null;
```

A missing ability then yields a clean 404 with no `_doing_it_wrong()`. The registry getters keep warning on **direct** misuse (that behavior is intentional and separately tested — unchanged here). Applied to all five lookup sites across the run, list, and categories controllers.

## Testing

Removed the now-unnecessary `@expectedIncorrectUsage` annotations from the four affected not-found REST tests, which now assert a **clean** 404.

- Before the fix, those tests fail: `Unexpected incorrect usage notice for WP_Abilities_Registry::get_registered`.
- After the fix, they pass.

Full suites green:

```
Abilities REST controllers: 67 tests
--group abilities-api: 361 tests, 962 assertions
```

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 4.8
Used for: Locating the affected call sites, reproducing the notice, implementing the guards, and updating the tests. All changes were reviewed by me.
