### PR TITLE
Docs: Correct type for WP_Screen screen settings.

### DIFF
--- a/src/wp-admin/includes/class-wp-screen.php
+++ b/src/wp-admin/includes/class-wp-screen.php
@@ -186,7 +186,7 @@ final class WP_Screen {
 	 * Stores the 'screen_settings' section of screen options.
 	 *
 	 * @since 3.3.0
-	 * @var string
+	 * @var string|null
 	 */
 	private $_screen_settings;
 


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/56607

## Summary

- Correct the documented type of `WP_Screen::$_screen_settings`.
- Account for the property being `null` until `show_screen_options()` initializes it.

The ticket's other proposed type changes have already been addressed by later commits or are no longer applicable to current trunk.

## Testing

- `php -l src/wp-admin/includes/class-wp-screen.php`
- `phpcbf --standard=phpcs.xml.dist src/wp-admin/includes/class-wp-screen.php`
- `phpcs --standard=phpcs.xml.dist src/wp-admin/includes/class-wp-screen.php`
