### PR TITLE
Administration: allow optional `wp_get_toggletip()` `$args` as documented

### DIFF
--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -426,7 +426,7 @@ function wp_get_tooltip( $content, $args = array() ) {
  * }
  * @return string Tooltip HTML markup, or an empty string when no content is provided.
  */
-function wp_get_toggletip( $content, $args ) {
+function wp_get_toggletip( $content, $args = array() ) {
 	$args['type'] = 'toggletip';
 	return wp_get_tooltip_helper( $content, $args );
 }


### PR DESCRIPTION
`wp_get_toggletip()` has similarly documented "optional" `$args` as `wp_get_tooltip()`. This updates the function signature to match.

Trac ticket: https://core.trac.wordpress.org/ticket/55343

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
