### PR TITLE
Login and Registration: Add support for /.well-known/change-password

### DIFF
--- a/src/wp-includes/canonical.php
+++ b/src/wp-includes/canonical.php
@@ -1067,4 +1067,22 @@ function wp_redirect_admin_locations() {
 		wp_redirect( wp_login_url() );
 		exit;
 	}
+
+	$password_change_urls = array(
+		home_url( '.well-known/change-password', 'relative' ),
+		site_url( '.well-known/change-password', 'relative' ),
+	);
+
+	if ( in_array( untrailingslashit( $_SERVER['REQUEST_URI'] ), $password_change_urls, true ) ) {
+		/**
+		 * Filters the URL to redirect to when a browser or password manager
+		 * requests the well-known change-password URL (/.well-known/change-password).
+		 *
+		 * @since 6.9.0
+		 *
+		 * @param string $url The URL to redirect to. Default is the user profile page.
+		 */
+		wp_redirect( apply_filters( 'wp_change_password_url', admin_url( 'profile.php' ) ) );
+		exit;
+	}
 }

--- a/src/wp-includes/canonical.php
+++ b/src/wp-includes/canonical.php
@@ -1069,6 +1069,7 @@ function wp_redirect_admin_locations() {
 	}
 
 	$password_change_urls = array(
+		'/.well-known/change-password',
 		home_url( '.well-known/change-password', 'relative' ),
 		site_url( '.well-known/change-password', 'relative' ),
 	);

--- a/src/wp-includes/canonical.php
+++ b/src/wp-includes/canonical.php
@@ -1068,18 +1068,18 @@ function wp_redirect_admin_locations() {
 		exit;
 	}
 
-	$password_change_urls = array(
-		'/.well-known/change-password',
-		home_url( '.well-known/change-password', 'relative' ),
-		site_url( '.well-known/change-password', 'relative' ),
-	);
-
-	if ( in_array( untrailingslashit( $_SERVER['REQUEST_URI'] ), $password_change_urls, true ) ) {
+	/*
+	 * The well-known change-password URL is always at the root of the origin
+	 * per the spec (https://w3c.github.io/webappsec-change-password-url/), so
+	 * only the root-relative path is matched here, regardless of whether
+	 * WordPress is installed in a subdirectory.
+	 */
+	if ( '/.well-known/change-password' === untrailingslashit( $_SERVER['REQUEST_URI'] ) ) {
 		/**
 		 * Filters the URL to redirect to when a browser or password manager
 		 * requests the well-known change-password URL (/.well-known/change-password).
 		 *
-		 * @since 6.9.0
+		 * @since 7.2.0
 		 *
 		 * @param string $url The URL to redirect to. Default is the user profile page.
 		 */

--- a/tests/phpunit/tests/canonical/changePassword.php
+++ b/tests/phpunit/tests/canonical/changePassword.php
@@ -93,8 +93,8 @@ class Tests_Canonical_ChangePassword extends WP_UnitTestCase {
 	 */
 	public function test_wp_change_password_url_filter() {
 		$custom_url = 'https://example.com/my-account/change-password/';
+		$filter     = static fn() => $custom_url;
 
-		$filter = static fn() => $custom_url;
 		add_filter( 'wp_change_password_url', $filter );
 		$redirect = $this->get_redirect_for( '/.well-known/change-password' );
 		remove_filter( 'wp_change_password_url', $filter );

--- a/tests/phpunit/tests/canonical/changePassword.php
+++ b/tests/phpunit/tests/canonical/changePassword.php
@@ -11,6 +11,13 @@
 class Tests_Canonical_ChangePassword extends WP_UnitTestCase {
 
 	/**
+	 * Whether REQUEST_URI was set before the test.
+	 *
+	 * @var bool
+	 */
+	private $request_uri_was_set;
+
+	/**
 	 * Original REQUEST_URI value.
 	 *
 	 * @var string
@@ -19,12 +26,17 @@ class Tests_Canonical_ChangePassword extends WP_UnitTestCase {
 
 	public function set_up() {
 		parent::set_up();
+		$this->request_uri_was_set  = isset( $_SERVER['REQUEST_URI'] );
 		$this->original_request_uri = $_SERVER['REQUEST_URI'] ?? '';
 		$this->set_permalink_structure( '/%postname%/' );
 	}
 
 	public function tear_down() {
-		$_SERVER['REQUEST_URI'] = $this->original_request_uri;
+		if ( $this->request_uri_was_set ) {
+			$_SERVER['REQUEST_URI'] = $this->original_request_uri;
+		} else {
+			unset( $_SERVER['REQUEST_URI'] );
+		}
 		parent::tear_down();
 	}
 
@@ -39,6 +51,7 @@ class Tests_Canonical_ChangePassword extends WP_UnitTestCase {
 		$_SERVER['REQUEST_URI'] = $request_uri;
 
 		global $wp_query;
+		$original_is_404  = $wp_query->is_404;
 		$wp_query->is_404 = true;
 
 		$captured = null;
@@ -55,7 +68,7 @@ class Tests_Canonical_ChangePassword extends WP_UnitTestCase {
 			// Redirect was intercepted; $captured holds the URL.
 		} finally {
 			remove_filter( 'wp_redirect', $capture );
-			$wp_query->is_404 = false;
+			$wp_query->is_404 = $original_is_404;
 		}
 
 		return $captured;
@@ -66,6 +79,7 @@ class Tests_Canonical_ChangePassword extends WP_UnitTestCase {
 	 */
 	public function test_well_known_change_password_redirects_to_profile() {
 		$redirect = $this->get_redirect_for( '/.well-known/change-password' );
+		$this->assertNotNull( $redirect, 'A redirect should fire for the well-known change-password URL.' );
 		$this->assertStringContainsString( 'profile.php', $redirect, 'Should redirect to the profile page.' );
 	}
 
@@ -74,6 +88,7 @@ class Tests_Canonical_ChangePassword extends WP_UnitTestCase {
 	 */
 	public function test_well_known_change_password_with_trailing_slash_redirects_to_profile() {
 		$redirect = $this->get_redirect_for( '/.well-known/change-password/' );
+		$this->assertNotNull( $redirect, 'A redirect should fire for the trailing-slash variant.' );
 		$this->assertStringContainsString( 'profile.php', $redirect, 'Trailing slash variant should also redirect to the profile page.' );
 	}
 

--- a/tests/phpunit/tests/canonical/changePassword.php
+++ b/tests/phpunit/tests/canonical/changePassword.php
@@ -45,16 +45,18 @@ class Tests_Canonical_ChangePassword extends WP_UnitTestCase {
 
 		$capture = static function ( $location ) use ( &$captured ) {
 			$captured = $location;
-			// Return empty string so wp_redirect() sends no Location header
-			// and doesn't exit; execution returns to our caller.
-			return '';
+			throw new RuntimeException( 'Redirect intercepted.' );
 		};
 
 		add_filter( 'wp_redirect', $capture );
-		wp_redirect_admin_locations();
-		remove_filter( 'wp_redirect', $capture );
-
-		$wp_query->is_404 = false;
+		try {
+			wp_redirect_admin_locations();
+		} catch ( RuntimeException $e ) {
+			// Redirect was intercepted; $captured holds the URL.
+		} finally {
+			remove_filter( 'wp_redirect', $capture );
+			$wp_query->is_404 = false;
+		}
 
 		return $captured;
 	}
@@ -70,9 +72,9 @@ class Tests_Canonical_ChangePassword extends WP_UnitTestCase {
 	/**
 	 * @covers ::wp_redirect_admin_locations
 	 */
-	public function test_well_known_change_password_with_trailing_slash_does_not_redirect() {
+	public function test_well_known_change_password_with_trailing_slash_redirects_to_profile() {
 		$redirect = $this->get_redirect_for( '/.well-known/change-password/' );
-		$this->assertNull( $redirect, 'Trailing slash variant should not redirect (untrailingslashit handles exact match only).' );
+		$this->assertStringContainsString( 'profile.php', $redirect, 'Trailing slash variant should also redirect to the profile page.' );
 	}
 
 	/**
@@ -81,24 +83,9 @@ class Tests_Canonical_ChangePassword extends WP_UnitTestCase {
 	public function test_well_known_change_password_no_redirect_without_pretty_permalinks() {
 		$this->set_permalink_structure( '' );
 
-		$_SERVER['REQUEST_URI'] = '/.well-known/change-password';
+		$redirect = $this->get_redirect_for( '/.well-known/change-password' );
 
-		global $wp_query;
-		$wp_query->is_404 = true;
-
-		$captured = null;
-		$capture  = static function ( $location ) use ( &$captured ) {
-			$captured = $location;
-			return '';
-		};
-
-		add_filter( 'wp_redirect', $capture );
-		wp_redirect_admin_locations();
-		remove_filter( 'wp_redirect', $capture );
-
-		$wp_query->is_404 = false;
-
-		$this->assertNull( $captured, 'Should not redirect when pretty permalinks are disabled.' );
+		$this->assertNull( $redirect, 'Should not redirect when pretty permalinks are disabled.' );
 	}
 
 	/**
@@ -107,9 +94,10 @@ class Tests_Canonical_ChangePassword extends WP_UnitTestCase {
 	public function test_wp_change_password_url_filter() {
 		$custom_url = 'https://example.com/my-account/change-password/';
 
-		add_filter( 'wp_change_password_url', static fn() => $custom_url );
+		$filter = static fn() => $custom_url;
+		add_filter( 'wp_change_password_url', $filter );
 		$redirect = $this->get_redirect_for( '/.well-known/change-password' );
-		remove_all_filters( 'wp_change_password_url' );
+		remove_filter( 'wp_change_password_url', $filter );
 
 		$this->assertSame( $custom_url, $redirect );
 	}

--- a/tests/phpunit/tests/canonical/changePassword.php
+++ b/tests/phpunit/tests/canonical/changePassword.php
@@ -1,0 +1,116 @@
+<?php
+
+/**
+ * Tests for the /.well-known/change-password redirect.
+ *
+ * @group canonical
+ * @group rewrite
+ * @group query
+ * @ticket 51173
+ */
+class Tests_Canonical_ChangePassword extends WP_UnitTestCase {
+
+	/**
+	 * Original REQUEST_URI value.
+	 *
+	 * @var string
+	 */
+	private $original_request_uri;
+
+	public function set_up() {
+		parent::set_up();
+		$this->original_request_uri = $_SERVER['REQUEST_URI'] ?? '';
+		$this->set_permalink_structure( '/%postname%/' );
+	}
+
+	public function tear_down() {
+		$_SERVER['REQUEST_URI'] = $this->original_request_uri;
+		parent::tear_down();
+	}
+
+	/**
+	 * Returns the redirect URL triggered by wp_redirect_admin_locations()
+	 * for the given REQUEST_URI, or null if no redirect fires.
+	 *
+	 * @param string $request_uri
+	 * @return string|null
+	 */
+	private function get_redirect_for( $request_uri ) {
+		$_SERVER['REQUEST_URI'] = $request_uri;
+
+		global $wp_query;
+		$wp_query->is_404 = true;
+
+		$captured = null;
+
+		$capture = static function ( $location ) use ( &$captured ) {
+			$captured = $location;
+			// Return empty string so wp_redirect() sends no Location header
+			// and doesn't exit; execution returns to our caller.
+			return '';
+		};
+
+		add_filter( 'wp_redirect', $capture );
+		wp_redirect_admin_locations();
+		remove_filter( 'wp_redirect', $capture );
+
+		$wp_query->is_404 = false;
+
+		return $captured;
+	}
+
+	/**
+	 * @covers ::wp_redirect_admin_locations
+	 */
+	public function test_well_known_change_password_redirects_to_profile() {
+		$redirect = $this->get_redirect_for( '/.well-known/change-password' );
+		$this->assertStringContainsString( 'profile.php', $redirect, 'Should redirect to the profile page.' );
+	}
+
+	/**
+	 * @covers ::wp_redirect_admin_locations
+	 */
+	public function test_well_known_change_password_with_trailing_slash_does_not_redirect() {
+		$redirect = $this->get_redirect_for( '/.well-known/change-password/' );
+		$this->assertNull( $redirect, 'Trailing slash variant should not redirect (untrailingslashit handles exact match only).' );
+	}
+
+	/**
+	 * @covers ::wp_redirect_admin_locations
+	 */
+	public function test_well_known_change_password_no_redirect_without_pretty_permalinks() {
+		$this->set_permalink_structure( '' );
+
+		$_SERVER['REQUEST_URI'] = '/.well-known/change-password';
+
+		global $wp_query;
+		$wp_query->is_404 = true;
+
+		$captured = null;
+		$capture  = static function ( $location ) use ( &$captured ) {
+			$captured = $location;
+			return '';
+		};
+
+		add_filter( 'wp_redirect', $capture );
+		wp_redirect_admin_locations();
+		remove_filter( 'wp_redirect', $capture );
+
+		$wp_query->is_404 = false;
+
+		$this->assertNull( $captured, 'Should not redirect when pretty permalinks are disabled.' );
+	}
+
+	/**
+	 * @covers ::wp_redirect_admin_locations
+	 */
+	public function test_wp_change_password_url_filter() {
+		$custom_url = 'https://example.com/my-account/change-password/';
+
+		add_filter( 'wp_change_password_url', static fn() => $custom_url );
+		$redirect = $this->get_redirect_for( '/.well-known/change-password' );
+		remove_all_filters( 'wp_change_password_url' );
+
+		$this->assertSame( $custom_url, $redirect );
+	}
+}


### PR DESCRIPTION
Fixes https://core.trac.wordpress.org/ticket/51173

## What

Adds a redirect from `/.well-known/change-password` to `wp-admin/profile.php` inside the existing `wp_redirect_admin_locations()` function in `canonical.php`. This follows the [W3C Well-Known Change Password URL spec](https://www.w3.org/TR/change-password-url/).

## Why

Browsers (Chrome, Safari, Firefox) and password managers use `/.well-known/change-password` to automatically navigate users to the password-change page. Without this redirect, WordPress sites return a 404 for this URL, breaking password manager integrations.

## How

- Adds `/.well-known/change-password` detection to `wp_redirect_admin_locations()`, mirroring the existing pattern for `/login` and `/admin` aliases.
- Redirects to `admin_url( 'profile.php' )` — the profile page handles unauthenticated users by redirecting them to the login page with `redirect_to` set back to the profile page.
- A `wp_change_password_url` filter allows sites with custom user flows (membership plugins, WooCommerce accounts) to override the redirect target.
- Only fires when pretty permalinks are enabled (same guard as the rest of the function).

## Tests

Adds `tests/phpunit/tests/canonical/changePassword.php` covering:
- Redirect fires for `/.well-known/change-password`
- Trailing-slash variant does not redirect (consistent with `untrailingslashit` behavior elsewhere)
- No redirect when pretty permalinks are disabled
- `wp_change_password_url` filter is respected