### PR TITLE
Media REST API: Update sideload from url path to include an upload size check

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
@@ -641,6 +641,14 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 			'tmp_name' => $tmp_file,
 		);
 
+		$size_check = self::check_upload_size( $file_array );
+		if ( is_wp_error( $size_check ) ) {
+			if ( file_exists( $tmp_file ) ) {
+				wp_delete_file( $tmp_file );
+			}
+			return $size_check;
+		}
+
 		$attachment_id = media_handle_sideload( $file_array, $post_id );
 
 		if ( is_wp_error( $attachment_id ) ) {

--- a/tests/phpunit/tests/rest-api/rest-attachments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-attachments-controller.php
@@ -5331,6 +5331,70 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 	}
 
 	/**
+	 * Verifies that the URL sideload path enforces the multisite maximum file
+	 * size, for parity with the multipart and raw-body upload paths.
+	 *
+	 * @ticket 65517
+	 * @group multisite
+	 * @group ms-required
+	 *
+	 * @covers WP_REST_Attachments_Controller::create_item_from_url
+	 * @covers WP_REST_Attachments_Controller::check_upload_size
+	 */
+	public function test_create_item_from_url_exceeds_multisite_max_filesize() {
+		$this->enable_client_side_media_processing();
+
+		wp_set_current_user( self::$superadmin_id );
+		update_site_option( 'fileupload_maxk', 1 );
+		update_site_option( 'upload_space_check_disabled', false );
+
+		// Ensure ample space is available so the file-size limit is what rejects it.
+		add_filter( 'pre_get_space_used', '__return_zero' );
+		add_filter( 'pre_http_request', array( $this, 'mock_image_download' ), 10, 3 );
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/media' );
+		$request->set_param( 'url', 'https://example.com/too-big.jpg' );
+		$request->set_param( 'generate_sub_sizes', false );
+
+		$response = rest_get_server()->dispatch( $request );
+
+		remove_filter( 'pre_http_request', array( $this, 'mock_image_download' ), 10 );
+
+		$this->assertErrorResponse( 'rest_upload_file_too_big', $response, 400 );
+	}
+
+	/**
+	 * Verifies that the URL sideload path enforces the multisite site upload
+	 * space quota, for parity with the multipart and raw-body upload paths.
+	 *
+	 * @ticket 65517
+	 * @group multisite
+	 * @group ms-required
+	 *
+	 * @covers WP_REST_Attachments_Controller::create_item_from_url
+	 * @covers WP_REST_Attachments_Controller::check_upload_size
+	 */
+	public function test_create_item_from_url_exceeds_multisite_site_upload_space() {
+		$this->enable_client_side_media_processing();
+
+		wp_set_current_user( self::$superadmin_id );
+		add_filter( 'get_space_allowed', '__return_zero' );
+		update_site_option( 'upload_space_check_disabled', false );
+
+		add_filter( 'pre_http_request', array( $this, 'mock_image_download' ), 10, 3 );
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/media' );
+		$request->set_param( 'url', 'https://example.com/no-space.jpg' );
+		$request->set_param( 'generate_sub_sizes', false );
+
+		$response = rest_get_server()->dispatch( $request );
+
+		remove_filter( 'pre_http_request', array( $this, 'mock_image_download' ), 10 );
+
+		$this->assertErrorResponse( 'rest_upload_limited_space', $response, 400 );
+	}
+
+	/**
 	 * Verifies that a URL with no usable path bails with a 400 before any
 	 * download is attempted, rather than handing an empty filename to the
 	 * sideload handler.


### PR DESCRIPTION
In WP 7.1, the `/wp/v2/media` REST API endpoint supports a `url` param to allow sideloading media via a url, without requiring the browser to first download an image and upload via a standard media upload POST request.

This PR adds a call to `check_upload_size` for this upload path, to create parity with the other upload paths (e.g. the multipart and raw-body upload paths).

To test manually that this doesn't regress the "upload to media library" feature, try adding an Image block to a post using an external url and click the "upload to media library button". It should work as on trunk. Here's what that button looks like:

<img width="705" height="227" alt="image" src="https://github.com/user-attachments/assets/efd44446-8b14-4561-9827-b4b17aa1dc4b" />

And here's some test markup for you to try that out with:

```html
<!-- wp:image {"sizeSlug":"large"} -->
<figure class="wp-block-image size-large"><img src="https://user-images.githubusercontent.com/1204802/100067796-fc3e8700-2e36-11eb-993b-6b80b4310b87.png" alt=""/></figure>
<!-- /wp:image -->
```

Trac ticket: https://core.trac.wordpress.org/ticket/65517

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Opus 4.8
Used for: Identifying the gap in upload paths; final implementation and tests were reviewed and edited by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
