### PR TITLE
Posts, Post Types: Publish overdue scheduled posts on permalink request instead of 404

### DIFF
--- a/src/wp-includes/class-wp.php
+++ b/src/wp-includes/class-wp.php
@@ -794,6 +794,11 @@ class WP {
 			}
 		}
 
+		if ( $set_404 && $this->heal_overdue_scheduled_post() ) {
+			$this->query_posts();
+			$set_404 = empty( $wp_query->posts );
+		}
+
 		if ( $set_404 ) {
 			// Guess it's time to 404.
 			$wp_query->set_404();
@@ -802,6 +807,105 @@ class WP {
 		} else {
 			status_header( 200 );
 		}
+	}
+
+	/**
+	 * Publishes a scheduled post whose publish time has passed if its permalink was
+	 * just requested and the main query otherwise found nothing.
+	 *
+	 * WP-Cron only runs on incoming traffic, so a scheduled post can sit past its
+	 * publish time in `future` status until some request happens to trigger cron -
+	 * and the very request that would trigger it is served a 404 in the meantime.
+	 * This closes that gap for the one request shape it actually affects: a singular
+	 * permalink lookup that matched nothing because the matching post is still
+	 * `future`.
+	 *
+	 * See https://core.trac.wordpress.org/ticket/65663.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @global WP_Query $wp_query WordPress Query object.
+	 *
+	 * @return bool Whether an overdue post was found and published.
+	 */
+	private function heal_overdue_scheduled_post() {
+		global $wp_query;
+
+		if ( $wp_query->posts ) {
+			return false;
+		}
+
+		if ( ! empty( $this->query_vars['name'] ) ) {
+			$slug         = $this->query_vars['name'];
+			$post_type    = ! empty( $this->query_vars['post_type'] ) ? $this->query_vars['post_type'] : 'post';
+			$hierarchical = false;
+		} elseif ( ! empty( $this->query_vars['pagename'] ) ) {
+			$slug         = $this->query_vars['pagename'];
+			$post_type    = get_post_types( array( 'hierarchical' => true ) );
+			$hierarchical = true;
+		} else {
+			return false;
+		}
+
+		// Cheap short-circuit so 404 scans and normal traffic never reach the lookup below.
+		if ( ! wp_next_scheduled_post_is_due() ) {
+			return false;
+		}
+
+		if ( $hierarchical ) {
+			// get_page_by_path() walks the full ancestor path, not just the leaf slug,
+			// and doesn't filter by status, so the `future` check happens after.
+			$post = get_page_by_path( $slug, OBJECT, $post_type );
+
+			if ( ! $post || 'future' !== $post->post_status ) {
+				return false;
+			}
+		} else {
+			$candidates = get_posts(
+				array(
+					'name'                   => $slug,
+					'post_type'              => $post_type,
+					'post_status'            => 'future',
+					'posts_per_page'         => 1,
+					'orderby'                => 'none',
+					'no_found_rows'          => true,
+					'update_post_meta_cache' => false,
+					'update_post_term_cache' => false,
+				)
+			);
+
+			if ( ! $candidates ) {
+				return false;
+			}
+
+			$post = $candidates[0];
+		}
+
+		if ( strtotime( $post->post_date_gmt . ' GMT' ) > time() ) {
+			return false;
+		}
+
+		/*
+		 * Best-effort lock: narrows, but does not eliminate, the window where two
+		 * simultaneous first-visitors both try to publish the same post. If it's
+		 * already held, this request just falls through to its normal 404 - the
+		 * request holding the lock finishes publishing within milliseconds, so the
+		 * next request (or a reload of this one) will find it.
+		 */
+		$lock_key = 'heal_sched_post_' . $post->ID;
+
+		if ( false !== get_transient( $lock_key ) ) {
+			return false;
+		}
+
+		set_transient( $lock_key, 1, 30 );
+		check_and_publish_future_post( $post->ID );
+		delete_transient( $lock_key );
+
+		// Flushes any other overdue events the normal way, not just this post.
+		spawn_cron();
+
+		return 'publish' === get_post_status( $post->ID );
 	}
 
 	/**

--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -453,6 +453,7 @@ add_action( 'post_updated', 'wp_save_post_revision', 10, 1 );
 add_action( 'publish_post', '_publish_post_hook', 5, 1 );
 add_action( 'transition_post_status', '_transition_post_status', 5, 3 );
 add_action( 'transition_post_status', '_update_term_count_on_transition_post_status', 10, 3 );
+add_action( 'transition_post_status', 'clear_next_scheduled_post_cache', 10, 3 );
 add_action( 'comment_form', 'wp_comment_form_unfiltered_html_nonce' );
 
 // Privacy.

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -5488,6 +5488,56 @@ function check_and_publish_future_post( $post ) {
 }
 
 /**
+ * Checks whether any scheduled post's publish time has already passed, using a
+ * cached value so the check is cheap on every request that would otherwise 404.
+ *
+ * The cache is invalidated by clear_next_scheduled_post_cache() whenever a post
+ * enters or leaves `future` status, so it only recomputes when the answer could
+ * plausibly have changed.
+ *
+ * @since 7.1.0
+ * @access private
+ *
+ * @global wpdb $wpdb WordPress database abstraction object.
+ *
+ * @return bool Whether a `future` post's publish time has already passed.
+ */
+function wp_next_scheduled_post_is_due() {
+	global $wpdb;
+
+	$next_gmt = get_transient( 'next_scheduled_post_gmt' );
+
+	if ( false === $next_gmt ) {
+		$next_date = $wpdb->get_var(
+			"SELECT post_date_gmt FROM $wpdb->posts WHERE post_status = 'future' ORDER BY post_date_gmt ASC LIMIT 1"
+		);
+
+		$next_gmt = $next_date ? strtotime( $next_date . ' GMT' ) : 0;
+
+		set_transient( 'next_scheduled_post_gmt', $next_gmt );
+	}
+
+	return $next_gmt && (int) $next_gmt <= time();
+}
+
+/**
+ * Clears the cached "next scheduled post" time used by wp_next_scheduled_post_is_due()
+ * whenever a post transitions into or out of `future` status.
+ *
+ * @since 7.1.0
+ * @access private
+ *
+ * @param string  $new_status New post status.
+ * @param string  $old_status Old post status.
+ * @param WP_Post $post       Post object.
+ */
+function clear_next_scheduled_post_cache( $new_status, $old_status, $post ) {
+	if ( 'future' === $new_status || 'future' === $old_status ) {
+		delete_transient( 'next_scheduled_post_gmt' );
+	}
+}
+
+/**
  * Uses wp_checkdate to return a valid Gregorian-calendar value for post_date.
  * If post_date is not provided, this first checks post_date_gmt if provided,
  * then falls back to use the current time.


### PR DESCRIPTION
https://core.trac.wordpress.org/ticket/65663

Proof of concept for the proposal in the ticket above, posted for discussion rather than as a finished patch. Opening this as one data point alongside the ticket reporter's own working implementation, not to replace it.

## What this does

WP-Cron only runs on incoming traffic, so a scheduled post can pass its publish time while still sitting in `future` status, and its permalink 404s until some later request happens to trigger cron.

In `WP::handle_404()`, when the main query finds nothing and the requested `name`/`pagename` matches a post in `future` status whose `post_date` has already passed, this publishes it via `check_and_publish_future_post()` (the same function the `publish_future_post` cron hook uses, so the future/time checks are re-validated rather than duplicated) and re-runs the query instead of serving a 404.

Cost controls:
- A cached "next scheduled post" time (`wp_next_scheduled_post_is_due()`), invalidated via `transition_post_status` whenever a post enters or leaves `future`, short-circuits the check so ordinary 404s and scanner traffic never reach the posts table.
- A short-lived transient lock narrows (does not eliminate) the double-publish race between two near-simultaneous first visitors.
- `spawn_cron()` runs afterward to flush any other overdue events normally.

## Known open questions (not resolved by this PR)

- Whether this should be default-on or opt-in behind a filter, given it changes 404 behavior for every site.
- The transient lock is best-effort, not atomic.
- Interaction with full-page caches that deliberately cache 404 responses.

See the ticket discussion for more context and the original proposal.