### PR TITLE
General: Bump the pinned hash for Gutenberg to `fd715a6`

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"url": "https://develop.svn.wordpress.org/trunk"
 	},
 	"gutenberg": {
-		"sha": "4997026b75c922d8a6f77a03d72ed7cad04c7073",
+		"sha": "f65b5d553a42fa8a21b98e488b0f1f82819b4257",
 		"ghcrRepo": "WordPress/gutenberg/gutenberg-wp-develop-build"
 	},
 	"engines": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"url": "https://develop.svn.wordpress.org/trunk"
 	},
 	"gutenberg": {
-		"sha": "f65b5d553a42fa8a21b98e488b0f1f82819b4257",
+		"sha": "fd715a6833679d098d9fee84b642f8f1bc27341b",
 		"ghcrRepo": "WordPress/gutenberg/gutenberg-wp-develop-build"
 	},
 	"engines": {

--- a/src/wp-includes/assets/script-loader-packages.php
+++ b/src/wp-includes/assets/script-loader-packages.php
@@ -104,7 +104,7 @@
 			'wp-url',
 			'wp-warning'
 		),
-		'version' => '77626afea4a1cac03204'
+		'version' => 'b1292aac86a5d819f737'
 	),
 	'block-library.js' => array(
 		'dependencies' => array(
@@ -150,7 +150,7 @@
 				'import' => 'dynamic'
 			)
 		),
-		'version' => 'd24e08348f91bcfce1b7'
+		'version' => '97b70e2d8d72d9b83b4e'
 	),
 	'block-serialization-default-parser.js' => array(
 		'dependencies' => array(
@@ -183,7 +183,7 @@
 			'wp-shortcode',
 			'wp-warning'
 		),
-		'version' => 'dc4bdf700024000fd427'
+		'version' => '524509cfc84da30a4133'
 	),
 	'commands.js' => array(
 		'dependencies' => array(
@@ -224,7 +224,7 @@
 			'wp-theme',
 			'wp-warning'
 		),
-		'version' => 'd54375c07776a218ee99'
+		'version' => 'd5254b2fdf63282d09f7'
 	),
 	'compose.js' => array(
 		'dependencies' => array(
@@ -306,7 +306,7 @@
 			'wp-theme',
 			'wp-widgets'
 		),
-		'version' => 'f28ae391ffd39b8db426'
+		'version' => '05ff2e24b332f5dc0ea1'
 	),
 	'data.js' => array(
 		'dependencies' => array(
@@ -346,7 +346,7 @@
 		'dependencies' => array(
 			'wp-deprecated'
 		),
-		'version' => '22d969bde5c7182cdd2f'
+		'version' => 'e13e9a880cb4f091f98e'
 	),
 	'dom-ready.js' => array(
 		'dependencies' => array(
@@ -396,7 +396,7 @@
 				'import' => 'static'
 			)
 		),
-		'version' => '4aeb2f3aa372be39adb2'
+		'version' => '823ecf7905c05ce03022'
 	),
 	'edit-site.js' => array(
 		'dependencies' => array(
@@ -446,7 +446,7 @@
 				'import' => 'static'
 			)
 		),
-		'version' => 'c33d508cfc124b1b3e2d'
+		'version' => '64590e045eedae65347d'
 	),
 	'edit-widgets.js' => array(
 		'dependencies' => array(
@@ -487,7 +487,7 @@
 				'import' => 'static'
 			)
 		),
-		'version' => 'b6608ebdd73ddae5a250'
+		'version' => '9d38df85a4b408821722'
 	),
 	'editor.js' => array(
 		'dependencies' => array(
@@ -537,7 +537,7 @@
 				'import' => 'static'
 			)
 		),
-		'version' => 'cf691bc72eeac5643913'
+		'version' => '2f1a5efaa6f78167e6c7'
 	),
 	'element.js' => array(
 		'dependencies' => array(
@@ -794,7 +794,7 @@
 			'wp-keycodes',
 			'wp-private-apis'
 		),
-		'version' => '1c4b61567c93d486f1dc'
+		'version' => '9f145f4a11c41d022c83'
 	),
 	'router.js' => array(
 		'dependencies' => array(

--- a/src/wp-includes/assets/script-modules-packages.php
+++ b/src/wp-includes/assets/script-modules-packages.php
@@ -76,7 +76,7 @@
 				'import' => 'static'
 			)
 		),
-		'version' => '96a846e1d7b789c39ab9'
+		'version' => '1bf28ded04f9f188bdcb'
 	),
 	'block-library/playlist/view.js' => array(
 		'dependencies' => array(
@@ -315,7 +315,7 @@
 			'wp-private-apis',
 			'wp-style-engine'
 		),
-		'version' => '9d008e280440935933bc'
+		'version' => '0e40b71e65fda1397a4b'
 	),
 	'route/index.js' => array(
 		'dependencies' => array(

--- a/src/wp-includes/blocks/blocks-json.php
+++ b/src/wp-includes/blocks/blocks-json.php
@@ -4812,7 +4812,6 @@
 				'full'
 			),
 			'splitting' => true,
-			'editableRoot' => true,
 			'anchor' => true,
 			'className' => false,
 			'__experimentalBorder' => array(

--- a/src/wp-includes/blocks/navigation.php
+++ b/src/wp-includes/blocks/navigation.php
@@ -1250,7 +1250,7 @@ function block_core_navigation_add_directives_to_submenu( $tags, $block_attribut
 			)
 		) ) {
 			$tags->set_attribute( 'data-wp-on--click', 'actions.toggleMenuOnClick' );
-			$tags->set_attribute( 'data-wp-bind--aria-expanded', 'state.isMenuOpen' );
+			$tags->set_attribute( 'data-wp-bind--aria-expanded', 'state.isSubmenuOpen' );
 			// The `aria-expanded` attribute for SSR is already added in the submenu block.
 		}
 		// Add directives to the submenu.

--- a/src/wp-includes/blocks/paragraph/block.json
+++ b/src/wp-includes/blocks/paragraph/block.json
@@ -29,7 +29,6 @@
 	"supports": {
 		"align": [ "wide", "full" ],
 		"splitting": true,
-		"editableRoot": true,
 		"anchor": true,
 		"className": false,
 		"__experimentalBorder": {

--- a/src/wp-includes/build/pages/font-library/page-wp-admin.php
+++ b/src/wp-includes/build/pages/font-library/page-wp-admin.php
@@ -87,9 +87,10 @@ function wp_get_font_library_wp_admin_menu_items() {
  */
 function wp_font_library_wp_admin_preload_data() {
 	// Define paths to preload - same for all pages
-	// Please also change packages/core-data/src/entities.js when changing this.
+	// This must exactly match the _fields list in packages/core-data/src/entities.js,
+	// same fields in the same order, or the preload is never consumed.
 	$preload_paths = array(
-		'/?_fields=description,gmt_offset,home,image_sizes,image_size_threshold,name,site_icon,site_icon_url,site_logo,timezone_string,url,page_for_posts,page_on_front,show_on_front',
+		'/?_fields=description,gmt_offset,home,image_max_bit_depth,image_sizes,image_size_threshold,image_strip_meta,name,site_icon,site_icon_url,site_logo,timezone_string,url,page_for_posts,page_on_front,show_on_front',
 		array( '/wp/v2/settings', 'OPTIONS' ),
 	);
 

--- a/src/wp-includes/build/pages/font-library/page-wp-admin.php
+++ b/src/wp-includes/build/pages/font-library/page-wp-admin.php
@@ -270,23 +270,23 @@ function wp_font_library_wp_admin_render_page() {
 		#wpwrap {
 			overflow-y: auto;
 		}
-		body {
+		body.js {
 			background: #fff;
 		}
 
 		/* Reset wp-admin padding */
-		#wpcontent {
+		body.js #wpcontent {
 			padding-inline-start: 0;
 		}
-		#wpbody-content {
+		body.js #wpbody-content {
 			padding-bottom: 0;
 		}
 
 		/* Hide legacy admin elements */
-		#wpbody-content > div:not(.boot-layout-container):not(#screen-meta) {
+		body.js #wpbody-content > div:not(.boot-layout-container):not(#screen-meta) {
 			display: none;
 		}
-		#wpfooter {
+		body.js #wpfooter {
 			display: none;
 		}
 

--- a/src/wp-includes/build/pages/font-library/page.php
+++ b/src/wp-includes/build/pages/font-library/page.php
@@ -88,9 +88,10 @@ function wp_get_font_library_menu_items() {
  */
 function wp_font_library_preload_data() {
 	// Define paths to preload - same for all pages
-	// Please also change packages/core-data/src/entities.js when changing this.
+	// This must exactly match the _fields list in packages/core-data/src/entities.js,
+	// same fields in the same order, or the preload is never consumed.
 	$preload_paths = array(
-		'/?_fields=description,gmt_offset,home,image_sizes,image_size_threshold,name,site_icon,site_icon_url,site_logo,timezone_string,url,page_for_posts,page_on_front,show_on_front',
+		'/?_fields=description,gmt_offset,home,image_max_bit_depth,image_sizes,image_size_threshold,image_strip_meta,name,site_icon,site_icon_url,site_logo,timezone_string,url,page_for_posts,page_on_front,show_on_front',
 		array( '/wp/v2/settings', 'OPTIONS' ),
 	);
 

--- a/src/wp-includes/build/pages/options-connectors/page-wp-admin.php
+++ b/src/wp-includes/build/pages/options-connectors/page-wp-admin.php
@@ -87,9 +87,10 @@ function wp_get_options_connectors_wp_admin_menu_items() {
  */
 function wp_options_connectors_wp_admin_preload_data() {
 	// Define paths to preload - same for all pages
-	// Please also change packages/core-data/src/entities.js when changing this.
+	// This must exactly match the _fields list in packages/core-data/src/entities.js,
+	// same fields in the same order, or the preload is never consumed.
 	$preload_paths = array(
-		'/?_fields=description,gmt_offset,home,image_sizes,image_size_threshold,name,site_icon,site_icon_url,site_logo,timezone_string,url,page_for_posts,page_on_front,show_on_front',
+		'/?_fields=description,gmt_offset,home,image_max_bit_depth,image_sizes,image_size_threshold,image_strip_meta,name,site_icon,site_icon_url,site_logo,timezone_string,url,page_for_posts,page_on_front,show_on_front',
 		array( '/wp/v2/settings', 'OPTIONS' ),
 	);
 

--- a/src/wp-includes/build/pages/options-connectors/page-wp-admin.php
+++ b/src/wp-includes/build/pages/options-connectors/page-wp-admin.php
@@ -270,23 +270,23 @@ function wp_options_connectors_wp_admin_render_page() {
 		#wpwrap {
 			overflow-y: auto;
 		}
-		body {
+		body.js {
 			background: #fff;
 		}
 
 		/* Reset wp-admin padding */
-		#wpcontent {
+		body.js #wpcontent {
 			padding-inline-start: 0;
 		}
-		#wpbody-content {
+		body.js #wpbody-content {
 			padding-bottom: 0;
 		}
 
 		/* Hide legacy admin elements */
-		#wpbody-content > div:not(.boot-layout-container):not(#screen-meta) {
+		body.js #wpbody-content > div:not(.boot-layout-container):not(#screen-meta) {
 			display: none;
 		}
-		#wpfooter {
+		body.js #wpfooter {
 			display: none;
 		}
 

--- a/src/wp-includes/build/pages/options-connectors/page.php
+++ b/src/wp-includes/build/pages/options-connectors/page.php
@@ -88,9 +88,10 @@ function wp_get_options_connectors_menu_items() {
  */
 function wp_options_connectors_preload_data() {
 	// Define paths to preload - same for all pages
-	// Please also change packages/core-data/src/entities.js when changing this.
+	// This must exactly match the _fields list in packages/core-data/src/entities.js,
+	// same fields in the same order, or the preload is never consumed.
 	$preload_paths = array(
-		'/?_fields=description,gmt_offset,home,image_sizes,image_size_threshold,name,site_icon,site_icon_url,site_logo,timezone_string,url,page_for_posts,page_on_front,show_on_front',
+		'/?_fields=description,gmt_offset,home,image_max_bit_depth,image_sizes,image_size_threshold,image_strip_meta,name,site_icon,site_icon_url,site_logo,timezone_string,url,page_for_posts,page_on_front,show_on_front',
 		array( '/wp/v2/settings', 'OPTIONS' ),
 	);
 


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65529

This ticket is for syncing the changes between `4997026b75c922d8a6f77a03d72ed7cad04c7073` into `wordpress-develop` (`fd715a6833679d098d9fee84b642f8f1bc27341b`).

Diff: https://github.com/WordPress/gutenberg/compare/4997026b75c922d8a6f77a03d72ed7cad04c7073...fd715a6833679d098d9fee84b642f8f1bc27341b

- Update view config API versioning (https://github.com/WordPress/gutenberg/pull/80319)
- Perf Tests: Fix 'Selecting blocks' metric reporting 0 ms (https://github.com/WordPress/gutenberg/pull/80524)
- Notes: Register the inline note format at import time (https://github.com/WordPress/gutenberg/pull/80576)
- Media: Stop forcing crossorigin on IMG tags in media templates (https://github.com/WordPress/gutenberg/pull/80532)
- GradientPicker: select by slug so two presets sharing a gradient keep their identity (https://github.com/WordPress/gutenberg/pull/80554)
- Media Editor: Show a loading state while the cropped file loads (https://github.com/WordPress/gutenberg/pull/80460)
- Remove default paragraph from tab-panel template (https://github.com/WordPress/gutenberg/pull/80565)
- Global Styles: Resolve link element styles in block inspector controls for blocks that are links (https://github.com/WordPress/gutenberg/pull/80607)
- Media REST API: Backport sideload from url path upload size check (https://github.com/WordPress/gutenberg/pull/80659)
- Rich text: remove tabIndex from editable elements again to fix shift+click selection (https://github.com/WordPress/gutenberg/pull/80651)
- Gallery: make dynamic mode conversion a single undo level (https://github.com/WordPress/gutenberg/pull/80665)
- Background image control: Remove duplicated focus ring (https://github.com/WordPress/gutenberg/pull/80671)
- Detach core's note mention kses filter in the baseline strip test (https://github.com/WordPress/gutenberg/pull/80656)
- wp-build: sync the page template preload field list with core-data (https://github.com/WordPress/gutenberg/pull/80648)
- Read the contentEditable attribute in ownsSelection, not isContentEditable (https://github.com/WordPress/gutenberg/pull/80549)
- Writing flow: extend block selections with shift+arrow when there is no native selection (https://github.com/WordPress/gutenberg/pull/80687)
- Notes: Capture the target block before saving a block-level note (https://github.com/WordPress/gutenberg/pull/80690)
- Theme JSON: Level block-level preset class specificity with :where() (https://github.com/WordPress/gutenberg/pull/80657)
- Notes: Sync the sidebar selection to the inline marker under the caret (https://github.com/WordPress/gutenberg/pull/80610)
- Writing flow: use isMultiSelecting for shift+click (https://github.com/WordPress/gutenberg/pull/80286) (https://github.com/WordPress/gutenberg/pull/80726)
- Block supports: Return from layout support before resolving global settings (https://github.com/WordPress/gutenberg/pull/80771)
- Notes: Report save success consistently from note actions (https://github.com/WordPress/gutenberg/pull/80748)
- Dynamic Gallery: Rename toolbar button to Detach and add a modal explaining what will happen (https://github.com/WordPress/gutenberg/pull/80727) (https://github.com/WordPress/gutenberg/pull/80774)
- ToolsPanel: Migrate styles to an SCSS Module (https://github.com/WordPress/gutenberg/pull/80445) (https://github.com/WordPress/gutenberg/pull/80800)
- Add a responsiveEditingEnabled editor setting to hide the Responsive styles option (https://github.com/WordPress/gutenberg/pull/80814)
- iOS: remove jumping hack, add typewriter (https://github.com/WordPress/gutenberg/pull/74596)
- Writing flow: stop the page scrolling on caret moves within blocks taller than the viewport (https://github.com/WordPress/gutenberg/pull/80708)
- Global Styles: Put the inheritance UI behind a Gutenberg experiment (… (https://github.com/WordPress/gutenberg/pull/80818)
- Notes: Cancel in-flight hover highlight when focus leaves a note thread (https://github.com/WordPress/gutenberg/pull/80752)
- Block Editor: Try to fix typing performance regression (https://github.com/WordPress/gutenberg/pull/80507)
- List Block: Preserve ordered type on indent (https://github.com/WordPress/gutenberg/pull/75353)
- Make editableRoot a private block setting Symbol, not a public support (https://github.com/WordPress/gutenberg/pull/80820)
- Fix cursor position during forward delete of empty blocks (https://github.com/WordPress/gutenberg/pull/80827)
- Navigation: Fixes `aria-expanded` not updating on hover submenu inside overlay (https://github.com/WordPress/gutenberg/pull/80828)
- Remove redundant @jest-environment jsdom pragma and lint against it (https://github.com/WordPress/gutenberg/pull/80676)
- View config: reject shape-mismatched merges, define empty-array semantics, strip nulls from appended members (https://github.com/WordPress/gutenberg/pull/80829)
- Editor: leave undo to the browser in fields that handle their own undo (https://github.com/WordPress/gutenberg/pull/80768)
- Fix: New route-based admin pages are empty when no JS (https://github.com/WordPress/gutenberg/pull/80839)

