### PR TITLE
Build/Test Tools: Add a scoped Composer exception for the WPCS security advisory to unblock CI on the 7.0 branch.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
 		"yoast/phpunit-polyfills": "^1.1.0"
 	},
 	"config": {
+		"audit": { "ignore": [ "GHSA-3pwp-g2mj-5p3v" ] },
 		"allow-plugins": {
 			"dealerdirect/phpcodesniffer-composer-installer": true
 		},


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65739

This adds a scoped Composer audit exception for `GHSA-3pwp-g2mj-5p3v` to unblock dependency installation on the 7.0 branch.

It keeps WPCS at 3.3.0 and avoids introducing a broad coding-standards delta on the release branch.

## Testing

- `composer validate` passed, with the existing version-field warning.
- A fresh `composer install` resolved WPCS 3.3.0.
- `composer lint:errors` reported 35 existing errors. This change modifies only `composer.json`.
