### PR TITLE
Login: Replace hardcoded focus color with CSS variable

### DIFF
--- a/src/wp-admin/css/login.css
+++ b/src/wp-admin/css/login.css
@@ -32,7 +32,7 @@ a:active {
 }
 
 a:focus {
-	color: #043959;
+	color: var(--wp-admin-theme-color-darker-20);
 	box-shadow: 0 0 0 var(--wp-admin-border-width-focus, 1.5px) var(--wp-admin-theme-color, #3858e9);
 	/* Only visible in Windows High Contrast mode */
 	outline: 2px solid transparent;
@@ -339,7 +339,7 @@ p {
 .login #nav a:focus,
 .login #backtoblog a:focus,
 .login h1 a:focus {
-	color: #043959;
+	color: var(--wp-admin-theme-color-darker-20);
 }
 
 .login .privacy-policy-page-link {


### PR DESCRIPTION
## Summary

Fixes the focus color on login page links (`← Go to [Site Name]`, `Lost your password?`, and the WP logo link) which were still using the old hardcoded color `#043959` instead of the updated admin theme color variable.

- Replaces `#043959` with `var(--wp-admin-theme-color-darker-20)` in the `a:focus` rule
- Replaces `#043959` with `var(--wp-admin-theme-color-darker-20)` in the `.login #nav a:focus, .login #backtoblog a:focus, .login h1 a:focus` rule

The hover state for these same selectors already correctly uses `var(--wp-admin-theme-color-darker-20)` — this change makes focus consistent with hover.

## Trac Ticket

https://core.trac.wordpress.org/ticket/64953

## Test Plan

- [ ] Go to `/wp-login.php`
- [ ] Tab through the links: `Lost your password?` and `← Go to [Site Name]`
- [ ] Confirm the focused link color matches the hover color (blue, matching the admin theme)
- [ ] Test with different admin color schemes (Modern, Light, etc.) — color should adapt via CSS variable
- [ ] Confirm no regressions on other login page states