### PR TITLE
Administration: Handle AJAX failures for plugin and theme actions

### DIFF
--- a/src/js/_enqueues/wp/updates.js
+++ b/src/js/_enqueues/wp/updates.js
@@ -1341,7 +1341,7 @@
 		errorCallback = args.error;
 		if ( errorCallback ) {
 			args.error = function() {
-				$link.text( $link.data( 'originaltext' ) );
+				$link.html( $link.data( 'originaltext' ) );
 
 				errorCallback.apply( this, arguments );
 			};

--- a/src/js/_enqueues/wp/updates.js
+++ b/src/js/_enqueues/wp/updates.js
@@ -1330,12 +1330,22 @@
 	 *                     decorated with an abort() method.
 	 */
 	wp.updates.deletePlugin = function( args ) {
-		var $link = $( '[data-plugin="' + args.plugin + '"]' ).find( '.row-actions a.delete' );
+		var errorCallback,
+			$link = $( '[data-plugin="' + args.plugin + '"]' ).find( '.row-actions a.delete' );
 
 		args = _.extend( {
 			success: wp.updates.deletePluginSuccess,
 			error: wp.updates.deletePluginError
 		}, args );
+
+		errorCallback = args.error;
+		if ( errorCallback ) {
+			args.error = function() {
+				$link.text( $link.data( 'originaltext' ) );
+
+				errorCallback.apply( this, arguments );
+			};
+		}
 
 		if ( $link.html() !== __( 'Deleting...' ) ) {
 			$link
@@ -1488,12 +1498,7 @@
 	 * @param {string}  response.errorMessage The error that occurred.
 	 */
 	wp.updates.deletePluginError = function( response ) {
-		var $plugin, $pluginUpdateRow,
-			pluginUpdateRow  = wp.template( 'item-update-row' ),
-			noticeContent    = wp.updates.adminNotice( {
-				className: 'update-message notice-error notice-alt',
-				message:   response.errorMessage
-			} );
+		var $deleteLink, $plugin, $pluginUpdateRow, noticeContent, pluginUpdateRow;
 
 		if ( response.plugin ) {
 			$plugin          = $( 'tr.inactive[data-plugin="' + response.plugin + '"]' );
@@ -1503,6 +1508,9 @@
 			$pluginUpdateRow = $plugin.siblings( '[data-slug="' + response.slug + '"]' );
 		}
 
+		$deleteLink = $plugin.find( '.row-actions a.delete' );
+		$deleteLink.text( $deleteLink.data( 'originaltext' ) );
+
 		if ( ! wp.updates.isValidResponse( response, 'delete' ) ) {
 			return;
 		}
@@ -1510,6 +1518,12 @@
 		if ( wp.updates.maybeHandleCredentialError( response, 'delete-plugin' ) ) {
 			return;
 		}
+
+		pluginUpdateRow = wp.template( 'item-update-row' );
+		noticeContent   = wp.updates.adminNotice( {
+			className: 'update-message notice-error notice-alt',
+			message:   response.errorMessage
+		} );
 
 		// Add a plugin update row if it doesn't exist yet.
 		if ( ! $pluginUpdateRow.length ) {
@@ -1908,7 +1922,7 @@
 	 *                     decorated with an abort() method.
 	 */
 	wp.updates.deleteTheme = function( args ) {
-		var $button;
+		var $button, errorCallback;
 
 		if ( 'themes' === pagenow ) {
 			$button = $( '.theme-actions .delete-theme' );
@@ -1920,6 +1934,17 @@
 			success: wp.updates.deleteThemeSuccess,
 			error: wp.updates.deleteThemeError
 		}, args );
+
+		errorCallback = args.error;
+		if ( errorCallback ) {
+			args.error = function() {
+				if ( $button ) {
+					$button.html( $button.data( 'originaltext' ) );
+				}
+
+				errorCallback.apply( this, arguments );
+			};
+		}
 
 		if ( $button && $button.html() !== __( 'Deleting...' ) ) {
 			$button
@@ -2034,23 +2059,36 @@
 	 * @param {string} response.errorMessage The error that occurred.
 	 */
 	wp.updates.deleteThemeError = function( response ) {
-		var $themeRow    = $( 'tr.inactive[data-slug="' + response.slug + '"]' ),
-			$button      = $( '.theme-actions .delete-theme' ),
-			updateRow    = wp.template( 'item-update-row' ),
-			$updateRow   = $themeRow.siblings( '#' + response.slug + '-update' ),
-			errorMessage = sprintf(
-				/* translators: %s: Error string for a failed deletion. */
-				__( 'Deletion failed: %s' ),
-				response.errorMessage
-			),
-			$message     = wp.updates.adminNotice( {
-				className: 'update-message notice-error notice-alt',
-				message:   errorMessage
-			} );
+		var $button, $message, errorMessage, updateRow,
+			$themeRow  = $( 'tr.inactive[data-slug="' + response.slug + '"]' ),
+			$updateRow = $themeRow.siblings( '#' + response.slug + '-update' );
+
+		if ( 'themes-network' === pagenow ) {
+			$button = $themeRow.find( '.row-actions a.delete' );
+		} else {
+			$button = $( '.theme-actions .delete-theme' );
+		}
+
+		$button.html( $button.data( 'originaltext' ) );
+
+		if ( ! wp.updates.isValidResponse( response, 'delete' ) ) {
+			return;
+		}
 
 		if ( wp.updates.maybeHandleCredentialError( response, 'delete-theme' ) ) {
 			return;
 		}
+
+		updateRow    = wp.template( 'item-update-row' );
+		errorMessage = sprintf(
+			/* translators: %s: Error string for a failed deletion. */
+			__( 'Deletion failed: %s' ),
+			response.errorMessage
+		);
+		$message     = wp.updates.adminNotice( {
+			className: 'update-message notice-error notice-alt',
+			message:   errorMessage
+		} );
 
 		if ( 'themes-network' === pagenow ) {
 			if ( ! $updateRow.length ) {
@@ -2069,8 +2107,6 @@
 		} else {
 			$( '.theme-info .theme-description' ).before( $message );
 		}
-
-		$button.html( $button.data( 'originaltext' ) );
 
 		wp.a11y.speak( errorMessage, 'assertive' );
 
@@ -3418,7 +3454,7 @@
 						if ( response.data && response.data.error ) {
 							errorMessage = response.data.error;
 						} else {
-							errorMessage = __( 'The request could not be completed.' );
+							errorMessage = __( 'The request could not be completed. Please try again.' );
 						}
 
 						$parent.find( '.notice.notice-error' ).removeClass( 'hidden' ).find( 'p' ).text( errorMessage );
@@ -3482,11 +3518,15 @@
 					$parent.find( '.notice.notice-error' )
 						.removeClass( 'hidden' )
 						.find( 'p' )
-						.text( __( 'The request could not be completed.' ) );
+						.text( __( 'The request could not be completed. Please try again.' ) );
 
-					wp.a11y.speak( __( 'The request could not be completed.' ), 'assertive' );
+					wp.a11y.speak( __( 'The request could not be completed. Please try again.' ), 'assertive' );
 				} )
 				.always( function() {
+					if ( action === $toggler.attr( 'data-wp-action' ) ) {
+						$label.text( 'enable' === action ? __( 'Enable auto-updates' ) : __( 'Disable auto-updates' ) );
+					}
+
 					$toggler.removeAttr( 'data-doing-ajax' ).find( '.dashicons-update' ).addClass( 'hidden' );
 				} );
 			}

--- a/tests/qunit/wp-admin/js/updates.js
+++ b/tests/qunit/wp-admin/js/updates.js
@@ -123,6 +123,24 @@ jQuery( function( $ ) {
 		assert.equal( jQuery.ajax.getCall( 0 ).args[0].data.slug, 'jetpack' );
 	} );
 
+	/**
+	 * @ticket 55368
+	 */
+	QUnit.test( 'A failed plugin deletion should restore the delete link', function( assert ) {
+		var $pluginRow = $(
+				'<table><tbody><tr class="inactive" data-plugin="jetpack/jetpack.php" data-slug="jetpack">' +
+					'<td><div class="row-actions"><a class="delete">Delete</a></div></td>' +
+				'</tr></tbody></table>'
+			).appendTo( '#qunit-fixture' ).find( 'tr' );
+
+		sinon.stub( wp.ajax, 'send' ).returns( jQuery.Deferred().promise() );
+
+		wp.updates.deletePlugin( { slug: 'jetpack', plugin: 'jetpack/jetpack.php' } );
+		wp.ajax.send.firstCall.args[ 0 ].error( 'Briefly unavailable for scheduled maintenance.' );
+
+		assert.strictEqual( $pluginRow.find( 'a.delete' ).text(), 'Delete', 'The delete link text is restored.' );
+	} );
+
 	// QUnit.test( 'A successful update changes the message?', function( assert ) {} );
 	// QUnit.test( 'A failed update changes the message?', function( assert ) {} );
 
@@ -174,6 +192,79 @@ jQuery( function( $ ) {
 		assert.equal( jQuery.ajax.getCall( 0 ).args[0].data.slug, 'twentyeleven' );
 	} );
 
+	/**
+	 * @ticket 55368
+	 */
+	QUnit.test( 'A failed theme deletion should restore the delete button', function( assert ) {
+		var $button = $( '<div class="theme-actions"><button class="delete-theme">Delete</button></div>' )
+				.appendTo( '#qunit-fixture' )
+				.find( '.delete-theme' );
+
+		sinon.stub( wp.ajax, 'send' ).returns( jQuery.Deferred().promise() );
+
+		wp.updates.deleteTheme( { slug: 'twentyeleven' } );
+		wp.ajax.send.firstCall.args[ 0 ].error( 'Briefly unavailable for scheduled maintenance.' );
+
+		assert.strictEqual( $button.text(), 'Delete', 'The delete button text is restored.' );
+	} );
+
 	// QUnit.test( 'A successful update changes the message?', function( assert ) {} );
 	// QUnit.test( 'A failed update changes the message?', function( assert ) {} );
+
+	QUnit.module( 'wp.updates.autoUpdates', {
+		beforeEach: function() {
+			this.oldPagenow = window.pagenow;
+			window.pagenow = 'plugins';
+			this.request = jQuery.Deferred();
+			sinon.stub( jQuery, 'post' ).returns( this.request.promise() );
+			this.$column = $(
+				'<div class="column-auto-updates">' +
+					'<div class="notice notice-error hidden"><p></p></div>' +
+					'<button class="toggle-auto-update" data-wp-action="enable">' +
+						'<span class="dashicons-update hidden"></span>' +
+						'<span class="label">Enable auto-updates</span>' +
+					'</button>' +
+				'</div>'
+			).appendTo( '#qunit-fixture' );
+		},
+		afterEach: function() {
+			window.pagenow = this.oldPagenow;
+		}
+	} );
+
+	/**
+	 * @ticket 55368
+	 */
+	QUnit.test( 'A failed auto-update request should restore the toggle label', function( assert ) {
+		var $toggler = this.$column.find( '.toggle-auto-update' );
+
+		$toggler.trigger( 'click' );
+		assert.strictEqual( $toggler.find( '.label' ).text(), 'Enabling...', 'The pending label is shown.' );
+
+		this.request.reject();
+
+		assert.strictEqual( $toggler.find( '.label' ).text(), 'Enable auto-updates', 'The toggle label is restored.' );
+		assert.strictEqual(
+			this.$column.find( '.notice-error p' ).text(),
+			'The request could not be completed. Please try again.',
+			'The error message suggests retrying the request.'
+		);
+	} );
+
+	/**
+	 * @ticket 55368
+	 */
+	QUnit.test( 'An invalid auto-update response should restore the toggle label', function( assert ) {
+		var $toggler = this.$column.find( '.toggle-auto-update' );
+
+		$toggler.trigger( 'click' );
+		this.request.resolve( 'Briefly unavailable for scheduled maintenance.' );
+
+		assert.strictEqual( $toggler.find( '.label' ).text(), 'Enable auto-updates', 'The toggle label is restored.' );
+		assert.strictEqual(
+			this.$column.find( '.notice-error p' ).text(),
+			'The request could not be completed. Please try again.',
+			'The error message suggests retrying the request.'
+		);
+	} );
 });

--- a/tests/qunit/wp-admin/js/updates.js
+++ b/tests/qunit/wp-admin/js/updates.js
@@ -200,12 +200,14 @@ jQuery( function( $ ) {
 				.appendTo( '#qunit-fixture' )
 				.find( '.delete-theme' );
 
-		sinon.stub( wp.ajax, 'send' ).returns( jQuery.Deferred().promise() );
+		var sendStub = sinon.stub( wp.ajax, 'send' ).returns( jQuery.Deferred().promise() );
 
 		wp.updates.deleteTheme( { slug: 'twentyeleven' } );
 		wp.ajax.send.firstCall.args[ 0 ].error( 'Briefly unavailable for scheduled maintenance.' );
 
 		assert.strictEqual( $button.text(), 'Delete', 'The delete button text is restored.' );
+
+		sendStub.restore();
 	} );
 
 	// QUnit.test( 'A successful update changes the message?', function( assert ) {} );


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

## What changed

- Restore plugin and theme deletion controls when an Ajax request fails.
- Avoid showing an undefined theme deletion error for invalid responses.
- Restore auto-update toggle labels after failed requests and suggest retrying.
- Add focused QUnit coverage for maintenance-mode and network failure responses.

## Why

Plugin and theme actions can receive an invalid response while maintenance mode is active or when the server is unavailable. The existing handlers could leave controls displaying a permanent loading state or expose `undefined` as the error message.

## Testing

- `grunt jshint:core --file=wp/updates.js`
- `grunt jshint:tests`
- `npm run typecheck:js`
- QUnit source mode: 541/541 passed
- QUnit compiled mode: 541/541 passed

Trac ticket: https://core.trac.wordpress.org/ticket/55368

## Use of AI Tools

AI assistance: Yes
Tool(s): OpenAI Codex
Model(s): GPT-5
Used for: Reviewing the Trac ticket and relevant code, helping with the initial implementation and regression-test approach, and assisting with validation and PR-description drafting. The final implementation, tests, validation results, and description were reviewed and accepted by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**