### PR TITLE
Stop get_password_reset_key() from firing profile_update

### DIFF
--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -3145,16 +3145,15 @@ function get_password_reset_key( $user ) {
 
 	$hashed = time() . ':' . wp_fast_hash( $key );
 
-	$key_saved = wp_update_user(
-		array(
-			'ID'                  => $user->ID,
-			'user_activation_key' => $hashed,
-		)
+	global $wpdb;
+
+	$wpdb->update(
+		$wpdb->users,
+		array( 'user_activation_key' => $hashed ),
+		array( 'ID' => $user->ID )
 	);
 
-	if ( is_wp_error( $key_saved ) ) {
-		return $key_saved;
-	}
+	clean_user_cache( $user->ID );
 
 	return $key;
 }

--- a/tests/phpunit/tests/user.php
+++ b/tests/phpunit/tests/user.php
@@ -1577,6 +1577,39 @@ class Tests_User extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 62996
+	 */
+	public function test_get_password_reset_key_does_not_fire_profile_update() {
+		$user = $this->author;
+
+		$before_profile_update = did_action( 'profile_update' );
+
+		$key = get_password_reset_key( $user );
+
+		$this->assertNotWPError( $key );
+		$this->assertSame( $before_profile_update, did_action( 'profile_update' ), 'get_password_reset_key() should not fire profile_update.' );
+
+		$updated_user = get_userdata( $user->ID );
+		$this->assertNotEmpty( $updated_user->user_activation_key, 'The user_activation_key should have been persisted.' );
+	}
+
+	/**
+	 * @ticket 62996
+	 */
+	public function test_register_new_user_does_not_fire_profile_update() {
+		reset_phpmailer_instance();
+
+		$before_user_register  = did_action( 'user_register' );
+		$before_profile_update = did_action( 'profile_update' );
+
+		$user_id = register_new_user( 'user62996', 'user62996@example.com' );
+
+		$this->assertIsInt( $user_id );
+		$this->assertSame( $before_user_register + 1, did_action( 'user_register' ), 'register_new_user() should fire user_register once.' );
+		$this->assertSame( $before_profile_update, did_action( 'profile_update' ), 'register_new_user() should not fire profile_update for a brand-new account.' );
+	}
+
+	/**
 	 * @ticket 61366
 	 * @dataProvider data_remember_user
 	 */


### PR DESCRIPTION
`register_new_user()` and the `wp-login.php?action=lostpassword` flow both call `get_password_reset_key()` to generate an account-activation / password-reset link. That function saved the internal `user_activation_key` column via `wp_update_user()`, which routes through `wp_insert_user()` and unconditionally fires `profile_update` — even though nothing about the user's profile actually changed. Since `[45714]` (`#45746`), this means every brand-new account registration also fires `profile_update`, which breaks the long-standing distinction between `user_register` (a new account) and `profile_update` (an existing user editing their own profile) that plugins such as BuddyPress, bbPress, and Easy Digital Downloads rely on for user-facing profile-update integrations.

This updates `get_password_reset_key()` to write `user_activation_key` directly via `$wpdb->update()` plus `clean_user_cache()`, the same narrow pattern `wp_set_password()` already uses for its own single-column write, instead of going through the full `wp_insert_user()` path. This preserves the cache-consistency fix from `[45714]` while no longer firing `profile_update` (or any of the meta/role writes `wp_insert_user()` would otherwise perform) for what is only an internal key rotation.

Adds two regression tests to `tests/phpunit/tests/user.php`: one asserting `get_password_reset_key()` no longer fires `profile_update` (while still persisting `user_activation_key`), and one asserting `register_new_user()` still fires `user_register` exactly once but no longer fires `profile_update`. Both fail on current trunk and pass with this fix. Full `user` (1343 tests) and `auth` (143 tests) PHPUnit groups pass with no regressions; PHPCS and PHPStan are clean.

Trac ticket: https://core.trac.wordpress.org/ticket/62996

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Sonnet 5
Used for: Root cause analysis, implementation, test coverage, and verification. Reviewed and directed by me throughout.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**