### PR TITLE
Build/Test Tools: Allow the PHPUnit runner to be set by a repository variable.

### DIFF
--- a/.github/workflows/reusable-phpunit-tests-v3.yml
+++ b/.github/workflows/reusable-phpunit-tests-v3.yml
@@ -129,7 +129,7 @@ jobs:
   # - Submit the test results to the WordPress.org host test results.
   phpunit-tests:
     name: ${{ ( inputs.phpunit-test-groups || inputs.coverage-report ) && format( 'PHP {0} with ', inputs.php ) || '' }} ${{ 'mariadb' == inputs.db-type && 'MariaDB' || 'MySQL' }} ${{ inputs.db-version }}${{ inputs.multisite && ' multisite' || '' }}${{ inputs.db-innovation && ' (innovation release)' || '' }}${{ inputs.memcached && ' with memcached' || '' }}${{ inputs.report && ' (test reporting enabled)' || '' }} ${{ 'example.org' != inputs.tests-domain && inputs.tests-domain || '' }}
-    runs-on: ${{ inputs.os }}
+    runs-on: ${{ vars.PHPUNIT_RUNNER || inputs.os }}
     timeout-minutes: ${{ inputs.coverage-report && 120 || inputs.php == '8.4' && 30 || 20 }}
     permissions:
       contents: read


### PR DESCRIPTION
Allows the PHPUnit runner to be directed by a repository variable, defaulting to the current runner.

`reusable-phpunit-tests-v3.yml` changes its `runs-on` to `${{ vars.PHPUNIT_RUNNER || inputs.os }}`. With the `PHPUNIT_RUNNER` variable unset (the default), jobs run on `inputs.os` (`ubuntu-24.04`) exactly as before. When a maintainer sets `PHPUNIT_RUNNER` to a runner label, the PHPUnit matrices run on that runner instead—useful for directing them to a dedicated runner during high-load release windows, without editing the workflow.

- No behavior change by default; the variable is unset.
- Backward-compatible for every branch that calls this workflow `@trunk`; no input is added or made required.
- `vars` is available in `runs-on`, so the override is valid.

Trac: https://core.trac.wordpress.org/ticket/65749
