### PR TITLE
Application Passwords: Render a row header in the AJAX row template

### DIFF
--- a/src/wp-admin/includes/class-wp-application-passwords-list-table.php
+++ b/src/wp-admin/includes/class-wp-application-passwords-list-table.php
@@ -214,7 +214,12 @@ class WP_Application_Passwords_List_Table extends WP_List_Table {
 				$classes .= ' hidden';
 			}
 
-			printf( '<td class="%s" data-colname="%s">', esc_attr( $classes ), esc_attr( wp_strip_all_tags( $display_name ) ) );
+			// The primary column is a `<th scope="row">` row header, matching the
+			// server-rendered markup in WP_List_Table::single_row_columns().
+			$tag   = $is_primary ? 'th' : 'td';
+			$scope = $is_primary ? ' scope="row"' : '';
+
+			printf( '<%1$s class="%2$s" data-colname="%3$s"%4$s>', $tag, esc_attr( $classes ), esc_attr( wp_strip_all_tags( $display_name ) ), $scope );
 
 			switch ( $column_name ) {
 				case 'name':
@@ -259,7 +264,7 @@ class WP_Application_Passwords_List_Table extends WP_List_Table {
 				'</span></button>';
 			}
 
-			echo '</td>';
+			echo "</{$tag}>";
 		}
 
 		echo '</tr>';

--- a/tests/phpunit/tests/admin/wpApplicationPasswordsListTable.php
+++ b/tests/phpunit/tests/admin/wpApplicationPasswordsListTable.php
@@ -9,6 +9,8 @@
 class Tests_Admin_wpApplicationPasswordsListTable extends WP_UnitTestCase {
 
 	/**
+	 * The list table instance under test.
+	 *
 	 * @var WP_Application_Passwords_List_Table
 	 */
 	private $table;
@@ -42,12 +44,6 @@ class Tests_Admin_wpApplicationPasswordsListTable extends WP_UnitTestCase {
 			'/<th class="name column-name has-row-actions column-primary" data-colname="[^"]*" scope="row">/',
 			$html,
 			'The primary column should be rendered as a <th scope="row"> row header.'
-		);
-
-		$this->assertStringNotContainsString(
-			'<td class="name column-name',
-			$html,
-			'The primary column should not be rendered as a <td> cell.'
 		);
 
 		$this->assertStringContainsString(

--- a/tests/phpunit/tests/admin/wpApplicationPasswordsListTable.php
+++ b/tests/phpunit/tests/admin/wpApplicationPasswordsListTable.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * @group admin
+ * @group application-passwords
+ *
+ * @covers WP_Application_Passwords_List_Table
+ */
+class Tests_Admin_wpApplicationPasswordsListTable extends WP_UnitTestCase {
+
+	/**
+	 * @var WP_Application_Passwords_List_Table
+	 */
+	private $table;
+
+	public function set_up() {
+		parent::set_up();
+		$this->table = _get_list_table(
+			'WP_Application_Passwords_List_Table',
+			array( 'screen' => 'application-passwords-user' )
+		);
+	}
+
+	/**
+	 * Ensures the JavaScript row template used for a password created via AJAX
+	 * renders the primary column as a `<th scope="row">` row header, matching
+	 * the server-rendered markup from WP_List_Table::single_row_columns().
+	 *
+	 * @ticket 65707
+	 *
+	 * @covers WP_Application_Passwords_List_Table::print_js_template_row
+	 */
+	public function test_print_js_template_row_uses_th_row_header_for_primary_column() {
+		ob_start();
+		$this->table->print_js_template_row();
+		$html = ob_get_clean();
+
+		// Assert on the tag structure and `scope="row"` rather than the localized
+		// column label, so the test does not depend on the current locale or on
+		// filters that adjust the column headers.
+		$this->assertMatchesRegularExpression(
+			'/<th class="name column-name has-row-actions column-primary" data-colname="[^"]*" scope="row">/',
+			$html,
+			'The primary column should be rendered as a <th scope="row"> row header.'
+		);
+
+		$this->assertStringNotContainsString(
+			'<td class="name column-name',
+			$html,
+			'The primary column should not be rendered as a <td> cell.'
+		);
+
+		$this->assertStringContainsString(
+			'<td class="created column-created"',
+			$html,
+			'Non-primary columns should still be rendered as <td> cells.'
+		);
+	}
+}


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

Tables extending WP_List_Table render the primary column as a `<th scope="row">` element so screen readers can announce it as context when navigating the table vertically. The Application Passwords table did this for server-rendered rows but not for the JavaScript row template used when a password is created via AJAX, so the row header was missing until reload.

What the problem was:
- On page load, the app-name cell is a `<th scope="row">` (correct).
- After creating a new application password via AJAX, every cell in the new row was a `<td>` — the `<th>` row header was missing.
- The header only appeared after refreshing the page.

What the fix does:
- Renders the primary column of `print_js_template_row()` as a `<th scope="row">` element, mirroring `WP_List_Table::single_row_columns()`.

Approach and why:
- The AJAX row is produced verbatim from this PHP template, so the parity fix belongs here. `single_row_columns()` uses the same `$tag`/`$scope` logic; reusing it keeps the two rendering paths identical. No `aria-label` is added because the table does not override `get_primary_column_aria_label()`, so the server path emits none either — adding one would introduce a new mismatch.

Trac ticket: https://core.trac.wordpress.org/ticket/65707

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 4.8
Used for: Ticket analysis, tests implementation, and writing PR description. All changes were reviewed and validated by me.
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
