### PR TITLE
Docs: Document how to run the QUnit test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,17 @@ npm run test:php -- --filter <test name>
 npm run test:php -- --group <group name or ticket number>
 ```
 
+To run the JavaScript (QUnit) tests:
+
+```
+npm run grunt qunit:compiled
+```
+
+`qunit:compiled` builds first, then runs the suite. The QUnit runner loads
+scripts from the built `build/` directory, so a plain `npm run grunt qunit`
+requires a completed `npm run build` first—without a build, every test fails
+with a `jQuery is not defined` error.
+
 #### To lint the workflow files
 
 GitHub Actions workflows operate in a privileged software supply chain environment, therefore all workflow files must adhere to a high degree of quality and security standards.

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ npm run grunt qunit:compiled
 
 `qunit:compiled` builds first, then runs the suite. The QUnit runner loads
 scripts from the built `build/` directory, so a plain `npm run grunt qunit`
-requires a completed `npm run build` first—without a build, every test fails
+requires a completed `npm run build` first without a build, every test fails
 with a `jQuery is not defined` error.
 
 #### To lint the workflow files


### PR DESCRIPTION
Documents how to run the JavaScript QUnit test suite from a fresh checkout.

This adds the `qunit:compiled` command, which builds the required files before running the suite. It also explains the build prerequisite for running `qunit` directly.

Trac ticket: https://core.trac.wordpress.org/ticket/65719

## Use of AI Tools

AI assistance: Yes
Tool(s): OpenAI Codex
Model(s): GPT-5
Used for: Drafting, applying, and validating the documentation update under contributor direction.
