### PR TITLE
Remove the XSLT xml-stylesheet processing instruction from all sitemaps and sitemap indices...

### DIFF
--- a/src/wp-includes/sitemaps.php
+++ b/src/wp-includes/sitemaps.php
@@ -94,21 +94,27 @@ function wp_sitemaps_get_max_urls( $object_type ) {
  * Retrieves the full URL for a sitemap.
  *
  * @since 5.5.1
+ * @since 7.1.0 Added $format parameter.
  *
  * @param string $name         The sitemap name.
  * @param string $subtype_name The sitemap subtype name. Default empty string.
  * @param int    $page         The page of the sitemap. Default 1.
+ * @param string $format       The format for the sitemap index.  Accepts 'xml', 'html'.  Default 'xml'.
  * @return string|false The sitemap URL or false if the sitemap doesn't exist.
  */
-function get_sitemap_url( $name, $subtype_name = '', $page = 1 ) {
+function get_sitemap_url( $name, $subtype_name = '', $page = 1, $format = 'xml' ) {
 	$sitemaps = wp_sitemaps_get_server();
 
 	if ( ! $sitemaps ) {
 		return false;
 	}
 
+	if ( ! in_array( $format, array( 'xml', 'html' ), true ) ) {
+		$format = 'xml';
+	}
+
 	if ( 'index' === $name ) {
-		return $sitemaps->index->get_index_url();
+		return $sitemaps->index->get_index_url( $format );
 	}
 
 	$provider = $sitemaps->registry->get_provider( $name );
@@ -125,5 +131,5 @@ function get_sitemap_url( $name, $subtype_name = '', $page = 1 ) {
 		$page = 1;
 	}
 
-	return $provider->get_sitemap_url( $subtype_name, $page );
+	return $provider->get_sitemap_url( $subtype_name, $page, $format );
 }

--- a/src/wp-includes/sitemaps.php
+++ b/src/wp-includes/sitemaps.php
@@ -87,34 +87,28 @@ function wp_sitemaps_get_max_urls( $object_type ) {
 	 * @param int    $max_urls    The maximum number of URLs included in a sitemap. Default 2000.
 	 * @param string $object_type Object type for sitemap to be filtered (e.g. 'post', 'term', 'user').
 	 */
-	return apply_filters( 'wp_sitemaps_max_urls', 100,/*2000,*/ $object_type );
+	return apply_filters( 'wp_sitemaps_max_urls', 2000, $object_type );
 }
 
 /**
  * Retrieves the full URL for a sitemap.
  *
  * @since 5.5.1
- * @since 7.1.0 Added $format parameter.
  *
  * @param string $name         The sitemap name.
  * @param string $subtype_name The sitemap subtype name. Default empty string.
  * @param int    $page         The page of the sitemap. Default 1.
- * @param string $format       The format for the sitemap index.  Accepts 'xml', 'html'.  Default 'xml'.
  * @return string|false The sitemap URL or false if the sitemap doesn't exist.
  */
-function get_sitemap_url( $name, $subtype_name = '', $page = 1, $format = 'xml' ) {
+function get_sitemap_url( $name, $subtype_name = '', $page = 1 ) {
 	$sitemaps = wp_sitemaps_get_server();
 
 	if ( ! $sitemaps ) {
 		return false;
 	}
 
-	if ( ! in_array( $format, array( 'xml', 'html' ), true ) ) {
-		$format = 'xml';
-	}
-
 	if ( 'index' === $name ) {
-		return $sitemaps->index->get_index_url( $format );
+		return $sitemaps->index->get_index_url();
 	}
 
 	$provider = $sitemaps->registry->get_provider( $name );
@@ -131,5 +125,5 @@ function get_sitemap_url( $name, $subtype_name = '', $page = 1, $format = 'xml' 
 		$page = 1;
 	}
 
-	return $provider->get_sitemap_url( $subtype_name, $page, $format );
+	return $provider->get_sitemap_url( $subtype_name, $page );
 }

--- a/src/wp-includes/sitemaps.php
+++ b/src/wp-includes/sitemaps.php
@@ -87,28 +87,34 @@ function wp_sitemaps_get_max_urls( $object_type ) {
 	 * @param int    $max_urls    The maximum number of URLs included in a sitemap. Default 2000.
 	 * @param string $object_type Object type for sitemap to be filtered (e.g. 'post', 'term', 'user').
 	 */
-	return apply_filters( 'wp_sitemaps_max_urls', 2000, $object_type );
+	return apply_filters( 'wp_sitemaps_max_urls', 100,/*2000,*/ $object_type );
 }
 
 /**
  * Retrieves the full URL for a sitemap.
  *
  * @since 5.5.1
+ * @since 7.1.0 Added $format parameter.
  *
  * @param string $name         The sitemap name.
  * @param string $subtype_name The sitemap subtype name. Default empty string.
  * @param int    $page         The page of the sitemap. Default 1.
+ * @param string $format       The format for the sitemap index.  Accepts 'xml', 'html'.  Default 'xml'.
  * @return string|false The sitemap URL or false if the sitemap doesn't exist.
  */
-function get_sitemap_url( $name, $subtype_name = '', $page = 1 ) {
+function get_sitemap_url( $name, $subtype_name = '', $page = 1, $format = 'xml' ) {
 	$sitemaps = wp_sitemaps_get_server();
 
 	if ( ! $sitemaps ) {
 		return false;
 	}
 
+	if ( ! in_array( $format, array( 'xml', 'html' ), true ) ) {
+		$format = 'xml';
+	}
+
 	if ( 'index' === $name ) {
-		return $sitemaps->index->get_index_url();
+		return $sitemaps->index->get_index_url( $format );
 	}
 
 	$provider = $sitemaps->registry->get_provider( $name );
@@ -125,5 +131,5 @@ function get_sitemap_url( $name, $subtype_name = '', $page = 1 ) {
 		$page = 1;
 	}
 
-	return $provider->get_sitemap_url( $subtype_name, $page );
+	return $provider->get_sitemap_url( $subtype_name, $page, $format );
 }

--- a/src/wp-includes/sitemaps/class-wp-sitemaps-index.php
+++ b/src/wp-includes/sitemaps/class-wp-sitemaps-index.php
@@ -49,16 +49,22 @@ class WP_Sitemaps_Index {
 	 * Gets a sitemap list for the index.
 	 *
 	 * @since 5.5.0
+	 * @since 7.1.0 Added $format parameter.
 	 *
+	 * @param string $format The format for the sitemap index.  Accepts 'xml', 'html'.
 	 * @return array[] Array of all sitemaps.
 	 */
-	public function get_sitemap_list() {
+	public function get_sitemap_list( $format ) {
 		$sitemaps = array();
+
+		if ( ! in_array( $format, array( 'xml', 'html' ), true ) ) {
+			$format = 'xml';
+		}
 
 		$providers = $this->registry->get_providers();
 		/* @var WP_Sitemaps_Provider $provider */
 		foreach ( $providers as $name => $provider ) {
-			$sitemap_entries = $provider->get_sitemap_entries();
+			$sitemap_entries = $provider->get_sitemap_entries( $format );
 
 			// Prevent issues with array_push and empty arrays on PHP < 7.3.
 			if ( ! $sitemap_entries ) {
@@ -79,18 +85,24 @@ class WP_Sitemaps_Index {
 	 * Builds the URL for the sitemap index.
 	 *
 	 * @since 5.5.0
+	 * @since 7.1.0 Added $format parameter.
 	 *
 	 * @global WP_Rewrite $wp_rewrite WordPress rewrite component.
 	 *
+	 * @param string $format   The format for the sitemap index.  Accepts 'xml', 'html'.
 	 * @return string The sitemap index URL.
 	 */
-	public function get_index_url() {
+	public function get_index_url( $format ) {
 		global $wp_rewrite;
 
-		if ( ! $wp_rewrite->using_permalinks() ) {
-			return home_url( '/?sitemap=index' );
+		if ( ! in_array( $format, array( 'xml', 'html' ), true ) ) {
+			$format = 'xml';
 		}
 
-		return home_url( '/wp-sitemap.xml' );
+		if ( ! $wp_rewrite->using_permalinks() ) {
+			return home_url( '/?sitemap=index&sitemap-format=' . $format );
+		}
+
+		return home_url( "/wp-sitemap.{$format}" );
 	}
 }

--- a/src/wp-includes/sitemaps/class-wp-sitemaps-index.php
+++ b/src/wp-includes/sitemaps/class-wp-sitemaps-index.php
@@ -49,22 +49,16 @@ class WP_Sitemaps_Index {
 	 * Gets a sitemap list for the index.
 	 *
 	 * @since 5.5.0
-	 * @since 7.1.0 Added $format parameter.
 	 *
-	 * @param string $format The format for the sitemap index.  Accepts 'xml', 'html'.
 	 * @return array[] Array of all sitemaps.
 	 */
-	public function get_sitemap_list( $format ) {
+	public function get_sitemap_list() {
 		$sitemaps = array();
-
-		if ( ! in_array( $format, array( 'xml', 'html' ), true ) ) {
-			$format = 'xml';
-		}
 
 		$providers = $this->registry->get_providers();
 		/* @var WP_Sitemaps_Provider $provider */
 		foreach ( $providers as $name => $provider ) {
-			$sitemap_entries = $provider->get_sitemap_entries( $format );
+			$sitemap_entries = $provider->get_sitemap_entries();
 
 			// Prevent issues with array_push and empty arrays on PHP < 7.3.
 			if ( ! $sitemap_entries ) {
@@ -85,24 +79,18 @@ class WP_Sitemaps_Index {
 	 * Builds the URL for the sitemap index.
 	 *
 	 * @since 5.5.0
-	 * @since 7.1.0 Added $format parameter.
 	 *
 	 * @global WP_Rewrite $wp_rewrite WordPress rewrite component.
 	 *
-	 * @param string $format   The format for the sitemap index.  Accepts 'xml', 'html'.
 	 * @return string The sitemap index URL.
 	 */
-	public function get_index_url( $format ) {
+	public function get_index_url() {
 		global $wp_rewrite;
 
-		if ( ! in_array( $format, array( 'xml', 'html' ), true ) ) {
-			$format = 'xml';
-		}
-
 		if ( ! $wp_rewrite->using_permalinks() ) {
-			return home_url( '/?sitemap=index&sitemap-format=' . $format );
+			return home_url( '/?sitemap=index' );
 		}
 
-		return home_url( "/wp-sitemap.{$format}" );
+		return home_url( '/wp-sitemap.xml' );
 	}
 }

--- a/src/wp-includes/sitemaps/class-wp-sitemaps-provider.php
+++ b/src/wp-includes/sitemaps/class-wp-sitemaps-provider.php
@@ -100,32 +100,40 @@ abstract class WP_Sitemaps_Provider {
 	 * The returned data is used to populate the sitemap entries of the index.
 	 *
 	 * @since 5.5.0
+	 * @since 7.1.0 Added $format parameter.
 	 *
+	 * @param string $format The format for the sitemap index.  Accepts 'xml', 'html'.
 	 * @return array[] Array of sitemap entries.
 	 */
-	public function get_sitemap_entries() {
+	public function get_sitemap_entries( $format ) {
 		$sitemaps = array();
+
+		if ( ! in_array( $format, array( 'xml', 'html' ), true ) ) {
+			$format = 'xml';
+		}
 
 		$sitemap_types = $this->get_sitemap_type_data();
 
 		foreach ( $sitemap_types as $type ) {
 			for ( $page = 1; $page <= $type['pages']; $page++ ) {
 				$sitemap_entry = array(
-					'loc' => $this->get_sitemap_url( $type['name'], $page ),
+					'loc' => $this->get_sitemap_url( $type['name'], $page, $format ),
 				);
 
 				/**
 				 * Filters the sitemap entry for the sitemap index.
 				 *
 				 * @since 5.5.0
+				 * @since 7.1.0 Added $format parameter.
 				 *
 				 * @param array  $sitemap_entry  Sitemap entry for the post.
 				 * @param string $object_type    Object empty name.
 				 * @param string $object_subtype Object subtype name.
 				 *                               Empty string if the object type does not support subtypes.
 				 * @param int    $page           Page number of results.
+				 * @param string $format         The format for the sitemap index.  Accepts 'xml', 'html'.
 				 */
-				$sitemap_entry = apply_filters( 'wp_sitemaps_index_entry', $sitemap_entry, $this->object_type, $type['name'], $page );
+				$sitemap_entry = apply_filters( 'wp_sitemaps_index_entry', $sitemap_entry, $this->object_type, $type['name'], $page, $format );
 
 				$sitemaps[] = $sitemap_entry;
 			}
@@ -138,14 +146,16 @@ abstract class WP_Sitemaps_Provider {
 	 * Gets the URL of a sitemap entry.
 	 *
 	 * @since 5.5.0
+	 * @since 7.1.0 Added $format parameter.
 	 *
 	 * @global WP_Rewrite $wp_rewrite WordPress rewrite component.
 	 *
-	 * @param string $name The name of the sitemap.
-	 * @param int    $page The page of the sitemap.
+	 * @param string $name   The name of the sitemap.
+	 * @param int    $page   The page of the sitemap.
+	 * @param string $format The format for the sitemap index.  Accepts 'xml', 'html'.
 	 * @return string The composed URL for a sitemap entry.
 	 */
-	public function get_sitemap_url( $name, $page ) {
+	public function get_sitemap_url( $name, $page, $format ) {
 		global $wp_rewrite;
 
 		// Accounts for cases where name is not included, ex: sitemaps-users-1.xml.
@@ -157,12 +167,19 @@ abstract class WP_Sitemaps_Provider {
 			)
 		);
 
+		if ( ! in_array( $format, array( 'xml', 'html' ), true ) ) {
+			$format = 'xml';
+		}
+
 		$basename = sprintf(
-			'/wp-sitemap-%1$s.xml',
-			implode( '-', $params )
+			'/wp-sitemap-%1$s.%2$s',
+			implode( '-', $params ),
+			$format
 		);
 
 		if ( ! $wp_rewrite->using_permalinks() ) {
+			$params['sitemap-format'] = $format;
+
 			$basename = '/?' . http_build_query( $params, '', '&' );
 		}
 

--- a/src/wp-includes/sitemaps/class-wp-sitemaps-provider.php
+++ b/src/wp-includes/sitemaps/class-wp-sitemaps-provider.php
@@ -100,40 +100,32 @@ abstract class WP_Sitemaps_Provider {
 	 * The returned data is used to populate the sitemap entries of the index.
 	 *
 	 * @since 5.5.0
-	 * @since 7.1.0 Added $format parameter.
 	 *
-	 * @param string $format The format for the sitemap index.  Accepts 'xml', 'html'.
 	 * @return array[] Array of sitemap entries.
 	 */
-	public function get_sitemap_entries( $format ) {
+	public function get_sitemap_entries() {
 		$sitemaps = array();
-
-		if ( ! in_array( $format, array( 'xml', 'html' ), true ) ) {
-			$format = 'xml';
-		}
 
 		$sitemap_types = $this->get_sitemap_type_data();
 
 		foreach ( $sitemap_types as $type ) {
 			for ( $page = 1; $page <= $type['pages']; $page++ ) {
 				$sitemap_entry = array(
-					'loc' => $this->get_sitemap_url( $type['name'], $page, $format ),
+					'loc' => $this->get_sitemap_url( $type['name'], $page ),
 				);
 
 				/**
 				 * Filters the sitemap entry for the sitemap index.
 				 *
 				 * @since 5.5.0
-				 * @since 7.1.0 Added $format parameter.
 				 *
 				 * @param array  $sitemap_entry  Sitemap entry for the post.
 				 * @param string $object_type    Object empty name.
 				 * @param string $object_subtype Object subtype name.
 				 *                               Empty string if the object type does not support subtypes.
 				 * @param int    $page           Page number of results.
-				 * @param string $format         The format for the sitemap index.  Accepts 'xml', 'html'.
 				 */
-				$sitemap_entry = apply_filters( 'wp_sitemaps_index_entry', $sitemap_entry, $this->object_type, $type['name'], $page, $format );
+				$sitemap_entry = apply_filters( 'wp_sitemaps_index_entry', $sitemap_entry, $this->object_type, $type['name'], $page );
 
 				$sitemaps[] = $sitemap_entry;
 			}
@@ -146,16 +138,14 @@ abstract class WP_Sitemaps_Provider {
 	 * Gets the URL of a sitemap entry.
 	 *
 	 * @since 5.5.0
-	 * @since 7.1.0 Added $format parameter.
 	 *
 	 * @global WP_Rewrite $wp_rewrite WordPress rewrite component.
 	 *
-	 * @param string $name   The name of the sitemap.
-	 * @param int    $page   The page of the sitemap.
-	 * @param string $format The format for the sitemap index.  Accepts 'xml', 'html'.
+	 * @param string $name The name of the sitemap.
+	 * @param int    $page The page of the sitemap.
 	 * @return string The composed URL for a sitemap entry.
 	 */
-	public function get_sitemap_url( $name, $page, $format ) {
+	public function get_sitemap_url( $name, $page ) {
 		global $wp_rewrite;
 
 		// Accounts for cases where name is not included, ex: sitemaps-users-1.xml.
@@ -167,19 +157,12 @@ abstract class WP_Sitemaps_Provider {
 			)
 		);
 
-		if ( ! in_array( $format, array( 'xml', 'html' ), true ) ) {
-			$format = 'xml';
-		}
-
 		$basename = sprintf(
-			'/wp-sitemap-%1$s.%2$s',
-			implode( '-', $params ),
-			$format
+			'/wp-sitemap-%1$s.xml',
+			implode( '-', $params )
 		);
 
 		if ( ! $wp_rewrite->using_permalinks() ) {
-			$params['sitemap-format'] = $format;
-
 			$basename = '/?' . http_build_query( $params, '', '&' );
 		}
 

--- a/src/wp-includes/sitemaps/class-wp-sitemaps-renderer.php
+++ b/src/wp-includes/sitemaps/class-wp-sitemaps-renderer.php
@@ -17,121 +17,45 @@
 #[AllowDynamicProperties]
 class WP_Sitemaps_Renderer {
 	/**
-	 * XSL stylesheet for styling a sitemap for web browsers.
-	 *
-	 * @since 5.5.0
-	 *
-	 * @var string
-	 */
-	protected $stylesheet = '';
-
-	/**
-	 * XSL stylesheet for styling a sitemap for web browsers.
-	 *
-	 * @since 5.5.0
-	 *
-	 * @var string
-	 */
-	protected $stylesheet_index = '';
-
-	/**
-	 * WP_Sitemaps_Renderer constructor.
-	 *
-	 * @since 5.5.0
-	 */
-	public function __construct() {
-		$stylesheet_url = $this->get_sitemap_stylesheet_url();
-
-		if ( $stylesheet_url ) {
-			$this->stylesheet = '<?xml-stylesheet type="text/xsl" href="' . esc_url( $stylesheet_url ) . '" ?>';
-		}
-
-		$stylesheet_index_url = $this->get_sitemap_index_stylesheet_url();
-
-		if ( $stylesheet_index_url ) {
-			$this->stylesheet_index = '<?xml-stylesheet type="text/xsl" href="' . esc_url( $stylesheet_index_url ) . '" ?>';
-		}
-	}
-
-	/**
-	 * Gets the URL for the sitemap stylesheet.
-	 *
-	 * @since 5.5.0
-	 *
-	 * @global WP_Rewrite $wp_rewrite WordPress rewrite component.
-	 *
-	 * @return string The sitemap stylesheet URL.
-	 */
-	public function get_sitemap_stylesheet_url() {
-		global $wp_rewrite;
-
-		$sitemap_url = home_url( '/wp-sitemap.xsl' );
-
-		if ( ! $wp_rewrite->using_permalinks() ) {
-			$sitemap_url = home_url( '/?sitemap-stylesheet=sitemap' );
-		}
-
-		/**
-		 * Filters the URL for the sitemap stylesheet.
-		 *
-		 * If a falsey value is returned, no stylesheet will be used and
-		 * the "raw" XML of the sitemap will be displayed.
-		 *
-		 * @since 5.5.0
-		 *
-		 * @param string $sitemap_url Full URL for the sitemaps XSL file.
-		 */
-		return apply_filters( 'wp_sitemaps_stylesheet_url', $sitemap_url );
-	}
-
-	/**
-	 * Gets the URL for the sitemap index stylesheet.
-	 *
-	 * @since 5.5.0
-	 *
-	 * @global WP_Rewrite $wp_rewrite WordPress rewrite component.
-	 *
-	 * @return string The sitemap index stylesheet URL.
-	 */
-	public function get_sitemap_index_stylesheet_url() {
-		global $wp_rewrite;
-
-		$sitemap_url = home_url( '/wp-sitemap-index.xsl' );
-
-		if ( ! $wp_rewrite->using_permalinks() ) {
-			$sitemap_url = home_url( '/?sitemap-stylesheet=index' );
-		}
-
-		/**
-		 * Filters the URL for the sitemap index stylesheet.
-		 *
-		 * If a falsey value is returned, no stylesheet will be used and
-		 * the "raw" XML of the sitemap index will be displayed.
-		 *
-		 * @since 5.5.0
-		 *
-		 * @param string $sitemap_url Full URL for the sitemaps index XSL file.
-		 */
-		return apply_filters( 'wp_sitemaps_stylesheet_index_url', $sitemap_url );
-	}
-
-	/**
 	 * Renders a sitemap index.
 	 *
 	 * @since 5.5.0
+	 * @since 7.1.0 Added $format parameter.
 	 *
-	 * @param array $sitemaps Array of sitemap URLs.
+	 * @param array  $sitemaps Array of sitemap URLs.
+	 * @param string $format   The format for the sitemap index.  Accepts 'xml', 'html'.
 	 */
-	public function render_index( $sitemaps ) {
-		header( 'Content-Type: application/xml; charset=UTF-8' );
-
+	public function render_index( $sitemaps, $format ) {
 		$this->check_for_simple_xml_availability();
 
 		$index_xml = $this->get_sitemap_index_xml( $sitemaps );
+		if ( ! $index_xml ) {
+			return;
+		}
 
-		if ( ! empty( $index_xml ) ) {
-			// All output is escaped within get_sitemap_index_xml().
-			echo $index_xml;
+		if ( ! in_array( $format, array( 'xml', 'html' ), true ) ) {
+			$format = 'xml';
+		}
+
+		switch ( $format ) {
+			case 'html':
+				$this->check_for_xslt_availability();
+
+				$xslt = ( new WP_Sitemaps_Stylesheet() )->get_sitemap_index_stylesheet();
+
+				$html = $this->generate_html( $index_xml, $xslt );
+
+				echo $html;
+
+				break;
+			case 'xml':
+			default:
+				header( 'Content-Type: application/xml; charset=UTF-8' );
+
+				// All output is escaped within get_sitemap_xml().
+				echo $index_xml;
+
+				break;
 		}
 	}
 
@@ -146,9 +70,8 @@ class WP_Sitemaps_Renderer {
 	public function get_sitemap_index_xml( $sitemaps ) {
 		$sitemap_index = new SimpleXMLElement(
 			sprintf(
-				'%1$s%2$s%3$s',
+				'%1$s%2$s',
 				'<?xml version="1.0" encoding="UTF-8" ?>',
-				$this->stylesheet_index,
 				'<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" />'
 			)
 		);
@@ -183,19 +106,42 @@ class WP_Sitemaps_Renderer {
 	 * Renders a sitemap.
 	 *
 	 * @since 5.5.0
+	 * @since 7.1.0 Added $format parameter.
 	 *
-	 * @param array $url_list Array of URLs for a sitemap.
+	 * @param array  $url_list Array of URLs for a sitemap.
+	 * @param string $format   The format for the sitemap index.  Accepts 'xml', 'html'.
 	 */
-	public function render_sitemap( $url_list ) {
-		header( 'Content-Type: application/xml; charset=UTF-8' );
-
+	public function render_sitemap( $url_list, $format ) {
 		$this->check_for_simple_xml_availability();
 
 		$sitemap_xml = $this->get_sitemap_xml( $url_list );
+		if ( empty( $sitemap_xml ) ) {
+			return;
+		}
 
-		if ( ! empty( $sitemap_xml ) ) {
-			// All output is escaped within get_sitemap_xml().
-			echo $sitemap_xml;
+		if ( ! in_array( $format, array( 'xml', 'html' ), true ) ) {
+			$format = 'xml';
+		}
+
+		switch ( $format ) {
+			case 'html':
+				$this->check_for_xslt_availability();
+
+				$xslt = ( new WP_Sitemaps_Stylesheet() )->get_sitemap_stylesheet();
+
+				$html = $this->generate_html( $sitemap_xml, $xslt );
+
+				echo $html;
+
+				break;
+			case 'xml':
+			default:
+				header( 'Content-Type: application/xml; charset=UTF-8' );
+
+				// All output is escaped within get_sitemap_xml().
+				echo $sitemap_xml;
+
+				break;
 		}
 	}
 
@@ -210,9 +156,8 @@ class WP_Sitemaps_Renderer {
 	public function get_sitemap_xml( $url_list ) {
 		$urlset = new SimpleXMLElement(
 			sprintf(
-				'%1$s%2$s%3$s',
+				'%1$s%2$s',
 				'<?xml version="1.0" encoding="UTF-8" ?>',
-				$this->stylesheet,
 				'<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" />'
 			)
 		);
@@ -269,5 +214,76 @@ class WP_Sitemaps_Renderer {
 				)
 			);
 		}
+	}
+
+	/**
+	 * Checks for the availability of the DOMDocument & XSLTProcessor extension and errors if missing.
+	 *
+	 * @since 7.1.0
+	 */
+	private function check_for_xslt_availability() {
+		if ( ! class_exists( 'DOMDocument' ) ) {
+			wp_die(
+				sprintf(
+					/* translators: %s: DOMDocument */
+					esc_html( __( 'Could not generate XML sitemap due to missing %s extension' ) ),
+					'DOMDocument'
+				),
+				esc_html( __( 'WordPress &rsaquo; Error' ) ),
+				array(
+					'response' => 501, // "Not implemented".
+				)
+			);
+		}
+
+		if ( ! class_exists( 'XSLTProcessor' ) ) {
+			wp_die(
+				sprintf(
+					/* translators: %s: XSLTProcessor */
+					esc_html( __( 'Could not generate XML sitemap due to missing %s extension' ) ),
+					'XSLTProcessor'
+				),
+				esc_html( __( 'WordPress &rsaquo; Error' ) ),
+				array(
+					'response' => 501, // "Not implemented".
+				)
+			);
+		}
+	}
+
+	/**
+	 * Generate the HTML rendering of the sitemap or sitemap index using XSLT.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param SimpleXMLElement $xml        The XML of the sitemap or sitemap index.
+	 * @param string           $stylesheet The XSLT to apply to $xml.
+	 * @return string
+	 */
+	protected function generate_html( $xml, $stylesheet ) {
+		// @todo add some DOM/XSLTProcessor related error checking.
+
+		// Load the XML source document into a DOM.
+		$dom = new DOMDocument();
+		$dom->loadXML( $xml );
+
+		// Load the XSLT into a DOM.
+		$xslt = new DOMDocument();
+		$xslt->loadXML( $stylesheet );
+
+		// Create the XSLT processor and load the XSLT.
+		$proc = new XSLTProcessor();
+		$proc->importStylesheet( $xslt );
+
+		// Run the XSLT on the source XML.
+		// Note: XSLTProcessor::transformToXML() is poorly named and need NOT produce XML;
+		//       that is, it will produce whatever is specified by xsl:output/@method in the transform,
+		//       which in our case is 'text/html'.
+		$html = $proc->transformToXML( $dom );
+		if ( ! $html ) {
+			$html = '';
+		}
+
+		return $html;
 	}
 }

--- a/src/wp-includes/sitemaps/class-wp-sitemaps-renderer.php
+++ b/src/wp-includes/sitemaps/class-wp-sitemaps-renderer.php
@@ -17,45 +17,121 @@
 #[AllowDynamicProperties]
 class WP_Sitemaps_Renderer {
 	/**
+	 * XSL stylesheet for styling a sitemap for web browsers.
+	 *
+	 * @since 5.5.0
+	 *
+	 * @var string
+	 */
+	protected $stylesheet = '';
+
+	/**
+	 * XSL stylesheet for styling a sitemap for web browsers.
+	 *
+	 * @since 5.5.0
+	 *
+	 * @var string
+	 */
+	protected $stylesheet_index = '';
+
+	/**
+	 * WP_Sitemaps_Renderer constructor.
+	 *
+	 * @since 5.5.0
+	 */
+	public function __construct() {
+		$stylesheet_url = $this->get_sitemap_stylesheet_url();
+
+		if ( $stylesheet_url ) {
+			$this->stylesheet = '<?xml-stylesheet type="text/xsl" href="' . esc_url( $stylesheet_url ) . '" ?>';
+		}
+
+		$stylesheet_index_url = $this->get_sitemap_index_stylesheet_url();
+
+		if ( $stylesheet_index_url ) {
+			$this->stylesheet_index = '<?xml-stylesheet type="text/xsl" href="' . esc_url( $stylesheet_index_url ) . '" ?>';
+		}
+	}
+
+	/**
+	 * Gets the URL for the sitemap stylesheet.
+	 *
+	 * @since 5.5.0
+	 *
+	 * @global WP_Rewrite $wp_rewrite WordPress rewrite component.
+	 *
+	 * @return string The sitemap stylesheet URL.
+	 */
+	public function get_sitemap_stylesheet_url() {
+		global $wp_rewrite;
+
+		$sitemap_url = home_url( '/wp-sitemap.xsl' );
+
+		if ( ! $wp_rewrite->using_permalinks() ) {
+			$sitemap_url = home_url( '/?sitemap-stylesheet=sitemap' );
+		}
+
+		/**
+		 * Filters the URL for the sitemap stylesheet.
+		 *
+		 * If a falsey value is returned, no stylesheet will be used and
+		 * the "raw" XML of the sitemap will be displayed.
+		 *
+		 * @since 5.5.0
+		 *
+		 * @param string $sitemap_url Full URL for the sitemaps XSL file.
+		 */
+		return apply_filters( 'wp_sitemaps_stylesheet_url', $sitemap_url );
+	}
+
+	/**
+	 * Gets the URL for the sitemap index stylesheet.
+	 *
+	 * @since 5.5.0
+	 *
+	 * @global WP_Rewrite $wp_rewrite WordPress rewrite component.
+	 *
+	 * @return string The sitemap index stylesheet URL.
+	 */
+	public function get_sitemap_index_stylesheet_url() {
+		global $wp_rewrite;
+
+		$sitemap_url = home_url( '/wp-sitemap-index.xsl' );
+
+		if ( ! $wp_rewrite->using_permalinks() ) {
+			$sitemap_url = home_url( '/?sitemap-stylesheet=index' );
+		}
+
+		/**
+		 * Filters the URL for the sitemap index stylesheet.
+		 *
+		 * If a falsey value is returned, no stylesheet will be used and
+		 * the "raw" XML of the sitemap index will be displayed.
+		 *
+		 * @since 5.5.0
+		 *
+		 * @param string $sitemap_url Full URL for the sitemaps index XSL file.
+		 */
+		return apply_filters( 'wp_sitemaps_stylesheet_index_url', $sitemap_url );
+	}
+
+	/**
 	 * Renders a sitemap index.
 	 *
 	 * @since 5.5.0
-	 * @since 7.1.0 Added $format parameter.
 	 *
-	 * @param array  $sitemaps Array of sitemap URLs.
-	 * @param string $format   The format for the sitemap index.  Accepts 'xml', 'html'.
+	 * @param array $sitemaps Array of sitemap URLs.
 	 */
-	public function render_index( $sitemaps, $format ) {
+	public function render_index( $sitemaps ) {
+		header( 'Content-Type: application/xml; charset=UTF-8' );
+
 		$this->check_for_simple_xml_availability();
 
 		$index_xml = $this->get_sitemap_index_xml( $sitemaps );
-		if ( ! $index_xml ) {
-			return;
-		}
 
-		if ( ! in_array( $format, array( 'xml', 'html' ), true ) ) {
-			$format = 'xml';
-		}
-
-		switch ( $format ) {
-			case 'html':
-				$this->check_for_xslt_availability();
-
-				$xslt = ( new WP_Sitemaps_Stylesheet() )->get_sitemap_index_stylesheet();
-
-				$html = $this->generate_html( $index_xml, $xslt );
-
-				echo $html;
-
-				break;
-			case 'xml':
-			default:
-				header( 'Content-Type: application/xml; charset=UTF-8' );
-
-				// All output is escaped within get_sitemap_xml().
-				echo $index_xml;
-
-				break;
+		if ( ! empty( $index_xml ) ) {
+			// All output is escaped within get_sitemap_index_xml().
+			echo $index_xml;
 		}
 	}
 
@@ -70,8 +146,9 @@ class WP_Sitemaps_Renderer {
 	public function get_sitemap_index_xml( $sitemaps ) {
 		$sitemap_index = new SimpleXMLElement(
 			sprintf(
-				'%1$s%2$s',
+				'%1$s%2$s%3$s',
 				'<?xml version="1.0" encoding="UTF-8" ?>',
+				$this->stylesheet_index,
 				'<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" />'
 			)
 		);
@@ -106,42 +183,19 @@ class WP_Sitemaps_Renderer {
 	 * Renders a sitemap.
 	 *
 	 * @since 5.5.0
-	 * @since 7.1.0 Added $format parameter.
 	 *
-	 * @param array  $url_list Array of URLs for a sitemap.
-	 * @param string $format   The format for the sitemap index.  Accepts 'xml', 'html'.
+	 * @param array $url_list Array of URLs for a sitemap.
 	 */
-	public function render_sitemap( $url_list, $format ) {
+	public function render_sitemap( $url_list ) {
+		header( 'Content-Type: application/xml; charset=UTF-8' );
+
 		$this->check_for_simple_xml_availability();
 
 		$sitemap_xml = $this->get_sitemap_xml( $url_list );
-		if ( empty( $sitemap_xml ) ) {
-			return;
-		}
 
-		if ( ! in_array( $format, array( 'xml', 'html' ), true ) ) {
-			$format = 'xml';
-		}
-
-		switch ( $format ) {
-			case 'html':
-				$this->check_for_xslt_availability();
-
-				$xslt = ( new WP_Sitemaps_Stylesheet() )->get_sitemap_stylesheet();
-
-				$html = $this->generate_html( $sitemap_xml, $xslt );
-
-				echo $html;
-
-				break;
-			case 'xml':
-			default:
-				header( 'Content-Type: application/xml; charset=UTF-8' );
-
-				// All output is escaped within get_sitemap_xml().
-				echo $sitemap_xml;
-
-				break;
+		if ( ! empty( $sitemap_xml ) ) {
+			// All output is escaped within get_sitemap_xml().
+			echo $sitemap_xml;
 		}
 	}
 
@@ -156,8 +210,9 @@ class WP_Sitemaps_Renderer {
 	public function get_sitemap_xml( $url_list ) {
 		$urlset = new SimpleXMLElement(
 			sprintf(
-				'%1$s%2$s',
+				'%1$s%2$s%3$s',
 				'<?xml version="1.0" encoding="UTF-8" ?>',
+				$this->stylesheet,
 				'<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" />'
 			)
 		);
@@ -214,76 +269,5 @@ class WP_Sitemaps_Renderer {
 				)
 			);
 		}
-	}
-
-	/**
-	 * Checks for the availability of the DOMDocument & XSLTProcessor extension and errors if missing.
-	 *
-	 * @since 7.1.0
-	 */
-	private function check_for_xslt_availability() {
-		if ( ! class_exists( 'DOMDocument' ) ) {
-			wp_die(
-				sprintf(
-					/* translators: %s: DOMDocument */
-					esc_html( __( 'Could not generate XML sitemap due to missing %s extension' ) ),
-					'DOMDocument'
-				),
-				esc_html( __( 'WordPress &rsaquo; Error' ) ),
-				array(
-					'response' => 501, // "Not implemented".
-				)
-			);
-		}
-
-		if ( ! class_exists( 'XSLTProcessor' ) ) {
-			wp_die(
-				sprintf(
-					/* translators: %s: XSLTProcessor */
-					esc_html( __( 'Could not generate XML sitemap due to missing %s extension' ) ),
-					'XSLTProcessor'
-				),
-				esc_html( __( 'WordPress &rsaquo; Error' ) ),
-				array(
-					'response' => 501, // "Not implemented".
-				)
-			);
-		}
-	}
-
-	/**
-	 * Generate the HTML rendering of the sitemap or sitemap index using XSLT.
-	 *
-	 * @since 7.1.0
-	 *
-	 * @param SimpleXMLElement $xml        The XML of the sitemap or sitemap index.
-	 * @param string           $stylesheet The XSLT to apply to $xml.
-	 * @return string
-	 */
-	protected function generate_html( $xml, $stylesheet ) {
-		// @todo add some DOM/XSLTProcessor related error checking.
-
-		// Load the XML source document into a DOM.
-		$dom = new DOMDocument();
-		$dom->loadXML( $xml );
-
-		// Load the XSLT into a DOM.
-		$xslt = new DOMDocument();
-		$xslt->loadXML( $stylesheet );
-
-		// Create the XSLT processor and load the XSLT.
-		$proc = new XSLTProcessor();
-		$proc->importStylesheet( $xslt );
-
-		// Run the XSLT on the source XML.
-		// Note: XSLTProcessor::transformToXML() is poorly named and need NOT produce XML;
-		//       that is, it will produce whatever is specified by xsl:output/@method in the transform,
-		//       which in our case is 'text/html'.
-		$html = $proc->transformToXML( $dom );
-		if ( ! $html ) {
-			$html = '';
-		}
-
-		return $html;
 	}
 }

--- a/src/wp-includes/sitemaps/class-wp-sitemaps-stylesheet.php
+++ b/src/wp-includes/sitemaps/class-wp-sitemaps-stylesheet.php
@@ -19,23 +19,12 @@ class WP_Sitemaps_Stylesheet {
 	/**
 	 * Renders the XSL stylesheet depending on whether it's the sitemap index or not.
 	 *
+	 * @deprecated 7.1.0 Deprecated because browsers will soon not support XSLT.
+	 *
 	 * @param string $type Stylesheet type. Either 'sitemap' or 'index'.
-	 * @return never
 	 */
 	public function render_stylesheet( $type ) {
-		header( 'Content-Type: application/xml; charset=UTF-8' );
-
-		if ( 'sitemap' === $type ) {
-			// All content is escaped below.
-			echo $this->get_sitemap_stylesheet();
-		}
-
-		if ( 'index' === $type ) {
-			// All content is escaped below.
-			echo $this->get_sitemap_index_stylesheet();
-		}
-
-		exit;
+		_deprecated_function( __FUNCTION__, '7.1.0' );
 	}
 
 	/**
@@ -85,6 +74,7 @@ class WP_Sitemaps_Stylesheet {
 	<xsl:variable name="has-priority"   select="count( /sitemap:urlset/sitemap:url/sitemap:priority )"   />
 
 	<xsl:template match="/">
+		<xsl:text disable-output-escaping="yes">&lt;!DOCTYPE html&gt;&#10;</xsl:text>
 		<html {$lang}>
 			<head>
 				<title>{$title}</title>
@@ -93,48 +83,50 @@ class WP_Sitemaps_Stylesheet {
 				</style>
 			</head>
 			<body>
-				<div id="sitemap">
-					<div id="sitemap__header">
-						<h1>{$title}</h1>
-						<p>{$description}</p>
-						<p>{$learn_more}</p>
-					</div>
-					<div id="sitemap__content">
-						<p class="text">{$text}</p>
-						<table id="sitemap__table">
-							<thead>
-								<tr>
-									<th class="loc">{$url}</th>
-									<xsl:if test="\$has-lastmod">
-										<th class="lastmod">{$lastmod}</th>
-									</xsl:if>
-									<xsl:if test="\$has-changefreq">
-										<th class="changefreq">{$changefreq}</th>
-									</xsl:if>
-									<xsl:if test="\$has-priority">
-										<th class="priority">{$priority}</th>
-									</xsl:if>
-								</tr>
-							</thead>
-							<tbody>
-								<xsl:for-each select="sitemap:urlset/sitemap:url">
+				<main>
+					<div id="sitemap">
+						<div id="sitemap__header">
+							<h1>{$title}</h1>
+							<p>{$description}</p>
+							<p>{$learn_more}</p>
+						</div>
+						<div id="sitemap__content">
+							<p class="text">{$text}</p>
+							<table id="sitemap__table">
+								<thead>
 									<tr>
-										<td class="loc"><a href="{sitemap:loc}"><xsl:value-of select="sitemap:loc" /></a></td>
+										<th class="loc">{$url}</th>
 										<xsl:if test="\$has-lastmod">
-											<td class="lastmod"><xsl:value-of select="sitemap:lastmod" /></td>
+											<th class="lastmod">{$lastmod}</th>
 										</xsl:if>
 										<xsl:if test="\$has-changefreq">
-											<td class="changefreq"><xsl:value-of select="sitemap:changefreq" /></td>
+											<th class="changefreq">{$changefreq}</th>
 										</xsl:if>
 										<xsl:if test="\$has-priority">
-											<td class="priority"><xsl:value-of select="sitemap:priority" /></td>
+											<th class="priority">{$priority}</th>
 										</xsl:if>
 									</tr>
-								</xsl:for-each>
-							</tbody>
-						</table>
+								</thead>
+								<tbody>
+									<xsl:for-each select="sitemap:urlset/sitemap:url">
+										<tr>
+											<td class="loc"><a href="{sitemap:loc}"><xsl:value-of select="sitemap:loc" /></a></td>
+											<xsl:if test="\$has-lastmod">
+												<td class="lastmod"><xsl:value-of select="sitemap:lastmod" /></td>
+											</xsl:if>
+											<xsl:if test="\$has-changefreq">
+												<td class="changefreq"><xsl:value-of select="sitemap:changefreq" /></td>
+											</xsl:if>
+											<xsl:if test="\$has-priority">
+												<td class="priority"><xsl:value-of select="sitemap:priority" /></td>
+											</xsl:if>
+										</tr>
+									</xsl:for-each>
+								</tbody>
+							</table>
+						</div>
 					</div>
-				</div>
+				</main>
 			</body>
 		</html>
 	</xsl:template>
@@ -195,6 +187,7 @@ XSL;
 	<xsl:variable name="has-lastmod" select="count( /sitemap:sitemapindex/sitemap:sitemap/sitemap:lastmod )" />
 
 	<xsl:template match="/">
+		<xsl:text disable-output-escaping="yes">&lt;!DOCTYPE html&gt;&#10;</xsl:text>
 		<html {$lang}>
 			<head>
 				<title>{$title}</title>
@@ -203,36 +196,38 @@ XSL;
 				</style>
 			</head>
 			<body>
-				<div id="sitemap">
-					<div id="sitemap__header">
-						<h1>{$title}</h1>
-						<p>{$description}</p>
-						<p>{$learn_more}</p>
-					</div>
-					<div id="sitemap__content">
-						<p class="text">{$text}</p>
-						<table id="sitemap__table">
-							<thead>
-								<tr>
-									<th class="loc">{$url}</th>
-									<xsl:if test="\$has-lastmod">
-										<th class="lastmod">{$lastmod}</th>
-									</xsl:if>
-								</tr>
-							</thead>
-							<tbody>
-								<xsl:for-each select="sitemap:sitemapindex/sitemap:sitemap">
+				<main>
+					<div id="sitemap">
+						<div id="sitemap__header">
+							<h1>{$title}</h1>
+							<p>{$description}</p>
+							<p>{$learn_more}</p>
+						</div>
+						<div id="sitemap__content">
+							<p class="text">{$text}</p>
+							<table id="sitemap__table">
+								<thead>
 									<tr>
-										<td class="loc"><a href="{sitemap:loc}"><xsl:value-of select="sitemap:loc" /></a></td>
+										<th class="loc">{$url}</th>
 										<xsl:if test="\$has-lastmod">
-											<td class="lastmod"><xsl:value-of select="sitemap:lastmod" /></td>
+											<th class="lastmod">{$lastmod}</th>
 										</xsl:if>
 									</tr>
-								</xsl:for-each>
-							</tbody>
-						</table>
+								</thead>
+								<tbody>
+									<xsl:for-each select="sitemap:sitemapindex/sitemap:sitemap">
+										<tr>
+											<td class="loc"><a href="{sitemap:loc}"><xsl:value-of select="sitemap:loc" /></a></td>
+											<xsl:if test="\$has-lastmod">
+												<td class="lastmod"><xsl:value-of select="sitemap:lastmod" /></td>
+											</xsl:if>
+										</tr>
+									</xsl:for-each>
+								</tbody>
+							</table>
+						</div>
 					</div>
-				</div>
+				</main>
 			</body>
 		</html>
 	</xsl:template>

--- a/src/wp-includes/sitemaps/class-wp-sitemaps-stylesheet.php
+++ b/src/wp-includes/sitemaps/class-wp-sitemaps-stylesheet.php
@@ -19,12 +19,23 @@ class WP_Sitemaps_Stylesheet {
 	/**
 	 * Renders the XSL stylesheet depending on whether it's the sitemap index or not.
 	 *
-	 * @deprecated 7.1.0 Deprecated because browsers will soon not support XSLT.
-	 *
 	 * @param string $type Stylesheet type. Either 'sitemap' or 'index'.
+	 * @return never
 	 */
 	public function render_stylesheet( $type ) {
-		_deprecated_function( __FUNCTION__, '7.1.0' );
+		header( 'Content-Type: application/xml; charset=UTF-8' );
+
+		if ( 'sitemap' === $type ) {
+			// All content is escaped below.
+			echo $this->get_sitemap_stylesheet();
+		}
+
+		if ( 'index' === $type ) {
+			// All content is escaped below.
+			echo $this->get_sitemap_index_stylesheet();
+		}
+
+		exit;
 	}
 
 	/**
@@ -74,7 +85,6 @@ class WP_Sitemaps_Stylesheet {
 	<xsl:variable name="has-priority"   select="count( /sitemap:urlset/sitemap:url/sitemap:priority )"   />
 
 	<xsl:template match="/">
-		<xsl:text disable-output-escaping="yes">&lt;!DOCTYPE html&gt;&#10;</xsl:text>
 		<html {$lang}>
 			<head>
 				<title>{$title}</title>
@@ -83,50 +93,48 @@ class WP_Sitemaps_Stylesheet {
 				</style>
 			</head>
 			<body>
-				<main>
-					<div id="sitemap">
-						<div id="sitemap__header">
-							<h1>{$title}</h1>
-							<p>{$description}</p>
-							<p>{$learn_more}</p>
-						</div>
-						<div id="sitemap__content">
-							<p class="text">{$text}</p>
-							<table id="sitemap__table">
-								<thead>
+				<div id="sitemap">
+					<div id="sitemap__header">
+						<h1>{$title}</h1>
+						<p>{$description}</p>
+						<p>{$learn_more}</p>
+					</div>
+					<div id="sitemap__content">
+						<p class="text">{$text}</p>
+						<table id="sitemap__table">
+							<thead>
+								<tr>
+									<th class="loc">{$url}</th>
+									<xsl:if test="\$has-lastmod">
+										<th class="lastmod">{$lastmod}</th>
+									</xsl:if>
+									<xsl:if test="\$has-changefreq">
+										<th class="changefreq">{$changefreq}</th>
+									</xsl:if>
+									<xsl:if test="\$has-priority">
+										<th class="priority">{$priority}</th>
+									</xsl:if>
+								</tr>
+							</thead>
+							<tbody>
+								<xsl:for-each select="sitemap:urlset/sitemap:url">
 									<tr>
-										<th class="loc">{$url}</th>
+										<td class="loc"><a href="{sitemap:loc}"><xsl:value-of select="sitemap:loc" /></a></td>
 										<xsl:if test="\$has-lastmod">
-											<th class="lastmod">{$lastmod}</th>
+											<td class="lastmod"><xsl:value-of select="sitemap:lastmod" /></td>
 										</xsl:if>
 										<xsl:if test="\$has-changefreq">
-											<th class="changefreq">{$changefreq}</th>
+											<td class="changefreq"><xsl:value-of select="sitemap:changefreq" /></td>
 										</xsl:if>
 										<xsl:if test="\$has-priority">
-											<th class="priority">{$priority}</th>
+											<td class="priority"><xsl:value-of select="sitemap:priority" /></td>
 										</xsl:if>
 									</tr>
-								</thead>
-								<tbody>
-									<xsl:for-each select="sitemap:urlset/sitemap:url">
-										<tr>
-											<td class="loc"><a href="{sitemap:loc}"><xsl:value-of select="sitemap:loc" /></a></td>
-											<xsl:if test="\$has-lastmod">
-												<td class="lastmod"><xsl:value-of select="sitemap:lastmod" /></td>
-											</xsl:if>
-											<xsl:if test="\$has-changefreq">
-												<td class="changefreq"><xsl:value-of select="sitemap:changefreq" /></td>
-											</xsl:if>
-											<xsl:if test="\$has-priority">
-												<td class="priority"><xsl:value-of select="sitemap:priority" /></td>
-											</xsl:if>
-										</tr>
-									</xsl:for-each>
-								</tbody>
-							</table>
-						</div>
+								</xsl:for-each>
+							</tbody>
+						</table>
 					</div>
-				</main>
+				</div>
 			</body>
 		</html>
 	</xsl:template>
@@ -187,7 +195,6 @@ XSL;
 	<xsl:variable name="has-lastmod" select="count( /sitemap:sitemapindex/sitemap:sitemap/sitemap:lastmod )" />
 
 	<xsl:template match="/">
-		<xsl:text disable-output-escaping="yes">&lt;!DOCTYPE html&gt;&#10;</xsl:text>
 		<html {$lang}>
 			<head>
 				<title>{$title}</title>
@@ -196,38 +203,36 @@ XSL;
 				</style>
 			</head>
 			<body>
-				<main>
-					<div id="sitemap">
-						<div id="sitemap__header">
-							<h1>{$title}</h1>
-							<p>{$description}</p>
-							<p>{$learn_more}</p>
-						</div>
-						<div id="sitemap__content">
-							<p class="text">{$text}</p>
-							<table id="sitemap__table">
-								<thead>
+				<div id="sitemap">
+					<div id="sitemap__header">
+						<h1>{$title}</h1>
+						<p>{$description}</p>
+						<p>{$learn_more}</p>
+					</div>
+					<div id="sitemap__content">
+						<p class="text">{$text}</p>
+						<table id="sitemap__table">
+							<thead>
+								<tr>
+									<th class="loc">{$url}</th>
+									<xsl:if test="\$has-lastmod">
+										<th class="lastmod">{$lastmod}</th>
+									</xsl:if>
+								</tr>
+							</thead>
+							<tbody>
+								<xsl:for-each select="sitemap:sitemapindex/sitemap:sitemap">
 									<tr>
-										<th class="loc">{$url}</th>
+										<td class="loc"><a href="{sitemap:loc}"><xsl:value-of select="sitemap:loc" /></a></td>
 										<xsl:if test="\$has-lastmod">
-											<th class="lastmod">{$lastmod}</th>
+											<td class="lastmod"><xsl:value-of select="sitemap:lastmod" /></td>
 										</xsl:if>
 									</tr>
-								</thead>
-								<tbody>
-									<xsl:for-each select="sitemap:sitemapindex/sitemap:sitemap">
-										<tr>
-											<td class="loc"><a href="{sitemap:loc}"><xsl:value-of select="sitemap:loc" /></a></td>
-											<xsl:if test="\$has-lastmod">
-												<td class="lastmod"><xsl:value-of select="sitemap:lastmod" /></td>
-											</xsl:if>
-										</tr>
-									</xsl:for-each>
-								</tbody>
-							</table>
-						</div>
+								</xsl:for-each>
+							</tbody>
+						</table>
 					</div>
-				</main>
+				</div>
 			</body>
 		</html>
 	</xsl:template>

--- a/src/wp-includes/sitemaps/class-wp-sitemaps.php
+++ b/src/wp-includes/sitemaps/class-wp-sitemaps.php
@@ -262,7 +262,7 @@ class WP_Sitemaps {
 	 */
 	public function add_robots( $output, $is_public ) {
 		if ( $is_public ) {
-			$output .= "\nSitemap: " . esc_url( $this->index->get_index_url() ) . "\n";
+			$output .= "\nSitemap: " . esc_url( $this->index->get_index_url( 'xml' ) ) . "\n";
 		}
 
 		return $output;

--- a/src/wp-includes/sitemaps/class-wp-sitemaps.php
+++ b/src/wp-includes/sitemaps/class-wp-sitemaps.php
@@ -180,8 +180,8 @@ class WP_Sitemaps {
 			$format = 'xml';
 		}
 
-		// Bail early if this isn't a sitemap or stylesheet route.
-		if ( ! ( $sitemap || $stylesheet_type ) ) {
+		// Bail early if this isn't a sitemap route.
+		if ( ! $sitemap ) {
 			return;
 		}
 

--- a/src/wp-includes/sitemaps/class-wp-sitemaps.php
+++ b/src/wp-includes/sitemaps/class-wp-sitemaps.php
@@ -131,24 +131,31 @@ class WP_Sitemaps {
 		// Add rewrite tags.
 		add_rewrite_tag( '%sitemap%', '([^?]+)' );
 		add_rewrite_tag( '%sitemap-subtype%', '([^?]+)' );
+		add_rewrite_tag( '%sitemap-format%', '([^?]+)' );
 
 		// Register index route.
-		add_rewrite_rule( '^wp-sitemap\.xml$', 'index.php?sitemap=index', 'top' );
-
-		// Register rewrites for the XSL stylesheet.
-		add_rewrite_tag( '%sitemap-stylesheet%', '([^?]+)' );
-		add_rewrite_rule( '^wp-sitemap\.xsl$', 'index.php?sitemap-stylesheet=sitemap', 'top' );
-		add_rewrite_rule( '^wp-sitemap-index\.xsl$', 'index.php?sitemap-stylesheet=index', 'top' );
+		add_rewrite_rule( '^wp-sitemap\.xml$', 'index.php?sitemap=index&sitemap-format=xml', 'top' );
+		add_rewrite_rule( '^wp-sitemap\.html$', 'index.php?sitemap=index&sitemap-format=html', 'top' );
 
 		// Register routes for providers.
 		add_rewrite_rule(
 			'^wp-sitemap-([a-z]+?)-([a-z\d_-]+?)-(\d+?)\.xml$',
-			'index.php?sitemap=$matches[1]&sitemap-subtype=$matches[2]&paged=$matches[3]',
+			'index.php?sitemap=$matches[1]&sitemap-subtype=$matches[2]&paged=$matches[3]&sitemap-format=xml',
+			'top'
+		);
+		add_rewrite_rule(
+			'^wp-sitemap-([a-z]+?)-([a-z\d_-]+?)-(\d+?)\.html$',
+			'index.php?sitemap=$matches[1]&sitemap-subtype=$matches[2]&paged=$matches[3]&sitemap-format=html',
 			'top'
 		);
 		add_rewrite_rule(
 			'^wp-sitemap-([a-z]+?)-(\d+?)\.xml$',
-			'index.php?sitemap=$matches[1]&paged=$matches[2]',
+			'index.php?sitemap=$matches[1]&paged=$matches[2]&sitemap-format=xml',
+			'top'
+		);
+		add_rewrite_rule(
+			'^wp-sitemap-([a-z]+?)-(\d+?)\.html$',
+			'index.php?sitemap=$matches[1]&paged=$matches[2]&sitemap-format=html',
 			'top'
 		);
 	}
@@ -164,9 +171,14 @@ class WP_Sitemaps {
 		global $wp_query;
 
 		$sitemap         = sanitize_text_field( get_query_var( 'sitemap' ) );
+		$format         = sanitize_text_field( get_query_var( 'sitemap-format' ) );
 		$object_subtype  = sanitize_text_field( get_query_var( 'sitemap-subtype' ) );
-		$stylesheet_type = sanitize_text_field( get_query_var( 'sitemap-stylesheet' ) );
 		$paged           = absint( get_query_var( 'paged' ) );
+
+		if ( ! in_array( $format, array( 'xml', 'html' ), true ) ) {
+			// Force xml if the format is unknown.
+			$format = 'xml';
+		}
 
 		// Bail early if this isn't a sitemap or stylesheet route.
 		if ( ! ( $sitemap || $stylesheet_type ) ) {
@@ -179,19 +191,11 @@ class WP_Sitemaps {
 			return;
 		}
 
-		// Render stylesheet if this is stylesheet route.
-		if ( $stylesheet_type ) {
-			$stylesheet = new WP_Sitemaps_Stylesheet();
-
-			$stylesheet->render_stylesheet( $stylesheet_type );
-			exit;
-		}
-
 		// Render the index.
 		if ( 'index' === $sitemap ) {
-			$sitemap_list = $this->index->get_sitemap_list();
+			$sitemap_list = $this->index->get_sitemap_list( $format );
 
-			$this->renderer->render_index( $sitemap_list );
+			$this->renderer->render_index( $sitemap_list, $format );
 			exit;
 		}
 
@@ -214,7 +218,7 @@ class WP_Sitemaps {
 			return;
 		}
 
-		$this->renderer->render_sitemap( $url_list );
+		$this->renderer->render_sitemap( $url_list, $format );
 		exit;
 	}
 

--- a/src/wp-includes/sitemaps/class-wp-sitemaps.php
+++ b/src/wp-includes/sitemaps/class-wp-sitemaps.php
@@ -131,31 +131,24 @@ class WP_Sitemaps {
 		// Add rewrite tags.
 		add_rewrite_tag( '%sitemap%', '([^?]+)' );
 		add_rewrite_tag( '%sitemap-subtype%', '([^?]+)' );
-		add_rewrite_tag( '%sitemap-format%', '([^?]+)' );
 
 		// Register index route.
-		add_rewrite_rule( '^wp-sitemap\.xml$', 'index.php?sitemap=index&sitemap-format=xml', 'top' );
-		add_rewrite_rule( '^wp-sitemap\.html$', 'index.php?sitemap=index&sitemap-format=html', 'top' );
+		add_rewrite_rule( '^wp-sitemap\.xml$', 'index.php?sitemap=index', 'top' );
+
+		// Register rewrites for the XSL stylesheet.
+		add_rewrite_tag( '%sitemap-stylesheet%', '([^?]+)' );
+		add_rewrite_rule( '^wp-sitemap\.xsl$', 'index.php?sitemap-stylesheet=sitemap', 'top' );
+		add_rewrite_rule( '^wp-sitemap-index\.xsl$', 'index.php?sitemap-stylesheet=index', 'top' );
 
 		// Register routes for providers.
 		add_rewrite_rule(
 			'^wp-sitemap-([a-z]+?)-([a-z\d_-]+?)-(\d+?)\.xml$',
-			'index.php?sitemap=$matches[1]&sitemap-subtype=$matches[2]&paged=$matches[3]&sitemap-format=xml',
-			'top'
-		);
-		add_rewrite_rule(
-			'^wp-sitemap-([a-z]+?)-([a-z\d_-]+?)-(\d+?)\.html$',
-			'index.php?sitemap=$matches[1]&sitemap-subtype=$matches[2]&paged=$matches[3]&sitemap-format=html',
+			'index.php?sitemap=$matches[1]&sitemap-subtype=$matches[2]&paged=$matches[3]',
 			'top'
 		);
 		add_rewrite_rule(
 			'^wp-sitemap-([a-z]+?)-(\d+?)\.xml$',
-			'index.php?sitemap=$matches[1]&paged=$matches[2]&sitemap-format=xml',
-			'top'
-		);
-		add_rewrite_rule(
-			'^wp-sitemap-([a-z]+?)-(\d+?)\.html$',
-			'index.php?sitemap=$matches[1]&paged=$matches[2]&sitemap-format=html',
+			'index.php?sitemap=$matches[1]&paged=$matches[2]',
 			'top'
 		);
 	}
@@ -171,14 +164,9 @@ class WP_Sitemaps {
 		global $wp_query;
 
 		$sitemap         = sanitize_text_field( get_query_var( 'sitemap' ) );
-		$format         = sanitize_text_field( get_query_var( 'sitemap-format' ) );
 		$object_subtype  = sanitize_text_field( get_query_var( 'sitemap-subtype' ) );
+		$stylesheet_type = sanitize_text_field( get_query_var( 'sitemap-stylesheet' ) );
 		$paged           = absint( get_query_var( 'paged' ) );
-
-		if ( ! in_array( $format, array( 'xml', 'html' ), true ) ) {
-			// Force xml if the format is unknown.
-			$format = 'xml';
-		}
 
 		// Bail early if this isn't a sitemap or stylesheet route.
 		if ( ! ( $sitemap || $stylesheet_type ) ) {
@@ -191,11 +179,19 @@ class WP_Sitemaps {
 			return;
 		}
 
+		// Render stylesheet if this is stylesheet route.
+		if ( $stylesheet_type ) {
+			$stylesheet = new WP_Sitemaps_Stylesheet();
+
+			$stylesheet->render_stylesheet( $stylesheet_type );
+			exit;
+		}
+
 		// Render the index.
 		if ( 'index' === $sitemap ) {
-			$sitemap_list = $this->index->get_sitemap_list( $format );
+			$sitemap_list = $this->index->get_sitemap_list();
 
-			$this->renderer->render_index( $sitemap_list, $format );
+			$this->renderer->render_index( $sitemap_list );
 			exit;
 		}
 
@@ -218,7 +214,7 @@ class WP_Sitemaps {
 			return;
 		}
 
-		$this->renderer->render_sitemap( $url_list, $format );
+		$this->renderer->render_sitemap( $url_list );
 		exit;
 	}
 

--- a/tests/phpunit/includes/class-wp-sitemaps-large-test-provider.php
+++ b/tests/phpunit/includes/class-wp-sitemaps-large-test-provider.php
@@ -43,7 +43,7 @@ class WP_Sitemaps_Large_Test_Provider extends WP_Sitemaps_Provider {
 	 *
 	 * @return array[] Array of sitemap entries.
 	 */
-	public function get_sitemap_entries() {
+	public function get_sitemap_entries( $format ) {
 		return array_fill( 0, $this->num_entries, array( 'loc' => home_url( '/' ) ) );
 	}
 

--- a/tests/phpunit/tests/canonical/sitemaps.php
+++ b/tests/phpunit/tests/canonical/sitemaps.php
@@ -20,24 +20,12 @@ class Tests_Canonical_Sitemaps extends WP_Canonical_UnitTestCase {
 		$this->assertCanonical( '/wp-sitemap.xml/', '/wp-sitemap.xml' );
 	}
 
-	public function test_remove_trailing_slashes_for_sitemap_index_stylesheet_requests() {
-		$this->set_permalink_structure( '/%postname%/' );
-		$this->assertCanonical( '/wp-sitemap-index.xsl', '/wp-sitemap-index.xsl' );
-		$this->assertCanonical( '/wp-sitemap-index.xsl/', '/wp-sitemap-index.xsl' );
-	}
-
 	public function test_remove_trailing_slashes_for_sitemap_requests() {
 		$this->set_permalink_structure( '/%postname%/' );
 		$this->assertCanonical( '/wp-sitemap-posts-post-1.xml', '/wp-sitemap-posts-post-1.xml' );
 		$this->assertCanonical( '/wp-sitemap-posts-post-1.xml/', '/wp-sitemap-posts-post-1.xml' );
 		$this->assertCanonical( '/wp-sitemap-users-1.xml', '/wp-sitemap-users-1.xml' );
 		$this->assertCanonical( '/wp-sitemap-users-1.xml/', '/wp-sitemap-users-1.xml' );
-	}
-
-	public function test_remove_trailing_slashes_for_sitemap_stylesheet_requests() {
-		$this->set_permalink_structure( '/%postname%/' );
-		$this->assertCanonical( '/wp-sitemap.xsl', '/wp-sitemap.xsl' );
-		$this->assertCanonical( '/wp-sitemap.xsl/', '/wp-sitemap.xsl' );
 	}
 
 	/**

--- a/tests/phpunit/tests/query/vars.php
+++ b/tests/phpunit/tests/query/vars.php
@@ -73,7 +73,7 @@ class Tests_Query_Vars extends WP_UnitTestCase {
 				'rest_route',
 				'sitemap',
 				'sitemap-subtype',
-				'sitemap-stylesheet',
+				'sitemap-format',
 
 			),
 			$wp->public_query_vars,

--- a/tests/phpunit/tests/sitemaps/functions.php
+++ b/tests/phpunit/tests/sitemaps/functions.php
@@ -98,17 +98,17 @@ class Tests_Sitemaps_Functions extends WP_UnitTestCase {
 	 */
 	public function data_get_sitemap_url_plain_permalinks() {
 		return array(
-			array( 'posts', 'post', 1, home_url( '/?sitemap=posts&sitemap-subtype=post&paged=1' ) ),
-			array( 'posts', 'post', 0, home_url( '/?sitemap=posts&sitemap-subtype=post&paged=1' ) ),
-			array( 'posts', 'page', 1, home_url( '/?sitemap=posts&sitemap-subtype=page&paged=1' ) ),
-			array( 'posts', 'page', 5, home_url( '/?sitemap=posts&sitemap-subtype=page&paged=5' ) ),
+			array( 'posts', 'post', 1, home_url( '/?sitemap=posts&sitemap-subtype=post&paged=1&sitemap-format=xml' ) ),
+			array( 'posts', 'post', 0, home_url( '/?sitemap=posts&sitemap-subtype=post&paged=1&sitemap-format=xml' ) ),
+			array( 'posts', 'page', 1, home_url( '/?sitemap=posts&sitemap-subtype=page&paged=1&sitemap-format=xml' ) ),
+			array( 'posts', 'page', 5, home_url( '/?sitemap=posts&sitemap-subtype=page&paged=5&sitemap-format=xml' ) ),
 			// Post type doesn't exist.
 			array( 'posts', 'foo', 5, false ),
-			array( 'taxonomies', 'category', 1, home_url( '/?sitemap=taxonomies&sitemap-subtype=category&paged=1' ) ),
-			array( 'taxonomies', 'post_tag', 1, home_url( '/?sitemap=taxonomies&sitemap-subtype=post_tag&paged=1' ) ),
+			array( 'taxonomies', 'category', 1, home_url( '/?sitemap=taxonomies&sitemap-subtype=category&paged=1&sitemap-format=xml' ) ),
+			array( 'taxonomies', 'post_tag', 1, home_url( '/?sitemap=taxonomies&sitemap-subtype=post_tag&paged=1&sitemap-format=xml' ) ),
 			// Negative paged, gets converted to its absolute value.
-			array( 'taxonomies', 'post_tag', -1, home_url( '/?sitemap=taxonomies&sitemap-subtype=post_tag&paged=1' ) ),
-			array( 'users', '', 4, home_url( '/?sitemap=users&paged=4' ) ),
+			array( 'taxonomies', 'post_tag', -1, home_url( '/?sitemap=taxonomies&sitemap-subtype=post_tag&paged=1&sitemap-format=xml' ) ),
+			array( 'users', '', 4, home_url( '/?sitemap=users&paged=4&sitemap-format=xml' ) ),
 			// Users provider doesn't allow subtypes.
 			array( 'users', 'foo', 4, false ),
 			// Provider doesn't exist.

--- a/tests/phpunit/tests/sitemaps/sitemaps.php
+++ b/tests/phpunit/tests/sitemaps/sitemaps.php
@@ -104,7 +104,7 @@ class Tests_Sitemaps_Sitemaps extends WP_UnitTestCase {
 
 		foreach ( $providers as $provider ) {
 			// Using `array_push` is more efficient than `array_merge` in the loop.
-			array_push( $entries, ...$provider->get_sitemap_entries() );
+			array_push( $entries, ...$provider->get_sitemap_entries( 'xml' ) );
 		}
 
 		return $entries;
@@ -118,19 +118,19 @@ class Tests_Sitemaps_Sitemaps extends WP_UnitTestCase {
 
 		$expected = array(
 			array(
-				'loc' => 'http://' . WP_TESTS_DOMAIN . '/?sitemap=posts&sitemap-subtype=post&paged=1',
+				'loc' => 'http://' . WP_TESTS_DOMAIN . '/?sitemap=posts&sitemap-subtype=post&paged=1&sitemap-format=xml',
 			),
 			array(
-				'loc' => 'http://' . WP_TESTS_DOMAIN . '/?sitemap=posts&sitemap-subtype=page&paged=1',
+				'loc' => 'http://' . WP_TESTS_DOMAIN . '/?sitemap=posts&sitemap-subtype=page&paged=1&sitemap-format=xml',
 			),
 			array(
-				'loc' => 'http://' . WP_TESTS_DOMAIN . '/?sitemap=taxonomies&sitemap-subtype=category&paged=1',
+				'loc' => 'http://' . WP_TESTS_DOMAIN . '/?sitemap=taxonomies&sitemap-subtype=category&paged=1&sitemap-format=xml',
 			),
 			array(
-				'loc' => 'http://' . WP_TESTS_DOMAIN . '/?sitemap=taxonomies&sitemap-subtype=post_tag&paged=1',
+				'loc' => 'http://' . WP_TESTS_DOMAIN . '/?sitemap=taxonomies&sitemap-subtype=post_tag&paged=1&sitemap-format=xml',
 			),
 			array(
-				'loc' => 'http://' . WP_TESTS_DOMAIN . '/?sitemap=users&paged=1',
+				'loc' => 'http://' . WP_TESTS_DOMAIN . '/?sitemap=users&paged=1&sitemap-format=xml',
 			),
 		);
 
@@ -187,8 +187,8 @@ class Tests_Sitemaps_Sitemaps extends WP_UnitTestCase {
 		unregister_post_type( 'public_cpt' );
 		unregister_post_type( 'private_cpt' );
 
-		$this->assertContains( 'http://' . WP_TESTS_DOMAIN . '/?sitemap=posts&sitemap-subtype=public_cpt&paged=1', $entries, 'Public CPTs are not in the index.' );
-		$this->assertNotContains( 'http://' . WP_TESTS_DOMAIN . '/?sitemap=posts&sitemap-subtype=private_cpt&paged=1', $entries, 'Private CPTs are visible in the index.' );
+		$this->assertContains( 'http://' . WP_TESTS_DOMAIN . '/?sitemap=posts&sitemap-subtype=public_cpt&paged=1&sitemap-format=xml', $entries, 'Public CPTs are not in the index.' );
+		$this->assertNotContains( 'http://' . WP_TESTS_DOMAIN . '/?sitemap=posts&sitemap-subtype=private_cpt&paged=1&sitemap-format=xml', $entries, 'Private CPTs are visible in the index.' );
 	}
 
 	/**

--- a/tests/phpunit/tests/sitemaps/wpSitemapsIndex.php
+++ b/tests/phpunit/tests/sitemaps/wpSitemapsIndex.php
@@ -18,7 +18,7 @@ class Tests_Sitemaps_wpSitemapsIndex extends WP_UnitTestCase {
 		$registry->add_provider( 'bar', new WP_Sitemaps_Test_Provider( 'bar' ) );
 
 		$sitemap_index = new WP_Sitemaps_Index( $registry );
-		$this->assertCount( 24, $sitemap_index->get_sitemap_list() );
+		$this->assertCount( 24, $sitemap_index->get_sitemap_list( 'xml' ) );
 	}
 
 	/**
@@ -41,7 +41,7 @@ class Tests_Sitemaps_wpSitemapsIndex extends WP_UnitTestCase {
 		$this->assertGreaterThan( 50000, $count );
 
 		$sitemap_index = new WP_Sitemaps_Index( $registry );
-		$this->assertCount( 50000, $sitemap_index->get_sitemap_list() );
+		$this->assertCount( 50000, $sitemap_index->get_sitemap_list( 'xml' ) );
 	}
 
 	public function test_get_sitemap_list_no_entries() {
@@ -50,14 +50,14 @@ class Tests_Sitemaps_wpSitemapsIndex extends WP_UnitTestCase {
 		$registry->add_provider( 'foo', new WP_Sitemaps_Empty_Test_Provider( 'foo' ) );
 
 		$sitemap_index = new WP_Sitemaps_Index( $registry );
-		$this->assertCount( 0, $sitemap_index->get_sitemap_list() );
+		$this->assertCount( 0, $sitemap_index->get_sitemap_list( 'xml' ) );
 	}
 
 	public function test_get_index_url() {
 		$sitemap_index = new WP_Sitemaps_Index( new WP_Sitemaps_Registry() );
-		$index_url     = $sitemap_index->get_index_url();
+		$index_url     = $sitemap_index->get_index_url( 'xml' );
 
-		$this->assertStringEndsWith( '/?sitemap=index', $index_url );
+		$this->assertStringEndsWith( '/?sitemap=index&sitemap-format=xml', $index_url );
 	}
 
 	public function test_get_index_url_pretty_permalinks() {
@@ -65,7 +65,7 @@ class Tests_Sitemaps_wpSitemapsIndex extends WP_UnitTestCase {
 		$this->set_permalink_structure( '/%year%/%postname%/' );
 
 		$sitemap_index = new WP_Sitemaps_Index( new WP_Sitemaps_Registry() );
-		$index_url     = $sitemap_index->get_index_url();
+		$index_url     = $sitemap_index->get_index_url( 'xml' );
 
 		// Clean up permalinks.
 		$this->set_permalink_structure();

--- a/tests/phpunit/tests/sitemaps/wpSitemapsPosts.php
+++ b/tests/phpunit/tests/sitemaps/wpSitemapsPosts.php
@@ -17,11 +17,11 @@ class Tests_Sitemaps_wpSitemapsPosts extends WP_UnitTestCase {
 
 		$posts_provider = new WP_Sitemaps_Posts();
 
-		$post_list = $posts_provider->get_sitemap_entries();
+		$post_list = $posts_provider->get_sitemap_entries( 'xml' );
 
 		$expected = array(
 			array(
-				'loc' => home_url( '/?sitemap=posts&sitemap-subtype=page&paged=1' ),
+				'loc' => home_url( '/?sitemap=posts&sitemap-subtype=page&paged=1&sitemap-format=xml' ),
 			),
 		);
 

--- a/tests/phpunit/tests/sitemaps/wpSitemapsRenderer.php
+++ b/tests/phpunit/tests/sitemaps/wpSitemapsRenderer.php
@@ -5,13 +5,18 @@
  */
 class Tests_Sitemaps_wpSitemapsRenderer extends WP_Test_XML_TestCase {
 
+	/*
+	 * pvb
 	public function test_get_sitemap_stylesheet_url() {
 		$sitemap_renderer = new WP_Sitemaps_Renderer();
 		$stylesheet_url   = $sitemap_renderer->get_sitemap_stylesheet_url();
 
 		$this->assertStringEndsWith( '/?sitemap-stylesheet=sitemap', $stylesheet_url );
 	}
+	*/
 
+	/*
+	 * pvb
 	public function test_get_sitemap_stylesheet_url_pretty_permalinks() {
 		// Set permalinks for testing.
 		$this->set_permalink_structure( '/%year%/%postname%/' );
@@ -24,14 +29,20 @@ class Tests_Sitemaps_wpSitemapsRenderer extends WP_Test_XML_TestCase {
 
 		$this->assertStringEndsWith( '/wp-sitemap.xsl', $stylesheet_url );
 	}
+	*/
 
+	/*
+	 * pvb
 	public function test_get_sitemap_index_stylesheet_url() {
 		$sitemap_renderer = new WP_Sitemaps_Renderer();
 		$stylesheet_url   = $sitemap_renderer->get_sitemap_index_stylesheet_url();
 
 		$this->assertStringEndsWith( '/?sitemap-stylesheet=index', $stylesheet_url );
 	}
+	 */
 
+	/*
+	 * pvb
 	public function test_get_sitemap_index_stylesheet_url_pretty_permalinks() {
 		// Set permalinks for testing.
 		$this->set_permalink_structure( '/%year%/%postname%/' );
@@ -44,6 +55,7 @@ class Tests_Sitemaps_wpSitemapsRenderer extends WP_Test_XML_TestCase {
 
 		$this->assertStringEndsWith( '/wp-sitemap-index.xsl', $stylesheet_url );
 	}
+	*/
 
 	/**
 	 * Test XML output for the sitemap index renderer.
@@ -71,7 +83,6 @@ class Tests_Sitemaps_wpSitemapsRenderer extends WP_Test_XML_TestCase {
 
 		$actual   = $renderer->get_sitemap_index_xml( $entries );
 		$expected = '<?xml version="1.0" encoding="UTF-8"?>' .
-					'<?xml-stylesheet type="text/xsl" href="http://' . WP_TESTS_DOMAIN . '/?sitemap-stylesheet=index" ?>' .
 					'<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' .
 					'<sitemap><loc>http://' . WP_TESTS_DOMAIN . '/wp-sitemap-posts-post-1.xml</loc></sitemap>' .
 					'<sitemap><loc>http://' . WP_TESTS_DOMAIN . '/wp-sitemap-posts-page-1.xml</loc></sitemap>' .
@@ -114,7 +125,6 @@ class Tests_Sitemaps_wpSitemapsRenderer extends WP_Test_XML_TestCase {
 
 		$actual   = $renderer->get_sitemap_index_xml( $entries );
 		$expected = '<?xml version="1.0" encoding="UTF-8"?>' .
-			'<?xml-stylesheet type="text/xsl" href="http://' . WP_TESTS_DOMAIN . '/?sitemap-stylesheet=index" ?>' .
 			'<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' .
 			'<sitemap><loc>http://' . WP_TESTS_DOMAIN . '/wp-sitemap-posts-post-1.xml</loc><lastmod>2005-01-01</lastmod></sitemap>' .
 			'<sitemap><loc>http://' . WP_TESTS_DOMAIN . '/wp-sitemap-posts-page-1.xml</loc><lastmod>2005-01-01</lastmod></sitemap>' .
@@ -210,7 +220,6 @@ class Tests_Sitemaps_wpSitemapsRenderer extends WP_Test_XML_TestCase {
 
 		$actual   = $renderer->get_sitemap_xml( $url_list );
 		$expected = '<?xml version="1.0" encoding="UTF-8"?>' .
-					'<?xml-stylesheet type="text/xsl" href="http://' . WP_TESTS_DOMAIN . '/?sitemap-stylesheet=sitemap" ?>' .
 					'<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' .
 					'<url><loc>http://' . WP_TESTS_DOMAIN . '/2019/10/post-1</loc></url>' .
 					'<url><loc>http://' . WP_TESTS_DOMAIN . '/2019/10/post-2</loc></url>' .

--- a/tests/phpunit/tests/sitemaps/wpSitemapsTaxonomies.php
+++ b/tests/phpunit/tests/sitemaps/wpSitemapsTaxonomies.php
@@ -195,16 +195,16 @@ class Tests_Sitemaps_wpSitemapsTaxonomies extends WP_UnitTestCase {
 		);
 
 		$tax_provider = new WP_Sitemaps_Taxonomies();
-		$entries      = wp_list_pluck( $tax_provider->get_sitemap_entries(), 'loc' );
+		$entries      = wp_list_pluck( $tax_provider->get_sitemap_entries( 'xml' ), 'loc' );
 
 		// Clean up.
 		unregister_taxonomy_for_object_type( 'public_taxonomy', 'post' );
 		unregister_taxonomy_for_object_type( 'non_queryable_taxonomy', 'post' );
 		unregister_taxonomy_for_object_type( 'private_taxonomy', 'post' );
 
-		$this->assertContains( 'http://' . WP_TESTS_DOMAIN . '/?sitemap=taxonomies&sitemap-subtype=public_taxonomy&paged=1', $entries, 'Public Taxonomies are not in the index.' );
-		$this->assertNotContains( 'http://' . WP_TESTS_DOMAIN . '/?sitemap=taxonomies&sitemap-subtype=non_queryable_taxonomy&paged=1', $entries, 'Private Taxonomies are visible in the index.' );
-		$this->assertNotContains( 'http://' . WP_TESTS_DOMAIN . '/?sitemap=taxonomies&sitemap-subtype=private_taxonomy&paged=1', $entries, 'Private Taxonomies are visible in the index.' );
+		$this->assertContains( 'http://' . WP_TESTS_DOMAIN . '/?sitemap=taxonomies&sitemap-subtype=public_taxonomy&paged=1&sitemap-format=xml', $entries, 'Public Taxonomies are not in the index.' );
+		$this->assertNotContains( 'http://' . WP_TESTS_DOMAIN . '/?sitemap=taxonomies&sitemap-subtype=non_queryable_taxonomy&paged=1&sitemap-format=xml', $entries, 'Private Taxonomies are visible in the index.' );
+		$this->assertNotContains( 'http://' . WP_TESTS_DOMAIN . '/?sitemap=taxonomies&sitemap-subtype=private_taxonomy&paged=1&sitemap-format=xml', $entries, 'Private Taxonomies are visible in the index.' );
 	}
 
 	/**


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->

In addition to removing xml-stylesheet PI to render the sitemap or index into HTML client-side, this PR adds the ability the render the HTML version of the sitemaps and sitemap indices server-side when a user uses the '.html' extension on any sitemap or sitemap index URL.

In it's current form, this PR does not yet address any necessary changes to unit tests.

Trac ticket: https://core.trac.wordpress.org/ticket/65593

## Use of AI Tools

No AI Tools used

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
