### PR TITLE
#64893 Don't attempt to upload a SARIF to GitHub Code Security on private repos

### DIFF
--- a/.github/workflows/reusable-workflow-lint.yml
+++ b/.github/workflows/reusable-workflow-lint.yml
@@ -44,6 +44,8 @@ jobs:
   zizmor:
     name: Zizmor
     runs-on: ubuntu-24.04
+    # GitHub Code Security is not enabled on any of the private mirrors.
+    if: ${{ github.event.repository.private == false }}
     permissions:
       security-events: write
       actions: read


### PR DESCRIPTION
GitHub Code Security is not enabled on any of the private mirrors. This change prevents this workflow from attempting and failing to upload a SARIF to GitHub Code Security on private repos.

Trac ticket: https://core.trac.wordpress.org/ticket/64893

## Use of AI Tools

AI assistance: None