### PR TITLE
Users: Validate the whitespace-normalized username in add_user()

### DIFF
--- a/src/wp-admin/includes/user.php
+++ b/src/wp-admin/includes/user.php
@@ -188,8 +188,18 @@ function edit_user( $user_id = 0 ) {
 		$user->user_pass = $pass1;
 	}
 
-	if ( ! $update && isset( $_POST['user_login'] ) && ! validate_username( $_POST['user_login'] ) ) {
-		$errors->add( 'user_login', __( '<strong>Error:</strong> This username is invalid because it uses illegal characters. Please enter a valid username.' ) );
+	if ( ! $update && isset( $_POST['user_login'] ) ) {
+		/*
+		 * Leading/trailing and repeated whitespace is trimmed and collapsed when the
+		 * username is stored, so validate against that same normalization instead of
+		 * the raw input. Otherwise a valid username is rejected solely for whitespace
+		 * that will never end up in the stored value.
+		 */
+		$normalized_user_login = preg_replace( '/\s+/', ' ', trim( wp_unslash( $_POST['user_login'] ) ) );
+
+		if ( ! validate_username( $normalized_user_login ) ) {
+			$errors->add( 'user_login', __( '<strong>Error:</strong> This username is invalid because it uses illegal characters. Please enter a valid username.' ) );
+		}
 	}
 
 	if ( ! $update && username_exists( $user->user_login ) ) {

--- a/tests/phpunit/tests/admin/includes/user/addUser.php
+++ b/tests/phpunit/tests/admin/includes/user/addUser.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * @group admin
+ * @group user
+ */
+class Tests_Admin_Includes_User_AddUser extends WP_UnitTestCase {
+
+	public function set_up() {
+		parent::set_up();
+
+		$admin_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+	}
+
+	/**
+	 * @ticket 65672
+	 */
+	public function test_add_user_should_accept_username_with_leading_or_trailing_whitespace() {
+		$_POST               = array();
+		$_POST['user_login'] = ' bob ';
+		$_POST['pass1']      = 'password';
+		$_POST['pass2']      = 'password';
+		$_POST['role']       = 'subscriber';
+		$_POST['email']      = 'bob@example.com';
+
+		$user_id = add_user();
+
+		$this->assertIsInt( $user_id, 'add_user() should return the new user ID, not a WP_Error.' );
+
+		$user = get_userdata( $user_id );
+		$this->assertSame( 'bob', $user->user_login );
+	}
+
+	/**
+	 * @ticket 65672
+	 */
+	public function test_add_user_should_accept_username_with_repeated_internal_whitespace() {
+		$_POST               = array();
+		$_POST['user_login'] = 'bob  smith';
+		$_POST['pass1']      = 'password';
+		$_POST['pass2']      = 'password';
+		$_POST['role']       = 'subscriber';
+		$_POST['email']      = 'bobsmith@example.com';
+
+		$user_id = add_user();
+
+		$this->assertIsInt( $user_id, 'add_user() should return the new user ID, not a WP_Error.' );
+
+		$user = get_userdata( $user_id );
+		$this->assertSame( 'bob smith', $user->user_login );
+	}
+
+	/**
+	 * @ticket 65672
+	 */
+	public function test_add_user_should_still_reject_username_with_illegal_characters() {
+		$_POST               = array();
+		$_POST['user_login'] = 'bob@#&99';
+		$_POST['pass1']      = 'password';
+		$_POST['pass2']      = 'password';
+		$_POST['role']       = 'subscriber';
+		$_POST['email']      = 'bob99@example.com';
+
+		$user_id = add_user();
+
+		$this->assertWPError( $user_id );
+		$this->assertSame( 'user_login', $user_id->get_error_code() );
+	}
+}


### PR DESCRIPTION
## Description

`edit_user()` (used by `add_user()` when creating a new user from wp-admin) stores the sanitized username:

```php
$user->user_login = sanitize_user( wp_unslash( $_POST['user_login'] ), true );
```

but validated the raw, un-unslashed `$_POST['user_login']` value instead:

```php
if ( ! $update && isset( $_POST['user_login'] ) && ! validate_username( $_POST['user_login'] ) ) {
```

`validate_username()` does a strict equality check against `sanitize_user()`, and `sanitize_user()` trims leading/trailing whitespace and collapses repeated internal whitespace. Since the raw input still has that whitespace, the check fails even though the same value would be stored successfully once sanitized — a common false rejection when a username is pasted with a trailing space.

I initially tried validating the fully-sanitized `$user->user_login` value directly, but that turned out to be too broad: since `wp_insert_user()` re-sanitizes on insert regardless, the fully-sanitized value trivially equals itself, so it silently stopped rejecting *any* illegal characters too (e.g. `bob@#&99` would silently become `bob@99` instead of erroring). That's a bigger behavior change than the ticket asks for.

This PR instead normalizes only the whitespace (trim + collapse, matching what `sanitize_user()` does) before validating, so:
- Leading/trailing and repeated internal whitespace no longer cause a false rejection.
- Genuinely illegal characters are still caught and still produce the "illegal characters" error, unchanged from current behavior.

Trac ticket: https://core.trac.wordpress.org/ticket/65672

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Sonnet 5
Used for: Implementation, tests, and PR description. Reviewed by irozum.

---
This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/best-practices/pull-requests-for-code-review/) in the Core Handbook for more details.