### PR TITLE
Build/Test Tools: Exclude the .cache directory from PHPCS scans

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -46,6 +46,7 @@
 	<exclude-pattern>/gutenberg/*</exclude-pattern>
 
 	<!-- Directories and third party library exclusions. -->
+	<exclude-pattern>/.cache/*</exclude-pattern>
 	<exclude-pattern>/node_modules/*</exclude-pattern>
 	<exclude-pattern>/vendor/*</exclude-pattern>
 


### PR DESCRIPTION
## Problem

Running `composer run lint` can fail with a fatal out-of-memory error:

> Allowed memory size of 536870912 bytes exhausted ... in PHP_CodeSniffer/src/Files/File.php

PHPCS scans the working directory recursively (`<file>.</file>`) and does **not** respect `.gitignore` — it only honors its own `exclude-pattern` entries. The `.cache/` directory is not excluded, so generated cache files inside it get linted.

PHPStan stores its cache as PHP files under `.cache/cache/PHPStan/`, some of them 20,000–39,000+ lines long with 100,000+ style violations per file. The `Universal.WhiteSpace.PrecisionAlignment` sniff records a message on nearly every line; with `parallel=20`, a worker building that list blows past the `512M` limit and PHPCS crashes.

## Fix

Add `/.cache/*` to the exclude patterns, next to the existing `/vendor/*`, `/node_modules/*`, and `/build/*` exclusions.

## Notes

- Raising `memory_limit` would only mask the issue — the cache files should never be linted in the first place.
- Excluding them also makes linting faster, since the oversized files are no longer tokenized.

Trac ticket: https://core.trac.wordpress.org/ticket/65649

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
