### PR TITLE
wptexturize(): fix apostrophe curling to an opening quote after an opening inline tag

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -230,6 +230,8 @@ function wptexturize( $text, $reset = false ) {
 	$no_texturize_tags_stack       = array();
 	$no_texturize_shortcodes_stack = array();
 
+	$prev_text_ends_in_word_char = false;
+
 	// Look for shortcodes and HTML elements.
 
 	preg_match_all( '@\[/?([^<>&/\[\]\x00-\x20=]++)@', $text, $matches );
@@ -246,6 +248,7 @@ function wptexturize( $text, $reset = false ) {
 		if ( '<' === $first ) {
 			if ( str_starts_with( $curl, '<!--' ) ) {
 				// This is an HTML comment delimiter.
+				$prev_text_ends_in_word_char = false;
 				continue;
 			} else {
 				// This is an HTML element delimiter.
@@ -253,14 +256,18 @@ function wptexturize( $text, $reset = false ) {
 				// Replace each & with &#038; unless it already looks like an entity.
 				$curl = preg_replace( '/&(?!#(?:\d+|x[a-f0-9]+);|[a-z1-4]{1,8};)/i', '&#038;', $curl );
 
+				$prev_text_ends_in_word_char = $prev_text_ends_in_word_char && _wptexturize_is_inline_opening_tag( $curl );
+
 				_wptexturize_pushpop_element( $curl, $no_texturize_tags_stack, $no_texturize_tags );
 			}
 		} elseif ( '' === trim( $curl ) ) {
 			// This is a newline between delimiters. Performance improves when we check this.
+			$prev_text_ends_in_word_char = false;
 			continue;
 
 		} elseif ( '[' === $first && $found_shortcodes && 1 === preg_match( '/^' . $shortcode_regex . '$/', $curl ) ) {
 			// This is a shortcode delimiter.
+			$prev_text_ends_in_word_char = false;
 
 			if ( ! str_starts_with( $curl, '[[' ) && ! str_ends_with( $curl, ']]' ) ) {
 				// Looks like a normal shortcode.
@@ -271,6 +278,12 @@ function wptexturize( $text, $reset = false ) {
 			}
 		} elseif ( empty( $no_texturize_shortcodes_stack ) && empty( $no_texturize_tags_stack ) ) {
 			// This is neither a delimiter, nor is this content inside of no_texturize pairs. Do texturize.
+
+			// Continues the word split by the inline tag's opening boundary (ticket #43810).
+			if ( $prev_text_ends_in_word_char && "'" === $curl[0] ) {
+				$curl = $closing_single_quote . substr( $curl, 1 );
+			}
+			$prev_text_ends_in_word_char = false;
 
 			$curl = str_replace( $static_characters, $static_replacements, $curl );
 
@@ -297,6 +310,8 @@ function wptexturize( $text, $reset = false ) {
 
 			// Replace each & with &#038; unless it already looks like an entity.
 			$curl = preg_replace( '/&(?!#(?:\d+|x[a-f0-9]+);|[a-z1-4]{1,8};)/i', '&#038;', $curl );
+
+			$prev_text_ends_in_word_char = 1 === preg_match( '/[a-zA-Z0-9]$/', $curl );
 		}
 	}
 
@@ -426,6 +441,62 @@ function _wptexturize_pushpop_element( $text, &$stack, $disabled_elements ) {
 			array_pop( $stack );
 		}
 	}
+}
+
+/**
+ * Determines whether a delimiter is the opening tag of an inline HTML element.
+ *
+ * Used by wptexturize() to tell whether a leading quote character in the text that
+ * follows continues the word immediately preceding the tag (e.g. a contraction split
+ * by `<strong>` in `I<strong>'ve been</strong>`) rather than opening a new quoted
+ * phrase. Block-level tags are excluded, since their boundary already reads as a
+ * break between sentences.
+ *
+ * Assumes first char of `$text` is tag opening and last char is tag closing.
+ *
+ * @since 7.1.0
+ * @access private
+ *
+ * @param string $text Text to check. Must be a tag like `<strong>`.
+ * @return bool True if `$text` is the opening tag of one of the recognized inline elements.
+ */
+function _wptexturize_is_inline_opening_tag( $text ) {
+	static $inline_elements = array(
+		'a',
+		'abbr',
+		'b',
+		'cite',
+		'del',
+		'em',
+		'i',
+		'ins',
+		'mark',
+		'q',
+		's',
+		'small',
+		'span',
+		'strong',
+		'sub',
+		'sup',
+		'time',
+		'u',
+	);
+
+	// Closing tags and self-closing tags have no interior content to continue.
+	if ( ! isset( $text[1] ) || '/' === $text[1] || str_ends_with( $text, '/>' ) ) {
+		return false;
+	}
+
+	// Parse out the tag name, the same way _wptexturize_pushpop_element() does for opening tags.
+	$space = strpos( $text, ' ' );
+	if ( false === $space ) {
+		$space = -1;
+	} else {
+		--$space;
+	}
+	$tag = substr( $text, 1, $space );
+
+	return in_array( $tag, $inline_elements, true );
 }
 
 /**

--- a/tests/phpunit/tests/formatting/wpTexturize.php
+++ b/tests/phpunit/tests/formatting/wpTexturize.php
@@ -157,6 +157,54 @@ class Tests_Formatting_wpTexturize extends WP_UnitTestCase {
 		// $this->assertSame( '&#8220;<strong>Quoted Text</strong>&#8221;,', wptexturize( '"<strong>Quoted Text</strong>",' ) );
 	}
 
+	/**
+	 * An apostrophe right after the *opening* tag of an inline element continues the
+	 * word that precedes the tag (e.g. a contraction split by <strong>), instead of
+	 * being read as opening a new quoted phrase, but only when that preceding text
+	 * actually ends in a letter or digit and the tag is one of the recognized inline
+	 * elements.
+	 *
+	 * @ticket 43810
+	 * @dataProvider data_apostrophe_after_opening_inline_tag
+	 */
+	public function test_apostrophe_after_opening_inline_tag( $input, $output ) {
+		$this->assertSame( $output, wptexturize( $input ) );
+	}
+
+	public function data_apostrophe_after_opening_inline_tag() {
+		return array(
+			// The reported bug: a contraction split across an inline tag boundary.
+			array(
+				"I<strong>'ve been</strong>",
+				'I<strong>&#8217;ve been</strong>',
+			),
+			array(
+				"That<em>'s</em> right.",
+				'That<em>&#8217;s</em> right.',
+			),
+			// Nested inline tags still continue the word.
+			array(
+				"I<strong><em>'ve been</em></strong>",
+				'I<strong><em>&#8217;ve been</em></strong>',
+			),
+			// No preceding word: a genuine opening quote is left untouched.
+			array(
+				"<em>'Hello'</em>",
+				'<em>&#8216;Hello&#8217;</em>',
+			),
+			// A space before the tag also keeps normal opening-quote behavior.
+			array(
+				"word <strong>'ve been</strong>",
+				'word <strong>&#8216;ve been</strong>',
+			),
+			// Block-level tags aren't treated as word-continuing.
+			array(
+				"word<div>'ve been</div>",
+				'word<div>&#8216;ve been</div>',
+			),
+		);
+	}
+
 	public function test_x() {
 		$this->assertSame( '14&#215;24', wptexturize( '14x24' ) );
 	}


### PR DESCRIPTION
This fixes the "opening tag" half of the bug described on this ticket — the mirror image of #18549 (PR #12249), which covers the closing-tag case.

wptexturize() splits text on HTML tag boundaries and processes each resulting token independently. When a token starts with a straight quote/apostrophe immediately after the *opening* tag of an inline element (e.g. bolding a contraction), the word before the tag is in a separate token, so the apostrophe-in-a-word pattern can't see it — the quote is read as being at the start of a string and curls as an *opening* quote instead:

```
I<strong>'ve been</strong>  →  I<strong>&#8216;ve been</strong>  (wrong)
                                I<strong>&#8217;ve been</strong> (correct)
```

This adds a small piece of cross-token state to wptexturize(): whether the text immediately preceding the current position ends in a letter or digit. When that's true and the very next tag is the opening tag of a recognized inline element (a, abbr, b, cite, del, em, i, ins, mark, q, s, small, span, strong, sub, sup, time, u), a leading apostrophe in the following text token is treated as continuing that word rather than opening a new quoted phrase.

Block-level tags are deliberately excluded — their boundary already reads as a break between sentences, so adjacency there doesn't imply word continuation (e.g. `word<div>'ve been</div>` still curls as an opening quote). A space before the tag, or no preceding text at all (e.g. `<em>'Hello'</em>`), also keeps the existing opening-quote behavior.

Double quotes are out of scope here — there's no realistic mid-word continuation case for `"`, unlike the apostrophe/contraction case this targets.

Note: the recognized inline-tag list here (`a, abbr, b, cite, del, em, i, ins, mark, q, s, small, span, strong, sub, sup, time, u`) was chosen independently of #18549's PR #12249, since that PR hasn't landed and its exact list isn't available from the ticket discussion alone. Worth reconciling the two lists if both land.

Trac ticket: https://core.trac.wordpress.org/ticket/43810

## Testing

Adds `test_apostrophe_after_opening_inline_tag()` with 6 cases to `Tests_Formatting_wpTexturize` covering: the reported bug, a second inline tag (`<em>`), tags nested two deep, the no-preceding-word case, the space-before-tag case, and a block-level tag. Full `Tests_Formatting_wpTexturize` class (363 tests) and the broader `formatting` group (2077 tests) pass with no regressions. PHPCS (WordPress-Core ruleset) and PHPStan are clean on the changed files.

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Sonnet 5
Used for: Implementation, tests, and PR description. Reviewed by irozum.

---
This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/best-practices/pull-requests-code-review/) in the Core Handbook for more details.
