### PR TITLE
Administration: Fix the update button layout in At a Glance

### DIFF
--- a/src/wp-admin/css/dashboard.css
+++ b/src/wp-admin/css/dashboard.css
@@ -724,11 +724,21 @@ body #dashboard-widgets .postbox form .submit {
 	margin: 0;
 }
 
+#dashboard_right_now #wp-version-message {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: baseline;
+	gap: 5px;
+}
+
+#dashboard_right_now #wp-version {
+	flex: 1;
+}
+
 #dashboard_right_now #wp-version-message .button {
-	float: right;
-	position: relative;
-	top: -5px;
-	margin-left: 5px;
+	/* The button is first in the markup, but is displayed after the version text. */
+	order: 1;
+	margin-left: auto;
 }
 
 #dashboard_right_now p.search-engines-info {

--- a/src/wp-admin/css/dashboard.css
+++ b/src/wp-admin/css/dashboard.css
@@ -727,8 +727,8 @@ body #dashboard-widgets .postbox form .submit {
 #dashboard_right_now #wp-version-message {
 	display: flex;
 	flex-wrap: wrap;
-	align-items: flex-end;
-	gap: 5px;
+	align-items: center;
+	gap: 8px;
 }
 
 #dashboard_right_now #wp-version {

--- a/src/wp-admin/css/dashboard.css
+++ b/src/wp-admin/css/dashboard.css
@@ -727,7 +727,7 @@ body #dashboard-widgets .postbox form .submit {
 #dashboard_right_now #wp-version-message {
 	display: flex;
 	flex-wrap: wrap;
-	align-items: baseline;
+	align-items: flex-end;
 	gap: 5px;
 }
 
@@ -736,8 +736,6 @@ body #dashboard-widgets .postbox form .submit {
 }
 
 #dashboard_right_now #wp-version-message .button {
-	/* The button is first in the markup, but is displayed after the version text. */
-	order: 1;
 	margin-left: auto;
 }
 

--- a/src/wp-admin/includes/update.php
+++ b/src/wp-admin/includes/update.php
@@ -362,21 +362,6 @@ function update_right_now_message() {
 		$theme_name = sprintf( '<a href="themes.php">%1$s</a>', $theme_name );
 	}
 
-	$msg = '';
-
-	if ( current_user_can( 'update_core' ) ) {
-		$cur = get_preferred_from_update_core();
-
-		if ( isset( $cur->response ) && 'upgrade' === $cur->response ) {
-			$msg .= sprintf(
-				'<a href="%s" class="button" aria-describedby="wp-version">%s</a> ',
-				network_admin_url( 'update-core.php' ),
-				/* translators: %s: WordPress version number, or 'Latest' string. */
-				sprintf( __( 'Update to %s' ), $cur->current ? $cur->current : __( 'Latest' ) )
-			);
-		}
-	}
-
 	/* translators: 1: Version number, 2: Theme name. */
 	$content = __( 'WordPress %1$s running %2$s theme.' );
 
@@ -391,7 +376,20 @@ function update_right_now_message() {
 	 */
 	$content = apply_filters( 'update_right_now_text', $content );
 
-	$msg .= sprintf( '<span id="wp-version">' . $content . '</span>', get_bloginfo( 'version', 'display' ), $theme_name );
+	$msg = sprintf( '<span id="wp-version">' . $content . '</span>', get_bloginfo( 'version', 'display' ), $theme_name );
+
+	if ( current_user_can( 'update_core' ) ) {
+		$cur = get_preferred_from_update_core();
+
+		if ( isset( $cur->response ) && 'upgrade' === $cur->response ) {
+			$msg .= sprintf(
+				' <a href="%s" class="button" aria-describedby="wp-version">%s</a>',
+				network_admin_url( 'update-core.php' ),
+				/* translators: %s: WordPress version number, or 'Latest' string. */
+				sprintf( __( 'Update to %s' ), $cur->current ? $cur->current : __( 'Latest' ) )
+			);
+		}
+	}
 
 	echo "<p id='wp-version-message'>$msg</p>";
 }

--- a/src/wp-admin/includes/update.php
+++ b/src/wp-admin/includes/update.php
@@ -383,7 +383,7 @@ function update_right_now_message() {
 
 		if ( isset( $cur->response ) && 'upgrade' === $cur->response ) {
 			$msg .= sprintf(
-				' <a href="%s" class="button" aria-describedby="wp-version">%s</a>',
+				'<a href="%s" class="button" aria-describedby="wp-version">%s</a>',
 				network_admin_url( 'update-core.php' ),
 				/* translators: %s: WordPress version number, or 'Latest' string. */
 				sprintf( __( 'Update to %s' ), $cur->current ? $cur->current : __( 'Latest' ) )


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

Lays out the 'At a Glance' version message with flexbox so the 'Update to n.n.n' button stays inside the widget and aligns with the version text.

What the problem was:
- The button was floated out of the version message line box and pulled up 5px, a hack from [31812] that assumed a ~30px tall button.
- The admin reskin set `.wp-core-ui .button` to `min-height: 40px`, so the float no longer fits the ~18px line box it vacated. It eats the widget's 12px bottom padding and overflows the postbox border by 3px.
- The button does not line up with the version text.

What the fix does:
- Outputs the `#wp-version` span before the update button in `update_right_now_message()`, so the DOM order matches the visual order.
- Makes `#wp-version-message` a flex container with `align-items: center`, so the paragraph contains the button and the two are vertically centered against each other.
- `margin-left: auto` keeps the button flush right, replacing `float: right`.
- `flex: 1` on `#wp-version` keeps the button on the first line of text, matching the previous float layout instead of pushing it onto its own line.
- `flex-wrap: wrap` preserves the intent of [31812] for long strings, e.g. long translated button labels in narrow widgets.
- A `gap` of 8px separates the version text from the button, replacing the literal space that used to be printed before the anchor.

Approach and why:
- The source order change is what keeps focus order in reading order. `#wp-version` contains the `themes.php` link, so reordering in CSS alone (`order: 1`) would leave the update button receiving focus before the theme link. Moving the button in the markup instead means no `order` is needed at all.
- The button keeps its `aria-describedby="wp-version"`, and content added via the `update_right_now_text` filter still lives inside `#wp-version`, so neither is affected. No hook changes, so there is nothing for plugins to have bound to.
- Flexbox is the minimum tool that fixes both reported issues at once: a float is out of flow, so no float-based fix can align the button to the text.
- `gap` in a flex context already has precedent in this file (`.community-events-form`).
- The space that preceded the anchor is dropped: whitespace-only text between flex items is not rendered as an anonymous flex item, so it was already inert here, and `gap` is what actually separates the two.
- RTL was verified against the generated `dashboard-rtl.css`: `margin-left: auto` flips to `margin-right: auto` and every other declaration, `align-items` and `gap` included, is direction-agnostic.
- When no update is available the rendered geometry is identical to trunk (box height, paragraph height and position, text start all unchanged).

Trac ticket: https://core.trac.wordpress.org/ticket/65733

## Use of AI Tools
AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Ticket analysis, verified tests and writing PR description. All changes were reviewed and validated by me

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**


