### PR TITLE
Fix undefined variables and do_enclose bug

### DIFF
--- a/src/wp-admin/includes/class-wp-plugins-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugins-list-table.php
@@ -1365,7 +1365,7 @@ class WP_Plugins_List_Table extends WP_List_Table {
 					if ( $paused ) {
 						$notice_text = __( 'This plugin failed to load properly and is paused during recovery mode.' );
 
-						printf( '<p><span class="dashicons dashicons-warning"></span> <strong>%s</strong></p>', $notice_text );
+						printf( '<p><span class="dashicons dashicons-warning" aria-hidden="true"></span> <strong>%s</strong></p>', $notice_text );
 
 						$error = wp_get_plugin_error( $plugin_file );
 

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -970,7 +970,7 @@ function do_enclose( $content, $post ) {
 				}
 
 				if ( in_array( substr( $type, 0, strpos( $type, '/' ) ), $allowed_types, true ) ) {
-					add_post_meta( $post->ID, 'enclosure', "$url\n$len\n$mime\n" );
+					add_post_meta( $post->ID, 'enclosure', "$url\n$len\n$type\n" );
 				}
 			}
 		}

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -1878,6 +1878,8 @@ function single_month_title( $prefix = '', $display = true ) {
 	$m        = get_query_var( 'm' );
 	$year     = get_query_var( 'year' );
 	$monthnum = get_query_var( 'monthnum' );
+	$my_year  = '';
+	$my_month = '';
 
 	if ( ! empty( $monthnum ) && ! empty( $year ) ) {
 		$my_year  = $year;
@@ -5421,6 +5423,7 @@ function get_the_generator( $type = '' ) {
 				break;
 		}
 	}
+	$gen = '';
 
 	switch ( $type ) {
 		case 'html':

--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -3394,6 +3394,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 		 * of boundary in the stack. For example, a `</custom-tag>` should not
 		 * close anything beyond its containing `P` or `DIV` element.
 		 */
+		$node = null;
 		foreach ( $this->state->stack_of_open_elements->walk_up() as $node ) {
 			if ( 'html' === $node->namespace && $token_name === $node->node_name ) {
 				break;

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -7489,6 +7489,7 @@ function wp_mime_type_icon( $mime = 0, $preferred_ext = '.png' ) {
 		$matches            = wp_match_mime_types( array_keys( $types ), $post_mimes );
 		$matches['default'] = array( 'default' );
 
+		$icon = false;
 		foreach ( $matches as $match => $wilds ) {
 			foreach ( $wilds as $wild ) {
 				if ( ! isset( $types[ $wild ] ) ) {

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -4275,6 +4275,7 @@ function _wp_privacy_send_request_confirmation_notification( $request_id ) {
 		return;
 	}
 
+	$manage_url = '';
 	if ( 'export_personal_data' === $request->action_name ) {
 		$manage_url = admin_url( 'export-personal-data.php' );
 	} elseif ( 'remove_personal_data' === $request->action_name ) {

--- a/tests/phpunit/tests/functions/doEnclose.php
+++ b/tests/phpunit/tests/functions/doEnclose.php
@@ -125,6 +125,10 @@ class Tests_Functions_DoEnclose extends WP_UnitTestCase {
 				'content'  => 'https://example.com?test=1',
 				'expected' => '',
 			),
+			'header-type-no-extension' => array(
+				'content'  => 'https://example.com/media/stream-mp4',
+				'expected' => "https://example.com/media/stream-mp4\n123\nvideo/mp4\n",
+			),
 		);
 	}
 
@@ -276,6 +280,9 @@ class Tests_Functions_DoEnclose extends WP_UnitTestCase {
 		$path = parse_url( $url, PHP_URL_PATH );
 
 		if ( is_string( $path ) ) {
+			if ( str_contains( $path, 'stream-mp4' ) ) {
+				return $fake_headers['mp4'];
+			}
 			$extension = pathinfo( $path, PATHINFO_EXTENSION );
 			if ( isset( $fake_headers[ $extension ] ) ) {
 				return $fake_headers[ $extension ];


### PR DESCRIPTION
Initialize undefined variables in several functions to prevent PHP 8.2+ warnings (in single_month_title, get_the_generator, WP_HTML_Processor, wp_mime_type_icon, and _wp_privacy_send_request_confirmation_notification).

Fix a bug in do_enclose() where the enclosure meta was storing the variable name 'mime' instead of the actual MIME type variable '$type'.

Add aria-hidden attribute to dashicons span for improved accessibility, and add test coverage for the do_enclose fix with no-extension content types.

### Description

This PR addresses multiple PHP 8.2+ compatibility issues, undefined variable warnings, a bug in enclosure postmeta creation, accessibility improvements, and unit test coverage:

1. **PHP 8.2+ Compatibility & Undefined Variable Fixes**:
   - **`single_month_title()`**: Initialized `$my_year` and `$my_month` to prevent `E_WARNING` notices when `$monthnum` is supplied without `$year`.
   - **`get_the_generator()`**: Initialized `$gen` to an empty string before `switch ( $type )` to handle custom generator types passed via filters without throwing undefined variable warnings.
   - **`WP_HTML_Processor::in_body_any_other_end_tag()`**: Initialized `$node = null` prior to traversing open element stack to avoid undefined variable access when stack is empty.
   - **`wp_mime_type_icon()`**: Initialized `$icon = false` before mime type matching loop to guarantee definition when passed to `wp_mime_type_icon` filter.
   - **`_wp_privacy_send_request_confirmation_notification()`**: Initialized `$manage_url` to avoid undefined variable warnings when custom privacy request actions are used.

2. **Fix `do_enclose()` Bug**:
   - Updated `do_enclose()` in `wp-includes/functions.php` to use `$type` instead of undefined `$mime` when setting the `enclosure` postmeta value. This resolves an `E_WARNING` notice under PHP 8+ and ensures the HTTP `Content-Type` header (e.g. `video/mp4`) is correctly persisted for URLs without extension mapping.

3. **Accessibility Improvements**:
   - Added `aria-hidden="true"` to decorative `<span class="dashicons dashicons-warning"></span>` element in recovery mode notices within `class-wp-plugins-list-table.php` to improve screen reader accessibility.

4. **Test Coverage**:
   - Added test dataset `header-type-no-extension` and HTTP response mocking in `tests/phpunit/tests/functions/doEnclose.php` to verify `do_enclose()` processes extensionless media URLs without PHP 8 warnings.

Trac ticket: https://core.trac.wordpress.org/ticket/65674

## Use of AI Tools

AI assistance: Yes
Tool(s): Antigravity AI
Model(s): Gemini 3.6 Flash
Used for: Identifying PHP 8.2+ undefined variable warnings and `do_enclose()` bug, generating unit test dataset, and assisting with code formatting. All code changes and tests were verified against static analysis tools and unit tests.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**