### PR TITLE
Build/Test Tools: Trim the PHPUnit matrix to boundary PHP versions on the 7.0 branch

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -72,7 +72,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-24.04 ]
-        php: [ '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5' ]
+        # Test highest and lowest supported version of each major.
+        php: [ '7.4', '8.0', '8.5' ]
         db-type: [ 'mysql' ]
         db-version: [ '5.7', '8.0', '8.4' ]
         tests-domain: [ 'example.org' ]
@@ -149,7 +150,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-24.04 ]
-        php: [ '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5' ]
+        # Test highest and lowest supported version of each major.
+        php: [ '7.4', '8.0', '8.5' ]
         db-type: [ 'mariadb' ]
         db-version: [ '5.5', '10.3', '10.5', '10.6', '10.11', '11.4', '11.8' ]
         multisite: [ false, true ]
@@ -201,7 +203,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-24.04 ]
-        php: [ '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5' ]
+        # Test highest and lowest supported version of each major.
+        php: [ '7.4', '8.0', '8.5' ]
         db-type: [ 'mysql', 'mariadb' ]
         db-version: [ '9.6', '12.1' ]
         multisite: [ false, true ]


### PR DESCRIPTION
## What

Trims the PHPUnit test matrix on the 7.0 branch to boundary PHP versions: `7.4`, `8.0`, and `8.5` in place of the full seven-minor list, across `test-with-mysql`, `test-with-mariadb`, and `test-innovation-releases`.

## Why

This applies to the 7.0 branch the same boundary trim #64083 used on older branches (Trac #65736 tracks extending it to the current branches). The immediate benefit is at release time. When many 7.0.x backports land together, the full matrix floods the shared runner pool. Tests get cancelled, or the release ships before they finish.

## Impact

Base PHPUnit combinations drop from ~168 to ~72 per run, roughly a 55% cut, before the unchanged `include:` jobs.

## Scope

PHP axis only. The 7.0 branch does not run the weekly scheduled full matrix. Scheduled workflows fire only from the default branch. So this is a plain trim, not the conditional used on trunk. Database versions, multisite, and memcached are untouched.

Trac ticket: Core-65736

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Opus 4.8
Used for: Applying the boundary-trim approach from the existing older-branch precedent. Verified manually.
