### PR TITLE
Themes: Open and close the block theme document in get_header() and get_footer()

### DIFF
--- a/src/wp-includes/block-template.php
+++ b/src/wp-includes/block-template.php
@@ -234,6 +234,50 @@ function _block_template_render_title_tag() {
 }
 
 /**
+ * Prints the opening of the document a block theme renders into.
+ *
+ * Block themes have no header.php, so the markup that opens their documents lives in the
+ * template canvas rather than in the theme. Printing it from here lets anything that has to
+ * open a document on a block theme's behalf produce exactly what the canvas produces.
+ *
+ * @since 7.1.0
+ * @access private
+ */
+function _wp_block_theme_document_start() {
+	echo '<!DOCTYPE html>' . "\n";
+	echo '<html ';
+	language_attributes();
+	echo ">\n";
+	echo "<head>\n";
+	echo "\t" . '<meta charset="';
+	bloginfo( 'charset' );
+	echo '" />' . "\n";
+	echo "\t";
+	wp_head();
+	echo "</head>\n";
+	echo "\n";
+	echo '<body ';
+	body_class();
+	echo ">\n";
+	wp_body_open();
+}
+
+/**
+ * Prints the closing of the document a block theme renders into.
+ *
+ * The counterpart to _wp_block_theme_document_start().
+ *
+ * @since 7.1.0
+ * @access private
+ */
+function _wp_block_theme_document_end() {
+	echo "\n";
+	wp_footer();
+	echo "</body>\n";
+	echo "</html>\n";
+}
+
+/**
  * Returns the markup for the current template.
  *
  * @access private

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -45,6 +45,19 @@ function get_header( $name = null, $args = array() ) {
 
 	$templates[] = 'header.php';
 
+	/*
+	 * A block theme has no header.php by design, so locate_template() falls through to
+	 * wp-includes/theme-compat/header.php: markup deprecated since 3.0.0 that opens the
+	 * document with the old default theme's page frame and its site title and description.
+	 * Print the same document opening the template canvas uses instead, so a block theme
+	 * gets its own markup whether the page is rendered by a block template or by a caller
+	 * of this function.
+	 */
+	if ( wp_is_block_theme() && ! _wp_theme_has_template( $templates ) ) {
+		_wp_block_theme_document_start();
+		return;
+	}
+
 	if ( ! locate_template( $templates, true, true, $args ) ) {
 		return false;
 	}
@@ -88,6 +101,12 @@ function get_footer( $name = null, $args = array() ) {
 	}
 
 	$templates[] = 'footer.php';
+
+	// See get_header(): block themes close their document the way the canvas does.
+	if ( wp_is_block_theme() && ! _wp_theme_has_template( $templates ) ) {
+		_wp_block_theme_document_end();
+		return;
+	}
 
 	if ( ! locate_template( $templates, true, true, $args ) ) {
 		return false;

--- a/src/wp-includes/template-canvas.php
+++ b/src/wp-includes/template-canvas.php
@@ -10,18 +10,10 @@
  * This needs to run before <head> so that blocks can add scripts and styles in wp_head().
  */
 $template_html = get_the_block_template_html();
-?><!DOCTYPE html>
-<html <?php language_attributes(); ?>>
-<head>
-	<meta charset="<?php bloginfo( 'charset' ); ?>" />
-	<?php wp_head(); ?>
-</head>
 
-<body <?php body_class(); ?>>
-<?php wp_body_open(); ?>
+_wp_block_theme_document_start();
+?>
 
 <?php echo $template_html; ?>
-
-<?php wp_footer(); ?>
-</body>
-</html>
+<?php
+_wp_block_theme_document_end();

--- a/src/wp-includes/template.php
+++ b/src/wp-includes/template.php
@@ -753,6 +753,40 @@ function locate_template( $template_names, $load = false, $load_once = true, $ar
 }
 
 /**
+ * Determines whether the active theme provides one of the given template files.
+ *
+ * Unlike locate_template(), this ignores the deprecated fallbacks in wp-includes/theme-compat/,
+ * so a caller can tell a template the theme actually ships from one of those.
+ *
+ * @since 7.1.0
+ * @access private
+ *
+ * @param string[] $template_names Template file names to look for, in order of priority.
+ * @return bool Whether the theme, or its parent, provides one of the templates.
+ */
+function _wp_theme_has_template( $template_names ) {
+	$stylesheet_path = get_stylesheet_directory();
+	$template_path   = get_template_directory();
+	$is_child_theme  = $stylesheet_path !== $template_path;
+
+	foreach ( (array) $template_names as $template_name ) {
+		if ( ! $template_name ) {
+			continue;
+		}
+
+		if ( file_exists( $stylesheet_path . '/' . $template_name ) ) {
+			return true;
+		}
+
+		if ( $is_child_theme && file_exists( $template_path . '/' . $template_name ) ) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/**
  * Requires the template file with WordPress environment.
  *
  * The globals are set up for the template file to ensure that the WordPress

--- a/tests/phpunit/tests/general/template.php
+++ b/tests/phpunit/tests/general/template.php
@@ -750,6 +750,83 @@ class Tests_General_Template extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that a block theme opens its own document rather than the deprecated fallback.
+	 *
+	 * A block theme ships no header.php, so locate_template() reaches
+	 * wp-includes/theme-compat/header.php, whose markup opens the page with the old default
+	 * theme's frame, site title and description.
+	 *
+	 * @ticket 55023
+	 *
+	 * @covers ::get_header
+	 */
+	public function test_get_header_uses_block_theme_document_when_theme_has_no_header() {
+		switch_theme( 'block-theme' );
+
+		$output = get_echo( 'get_header' );
+
+		$this->assertStringContainsString( '<!DOCTYPE html>', $output, 'The document should be opened.' );
+		$this->assertStringContainsString( '<body', $output, 'The body element should be opened.' );
+		$this->assertStringNotContainsString( 'id="page"', $output, 'The theme-compat page frame should not be printed.' );
+		$this->assertStringNotContainsString( 'id="header"', $output, 'The theme-compat header should not be printed.' );
+	}
+
+	/**
+	 * Tests that a block theme closes the document it opened.
+	 *
+	 * @ticket 55023
+	 *
+	 * @covers ::get_footer
+	 */
+	public function test_get_footer_uses_block_theme_document_when_theme_has_no_footer() {
+		switch_theme( 'block-theme' );
+
+		// As a page does: wp_head() is where the back-compat skip link action is unhooked.
+		get_echo( 'get_header' );
+		$output = get_echo( 'get_footer' );
+
+		$this->assertStringContainsString( '</body>', $output, 'The body element should be closed.' );
+		$this->assertStringContainsString( '</html>', $output, 'The document should be closed.' );
+		$this->assertStringNotContainsString( 'proudly powered by', $output, 'The theme-compat footer should not be printed.' );
+		$this->assertStringNotContainsString( 'id="footer"', $output, 'The theme-compat footer should not be printed.' );
+	}
+
+	/**
+	 * Tests that the deprecation notice for a missing header.php is not raised for block themes,
+	 * which are not expected to provide one.
+	 *
+	 * @ticket 55023
+	 *
+	 * @covers ::get_header
+	 */
+	public function test_get_header_does_not_deprecate_for_block_theme() {
+		switch_theme( 'block-theme' );
+
+		// Would trigger the deprecation notice handled by WP_UnitTestCase and fail the test.
+		get_echo( 'get_header' );
+
+		$this->assertTrue( wp_is_block_theme(), 'The test should run on a block theme.' );
+	}
+
+	/**
+	 * Tests that a classic theme without header.php keeps the deprecated fallback, so themes
+	 * relying on it are unaffected. camelCase is a classic fixture theme with no header.php.
+	 *
+	 * @ticket 55023
+	 *
+	 * @expectedDeprecated Theme without header.php
+	 *
+	 * @covers ::get_header
+	 */
+	public function test_get_header_still_falls_back_for_classic_theme() {
+		switch_theme( 'camelCase' );
+
+		$output = get_echo( 'get_header' );
+
+		$this->assertStringContainsString( 'id="page"', $output, 'The theme-compat markup should still be printed for classic themes.' );
+	}
+
+	/**
 	 * @ticket 40969
 	 *
 	 * @covers ::get_sidebar


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/55023

## The problem, seen in production

I found this in the served markup of my own news site, which runs a block theme:

```html
<!-- Gorgeous design by Michael Heilemann - http://binarybonsai.com/ -->
```

Tracing it back, a plugin of mine serves several routes from PHP and calls `get_header()` and `get_footer()` around its own markup, which plugins are allowed to do. A block theme ships no `header.php` or `footer.php`, so `locate_template()` falls through to `wp-includes/theme-compat/`, and those routes were being served like this:

```html
<div id="page">
<div id="header" role="banner">
	<div id="headerimg">
		<h1><a href="https://example.com/">Site name</a></h1>
		<div class="description">Tagline</div>
	</div>
</div>
<hr />
...
<div id="footer" role="contentinfo">
	<p>Site name is proudly powered by <a href="https://wordpress.org/">WordPress</a></p>
</div>
</div>

<!-- Gorgeous design by Michael Heilemann - http://binarybonsai.com/ -->
```

Eight public URLs were affected. My own header and footer were nowhere in the markup; in their place were the old default theme's page frame, a duplicate site title and tagline, a "proudly powered by WordPress" promo, and a design credit for a theme the site has never used. The deprecation notice discussed on this ticket is that same fallback announcing itself. The markup is what visitors and crawlers actually received.

`wp-signup.php` and `wp-activate.php` reach the same fallback inside core, which is where the ticket started.

## The change

`get_header()` and `get_footer()` now print the document opening and closing that the template canvas already uses, whenever the active theme is a block theme providing no template of its own. A block theme therefore opens the same document whether the page is rendered by a block template or by a caller of these functions.

Classic themes are untouched: with no `header.php` they still reach `wp-includes/theme-compat/` and still raise the deprecation notice, which for them remains correct advice.

This follows the approach the ticket converged on in comment 23, that the markup needed is the one in `template-canvas.php`, rather than `block_header_area()` / `block_footer_area()`, which cannot open and close a document and were argued against there for exactly that reason.

- `_wp_block_theme_document_start()` and `_wp_block_theme_document_end()` in `block-template.php` hold the document markup so it has a single definition. `template-canvas.php` calls them, and its output is byte for byte unchanged.
- `_wp_theme_has_template()` in `template.php` answers whether the theme itself provides a template, which `locate_template()` cannot be asked, since it is the function doing the falling back.

## Tests

Four tests added to `tests/phpunit/tests/general/template.php`:

- a block theme's `get_header()` opens a document and prints none of the theme-compat frame;
- its `get_footer()` closes the document and prints no "proudly powered by";
- no deprecation notice is raised for a block theme;
- a classic theme with no `header.php` still gets the fallback and still raises the notice.

Run against trunk:

```
tests/phpunit/tests/general/template.php   OK (39 tests, 84 assertions)
tests/phpunit/tests/theme.php              OK (93 tests, 5562 assertions)
tests/phpunit/tests/template.php           OK (86 tests, 464 assertions)
Block template classes                     OK (136 tests, 339 assertions)
```

`phpcs` is clean on every changed file.

## Notes

- Nothing here changes what block themes already render. The canvas output is identical; only the path that previously produced theme-compat markup behaves differently.
- The deprecation notice stays where it belongs. Silencing it for block themes without giving them an alternative was raised and rejected in comments 22 and 23, as that un-deprecates files which should not be loaded at all.
- If the shared helpers would be better public, or living somewhere other than `block-template.php`, I'm happy to move them.
