### PR TITLE
Administration: Strip escaped HTML from list table aria-labels

### DIFF
--- a/src/wp-admin/includes/class-wp-links-list-table.php
+++ b/src/wp-admin/includes/class-wp-links-list-table.php
@@ -203,11 +203,20 @@ class WP_Links_List_Table extends WP_List_Table {
 	 */
 	public function column_name( $link ) {
 		$edit_link = get_edit_bookmark_link( $link );
+
+		/*
+		 * `display_rows()` escapes the name, so entities are decoded first to let
+		 * `wp_strip_all_tags()` detect the HTML. Otherwise it survives the
+		 * `esc_attr()` call below and is announced as literal text.
+		 */
+		$aria_label_name = html_entity_decode( $link->link_name, ENT_QUOTES, get_bloginfo( 'charset' ) );
+		$aria_label_name = wp_strip_all_tags( $aria_label_name );
+
 		printf(
 			'<strong><a class="row-title" href="%s" aria-label="%s">%s</a></strong>',
 			$edit_link,
 			/* translators: %s: Link name. */
-			esc_attr( sprintf( __( 'Edit &#8220;%s&#8221;' ), $link->link_name ) ),
+			esc_attr( sprintf( __( 'Edit &#8220;%s&#8221;' ), $aria_label_name ) ),
 			$link->link_name
 		);
 	}

--- a/src/wp-admin/includes/class-wp-media-list-table.php
+++ b/src/wp-admin/includes/class-wp-media-list-table.php
@@ -927,7 +927,13 @@ class WP_Media_List_Table extends WP_List_Table {
 		// Restores the more descriptive, specific name for use within this method.
 		$post = $item;
 
-		$att_title = _draft_or_post_title();
+		/*
+		 * `_draft_or_post_title()` escapes the title, so entities are decoded first
+		 * to let `wp_strip_all_tags()` detect the HTML. Otherwise it survives the
+		 * `esc_attr()` calls on the `aria-label` values and is announced as literal text.
+		 */
+		$att_title = html_entity_decode( _draft_or_post_title(), ENT_QUOTES, get_bloginfo( 'charset' ) );
+		$att_title = wp_strip_all_tags( $att_title );
 		$actions   = $this->_get_row_actions( $post, $att_title );
 
 		return $this->row_actions( $actions );

--- a/src/wp-admin/includes/class-wp-posts-list-table.php
+++ b/src/wp-admin/includes/class-wp-posts-list-table.php
@@ -1579,7 +1579,14 @@ class WP_Posts_List_Table extends WP_List_Table {
 		$post_type_object = get_post_type_object( $post->post_type );
 		$can_edit_post    = current_user_can( 'edit_post', $post->ID );
 		$actions          = array();
-		$title            = _draft_or_post_title();
+
+		/*
+		 * `_draft_or_post_title()` escapes the title, so entities are decoded first
+		 * to let `wp_strip_all_tags()` detect the HTML. Otherwise it survives the
+		 * `esc_attr()` calls below and is announced as literal text.
+		 */
+		$title = html_entity_decode( _draft_or_post_title(), ENT_QUOTES, get_bloginfo( 'charset' ) );
+		$title = wp_strip_all_tags( $title );
 
 		if ( $can_edit_post && 'trash' !== $post->post_status ) {
 			$actions['edit'] = sprintf(

--- a/tests/phpunit/tests/admin/wpLinksListTable.php
+++ b/tests/phpunit/tests/admin/wpLinksListTable.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * @group admin
+ */
+class Tests_Admin_wpLinksListTable extends WP_UnitTestCase {
+	/**
+	 * A list table for testing.
+	 *
+	 * @var WP_Links_List_Table
+	 */
+	protected $table;
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->table = _get_list_table( 'WP_Links_List_Table', array( 'screen' => 'link-manager' ) );
+	}
+
+	/**
+	 * Tests that `WP_Links_List_Table::column_name()` strips HTML from the link
+	 * name used within the `aria-label` attribute.
+	 *
+	 * The name is escaped by `WP_Links_List_Table::display_rows()`, so any HTML
+	 * it contains survives `esc_attr()` and is announced as literal text by
+	 * screen readers.
+	 *
+	 * @ticket 65729
+	 *
+	 * @covers WP_Links_List_Table::column_name
+	 */
+	public function test_column_name_should_strip_html_from_the_aria_label() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+
+		// A link name is saved to the database with any HTML it contains already escaped.
+		$link = self::factory()->bookmark->create_and_get( array( 'link_name' => 'my&lt;div&gt;link' ) );
+
+		// Replicate the escaping applied by `WP_Links_List_Table::display_rows()`.
+		$link->link_name = esc_attr( $link->link_name );
+
+		ob_start();
+		$this->table->column_name( $link );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString(
+			'aria-label="Edit &#8220;mylink&#8221;"',
+			$output,
+			'The aria-label did not contain the stripped name.'
+		);
+		$this->assertStringContainsString(
+			'>my&lt;div&gt;link</a>',
+			$output,
+			'The displayed link name should be left unchanged.'
+		);
+	}
+}

--- a/tests/phpunit/tests/admin/wpMediaListTable.php
+++ b/tests/phpunit/tests/admin/wpMediaListTable.php
@@ -480,6 +480,46 @@ class Tests_Admin_wpMediaListTable extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that `WP_Media_List_Table::handle_row_actions()` strips HTML from the
+	 * attachment title used within the row action `aria-label` attributes.
+	 *
+	 * The title is escaped by `_draft_or_post_title()`, so any HTML it contains
+	 * survives `esc_attr()` and is announced as literal text by screen readers.
+	 *
+	 * @ticket 65729
+	 *
+	 * @covers WP_Media_List_Table::handle_row_actions
+	 */
+	public function test_handle_row_actions_should_strip_html_from_aria_labels() {
+		wp_set_current_user( self::$admin );
+		self::set_is_trash( false );
+
+		$attachment = self::factory()->attachment->create_and_get(
+			array(
+				'post_title'     => 'my<div>image',
+				'file'           => 'image.jpg',
+				'post_mime_type' => 'image/jpeg',
+			)
+		);
+
+		$GLOBALS['post'] = $attachment;
+
+		$handle_row_actions = new ReflectionMethod( self::$list_table, 'handle_row_actions' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$handle_row_actions->setAccessible( true );
+		}
+		$output = $handle_row_actions->invoke( self::$list_table, $attachment, 'title', 'title' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$handle_row_actions->setAccessible( false );
+		}
+
+		unset( $GLOBALS['post'] );
+
+		$this->assertStringNotContainsString( '&lt;div&gt;', $output, 'The escaped HTML was not stripped from the title.' );
+		$this->assertStringContainsString( 'aria-label="Edit &#8220;myimage&#8221;"', $output, 'The "edit" aria-label did not contain the stripped title.' );
+	}
+
+	/**
 	 * Sets the `$is_trash` property.
 	 *
 	 * Helper method.

--- a/tests/phpunit/tests/admin/wpPostsListTable.php
+++ b/tests/phpunit/tests/admin/wpPostsListTable.php
@@ -596,4 +596,44 @@ class Tests_Admin_wpPostsListTable extends WP_UnitTestCase {
 
 		$this->assertStringContainsString( 'Select (no title) Hello world example excerpt.', $output );
 	}
+
+	/**
+	 * Tests that `WP_Posts_List_Table::handle_row_actions()` strips HTML from the
+	 * post title used within the row action `aria-label` attributes.
+	 *
+	 * The title is escaped by `_draft_or_post_title()`, so any HTML it contains
+	 * survives `esc_attr()` and is announced as literal text by screen readers.
+	 *
+	 * @ticket 65729
+	 *
+	 * @covers WP_Posts_List_Table::handle_row_actions
+	 */
+	public function test_handle_row_actions_should_strip_html_from_aria_labels() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+
+		$post = self::factory()->post->create_and_get(
+			array(
+				'post_title'  => 'my<div>post',
+				'post_status' => 'publish',
+			)
+		);
+
+		$GLOBALS['post'] = $post;
+
+		$table = _get_list_table( 'WP_Posts_List_Table', array( 'screen' => 'edit-post' ) );
+
+		$handle_row_actions = new ReflectionMethod( $table, 'handle_row_actions' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$handle_row_actions->setAccessible( true );
+		}
+		$output = $handle_row_actions->invoke( $table, $post, 'title', 'title' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$handle_row_actions->setAccessible( false );
+		}
+
+		unset( $GLOBALS['post'] );
+
+		$this->assertStringNotContainsString( '&lt;div&gt;', $output, 'The escaped HTML was not stripped from the title.' );
+		$this->assertStringContainsString( 'aria-label="Edit &#8220;mypost&#8221;"', $output, 'The "edit" aria-label did not contain the stripped title.' );
+	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

Some of the values used in list table `aria-label` attributes reach the attribute with their HTML already escaped, so screen readers announce the markup as literal text.

What the problem was:
- The attachment and post titles are escaped by `_draft_or_post_title()`, and the link name is escaped by `WP_Links_List_Table::display_rows()`. Some of these values are also stored in the database with any HTML already escaped.
- `esc_attr()` does not double encode, so the escaped HTML survives into the attribute. The browser decodes it back and the accessible name becomes `Edit "my<div>image"` instead of `Edit "myimage"`.

What the fix does:
- Decodes entities with `html_entity_decode()` before calling `wp_strip_all_tags()`, so the HTML can be detected and removed, in `WP_Media_List_Table::handle_row_actions()`, `WP_Posts_List_Table::handle_row_actions()`, and `WP_Links_List_Table::column_name()`.
- The displayed link name is intentionally left unchanged; only the `aria-label` value is cleaned.

Approach and why:
- This follows the pattern already established in core by `WP_REST_URL_Details_Controller::prepare_metadata_for_output()`, rather than introducing a new formatting helper. The ticket raises a helper as a possibility ("maybe a new formatting helper function could be handy"), but that is a new public API worth deciding separately with committer input, so this patch keeps the change to the affected call sites only.
- The site title (`blogname`) case named in the ticket is not currently used in any trunk list table attribute, so nothing is changed for it here.
- Term names are left alone, as they are already sanitized via `sanitize_term()` on creation and update.

Trac ticket: https://core.trac.wordpress.org/ticket/65729

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 4.8
Used for: Ticket analysis, tests and writing PR description.

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
