### PR TITLE
Added && ! wp_installing() to the guard around get_language_attributes()

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -3955,9 +3955,14 @@ function _default_wp_die_handler( $message, $title = '', $args = array() ) {
 		/*
 		 * If `text_direction` was not explicitly passed,
 		 * use get_language_attributes() if available.
+		 *
+		 * Skipped while installing: get_language_attributes() queries the
+		 * database, which could re-trigger the DB error that led here and
+		 * loop wp_die() indefinitely. See #50228.
 		 */
 		if ( empty( $args['text_direction'] )
 			&& function_exists( 'language_attributes' ) && function_exists( 'is_rtl' )
+			&& ! wp_installing()
 		) {
 			$dir_attr = get_language_attributes();
 		}

--- a/tests/phpunit/tests/functions.php
+++ b/tests/phpunit/tests/functions.php
@@ -2252,17 +2252,8 @@ class Tests_Functions extends WP_UnitTestCase {
 	 * Tests that _default_wp_die_handler() only queries the database for language
 	 * attributes when WordPress is not installing.
 	 *
-	 * get_language_attributes() queries the database. During install (for example,
-	 * mid-way through Multisite site creation, before the new site's tables exist),
-	 * that query can re-trigger the database error that led to wp_die() in the first
-	 * place, looping wp_die() until PHP's function nesting limit is reached. While
-	 * installing, the handler must fall back to the already-computed `dir` attribute
-	 * instead.
-	 *
 	 * @ticket 50228
-	 *
 	 * @covers ::_default_wp_die_handler
-	 *
 	 * @dataProvider data_default_wp_die_handler_language_attributes
 	 *
 	 * @param bool   $installing      Whether WordPress is installing.

--- a/tests/phpunit/tests/functions.php
+++ b/tests/phpunit/tests/functions.php
@@ -2247,4 +2247,63 @@ class Tests_Functions extends WP_UnitTestCase {
 		);
 		$this->assertSameSetsWithIndex( $theme_json, $expected_theme_json );
 	}
+
+	/**
+	 * Tests that _default_wp_die_handler() only queries the database for language
+	 * attributes when WordPress is not installing.
+	 *
+	 * get_language_attributes() queries the database. During install (for example,
+	 * mid-way through Multisite site creation, before the new site's tables exist),
+	 * that query can re-trigger the database error that led to wp_die() in the first
+	 * place, looping wp_die() until PHP's function nesting limit is reached. While
+	 * installing, the handler must fall back to the already-computed `dir` attribute
+	 * instead.
+	 *
+	 * @ticket 50228
+	 *
+	 * @covers ::_default_wp_die_handler
+	 *
+	 * @dataProvider data_default_wp_die_handler_language_attributes
+	 *
+	 * @param bool   $installing      Whether WordPress is installing.
+	 * @param string $expected_attr   Substring the output is expected to contain.
+	 * @param string $unexpected_attr Substring the output is expected not to contain.
+	 */
+	public function test_default_wp_die_handler_language_attributes( $installing, $expected_attr, $unexpected_attr ) {
+		$was_installing = wp_installing();
+		wp_installing( $installing );
+
+		ob_start();
+		_default_wp_die_handler( 'Error message', 'Error title', array( 'exit' => false ) );
+		$output = ob_get_clean();
+
+		wp_installing( $was_installing );
+
+		$this->assertStringContainsString( $expected_attr, $output );
+		$this->assertStringNotContainsString( $unexpected_attr, $output );
+	}
+
+	/**
+	 * Data provider for test_default_wp_die_handler_language_attributes().
+	 *
+	 * @return array[] {
+	 *     @type bool   $installing      Whether WordPress is installing.
+	 *     @type string $expected_attr   Substring the output is expected to contain.
+	 *     @type string $unexpected_attr Substring the output is expected not to contain.
+	 * }
+	 */
+	public function data_default_wp_die_handler_language_attributes() {
+		return array(
+			'installing: falls back to the dir attribute'          => array(
+				'installing'      => true,
+				'expected_attr'   => "<html dir='ltr'>",
+				'unexpected_attr' => 'lang=',
+			),
+			'not installing: uses get_language_attributes()'       => array(
+				'installing'      => false,
+				'expected_attr'   => 'lang="',
+				'unexpected_attr' => "dir='ltr'",
+			),
+		);
+	}
 }

--- a/tests/phpunit/tests/functions.php
+++ b/tests/phpunit/tests/functions.php
@@ -2287,13 +2287,13 @@ class Tests_Functions extends WP_UnitTestCase {
 		return array(
 			'installing: falls back to the dir attribute' => array(
 				'installing'      => true,
-				'expected_attr'   => "<html dir='ltr'>",
+				'expected_attr'   => "<html dir='",
 				'unexpected_attr' => 'lang=',
 			),
 			'not installing: uses get_language_attributes()' => array(
 				'installing'      => false,
 				'expected_attr'   => 'lang="',
-				'unexpected_attr' => "dir='ltr'",
+				'unexpected_attr' => "dir='",
 			),
 		);
 	}

--- a/tests/phpunit/tests/functions.php
+++ b/tests/phpunit/tests/functions.php
@@ -2285,12 +2285,12 @@ class Tests_Functions extends WP_UnitTestCase {
 	 */
 	public function data_default_wp_die_handler_language_attributes() {
 		return array(
-			'installing: falls back to the dir attribute'          => array(
+			'installing: falls back to the dir attribute' => array(
 				'installing'      => true,
 				'expected_attr'   => "<html dir='ltr'>",
 				'unexpected_attr' => 'lang=',
 			),
-			'not installing: uses get_language_attributes()'       => array(
+			'not installing: uses get_language_attributes()' => array(
 				'installing'      => false,
 				'expected_attr'   => 'lang="',
 				'unexpected_attr' => "dir='ltr'",


### PR DESCRIPTION
https://core.trac.wordpress.org/ticket/50228

`get_language_attributes()` queries the database. During install (for example, midway through Multisite site creation, before the new site's tables exist), that query can re-trigger the database error that led to `wp_die()` in the first place, looping `wp_die()` until PHP's function nesting limit is reached. While installing, the handler must fall back to the already-computed `dir` attribute instead.