### PR TITLE
Options, Meta APIs: Avoid caching options as nonexistent after database errors.

### DIFF
--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -209,9 +209,17 @@ function get_option( $option, $default_value = false ) {
 				if ( is_object( $row ) ) {
 					$value = $row->option_value;
 					wp_cache_add( $option, $value, 'options' );
-				} else { // Option does not exist, so we must cache its non-existence.
-					$notoptions[ $option ] = true;
-					wp_cache_set( 'notoptions', $notoptions, 'options' );
+				} else {
+					/*
+					 * The query returns null both when the option does not exist and when
+					 * the query itself failed. Only cache the option's non-existence when
+					 * the query is known to have succeeded, otherwise a database error
+					 * would hide an option that is present.
+					 */
+					if ( ! $wpdb->last_error ) {
+						$notoptions[ $option ] = true;
+						wp_cache_set( 'notoptions', $notoptions, 'options' );
+					}
 
 					/** This filter is documented in wp-includes/option.php */
 					return apply_filters( "default_option_{$option}", $default_value, $option, $passed_default );
@@ -1240,14 +1248,22 @@ function delete_option( $option ) {
 			wp_cache_delete( $option, 'options' );
 		}
 
-		$notoptions = wp_cache_get( 'notoptions', 'options' );
+		/*
+		 * A false result indicates the delete query failed, in which case the
+		 * option may still exist in the database. A result of zero means no rows
+		 * were deleted, so the option is known to be absent and can be cached as
+		 * such.
+		 */
+		if ( false !== $result ) {
+			$notoptions = wp_cache_get( 'notoptions', 'options' );
 
-		if ( ! is_array( $notoptions ) ) {
-			$notoptions = array();
+			if ( ! is_array( $notoptions ) ) {
+				$notoptions = array();
+			}
+			$notoptions[ $option ] = true;
+
+			wp_cache_set( 'notoptions', $notoptions, 'options' );
 		}
-		$notoptions[ $option ] = true;
-
-		wp_cache_set( 'notoptions', $notoptions, 'options' );
 	}
 
 	if ( $result ) {
@@ -2100,12 +2116,20 @@ function get_network_option( $network_id, $option, $default_value = false ) {
 				$value = maybe_unserialize( $value );
 				wp_cache_set( $cache_key, $value, 'site-options' );
 			} else {
-				if ( ! is_array( $notoptions ) ) {
-					$notoptions = array();
-				}
+				/*
+				 * The query returns null both when the option does not exist and when
+				 * the query itself failed. Only cache the option's non-existence when
+				 * the query is known to have succeeded, otherwise a database error
+				 * would hide an option that is present.
+				 */
+				if ( ! $wpdb->last_error ) {
+					if ( ! is_array( $notoptions ) ) {
+						$notoptions = array();
+					}
 
-				$notoptions[ $option ] = true;
-				wp_cache_set( $notoptions_key, $notoptions, 'site-options' );
+					$notoptions[ $option ] = true;
+					wp_cache_set( $notoptions_key, $notoptions, 'site-options' );
+				}
 
 				/** This filter is documented in wp-includes/option.php */
 				$value = apply_filters( 'default_site_option_' . $option, $default_value, $option, $network_id );
@@ -2323,7 +2347,13 @@ function delete_network_option( $network_id, $option ) {
 			)
 		);
 
-		if ( $result ) {
+		/*
+		 * A false result indicates the delete query failed, in which case the
+		 * option may still exist in the database. A result of zero means no rows
+		 * were deleted, so the option is known to be absent and can be cached as
+		 * such.
+		 */
+		if ( false !== $result ) {
 			$notoptions_key = "$network_id:notoptions";
 			$notoptions     = wp_cache_get( $notoptions_key, 'site-options' );
 

--- a/tests/phpunit/tests/option/networkOption.php
+++ b/tests/phpunit/tests/option/networkOption.php
@@ -87,6 +87,151 @@ class Tests_Option_NetworkOption extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that a database error while reading a network option does not cache its non-existence.
+	 *
+	 * A failed query and a missing row both result in `null`, so the non-existence of an
+	 * option is only known when the query succeeded.
+	 *
+	 * @ticket 61762
+	 * @group ms-required
+	 *
+	 * @covers ::get_network_option
+	 */
+	public function test_get_network_option_does_not_cache_notoptions_on_database_error() {
+		global $wpdb;
+
+		$option_name = 'ticket_61762_network_option';
+
+		add_network_option( 1, $option_name, 'value1' );
+		wp_cache_delete( "1:$option_name", 'site-options' );
+		wp_cache_delete( '1:notoptions', 'site-options' );
+
+		$suppress = $wpdb->suppress_errors( true );
+		add_filter( 'query', array( $this, 'break_network_option_select_query' ) );
+
+		$value = get_network_option( 1, $option_name );
+
+		remove_filter( 'query', array( $this, 'break_network_option_select_query' ) );
+		$wpdb->suppress_errors( $suppress );
+
+		$this->assertFalse( $value, 'The default value should be returned when the query fails.' );
+
+		$notoptions = wp_cache_get( '1:notoptions', 'site-options' );
+
+		$this->assertTrue(
+			! is_array( $notoptions ) || ! isset( $notoptions[ $option_name ] ),
+			'An existing network option should not be added to the notoptions cache after a database error.'
+		);
+		$this->assertSame( 'value1', get_network_option( 1, $option_name ), 'The network option should still be readable once the database recovers.' );
+	}
+
+	/**
+	 * Tests that a failed delete query does not cache the network option's non-existence.
+	 *
+	 * @ticket 61762
+	 * @group ms-required
+	 *
+	 * @covers ::delete_network_option
+	 */
+	public function test_delete_network_option_does_not_cache_notoptions_on_database_error() {
+		global $wpdb;
+
+		$option_name = 'ticket_61762_network_option';
+
+		add_network_option( 1, $option_name, 'value1' );
+		wp_cache_delete( '1:notoptions', 'site-options' );
+
+		$suppress = $wpdb->suppress_errors( true );
+		add_filter( 'query', array( $this, 'break_network_option_delete_query' ) );
+
+		$result = delete_network_option( 1, $option_name );
+
+		remove_filter( 'query', array( $this, 'break_network_option_delete_query' ) );
+		$wpdb->suppress_errors( $suppress );
+
+		$this->assertFalse( $result, 'delete_network_option() should return false when the query fails.' );
+
+		$notoptions = wp_cache_get( '1:notoptions', 'site-options' );
+
+		$this->assertTrue(
+			! is_array( $notoptions ) || ! isset( $notoptions[ $option_name ] ),
+			'A network option that failed to delete should not be added to the notoptions cache.'
+		);
+		$this->assertSame( 'value1', get_network_option( 1, $option_name ), 'The network option should still be readable after a failed delete.' );
+	}
+
+	/**
+	 * Tests that a delete query affecting no rows still caches the network option's non-existence.
+	 *
+	 * Unlike `false`, a result of zero means the query succeeded, so the option is known
+	 * to be absent from the database.
+	 *
+	 * @ticket 61762
+	 * @group ms-required
+	 *
+	 * @covers ::delete_network_option
+	 */
+	public function test_delete_network_option_caches_notoptions_when_no_rows_are_deleted() {
+		$option_name = 'ticket_61762_network_option';
+
+		add_network_option( 1, $option_name, 'value1' );
+		wp_cache_delete( '1:notoptions', 'site-options' );
+
+		add_filter( 'query', array( $this, 'match_no_rows_in_network_option_delete_query' ) );
+
+		delete_network_option( 1, $option_name );
+
+		remove_filter( 'query', array( $this, 'match_no_rows_in_network_option_delete_query' ) );
+
+		$notoptions = wp_cache_get( '1:notoptions', 'site-options' );
+
+		$this->assertIsArray( $notoptions, 'The notoptions cache is expected to be an array.' );
+		$this->assertArrayHasKey( $option_name, $notoptions, 'The network option is expected to be in the notoptions cache.' );
+	}
+
+	/**
+	 * Rewrites the network option read query to reference a table that does not exist.
+	 *
+	 * @param string $query The query to filter.
+	 * @return string The filtered query.
+	 */
+	public function break_network_option_select_query( $query ) {
+		if ( str_starts_with( $query, 'SELECT meta_value FROM' ) ) {
+			return str_replace( 'SELECT meta_value FROM', 'SELECT meta_value FROM no_such_table_', $query );
+		}
+
+		return $query;
+	}
+
+	/**
+	 * Rewrites the network option delete query to reference a table that does not exist.
+	 *
+	 * @param string $query The query to filter.
+	 * @return string The filtered query.
+	 */
+	public function break_network_option_delete_query( $query ) {
+		if ( str_starts_with( $query, 'DELETE FROM' ) ) {
+			return str_replace( 'DELETE FROM', 'DELETE FROM no_such_table_', $query );
+		}
+
+		return $query;
+	}
+
+	/**
+	 * Rewrites the network option delete query so that it succeeds without deleting any rows.
+	 *
+	 * @param string $query The query to filter.
+	 * @return string The filtered query.
+	 */
+	public function match_no_rows_in_network_option_delete_query( $query ) {
+		if ( str_starts_with( $query, 'DELETE FROM' ) ) {
+			return $query . ' AND 1 = 0';
+		}
+
+		return $query;
+	}
+
+	/**
 	 * @ticket 22846
 	 * @group ms-excluded
 	 *

--- a/tests/phpunit/tests/option/option.php
+++ b/tests/phpunit/tests/option/option.php
@@ -487,6 +487,148 @@ class Tests_Option_Option extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that a database error while reading an option does not cache its non-existence.
+	 *
+	 * A failed query and a missing row both result in `null`, so the non-existence of an
+	 * option is only known when the query succeeded.
+	 *
+	 * @ticket 61762
+	 *
+	 * @covers ::get_option
+	 */
+	public function test_get_option_does_not_cache_notoptions_on_database_error() {
+		global $wpdb;
+
+		$option_name = 'ticket_61762_option';
+
+		add_option( $option_name, 'value1', '', false );
+		wp_cache_delete( $option_name, 'options' );
+		wp_cache_delete( 'notoptions', 'options' );
+
+		$suppress = $wpdb->suppress_errors( true );
+		add_filter( 'query', array( $this, 'break_option_select_query' ) );
+
+		$value = get_option( $option_name );
+
+		remove_filter( 'query', array( $this, 'break_option_select_query' ) );
+		$wpdb->suppress_errors( $suppress );
+
+		$this->assertFalse( $value, 'The default value should be returned when the query fails.' );
+
+		$notoptions = wp_cache_get( 'notoptions', 'options' );
+
+		$this->assertTrue(
+			! is_array( $notoptions ) || ! isset( $notoptions[ $option_name ] ),
+			'An existing option should not be added to the notoptions cache after a database error.'
+		);
+		$this->assertSame( 'value1', get_option( $option_name ), 'The option should still be readable once the database recovers.' );
+	}
+
+	/**
+	 * Tests that a failed delete query does not cache the option's non-existence.
+	 *
+	 * @ticket 61762
+	 *
+	 * @covers ::delete_option
+	 */
+	public function test_delete_option_does_not_cache_notoptions_on_database_error() {
+		global $wpdb;
+
+		$option_name = 'ticket_61762_option';
+
+		add_option( $option_name, 'value1', '', false );
+		wp_cache_delete( 'notoptions', 'options' );
+
+		$suppress = $wpdb->suppress_errors( true );
+		add_filter( 'query', array( $this, 'break_option_delete_query' ) );
+
+		$result = delete_option( $option_name );
+
+		remove_filter( 'query', array( $this, 'break_option_delete_query' ) );
+		$wpdb->suppress_errors( $suppress );
+
+		$this->assertFalse( $result, 'delete_option() should return false when the query fails.' );
+
+		$notoptions = wp_cache_get( 'notoptions', 'options' );
+
+		$this->assertTrue(
+			! is_array( $notoptions ) || ! isset( $notoptions[ $option_name ] ),
+			'An option that failed to delete should not be added to the notoptions cache.'
+		);
+		$this->assertSame( 'value1', get_option( $option_name ), 'The option should still be readable after a failed delete.' );
+	}
+
+	/**
+	 * Tests that a delete query affecting no rows still caches the option's non-existence.
+	 *
+	 * Unlike `false`, a result of zero means the query succeeded, so the option is known
+	 * to be absent from the database.
+	 *
+	 * @ticket 61762
+	 *
+	 * @covers ::delete_option
+	 */
+	public function test_delete_option_caches_notoptions_when_no_rows_are_deleted() {
+		$option_name = 'ticket_61762_option';
+
+		add_option( $option_name, 'value1', '', false );
+		wp_cache_delete( 'notoptions', 'options' );
+
+		add_filter( 'query', array( $this, 'match_no_rows_in_option_delete_query' ) );
+
+		delete_option( $option_name );
+
+		remove_filter( 'query', array( $this, 'match_no_rows_in_option_delete_query' ) );
+
+		$notoptions = wp_cache_get( 'notoptions', 'options' );
+
+		$this->assertIsArray( $notoptions, 'The notoptions cache is expected to be an array.' );
+		$this->assertArrayHasKey( $option_name, $notoptions, 'The option is expected to be in the notoptions cache.' );
+	}
+
+	/**
+	 * Rewrites the option read query to reference a table that does not exist.
+	 *
+	 * @param string $query The query to filter.
+	 * @return string The filtered query.
+	 */
+	public function break_option_select_query( $query ) {
+		if ( str_starts_with( $query, 'SELECT option_value FROM' ) ) {
+			return str_replace( 'SELECT option_value FROM', 'SELECT option_value FROM no_such_table_', $query );
+		}
+
+		return $query;
+	}
+
+	/**
+	 * Rewrites the option delete query to reference a table that does not exist.
+	 *
+	 * @param string $query The query to filter.
+	 * @return string The filtered query.
+	 */
+	public function break_option_delete_query( $query ) {
+		if ( str_starts_with( $query, 'DELETE FROM' ) ) {
+			return str_replace( 'DELETE FROM', 'DELETE FROM no_such_table_', $query );
+		}
+
+		return $query;
+	}
+
+	/**
+	 * Rewrites the option delete query so that it succeeds without deleting any rows.
+	 *
+	 * @param string $query The query to filter.
+	 * @return string The filtered query.
+	 */
+	public function match_no_rows_in_option_delete_query( $query ) {
+		if ( str_starts_with( $query, 'DELETE FROM' ) ) {
+			return $query . ' AND 1 = 0';
+		}
+
+		return $query;
+	}
+
+	/**
 	 * Tests that calling update_option() clears the notoptions cache.
 	 *
 	 * @ticket 61484


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/61762

`$wpdb->get_row()` returns null both when an option row is missing and when the query itself failed. `get_option()` and `get_network_option()` treated the second case as the first and primed the `notoptions` cache, so a transient database error could hide an option that is still in the database. With a persistent object cache that state sticks around, and the option keeps returning its default long after the database has recovered.

`delete_option()` had the same problem from the other direction: it primed `notoptions` before checking the result of `$wpdb->delete()`, so a failed delete marked a still-present option as nonexistent.

Each `notoptions` write is now gated on the query being known to have succeeded, using `$wpdb->last_error` on the read paths and `false !== $result` on the delete paths. `delete_network_option()` was guarded on a truthy result, which meant a successful delete affecting zero rows never primed the cache. Zero rows is a successful query, so it primes there now too.

Adds regression tests covering the read and delete paths, including the zero-row case.

Clearing `notoptions` in `add_network_option()` and `update_network_option()` is left for a follow-up, per the ticket.
