### PR TITLE
Editor: sync the REST index preload field list with core-data.

### DIFF
--- a/src/wp-admin/edit-form-blocks.php
+++ b/src/wp-admin/edit-form-blocks.php
@@ -85,10 +85,10 @@ $preload_paths = array(
 	'/wp/v2/global-styles/' . WP_Theme_JSON_Resolver::get_user_global_styles_post_id() . '?context=' . $global_styles_endpoint_context,
 	// Used by getBlockPatternCategories in useBlockEditorSettings.
 	'/wp/v2/block-patterns/categories',
-	/*
+	/**
 	 * The preloaded URL must exactly match the request the client makes,
 	 * including the field order.
-	 * @see packages/core-data/src/entities.js
+	 * @link https://github.com/WordPress/gutenberg/blob/4eba946a8adced338b1f23eb3016fbbd399c2e83/packages/core-data/src/entities.js
 	 */
 	'/?_fields=' . implode(
 		',',

--- a/src/wp-admin/edit-form-blocks.php
+++ b/src/wp-admin/edit-form-blocks.php
@@ -88,7 +88,7 @@ $preload_paths = array(
 	/**
 	 * The preloaded URL must exactly match the request the client makes,
 	 * including the field order.
-	 * @link https://github.com/WordPress/gutenberg/blob/4eba946a8adced338b1f23eb3016fbbd399c2e83/packages/core-data/src/entities.js
+	 * @link https://github.com/WordPress/gutenberg/blob/trunk/packages/core-data/src/entities.js
 	 */
 	'/?_fields=' . implode(
 		',',

--- a/src/wp-admin/edit-form-blocks.php
+++ b/src/wp-admin/edit-form-blocks.php
@@ -85,19 +85,21 @@ $preload_paths = array(
 	'/wp/v2/global-styles/' . WP_Theme_JSON_Resolver::get_user_global_styles_post_id() . '?context=' . $global_styles_endpoint_context,
 	// Used by getBlockPatternCategories in useBlockEditorSettings.
 	'/wp/v2/block-patterns/categories',
-	// @see packages/core-data/src/entities.js
+	/*
+	 * The preloaded URL must exactly match the request the client makes,
+	 * including the field order.
+	 * @see packages/core-data/src/entities.js
+	 */
 	'/?_fields=' . implode(
 		',',
 		array(
 			'description',
 			'gmt_offset',
 			'home',
+			'image_max_bit_depth',
 			'image_sizes',
 			'image_size_threshold',
-			'image_output_formats',
-			'jpeg_interlaced',
-			'png_interlaced',
-			'gif_interlaced',
+			'image_strip_meta',
 			'name',
 			'site_icon',
 			'site_icon_url',
@@ -109,7 +111,7 @@ $preload_paths = array(
 			'show_on_front',
 		)
 	),
-	$paths[] = add_query_arg(
+	add_query_arg(
 		'slug',
 		// @link https://github.com/WordPress/gutenberg/blob/e093fefd041eb6cc4a4e7f67b92ab54fd75c8858/packages/core-data/src/private-selectors.ts#L244-L254
 		$template_lookup_slug,

--- a/src/wp-admin/site-editor.php
+++ b/src/wp-admin/site-editor.php
@@ -211,19 +211,21 @@ $preload_paths = array(
 	array( '/wp/v2/settings', 'OPTIONS' ),
 	// Used by getBlockPatternCategories in useBlockEditorSettings.
 	'/wp/v2/block-patterns/categories',
-	// @see packages/core-data/src/entities.js
+	/*
+	 * The preloaded URL must exactly match the request the client makes,
+	 * including the field order.
+	 * @see packages/core-data/src/entities.js
+	 */
 	'/?_fields=' . implode(
 		',',
 		array(
 			'description',
 			'gmt_offset',
 			'home',
+			'image_max_bit_depth',
 			'image_sizes',
 			'image_size_threshold',
-			'image_output_formats',
-			'jpeg_interlaced',
-			'png_interlaced',
-			'gif_interlaced',
+			'image_strip_meta',
 			'name',
 			'site_icon',
 			'site_icon_url',

--- a/src/wp-admin/site-editor.php
+++ b/src/wp-admin/site-editor.php
@@ -214,7 +214,7 @@ $preload_paths = array(
 	/**
 	 * The preloaded URL must exactly match the request the client makes,
 	 * including the field order.
-	 * @link https://github.com/WordPress/gutenberg/blob/4eba946a8adced338b1f23eb3016fbbd399c2e83/packages/core-data/src/entities.js
+	 * @link https://github.com/WordPress/gutenberg/blob/trunk/packages/core-data/src/entities.js
 	 */
 	'/?_fields=' . implode(
 		',',

--- a/src/wp-admin/site-editor.php
+++ b/src/wp-admin/site-editor.php
@@ -211,10 +211,10 @@ $preload_paths = array(
 	array( '/wp/v2/settings', 'OPTIONS' ),
 	// Used by getBlockPatternCategories in useBlockEditorSettings.
 	'/wp/v2/block-patterns/categories',
-	/*
+	/**
 	 * The preloaded URL must exactly match the request the client makes,
 	 * including the field order.
-	 * @see packages/core-data/src/entities.js
+	 * @link https://github.com/WordPress/gutenberg/blob/4eba946a8adced338b1f23eb3016fbbd399c2e83/packages/core-data/src/entities.js
 	 */
 	'/?_fields=' . implode(
 		',',


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65699

## Description

Loading the post editor or site editor on trunk logs a warning in the console:

```
[api-fetch] [preload] Some preloads were never consumed:
['GET /?_fields=description%2Cgmt_offset%2Chome%2Cimage_...']
```

The editors preload `/?_fields=...` so the initial site entity request from `@wordpress/core-data` is served from cache. The preload is matched by exact URL, so the field list in the PHP has to match the list the client builds in `packages/core-data/src/entities.js` - same fields, same order. The lists drifted after two Gutenberg changes were only partially backported:

- https://github.com/WordPress/gutenberg/pull/75793 removed `image_output_formats`, `jpeg_interlaced`, `png_interlaced` and `gif_interlaced` from the entity request.
- https://github.com/WordPress/gutenberg/pull/80218 added `image_max_bit_depth` and `image_strip_meta`. The `WP_REST_Server::get_index()` side of that change made it into core, the preload path did not.

Because the URLs no longer match, the preloaded response is never consumed and the editor makes a second, uncached request to `/` on every load. With the Gutenberg plugin active the problem disappears, since the plugin's `block_editor_rest_api_preload_paths` filter rewrites the path with the current field list - which is how this went unnoticed.

This PR updates the field lists in `edit-form-blocks.php` and `site-editor.php` to match the bundled package exactly. It also removes a stray `$paths[] =` assignment in `edit-form-blocks.php` left over from a previous backport.

Note: the generated admin pages under `wp-includes/build/pages/` (font library, options connectors) carry their own stale copy of this list; that comes from the `packages/wp-build` page templates in Gutenberg, so I will fix it upstream and it will land here with the next package sync.

## How has this been tested

[![Test in WordPress Playground](https://img.shields.io/badge/Test_in-WP_Playground-blue?style=for-the-badge&logo=wordpress)](https://playground.wordpress.net/wordpress.html?pr=12665)

1. On trunk, open a post in the block editor with the Gutenberg plugin deactivated.
2. In the dev tools console, note the `[api-fetch] [preload] Some preloads were never consumed` warning, and in the network tab note the duplicate request to `/?_fields=...`.
3. Apply the patch and reload: the console shows `[api-fetch][preload] All preloads consumed.` and the duplicate request is gone.
4. Repeat in the site editor.

I also verified the PHP lists now match the `_fields` list in the bundled `wp-includes/js/dist/core-data.js` exactly, including order.




## Commit message

```
Editor: Sync the REST index preload field list with core-data.

Sync the REST index preload field list in the post and site editors with the list the client requests, fixing a mismatch that left the preloaded response unused and logged a console warning on every editor load.

Follow-up to [61703], [62806].

Props wildworks, westonruter.
Fixes #65699.
```
