### PR TITLE
Register wp-theme design tokens stylesheet

### DIFF
--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -1761,7 +1761,7 @@ function wp_default_styles( $styles ) {
 	$package_styles = array(
 		'block-editor'         => array( 'wp-components', 'wp-preferences' ),
 		'block-library'        => array(),
-		'block-directory'      => array( 'wp-theme' ),
+		'block-directory'      => array(),
 		'theme'                => array(),
 		'base-styles'          => array(),
 		'components'           => array( 'wp-theme' ),

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -1721,6 +1721,7 @@ function wp_default_styles( $styles ) {
 
 	// Only add CONTENT styles here that should be enqueued in the iframe!
 	$wp_edit_blocks_dependencies = array(
+		'wp-theme',
 		'wp-base-styles',
 		'wp-components',
 		/*
@@ -1760,9 +1761,10 @@ function wp_default_styles( $styles ) {
 	$package_styles = array(
 		'block-editor'         => array( 'wp-components', 'wp-preferences' ),
 		'block-library'        => array(),
-		'block-directory'      => array(),
+		'block-directory'      => array( 'wp-theme' ),
+		'theme'                => array(),
 		'base-styles'          => array(),
-		'components'           => array(),
+		'components'           => array( 'wp-theme' ),
 		'commands'             => array( 'wp-components' ),
 		'edit-post'            => array(
 			'wp-components',
@@ -1829,6 +1831,10 @@ function wp_default_styles( $styles ) {
 			$path = "/wp-includes/css/dist/base-styles/admin-schemes$suffix.css";
 		}
 
+		if ( 'theme' === $package ) {
+			$path = "/wp-includes/css/dist/theme/design-tokens$suffix.css";
+		}
+
 		$styles->add( $handle, $path, $dependencies );
 		$styles->add_data( $handle, 'path', ABSPATH . $path );
 	}
@@ -1872,6 +1878,7 @@ function wp_default_styles( $styles ) {
 		'wp-reset-editor-styles',
 		'wp-editor-classic-layout-styles',
 		'wp-block-library-theme',
+		'wp-theme',
 		'wp-edit-blocks',
 		'wp-block-editor',
 		'wp-block-library',

--- a/tests/phpunit/tests/dependencies/styles.php
+++ b/tests/phpunit/tests/dependencies/styles.php
@@ -587,20 +587,6 @@ class Tests_Dependencies_Styles extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that wp-block-directory depends on wp-theme for design token CSS.
-	 *
-	 * @covers ::wp_default_styles
-	 */
-	public function test_wp_block_directory_depends_on_wp_theme() {
-		wp_default_styles( $GLOBALS['wp_styles'] );
-
-		$this->assertContains(
-			'wp-theme',
-			$GLOBALS['wp_styles']->registered['wp-block-directory']->deps
-		);
-	}
-
-	/**
 	 * Tests that wp-edit-blocks loads design tokens before other editor styles.
 	 *
 	 * @covers ::wp_default_styles

--- a/tests/phpunit/tests/dependencies/styles.php
+++ b/tests/phpunit/tests/dependencies/styles.php
@@ -560,6 +560,8 @@ class Tests_Dependencies_Styles extends WP_UnitTestCase {
 	/**
 	 * Tests that the design tokens stylesheet is registered in core.
 	 *
+	 * @ticket 65646
+	 *
 	 * @covers ::wp_default_styles
 	 */
 	public function test_wp_theme_style_is_registered() {
@@ -575,6 +577,8 @@ class Tests_Dependencies_Styles extends WP_UnitTestCase {
 	/**
 	 * Tests that wp-components depends on wp-theme so tokens load before component styles.
 	 *
+	 * @ticket 65646
+	 *
 	 * @covers ::wp_default_styles
 	 */
 	public function test_wp_components_depends_on_wp_theme() {
@@ -588,6 +592,8 @@ class Tests_Dependencies_Styles extends WP_UnitTestCase {
 
 	/**
 	 * Tests that wp-edit-blocks loads design tokens before other editor styles.
+	 *
+	 * @ticket 65646
 	 *
 	 * @covers ::wp_default_styles
 	 */

--- a/tests/phpunit/tests/dependencies/styles.php
+++ b/tests/phpunit/tests/dependencies/styles.php
@@ -558,6 +558,63 @@ class Tests_Dependencies_Styles extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that the design tokens stylesheet is registered in core.
+	 *
+	 * @covers ::wp_default_styles
+	 */
+	public function test_wp_theme_style_is_registered() {
+		wp_default_styles( $GLOBALS['wp_styles'] );
+
+		$this->assertArrayHasKey( 'wp-theme', $GLOBALS['wp_styles']->registered );
+		$this->assertSame(
+			'/' . WPINC . '/css/dist/theme/design-tokens.css',
+			$GLOBALS['wp_styles']->registered['wp-theme']->src
+		);
+	}
+
+	/**
+	 * Tests that wp-components depends on wp-theme so tokens load before component styles.
+	 *
+	 * @covers ::wp_default_styles
+	 */
+	public function test_wp_components_depends_on_wp_theme() {
+		wp_default_styles( $GLOBALS['wp_styles'] );
+
+		$this->assertContains(
+			'wp-theme',
+			$GLOBALS['wp_styles']->registered['wp-components']->deps
+		);
+	}
+
+	/**
+	 * Tests that wp-block-directory depends on wp-theme for design token CSS.
+	 *
+	 * @covers ::wp_default_styles
+	 */
+	public function test_wp_block_directory_depends_on_wp_theme() {
+		wp_default_styles( $GLOBALS['wp_styles'] );
+
+		$this->assertContains(
+			'wp-theme',
+			$GLOBALS['wp_styles']->registered['wp-block-directory']->deps
+		);
+	}
+
+	/**
+	 * Tests that wp-edit-blocks loads design tokens before other editor styles.
+	 *
+	 * @covers ::wp_default_styles
+	 */
+	public function test_wp_edit_blocks_depends_on_wp_theme_first() {
+		wp_default_styles( $GLOBALS['wp_styles'] );
+
+		$deps = $GLOBALS['wp_styles']->registered['wp-edit-blocks']->deps;
+
+		$this->assertContains( 'wp-theme', $deps );
+		$this->assertSame( 0, array_search( 'wp-theme', $deps, true ) );
+	}
+
+	/**
 	 * @ticket 58394
 	 * @ticket 63887
 	 *


### PR DESCRIPTION
Register the `wp-theme` design tokens stylesheet in Core so `--wpds-*` custom properties are available without the Gutenberg plugin.

Trac ticket: https://core.trac.wordpress.org/ticket/65646

## Changes

- Register `wp-theme` in `wp_default_styles()` at `/wp-includes/css/dist/theme/design-tokens$suffix.css`.
- Add `wp-theme` first in `$wp_edit_blocks_dependencies` for the editor iframe.
- Add `wp-theme` as a dependency of `wp-components`.
- Add `wp-theme` to the RTL styles list (mostly a formality, since it doesn't really have separate RTL styles).
- Add PHPUnit coverage for registration and dependency wiring.

We also try to match this Core style dependency behavior as closely as possible with some tweaks in https://github.com/WordPress/gutenberg/pull/80362.

## Test plan

- [x] PHPUnit: `test_wp_theme_style_is_registered`, `test_wp_components_depends_on_wp_theme`, `test_wp_edit_blocks_depends_on_wp_theme_first`
- [x] Local admin and block editor without Gutenberg plugin: should be loading the design-tokens stylesheet
- [x] Verified with `SCRIPT_DEBUG` on and off

## Use of AI Tools

AI assistance: Yes
Tool(s): Cursor
Used for: Implementation exploration, dependency analysis, test scaffolding, and PR description drafting; changes were reviewed and tested locally by me.