### PR TITLE
Security: Use aria-controls attribute with safe $( '#' + id ) selector pattern avoiding unsafe use of href

### DIFF
--- a/src/js/_enqueues/admin/common.js
+++ b/src/js/_enqueues/admin/common.js
@@ -695,7 +695,7 @@ $('.contextual-help-tabs').on( 'click', 'a', function(e) {
 	$('.contextual-help-tabs .active').removeClass('active');
 	link.parent('li').addClass('active');
 
-	panel = $( link.attr('href') );
+	panel = $( '#' + link.attr( 'aria-controls' ) );
 
 	// Panels.
 	$('.help-tab-content').not( panel ).removeClass('active').hide();

--- a/src/js/_enqueues/admin/common.js
+++ b/src/js/_enqueues/admin/common.js
@@ -695,7 +695,7 @@ $('.contextual-help-tabs').on( 'click', 'a', function(e) {
 	$('.contextual-help-tabs .active').removeClass('active');
 	link.parent('li').addClass('active');
 
-	panel = $( '#' + link.attr( 'aria-controls' ) );
+	panel = $( document.getElementById( link.attr( 'aria-controls' ) ) );
 
 	// Panels.
 	$('.help-tab-content').not( panel ).removeClass('active').hide();

--- a/src/js/_enqueues/admin/common.js
+++ b/src/js/_enqueues/admin/common.js
@@ -695,7 +695,11 @@ $('.contextual-help-tabs').on( 'click', 'a', function(e) {
 	$('.contextual-help-tabs .active').removeClass('active');
 	link.parent('li').addClass('active');
 
-	panel = $( document.getElementById( link.attr( 'aria-controls' ) ) );
+	panel = $( document.getElementById( link.attr( 'aria-controls' ) || '' ) );
+
+	if ( ! panel.length ) {
+		return;
+	}
 
 	// Panels.
 	$('.help-tab-content').not( panel ).removeClass('active').hide();


### PR DESCRIPTION


The contextual help tab click handler passed the raw `href` attribute to jQuery's `$()`, which accepts both CSS selectors and raw HTML. 

**Fix:** Use `aria-controls` with the `$( '#' + id )` pattern, the same convention used elsewhere in the same file and across admin JS (`privacy-tools.js`, `site-health.js`).

Trac ticket: [#65574](https://core.trac.wordpress.org/ticket/65574)


## Use of AI Tools

AI assistance: Yes
Tool(s): GitHub Copilot
Model(s): Gemini, Claude
Used for: Checking for potential edge cases, drafting the PR description, and assisting with local code review. The final implementation and testing were written and executed manually by me.

---

**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
