### PR TITLE
Fix: Plugin dependencies: better messaging or management of plugin active states

### DIFF
--- a/src/wp-admin/includes/class-wp-plugins-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugins-list-table.php
@@ -1619,7 +1619,30 @@ class WP_Plugins_List_Table extends WP_List_Table {
 			return;
 		}
 
-		$dependency_note = __( 'Note: This plugin cannot be deactivated or deleted until the plugins that require it are deactivated or deleted.' );
+		$is_active = ( is_multisite() && $this->screen->in_admin( 'network' ) )
+			? is_plugin_active_for_network( $dependency )
+			: is_plugin_active( $dependency );
+
+		if ( $is_active ) {
+			if ( WP_Plugin_Dependencies::has_active_dependents( $dependency ) ) {
+				$dependency_note = __( 'Note: This plugin cannot be deactivated until the plugins that require it are deactivated.' );
+			} else {
+				$dependency_note = '';
+			}
+		} else {
+			$dependency_note = __( 'Note: This plugin cannot be deleted until the plugins that require it are deleted.' );
+		}
+
+		$dependency_notice = '';
+		if ( '' !== $dependency_note ) {
+			$dependency_notice = wp_get_admin_notice(
+				$dependency_note,
+				array(
+					'type'               => 'error',
+					'additional_classes' => array( 'inline' ),
+				)
+			);
+		}
 
 		$comma       = wp_get_list_item_separator();
 		$required_by = sprintf(
@@ -1629,9 +1652,9 @@ class WP_Plugins_List_Table extends WP_List_Table {
 		);
 
 		printf(
-			'<div class="required-by"><p>%1$s</p><p>%2$s</p></div>',
+			'<div class="required-by"><p>%1$s</p>%2$s</div>',
 			$required_by,
-			$dependency_note
+			$dependency_notice
 		);
 	}
 

--- a/src/wp-admin/includes/class-wp-plugins-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugins-list-table.php
@@ -1619,18 +1619,22 @@ class WP_Plugins_List_Table extends WP_List_Table {
 			return;
 		}
 
-		$is_active = ( is_multisite() && $this->screen->in_admin( 'network' ) )
-			? is_plugin_active_for_network( $dependency )
-			: is_plugin_active( $dependency );
+		$dependency_note = '';
 
-		if ( $is_active ) {
+		if ( is_multisite() && $this->screen->in_admin( 'network' ) ) {
+			$is_network_active = is_plugin_active_for_network( $dependency );
+
+			if ( $is_network_active && WP_Plugin_Dependencies::has_active_dependents( $dependency ) ) {
+				$dependency_note = __( 'Note: This plugin cannot be deactivated until the plugins that require it are deactivated.' );
+			} elseif ( current_user_can( 'delete_plugins' ) && ! is_plugin_active( $dependency ) ) {
+				$dependency_note = __( 'Note: This plugin cannot be deleted until the plugins that require it are deleted.' );
+			}
+		} elseif ( is_plugin_active( $dependency ) ) {
 			if ( WP_Plugin_Dependencies::has_active_dependents( $dependency ) ) {
 				$dependency_note = __( 'Note: This plugin cannot be deactivated until the plugins that require it are deactivated.' );
-			} else {
-				$dependency_note = '';
+			} elseif ( ! is_multisite() && current_user_can( 'delete_plugins' ) ) {
+				$dependency_note = __( 'Note: This plugin cannot be deleted until the plugins that require it are deleted.' );
 			}
-		} else {
-			$dependency_note = __( 'Note: This plugin cannot be deleted until the plugins that require it are deleted.' );
 		}
 
 		$dependency_notice = '';

--- a/src/wp-admin/includes/class-wp-plugins-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugins-list-table.php
@@ -1621,18 +1621,20 @@ class WP_Plugins_List_Table extends WP_List_Table {
 
 		$dependency_note = '';
 
-		if ( is_multisite() && $this->screen->in_admin( 'network' ) ) {
+		if ( $this->screen->in_admin( 'network' ) ) {
 			$is_network_active = is_plugin_active_for_network( $dependency );
 
-			if ( $is_network_active && WP_Plugin_Dependencies::has_active_dependents( $dependency ) ) {
+			if ( $is_network_active && current_user_can( 'manage_network_plugins' ) && WP_Plugin_Dependencies::has_active_dependents( $dependency ) ) {
 				$dependency_note = __( 'Note: This plugin cannot be deactivated until the plugins that require it are deactivated.' );
-			} elseif ( current_user_can( 'delete_plugins' ) && ! is_plugin_active( $dependency ) ) {
+			} elseif ( ! $is_network_active && ! is_plugin_active( $dependency ) && current_user_can( 'delete_plugins' ) ) {
 				$dependency_note = __( 'Note: This plugin cannot be deleted until the plugins that require it are deleted.' );
 			}
-		} elseif ( is_plugin_active( $dependency ) ) {
-			if ( WP_Plugin_Dependencies::has_active_dependents( $dependency ) ) {
+		} else {
+			$is_active = is_plugin_active( $dependency );
+
+			if ( $is_active && current_user_can( 'deactivate_plugin', $dependency ) && WP_Plugin_Dependencies::has_active_dependents( $dependency ) ) {
 				$dependency_note = __( 'Note: This plugin cannot be deactivated until the plugins that require it are deactivated.' );
-			} elseif ( ! is_multisite() && current_user_can( 'delete_plugins' ) ) {
+			} elseif ( ! $is_active && ! is_multisite() && current_user_can( 'delete_plugins' ) ) {
 				$dependency_note = __( 'Note: This plugin cannot be deleted until the plugins that require it are deleted.' );
 			}
 		}


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/64493

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->
- Claude Code, Opus 5
- Used on inital implementation and drafting the message and PR description. Final implementation reviwed by me and tested in local env.

---

## AI Summary

The "Required by" note on the Plugins screen uses a single static message that doesn't match reality. This change generates it from the plugin's current state so it reflects the action that's actually available.

## Problem

For any plugin with dependents, the note always reads:

> Note: This plugin cannot be deactivated or deleted until the plugins that require it are deactivated or deleted.

This is wrong in two ways:

1. **Deletion** — a dependent must be *deleted*; deactivating it is not sufficient. So "deactivated or deleted" is inaccurate.
2. **State** — the message never changes. It claims a plugin "cannot be deactivated" even when it has no active dependents (deactivation is actually allowed), or when the plugin is already inactive. It also mentions deletion for active plugins, which can't be deleted anyway (Delete is only offered for inactive plugins).

## Fix

The note in `WP_Plugins_List_Table::add_dependents_to_dependency_plugin_row()` now branches on the plugin's active state, using the same signals that gate the action links (`is_plugin_active()` / `has_active_dependents()`):

- **Active plugin, with an active dependent** → `Note: This plugin cannot be deactivated until the plugins that require it are deactivated.`
- **Active plugin, no active dependents** → no note (deactivation is allowed).
- **Inactive plugin** → `Note: This plugin cannot be deleted until the plugins that require it are deleted.`

The message is also now rendered as an **inline admin notice** via `wp_get_admin_notice()` (`type => 'error'`, `additional_classes => array( 'inline' )`) instead of a plain paragraph, so it's styled consistently with other admin notices. 

When there is no applicable restriction, no notice is output.

## Example

Plugin "Example Dependency" is required by "Example Dependent One":

| Scenario | Old note | New note |
| --- | --- | --- |
| Both active | cannot be deactivated **or deleted** until … deactivated **or deleted** | cannot be **deactivated** until … deactivated |
| Dependency active, dependent inactive | _(same wrong message)_ | _(no note — deactivation is allowed)_ |
| Dependency inactive | _(same wrong message)_ | cannot be **deleted** until … deleted |


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
