### PR TITLE
Build/Test Tools: Trim the PHPUnit matrix to boundary PHP versions (full matrix runs weekly)

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -74,7 +74,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-24.04 ]
-        php: [ '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5' ]
+        # Test highest and lowest supported version of each major.
+        php: [ '7.4', '8.0', '8.5' ]
         db-type: [ 'mysql' ]
         db-version: [ '5.7', '8.0', '8.4', '9.7' ]
         tests-domain: [ 'example.org' ]
@@ -153,7 +154,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-24.04 ]
-        php: [ '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5' ]
+        # Test highest and lowest supported version of each major.
+        php: [ '7.4', '8.0', '8.5' ]
         db-type: [ 'mariadb' ]
         db-version: [ '5.5', '10.3', '10.5', '10.6', '10.11', '11.4', '11.8' ]
         multisite: [ false, true ]
@@ -207,7 +209,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-24.04 ]
-        php: [ '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5' ]
+        # Test highest and lowest supported version of each major.
+        php: [ '7.4', '8.0', '8.5' ]
         db-type: [ 'mysql', 'mariadb' ]
         db-version: [ '12.1' ]
         multisite: [ false, true ]

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -74,8 +74,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-24.04 ]
-        # Test highest and lowest supported version of each major.
-        php: [ '7.4', '8.0', '8.5' ]
+        # The scheduled run tests every supported PHP version. Other events test the highest and lowest of each major.
+        php: ${{ github.event_name == 'schedule' && fromJSON('["7.4","8.0","8.1","8.2","8.3","8.4","8.5"]') || fromJSON('["7.4","8.0","8.5"]') }}
         db-type: [ 'mysql' ]
         db-version: [ '5.7', '8.0', '8.4', '9.7' ]
         tests-domain: [ 'example.org' ]
@@ -154,8 +154,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-24.04 ]
-        # Test highest and lowest supported version of each major.
-        php: [ '7.4', '8.0', '8.5' ]
+        # The scheduled run tests every supported PHP version. Other events test the highest and lowest of each major.
+        php: ${{ github.event_name == 'schedule' && fromJSON('["7.4","8.0","8.1","8.2","8.3","8.4","8.5"]') || fromJSON('["7.4","8.0","8.5"]') }}
         db-type: [ 'mariadb' ]
         db-version: [ '5.5', '10.3', '10.5', '10.6', '10.11', '11.4', '11.8' ]
         multisite: [ false, true ]
@@ -209,8 +209,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-24.04 ]
-        # Test highest and lowest supported version of each major.
-        php: [ '7.4', '8.0', '8.5' ]
+        # The scheduled run tests every supported PHP version. Other events test the highest and lowest of each major.
+        php: ${{ github.event_name == 'schedule' && fromJSON('["7.4","8.0","8.1","8.2","8.3","8.4","8.5"]') || fromJSON('["7.4","8.0","8.5"]') }}
         db-type: [ 'mysql', 'mariadb' ]
         db-version: [ '12.1' ]
         multisite: [ false, true ]


### PR DESCRIPTION
## What

Trims the PHPUnit test matrix to boundary PHP versions on trunk and pull requests: the highest and lowest supported version of each major. `7.4`, `8.0`, and `8.5` replace the full seven-minor list, in `test-with-mysql`, `test-with-mariadb`, and `test-innovation-releases`.

Full coverage is preserved by the existing weekly scheduled run: on the Sunday cron, every supported PHP version is tested; push and pull request events test the boundary versions only.

## Why

This mirrors the trim #64083 applied to older branches, whose title named "(and possibly `trunk`)". Version-specific failures cluster at the boundaries of each major, so the intermediate minors add job count without adding coverage. The weekly full run keeps the intermediate versions covered without multiplying job count on every change.

## Impact

Base PHPUnit combinations drop from ~168 to ~72 on push and pull requests, roughly a 55% cut, before the unchanged `include:` jobs. The weekly run is unchanged.

## How the weekly full matrix works

The `php` matrix is conditional on the event:

```yaml
php: ${{ github.event_name == 'schedule'
        && fromJSON('["7.4","8.0","8.1","8.2","8.3","8.4","8.5"]')
        || fromJSON('["7.4","8.0","8.5"]') }}
```

Scheduled runs fire from the default branch, so the weekly full sweep covers trunk.

## Scope

PHP axis only. Database versions, multisite, memcached, and the single-representative `include:` jobs are untouched. A database-axis trim on the same principle is a possible follow-up, filed separately.

Trac ticket: Core-65736

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Opus 4.8
Used for: Identifying the boundary-trim approach from the existing older-branch precedent, the weekly-full conditional, and drafting the change and ticket text. Verified manually.
