### PR TITLE
Widgets: Keep the widget Edit/Add text link visible when JavaScript is available

### DIFF
--- a/src/wp-admin/css/widgets.css
+++ b/src/wp-admin/css/widgets.css
@@ -559,6 +559,12 @@ div#widgets-right .closed .widgets-sortables {
 	border-left: 1px solid #dcdcde;
 }
 
+/* Sit next to the JS expand/collapse button rather than stacking below it. */
+.widget-title-action .widget-control-edit {
+	display: inline-block;
+	vertical-align: top;
+}
+
 #widgets-left .widget-control-edit:hover,
 #widgets-right .widget-control-edit:hover {
 	color: #fff;

--- a/src/wp-admin/includes/widgets.php
+++ b/src/wp-admin/includes/widgets.php
@@ -259,7 +259,7 @@ function wp_widget_control( $sidebar_args ) {
 			</span>
 			<span class="toggle-indicator" aria-hidden="true"></span>
 		</button>
-		<a class="widget-control-edit hide-if-js" href="<?php echo esc_url( add_query_arg( $query_arg ) ); ?>">
+		<a class="widget-control-edit" href="<?php echo esc_url( add_query_arg( $query_arg ) ); ?>">
 			<span class="edit"><?php _ex( 'Edit', 'widget' ); ?></span>
 			<span class="add"><?php _ex( 'Add', 'widget' ); ?></span>
 			<span class="screen-reader-text"><?php echo $widget_title; ?></span>

--- a/tests/phpunit/tests/widgets.php
+++ b/tests/phpunit/tests/widgets.php
@@ -789,42 +789,7 @@ class Tests_Widgets extends WP_UnitTestCase {
 	 * @see wp_widget_control()
 	 */
 	public function test_wp_widget_control() {
-		global $wp_registered_widgets;
-
-		update_option(
-			'widget_search',
-			array(
-				2              => array( 'title' => '' ),
-				'_multiwidget' => 1,
-			)
-		);
-		update_option(
-			'sidebars_widgets',
-			array(
-				'wp_inactive_widgets' => array(),
-				'sidebar-1'           => array( 'search-2' ),
-				'sidebar-2'           => array(),
-				'array_version'       => 3,
-			)
-		);
-
-		wp_widgets_init();
-		require_once ABSPATH . 'wp-admin/includes/widgets.php';
-		$widget_id    = 'search-2';
-		$widget       = $wp_registered_widgets[ $widget_id ];
-		$params       = array(
-			'widget_id'   => $widget['id'],
-			'widget_name' => $widget['name'],
-		);
-		$control_args = array(
-			0 => $params,
-			1 => $widget['params'][0],
-		);
-		$sidebar_args = wp_list_widget_controls_dynamic_sidebar( $control_args );
-
-		ob_start();
-		wp_widget_control( ...$sidebar_args );
-		$control = ob_get_clean();
+		$control = $this->render_search_widget_control();
 		$this->assertNotEmpty( $control );
 
 		$this->assertStringContainsString( '<div class="widget-top">', $control );
@@ -847,16 +812,7 @@ class Tests_Widgets extends WP_UnitTestCase {
 			'before_widget_content' => '<!-- before_widget_content -->',
 			'after_widget_content'  => '<!-- after_widget_content -->',
 		);
-		$params          = array_merge( $params, $param_overrides );
-		$control_args    = array(
-			0 => $params,
-			1 => $widget['params'][0],
-		);
-		$sidebar_args    = wp_list_widget_controls_dynamic_sidebar( $control_args );
-
-		ob_start();
-		wp_widget_control( ...$sidebar_args );
-		$control = ob_get_clean();
+		$control         = $this->render_search_widget_control( $param_overrides );
 		$this->assertNotEmpty( $control );
 		$this->assertStringNotContainsString( '<form method="post">', $control );
 		$this->assertStringNotContainsString( '<div class="widget-content">', $control );
@@ -864,6 +820,64 @@ class Tests_Widgets extends WP_UnitTestCase {
 		foreach ( $param_overrides as $contained ) {
 			$this->assertStringContainsString( $contained, $control );
 		}
+	}
+
+	/**
+	 * @ticket 52399
+	 * @see wp_widget_control()
+	 */
+	public function test_wp_widget_control_edit_link_is_not_hidden_from_js() {
+		$control = $this->render_search_widget_control();
+
+		$this->assertStringContainsString( 'class="widget-control-edit"', $control, 'The Edit/Add text link should remain visible when JavaScript is available, as a plain-text path to the accessible single-widget edit screen.' );
+		$this->assertStringNotContainsString( 'widget-control-edit hide-if-js', $control );
+	}
+
+	/**
+	 * Registers a `search-2` widget in `sidebar-1` and renders its control markup via wp_widget_control().
+	 *
+	 * @param array $param_overrides Optional. Extra values merged into the sidebar params passed to wp_widget_control().
+	 * @return string The rendered control markup.
+	 */
+	private function render_search_widget_control( array $param_overrides = array() ) {
+		global $wp_registered_widgets;
+
+		update_option(
+			'widget_search',
+			array(
+				2              => array( 'title' => '' ),
+				'_multiwidget' => 1,
+			)
+		);
+		update_option(
+			'sidebars_widgets',
+			array(
+				'wp_inactive_widgets' => array(),
+				'sidebar-1'           => array( 'search-2' ),
+				'sidebar-2'           => array(),
+				'array_version'       => 3,
+			)
+		);
+
+		wp_widgets_init();
+		require_once ABSPATH . 'wp-admin/includes/widgets.php';
+		$widget       = $wp_registered_widgets['search-2'];
+		$params       = array_merge(
+			array(
+				'widget_id'   => $widget['id'],
+				'widget_name' => $widget['name'],
+			),
+			$param_overrides
+		);
+		$control_args = array(
+			0 => $params,
+			1 => $widget['params'][0],
+		);
+		$sidebar_args = wp_list_widget_controls_dynamic_sidebar( $control_args );
+
+		ob_start();
+		wp_widget_control( ...$sidebar_args );
+		return ob_get_clean();
 	}
 
 	public function test_the_widget_custom_before_title_arg() {


### PR DESCRIPTION
This is Phase 1 of the phased plan proposed by @sanketparmar in comment:16 and endorsed by @joedolson in comment:17. It does **not** remove Accessibility Mode itself — that depends on Phases 2 and 3 landing first.

**The problem:** On the classic Widgets screen (`wp-admin/widgets.php`), each widget already renders a plain-text "Edit"/"Add" link (`.widget-control-edit`) pointing at the accessible single-widget edit screen, alongside the JS-only expand/collapse toggle button. That text link was hidden whenever JavaScript is available (via the `hide-if-js` class), so keyboard and assistive-technology users had no way to reach the accessible single-widget edit screen without first switching into Accessibility Mode.

**The fix:**
- Removed `hide-if-js` from the link in `wp_widget_control()`, so it stays visible alongside the toggle button.
- Removing that class alone caused a layout regression: the link stacked *below* the toggle button instead of sitting beside it, since both are children of the floated `.widget-title-action` container and the link's `display: block` forced a line break. Added a small CSS rule scoping the link to `display: inline-block` when rendered next to the toggle button.
- Accessibility Mode's existing higher-specificity override (`.widgets_access #wpwrap .widget-control-edit { display: block; }`) is unaffected, since that mode hides the toggle button entirely.

**Verification:**
- Manually tested in the browser with the Classic Widgets plugin active, in both standard mode and Accessibility Mode.
- Existing and new PHPUnit coverage added in `tests/phpunit/tests/widgets.php`.

Trac ticket: https://core.trac.wordpress.org/ticket/52399

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Sonnet 5
Used for: Implementation, tests, browser verification, and PR description. Reviewed by Igor Rozum.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
