### PR TITLE
Plugins: Distinguish a missing admin page from an access denial (#14060)

### DIFF
--- a/src/wp-admin/includes/menu.php
+++ b/src/wp-admin/includes/menu.php
@@ -372,7 +372,17 @@ if ( ! empty( $menu ) && 'wp-menu-separator' === $menu[ $last_menu_key ][4] ) {
 }
 unset( $last_menu_key );
 
-if ( ! user_can_access_admin_page() ) {
+if ( ! admin_page_exists() ) {
+
+	/**
+	 * Fires when an attempt is made to access an admin page that does not exist.
+	 *
+	 * @since 7.1.0
+	 */
+	do_action( 'admin_page_not_found' );
+
+	wp_die( __( 'The requested page does not exist.' ), 404 );
+} elseif ( ! user_can_access_admin_page() ) {
 
 	/**
 	 * Fires when access to an admin page is denied.

--- a/src/wp-admin/includes/plugin.php
+++ b/src/wp-admin/includes/plugin.php
@@ -2126,6 +2126,35 @@ function get_plugin_page_hook( $plugin_page, $parent_page ) {
 }
 
 /**
+ * Determines whether the current admin page exists.
+ *
+ * Checks whether the plugin page currently being requested has been registered,
+ * independently of whether the current user has the capability to access it. This
+ * allows a request for a page that no longer exists to be distinguished from a
+ * request the current user is not permitted to make.
+ *
+ * @since 7.1.0
+ *
+ * @global string $plugin_page       The slug name of the plugin page being requested.
+ * @global array  $_registered_pages Array of registered admin page hooks.
+ *
+ * @return bool True if the admin page exists, false otherwise.
+ */
+function admin_page_exists() {
+	global $plugin_page, $_registered_pages;
+
+	if ( isset( $plugin_page ) ) {
+		$hookname = get_plugin_page_hookname( $plugin_page, get_admin_page_parent() );
+
+		if ( ! isset( $_registered_pages[ $hookname ] ) ) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+/**
  * Gets the hook name for the administrative page of a plugin.
  *
  * @since 1.5.0
@@ -2169,13 +2198,12 @@ function get_plugin_page_hookname( $plugin_page, $parent_page ) {
  * @global array  $_wp_menu_nopriv
  * @global array  $_wp_submenu_nopriv
  * @global string $plugin_page
- * @global array  $_registered_pages
  *
  * @return bool True if the current user can access the admin page, false otherwise.
  */
 function user_can_access_admin_page() {
 	global $pagenow, $menu, $submenu, $_wp_menu_nopriv, $_wp_submenu_nopriv,
-		$plugin_page, $_registered_pages;
+		$plugin_page;
 
 	$parent = get_admin_page_parent();
 
@@ -2188,9 +2216,7 @@ function user_can_access_admin_page() {
 			return false;
 		}
 
-		$hookname = get_plugin_page_hookname( $plugin_page, $parent );
-
-		if ( ! isset( $_registered_pages[ $hookname ] ) ) {
+		if ( ! admin_page_exists() ) {
 			return false;
 		}
 	}

--- a/tests/phpunit/tests/admin/includesPlugin.php
+++ b/tests/phpunit/tests/admin/includesPlugin.php
@@ -75,6 +75,79 @@ class Tests_Admin_IncludesPlugin extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Ensures a request with no plugin page is treated as an existing page.
+	 *
+	 * Core admin screens (those without a `page` query argument) always exist,
+	 * so the function must not report them as missing.
+	 *
+	 * @ticket 14060
+	 *
+	 * @covers ::admin_page_exists
+	 */
+	public function test_admin_page_exists_returns_true_when_no_plugin_page() {
+		global $plugin_page;
+
+		$previous_plugin_page = $plugin_page;
+		unset( $plugin_page );
+
+		$this->assertTrue( admin_page_exists() );
+
+		$plugin_page = $previous_plugin_page;
+	}
+
+	/**
+	 * Ensures a registered plugin page is reported as existing.
+	 *
+	 * @ticket 14060
+	 *
+	 * @covers ::admin_page_exists
+	 */
+	public function test_admin_page_exists_returns_true_for_registered_page() {
+		global $plugin_page, $pagenow;
+
+		$current_user         = get_current_user_id();
+		$previous_plugin_page = $plugin_page;
+		$previous_pagenow     = $pagenow;
+		wp_set_current_user( self::$admin_id );
+
+		add_options_page( 'Existing Page', 'Existing Page', 'manage_options', 'existing-page-14060', '__return_null' );
+
+		$pagenow     = 'options-general.php';
+		$plugin_page = 'existing-page-14060';
+
+		$this->assertTrue( admin_page_exists() );
+
+		$plugin_page = $previous_plugin_page;
+		$pagenow     = $previous_pagenow;
+		wp_set_current_user( $current_user );
+	}
+
+	/**
+	 * Ensures a plugin page that was never registered is reported as missing.
+	 *
+	 * This is the scenario the fix targets: accessing the URL of a plugin page
+	 * that no longer exists should be distinguishable from an access denial.
+	 *
+	 * @ticket 14060
+	 *
+	 * @covers ::admin_page_exists
+	 */
+	public function test_admin_page_exists_returns_false_for_unregistered_page() {
+		global $plugin_page, $pagenow;
+
+		$previous_plugin_page = $plugin_page;
+		$previous_pagenow     = $pagenow;
+
+		$pagenow     = 'options-general.php';
+		$plugin_page = 'nonexistent-page-14060';
+
+		$this->assertFalse( admin_page_exists() );
+
+		$plugin_page = $previous_plugin_page;
+		$pagenow     = $previous_pagenow;
+	}
+
+	/**
 	 * Tests the position parameter.
 	 *
 	 * @ticket 39776


### PR DESCRIPTION
## Description

Accessing the URL of a plugin admin page that is no longer registered previously
showed the misleading "Sorry, you are not allowed to access this page." message,
implying a permissions problem where none exists.

This introduces `admin_page_exists()`, which determines whether the requested page
is registered independently of the current user's capabilities. When the page does
not exist, `wp_die()` is now called with a clearer "The requested page does not
exist." message and a 404 status, and a new `admin_page_not_found` action fires,
mirroring the existing `admin_page_access_denied` action.
`user_can_access_admin_page()` reuses the new function so the registration check is
no longer duplicated.

## Testing Instructions

- Install and activate a plugin that includes a settings page.
- Navigate to the plugin's settings page and copy the URL.
- Deactivate the plugin.
- Paste the copied URL into the browser's address bar and press Enter.
- You should see "The requested page does not exist." (404) instead of "Sorry, you
  are not allowed to access this page."

Unit tests:
`npm run test:php -- --filter admin_page_exists tests/phpunit/tests/admin/includesPlugin.php`

Trac ticket: https://core.trac.wordpress.org/ticket/14060
