### PR TITLE
KSES: Allow autofocus attribute only on the dialog element.

### DIFF
--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -158,9 +158,10 @@ if ( ! CUSTOM_TAGS ) {
 			'popover' => true,
 		),
 		'dialog'     => array(
-			'closedby' => true,
-			'open'     => true,
-			'popover'  => true,
+			'closedby'  => true,
+			'open'      => true,
+			'popover'   => true,
+			'autofocus' => true,
 		),
 		'dl'         => array(),
 		'dt'         => array(),

--- a/tests/phpunit/tests/kses.php
+++ b/tests/phpunit/tests/kses.php
@@ -2184,6 +2184,18 @@ EOF;
 	}
 
 	/**
+	 * Tests that the autofocus attribute is allowed on dialog elements and removed from other focusable elements.
+	 *
+	 * @ticket 65491
+	 */
+	public function test_wp_kses_dialog_autofocus_attribute() {
+		$html     = '<dialog open autofocus>Content</dialog><button type="button" autofocus>Button</button><textarea autofocus>Some content</textarea><div tabindex="0" autofocus>Some content</div>';
+		$expected = '<dialog open autofocus>Content</dialog><button type="button">Button</button><textarea>Some content</textarea><div tabindex="0">Some content</div>';
+
+		$this->assertEqualHTML( $expected, wp_kses_post( $html ) );
+	}
+
+	/**
 	 * Test that Invoker Commands API attributes are preserved on buttons in post content.
 	 *
 	 * @ticket 64576


### PR DESCRIPTION
<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/65491

Allows the `autofocus` attribute in KSES, only for the `<dialog>` element for now.

## Use of AI Tools

None
---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
