### PR TITLE
Media: Add unit tests for wp_get_registered_image_subsizes()

### DIFF
--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -1401,6 +1401,9 @@ VIDEO;
 		remove_image_size( 'test-size' );
 	}
 
+	/**
+	 * @ticket 65751
+	 */
 	public function test_wp_get_registered_image_subsizes_includes_custom_size() {
 		add_image_size( 'test-size', 200, 600 );
 
@@ -1415,6 +1418,9 @@ VIDEO;
 		$this->assertFalse( $sizes['test-size']['crop'] );
 	}
 
+	/**
+	 * @ticket 65751
+	 */
 	public function test_wp_get_registered_image_subsizes_preserves_crop_position() {
 		add_image_size( 'test-size', 200, 600, array( 'center', 'top' ) );
 
@@ -1426,6 +1432,9 @@ VIDEO;
 		$this->assertSame( array( 'center', 'top' ), $sizes['test-size']['crop'] );
 	}
 
+	/**
+	 * @ticket 65751
+	 */
 	public function test_wp_get_registered_image_subsizes_omits_size_with_no_dimensions() {
 		add_image_size( 'test-size', 0, 0 );
 
@@ -1437,6 +1446,9 @@ VIDEO;
 		$this->assertArrayNotHasKey( 'test-size', $sizes );
 	}
 
+	/**
+	 * @ticket 65751
+	 */
 	public function test_wp_get_registered_image_subsizes_honors_intermediate_image_sizes_filter() {
 		add_image_size( 'test-size', 200, 600 );
 

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -1401,6 +1401,59 @@ VIDEO;
 		remove_image_size( 'test-size' );
 	}
 
+	public function test_wp_get_registered_image_subsizes_includes_custom_size() {
+		add_image_size( 'test-size', 200, 600 );
+
+		$sizes = wp_get_registered_image_subsizes();
+
+		// Clean up.
+		remove_image_size( 'test-size' );
+
+		$this->assertArrayHasKey( 'test-size', $sizes );
+		$this->assertSame( 200, $sizes['test-size']['width'] );
+		$this->assertSame( 600, $sizes['test-size']['height'] );
+		$this->assertFalse( $sizes['test-size']['crop'] );
+	}
+
+	public function test_wp_get_registered_image_subsizes_preserves_crop_position() {
+		add_image_size( 'test-size', 200, 600, array( 'center', 'top' ) );
+
+		$sizes = wp_get_registered_image_subsizes();
+
+		// Clean up.
+		remove_image_size( 'test-size' );
+
+		$this->assertSame( array( 'center', 'top' ), $sizes['test-size']['crop'] );
+	}
+
+	public function test_wp_get_registered_image_subsizes_omits_size_with_no_dimensions() {
+		add_image_size( 'test-size', 0, 0 );
+
+		$sizes = wp_get_registered_image_subsizes();
+
+		// Clean up.
+		remove_image_size( 'test-size' );
+
+		$this->assertArrayNotHasKey( 'test-size', $sizes );
+	}
+
+	public function test_wp_get_registered_image_subsizes_honors_intermediate_image_sizes_filter() {
+		add_image_size( 'test-size', 200, 600 );
+
+		$exclude_test_size = static function ( $sizes ) {
+			return array_diff( $sizes, array( 'test-size' ) );
+		};
+		add_filter( 'intermediate_image_sizes', $exclude_test_size );
+
+		$sizes = wp_get_registered_image_subsizes();
+
+		// Clean up.
+		remove_filter( 'intermediate_image_sizes', $exclude_test_size );
+		remove_image_size( 'test-size' );
+
+		$this->assertArrayNotHasKey( 'test-size', $sizes );
+	}
+
 	/**
 	 * @ticket 30346
 	 */


### PR DESCRIPTION
`wp_get_registered_image_subsizes()` (`wp-includes/media.php`, since 5.3.0) had no PHPUnit coverage at all. It's a pure function that composes `get_intermediate_image_sizes()` and `wp_get_additional_image_sizes()` into a normalized `{width, height, crop}` array per registered image size, so it's straightforward to pin down. This adds 4 tests to `Tests_Media`:

- A custom size registered via `add_image_size()` shows up with the correct width/height and `crop` as `false`.
- A size registered with a crop **position** (e.g. `array( 'center', 'top' )`) preserves that array rather than coercing it to a bool.
- A size with no width/height set is omitted from the result entirely.
- The `intermediate_image_sizes` filter can exclude a size from the result.

This is a test-only change — no production behavior is added or modified. Each test was verified to actually constrain the code: I temporarily broke the corresponding logic in `wp_get_registered_image_subsizes()` (inverting the crop bool cast, disabling the zero-dimension skip, disabling the filter application) and confirmed the relevant test went red, then restored the original and confirmed green again.

Ran the full `Tests_Media` class (453 tests) after adding these — no regressions. Lint and PHPStan clean.

Trac ticket: https://core.trac.wordpress.org/ticket/65751

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Identifying the coverage gap, implementation, and mutation-testing verification of each assertion. Reviewed by @irozum.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
