### PR TITLE
Media: Remove obsolete Flash fallback message from MediaElement l10n strings

### DIFF
--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -1099,7 +1099,6 @@ function wp_default_scripts( $scripts ) {
 					'language' => strtolower( strtok( determine_locale(), '_-' ) ),
 					'strings'  => array(
 						'mejs.download-file'       => __( 'Download File' ),
-						'mejs.install-flash'       => __( 'You are using a browser that does not have Flash player enabled or installed. Please turn on your Flash player plugin or download the latest version from https://get.adobe.com/flashplayer/' ),
 						'mejs.fullscreen'          => __( 'Fullscreen' ),
 						'mejs.play'                => __( 'Play' ),
 						'mejs.pause'               => __( 'Pause' ),

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -1777,6 +1777,23 @@ HTML;
 	}
 
 	/**
+	 * Tests that the obsolete Flash-related MediaElement.js string is no longer localized.
+	 *
+	 * @ticket 65737
+	 *
+	 * @covers ::wp_default_scripts
+	 */
+	public function test_mediaelement_l10n_does_not_include_flash_message() {
+		$wp_scripts = wp_scripts();
+		wp_default_scripts( $wp_scripts );
+
+		$inline_script = implode( '', (array) $wp_scripts->get_data( 'mediaelement-core', 'before' ) );
+
+		$this->assertStringNotContainsString( 'mejs.install-flash', $inline_script );
+		$this->assertStringContainsString( 'mejs.play', $inline_script );
+	}
+
+	/**
 	 * Tests that printing a script without enqueueing has the same output as when it is enqueued.
 	 *
 	 * @ticket 61734


### PR DESCRIPTION
Removes the obsolete `mejs.install-flash` localized string from the MediaElement.js `mejsL10n` object registered in `wp_default_scripts()`. This message told users to install/enable Adobe Flash Player, but Adobe ended support for Flash Player on December 31, 2020 and WordPress's MediaElement configuration never produces the SWF-based renderer that would trigger this message, so it can never actually be shown to a visitor. Removing it drops dead translated content from every page that enqueues `mediaelement-core`.

Added a PHPUnit test (`Tests_Dependencies_Scripts::test_mediaelement_l10n_does_not_include_flash_message`) asserting the inline `mejsL10n` script data registered for `mediaelement-core` no longer includes the `mejs.install-flash` key, while confirming sibling strings such as `mejs.play` are still present.

Trac ticket: https://core.trac.wordpress.org/ticket/65737

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Sonnet 5
Used for: Implementation, tests, and PR description. Reviewed by Igor Rozum.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
