### PR TITLE
Admin: Return `WP_Error` from `add_meta()` for protected or unauthorized meta keys 

### DIFF
--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -1660,7 +1660,9 @@ function wp_ajax_add_meta() {
 
 				$meta_id = add_meta( $post_id );
 
-				if ( ! $meta_id ) {
+				if ( is_wp_error( $meta_id ) ) {
+					wp_die( $meta_id->get_error_message() );
+				} elseif ( ! $meta_id ) {
 					wp_die( __( 'Please provide a custom field value.' ) );
 				}
 			} else {
@@ -1669,7 +1671,9 @@ function wp_ajax_add_meta() {
 		} else {
 			$meta_id = add_meta( $post_id );
 
-			if ( ! $meta_id ) {
+			if ( is_wp_error( $meta_id ) ) {
+				wp_die( $meta_id->get_error_message() );
+			} elseif ( ! $meta_id ) {
 				wp_die( __( 'Please provide a custom field value.' ) );
 			}
 		}
@@ -1707,7 +1711,7 @@ function wp_ajax_add_meta() {
 			! current_user_can( 'edit_post_meta', $meta->post_id, $meta->meta_key ) ||
 			! current_user_can( 'edit_post_meta', $meta->post_id, $key )
 		) {
-			wp_die( -1 );
+			wp_die( __( 'Sorry, you are not allowed to edit this custom field.' ) );
 		}
 
 		if ( $meta->meta_value !== $value || $meta->meta_key !== $key ) {

--- a/src/wp-admin/includes/post.php
+++ b/src/wp-admin/includes/post.php
@@ -1001,9 +1001,12 @@ function write_post() {
  * Adds post meta data defined in the `$_POST` superglobal for a post with given ID.
  *
  * @since 1.2.0
+ * @since 7.1.0 Returns a WP_Error object when the meta key is protected or the user
+ *              does not have the capability to add post meta.
  *
  * @param int $post_id
- * @return int|bool
+ * @return int|bool|WP_Error Meta ID on success, false if no key/value pair was provided,
+ *                           WP_Error if the meta key is protected or the user lacks capability.
  */
 function add_meta( $post_id ) {
 	$post_id = (int) $post_id;
@@ -1029,7 +1032,10 @@ function add_meta( $post_id ) {
 		}
 
 		if ( is_protected_meta( $metakey, 'post' ) || ! current_user_can( 'add_post_meta', $post_id, $metakey ) ) {
-			return false;
+			return new WP_Error(
+				'protected_meta',
+				__( 'Sorry, you are not allowed to add this custom field.' )
+			);
 		}
 
 		$metakey = wp_slash( $metakey );

--- a/tests/phpunit/tests/admin/includesPost.php
+++ b/tests/phpunit/tests/admin/includesPost.php
@@ -1170,22 +1170,22 @@ class Tests_Admin_IncludesPost extends WP_UnitTestCase {
 	 */
 	public function data_add_meta_authorization() {
 		return array(
-			'has capability, unprotected metakey'     => array(
+			'has capability, unprotected metakey' => array(
 				'metakey'        => 'ordinary_key',
 				'role'           => 'administrator',
 				'expected_error' => false,
 			),
-			'no capability, unprotected metakey'      => array(
+			'no capability, unprotected metakey'  => array(
 				'metakey'        => 'ordinary_key',
 				'role'           => 'subscriber',
 				'expected_error' => true,
 			),
-			'has capability, protected metakey'       => array(
+			'has capability, protected metakey'   => array(
 				'metakey'        => '_protected_testkey',
 				'role'           => 'administrator',
 				'expected_error' => true,
 			),
-			'no capability, protected metakey'        => array(
+			'no capability, protected metakey'    => array(
 				'metakey'        => '_protected_testkey',
 				'role'           => 'subscriber',
 				'expected_error' => true,

--- a/tests/phpunit/tests/admin/includesPost.php
+++ b/tests/phpunit/tests/admin/includesPost.php
@@ -1163,6 +1163,11 @@ class Tests_Admin_IncludesPost extends WP_UnitTestCase {
 		$this->assertSame( '', get_post_meta( $p, 'testkey', true ) );
 	}
 
+	/**
+	 * Data provider for test_add_meta_authorization.
+	 *
+	 * @return array[]
+	 */
 	public function data_add_meta_authorization() {
 		return array(
 			'has capability, unprotected metakey'     => array(
@@ -1188,6 +1193,13 @@ class Tests_Admin_IncludesPost extends WP_UnitTestCase {
 		);
 	}
 
+	/**
+	 * @ticket 32565
+	 *
+	 * @covers ::add_meta
+	 *
+	 * @dataProvider data_add_meta_authorization
+	 */
 	public function test_add_meta_authorization( string $metakey, string $role, bool $expected_error ) {
 		$post_id = self::factory()->post->create();
 		$user_id = 'administrator' === $role ? self::$admin_id : self::factory()->user->create( array( 'role' => $role ) );

--- a/tests/phpunit/tests/admin/includesPost.php
+++ b/tests/phpunit/tests/admin/includesPost.php
@@ -1188,6 +1188,28 @@ class Tests_Admin_IncludesPost extends WP_UnitTestCase {
 		);
 	}
 
+	public function test_add_meta_authorization( string $metakey, string $role, bool $expected_error ) {
+		$post_id = self::factory()->post->create();
+		$user_id = 'administrator' === $role ? self::$admin_id : self::factory()->user->create( array( 'role' => $role ) );
+
+		$_POST = array(
+			'metakeyinput' => $metakey,
+			'metavalue'    => 'test_value',
+		);
+
+		wp_set_current_user( $user_id );
+
+		$result = add_meta( $post_id );
+
+		if ( $expected_error ) {
+			$this->assertWPError( $result );
+			$this->assertSame( 'protected_meta', $result->get_error_code() );
+		} else {
+			$this->assertIsInt( $result );
+			$this->assertSame( 'test_value', get_post_meta( $post_id, $metakey, true ) );
+		}
+	}
+
 	/**
 	 * Test the post type support in post_exists().
 	 *

--- a/tests/phpunit/tests/admin/includesPost.php
+++ b/tests/phpunit/tests/admin/includesPost.php
@@ -1163,6 +1163,31 @@ class Tests_Admin_IncludesPost extends WP_UnitTestCase {
 		$this->assertSame( '', get_post_meta( $p, 'testkey', true ) );
 	}
 
+	public function data_add_meta_authorization() {
+		return array(
+			'has capability, unprotected metakey'     => array(
+				'metakey'        => 'ordinary_key',
+				'role'           => 'administrator',
+				'expected_error' => false,
+			),
+			'no capability, unprotected metakey'      => array(
+				'metakey'        => 'ordinary_key',
+				'role'           => 'subscriber',
+				'expected_error' => true,
+			),
+			'has capability, protected metakey'       => array(
+				'metakey'        => '_protected_testkey',
+				'role'           => 'administrator',
+				'expected_error' => true,
+			),
+			'no capability, protected metakey'        => array(
+				'metakey'        => '_protected_testkey',
+				'role'           => 'subscriber',
+				'expected_error' => true,
+			),
+		);
+	}
+
 	/**
 	 * Test the post type support in post_exists().
 	 *


### PR DESCRIPTION

Trac ticket: https://core.trac.wordpress.org/ticket/32565

When a user tried to add a custom field with an underscore-prefixed (protected) key via the Classic Editor's Custom Fields panel, WordPress showed:

> "Please provide a custom field value."

This is misleading as the value was present, but the key is protected. The root cause is that `add_meta()` returned plain `false` for two distinct failure modes (missing value *and* protected/unauthorized key), making them indistinguishable to the AJAX handler.


- **`post.php`** - `add_meta()` now returns a `WP_Error` (code `protected_meta`) when the key is protected or the user lacks `add_post_meta` capability. Plain `false` is kept for "no key/value pair provided" to preserve
  backward compatibility.
- **`ajax-actions.php`** - `wp_ajax_add_meta()` checks `is_wp_error()` before the existing `! $meta_id` fallback so each failure gets the right message. The update path is also updated from `wp_die( -1 )` to a translatable human-readable string for consistency.
- **`tests/phpunit/tests/admin/includesPost.php`** - the data-provider test covers all 4 authorization and protection scenarios in a single method (admin vs subscriber, protected vs unprotected key).

#### Testing

```bash
npm run test:php -- --filter=Tests_Admin_IncludesPost
```

