### PR TITLE
Administration: Prevent PHP deprecation notice in get_admin_page_title()

### DIFF
--- a/src/wp-admin/includes/plugin.php
+++ b/src/wp-admin/includes/plugin.php
@@ -2041,6 +2041,10 @@ function get_admin_page_title() {
 		return $title;
 	}
 
+	if ( ! is_string( $plugin_page ) ) {
+		$plugin_page = '';
+	}
+
 	$hook = get_plugin_page_hook( $plugin_page, $pagenow );
 
 	$parent  = get_admin_page_parent();


### PR DESCRIPTION
Prevents a PHP 8.1+ deprecation notice when calling `get_admin_page_title()` on admin pages where the global `$plugin_page` is null (e.g., Tools, Plugins pages).

Trac ticket: https://core.trac.wordpress.org/ticket/59365

**Changes:**
- Adds an early type guard in `get_admin_page_title()` to ensure `$plugin_page` is a string before passing it to `get_plugin_page_hook()`