### PR TITLE
Build/Test Tools: Reference reusable-prepare-gutenberg.yml at trunk in the 7.0 PHPUnit workflow

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -63,7 +63,7 @@ jobs:
   # them, because a job that needs a skipped job is skipped too, and a broader one
   # downloads a build that nothing consumes.
   prepare-gutenberg:
-    uses: WordPress/wordpress-develop/.github/workflows/reusable-prepare-gutenberg.yml@80fb78da3153431dee7e5d66e7463e71fda31ec7
+    uses: WordPress/wordpress-develop/.github/workflows/reusable-prepare-gutenberg.yml@trunk
     permissions:
       contents: read
     if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -63,7 +63,8 @@ jobs:
   # them, because a job that needs a skipped job is skipped too, and a broader one
   # downloads a build that nothing consumes.
   prepare-gutenberg:
-    uses: WordPress/wordpress-develop/.github/workflows/reusable-prepare-gutenberg.yml@trunk
+    # Keep the producer aligned with the consumer workflows that also follow trunk.
+    uses: WordPress/wordpress-develop/.github/workflows/reusable-prepare-gutenberg.yml@trunk # zizmor: ignore[unpinned-uses]
     permissions:
       contents: read
     if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}


### PR DESCRIPTION
This updates the 7.0 PHPUnit workflow to reference `reusable-prepare-gutenberg.yml@trunk` instead of a pinned commit SHA.

The `reusable-phpunit-tests-v3.yml` callers already use `@trunk`. Keeping both shared workflows on the same ref prevents their output contract from drifting and preserves the one-version-to-maintain intent.

No PHP matrix or caller wiring changed.

Trac ticket: https://core.trac.wordpress.org/ticket/65721

## Testing

- `actionlint .github/workflows/phpunit-tests.yml`
- `git diff --check`

## Use of AI Tools

AI assistance: Yes  
Tool(s): Codex  
Model(s): GPT-5  
Used for: Applied and validated the one-line workflow reference change. The final diff was reviewed by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request.**
