### PR TITLE
65683 list table view mode switcher

### DIFF
--- a/src/js/media/views/attachments/browser.js
+++ b/src/js/media/views/attachments/browser.js
@@ -223,7 +223,7 @@ AttachmentsBrowser = View.extend(/** @lends wp.media.view.AttachmentsBrowser.pro
 				this.toolbar.set( 'filters', Filters.render() );
 			}
 		}
-		
+
 		/*
 		 * Feels odd to bring the global media library switcher into the Attachment browser view.
 		 * Is this a use case for doAction( 'add:toolbar-items:attachments-browser', this.toolbar );
@@ -231,8 +231,12 @@ AttachmentsBrowser = View.extend(/** @lends wp.media.view.AttachmentsBrowser.pro
 		 */
 		if ( this.controller.isModeActive( 'grid' ) ) {
 			LibraryViewSwitcher = View.extend({
-				className: 'view-switch media-grid-view-switch',
-				template: wp.template( 'media-library-view-switcher')
+				className: 'view-switch media-grid-view-switch view-switcher-group',
+				template: wp.template( 'media-library-view-switcher'),
+				attributes: {
+					'role': 'group',
+					'aria-label': l10n.viewSwitcherAriaLabel
+				}
 			});
 
 			this.toolbar.set( 'libraryViewSwitcher', new LibraryViewSwitcher({

--- a/src/wp-admin/css/list-tables.css
+++ b/src/wp-admin/css/list-tables.css
@@ -752,20 +752,28 @@ th.sorted a span {
 }
 
 .wp-filter .view-switch {
-	display: inline-block;
+	display: inline-grid;
+	grid-auto-flow: column;
 	vertical-align: middle;
-	padding: 12px 0;
+	padding: 0;
 	margin: 0 8px 0 2px;
+	gap: 12px;
+}
+
+.media-toolbar.wp-filter {
+	padding: 12px 16px;
 }
 
 .media-toolbar.wp-filter .view-switch {
 	margin: 0 12px 0 2px;
 }
 
+.view-switch .view-switch-label {
+	display: block;
+}
+
 .view-switch a {
-	float: left;
-	width: 28px;
-	height: 28px;
+	min-width: 40px;
 	text-align: center;
 	line-height: 1.84615384;
 	text-decoration: none;
@@ -802,6 +810,10 @@ th.sorted a span {
 .view-switch .view-grid:before {
 	content: "\f509";
 	content: "\f509" / '';
+}
+
+.view-switch-label {
+	font-size: 11px;
 }
 
 .filter {

--- a/src/wp-admin/css/media.css
+++ b/src/wp-admin/css/media.css
@@ -448,7 +448,11 @@ border color while dragging a file over the uploader drop area */
 }
 
 .post-type-attachment .wp-filter select {
-	margin: 0 6px 0 0;
+	margin: 0 10px 0 0;
+}
+
+.post-type-attachment .wp-filter .actions select {
+	margin: 0 14px 0 0;
 }
 
 /**
@@ -585,6 +589,7 @@ border color while dragging a file over the uploader drop area */
 	padding: 0 8px;
 }
 
+.media-toolbar .filter-items,
 .media-frame.mode-grid .media-toolbar-secondary {
 	display: flex;
 	flex-wrap: wrap;

--- a/src/wp-admin/includes/class-wp-list-table.php
+++ b/src/wp-admin/includes/class-wp-list-table.php
@@ -807,7 +807,7 @@ class WP_List_Table {
 	protected function view_switcher( $current_mode ) {
 		?>
 		<input type="hidden" name="mode" value="<?php echo esc_attr( $current_mode ); ?>" />
-		<div class="view-switch">
+		<div class="view-switch" role="group" aria-label="<?php esc_attr_e( 'View mode' ); ?>'">
 		<?php
 		foreach ( $this->modes as $mode => $title ) {
 			$classes      = array( 'view-' . $mode );
@@ -820,7 +820,7 @@ class WP_List_Table {
 
 			printf(
 				"<a href='%s' class='%s' id='view-switch-$mode'$aria_current>" .
-					"<span class='screen-reader-text'>%s</span>" .
+					'<span class="view-switch-label">%s</span>' .
 				"</a>\n",
 				esc_url( remove_query_arg( 'attachment-filter', add_query_arg( 'mode', $mode ) ) ),
 				implode( ' ', $classes ),

--- a/src/wp-admin/includes/class-wp-list-table.php
+++ b/src/wp-admin/includes/class-wp-list-table.php
@@ -807,7 +807,7 @@ class WP_List_Table {
 	protected function view_switcher( $current_mode ) {
 		?>
 		<input type="hidden" name="mode" value="<?php echo esc_attr( $current_mode ); ?>" />
-		<div class="view-switch" role="group" aria-label="<?php esc_attr_e( 'View mode' ); ?>'">
+		<div class="view-switch" role="group" aria-label="<?php esc_attr_e( 'View mode' ); ?>">
 		<?php
 		foreach ( $this->modes as $mode => $title ) {
 			$classes      = array( 'view-' . $mode );

--- a/src/wp-admin/includes/class-wp-media-list-table.php
+++ b/src/wp-admin/includes/class-wp-media-list-table.php
@@ -52,8 +52,10 @@ class WP_Media_List_Table extends WP_List_Table {
 		$this->detached = ( isset( $_REQUEST['attachment-filter'] ) && 'detached' === $_REQUEST['attachment-filter'] );
 
 		$this->modes = array(
-			'list' => __( 'List view' ),
-			'grid' => __( 'Grid view' ),
+			/* translators: Media Library view mode. */
+			'list' => __( 'List' ),
+			/* translators: Media Library view mode. */
+			'grid' => __( 'Grid' ),
 		);
 
 		parent::__construct(
@@ -305,7 +307,7 @@ class WP_Media_List_Table extends WP_List_Table {
 
 		$this->screen->render_screen_reader_content( 'heading_views' );
 		?>
-		<div class="wp-filter">
+		<div class="wp-filter media-toolbar">
 			<div class="filter-items">
 				<?php $this->view_switcher( $mode ); ?>
 

--- a/src/wp-admin/includes/class-wp-ms-sites-list-table.php
+++ b/src/wp-admin/includes/class-wp-ms-sites-list-table.php
@@ -65,19 +65,11 @@ class WP_MS_Sites_List_Table extends WP_List_Table {
 	 *
 	 * @since 3.1.0
 	 *
-	 * @global string $mode List table view mode.
 	 * @global string $s    Search string.
 	 * @global wpdb   $wpdb WordPress database abstraction object.
 	 */
 	public function prepare_items() {
-		global $mode, $s, $wpdb;
-
-		if ( ! empty( $_REQUEST['mode'] ) ) {
-			$mode = 'excerpt' === $_REQUEST['mode'] ? 'excerpt' : 'list';
-			set_user_setting( 'sites_list_mode', $mode );
-		} else {
-			$mode = get_user_setting( 'sites_list_mode', 'list' );
-		}
+		global $s, $wpdb;
 
 		$per_page = $this->get_items_per_page( 'sites_network_per_page' );
 
@@ -315,18 +307,10 @@ class WP_MS_Sites_List_Table extends WP_List_Table {
 	 *
 	 * @since 3.1.0
 	 *
-	 * @global string $mode List table view mode.
-	 *
 	 * @param string $which The location of the pagination nav markup: Either 'top' or 'bottom'.
 	 */
 	protected function pagination( $which ) {
-		global $mode;
-
 		parent::pagination( $which );
-
-		if ( 'top' === $which ) {
-			$this->view_switcher( $mode );
-		}
 	}
 
 	/**
@@ -472,13 +456,9 @@ class WP_MS_Sites_List_Table extends WP_List_Table {
 	 *
 	 * @since 4.3.0
 	 *
-	 * @global string $mode List table view mode.
-	 *
 	 * @param array $blog Current site.
 	 */
 	public function column_blogname( $blog ) {
-		global $mode;
-
 		$blogname = untrailingslashit( $blog['domain'] . $blog['path'] );
 
 		?>
@@ -494,18 +474,16 @@ class WP_MS_Sites_List_Table extends WP_List_Table {
 			?>
 		</strong>
 		<?php
-		if ( 'list' !== $mode ) {
-			switch_to_blog( $blog['blog_id'] );
-			echo '<p>';
-			printf(
-				/* translators: 1: Site title, 2: Site tagline. */
-				__( '%1$s &#8211; %2$s' ),
-				get_option( 'blogname' ),
-				'<em>' . get_option( 'blogdescription' ) . '</em>'
-			);
-			echo '</p>';
-			restore_current_blog();
-		}
+		switch_to_blog( $blog['blog_id'] );
+		echo '<p>';
+		printf(
+			/* translators: 1: Site title, 2: Site tagline. */
+			__( '%1$s &#8211; %2$s' ),
+			get_option( 'blogname' ),
+			'<em>' . get_option( 'blogdescription' ) . '</em>'
+		);
+		echo '</p>';
+		restore_current_blog();
 	}
 
 	/**
@@ -513,18 +491,10 @@ class WP_MS_Sites_List_Table extends WP_List_Table {
 	 *
 	 * @since 4.3.0
 	 *
-	 * @global string $mode List table view mode.
-	 *
 	 * @param array $blog Current site.
 	 */
 	public function column_lastupdated( $blog ) {
-		global $mode;
-
-		if ( 'list' === $mode ) {
-			$date = __( 'Y/m/d' );
-		} else {
-			$date = __( 'Y/m/d g:i:s a' );
-		}
+		$date = __( 'Y/m/d g:i:s a' );
 
 		if ( '0000-00-00 00:00:00' === $blog['last_updated'] ) {
 			_e( 'Never' );
@@ -538,18 +508,10 @@ class WP_MS_Sites_List_Table extends WP_List_Table {
 	 *
 	 * @since 4.3.0
 	 *
-	 * @global string $mode List table view mode.
-	 *
 	 * @param array $blog Current site.
 	 */
 	public function column_registered( $blog ) {
-		global $mode;
-
-		if ( 'list' === $mode ) {
-			$date = __( 'Y/m/d' );
-		} else {
-			$date = __( 'Y/m/d g:i:s a' );
-		}
+		$date = __( 'Y/m/d g:i:s a' );
 
 		if ( '0000-00-00 00:00:00' === $blog['registered'] ) {
 			echo '&#x2014;';

--- a/src/wp-admin/includes/class-wp-ms-users-list-table.php
+++ b/src/wp-admin/includes/class-wp-ms-users-list-table.php
@@ -23,7 +23,7 @@ class WP_MS_Users_List_Table extends WP_List_Table {
 	}
 
 	/**
-	 * Prepares the list of sites for display.
+	 * Prepares the list of users for display.
 	 *
 	 * @since 3.1.0
 	 *

--- a/src/wp-admin/includes/class-wp-ms-users-list-table.php
+++ b/src/wp-admin/includes/class-wp-ms-users-list-table.php
@@ -23,19 +23,15 @@ class WP_MS_Users_List_Table extends WP_List_Table {
 	}
 
 	/**
-	 * @global string $mode       List table view mode.
+	 * Prepares the list of sites for display.
+	 *
+	 * @since 3.1.0
+	 *
 	 * @global string $usersearch
 	 * @global string $role
 	 */
 	public function prepare_items() {
-		global $mode, $usersearch, $role;
-
-		if ( ! empty( $_REQUEST['mode'] ) ) {
-			$mode = 'excerpt' === $_REQUEST['mode'] ? 'excerpt' : 'list';
-			set_user_setting( 'network_users_list_mode', $mode );
-		} else {
-			$mode = get_user_setting( 'network_users_list_mode', 'list' );
-		}
+		global $usersearch, $role;
 
 		$usersearch = isset( $_REQUEST['s'] ) ? wp_unslash( trim( $_REQUEST['s'] ) ) : '';
 
@@ -170,18 +166,14 @@ class WP_MS_Users_List_Table extends WP_List_Table {
 	}
 
 	/**
-	 * @global string $mode List table view mode.
+	 * Displays the pagination.
 	 *
-	 * @param string $which
+	 * @since 3.1.0
+	 *
+	 * @param string $which The location of the pagination nav markup: Either 'top' or 'bottom'.
 	 */
 	protected function pagination( $which ) {
-		global $mode;
-
 		parent::pagination( $which );
-
-		if ( 'top' === $which ) {
-			$this->view_switcher( $mode );
-		}
 	}
 
 	/**
@@ -334,17 +326,10 @@ class WP_MS_Users_List_Table extends WP_List_Table {
 	 *
 	 * @since 4.3.0
 	 *
-	 * @global string $mode List table view mode.
-	 *
 	 * @param WP_User $user The current WP_User object.
 	 */
 	public function column_registered( $user ) {
-		global $mode;
-		if ( 'list' === $mode ) {
-			$date = __( 'Y/m/d' );
-		} else {
-			$date = __( 'Y/m/d g:i:s a' );
-		}
+		$date = __( 'Y/m/d g:i:s a' );
 		echo mysql2date( $date, $user->user_registered );
 	}
 

--- a/src/wp-includes/media-template.php
+++ b/src/wp-includes/media-template.php
@@ -327,18 +327,18 @@ function wp_print_media_templates() {
 	<?php // Template for the view switchers, used for example in the Media Grid. ?>
 	<script type="text/html" id="tmpl-media-library-view-switcher">
 		<a href="<?php echo esc_url( add_query_arg( 'mode', 'list', admin_url( 'upload.php' ) ) ); ?>" class="view-list">
-			<span class="screen-reader-text">
+			<span class="view-switch-label">
 				<?php
-				/* translators: Hidden accessibility text. */
-				_e( 'List view' );
+				/* translators: Media Library view mode. */
+				_e( 'List' );
 				?>
 			</span>
 		</a>
 		<a href="<?php echo esc_url( add_query_arg( 'mode', 'grid', admin_url( 'upload.php' ) ) ); ?>" class="view-grid current" aria-current="page">
-			<span class="screen-reader-text">
+			<span class="view-switch-label">
 				<?php
-				/* translators: Hidden accessibility text. */
-				_e( 'Grid view' );
+				/* translators: Media Library view mode. */
+				_e( 'Grid' );
 				?>
 			</span>
 		</a>

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -5189,6 +5189,7 @@ function wp_enqueue_media( $args = array() ) {
 		'mediaFound'                  => __( 'Number of media items found: %d' ),
 		'noMedia'                     => __( 'No media items found.' ),
 		'noMediaTryNewSearch'         => __( 'No media items found. Try a different search.' ),
+		'viewSwitcherAriaLabel'       => __( 'View mode' ),
 
 		// Library Details.
 		'attachmentDetails'           => __( 'Attachment details' ),


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65683
Trac ticket: https://core.trac.wordpress.org/ticket/65697

Work in progress to make the  edia Library 'List view' and 'Grid view' labels visible.

Regarding rhe removed list views: This is exactly what we want to do: remove list/excerpt view modes and simplify. There will be only one view that shows all the information that was previously split in the two modes.

Currently, the two view modes show minimal differences. 
As noted in the Trac ticket at https://core.trac.wordpress.org/ticket/65683#comment:6 I'd like to propose to entirely remove the switch view functionality from the Network Sites and the Network Users pages because it adds little value. The additional info could be shown by default.

Still to address: the 'active' state needs to be improved. Currently, it only uses color...

Screenshot so far:

<img width="842" height="235" alt="Screenshot 2026-07-23 at 16 00 39" src="https://github.com/user-attachments/assets/cf220a26-d9a6-4790-a6c2-eb473722feb3" />


## Use of AI Tools
None
---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
