### PR TITLE
Block Supports: Guard against non-string attribute values to avoid fatal errors (Backport for GB #80501)

### DIFF
--- a/src/wp-includes/block-supports/layout.php
+++ b/src/wp-includes/block-supports/layout.php
@@ -190,8 +190,9 @@ function wp_get_child_layout_style_rules( $selector, $child_layout, $parent_layo
 		);
 	}
 
-	$minimum_column_width = $parent_layout['minimumColumnWidth'] ?? null;
-	$column_count         = $parent_layout['columnCount'] ?? null;
+	$minimum_column_width_attr = $parent_layout['minimumColumnWidth'] ?? null;
+	$minimum_column_width      = is_string( $minimum_column_width_attr ) ? $minimum_column_width_attr : null;
+	$column_count              = $parent_layout['columnCount'] ?? null;
 
 	/*
 	 * If columnSpan or columnStart is set, and the parent grid is responsive, i.e. if it has a minimumColumnWidth set,
@@ -548,9 +549,14 @@ function wp_get_layout_style( $selector, $layout, $has_block_gap_support = false
 			}
 		}
 	} elseif ( 'constrained' === $layout_type ) {
-		$content_size    = $layout_for_styles['contentSize'] ?? '';
-		$wide_size       = $layout_for_styles['wideSize'] ?? '';
-		$justify_content = $layout_for_styles['justifyContent'] ?? 'center';
+		// The schemas and editor UI only produce strings here, so treat a non-string
+		// value as absent rather than casting it — it couldn't render as valid CSS anyway.
+		$content_size_attr    = $layout_for_styles['contentSize'] ?? null;
+		$content_size         = is_string( $content_size_attr ) ? $content_size_attr : '';
+		$wide_size_attr       = $layout_for_styles['wideSize'] ?? null;
+		$wide_size            = is_string( $wide_size_attr ) ? $wide_size_attr : '';
+		$justify_content_attr = $layout_for_styles['justifyContent'] ?? null;
+		$justify_content      = is_string( $justify_content_attr ) ? $justify_content_attr : 'center';
 
 		// Check if viewport-specific ("override") values exist. Null values are valid and mean the user cleared a value inherited from the default viewport.
 		$has_justify_content_override = null !== $viewport_overrides && $has_viewport_property_override( 'justifyContent' );
@@ -771,23 +777,26 @@ function wp_get_layout_style( $selector, $layout, $has_block_gap_support = false
 			}
 		}
 
+		$flex_justify_content    = $layout_for_styles['justifyContent'] ?? null;
+		$flex_vertical_alignment = $layout_for_styles['verticalAlignment'] ?? null;
+
 		if ( 'horizontal' === $layout_orientation ) {
 			/*
 			 * Add this style only if is not empty for backwards compatibility,
 			 * since we intend to convert blocks that had flex layout implemented
 			 * by custom css.
 			 */
-			if ( $should_output_flex_justification && ! empty( $layout_for_styles['justifyContent'] ) && array_key_exists( $layout_for_styles['justifyContent'], $justify_content_options ) ) {
+			if ( $should_output_flex_justification && ! empty( $flex_justify_content ) && is_string( $flex_justify_content ) && array_key_exists( $flex_justify_content, $justify_content_options ) ) {
 				$layout_styles[] = array(
 					'selector'     => $selector,
-					'declarations' => array( 'justify-content' => $justify_content_options[ $layout_for_styles['justifyContent'] ] ),
+					'declarations' => array( 'justify-content' => $justify_content_options[ $flex_justify_content ] ),
 				);
 			}
 
-			if ( $should_output_flex_alignment && ! empty( $layout_for_styles['verticalAlignment'] ) && array_key_exists( $layout_for_styles['verticalAlignment'], $vertical_alignment_options ) ) {
+			if ( $should_output_flex_alignment && ! empty( $flex_vertical_alignment ) && is_string( $flex_vertical_alignment ) && array_key_exists( $flex_vertical_alignment, $vertical_alignment_options ) ) {
 				$layout_styles[] = array(
 					'selector'     => $selector,
-					'declarations' => array( 'align-items' => $vertical_alignment_options[ $layout_for_styles['verticalAlignment'] ] ),
+					'declarations' => array( 'align-items' => $vertical_alignment_options[ $flex_vertical_alignment ] ),
 				);
 			}
 		} else {
@@ -797,10 +806,10 @@ function wp_get_layout_style( $selector, $layout, $has_block_gap_support = false
 					'declarations' => array( 'flex-direction' => 'column' ),
 				);
 			}
-			if ( $should_output_flex_justification && ! empty( $layout_for_styles['justifyContent'] ) && array_key_exists( $layout_for_styles['justifyContent'], $justify_content_options ) ) {
+			if ( $should_output_flex_justification && ! empty( $flex_justify_content ) && is_string( $flex_justify_content ) && array_key_exists( $flex_justify_content, $justify_content_options ) ) {
 				$layout_styles[] = array(
 					'selector'     => $selector,
-					'declarations' => array( 'align-items' => $justify_content_options[ $layout_for_styles['justifyContent'] ] ),
+					'declarations' => array( 'align-items' => $justify_content_options[ $flex_justify_content ] ),
 				);
 			} elseif ( $should_output_flex_justification ) {
 				$layout_styles[] = array(
@@ -808,10 +817,10 @@ function wp_get_layout_style( $selector, $layout, $has_block_gap_support = false
 					'declarations' => array( 'align-items' => 'flex-start' ),
 				);
 			}
-			if ( $should_output_flex_alignment && ! empty( $layout_for_styles['verticalAlignment'] ) && array_key_exists( $layout_for_styles['verticalAlignment'], $vertical_alignment_options ) ) {
+			if ( $should_output_flex_alignment && ! empty( $flex_vertical_alignment ) && is_string( $flex_vertical_alignment ) && array_key_exists( $flex_vertical_alignment, $vertical_alignment_options ) ) {
 				$layout_styles[] = array(
 					'selector'     => $selector,
-					'declarations' => array( 'justify-content' => $vertical_alignment_options[ $layout_for_styles['verticalAlignment'] ] ),
+					'declarations' => array( 'justify-content' => $vertical_alignment_options[ $flex_vertical_alignment ] ),
 				);
 			}
 		}
@@ -1123,20 +1132,23 @@ function wp_render_layout_support_flag( $block_content, $block ) {
 	 * not intended to provide an extended set of classes to match all block layout attributes
 	 * here.
 	 */
-	if ( ! empty( $block['attrs']['layout']['orientation'] ) ) {
-		$class_names[] = 'is-' . sanitize_title( $block['attrs']['layout']['orientation'] );
+	$orientation = $block['attrs']['layout']['orientation'] ?? null;
+	if ( ! empty( $orientation ) && is_string( $orientation ) ) {
+		$class_names[] = 'is-' . sanitize_title( $orientation );
 	}
 
-	if ( ! empty( $block['attrs']['layout']['justifyContent'] ) ) {
-		$class_names[] = 'is-content-justification-' . sanitize_title( $block['attrs']['layout']['justifyContent'] );
+	$justify_content = $block['attrs']['layout']['justifyContent'] ?? null;
+	if ( ! empty( $justify_content ) && is_string( $justify_content ) ) {
+		$class_names[] = 'is-content-justification-' . sanitize_title( $justify_content );
 	}
 
-	if ( ! empty( $block['attrs']['layout']['flexWrap'] ) && 'nowrap' === $block['attrs']['layout']['flexWrap'] ) {
+	$flex_wrap = $block['attrs']['layout']['flexWrap'] ?? null;
+	if ( ! empty( $flex_wrap ) && 'nowrap' === $flex_wrap ) {
 		$class_names[] = 'is-nowrap';
 	}
 
 	// Get classname for layout type.
-	if ( isset( $used_layout['type'] ) ) {
+	if ( isset( $used_layout['type'] ) && is_string( $used_layout['type'] ) ) {
 		$layout_classname = $layout_definitions[ $used_layout['type'] ]['className'] ?? '';
 	} else {
 		$layout_classname = $layout_definitions['default']['className'] ?? '';
@@ -1463,7 +1475,8 @@ add_filter( 'render_block', 'wp_render_layout_support_flag', 10, 2 );
  * @return string Filtered block content.
  */
 function wp_restore_group_inner_container( $block_content, $block ) {
-	$tag_name                         = $block['attrs']['tagName'] ?? 'div';
+	$tag_name_attr                    = $block['attrs']['tagName'] ?? null;
+	$tag_name                         = is_string( $tag_name_attr ) ? $tag_name_attr : 'div';
 	$group_with_inner_container_regex = sprintf(
 		'/(^\s*<%1$s\b[^>]*wp-block-group(\s|")[^>]*>)(\s*<div\b[^>]*wp-block-group__inner-container(\s|")[^>]*>)((.|\S|\s)*)/U',
 		preg_quote( $tag_name, '/' )

--- a/src/wp-includes/block-supports/layout.php
+++ b/src/wp-includes/block-supports/layout.php
@@ -159,8 +159,17 @@ function wp_get_child_layout_style_rules( $selector, $child_layout, $parent_layo
 		}
 	}
 
-	$column_start = $child_layout['columnStart'] ?? null;
-	$column_span  = $child_layout['columnSpan'] ?? null;
+	/*
+	 * Grid line numbers and spans are whole numbers. The editor stores them as numbers, but
+	 * content saved by WordPress 6.3 to 6.6 stored them as numeric strings, and that
+	 * migration only runs when a block is parsed in JavaScript, so the front end still sees
+	 * strings. Accept any numeric value and cast it, and treat anything else as absent
+	 * because it can't render as valid CSS.
+	 */
+	$column_start_attr = $child_layout['columnStart'] ?? null;
+	$column_start      = is_numeric( $column_start_attr ) ? (int) $column_start_attr : null;
+	$column_span_attr  = $child_layout['columnSpan'] ?? null;
+	$column_span       = is_numeric( $column_span_attr ) ? (int) $column_span_attr : null;
 	if ( null === $viewport_overrides || $has_viewport_property_override( 'columnStart' ) || $has_viewport_property_override( 'columnSpan' ) ) {
 		if ( $column_start && $column_span ) {
 			$child_layout_declarations['grid-column'] = "$column_start / span $column_span";
@@ -171,8 +180,10 @@ function wp_get_child_layout_style_rules( $selector, $child_layout, $parent_layo
 		}
 	}
 
-	$row_start = $child_layout['rowStart'] ?? null;
-	$row_span  = $child_layout['rowSpan'] ?? null;
+	$row_start_attr = $child_layout['rowStart'] ?? null;
+	$row_start      = is_numeric( $row_start_attr ) ? (int) $row_start_attr : null;
+	$row_span_attr  = $child_layout['rowSpan'] ?? null;
+	$row_span       = is_numeric( $row_span_attr ) ? (int) $row_span_attr : null;
 	if ( null === $viewport_overrides || $has_viewport_property_override( 'rowStart' ) || $has_viewport_property_override( 'rowSpan' ) ) {
 		if ( $row_start && $row_span ) {
 			$child_layout_declarations['grid-row'] = "$row_start / span $row_span";
@@ -826,6 +837,15 @@ function wp_get_layout_style( $selector, $layout, $has_block_gap_support = false
 		}
 	} elseif ( 'grid' === $layout_type ) {
 		/*
+		 * Column and row counts are whole numbers, for the same reason as the grid line
+		 * numbers in wp_get_child_layout_style_rules().
+		 */
+		$column_count_attr = $layout_for_styles['columnCount'] ?? null;
+		$column_count      = is_numeric( $column_count_attr ) ? (int) $column_count_attr : null;
+		$row_count_attr    = $layout_for_styles['rowCount'] ?? null;
+		$row_count         = is_numeric( $row_count_attr ) ? (int) $row_count_attr : null;
+
+		/*
 		 * If the gap value is an array, we use the "left" value because it represents the vertical gap, which
 		 * is the relevant one for computation of responsive grid columns.
 		 */
@@ -871,12 +891,12 @@ function wp_get_layout_style( $selector, $layout, $has_block_gap_support = false
 		 * value for any of the grid properties.
 		 */
 		$should_output_grid_columns = null === $viewport_overrides || $has_viewport_property_override( 'minimumColumnWidth' ) || $has_viewport_property_override( 'columnCount' ) || $has_viewport_property_override( 'autoFit' );
-		$uses_gap_in_grid_columns   = ! empty( $layout_for_styles['columnCount'] ) && ! empty( $layout_for_styles['minimumColumnWidth'] );
+		$uses_gap_in_grid_columns   = ! empty( $column_count ) && ! empty( $layout_for_styles['minimumColumnWidth'] );
 		if ( $has_block_gap_override && $uses_gap_in_grid_columns ) {
 			$should_output_grid_columns = true;
 		}
 
-		$should_output_grid_rows = ( null === $viewport_overrides || $has_viewport_property_override( 'rowCount' ) ) && ! empty( $layout_for_styles['columnCount'] ) && ! empty( $layout_for_styles['rowCount'] );
+		$should_output_grid_rows = ( null === $viewport_overrides || $has_viewport_property_override( 'rowCount' ) ) && ! empty( $column_count ) && ! empty( $row_count );
 		$grid_declarations       = array();
 
 		/*
@@ -885,11 +905,11 @@ function wp_get_layout_style( $selector, $layout, $has_block_gap_support = false
 		 */
 		$auto_placement = ! empty( $layout_for_styles['autoFit'] ) ? 'auto-fit' : 'auto-fill';
 
-		if ( $should_output_grid_columns && ! empty( $layout_for_styles['columnCount'] ) && ! empty( $layout_for_styles['minimumColumnWidth'] ) ) {
-			$max_value                                  = 'max(min(' . $layout_for_styles['minimumColumnWidth'] . ', 100%), (100% - (' . $responsive_gap_value . ' * (' . $layout_for_styles['columnCount'] . ' - 1))) /' . $layout_for_styles['columnCount'] . ')';
+		if ( $should_output_grid_columns && ! empty( $column_count ) && ! empty( $layout_for_styles['minimumColumnWidth'] ) ) {
+			$max_value                                  = 'max(min(' . $layout_for_styles['minimumColumnWidth'] . ', 100%), (100% - (' . $responsive_gap_value . ' * (' . $column_count . ' - 1))) /' . $column_count . ')';
 			$grid_declarations['grid-template-columns'] = 'repeat(' . $auto_placement . ', minmax(' . $max_value . ', 1fr))';
-		} elseif ( $should_output_grid_columns && ! empty( $layout_for_styles['columnCount'] ) ) {
-			$grid_declarations['grid-template-columns'] = 'repeat(' . $layout_for_styles['columnCount'] . ', minmax(0, 1fr))';
+		} elseif ( $should_output_grid_columns && ! empty( $column_count ) ) {
+			$grid_declarations['grid-template-columns'] = 'repeat(' . $column_count . ', minmax(0, 1fr))';
 		} elseif ( $should_output_grid_columns ) {
 			$minimum_column_width                       = ! empty( $layout_for_styles['minimumColumnWidth'] ) ? $layout_for_styles['minimumColumnWidth'] : '12rem';
 			$grid_declarations['grid-template-columns'] = 'repeat(' . $auto_placement . ', minmax(min(' . $minimum_column_width . ', 100%), 1fr))';
@@ -897,7 +917,7 @@ function wp_get_layout_style( $selector, $layout, $has_block_gap_support = false
 
 		if ( ! empty( $grid_declarations ) ) {
 			$base_has_container_type = empty( $base_layout['columnCount'] ) || ( ! empty( $base_layout['columnCount'] ) && ! empty( $base_layout['minimumColumnWidth'] ) );
-			if ( empty( $layout_for_styles['columnCount'] ) || ! empty( $layout_for_styles['minimumColumnWidth'] ) ) {
+			if ( empty( $column_count ) || ! empty( $layout_for_styles['minimumColumnWidth'] ) ) {
 				if ( null === $viewport_overrides || ! $base_has_container_type ) {
 					$grid_declarations['container-type'] = 'inline-size';
 				}
@@ -911,7 +931,7 @@ function wp_get_layout_style( $selector, $layout, $has_block_gap_support = false
 		if ( $should_output_grid_rows ) {
 			$layout_styles[] = array(
 				'selector'     => $selector,
-				'declarations' => array( 'grid-template-rows' => 'repeat(' . $layout_for_styles['rowCount'] . ', minmax(1rem, auto))' ),
+				'declarations' => array( 'grid-template-rows' => 'repeat(' . $row_count . ', minmax(1rem, auto))' ),
 			);
 		}
 

--- a/tests/phpunit/tests/block-supports/layout.php
+++ b/tests/phpunit/tests/block-supports/layout.php
@@ -1194,6 +1194,7 @@ class Tests_Block_Supports_Layout extends WP_UnitTestCase {
 	 * values (e.g. from hand-edited, imported, or AI-generated content) does not cause a
 	 * fatal error in the explode() calls.
 	 *
+	 * @ticket 65774
 	 * @covers ::wp_get_layout_style
 	 */
 	public function test_wp_get_layout_style_with_non_string_constrained_sizes() {
@@ -1215,6 +1216,7 @@ class Tests_Block_Supports_Layout extends WP_UnitTestCase {
 	 * Tests that a flex layout with non-string justifyContent/verticalAlignment values
 	 * does not cause a fatal error in the array_key_exists() calls.
 	 *
+	 * @ticket 65774
 	 * @covers ::wp_get_layout_style
 	 */
 	public function test_wp_get_layout_style_with_non_string_flex_alignment() {
@@ -1235,6 +1237,7 @@ class Tests_Block_Supports_Layout extends WP_UnitTestCase {
 	 * Tests that a responsive grid child with a non-string parent minimumColumnWidth
 	 * does not cause a fatal error in the explode() call.
 	 *
+	 * @ticket 65774
 	 * @covers ::wp_get_child_layout_style_rules
 	 */
 	public function test_wp_get_child_layout_style_rules_with_non_string_minimum_column_width() {
@@ -1252,6 +1255,7 @@ class Tests_Block_Supports_Layout extends WP_UnitTestCase {
 	 * Tests that layout classname generation does not fatal when the layout type,
 	 * orientation, or justifyContent attributes are not strings.
 	 *
+	 * @ticket 65774
 	 * @covers ::wp_render_layout_support_flag
 	 */
 	public function test_layout_support_flag_with_non_string_layout_values() {
@@ -1277,6 +1281,7 @@ class Tests_Block_Supports_Layout extends WP_UnitTestCase {
 	 * Tests that restoring the group inner container does not fatal when the tagName
 	 * attribute is not a string (which would break the preg_quote() calls).
 	 *
+	 * @ticket 65774
 	 * @covers ::wp_restore_group_inner_container
 	 */
 	public function test_restore_group_inner_container_with_non_string_tag_name() {

--- a/tests/phpunit/tests/block-supports/layout.php
+++ b/tests/phpunit/tests/block-supports/layout.php
@@ -1188,4 +1188,111 @@ class Tests_Block_Supports_Layout extends WP_UnitTestCase {
 			'Global settings should still be resolved for a block that supports layout.'
 		);
 	}
+
+	/**
+	 * Tests that a constrained layout with non-string contentSize/wideSize/justifyContent
+	 * values (e.g. from hand-edited, imported, or AI-generated content) does not cause a
+	 * fatal error in the explode() calls.
+	 *
+	 * @covers ::wp_get_layout_style
+	 */
+	public function test_wp_get_layout_style_with_non_string_constrained_sizes() {
+		$layout_styles = wp_get_layout_style(
+			'.wp-layout',
+			array(
+				'type'           => 'constrained',
+				'contentSize'    => array( '800px' ),
+				'wideSize'       => array( '1200px' ),
+				'justifyContent' => array( 'center' ),
+			)
+		);
+
+		$this->assertIsString( $layout_styles, 'Constrained layout should not fatal when sizes are not strings.' );
+		$this->assertStringNotContainsString( 'Array', $layout_styles, 'A non-string size value should not leak into the output.' );
+	}
+
+	/**
+	 * Tests that a flex layout with non-string justifyContent/verticalAlignment values
+	 * does not cause a fatal error in the array_key_exists() calls.
+	 *
+	 * @covers ::wp_get_layout_style
+	 */
+	public function test_wp_get_layout_style_with_non_string_flex_alignment() {
+		$layout_styles = wp_get_layout_style(
+			'.wp-layout',
+			array(
+				'type'              => 'flex',
+				'orientation'       => 'horizontal',
+				'justifyContent'    => array( 'right' ),
+				'verticalAlignment' => array( 'center' ),
+			)
+		);
+
+		$this->assertIsString( $layout_styles, 'Flex layout should not fatal when alignment values are not strings.' );
+	}
+
+	/**
+	 * Tests that a responsive grid child with a non-string parent minimumColumnWidth
+	 * does not cause a fatal error in the explode() call.
+	 *
+	 * @covers ::wp_get_child_layout_style_rules
+	 */
+	public function test_wp_get_child_layout_style_rules_with_non_string_minimum_column_width() {
+		$actual_output = wp_get_child_layout_style_rules(
+			'.wp-container-content-test',
+			array( 'columnSpan' => '2' ),
+			array( 'minimumColumnWidth' => array( '12rem' ) ),
+			null
+		);
+
+		$this->assertIsArray( $actual_output, 'Child layout rules should not fatal when minimumColumnWidth is not a string.' );
+	}
+
+	/**
+	 * Tests that layout classname generation does not fatal when the layout type,
+	 * orientation, or justifyContent attributes are not strings.
+	 *
+	 * @covers ::wp_render_layout_support_flag
+	 */
+	public function test_layout_support_flag_with_non_string_layout_values() {
+		$block_content = '<div class="wp-block-group"></div>';
+		$block         = array(
+			'blockName' => 'core/group',
+			'attrs'     => array(
+				'layout' => array(
+					'type'           => array( 'constrained' ),
+					'orientation'    => array( 'horizontal' ),
+					'justifyContent' => array( 'center' ),
+				),
+			),
+		);
+
+		$this->assertIsString(
+			wp_render_layout_support_flag( $block_content, $block ),
+			'Layout support should not fatal when layout values are not strings.'
+		);
+	}
+
+	/**
+	 * Tests that restoring the group inner container does not fatal when the tagName
+	 * attribute is not a string (which would break the preg_quote() calls).
+	 *
+	 * @covers ::wp_restore_group_inner_container
+	 */
+	public function test_restore_group_inner_container_with_non_string_tag_name() {
+		// The "default" theme doesn't have theme.json support, so the preg_quote() path runs.
+		switch_theme( 'default' );
+		$block_content = '<div class="wp-block-group"><p>Test</p></div>';
+		$block         = array(
+			'blockName' => 'core/group',
+			'attrs'     => array(
+				'tagName' => array( 'div' ),
+			),
+		);
+
+		$this->assertIsString(
+			wp_restore_group_inner_container( $block_content, $block ),
+			'Group inner container restore should not fatal when tagName is not a string.'
+		);
+	}
 }

--- a/tests/phpunit/tests/block-supports/layout.php
+++ b/tests/phpunit/tests/block-supports/layout.php
@@ -1300,4 +1300,129 @@ class Tests_Block_Supports_Layout extends WP_UnitTestCase {
 			'Group inner container restore should not fatal when tagName is not a string.'
 		);
 	}
+
+	/**
+	 * Tests that non-numeric grid placement values are dropped rather than being
+	 * interpolated into the `grid-column` and `grid-row` declarations.
+	 *
+	 * @ticket 65774
+	 * @covers ::wp_get_child_layout_style_rules
+	 */
+	public function test_get_child_layout_style_rules_with_non_numeric_grid_placement() {
+		$actual_output = wp_get_child_layout_style_rules(
+			'.wp-container-content-test',
+			array(
+				'columnStart' => array( 2 ),
+				'columnSpan'  => array( 3 ),
+				'rowStart'    => array( 1 ),
+				'rowSpan'     => array( 2 ),
+			),
+			array(),
+			null
+		);
+
+		$this->assertSame(
+			array(),
+			$actual_output,
+			'Non-numeric grid placement values should not produce any child layout rules.'
+		);
+	}
+
+	/**
+	 * Tests that grid placement values saved as numeric strings (WordPress 6.3 to 6.6)
+	 * produce the same declarations as numbers.
+	 *
+	 * @ticket 65774
+	 * @covers ::wp_get_child_layout_style_rules
+	 */
+	public function test_get_child_layout_style_rules_with_numeric_string_grid_placement() {
+		$expected_output = array(
+			array(
+				'selector'     => '.wp-container-content-test',
+				'declarations' => array(
+					'grid-column' => '2 / span 3',
+					'grid-row'    => '1 / span 2',
+				),
+			),
+		);
+
+		$actual_output = wp_get_child_layout_style_rules(
+			'.wp-container-content-test',
+			array(
+				'columnStart' => '2',
+				'columnSpan'  => '3',
+				'rowStart'    => '1',
+				'rowSpan'     => '2',
+			),
+			array( 'columnCount' => '3' ),
+			null
+		);
+
+		$this->assertSame( $expected_output, $actual_output );
+	}
+
+	/**
+	 * Tests that non-numeric grid counts are treated as absent instead of leaking into the
+	 * CSS. The rowCount case keeps columnCount valid, because the row track rule is only
+	 * reached when there is a column count.
+	 *
+	 * @dataProvider data_get_layout_style_with_non_numeric_grid_counts
+	 *
+	 * @ticket 65774
+	 * @covers ::wp_get_layout_style
+	 *
+	 * @param array  $layout          Grid layout values.
+	 * @param string $expected_output The expected output.
+	 */
+	public function test_get_layout_style_with_non_numeric_grid_counts( $layout, $expected_output ) {
+		$this->assertSame( $expected_output, wp_get_layout_style( '.wp-layout', $layout ) );
+	}
+
+	/**
+	 * Data provider for test_get_layout_style_with_non_numeric_grid_counts().
+	 *
+	 * @return array
+	 */
+	public function data_get_layout_style_with_non_numeric_grid_counts() {
+		return array(
+			'non-numeric columnCount falls back to the responsive default' => array(
+				'layout'          => array(
+					'type'        => 'grid',
+					'columnCount' => array( 3 ),
+				),
+				'expected_output' => '.wp-layout{grid-template-columns:repeat(auto-fill, minmax(min(12rem, 100%), 1fr));container-type:inline-size;}',
+			),
+			'non-numeric rowCount drops the row track rule' => array(
+				'layout'          => array(
+					'type'        => 'grid',
+					'columnCount' => 3,
+					'rowCount'    => array( 2 ),
+				),
+				'expected_output' => '.wp-layout{grid-template-columns:repeat(3, minmax(0, 1fr));}',
+			),
+		);
+	}
+
+	/**
+	 * Tests that grid counts saved as numeric strings (WordPress 6.3 to 6.6) produce the
+	 * same CSS as numbers.
+	 *
+	 * @ticket 65774
+	 * @covers ::wp_get_layout_style
+	 */
+	public function test_get_layout_style_with_numeric_string_grid_counts() {
+		$layout_styles = wp_get_layout_style(
+			'.wp-layout',
+			array(
+				'type'        => 'grid',
+				'columnCount' => '3',
+				'rowCount'    => '2',
+			)
+		);
+
+		$this->assertSame(
+			'.wp-layout{grid-template-columns:repeat(3, minmax(0, 1fr));grid-template-rows:repeat(2, minmax(1rem, auto));}',
+			$layout_styles
+		);
+	}
 }


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65774

## What?

Backport PR of:

- https://github.com/WordPress/gutenberg/pull/80501
- https://github.com/WordPress/gutenberg/pull/81560

Guards block supports callbacks against wrong-typed attribute values.

## Why?

`block.json` / `theme.json` types aren't enforced at render time, so wrong-typed values reach strict PHP ops and fatal in PHP 8+. The numeric grid attributes had the same problem in reverse, interpolating straight into the CSS as `grid-column: span Array`.

## How?

Guard with `is_string()` / `is_array()` / `is_scalar()` before each strict op, and run the six numeric grid attributes through `is_numeric()` with an `int` cast. Wrong-typed values are treated as absent.

## Testing Instructions

Existing tests should pass.

### Testing Instructions for Keyboard

N/A — no UI changes.

## Use of AI Tools

Claude Code
