### PR TITLE
Layout: avoid resolving global settings for blocks with no layout output

### DIFF
--- a/src/wp-includes/block-supports/layout.php
+++ b/src/wp-includes/block-supports/layout.php
@@ -955,13 +955,40 @@ function wp_get_layout_style( $selector, $layout, $has_block_gap_support = false
 function wp_render_layout_support_flag( $block_content, $block ) {
 	static $global_styles = null;
 
-	$block_type               = WP_Block_Type_Registry::get_instance()->get_registered( $block['blockName'] );
-	$block_supports_layout    = block_has_support( $block_type, 'layout', false ) || block_has_support( $block_type, '__experimentalLayout', false );
-	$style_attr               = $block['attrs']['style'] ?? array();
+	$block_type            = WP_Block_Type_Registry::get_instance()->get_registered( $block['blockName'] );
+	$block_supports_layout = block_has_support( $block_type, 'layout', false ) || block_has_support( $block_type, '__experimentalLayout', false );
+	$style_attr            = $block['attrs']['style'] ?? array();
+	// If there is any value in style -> layout, the block has a child layout.
+	$child_layout = $style_attr['layout'] ?? null;
+
+	/*
+	 * Responsive child layouts are nested under a style state key such as
+	 * `@mobile`. Which of those keys are active depends on the breakpoints in
+	 * global settings, but whether any of them exist at all does not, so this
+	 * can be answered without resolving settings.
+	 */
+	$has_state_child_layout = false;
+	foreach ( (array) $style_attr as $state_styles ) {
+		if ( is_array( $state_styles ) && ! empty( $state_styles['layout'] ) ) {
+			$has_state_child_layout = true;
+			break;
+		}
+	}
+
+	/*
+	 * Bail out before resolving global settings when the block cannot produce
+	 * layout output. Resolving settings is not read-only: on a cold cache it
+	 * queries the user's `wp_global_styles` post, which fires `the_posts`. A
+	 * callback on that hook that renders blocks would re-enter this filter and,
+	 * without this early return, recurse without a base case.
+	 */
+	if ( ! $block_supports_layout && ! $child_layout && ! $has_state_child_layout ) {
+		return $block_content;
+	}
+
 	$global_settings          = wp_get_global_settings();
 	$viewport_settings        = $global_settings['viewport'] ?? null;
 	$responsive_media_queries = WP_Theme_JSON::get_viewport_media_queries( $viewport_settings );
-	$child_layout             = $style_attr['layout'] ?? null;
 
 	/*
 	 * Collect responsive viewport child layout overrides so that a block with

--- a/src/wp-includes/block-supports/layout.php
+++ b/src/wp-includes/block-supports/layout.php
@@ -946,7 +946,6 @@ function wp_get_layout_style( $selector, $layout, $has_block_gap_support = false
  * @since 6.3.0 Adds compound class to layout wrapper for global spacing styles.
  * @since 6.3.0 Check for layout support via the `layout` key with fallback to `__experimentalLayout`.
  * @since 6.6.0 Removed duplicate container class from layout styles.
- * @since 7.1.0 Returns early before resolving global settings.
  * @access private
  *
  * @param string $block_content Rendered block content.

--- a/src/wp-includes/block-supports/layout.php
+++ b/src/wp-includes/block-supports/layout.php
@@ -959,37 +959,25 @@ function wp_render_layout_support_flag( $block_content, $block ) {
 	$block_type            = WP_Block_Type_Registry::get_instance()->get_registered( $block['blockName'] );
 	$block_supports_layout = block_has_support( $block_type, 'layout', false ) || block_has_support( $block_type, '__experimentalLayout', false );
 	$style_attr            = $block['attrs']['style'] ?? array();
-	// If there is any value in style -> layout, the block has a child layout.
-	$child_layout = $style_attr['layout'] ?? null;
-
 	/*
-	 * Responsive child layouts are nested under a style state key such as
-	 * `@mobile`. Which of those keys are active depends on the breakpoints in
-	 * global settings, but whether any of them exist at all does not, so this
-	 * can be answered without resolving settings.
+	 * A block with no layout support and no style attribute at all cannot
+	 * produce layout output, so return before resolving global settings.
+	 *
+	 * Resolving settings is not read-only: on a cold cache it queries the
+	 * user's `wp_global_styles` post, which fires `the_posts`. A callback on
+	 * that hook that renders blocks re-enters this filter, and the content it
+	 * renders at that point is the global styles post itself, which parses to a
+	 * single block with no name and no attributes. Without this return that
+	 * block resolves settings again and the recursion has no base case.
 	 */
-	$has_state_child_layout = false;
-	foreach ( (array) $style_attr as $state_styles ) {
-		if ( is_array( $state_styles ) && ! empty( $state_styles['layout'] ) ) {
-			$has_state_child_layout = true;
-			break;
-		}
-	}
-
-	/*
-	 * Bail out before resolving global settings when the block cannot produce
-	 * layout output. Resolving settings is not read-only: on a cold cache it
-	 * queries the user's `wp_global_styles` post, which fires `the_posts`. A
-	 * callback on that hook that renders blocks would re-enter this filter and,
-	 * without this early return, recurse without a base case.
-	 */
-	if ( ! $block_supports_layout && ! $child_layout && ! $has_state_child_layout ) {
+	if ( ! $block_supports_layout && empty( $style_attr ) ) {
 		return $block_content;
 	}
 
 	$global_settings          = wp_get_global_settings();
 	$viewport_settings        = $global_settings['viewport'] ?? null;
 	$responsive_media_queries = WP_Theme_JSON::get_viewport_media_queries( $viewport_settings );
+	$child_layout             = $style_attr['layout'] ?? null;
 
 	/*
 	 * Collect responsive viewport child layout overrides so that a block with

--- a/src/wp-includes/block-supports/layout.php
+++ b/src/wp-includes/block-supports/layout.php
@@ -946,6 +946,7 @@ function wp_get_layout_style( $selector, $layout, $has_block_gap_support = false
  * @since 6.3.0 Adds compound class to layout wrapper for global spacing styles.
  * @since 6.3.0 Check for layout support via the `layout` key with fallback to `__experimentalLayout`.
  * @since 6.6.0 Removed duplicate container class from layout styles.
+ * @since 7.1.0 Returns early before resolving global settings.
  * @access private
  *
  * @param string $block_content Rendered block content.

--- a/tests/phpunit/tests/block-supports/layout.php
+++ b/tests/phpunit/tests/block-supports/layout.php
@@ -1124,4 +1124,77 @@ class Tests_Block_Supports_Layout extends WP_UnitTestCase {
 			'Layout support should render the expected markup when className is not a string'
 		);
 	}
+
+	/**
+	 * Tests that layout support returns early, without resolving global settings,
+	 * for a block that cannot produce any layout output.
+	 *
+	 * Resolving global settings reads the user's `wp_global_styles` post with a
+	 * `WP_Query`, which fires `the_posts`. A callback on that hook that renders
+	 * blocks re-enters this filter, so the bail-out has to happen before the
+	 * lookup or the recursion has no base case.
+	 *
+	 * @ticket 65741
+	 *
+	 * @covers ::wp_render_layout_support_flag
+	 */
+	public function test_layout_support_flag_returns_early_before_resolving_global_settings() {
+		$user_data_resolutions = 0;
+		add_filter(
+			'wp_theme_json_data_user',
+			static function ( $theme_json ) use ( &$user_data_resolutions ) {
+				++$user_data_resolutions;
+				return $theme_json;
+			}
+		);
+
+		// A block with no layout support and no child layout, as produced by
+		// parsing content that has no block delimiters.
+		$block_content = '<p>Not a block.</p>';
+		$block         = array(
+			'blockName' => null,
+			'attrs'     => array(),
+		);
+
+		$this->reset_global_settings();
+
+		$this->assertSame(
+			$block_content,
+			wp_render_layout_support_flag( $block_content, $block ),
+			'Block content should be returned unchanged when the block has no layout support.'
+		);
+		$this->assertSame(
+			0,
+			$user_data_resolutions,
+			'Global settings should not be resolved for a block that cannot produce layout output.'
+		);
+
+		// A block that does support layout still resolves global settings, which
+		// confirms the assertion above is not passing because of a warm cache.
+		$this->reset_global_settings();
+
+		wp_render_layout_support_flag(
+			'<div class="wp-block-group"></div>',
+			array(
+				'blockName' => 'core/group',
+				'attrs'     => array( 'layout' => array( 'type' => 'constrained' ) ),
+			)
+		);
+
+		$this->assertGreaterThan(
+			0,
+			$user_data_resolutions,
+			'Global settings should still be resolved for a block that supports layout.'
+		);
+	}
+
+	/**
+	 * Drops both layers of global settings caching: the resolver's static
+	 * properties and the array cached by wp_get_global_settings().
+	 */
+	private function reset_global_settings() {
+		WP_Theme_JSON_Resolver::clean_cached_data();
+		wp_cache_delete( 'wp_get_global_settings_custom', 'theme_json' );
+		wp_cache_delete( 'wp_get_global_settings_theme', 'theme_json' );
+	}
 }

--- a/tests/phpunit/tests/block-supports/layout.php
+++ b/tests/phpunit/tests/block-supports/layout.php
@@ -1156,7 +1156,8 @@ class Tests_Block_Supports_Layout extends WP_UnitTestCase {
 			'attrs'     => array(),
 		);
 
-		$this->reset_global_settings();
+		// Start from a cold cache, as on a front-end request.
+		wp_clean_theme_json_cache();
 
 		$this->assertSame(
 			$block_content,
@@ -1171,7 +1172,7 @@ class Tests_Block_Supports_Layout extends WP_UnitTestCase {
 
 		// A block that does support layout still resolves global settings, which
 		// confirms the assertion above is not passing because of a warm cache.
-		$this->reset_global_settings();
+		wp_clean_theme_json_cache();
 
 		wp_render_layout_support_flag(
 			'<div class="wp-block-group"></div>',
@@ -1186,15 +1187,5 @@ class Tests_Block_Supports_Layout extends WP_UnitTestCase {
 			$user_data_resolutions,
 			'Global settings should still be resolved for a block that supports layout.'
 		);
-	}
-
-	/**
-	 * Drops both layers of global settings caching: the resolver's static
-	 * properties and the array cached by wp_get_global_settings().
-	 */
-	private function reset_global_settings() {
-		WP_Theme_JSON_Resolver::clean_cached_data();
-		wp_cache_delete( 'wp_get_global_settings_custom', 'theme_json' );
-		wp_cache_delete( 'wp_get_global_settings_theme', 'theme_json' );
 	}
 }


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65741

Backport of https://github.com/WordPress/gutenberg/pull/80771 (currently open upstream).

## What

Move the global settings lookup in `wp_render_layout_support_flag()` back below the early return for blocks that cannot produce layout output.

## Why

Resolving global settings is not read-only. On a cold cache it runs `WP_Theme_JSON_Resolver::get_merged_data()`, then `get_user_data()`, which fires a `WP_Query` for the user's `wp_global_styles` post, which fires `the_posts`. A plugin whose `the_posts` callback renders blocks (a legitimate way to collect block asset dependencies) re-enters `render_block`, which re-enters the settings lookup, which runs the query again.

Before the responsive viewport changes (https://github.com/WordPress/gutenberg/pull/79104), the lookup sat below the `! $block_supports_layout` return. The `wp_global_styles` post content is a single line of JSON with no block delimiters, so `parse_blocks()` yields one block with `blockName === null`, which has no block type and therefore no layout support. That return was the base case, and the cycle closed after one iteration.

The viewport changes had to move the lookup up: the guard depended on `$viewport_child_layouts`, which needs the responsive media queries, which now come from `settings.viewport`. The base case went with it, and the request can now exhaust the PHP memory limit.

## What changed

`src/wp-includes/block-supports/layout.php`: one early return, before the lookup.

```php
if ( ! $block_supports_layout && empty( $style_attr ) ) {
    return $block_content;
}
```

The block that closes the cycle is the `wp_global_styles` post content parsed as a single block with no name and no attributes, so that condition always holds for it.

Nothing else in the function moves. The collection loop and both existing guards are untouched, and every block that renders anything today takes exactly the path it took before, because a block with no style attribute already returned unchanged twenty lines further down. The only other change in the file is whitespace realignment that phpcs requires once a statement is inserted into that assignment block, and a `@since 7.1.0` note.

`tests/phpunit/tests/block-supports/layout.php`: one test, asserting that a block with no layout support does not resolve user global styles data, with a control case proving that is not a warm cache passing by accident.

The other `render_block` filters that resolve settings already return before their lookup for a block with no name, so layout was the only one affected.

## Manual testing

Requires a site whose active theme has a user global styles post. Opening the site editor once creates it.

1. Check out `trunk` and open the site editor once so the `wp_global_styles` post exists.
2. Add this mu-plugin:

   ```php
   <?php
   add_filter( 'the_posts', function ( $posts ) {
       foreach ( $posts as $post ) {
           do_blocks( $post->post_content );
       }
       return $posts;
   } );
   ```

3. Make sure at least one published post contains a block with layout support, for example a Group block.
4. Load the front page. It dies with `Allowed memory size ... exhausted`.
5. Check out this branch and reload the front page. It renders, and the callback's `do_blocks()` calls complete.
6. Confirm ordinary layout output is unchanged: a Group block with a content width still renders `is-layout-constrained`, and a Grid child with a column span still gets its `wp-container-content-*` class.
