### PR TITLE
get_block_templates(): Fix non-sequential array keys for registry-only template matches

### DIFF
--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -1255,7 +1255,7 @@ function get_block_templates( $query = array(), $template_type = 'wp_template' )
 				$matching_registered_templates
 			);
 
-			$query_result = array_merge( $query_result, $matching_registered_templates );
+			$query_result = array_merge( $query_result, array_values( $matching_registered_templates ) );
 		}
 	}
 

--- a/tests/phpunit/tests/blocks/editor.php
+++ b/tests/phpunit/tests/blocks/editor.php
@@ -485,6 +485,39 @@ class Tests_Blocks_Editor extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Reproduces WordPress/gutenberg#80291: PHP warnings when a
+	 * plugin-registered template (registered via register_block_template())
+	 * is assigned to an individual post that hasn't had that template saved
+	 * as a 'wp_template' post yet.
+	 *
+	 * @ticket <fill in Trac ticket number>
+	 */
+	public function test_wp_get_post_content_block_attributes_with_registry_only_assigned_template() {
+		switch_theme( 'block-theme' );
+
+		$template_name = 'test-plugin//solo-post-template';
+		register_block_template(
+			$template_name,
+			array(
+				'content'    => '<!-- wp:post-content {"layout":{"type":"constrained"}} /-->',
+				'post_types' => array( 'post' ),
+			)
+		);
+
+		$post_id = self::factory()->post->create();
+		update_post_meta( $post_id, '_wp_page_template', 'solo-post-template' );
+
+		global $post_ID;
+		$post_ID = $post_id;
+
+		$attributes = wp_get_post_content_block_attributes();
+
+		unregister_block_template( $template_name );
+
+		$this->assertSame( array( 'layout' => array( 'type' => 'constrained' ) ), $attributes );
+	}
+
+	/**
 	 * @ticket 53458
 	 */
 	public function test_get_block_editor_settings_theme_json_settings() {

--- a/tests/phpunit/tests/blocks/getBlockTemplates.php
+++ b/tests/phpunit/tests/blocks/getBlockTemplates.php
@@ -260,6 +260,44 @@ class Tests_Blocks_GetBlockTemplates extends WP_UnitTestCase {
 	}
 
 	/**
+	 * When the only template matching the query comes from the plugin
+	 * template registry — i.e. there is no corresponding 'wp_template' post
+	 * and no matching theme template file — get_block_templates() must
+	 * still return a sequentially indexed array so that callers can safely
+	 * rely on $templates[0].
+	 *
+	 * @ticket <fill in Trac ticket number>
+	 *
+	 * @covers ::get_block_templates
+	 */
+	public function test_get_block_templates_returns_sequentially_indexed_array_for_registry_only_match() {
+		$template_name = 'test-plugin//registry-only-template';
+		register_block_template(
+			$template_name,
+			array(
+				'content'    => 'Template content',
+				'post_types' => array( 'post' ),
+			)
+		);
+
+		$templates = get_block_templates( array( 'slug__in' => array( 'registry-only-template' ) ) );
+
+		unregister_block_template( $template_name );
+
+		$this->assertSame(
+			array_values( $templates ),
+			$templates,
+			'get_block_templates() must return a sequentially indexed array, even when the only match comes from the plugin template registry.'
+		);
+		$this->assertArrayHasKey(
+			0,
+			$templates,
+			'Index 0 must exist so callers like wp_get_post_content_block_attributes() can safely access $templates[0].'
+		);
+		$this->assertSame( 'registry-only-template', $templates[0]->slug );
+	}
+
+	/**
 	 * Data provider.
 	 *
 	 * Make sure that plugin-registered templates with default post type slugs (ie: `single` or `page`)


### PR DESCRIPTION


Trac ticket: https://core.trac.wordpress.org/ticket/65689

### What Why How

**get_block_templates()** returns an array whose keys are not sequential when the only matching template comes from the plugin template registry (**WP_Block_Templates_Registry**), which stores templates keyed by name. When no **wp_template** post or theme file also matches, `array_merge()` carries those string keys straight into the result with no numeric `0` index.

This breaks callers that assume a plain list, e.g. **wp_get_post_content_block_attributes()** in `block-editor.php`, which accesses `$templates[0]`. Reproduced in https://github.com/WordPress/gutenberg/issues/80291 : assigning a plugin-registered template to a post and opening it in the editor triggers PHP warnings and deprecation notices.

Two tests added:
- **test_get_block_templates_returns_sequentially_indexed_array_for_registry_only_match** - asserts `get_block_templates()` returns a sequentially indexed array when the registry is the sole match.
- **test_wp_get_post_content_block_attributes_with_registry_only_assigned_template** - reproduces the original issue end-to-end.



### Before 
Both the tests I added were failing locally.

### After 

<img width="1034" height="333" alt="image" src="https://github.com/user-attachments/assets/eace6bbc-3db2-435f-934e-f3f6d01d0f28" />

<img width="1011" height="349" alt="image" src="https://github.com/user-attachments/assets/26d0b220-ec50-4026-ad36-3b065dfb4245" />


## Use of AI Tools

AI assistance: Yes
Tool(s): Claude
Model(s): Claude Sonnet 4.5
