### PR TITLE
Permalinks: Preserve post status in sample permalink filters

### DIFF
--- a/src/wp-admin/includes/post.php
+++ b/src/wp-admin/includes/post.php
@@ -1471,15 +1471,15 @@ function get_sample_permalink( $post, $title = null, $name = null ) {
 
 	$ptype = get_post_type_object( $post->post_type );
 
-	$original_status = $post->post_status;
 	$original_date   = $post->post_date;
 	$original_name   = $post->post_name;
 	$original_filter = $post->filter;
+	$post_status     = $post->post_status;
 
-	// Hack: get_permalink() would return plain permalink for drafts, so we will fake that our post is published.
+	// Drafts do not have unique slugs, so use a published status when determining the sample slug.
 	if ( in_array( $post->post_status, array( 'auto-draft', 'draft', 'pending', 'future' ), true ) ) {
-		$post->post_status = 'publish';
-		$post->post_name   = sanitize_title( $post->post_name ? $post->post_name : $post->post_title, $post->ID );
+		$post_status     = 'publish';
+		$post->post_name = sanitize_title( $post->post_name ? $post->post_name : $post->post_title, $post->ID );
 	}
 
 	/*
@@ -1490,9 +1490,8 @@ function get_sample_permalink( $post, $title = null, $name = null ) {
 		$post->post_name = sanitize_title( $name ? $name : $title, $post->ID );
 	}
 
-	$post->post_name = wp_unique_post_slug( $post->post_name, $post->ID, $post->post_status, $post->post_type, $post->post_parent );
-
-	$post->filter = 'sample';
+	$post->post_name = wp_unique_post_slug( $post->post_name, $post->ID, $post_status, $post->post_type, $post->post_parent );
+	$post->filter    = 'sample';
 
 	$permalink = get_permalink( $post, true );
 
@@ -1517,11 +1516,10 @@ function get_sample_permalink( $post, $title = null, $name = null ) {
 	}
 
 	/** This filter is documented in wp-admin/edit-tag-form.php */
-	$permalink         = array( $permalink, apply_filters( 'editable_slug', $post->post_name, $post ) );
-	$post->post_status = $original_status;
-	$post->post_date   = $original_date;
-	$post->post_name   = $original_name;
-	$post->filter      = $original_filter;
+	$permalink       = array( $permalink, apply_filters( 'editable_slug', $post->post_name, $post ) );
+	$post->post_date = $original_date;
+	$post->post_name = $original_name;
+	$post->filter    = $original_filter;
 
 	/**
 	 * Filters the sample permalink.

--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -132,8 +132,8 @@ function wp_force_plain_post_permalink( $post = null, $sample = null ) {
 			$post_status_obj->private &&
 			current_user_can( 'read_post', $post->ID )
 		) ||
-		// Protected posts don't have plain links if getting a sample URL.
-		( $post_status_obj->protected && $sample )
+		// Protected posts and auto-drafts don't have plain links if getting a sample URL.
+		( $sample && ( $post_status_obj->protected || 'auto-draft' === $post->post_status ) )
 	) {
 		return false;
 	}

--- a/tests/phpunit/tests/admin/includesPost.php
+++ b/tests/phpunit/tests/admin/includesPost.php
@@ -949,6 +949,53 @@ class Tests_Admin_IncludesPost extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that get_sample_permalink() passes the original post status to permalink filters.
+	 *
+	 * @ticket 50002
+	 *
+	 * @covers ::get_sample_permalink
+	 */
+	public function test_get_sample_permalink_should_pass_original_post_status_to_permalink_filters() {
+		$this->set_permalink_structure( '/%postname%/' );
+
+		$post = self::factory()->post->create_and_get(
+			array(
+				'post_status' => 'draft',
+				'post_title'  => 'A Draft Post',
+			)
+		);
+
+		$pre_post_link_status = null;
+		$post_link_status     = null;
+
+		add_filter(
+			'pre_post_link',
+			function ( $permalink, $filtered_post ) use ( &$pre_post_link_status ) {
+				$pre_post_link_status = $filtered_post->post_status;
+				return $permalink;
+			},
+			10,
+			2
+		);
+		add_filter(
+			'post_link',
+			function ( $permalink, $filtered_post ) use ( &$post_link_status ) {
+				$post_link_status = $filtered_post->post_status;
+				return $permalink;
+			},
+			10,
+			2
+		);
+
+		$actual = get_sample_permalink( $post );
+
+		$this->assertSame( 'draft', $pre_post_link_status );
+		$this->assertSame( 'draft', $post_link_status );
+		$this->assertSame( home_url( '/%postname%/' ), $actual[0] );
+		$this->assertSame( 'a-draft-post', $actual[1] );
+	}
+
+	/**
 	 * Tests that get_sample_permalink() preserves the original WP_Post properties.
 	 *
 	 * @ticket 54736


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

`get_sample_permalink()` currently changes draft, pending, future, and auto-draft posts to `publish` before generating the permalink. This causes the `pre_post_link` and `post_link` filters to receive an inaccurate post status.

This changes the function to use a separate published status only when determining a unique sample slug, while keeping the `WP_Post` status unchanged. It also preserves pretty sample permalinks for auto-drafts through `wp_force_plain_post_permalink()`.

The regression test verifies that both permalink filters receive the original `draft` status and that the generated sample permalink remains unchanged.`n`n## Testing

- `npm run test:php -- --filter=Tests_Admin_IncludesPost`
- `php -d xdebug.mode=off vendor/bin/phpcbf src/wp-admin/includes/post.php src/wp-includes/link-template.php tests/phpunit/tests/admin/includesPost.php`
- `php -d xdebug.mode=off vendor/bin/phpcs --warning-severity=0 src/wp-admin/includes/post.php src/wp-includes/link-template.php tests/phpunit/tests/admin/includesPost.php`

## Use of AI Tools

AI assistance: Yes  
Tool(s): Codex  
Model(s): GPT-5  
Used for: Investigating the current code path, implementing the fix and regression test, and running validation. The final changes were reviewed and verified against the focused test suite.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**

Trac ticket: https://core.trac.wordpress.org/ticket/50002

## Use of AI Tools

AI assistance: Yes
Tool(s): OpenAI Codex
Model(s): GPT-5
Used for: Reviewing the Trac ticket and relevant code, helping with the initial implementation and regression-test approach, and assisting with validation and PR-description drafting. The final implementation, tests, validation results, and description were reviewed and accepted by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**