### PR TITLE
Plugins: Fix search box margin when filter links wrap on Add Plugins/Media screens

### DIFF
--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -1146,6 +1146,7 @@ th.action-links {
 	flex-wrap: wrap;
 	justify-content: space-between;
 	align-items: center;
+	row-gap: 11px;
 }
 
 .wp-filter .search-form.search-plugins select,
@@ -1385,12 +1386,6 @@ th.action-links {
 
 @media only screen and (max-width: 1138px) {
 	.wp-filter .search-form {
-		margin: 11px 0;
-	}
-}
-
-@media only screen and (max-width: 1250px) {
-	.wp-filter:has(.plugin-install-search) .search-form {
 		margin: 11px 0;
 	}
 }


### PR DESCRIPTION
On the Add Plugins screen (`plugin-install.php`) and the Media Library (`upload.php`), the filter-links row and the search box are laid out with flexbox and `flex-wrap: wrap`, but the container had no `row-gap`. When the filter-links row is long enough to wrap onto its own line — which happens once enough tabs are present (e.g. after a search adds a "Search Results" tab, or a plugin like WooCommerce adds extra tabs) — the search box below it has no separation and sits flush against the wrapped row. A prior fix (#64809) patched this only below a fixed 1250px viewport width, but the underlying wrap point depends on tab content length, not a fixed breakpoint, so the same bug still reproduces above 1250px with a long enough filter-links row.

This replaces that fragile fixed-breakpoint rule with `row-gap: 11px` on the flex container itself, so spacing is applied automatically whenever the row wraps, at any viewport width. The old `@media (max-width: 1250px)` rule targeting `.plugin-install-search` is removed as redundant — worse, it was stacking with the new `row-gap` to produce a 22px gap instead of 11px in that specific case.

Note on scope: this ticket's title refers to the Installed Plugins screen's search box (`plugins.php`), and the currently open PR #10414 targets that page specifically. I found that page already has correct margin (`p.search-box { margin: 11px 0; }`, added in 2024) and PR #10414's selector (`.wp-filter .search-form.search-plugins`) doesn't match anything there — that page's search form isn't nested inside a `.wp-filter` container. The actual reproducible bug described by the original commenters (using the "Search Results"/"Beta Testing" tabs, which only exist on the Add Plugins screen) is on `plugin-install.php` and `upload.php`, which is what this PR fixes.

Trac ticket: https://core.trac.wordpress.org/ticket/64143

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Sonnet 5
Used for: Investigation (including determining that the ticket's original proposed fix and PR #10414 don't address a reproducible bug), implementation, and PR description. Reviewed by Igor Rozum.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
