### PR TITLE
Build/test tools: run test-old-branches on the security mirror (checks only, no Slack)

### DIFF
--- a/.github/workflows/test-old-branches.yml
+++ b/.github/workflows/test-old-branches.yml
@@ -34,7 +34,7 @@ jobs:
     permissions:
       actions: write
     timeout-minutes: 20
-    if: ${{ github.repository == 'WordPress/wordpress-develop' }}
+    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.repository == 'WordPress/wordpress-develop-security' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-old-branches.yml
+++ b/.github/workflows/test-old-branches.yml
@@ -34,7 +34,7 @@ jobs:
     permissions:
       actions: write
     timeout-minutes: 20
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.repository == 'WordPress/wordpress-develop-security' }}
+    if: ${{ github.repository == 'WordPress/wordpress-develop' || ( github.repository == 'WordPress/wordpress-develop-security' && github.event_name == 'workflow_dispatch' ) }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/64893

## Summary

`test-old-branches.yml` restricts its dispatch job to `github.repository == 'WordPress/wordpress-develop'`, so it only runs on the canonical public repository. This extends that one guard to also allow the private security mirror (`WordPress/wordpress-develop-security`), so backport branches there get the same cross-branch test coverage. The Slack notification job is deliberately left public-only, so the mirror runs the tests without posting to the public channel. The public repository's behavior is unchanged.

## Why

Security backport branches are prepared on the private mirror, which shares this workflow file but is excluded by the repo-name guard. As a result the suite never runs across old branches there, and a missed backport can ship without a red test. Enabling the dispatch job closes that gap; the per-branch results are visible as checks without a Slack alert.

## Guard expression

Two options enable a private mirror: the explicit repository name (used here) or `github.event.repository.private`. `test-old-branches.yml` runs on pushes to `trunk` that change its workflow files, twice-monthly schedules, and manual `workflow_dispatch` events. Because `github.event.repository` is not reliably populated on schedule events, the explicit-name form is used for reliability. Happy to switch to the private-flag form if preferred.

## Testing

- `actionlint` passes on the changed workflow.
- `git diff --check` passes.
- The change is limited to the dispatch job's `if:` guard; the Slack notification job's guard is untouched.
- The public repository's guard clause is unchanged, so canonical CI is unaffected.
