### PR TITLE
Don't show a fake password on the site activation confirmation page when the user already exists

### DIFF
--- a/src/wp-activate.php
+++ b/src/wp-activate.php
@@ -183,7 +183,11 @@ $blog_details = get_site();
 
 			<div id="signup-welcome">
 			<p><span class="h3"><?php _e( 'Username:' ); ?></span> <?php echo esc_html( $user->user_login ); ?></p>
-			<p><span class="h3"><?php _e( 'Password:' ); ?></span> <?php echo esc_html( $result['password'] ); ?></p>
+			<?php if ( empty( $result['user_already_exists'] ) ) : ?>
+				<p><span class="h3"><?php _e( 'Password:' ); ?></span> <?php echo esc_html( $result['password'] ); ?></p>
+			<?php else : ?>
+				<p><?php _e( 'You already have an account, so this site has been added using your existing username and password.' ); ?></p>
+			<?php endif; ?>
 			</div>
 
 			<?php

--- a/src/wp-includes/ms-functions.php
+++ b/src/wp-includes/ms-functions.php
@@ -1200,6 +1200,7 @@ function wpmu_signup_user_notification(
  *     password: string,
  *     title: string,
  *     meta: array<string, mixed>,
+ *     user_already_exists: bool,
  * }|WP_Error
  */
 function wpmu_activate_signup(
@@ -1323,11 +1324,12 @@ function wpmu_activate_signup(
 	do_action( 'wpmu_activate_blog', $blog_id, $user_id, $password, $signup->title, $meta );
 
 	return array(
-		'blog_id'  => $blog_id,
-		'user_id'  => $user_id,
-		'password' => $password,
-		'title'    => $signup->title,
-		'meta'     => $meta,
+		'blog_id'             => $blog_id,
+		'user_id'             => $user_id,
+		'password'            => isset( $user_already_exists ) ? '' : $password,
+		'title'               => $signup->title,
+		'meta'                => $meta,
+		'user_already_exists' => isset( $user_already_exists ),
 	);
 }
 

--- a/tests/phpunit/tests/multisite/wpmuActivateSignup.php
+++ b/tests/phpunit/tests/multisite/wpmuActivateSignup.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * @group ms-required
+ * @group multisite
+ *
+ * @covers ::wpmu_activate_signup
+ */
+class Tests_Multisite_wpmuActivateSignup extends WP_UnitTestCase {
+
+	/**
+	 * @ticket 42389
+	 */
+	public function test_should_not_return_freshly_generated_password_for_existing_user_activating_additional_site() {
+		$user_id = self::factory()->user->create( array( 'user_login' => 'existinguser42389' ) );
+
+		$result = $this->signup_and_activate_blog_for( 'existinguser42389', '/existingusersite42389/' );
+
+		$this->assertNotWPError( $result );
+		$this->assertSame( $user_id, $result['user_id'] );
+		$this->assertTrue( $result['user_already_exists'] );
+		$this->assertSame( '', $result['password'] );
+	}
+
+	/**
+	 * @ticket 42389
+	 */
+	public function test_should_return_generated_password_for_new_user_activating_a_site() {
+		$result = $this->signup_and_activate_blog_for( 'newuser42389', '/newusersite42389/' );
+
+		$this->assertNotWPError( $result );
+		$this->assertFalse( $result['user_already_exists'] );
+		$this->assertNotEmpty( $result['password'] );
+	}
+
+	/**
+	 * Signs up and activates a new site for the given user login, returning the
+	 * activation result.
+	 *
+	 * @param string $user_login User login to sign up the site for.
+	 * @param string $path       Site path, used to keep signups from different
+	 *                           tests from colliding.
+	 * @return array|WP_Error The return value of wpmu_activate_signup().
+	 */
+	private function signup_and_activate_blog_for( $user_login, $path ) {
+		global $wpdb;
+
+		add_filter( 'wpmu_signup_blog_notification', '__return_false' );
+
+		wpmu_signup_blog( WP_TESTS_DOMAIN, $path, 'A Test Site', $user_login, "{$user_login}@example.com" );
+
+		$key = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT activation_key FROM $wpdb->signups WHERE user_login = %s AND path = %s",
+				$user_login,
+				$path
+			)
+		);
+
+		$result = wpmu_activate_signup( $key );
+
+		remove_filter( 'wpmu_signup_blog_notification', '__return_false' );
+
+		return $result;
+	}
+}


### PR DESCRIPTION
When manual activation is enabled for additional site signups on a Multisite network (so a user who already has one site is required to confirm before an additional site is created), `wpmu_activate_signup()` still generates a brand-new password for the (already-registered) user and returns it in the result array. `wp-activate.php` then displays that freshly generated password on the confirmation page, even though it was never actually applied to the existing account — logging in with it fails and the user is confused about their real password.

This PR has `wpmu_activate_signup()` track whether the user already existed (it already computed this locally to decide whether to create a new user) and exposes it via a new `user_already_exists` key in the returned array. When the user already existed, the `password` key is now an empty string instead of the misleading generated one. `wp-activate.php` uses the new flag to show a message pointing the user at their existing username and password instead of a bogus one.

Trac ticket: https://core.trac.wordpress.org/ticket/42389

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Sonnet 5
Used for: Implementation, tests, and PR description. Reviewed by Igor Rozum.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
