### PR TITLE
Media: Set HEIC upload support flag for canvas-based conversion

### DIFF
--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -6603,6 +6603,14 @@ function wp_set_client_side_media_processing_flag(): void {
 
 	wp_add_inline_script( 'wp-block-editor', 'window.__clientSideMediaProcessing = true;', 'before' );
 
+	/*
+	 * Indicates that HEIC canvas-based upload support is available. Unlike the
+	 * full WebAssembly pipeline, this fallback does not require cross-origin
+	 * isolation, so browsers such as Safari can use createImageBitmap() to
+	 * decode HEIC images and convert them to JPEG before uploading.
+	 */
+	wp_add_inline_script( 'wp-block-editor', 'window.__heicUploadSupport = true;', 'before' );
+
 	$chromium_version = wp_get_chromium_major_version();
 
 	if ( null !== $chromium_version && $chromium_version >= 137 ) {

--- a/tests/phpunit/tests/media/wpSetClientSideMediaProcessingFlag.php
+++ b/tests/phpunit/tests/media/wpSetClientSideMediaProcessingFlag.php
@@ -1,0 +1,123 @@
+<?php
+
+/**
+ * Tests for wp_set_client_side_media_processing_flag().
+ *
+ * @group media
+ * @covers ::wp_set_client_side_media_processing_flag
+ */
+class Tests_Media_wpSetClientSideMediaProcessingFlag extends WP_UnitTestCase {
+
+	/**
+	 * Original HTTP_USER_AGENT value.
+	 */
+	private ?string $original_user_agent;
+
+	/**
+	 * Original HTTP_HOST value.
+	 */
+	private ?string $original_http_host;
+
+	/**
+	 * Original HTTPS value.
+	 */
+	private ?string $original_https;
+
+	public function set_up() {
+		parent::set_up();
+		$this->original_user_agent = $_SERVER['HTTP_USER_AGENT'] ?? null;
+		$this->original_http_host  = $_SERVER['HTTP_HOST'] ?? null;
+		$this->original_https      = $_SERVER['HTTPS'] ?? null;
+
+		// Ensure client-side media processing is considered enabled.
+		$_SERVER['HTTP_HOST'] = 'localhost';
+
+		$GLOBALS['wp_scripts'] = new WP_Scripts();
+	}
+
+	public function tear_down() {
+		if ( null === $this->original_user_agent ) {
+			unset( $_SERVER['HTTP_USER_AGENT'] );
+		} else {
+			$_SERVER['HTTP_USER_AGENT'] = $this->original_user_agent;
+		}
+
+		if ( null === $this->original_http_host ) {
+			unset( $_SERVER['HTTP_HOST'] );
+		} else {
+			$_SERVER['HTTP_HOST'] = $this->original_http_host;
+		}
+
+		if ( null === $this->original_https ) {
+			unset( $_SERVER['HTTPS'] );
+		} else {
+			$_SERVER['HTTPS'] = $this->original_https;
+		}
+
+		unset( $GLOBALS['wp_scripts'] );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Returns the inline scripts added before the 'wp-block-editor' script.
+	 *
+	 * @return string Concatenated inline scripts, or an empty string if none.
+	 */
+	private function get_block_editor_before_scripts(): string {
+		$before = wp_scripts()->get_data( 'wp-block-editor', 'before' );
+
+		if ( ! is_array( $before ) ) {
+			return '';
+		}
+
+		return implode( "\n", array_filter( $before ) );
+	}
+
+	/**
+	 * @ticket 64906
+	 */
+	public function test_sets_heic_upload_support_flag_for_non_chromium_browsers() {
+		// Safari 26 on macOS.
+		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.0 Safari/605.1.15';
+
+		wp_set_client_side_media_processing_flag();
+
+		$before = $this->get_block_editor_before_scripts();
+
+		$this->assertStringContainsString( 'window.__clientSideMediaProcessing = true;', $before, 'The client-side media processing flag should be set.' );
+		$this->assertStringContainsString( 'window.__heicUploadSupport = true;', $before, 'The HEIC upload support flag should be set for non-Chromium browsers.' );
+		$this->assertStringNotContainsString( 'window.__documentIsolationPolicy', $before, 'The Document-Isolation-Policy flag should not be set for non-Chromium browsers.' );
+	}
+
+	/**
+	 * @ticket 64906
+	 */
+	public function test_sets_heic_upload_support_flag_for_chromium_browsers() {
+		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36';
+
+		wp_set_client_side_media_processing_flag();
+
+		$before = $this->get_block_editor_before_scripts();
+
+		$this->assertStringContainsString( 'window.__clientSideMediaProcessing = true;', $before, 'The client-side media processing flag should be set.' );
+		$this->assertStringContainsString( 'window.__heicUploadSupport = true;', $before, 'The HEIC upload support flag should be set for Chromium browsers.' );
+		$this->assertStringContainsString( 'window.__documentIsolationPolicy = true;', $before, 'The Document-Isolation-Policy flag should be set for Chromium 137+.' );
+	}
+
+	/**
+	 * @ticket 64906
+	 */
+	public function test_does_not_set_flags_when_client_side_media_processing_is_disabled() {
+		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.0 Safari/605.1.15';
+
+		add_filter( 'wp_client_side_media_processing_enabled', '__return_false' );
+
+		wp_set_client_side_media_processing_flag();
+
+		$before = $this->get_block_editor_before_scripts();
+
+		$this->assertStringNotContainsString( 'window.__clientSideMediaProcessing', $before, 'The client-side media processing flag should not be set when the feature is disabled.' );
+		$this->assertStringNotContainsString( 'window.__heicUploadSupport', $before, 'The HEIC upload support flag should not be set when the feature is disabled.' );
+	}
+}

--- a/tests/phpunit/tests/media/wpSetClientSideMediaProcessingFlag.php
+++ b/tests/phpunit/tests/media/wpSetClientSideMediaProcessingFlag.php
@@ -75,7 +75,7 @@ class Tests_Media_wpSetClientSideMediaProcessingFlag extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @ticket 64906
+	 * @ticket 65648
 	 */
 	public function test_sets_heic_upload_support_flag_for_non_chromium_browsers() {
 		// Safari 26 on macOS.
@@ -91,7 +91,7 @@ class Tests_Media_wpSetClientSideMediaProcessingFlag extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @ticket 64906
+	 * @ticket 65648
 	 */
 	public function test_sets_heic_upload_support_flag_for_chromium_browsers() {
 		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36';
@@ -106,7 +106,7 @@ class Tests_Media_wpSetClientSideMediaProcessingFlag extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @ticket 64906
+	 * @ticket 65648
 	 */
 	public function test_does_not_set_flags_when_client_side_media_processing_is_disabled() {
 		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.0 Safari/605.1.15';


### PR DESCRIPTION
## Summary

The block editor's HEIC canvas fallback is gated on `window.__heicUploadSupport`, but core never sets that flag. The Gutenberg plugin sets it via `gutenberg_set_heic_upload_support_flag()`, and core has no equivalent.

As a result, on a core-only WordPress 7.1 install, browsers that cannot use the full WebAssembly (vips) pipeline get no client-side HEIC conversion at all. This primarily affects Safari:

1. Core only enables cross-origin isolation via `Document-Isolation-Policy` for Chromium 137+ (`wp_set_up_cross_origin_isolation()`), so in Safari `detectClientSideMediaSupport()` fails and the full vips pipeline is disabled.
2. The editor then checks the HEIC-only canvas path (`shouldEnableHeicCanvasProcessing()` in `@wordpress/block-editor`), which requires `window.__heicUploadSupport` - never set by core - so it bails before even checking browser capability.

Safari is exactly the browser this fallback was built for: it can decode HEIC natively via `createImageBitmap()` and convert to JPEG on a canvas, without needing SharedArrayBuffer or cross-origin isolation.

## Changes

- Set `window.__heicUploadSupport = true` in `wp_set_client_side_media_processing_flag()`, alongside the existing `__clientSideMediaProcessing` flag. It respects the same `wp_client_side_media_processing_enabled` filter, so disabling client-side processing disables this path too. The browser-capability check (`createImageBitmap` + `OffscreenCanvas` + successful HEIC decode) still happens client-side, so setting the flag for all browsers is safe - Chromium browsers with the full pipeline ignore it.
- Add unit tests covering the new flag for Chromium and non-Chromium user agents, and the disabled-by-filter case.

## Testing
- Before the patch: on a server lacking HEIC support, upload an HEIC file to Safari. Note that while the image shows (because Safari supports HEIC natively), the resizes do not work, no srcset is created and the image does not load if the post is loaded in Chrome or Firefox
- Apply the patch and try again: the image is converted into JPEGs and uploaded. Checking the front end, srcset works, the image is a jpeg and works in Chrome/Firefox. 

Trac ticket: https://core.trac.wordpress.org/ticket/65648
