### PR TITLE
Privacy: Add unit tests for wp_schedule_delete_old_privacy_export_files()

### DIFF
--- a/tests/phpunit/tests/functions/wpScheduleDeleteOldPrivacyExportFiles.php
+++ b/tests/phpunit/tests/functions/wpScheduleDeleteOldPrivacyExportFiles.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Test cases for the `wp_schedule_delete_old_privacy_export_files()` function.
+ *
+ * @package WordPress
+ * @subpackage UnitTests
+ * @since 4.9.6
+ *
+ * @group functions
+ * @group privacy
+ * @covers ::wp_schedule_delete_old_privacy_export_files
+ */
+class Tests_Functions_wpScheduleDeleteOldPrivacyExportFiles extends WP_UnitTestCase {
+
+	/**
+	 * Ensures each test starts without the event scheduled.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		wp_unschedule_event( wp_next_scheduled( 'wp_privacy_delete_old_export_files' ), 'wp_privacy_delete_old_export_files' );
+	}
+
+	/**
+	 * Resets the installing state that some tests set.
+	 */
+	public function tear_down() {
+		wp_installing( false );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Tests that the event is scheduled when it is not already.
+	 *
+	 * @ticket 59707
+	 */
+	public function test_wp_schedule_delete_old_privacy_export_files() {
+		$this->assertFalse( wp_next_scheduled( 'wp_privacy_delete_old_export_files' ), 'The event should not be scheduled before the function runs.' );
+
+		wp_schedule_delete_old_privacy_export_files();
+
+		$this->assertIsInt( wp_next_scheduled( 'wp_privacy_delete_old_export_files' ), 'The event should be scheduled after the function runs.' );
+	}
+
+	/**
+	 * Tests that no event is scheduled while WordPress is installing.
+	 *
+	 * @ticket 59707
+	 */
+	public function test_wp_schedule_delete_old_privacy_export_files_is_installing() {
+		wp_installing( true );
+
+		$this->assertFalse( wp_next_scheduled( 'wp_privacy_delete_old_export_files' ), 'The event should not be scheduled before the function runs.' );
+
+		wp_schedule_delete_old_privacy_export_files();
+
+		$this->assertFalse( wp_next_scheduled( 'wp_privacy_delete_old_export_files' ), 'The event should not be scheduled while WordPress is installing.' );
+	}
+
+	/**
+	 * Tests that calling the function again does not create a duplicate event.
+	 *
+	 * @ticket 59707
+	 */
+	public function test_wp_schedule_delete_old_privacy_export_files_already_scheduled() {
+		wp_schedule_delete_old_privacy_export_files();
+		$first = wp_next_scheduled( 'wp_privacy_delete_old_export_files' );
+
+		wp_schedule_delete_old_privacy_export_files();
+
+		$this->assertSame( $first, wp_next_scheduled( 'wp_privacy_delete_old_export_files' ), 'Calling the function again should not reschedule the event.' );
+	}
+}


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/59707

Adds unit-test coverage for `wp_schedule_delete_old_privacy_export_files()`, exercising all three branches of the function:

- Schedules the `wp_privacy_delete_old_export_files` event when it is not already scheduled.
- Skips scheduling while WordPress is installing (`wp_installing()`).
- Does not create a duplicate event when one is already scheduled.

This builds on the work in https://github.com/WordPress/wordpress-develop/pull/5550 and incorporates the review feedback from that PR:

- Calls `parent::set_up()` / `parent::tear_down()`.
- Moves the `wp_installing( false )` reset into `tear_down()` so it always runs.
- Adds the "already scheduled" branch test.
- Adds a standard file docblock, `@group privacy`, and assertion failure messages.

Verified locally against `trunk`: `OK (3 tests, 5 assertions)`; PHPCS clean.

Note: this is an alternative to https://github.com/WordPress/wordpress-develop/pull/5550 for the same ticket — happy to fold it back into that PR instead if maintainers prefer.