### PR TITLE
I18N: Add wp_search_term filter to allow per-term normalization

### DIFF
--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -1576,6 +1576,24 @@ class WP_Query {
 				continue;
 			}
 
+			/**
+			 * Filters a search term after it has passed the length and stopwords checks.
+			 *
+			 * Can be used to normalize or remove a term. Returning an empty string
+			 * will cause the term to be skipped. This is particularly useful for
+			 * languages such as Arabic that require stripping diacritics, Hamza
+			 * variants, or other decorative characters before meaningful comparison.
+			 *
+			 * @since 6.9.0
+			 *
+			 * @param string $term The search term.
+			 */
+			$term = apply_filters( 'wp_search_term', $term );
+
+			if ( ! $term ) {
+				continue;
+			}
+
 			$checked[] = $term;
 		}
 

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -1572,25 +1572,23 @@ class WP_Query {
 				continue;
 			}
 
-			if ( in_array( call_user_func( $strtolower, $term ), $stopwords, true ) ) {
-				continue;
-			}
-
 			/**
-			 * Filters a search term after it has passed the length and stopwords checks.
-			 *
-			 * Can be used to normalize or remove a term. Returning an empty string
+			 * Filters an individual search term before it is added to the search query. Returning an empty string
 			 * will cause the term to be skipped. This is particularly useful for
 			 * languages such as Arabic that require stripping diacritics, Hamza
 			 * variants, or other decorative characters before meaningful comparison.
 			 *
-			 * @since 6.9.0
+			 * @since 7.2.0
 			 *
 			 * @param string $term The search term.
 			 */
 			$term = apply_filters( 'wp_search_term', $term );
 
 			if ( ! $term ) {
+				continue;
+			}
+
+			if ( in_array( call_user_func( $strtolower, $term ), $stopwords, true ) ) {
 				continue;
 			}
 

--- a/tests/phpunit/tests/query/search.php
+++ b/tests/phpunit/tests/query/search.php
@@ -644,4 +644,35 @@ class Tests_Query_Search extends WP_UnitTestCase {
 	public function filter_posts_search( $sql ) {
 		return $sql . ' /* posts_search */';
 	}
+
+	/**
+	 * @ticket 25585
+	 */
+	public function test_wp_search_term_filter_empty_string_removes_term() {
+		$callback = static function ( $term ) {
+			return 'foo' === $term ? '' : $term;
+		};
+
+		add_filter( 'wp_search_term', $callback );
+		$query = new WP_Query( array( 's' => 'foo bar' ) );
+		remove_filter( 'wp_search_term', $callback );
+
+		$this->assertSame( array( 'bar' ), $query->get( 'search_terms' ) );
+	}
+
+	/**
+	 * @ticket 25585
+	 */
+	public function test_wp_search_term_filter_normalizes_arabic_characters() {
+		$callback = static function ( $term ) {
+			$term = str_replace( array( 'أ', 'إ', 'آ' ), 'ا', $term );
+			return str_replace( array( 'َ', 'ً', 'ُ', 'ٌ', 'ِ', 'ٍ', 'ْ', 'ّ' ), '', $term );
+		};
+
+		add_filter( 'wp_search_term', $callback );
+		$query = new WP_Query( array( 's' => 'أَنْتَ بَيْت' ) );
+		remove_filter( 'wp_search_term', $callback );
+
+		$this->assertSame( array( 'انت', 'بيت' ), $query->get( 'search_terms' ) );
+	}
 }


### PR DESCRIPTION
Trac ticket: [#25585](https://core.trac.wordpress.org/ticket/25585)

Adds a new `wp_search_term` filter to `WP_Query::parse_search_terms()`. This allows plugins to normalize individual search terms (e.g., stripping Arabic diacritics/Hamza variants) or completely remove specific terms from a search query by returning an empty string.

### Testing Instructions:
1. Run PHPUnit tests: `npm run test:php -- tests/phpunit/tests/query/search.php`
2. Verify all tests pass.

## Use of AI Tools

AI assistance: Yes
Tool(s): GitHub Copilot
Model(s): Gemini, Claude
Used for: Checking for potential edge cases, drafting the PR description, and assisting with local code review. The final implementation and testing were written and executed manually by me.

---

**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
