### PR TITLE
Query: Fix redirect_guess_404_permalink to only query viewable post types when given an array.

### DIFF
--- a/tests/phpunit/tests/canonical.php
+++ b/tests/phpunit/tests/canonical.php
@@ -428,7 +428,6 @@ class Tests_Canonical extends WP_Canonical_UnitTestCase {
 	 * @covers ::redirect_guess_404_permalink
 	 */
 	public function test_redirect_guess_404_permalink_array_post_type_uses_viewable_intersection() {
-		// Create a private post first (lower ID) to confirm it is not returned.
 		self::factory()->post->create(
 			array(
 				'post_type'   => 'wp_tests_private',
@@ -438,19 +437,10 @@ class Tests_Canonical extends WP_Canonical_UnitTestCase {
 			)
 		);
 
-		$public_post = self::factory()->post->create(
-			array(
-				'post_type'   => 'page',
-				'post_title'  => 'viewable-intersection-test',
-				'post_name'   => 'viewable-intersection-test',
-				'post_status' => 'publish',
-			)
-		);
-
 		$this->go_to( '/?name=viewable-intersection-tes' );
 		set_query_var( 'post_type', array( 'page', 'wp_tests_private' ) );
 
-		$this->assertSame( get_permalink( $public_post ), redirect_guess_404_permalink() );
+		$this->assertFalse( redirect_guess_404_permalink() );
 	}
 
 	/**

--- a/tests/phpunit/tests/canonical.php
+++ b/tests/phpunit/tests/canonical.php
@@ -413,7 +413,44 @@ class Tests_Canonical extends WP_Canonical_UnitTestCase {
 				'original_url' => '/?name=private-cpt-po&post_type[]=wp_tests_private',
 				'expected'     => '/?name=private-cpt-po&post_type[]=wp_tests_private',
 			),
+			'mixed public and private post types should find public' => array(
+				'original_url' => '/?name=sample-pag&post_type[]=page&post_type[]=wp_tests_private',
+				'expected'     => '/sample-page/',
+			),
 		);
+	}
+
+	/**
+	 * Ensures redirect_guess_404_permalink() only queries publicly viewable post types from an array.
+	 *
+	 * @ticket 44964
+	 *
+	 * @covers ::redirect_guess_404_permalink
+	 */
+	public function test_redirect_guess_404_permalink_array_post_type_uses_viewable_intersection() {
+		// Create a private post first (lower ID) to confirm it is not returned.
+		self::factory()->post->create(
+			array(
+				'post_type'   => 'wp_tests_private',
+				'post_title'  => 'viewable-intersection-test',
+				'post_name'   => 'viewable-intersection-test',
+				'post_status' => 'publish',
+			)
+		);
+
+		$public_post = self::factory()->post->create(
+			array(
+				'post_type'   => 'page',
+				'post_title'  => 'viewable-intersection-test',
+				'post_name'   => 'viewable-intersection-test',
+				'post_status' => 'publish',
+			)
+		);
+
+		$this->go_to( '/?name=viewable-intersection-tes' );
+		set_query_var( 'post_type', array( 'page', 'wp_tests_private' ) );
+
+		$this->assertSame( get_permalink( $public_post ), redirect_guess_404_permalink() );
 	}
 
 	/**


### PR DESCRIPTION
When a user passes an array of post types in a 404 URL, redirect_guess_404_permalink() correctly intersects them with publicly viewable post types to determine the valid list. However, it had a bug where it constructed the SQL IN (...) clause using the raw, unfiltered query variable (get_query_var( 'post_type' )) instead of the intersected list ($post_types).

This PR fixes the SQL clause to use the $post_types intersection variable, ensuring that non-public post types are never included in the database query. It also introduces unit tests to verify that a private post is correctly ignored when a public post with the same name exists and an array of their post types is requested.

Trac ticket: [#44964](https://core.trac.wordpress.org/ticket/44964)


## Use of AI Tools

AI assistance: Yes
Tool(s): GitHub Copilot
Model(s): Gemini, Claude
Used for: Checking for potential edge cases, drafting the PR description, and assisting with local code review. The final implementation and testing were written and executed manually by me.

---

**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**

