### PR TITLE
Media: Support cropping remote images when URL fopen is disabled

### DIFF
--- a/src/wp-admin/includes/image.php
+++ b/src/wp-admin/includes/image.php
@@ -24,7 +24,10 @@
  */
 function wp_crop_image( $src, $src_x, $src_y, $src_w, $src_h, $dst_w, $dst_h, $src_abs = false, $dst_file = false ) {
 	$src_file = $src;
-	if ( is_numeric( $src ) ) { // Handle int as attachment ID.
+	$tmp_file = false;
+
+	// Handle int as attachment ID.
+	if ( is_numeric( $src ) ) {
 		$src_file = get_attached_file( $src );
 
 		if ( ! file_exists( $src_file ) ) {
@@ -38,7 +41,25 @@ function wp_crop_image( $src, $src_x, $src_y, $src_w, $src_h, $dst_w, $dst_h, $s
 		}
 	}
 
+	if ( wp_http_validate_url( $src ) ) {
+		if ( ! function_exists( 'download_url' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/file.php';
+		}
+
+		$tmp_file = download_url( $src );
+		if ( is_wp_error( $tmp_file ) ) {
+			return $tmp_file;
+		}
+
+		$src = $tmp_file;
+	}
+
 	$editor = wp_get_image_editor( $src );
+
+	if ( $tmp_file ) {
+		wp_delete_file( $tmp_file );
+	}
+
 	if ( is_wp_error( $editor ) ) {
 		return $editor;
 	}

--- a/src/wp-admin/includes/image.php
+++ b/src/wp-admin/includes/image.php
@@ -51,6 +51,10 @@ function wp_crop_image( $src, $src_x, $src_y, $src_w, $src_h, $dst_w, $dst_h, $s
 			return $tmp_file;
 		}
 
+		if ( wp_http_validate_url( $src_file ) ) {
+			$src_file = $tmp_file;
+		}
+
 		$src = $tmp_file;
 	}
 

--- a/tests/phpunit/tests/image/functions.php
+++ b/tests/phpunit/tests/image/functions.php
@@ -636,13 +636,30 @@ class Tests_Image_Functions extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 42064
+	 *
 	 * @covers ::wp_crop_image
 	 * @requires function imagejpeg
-	 * @requires extension openssl
 	 */
 	public function test_wp_crop_image_with_url() {
+		$mock_image_download = static function ( $response, $args ) {
+			copy( DIR_TESTDATA . '/images/canola.jpg', $args['filename'] );
+
+			return array(
+				'response' => array(
+					'code'    => 200,
+					'message' => 'OK',
+				),
+				'headers'  => array(),
+				'cookies'  => array(),
+				'body'     => '',
+			);
+		};
+
+		add_filter( 'pre_http_request', $mock_image_download, 10, 2 );
+
 		$file = wp_crop_image(
-			'https://s.w.org/screenshots/3.9/dashboard.png',
+			'https://example.org/canola.jpg',
 			0,
 			0,
 			100,
@@ -653,9 +670,7 @@ class Tests_Image_Functions extends WP_UnitTestCase {
 			DIR_TESTDATA . '/images/' . __FUNCTION__ . '.png'
 		);
 
-		if ( is_wp_error( $file ) && $file->get_error_code() === 'invalid_image' ) {
-			$this->markTestSkipped( 'Tests_Image_Functions::test_wp_crop_image_url() cannot access remote image.' );
-		}
+		remove_filter( 'pre_http_request', $mock_image_download, 10 );
 
 		$this->assertNotWPError( $file, 'Cropping the image resulted in a WP_Error.' );
 		$this->assertFileExists( $file, "The file $file does not exist." );

--- a/tests/phpunit/tests/image/functions.php
+++ b/tests/phpunit/tests/image/functions.php
@@ -642,8 +642,15 @@ class Tests_Image_Functions extends WP_UnitTestCase {
 	 * @requires function imagejpeg
 	 */
 	public function test_wp_crop_image_with_url() {
-		$mock_image_download = static function ( $response, $args ) {
-			copy( DIR_TESTDATA . '/images/canola.jpg', $args['filename'] );
+		$url                 = 'https://example.org/canola.jpg';
+		$mock_image_download = static function ( $response, $args, $requested_url ) use ( $url ) {
+			if ( $url !== $requested_url ) {
+				return $response;
+			}
+
+			if ( empty( $args['filename'] ) || ! copy( DIR_TESTDATA . '/images/canola.jpg', $args['filename'] ) ) {
+				return new WP_Error( 'copy_failed', 'Could not copy the image fixture.' );
+			}
 
 			return array(
 				'response' => array(
@@ -656,21 +663,21 @@ class Tests_Image_Functions extends WP_UnitTestCase {
 			);
 		};
 
-		add_filter( 'pre_http_request', $mock_image_download, 10, 2 );
+		add_filter( 'pre_http_request', $mock_image_download, 10, 3 );
 
-		$file = wp_crop_image(
-			'https://example.org/canola.jpg',
-			0,
-			0,
-			100,
-			100,
-			100,
-			100,
-			false,
-			DIR_TESTDATA . '/images/' . __FUNCTION__ . '.png'
-		);
-
-		remove_filter( 'pre_http_request', $mock_image_download, 10 );
+		try {
+			$file = wp_crop_image(
+				$url,
+				0,
+				0,
+				100,
+				100,
+				100,
+				100
+			);
+		} finally {
+			remove_filter( 'pre_http_request', $mock_image_download, 10 );
+		}
 
 		$this->assertNotWPError( $file, 'Cropping the image resulted in a WP_Error.' );
 		$this->assertFileExists( $file, "The file $file does not exist." );


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

## Summary
- download remote crop sources through the WordPress HTTP API
- remove the temporary source file after the image editor loads it
- replace the external-network crop test with a deterministic HTTP mock

## Testing
- PHP lint for both changed files
- PHPCBF and PHPCS for both changed files
- focused PHPUnit with allow_url_fopen=0: 1 test, 4 assertions
- Tests_Image_Functions: 113 tests, 211 assertions

Trac ticket: https://core.trac.wordpress.org/ticket/42064

## Use of AI Tools

AI assistance: Yes
Tool(s): OpenAI Codex
Model(s): GPT-5
Used for: Reviewing the Trac ticket and relevant code, helping with the initial implementation and regression-test approach, and assisting with validation and PR-description drafting. The final implementation, tests, validation results, and description were reviewed and accepted by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**