### PR TITLE
Build/Test Tools: Add a scoped Composer exception for the WPCS security advisory to unblock CI on the 6.9 branch.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
 		"yoast/phpunit-polyfills": "^1.1.0"
 	},
 	"config": {
+		"audit": { "ignore": [ "GHSA-3pwp-g2mj-5p3v" ] },
 		"allow-plugins": {
 			"dealerdirect/phpcodesniffer-composer-installer": true
 		},


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65739

This adds a scoped Composer audit exception for `GHSA-3pwp-g2mj-5p3v` to unblock dependency installation on the 6.9 branch.

It keeps WPCS at 3.2.0 and avoids introducing a broad coding-standards delta on the release branch.

## Testing

- `composer validate` passed, with the existing version-field warning.
- A fresh `composer install` resolved WPCS 3.2.0.
- `composer lint:errors` could not complete under PHP 8.4.20 because PHPCS 3.13.2 raised a `ValueError` before producing results.
