### PR TITLE
Icons: Reject icon names ending in a hyphen or underscore.

### DIFF
--- a/src/wp-includes/class-wp-icons-registry.php
+++ b/src/wp-includes/class-wp-icons-registry.php
@@ -92,10 +92,10 @@ class WP_Icons_Registry {
 			return false;
 		}
 
-		if ( ! preg_match( '/^[a-z0-9][a-z0-9_-]*$/', $unqualified_name ) ) {
+		if ( ! preg_match( '/^[a-z0-9]([a-z0-9_-]*[a-z0-9])?$/', $unqualified_name ) ) {
 			_doing_it_wrong(
 				__METHOD__,
-				__( 'Icon names must start with a lowercase letter or digit and contain only lowercase letters, digits, hyphens, and underscores.' ),
+				__( 'Icon names must start and end with a lowercase letter or digit and contain only lowercase letters, digits, hyphens, and underscores.' ),
 				'7.1.0'
 			);
 			return false;

--- a/src/wp-includes/class-wp-icons-registry.php
+++ b/src/wp-includes/class-wp-icons-registry.php
@@ -92,7 +92,7 @@ class WP_Icons_Registry {
 			return false;
 		}
 
-		if ( ! preg_match( '/^[a-z0-9]([a-z0-9_-]*[a-z0-9])?$/', $unqualified_name ) ) {
+		if ( ! preg_match( '/^[a-z0-9](?:[a-z0-9_-]*[a-z0-9])?$/', $unqualified_name ) ) {
 			_doing_it_wrong(
 				__METHOD__,
 				__( 'Icon names must start and end with a lowercase letter or digit and contain only lowercase letters, digits, hyphens, and underscores.' ),

--- a/tests/phpunit/tests/icons/wpIconsRegistry.php
+++ b/tests/phpunit/tests/icons/wpIconsRegistry.php
@@ -82,12 +82,14 @@ class Tests_Icons_WpIconsRegistry extends WP_UnitTestCase {
 	 */
 	public function data_valid_icon_names() {
 		return array(
-			'simple name'            => array( 'test-collection/icon' ),
-			'digit at the start'     => array( 'test-collection/1icon' ),
-			'digit in the name'      => array( 'test-collection/my1icon' ),
-			'digit at the end'       => array( 'test-collection/icon1' ),
-			'underscore in the name' => array( 'test-collection/my_icon' ),
-			'hyphen in the name'     => array( 'test-collection/my-icon' ),
+			'simple name'                     => array( 'test-collection/icon' ),
+			'digit at the start'              => array( 'test-collection/1icon' ),
+			'digit in the name'               => array( 'test-collection/my1icon' ),
+			'digit at the end'                => array( 'test-collection/icon1' ),
+			'underscore in the name'          => array( 'test-collection/my_icon' ),
+			'hyphen in the name'              => array( 'test-collection/my-icon' ),
+			'digit adjacent to a hyphen'      => array( 'test-collection/my-1-icon' ),
+			'digit adjacent to an underscore' => array( 'test-collection/my_1_icon' ),
 		);
 	}
 

--- a/tests/phpunit/tests/icons/wpIconsRegistry.php
+++ b/tests/phpunit/tests/icons/wpIconsRegistry.php
@@ -76,15 +76,15 @@ class Tests_Icons_WpIconsRegistry extends WP_UnitTestCase {
 
 	/**
 	 * Provides valid namespaced icon names, including names that contain,
-	 * start or end with digits, as well as underscores.
+	 * start or end with digits, as well as underscores and hyphens.
 	 *
 	 * @return array<string, array{0: string}>
 	 */
 	public function data_valid_icon_names() {
 		return array(
-			'simple name'            => array( 'test-collection/my-icon' ),
-			'digit at the start'     => array( 'test-collection/1-icon' ),
-			'digit in the name'      => array( 'test-collection/my-1-icon' ),
+			'simple name'            => array( 'test-collection/icon' ),
+			'digit at the start'     => array( 'test-collection/1icon' ),
+			'digit in the name'      => array( 'test-collection/my1icon' ),
 			'digit at the end'       => array( 'test-collection/icon1' ),
 			'underscore in the name' => array( 'test-collection/my_icon' ),
 			'hyphen in the name'     => array( 'test-collection/my-icon' ),

--- a/tests/phpunit/tests/icons/wpIconsRegistry.php
+++ b/tests/phpunit/tests/icons/wpIconsRegistry.php
@@ -75,8 +75,8 @@ class Tests_Icons_WpIconsRegistry extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Provides valid namespaced icon names, including names that contain or
-	 * start with digits, as well as underscores.
+	 * Provides valid namespaced icon names, including names that contain,
+	 * start or end with digits, as well as underscores.
 	 *
 	 * @return array<string, array{0: string}>
 	 */
@@ -87,8 +87,7 @@ class Tests_Icons_WpIconsRegistry extends WP_UnitTestCase {
 			'digit in the name'      => array( 'test-collection/my-1-icon' ),
 			'digit at the end'       => array( 'test-collection/icon1' ),
 			'underscore in the name' => array( 'test-collection/my_icon' ),
-			'underscore at the end'  => array( 'test-collection/my-icon_' ),
-			'hyphen at the end'      => array( 'test-collection/my-icon-' ),
+			'hyphen in the name'     => array( 'test-collection/my-icon' ),
 		);
 	}
 
@@ -125,7 +124,9 @@ class Tests_Icons_WpIconsRegistry extends WP_UnitTestCase {
 			'uppercase in the name'   => array( 'test-collection/my-Icon' ),
 			'uppercase at the end'    => array( 'test-collection/my-iconX' ),
 			'underscore at the start' => array( 'test-collection/_my-icon' ),
+			'underscore at the end'   => array( 'test-collection/my-icon_' ),
 			'hyphen at the start'     => array( 'test-collection/-my-icon' ),
+			'hyphen at the end'       => array( 'test-collection/my-icon-' ),
 		);
 	}
 

--- a/tests/phpunit/tests/icons/wpIconsRegistry.php
+++ b/tests/phpunit/tests/icons/wpIconsRegistry.php
@@ -82,6 +82,7 @@ class Tests_Icons_WpIconsRegistry extends WP_UnitTestCase {
 	 */
 	public function data_valid_icon_names() {
 		return array(
+			'single character'                => array( 'test-collection/a' ),
 			'simple name'                     => array( 'test-collection/icon' ),
 			'digit at the start'              => array( 'test-collection/1icon' ),
 			'digit in the name'               => array( 'test-collection/my1icon' ),


### PR DESCRIPTION
There was a mismatch in the validation of allowed icon names. The REST route does not allow names ending with `_` or `-`, but the icon registry does. While names ending with those characters are not supposed to be allowed, I believe a discrepancy arose due to repeated synchronization between Gutenberg and core. This mismatch does not exist on the Gutenberg side.

As a result of this PR, the rules for icon names expected by core and Gutenberg will be completely consistent.

- Vaild icon names:
  - Core: https://github.com/t-hamano/wordpress-develop/blob/7920dd05d86715cae434a1302f68a41199abfc54/tests/phpunit/tests/icons/wpIconsRegistry.php#L83-L93
  - Gutenberg: https://github.com/WordPress/gutenberg/blob/f0b3a342845d949bd9d845eba800d7c811785818/phpunit/class-wp-icons-registry-gutenberg-test.php#L105-L114
- Invalid icon names:
  - Core: https://github.com/t-hamano/wordpress-develop/blob/7920dd05d86715cae434a1302f68a41199abfc54/tests/phpunit/tests/icons/wpIconsRegistry.php#L117-L130
  - Gutenberg: https://github.com/WordPress/gutenberg/blob/f0b3a342845d949bd9d845eba800d7c811785818/phpunit/class-wp-icons-registry-gutenberg-test.php#L139-L154


Trac ticket: https://core.trac.wordpress.org/ticket/64847

## Use of AI Tools

Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
