### PR TITLE
Reuse user accounts in AJAX test suites.

### DIFF
--- a/tests/phpunit/includes/testcase-ajax.php
+++ b/tests/phpunit/includes/testcase-ajax.php
@@ -16,7 +16,7 @@ abstract class WP_Ajax_UnitTestCase extends WP_UnitTestCase {
 	protected $_last_response = '';
 
 	/**
-	 * User IDs created by self::_setRole().
+	 * User IDs created by shared fixtures.
 	 *
 	 * This stores the user IDs of various roles to allow for reuse.
 	 */

--- a/tests/phpunit/includes/testcase-ajax.php
+++ b/tests/phpunit/includes/testcase-ajax.php
@@ -247,11 +247,13 @@ abstract class WP_Ajax_UnitTestCase extends WP_UnitTestCase {
 	 *
 	 * E.g. administrator, editor, author, contributor, subscriber.
 	 *
-	 * @param string $role The role to set.
+	 * @param string $role              The role to set.
+	 * @param bool   $force_new_account Optional. Whether to force a new account to be created even if an account
+	 *                                  with the role already exists in the shared fixtures. Default false.
 	 */
-	protected function _setRole( $role ) {
+	protected function _setRole( $role, $force_new_account = false ) {
 		$post = $_POST;
-		if ( isset( self::$_user_ids[ $role ] ) ) {
+		if ( isset( self::$_user_ids[ $role ] ) && ! $force_new_account ) {
 			$user_id = self::$_user_ids[ $role ];
 		} else {
 			$user_id = self::factory()->user->create( array( 'role' => $role ) );

--- a/tests/phpunit/includes/testcase-ajax.php
+++ b/tests/phpunit/includes/testcase-ajax.php
@@ -20,7 +20,7 @@ abstract class WP_Ajax_UnitTestCase extends WP_UnitTestCase {
 	 *
 	 * This stores the user IDs of various roles to allow for reuse.
 	 */
-	protected $_user_ids = array();
+	protected static $_user_ids = array();
 
 	/**
 	 * List of Ajax actions called via GET.
@@ -124,6 +124,14 @@ abstract class WP_Ajax_UnitTestCase extends WP_UnitTestCase {
 
 	public static function set_up_before_class() {
 		parent::set_up_before_class();
+
+		self::$_user_ids = array(
+			'administrator' => self::factory()->user->create( array( 'role' => 'administrator' ) ),
+			'editor'        => self::factory()->user->create( array( 'role' => 'editor' ) ),
+			'author'        => self::factory()->user->create( array( 'role' => 'author' ) ),
+			'contributor'   => self::factory()->user->create( array( 'role' => 'contributor' ) ),
+			'subscriber'    => self::factory()->user->create( array( 'role' => 'subscriber' ) ),
+		);
 
 		remove_action( 'admin_init', '_maybe_update_core' );
 		remove_action( 'admin_init', '_maybe_update_plugins' );
@@ -243,11 +251,10 @@ abstract class WP_Ajax_UnitTestCase extends WP_UnitTestCase {
 	 */
 	protected function _setRole( $role ) {
 		$post = $_POST;
-		if ( isset( $this->_user_ids[ $role ] ) ) {
-			$user_id = $this->_user_ids[ $role ];
+		if ( isset( self::$_user_ids[ $role ] ) ) {
+			$user_id = self::$_user_ids[ $role ];
 		} else {
-			$user_id                  = self::factory()->user->create( array( 'role' => $role ) );
-			$this->_user_ids[ $role ] = $user_id;
+			$user_id = self::factory()->user->create( array( 'role' => $role ) );
 		}
 		wp_set_current_user( $user_id );
 		$_POST = array_merge( $_POST, $post );

--- a/tests/phpunit/includes/testcase-ajax.php
+++ b/tests/phpunit/includes/testcase-ajax.php
@@ -16,6 +16,13 @@ abstract class WP_Ajax_UnitTestCase extends WP_UnitTestCase {
 	protected $_last_response = '';
 
 	/**
+	 * User IDs created by self::_setRole().
+	 *
+	 * This stores the user IDs of various roles to allow for reuse.
+	 */
+	protected $_user_ids = array();
+
+	/**
 	 * List of Ajax actions called via GET.
 	 *
 	 * @var array
@@ -235,8 +242,13 @@ abstract class WP_Ajax_UnitTestCase extends WP_UnitTestCase {
 	 * @param string $role The role to set.
 	 */
 	protected function _setRole( $role ) {
-		$post    = $_POST;
-		$user_id = self::factory()->user->create( array( 'role' => $role ) );
+		$post = $_POST;
+		if ( isset( $this->_user_ids[ $role ] ) ) {
+			$user_id = $this->_user_ids[ $role ];
+		} else {
+			$user_id                  = self::factory()->user->create( array( 'role' => $role ) );
+			$this->_user_ids[ $role ] = $user_id;
+		}
 		wp_set_current_user( $user_id );
 		$_POST = array_merge( $_POST, $post );
 	}


### PR DESCRIPTION
Try speeding up the AJAX test suite by re-using roles between tests.

Looks to save about a minute on the full PHPUnit action (which is only about a second on each individual test suite).

Trac ticket: https://core.trac.wordpress.org/ticket/64894

## Use of AI Tools

VS Code/Co-pilot type ahead.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
