### PR TITLE
Customize: Support hiding random default headers

### DIFF
--- a/src/wp-includes/class-wp-customize-manager.php
+++ b/src/wp-includes/class-wp-customize-manager.php
@@ -5410,7 +5410,7 @@ final class WP_Customize_Manager {
 				$this,
 				'header_image',
 				array(
-					'default'        => sprintf( get_theme_support( 'custom-header', 'default-image' ), get_template_directory_uri(), get_stylesheet_directory_uri() ),
+					'default'        => current_theme_supports( 'custom-header', 'random-default' ) ? 'random-default-image' : sprintf( get_theme_support( 'custom-header', 'default-image' ), get_template_directory_uri(), get_stylesheet_directory_uri() ),
 					'theme_supports' => 'custom-header',
 				)
 			)

--- a/tests/phpunit/tests/customize/manager.php
+++ b/tests/phpunit/tests/customize/manager.php
@@ -3695,14 +3695,24 @@ class Tests_WP_Customize_Manager extends WP_UnitTestCase {
 	public function test_header_image_setting_default( $random_default, $expected_default ) {
 		global $_wp_theme_features;
 
-		$_wp_theme_features['custom-header'][0] = array(
-			'default-image'  => 'https://example.org/header.jpg',
-			'random-default' => $random_default,
-		);
+		$custom_header_support = isset( $_wp_theme_features['custom-header'] ) ? $_wp_theme_features['custom-header'] : null;
 
-		$this->manager->register_controls();
+		try {
+			$_wp_theme_features['custom-header'][0] = array(
+				'default-image'  => 'https://example.org/header.jpg',
+				'random-default' => $random_default,
+			);
 
-		$this->assertSame( $expected_default, $this->manager->get_setting( 'header_image' )->default );
+			$this->manager->register_controls();
+
+			$this->assertSame( $expected_default, $this->manager->get_setting( 'header_image' )->default );
+		} finally {
+			if ( null === $custom_header_support ) {
+				unset( $_wp_theme_features['custom-header'] );
+			} else {
+				$_wp_theme_features['custom-header'] = $custom_header_support;
+			}
+		}
 	}
 
 	/**

--- a/tests/phpunit/tests/customize/manager.php
+++ b/tests/phpunit/tests/customize/manager.php
@@ -3683,6 +3683,39 @@ class Tests_WP_Customize_Manager extends WP_UnitTestCase {
 			$this->assertSame( $video_url, $sanitized );
 		}
 	}
+
+	/**
+	 * @ticket 46128
+	 *
+	 * @dataProvider data_header_image_setting_default
+	 *
+	 * @param bool   $random_default   Whether to randomize default headers.
+	 * @param string $expected_default Expected setting default.
+	 */
+	public function test_header_image_setting_default( $random_default, $expected_default ) {
+		global $_wp_theme_features;
+
+		$_wp_theme_features['custom-header'][0] = array(
+			'default-image'  => 'https://example.org/header.jpg',
+			'random-default' => $random_default,
+		);
+
+		$this->manager->register_controls();
+
+		$this->assertSame( $expected_default, $this->manager->get_setting( 'header_image' )->default );
+	}
+
+	/**
+	 * Data provider for test_header_image_setting_default().
+	 *
+	 * @return array[] Test parameters.
+	 */
+	public function data_header_image_setting_default() {
+		return array(
+			'random default headers' => array( true, 'random-default-image' ),
+			'fixed default header'   => array( false, 'https://example.org/header.jpg' ),
+		);
+	}
 }
 
 require_once ABSPATH . WPINC . '/class-wp-customize-setting.php';


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

When a theme enables random default header images without setting a fixed default image, the Customizer currently treats the header image setting as empty. This hides the Hide image button even though a randomized header is displayed.

This sets the Customizer setting default to random-default-image when the theme enables random default headers, while preserving the existing fixed default behavior otherwise. Regression coverage verifies both cases.

## Testing

- npm run test:php -- --filter Tests_WP_Customize_Manager::test_header_image_setting_default
- PHPCS for both changed files
- PHP syntax checks for both changed files

Trac ticket: https://core.trac.wordpress.org/ticket/46128

## Use of AI Tools

AI assistance: Yes
Tool(s): OpenAI Codex
Model(s): GPT-5
Used for: Reviewing the Trac ticket and relevant code, helping with the initial implementation and regression-test approach, and assisting with validation and PR-description drafting. The final implementation, tests, validation results, and description were reviewed and accepted by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**