### PR TITLE
REST API: Normalize non-integer attachment filesize metadata

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -3652,7 +3652,7 @@ function wp_filesize( $path ): int {
 	 * Filters the result of wp_filesize() before the file_exists() PHP function is run.
 	 *
 	 * @since 6.0.0
-	 * @since 7.1.0 Negative values are now ignored, being treated the same as null. Numeric strings are cast to integers.
+	 * @since 7.1.0 Negative values are now ignored, being treated the same as null. Numeric values are cast to integers.
 	 *
 	 * @param null|int $size The unfiltered value. Returning a non-negative int from the callback bypasses the filesize call.
 	 * @param string   $path Path to the file.
@@ -3671,7 +3671,7 @@ function wp_filesize( $path ): int {
 	 * Filters the size of the file.
 	 *
 	 * @since 6.0.0
-	 * @since 7.1.0 The return value is now always zero or greater. Numeric strings are cast to integers.
+	 * @since 7.1.0 The return value is now always zero or greater. Numeric values are cast to integers.
 	 *
 	 * @param int    $size The result of PHP filesize on the file.
 	 * @param string $path Path to the file.

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -3669,7 +3669,7 @@ function wp_filesize( $path ): int {
 	 * Filters the size of the file.
 	 *
 	 * @since 6.0.0
-	 * @since 7.1.0 Negative numbers are discarded in favor of zero.
+	 * @since 7.1.0 The return value is now always zero or greater.
 	 *
 	 * @param int    $size The result of PHP filesize on the file.
 	 * @param string $path Path to the file.

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -3639,7 +3639,7 @@ function wp_get_ext_types() {
  * Wrapper for PHP filesize with filters and casting the result as an integer.
  *
  * @since 6.0.0
- * @since 7.1.0 The minimum integer now returnable is zero.
+ * @since 7.1.0 The return value is now always zero or greater.
  *
  * @link https://www.php.net/manual/en/function.filesize.php
  *
@@ -3654,7 +3654,7 @@ function wp_filesize( $path ): int {
 	 * @since 6.0.0
 	 * @since 7.1.0 Negative values are now ignored, being treated the same as null. Numeric values are cast to integers.
 	 *
-	 * @param null|int $size The unfiltered value. Returning a non-negative int from the callback bypasses the filesize call.
+	 * @param null|int $size The unfiltered value. Returning a non-negative number from the callback bypasses the filesize call.
 	 * @param string   $path Path to the file.
 	 */
 	$size = apply_filters( 'pre_wp_filesize', null, $path );

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -3639,6 +3639,7 @@ function wp_get_ext_types() {
  * Wrapper for PHP filesize with filters and casting the result as an integer.
  *
  * @since 6.0.0
+ * @since 7.1.0 The minimum integer now returnable is zero.
  *
  * @link https://www.php.net/manual/en/function.filesize.php
  *
@@ -3651,6 +3652,7 @@ function wp_filesize( $path ): int {
 	 * Filters the result of wp_filesize() before the file_exists() PHP function is run.
 	 *
 	 * @since 6.0.0
+	 * @since 7.1.0 Negative values are now ignored, being treated the same as null.
 	 *
 	 * @param null|int $size The unfiltered value. Returning a non-negative int from the callback bypasses the filesize call.
 	 * @param string   $path Path to the file.
@@ -3667,11 +3669,17 @@ function wp_filesize( $path ): int {
 	 * Filters the size of the file.
 	 *
 	 * @since 6.0.0
+	 * @since 7.1.0 Negative numbers are discarded in favor of zero.
 	 *
 	 * @param int    $size The result of PHP filesize on the file.
 	 * @param string $path Path to the file.
 	 */
-	$size = (int) apply_filters( 'wp_filesize', $size, $path );
+	$size = apply_filters( 'wp_filesize', $size, $path );
+	if ( is_numeric( $size ) ) {
+		$size = (int) $size;
+	} else {
+		$size = 0;
+	}
 	return max( 0, $size );
 }
 

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -3652,7 +3652,7 @@ function wp_filesize( $path ): int {
 	 *
 	 * @since 6.0.0
 	 *
-	 * @param null|int $size The unfiltered value. Returning an int from the callback bypasses the filesize call.
+	 * @param null|int $size The unfiltered value. Returning a non-negative int from the callback bypasses the filesize call.
 	 * @param string   $path Path to the file.
 	 */
 	$size = apply_filters( 'pre_wp_filesize', null, $path );

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -3652,13 +3652,15 @@ function wp_filesize( $path ): int {
 	 * Filters the result of wp_filesize() before the file_exists() PHP function is run.
 	 *
 	 * @since 6.0.0
-	 * @since 7.1.0 Negative values are now ignored, being treated the same as null.
+	 * @since 7.1.0 Negative values are now ignored, being treated the same as null. Numeric strings are cast to integers.
 	 *
 	 * @param null|int $size The unfiltered value. Returning a non-negative int from the callback bypasses the filesize call.
 	 * @param string   $path Path to the file.
 	 */
 	$size = apply_filters( 'pre_wp_filesize', null, $path );
-
+	if ( is_numeric( $size ) ) {
+		$size = (int) $size;
+	}
 	if ( is_int( $size ) && $size >= 0 ) {
 		return $size;
 	}
@@ -3669,7 +3671,7 @@ function wp_filesize( $path ): int {
 	 * Filters the size of the file.
 	 *
 	 * @since 6.0.0
-	 * @since 7.1.0 The return value is now always zero or greater.
+	 * @since 7.1.0 The return value is now always zero or greater. Numeric strings are cast to integers.
 	 *
 	 * @param int    $size The result of PHP filesize on the file.
 	 * @param string $path Path to the file.

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -3644,8 +3644,9 @@ function wp_get_ext_types() {
  *
  * @param string $path Path to the file.
  * @return int The size of the file in bytes, or 0 in the event of an error.
+ * @phpstan-return non-negative-int
  */
-function wp_filesize( $path ) {
+function wp_filesize( $path ): int {
 	/**
 	 * Filters the result of wp_filesize() before the file_exists() PHP function is run.
 	 *
@@ -3656,7 +3657,7 @@ function wp_filesize( $path ) {
 	 */
 	$size = apply_filters( 'pre_wp_filesize', null, $path );
 
-	if ( is_int( $size ) ) {
+	if ( is_int( $size ) && $size >= 0 ) {
 		return $size;
 	}
 
@@ -3670,7 +3671,8 @@ function wp_filesize( $path ) {
 	 * @param int    $size The result of PHP filesize on the file.
 	 * @param string $path Path to the file.
 	 */
-	return (int) apply_filters( 'wp_filesize', $size, $path );
+	$size = (int) apply_filters( 'wp_filesize', $size, $path );
+	return max( 0, $size );
 }
 
 /**

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
@@ -2369,9 +2369,13 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 		 * value (including a digit-only string, as stored by some plugins).
 		 * Fall through to recompute the size from the file otherwise.
 		 */
-		if ( isset( $meta['filesize'] )
-			&& ( is_int( $meta['filesize'] ) || ( is_string( $meta['filesize'] ) && ctype_digit( $meta['filesize'] ) ) )
-			&& $meta['filesize'] > 0
+		if (
+			isset( $meta['filesize'] ) &&
+			(
+				is_int( $meta['filesize'] ) ||
+				( is_string( $meta['filesize'] ) && ctype_digit( $meta['filesize'] ) )
+			) &&
+			$meta['filesize'] > 0
 		) {
 			return (int) $meta['filesize'];
 		}

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
@@ -2359,7 +2359,6 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 	 *
 	 * @param int $attachment_id Attachment ID.
 	 * @return int|null Attachment file size in bytes, or null if not available.
-	 *
 	 * @phpstan-return non-negative-int|null
 	 */
 	protected function get_attachment_filesize( int $attachment_id ): ?int {

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
@@ -2364,19 +2364,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 	protected function get_attachment_filesize( int $attachment_id ): ?int {
 		$meta = wp_get_attachment_metadata( $attachment_id );
 
-		/*
-		 * Attachment metadata is untyped, so only trust a positive integer
-		 * value (including a digit-only string, as stored by some plugins).
-		 * Fall through to recompute the size from the file otherwise.
-		 */
-		if (
-			isset( $meta['filesize'] ) &&
-			(
-				is_int( $meta['filesize'] ) ||
-				( is_string( $meta['filesize'] ) && ctype_digit( $meta['filesize'] ) )
-			) &&
-			$meta['filesize'] > 0
-		) {
+		if ( isset( $meta['filesize'] ) && is_numeric( $meta['filesize'] ) && $meta['filesize'] > 0 ) {
 			return (int) $meta['filesize'];
 		}
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
@@ -2363,8 +2363,14 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 	protected function get_attachment_filesize( int $attachment_id ): ?int {
 		$meta = wp_get_attachment_metadata( $attachment_id );
 
-		if ( isset( $meta['filesize'] ) ) {
-			return $meta['filesize'];
+		/*
+		 * Attachment metadata is untyped, so the stored file size may be a
+		 * string (for example, plugins that populate it from a remote storage
+		 * API response). Only trust numeric values, and fall through to
+		 * recompute the size from the file otherwise.
+		 */
+		if ( isset( $meta['filesize'] ) && is_numeric( $meta['filesize'] ) ) {
+			return (int) $meta['filesize'];
 		}
 
 		$original_path = wp_get_original_image_path( $attachment_id );

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
@@ -2359,15 +2359,21 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 	 *
 	 * @param int $attachment_id Attachment ID.
 	 * @return int|null Attachment file size in bytes, or null if not available.
+	 *
+	 * @phpstan-return non-negative-int|null
 	 */
 	protected function get_attachment_filesize( int $attachment_id ): ?int {
 		$meta = wp_get_attachment_metadata( $attachment_id );
 
 		/*
-		 * Only trust numeric values, and fall through to
-		 * recompute the size from the file otherwise.
+		 * Attachment metadata is untyped, so only trust a positive integer
+		 * value (including a digit-only string, as stored by some plugins).
+		 * Fall through to recompute the size from the file otherwise.
 		 */
-		if ( isset( $meta['filesize'] ) && is_numeric( $meta['filesize'] ) ) {
+		if ( isset( $meta['filesize'] )
+			&& ( is_int( $meta['filesize'] ) || ctype_digit( $meta['filesize'] ) )
+			&& $meta['filesize'] > 0
+		) {
 			return (int) $meta['filesize'];
 		}
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
@@ -2364,9 +2364,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 		$meta = wp_get_attachment_metadata( $attachment_id );
 
 		/*
-		 * Attachment metadata is untyped, so the stored file size may be a
-		 * string (for example, plugins that populate it from a remote storage
-		 * API response). Only trust numeric values, and fall through to
+		 * Only trust numeric values, and fall through to
 		 * recompute the size from the file otherwise.
 		 */
 		if ( isset( $meta['filesize'] ) && is_numeric( $meta['filesize'] ) ) {

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
@@ -2371,7 +2371,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 		 * Fall through to recompute the size from the file otherwise.
 		 */
 		if ( isset( $meta['filesize'] )
-			&& ( is_int( $meta['filesize'] ) || ctype_digit( $meta['filesize'] ) )
+			&& ( is_int( $meta['filesize'] ) || ( is_string( $meta['filesize'] ) && ctype_digit( $meta['filesize'] ) ) )
 			&& $meta['filesize'] > 0
 		) {
 			return (int) $meta['filesize'];

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
@@ -1707,7 +1707,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 
 		$schema['properties']['filesize'] = array(
 			'description' => __( 'Attachment file size in bytes.' ),
-			'type'        => 'integer',
+			'type'        => array( 'integer', 'null' ),
 			'context'     => array( 'view', 'edit' ),
 			'readonly'    => true,
 		);

--- a/tests/phpunit/tests/functions/wpFilesize.php
+++ b/tests/phpunit/tests/functions/wpFilesize.php
@@ -59,7 +59,7 @@ class Tests_Functions_wpFilesize extends WP_UnitTestCase {
 	/**
 	 * @ticket 65670
 	 *
-	 * @dataProvider data_provider_test_wp_filesize_filter_invalid_value
+	 * @dataProvider data_wp_filesize_filter_invalid_value
 	 *
 	 * @param mixed $value
 	 */
@@ -73,7 +73,7 @@ class Tests_Functions_wpFilesize extends WP_UnitTestCase {
 	 *
 	 * @return array<string, array{ 0: mixed }>
 	 */
-	public function data_provider_test_wp_filesize_filter_invalid_value(): array {
+	public function data_wp_filesize_filter_invalid_value(): array {
 		return array(
 			'negative' => array( -1 ),
 			'null'     => array( null ),

--- a/tests/phpunit/tests/functions/wpFilesize.php
+++ b/tests/phpunit/tests/functions/wpFilesize.php
@@ -57,11 +57,28 @@ class Tests_Functions_wpFilesize extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 65670
+	 *
+	 * @dataProvider data_wp_filesize_pre_wp_filesize_filter_negative
+	 *
+	 * @param float|int|string $value Negative value returned by the filter.
 	 */
-	public function test_wp_filesize_pre_wp_filesize_filter_negative(): void {
-		add_filter( 'pre_wp_filesize', static fn () => -1 );
+	public function test_wp_filesize_pre_wp_filesize_filter_negative( $value ): void {
+		add_filter( 'pre_wp_filesize', static fn () => $value );
 
 		$this->assertSame( filesize( self::TEST_FILE ), wp_filesize( self::TEST_FILE ) );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array<string, array{ 0: float|int|string }>
+	 */
+	public function data_wp_filesize_pre_wp_filesize_filter_negative(): array {
+		return array(
+			'negative int'            => array( -1 ),
+			'negative numeric string' => array( '-1' ),
+			'negative float'          => array( -1.5 ),
+		);
 	}
 
 	/**

--- a/tests/phpunit/tests/functions/wpFilesize.php
+++ b/tests/phpunit/tests/functions/wpFilesize.php
@@ -34,6 +34,9 @@ class Tests_Functions_wpFilesize extends WP_UnitTestCase {
 
 		add_filter( 'pre_wp_filesize', static fn () => '2222', 100 );
 		$this->assertSame( 2222, wp_filesize( self::TEST_FILE ) );
+
+		add_filter( 'pre_wp_filesize', static fn () => -100, 200 );
+		$this->assertSame( 9991, wp_filesize( self::TEST_FILE ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/functions/wpFilesize.php
+++ b/tests/phpunit/tests/functions/wpFilesize.php
@@ -51,7 +51,7 @@ class Tests_Functions_wpFilesize extends WP_UnitTestCase {
 	 * @ticket 65670
 	 */
 	public function test_wp_filesize_pre_wp_filesize_filter_negative(): void {
-		add_filter( 'pre_wp_filesize', static fn() => -1 );
+		add_filter( 'pre_wp_filesize', static fn () => -1 );
 
 		$this->assertSame( filesize( self::TEST_FILE ), wp_filesize( self::TEST_FILE ) );
 	}
@@ -64,7 +64,7 @@ class Tests_Functions_wpFilesize extends WP_UnitTestCase {
 	 * @param mixed $value
 	 */
 	public function test_wp_filesize_wp_filesize_filter_invalid_value( $value ): void {
-		add_filter( 'wp_filesize', static fn() => $value );
+		add_filter( 'wp_filesize', static fn () => $value );
 		$this->assertSame( 0, wp_filesize( self::TEST_FILE ) );
 	}
 

--- a/tests/phpunit/tests/functions/wpFilesize.php
+++ b/tests/phpunit/tests/functions/wpFilesize.php
@@ -20,15 +20,20 @@ class Tests_Functions_wpFilesize extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 49412
+	 * @ticket 65670
 	 */
 	public function test_wp_filesize_filters(): void {
 		add_filter( 'wp_filesize', static fn () => 999 );
-
 		$this->assertSame( 999, wp_filesize( self::TEST_FILE ) );
 
-		add_filter( 'pre_wp_filesize', static fn () => 111 );
+		add_filter( 'wp_filesize', static fn () => '9991', 100 );
+		$this->assertSame( 9991, wp_filesize( self::TEST_FILE ) );
 
+		add_filter( 'pre_wp_filesize', static fn () => 111 );
 		$this->assertSame( 111, wp_filesize( self::TEST_FILE ) );
+
+		add_filter( 'pre_wp_filesize', static fn () => '2222', 100 );
+		$this->assertSame( 2222, wp_filesize( self::TEST_FILE ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/functions/wpFilesize.php
+++ b/tests/phpunit/tests/functions/wpFilesize.php
@@ -9,46 +9,75 @@
  */
 class Tests_Functions_wpFilesize extends WP_UnitTestCase {
 
+	const TEST_FILE = DIR_TESTDATA . '/images/test-image-upside-down.jpg';
+
 	/**
 	 * @ticket 49412
 	 */
-	public function test_wp_filesize() {
-		$file = DIR_TESTDATA . '/images/test-image-upside-down.jpg';
-
-		$this->assertSame( filesize( $file ), wp_filesize( $file ) );
+	public function test_wp_filesize(): void {
+		$this->assertSame( filesize( self::TEST_FILE ), wp_filesize( self::TEST_FILE ) );
 	}
 
 	/**
 	 * @ticket 49412
 	 */
-	public function test_wp_filesize_filters() {
-		$file = DIR_TESTDATA . '/images/test-image-upside-down.jpg';
+	public function test_wp_filesize_filters(): void {
+		add_filter( 'wp_filesize', static fn () => 999 );
 
-		add_filter(
-			'wp_filesize',
-			static function () {
-				return 999;
-			}
-		);
+		$this->assertSame( 999, wp_filesize( self::TEST_FILE ) );
 
-		$this->assertSame( 999, wp_filesize( $file ) );
+		add_filter( 'pre_wp_filesize', static fn () => 111 );
 
-		add_filter(
-			'pre_wp_filesize',
-			static function () {
-				return 111;
-			}
-		);
-
-		$this->assertSame( 111, wp_filesize( $file ) );
+		$this->assertSame( 111, wp_filesize( self::TEST_FILE ) );
 	}
 
 	/**
 	 * @ticket 49412
 	 */
-	public function test_wp_filesize_with_nonexistent_file() {
-		$file = 'nonexistent/file.jpg';
+	public function test_wp_filesize_with_nonexistent_file(): void {
+		$this->assertSame( 0, wp_filesize( 'nonexistent/file.jpg' ) );
+	}
 
-		$this->assertSame( 0, wp_filesize( $file ) );
+	/**
+	 * @ticket 65670
+	 */
+	public function test_wp_filesize_pre_wp_filesize_filter_null(): void {
+		add_filter( 'pre_wp_filesize', '__return_null' );
+
+		$this->assertSame( filesize( self::TEST_FILE ), wp_filesize( self::TEST_FILE ) );
+	}
+
+	/**
+	 * @ticket 65670
+	 */
+	public function test_wp_filesize_pre_wp_filesize_filter_negative(): void {
+		add_filter( 'pre_wp_filesize', static fn() => -1 );
+
+		$this->assertSame( filesize( self::TEST_FILE ), wp_filesize( self::TEST_FILE ) );
+	}
+
+	/**
+	 * @ticket 65670
+	 *
+	 * @dataProvider data_provider_test_wp_filesize_filter_invalid_value
+	 *
+	 * @param mixed $value
+	 */
+	public function test_wp_filesize_wp_filesize_filter_invalid_value( $value ): void {
+		add_filter( 'wp_filesize', static fn() => $value );
+		$this->assertSame( 0, wp_filesize( self::TEST_FILE ) );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array<string, array{ 0: mixed }>
+	 */
+	public function data_provider_test_wp_filesize_filter_invalid_value(): array {
+		return array(
+			'negative' => array( -1 ),
+			'null'     => array( null ),
+			'array'    => array( array( 'bad', 'array' ) ),
+		);
 	}
 }

--- a/tests/phpunit/tests/rest-api/rest-attachments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-attachments-controller.php
@@ -1006,15 +1006,20 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 	}
 
 	/**
-	 * Ensures a numeric-string `filesize` in attachment metadata is normalized
+	 * Ensures int-castable `filesize` values in attachment metadata are normalized
 	 * to an integer in the response.
 	 *
 	 * Attachment metadata is untyped, so plugins that populate `filesize` from
 	 * a remote storage API may store it as a string.
 	 *
 	 * @ticket 65670
+	 *
+	 * @dataProvider data_valid_filesize_meta
+	 *
+	 * @param mixed $stored_filesize Valid `filesize` metadata value.
+	 * @param int   $actual_filesize Actual filesize.
 	 */
-	public function test_get_item_normalizes_numeric_string_filesize_meta() {
+	public function test_get_item_normalizes_numeric_string_filesize_meta( $stored_filesize, int $actual_filesize ) {
 		$attachment_id = self::factory()->attachment->create_object(
 			array(
 				'file'           => self::$test_file,
@@ -1025,7 +1030,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 
 		$meta             = wp_get_attachment_metadata( $attachment_id );
 		$meta             = is_array( $meta ) ? $meta : array();
-		$meta['filesize'] = '123456';
+		$meta['filesize'] = $stored_filesize;
 		$this->assertNotFalse( wp_update_attachment_metadata( $attachment_id, $meta ) );
 
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/media/' . $attachment_id );
@@ -1034,7 +1039,21 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 
 		$this->assertIsArray( $data );
 		$this->assertSame( 200, $response->get_status() );
-		$this->assertSame( 123456, $data['filesize'] );
+		$this->assertSame( $actual_filesize, $data['filesize'] );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array<string, array{ 0: mixed, 1: int }>
+	 */
+	public function data_valid_filesize_meta(): array {
+		return array(
+			'integer string'      => array( '123456', 123456 ),
+			'float string'        => array( '123.4', 123 ),
+			'scientific notation' => array( '1e3', 1000 ),
+			'float'               => array( 123.0, 123 ),
+		);
 	}
 
 	/**
@@ -1083,9 +1102,6 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 	public function data_invalid_filesize_meta(): array {
 		return array(
 			'non-numeric string'      => array( 'corrupt' ),
-			'float string'            => array( '123.4' ),
-			'scientific notation'     => array( '1e3' ),
-			'float'                   => array( 123.0 ),
 			'boolean'                 => array( true ),
 			'zero'                    => array( 0 ),
 			'zero string'             => array( '0' ),

--- a/tests/phpunit/tests/rest-api/rest-attachments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-attachments-controller.php
@@ -1069,7 +1069,10 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		$this->assertIsArray( $data );
 		$this->assertSame( 200, $response->get_status() );
 		$this->assertIsInt( $data['filesize'] );
-		$this->assertSame( filesize( self::$test_file ), $data['filesize'] );
+		$attached_file = wp_get_original_image_path( $attachment_id );
+		$attached_file = $attached_file ? $attached_file : get_attached_file( $attachment_id );
+		$this->assertIsString( $attached_file );
+		$this->assertSame( filesize( $attached_file ), $data['filesize'] );
 	}
 
 	/**

--- a/tests/phpunit/tests/rest-api/rest-attachments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-attachments-controller.php
@@ -1016,10 +1016,10 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 	 *
 	 * @dataProvider data_valid_filesize_meta
 	 *
-	 * @param mixed $stored_filesize Valid `filesize` metadata value.
-	 * @param int   $actual_filesize Actual filesize.
+	 * @param mixed $stored_filesize   Valid `filesize` metadata value.
+	 * @param int   $expected_filesize Expected `filesize` value in the REST response after normalization.
 	 */
-	public function test_get_item_normalizes_int_castable_filesize_meta( $stored_filesize, int $actual_filesize ) {
+	public function test_get_item_normalizes_int_castable_filesize_meta( $stored_filesize, int $expected_filesize ) {
 		$attachment_id = self::factory()->attachment->create_object(
 			array(
 				'file'           => self::$test_file,
@@ -1039,7 +1039,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 
 		$this->assertIsArray( $data );
 		$this->assertSame( 200, $response->get_status() );
-		$this->assertSame( $actual_filesize, $data['filesize'] );
+		$this->assertSame( $expected_filesize, $data['filesize'] );
 	}
 
 	/**

--- a/tests/phpunit/tests/rest-api/rest-attachments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-attachments-controller.php
@@ -1023,7 +1023,10 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		);
 		$this->assertIsInt( $attachment_id );
 
-		wp_update_attachment_metadata( $attachment_id, array( 'filesize' => '123456' ) );
+		$meta             = wp_get_attachment_metadata( $attachment_id );
+		$meta             = is_array( $meta ) ? $meta : array();
+		$meta['filesize'] = '123456';
+		$this->assertNotFalse( wp_update_attachment_metadata( $attachment_id, $meta ) );
 
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/media/' . $attachment_id );
 		$response = rest_get_server()->dispatch( $request );
@@ -1054,7 +1057,10 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		);
 		$this->assertIsInt( $attachment_id );
 
-		wp_update_attachment_metadata( $attachment_id, array( 'filesize' => $filesize ) );
+		$meta             = wp_get_attachment_metadata( $attachment_id );
+		$meta             = is_array( $meta ) ? $meta : array();
+		$meta['filesize'] = $filesize;
+		$this->assertNotFalse( wp_update_attachment_metadata( $attachment_id, $meta ) );
 
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/media/' . $attachment_id );
 		$response = rest_get_server()->dispatch( $request );

--- a/tests/phpunit/tests/rest-api/rest-attachments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-attachments-controller.php
@@ -1076,6 +1076,8 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 			'non-numeric string'      => array( 'corrupt' ),
 			'float string'            => array( '123.4' ),
 			'scientific notation'     => array( '1e3' ),
+			'float'                   => array( 123.0 ),
+			'boolean'                 => array( true ),
 			'zero'                    => array( 0 ),
 			'zero string'             => array( '0' ),
 			'negative integer'        => array( -5 ),

--- a/tests/phpunit/tests/rest-api/rest-attachments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-attachments-controller.php
@@ -1035,12 +1035,17 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 	}
 
 	/**
-	 * Ensures a non-numeric `filesize` in attachment metadata does not cause a
-	 * fatal TypeError, falling back to the actual file size.
+	 * Ensures a `filesize` metadata value that is not a positive integer does
+	 * not cause a fatal TypeError or a silently truncated size, falling back to
+	 * the actual file size instead.
 	 *
 	 * @ticket 65670
+	 *
+	 * @dataProvider data_invalid_filesize_meta
+	 *
+	 * @param mixed $filesize Invalid `filesize` metadata value.
 	 */
-	public function test_get_item_recovers_from_non_numeric_filesize_meta() {
+	public function test_get_item_recovers_from_invalid_filesize_meta( $filesize ) {
 		$attachment_id = self::factory()->attachment->create_object(
 			array(
 				'file'           => self::$test_file,
@@ -1049,7 +1054,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		);
 		$this->assertIsInt( $attachment_id );
 
-		wp_update_attachment_metadata( $attachment_id, array( 'filesize' => 'corrupt' ) );
+		wp_update_attachment_metadata( $attachment_id, array( 'filesize' => $filesize ) );
 
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/media/' . $attachment_id );
 		$response = rest_get_server()->dispatch( $request );
@@ -1059,6 +1064,23 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		$this->assertSame( 200, $response->get_status() );
 		$this->assertIsInt( $data['filesize'] );
 		$this->assertSame( filesize( self::$test_file ), $data['filesize'] );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_invalid_filesize_meta() {
+		return array(
+			'non-numeric string'      => array( 'corrupt' ),
+			'float string'            => array( '123.4' ),
+			'scientific notation'     => array( '1e3' ),
+			'zero'                    => array( 0 ),
+			'zero string'             => array( '0' ),
+			'negative integer'        => array( -5 ),
+			'negative integer string' => array( '-5' ),
+		);
 	}
 
 	/**

--- a/tests/phpunit/tests/rest-api/rest-attachments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-attachments-controller.php
@@ -1069,9 +1069,9 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 	/**
 	 * Data provider.
 	 *
-	 * @return array[]
+	 * @return array<string, array{ 0: mixed }>
 	 */
-	public function data_invalid_filesize_meta() {
+	public function data_invalid_filesize_meta(): array {
 		return array(
 			'non-numeric string'      => array( 'corrupt' ),
 			'float string'            => array( '123.4' ),

--- a/tests/phpunit/tests/rest-api/rest-attachments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-attachments-controller.php
@@ -1019,7 +1019,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 	 * @param mixed $stored_filesize Valid `filesize` metadata value.
 	 * @param int   $actual_filesize Actual filesize.
 	 */
-	public function test_get_item_normalizes_numeric_string_filesize_meta( $stored_filesize, int $actual_filesize ) {
+	public function test_get_item_normalizes_int_castable_filesize_meta( $stored_filesize, int $actual_filesize ) {
 		$attachment_id = self::factory()->attachment->create_object(
 			array(
 				'file'           => self::$test_file,

--- a/tests/phpunit/tests/rest-api/rest-attachments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-attachments-controller.php
@@ -1016,12 +1016,12 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 	 */
 	public function test_get_item_normalizes_numeric_string_filesize_meta() {
 		$attachment_id = self::factory()->attachment->create_object(
-			self::$test_file,
-			0,
 			array(
+				'file'           => self::$test_file,
 				'post_mime_type' => 'image/jpeg',
 			)
 		);
+		$this->assertIsInt( $attachment_id );
 
 		wp_update_attachment_metadata( $attachment_id, array( 'filesize' => '123456' ) );
 
@@ -1029,6 +1029,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 
+		$this->assertIsArray( $data );
 		$this->assertSame( 200, $response->get_status() );
 		$this->assertSame( 123456, $data['filesize'] );
 	}
@@ -1041,12 +1042,12 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 	 */
 	public function test_get_item_recovers_from_non_numeric_filesize_meta() {
 		$attachment_id = self::factory()->attachment->create_object(
-			self::$test_file,
-			0,
 			array(
+				'file'           => self::$test_file,
 				'post_mime_type' => 'image/jpeg',
 			)
 		);
+		$this->assertIsInt( $attachment_id );
 
 		wp_update_attachment_metadata( $attachment_id, array( 'filesize' => 'corrupt' ) );
 
@@ -1054,6 +1055,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 
+		$this->assertIsArray( $data );
 		$this->assertSame( 200, $response->get_status() );
 		$this->assertIsInt( $data['filesize'] );
 		$this->assertSame( filesize( self::$test_file ), $data['filesize'] );
@@ -1072,6 +1074,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 			),
 			self::$test_file
 		);
+		$this->assertIsInt( $attachment_id );
 
 		add_image_size( 'rest-api-test', 119, 119, true );
 		wp_update_attachment_metadata( $attachment_id, wp_generate_attachment_metadata( $attachment_id, self::$test_file ) );

--- a/tests/phpunit/tests/rest-api/rest-attachments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-attachments-controller.php
@@ -1006,6 +1006,60 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 	}
 
 	/**
+	 * Ensures a numeric-string `filesize` in attachment metadata is normalized
+	 * to an integer in the response.
+	 *
+	 * Attachment metadata is untyped, so plugins that populate `filesize` from
+	 * a remote storage API may store it as a string.
+	 *
+	 * @ticket 65670
+	 */
+	public function test_get_item_normalizes_numeric_string_filesize_meta() {
+		$attachment_id = self::factory()->attachment->create_object(
+			self::$test_file,
+			0,
+			array(
+				'post_mime_type' => 'image/jpeg',
+			)
+		);
+
+		wp_update_attachment_metadata( $attachment_id, array( 'filesize' => '123456' ) );
+
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/media/' . $attachment_id );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( 123456, $data['filesize'] );
+	}
+
+	/**
+	 * Ensures a non-numeric `filesize` in attachment metadata does not cause a
+	 * fatal TypeError, falling back to the actual file size.
+	 *
+	 * @ticket 65670
+	 */
+	public function test_get_item_recovers_from_non_numeric_filesize_meta() {
+		$attachment_id = self::factory()->attachment->create_object(
+			self::$test_file,
+			0,
+			array(
+				'post_mime_type' => 'image/jpeg',
+			)
+		);
+
+		wp_update_attachment_metadata( $attachment_id, array( 'filesize' => 'corrupt' ) );
+
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/media/' . $attachment_id );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertIsInt( $data['filesize'] );
+		$this->assertSame( filesize( self::$test_file ), $data['filesize'] );
+	}
+
+	/**
 	 * @requires function imagejpeg
 	 */
 	public function test_get_item_sizes() {

--- a/tests/phpunit/tests/rest-api/rest-attachments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-attachments-controller.php
@@ -1098,7 +1098,6 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 			),
 			self::$test_file
 		);
-		$this->assertIsInt( $attachment_id );
 
 		add_image_size( 'rest-api-test', 119, 119, true );
 		wp_update_attachment_metadata( $attachment_id, wp_generate_attachment_metadata( $attachment_id, self::$test_file ) );


### PR DESCRIPTION
## Trac ticket

https://core.trac.wordpress.org/ticket/65670

## Problem

`WP_REST_Attachments_Controller::get_attachment_filesize()` (new in 7.0.0) returns the `filesize` value from attachment metadata verbatim against a strict `?int` return type. Attachment metadata is untyped postmeta, so a non-numeric string value throws a fatal `TypeError` when the media endpoint is requested:

```
TypeError: WP_REST_Attachments_Controller::get_attachment_filesize():
Return value must be of type ?int, string returned
```

A numeric string only survives because the file has no `strict_types` declaration (coercion). A non-numeric one fatals.

Plugins populate `filesize` from remote storage API responses — e.g. the Google Drive `fileSize` field (returned as a string) via WP Media Folder, and the equivalent Dropbox/OneDrive addons — so this occurs on real sites.

## Fix

Only return the stored value when it is numeric, cast to `int`; otherwise fall through to recompute the size from the file via `wp_filesize()` (which always casts to int), returning `null` if unavailable. This matches the `'type' => 'integer'` REST schema.

## Testing

Two regression tests added to `tests/phpunit/tests/rest-api/rest-attachments-controller.php`:

- numeric-string `filesize` meta → normalized to `int` in the response;
- non-numeric `filesize` meta → no fatal, falls back to the real file size.

The non-numeric test reproduces the reported `TypeError` against unpatched `trunk` (red), and passes with the fix (green).

## Disclosure

Claude (Anthropic) assisted in diagnosing the root cause and drafting the patch and tests. I reviewed the change, verified the red/green test behavior locally, and take responsibility for it.
