### PR TITLE
Twenty Twenty-One: Skip the untitled title filter in the admin

### DIFF
--- a/src/wp-content/themes/twentytwentyone/inc/template-functions.php
+++ b/src/wp-content/themes/twentytwentyone/inc/template-functions.php
@@ -182,11 +182,16 @@ if ( ! function_exists( 'twenty_twenty_one_post_title' ) ) {
 	 * Adds a title to posts and pages that are missing titles.
 	 *
 	 * @since Twenty Twenty-One 1.0
+	 * @since Twenty Twenty-One 2.9 Only applies the filter on the front end.
 	 *
 	 * @param string $title The title.
 	 * @return string
 	 */
 	function twenty_twenty_one_post_title( $title ) {
+		if ( is_admin() ) {
+			return $title;
+		}
+
 		return '' === $title ? esc_html_x( 'Untitled', 'Added to posts and pages that are missing titles', 'twentytwentyone' ) : $title;
 	}
 }

--- a/src/wp-content/themes/twentytwentyone/inc/template-functions.php
+++ b/src/wp-content/themes/twentytwentyone/inc/template-functions.php
@@ -192,7 +192,7 @@ if ( ! function_exists( 'twenty_twenty_one_post_title' ) ) {
 			return $title;
 		}
 
-		return '' === $title ? esc_html_x( 'Untitled', 'Added to posts and pages that are missing titles', 'twentytwentyone' ) : $title;
+		return '' === $title ? esc_html_x( 'Untitled', 'Added on the front end to posts and pages that are missing titles', 'twentytwentyone' ) : $title;
 	}
 }
 add_filter( 'the_title', 'twenty_twenty_one_post_title' );

--- a/tests/e2e/specs/dashboard.test.js
+++ b/tests/e2e/specs/dashboard.test.js
@@ -149,11 +149,9 @@ test.describe( 'Quick Draft', () => {
 		await saveDraftButton.click();
 
 		// Check that the new draft title appears in the 'Your Recent Drafts' section.
-		// This test relies on Twenty Twenty-One being the active theme.
-		// Twenty Twenty-One alters the default post title from "(no title)" to "Untitled".
 		await expect(
 			page.locator( '.drafts .draft-title' ).first().getByRole( 'link' )
-		).toHaveText( 'Untitled' );
+		).toHaveText( '(no title)' );
 
 		await expect(
 			page.locator( '.drafts .draft-content' ).first()
@@ -164,6 +162,6 @@ test.describe( 'Quick Draft', () => {
 
 		await expect(
 			page.locator( '.type-post.status-draft .title' ).first()
-		).toContainText( 'Untitled' );
+		).toContainText( '(no title)' );
 	} );
 } );


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

Twenty Twenty-One filters `the_title` to display "Untitled" for posts and pages that are missing a title. This is a front-end presentation concern, but the filter also runs in the admin.

What the problem was:
- Since #65022, the post list table shows a trimmed excerpt in place of a missing title, gated on `'' === get_the_title( $post )`.
- Twenty Twenty-One's filter fills empty titles with "Untitled", so that condition is never met in the admin. The excerpt fallback is suppressed and untitled posts display "Untitled" in the list table instead.

What the fix does:
- Adds an `is_admin()` guard to `twenty_twenty_one_post_title()` so the "Untitled" replacement only applies on the front end. Admin titles are returned unchanged, restoring the excerpt fallback introduced in #65022.

Approach and why:
- This matches the theme's existing idiom: the sibling callbacks `twenty_twenty_one_continue_reading_link_excerpt()` and `twenty_twenty_one_continue_reading_link()` already use the same in-function `is_admin()` check. It is the smallest change that resolves the ticket and does not alter front-end behaviour.

Trac ticket: https://core.trac.wordpress.org/ticket/65710

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 4.8
Used for: Ticket analysis and writing PR desription. All changes were reviewed and validated by me.
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
