### PR TITLE
Improve typing and documentation for `wp_parse_list()`, `wp_parse_id_list()`, and `wp_parse_slug_list()`

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -5022,8 +5022,8 @@ function wp_parse_args( $args, $defaults = array() ) {
  * @since 5.1.0
  *
  * @param mixed[]|string $input_list List of values.
- * @return array Array of values. Keys are preserved when an array is passed,
- *               so the result is not necessarily a list.
+ * @return array Array of values. A string is split into a list, while an array
+ *               keeps its keys, so the result is not necessarily a list.
  * @phpstan-return ($input_list is string ? list<string> : array<scalar>)
  */
 function wp_parse_list( $input_list ) {

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -5042,7 +5042,7 @@ function wp_parse_list( $input_list ) {
  * @since 3.0.0
  * @since 5.1.0 Refactored to use wp_parse_list().
  *
- * @param array|string $input_list List of IDs.
+ * @param mixed[]|string $input_list List of IDs.
  * @return int[] Sanitized array of IDs.
  * @phpstan-return list<non-negative-int>
  */

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -5027,7 +5027,8 @@ function wp_parse_args( $args, $defaults = array() ) {
  */
 function wp_parse_list( $input_list ) {
 	if ( ! is_array( $input_list ) ) {
-		return (array) preg_split( '/[\s,]+/', $input_list, -1, PREG_SPLIT_NO_EMPTY );
+		$parsed_list = preg_split( '/[\s,]+/', $input_list, -1, PREG_SPLIT_NO_EMPTY );
+		return is_array( $parsed_list ) ? $parsed_list : array();
 	}
 
 	// Validate all entries of the list are scalar.

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -5049,7 +5049,7 @@ function wp_parse_list( $input_list ) {
 function wp_parse_id_list( $input_list ) {
 	$input_list = wp_parse_list( $input_list );
 
-	return array_unique( array_map( 'absint', $input_list ) );
+	return array_values( array_unique( array_map( 'absint', $input_list ) ) );
 }
 
 /**

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -5044,6 +5044,7 @@ function wp_parse_list( $input_list ) {
  *
  * @param array|string $input_list List of IDs.
  * @return int[] Sanitized array of IDs.
+ * @phpstan-return list<non-negative-int>
  */
 function wp_parse_id_list( $input_list ) {
 	$input_list = wp_parse_list( $input_list );

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -5021,13 +5021,13 @@ function wp_parse_args( $args, $defaults = array() ) {
  *
  * @since 5.1.0
  *
- * @param array|string $input_list List of values.
+ * @param mixed[]|string $input_list List of values.
  * @return array Array of values.
  * @phpstan-return list<scalar>
  */
 function wp_parse_list( $input_list ) {
 	if ( ! is_array( $input_list ) ) {
-		return preg_split( '/[\s,]+/', $input_list, -1, PREG_SPLIT_NO_EMPTY );
+		return (array) preg_split( '/[\s,]+/', $input_list, -1, PREG_SPLIT_NO_EMPTY );
 	}
 
 	// Validate all entries of the list are scalar.

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -5023,6 +5023,7 @@ function wp_parse_args( $args, $defaults = array() ) {
  *
  * @param array|string $input_list List of values.
  * @return array Array of values.
+ * @phpstan-return list<scalar>
  */
 function wp_parse_list( $input_list ) {
 	if ( ! is_array( $input_list ) ) {
@@ -5030,7 +5031,7 @@ function wp_parse_list( $input_list ) {
 	}
 
 	// Validate all entries of the list are scalar.
-	$input_list = array_filter( $input_list, 'is_scalar' );
+	$input_list = array_values( array_filter( $input_list, 'is_scalar' ) );
 
 	return $input_list;
 }

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -5024,7 +5024,7 @@ function wp_parse_args( $args, $defaults = array() ) {
  * @param mixed[]|string $input_list List of values.
  * @return array Array of values. Keys are preserved when an array is passed,
  *               so the result is not necessarily a list.
- * @phpstan-return array<scalar>
+ * @phpstan-return ($input_list is string ? list<string> : array<scalar>)
  */
 function wp_parse_list( $input_list ) {
 	if ( ! is_array( $input_list ) ) {

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -5026,7 +5026,7 @@ function wp_parse_args( $args, $defaults = array() ) {
  *               keeps its keys, so the result is not necessarily a list.
  * @phpstan-return ($input_list is string ? list<string> : array<scalar>)
  */
-function wp_parse_list( $input_list ) {
+function wp_parse_list( $input_list ): array {
 	if ( ! is_array( $input_list ) ) {
 		$parsed_list = preg_split( '/[\s,]+/', $input_list, -1, PREG_SPLIT_NO_EMPTY );
 		return is_array( $parsed_list ) ? $parsed_list : array();
@@ -5050,7 +5050,7 @@ function wp_parse_list( $input_list ) {
  *               result is not necessarily a list.
  * @phpstan-return array<non-negative-int>
  */
-function wp_parse_id_list( $input_list ) {
+function wp_parse_id_list( $input_list ): array {
 	$input_list = wp_parse_list( $input_list );
 
 	return array_unique( array_map( 'absint', $input_list ) );
@@ -5067,7 +5067,7 @@ function wp_parse_id_list( $input_list ) {
  *                  are preserved from the input and `array_unique()` may leave
  *                  gaps, so the result is not necessarily a list.
  */
-function wp_parse_slug_list( $input_list ) {
+function wp_parse_slug_list( $input_list ): array {
 	$input_list = wp_parse_list( $input_list );
 
 	return array_unique(

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -5022,8 +5022,8 @@ function wp_parse_args( $args, $defaults = array() ) {
  * @since 5.1.0
  *
  * @param mixed[]|string $input_list List of values.
- * @return array Array of values.
- * @phpstan-return list<scalar>
+ * @return array Array of values. Not guaranteed to be a PHP list.
+ * @phpstan-return array<scalar>
  */
 function wp_parse_list( $input_list ) {
 	if ( ! is_array( $input_list ) ) {
@@ -5031,7 +5031,7 @@ function wp_parse_list( $input_list ) {
 	}
 
 	// Validate all entries of the list are scalar.
-	$input_list = array_values( array_filter( $input_list, 'is_scalar' ) );
+	$input_list = array_filter( $input_list, 'is_scalar' );
 
 	return $input_list;
 }
@@ -5043,13 +5043,13 @@ function wp_parse_list( $input_list ) {
  * @since 5.1.0 Refactored to use wp_parse_list().
  *
  * @param mixed[]|string $input_list List of IDs.
- * @return int[] Sanitized array of IDs. May include zero.
- * @phpstan-return list<non-negative-int>
+ * @return int[] Sanitized array of IDs. May include zero. Not guaranteed to be a PHP list.
+ * @phpstan-return array<non-negative-int>
  */
 function wp_parse_id_list( $input_list ) {
 	$input_list = wp_parse_list( $input_list );
 
-	return array_values( array_unique( array_map( 'absint', $input_list ) ) );
+	return array_unique( array_map( 'absint', $input_list ) );
 }
 
 /**
@@ -5059,24 +5059,21 @@ function wp_parse_id_list( $input_list ) {
  * @since 5.1.0 Refactored to use wp_parse_list().
  *
  * @param mixed[]|string $input_list List of slugs.
- * @return string[] Sanitized array of slugs. May include an empty string.
- * @phpstan-return list<string>
+ * @return string[] Sanitized array of slugs. May include an empty string. Not guaranteed to be a PHP list.
  */
 function wp_parse_slug_list( $input_list ) {
 	$input_list = wp_parse_list( $input_list );
 
-	return array_values(
-		array_unique(
+	return array_unique(
+		array_map(
+			'sanitize_title',
 			array_map(
-				'sanitize_title',
-				array_map(
-					/*
-					 * Cast booleans, integers, and floats to strings. Non-scalar types (including null) have already
-					 * been filtered out by wp_parse_list().
-					 */
-					'strval',
-					$input_list
-				)
+				/*
+				 * Cast booleans, integers, and floats to strings. Non-scalar types (including null) have already
+				 * been filtered out by wp_parse_list().
+				 */
+				'strval',
+				$input_list
 			)
 		)
 	);

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -5043,7 +5043,7 @@ function wp_parse_list( $input_list ) {
  * @since 5.1.0 Refactored to use wp_parse_list().
  *
  * @param mixed[]|string $input_list List of IDs.
- * @return int[] Sanitized array of IDs.
+ * @return int[] Sanitized array of IDs. May include zero.
  * @phpstan-return list<non-negative-int>
  */
 function wp_parse_id_list( $input_list ) {
@@ -5059,7 +5059,7 @@ function wp_parse_id_list( $input_list ) {
  * @since 5.1.0 Refactored to use wp_parse_list().
  *
  * @param mixed[]|string $input_list List of slugs.
- * @return string[] Sanitized array of slugs.
+ * @return string[] Sanitized array of slugs. May include an empty string.
  * @phpstan-return list<string>
  */
 function wp_parse_slug_list( $input_list ) {

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -5022,7 +5022,8 @@ function wp_parse_args( $args, $defaults = array() ) {
  * @since 5.1.0
  *
  * @param mixed[]|string $input_list List of values.
- * @return array Array of values. Not guaranteed to be a PHP list.
+ * @return array Array of values. Keys are preserved when an array is passed,
+ *               so the result is not necessarily a list.
  * @phpstan-return array<scalar>
  */
 function wp_parse_list( $input_list ) {
@@ -5044,7 +5045,9 @@ function wp_parse_list( $input_list ) {
  * @since 5.1.0 Refactored to use wp_parse_list().
  *
  * @param mixed[]|string $input_list List of IDs.
- * @return int[] Sanitized array of IDs. May include zero. Not guaranteed to be a PHP list.
+ * @return int[] Sanitized array of IDs. May include zero. Keys are preserved
+ *               from the input and `array_unique()` may leave gaps, so the
+ *               result is not necessarily a list.
  * @phpstan-return array<non-negative-int>
  */
 function wp_parse_id_list( $input_list ) {
@@ -5060,7 +5063,9 @@ function wp_parse_id_list( $input_list ) {
  * @since 5.1.0 Refactored to use wp_parse_list().
  *
  * @param mixed[]|string $input_list List of slugs.
- * @return string[] Sanitized array of slugs. May include an empty string. Not guaranteed to be a PHP list.
+ * @return string[] Sanitized array of slugs. May include an empty string. Keys
+ *                  are preserved from the input and `array_unique()` may leave
+ *                  gaps, so the result is not necessarily a list.
  */
 function wp_parse_slug_list( $input_list ) {
 	$input_list = wp_parse_list( $input_list );

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -5058,13 +5058,28 @@ function wp_parse_id_list( $input_list ) {
  * @since 4.7.0
  * @since 5.1.0 Refactored to use wp_parse_list().
  *
- * @param array|string $input_list List of slugs.
+ * @param mixed[]|string $input_list List of slugs.
  * @return string[] Sanitized array of slugs.
+ * @phpstan-return list<string>
  */
 function wp_parse_slug_list( $input_list ) {
 	$input_list = wp_parse_list( $input_list );
 
-	return array_unique( array_map( 'sanitize_title', $input_list ) );
+	return array_values(
+		array_unique(
+			array_map(
+				'sanitize_title',
+				array_map(
+					/*
+					 * Cast booleans, integers, and floats to strings. Non-scalar types (including null) have already
+					 * been filtered out by wp_parse_list().
+					 */
+					'strval',
+					$input_list
+				)
+			)
+		)
+	);
 }
 
 /**

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -5075,8 +5075,8 @@ function wp_parse_slug_list( $input_list ) {
 			'sanitize_title',
 			array_map(
 				/*
-				 * Cast booleans, integers, and floats to strings. Non-scalar types (including null) have already
-				 * been filtered out by wp_parse_list().
+				 * Cast booleans, integers, and floats to strings. Non-scalar types
+				 * (including null) have already been filtered out by wp_parse_list().
 				 */
 				'strval',
 				$input_list

--- a/tests/phpunit/tests/functions/wpParseIdList.php
+++ b/tests/phpunit/tests/functions/wpParseIdList.php
@@ -17,11 +17,10 @@ class Tests_Functions_wpParseIdList extends WP_UnitTestCase {
 	 * @dataProvider data_unexpected_input
 	 *
 	 * @param mixed[]|string $input_list
-	 * @param list<non-negative-int> $expected
+	 * @param array<non-negative-int> $expected
 	 */
 	public function test_wp_parse_id_list( $input_list, array $expected ): void {
 		$parsed_list = wp_parse_id_list( $input_list );
-		$this->assertTrue( array_is_list( $parsed_list ), 'Expected value to be a list.' );
 		$this->assertThat(
 			$parsed_list,
 			$this->callback(
@@ -38,7 +37,7 @@ class Tests_Functions_wpParseIdList extends WP_UnitTestCase {
 	/**
 	 * Data provider.
 	 *
-	 * @return array<string, array{ input_list: mixed[]|string, expected: list<non-negative-int> }>
+	 * @return array<string, array{ input_list: mixed[]|string, expected: array<non-negative-int> }>
 	 */
 	public function data_wp_parse_id_list(): array {
 		return array(
@@ -52,7 +51,12 @@ class Tests_Functions_wpParseIdList extends WP_UnitTestCase {
 			),
 			'duplicate id in a string' => array(
 				'input_list' => '1,2,2,3,4',
-				'expected'   => array( 1, 2, 3, 4 ),
+				'expected'   => array(
+					0 => 1,
+					1 => 2,
+					3 => 3,
+					4 => 4,
+				),
 			),
 			'duplicate id in an array' => array(
 				'input_list' => array( '1', '2', '3', '4', '3' ),
@@ -76,7 +80,7 @@ class Tests_Functions_wpParseIdList extends WP_UnitTestCase {
 	/**
 	 * Data provider.
 	 *
-	 * @return array<string, array{ input_list: mixed[]|string, expected: list<non-negative-int> }>
+	 * @return array<string, array{ input_list: mixed[]|string, expected: array<non-negative-int> }>
 	 */
 	public function data_unexpected_input(): array {
 		return array(
@@ -114,7 +118,10 @@ class Tests_Functions_wpParseIdList extends WP_UnitTestCase {
 			),
 			'array with array'   => array(
 				'input_list' => array( 1, array(), 2 ),
-				'expected'   => array( 1, 2 ),
+				'expected'   => array(
+					0 => 1,
+					2 => 2,
+				),
 			),
 			'passed assoc array' => array(
 				'input_list' => array(
@@ -122,7 +129,11 @@ class Tests_Functions_wpParseIdList extends WP_UnitTestCase {
 					'two'   => '2',
 					'three' => '3 is company',
 				),
-				'expected'   => array( 1, 2, 3 ),
+				'expected'   => array(
+					'one'   => 1,
+					'two'   => 2,
+					'three' => 3,
+				),
 			),
 		);
 	}

--- a/tests/phpunit/tests/functions/wpParseIdList.php
+++ b/tests/phpunit/tests/functions/wpParseIdList.php
@@ -32,7 +32,7 @@ class Tests_Functions_wpParseIdList extends WP_UnitTestCase {
 			),
 			'Array should contain only non-negative ints.'
 		);
-		$this->assertSameSets( $expected, $parsed_list );
+		$this->assertSame( $expected, $parsed_list );
 	}
 
 	/**

--- a/tests/phpunit/tests/functions/wpParseIdList.php
+++ b/tests/phpunit/tests/functions/wpParseIdList.php
@@ -15,17 +15,32 @@ class Tests_Functions_wpParseIdList extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_wp_parse_id_list
 	 * @dataProvider data_unexpected_input
+	 *
+	 * @param mixed[]|string $input_list
+	 * @param list<string> $expected
 	 */
-	public function test_wp_parse_id_list( $input_list, $expected ) {
-		$this->assertSameSets( $expected, wp_parse_id_list( $input_list ) );
+	public function test_wp_parse_id_list( $input_list, $expected ): void {
+		$parsed_list = wp_parse_id_list( $input_list );
+		$this->assertTrue( array_is_list( $parsed_list ), 'Expected value to be a list.' );
+		$this->assertThat(
+			$parsed_list,
+			$this->callback(
+				static fn ( array $arr ): bool => array_all(
+					$arr,
+					static fn( $v ) => is_int( $v ) && $v >= 0
+				)
+			),
+			'Array should contain only non-negative ints.'
+		);
+		$this->assertSameSets( $expected, $parsed_list );
 	}
 
 	/**
 	 * Data provider.
 	 *
-	 * @return array[]
+	 * @return array<string, array{ input_list: mixed[]|string, expected: list<non-negative-int> }>
 	 */
-	public function data_wp_parse_id_list() {
+	public function data_wp_parse_id_list(): array {
 		return array(
 			'regular'                  => array(
 				'input_list' => '1,2,3,4',
@@ -61,9 +76,9 @@ class Tests_Functions_wpParseIdList extends WP_UnitTestCase {
 	/**
 	 * Data provider.
 	 *
-	 * @return array[]
+	 * @return array<string, array{ input_list: mixed[]|string, expected: list<non-negative-int> }>
 	 */
-	public function data_unexpected_input() {
+	public function data_unexpected_input(): array {
 		return array(
 			'string with commas' => array(
 				'input_list' => '1,2,string with spaces',
@@ -96,6 +111,10 @@ class Tests_Functions_wpParseIdList extends WP_UnitTestCase {
 			'array with false'   => array(
 				'input_list' => array( 1, 2, false ),
 				'expected'   => array( 1, 2, 0 ),
+			),
+			'array with array'   => array(
+				'input_list' => array( 1, array(), 2 ),
+				'expected'   => array( 1, 2 ),
 			),
 		);
 	}

--- a/tests/phpunit/tests/functions/wpParseIdList.php
+++ b/tests/phpunit/tests/functions/wpParseIdList.php
@@ -116,6 +116,14 @@ class Tests_Functions_wpParseIdList extends WP_UnitTestCase {
 				'input_list' => array( 1, array(), 2 ),
 				'expected'   => array( 1, 2 ),
 			),
+			'passed assoc array' => array(
+				'input_list' => array(
+					'one'   => 1,
+					'two'   => '2',
+					'three' => '3 is company',
+				),
+				'expected'   => array( 1, 2, 3 ),
+			),
 		);
 	}
 }

--- a/tests/phpunit/tests/functions/wpParseIdList.php
+++ b/tests/phpunit/tests/functions/wpParseIdList.php
@@ -17,7 +17,7 @@ class Tests_Functions_wpParseIdList extends WP_UnitTestCase {
 	 * @dataProvider data_unexpected_input
 	 *
 	 * @param mixed[]|string $input_list
-	 * @param list<string> $expected
+	 * @param list<non-negative-int> $expected
 	 */
 	public function test_wp_parse_id_list( $input_list, $expected ): void {
 		$parsed_list = wp_parse_id_list( $input_list );

--- a/tests/phpunit/tests/functions/wpParseIdList.php
+++ b/tests/phpunit/tests/functions/wpParseIdList.php
@@ -19,15 +19,15 @@ class Tests_Functions_wpParseIdList extends WP_UnitTestCase {
 	 * @param mixed[]|string $input_list
 	 * @param list<non-negative-int> $expected
 	 */
-	public function test_wp_parse_id_list( $input_list, $expected ): void {
+	public function test_wp_parse_id_list( $input_list, array $expected ): void {
 		$parsed_list = wp_parse_id_list( $input_list );
 		$this->assertTrue( array_is_list( $parsed_list ), 'Expected value to be a list.' );
 		$this->assertThat(
 			$parsed_list,
 			$this->callback(
-				static fn ( array $arr ): bool => array_all(
+				static fn ( array $arr ) => array_all(
 					$arr,
-					static fn( $v ) => is_int( $v ) && $v >= 0
+					static fn ( $v ) => is_int( $v ) && $v >= 0
 				)
 			),
 			'Array should contain only non-negative ints.'

--- a/tests/phpunit/tests/functions/wpParseList.php
+++ b/tests/phpunit/tests/functions/wpParseList.php
@@ -13,61 +13,74 @@ class Tests_Functions_wpParseList extends WP_UnitTestCase {
 	 * @ticket 43977
 	 *
 	 * @dataProvider data_wp_parse_list
+	 *
+	 * @param mixed[]|string $input_list
+	 * @param list<scalar> $expected
 	 */
-	public function test_wp_parse_list( $input_list, $expected ) {
-		$this->assertSameSets( $expected, wp_parse_list( $input_list ) );
+	public function test_wp_parse_list( $input_list, array $expected ): void {
+		$parsed_list = wp_parse_list( $input_list );
+		$this->assertTrue( array_is_list( $parsed_list ), 'Expected value to be a list.' );
+		$this->assertSameSets( $expected, $parsed_list );
 	}
 
 	/**
 	 * Data provider.
 	 *
-	 * @return array[]
+	 * @return array<string, array{ input_list: mixed[]|string, expected: list<scalar> }>
 	 */
-	public function data_wp_parse_list() {
+	public function data_wp_parse_list(): array {
 		return array(
-			'ids only'           => array(
+			'ids only'            => array(
 				'input_list' => '1,2,3,4',
 				'expected'   => array( '1', '2', '3', '4' ),
 			),
-			'slugs only'         => array(
+			'slugs only'          => array(
 				'input_list' => 'apple,banana,carrot,dog',
 				'expected'   => array( 'apple', 'banana', 'carrot', 'dog' ),
 			),
-			'ids and slugs'      => array(
+			'ids and slugs'       => array(
 				'input_list' => '1,2,apple,banana',
 				'expected'   => array( '1', '2', 'apple', 'banana' ),
 			),
-			'space after comma'  => array(
+			'space after comma'   => array(
 				'input_list' => '1, 2,apple,banana',
 				'expected'   => array( '1', '2', 'apple', 'banana' ),
 			),
-			'double comma'       => array(
+			'double comma'        => array(
 				'input_list' => '1,2,apple,,banana',
 				'expected'   => array( '1', '2', 'apple', 'banana' ),
 			),
-			'leading comma'      => array(
+			'leading comma'       => array(
 				'input_list' => ',1,2,apple,banana',
 				'expected'   => array( '1', '2', 'apple', 'banana' ),
 			),
-			'trailing comma'     => array(
+			'trailing comma'      => array(
 				'input_list' => '1,2,apple,banana,',
 				'expected'   => array( '1', '2', 'apple', 'banana' ),
 			),
-			'space before comma' => array(
+			'space before comma'  => array(
 				'input_list' => '1,2 ,apple,banana',
 				'expected'   => array( '1', '2', 'apple', 'banana' ),
 			),
-			'empty string'       => array(
+			'empty string'        => array(
 				'input_list' => '',
 				'expected'   => array(),
 			),
-			'comma only'         => array(
+			'comma only'          => array(
 				'input_list' => ',',
 				'expected'   => array(),
 			),
-			'double comma only'  => array(
+			'double comma only'   => array(
 				'input_list' => ',,',
 				'expected'   => array(),
+			),
+			'passed scalar array' => array(
+				'input_list' => array( 'foo', true, false, 1, 3.14 ),
+				'expected'   => array( 'foo', true, false, 1, 3.14 ),
+			),
+			'passed mixed array'  => array(
+				'input_list' => array( null, 'foo', array(), true, new stdClass(), false, 1, 3.14 ),
+				'expected'   => array( 'foo', true, false, 1, 3.14 ),
 			),
 		);
 	}

--- a/tests/phpunit/tests/functions/wpParseList.php
+++ b/tests/phpunit/tests/functions/wpParseList.php
@@ -15,18 +15,17 @@ class Tests_Functions_wpParseList extends WP_UnitTestCase {
 	 * @dataProvider data_wp_parse_list
 	 *
 	 * @param mixed[]|string $input_list
-	 * @param list<scalar> $expected
+	 * @param array<scalar> $expected
 	 */
 	public function test_wp_parse_list( $input_list, array $expected ): void {
 		$parsed_list = wp_parse_list( $input_list );
-		$this->assertTrue( array_is_list( $parsed_list ), 'Expected value to be a list.' );
 		$this->assertSame( $expected, $parsed_list );
 	}
 
 	/**
 	 * Data provider.
 	 *
-	 * @return array<string, array{ input_list: mixed[]|string, expected: list<scalar> }>
+	 * @return array<string, array{ input_list: mixed[]|string, expected: array<scalar> }>
 	 */
 	public function data_wp_parse_list(): array {
 		return array(
@@ -80,7 +79,13 @@ class Tests_Functions_wpParseList extends WP_UnitTestCase {
 			),
 			'passed mixed array'  => array(
 				'input_list' => array( null, 'foo', array(), true, new stdClass(), false, 1, 3.14 ),
-				'expected'   => array( 'foo', true, false, 1, 3.14 ),
+				'expected'   => array(
+					1 => 'foo',
+					3 => true,
+					5 => false,
+					6 => 1,
+					7 => 3.14,
+				),
 			),
 			'passed assoc array'  => array(
 				'input_list' => array(
@@ -88,7 +93,11 @@ class Tests_Functions_wpParseList extends WP_UnitTestCase {
 					'bar' => true,
 					'baz' => 3.14,
 				),
-				'expected'   => array( 1, true, 3.14 ),
+				'expected'   => array(
+					'foo' => 1,
+					'bar' => true,
+					'baz' => 3.14,
+				),
 			),
 		);
 	}

--- a/tests/phpunit/tests/functions/wpParseList.php
+++ b/tests/phpunit/tests/functions/wpParseList.php
@@ -19,6 +19,16 @@ class Tests_Functions_wpParseList extends WP_UnitTestCase {
 	 */
 	public function test_wp_parse_list( $input_list, array $expected ): void {
 		$parsed_list = wp_parse_list( $input_list );
+		$this->assertThat(
+			$parsed_list,
+			$this->callback(
+				static fn ( array $arr ) => array_all(
+					$arr,
+					static fn ( $v ) => is_scalar( $v )
+				)
+			),
+			'Array should contain only scalars.'
+		);
 		$this->assertSame( $expected, $parsed_list );
 	}
 

--- a/tests/phpunit/tests/functions/wpParseList.php
+++ b/tests/phpunit/tests/functions/wpParseList.php
@@ -82,6 +82,14 @@ class Tests_Functions_wpParseList extends WP_UnitTestCase {
 				'input_list' => array( null, 'foo', array(), true, new stdClass(), false, 1, 3.14 ),
 				'expected'   => array( 'foo', true, false, 1, 3.14 ),
 			),
+			'passed assoc array'  => array(
+				'input_list' => array(
+					'foo' => 1,
+					'bar' => true,
+					'baz' => 3.14,
+				),
+				'expected'   => array( 1, true, 3.14 ),
+			),
 		);
 	}
 }

--- a/tests/phpunit/tests/functions/wpParseList.php
+++ b/tests/phpunit/tests/functions/wpParseList.php
@@ -20,7 +20,7 @@ class Tests_Functions_wpParseList extends WP_UnitTestCase {
 	public function test_wp_parse_list( $input_list, array $expected ): void {
 		$parsed_list = wp_parse_list( $input_list );
 		$this->assertTrue( array_is_list( $parsed_list ), 'Expected value to be a list.' );
-		$this->assertSameSets( $expected, $parsed_list );
+		$this->assertSame( $expected, $parsed_list );
 	}
 
 	/**

--- a/tests/phpunit/tests/functions/wpParseSlugList.php
+++ b/tests/phpunit/tests/functions/wpParseSlugList.php
@@ -116,6 +116,14 @@ class Tests_Functions_WpParseSlugList extends WP_UnitTestCase {
 				'input_list' => array( 1, '<br>', 2 ),
 				'expected'   => array( '1', '', '2' ),
 			),
+			'passed assoc array' => array(
+				'input_list' => array(
+					'one'   => 'foo',
+					'two'   => 'bar',
+					'three' => 'baz',
+				),
+				'expected'   => array( 'foo', 'bar', 'baz' ),
+			),
 		);
 	}
 }

--- a/tests/phpunit/tests/functions/wpParseSlugList.php
+++ b/tests/phpunit/tests/functions/wpParseSlugList.php
@@ -29,7 +29,7 @@ class Tests_Functions_WpParseSlugList extends WP_UnitTestCase {
 					static fn ( $v ) => is_string( $v )
 				)
 			),
-			'Array should contain only non-negative ints.'
+			'Array should contain only strings.'
 		);
 		$this->assertSame( $expected, $parsed_list );
 	}

--- a/tests/phpunit/tests/functions/wpParseSlugList.php
+++ b/tests/phpunit/tests/functions/wpParseSlugList.php
@@ -17,11 +17,10 @@ class Tests_Functions_WpParseSlugList extends WP_UnitTestCase {
 	 * @dataProvider data_unexpected_input
 	 *
 	 * @param mixed[]|string $input_list
-	 * @param list<string> $expected
+	 * @param array<string> $expected
 	 */
 	public function test_wp_parse_slug_list( $input_list, array $expected ): void {
 		$parsed_list = wp_parse_slug_list( $input_list );
-		$this->assertTrue( array_is_list( $parsed_list ), 'Expected value to be a list.' );
 		$this->assertThat(
 			$parsed_list,
 			$this->callback(
@@ -38,7 +37,7 @@ class Tests_Functions_WpParseSlugList extends WP_UnitTestCase {
 	/**
 	 * Data provider.
 	 *
-	 * @return array<string, array{ input_list: mixed[]|string, expected: list<string> }>
+	 * @return array<string, array{ input_list: mixed[]|string, expected: array<string> }>
 	 */
 	public function data_wp_parse_slug_list(): array {
 		return array(
@@ -52,11 +51,21 @@ class Tests_Functions_WpParseSlugList extends WP_UnitTestCase {
 			),
 			'duplicate slug in a string' => array(
 				'input_list' => 'apple,banana,carrot,carrot,dog',
-				'expected'   => array( 'apple', 'banana', 'carrot', 'dog' ),
+				'expected'   => array(
+					0 => 'apple',
+					1 => 'banana',
+					2 => 'carrot',
+					4 => 'dog',
+				),
 			),
 			'duplicate slug in an array' => array(
 				'input_list' => array( 'apple', 'banana', 'carrot', 'carrot', 'dog' ),
-				'expected'   => array( 'apple', 'banana', 'carrot', 'dog' ),
+				'expected'   => array(
+					0 => 'apple',
+					1 => 'banana',
+					2 => 'carrot',
+					4 => 'dog',
+				),
 			),
 			'string with spaces'         => array(
 				'input_list' => 'apple banana carrot dog',
@@ -66,13 +75,25 @@ class Tests_Functions_WpParseSlugList extends WP_UnitTestCase {
 				'input_list' => array( 'apple ', 'banana carrot', 'd o g' ),
 				'expected'   => array( 'apple', 'banana-carrot', 'd-o-g' ),
 			),
+			'passed assoc array'         => array(
+				'input_list' => array(
+					'one'   => 'foo',
+					'two'   => 'bar',
+					'three' => 'baz',
+				),
+				'expected'   => array(
+					'one'   => 'foo',
+					'two'   => 'bar',
+					'three' => 'baz',
+				),
+			),
 		);
 	}
 
 	/**
 	 * Data provider.
 	 *
-	 * @return array<string, array{ input_list: mixed[]|string, expected: list<string> }>
+	 * @return array<string, array{ input_list: mixed[]|string, expected: array<string> }>
 	 */
 	public function data_unexpected_input(): array {
 		return array(
@@ -110,19 +131,14 @@ class Tests_Functions_WpParseSlugList extends WP_UnitTestCase {
 			),
 			'array with array'   => array(
 				'input_list' => array( 1, array(), 2 ),
-				'expected'   => array( '1', '2' ),
+				'expected'   => array(
+					0 => '1',
+					2 => '2',
+				),
 			),
 			'array with tag'     => array(
 				'input_list' => array( 1, '<br>', 2 ),
 				'expected'   => array( '1', '', '2' ),
-			),
-			'passed assoc array' => array(
-				'input_list' => array(
-					'one'   => 'foo',
-					'two'   => 'bar',
-					'three' => 'baz',
-				),
-				'expected'   => array( 'foo', 'bar', 'baz' ),
 			),
 		);
 	}

--- a/tests/phpunit/tests/functions/wpParseSlugList.php
+++ b/tests/phpunit/tests/functions/wpParseSlugList.php
@@ -17,7 +17,7 @@ class Tests_Functions_WpParseSlugList extends WP_UnitTestCase {
 	 * @dataProvider data_unexpected_input
 	 */
 	public function test_wp_parse_slug_list( $input_list, $expected ) {
-		$this->assertSameSets( $expected, wp_parse_slug_list( $input_list ) );
+		$this->assertSame( $expected, wp_parse_slug_list( $input_list ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/functions/wpParseSlugList.php
+++ b/tests/phpunit/tests/functions/wpParseSlugList.php
@@ -15,17 +15,32 @@ class Tests_Functions_WpParseSlugList extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_wp_parse_slug_list
 	 * @dataProvider data_unexpected_input
+	 *
+	 * @param mixed[]|string $input_list
+	 * @param list<string> $expected
 	 */
-	public function test_wp_parse_slug_list( $input_list, $expected ) {
-		$this->assertSame( $expected, wp_parse_slug_list( $input_list ) );
+	public function test_wp_parse_slug_list( $input_list, array $expected ): void {
+		$parsed_list = wp_parse_slug_list( $input_list );
+		$this->assertTrue( array_is_list( $parsed_list ), 'Expected value to be a list.' );
+		$this->assertThat(
+			$parsed_list,
+			$this->callback(
+				static fn ( array $arr ) => array_all(
+					$arr,
+					static fn ( $v ) => is_string( $v )
+				)
+			),
+			'Array should contain only non-negative ints.'
+		);
+		$this->assertSame( $expected, $parsed_list );
 	}
 
 	/**
 	 * Data provider.
 	 *
-	 * @return array[]
+	 * @return array<string, array{ input_list: mixed[]|string, expected: list<string> }>
 	 */
-	public function data_wp_parse_slug_list() {
+	public function data_wp_parse_slug_list(): array {
 		return array(
 			'regular'                    => array(
 				'input_list' => 'apple,banana,carrot,dog',
@@ -57,9 +72,9 @@ class Tests_Functions_WpParseSlugList extends WP_UnitTestCase {
 	/**
 	 * Data provider.
 	 *
-	 * @return array[]
+	 * @return array<string, array{ input_list: mixed[]|string, expected: list<string> }>
 	 */
-	public function data_unexpected_input() {
+	public function data_unexpected_input(): array {
 		return array(
 			'string with commas' => array(
 				'input_list' => '1,2,string with spaces',
@@ -92,6 +107,14 @@ class Tests_Functions_WpParseSlugList extends WP_UnitTestCase {
 			'array with false'   => array(
 				'input_list' => array( 1, 2, false ),
 				'expected'   => array( '1', '2', '' ),
+			),
+			'array with array'   => array(
+				'input_list' => array( 1, array(), 2 ),
+				'expected'   => array( '1', '2' ),
+			),
+			'array with tag'     => array(
+				'input_list' => array( 1, '<br>', 2 ),
+				'expected'   => array( '1', '', '2' ),
 			),
 		);
 	}


### PR DESCRIPTION
✅  Committed in r62797 (983a066968747914d27b08e3c67e211a7a80c18c).

----

The `wp_parse_list()`, `wp_parse_id_list()`, and `wp_parse_slug_list()` functions are key utility functions. The `wp_parse_id_list()` function was used in a security fix for 7.0.2 in r62771 (97b5a75246f6c82fe9d9f0ba492f06d93b602b98). However, these functions can be further hardened to give precise types and to address various PHPStan errors at rule level 10:

> **`wp_parse_list()` (5027–5029)**
> - `missingType.iterableValue` ×2 — `$input_list` param and return are bare `array`.
> - `return.type` — `preg_split()` can return `false`, which isn't in the declared `array` return.
>
> **`wp_parse_id_list()` (5047)**
> - `missingType.iterableValue` — bare `array` param.
>
> **`wp_parse_slug_list()` (5062, 5065)**
> - `missingType.iterableValue` — bare `array` param.
> - `argument.type` — `array_map( 'sanitize_title', ... )`: `sanitize_title()`'s first param is `string`, but the array's value type is `mixed`, so it isn't accepted as `callable(mixed): mixed`. (`absint` in `wp_parse_id_list` doesn't trip this because its param is `mixed`.)

## What this changes

No return value changes for any input, with one exception noted below. The keys, values, and ordering that callers see today are all preserved.

* **Types.** `@param array|string` becomes `@param mixed[]|string` on all three. `wp_parse_list()` gains `@phpstan-return ($input_list is string ? list<string> : array<scalar>)` — splitting a string yields sequential keys, so that branch really is a list, while the array branch carries its argument's keys through. `wp_parse_id_list()` gains `@phpstan-return array<non-negative-int>`; `wp_parse_slug_list()` needs no PHPStan tag, since `@return string[]` already means `array<string>`.

  The conditional does **not** extend to `wp_parse_id_list()` or `wp_parse_slug_list()`, because `array_unique()` keeps the first occurrence of a duplicate and so leaves gaps in the keys even when a string was passed: `wp_parse_id_list( '1,2,2,3' )` returns `[0 => 1, 1 => 2, 3 => 3]`.

* **`preg_split()` failure handling.** The declared `array` return didn't account for `preg_split()` returning `false` on a PCRE runtime failure. Casting the result would turn that into `array( false )` rather than an empty array, and the stray `false` would go on to reach `absint()` as `0` or `sanitize_title()` as `''`, adding a phantom entry. The result is checked with `is_array()` instead. This is the one behavior change, and only on a code path that previously produced a wrong value.

* **`sanitize_title()` input.** Values are passed through `strval()` first. `wp_parse_list()` has already filtered out non-scalars, so this only affects booleans, integers, and floats — which PHP was coercing identically anyway. No output changes; it just makes the `callable(mixed): mixed` mismatch go away honestly.

* **Docs.** The `@return` descriptions now say *why* the result isn't necessarily a list — keys carried over from an array argument, and gaps left by `array_unique()` — rather than leaving it to be inferred from the implementation.

* **Tests.** Coverage for associative arrays, non-scalar entries, and duplicate values, with the resulting keys asserted explicitly. `assertSameSets()` is replaced with `assertSame()` so key order and types are actually checked. Each test also asserts the documented value contract (`scalar` / non-negative `int` / `string`) independently of what the data provider expects, so a regression in the function is caught even if a provider row is updated to match the new output.

## Why not lists

Originally, I intended to type these so that they returned `list` instead of `array`, bypassing through the value through `array_values()`.  The use of `array_filter()` can cause sparse arrays to be returned unexpectedly, and also for passed associative to have their keys passed through. However, passing in an associative array and getting those same string keys back out appears to be done intentionally in at least one case.

<details><summary>Claude Research of Veloria</summary>

Checked Veloria (latest versions of all wp.org-hosted plugins + themes). Here's what I found.

## Yes — there's one real break, and it's in `wp_parse_list()`

The Hizzle store library deliberately passes an **associative** array and branches on the string key:

`vendor/hizzle/store/src/Query.php:472` — shipped in **Noptin** (10k installs) and **Hizzle Downloads**:

```php
foreach ( wp_parse_list( $qv['groupby'] ) as $index => $field ) {
    $cast = false;
    // Check if $index is a string and different from $field
    if ( is_string( $index ) && $index !== $field ) {
        $cast  = $field;
        $field = $index;
    }
    ...
    $this->query_groupby .= ', `' . $field . '`';
```

So `array( 'date' => 'DATE' )` means "group by `date`, cast it as DATE". `array_values()` silently discards the key, so `$field` becomes the cast type `'DATE'` — the generated `GROUP BY` and `SELECT ... AS` clauses would reference a nonexistent column. That's a fatal SQL error or wrong aggregation in their reporting queries, failing silently at the WP level.

## Everything else is clean

- **Key-consuming `foreach` over the result:** exactly those 2 plugins, ecosystem-wide (0 in themes). `array_keys( wp_parse_*list(...) )` — 0 hits.
- **Assoc arrays going in:** all 29 `wp_parse_id_list( wp_list_pluck( ... ) )` call sites use the two-arg `wp_list_pluck` (no `index_key`), so they pass lists. No assoc array literals passed in anywhere.
- **Core:** every usage is key-agnostic — `implode`, `in_array`, `array_merge`, `foreach` by value. And `class-wp-widget-media-gallery.php:72` uses `wp_parse_id_list` as a `sanitize_callback`; today a duplicate ID leaves gapped keys, so `wp_json_encode` emits `{"0":1,"2":3}` instead of an array. Your change actually **fixes** that latent wart.

## Recommendation

The risk is asymmetric across the three functions, so I'd split them:

- **`wp_parse_id_list()` / `wp_parse_slug_list()`** — keep `array_values()`. Zero evidence of key dependence, and it fixes the gapped-key JSON issue. `list<...>` is honest.
- **`wp_parse_list()`** — I'd drop the `array_values()`. It's the general-purpose one, its keys carry meaning for at least one real consumer, and unlike the other two it does no per-element transformation, so preserving the input's shape is arguably its contract. Declare `@phpstan-return ($input_list is string ? list<string> : array<array-key, scalar>)` instead.

One caveat on the evidence: Veloria indexes the current release of wp.org-hosted plugins and themes only — premium plugins, agency/client code, and mu-plugins aren't covered. Finding a deliberate key-dependent consumer in the first sweep of a fairly obscure pattern suggests the unmeasured tail probably holds a few more.

</details>

Therefore, it is safer to not change these functions for risk of a back-compat breakage. To obtain true lists, the return value can be passed through `array_values()`.

**Note:** the per-function split recommended at the end of that research was not taken. `array_values()` is dropped from all three functions, not just `wp_parse_list()` — the gapped-key JSON behavior it would have fixed in `wp_parse_id_list()` isn't worth a separate compatibility risk in a PR that is otherwise type-only.

## PHPStan impact

Measured with two cold-cache runs over `src/`, comparing this branch against `trunk`:

| Metric | Value |
|---|---|
| Errors in `trunk` | 32,863 |
| Errors in this branch | 32,857 |
| **Net change** | **−6** |

The six are exactly the errors quoted at the top, all in `wp-includes/functions.php`. Nothing is introduced.

The raw diff also reports ~52 fixed/introduced pairs that are purely cosmetic — `@param mixed[]` renders as `array<mixed>` where bare `array` rendered as `array`, so every unchanged call site's message text shifted. Separately, nine pre-existing errors at unchanged call sites are now reported with narrower types (`mixed` → `bool|float|int|string`), which makes them actionable: `trim()` receiving `mixed` is unfixable noise, whereas `trim()` receiving `bool|float|int|string` is a concrete finding.

Trac ticket: https://core.trac.wordpress.org/ticket/64898

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Opus 4.8
Used for: Coming up with some test assertion logic. Obtaining PHPStan errors and measuring the branch-vs-trunk impact. Surveying the plugin/theme ecosystem for back-compat risk. Reviewing the change, and authoring the follow-up commits that came out of that review (the `preg_split()` failure handling, the conditional return type, the return-contract test assertions, and the `@return` documentation).

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
