### PR TITLE
Editor: Reuse the shared selector-list parser in the states block support

### DIFF
--- a/src/wp-includes/block-supports/states.php
+++ b/src/wp-includes/block-supports/states.php
@@ -309,7 +309,7 @@ function wp_get_block_state_element_selectors( $root_selector ) {
 		return array();
 	}
 
-	$block_selectors   = wp_split_selector_list( $root_selector );
+	$block_selectors   = WP_Theme_JSON::split_selector_list( $root_selector );
 	$element_selectors = array();
 
 	foreach ( WP_Theme_JSON::ELEMENTS as $element_name => $element_selector ) {
@@ -333,7 +333,7 @@ function wp_get_block_state_element_selectors( $root_selector ) {
 			}
 
 			$prepended_selectors = array();
-			foreach ( wp_split_selector_list( $element_selector ) as $selector ) {
+			foreach ( WP_Theme_JSON::split_selector_list( $element_selector ) as $selector ) {
 				$prepended_selectors[] = $selector_prefix . $selector;
 			}
 			$selectors[] = implode( ',', $prepended_selectors );
@@ -447,45 +447,6 @@ function wp_get_block_state_unique_class( $block_name, $css_rules ) {
 }
 
 /**
- * Splits a selector list by top-level commas.
- *
- * @since 7.1.0
- *
- * @param string $selector CSS selector list.
- * @return string[] Selectors.
- */
-function wp_split_selector_list( $selector ) {
-	if ( ! str_contains( $selector, ',' ) ) {
-		return array( $selector );
-	}
-
-	$selectors         = array();
-	$current_selector  = '';
-	$parentheses_depth = 0;
-	$selector_length   = strlen( $selector );
-
-	for ( $i = 0; $i < $selector_length; $i++ ) {
-		$char = $selector[ $i ];
-
-		if ( '(' === $char ) {
-			++$parentheses_depth;
-		} elseif ( ')' === $char && $parentheses_depth > 0 ) {
-			--$parentheses_depth;
-		} elseif ( ',' === $char && 0 === $parentheses_depth ) {
-			$selectors[]      = $current_selector;
-			$current_selector = '';
-			continue;
-		}
-
-		$current_selector .= $char;
-	}
-
-	$selectors[] = $current_selector;
-
-	return $selectors;
-}
-
-/**
  * Builds a scoped selector from a block selector and optional pseudo-state.
  *
  * @since 7.1.0
@@ -500,7 +461,7 @@ function wp_build_state_selector( $base_selector, $block_selector, $state ) {
 		return $base_selector . $state;
 	}
 
-	$selectors        = wp_split_selector_list( $block_selector );
+	$selectors        = WP_Theme_JSON::split_selector_list( $block_selector );
 	$scoped_selectors = array();
 
 	foreach ( $selectors as $selector ) {

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -1601,6 +1601,8 @@ class WP_Theme_JSON {
 	 *     // Comments stay with the selector they follow.
 	 *     array( '.a /* a, the first *\/', '.b' ) === self::split_selector_list( '.a /* a, the first *\/,.b' );
 	 *
+	 * This is also called from the block supports states layer, so it is public.
+	 *
 	 * @see https://www.w3.org/TR/selectors/#parse-selector
 	 * @see https://www.w3.org/TR/css-syntax-3/
 	 *
@@ -1609,7 +1611,7 @@ class WP_Theme_JSON {
 	 * @param string $selector CSS selector list as a string, e.g. '.wp-block .wp-block-paragraph'.
 	 * @return string[] List of trimmed selectors parsed from input list.
 	 */
-	protected static function split_selector_list( $selector ): array {
+	public static function split_selector_list( $selector ): array {
 		if ( ! str_contains( $selector, ',' ) ) {
 			// See note on trimming CSS whitespace in main loop.
 			return array( trim( $selector, " \t\n" ) );

--- a/tests/phpunit/tests/block-supports/states.php
+++ b/tests/phpunit/tests/block-supports/states.php
@@ -368,6 +368,24 @@ class Tests_Block_Supports_States extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that a comma inside an attribute selector string does not split the
+	 * selector when scoping a state selector to the block wrapper.
+	 *
+	 * @covers ::wp_build_state_selector
+	 *
+	 * @ticket 65669
+	 */
+	public function test_build_state_selector_does_not_split_attribute_string_comma() {
+		$actual = wp_build_state_selector(
+			'.wp-states-test',
+			'[data-label="Save, continue"]',
+			':hover'
+		);
+
+		$this->assertSame( '.wp-states-test:hover', $actual );
+	}
+
+	/**
 	 * Tests that preset values are converted to CSS custom property references.
 	 *
 	 * @covers ::wp_normalize_state_preset_vars


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

`wp_split_selector_list()` in the states block support (`src/wp-includes/block-supports/states.php`, added in [62453] / #65239) splits a CSS selector list on top-level commas but only tracks parenthesis depth. It therefore mis-splits selectors that contain commas inside strings, escaped commas, or CSS comments:

| Input | Before | Correct |
|---|---|---|
| `[data-label="Save, continue"]` | `['[data-label="Save', ' continue"]']` | one selector |
| `.foo\,bar,.baz` | `['.foo\', 'bar', '.baz']` | `['.foo\,bar', '.baz']` |

In the same release, [62607] / #65265 added `WP_Theme_JSON::split_selector_list()`, a robust parser that already handles commas inside strings, escaped commas, CSS comments, and CDO/CDC tokens — the exact cases the states copy gets wrong.

## Changes
- Make `WP_Theme_JSON::split_selector_list()` `public` (was `protected`). The class is `@access private`, so this is not a new stable public API surface.
- Remove the duplicate naive `wp_split_selector_list()` and call `WP_Theme_JSON::split_selector_list()` directly from the three states call sites. That function was new in 7.1, unshipped, and had no callers outside `states.php`.
- Add a regression test through `wp_build_state_selector()` for the attribute-string case (fails on the old splitter, passes now).

Trac ticket: https://core.trac.wordpress.org/ticket/65669

## Use of AI Tools
N/A
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
