### PR TITLE
List Tables: Prevent Filter button submission and show admin notice when no filters are selected

### DIFF
--- a/src/js/_enqueues/admin/common.js
+++ b/src/js/_enqueues/admin/common.js
@@ -1330,7 +1330,53 @@ $( function() {
 			'bulk_action' : window.bulkActionObserverIds.bulk_action,
 			'changeit' : window.bulkActionObserverIds.changeit
 		};
-		if ( ! Object.keys( bulkFieldRelations ).includes( submitterName ) ) {
+		
+		var filterButtonNames = [
+			window.bulkActionObserverIds.filter_action,
+			window.bulkActionObserverIds['post-query-submit']
+		];
+
+		if ( ! Object.keys( bulkFieldRelations ).includes( submitterName ) && ! filterButtonNames.includes( submitterName ) ) {
+			return;
+		}
+
+		if ( filterButtonNames.includes( submitterName ) ) {
+			var filterDropdowns = form.querySelectorAll( '.actions select' );
+			var isFilterActionValid = false;
+			var urlParams = new URLSearchParams( window.location.search );
+			
+			for ( var i = 0; i < filterDropdowns.length; i++ ) {
+				var select = filterDropdowns[ i ];
+				if ( select.name === 'action' || select.name === 'action2' ) {
+					continue;
+				}
+				if ( select.value !== '0' && select.value !== '' && select.value !== '-1' ) {
+					isFilterActionValid = true;
+					break;
+				}
+				if ( urlParams.has( select.name ) ) {
+					isFilterActionValid = true;
+					break;
+				}
+			}
+			
+			if ( isFilterActionValid ) {
+				return;
+			}
+			
+			event.preventDefault();
+			event.stopPropagation();
+			$( 'html, body' ).animate( { scrollTop: 0 } );
+			
+			var filterErrorMessage = __( 'Please select a filter to apply.' );
+			addAdminNotice( {
+				id: 'no-filter-selected',
+				type: 'error',
+				message: filterErrorMessage,
+				dismissible: true,
+			} );
+			
+			wp.a11y.speak( filterErrorMessage );
 			return;
 		}
 

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -779,12 +779,15 @@ function wp_default_scripts( $scripts ) {
 		 * Filters the array of field name attributes for bulk actions.
 		 *
 		 * @since 6.8.1
+		 * @since 7.2.0 Added 'filter_action' and 'post-query-submit' keys.
 		 *
 		 * @param array $bulk_action_observer_ids {
 		 *      An array of field name attributes for bulk actions.
 		 *
-		 *      @type string $bulk_action The bulk action field name. Default 'action'.
-		 *      @type string $changeit    The new role field name. Default 'new_role'.
+		 *      @type string $bulk_action       The bulk action field name. Default 'action'.
+		 *      @type string $changeit          The new role field name. Default 'new_role'.
+		 *      @type string $filter_action     The list table Filter button field name. Default 'filter_action'.
+		 *      @type string $post-query-submit The media library Filter button field name. Default 'post-query-submit'.
 		 * }
 		 */
 		apply_filters( 'bulk_action_observer_ids', $bulk_action_observer_ids )

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -767,8 +767,10 @@ function wp_default_scripts( $scripts ) {
 	$scripts->set_translations( 'common' );
 
 	$bulk_action_observer_ids = array(
-		'bulk_action' => 'action',
-		'changeit'    => 'new_role',
+		'bulk_action'       => 'action',
+		'changeit'          => 'new_role',
+		'filter_action'     => 'filter_action',
+		'post-query-submit' => 'post-query-submit',
 	);
 	did_action( 'init' ) && $scripts->localize(
 		'common',


### PR DESCRIPTION

Trac ticket: https://core.trac.wordpress.org/ticket/31634


Adds client-side validation to the Filter button in WP_List_Table admin screens (Posts, Comments, Media, Links, Sites). When the Filter button is clicked with no meaningful filter criteria selected, the form submission is intercepted. A dismissible admin error notice reading "Please select a filter to apply." is injected at the top of the page, and wp.a11y.speak() announces it for screen reader users.

The two new button name identifiers (filter_action, post-query-submit) are registered alongside the existing bulk-action observer IDs in script-loader.php and remain filterable via the bulk_action_observer_ids filter for third-party extensibility.
