### PR TITLE
Filesystem API: Fix inaccurate `WP_Filesystem_Direct::chmod()` file permissions comparison

### DIFF
--- a/src/wp-admin/includes/class-wp-filesystem-direct.php
+++ b/src/wp-admin/includes/class-wp-filesystem-direct.php
@@ -176,7 +176,7 @@ class WP_Filesystem_Direct extends WP_Filesystem_Base {
 		}
 
 		if ( ! $recursive || ! $this->is_dir( $file ) ) {
-			$current_mode = fileperms( $file ) & 0777 | 0644;
+			$current_mode = fileperms( $file ) & 0777;
 
 			/*
 			 * fileperms() populates the stat cache, so have to clear it


### PR DESCRIPTION
The use of `| 0644` alters the permission bits read from the file to a minimum floor before comparing them with the requested mode.

This results in an inaccurate comparison.

Removing this allows the `& 0777` mask to perform as intended: strip the filetype bits from the value returned by `fileperms( $file )` so that the current permission bits can be used for comparison with the requested mode.

This was added during review as part of #64610 for consistency with other parts of core, but those are using `| 0755` and `| 0644` to ensure `FS_CHMOD_DIR` and `FS_CHMOD_FILE` are set with the minimum permission bits required.

Trac ticket: https://core.trac.wordpress.org/ticket/65695

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Opus 4.8
Used for: Code review

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
