### PR TITLE
Toolbar: optimization: add 64px crop size for the site icon

### DIFF
--- a/src/wp-admin/includes/class-wp-site-icon.php
+++ b/src/wp-admin/includes/class-wp-site-icon.php
@@ -60,6 +60,9 @@ class WP_Site_Icon {
 		 */
 		180,
 
+		// High-density (2x) site icon for the admin bar and post embeds.
+		64,
+
 		// Our regular Favicon.
 		32,
 	);


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/65668

## What

A follow-up to #11781 (site icon in the admin bar). The toolbar builds a 2x `srcset` for retina displays:

https://github.com/WordPress/wordpress-develop/blob/d792cbd66941a708d62b1778f044393206b95c63/src/wp-includes/admin-bar.php#L397-L404

But `WP_Site_Icon` only generates crops at `270, 192, 180, 32`. There is no 64px crop:

https://github.com/WordPress/wordpress-develop/blob/d792cbd66941a708d62b1778f044393206b95c63/src/wp-admin/includes/class-wp-site-icon.php#L46-L64

So the `get_site_icon_url( 64 )` call finds no exact match and falls back to get the first larger size than 64, which is the default thumbnail size (150 x 150). This is too large to serve a 20x20 (or 28x28 in mobile) site icon in the admin bar.

This PR simply adds a new `64` entry to it. With this, browsers can download much smaller image file in retina displays.

> [!NOTE]  
> This only affects NEW site icon uploads. Existing icons unfortunately won't get the new crop size until it's reuploaded.

This will also benefit the post embeds as it also calls `get_site_icon_url( 64 )`:

https://github.com/WordPress/wordpress-develop/blob/d792cbd66941a708d62b1778f044393206b95c63/src/wp-includes/embed.php#L1242

## Testing

1. Go to Settings -> General.
2. Upload a site icon.
3. Save.
4. Go to wp-admin / frontend.
5. Inspect the site icon element.
6. Verify you get the 64x64 crop. Before this, you get 150x150

See the difference in the image file sizes:

| Before | After |
| - | - |
| <img width="506" height="467" alt="image" src="https://github.com/user-attachments/assets/c7bbcccb-6194-4fd3-9994-20ab2bcb394a" /> | <img width="504" height="468" alt="image" src="https://github.com/user-attachments/assets/0869a090-8521-4180-a309-e6b5c7fa8bba" /> |

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Opus 4.8
Used for: brainstorming and code generation; reviewed by me.


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
