### PR TITLE
Comments: Exclude notes from get_lastcommentmodified().

### DIFF
--- a/src/wp-includes/comment.php
+++ b/src/wp-includes/comment.php
@@ -363,15 +363,15 @@ function get_lastcommentmodified( $timezone = 'server' ) {
 
 	switch ( $timezone ) {
 		case 'gmt':
-			$comment_modified_date = $wpdb->get_var( "SELECT comment_date_gmt FROM $wpdb->comments WHERE comment_approved = '1' ORDER BY comment_date_gmt DESC LIMIT 1" );
+			$comment_modified_date = $wpdb->get_var( "SELECT comment_date_gmt FROM $wpdb->comments WHERE comment_approved = '1' AND comment_type != 'note' ORDER BY comment_date_gmt DESC LIMIT 1" );
 			break;
 		case 'blog':
-			$comment_modified_date = $wpdb->get_var( "SELECT comment_date FROM $wpdb->comments WHERE comment_approved = '1' ORDER BY comment_date_gmt DESC LIMIT 1" );
+			$comment_modified_date = $wpdb->get_var( "SELECT comment_date FROM $wpdb->comments WHERE comment_approved = '1' AND comment_type != 'note' ORDER BY comment_date_gmt DESC LIMIT 1" );
 			break;
 		case 'server':
 			$add_seconds_server = gmdate( 'Z' );
 
-			$comment_modified_date = $wpdb->get_var( $wpdb->prepare( "SELECT DATE_ADD(comment_date_gmt, INTERVAL %s SECOND) FROM $wpdb->comments WHERE comment_approved = '1' ORDER BY comment_date_gmt DESC LIMIT 1", $add_seconds_server ) );
+			$comment_modified_date = $wpdb->get_var( $wpdb->prepare( "SELECT DATE_ADD(comment_date_gmt, INTERVAL %s SECOND) FROM $wpdb->comments WHERE comment_approved = '1' AND comment_type != 'note' ORDER BY comment_date_gmt DESC LIMIT 1", $add_seconds_server ) );
 			break;
 	}
 

--- a/tests/phpunit/tests/comment/getLastCommentModified.php
+++ b/tests/phpunit/tests/comment/getLastCommentModified.php
@@ -11,6 +11,37 @@ class Tests_Comment_GetLastCommentModified extends WP_UnitTestCase {
 		$this->assertFalse( get_lastcommentmodified() );
 	}
 
+	/**
+	 * Ensures internal 'note' comments are excluded from the last modified time.
+	 *
+	 * The value feeds the comments feed Last-Modified/ETag headers, so a note --
+	 * which is never part of the public feed -- must not bump it.
+	 *
+	 * @ticket 65657
+	 */
+	public function test_notes_are_excluded() {
+		// A regular approved comment.
+		self::factory()->comment->create(
+			array(
+				'comment_approved' => '1',
+				'comment_date'     => '2000-01-01 11:00:00',
+				'comment_date_gmt' => '2000-01-01 10:00:00',
+			)
+		);
+
+		// A later internal note, which must be ignored.
+		self::factory()->comment->create(
+			array(
+				'comment_approved' => '1',
+				'comment_type'     => 'note',
+				'comment_date'     => '2000-01-02 11:00:00',
+				'comment_date_gmt' => '2000-01-02 10:00:00',
+			)
+		);
+
+		$this->assertSame( strtotime( '2000-01-01 10:00:00' ), strtotime( get_lastcommentmodified( 'GMT' ) ) );
+	}
+
 	public function test_default_timezone() {
 		self::factory()->comment->create_and_get(
 			array(


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65657

## Summary

`get_lastcommentmodified()` returns the date of the most recent approved comment, and `WP::send_headers()` uses it (max'd with `get_lastpostmodified()`) to build the `Last-Modified` and `ETag` headers for the comments feed.

Its three queries did not exclude the internal `note` comment type:

```sql
SELECT comment_date_gmt FROM wp_comments WHERE comment_approved = '1' ORDER BY comment_date_gmt DESC LIMIT 1
```

Notes are stored as approved comments (`comment_type = 'note'`), so adding or resolving a note makes it the most recent comment. The **public** comments feed's `Last-Modified`/`ETag` then change, even though the feed body already excludes notes (#64145 / #65613) and did not change.

Consequences:
- Conditional GET (304 Not Modified) caching of the comments feed is defeated whenever notes are used — clients and CDNs re-fetch an identical feed.
- The public `Last-Modified` header exposes the timing of internal editorial notes.

## Reproduction

On a site using Notes:

```
curl -I '/?feed=comments-rss2'   # note Last-Modified + ETag
# add an internal note to any post
curl -I '/?feed=comments-rss2'   # Last-Modified + ETag have changed; feed body is unchanged
```

Verified live: adding one note moved `Last-Modified` from `Fri, 01 Jan 2027 10:00:00 GMT` to `Sat, 02 Jan 2027 10:00:00 GMT` and changed the `ETag`. See the before/after screenshots on the Trac ticket.

## Fix

Add `AND comment_type != 'note'` to the three `get_lastcommentmodified()` queries, matching the exclusion already used by `wp_update_comment_count_now()` and the comment feed queries.

## Testing

Added `test_notes_are_excluded` to `Tests_Comment_GetLastCommentModified`.

- Before the fix, it fails: `Failed asserting that <note timestamp> is identical to <regular-comment timestamp>`.
- After the fix, it passes.

Full comment group is green:

```
./vendor/bin/phpunit --group comment
OK (583 tests, 1428 assertions)
```

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 4.8
Used for: Auditing the notes-exclusion surfaces, reproducing the feed-header change, implementing the fix, and writing the regression test. All changes were reviewed by me.
