### PR TITLE
Administration: A11y: Use a shape for the 'Collapse menu' focus style

### DIFF
--- a/src/wp-admin/css/admin-menu.css
+++ b/src/wp-admin/css/admin-menu.css
@@ -470,12 +470,14 @@ ul#adminmenu > li.current > a.current:after {
 	cursor: pointer;
 }
 
-#collapse-button:hover {
+#collapse-button:hover,
+#collapse-button:focus {
 	color: #72aee6;
+	box-shadow: inset 4px 0 0 0 currentColor;
+	transition: box-shadow .1s linear;
 }
 
 #collapse-button:focus {
-	color: #72aee6;
 	/* Only visible in Windows High Contrast mode */
 	outline: 1px solid transparent;
 	outline-offset: -1px;

--- a/src/wp-admin/css/colors/_admin.scss
+++ b/src/wp-admin/css/colors/_admin.scss
@@ -375,12 +375,13 @@ ul#adminmenu > li.current > a.current:after {
 /* Admin Menu: collapse button */
 
 #collapse-button {
-    color: variables.$menu-collapse-text;
+	color: variables.$menu-collapse-text;
 }
 
 #collapse-button:hover,
 #collapse-button:focus {
-    color: variables.$menu-submenu-focus-text;
+	color: variables.$menu-highlight-text;
+	background: variables.$menu-highlight-background;
 }
 
 /* Admin Bar */


### PR DESCRIPTION
## Trac ticket

https://core.trac.wordpress.org/ticket/65726

## Problem

A focus style that only uses a color change is not a sufficient focus indication. The focus style must use a shape that can be perceived regardless of any color perception ability. The 'Collapse menu' item was the only one in the admin menu that didn't use a shape.

Separately, on current trunk the color change on focus is entirely missing when an alternative admin color scheme is in use - a regression from WordPress 7.0.

### Cause of the regression

`_admin.scss` styled `#collapse-button:hover, #collapse-button:focus` with `$menu-submenu-focus-text`. In 7.0 that variable defaulted to `$highlight-color` (Ectoplasm's bright olive `#a3b745`), so the change was clearly visible. The color schemes now set `$menu-submenu-focus-text: #fff` explicitly and use `$highlight-color` as a *background* instead, so the collapse button went from `#ece6f6` to `#fff` on focus - effectively invisible.

## Changes

- `src/wp-admin/css/admin-menu.css`: `:focus` joins `:hover` and both get `box-shadow: inset 4px 0 0 0 currentColor`, the shape `#adminmenu a:focus` already uses.
- `src/wp-admin/css/colors/_admin.scss`: hover/focus now use `$menu-highlight-text` and `$menu-highlight-background`, matching `#adminmenu li > a.menu-top:focus`.

Every color scheme now has at least one non-color-dependent cue. The default scheme gets the bar (its focus background matches the sidebar, exactly as the menu items do there); the alternative schemes get both the filled block and the bar.

Only source files are touched. `admin-menu-rtl.css`, `*.min.css`, and `colors/*/*.css` are gitignored build artifacts; `rtlcss` flips the box-shadow to `inset -4px 0 …` automatically.

## Testing instructions

1. Run `npm run dev` and hard-reload wp-admin.
2. Tab to 'Collapse menu' in the default color scheme - a 4px bar appears on the left edge.
3. Users → Profile, select **Ectoplasm** (previews live), Tab to 'Collapse menu' - the item now fills with the scheme's highlight background. Before the patch there was no perceivable change. Repeat for the other schemes.
4. In DevTools → Rendering → *Emulate vision deficiencies* → Achromatopsia, confirm the focus state is still identifiable with all color removed.
5. Collapse the menu and Tab back to the button to check the folded state.
6. Switch to an RTL locale and confirm the bar is on the right edge.

## Screenshots

Before -

<img width="252" height="517" alt="image" src="https://github.com/user-attachments/assets/80a966d7-1ea1-4330-bbf9-b1c020465d12" />

<img width="267" height="526" alt="image" src="https://github.com/user-attachments/assets/0bbd4aba-d2a3-4e7e-a44e-3e96c4d29977" />


After -

<img width="287" height="730" alt="image" src="https://github.com/user-attachments/assets/79896dbf-eb14-4029-8c83-cfa3b649764d" />

<img width="253" height="525" alt="image" src="https://github.com/user-attachments/assets/573603aa-a39c-4c67-9989-afcf24b797f1" />

<img width="206" height="622" alt="image" src="https://github.com/user-attachments/assets/2743f303-6da4-4a40-888b-d3f36854d7e2" />

<img width="261" height="523" alt="image" src="https://github.com/user-attachments/assets/d9137c7d-2b98-47e2-b9eb-0391b6345d21" />

<img width="56" height="477" alt="image" src="https://github.com/user-attachments/assets/6f01c032-25e1-46e5-8989-cf560ede32bf" />

## Use of AI Tools

AI Assistance - Yes
Claude Code Opus 5
Identify issue and file paths.


**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
