### PR TITLE
Rewrite Rules: Treat a request path of "0" as a real request

### DIFF
--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -1193,7 +1193,12 @@ class WP_Query {
 				continue; // Handled further down in the $query_vars['tag'] block.
 			}
 
-			if ( $t->query_var && ! empty( $query_vars[ $t->query_var ] ) ) {
+			if ( $t->query_var
+				&& isset( $query_vars[ $t->query_var ] )
+				&& ( is_array( $query_vars[ $t->query_var ] )
+					? ! empty( $query_vars[ $t->query_var ] )
+					: '' !== (string) $query_vars[ $t->query_var ] )
+			) {
 				$tax_query_defaults = array(
 					'taxonomy' => $taxonomy,
 					'field'    => 'slug',
@@ -3998,7 +4003,7 @@ class WP_Query {
 
 				if ( $cat ) {
 					$term = get_term( $cat, 'category' );
-				} elseif ( $category_name ) {
+				} elseif ( '' !== (string) $category_name ) {
 					$term = get_term_by( 'slug', $category_name, 'category' );
 				}
 			} elseif ( $this->is_tag ) {

--- a/src/wp-includes/class-wp.php
+++ b/src/wp-includes/class-wp.php
@@ -218,7 +218,7 @@ class WP {
 
 			// Look for matches.
 			$request_match = $requested_path;
-			if ( empty( $request_match ) ) {
+			if ( '' === $request_match ) {
 				// An empty request could only match against ^$ regex.
 				if ( isset( $rewrite['$'] ) ) {
 					$this->matched_rule = '$';

--- a/tests/phpunit/tests/rewrite/zeroPathSegment.php
+++ b/tests/phpunit/tests/rewrite/zeroPathSegment.php
@@ -1,0 +1,113 @@
+<?php
+
+/**
+ * Tests for requests whose path segment is the string "0".
+ *
+ * "0" is falsy in PHP, so code that guards on `empty()` or truthiness treats
+ * a legitimate "0" path segment as if no path had been requested at all.
+ *
+ * @group rewrite
+ * @group query
+ * @ticket 57858
+ */
+class Tests_Rewrite_ZeroPathSegment extends WP_UnitTestCase {
+
+	/**
+	 * Sets a permalink structure and rebuilds the rules with the taxonomy
+	 * rewrite tags registered.
+	 *
+	 * `WP_Rewrite::init()` resets the registered rewrite tags to the built-in
+	 * defaults, which do not include `%category%`. The taxonomies have to be
+	 * re-registered and the rules flushed again, otherwise `%category%` is
+	 * never substituted into the generated rules.
+	 *
+	 * @param string $structure Permalink structure to set.
+	 */
+	private function set_category_permalink_structure( $structure ) {
+		global $wp_rewrite;
+
+		$this->set_permalink_structure( $structure );
+		create_initial_taxonomies();
+		$wp_rewrite->flush_rules();
+	}
+
+	/**
+	 * A "0" path segment should not silently fall through to the front page.
+	 *
+	 * @ticket 57858
+	 */
+	public function test_zero_path_segment_should_404_when_no_matching_category_exists() {
+		$this->set_category_permalink_structure( '/%category%/%postname%/' );
+
+		self::factory()->post->create( array( 'post_status' => 'publish' ) );
+
+		$this->go_to( home_url( '/0/' ) );
+
+		$this->assertQueryTrue( 'is_404' );
+	}
+
+	/**
+	 * A deeper path ending in "0" should 404 rather than resolve to an archive.
+	 *
+	 * @ticket 57858
+	 */
+	public function test_nested_zero_path_segment_should_404() {
+		$this->set_category_permalink_structure( '/%category%/%postname%/' );
+
+		self::factory()->post->create( array( 'post_status' => 'publish' ) );
+
+		$this->go_to( home_url( '/wp-content/0/' ) );
+
+		$this->assertTrue( is_404() );
+		$this->assertFalse( is_home() );
+	}
+
+	/**
+	 * A category whose slug is "0" should still resolve to its archive.
+	 *
+	 * This guards against fixing the 404 by ignoring "0" outright.
+	 *
+	 * @ticket 57858
+	 */
+	public function test_category_with_zero_slug_should_resolve_to_its_archive() {
+		global $wpdb;
+
+		$this->set_category_permalink_structure( '/%category%/%postname%/' );
+
+		$category_id = self::factory()->category->create( array( 'name' => 'Zero' ) );
+
+		/*
+		 * The slug has to be forced directly, as `wp_insert_term()` discards a
+		 * slug of "0" and falls back to one derived from the name.
+		 */
+		$wpdb->update( $wpdb->terms, array( 'slug' => '0' ), array( 'term_id' => $category_id ) );
+		clean_term_cache( $category_id, 'category' );
+
+		self::factory()->post->create(
+			array(
+				'post_status'   => 'publish',
+				'post_category' => array( $category_id ),
+			)
+		);
+
+		$this->go_to( home_url( '/0/' ) );
+
+		$this->assertQueryTrue( 'is_archive', 'is_category' );
+		$this->assertSame( $category_id, get_queried_object_id() );
+	}
+
+	/**
+	 * The front page must keep working, since an empty request is also falsy.
+	 *
+	 * @ticket 57858
+	 */
+	public function test_empty_request_still_resolves_to_the_front_page() {
+		$this->set_category_permalink_structure( '/%category%/%postname%/' );
+
+		self::factory()->post->create( array( 'post_status' => 'publish' ) );
+
+		$this->go_to( home_url( '/' ) );
+
+		$this->assertQueryTrue( 'is_home', 'is_front_page' );
+	}
+}


### PR DESCRIPTION
## Summary

Fixes [#57858](https://core.trac.wordpress.org/ticket/57858).

A request path consisting of the string `0` is falsy in PHP, so several truthiness guards treat it as though no path had been requested at all.

With a permalink structure of `/%category%/%postname%/`, a request for `/0/` never reaches the rewrite rule loop and silently falls through to the **front page** instead of resolving the `(.+?)/?$` catch-all rule and returning a 404.

This is the case @kalpeshh re-confirmed still reproduces on trunk in [comment:10](https://core.trac.wordpress.org/ticket/57858#comment:10) ("test case 3 ... Working but should have given 404").

### Reproduction

1. Settings → Permalinks → Custom Structure: `/%category%/%postname%/`
2. Visit `example.com/0/`
3. It renders the front page (HTTP 200) instead of a 404.

## Root cause

Three separate falsy-`"0"` checks along the request path, each of which is independently load-bearing (verified by reverting them one at a time against the new tests):

1. **`WP::parse_request()`** — `if ( empty( $request_match ) )` treats a requested path of `"0"` as an empty request, so the entire rewrite-rule loop is skipped and only the `^$` (home) rule is considered. This is the primary bug: `matched_rule` comes back empty and no query vars are set at all.
2. **`WP_Query::parse_tax_query()`** — `! empty( $query_vars[ $t->query_var ] )` skips building the taxonomy clause for a term slug of `"0"`, so `is_category` is never set and `is_home` wins. `handle_404()` then short-circuits on `is_home()` and never 404s.
3. **`WP_Query::get_queried_object()`** — `elseif ( $category_name )` fails to look up a category whose slug is `"0"`, so `get_queried_object()` returns `null` and `handle_404()` 404s a category archive that genuinely exists.

The change in (2) is deliberately narrow: for scalars it swaps `! empty( $x )` for `'' !== (string) $x`, whose only behavioural delta versus the original is the numeric-zero family (`"0"`, `0`). `null`, `false`, `''`, and empty arrays are all still skipped exactly as before.

## Testing

New test file `tests/phpunit/tests/rewrite/zeroPathSegment.php` (4 tests):

| Test | Before | After |
|---|---|---|
| `/0/` 404s when no matching category exists | ❌ fails (renders front page) | ✅ passes |
| Category with slug `0` resolves to its archive | ❌ fails (404s) | ✅ passes |
| `/wp-content/0/` 404s | ✅ passes | ✅ passes (guard) |
| `/` still resolves to the front page | ✅ passes | ✅ passes (guard) |

The two guard tests pass both before and after; they exist to prove the fix does not 404 a legitimate `"0"` category, and does not regress the empty-request path (which is also falsy).

```
npm run test:php -- --filter Tests_Rewrite_ZeroPathSegment
OK (4 tests, 8 assertions)
```

Full suite, single site:

```
Tests: 30520, Assertions: 4558386, Warnings: 86, Skipped: 49
```

No failures or errors. The 86 warnings are pre-existing PHPUnit 10 forward-compatibility notices (`Expecting E_DEPRECATED ... is deprecated`) and are unrelated to this change. Focused groups `--group rewrite` (1392), `--group query` (1896), `--group canonical` (1057) and `--group taxonomy` (878) all pass.

PHPCS on `class-wp-query.php` reports an identical 0 errors / 34 warnings before and after the patch; none of the warnings fall on the changed lines.

### A note on the test setup

`WP_Rewrite::init()` resets the registered rewrite tags to the built-in defaults, which do **not** include `%category%`. Tests that use a `%category%` permalink structure therefore have to call `create_initial_taxonomies()` and flush again, otherwise `%category%` is never substituted and the generated rules are literally `%category%/?$ => index.php?%category%$matches[1]`. This mirrors the existing approach in `tests/phpunit/tests/query/verboseRewriteRules.php`.

## Out of scope (siblings found while investigating)

Two adjacent instances of the same falsy-`"0"` defect turned up but are deliberately **not** included here, to keep the diff reviewable:

- **`wp_insert_term()`** discards a slug of `"0"` — `! empty( $args['slug'] )` falls back to a slug derived from the name, so a category with slug `"0"` cannot currently be created through the API at all. (The new test forces the slug directly via `$wpdb` for this reason.)
- **`WP_Query::get_queried_object()`, the `is_tag` branch** — `elseif ( $tag )` has the identical problem for a tag slug of `"0"`. Not reachable as a reported bug today, partly because of the `wp_insert_term()` issue above.

Happy to fold either or both in, or open separate tickets, if reviewers prefer.

The `.html`-suffixed variant discussed in [comment:3](https://core.trac.wordpress.org/ticket/57858#comment:3)/[comment:4](https://core.trac.wordpress.org/ticket/57858#comment:4) and the pagination report in [comment:11](https://core.trac.wordpress.org/ticket/57858#comment:11) are not addressed here; the multi-segment cases from the original report (`/wp-content/0/` etc.) already 404 on current trunk.

Trac ticket: https://core.trac.wordpress.org/ticket/57858

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Investigation, implementation, and test drafting; the root cause was confirmed empirically by tracing the request through the local Docker environment, and the final code and tests were reviewed and verified by me.
