### PR TITLE
Filesystem: Retry ftp_fput() up to 3 times on failure

### DIFF
--- a/src/wp-admin/includes/class-wp-filesystem-ftpext.php
+++ b/src/wp-admin/includes/class-wp-filesystem-ftpext.php
@@ -263,7 +263,23 @@ class WP_Filesystem_FTPext extends WP_Filesystem_Base {
 
 		fseek( $temphandle, 0 ); // Skip back to the start of the file being written to.
 
-		$ret = ftp_fput( $this->link, $file, $temphandle, FTP_BINARY );
+		$ret = false;
+
+		for ( $tries = 1; $tries <= 3; $tries++ ) {
+			$ret = ftp_fput( $this->link, $file, $temphandle, FTP_BINARY );
+
+			if ( $ret ) {
+				break;
+			}
+
+			if ( $tries < 3 ) {
+				if ( ! $this->connect() ) {
+					break;
+				}
+
+				fseek( $temphandle, 0 );
+			}
+		}
 
 		fclose( $temphandle );
 		unlink( $tempfile );

--- a/src/wp-admin/includes/class-wp-filesystem-ftpext.php
+++ b/src/wp-admin/includes/class-wp-filesystem-ftpext.php
@@ -273,22 +273,23 @@ class WP_Filesystem_FTPext extends WP_Filesystem_Base {
 				break;
 			}
 
-			// On failure, try to reconnect before the next attempt.
 			if ( $tries < $max_tries ) {
-				$cwd = $this->cwd();
-
-				if ( $this->link ) {
-					ftp_close( $this->link );
-					$this->link = false;
-				}
+				$cwd      = $this->cwd();
+				$old_link = $this->link;
 
 				if ( ! $this->connect() ) {
+					$this->link = $old_link;
 					break;
 				}
 
-				// Restore the working directory, as a new connection resets it.
 				if ( $cwd && ! $this->chdir( $cwd ) ) {
+					ftp_close( $this->link );
+					$this->link = $old_link;
 					break;
+				}
+
+				if ( $old_link ) {
+					ftp_close( $old_link );
 				}
 
 				fseek( $temphandle, 0 );

--- a/src/wp-admin/includes/class-wp-filesystem-ftpext.php
+++ b/src/wp-admin/includes/class-wp-filesystem-ftpext.php
@@ -263,17 +263,31 @@ class WP_Filesystem_FTPext extends WP_Filesystem_Base {
 
 		fseek( $temphandle, 0 ); // Skip back to the start of the file being written to.
 
-		$ret = false;
+		$ret       = false;
+		$max_tries = 3;
 
-		for ( $tries = 1; $tries <= 3; $tries++ ) {
+		for ( $tries = 1; $tries <= $max_tries; $tries++ ) {
 			$ret = ftp_fput( $this->link, $file, $temphandle, FTP_BINARY );
 
 			if ( $ret ) {
 				break;
 			}
 
-			if ( $tries < 3 ) {
+			// On failure, try to reconnect before the next attempt.
+			if ( $tries < $max_tries ) {
+				$cwd = $this->cwd();
+
+				if ( $this->link ) {
+					ftp_close( $this->link );
+					$this->link = false;
+				}
+
 				if ( ! $this->connect() ) {
+					break;
+				}
+
+				// Restore the working directory, as a new connection resets it.
+				if ( $cwd && ! $this->chdir( $cwd ) ) {
 					break;
 				}
 


### PR DESCRIPTION
This PR adds a retry mechanism to WP_Filesystem_FTPext::put_contents() to improve resilience against transient network failures during FTP transfers (like auto-upgrades).

It now safely retries ftp_fput() up to 3 times. On failure, it automatically re-establishes the connection and restores the working directory before retrying, while preventing downstream PHP 8+ TypeErrors if the reconnect fails entirely.

Trac ticket: [#28616](https://core.trac.wordpress.org/ticket/28616)

## Use of AI Tools

AI assistance: Yes
Tool(s): GitHub Copilot
Model(s): Gemini, Claude
Used for: Checking for potential edge cases, drafting the PR description, and assisting with local code review. The final implementation and testing were written and executed manually by me.

---

**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
