### PR TITLE
Theme JSON: Level block-level preset class specificity with :where()

### DIFF
--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -2437,8 +2437,6 @@ class WP_Theme_JSON {
 	 *   }
 	 *
 	 * @since 5.9.0
-	 * @since 7.1.0 Block-level preset classes are wrapped in `:where()` to keep
-	 *              the same specificity as root-level preset classes.
 	 *
 	 * @param array    $setting_nodes Nodes with settings.
 	 * @param string[] $origins       List of origins to process presets from.
@@ -2616,7 +2614,7 @@ class WP_Theme_JSON {
 	 * @since 5.9.0 Added the `$origins` parameter.
 	 * @since 6.6.0 Added check for root CSS properties selector.
 	 * @since 7.1.0 Block-level preset classes are wrapped in `:where()` to keep
-	 *              the same specificity as root-level preset classes.
+	 * @since 7.1.0 Wraps block-level preset classes in `:where()` to match root-level specificity.
 	 *
 	 * @param array    $settings Settings to process.
 	 * @param string   $selector Selector wrapping the classes.

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -2432,11 +2432,13 @@ class WP_Theme_JSON {
 	 *     background: value;
 	 *   }
 	 *
-	 *   p.has-value-gradient-background {
+	 *   :where(p).has-value-gradient-background {
 	 *     background: value;
 	 *   }
 	 *
 	 * @since 5.9.0
+	 * @since 7.1.0 Block-level preset classes are wrapped in `:where()` to keep
+	 *              the same specificity as root-level preset classes.
 	 *
 	 * @param array    $setting_nodes Nodes with settings.
 	 * @param string[] $origins       List of origins to process presets from.
@@ -2613,6 +2615,8 @@ class WP_Theme_JSON {
 	 * @since 5.8.0
 	 * @since 5.9.0 Added the `$origins` parameter.
 	 * @since 6.6.0 Added check for root CSS properties selector.
+	 * @since 7.1.0 Block-level preset classes are wrapped in `:where()` to keep
+	 *              the same specificity as root-level preset classes.
 	 *
 	 * @param array    $settings Settings to process.
 	 * @param string   $selector Selector wrapping the classes.
@@ -2639,8 +2643,16 @@ class WP_Theme_JSON {
 					$css_var    = static::replace_slug_in_string( $preset_metadata['css_vars'], $slug );
 					$class_name = static::replace_slug_in_string( $class, $slug );
 
-					// $selector is often empty, so we can save ourselves the `append_to_selector()` call then.
-					$new_selector = '' === $selector ? $class_name : static::append_to_selector( $selector, $class_name );
+					/*
+					 * $selector is often empty (root-level presets), in which case the
+					 * bare class is used. For block-level presets the block selector is
+					 * wrapped in `:where()` so the class keeps the same 0-1-0 specificity
+					 * as a root-level preset. Without this, block-level palette rules
+					 * (e.g. `p.has-x-color`) out-rank equally-important rules that also
+					 * target the same property at 0-1-0, such as per-instance responsive
+					 * state styles.
+					 */
+					$new_selector = '' === $selector ? $class_name : ':where(' . $selector . ')' . $class_name;
 					$stylesheet  .= static::to_ruleset(
 						$new_selector,
 						array(

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -2613,7 +2613,6 @@ class WP_Theme_JSON {
 	 * @since 5.8.0
 	 * @since 5.9.0 Added the `$origins` parameter.
 	 * @since 6.6.0 Added check for root CSS properties selector.
-	 * @since 7.1.0 Block-level preset classes are wrapped in `:where()` to keep
 	 * @since 7.1.0 Wraps block-level preset classes in `:where()` to match root-level specificity.
 	 *
 	 * @param array    $settings Settings to process.

--- a/tests/phpunit/tests/theme/wpThemeJson.php
+++ b/tests/phpunit/tests/theme/wpThemeJson.php
@@ -805,6 +805,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 	/**
 	 * @ticket 52991
 	 * @ticket 54336
+	 * @ticket 65724
 	 */
 	public function test_get_stylesheet_preset_classes_work_with_compounded_selectors() {
 		$theme_json = new WP_Theme_JSON(
@@ -828,7 +829,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 		);
 
 		$this->assertSame(
-			'.wp-block-heading.has-white-color{color: var(--wp--preset--color--white) !important;}.wp-block-heading.has-white-background-color{background-color: var(--wp--preset--color--white) !important;}.wp-block-heading.has-white-border-color{border-color: var(--wp--preset--color--white) !important;}',
+			':where(.wp-block-heading).has-white-color{color: var(--wp--preset--color--white) !important;}:where(.wp-block-heading).has-white-background-color{background-color: var(--wp--preset--color--white) !important;}:where(.wp-block-heading).has-white-border-color{border-color: var(--wp--preset--color--white) !important;}',
 			$theme_json->get_stylesheet( array( 'presets' ) )
 		);
 	}
@@ -894,6 +895,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 	 * @ticket 58550
 	 * @ticket 60936
 	 * @ticket 61165
+	 * @ticket 65724
 	 */
 	public function test_get_stylesheet_preset_rules_come_after_block_rules() {
 		$theme_json = new WP_Theme_JSON(
@@ -926,7 +928,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 		);
 
 		$styles    = ':root :where(.wp-block-group){color: red;}';
-		$presets   = '.wp-block-group.has-grey-color{color: var(--wp--preset--color--grey) !important;}.wp-block-group.has-grey-background-color{background-color: var(--wp--preset--color--grey) !important;}.wp-block-group.has-grey-border-color{border-color: var(--wp--preset--color--grey) !important;}';
+		$presets   = ':where(.wp-block-group).has-grey-color{color: var(--wp--preset--color--grey) !important;}:where(.wp-block-group).has-grey-background-color{background-color: var(--wp--preset--color--grey) !important;}:where(.wp-block-group).has-grey-border-color{border-color: var(--wp--preset--color--grey) !important;}';
 		$variables = '.wp-block-group{--wp--preset--color--grey: grey;}';
 
 		$all = $variables . $styles . $presets;


### PR DESCRIPTION
## What

Backports [Gutenberg #80657](https://github.com/WordPress/gutenberg/pull/80657) (PHP only). Block-level preset classes are now wrapped in `:where()` so they keep the same `0-1-0` specificity as root-level preset classes.

## Why

A palette defined at block level (via the `wp_theme_json_data_theme` filter or `settings.blocks`) emits `p.has-x-color` at `0-1-1` specificity, while a root-level palette emits `.has-x-color` at `0-1-0`. Responsive style states emit their rules at `0-1-0`. Both use `!important`, so specificity decides the winner: the block-level preset out-ranks the state rule, and a Desktop palette colour overrides the Mobile colour at every viewport width.

Wrapping the block selector in `:where()` contributes zero specificity while keeping the same scoping, so the preset ties the state rule and loses on source order, matching root-level behaviour. Palette values are unaffected because they flow through the scoped `--wp--preset--color--*` variable, not the class.

Root-level palettes (e.g. Twenty Twenty-Four) are unchanged.

## What changed

- `WP_Theme_JSON::compute_preset_classes()` wraps non-empty block selectors in `:where()`, so block-level presets emit `:where(p).has-x-color` instead of `p.has-x-color`.
- Updated the docblock example in `get_preset_classes()` and the `@since` annotations on both methods.
- Updated the unit test expectations that asserted the old selectors.

## Manual testing

1. On a block theme, add `wp-content/mu-plugins/repro.php`:

```php
<?php
add_filter( 'wp_theme_json_data_theme', function ( $tj ) {
	$palette = array(
		array( 'slug' => 'uw-text',   'color' => '#121212', 'name' => 'Text' ),
		array( 'slug' => 'secondary', 'color' => '#036796', 'name' => 'Link Blue' ),
	);
	return $tj->update_with( array(
		'version'  => 3,
		'settings' => array( 'blocks' => array(
			'core/paragraph' => array( 'color' => array( 'palette' => $palette ) ),
		) ),
	) );
} );
```

2. Insert a Paragraph, set a Desktop text colour from that palette, then set a different Mobile text colour via Styles > Responsive.
3. On the front end, narrow the viewport to 480px or less. Before this change the Desktop colour wins at all widths; after, the Mobile colour wins at 480px and below.
4. View source and confirm the preset rule reads `:where(p).has-uw-text-color` (previously `p.has-uw-text-color`).
5. Confirm a theme with a root-level palette (e.g. Twenty Twenty-Four) renders unchanged.

Trac ticket: https://core.trac.wordpress.org/ticket/65724
