### PR TITLE
Enforce non-empty constraints for Site Title and Network Title across all contexts

### DIFF
--- a/src/wp-admin/css/forms.css
+++ b/src/wp-admin/css/forms.css
@@ -1222,6 +1222,10 @@ table.form-table td .updated p {
   20.0 - Settings
 ------------------------------------------------------------------------------*/
 
+.form-field #blogname {
+	max-width: 25em;
+}
+
 .timezone-info code {
 	white-space: nowrap;
 }
@@ -1317,7 +1321,8 @@ table.form-table td .updated p {
 .form-field #admin-email,
 .form-field #path,
 .form-field #blog_registered,
-.form-field #blog_last_updated {
+.form-field #blog_last_updated,
+.form-field #site_name {
 	max-width: 25em;
 }
 

--- a/src/wp-admin/network/settings.php
+++ b/src/wp-admin/network/settings.php
@@ -122,8 +122,9 @@ if ( $_POST ) {
 		$site_name = wp_unslash( $_POST['site_name'] );
 
 		if ( ! is_scalar( $site_name ) || '' === trim( (string) $site_name ) ) {
-		unset( $_POST['site_name'] );
-		$network_title_error = __( 'The network title cannot be empty. Please enter a title for your network.' );
+			unset( $_POST['site_name'] );
+			$network_title_error = __( 'The network title cannot be empty. Please enter a title for your network.' );
+		}
 	}
 
 	foreach ( $options as $option_name ) {
@@ -173,7 +174,6 @@ if ( isset( $_GET['updated'] ) ) {
 				array(
 					'type'        => 'error',
 					'dismissible' => true,
-					'id'          => 'message',
 				)
 			);
 		}

--- a/src/wp-admin/network/settings.php
+++ b/src/wp-admin/network/settings.php
@@ -116,6 +116,13 @@ if ( $_POST ) {
 		}
 	}
 
+	// Ensure the network title (site_name) is not left empty.
+	$network_title_error = '';
+	if ( isset( $_POST['site_name'] ) && '' === trim( wp_unslash( $_POST['site_name'] ) ) ) {
+		unset( $_POST['site_name'] );
+		$network_title_error = __( 'The network title cannot be empty. Please enter a title for your network.' );
+	}
+
 	foreach ( $options as $option_name ) {
 		if ( ! isset( $_POST[ $option_name ] ) ) {
 			continue;
@@ -131,21 +138,43 @@ if ( $_POST ) {
 	 */
 	do_action( 'update_wpmu_options' );
 
-	wp_redirect( add_query_arg( 'updated', 'true', network_admin_url( 'settings.php' ) ) );
+	if ( $network_title_error ) {
+		set_transient( 'network_settings_errors', array( $network_title_error ), 30 );
+		wp_redirect( add_query_arg( 'updated', 'error', network_admin_url( 'settings.php' ) ) );
+	} else {
+		wp_redirect( add_query_arg( 'updated', 'true', network_admin_url( 'settings.php' ) ) );
+	}
 	exit;
 }
 
 require_once ABSPATH . 'wp-admin/admin-header.php';
 
 if ( isset( $_GET['updated'] ) ) {
-	wp_admin_notice(
-		__( 'Settings saved.' ),
-		array(
-			'type'        => 'success',
-			'dismissible' => true,
-			'id'          => 'message',
-		)
-	);
+	if ( 'true' === $_GET['updated'] ) {
+		wp_admin_notice(
+			__( 'Settings saved.' ),
+			array(
+				'type'        => 'success',
+				'dismissible' => true,
+				'id'          => 'message',
+			)
+		);
+	} elseif ( 'error' === $_GET['updated'] ) {
+		$network_settings_errors = get_transient( 'network_settings_errors' );
+		delete_transient( 'network_settings_errors' );
+
+		$error_messages = is_array( $network_settings_errors ) ? $network_settings_errors : array( __( 'Some settings could not be saved.' ) );
+		foreach ( $error_messages as $error_message ) {
+			wp_admin_notice(
+				$error_message,
+				array(
+					'type'        => 'error',
+					'dismissible' => true,
+					'id'          => 'message',
+				)
+			);
+		}
+	}
 }
 ?>
 
@@ -155,10 +184,10 @@ if ( isset( $_GET['updated'] ) ) {
 		<?php wp_nonce_field( 'siteoptions' ); ?>
 		<h2 id="wp-settings-section-operational-settings"><?php _e( 'Operational Settings' ); ?></h2>
 		<table class="form-table" role="presentation">
-			<tr>
+			<tr class="form-field form-required">
 				<th scope="row"><label for="site_name"><?php _e( 'Network Title' ); ?></label></th>
 				<td>
-					<input name="site_name" type="text" id="site_name" class="regular-text" value="<?php echo esc_attr( get_network()->site_name ); ?>" />
+					<input name="site_name" type="text" id="site_name" class="regular-text" value="<?php echo esc_attr( get_network()->site_name ); ?>" required aria-required="true" />
 				</td>
 			</tr>
 

--- a/src/wp-admin/network/settings.php
+++ b/src/wp-admin/network/settings.php
@@ -118,7 +118,10 @@ if ( $_POST ) {
 
 	// Ensure the network title (site_name) is not left empty.
 	$network_title_error = '';
-	if ( isset( $_POST['site_name'] ) && '' === trim( wp_unslash( $_POST['site_name'] ) ) ) {
+	if ( isset( $_POST['site_name'] ) ) {
+		$site_name = wp_unslash( $_POST['site_name'] );
+
+		if ( ! is_scalar( $site_name ) || '' === trim( (string) $site_name ) ) {
 		unset( $_POST['site_name'] );
 		$network_title_error = __( 'The network title cannot be empty. Please enter a title for your network.' );
 	}

--- a/src/wp-admin/network/site-settings.php
+++ b/src/wp-admin/network/site-settings.php
@@ -140,7 +140,6 @@ if ( ! empty( $error_messages ) ) {
 			array(
 				'type'        => 'error',
 				'dismissible' => true,
-				'id'          => 'message',
 			)
 		);
 	}

--- a/src/wp-admin/network/site-settings.php
+++ b/src/wp-admin/network/site-settings.php
@@ -40,13 +40,6 @@ if ( isset( $_REQUEST['action'] ) && 'update-site' === $_REQUEST['action'] && is
 	switch_to_blog( $id );
 
 	$skip_options = array( 'allowedthemes' ); // Don't update these options since they are handled elsewhere in the form.
-
-	// Ensure the site title (blogname) is not left empty.
-	if ( isset( $_POST['option']['blogname'] ) && '' === trim( $_POST['option']['blogname'] ) ) {
-		$skip_options[] = 'blogname';
-		$update_error   = __( 'The site title cannot be empty.' );
-	}
-
 	foreach ( (array) $_POST['option'] as $key => $val ) {
 		$key = wp_unslash( $key );
 		$val = wp_unslash( $val );
@@ -68,32 +61,51 @@ if ( isset( $_REQUEST['action'] ) && 'update-site' === $_REQUEST['action'] && is
 
 	restore_current_blog();
 
-	$redirect_args = array(
-		'update' => isset( $update_error ) ? 'error' : 'updated',
-		'id'     => $id,
-	);
+	$update = 'updated';
+
+	/*
+	 * sanitize_option() rejects invalid values (such as an empty, required
+	 * Site Title) by registering a settings error and keeping the stored value.
+	 * Carry those errors across the redirect so an error notice can be shown
+	 * instead of a success message.
+	 */
+	$settings_errors = get_settings_errors();
+	if ( ! empty( $settings_errors ) ) {
+		set_transient( 'settings_errors', $settings_errors, 30 );
+		$update = 'not-updated';
+	}
 
 	wp_redirect(
 		add_query_arg(
-			$redirect_args,
+			array(
+				'update' => $update,
+				'id'     => $id,
+			),
 			'site-settings.php'
 		)
 	);
 	exit;
 }
 
+$messages       = array();
+$error_messages = array();
+
 if ( isset( $_GET['update'] ) ) {
-	$messages = array();
 	if ( 'updated' === $_GET['update'] ) {
-		$messages[] = array(
-			'text' => __( 'Site options updated.' ),
-			'type' => 'success',
-		);
-	} elseif ( 'error' === $_GET['update'] ) {
-		$messages[] = array(
-			'text' => __( 'The site title cannot be empty.' ),
-			'type' => 'error',
-		);
+		$messages[] = __( 'Site options updated.' );
+	} elseif ( 'not-updated' === $_GET['update'] ) {
+		$settings_errors = get_transient( 'settings_errors' );
+		delete_transient( 'settings_errors' );
+
+		if ( is_array( $settings_errors ) ) {
+			foreach ( $settings_errors as $settings_error ) {
+				$error_messages[] = $settings_error['message'];
+			}
+		}
+
+		if ( empty( $error_messages ) ) {
+			$error_messages[] = __( 'Some settings could not be saved.' );
+		}
 	}
 }
 
@@ -121,17 +133,28 @@ network_edit_site_nav(
 	)
 );
 
-if ( ! empty( $messages ) ) {
-	foreach ( $messages as $msg ) {
+if ( ! empty( $error_messages ) ) {
+	foreach ( $error_messages as $msg ) {
 		wp_admin_notice(
-			$msg['text'],
+			$msg,
 			array(
-				'type'        => $msg['type'],
+				'type'        => 'error',
 				'dismissible' => true,
 				'id'          => 'message',
 			)
 		);
 	}
+}
+
+if ( ! empty( $messages ) ) {
+	wp_admin_notice(
+		$messages[0],
+		array(
+			'type'        => 'success',
+			'dismissible' => true,
+			'id'          => 'message',
+		)
+	);
 }
 ?>
 <form method="post" action="site-settings.php?action=update-site">

--- a/src/wp-admin/network/site-settings.php
+++ b/src/wp-admin/network/site-settings.php
@@ -40,6 +40,13 @@ if ( isset( $_REQUEST['action'] ) && 'update-site' === $_REQUEST['action'] && is
 	switch_to_blog( $id );
 
 	$skip_options = array( 'allowedthemes' ); // Don't update these options since they are handled elsewhere in the form.
+
+	// Ensure the site title (blogname) is not left empty.
+	if ( isset( $_POST['option']['blogname'] ) && '' === trim( $_POST['option']['blogname'] ) ) {
+		$skip_options[] = 'blogname';
+		$update_error   = __( 'The site title cannot be empty.' );
+	}
+
 	foreach ( (array) $_POST['option'] as $key => $val ) {
 		$key = wp_unslash( $key );
 		$val = wp_unslash( $val );
@@ -60,12 +67,15 @@ if ( isset( $_REQUEST['action'] ) && 'update-site' === $_REQUEST['action'] && is
 	do_action( 'wpmu_update_blog_options', $id );
 
 	restore_current_blog();
+
+	$redirect_args = array(
+		'update' => isset( $update_error ) ? 'error' : 'updated',
+		'id'     => $id,
+	);
+
 	wp_redirect(
 		add_query_arg(
-			array(
-				'update' => 'updated',
-				'id'     => $id,
-			),
+			$redirect_args,
 			'site-settings.php'
 		)
 	);
@@ -75,7 +85,15 @@ if ( isset( $_REQUEST['action'] ) && 'update-site' === $_REQUEST['action'] && is
 if ( isset( $_GET['update'] ) ) {
 	$messages = array();
 	if ( 'updated' === $_GET['update'] ) {
-		$messages[] = __( 'Site options updated.' );
+		$messages[] = array(
+			'text' => __( 'Site options updated.' ),
+			'type' => 'success',
+		);
+	} elseif ( 'error' === $_GET['update'] ) {
+		$messages[] = array(
+			'text' => __( 'The site title cannot be empty.' ),
+			'type' => 'error',
+		);
 	}
 }
 
@@ -104,14 +122,15 @@ network_edit_site_nav(
 );
 
 if ( ! empty( $messages ) ) {
-	$notice_args = array(
-		'type'        => 'success',
-		'dismissible' => true,
-		'id'          => 'message',
-	);
-
 	foreach ( $messages as $msg ) {
-		wp_admin_notice( $msg, $notice_args );
+		wp_admin_notice(
+			$msg['text'],
+			array(
+				'type'        => $msg['type'],
+				'dismissible' => true,
+				'id'          => 'message',
+			)
+		);
 	}
 }
 ?>

--- a/src/wp-admin/options-general.php
+++ b/src/wp-admin/options-general.php
@@ -72,9 +72,9 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 
 <table class="form-table" role="presentation">
 
-<tr>
+<tr class="form-field form-required">
 <th scope="row"><label for="blogname"><?php _e( 'Site Title' ); ?></label></th>
-<td><input name="blogname" type="text" id="blogname" value="<?php form_option( 'blogname' ); ?>" class="regular-text" /></td>
+<td><input name="blogname" type="text" id="blogname" value="<?php form_option( 'blogname' ); ?>" class="regular-text" required /></td>
 </tr>
 
 <?php

--- a/src/wp-admin/options-general.php
+++ b/src/wp-admin/options-general.php
@@ -74,7 +74,7 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 
 <tr class="form-field form-required">
 <th scope="row"><label for="blogname"><?php _e( 'Site Title' ); ?></label></th>
-<td><input name="blogname" type="text" id="blogname" value="<?php form_option( 'blogname' ); ?>" class="regular-text" required /></td>
+<td><input name="blogname" type="text" id="blogname" value="<?php form_option( 'blogname' ); ?>" class="regular-text" required aria-required="true" /></td>
 </tr>
 
 <?php

--- a/src/wp-admin/options.php
+++ b/src/wp-admin/options.php
@@ -303,6 +303,18 @@ if ( 'update' === $action ) { // We are saving settings sent from a settings pag
 			);
 		}
 
+		// Ensure the site title is not left empty.
+		if ( isset( $_POST['blogname'] ) && '' === trim( $_POST['blogname'] ) ) {
+			$_POST['blogname'] = get_option( 'blogname' );
+
+			add_settings_error(
+				'general',
+				'blogname',
+				__( 'The site title cannot be empty.' ),
+				'error'
+			);
+		}
+
 		// Handle translation installation.
 		if ( ! empty( $_POST['WPLANG'] ) && current_user_can( 'install_languages' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/translation-install.php';

--- a/src/wp-admin/options.php
+++ b/src/wp-admin/options.php
@@ -303,18 +303,6 @@ if ( 'update' === $action ) { // We are saving settings sent from a settings pag
 			);
 		}
 
-		// Ensure the site title is not left empty.
-		if ( isset( $_POST['blogname'] ) && '' === trim( $_POST['blogname'] ) ) {
-			$_POST['blogname'] = get_option( 'blogname' );
-
-			add_settings_error(
-				'general',
-				'blogname',
-				__( 'The site title cannot be empty.' ),
-				'error'
-			);
-		}
-
 		// Handle translation installation.
 		if ( ! empty( $_POST['WPLANG'] ) && current_user_can( 'install_languages' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/translation-install.php';

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -5006,6 +5006,11 @@ function sanitize_option( $option, $value ) {
 				$error = $value->get_error_message();
 			} else {
 				$value = esc_html( $value );
+
+				// The site title (blogname) cannot be empty.
+				if ( 'blogname' === $option && '' === trim( $value ) ) {
+					$error = __( 'The site title cannot be empty. Please enter a title for your site.' );
+				}
 			}
 			break;
 

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -2746,7 +2746,11 @@ function register_initial_settings() {
 		'blogname',
 		array(
 			'show_in_rest' => array(
-				'name' => 'title',
+				'name'   => 'title',
+				'schema' => array(
+					'minLength' => 1,
+					'pattern'   => '\S',
+				),
 			),
 			'type'         => 'string',
 			'label'        => __( 'Title' ),

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-settings-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-settings-controller.php
@@ -198,6 +198,14 @@ class WP_REST_Settings_Controller extends WP_REST_Controller {
 					);
 				}
 
+				if ( 'blogname' === $args['option_name'] ) {
+					return new WP_Error(
+						'rest_invalid_param',
+						__( 'The site title cannot be empty. Please enter a title for your site.' ),
+						array( 'status' => 400 )
+					);
+				}
+
 				delete_option( $args['option_name'] );
 			} else {
 				update_option( $args['option_name'], $request[ $name ] );

--- a/tests/phpunit/tests/rest-api/rest-settings-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-settings-controller.php
@@ -598,6 +598,36 @@ class WP_Test_REST_Settings_Controller extends WP_Test_REST_Controller_Testcase 
 		$this->assertErrorResponse( 'rest_invalid_param', $response, 400 );
 	}
 
+	/**
+	 * @ticket 65718
+	 *
+	 * @dataProvider data_update_item_with_invalid_title
+	 */
+	public function test_update_item_with_invalid_title( $invalid_title ) {
+		wp_set_current_user( self::$administrator );
+		$original_title = get_option( 'blogname' );
+
+		$request = new WP_REST_Request( 'PUT', '/wp/v2/settings' );
+		$request->set_param( 'title', $invalid_title );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertErrorResponse( 'rest_invalid_param', $response, 400 );
+		$this->assertSame( $original_title, get_option( 'blogname' ) );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_update_item_with_invalid_title() {
+		return array(
+			'empty string'    => array( '' ),
+			'whitespace only' => array( '   ' ),
+			'null'            => array( null ),
+		);
+	}
+
 	public function test_update_item_with_integer() {
 		wp_set_current_user( self::$administrator );
 		$request = new WP_REST_Request( 'PUT', '/wp/v2/settings' );

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -11143,6 +11143,8 @@ mockedApiResponse.Schema = {
                             "title": "Title",
                             "description": "Site title.",
                             "type": "string",
+                            "minLength": 1,
+                            "pattern": "\\S",
                             "required": false
                         },
                         "description": {


### PR DESCRIPTION

Trac ticket: https://core.trac.wordpress.org/ticket/65718

The site title (`blogname`) is enforced as required during multisite site creation, but could be cleared to an empty string via admin paths or the REST API after creation. Also resolves a related issue where the Network Title (`site_name`) could be saved empty.


- Added `minLength: 1` and `pattern: \S` to the `title` (`blogname`) schema in `register_initial_settings()` so that empty submissions via the block editor correctly return a 400 Bad Request validation error rather than silently failing.
- Added a specific guard to `WP_REST_Settings_Controller::update_item()` to prevent `title: null` from mapping to `delete_option('blogname')`, which bypassed option sanitization completely.
- Added empty validation for `blogname` within `sanitize_option()` to reject empty values during direct `update_option()` or CLI calls, registering a standard settings error.
- Added server-side empty validation for the `site_name` network option before the save loop in `wp-admin/network/settings.php`, and hardened the payload check against non-scalar inputs.
