### PR TITLE
Comments: Update the Mine count after AJAX actions

### DIFF
--- a/src/js/_enqueues/admin/edit-comments.js
+++ b/src/js/_enqueues/admin/edit-comments.js
@@ -623,6 +623,10 @@ window.setCommentsList = function() {
 			}
 		}
 
+		if ( response.supplemental && 1 === parseInt( response.supplemental.is_current_user, 10 ) ) {
+			updateCountText( 'span.mine-count', ( pendingDiff || 0 ) + ( approvedDiff || 0 ) );
+		}
+
 		if ( pendingDiff ) {
 			updatePending( pendingDiff, commentPostId );
 			updateCountText( 'span.all-count', pendingDiff );
@@ -1155,6 +1159,7 @@ window.commentReply = {
 			updateInModerationText( r.supplemental );
 			updateApproved( 1, r.supplemental.parent_post_id );
 			updateCountText( 'span.all-count', 1 );
+			updateCountText( 'span.mine-count', 1 );
 		}
 
 		r.data = r.data || '';

--- a/src/js/_enqueues/admin/edit-comments.js
+++ b/src/js/_enqueues/admin/edit-comments.js
@@ -485,7 +485,7 @@ window.setCommentsList = function() {
 			targetParent = $( settings.target ).parent(),
 			commentRow = $('#' + settings.element),
 
-			spamDiff, trashDiff, pendingDiff, approvedDiff,
+			spamDiff, trashDiff, pendingDiff, approvedDiff, mineDiff,
 
 			/*
 			 * As `wpList` toggles only the `unapproved` class, the approved comment
@@ -623,8 +623,9 @@ window.setCommentsList = function() {
 			}
 		}
 
-		if ( response.supplemental && 1 === parseInt( response.supplemental.is_current_user, 10 ) ) {
-			updateCountText( 'span.mine-count', ( pendingDiff || 0 ) + ( approvedDiff || 0 ) );
+		mineDiff = ( pendingDiff || 0 ) + ( approvedDiff || 0 );
+		if ( mineDiff && response.supplemental && 1 === parseInt( response.supplemental.is_current_user, 10 ) ) {
+			updateCountText( 'span.mine-count', mineDiff );
 		}
 
 		if ( pendingDiff ) {

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -488,6 +488,7 @@ function _wp_ajax_delete_comment_response( $comment_id, $delta = -1 ) {
 				'supplemental' => array(
 					'status'               => $comment_status,
 					'postId'               => $comment ? $comment->comment_post_ID : '',
+					'is_current_user'      => (int) ( $comment && get_current_user_id() === (int) $comment->user_id ),
 					'time'                 => $time,
 					'in_moderation'        => $counts->moderated,
 					'i18n_comments_text'   => sprintf(
@@ -559,6 +560,7 @@ function _wp_ajax_delete_comment_response( $comment_id, $delta = -1 ) {
 			'supplemental' => array(
 				'status'               => $comment ? $comment->comment_approved : '',
 				'postId'               => $comment ? $comment->comment_post_ID : '',
+				'is_current_user'      => (int) ( $comment && get_current_user_id() === (int) $comment->user_id ),
 				/* translators: %s: Number of comments. */
 				'total_items_i18n'     => sprintf( _n( '%s item', '%s items', $total ), number_format_i18n( $total ) ),
 				'total_pages'          => (int) ceil( $total / $per_page ),

--- a/tests/phpunit/tests/ajax/wpAjaxDeleteComment.php
+++ b/tests/phpunit/tests/ajax/wpAjaxDeleteComment.php
@@ -272,6 +272,7 @@ class Tests_Ajax_wpAjaxDeleteComment extends WP_Ajax_UnitTestCase {
 	 * @covers ::_wp_ajax_delete_comment_response
 	 */
 	public function test_ajax_comment_trash_actions_as_administrator() {
+
 		// Test trash/untrash.
 		$this->_test_as_admin( self::$comments[0], 'trash' );
 		$this->_test_as_admin( self::$comments[0], 'untrash' );
@@ -282,6 +283,43 @@ class Tests_Ajax_wpAjaxDeleteComment extends WP_Ajax_UnitTestCase {
 
 		// Test delete.
 		$this->_test_as_admin( self::$comments[2], 'delete' );
+	}
+
+	/**
+	 * Tests that the response identifies a comment by the current user.
+	 *
+	 * @ticket 46017
+	 * @covers ::_wp_ajax_delete_comment_response
+	 */
+	public function test_ajax_comment_response_identifies_current_user_comment() {
+
+		$this->_setRole( 'administrator' );
+
+		$comment = self::$comments[3];
+		wp_update_comment(
+			array(
+				'comment_ID' => $comment->comment_ID,
+				'user_id'    => get_current_user_id(),
+			)
+		);
+
+		$_POST['id']          = $comment->comment_ID;
+		$_POST['_ajax_nonce'] = wp_create_nonce( 'delete-comment_' . $comment->comment_ID );
+		$_POST['trash']       = '1';
+		$_POST['_total']      = count( self::$comments );
+		$_POST['_per_page']   = '100';
+		$_POST['_page']       = '1';
+		$_POST['_url']        = admin_url( 'edit-comments.php' );
+
+		try {
+			$this->_handleAjax( 'delete-comment' );
+		} catch ( WPAjaxDieContinueException $e ) {
+			unset( $e );
+		}
+
+		$xml = simplexml_load_string( $this->_last_response, 'SimpleXMLElement', LIBXML_NOCDATA );
+
+		$this->assertSame( '1', (string) $xml->response[0]->comment[0]->supplemental[0]->is_current_user[0] );
 	}
 
 	/**


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

## Summary

- Updates the "Mine" comment count after replying to a comment through AJAX.
- Adds current-user ownership metadata to comment moderation AJAX responses.
- Uses the existing approved and pending deltas to update "Mine" only when the affected comment belongs to the current user.
- Adds regression coverage for the ownership metadata.

## Why

The comments screen already updates the All, Pending, Approved, Spam, and Trash counts after AJAX actions, but it does not update Mine. Moderation responses also did not expose enough information for the client to know whether the affected comment belonged to the current user.

## Testing

- `npm run test:php -- --group ajax --filter "Tests_Ajax_wpAjax(DeleteComment|DimComment|ReplytoComment)"` (18 tests, 132 assertions)
- `npm run test:php -- --group ajax --filter Tests_Ajax_wpAjaxDeleteComment` (6 tests, 85 assertions)
- PHPCBF and PHPCS with `phpcs.xml.dist` on both touched PHP files
- JavaScript JSHint passed for `src/js/_enqueues/admin/edit-comments.js`

Trac ticket: https://core.trac.wordpress.org/ticket/46017

## Use of AI Tools

AI assistance: Yes
Tool(s): OpenAI Codex
Model(s): GPT-5
Used for: Reviewing the Trac ticket and relevant code, helping with the initial implementation and regression-test approach, and assisting with validation and PR-description drafting. The final implementation, tests, validation results, and description were reviewed and accepted by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**