### PR TITLE
Privacy: Compare personal data request expiry in UTC

### DIFF
--- a/src/wp-admin/includes/privacy-tools.php
+++ b/src/wp-admin/includes/privacy-tools.php
@@ -205,13 +205,14 @@ function _wp_personal_data_cleanup_requests() {
 			'date_query'     => array(
 				array(
 					/*
-					 * The local-time column must be used here, not post_modified_gmt:
+					 * An absolute UTC threshold is compared against the GMT column so that
+					 * the expiry window matches wp_validate_user_request_key() and is not
+					 * affected by the site's timezone changing after a request was made.
 					 * WP_Date_Query resolves relative date strings like "N seconds ago"
-					 * in the site's timezone, so comparing against the GMT column would
-					 * shift the expiry window by the site's UTC offset.
+					 * in the site's timezone, so a relative string cannot be used here.
 					 */
-					'column' => 'post_modified',
-					'before' => $expires . ' seconds ago',
+					'column' => 'post_modified_gmt',
+					'before' => gmdate( 'Y-m-d H:i:s', time() - $expires ),
 				),
 			),
 		)

--- a/tests/phpunit/tests/privacy/wpPersonalDataCleanupRequests.php
+++ b/tests/phpunit/tests/privacy/wpPersonalDataCleanupRequests.php
@@ -5,7 +5,7 @@
  * Covers:
  *  - wp_schedule_personal_data_cleanup_requests()
  *  - wp_privacy_personal_data_cleanup_requests()
- *  - _wp_personal_data_cleanup_requests() (including the post_modified timezone fix)
+ *  - _wp_personal_data_cleanup_requests() (including the expiry timezone fixes)
  *
  * @package WordPress
  * @subpackage UnitTests
@@ -329,16 +329,12 @@ class Tests_Privacy_WpPersonalDataCleanupRequests extends WP_UnitTestCase {
 	 * Timezone fix: a request-pending post that is only 20 hours old must not
 	 * be marked failed on a UTC+5 site.
 	 *
-	 * Before the fix, the date_query used 'post_modified_gmt' (a UTC column) but
-	 * WP_Date_Query::build_mysql_datetime() resolved the relative 'before' string
-	 * (e.g. "86400 seconds ago") using the site's local timezone and returned a
-	 * *local-time* string. Comparing a UTC column against a local-time threshold
+	 * The expiry threshold must be an absolute UTC time. A relative 'before'
+	 * string such as "86400 seconds ago" is resolved by WP_Date_Query in the
+	 * site's timezone, so comparing it against the UTC post_modified_gmt column
 	 * shifted the effective expiry window by the UTC offset — on UTC+5 sites,
 	 * requests expired 5 hours too early, flagging posts that were as recent as
 	 * 19 hours old as expired.
-	 *
-	 * The fix changes the column to 'post_modified' (local time) so both sides
-	 * of the comparison are in the same timezone.
 	 *
 	 * @ticket 44498
 	 */
@@ -374,9 +370,9 @@ class Tests_Privacy_WpPersonalDataCleanupRequests extends WP_UnitTestCase {
 	 * Symmetric check for UTC- sites: a request just over the expiry threshold
 	 * must be correctly marked as failed even on a UTC- site.
 	 *
-	 * On UTC- sites, the old buggy code shifted the effective expiry window in
-	 * the opposite direction — requests would linger longer than intended before
-	 * being cleaned up. With the fix, the threshold is always applied consistently.
+	 * A relative 'before' string shifted the effective expiry window in the
+	 * opposite direction on UTC- sites — requests lingered longer than intended
+	 * before being cleaned up. An absolute UTC threshold applies consistently.
 	 *
 	 * @ticket 44498
 	 */
@@ -397,6 +393,30 @@ class Tests_Privacy_WpPersonalDataCleanupRequests extends WP_UnitTestCase {
 			'request-failed',
 			get_post_status( $id ),
 			'A 25-hour-old request should be expired on a UTC-5 site.'
+		);
+	}
+
+	/**
+	 * Changing the site timezone must not retroactively expire a fresh request.
+	 *
+	 * @ticket 65731
+	 */
+	public function test_fresh_request_survives_a_large_timezone_change(): void {
+		// UTC-11 at request time.
+		update_option( 'timezone_string', 'Pacific/Pago_Pago' );
+
+		$id = wp_create_user_request( $this->unique_email(), 'export_personal_data' );
+		$this->assertIsInt( $id );
+
+		// UTC+14 afterwards: 25 hours ahead, more than the 24-hour expiry window.
+		update_option( 'timezone_string', 'Pacific/Kiritimati' );
+
+		_wp_personal_data_cleanup_requests();
+
+		$this->assertSame(
+			'request-pending',
+			get_post_status( $id ),
+			'A seconds-old request should stay request-pending after the site timezone changes.'
 		);
 	}
 


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

Personal data request cleanup resolved its expiry threshold in the site's timezone and compared it against the local post_modified column, so changing the site timezone retroactively expired pending requests.

What the problem was:
- `_wp_personal_data_cleanup_requests()` passed `'before' => $expires . ' seconds ago'`. `WP_Date_Query::build_mysql_datetime()` resolves relative strings via `date_create( $datetime, wp_timezone() )`, so the threshold is a site-local wall clock.
- [62662] paired that threshold with the local `post_modified` column, but `post_modified` stores the local time in effect when the request was created.
- Changing the timezone by more than the expiry window (Pago Pago UTC-11 to Kiritimati UTC+14 is 25 hours, past the 24-hour window) leaves every stored wall clock behind the new threshold. A seconds-old request is marked `request-failed` and its `post_password` cleared, so the confirmation link already emailed to the recipient returns "Invalid personal data request."

What the fix does:
- Compares an absolute UTC threshold, `gmdate( 'Y-m-d H:i:s', time() - $expires )`, against the `post_modified_gmt` column.
- Adds a regression test covering a timezone change after request creation.

Approach and why:
- Both sides of the comparison are now timezone-invariant, so neither the site's UTC offset (#44498) nor a later timezone change (this ticket) can shift the window.
- This matches `wp_validate_user_request_key()`, which is the authoritative expiry check and already compares `modified_timestamp` (parsed from `post_modified_gmt`) against `time()`. Cleanup and validation can no longer disagree.
- An absolute GMT value against a GMT column follows existing core precedent in `wp_get_comment_reply_link()` (`src/wp-includes/comment.php`).
- Verified that absolute `Y-m-d H:i:s` strings pass through `build_mysql_datetime()` unchanged under UTC, Pago Pago, Kiritimati and New York.
- Sites on UTC are byte-for-byte unaffected.

Trac ticket: https://core.trac.wordpress.org/ticket/65731

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Ticket analysis, code implementation, and tests. All changes were reviewed and validated by me.
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
