### PR TITLE
Login and Registration: Don't duplicate the network base path in wp_lostpassword_url() on subdirectory Multisite

### DIFF
--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -871,8 +871,16 @@ function wp_lostpassword_url( $redirect = '' ) {
 	}
 
 	if ( is_multisite() ) {
-		$blog_details  = get_site();
-		$wp_login_path = $blog_details->path . 'wp-login.php';
+		$blog_details    = get_site();
+		$current_network = get_network();
+		$site_path       = $blog_details->path;
+
+		// Strip the network's base path, as network_site_url() below adds it back.
+		if ( $current_network && str_starts_with( $site_path, $current_network->path ) ) {
+			$site_path = substr( $site_path, strlen( $current_network->path ) );
+		}
+
+		$wp_login_path = $site_path . 'wp-login.php';
 	} else {
 		$wp_login_path = 'wp-login.php';
 	}

--- a/tests/phpunit/tests/general/template.php
+++ b/tests/phpunit/tests/general/template.php
@@ -923,4 +923,58 @@ class Tests_General_Template extends WP_UnitTestCase {
 		$this->assertSame( $fallback, $processor->get_attribute( 'src' ), 'Output should contain fallback icon URL in src.' );
 		$this->assertNull( $processor->get_attribute( 'srcset' ), 'srcset should be omitted when 1x and 2x fallback URLs are identical.' );
 	}
+
+	/**
+	 * @ticket 65702
+	 * @group multisite
+	 * @group ms-required
+	 * @covers ::wp_lostpassword_url
+	 */
+	public function test_wp_lostpassword_url_does_not_duplicate_the_network_path_for_the_main_site() {
+		$lostpassword_url = $this->get_lostpassword_url_for_paths( '/subdir/', '/subdir/' );
+
+		$this->assertStringNotContainsString( '/subdir/subdir/', $lostpassword_url, 'The network base path should not be duplicated in the lost password URL.' );
+		$this->assertStringContainsString( '/subdir/wp-login.php', $lostpassword_url );
+	}
+
+	/**
+	 * @ticket 65702
+	 * @group multisite
+	 * @group ms-required
+	 * @covers ::wp_lostpassword_url
+	 */
+	public function test_wp_lostpassword_url_does_not_duplicate_the_network_path_for_a_subsite() {
+		$lostpassword_url = $this->get_lostpassword_url_for_paths( '/subdir/', '/subdir/site2/' );
+
+		$this->assertStringNotContainsString( '/subdir/subdir/', $lostpassword_url, 'The network base path should not be duplicated for a subsite either.' );
+		$this->assertStringContainsString( '/subdir/site2/wp-login.php', $lostpassword_url );
+	}
+
+	/**
+	 * Retrieves the lost password URL as seen from a site with the given network and site paths.
+	 *
+	 * @param string $network_path The network's base path, e.g. '/subdir/'.
+	 * @param string $site_path    The current site's path, e.g. '/subdir/site2/'.
+	 * @return string The lost password URL.
+	 */
+	private function get_lostpassword_url_for_paths( $network_path, $site_path ) {
+		$set_network_path = static function ( $network ) use ( $network_path ) {
+			$network->path = $network_path;
+			return $network;
+		};
+		$set_site_path    = static function ( $site ) use ( $site_path ) {
+			$site->path = $site_path;
+			return $site;
+		};
+
+		add_filter( 'get_network', $set_network_path );
+		add_filter( 'get_site', $set_site_path );
+
+		$lostpassword_url = wp_lostpassword_url();
+
+		remove_filter( 'get_network', $set_network_path );
+		remove_filter( 'get_site', $set_site_path );
+
+		return $lostpassword_url;
+	}
 }


### PR DESCRIPTION
On a Multisite network installed in a subdirectory (e.g. `http://example.com/subdir/`), `wp_lostpassword_url()` returns a URL with the base path duplicated, such as `http://example.com/subdir/subdir/wp-login.php?action=lostpassword`. This happens because `network_site_url()` already prepends the network's base path (`$current_network->path`) to the given path, but `wp_lostpassword_url()` was separately prepending the current site's own path (`$blog_details->path`) in front of `wp-login.php` before handing it to `network_site_url()`. For the main site of a subdirectory network, and more generally for any site whose path is nested under a non-root network path, this results in the base path being added twice. This fix strips the network's base path from the site's path before it's appended, since `network_site_url()` adds that prefix back on its own — matching how the per-site path handling introduced in #39311 was intended to work. Two tests were added covering both the main site of a subdirectory network (where the site path and network path are identical) and a subsite nested under a non-root network path, confirming the duplicate segment is gone in both cases while the existing subsite-at-root-network case (the original #39311 fix) continues to resolve correctly.

Trac ticket: https://core.trac.wordpress.org/ticket/65702

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Sonnet 5
Used for: Root-cause analysis, implementation, and tests. Reviewed by Igor Rozum.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
