### PR TITLE
Administration: Fix tooltip/toggletip nesting inside paragraphs

### DIFF
--- a/src/js/_enqueues/wp/wp-tooltip.js
+++ b/src/js/_enqueues/wp/wp-tooltip.js
@@ -8,7 +8,7 @@
  */
 (() => {
 
-	const popovers = /** @type {NodeListOf<HTMLDivElement>} */ ( document.querySelectorAll( '.wp-is-tooltip' ) );
+	const popovers = /** @type {NodeListOf<HTMLSpanElement>} */ ( document.querySelectorAll( '.wp-is-tooltip' ) );
 
 	/** @type {ReturnType<typeof setTimeout>} */
 	let openTimeout;

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -430,6 +430,7 @@ function wp_get_toggletip( $content, $args ) {
 	$args['type'] = 'toggletip';
 	return wp_get_tooltip_helper( $content, $args );
 }
+
 /**
  * Retrieves the markup for an accessible tooltip or toggletip.
  *
@@ -488,18 +489,24 @@ function wp_get_tooltip_helper( $content, $args = array() ) {
 
 	$icon = '' !== $args['icon'] ? ' ' . $args['icon'] : '';
 
+	/*
+	 * The markup is built from phrasing content only (`span` and `button`) so it stays
+	 * valid when nested inside a paragraph or other phrasing context. A `div` wrapper or
+	 * `dialog` element would force the parser to close an open `p`, leaving an empty
+	 * paragraph behind and breaking the layout. See #65660.
+	 */
 	if ( 'tooltip' === $args['type'] ) {
 		// Tooltips are only used to visually display labels.
 		$label  = wp_strip_all_tags( $content, true );
 		$markup = sprintf(
-			'<div class="%1$s">' .
+			'<span class="%1$s">' .
 				'<button type="button" class="wp-tooltip__toggle" popovertarget="%2$s" aria-label="%3$s">' .
 					'<span class="dashicons%4$s" aria-hidden="true"></span>' .
 				'</button>' .
 				'<span popover="hint" id="%2$s" class="wp-tooltip__bubble" role="tooltip">' .
 					'<span id="%2$s-text" class="wp-tooltip__text">%5$s</span>' .
 				'</span>' .
-			'</div>',
+			'</span>',
 			esc_attr( $classes ),
 			esc_attr( $id ),
 			esc_attr( $label ),
@@ -507,18 +514,23 @@ function wp_get_tooltip_helper( $content, $args = array() ) {
 			esc_html( $content ),
 		);
 	} else {
+		/*
+		 * A `span` with `role="dialog"` is used instead of a `dialog` element to keep the
+		 * markup as phrasing content. The `aria-label`, `tabindex`, and `autofocus`
+		 * attributes reproduce the accessible name and focus handling of the native element.
+		 */
 		$markup = sprintf(
-			'<div class="%1$s">' .
+			'<span class="%1$s">' .
 				'<button type="button" class="wp-tooltip__toggle" popovertarget="%2$s" aria-label="%3$s" aria-haspopup="dialog">' .
 					'<span class="dashicons%4$s" aria-hidden="true"></span>' .
 				'</button>' .
-				'<dialog popover="auto" id="%2$s" class="wp-tooltip__bubble" autofocus>' .
+				'<span popover="auto" id="%2$s" class="wp-tooltip__bubble" role="dialog" aria-label="%3$s" tabindex="-1" autofocus>' .
 					'<span id="%2$s-text" class="wp-tooltip__text">%5$s</span>' .
 					'<button type="button" class="wp-tooltip__close" popovertarget="%2$s" popovertargetaction="hide" aria-label="%6$s">' .
 						'<span class="dashicons dashicons-no-alt" aria-hidden="true"></span>' .
 					'</button>' .
-				'</dialog>' .
-			'</div>',
+				'</span>' .
+			'</span>',
 			esc_attr( $classes ),
 			esc_attr( $id ),
 			esc_attr( $args['label'] ),

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -475,7 +475,6 @@ function wp_get_tooltip_helper( $content, $args = array() ) {
 		'icon'        => 'dashicons-editor-help',
 		'class'       => '',
 		'type'        => 'tooltip',
-		'attributes'  => array(),
 	);
 
 	$args = wp_parse_args( $args, $defaults );

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -437,7 +437,7 @@ function wp_get_toggletip( $content, $args ) {
  * Returns a button and either a hover/focus triggered tooltip popover or an action
  * triggered toggle tip. Enqueue the `wp-tooltip` style and script where it is used.
  * Tooltips are used to show the accessible name of a control.
- * Toggletips are be used for longer supporting text explaining context.
+ * Toggletips are used for longer supporting text explaining context.
  *
  * @since 7.1.0
  *
@@ -489,10 +489,10 @@ function wp_get_tooltip_helper( $content, $args = array() ) {
 	$icon = '' !== $args['icon'] ? ' ' . $args['icon'] : '';
 
 	/*
-	 * The markup is built from phrasing content only (`span` and `button`) so it stays
-	 * valid when nested inside a paragraph or other phrasing context. A `div` wrapper or
-	 * `dialog` element would force the parser to close an open `p`, leaving an empty
-	 * paragraph behind and breaking the layout. See #65660.
+	 * The markup only uses phrasing content so it is valid when nested
+	 * in a phrasing context. Sectioning content (e.g. `div`, `dialog`) will
+	 * cause the parser to close an open `p`, creating an empty and breaking
+	 * the layout. See #65660.
 	 */
 	if ( 'tooltip' === $args['type'] ) {
 		// Tooltips are only used to visually display labels.

--- a/tests/phpunit/tests/general/wpGetTooltip.php
+++ b/tests/phpunit/tests/general/wpGetTooltip.php
@@ -114,4 +114,56 @@ class Tests_General_wpGetTooltip extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'popovertarget="' . $id . '"', $html );
 		$this->assertStringContainsString( 'id="' . $id . '-text"', $html );
 	}
+
+	/**
+	 * Tests that the markup consists only of phrasing content so it can be nested
+	 * inside a paragraph (or other phrasing context) without the parser closing
+	 * the enclosing element and leaving a stray empty paragraph behind.
+	 *
+	 * @ticket 65660
+	 *
+	 * @dataProvider data_tooltip_types
+	 *
+	 * @param string $type The tooltip type, 'tooltip' or 'toggletip'.
+	 */
+	public function test_wp_get_tooltip_markup_is_phrasing_content( $type ) {
+		$html = ( 'toggletip' === $type )
+			? wp_get_toggletip( 'Helpful text.', array( 'id' => 'my-tip' ) )
+			: wp_get_tooltip( 'Helpful text.', array( 'id' => 'my-tip' ) );
+
+		// The wrapper and popover must not use flow-content elements.
+		$this->assertStringNotContainsString( '<div', $html, 'The markup should not contain a div element.' );
+		$this->assertStringNotContainsString( '<dialog', $html, 'The markup should not contain a dialog element.' );
+
+		// The wrapper is an inline span.
+		$this->assertStringContainsString( '<span class="wp-tooltip ', $html );
+	}
+
+	/**
+	 * Tests that the toggletip popover preserves dialog semantics and focus
+	 * handling after moving away from the native dialog element.
+	 *
+	 * @ticket 65660
+	 */
+	public function test_wp_get_toggletip_bubble_uses_dialog_role_and_autofocus() {
+		$html = wp_get_toggletip( 'Helpful text.', array( 'id' => 'my-tip' ) );
+
+		// The bubble is a span popover exposing a dialog role.
+		$this->assertStringContainsString( '<span popover="auto" id="my-tip" class="wp-tooltip__bubble" role="dialog"', $html );
+
+		// Focus is moved into the popover when opened, matching the native dialog behavior.
+		$this->assertStringContainsString( 'tabindex="-1" autofocus>', $html );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_tooltip_types() {
+		return array(
+			'tooltip'   => array( 'tooltip' ),
+			'toggletip' => array( 'toggletip' ),
+		);
+	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

## Problem

`wp_get_tooltip_helper()` (added in 7.1.0, powering `wp_get_tooltip()` and `wp_get_toggletip()`) wraps its output in a `<div>`, and for toggletips uses a `<dialog>` element. Both are *flow content*, not *phrasing content*.

When that markup is placed inside a `<p>` — as it is for the "Remember Me" field on the login form (`wp_get_toggletip()` inside `<p class="forgetmenot">`) — the HTML parser applies its "close a p element" rule on the `<div>`/`<dialog>` start tag. This:

1. Auto-closes the paragraph, moving the tooltip out to become a sibling of the `<form>`, and
2. Leaves a **stray empty `<p></p>`** behind (from the literal `</p>` in the source), whose default margins produce the extra gap reported under the Remember Me row.

Before the toggletip feature landed the wrapper was a `<span>` (valid phrasing content), so this is a 7.1-only regression.

### Reproduction
Load `wp-login.php`. Inspect the DOM around `p.forgetmenot`: it contains only the checkbox + label, the `.wp-tooltip` element is a direct child of `<form>`, and an empty `<p></p>` sits between it and `p.submit`, adding a visible gap before the Log In button.

## Fix

Build the markup from **phrasing content only** so it is valid wherever it's used, including inside a paragraph:

- `<div>` wrapper → `<span>` for both tooltips and toggletips (the CSS is already `display: inline-flex`).
- Toggletip `<dialog popover="auto" autofocus>` → `<span popover="auto" role="dialog" aria-label="…" tabindex="-1" autofocus>`. The Popover API works on any element; `role="dialog"` + `tabindex="-1"` + `autofocus` reproduce the native dialog's accessible name and "focus moves into the popover on open" behavior. Escape / light-dismiss / the close button are all driven by `popover="auto"` and are unchanged.

Also updates the `wp-tooltip.js` JSDoc type (`HTMLDivElement` → `HTMLSpanElement`) to match the new wrapper.

## Testing

Verified on the local Docker environment (`wp-login.php`):

- `p.forgetmenot` now contains the toggletip; **zero empty paragraphs**; Remember Me and Log In align on one row.
- Toggletip opens, is anchored above its toggle with the arrow, shows the close button, and dismisses correctly.
- On open, focus moves onto the bubble — identical to the previous native `<dialog autofocus>`.
- Escape/light-dismiss behavior confirmed equivalent to a native `<dialog popover="auto">` (differential check).

Automated:
- `Tests_General_wpGetTooltip` → **OK (9 tests, 27 assertions)**, including new `@ticket 65660` regression tests asserting the output contains no `<div>`/`<dialog>` and that the toggletip bubble uses `role="dialog"` with `tabindex="-1" autofocus`.
- PHPCS (`phpcs.xml.dist`) → **0 errors** on the changed files.

## Notes for reviewers

- The second commit removes an unused `attributes` default from `wp_get_tooltip_helper()` (never read, undocumented, no caller passes it). It's isolated so it can be dropped independently if you'd prefer to keep this PR strictly scoped to the layout bug.

Trac ticket: https://core.trac.wordpress.org/ticket/65660

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 4.8
Used for: Generate test cases and all implementation and tests were reviewed and edited by me.
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
