### PR TITLE
Security: Harden taxonomy tab handler in post.js

### DIFF
--- a/src/js/_enqueues/admin/post.js
+++ b/src/js/_enqueues/admin/post.js
@@ -567,7 +567,7 @@ jQuery( function($) {
 
 		// @todo Move to jQuery 1.3+, support for multiple hierarchical taxonomies, see wp-lists.js.
 		$('a', '#' + taxonomy + '-tabs').on( 'click keyup keydown', function( event ) {
-			var t = $(this).attr('href');
+			var t = $(this).attr( 'aria-controls' );
 			if ( event.type === 'keydown' && event.key === ' ' ) {
 				event.preventDefault();
 			}
@@ -577,8 +577,8 @@ jQuery( function($) {
 				$(this).attr( 'aria-selected', 'true' ).removeAttr( 'tabindex' );
 				$(this).parent().addClass('tabs').siblings('li').removeClass('tabs');
 				$('#' + taxonomy + '-tabs').siblings('.tabs-panel').hide();
-				$(t).show();
-				if ( '#' + taxonomy + '-all' == t ) {
+				$( document.getElementById( t || '' ) ).show();
+				if ( taxonomy + '-all' === t ) {
 					deleteUserSetting( settingName );
 				} else {
 					setUserSetting( settingName, 'pop' );


### PR DESCRIPTION
This PR hardens the taxonomy tab click handler in wp-admin/js/post.js to avoid passing a raw href value into jQuery’s $() constructor. This mitigates the risk of unintended HTML parsing or CSS selector injection.

Trac ticket: [#65572](https://core.trac.wordpress.org/ticket/65572)

## Use of AI Tools

AI assistance: Yes
Tool(s): GitHub Copilot
Model(s): Gemini, Claude
Used for: Checking for potential edge cases, drafting the PR description, and assisting with local code review. The final implementation and testing were written and executed manually by me.

---

**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
