### PR TITLE
Media: Exclude IMG from crossorigin injection in media templates

### DIFF
--- a/src/wp-includes/media-template.php
+++ b/src/wp-includes/media-template.php
@@ -1619,11 +1619,17 @@ function wp_print_media_templates() {
 			 * The crossorigin attribute is added unconditionally to all relevant
 			 * media tags to ensure cross-origin isolation works regardless of
 			 * the final URL value at render time.
+			 *
+			 * IMG is intentionally excluded, matching wp_add_crossorigin_attributes().
+			 * Under Document-Isolation-Policy: isolate-and-credentialless the browser
+			 * loads cross-origin images in credentialless mode without CORS headers,
+			 * so adding crossorigin="anonymous" would force a CORS request and break
+			 * previews of images served without Access-Control-Allow-Origin headers.
 			 */
 			$template_processor = new WP_HTML_Tag_Processor( $script_processor->get_modifiable_text() );
 			while ( $template_processor->next_tag() ) {
 				if (
-					in_array( $template_processor->get_tag(), array( 'AUDIO', 'IMG', 'VIDEO' ), true )
+					in_array( $template_processor->get_tag(), array( 'AUDIO', 'VIDEO' ), true )
 					&& ! is_string( $template_processor->get_attribute( 'crossorigin' ) )
 				) {
 					$template_processor->set_attribute( 'crossorigin', 'anonymous' );

--- a/tests/phpunit/tests/media/wpCrossOriginIsolation.php
+++ b/tests/phpunit/tests/media/wpCrossOriginIsolation.php
@@ -538,4 +538,30 @@ class Tests_Media_wpCrossOriginIsolation extends WP_UnitTestCase {
 		// Script and audio should have crossorigin.
 		$this->assertSame( 2, substr_count( $output, 'crossorigin="anonymous"' ), 'Script and audio should both get crossorigin, but not img.' );
 	}
+
+	/**
+	 * IMG tags in the media manager templates must not receive
+	 * crossorigin="anonymous", matching wp_add_crossorigin_attributes().
+	 *
+	 * Adding the attribute forces a CORS request that breaks previews of
+	 * images served without Access-Control-Allow-Origin headers, such as
+	 * media offloaded to a CDN.
+	 *
+	 * @ticket 65673
+	 *
+	 * @covers ::wp_print_media_templates
+	 */
+	public function test_print_media_templates_does_not_add_crossorigin_to_img() {
+		require_once ABSPATH . WPINC . '/media-template.php';
+
+		add_filter( 'wp_client_side_media_processing_enabled', '__return_true' );
+
+		ob_start();
+		wp_print_media_templates();
+		$output = ob_get_clean();
+
+		$this->assertMatchesRegularExpression( '/<img\b/i', $output, 'Expected the media templates to contain IMG tags.' );
+		$this->assertDoesNotMatchRegularExpression( '/<img\b[^>]*\bcrossorigin\b/i', $output, 'IMG tags in the media templates must not receive a crossorigin attribute.' );
+		$this->assertMatchesRegularExpression( '/<(?:audio|video)\b[^>]*crossorigin="anonymous"/i', $output, 'AUDIO and VIDEO tags in the media templates should still receive crossorigin="anonymous".' );
+	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

Media library picker previews break for media served from a CDN (or any host without CORS headers) because `wp_print_media_templates()` injects crossorigin="anonymous" on IMG tags in the media manager Backbone templates.

What the problem was:
- When the client-side media processing feature was re-introduced in trunk, `wp_print_media_templates()` began adding crossorigin="anonymous" to AUDIO, IMG, and VIDEO tags in the media templates.
- This reintroduced, for the media library picker, the exact issue already fixed for `wp_add_crossorigin_attributes()` in [62048] (#64886).
- Under Document-Isolation-Policy: isolate-and-credentialless the browser loads cross-origin images in credentialless mode without CORS headers. Forcing crossorigin="anonymous" on IMG triggers a CORS request that fails for images served without Access-Control-Allow-Origin headers, so offloaded media previews break.

What the fix does:
- Removes IMG from the tags that receive crossorigin="anonymous" in `wp_print_media_templates()`, so it matches `wp_add_crossorigin_attributes()`.
- AUDIO and VIDEO tags continue to receive the attribute, unchanged.
- Adds a code comment explaining why IMG is excluded, to prevent recurrence.

Approach and why:
- Mirrors the established, intentional behaviour from [62048]; it is the minimal one-list change that resolves the regression without touching audio/video handling or the output-buffer path.

Trac ticket: https://core.trac.wordpress.org/ticket/65673

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 4.8
Used for: Ticket analysis, writing the unit tests, and PR Description. All changes were reviewed by me.
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**


---

## Commit message

```
Media: Exclude IMG tags from crossorigin injection in media templates.

The client-side media processing feature added `crossorigin="anonymous"` to AUDIO, IMG, and VIDEO tags in the Backbone media templates printed by `wp_print_media_templates()`. Forcing the attribute on IMG tags triggers CORS requests that fail for images served without `Access-Control-Allow-Origin` headers, breaking media library previews for media offloaded to a CDN.

This is the same problem previously fixed for `wp_add_crossorigin_attributes()` in [62048]: under `Document-Isolation-Policy: isolate-and-credentialless`, browsers load cross-origin images in credentialless mode, so the attribute is unnecessary on IMG tags. The media templates have a separate injection path that was missed at the time. Remove IMG from the list of tags receiving the attribute so both paths match. AUDIO and VIDEO tags are unchanged.

Follow-up to [62048].

Props khokansardar, iamchitti, ianmjones, swissspidy.
Fixes #65673.
```
