### PR TITLE
Formatting: Fix wptexturize encoding ampersands inside script/pre/code when content contains <

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -250,8 +250,18 @@ function wptexturize( $text, $reset = false ) {
 			} else {
 				// This is an HTML element delimiter.
 
-				// Replace each & with &#038; unless it already looks like an entity.
-				$curl = preg_replace( '/&(?!#(?:\d+|x[a-f0-9]+);|[a-z1-4]{1,8};)/i', '&#038;', $curl );
+				/*
+				 * Replace each & with &#038; unless it already looks like an entity,
+				 * but only when outside no-texturize tags like <script> and <pre>.
+				 *
+				 * When a no-texturize tag contains a raw '<' character (e.g. JavaScript
+				 * like `if(a<b)`), preg_split() with _get_wptexturize_split_regex()
+				 * misidentifies that content as an HTML element delimiter. Encoding &
+				 * inside such a token would corrupt the script or preformatted content.
+				 */
+				if ( empty( $no_texturize_tags_stack ) ) {
+					$curl = preg_replace( '/&(?!#(?:\d+|x[a-f0-9]+);|[a-z1-4]{1,8};)/i', '&#038;', $curl );
+				}
 
 				_wptexturize_pushpop_element( $curl, $no_texturize_tags_stack, $no_texturize_tags );
 			}

--- a/tests/phpunit/tests/formatting/wpTexturize.php
+++ b/tests/phpunit/tests/formatting/wpTexturize.php
@@ -35,6 +35,34 @@ class Tests_Formatting_wpTexturize extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 43785
+	 * @covers ::wptexturize
+	 */
+	public function test_no_texturize_ampersand_inside_script_with_less_than() {
+		$this->assertSame(
+			'<script>if(a<b)window&&document</script>',
+			wptexturize( '<script>if(a<b)window&&document</script>' )
+		);
+		$this->assertSame(
+			'<script type="text/javascript">if(a<b)window&&document</script>',
+			wptexturize( '<script type="text/javascript">if(a<b)window&&document</script>' )
+		);
+		$this->assertSame(
+			'<pre>if(a<b)c&&d</pre>',
+			wptexturize( '<pre>if(a<b)c&&d</pre>' )
+		);
+		$this->assertSame(
+			'<code>if(a<b)c&&d</code>',
+			wptexturize( '<code>if(a<b)c&&d</code>' )
+		);
+		// Ensure & in real HTML attributes is still encoded outside no-texturize tags.
+		$this->assertSame(
+			'<a href="foo&#038;bar">link</a>',
+			wptexturize( '<a href="foo&bar">link</a>' )
+		);
+	}
+
+	/**
 	 * @ticket 1418
 	 */
 	public function test_bracketed_quotes_1418() {


### PR DESCRIPTION
## Summary

`wptexturize()` corrupts `&` characters inside `<script>`, `<pre>`, and `<code>` blocks when the block content contains a raw `<` character (e.g. JavaScript like `if(a<b)`).

### Root cause

`wp_html_split()` splits content at every `<` it recognises as an HTML tag boundary. When a no-texturize block contains `<` — as in `<script>if(a<b)window&&document</script>` — the split produces a token like `<b)window&&document</script>`. The `wptexturize()` loop then treats that token as an HTML element delimiter and encodes `&&` → `&#038;&#038;`, corrupting the output.

This was introduced in [36036] and became significantly more user-visible in WordPress 7.0, which added a dedicated JavaScript panel to the Custom HTML block. Valid JS entered there (e.g. `if (1 < 2 && 2 < 3) { … }`) can silently break on the frontend.

### Fix

Only run the `&` → `&#038;` substitution when the `no_texturize_tags_stack` is empty (i.e. we are **not** already inside a `<script>`, `<pre>`, `<code>`, etc. block). Real HTML tag attributes are only encountered at the top level, so this change has no effect on them.

### Tests

Added `test_no_texturize_ampersand_inside_script_with_less_than()` with 5 assertions covering `<script>` (with and without attributes), `<pre>`, `<code>`, and a regression assertion that `&` in real HTML attributes is still encoded correctly.

Fixes https://core.trac.wordpress.org/ticket/43785