### PR TITLE
Taxonomy: Fix strtolower() deprecation in WP_Term_Query::parse_orderby()

### DIFF
--- a/src/wp-includes/class-wp-term-query.php
+++ b/src/wp-includes/class-wp-term-query.php
@@ -918,6 +918,10 @@ class WP_Term_Query {
 	 * @return string|false Value to used in the ORDER clause. False otherwise.
 	 */
 	protected function parse_orderby( $orderby_raw ) {
+		if ( ! is_string( $orderby_raw ) ) {
+			$orderby_raw = '';
+		}
+
 		$_orderby           = strtolower( $orderby_raw );
 		$maybe_orderby_meta = false;
 

--- a/tests/phpunit/tests/term/query.php
+++ b/tests/phpunit/tests/term/query.php
@@ -286,6 +286,28 @@ class Tests_Term_Query extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The absence of a deprecation notice on PHP 8.1+ also shows that the issue is resolved.
+	 *
+	 * @ticket 65679
+	 */
+	public function test_orderby_null_should_not_throw_deprecation() {
+		register_taxonomy( 'wptests_tax_1', 'post' );
+
+		$terms = self::factory()->term->create_many( 2, array( 'taxonomy' => 'wptests_tax_1' ) );
+
+		$q = new WP_Term_Query(
+			array(
+				'taxonomy'   => 'wptests_tax_1',
+				'orderby'    => null,
+				'hide_empty' => false,
+				'fields'     => 'ids',
+			)
+		);
+
+		$this->assertSame( $terms, $q->terms );
+	}
+
+	/**
 	 * @ticket 37198
 	 */
 	public function test_object_ids_single() {

--- a/tests/phpunit/tests/term/query.php
+++ b/tests/phpunit/tests/term/query.php
@@ -293,7 +293,18 @@ class Tests_Term_Query extends WP_UnitTestCase {
 	public function test_orderby_null_should_not_throw_deprecation() {
 		register_taxonomy( 'wptests_tax_1', 'post' );
 
-		$terms = self::factory()->term->create_many( 2, array( 'taxonomy' => 'wptests_tax_1' ) );
+		$t1 = self::factory()->term->create(
+			array(
+				'taxonomy' => 'wptests_tax_1',
+				'name'     => 'b',
+			)
+		);
+		$t2 = self::factory()->term->create(
+			array(
+				'taxonomy' => 'wptests_tax_1',
+				'name'     => 'a',
+			)
+		);
 
 		$q = new WP_Term_Query(
 			array(
@@ -304,7 +315,7 @@ class Tests_Term_Query extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertSame( $terms, $q->terms );
+		$this->assertSame( array( $t1, $t2 ), $q->terms );
 	}
 
 	/**


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

`WP_Term_Query::parse_orderby()` passes the `orderby` query var straight into `strtolower()`. If a caller explicitly passes `'orderby' => null`, this triggers a `Deprecated: strtolower(): Passing null to parameter #1 ($string) of type string is deprecated` notice on PHP 8.1+.

`parse_order()` in the same class already guards against this with an `is_string()` check; this PR adds the same guard to `parse_orderby()`. A `null` value now falls through to the existing empty-string handling, preserving the current `ORDER BY t.term_id` fallback behavior with no notice.

Adds a test asserting no deprecation is thrown and that ordering falls back to `term_id` as before.

Trac ticket: https://core.trac.wordpress.org/ticket/65679

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->
AI assistance: Yes
Tool(s): Opencode
Model(s): DeepSeek V4 Flash
Used for: Diagnosing the issue.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
