### PR TITLE
Networks and Sites: Add a filter for default Multisite port suffixes

### DIFF
--- a/src/wp-admin/includes/network.php
+++ b/src/wp-admin/includes/network.php
@@ -150,7 +150,8 @@ function network_step1( $errors = false ) {
 	}
 
 	// Strip standard port from hostname.
-	$hostname = preg_replace( '/(?::80|:443)$/', '', get_clean_basedomain() );
+	$port_pattern = '/(?:' . implode( '|', array_map( 'preg_quote', ms_default_port_suffixes() ) ) . ')$/';
+	$hostname     = preg_replace( $port_pattern, '', get_clean_basedomain() );
 
 	echo '<form method="post">';
 

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -760,6 +760,28 @@ function is_serialized_string( $data ) {
 }
 
 /**
+ * Retrieves the port suffixes considered "default" for a Multisite domain.
+ *
+ * These port suffixes are stripped from a hostname during the Multisite
+ * bootstrap process, and used to suggest a default network hostname when
+ * setting up a new network.
+ *
+ * @since 7.2.0
+ *
+ * @return string[] Array of default port suffixes, e.g. array( ':80', ':443' ).
+ */
+function ms_default_port_suffixes() {
+	/**
+	 * Filters the port suffixes considered "default" for a Multisite domain.
+	 *
+	 * @since 7.2.0
+	 *
+	 * @param string[] $port_suffixes Array of default port suffixes, e.g. array( ':80', ':443' ).
+	 */
+	return apply_filters( 'ms_default_port_suffixes', array( ':80', ':443' ) );
+}
+
+/**
  * Retrieves post title from XML-RPC XML.
  *
  * If the `title` element is not found in the XML, the default post title

--- a/src/wp-includes/ms-settings.php
+++ b/src/wp-includes/ms-settings.php
@@ -60,12 +60,12 @@ ms_subdomain_constants();
 if ( ! isset( $current_site ) || ! isset( $current_blog ) ) {
 
 	$domain = strtolower( stripslashes( $_SERVER['HTTP_HOST'] ?? '' ) );
-	if ( str_ends_with( $domain, ':80' ) ) {
-		$domain               = substr( $domain, 0, -3 );
-		$_SERVER['HTTP_HOST'] = substr( $_SERVER['HTTP_HOST'], 0, -3 );
-	} elseif ( str_ends_with( $domain, ':443' ) ) {
-		$domain               = substr( $domain, 0, -4 );
-		$_SERVER['HTTP_HOST'] = substr( $_SERVER['HTTP_HOST'], 0, -4 );
+	foreach ( ms_default_port_suffixes() as $port_suffix ) {
+		if ( str_ends_with( $domain, $port_suffix ) ) {
+			$domain               = substr( $domain, 0, -strlen( $port_suffix ) );
+			$_SERVER['HTTP_HOST'] = substr( $_SERVER['HTTP_HOST'], 0, -strlen( $port_suffix ) );
+			break;
+		}
 	}
 
 	$path = stripslashes( $_SERVER['REQUEST_URI'] );

--- a/tests/phpunit/tests/functions/msDefaultPortSuffixes.php
+++ b/tests/phpunit/tests/functions/msDefaultPortSuffixes.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * Tests for the ms_default_port_suffixes() function.
+ *
+ * @group functions
+ * @group multisite
+ *
+ * @covers ::ms_default_port_suffixes
+ */
+class Tests_Functions_MsDefaultPortSuffixes extends WP_UnitTestCase {
+
+	/**
+	 * @ticket 55488
+	 */
+	public function test_returns_standard_ports_by_default() {
+		$this->assertSame( array( ':80', ':443' ), ms_default_port_suffixes() );
+	}
+
+	/**
+	 * @ticket 55488
+	 */
+	public function test_result_is_filterable() {
+		add_filter( 'ms_default_port_suffixes', array( $this, 'filter_port_suffixes' ) );
+
+		$this->assertSame( array( ':8080' ), ms_default_port_suffixes() );
+	}
+
+	public function filter_port_suffixes() {
+		return array( ':8080' );
+	}
+}


### PR DESCRIPTION
Adds a `ms_default_port_suffixes` filter so site owners can customize which port suffixes are treated as "default" when Multisite bootstraps a request and when the Tools → Network Setup screen suggests a hostname, instead of the hardcoded `:80`/`:443`. Without this, a Multisite install served from a non-standard port (e.g. `:8080`) has no supported way to make that port behave like the standard ones during domain matching.

Introduces `ms_default_port_suffixes()` in `wp-includes/functions.php`, which wraps the new filter and defaults to `array( ':80', ':443' )` — the same values previously hardcoded. Both existing call sites now use it: the Multisite bootstrap domain normalization in `wp-includes/ms-settings.php`, and the default hostname suggestion in `wp-admin/includes/network.php`'s network setup wizard. Behavior is unchanged unless the new filter is used, since both call sites fall back to the same default port list.

The function is defined in `wp-includes/functions.php` (rather than an `ms-*` file) because `wp-admin/includes/network.php` runs during the one-time "enable Multisite" step, before Multisite itself is active — so `ms-functions.php`/`ms-load.php` aren't guaranteed loaded yet at that point, while `functions.php` always is.

Added `tests/phpunit/tests/functions/msDefaultPortSuffixes.php`, covering the default return value and that it can be filtered. The existing `Tests_Multisite_Bootstrap` suite (60 tests) continues to pass unchanged, confirming no regression to domain/network resolution.

Trac ticket: https://core.trac.wordpress.org/ticket/55488

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Sonnet 5
Used for: Implementation, tests, and PR description. Reviewed by Igor Rozum.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
