### PR TITLE
Interactivity API: Preserve colons and semicolons in existing style attributes

### DIFF
--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -1170,6 +1170,11 @@ final class WP_Interactivity_API {
 	 *     merge_style_property( 'background:green;', 'color', 'red' ) => 'background:green;color:red;'
 	 *     merge_style_property( 'color:green;', 'color', null )       => ''
 	 *
+	 * Declarations are separated on semicolons without regard for quoted strings or
+	 * `url()` values, so the property being replaced is not recognized when its own
+	 * value contains a semicolon. Resolving that requires tokenizing the declaration
+	 * list rather than splitting it. See #65738.
+	 *
 	 * @param string            $style_attribute_value The current style attribute value.
 	 * @param string            $style_property_name   The style property name to set.
 	 * @param string|false|null $style_property_value  The value to set for the style property. With false, null or an
@@ -1187,7 +1192,25 @@ final class WP_Interactivity_API {
 			if ( empty( trim( $style_assignment ) ) ) {
 				continue;
 			}
-			list( $name, $value ) = explode( ':', $style_assignment );
+
+			/*
+			 * Only the first colon separates a property name from its value; a value may
+			 * legitimately contain more, as in `background-image:url(https://…)`.
+			 */
+			$name_and_value = explode( ':', $style_assignment, 2 );
+
+			/*
+			 * A segment with no colon is not a declaration. It is most often the remainder
+			 * of a value that was split above by a semicolon inside a quoted string or a
+			 * `url()`, as in `font-family:"Foo;Bar"`. Preserving it verbatim means
+			 * re-joining the segments restores the original value.
+			 */
+			if ( ! isset( $name_and_value[1] ) ) {
+				$result[] = $style_assignment . ';';
+				continue;
+			}
+
+			list( $name, $value ) = $name_and_value;
 			if ( trim( $name ) !== $style_property_name ) {
 				$result[] = trim( $name ) . ':' . trim( $value ) . ';';
 			}

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPI-wp-style.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPI-wp-style.php
@@ -107,6 +107,66 @@ class Tests_WP_Interactivity_API_WP_Style extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that `merge_style_property` preserves values containing a colon.
+	 *
+	 * Only the first colon in a declaration separates the property name from its
+	 * value, so a value may legitimately contain more of them.
+	 *
+	 * @ticket 63899
+	 *
+	 * @covers ::merge_style_property
+	 */
+	public function test_merge_style_property_preserves_values_containing_colons() {
+		// Keeps an untouched property whose value contains a URL.
+		$result = $this->merge_style_property( 'background-image:url(https://example.com/a.png)', 'color', 'green' );
+		$this->assertSame( 'background-image:url(https://example.com/a.png);color:green;', $result );
+
+		// Replaces a property whose previous value contained a URL.
+		$result = $this->merge_style_property( 'background-image:url(https://example.com/a.png)', 'background-image', 'none' );
+		$this->assertSame( 'background-image:none;', $result );
+
+		// Keeps every colon after the first, not only the second.
+		$result = $this->merge_style_property( '--fallback:url(https://a.test/x.png), url(https://b.test/y.png);', 'color', 'green' );
+		$this->assertSame( '--fallback:url(https://a.test/x.png), url(https://b.test/y.png);color:green;', $result );
+	}
+
+	/**
+	 * Tests that `merge_style_property` preserves values containing a semicolon.
+	 *
+	 * Declarations are separated on semicolons, so a semicolon inside a quoted
+	 * string or a `url()` splits a value across two segments. The segments must
+	 * re-join to the original value.
+	 *
+	 * @ticket 63899
+	 *
+	 * @covers ::merge_style_property
+	 */
+	public function test_merge_style_property_preserves_values_containing_semicolons() {
+		// Keeps a quoted value containing a semicolon.
+		$result = $this->merge_style_property( 'font-family:"Foo;Bar",serif', 'color', 'green' );
+		$this->assertSame( 'font-family:"Foo;Bar",serif;color:green;', $result );
+
+		// Keeps a data URI, which contains both a colon and a semicolon.
+		$result = $this->merge_style_property( 'background-image:url(data:image/gif;base64,R0lGODlhAQ)', 'color', 'green' );
+		$this->assertSame( 'background-image:url(data:image/gif;base64,R0lGODlhAQ);color:green;', $result );
+	}
+
+	/**
+	 * Tests that `merge_style_property` handles segments that contain no colon.
+	 *
+	 * Malformed input previously raised "Undefined array key 1" and a `trim()`
+	 * deprecation notice, and emitted a stray colon into the result.
+	 *
+	 * @ticket 63899
+	 *
+	 * @covers ::merge_style_property
+	 */
+	public function test_merge_style_property_handles_segments_without_a_colon() {
+		$result = $this->merge_style_property( 'translate:none;translate3d(0px, 0px, 0px);', 'color', 'green' );
+		$this->assertSame( 'translate:none;translate3d(0px, 0px, 0px);color:green;', $result );
+	}
+
+	/**
 	 * Tests that `merge_style_property` works correctly with falsy values,
 	 * removing or ignoring them as appropriate.
 	 *
@@ -232,6 +292,20 @@ class Tests_WP_Interactivity_API_WP_Style extends WP_UnitTestCase {
 		$html    = '<div style="padding:10px;" data-wp-style--color="myPlugin::state.green">Text</div>';
 		list($p) = $this->process_directives( $html );
 		$this->assertSame( 'padding:10px;color:green;', $p->get_attribute( 'style' ) );
+	}
+
+	/**
+	 * Tests that the `data-wp-style` directive leaves an existing style attribute
+	 * intact when one of its values contains a colon.
+	 *
+	 * @ticket 63899
+	 *
+	 * @covers ::process_directives
+	 */
+	public function test_wp_style_preserves_existing_style_attribute_containing_a_url() {
+		$html    = '<div style="background-image:url(https://example.com/a.png)" data-wp-style--color="myPlugin::state.green">Text</div>';
+		list($p) = $this->process_directives( $html );
+		$this->assertSame( 'background-image:url(https://example.com/a.png);color:green;', $p->get_attribute( 'style' ) );
 	}
 
 	/**


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

`WP_Interactivity_API::merge_style_property()` re-serializes the entire `style` attribute every time a `data-wp-style--*` directive is processed. Two defects sit in that loop, both on the same line.

**1. Values containing a colon are truncated.** `explode( ':', $style_assignment )` is called without a limit, so everything after the first colon is discarded. This corrupts valid CSS silently, with no warning:

```
in:  <div style="background-image:url(https://example.com/a.png)"
          data-wp-style--color="myPlugin::state.green">Text</div>

out: <div style="background-image:url(https;color:green;"
          data-wp-style--color="myPlugin::state.green">Text</div>
```

The background image is destroyed on the front end. Any `url()` with a scheme triggers it, as does any custom property holding one.

**2. Segments containing no colon raise PHP diagnostics.** They yield no `$value`, so `list()` raises `Undefined array key 1` and the subsequent `trim( null )` is deprecated on PHP 8.1+. This is the half originally reported on the ticket.

There is a third, related symptom: declarations are split on `;` before anything knows where strings begin and end, so a semicolon inside a quoted string or a `url()` cuts a value in two. `font-family:"Foo;Bar",serif` and `url(data:image/gif;base64,…)` both split, and the tail then hits the colon-less path above and picks up a stray `:`.

## Changes

- `explode( ':', $style_assignment, 2 )`, so only the first colon separates a property name from its value.
- A guard for segments containing no colon, resolving the reported warning and deprecation.

The guard **preserves such segments verbatim and untrimmed** rather than dropping them. This also repairs the semicolon cases: because segments are re-joined with `;`, preserving the tail restores `font-family:"Foo;Bar",serif` and `url(data:image/gif;base64,…)` intact. Dropping them would emit `font-family:"Foo` — an unterminated string, which is worse than the original bug. Leaving them untrimmed matters too, or the space in `"Foo; Bar"` is lost.

Trac ticket: https://core.trac.wordpress.org/ticket/63899

## Use of AI Tools
AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Ticket analysis, tests cases and writing PR description. All changes were reviewed and validated by me.
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
