### PR TITLE
Build/Test Tools: Use strict assertions in REST schema sanitization tests

### DIFF
--- a/tests/phpunit/tests/rest-api/rest-schema-sanitization.php
+++ b/tests/phpunit/tests/rest-api/rest-schema-sanitization.php
@@ -111,8 +111,8 @@ class WP_Test_REST_Schema_Sanitization extends WP_UnitTestCase {
 				'type' => 'number',
 			),
 		);
-		$this->assertEquals( array( 1 ), rest_sanitize_value_from_schema( array( 1 ), $schema ) );
-		$this->assertEquals( array( 1 ), rest_sanitize_value_from_schema( array( '1' ), $schema ) );
+		$this->assertSame( array( 1.0 ), rest_sanitize_value_from_schema( array( 1 ), $schema ) );
+		$this->assertSame( array( 1.0 ), rest_sanitize_value_from_schema( array( '1' ), $schema ) );
 	}
 
 	public function test_type_array_nested() {
@@ -125,8 +125,8 @@ class WP_Test_REST_Schema_Sanitization extends WP_UnitTestCase {
 				),
 			),
 		);
-		$this->assertEquals( array( array( 1 ), array( 2 ) ), rest_sanitize_value_from_schema( array( array( 1 ), array( 2 ) ), $schema ) );
-		$this->assertEquals( array( array( 1 ), array( 2 ) ), rest_sanitize_value_from_schema( array( array( '1' ), array( '2' ) ), $schema ) );
+		$this->assertSame( array( array( 1.0 ), array( 2.0 ) ), rest_sanitize_value_from_schema( array( array( 1 ), array( 2 ) ), $schema ) );
+		$this->assertSame( array( array( 1.0 ), array( 2.0 ) ), rest_sanitize_value_from_schema( array( array( '1' ), array( '2' ) ), $schema ) );
 	}
 
 	public function test_type_array_as_csv() {
@@ -136,9 +136,9 @@ class WP_Test_REST_Schema_Sanitization extends WP_UnitTestCase {
 				'type' => 'number',
 			),
 		);
-		$this->assertEquals( array( 1, 2 ), rest_sanitize_value_from_schema( '1,2', $schema ) );
-		$this->assertEquals( array( 1, 2, 0 ), rest_sanitize_value_from_schema( '1,2,a', $schema ) );
-		$this->assertEquals( array( 1, 2 ), rest_sanitize_value_from_schema( '1,2,', $schema ) );
+		$this->assertSame( array( 1.0, 2.0 ), rest_sanitize_value_from_schema( '1,2', $schema ) );
+		$this->assertSame( array( 1.0, 2.0, 0.0 ), rest_sanitize_value_from_schema( '1,2,a', $schema ) );
+		$this->assertSame( array( 1.0, 2.0 ), rest_sanitize_value_from_schema( '1,2,', $schema ) );
 	}
 
 	public function test_type_array_with_enum() {
@@ -194,11 +194,11 @@ class WP_Test_REST_Schema_Sanitization extends WP_UnitTestCase {
 				),
 			),
 		);
-		$this->assertEquals( array( 'a' => 1 ), rest_sanitize_value_from_schema( array( 'a' => 1 ), $schema ) );
-		$this->assertEquals( array( 'a' => 1 ), rest_sanitize_value_from_schema( array( 'a' => '1' ), $schema ) );
-		$this->assertEquals(
+		$this->assertSame( array( 'a' => 1.0 ), rest_sanitize_value_from_schema( array( 'a' => 1 ), $schema ) );
+		$this->assertSame( array( 'a' => 1.0 ), rest_sanitize_value_from_schema( array( 'a' => '1' ), $schema ) );
+		$this->assertSame(
 			array(
-				'a' => 1,
+				'a' => 1.0,
 				'b' => 1,
 			),
 			rest_sanitize_value_from_schema(
@@ -221,10 +221,10 @@ class WP_Test_REST_Schema_Sanitization extends WP_UnitTestCase {
 			),
 			'additionalProperties' => false,
 		);
-		$this->assertEquals( array( 'a' => 1 ), rest_sanitize_value_from_schema( array( 'a' => 1 ), $schema ) );
-		$this->assertEquals( array( 'a' => 1 ), rest_sanitize_value_from_schema( array( 'a' => '1' ), $schema ) );
-		$this->assertEquals(
-			array( 'a' => 1 ),
+		$this->assertSame( array( 'a' => 1.0 ), rest_sanitize_value_from_schema( array( 'a' => 1 ), $schema ) );
+		$this->assertSame( array( 'a' => 1.0 ), rest_sanitize_value_from_schema( array( 'a' => '1' ), $schema ) );
+		$this->assertSame(
+			array( 'a' => 1.0 ),
 			rest_sanitize_value_from_schema(
 				array(
 					'a' => '1',
@@ -345,11 +345,11 @@ class WP_Test_REST_Schema_Sanitization extends WP_UnitTestCase {
 			),
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				'a' => array(
-					'b' => 1,
-					'c' => 3,
+					'b' => 1.0,
+					'c' => 3.0,
 				),
 			),
 			rest_sanitize_value_from_schema(
@@ -362,11 +362,11 @@ class WP_Test_REST_Schema_Sanitization extends WP_UnitTestCase {
 				$schema
 			)
 		);
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				'a' => array(
-					'b' => 1,
-					'c' => 3,
+					'b' => 1.0,
+					'c' => 3.0,
 					'd' => '1',
 				),
 				'b' => 1,
@@ -395,7 +395,7 @@ class WP_Test_REST_Schema_Sanitization extends WP_UnitTestCase {
 				),
 			),
 		);
-		$this->assertEquals( array( 'a' => 1 ), rest_sanitize_value_from_schema( (object) array( 'a' => '1' ), $schema ) );
+		$this->assertSame( array( 'a' => 1.0 ), rest_sanitize_value_from_schema( (object) array( 'a' => '1' ), $schema ) );
 	}
 
 	/**


### PR DESCRIPTION
Replaces the remaining `assertEquals()` calls in the REST schema sanitization tests with `assertSame()`.

These assertions are a good fit for strict comparison, because the type of the returned value *is* the thing under test. `rest_sanitize_value_from_schema()` promises to coerce a value to the type declared in the schema, and most of these cases pass a deliberately mistyped input to prove it does:

    $this->assertSame( array( 1.0 ), rest_sanitize_value_from_schema( array( '1' ), $schema ) );

With a loose assertion that test still passes if the sanitizer hands back the uncoerced `array( '1' )`, so it cannot fail for the one reason it exists.

Worth flagging for review, since it is the easy thing to get wrong here: every schema in these particular tests declares `'type' => 'number'`, which returns `(float)`, so the expected values are floats rather than integers. That matches the convention already used by `test_type_number()` at the top of this file, which asserts `assertSame( 1.0, ... )`.

I checked each expected literal against its own schema rather than swapping the method names mechanically, which also means three values are deliberately left alone:

- `'d' => '1'` in the nested-properties test stays a string, because `d` has no matching entry in `properties`, no `patternProperties`, and `additionalProperties` is unset, so it is never coerced.
- The top-level `'b' => 1` in that same test stays an integer for the same reason.
- `'b' => 1` in `test_type_object()` likewise stays an integer.

The strict assertions now document that behaviour instead of glossing over it.

Only assertion methods and expected literals changed. The file already used `assertSame()` for 65 of its assertions, so this makes it consistent throughout.

One disclosure on verification: this box has no Docker/`wp-env`, so I could not run the full PHPUnit suite locally. I verified each conversion by reading the schema declared in each test and matching the expected literal to the type `rest_sanitize_value_from_schema()` returns for it, and `php -l` is clean. I would appreciate a CI run confirming it.

Trac ticket: https://core.trac.wordpress.org/ticket/64895

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 4.8
Used for: Helping locate candidate files and cross-check each expected literal against the schema type. I reviewed the conversions and take responsibility for the final code.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
