### PR TITLE
Fix template `date` and `modified` return value for file templates

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
@@ -668,6 +668,8 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 	 * @since 5.9.0 Renamed `$template` to `$item` to match parent class for PHP 8 named parameter support.
 	 * @since 6.3.0 Added `modified` property to the response.
 	 * @since 7.1.0 Added `date` property to the response.
+	 * @since 7.1.0 The `modified` property is `null` for templates that have no
+	 *              modification date.
 	 *
 	 * @param WP_Block_Template $item    Template instance.
 	 * @param WP_REST_Request   $request Request object.
@@ -776,16 +778,23 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 		}
 
 		if ( rest_is_field_included( 'modified', $fields ) ) {
-			$data['modified'] = mysql_to_rfc3339( $template->modified );
+			/*
+			 * File-backed templates have no modification date, and `mysql_to_rfc3339()`
+			 * returns `false` for an empty or malformed value, which the schema does
+			 * not allow. Return `null` in that case.
+			 */
+			$modified         = mysql_to_rfc3339( $template->modified );
+			$data['modified'] = false !== $modified ? $modified : null;
 		}
 
 		if ( rest_is_field_included( 'date', $fields ) ) {
 			/*
-			 * File-backed templates have no date. Return `null` in that case, as
-			 * `mysql_to_rfc3339()` would return `false` for an empty value, which
-			 * the schema does not allow.
+			 * File-backed templates have no date, and `mysql_to_rfc3339()` returns
+			 * `false` for an empty or malformed value, which the schema does not
+			 * allow. Return `null` in that case.
 			 */
-			$data['date'] = empty( $template->date ) ? null : mysql_to_rfc3339( $template->date );
+			$date         = mysql_to_rfc3339( $template->date );
+			$data['date'] = false !== $date ? $date : null;
 		}
 
 		if ( rest_is_field_included( 'author_text', $fields ) ) {
@@ -1159,7 +1168,7 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 				),
 				'modified'        => array(
 					'description' => __( "The date the template was last modified, in the site's timezone." ),
-					'type'        => 'string',
+					'type'        => array( 'string', 'null' ),
 					'format'      => 'date-time',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
@@ -780,7 +780,12 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 		}
 
 		if ( rest_is_field_included( 'date', $fields ) ) {
-			$data['date'] = mysql_to_rfc3339( $template->date );
+			/*
+			 * File-backed templates have no date. Return `null` in that case, as
+			 * `mysql_to_rfc3339()` would return `false` for an empty value, which
+			 * the schema does not allow.
+			 */
+			$data['date'] = empty( $template->date ) ? null : mysql_to_rfc3339( $template->date );
 		}
 
 		if ( rest_is_field_included( 'author_text', $fields ) ) {
@@ -1177,7 +1182,7 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 						'user',
 					),
 				),
-				'date'        => array(
+				'date'            => array(
 					'description' => __( "The date the template was published, in the site's timezone." ),
 					'type'        => array( 'string', 'null' ),
 					'format'      => 'date-time',

--- a/tests/phpunit/tests/rest-api/wpRestTemplatesController.php
+++ b/tests/phpunit/tests/rest-api/wpRestTemplatesController.php
@@ -639,13 +639,13 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 	}
 
 	/**
-	 * A file-backed template has no date, which should be exposed as `null`
-	 * rather than the `false` returned by `mysql_to_rfc3339()`.
+	 * A file-backed template has no publication or modification date, which should
+	 * be exposed as `null` rather than the `false` returned by `mysql_to_rfc3339()`.
 	 *
 	 * @ticket 65728
 	 * @covers WP_REST_Templates_Controller::prepare_item_for_response
 	 */
-	public function test_get_item_date_is_null_for_file_backed_template() {
+	public function test_get_item_dates_are_null_for_file_backed_template() {
 		wp_set_current_user( self::$admin_id );
 		switch_theme( 'block-theme' );
 
@@ -655,6 +655,7 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 
 		$this->assertSame( 200, $response->get_status(), 'Fetching a file-backed template should return 200.' );
 		$this->assertNull( $data['date'], 'The date should be null for a file-backed template.' );
+		$this->assertNull( $data['modified'], 'The modified date should be null for a file-backed template.' );
 	}
 
 	/**

--- a/tests/phpunit/tests/rest-api/wpRestTemplatesController.php
+++ b/tests/phpunit/tests/rest-api/wpRestTemplatesController.php
@@ -639,6 +639,25 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 	}
 
 	/**
+	 * A file-backed template has no date, which should be exposed as `null`
+	 * rather than the `false` returned by `mysql_to_rfc3339()`.
+	 *
+	 * @ticket 65728
+	 * @covers WP_REST_Templates_Controller::prepare_item_for_response
+	 */
+	public function test_get_item_date_is_null_for_file_backed_template() {
+		wp_set_current_user( self::$admin_id );
+		switch_theme( 'block-theme' );
+
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/templates/block-theme//page-home' );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status(), 'Fetching a file-backed template should return 200.' );
+		$this->assertNull( $data['date'], 'The date should be null for a file-backed template.' );
+	}
+
+	/**
 	 * @ticket 54507
 	 * @dataProvider data_sanitize_template_id
 	 */


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/65728

Follow up of: https://core.trac.wordpress.org/ticket/65049

Backports: https://github.com/WordPress/gutenberg/pull/80733

As noted here: https://github.com/WordPress/gutenberg/pull/77134#issuecomment-5044727859, the new date field for templates and template parts can return false for file templates.

In practice this doesn't cause any errors but still the returned value should match the declared type (`string|null`).


With that comment I realized that `modified` has the exact same problem for many versions (since 6.3). 

We should update the type of `modified` to be the same with `date` to `string|null` and not return `false` for file templates.



## Testing instructions

1. Log in and ensure you have a block theme enabled
2. Test the templates REST endpoint in dev tools: `const templates = await wp.apiFetch( { path:
  '/wp/v2/templates?per_page=100' } );`.  Then inspect `templates`
3. Observe that `date` and `modified` is `null` for file templates.

## Use of AI Tools

Opus 5 with direction, changes and review


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
