### PR TITLE
Build/Test Tools: Preserve plugin query vars between tests

### DIFF
--- a/tests/phpunit/includes/abstract-testcase.php
+++ b/tests/phpunit/includes/abstract-testcase.php
@@ -183,6 +183,10 @@ abstract class WP_UnitTestCase_Base extends PHPUnit_Adapter_TestCase {
 		$wp_query     = $wp_the_query;
 		$wp           = new WP();
 
+		if ( isset( $GLOBALS['_wp_tests_initial_public_query_vars'] ) ) {
+			$wp->public_query_vars = $GLOBALS['_wp_tests_initial_public_query_vars'];
+		}
+
 		// Reset globals related to the post loop and `setup_postdata()`.
 		$post_globals = array( 'post', 'id', 'authordata', 'currentday', 'currentmonth', 'page', 'pages', 'multipage', 'more', 'numpages' );
 		foreach ( $post_globals as $global ) {

--- a/tests/phpunit/includes/bootstrap.php
+++ b/tests/phpunit/includes/bootstrap.php
@@ -299,6 +299,15 @@ if ( isset( $GLOBALS['wp_tests_options'] ) ) {
 
 // Load WordPress.
 require_once ABSPATH . 'wp-settings.php';
+/*
+ * Preserve public query variables registered by plugins during bootstrap.
+ *
+ * Core tests reset these variables between tests, while plugin tests expect
+ * registrations made on `init` to remain available throughout the test run.
+ */
+if ( ! defined( 'WP_RUN_CORE_TESTS' ) || ! WP_RUN_CORE_TESTS ) {
+	$GLOBALS['_wp_tests_initial_public_query_vars'] = $GLOBALS['wp']->public_query_vars;
+}
 
 // Override the PHPMailer.
 require_once __DIR__ . '/mock-mailer.php';

--- a/tests/phpunit/tests/rewrite/addRewriteEndpoint.php
+++ b/tests/phpunit/tests/rewrite/addRewriteEndpoint.php
@@ -48,6 +48,33 @@ class Tests_Rewrite_AddRewriteEndpoint extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Sets up the non-core test-suite state before the test case is torn down.
+	 *
+	 * @ticket 37207
+	 */
+	public function test_should_preserve_query_vars_registered_during_plugin_bootstrap() {
+		add_rewrite_endpoint( 'plugin-endpoint', EP_ROOT );
+		$GLOBALS['_wp_tests_initial_public_query_vars'] = $GLOBALS['wp']->public_query_vars;
+
+		$this->assertContains( 'plugin-endpoint', $GLOBALS['wp']->public_query_vars );
+	}
+
+	/**
+	 * Verifies the query variables after the preceding test's tear down.
+	 *
+	 * @ticket 37207
+	 *
+	 * @depends test_should_preserve_query_vars_registered_during_plugin_bootstrap
+	 */
+	public function test_should_restore_query_vars_registered_during_plugin_bootstrap() {
+		try {
+			$this->assertContains( 'plugin-endpoint', $GLOBALS['wp']->public_query_vars );
+		} finally {
+			unset( $GLOBALS['_wp_tests_initial_public_query_vars'] );
+		}
+	}
+
+	/**
 	 * @ticket 25143
 	 */
 	public function test_should_register_query_var_using_name_param_if_true_is_passed_as_query_var() {

--- a/tests/phpunit/tests/rewrite/addRewriteEndpoint.php
+++ b/tests/phpunit/tests/rewrite/addRewriteEndpoint.php
@@ -51,12 +51,21 @@ class Tests_Rewrite_AddRewriteEndpoint extends WP_UnitTestCase {
 	 * Sets up the non-core test-suite state before the test case is torn down.
 	 *
 	 * @ticket 37207
+	 *
+	 * @return array{exists: bool, value: string[]|null} Previous global state.
 	 */
 	public function test_should_preserve_query_vars_registered_during_plugin_bootstrap() {
+		$previous_state = array(
+			'exists' => isset( $GLOBALS['_wp_tests_initial_public_query_vars'] ),
+			'value'  => $GLOBALS['_wp_tests_initial_public_query_vars'] ?? null,
+		);
+
 		add_rewrite_endpoint( 'plugin-endpoint', EP_ROOT );
+		$this->assertContains( 'plugin-endpoint', $GLOBALS['wp']->public_query_vars );
+
 		$GLOBALS['_wp_tests_initial_public_query_vars'] = $GLOBALS['wp']->public_query_vars;
 
-		$this->assertContains( 'plugin-endpoint', $GLOBALS['wp']->public_query_vars );
+		return $previous_state;
 	}
 
 	/**
@@ -65,12 +74,18 @@ class Tests_Rewrite_AddRewriteEndpoint extends WP_UnitTestCase {
 	 * @ticket 37207
 	 *
 	 * @depends test_should_preserve_query_vars_registered_during_plugin_bootstrap
+	 *
+	 * @param array{exists: bool, value: string[]|null} $previous_state Previous global state.
 	 */
-	public function test_should_restore_query_vars_registered_during_plugin_bootstrap() {
+	public function test_should_restore_query_vars_registered_during_plugin_bootstrap( $previous_state ) {
 		try {
 			$this->assertContains( 'plugin-endpoint', $GLOBALS['wp']->public_query_vars );
 		} finally {
-			unset( $GLOBALS['_wp_tests_initial_public_query_vars'] );
+			if ( $previous_state['exists'] ) {
+				$GLOBALS['_wp_tests_initial_public_query_vars'] = $previous_state['value'];
+			} else {
+				unset( $GLOBALS['_wp_tests_initial_public_query_vars'] );
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

Preserves public query variables registered by plugins during bootstrap when the WordPress test suite runs in non-core mode. This prevents endpoints registered on init from disappearing after the first test while retaining the existing reset behavior for core tests.

Adds regression coverage across the actual test teardown boundary.`n`n## Testing

- Focused rewrite endpoint suite: 10 tests, 19 assertions
- Ticket group: 2 tests, 2 assertions
- External plugin-mode reproduction: 2 tests, 2 assertions
- PHP syntax checks
- PHPCBF and PHPCS
- git diff --check

## Use of AI Tools

AI assistance: Yes
Tool(s): OpenAI Codex
Model(s): GPT-5
Used for: Ticket investigation, implementation, regression tests, and local validation; the resulting diff and test output were reviewed before publication.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**

Trac ticket: https://core.trac.wordpress.org/ticket/37207

## Use of AI Tools

AI assistance: Yes
Tool(s): OpenAI Codex
Model(s): GPT-5
Used for: Reviewing the Trac ticket and relevant code, helping with the initial implementation and regression-test approach, and assisting with validation and PR-description drafting. The final implementation, tests, validation results, and description were reviewed and accepted by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**