### PR TITLE
Media: Fix accessible name of the width input in the image editor Scale panel

### DIFF
--- a/src/wp-admin/includes/image-edit.php
+++ b/src/wp-admin/includes/image-edit.php
@@ -151,7 +151,7 @@ function wp_image_editor( $post_id, $msg = false ) {
 							<label for="imgedit-scale-width-<?php echo $post_id; ?>" class="screen-reader-text">
 							<?php
 							/* translators: Hidden accessibility text. */
-							_e( 'scale height' );
+							_e( 'scale width' );
 							?>
 							</label>
 							<input type="number" step="1" min="0" max="<?php echo $meta['width'] ?? ''; ?>" aria-describedby="imgedit-scale-warn-<?php echo $post_id; ?>"  id="imgedit-scale-width-<?php echo $post_id; ?>" onkeyup="imageEdit.scaleChanged(<?php echo $post_id; ?>, 1, this)" onblur="imageEdit.scaleChanged(<?php echo $post_id; ?>, 1, this)" value="<?php echo $meta['width'] ?? 0; ?>" />


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

The classic image editor's Scale panel gives its width and height inputs the same hidden `screen-reader-text` label, "scale height", so a screen reader announces both dimension fields identically. This changes the width input's label to "scale width" so each field is announced accurately.

What the problem was:
- In `wp-admin/includes/image-edit.php`, the width input's `screen-reader-text` label reused the height string: `_e( 'scale height' )`.
- The height input immediately below uses the same `_e( 'scale height' )`.
- Result: both fields under "New dimensions:" are announced as "scale height", so a screen reader user cannot tell the width and height fields apart. Present since WordPress 4.5, when these labels were added.

What the fix does:
- Changes the width input's label to `_e( 'scale width' )`. One string, on the width field only.

Approach and why:
- Minimal, matches the field, and is exactly the fix the ticket calls for and the accepted patch (65685.patch) makes. The height label is already correct and is left untouched. The reporter raised possibly rewording both labels but deferred wording to the accessibility team, so that is intentionally out of scope here.
- The existing `/* translators: Hidden accessibility text. */` comment on the width label is retained; "scale width" is a new translatable string.

Trac ticket: https://core.trac.wordpress.org/ticket/65685

## Use of AI Tools
N/A
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
