### PR TITLE
Build/test tools: fix Zod export error in JavaScript linting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14237,16 +14237,6 @@
 				"eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
 			}
 		},
-		"node_modules/eslint-plugin-react-hooks/node_modules/zod": {
-			"version": "4.4.3",
-			"resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-			"integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-			"dev": true,
-			"license": "MIT",
-			"funding": {
-				"url": "https://github.com/sponsors/colinhacks"
-			}
-		},
 		"node_modules/eslint-plugin-react/node_modules/estraverse": {
 			"version": "5.3.0",
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
@@ -33728,10 +33718,11 @@
 			}
 		},
 		"node_modules/zod": {
-			"version": "3.23.8",
-			"resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
-			"integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+			"version": "3.25.1",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-3.25.1.tgz",
+			"integrity": "sha512-bkxUGQiqWDTXHSgqtevYDri5ee2GPC9szPct4pqpzLEpswgDQmuseDz81ZF0AnNu1xsmnBVmbtv/t/WeUIHlpg==",
 			"dev": true,
+			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}

--- a/package.json
+++ b/package.json
@@ -112,6 +112,9 @@
 		"whatwg-fetch": "3.6.20",
 		"wicg-inert": "3.1.3"
 	},
+	"overrides": {
+		"zod": "3.25.1"
+	},
 	"scripts": {
 		"build": "grunt build",
 		"build:dev": "grunt build --dev",


### PR DESCRIPTION
Fixes the `ERR_PACKAGE_PATH_NOT_EXPORTED` error for `zod/v4/core` after a clean `npm ci`.

The dependency tree installed Zod 3.23.8. This change overrides Zod to 3.25.1 and updates the
lockfile.

Zod 3.25.0 declares the export but lacks its CommonJS target. Version 3.25.1 is the smallest working release.

Trac ticket: https://core.trac.wordpress.org/ticket/65723

## Verification

- Reproduced the failure after a
clean `npm ci`.
- Ran `npm run lint:jsdoc`.
- Ran `npm run grunt -- jshint`.
- Ran `npm run typecheck:js`.
- Confirmed all Zod consumers resolve to 3.25.1.
- Loaded the Chromium BiDi parser
successfully.