### PR TITLE
oEmbed: Fall back to XML parsing when JSON parsing fails

### DIFF
--- a/src/wp-includes/class-wp-oembed.php
+++ b/src/wp-includes/class-wp-oembed.php
@@ -646,11 +646,11 @@ class WP_oEmbed {
 		$data         = $this->$parse_method( $body );
 
 		/*
-		* Some providers ignore the `format` query parameter when it's already
-		* implied by the request URL (e.g. a `.xml` endpoint). If
-		* JSON parsing failed, try parsing the same response body as XML before
-		* giving up, since XML parsing predictably fails on non-XML content.
-		*/
+		 * Some providers ignore the `format` query parameter when it's already
+		 * implied by the request URL (e.g. a `.xml` endpoint). If JSON parsing
+		 * failed, try parsing the same response body as XML before giving up,
+		 * since XML parsing predictably fails on non-XML content.
+		 */
 		if ( false === $data && 'json' === $format ) {
 			$data = $this->_parse_xml( $body );
 		}

--- a/src/wp-includes/class-wp-oembed.php
+++ b/src/wp-includes/class-wp-oembed.php
@@ -651,7 +651,7 @@ class WP_oEmbed {
 		 * failed, try parsing the same response body as XML before giving up,
 		 * since XML parsing predictably fails on non-XML content.
 		 */
-		if ( false === $data && 'json' === $format ) {
+		if ( false === $data && 'json' === $format && false !== stripos( $body, '<oembed' ) ) {
 			$data = $this->_parse_xml( $body );
 		}
 

--- a/src/wp-includes/class-wp-oembed.php
+++ b/src/wp-includes/class-wp-oembed.php
@@ -643,8 +643,19 @@ class WP_oEmbed {
 		}
 
 		$parse_method = "_parse_$format";
+		$data         = $this->$parse_method( $body );
 
-		return $this->$parse_method( $body );
+		/*
+		* Some providers ignore the `format` query parameter when it's already
+		* implied by the request URL (e.g. a `.xml` endpoint). If
+		* JSON parsing failed, try parsing the same response body as XML before
+		* giving up, since XML parsing predictably fails on non-XML content.
+		*/
+		if ( false === $data && 'json' === $format ) {
+			$data = $this->_parse_xml( $body );
+		}
+
+		return $data;
 	}
 
 	/**

--- a/tests/phpunit/tests/oembed/wpOembed.php
+++ b/tests/phpunit/tests/oembed/wpOembed.php
@@ -312,4 +312,89 @@ class Tests_oEmbed_wpOembed extends WP_UnitTestCase {
 
 		$this->assertSame( 'https://example.site/api/oembed', $result );
 	}
+
+	/**
+	 * @ticket 44231
+	 * @covers WP_oEmbed::fetch
+	 */
+	public function test_fetch_falls_back_to_xml_when_json_parsing_fails() {
+		$xml_body = '<?xml version="1.0" encoding="utf-8" standalone="yes"?>'
+			. '<oembed><type>rich</type><version>1.0</version>'
+			. '<html>&lt;p&gt;Test&lt;/p&gt;</html><width>400</width><height>300</height></oembed>';
+
+		$filter = static function ( $preempt, $parsed_args, $url ) use ( $xml_body ) {
+			if ( str_contains( $url, 'format=json' ) ) {
+				return array(
+					'body'     => $xml_body,
+					'response' => array( 'code' => 200 ),
+				);
+			}
+			return $preempt;
+		};
+
+		add_filter( 'pre_http_request', $filter, 10, 3 );
+		$result = $this->oembed->fetch( 'https://example.com/oembed', 'https://example.com/some-video' );
+		remove_filter( 'pre_http_request', $filter, 10 );
+
+		$this->assertInstanceOf( 'stdClass', $result );
+		$this->assertSame( 'rich', $result->type );
+		$this->assertSame( '<p>Test</p>', $result->html );
+	}
+
+	/**
+	 * @ticket 44231
+	 * @covers WP_oEmbed::fetch
+	 */
+	public function test_fetch_does_not_fall_back_to_xml_for_non_oembed_xml() {
+		$error_xml = '<?xml version="1.0" encoding="utf-8"?><error>Not found</error>';
+
+		$filter = static function ( $preempt, $parsed_args, $url ) use ( $error_xml ) {
+			if ( str_contains( $url, 'format=json' ) ) {
+				return array(
+					'body'     => $error_xml,
+					'response' => array( 'code' => 200 ),
+				);
+			}
+			return $preempt;
+		};
+
+		add_filter( 'pre_http_request', $filter, 10, 3 );
+		$result = $this->oembed->fetch( 'https://example.com/oembed', 'https://example.com/some-video' );
+		remove_filter( 'pre_http_request', $filter, 10 );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * @ticket 44231
+	 * @covers WP_oEmbed::fetch
+	 */
+	public function test_fetch_still_parses_valid_json_normally() {
+		$json_body = wp_json_encode(
+			array(
+				'type'    => 'rich',
+				'version' => '1.0',
+				'html'    => '<p>Test</p>',
+				'width'   => 400,
+				'height'  => 300,
+			)
+		);
+
+		$filter = static function ( $preempt, $parsed_args, $url ) use ( $json_body ) {
+			if ( str_contains( $url, 'format=json' ) ) {
+				return array(
+					'body'     => $json_body,
+					'response' => array( 'code' => 200 ),
+				);
+			}
+			return $preempt;
+		};
+
+		add_filter( 'pre_http_request', $filter, 10, 3 );
+		$result = $this->oembed->fetch( 'https://example.com/oembed', 'https://example.com/some-video' );
+		remove_filter( 'pre_http_request', $filter, 10 );
+
+		$this->assertInstanceOf( 'stdClass', $result );
+		$this->assertSame( 'rich', $result->type );
+	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->
When `WP_oEmbed::_fetch_with_format()` requests `format=json` but JSON parsing of the response fails, this falls back to attempting to parse the same response body as XML before giving up. Some oEmbed providers advertise an XML-only endpoint via a `<link rel="alternate" type="text/xml+oembed" href="...">` discovery tag. 

WordPress's `fetch()` always appends `&format=json` to the request regardless of the discovered endpoint's declared type. A spec-compliant provider correctly ignores that parameter and returns a valid XML response with an HTTP 200 status.

Trac ticket: https://core.trac.wordpress.org/ticket/44231

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude
Model(s): Claude Sonnet 5
Used for: Investigating the bug and drafting the initial fix. Reviewed, debugged, and verified end-to-end by me.
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
