### PR TITLE
Docs: Require view config filter callbacks to return the container

### DIFF
--- a/src/wp-includes/class-wp-view-config-data.php
+++ b/src/wp-includes/class-wp-view-config-data.php
@@ -159,10 +159,12 @@ class WP_View_Config_Data {
 		 *   individual list members.
 		 *
 		 * A change that declares an unsupported schema version is rejected and does
-		 * not alter anything. Callbacks mutate the container in place, so there is no
-		 * need to return it; any returned value is ignored. Callbacks must not replace
-		 * the container with a different value, as later callbacks receive whatever the
-		 * the previous one returned.
+		 * not alter anything. As with any filter, each callback's return value is
+		 * passed to the next callback as `$data`, so callbacks must return the
+		 * container they received: a callback that returns nothing, or any other
+		 * value, hands that result to every callback hooked at a later priority
+		 * instead of the container. Since the write methods return the container,
+		 * a callback can end with `return $data->merge( $patch, $version );`.
 		 *
 		 * @since 7.1.0
 		 *


### PR DESCRIPTION
## What

Corrects the `get_entity_view_config_{$kind}_{$name}` filter docblock: callbacks must return the container they receive. Also fixes a doubled "the" in the same paragraph.

Follow-up to https://github.com/WordPress/wordpress-develop/pull/12638.

## Why

The docblock told callbacks the container is mutated in place, so there is "no need to return it; any returned value is ignored". Only the final return is discarded: as with any filter, `WP_Hook::apply_filters()` passes each callback's return value to the next callback as `$data`, so a callback that follows that advice hands `null` to every callback hooked at a later priority, which fatals the moment it calls a method on it (`Call to a member function merge() on null`). A single callback never surfaces this, so it would only show up in the wild once two plugins hook the same filter.

Docs-only; the dispatch is unchanged. The new text states the standard filter rule and points out that the write methods return the container, so a callback can end with `return $data->merge( $patch, $version );`. The existing filter tests already register callbacks that return the container.


## AI usage disclosure

AI assistance: Yes
Tool(s): Claude Code
Model(s): Opus
Used for: PR description and code comment. Manually verified and tuned.

Trac ticket: https://core.trac.wordpress.org/ticket/65577