### PR TITLE
REST API: Fix WP_REST_Autosaves_Controller silently preserving stale revision field

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php
@@ -385,26 +385,8 @@ class WP_REST_Autosaves_Controller extends WP_REST_Revisions_Controller {
 
 		$new_autosave = _wp_post_revision_data( $post_data, true );
 
-		foreach ( array_intersect( array_keys( $new_autosave ), array_keys( _wp_post_revision_fields( $post ) ) ) as $field ) {
-			if ( normalize_whitespace( $new_autosave[ $field ] ) !== normalize_whitespace( $post->$field ) ) {
-				$autosave_is_different = true;
-				break;
-			}
-		}
-
-		// Check if meta values have changed.
 		if ( ! empty( $meta ) ) {
 			$revisioned_meta_keys = wp_post_revision_meta_keys( $post->post_type );
-			foreach ( $revisioned_meta_keys as $meta_key ) {
-				// get_metadata_raw is used to avoid retrieving the default value.
-				$old_meta = get_metadata_raw( 'post', $post_id, $meta_key, true );
-				$new_meta = $meta[ $meta_key ] ?? '';
-
-				if ( $new_meta !== $old_meta ) {
-					$autosave_is_different = true;
-					break;
-				}
-			}
 		}
 
 		$user_id = get_current_user_id();

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php
@@ -376,7 +376,6 @@ class WP_REST_Autosaves_Controller extends WP_REST_Revisions_Controller {
 	 * @return mixed The autosave revision ID or WP_Error.
 	 */
 	public function create_post_autosave( $post_data, array $meta = array() ) {
-
 		$post_id = (int) $post_data['ID'];
 		$post    = get_post( $post_id );
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php
@@ -370,6 +370,8 @@ class WP_REST_Autosaves_Controller extends WP_REST_Revisions_Controller {
 	 *
 	 * @since 5.0.0
 	 * @since 6.4.0 The `$meta` parameter was added.
+	 * @since 7.1.0 Compares incoming data against the existing autosave instead
+	 *              of the published post.
 	 *
 	 * @param array $post_data Associative array containing the post data.
 	 * @param array $meta      Associative array containing the post meta data.
@@ -423,9 +425,9 @@ class WP_REST_Autosaves_Controller extends WP_REST_Revisions_Controller {
 			}
 
 			if ( ! $autosave_is_different ) {
-			// Nothing to save, return the existing autosave.
-			return $old_autosave->ID;
-		}
+				// Nothing to save, return the existing autosave.
+				return $old_autosave->ID;
+			}
 
 			$new_autosave['ID']          = $old_autosave->ID;
 			$new_autosave['post_author'] = $user_id;

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php
@@ -414,8 +414,12 @@ class WP_REST_Autosaves_Controller extends WP_REST_Revisions_Controller {
 
 			if ( ! $autosave_is_different && ! empty( $meta ) ) {
 				foreach ( $revisioned_meta_keys as $meta_key ) {
+					if ( ! array_key_exists( $meta_key, $meta ) ) {
+						continue;
+					}
+
 					$old_meta_value = get_metadata_raw( 'post', $old_autosave->ID, $meta_key, true );
-					$new_meta_value = $meta[ $meta_key ] ?? '';
+					$new_meta_value = $meta[ $meta_key ];
 
 					if ( $new_meta_value !== $old_meta_value ) {
 						$autosave_is_different = true;

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php
@@ -394,12 +394,39 @@ class WP_REST_Autosaves_Controller extends WP_REST_Revisions_Controller {
 		// Store one autosave per author. If there is already an autosave, overwrite it.
 		$old_autosave = wp_get_post_autosave( $post_id, $user_id );
 
-		if ( ! $autosave_is_different && $old_autosave ) {
+		if ( $old_autosave ) {
+			/*
+			 * When an autosave revision already exists, compare the incoming data
+			 * against its current field values rather than the published post. A field
+			 * reverted to the published value - such as a title edit that was undone -
+			 * must still overwrite any stale value in the existing autosave, otherwise
+			 * consumers like Preview will display incorrect content indefinitely.
+			 */
+			$autosave_is_different = false;
+			foreach ( array_intersect( array_keys( $new_autosave ), array_keys( _wp_post_revision_fields( $post ) ) ) as $field ) {
+				if ( normalize_whitespace( $new_autosave[ $field ] ) !== normalize_whitespace( $old_autosave->$field ) ) {
+					$autosave_is_different = true;
+					break;
+				}
+			}
+
+			if ( ! $autosave_is_different && ! empty( $meta ) ) {
+				foreach ( $revisioned_meta_keys as $meta_key ) {
+					$old_meta_value = get_metadata_raw( 'post', $old_autosave->ID, $meta_key, true );
+					$new_meta_value = $meta[ $meta_key ] ?? '';
+
+					if ( $new_meta_value !== $old_meta_value ) {
+						$autosave_is_different = true;
+						break;
+					}
+				}
+			}
+
+			if ( ! $autosave_is_different ) {
 			// Nothing to save, return the existing autosave.
 			return $old_autosave->ID;
 		}
 
-		if ( $old_autosave ) {
 			$new_autosave['ID']          = $old_autosave->ID;
 			$new_autosave['post_author'] = $user_id;
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php
@@ -383,9 +383,7 @@ class WP_REST_Autosaves_Controller extends WP_REST_Revisions_Controller {
 			return $post;
 		}
 
-		// Only create an autosave when it is different from the saved post.
-		$autosave_is_different = false;
-		$new_autosave          = _wp_post_revision_data( $post_data, true );
+		$new_autosave = _wp_post_revision_data( $post_data, true );
 
 		foreach ( array_intersect( array_keys( $new_autosave ), array_keys( _wp_post_revision_fields( $post ) ) ) as $field ) {
 			if ( normalize_whitespace( $new_autosave[ $field ] ) !== normalize_whitespace( $post->$field ) ) {

--- a/tests/phpunit/tests/rest-api/rest-autosaves-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-autosaves-controller.php
@@ -927,23 +927,29 @@ class WP_Test_REST_Autosaves_Controller extends WP_Test_REST_Post_Type_Controlle
 	public function test_create_post_autosave_updates_stale_field_on_revert() {
 		wp_set_current_user( self::$editor_id );
 
-		$post_id = $this->factory->post->create( array(
-			'post_title'  => 'Original Title',
-			'post_status' => 'publish',
-			'post_author' => self::$editor_id,
-		) );
+		$post_id = $this->factory->post->create(
+			array(
+				'post_title'  => 'Original Title',
+				'post_status' => 'publish',
+				'post_author' => self::$editor_id,
+			)
+		);
 
 		$controller = new WP_REST_Autosaves_Controller( 'post' );
 
-		$controller->create_post_autosave( array(
-			'ID'         => $post_id,
-			'post_title' => 'Original Title !!',
-		) );
+		$controller->create_post_autosave(
+			array(
+				'ID'         => $post_id,
+				'post_title' => 'Original Title !!',
+			)
+		);
 
-		$controller->create_post_autosave( array(
-			'ID'         => $post_id,
-			'post_title' => 'Original Title',
-		) );
+		$controller->create_post_autosave(
+			array(
+				'ID'         => $post_id,
+				'post_title' => 'Original Title',
+			)
+		);
 
 		$autosave = wp_get_post_autosave( $post_id, self::$editor_id );
 		$this->assertSame( 'Original Title', $autosave->post_title );

--- a/tests/phpunit/tests/rest-api/rest-autosaves-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-autosaves-controller.php
@@ -920,4 +920,32 @@ class WP_Test_REST_Autosaves_Controller extends WP_Test_REST_Post_Type_Controlle
 			'get_items request' => array( '/wp/v2/posts/%d' ),
 		);
 	}
+
+	/**
+	 * @ticket 65694
+	 */
+	public function test_create_post_autosave_updates_stale_field_on_revert() {
+		wp_set_current_user( self::$editor_id );
+
+		$post_id = $this->factory->post->create( array(
+			'post_title'  => 'Original Title',
+			'post_status' => 'publish',
+			'post_author' => self::$editor_id,
+		) );
+
+		$controller = new WP_REST_Autosaves_Controller( 'post' );
+
+		$controller->create_post_autosave( array(
+			'ID'         => $post_id,
+			'post_title' => 'Original Title !!',
+		) );
+
+		$controller->create_post_autosave( array(
+			'ID'         => $post_id,
+			'post_title' => 'Original Title',
+		) );
+
+		$autosave = wp_get_post_autosave( $post_id, self::$editor_id );
+		$this->assertSame( 'Original Title', $autosave->post_title );
+	}
 }


### PR DESCRIPTION

Trac ticket: https://core.trac.wordpress.org/ticket/65694

When a post field (e.g. `post_title`) is reverted to the published value and an autosave is triggered via the REST API, `WP_REST_Autosaves_Controller::create_post_autosave()` silently skips the write if the submitted value matches the parent post — even when the existing autosave still holds a stale value from a prior edit.

The guard:

```php
if ( ! $autosave_is_different && $old_autosave ) {
    return $old_autosave->ID;
}
```

compares incoming data against the parent post only. When that comparison returns equal, it returns the existing autosave ID without checking whether that autosave itself is already consistent with what was submitted.

Reproduce - 
- Save an autosave with title `"My Post !!"`, then submit another with `"My Post"` (matching the published title). 
- The controller returns the old revision still holding `"My Post !!"` and no subsequent autosave can fix it, because every request with the correct title hits the same early return.

This PR expands the early-return guard to additionally compare the submitted fields against the existing autosave revision's fields using the same `normalize_whitespace()` loop already used earlier in the method. Only skip the update when the autosave is already consistent with the submitted data.

## Testing

- Manually reproduced the stale-title state and confirmed it is resolved with the fix.
- New PHPUnit test covers the exact sequence from the ticket: modified autosave → revert → assert autosave is updated, tested by - 

```php
npm run test:php -- --filter=WP_Test_REST_Autosaves_Controller
```