### PR TITLE
Administration: Add box reordering toggle to Screen Options.

### DIFF
--- a/src/js/_enqueues/admin/common.js
+++ b/src/js/_enqueues/admin/common.js
@@ -1845,7 +1845,7 @@ $( function() {
 			$document.on( 'postbox-toggled', this.maybeDisableSortables );
 
 			// When the screen columns are changed, potentially disable sortables.
-			$( '#screen-options-wrap input' ).on( 'click', this.maybeDisableSortables );
+			$( '#screen-options-wrap input:not(.meta-box-reordering-toggle)' ).on( 'click', this.maybeDisableSortables );
 		},
 
 		/**

--- a/src/js/_enqueues/admin/common.js
+++ b/src/js/_enqueues/admin/common.js
@@ -1859,6 +1859,7 @@ $( function() {
 			var width = navigator.userAgent.indexOf('AppleWebKit/') > -1 ? $window.width() : window.innerWidth;
 
 			if (
+				$body.hasClass( 'meta-box-reordering-disabled' ) ||
 				( width <= 782 ) ||
 				( 1 >= $sortables.find( '.ui-sortable-handle:visible' ).length && jQuery( '.columns-prefs-1 input' ).prop( 'checked' ) )
 			) {

--- a/src/js/_enqueues/admin/postbox.js
+++ b/src/js/_enqueues/admin/postbox.js
@@ -104,6 +104,10 @@
 				postboxWithinSortablesIndex = postboxesWithinSortables.index( postbox ),
 				firstOrLastPositionMessage;
 
+			if ( ! postboxes.metaBoxReorderingEnabled ) {
+				return;
+			}
+
 			if ( 'dashboard_browser_nag' === postboxId ) {
 				return;
 			}
@@ -344,6 +348,13 @@
 					postboxes.save_order( page );
 				}
 			});
+
+			$( '.meta-box-reordering-toggle' ).on( 'click.postboxes', function() {
+				var enabled = $( this ).prop( 'checked' );
+
+				postboxes.setMetaBoxReordering( enabled );
+				postboxes.save_meta_box_reordering_state( enabled );
+			} );
 		},
 
 		/**
@@ -419,6 +430,8 @@
 				}
 			});
 
+			this.setMetaBoxReordering( this.isMetaBoxReorderingEnabled() );
+
 			if ( isMobile ) {
 				$(document.body).on('orientationchange.postboxes', function(){ postboxes._pb_change(); });
 				this._pb_change();
@@ -435,6 +448,68 @@
 				var $el = $( this );
 				$el.attr( 'aria-expanded', ! $el.closest( '.postbox' ).hasClass( 'closed' ) );
 			});
+		},
+
+		/**
+		 * Checks whether meta box reordering is enabled.
+		 *
+		 * @since 7.1.0
+		 *
+		 * @return {boolean} Whether meta box reordering is enabled.
+		 */
+		isMetaBoxReorderingEnabled: function() {
+			var $toggle = $( '#meta-box-reordering' );
+
+			if ( $toggle.length ) {
+				return $toggle.prop( 'checked' );
+			}
+
+			return ! $( document.body ).hasClass( 'meta-box-reordering-disabled' );
+		},
+
+		/**
+		 * Enables or disables the meta box reordering UI.
+		 *
+		 * @since 7.1.0
+		 *
+		 * @param {boolean} enabled Whether reordering should be enabled.
+		 * @return {void}
+		 */
+		setMetaBoxReordering: function( enabled ) {
+			var $body = $( document.body ),
+				$orderButtons = $( '.postbox .handle-order-higher, .postbox .handle-order-lower' );
+
+			this.metaBoxReorderingEnabled = !! enabled;
+
+			$body
+				.toggleClass( 'meta-box-reordering-enabled', this.metaBoxReorderingEnabled )
+				.toggleClass( 'meta-box-reordering-disabled', ! this.metaBoxReorderingEnabled );
+
+			if ( this.metaBoxReorderingEnabled ) {
+				$orderButtons
+					.prop( 'disabled', false )
+					.removeAttr( 'tabindex aria-hidden' );
+				this.updateOrderButtonsProperties();
+			} else {
+				$orderButtons
+					.prop( 'disabled', true )
+					.attr( {
+						'aria-hidden': 'true',
+						tabindex: '-1'
+					} );
+			}
+
+			if ( window.wpResponsive && window.wpResponsive.maybeDisableSortables ) {
+				window.wpResponsive.maybeDisableSortables();
+				return;
+			}
+
+			try {
+				$( '.meta-box-sortables' )
+					.sortable( this.metaBoxReorderingEnabled ? 'enable' : 'disable' )
+					.find( '.ui-sortable-handle' )
+						.toggleClass( 'is-non-sortable', ! this.metaBoxReorderingEnabled );
+			} catch ( e ) {}
 		},
 
 		/**
@@ -469,6 +544,30 @@
 					hidden: hidden,
 					closedpostboxesnonce: jQuery('#closedpostboxesnonce').val(),
 					page: page
+				},
+				function() {
+					wp.a11y.speak( __( 'Screen Options updated.' ) );
+				}
+			);
+		},
+
+		/**
+		 * Saves the meta box reordering setting to the server.
+		 *
+		 * @since 7.1.0
+		 *
+		 * @memberof postboxes
+		 *
+		 * @param {boolean} enabled Whether meta box reordering is enabled.
+		 * @return {void}
+		 */
+		save_meta_box_reordering_state : function( enabled ) {
+			$.post(
+				ajaxurl,
+				{
+					action: 'meta-box-reordering',
+					enabled: enabled ? 1 : 0,
+					screenoptionnonce: $( '#screenoptionnonce' ).val()
 				},
 				function() {
 					wp.a11y.speak( __( 'Screen Options updated.' ) );

--- a/src/js/_enqueues/admin/postbox.js
+++ b/src/js/_enqueues/admin/postbox.js
@@ -476,40 +476,23 @@
 		 * @return {void}
 		 */
 		setMetaBoxReordering: function( enabled ) {
-			var $body = $( document.body ),
-				$orderButtons = $( '.postbox .handle-order-higher, .postbox .handle-order-lower' );
+			var $sortables = $( '.meta-box-sortables' );
 
 			this.metaBoxReorderingEnabled = !! enabled;
 
-			$body
-				.toggleClass( 'meta-box-reordering-enabled', this.metaBoxReorderingEnabled )
-				.toggleClass( 'meta-box-reordering-disabled', ! this.metaBoxReorderingEnabled );
-
-			if ( this.metaBoxReorderingEnabled ) {
-				$orderButtons
-					.prop( 'disabled', false )
-					.removeAttr( 'tabindex aria-hidden' );
-				this.updateOrderButtonsProperties();
-			} else {
-				$orderButtons
-					.prop( 'disabled', true )
-					.attr( {
-						'aria-hidden': 'true',
-						tabindex: '-1'
-					} );
-			}
+			$( document.body ).toggleClass( 'meta-box-reordering-disabled', ! this.metaBoxReorderingEnabled );
 
 			if ( window.wpResponsive && window.wpResponsive.maybeDisableSortables ) {
 				window.wpResponsive.maybeDisableSortables();
 				return;
 			}
 
-			try {
-				$( '.meta-box-sortables' )
+			if ( $sortables.hasClass( 'ui-sortable' ) ) {
+				$sortables
 					.sortable( this.metaBoxReorderingEnabled ? 'enable' : 'disable' )
 					.find( '.ui-sortable-handle' )
 						.toggleClass( 'is-non-sortable', ! this.metaBoxReorderingEnabled );
-			} catch ( e ) {}
+			}
 		},
 
 		/**

--- a/src/wp-admin/admin-ajax.php
+++ b/src/wp-admin/admin-ajax.php
@@ -79,6 +79,7 @@ $core_actions_post = array(
 	'add-user',
 	'closed-postboxes',
 	'hidden-columns',
+	'meta-box-reordering',
 	'update-welcome-panel',
 	'menu-get-metabox',
 	'wp-link-ajax',

--- a/src/wp-admin/admin-header.php
+++ b/src/wp-admin/admin-header.php
@@ -214,6 +214,8 @@ if ( $current_screen->is_block_editor() ) {
 	$admin_body_class .= ' block-editor-page wp-embed-responsive';
 }
 
+$admin_body_class .= wp_is_meta_box_reordering_enabled() ? ' meta-box-reordering-enabled' : ' meta-box-reordering-disabled';
+
 $admin_body_class .= ' wp-theme-' . sanitize_html_class( get_template() );
 if ( is_child_theme() ) {
 	$admin_body_class .= ' wp-child-theme-' . sanitize_html_class( get_stylesheet() );

--- a/src/wp-admin/admin-header.php
+++ b/src/wp-admin/admin-header.php
@@ -214,7 +214,9 @@ if ( $current_screen->is_block_editor() ) {
 	$admin_body_class .= ' block-editor-page wp-embed-responsive';
 }
 
-$admin_body_class .= wp_is_meta_box_reordering_enabled() ? ' meta-box-reordering-enabled' : ' meta-box-reordering-disabled';
+if ( ! wp_is_meta_box_reordering_enabled() ) {
+	$admin_body_class .= ' meta-box-reordering-disabled';
+}
 
 $admin_body_class .= ' wp-theme-' . sanitize_html_class( get_template() );
 if ( is_child_theme() ) {

--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -1962,6 +1962,18 @@ p.auto-update-status {
 	line-height: 2.35;
 }
 
+.metabox-prefs > p {
+	margin: 0 0 8px;
+}
+
+.additional-settings-prefs {
+	margin-top: 14px;
+}
+
+.additional-settings-prefs legend {
+	padding-bottom: 2px;
+}
+
 #number-of-columns {
 	display: inline-block;
 	vertical-align: middle;
@@ -2257,6 +2269,11 @@ html.wp-toolbar {
 .postbox .handle-order-lower {
 	color: #646970;
 	width: 1.62rem;
+}
+
+.js.meta-box-reordering-disabled .postbox .handle-order-higher,
+.js.meta-box-reordering-disabled .postbox .handle-order-lower {
+	display: none;
 }
 
 /* Post box order buttons in the block editor meta boxes area. */

--- a/src/wp-admin/css/dashboard.css
+++ b/src/wp-admin/css/dashboard.css
@@ -1408,6 +1408,10 @@ a.rsswidget {
 	}
 }
 
+.js.meta-box-reordering-disabled #dashboard-widgets .postbox-container .empty-container {
+	display: none;
+}
+
 @media screen and (max-width: 870px) {
 	/* @deprecated 5.9.0 -- Lists removed from welcome panel. */
 	.welcome-panel .welcome-panel-column li {

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -1857,6 +1857,25 @@ function wp_ajax_hidden_columns() {
 }
 
 /**
+ * Handles the meta box reordering setting via Ajax.
+ *
+ * @since 7.1.0
+ */
+function wp_ajax_meta_box_reordering() {
+	check_ajax_referer( 'screen-options-nonce', 'screenoptionnonce' );
+
+	$user = wp_get_current_user();
+	if ( ! $user ) {
+		wp_die( -1 );
+	}
+
+	$enabled = isset( $_POST['enabled'] ) && '1' === (string) $_POST['enabled'];
+	update_user_meta( $user->ID, 'meta_box_reordering', $enabled ? 'enabled' : 'disabled' );
+
+	wp_die( 1 );
+}
+
+/**
  * Handles updating whether to display the welcome panel via AJAX.
  *
  * @since 3.1.0

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -1864,13 +1864,8 @@ function wp_ajax_hidden_columns() {
 function wp_ajax_meta_box_reordering() {
 	check_ajax_referer( 'screen-options-nonce', 'screenoptionnonce' );
 
-	$user = wp_get_current_user();
-	if ( ! $user ) {
-		wp_die( -1 );
-	}
-
 	$enabled = isset( $_POST['enabled'] ) && '1' === (string) $_POST['enabled'];
-	update_user_meta( $user->ID, 'meta_box_reordering', $enabled ? 'enabled' : 'disabled' );
+	update_user_option( get_current_user_id(), 'meta_box_reordering', $enabled ? 'enabled' : 'disabled' );
 
 	wp_die( 1 );
 }

--- a/src/wp-admin/includes/class-wp-screen.php
+++ b/src/wp-admin/includes/class-wp-screen.php
@@ -1006,11 +1006,23 @@ final class WP_Screen {
 
 		$this->_screen_settings = '';
 
+		$additional_settings = '';
+
+		if ( $this->show_meta_box_reordering_options() ) {
+			$additional_settings .= $this->get_meta_box_reordering_option();
+		}
+
 		if ( 'post' === $this->base ) {
-			$expand                 = '<fieldset class="editor-expand hidden"><legend>' . __( 'Additional settings' ) . '</legend><label for="editor-expand-toggle">';
-			$expand                .= '<input type="checkbox" id="editor-expand-toggle"' . checked( get_user_setting( 'editor_expand', 'on' ), 'on', false ) . ' />';
-			$expand                .= __( 'Enable full-height editor and distraction-free functionality.' ) . '</label></fieldset>';
-			$this->_screen_settings = $expand;
+			$additional_settings .= '<label class="editor-expand hidden" for="editor-expand-toggle">';
+			$additional_settings .= '<input type="checkbox" id="editor-expand-toggle"' . checked( get_user_setting( 'editor_expand', 'on' ), 'on', false ) . ' /> ';
+			$additional_settings .= __( 'Enable full-height editor and distraction-free functionality.' ) . '</label>';
+		}
+
+		if ( $additional_settings ) {
+			$this->_screen_settings  = '<fieldset class="metabox-prefs additional-settings-prefs">';
+			$this->_screen_settings .= '<legend>' . __( 'Additional settings' ) . '</legend>';
+			$this->_screen_settings .= $additional_settings;
+			$this->_screen_settings .= '</fieldset>';
 		}
 
 		/**
@@ -1023,7 +1035,7 @@ final class WP_Screen {
 		 */
 		$this->_screen_settings = apply_filters( 'screen_settings', $this->_screen_settings, $this );
 
-		if ( $this->_screen_settings || $this->_options ) {
+		if ( $this->_screen_settings || $this->_options || $this->show_meta_box_reordering_options() ) {
 			$show_screen = true;
 		}
 
@@ -1120,8 +1132,8 @@ final class WP_Screen {
 		<fieldset class="metabox-prefs">
 		<legend><?php _e( 'Screen elements' ); ?></legend>
 		<p>
-			<?php _e( 'Some screen elements can be shown or hidden by using the checkboxes.' ); ?>
-			<?php _e( 'Expand or collapse the elements by clicking on their headings, and arrange them by dragging their headings or by clicking on the up and down arrows.' ); ?>
+			<?php _e( 'Use the checkboxes to show or hide screen elements.' ); ?>
+			<?php _e( 'Expand or collapse screen elements by clicking their headings.' ); ?>
 		</p>
 		<div class="metabox-prefs-container">
 		<?php
@@ -1146,6 +1158,53 @@ final class WP_Screen {
 		</div>
 		</fieldset>
 		<?php
+	}
+
+	/**
+	 * Renders the option to enable or disable meta box reordering.
+	 *
+	 * @since 7.1.0
+	 */
+	public function render_meta_box_reordering_options() {
+		if ( ! $this->show_meta_box_reordering_options() ) {
+			return;
+		}
+
+		?>
+		<fieldset class="metabox-prefs additional-settings-prefs">
+		<legend><?php _e( 'Additional settings' ); ?></legend>
+		<?php echo $this->get_meta_box_reordering_option(); ?>
+		</fieldset>
+		<?php
+	}
+
+	/**
+	 * Gets the option to enable or disable meta box reordering.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @return string Meta box reordering option markup.
+	 */
+	private function get_meta_box_reordering_option() {
+		return '<label for="meta-box-reordering">'
+			. '<input class="meta-box-reordering-toggle" name="meta-box-reordering" type="checkbox" id="meta-box-reordering" value="enabled" ' . checked( wp_is_meta_box_reordering_enabled(), true, false ) . ' /> '
+			. __( 'Enable box reordering' )
+			. '</label>';
+	}
+
+	/**
+	 * Determines whether to show the meta box reordering option.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @global array $wp_meta_boxes Global meta box state.
+	 *
+	 * @return bool Whether to show the option.
+	 */
+	private function show_meta_box_reordering_options() {
+		global $wp_meta_boxes;
+
+		return ! empty( $wp_meta_boxes[ $this->id ] );
 	}
 
 	/**

--- a/src/wp-admin/includes/class-wp-screen.php
+++ b/src/wp-admin/includes/class-wp-screen.php
@@ -1006,16 +1006,24 @@ final class WP_Screen {
 
 		$this->_screen_settings = '';
 
-		$additional_settings = '';
+		$additional_settings             = '';
+		$show_meta_box_reordering_option = $this->show_meta_box_reordering_options();
 
-		if ( $this->show_meta_box_reordering_options() ) {
+		if ( $show_meta_box_reordering_option ) {
 			$additional_settings .= $this->get_meta_box_reordering_option();
 		}
 
 		if ( 'post' === $this->base ) {
-			$additional_settings .= '<label class="editor-expand hidden" for="editor-expand-toggle">';
-			$additional_settings .= '<input type="checkbox" id="editor-expand-toggle"' . checked( get_user_setting( 'editor_expand', 'on' ), 'on', false ) . ' /> ';
-			$additional_settings .= __( 'Enable full-height editor and distraction-free functionality.' ) . '</label>';
+			if ( $show_meta_box_reordering_option ) {
+				$additional_settings .= '<label class="editor-expand hidden" for="editor-expand-toggle">';
+				$additional_settings .= '<input type="checkbox" id="editor-expand-toggle"' . checked( get_user_setting( 'editor_expand', 'on' ), 'on', false ) . ' /> ';
+				$additional_settings .= __( 'Enable full-height editor and distraction-free functionality.' ) . '</label>';
+			} else {
+				$expand                 = '<fieldset class="editor-expand hidden"><legend>' . __( 'Additional settings' ) . '</legend><label for="editor-expand-toggle">';
+				$expand                .= '<input type="checkbox" id="editor-expand-toggle"' . checked( get_user_setting( 'editor_expand', 'on' ), 'on', false ) . ' />';
+				$expand                .= __( 'Enable full-height editor and distraction-free functionality.' ) . '</label></fieldset>';
+				$this->_screen_settings = $expand;
+			}
 		}
 
 		if ( $additional_settings ) {
@@ -1035,7 +1043,7 @@ final class WP_Screen {
 		 */
 		$this->_screen_settings = apply_filters( 'screen_settings', $this->_screen_settings, $this );
 
-		if ( $this->_screen_settings || $this->_options || $this->show_meta_box_reordering_options() ) {
+		if ( $this->_screen_settings || $this->_options || $show_meta_box_reordering_option ) {
 			$show_screen = true;
 		}
 
@@ -1132,8 +1140,11 @@ final class WP_Screen {
 		<fieldset class="metabox-prefs">
 		<legend><?php _e( 'Screen elements' ); ?></legend>
 		<p>
-			<?php _e( 'Use the checkboxes to show or hide screen elements.' ); ?>
-			<?php _e( 'Expand or collapse screen elements by clicking their headings.' ); ?>
+			<?php _e( 'Some screen elements can be shown or hidden by using the checkboxes.' ); ?>
+			<?php _e( 'Expand or collapse the elements by clicking on their headings, and arrange them by dragging their headings or by clicking on the up and down arrows.' ); ?>
+			<?php if ( $this->show_meta_box_reordering_options() ) : ?>
+				<?php _e( 'Use the setting below to enable or disable box reordering.' ); ?>
+			<?php endif; ?>
 		</p>
 		<div class="metabox-prefs-container">
 		<?php
@@ -1156,24 +1167,6 @@ final class WP_Screen {
 		}
 		?>
 		</div>
-		</fieldset>
-		<?php
-	}
-
-	/**
-	 * Renders the option to enable or disable meta box reordering.
-	 *
-	 * @since 7.1.0
-	 */
-	public function render_meta_box_reordering_options() {
-		if ( ! $this->show_meta_box_reordering_options() ) {
-			return;
-		}
-
-		?>
-		<fieldset class="metabox-prefs additional-settings-prefs">
-		<legend><?php _e( 'Additional settings' ); ?></legend>
-		<?php echo $this->get_meta_box_reordering_option(); ?>
 		</fieldset>
 		<?php
 	}

--- a/src/wp-admin/includes/class-wp-screen.php
+++ b/src/wp-admin/includes/class-wp-screen.php
@@ -1143,7 +1143,7 @@ final class WP_Screen {
 			<?php _e( 'Some screen elements can be shown or hidden by using the checkboxes.' ); ?>
 			<?php _e( 'Expand or collapse the elements by clicking on their headings, and arrange them by dragging their headings or by clicking on the up and down arrows.' ); ?>
 			<?php if ( $this->show_meta_box_reordering_options() ) : ?>
-				<?php _e( 'Use the setting below to enable or disable box reordering.' ); ?>
+				<?php _e( 'Use the setting below to control whether boxes can be rearranged.' ); ?>
 			<?php endif; ?>
 		</p>
 		<div class="metabox-prefs-container">
@@ -1181,7 +1181,7 @@ final class WP_Screen {
 	private function get_meta_box_reordering_option() {
 		return '<label for="meta-box-reordering">'
 			. '<input class="meta-box-reordering-toggle" name="meta-box-reordering" type="checkbox" id="meta-box-reordering" value="enabled" ' . checked( wp_is_meta_box_reordering_enabled(), true, false ) . ' /> '
-			. __( 'Enable box reordering' )
+			. __( 'Allow boxes to be rearranged' )
 			. '</label>';
 	}
 

--- a/src/wp-admin/includes/screen.php
+++ b/src/wp-admin/includes/screen.php
@@ -195,6 +195,19 @@ function get_hidden_meta_boxes( $screen ) {
 }
 
 /**
+ * Determines whether meta box reordering is enabled.
+ *
+ * @since 7.1.0
+ *
+ * @return bool Whether meta box reordering is enabled.
+ */
+function wp_is_meta_box_reordering_enabled() {
+	$setting = get_user_option( 'meta_box_reordering' );
+
+	return false === $setting ? true : 'disabled' !== $setting;
+}
+
+/**
  * Register and configure an admin screen option
  *
  * @since 3.1.0

--- a/tests/phpunit/includes/testcase-ajax.php
+++ b/tests/phpunit/includes/testcase-ajax.php
@@ -66,6 +66,7 @@ abstract class WP_Ajax_UnitTestCase extends WP_UnitTestCase {
 		'add-user',
 		'closed-postboxes',
 		'hidden-columns',
+		'meta-box-reordering',
 		'update-welcome-panel',
 		'menu-get-metabox',
 		'wp-link-ajax',

--- a/tests/phpunit/tests/admin/includesScreen.php
+++ b/tests/phpunit/tests/admin/includesScreen.php
@@ -260,6 +260,41 @@ class Tests_Admin_IncludesScreen extends WP_UnitTestCase {
 		$this->assertFalse( $screen->is_block_editor );
 	}
 
+	public function test_meta_box_reordering_enabled_defaults_to_true() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+
+		$this->assertTrue( wp_is_meta_box_reordering_enabled() );
+	}
+
+	public function test_meta_box_reordering_enabled_respects_user_option() {
+		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user_id );
+		update_user_meta( $user_id, 'meta_box_reordering', 'disabled' );
+
+		$this->assertFalse( wp_is_meta_box_reordering_enabled() );
+	}
+
+	public function test_meta_box_reordering_option_is_rendered_for_screens_with_meta_boxes() {
+		global $wp_meta_boxes;
+
+		$old_wp_meta_boxes = $wp_meta_boxes;
+		$screen            = convert_to_screen( 'dashboard' );
+
+		add_meta_box( 'testbox1', 'Test Metabox', '__return_false', $screen );
+
+		try {
+			ob_start();
+			$screen->render_meta_box_reordering_options();
+			$output = ob_get_clean();
+		} finally {
+			$wp_meta_boxes = $old_wp_meta_boxes;
+		}
+
+		$this->assertStringContainsString( 'id="meta-box-reordering"', $output );
+		$this->assertStringContainsString( 'Additional settings', $output );
+		$this->assertStringContainsString( 'Enable box reordering', $output );
+	}
+
 	public function test_post_type_with_edit_prefix() {
 		register_post_type( 'edit-some-thing' );
 		$screen = convert_to_screen( 'edit-some-thing' );

--- a/tests/phpunit/tests/admin/includesScreen.php
+++ b/tests/phpunit/tests/admin/includesScreen.php
@@ -269,7 +269,7 @@ class Tests_Admin_IncludesScreen extends WP_UnitTestCase {
 	public function test_meta_box_reordering_enabled_respects_user_option() {
 		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $user_id );
-		update_user_meta( $user_id, 'meta_box_reordering', 'disabled' );
+		update_user_option( $user_id, 'meta_box_reordering', 'disabled' );
 
 		$this->assertFalse( wp_is_meta_box_reordering_enabled() );
 	}
@@ -278,13 +278,16 @@ class Tests_Admin_IncludesScreen extends WP_UnitTestCase {
 		global $wp_meta_boxes;
 
 		$old_wp_meta_boxes = $wp_meta_boxes;
-		$screen            = convert_to_screen( 'dashboard' );
+		set_current_screen( 'index.php' );
+		$screen = get_current_screen();
 
 		add_meta_box( 'testbox1', 'Test Metabox', '__return_false', $screen );
 
 		try {
+			$screen->show_screen_options();
+
 			ob_start();
-			$screen->render_meta_box_reordering_options();
+			$screen->render_screen_options();
 			$output = ob_get_clean();
 		} finally {
 			$wp_meta_boxes = $old_wp_meta_boxes;
@@ -293,6 +296,33 @@ class Tests_Admin_IncludesScreen extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'id="meta-box-reordering"', $output );
 		$this->assertStringContainsString( 'Additional settings', $output );
 		$this->assertStringContainsString( 'Enable box reordering', $output );
+		$this->assertStringContainsString( 'Some screen elements can be shown or hidden by using the checkboxes.', $output );
+		$this->assertStringContainsString( 'Expand or collapse the elements by clicking on their headings, and arrange them by dragging their headings or by clicking on the up and down arrows.', $output );
+		$this->assertStringContainsString( 'Use the setting below to enable or disable box reordering.', $output );
+	}
+
+	public function test_meta_box_reordering_option_does_not_render_empty_additional_settings() {
+		global $wp_meta_boxes;
+
+		$old_wp_meta_boxes = $wp_meta_boxes;
+		set_current_screen( 'post.php' );
+		$screen = get_current_screen();
+
+		unset( $wp_meta_boxes[ $screen->id ] );
+
+		try {
+			$screen->show_screen_options();
+
+			ob_start();
+			$screen->render_screen_options();
+			$output = ob_get_clean();
+		} finally {
+			$wp_meta_boxes = $old_wp_meta_boxes;
+		}
+
+		$this->assertStringNotContainsString( 'additional-settings-prefs', $output );
+		$this->assertStringContainsString( '<fieldset class="editor-expand hidden">', $output );
+		$this->assertStringContainsString( 'Enable full-height editor and distraction-free functionality.', $output );
 	}
 
 	public function test_post_type_with_edit_prefix() {

--- a/tests/phpunit/tests/admin/includesScreen.php
+++ b/tests/phpunit/tests/admin/includesScreen.php
@@ -295,10 +295,10 @@ class Tests_Admin_IncludesScreen extends WP_UnitTestCase {
 
 		$this->assertStringContainsString( 'id="meta-box-reordering"', $output );
 		$this->assertStringContainsString( 'Additional settings', $output );
-		$this->assertStringContainsString( 'Enable box reordering', $output );
+		$this->assertStringContainsString( 'Allow boxes to be rearranged', $output );
 		$this->assertStringContainsString( 'Some screen elements can be shown or hidden by using the checkboxes.', $output );
 		$this->assertStringContainsString( 'Expand or collapse the elements by clicking on their headings, and arrange them by dragging their headings or by clicking on the up and down arrows.', $output );
-		$this->assertStringContainsString( 'Use the setting below to enable or disable box reordering.', $output );
+		$this->assertStringContainsString( 'Use the setting below to control whether boxes can be rearranged.', $output );
 	}
 
 	public function test_meta_box_reordering_option_does_not_render_empty_additional_settings() {

--- a/tests/phpunit/tests/ajax/wpAjaxMetaBoxReordering.php
+++ b/tests/phpunit/tests/ajax/wpAjaxMetaBoxReordering.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * Admin Ajax functions to be tested.
+ */
+require_once ABSPATH . 'wp-admin/includes/ajax-actions.php';
+
+/**
+ * Testing meta box reordering AJAX functionality.
+ *
+ * @group ajax
+ *
+ * @covers ::wp_ajax_meta_box_reordering
+ */
+class Tests_Ajax_wpAjaxMetaBoxReordering extends WP_Ajax_UnitTestCase {
+
+	/**
+	 * @dataProvider data_meta_box_reordering_states
+	 *
+	 * @param int|string $enabled  Whether meta box reordering is enabled.
+	 * @param string     $expected The expected stored user option.
+	 */
+	public function test_wp_ajax_meta_box_reordering_saves_user_option( $enabled, $expected ) {
+		$this->_setRole( 'administrator' );
+
+		$_POST = array(
+			'screenoptionnonce' => wp_create_nonce( 'screen-options-nonce' ),
+			'enabled'           => $enabled,
+		);
+
+		try {
+			$this->_handleAjax( 'meta-box-reordering' );
+			$this->fail( 'Expected exception: WPAjaxDieStopException' );
+		} catch ( WPAjaxDieStopException $e ) {
+			unset( $e );
+		}
+
+		$this->assertSame( $expected, get_user_meta( get_current_user_id(), 'meta_box_reordering', true ) );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_meta_box_reordering_states() {
+		return array(
+			'enabled'             => array( 1, 'enabled' ),
+			'enabled as string'   => array( '1', 'enabled' ),
+			'disabled'            => array( 0, 'disabled' ),
+			'disabled as string'  => array( '0', 'disabled' ),
+			'disabled when false' => array( 'false', 'disabled' ),
+		);
+	}
+}

--- a/tests/phpunit/tests/ajax/wpAjaxMetaBoxReordering.php
+++ b/tests/phpunit/tests/ajax/wpAjaxMetaBoxReordering.php
@@ -35,7 +35,7 @@ class Tests_Ajax_wpAjaxMetaBoxReordering extends WP_Ajax_UnitTestCase {
 			unset( $e );
 		}
 
-		$this->assertSame( $expected, get_user_meta( get_current_user_id(), 'meta_box_reordering', true ) );
+		$this->assertSame( $expected, get_user_option( 'meta_box_reordering', get_current_user_id() ) );
 	}
 
 	/**


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/50699

This continues #12180, originally authored by @poligilad-auto. Poli’s original feature commit is preserved in this branch; I’m carrying the existing work and review feedback forward while Poli is away.

## Summary

- Adds a Screen Options setting for enabling or disabling box reordering.
- Stores the setting as one per-user preference shared across screens on the current site and keeps reordering enabled by default.
- Disables drag-and-drop sorting and hides the keyboard move controls and drop zones when reordering is disabled.
- Places the “Allow boxes to be rearranged” checkbox under “Additional settings” on screens that support meta boxes.

## Screenshot

<img width="811" height="286" alt="Screenshot 2026-07-22 at 1 05 54 PM" src="https://github.com/user-attachments/assets/9fa845e0-aff4-4577-8ba7-6900588d917a" />

## Review follow-up

- Uses the absence of the disabled body class to represent the enabled state.
- Leaves hidden move controls to CSS instead of changing their accessibility attributes in JavaScript.
- Preserves the existing Screen Options guidance and adds a separate sentence explaining the new setting.
- Uses the user option API consistently when saving and reading the per-user, per-site preference.
- Avoids duplicate sortable updates when the checkbox changes.
- Preserves the legacy hidden editor-expand fieldset when a post screen has no meta boxes.
- Replaces the unused rendering helper test with coverage through the real Screen Options rendering path.

## Compatibility

- Reordering remains enabled by default.
- Existing meta box markup and keyboard controls remain unchanged while reordering is enabled.
- The preference applies across screens on the current site for each user, matching the direction confirmed on the Trac ticket.

## AI assistance

Codex was used to inspect the existing feedback, implement revisions, add tests, and draft this description. I manually verified the user-facing behavior, and the automated checks listed below were run. I do not independently have the technical expertise to validate every code change, so this draft is seeking human developer review before it is considered ready.

## Testing

- `npm run test:php -- --filter Tests_Admin_IncludesScreen tests/phpunit/tests/admin/includesScreen.php`
- `npm run test:php -- --group ajax --filter Tests_Ajax_wpAjaxMetaBoxReordering`
- `npx grunt jshint:core --file=src/js/_enqueues/admin/postbox.js`
- `npx grunt jshint:core --file=src/js/_enqueues/admin/common.js`
- PHPCS on all eight touched PHP and PHPUnit files.
- `npm run build:dev`
- `git diff --check`

Manually verified on the Dashboard that disabling the setting disables drag-and-drop, hides both keyboard move controls, and that re-enabling it restores both interaction methods.
