### PR TITLE
Code Modernization: Fix null to non-nullable deprecation in WP_Term_Query::parse_orderby()

### DIFF
--- a/src/wp-includes/class-wp-term-query.php
+++ b/src/wp-includes/class-wp-term-query.php
@@ -918,7 +918,7 @@ class WP_Term_Query {
 	 * @return string|false Value to used in the ORDER clause. False otherwise.
 	 */
 	protected function parse_orderby( $orderby_raw ) {
-		$_orderby           = strtolower( $orderby_raw );
+		$_orderby           = strtolower( (string) $orderby_raw );
 		$maybe_orderby_meta = false;
 
 		if ( in_array( $_orderby, array( 'term_id', 'name', 'slug', 'term_group' ), true ) ) {

--- a/tests/phpunit/tests/term/getTerms.php
+++ b/tests/phpunit/tests/term/getTerms.php
@@ -1965,6 +1965,39 @@ class Tests_Term_getTerms extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Ensures a null 'orderby' falls back to term ID without a deprecation
+	 * notice on PHP 8.1 and above.
+	 *
+	 * @ticket 65679
+	 */
+	public function test_orderby_null_should_be_treated_as_term_id() {
+		register_taxonomy( 'wptests_tax', 'post' );
+		$t1 = self::factory()->term->create(
+			array(
+				'taxonomy' => 'wptests_tax',
+				'name'     => 'ZZZ',
+			)
+		);
+		$t2 = self::factory()->term->create(
+			array(
+				'taxonomy' => 'wptests_tax',
+				'name'     => 'AAA',
+			)
+		);
+
+		$found = get_terms(
+			array(
+				'taxonomy'   => 'wptests_tax',
+				'orderby'    => null,
+				'hide_empty' => false,
+				'fields'     => 'ids',
+			)
+		);
+
+		$this->assertSame( array( $t1, $t2 ), $found );
+	}
+
+	/**
 	 * @ticket 34996
 	 */
 	public function test_orderby_meta_value() {


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

`WP_Term_Query::parse_orderby()` passes the raw `orderby` query var straight to `strtolower()`. When that value is `null`, PHP 8.1+ emits a deprecation notice. This casts the value to string first, which silences the notice without altering any existing behaviour.

What the problem was:
- `get_terms( array( 'orderby' => null ) )` emitted `strtolower(): Passing null to parameter #1 ($string) of type string is deprecated` on PHP 8.1 and above, at `wp-includes/class-wp-term-query.php:921`.
- `'orderby'` defaults to `'name'`, but `wp_parse_args()` lets a caller override it with an explicit `null`, so the value reaches `strtolower()` unguarded.
- The method already handles a falsy value correctly further down — the `empty( $_orderby )` branch orders by `t.term_id`. Only the notice was wrong.

What the fix does:
- Casts the raw value to string before lowercasing: `strtolower( (string) $orderby_raw )`.
- Adds a regression test covering a `null` `orderby`.

Approach and why:
- One line, at the exact point of failure. This matches how Core has fixed the same class of issue in sibling query classes — see [51806], which guarded `WP_Comment_Query::get_comment_ids()` at its call site rather than reworking the method.
- A `(string)` cast was chosen over an `is_string()` guard (the idiom used by the neighbouring `parse_order()`) deliberately. The cast reproduces PHP's pre-8.1 implicit coercion exactly for every scalar type — `null`/`false` → `''`, `5` → `'5'`, `true` → `'1'` — so behaviour is unchanged for all of them.
- An `is_string()` guard would not be behaviour-preserving: `parse_orderby_meta()` resolves the value via `array_key_exists( $orderby_raw, $meta_clauses )`, and unnamed `meta_query` clauses receive integer keys. PHP normalises numeric string keys to integers, so `array_key_exists( '5', array( 5 => ... ) )` is `true` — meaning a numeric `orderby` can legitimately reference a meta clause today. Discarding non-strings would silently break that ordering.
- The `@param string` docblock is left as-is; the cast is defensive against callers, not a signature change.

Trac ticket: https://core.trac.wordpress.org/ticket/65679

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 4.8
Used for: Writting test case and PR desription. All changes were reviewed and tested by me.
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
