### PR TITLE
Docs: Add the missing $has_custom_overlay param to the Navigation block DocBlock

### DIFF
--- a/src/wp-includes/blocks/navigation.php
+++ b/src/wp-includes/blocks/navigation.php
@@ -670,7 +670,8 @@ class WP_Navigation_Block_Renderer {
 	 *
 	 * @since 7.0.0
 	 *
-	 * @param array $colors The colors array.
+	 * @param bool  $has_custom_overlay Whether a custom overlay is used.
+	 * @param array $colors             The colors array.
 	 * @return string Returns the overlay inline styles.
 	 */
 	private static function get_overlay_inline_styles( $has_custom_overlay, $colors ) {


### PR DESCRIPTION
## Trac ticket

https://core.trac.wordpress.org/ticket/65691

## Description

`WP_Navigation_Block_Renderer::get_overlay_inline_styles()`, introduced in WordPress 7.0.0, documented only its second parameter, `$colors`. Its first parameter, `$has_custom_overlay`, had no `@param` entry.

This adds the missing `@param bool $has_custom_overlay` tag in signature order, with columns aligned per the [WordPress PHP documentation standards][1]. The description matches the sibling method `get_responsive_container_classes()`, which documents the same parameter.

Documentation-only change; no behavior is affected.

[1]: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/