### PR TITLE
Tests: Improve coverage for url_shorten() and test the previously unexercised $length parameter

### DIFF
--- a/tests/phpunit/tests/formatting/urlShorten.php
+++ b/tests/phpunit/tests/formatting/urlShorten.php
@@ -6,20 +6,80 @@
  * @covers ::url_shorten
  */
 class Tests_Formatting_UrlShorten extends WP_UnitTestCase {
-	public function test_url_shorten() {
-		$tests = array(
-			'wordpress\.org/about/philosophy'            => 'wordpress\.org/about/philosophy', // No longer strips slashes.
-			'wordpress.org/about/philosophy'             => 'wordpress.org/about/philosophy',
-			'http://wordpress.org/about/philosophy/'     => 'wordpress.org/about/philosophy',  // Remove http, trailing slash.
-			'http://www.wordpress.org/about/philosophy/' => 'wordpress.org/about/philosophy',  // Remove http, www.
-			'http://wordpress.org/about/philosophy/#box' => 'wordpress.org/about/philosophy/#box',            // Don't shorten 35 characters.
-			'http://wordpress.org/about/philosophy/#decisions' => 'wordpress.org/about/philosophy/#&hellip;', // Shorten to 32 if > 35 after cleaning.
-		);
-		foreach ( $tests as $k => $v ) {
-			$this->assertSame( $v, url_shorten( $k ) );
-		}
 
-		// Shorten to 31 if > 34 after cleaning.
-		$this->assertSame( 'wordpress.org/about/philosophy/#&hellip;', url_shorten( 'http://wordpress.org/about/philosophy/#decisions' ), 31 );
+	/**
+	 * @dataProvider data_url_shorten
+	 *
+	 * @param string $expected Expected shortened URL.
+	 * @param string $url      URL to shorten.
+	 */
+	public function test_url_shorten( $expected, $url ) {
+		$this->assertSame( $expected, url_shorten( $url ) );
+	}
+
+	public function data_url_shorten() {
+		// When shortened, the URL is cut to ( $length - 3 ) characters before '&hellip;' is appended.
+		return array(
+			'escaped slashes are not stripped' => array(
+				'wordpress\.org/about/philosophy',
+				'wordpress\.org/about/philosophy',
+			),
+			'no change needed'                 => array(
+				'wordpress.org/about/philosophy',
+				'wordpress.org/about/philosophy',
+			),
+			'http and trailing slash removed'  => array(
+				'wordpress.org/about/philosophy',
+				'http://wordpress.org/about/philosophy/',
+			),
+			'http and www removed'             => array(
+				'wordpress.org/about/philosophy',
+				'http://www.wordpress.org/about/philosophy/',
+			),
+			'exactly 35 characters kept'       => array(
+				'wordpress.org/about/philosophy/#box',
+				'http://wordpress.org/about/philosophy/#box',
+			),
+			'shortened to 32 when over 35'     => array(
+				'wordpress.org/about/philosophy/#&hellip;',
+				'http://wordpress.org/about/philosophy/#decisions',
+			),
+		);
+	}
+
+	/**
+	 * Ensures the optional $length parameter overrides the default of 35.
+	 *
+	 * @dataProvider data_url_shorten_custom_length
+	 *
+	 * @param string $expected Expected shortened URL.
+	 * @param string $url      URL to shorten.
+	 * @param int    $length   Maximum length of the shortened URL.
+	 */
+	public function test_url_shorten_respects_custom_length( $expected, $url, $length ) {
+		$this->assertSame( $expected, url_shorten( $url, $length ) );
+	}
+
+	public function data_url_shorten_custom_length() {
+		// The URL below is 41 characters long after cleaning.
+		$url = 'http://wordpress.org/about/philosophy/#decisions';
+
+		return array(
+			'kept when length exceeds the URL' => array(
+				'wordpress.org/about/philosophy/#decisions',
+				$url,
+				100,
+			),
+			'kept when length equals the URL'  => array(
+				'wordpress.org/about/philosophy/#decisions',
+				$url,
+				41,
+			),
+			'shortened when length is smaller' => array(
+				'wordpress.org/about/philosophy/#decis&hellip;',
+				$url,
+				40,
+			),
+		);
 	}
 }


### PR DESCRIPTION
This refactors the tests in `tests/phpunit/tests/formatting/urlShorten.php` and adds coverage that was missing.

### Misplaced test argument

The case meant to test the optional `$length` parameter passed the length as the third argument to `assertSame()`:

```php
$this->assertSame( 'wordpress.org/about/philosophy/#&hellip;', url_shorten( 'http://wordpress.org/about/philosophy/#decisions' ), 31 );
```

That third argument is `assertSame()`'s `$message`, not the URL length. So `url_shorten()` ran with its default length of 35, the expected value happened to match the default output, and the assertion passed — while the `$length` parameter was never actually tested.

### Changes

- Convert the tests to `@dataProvider` data sets with descriptive keys, so a failure points to the exact case.
- Separate the default-behaviour cases from the custom-length cases.
- Add real coverage for `$length`: the URL is kept when the length exceeds or equals the cleaned URL (pinning the strict `>` comparison) and shortened when it is smaller.
- Add a comment clarifying that a shortened URL is cut to `( $length - 3 )` characters before `&hellip;` is appended.

No production code is changed — this is a test-only improvement.

All tests pass locally via `npm run test:php -- --filter Tests_Formatting_UrlShorten` (9 tests, 9 assertions).

Trac ticket: https://core.trac.wordpress.org/ticket/64894

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
