### PR TITLE
Register wp-theme design tokens stylesheet

### DIFF
--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -1721,6 +1721,8 @@ function wp_default_styles( $styles ) {
 
 	// Only add CONTENT styles here that should be enqueued in the iframe!
 	$wp_edit_blocks_dependencies = array(
+		// Design tokens must load first so token-consuming styles resolve their values.
+		'wp-theme',
 		'wp-base-styles',
 		'wp-components',
 		/*
@@ -1761,8 +1763,9 @@ function wp_default_styles( $styles ) {
 		'block-editor'         => array( 'wp-components', 'wp-preferences' ),
 		'block-library'        => array(),
 		'block-directory'      => array(),
+		'theme'                => array(),
 		'base-styles'          => array(),
-		'components'           => array(),
+		'components'           => array( 'wp-theme' ),
 		'commands'             => array( 'wp-components' ),
 		'edit-post'            => array(
 			'wp-components',
@@ -1829,6 +1832,10 @@ function wp_default_styles( $styles ) {
 			$path = "/wp-includes/css/dist/base-styles/admin-schemes$suffix.css";
 		}
 
+		if ( 'theme' === $package ) {
+			$path = "/wp-includes/css/dist/theme/design-tokens$suffix.css";
+		}
+
 		$styles->add( $handle, $path, $dependencies );
 		$styles->add_data( $handle, 'path', ABSPATH . $path );
 	}
@@ -1872,6 +1879,7 @@ function wp_default_styles( $styles ) {
 		'wp-reset-editor-styles',
 		'wp-editor-classic-layout-styles',
 		'wp-block-library-theme',
+		'wp-theme',
 		'wp-edit-blocks',
 		'wp-block-editor',
 		'wp-block-library',

--- a/tests/phpunit/tests/dependencies/styles.php
+++ b/tests/phpunit/tests/dependencies/styles.php
@@ -558,6 +558,67 @@ class Tests_Dependencies_Styles extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that the wp-theme design tokens stylesheet is registered.
+	 *
+	 * @ticket 65646
+	 *
+	 * @covers ::wp_default_styles
+	 */
+	public function test_wp_theme_design_tokens_style_is_registered() {
+		wp_default_styles( $GLOBALS['wp_styles'] );
+
+		$this->assertArrayHasKey(
+			'wp-theme',
+			$GLOBALS['wp_styles']->registered,
+			'The wp-theme style handle should be registered.'
+		);
+		$this->assertSame(
+			'/' . WPINC . '/css/dist/theme/design-tokens.css',
+			$GLOBALS['wp_styles']->registered['wp-theme']->src,
+			'The wp-theme style should point to the design tokens stylesheet.'
+		);
+	}
+
+	/**
+	 * Tests that token-consuming package styles depend on wp-theme.
+	 *
+	 * Design tokens must be registered as a dependency so their values are
+	 * defined before the consuming styles that reference them.
+	 *
+	 * @ticket 65646
+	 *
+	 * @covers ::wp_default_styles
+	 */
+	public function test_wp_components_depends_on_wp_theme() {
+		wp_default_styles( $GLOBALS['wp_styles'] );
+
+		$this->assertContains(
+			'wp-theme',
+			$GLOBALS['wp_styles']->registered['wp-components']->deps,
+			'The wp-components style should depend on wp-theme.'
+		);
+	}
+
+	/**
+	 * Tests that wp-theme is the first editor style dependency.
+	 *
+	 * Design tokens must load before any other editor styles so that
+	 * token-consuming rules resolve to their intended values.
+	 *
+	 * @ticket 65646
+	 *
+	 * @covers ::wp_default_styles
+	 */
+	public function test_wp_edit_blocks_loads_wp_theme_first() {
+		wp_default_styles( $GLOBALS['wp_styles'] );
+
+		$deps = $GLOBALS['wp_styles']->registered['wp-edit-blocks']->deps;
+
+		$this->assertContains( 'wp-theme', $deps, 'The wp-edit-blocks style should depend on wp-theme.' );
+		$this->assertSame( 'wp-theme', reset( $deps ), 'wp-theme should be the first wp-edit-blocks dependency.' );
+	}
+
+	/**
 	 * @ticket 58394
 	 * @ticket 63887
 	 *


### PR DESCRIPTION
## Trac ticket

Fixes https://core.trac.wordpress.org/ticket/65646

## Summary

The `wp-theme` JS package is registered in Core, but its accompanying design tokens stylesheet was only registered in the Gutenberg plugin. Without the stylesheet, token-consuming styles may see undefined values. Although first-party usage injects fallback values at build time, the intended behaviour is that the design tokens stylesheet is actually loaded wherever design tokens are used.

## Changes

In `wp_default_styles()`:

- Register a `theme` package style pointing to `/wp-includes/css/dist/theme/design-tokens$suffix.css` (special-cased like `base-styles`, since the filename is not the default `style.css`).
- Add `wp-theme` as a dependency of `wp-components` so token values are defined before the consuming styles reference them.
- Load `wp-theme` first among the editor (`wp-edit-blocks`) dependencies, and add it to the RTL styles list for consistency with the other package styles.

This mirrors the Gutenberg plugin setup.

Unit tests were added to `tests/phpunit/tests/dependencies/styles.php` covering registration of the handle/src, the `wp-components` dependency, and the editor style ordering.

## Note for reviewers

The registered file `css/dist/theme/design-tokens.css` is synced from the Gutenberg build (like all other `css/dist/*` assets), so a Gutenberg version bump that outputs the `theme/` styles directory must precede or accompany this change. Until then the handle resolves to a file that is not yet present in Core.

## Testing instructions

1. Run the dependency tests: `phpunit tests/phpunit/tests/dependencies/styles.php`.
2. Confirm the `wp-theme` handle is registered and that `wp-components` and `wp-edit-blocks` depend on it.