### PR TITLE
32892 Add more aria labels to list tables th row headers

### DIFF
--- a/src/wp-admin/includes/class-wp-links-list-table.php
+++ b/src/wp-admin/includes/class-wp-links-list-table.php
@@ -364,4 +364,19 @@ class WP_Links_List_Table extends WP_List_Table {
 
 		return $this->row_actions( $actions );
 	}
+
+	/**
+	 * Returns a clean label for the primary (Name) column's row header `aria-label`.
+	 *
+	 * Provides screen readers with just the link name as the row header name,
+	 * preventing them from computing the name from the full cell content.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param object $link The current link object.
+	 * @return string The link name.
+	 */
+	protected function get_primary_column_aria_label( $link ) {
+		return $link->link_name;
+	}
 }

--- a/src/wp-admin/includes/class-wp-links-list-table.php
+++ b/src/wp-admin/includes/class-wp-links-list-table.php
@@ -377,6 +377,9 @@ class WP_Links_List_Table extends WP_List_Table {
 	 * @return string The link name.
 	 */
 	protected function get_primary_column_aria_label( $link ) {
-		return $link->link_name;
+		$link_name = html_entity_decode( $link->link_name, ENT_QUOTES, get_bloginfo( 'charset' ) );
+		$link_name = wp_strip_all_tags( $link_name );
+
+		return $link_name;
 	}
 }

--- a/src/wp-admin/includes/class-wp-list-table.php
+++ b/src/wp-admin/includes/class-wp-list-table.php
@@ -1784,7 +1784,7 @@ class WP_List_Table {
 	 * identifier (e.g. post title, plugin name, username). Return an empty string
 	 * to omit the attribute.
 	 *
-	 * @since 6.9.0
+	 * @since 7.1.0
 	 *
 	 * @param object|array $item The current item.
 	 * @return string The aria-label value, or an empty string.

--- a/src/wp-admin/includes/class-wp-media-list-table.php
+++ b/src/wp-admin/includes/class-wp-media-list-table.php
@@ -945,6 +945,13 @@ class WP_Media_List_Table extends WP_List_Table {
 	 * @return string The attachment title.
 	 */
 	protected function get_primary_column_aria_label( $post ) {
-		return _draft_or_post_title( $post );
+		$attachment_title = $post->post_title ?? '';
+
+		if ( ! empty( $attachment_title ) ) {
+			// The title may contain HTML. The printed aria-label uses esc_attr() later.
+			$attachment_title = wp_strip_all_tags( $attachment_title );
+		}
+
+		return $attachment_title;
 	}
 }

--- a/src/wp-admin/includes/class-wp-media-list-table.php
+++ b/src/wp-admin/includes/class-wp-media-list-table.php
@@ -932,4 +932,19 @@ class WP_Media_List_Table extends WP_List_Table {
 
 		return $this->row_actions( $actions );
 	}
+
+	/**
+	 * Returns a clean label for the primary (File) column's row header `aria-label`.
+	 *
+	 * Provides screen readers with just the attachment title as the row header
+	 * name, preventing them from computing the name from the full cell content.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param WP_Post $post The current WP_Post object.
+	 * @return string The attachment title.
+	 */
+	protected function get_primary_column_aria_label( $post ) {
+		return _draft_or_post_title( $post );
+	}
 }

--- a/src/wp-admin/includes/class-wp-media-list-table.php
+++ b/src/wp-admin/includes/class-wp-media-list-table.php
@@ -945,12 +945,9 @@ class WP_Media_List_Table extends WP_List_Table {
 	 * @return string The attachment title.
 	 */
 	protected function get_primary_column_aria_label( $post ) {
-		$attachment_title = $post->post_title ?? '';
-
-		if ( ! empty( $attachment_title ) ) {
-			// The title may contain HTML. The printed aria-label uses esc_attr() later.
-			$attachment_title = wp_strip_all_tags( $attachment_title );
-		}
+		// The title may contain HTML. The printed aria-label uses esc_attr() later.
+		$attachment_title = html_entity_decode( _draft_or_post_title( $post ), ENT_QUOTES, get_bloginfo( 'charset' ) );
+		$attachment_title = wp_strip_all_tags( $attachment_title );
 
 		return $attachment_title;
 	}

--- a/src/wp-admin/includes/class-wp-ms-sites-list-table.php
+++ b/src/wp-admin/includes/class-wp-ms-sites-list-table.php
@@ -888,13 +888,13 @@ class WP_MS_Sites_List_Table extends WP_List_Table {
 	/**
 	 * Returns a clean label for the primary (URL) column's row header `aria-label`.
 	 *
-	 * Provides screen readers with just the Site Title as the row header name,
+	 * Provides screen readers with just the site title as the row header name,
 	 * preventing them from computing the name from the full cell content.
 	 *
 	 * @since 7.1.0
 	 *
 	 * @param array $blog The current site properties array.
-	 * @return string The Site title.
+	 * @return string The site title.
 	 */
 	protected function get_primary_column_aria_label( $blog ) {
 		$blog_name = html_entity_decode( get_blog_option( $blog['blog_id'], 'blogname' ), ENT_QUOTES, get_bloginfo( 'charset' ) );

--- a/src/wp-admin/includes/class-wp-ms-sites-list-table.php
+++ b/src/wp-admin/includes/class-wp-ms-sites-list-table.php
@@ -897,6 +897,9 @@ class WP_MS_Sites_List_Table extends WP_List_Table {
 	 * @return string The Site title.
 	 */
 	protected function get_primary_column_aria_label( $blog ) {
-		return get_blog_option( $blog['blog_id'], 'blogname' );
+		$blog_name = html_entity_decode( get_blog_option( $blog['blog_id'], 'blogname' ), ENT_QUOTES, get_bloginfo( 'charset' ) );
+		$blog_name = wp_strip_all_tags( $blog_name );
+
+		return $blog_name;
 	}
 }

--- a/src/wp-admin/includes/class-wp-ms-sites-list-table.php
+++ b/src/wp-admin/includes/class-wp-ms-sites-list-table.php
@@ -884,4 +884,23 @@ class WP_MS_Sites_List_Table extends WP_List_Table {
 
 		return $this->row_actions( $actions );
 	}
+
+	/**
+	 * Returns a clean label for the primary (URL) column's row header `aria-label`.
+	 *
+	 * Provides screen readers with just the Site Title as the row header name,
+	 * preventing them from computing the name from the full cell content.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param array $blog The current site properties array.
+	 * @return string The Site title.
+	 */
+	protected function get_primary_column_aria_label( $blog ) {
+		switch_to_blog( $blog['blog_id'] );
+		$site_title = get_option( 'blogname' );
+		restore_current_blog();
+
+		return $site_title;
+	}
 }

--- a/src/wp-admin/includes/class-wp-ms-sites-list-table.php
+++ b/src/wp-admin/includes/class-wp-ms-sites-list-table.php
@@ -897,10 +897,6 @@ class WP_MS_Sites_List_Table extends WP_List_Table {
 	 * @return string The Site title.
 	 */
 	protected function get_primary_column_aria_label( $blog ) {
-		switch_to_blog( $blog['blog_id'] );
-		$site_title = get_option( 'blogname' );
-		restore_current_blog();
-
-		return $site_title;
+		return get_blog_option( $blog['blog_id'], 'blogname' );
 	}
 }

--- a/src/wp-admin/includes/class-wp-ms-sites-list-table.php
+++ b/src/wp-admin/includes/class-wp-ms-sites-list-table.php
@@ -894,10 +894,10 @@ class WP_MS_Sites_List_Table extends WP_List_Table {
 	 * @since 7.1.0
 	 *
 	 * @param array $blog The current site properties array.
-	 * @return string The site title.
+	 * @return string The site title, or the site URL (domain + path) if the title is empty.
 	 */
 	protected function get_primary_column_aria_label( $blog ) {
-		$blog_name = html_entity_decode( get_blog_option( $blog['blog_id'], 'blogname' ), ENT_QUOTES, get_bloginfo( 'charset' ) );
+		$blog_name = html_entity_decode( (string) get_blog_option( $blog['blog_id'], 'blogname', '' ), ENT_QUOTES, get_bloginfo( 'charset' ) );
 		$blog_name = wp_strip_all_tags( $blog_name );
 
 		// Fall back to the blog URL and path if the blog name is empty.

--- a/src/wp-admin/includes/class-wp-ms-sites-list-table.php
+++ b/src/wp-admin/includes/class-wp-ms-sites-list-table.php
@@ -900,6 +900,7 @@ class WP_MS_Sites_List_Table extends WP_List_Table {
 		$blog_name = html_entity_decode( get_blog_option( $blog['blog_id'], 'blogname' ), ENT_QUOTES, get_bloginfo( 'charset' ) );
 		$blog_name = wp_strip_all_tags( $blog_name );
 
-		return $blog_name;
+		// Fall back to the blog URL and path if the blog name is empty.
+		return '' !== $blog_name ? $blog_name : untrailingslashit( $blog['domain'] . $blog['path'] );
 	}
 }

--- a/src/wp-admin/includes/class-wp-ms-users-list-table.php
+++ b/src/wp-admin/includes/class-wp-ms-users-list-table.php
@@ -574,7 +574,7 @@ class WP_MS_Users_List_Table extends WP_List_Table {
 	 * @since 7.1.0
 	 *
 	 * @param WP_User $user The current WP_User object.
-	 * @return string The User login.
+	 * @return string The user login.
 	 */
 	protected function get_primary_column_aria_label( $user ) {
 		return $user->user_login;

--- a/src/wp-admin/includes/class-wp-ms-users-list-table.php
+++ b/src/wp-admin/includes/class-wp-ms-users-list-table.php
@@ -564,4 +564,19 @@ class WP_MS_Users_List_Table extends WP_List_Table {
 
 		return $this->row_actions( $actions );
 	}
+
+	/**
+	 * Returns a clean label for the primary (Username) column's row header `aria-label`.
+	 *
+	 * Provides screen readers with just the user login as the row header name,
+	 * preventing them from computing the name from the full cell content.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param WP_User $user The current WP_User object.
+	 * @return string The User login.
+	 */
+	protected function get_primary_column_aria_label( $user ) {
+		return $user->user_login;
+	}
 }

--- a/src/wp-admin/includes/class-wp-posts-list-table.php
+++ b/src/wp-admin/includes/class-wp-posts-list-table.php
@@ -1129,7 +1129,7 @@ class WP_Posts_List_Table extends WP_List_Table {
 	 * preventing them from computing the name from the full cell content
 	 * (which includes row action links, post states, and possibly an excerpt).
 	 *
-	 * @since 6.9.0
+	 * @since 7.1.0
 	 *
 	 * @param WP_Post $item The current post object.
 	 * @return string The post title, or 'no title' if no title.
@@ -1215,7 +1215,7 @@ class WP_Posts_List_Table extends WP_List_Table {
 					/* translators: %s: Parent post title. */
 					esc_html( sprintf( __( 'Child of %s' ), wp_strip_all_tags( $parent_title ) ) )
 				);
-				$hierarchy_nolink  = sprintf(
+				$hierarchy_nolink = sprintf(
 					'<span id="%1$s" class="screen-reader-text"> (%2$s)</span>',
 					esc_attr( $hierarchy_id ),
 					/* translators: %s: Parent post title. */

--- a/src/wp-admin/includes/class-wp-privacy-data-export-requests-list-table.php
+++ b/src/wp-admin/includes/class-wp-privacy-data-export-requests-list-table.php
@@ -157,4 +157,19 @@ class WP_Privacy_Data_Export_Requests_List_Table extends WP_Privacy_Requests_Tab
 				break;
 		}
 	}
+
+	/**
+	 * Returns a clean label for the primary (Requester) column's row header `aria-label`.
+	 *
+	 * Provides screen readers with just the item email as the row header name,
+	 * preventing them from computing the name from the full cell content.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param WP_User_Request $item Item being shown.
+	 * @return string The user request item email.
+	 */
+	protected function get_primary_column_aria_label( $item ) {
+		return $item->email;
+	}
 }

--- a/src/wp-admin/includes/class-wp-privacy-data-removal-requests-list-table.php
+++ b/src/wp-admin/includes/class-wp-privacy-data-removal-requests-list-table.php
@@ -164,4 +164,19 @@ class WP_Privacy_Data_Removal_Requests_List_Table extends WP_Privacy_Requests_Ta
 				break;
 		}
 	}
+
+	/**
+	 * Returns a clean label for the primary (Requester) column's row header `aria-label`.
+	 *
+	 * Provides screen readers with just the item email as the row header name,
+	 * preventing them from computing the name from the full cell content.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param WP_User_Request $item Item being shown.
+	 * @return string The user request item email.
+	 */
+	protected function get_primary_column_aria_label( $item ) {
+		return $item->email;
+	}
 }

--- a/src/wp-admin/includes/class-wp-terms-list-table.php
+++ b/src/wp-admin/includes/class-wp-terms-list-table.php
@@ -751,4 +751,19 @@ class WP_Terms_List_Table extends WP_List_Table {
 		</form>
 		<?php
 	}
+
+	/**
+	 * Returns a clean label for the primary (Name) column's row header `aria-label`.
+	 *
+	 * Provides screen readers with just the term name as the row header name,
+	 * preventing them from computing the name from the full cell content.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param WP_Term $tag Term object.
+	 * @return string The term name.
+	 */
+	protected function get_primary_column_aria_label( $tag ) {
+		return $tag->name;
+	}
 }

--- a/src/wp-admin/includes/class-wp-terms-list-table.php
+++ b/src/wp-admin/includes/class-wp-terms-list-table.php
@@ -760,10 +760,11 @@ class WP_Terms_List_Table extends WP_List_Table {
 	 *
 	 * @since 7.1.0
 	 *
-	 * @param WP_Term $tag Term object.
+	 * @param WP_Term $term Term object.
 	 * @return string The term name.
 	 */
-	protected function get_primary_column_aria_label( $tag ) {
-		return $tag->name;
+	protected function get_primary_column_aria_label( $term ) {
+		// Term names are already sanitized via `sanitize_term()` on creation and update.
+		return $term->name;
 	}
 }


### PR DESCRIPTION
<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/32892

Adds aria-label attributes to more list table row headers, to provide cleaner names for screen reader users.
Corrects `@since` notation after [changeset 62838](https://core.trac.wordpress.org/changeset/62838).


## Use of AI Tools

None

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
