### PR TITLE
Code Quality: Use the null coalescing operator for isset() return checks

### DIFF
--- a/src/wp-includes/capabilities.php
+++ b/src/wp-includes/capabilities.php
@@ -1163,11 +1163,7 @@ function remove_role( $role ) {
 function get_super_admins() {
 	global $super_admins;
 
-	if ( isset( $super_admins ) ) {
-		return $super_admins;
-	} else {
-		return get_site_option( 'site_admins', array( 'admin' ) );
-	}
+	return $super_admins ?? get_site_option( 'site_admins', array( 'admin' ) );
 }
 
 /**

--- a/src/wp-includes/customize/class-wp-customize-selective-refresh.php
+++ b/src/wp-includes/customize/class-wp-customize-selective-refresh.php
@@ -120,11 +120,7 @@ final class WP_Customize_Selective_Refresh {
 	 * @return WP_Customize_Partial|null The partial, if set. Otherwise null.
 	 */
 	public function get_partial( $id ) {
-		if ( isset( $this->partials[ $id ] ) ) {
-			return $this->partials[ $id ];
-		} else {
-			return null;
-		}
+		return $this->partials[ $id ] ?? null;
 	}
 
 	/**

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -1445,11 +1445,7 @@ function get_status_header_desc( $code ) {
 		);
 	}
 
-	if ( isset( $wp_header_to_desc[ $code ] ) ) {
-		return $wp_header_to_desc[ $code ];
-	} else {
-		return '';
-	}
+	return $wp_header_to_desc[ $code ] ?? '';
 }
 
 /**

--- a/src/wp-includes/http.php
+++ b/src/wp-includes/http.php
@@ -855,9 +855,5 @@ function _wp_translate_php_url_constant_to_key( $constant ) {
 		PHP_URL_FRAGMENT => 'fragment',
 	);
 
-	if ( isset( $translation[ $constant ] ) ) {
-		return $translation[ $constant ];
-	} else {
-		return false;
-	}
+	return $translation[ $constant ] ?? false;
 }


### PR DESCRIPTION
## Description
Replaces a handful of verbose `isset()` guard patterns with the null coalescing operator (`??`):

```php
// Before
if ( isset( $x ) ) {
    return $x;
} else {
    return $default;
}
    
// After
return $x ?? $default;
```

Both forms are functionally identical; `??` is shorter and clearer.

## Notes
- No behavior change; PHP's minimum version already supports `??`.

Trac ticket: https://core.trac.wordpress.org/ticket/64897

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
