### PR TITLE
Administration: Use a unique nonce for Find Posts

### DIFF
--- a/src/js/_enqueues/admin/media.js
+++ b/src/js/_enqueues/admin/media.js
@@ -106,7 +106,7 @@
 			var post = {
 					ps: $( '#find-posts-input' ).val(),
 					action: 'find_posts',
-					_ajax_nonce: $('#_ajax_nonce').val()
+					_ajax_nonce: $( '#_ajax_nonce-find-posts' ).val()
 				},
 				spinner = $( '.find-box-search .spinner' );
 

--- a/src/wp-admin/includes/template.php
+++ b/src/wp-admin/includes/template.php
@@ -2043,7 +2043,7 @@ function find_posts_div( $found_action = '' ) {
 					<input type="hidden" name="found_action" value="<?php echo esc_attr( $found_action ); ?>" />
 				<?php } ?>
 				<input type="hidden" name="affected" id="affected" value="" />
-				<?php wp_nonce_field( 'find-posts', '_ajax_nonce', false ); ?>
+				<?php wp_nonce_field( 'find-posts', '_ajax_nonce-find-posts', false ); ?>
 				<label class="screen-reader-text" for="find-posts-input">
 					<?php
 					/* translators: Hidden accessibility text. */

--- a/tests/phpunit/tests/admin/includesTemplate.php
+++ b/tests/phpunit/tests/admin/includesTemplate.php
@@ -15,6 +15,20 @@ class Tests_Admin_IncludesTemplate extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 43611
+	 *
+	 * @covers ::find_posts_div
+	 */
+	public function test_find_posts_div_has_unique_nonce_field() {
+		ob_start();
+		find_posts_div();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'id="_ajax_nonce-find-posts"', $output );
+		$this->assertStringNotContainsString( 'id="_ajax_nonce"', $output );
+	}
+
+	/**
 	 * @ticket 51137
 	 * @dataProvider data_wp_terms_checklist_with_selected_cats
 	 */


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

The Find Posts modal used the generic `_ajax_nonce` field name and ID. On post edit screens with the Custom Fields meta box, that produced duplicate `#_ajax_nonce` elements, so `media.js` could read the Custom Fields nonce and the Find Posts request would fail with a 403 response.

This gives the Find Posts nonce a dedicated `_ajax_nonce-find-posts` field and updates the AJAX request to read it while continuing to send the nonce under the `_ajax_nonce` request key expected by the server.

A regression test verifies that `find_posts_div()` renders the unique nonce ID and no longer renders `id="_ajax_nonce"`.

Validation:
- `phpunit --filter Tests_Admin_IncludesTemplate` (43 tests, 125 assertions)
- `grunt jshint:core --file=src/js/_enqueues/admin/media.js`
- `phpcbf src/wp-admin/includes/template.php tests/phpunit/tests/admin/includesTemplate.php`
- `phpcs src/wp-admin/includes/template.php tests/phpunit/tests/admin/includesTemplate.php`

Trac ticket: https://core.trac.wordpress.org/ticket/43611

## Use of AI Tools

AI assistance: Yes
Tool(s): OpenAI Codex
Model(s): GPT-5
Used for: Reviewing the Trac ticket and relevant code, helping with the initial implementation and regression-test approach, and assisting with validation and PR-description drafting. The final implementation, tests, validation results, and description were reviewed and accepted by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**