### PR TITLE
Editor: Handle nested array block gap values properly

### DIFF
--- a/src/wp-includes/block-supports/layout.php
+++ b/src/wp-includes/block-supports/layout.php
@@ -86,7 +86,7 @@ function wp_get_layout_container_values( $layout ) {
 function wp_sanitize_block_gap_value( $gap_value ) {
 	if ( is_array( $gap_value ) ) {
 		foreach ( $gap_value as $key => $value ) {
-			$gap_value[ $key ] = $value && preg_match( '%[\\\(&=}]|/\*%', $value ) ? null : $value;
+			$gap_value[ $key ] = ! is_scalar( $value ) || ( $value && preg_match( '%[\\\(&=}]|/\*%', (string) $value ) ) ? null : $value;
 		}
 
 		return $gap_value;

--- a/tests/phpunit/tests/block-supports/layout.php
+++ b/tests/phpunit/tests/block-supports/layout.php
@@ -83,6 +83,26 @@ class Tests_Block_Supports_Layout extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 65667
+	 *
+	 * @covers ::wp_sanitize_block_gap_value
+	 */
+	public function test_sanitize_block_gap_value_rejects_nested_array_values() {
+		$this->assertSame(
+			array(
+				'top'  => null,
+				'left' => '2rem',
+			),
+			wp_sanitize_block_gap_value(
+				array(
+					'top'  => array( '1rem' ),
+					'left' => '2rem',
+				)
+			)
+		);
+	}
+
+	/**
 	 * @ticket 55505
 	 */
 	public function test_outer_container_not_restored_for_non_aligned_image_block_with_non_themejson_theme() {
@@ -224,6 +244,32 @@ class Tests_Block_Supports_Layout extends WP_UnitTestCase {
 						'attrs'        => array(
 							'layout' => array(
 								'type' => 'default',
+							),
+						),
+						'innerBlocks'  => array(),
+						'innerHTML'    => '<div class="wp-block-group"></div>',
+						'innerContent' => array(
+							'<div class="wp-block-group"></div>',
+						),
+					),
+				),
+				'expected_output' => '<div class="wp-block-group is-layout-flow wp-block-group-is-layout-flow"></div>',
+			),
+			'single wrapper block layout with malformed axial block gap' => array(
+				'args'            => array(
+					'block_content' => '<div class="wp-block-group"></div>',
+					'block'         => array(
+						'blockName'    => 'core/group',
+						'attrs'        => array(
+							'layout' => array(
+								'type' => 'default',
+							),
+							'style'  => array(
+								'spacing' => array(
+									'blockGap' => array(
+										'top' => array( '1rem' ),
+									),
+								),
 							),
 						),
 						'innerBlocks'  => array(),


### PR DESCRIPTION
## Description

Fixes an uncaught `TypeError` in `wp_sanitize_block_gap_value()` when a `blockGap` axis holds a nested array rather than a scalar:

```
Fatal error: Uncaught TypeError: preg_match(): Argument #2 ($subject) must be of type string, array given in wp-includes/block-supports/layout.php:89
```

The function iterates array gap values and passes each directly to `preg_match()`, which requires a string subject. A malformed axial gap value such as `blockGap.top` = `["1rem"]` fatals, breaking front-end rendering and REST API responses.

Non-scalar values are now treated as invalid and set to `null`, and scalar values are cast to string for the regex check.

This has been present since 6.0, when the array `foreach` branch was introduced in f187393d0a.

## Testing Instructions

### Automated

```bash
npm run test:php -- --filter Tests_Block_Supports_Layout
```

### Manual

1. Create and publish a page.
2. Open the code editor and replace the content with:

```html
<!-- wp:group {"style":{"spacing":{"blockGap":{"top":["1rem"],"left":"2rem"}}},"layout":{"type":"default"}} -->
<div class="wp-block-group">
	<!-- wp:paragraph -->
	<p>Malformed block gap reproduction</p>
	<!-- /wp:paragraph -->
</div>
<!-- /wp:group -->
```

3. Update and view the page.
4. Open `/wp-json/wp/v2/pages/<PAGE_ID>`.
5. Confirm the page and REST response load without the fatal error.

## Notes

Ports [WordPress/gutenberg#80464](https://github.com/WordPress/gutenberg/pull/80464) to core.

Trac ticket: https://core.trac.wordpress.org/ticket/65667

🤖 Generated with [Claude Code](https://claude.com/claude-code)