### PR TITLE
Build/Test Tools: Update PHPStan from 2.2.2 to 2.2.5 and phpstan-phpunit to 2.0.18

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
 		"wp-coding-standards/wpcs": "~3.4.0",
 		"phpcompatibility/phpcompatibility-wp": "~2.1.3",
 		"phpstan/phpstan": "2.2.5",
-		"phpstan/phpstan-phpunit": "2.0.16",
+		"phpstan/phpstan-phpunit": "2.0.18",
 		"yoast/phpunit-polyfills": "^1.1.0"
 	},
 	"config": {

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
 		"squizlabs/php_codesniffer": "3.13.5",
 		"wp-coding-standards/wpcs": "~3.4.0",
 		"phpcompatibility/phpcompatibility-wp": "~2.1.3",
-		"phpstan/phpstan": "2.2.2",
+		"phpstan/phpstan": "2.2.5",
 		"phpstan/phpstan-phpunit": "2.0.16",
 		"yoast/phpunit-polyfills": "^1.1.0"
 	},


### PR DESCRIPTION
✅  Committed in r62798 (361cd4de1e467718c48147d75711089ee9800f1e)

----

Updates two PHPStan Composer dependencies used for static analysis:

- `phpstan/phpstan`: `2.2.2` → `2.2.5`
- `phpstan/phpstan-phpunit`: `2.0.16` → `2.0.18`

Trac ticket: https://core.trac.wordpress.org/ticket/64898

### `phpstan/phpstan` (2.2.2 → 2.2.5)

**2.2.3**
- Improvements: result cache now invalidates only package-dependent files on a Composer package change; type predicates supported on `callable`/`Closure` types; several regex/string-narrowing improvements (e.g. `::class` in array shape keys, `ob_get_contents()` et al. narrowed to non-`false` during output buffering).
- Bugfixes: 52 issues fixed, including several `BooleanAnd`/`BooleanOr` conditional-expression-holder edge cases, `match` subject narrowing, and `preg_match_all()` return type inference.
- Performance: multiple hot-path optimizations in the type system and scope resolution, plus parallel analysis job striping improvements.

**2.2.4** — "RAMpocalypse": substantially reduced memory usage (PHPStan analysing itself dropped from 2.8 GB to 2.1 GB total worker memory), plus supporting bugfixes for boolean conditional holders and output-buffer tracking.

**2.2.5**
- Improvements: updated `nikic/PHP-Parser` to 5.8.0; narrows `explode()` when the delimiter is a known substring.
- Bugfixes: allows `null` values in the native `preg_replace_callback` callback array type when `PREG_UNMATCHED_AS_NULL` is used.
- Performance: further caching/LRU-capping work (member cache, resolved type aliases, cached parser sources) and PHP 8.5 `partitioned` cookie attribute support.

Full details: https://github.com/phpstan/phpstan/releases

### `phpstan/phpstan-phpunit` (2.0.16 → 2.0.18)

**2.0.17** — Adds `ClassAttributeRequiresPhpVersionRule` and sanity/range checking for `#[RequiresPhp]`/`#[RequiresPhpunit]` attribute values (the rest of the changes are CI/tooling maintenance).

**2.0.18** — Fixes `#[RequiresPhpunit]` version requirements being evaluated against the PHP version instead of the PHPUnit version, and adds default values for the bool parameters of `AttributeVersionRequirementHelper`.

Full details: https://github.com/phpstan/phpstan-phpunit/releases

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Sonnet 5
Used for: Drafting this pull request description (summarizing upstream changelogs); the dependency version bumps themselves were made directly by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
