### PR TITLE
XML-RPC: wp_editTerm, check 4th arg is an array

### DIFF
--- a/src/wp-includes/class-wp-xmlrpc-server.php
+++ b/src/wp-includes/class-wp-xmlrpc-server.php
@@ -2203,7 +2203,7 @@ class wp_xmlrpc_server extends IXR_Server {
 		$username       = $args[1];
 		$password       = $args[2];
 		$term_id        = (int) $args[3];
-		$content_struct = $args[4];
+		$content_struct = $args[4] ?? null;
 
 		$user = $this->login( $username, $password );
 		if ( ! $user ) {
@@ -2213,7 +2213,10 @@ class wp_xmlrpc_server extends IXR_Server {
 		/** This action is documented in wp-includes/class-wp-xmlrpc-server.php */
 		do_action( 'xmlrpc_call', 'wp.editTerm', $args, $this );
 
-		if ( ! taxonomy_exists( $content_struct['taxonomy'] ) ) {
+		if (
+			! is_array ( $content_struct )
+			|| ! taxonomy_exists( $content_struct['taxonomy'] )
+		) {
 			return new IXR_Error( 403, __( 'Invalid taxonomy.' ) );
 		}
 

--- a/src/wp-includes/class-wp-xmlrpc-server.php
+++ b/src/wp-includes/class-wp-xmlrpc-server.php
@@ -2214,7 +2214,7 @@ class wp_xmlrpc_server extends IXR_Server {
 		do_action( 'xmlrpc_call', 'wp.editTerm', $args, $this );
 
 		if (
-			! is_array ( $content_struct )
+			! is_array( $content_struct )
 			|| ! taxonomy_exists( $content_struct['taxonomy'] )
 		) {
 			return new IXR_Error( 403, __( 'Invalid taxonomy.' ) );

--- a/src/wp-includes/class-wp-xmlrpc-server.php
+++ b/src/wp-includes/class-wp-xmlrpc-server.php
@@ -2203,7 +2203,7 @@ class wp_xmlrpc_server extends IXR_Server {
 		$username       = $args[1];
 		$password       = $args[2];
 		$term_id        = (int) $args[3];
-		$content_struct = $args[4] ?? null;
+		$content_struct = $args[4];
 
 		$user = $this->login( $username, $password );
 		if ( ! $user ) {

--- a/src/wp-includes/class-wp-xmlrpc-server.php
+++ b/src/wp-includes/class-wp-xmlrpc-server.php
@@ -2215,6 +2215,7 @@ class wp_xmlrpc_server extends IXR_Server {
 
 		if (
 			! is_array( $content_struct )
+			|| empty( $content_struct['taxonomy'] )
 			|| ! taxonomy_exists( $content_struct['taxonomy'] )
 		) {
 			return new IXR_Error( 403, __( 'Invalid taxonomy.' ) );

--- a/tests/phpunit/tests/xmlrpc/wp/editTerm.php
+++ b/tests/phpunit/tests/xmlrpc/wp/editTerm.php
@@ -69,7 +69,7 @@ class Tests_XMLRPC_wp_editTerm extends WP_XMLRPC_UnitTestCase {
 	}
 
 	/**
-	 * Ensures a missing content struct is rejected rather than causing a fatal error.
+	 * Ensures a missing content struct is rejected with an insufficient arguments error.
 	 *
 	 * @ticket 65682
 	 */

--- a/tests/phpunit/tests/xmlrpc/wp/editTerm.php
+++ b/tests/phpunit/tests/xmlrpc/wp/editTerm.php
@@ -50,6 +50,37 @@ class Tests_XMLRPC_wp_editTerm extends WP_XMLRPC_UnitTestCase {
 		$this->assertSame( __( 'Invalid taxonomy.' ), $result->message );
 	}
 
+	/**
+	 * Ensures a non-array content struct is rejected rather than causing a fatal error.
+	 *
+	 * When the content struct (the fifth argument) is passed as a string instead of a
+	 * struct, the method must return an error instead of attempting to access a string
+	 * offset, which triggers "Cannot access offset of type string on string" on PHP 8+.
+	 *
+	 * @ticket 65682
+	 */
+	public function test_invalid_content_struct_should_return_error() {
+		$this->make_user_by_role( 'editor' );
+
+		$result = $this->myxmlrpcserver->wp_editTerm( array( 1, 'editor', 'editor', self::$parent_term, 'not-a-struct' ) );
+		$this->assertIXRError( $result );
+		$this->assertSame( 403, $result->code );
+		$this->assertSame( __( 'Invalid taxonomy.' ), $result->message );
+	}
+
+	/**
+	 * Ensures a missing content struct is rejected rather than causing a fatal error.
+	 *
+	 * @ticket 65682
+	 */
+	public function test_missing_content_struct_should_return_error() {
+		$this->make_user_by_role( 'editor' );
+
+		$result = $this->myxmlrpcserver->wp_editTerm( array( 1, 'editor', 'editor', self::$parent_term ) );
+		$this->assertIXRError( $result );
+		$this->assertSame( 400, $result->code );
+	}
+
 	public function test_incapable_user() {
 		$this->make_user_by_role( 'subscriber' );
 


### PR DESCRIPTION
https://core.trac.wordpress.org/ticket/65682

AI assistance: Yes
Tool(s): Claude
Model(s): Opus 4.8
Used for: Writing the unit tests

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
