### PR TITLE
Embeds: Skip autoembed processing inside <pre> and <code> tags

### DIFF
--- a/src/wp-includes/class-wp-embed.php
+++ b/src/wp-includes/class-wp-embed.php
@@ -440,6 +440,26 @@ class WP_Embed {
 	 * @return string Potentially modified $content.
 	 */
 	public function autoembed( $content ) {
+		// Protect URLs inside <pre> and <code> tags from being converted to embeds.
+		// This must run before wp_replace_in_html_tags() so that newlines inside
+		// opening tag attributes (e.g. <pre\nclass="...">) don't break the regex match.
+		$protected_tags   = array();
+		$protect_callback = static function ( $matches ) use ( &$protected_tags ) {
+			$placeholder                    = sprintf( '<!-- wp-embed-protected-%d -->', count( $protected_tags ) );
+			$protected_tags[ $placeholder ] = $matches[0];
+			return $placeholder;
+		};
+
+		foreach ( array( 'pre', 'code' ) as $tag ) {
+			if ( false !== stripos( $content, "<$tag" ) ) {
+				$content = preg_replace_callback(
+					'#<' . $tag . '[\s>].*?</' . $tag . '>#is',
+					$protect_callback,
+					$content
+				);
+			}
+		}
+
 		// Replace line breaks from all HTML elements with placeholders.
 		$content = wp_replace_in_html_tags( $content, array( "\n" => '<!-- wp-line-break -->' ) );
 
@@ -448,6 +468,11 @@ class WP_Embed {
 			$content = preg_replace_callback( '|^(\s*)(https?://[^\s<>"]+)(\s*)$|im', array( $this, 'autoembed_callback' ), $content );
 			// Find URLs in their own paragraph.
 			$content = preg_replace_callback( '|(<p(?: [^>]*)?>\s*)(https?://[^\s<>"]+)(\s*<\/p>)|i', array( $this, 'autoembed_callback' ), $content );
+		}
+
+		// Restore protected content.
+		if ( ! empty( $protected_tags ) ) {
+			$content = str_replace( array_keys( $protected_tags ), array_values( $protected_tags ), $content );
 		}
 
 		// Put the line breaks back.

--- a/tests/phpunit/tests/oembed/WpEmbed.php
+++ b/tests/phpunit/tests/oembed/WpEmbed.php
@@ -440,4 +440,86 @@ class Tests_oEmbed_WpEmbed extends WP_UnitTestCase {
 		$this->wp_embed->linkifunknown = false;
 		$this->assertSame( $url, $this->wp_embed->maybe_make_link( $url ) );
 	}
+
+	/**
+	 * @ticket 39472
+	 *
+	 * @covers ::autoembed
+	 */
+	public function test_autoembed_should_not_embed_url_inside_pre_tag() {
+		$handle   = __FUNCTION__;
+		$regex    = '#https?://example\.com/embed/([^/]+)#i';
+		$callback = array( $this, '_embed_handler_callback' );
+
+		wp_embed_register_handler( $handle, $regex, $callback );
+
+		$content = "<pre>\nhttp://example.com/embed/foo\n</pre>";
+
+		$actual = $GLOBALS['wp_embed']->autoembed( $content );
+		wp_embed_unregister_handler( $handle );
+
+		$this->assertSame( $content, $actual, 'URLs inside <pre> tags should not be converted to embeds.' );
+	}
+
+	/**
+	 * @ticket 39472
+	 *
+	 * @covers ::autoembed
+	 */
+	public function test_autoembed_should_not_embed_url_inside_code_tag() {
+		$handle   = __FUNCTION__;
+		$regex    = '#https?://example\.com/embed/([^/]+)#i';
+		$callback = array( $this, '_embed_handler_callback' );
+
+		wp_embed_register_handler( $handle, $regex, $callback );
+
+		$content = "<code>\nhttp://example.com/embed/foo\n</code>";
+
+		$actual = $GLOBALS['wp_embed']->autoembed( $content );
+		wp_embed_unregister_handler( $handle );
+
+		$this->assertSame( $content, $actual, 'URLs inside <code> tags should not be converted to embeds.' );
+	}
+
+	/**
+	 * @ticket 39472
+	 *
+	 * @covers ::autoembed
+	 */
+	public function test_autoembed_should_not_embed_url_inside_pre_tag_with_attributes() {
+		$handle   = __FUNCTION__;
+		$regex    = '#https?://example\.com/embed/([^/]+)#i';
+		$callback = array( $this, '_embed_handler_callback' );
+
+		wp_embed_register_handler( $handle, $regex, $callback );
+
+		$content = "<pre class=\"code-block\">\nhttp://example.com/embed/foo\n</pre>";
+
+		$actual = $GLOBALS['wp_embed']->autoembed( $content );
+		wp_embed_unregister_handler( $handle );
+
+		$this->assertSame( $content, $actual, 'URLs inside <pre> tags with attributes should not be converted to embeds.' );
+	}
+
+	/**
+	 * @ticket 39472
+	 *
+	 * @covers ::autoembed
+	 */
+	public function test_autoembed_should_still_embed_url_outside_pre_and_code_tags() {
+		$handle   = __FUNCTION__;
+		$regex    = '#https?://example\.com/embed/([^/]+)#i';
+		$callback = array( $this, '_embed_handler_callback' );
+
+		wp_embed_register_handler( $handle, $regex, $callback );
+
+		$content = "<pre>\nhttp://example.com/embed/protected\n</pre>\n\nhttp://example.com/embed/foo\n";
+
+		$actual = $GLOBALS['wp_embed']->autoembed( $content );
+		wp_embed_unregister_handler( $handle );
+
+		$this->assertStringContainsString( 'Embedded http://example.com/embed/foo', $actual, 'URLs outside protected tags should still be embedded.' );
+		$this->assertStringContainsString( 'http://example.com/embed/protected', $actual, 'URLs inside <pre> tags should remain as plain text.' );
+		$this->assertStringNotContainsString( 'Embedded http://example.com/embed/protected', $actual, 'URLs inside <pre> tags should not be embedded.' );
+	}
 }


### PR DESCRIPTION
## Summary

Fixes #39472. URLs inside `<pre>` and `<code>` blocks are meant to be displayed as literal text, but WordPress was converting them to embeds.

This fix protects `<pre>` and `<code>` block content with placeholders before URL detection runs, then restores the original content afterward — the same placeholder approach used by `wpautop()` for `<pre>` tags.

Trac ticket: https://core.trac.wordpress.org/ticket/39472

## Changes

- **`src/wp-includes/class-wp-embed.php`**: In `WP_Embed::autoembed()`, extract `<pre>` and `<code>` blocks into placeholders before URL scanning, restore them after.
- **`tests/phpunit/tests/oembed/WpEmbed.php`**: Three new tests covering: URL in `<pre>` not embedded, URL in `<code>` not embedded, URL outside protected tags is still embedded.

## Test plan

- [x] Run `npm run test:php -- --filter test_autoembed` — all 14 tests pass
- [ ] Manually create a post with a YouTube URL inside a `<code>` block — confirm it renders as literal text, not an embed
- [ ] Verify a YouTube URL outside `<code>`/`<pre>` still embeds normally