### PR TITLE
Script Loader: Guard compression_test() with manage_options check

### DIFF
--- a/src/wp-admin/includes/template.php
+++ b/src/wp-admin/includes/template.php
@@ -2495,6 +2495,9 @@ function get_media_states( $post ) {
  * @since 2.8.0
  */
 function compression_test() {
+	if ( ! current_user_can( 'manage_options' ) ) {
+		return;
+	}
 	?>
 	<script>
 	var compressionNonce = <?php echo wp_json_encode( wp_create_nonce( 'update_can_compress_scripts' ), JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ); ?>;

--- a/tests/phpunit/tests/admin/includesTemplate.php
+++ b/tests/phpunit/tests/admin/includesTemplate.php
@@ -547,4 +547,41 @@ class Tests_Admin_IncludesTemplate extends WP_UnitTestCase {
 			'raw button-compact unchanged' => array( 'button-compact', 'button button-compact' ),
 		);
 	}
+
+	/**
+	 * Tests that compression_test() has no effect for users who cannot
+	 * manage_options, matching its own documented behavior.
+	 *
+	 * @ticket 65750
+	 *
+	 * @covers ::compression_test
+	 */
+	public function test_compression_test_outputs_nothing_for_user_without_manage_options() {
+		wp_set_current_user( self::$editor_id );
+
+		ob_start();
+		compression_test();
+		$output = ob_get_clean();
+
+		$this->assertSame( '', $output );
+	}
+
+	/**
+	 * Tests that compression_test() still outputs the test script for
+	 * users who can manage_options.
+	 *
+	 * @ticket 65750
+	 *
+	 * @covers ::compression_test
+	 */
+	public function test_compression_test_outputs_script_for_user_with_manage_options() {
+		$admin_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+
+		ob_start();
+		compression_test();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'testCompression', $output );
+	}
 }


### PR DESCRIPTION
`compression_test()` is called from `wp-admin/admin-footer.php` for every user who can access wp-admin, whenever the `can_compress_scripts` option is unset — not only administrators. It outputs a `<script>` block that fires AJAX requests to the `wp-compression-test` action, but that AJAX handler (`wp_ajax_wp_compression_test()`) requires the `manage_options` capability, so non-admin users (e.g. Editors) get `-1` responses and can never actually resolve the test. This also contradicts the function's own docblock, which states it "Has no effect when the current user is not an administrator."

This PR adds a `current_user_can( 'manage_options' )` check at the top of `compression_test()` so it returns early — and outputs nothing — for users who can't act on the result, matching the documented behavior. Administrators are unaffected.

Trac ticket: https://core.trac.wordpress.org/ticket/65750

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Sonnet 5
Used for: Implementation, tests, and PR description. Reviewed by Igor Rozum.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**