### PR TITLE
Media: Exclude IMG from cross-origin injection in media templates

### DIFF
--- a/src/wp-includes/media-template.php
+++ b/src/wp-includes/media-template.php
@@ -1619,11 +1619,15 @@ function wp_print_media_templates() {
 			 * The crossorigin attribute is added unconditionally to all relevant
 			 * media tags to ensure cross-origin isolation works regardless of
 			 * the final URL value at render time.
+			 *
+			 * IMG is excluded because credentialless mode already handles
+			 * cross-origin images; adding crossorigin would break previews for
+			 * media served without CORS headers (e.g. offloaded/CDN media).
 			 */
 			$template_processor = new WP_HTML_Tag_Processor( $script_processor->get_modifiable_text() );
 			while ( $template_processor->next_tag() ) {
 				if (
-					in_array( $template_processor->get_tag(), array( 'AUDIO', 'IMG', 'VIDEO' ), true )
+					in_array( $template_processor->get_tag(), array( 'AUDIO', 'VIDEO' ), true )
 					&& ! is_string( $template_processor->get_attribute( 'crossorigin' ) )
 				) {
 					$template_processor->set_attribute( 'crossorigin', 'anonymous' );

--- a/tests/phpunit/tests/media/wpCrossOriginIsolation.php
+++ b/tests/phpunit/tests/media/wpCrossOriginIsolation.php
@@ -7,6 +7,7 @@
  * @covers ::wp_set_up_cross_origin_isolation
  * @covers ::wp_start_cross_origin_isolation_output_buffer
  * @covers ::wp_is_client_side_media_processing_enabled
+ * @covers ::wp_print_media_templates
  */
 class Tests_Media_wpCrossOriginIsolation extends WP_UnitTestCase {
 
@@ -491,5 +492,63 @@ class Tests_Media_wpCrossOriginIsolation extends WP_UnitTestCase {
 
 		// Script and audio should have crossorigin.
 		$this->assertSame( 2, substr_count( $output, 'crossorigin="anonymous"' ), 'Script and audio should both get crossorigin, but not img.' );
+	}
+
+	/**
+	 * IMG tags in the Backbone media templates must not receive crossorigin.
+	 *
+	 * Media templates power the media library picker. Under
+	 * Document-Isolation-Policy: isolate-and-credentialless the browser already
+	 * loads cross-origin images in credentialless mode, so adding
+	 * crossorigin="anonymous" would force a CORS request and break previews for
+	 * offloaded/CDN media served without Access-Control-Allow-Origin headers.
+	 *
+	 * @ticket 65673
+	 */
+	public function test_media_templates_do_not_add_crossorigin_to_img() {
+		$_SERVER['HTTP_HOST'] = 'localhost';
+
+		$this->assertTrue(
+			wp_is_client_side_media_processing_enabled(),
+			'Client-side media processing should be enabled on localhost.'
+		);
+
+		require_once ABSPATH . WPINC . '/media-template.php';
+
+		ob_start();
+		wp_print_media_templates();
+		$output = ob_get_clean();
+
+		$this->assertDoesNotMatchRegularExpression(
+			'/<img\b[^>]*\bcrossorigin=/i',
+			$output,
+			'IMG tags in media templates should not receive a crossorigin attribute.'
+		);
+	}
+
+	/**
+	 * AUDIO and VIDEO tags in the media templates should still receive crossorigin.
+	 *
+	 * @ticket 65673
+	 */
+	public function test_media_templates_add_crossorigin_to_audio_and_video() {
+		$_SERVER['HTTP_HOST'] = 'localhost';
+
+		require_once ABSPATH . WPINC . '/media-template.php';
+
+		ob_start();
+		wp_print_media_templates();
+		$output = ob_get_clean();
+
+		$this->assertMatchesRegularExpression(
+			'/<audio\b[^>]*\bcrossorigin="anonymous"/i',
+			$output,
+			'AUDIO tags in media templates should receive crossorigin="anonymous".'
+		);
+		$this->assertMatchesRegularExpression(
+			'/<video\b[^>]*\bcrossorigin="anonymous"/i',
+			$output,
+			'VIDEO tags in media templates should receive crossorigin="anonymous".'
+		);
 	}
 }


### PR DESCRIPTION
## Trac ticket

https://core.trac.wordpress.org/ticket/65673

## Problem

Under `Document-Isolation-Policy: isolate-and-credentialless`, the browser already loads cross-origin images in credentialless mode without requiring CORS headers. Adding `crossorigin="anonymous"` overrides that and forces a CORS request, so images served from a host without `Access-Control-Allow-Origin` (e.g. offloaded/CDN media) fail to load.

The fix in https://core.trac.wordpress.org/changeset/62048 removed `IMG` from `wp_add_crossorigin_attributes()` in `media.php`, but the media library picker never uses that function. It has a separate injection path in https://github.com/i-am-chitti/wordpress-develop/blob/9ace411f9e9c39a16d989dce7b617835ef864561/src/wp-includes/media-template.php#L156 that rewrites the Backbone `<script type="text/html">` templates and adds `crossorigin="anonymous"` unconditionally to `AUDIO`, `IMG`, and `VIDEO`. That `IMG` entry was never part of the https://core.trac.wordpress.org/ticket/64886 fix — it has been present since the original backport, and returned to shipping builds when the client-side media processing feature was re-introduced in 7.1beta2. As a result, every `<img>` in the picker receives `crossorigin="anonymous"` and offloaded-media previews break.

## Fix

Remove `IMG` from the tag list in `wp_print_media_templates()`, keeping `AUDIO` and `VIDEO`, which still need the attribute for media processing and error reporting. This mirrors https://core.trac.wordpress.org/changeset/62048.

## Testing

Added regression coverage to `Tests_Media_wpCrossOriginIsolation`:

- `test_media_templates_do_not_add_crossorigin_to_img` — no `<img>` in the rendered media templates receives a `crossorigin` attribute.
- `test_media_templates_add_crossorigin_to_audio_and_video` — `<audio>`/`<video>` still receive `crossorigin="anonymous"`.

Manually verified against the rendered templates: `<img>` tags with `crossorigin` dropped from 17 → 0 with the fix, while `<audio>`/`<video>` stayed at 3 each.

### Manual reproduction

1. Rewrite attachment URLs to a non-CORS host (e.g. filter `wp_prepare_attachment_for_js` to point `url`/`sizes[*].url` at `https://placehold.jp/1024x768.jpg`). Mu-plugin here - https://gist.github.com/i-am-chitti/3bcbd7d41221a1fd7d8d65bb4ca61d2f
2. Open the media modal (Add Media / Image block → Media Library) and inspect a grid thumbnail: before the fix it carries `crossorigin="anonymous"` and fails with a CORS error; after the fix the attribute is gone and the preview loads.


## Screenshots 

Before - 

<img width="1470" height="885" alt="image" src="https://github.com/user-attachments/assets/11fec533-23db-42aa-98ab-20995a110bd3" />

After - 

<img width="1460" height="871" alt="image" src="https://github.com/user-attachments/assets/62032e73-f818-4345-974c-0b0cf0005efe" />


## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Opus 4.8
Used for: used to help investigate this issue and prepare the patch. All changes were reviewed, tested, and verified by me before submitting.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
