### PR TITLE
Interactivity API: Make class-wp-interactivity-api extensible

### DIFF
--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -475,7 +475,21 @@ class WP_Interactivity_API {
 		$tag_stack  = array();
 		$unbalanced = false;
 
-		$directive_processor_prefixes          = array_keys( self::$directive_processors );
+		/**
+		 * Filters the server-side directive processor map.
+		 *
+		 * Allows plugins to register custom server-side directive processors
+		 * or replace existing ones. The array maps a directive attribute prefix
+		 * (e.g. 'data-wp-show') to a callable. Each callable receives three
+		 * parameters: the directives processor, the mode ('enter'|'exit'),
+		 * and a reference to the tag stack.
+		 *
+		 * @since 6.9.0
+		 *
+		 * @param array $processors Directive attribute prefix => processor mapping.
+		 */
+		$directive_processors                  = (array) apply_filters( 'wp_interactivity_directive_processors', static::$directive_processors );
+		$directive_processor_prefixes          = array_keys( $directive_processors );
 		$directive_processor_prefixes_reversed = array_reverse( $directive_processor_prefixes );
 
 		/*
@@ -542,7 +556,7 @@ class WP_Interactivity_API {
 							continue;
 						}
 						$directive_prefix = 'data-wp-' . $parsed_directive['prefix'];
-						if ( array_key_exists( $directive_prefix, self::$directive_processors ) ) {
+						if ( array_key_exists( $directive_prefix, $directive_processors ) ) {
 							$directives_prefixes[] = $directive_prefix;
 						}
 					}
@@ -597,9 +611,17 @@ class WP_Interactivity_API {
 					$directives_prefixes
 				);
 				foreach ( $existing_directives_prefixes as $directive_prefix ) {
-					$func = is_array( self::$directive_processors[ $directive_prefix ] )
-						? self::$directive_processors[ $directive_prefix ]
-						: array( $this, self::$directive_processors[ $directive_prefix ] );
+					$processor = $directive_processors[ $directive_prefix ];
+
+					if ( $processor instanceof Closure ) {
+						$func = $processor;
+					} elseif ( is_array( $processor ) ) {
+						$func = $processor;
+					} elseif ( is_string( $processor ) && method_exists( $this, $processor ) ) {
+						$func = array( $this, $processor );
+					} else {
+						$func = $processor;
+					}
 
 					call_user_func_array( $func, array( $p, $mode, &$tag_stack ) );
 				}

--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -623,6 +623,20 @@ class WP_Interactivity_API {
 						$func = $processor;
 					}
 
+					if ( ! is_callable( $func ) ) {
+						_doing_it_wrong(
+							__METHOD__,
+							sprintf(
+								/* translators: 1: The directive prefix, e.g. "data-wp-show". 2: The processor value that is not callable. */
+								__( 'The processor for "%1$s" is not a valid callable. Got: %2$s' ),
+								$directive_prefix,
+								wp_json_encode( $processor )
+							),
+							'6.9.0'
+						);
+						continue;
+					}
+
 					call_user_func_array( $func, array( $p, $mode, &$tag_stack ) );
 				}
 			}

--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -12,14 +12,14 @@
  *
  * @since 6.5.0
  */
-final class WP_Interactivity_API {
+class WP_Interactivity_API {
 	/**
 	 * Holds the mapping of directive attribute names to their processor methods.
 	 *
 	 * @since 6.5.0
 	 * @var array
 	 */
-	private static $directive_processors = array(
+	protected static $directive_processors = array(
 		'data-wp-interactive'   => 'data_wp_interactive_processor',
 		'data-wp-router-region' => 'data_wp_router_region_processor',
 		'data-wp-context'       => 'data_wp_context_processor',
@@ -45,7 +45,7 @@ final class WP_Interactivity_API {
 	 * @since 6.5.0
 	 * @var array
 	 */
-	private $state_data = array();
+	protected $state_data = array();
 
 	/**
 	 * Holds the configuration required by the different Interactivity API stores.
@@ -68,7 +68,7 @@ final class WP_Interactivity_API {
 	 * @since 6.9.0
 	 * @var array
 	 */
-	private $derived_state_closures = array();
+	protected $derived_state_closures = array();
 
 	/**
 	 * Flag that indicates whether the `data-wp-router-region` directive has
@@ -102,7 +102,7 @@ final class WP_Interactivity_API {
 	 * @since 6.6.0
 	 * @var array<string>|null
 	 */
-	private $namespace_stack = null;
+	protected $namespace_stack = null;
 
 	/**
 	 * Stack of contexts defined by `data-wp-context` directives, in
@@ -113,7 +113,7 @@ final class WP_Interactivity_API {
 	 * @since 6.6.0
 	 * @var array<array<mixed>>|null
 	 */
-	private $context_stack = null;
+	protected $context_stack = null;
 
 	/**
 	 * Representation in array format of the element currently being processed.
@@ -470,7 +470,7 @@ final class WP_Interactivity_API {
 	 * @param string $html The HTML content to process.
 	 * @return string|null The processed HTML content. It returns null when the HTML contains unbalanced tags.
 	 */
-	private function _process_directives( string $html ) {
+	protected function _process_directives( string $html ) {
 		$p          = new WP_Interactivity_API_Directives_Processor( $html );
 		$tag_stack  = array();
 		$unbalanced = false;
@@ -641,7 +641,7 @@ final class WP_Interactivity_API {
 	 * @param array $entry An array containing a whole directive entry with its namespace, value, suffix, or unique ID.
 	 * @return mixed|null The result of the evaluation. Null if the reference path doesn't exist or the namespace is falsy.
 	 */
-	private function evaluate( $entry ) {
+	protected function evaluate( $entry ) {
 		$context                               = end( $this->context_stack );
 		['namespace' => $ns, 'value' => $path] = $entry;
 
@@ -766,7 +766,7 @@ final class WP_Interactivity_API {
 	 * @param string $directive_name The directive attribute name.
 	 * @return array An array containing the directive prefix, optional suffix, and optional unique ID.
 	 */
-	private function parse_directive_name( string $directive_name ): ?array {
+	protected function parse_directive_name( string $directive_name ): ?array {
 		// Remove the first 8 characters (assumes "data-wp-" prefix)
 		$name = substr( $directive_name, 8 );
 
@@ -847,7 +847,7 @@ final class WP_Interactivity_API {
 	 * @return array An array containing the namespace in the first item and the JSON, the reference path, or null on the
 	 *               second item.
 	 */
-	private function extract_directive_value( $directive_value, $default_namespace = null ): array {
+	protected function extract_directive_value( $directive_value, $default_namespace = null ): array {
 		if ( empty( $directive_value ) || is_bool( $directive_value ) ) {
 			return array( $default_namespace, null );
 		}
@@ -879,7 +879,7 @@ final class WP_Interactivity_API {
 	 * @param string                                    $prefix The directive prefix to filter by.
 	 * @return array An array of entries containing the directive namespace, value, suffix, and unique ID.
 	 */
-	private function get_directive_entries( WP_Interactivity_API_Directives_Processor $p, string $prefix ) {
+	protected function get_directive_entries( WP_Interactivity_API_Directives_Processor $p, string $prefix ) {
 		$directive_attributes = $p->get_attribute_names_with_prefix( 'data-wp-' . $prefix );
 		$entries              = array();
 		foreach ( $directive_attributes as $attribute_name ) {
@@ -945,7 +945,7 @@ final class WP_Interactivity_API {
 	 * @param WP_Interactivity_API_Directives_Processor $p    The directives processor instance.
 	 * @param string                                    $mode Whether the processing is entering or exiting the tag.
 	 */
-	private function data_wp_interactive_processor( WP_Interactivity_API_Directives_Processor $p, string $mode ) {
+	protected function data_wp_interactive_processor( WP_Interactivity_API_Directives_Processor $p, string $mode ) {
 		// When exiting tags, it removes the last namespace from the stack.
 		if ( 'exit' === $mode ) {
 			array_pop( $this->namespace_stack );
@@ -988,7 +988,7 @@ final class WP_Interactivity_API {
 	 * @param WP_Interactivity_API_Directives_Processor $p               The directives processor instance.
 	 * @param string                                    $mode            Whether the processing is entering or exiting the tag.
 	 */
-	private function data_wp_context_processor( WP_Interactivity_API_Directives_Processor $p, string $mode ) {
+	protected function data_wp_context_processor( WP_Interactivity_API_Directives_Processor $p, string $mode ) {
 		// When exiting tags, it removes the last context from the stack.
 		if ( 'exit' === $mode ) {
 			array_pop( $this->context_stack );
@@ -1021,7 +1021,7 @@ final class WP_Interactivity_API {
 	 * @param WP_Interactivity_API_Directives_Processor $p               The directives processor instance.
 	 * @param string                                    $mode            Whether the processing is entering or exiting the tag.
 	 */
-	private function data_wp_bind_processor( WP_Interactivity_API_Directives_Processor $p, string $mode ) {
+	protected function data_wp_bind_processor( WP_Interactivity_API_Directives_Processor $p, string $mode ) {
 		if ( 'enter' === $mode ) {
 			$entries = $this->get_directive_entries( $p, 'bind' );
 			foreach ( $entries as $entry ) {
@@ -1084,7 +1084,7 @@ final class WP_Interactivity_API {
 	 * @param WP_Interactivity_API_Directives_Processor $p               The directives processor instance.
 	 * @param string                                    $mode            Whether the processing is entering or exiting the tag.
 	 */
-	private function data_wp_class_processor( WP_Interactivity_API_Directives_Processor $p, string $mode ) {
+	protected function data_wp_class_processor( WP_Interactivity_API_Directives_Processor $p, string $mode ) {
 		if ( 'enter' === $mode ) {
 			$entries = $this->get_directive_entries( $p, 'class' );
 			foreach ( $entries as $entry ) {
@@ -1121,7 +1121,7 @@ final class WP_Interactivity_API {
 	 * @param WP_Interactivity_API_Directives_Processor $p               The directives processor instance.
 	 * @param string                                    $mode            Whether the processing is entering or exiting the tag.
 	 */
-	private function data_wp_style_processor( WP_Interactivity_API_Directives_Processor $p, string $mode ) {
+	protected function data_wp_style_processor( WP_Interactivity_API_Directives_Processor $p, string $mode ) {
 		if ( 'enter' === $mode ) {
 			$entries = $this->get_directive_entries( $p, 'style' );
 			foreach ( $entries as $entry ) {
@@ -1210,7 +1210,7 @@ final class WP_Interactivity_API {
 	 * @param WP_Interactivity_API_Directives_Processor $p               The directives processor instance.
 	 * @param string                                    $mode            Whether the processing is entering or exiting the tag.
 	 */
-	private function data_wp_text_processor( WP_Interactivity_API_Directives_Processor $p, string $mode ) {
+	protected function data_wp_text_processor( WP_Interactivity_API_Directives_Processor $p, string $mode ) {
 		if ( 'enter' === $mode ) {
 			$entries     = $this->get_directive_entries( $p, 'text' );
 			$valid_entry = null;
@@ -1323,7 +1323,7 @@ HTML;
 	 * @param WP_Interactivity_API_Directives_Processor $p               The directives processor instance.
 	 * @param string                                    $mode            Whether the processing is entering or exiting the tag.
 	 */
-	private function data_wp_router_region_processor( WP_Interactivity_API_Directives_Processor $p, string $mode ) {
+	protected function data_wp_router_region_processor( WP_Interactivity_API_Directives_Processor $p, string $mode ) {
 		if ( 'enter' === $mode && ! $this->has_processed_router_region ) {
 			$this->has_processed_router_region = true;
 
@@ -1359,7 +1359,7 @@ HTML;
 	 * @param string                                    $mode            Whether the processing is entering or exiting the tag.
 	 * @param array                                     $tag_stack       The reference to the tag stack.
 	 */
-	private function data_wp_each_processor( WP_Interactivity_API_Directives_Processor $p, string $mode, array &$tag_stack ) {
+	protected function data_wp_each_processor( WP_Interactivity_API_Directives_Processor $p, string $mode, array &$tag_stack ) {
 		if ( 'enter' === $mode && 'TEMPLATE' === $p->get_tag() ) {
 			$entries = $this->get_directive_entries( $p, 'each' );
 			if ( count( $entries ) > 1 || empty( $entries ) ) {

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPIExtensibility.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPIExtensibility.php
@@ -106,7 +106,7 @@ class Tests_Interactivity_API_WpInteractivityAPIExtensibility extends WP_UnitTes
 		$this->assertStringContainsString( 'overridden', $overridden_result );
 		$this->assertStringNotContainsString( 'original', $overridden_result );
 
-		$normal_result     = $instance->process_directives( $html_normal );
+		$normal_result = $instance->process_directives( $html_normal );
 		$this->assertStringNotContainsString( 'fallback', $normal_result );
 		$this->assertStringContainsString( 'blue', $normal_result );
 	}

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPIExtensibility.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPIExtensibility.php
@@ -1,0 +1,262 @@
+<?php
+/**
+ * Unit tests covering WP_Interactivity_API extensibility.
+ *
+ * @package WordPress
+ * @subpackage Interactivity API
+ *
+ * @since 6.9.0
+ *
+ * @group interactivity-api
+ *
+ * @coversDefaultClass WP_Interactivity_API
+ */
+class Tests_Interactivity_API_WpInteractivityAPIExtensibility extends WP_UnitTestCase {
+
+	/**
+	 * Instance of WP_Interactivity_API.
+	 *
+	 * @var WP_Interactivity_API
+	 */
+	protected $interactivity;
+
+	/**
+	 * Set up.
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->interactivity = new class() extends WP_Interactivity_API {
+			/**
+			 * Processes the `data-wp-show` directive.
+			 *
+			 * @param WP_Interactivity_API_Directives_Processor $p    The directives processor.
+			 * @param string                                    $mode Processing mode ('enter'|'exit').
+			 */
+			public function show_processor( $p, $mode ) {
+				if ( 'enter' !== $mode ) {
+					return;
+				}
+				$entries = $this->get_directive_entries( $p, 'show' );
+				if ( empty( $entries ) ) {
+					return;
+				}
+				$resolved = $this->evaluate( $entries[0] );
+				if ( $resolved ) {
+					$p->remove_attribute( 'style' );
+				} else {
+					$p->set_attribute( 'style', 'display: none' );
+				}
+			}
+		};
+		wp_default_script_modules();
+		$this->interactivity->add_hooks();
+	}
+
+	/**
+	 * Tear down.
+	 */
+	public function tear_down() {
+		global $wp_script_modules;
+		parent::tear_down();
+		$wp_script_modules = null;
+	}
+
+	/*
+	 * ── Subclass: override evaluate() ─────────────────────────────────
+	 *
+	 * These tests verify that a subclass CAN override evaluate() and that
+	 * the override is invoked during directive processing. No expression
+	 * evaluation logic is implemented — just a proof of mechanism.
+	 */
+
+	/**
+	 * Tests that a subclass can override evaluate() and also delegate to
+	 * parent::evaluate() for paths it does not need to intercept.
+	 *
+	 * @ticket 65757
+	 *
+	 * @covers ::evaluate
+	 */
+	public function test_subclass_can_fall_back_to_parent() {
+		$instance = new class() extends WP_Interactivity_API {
+			protected function evaluate( $entry ) {
+				// Override for paths containing 'message'; delegate everything else.
+				if ( str_contains( $entry['value'], 'message' ) ) {
+					return 'overridden';
+				}
+				return parent::evaluate( $entry );
+			}
+		};
+
+		$instance->state(
+			'test',
+			array(
+				'message' => 'original',
+				'color'   => 'blue',
+			)
+		);
+
+		$html_overridden = '<div data-wp-interactive="test" data-wp-text="state.message">fallback</div>';
+		$html_normal     = '<div data-wp-interactive="test" data-wp-text="state.color">fallback</div>';
+
+		$overridden_result = $instance->process_directives( $html_overridden );
+
+		// The data-wp-text processor replaces the element content, so 'fallback' should be gone.
+		$this->assertStringNotContainsString( 'fallback', $overridden_result );
+		$this->assertStringContainsString( 'overridden', $overridden_result );
+		$this->assertStringNotContainsString( 'original', $overridden_result );
+
+		$normal_result     = $instance->process_directives( $html_normal );
+		$this->assertStringNotContainsString( 'fallback', $normal_result );
+		$this->assertStringContainsString( 'blue', $normal_result );
+	}
+
+	/**
+	 * Tests that a subclass can override the static $directive_processors
+	 * property to register a custom directive without using the filter.
+	 *
+	 * The custom processor calls $this->evaluate() to resolve the show
+	 * value via the normal evaluate path.
+	 *
+	 * @ticket 65757
+	 *
+	 * @covers ::_process_directives
+	 */
+	public function test_subclass_can_override_directive_processors() {
+		$instance = new class() extends WP_Interactivity_API {
+			protected static $directive_processors = array(
+				'data-wp-interactive' => 'data_wp_interactive_processor',
+				'data-wp-show'        => 'subclass_show',
+			);
+
+			public function subclass_show( $p, $mode ) {
+				if ( 'enter' !== $mode ) {
+					return;
+				}
+				$entries = $this->get_directive_entries( $p, 'show' );
+				if ( empty( $entries ) ) {
+					return;
+				}
+				$resolved = $this->evaluate( $entries[0] );
+				if ( $resolved ) {
+					$p->remove_attribute( 'style' );
+				} else {
+					$p->set_attribute( 'style', 'display: none' );
+				}
+			}
+		};
+
+		$instance->state(
+			'test',
+			array( 'shouldShow' => false )
+		);
+
+		$html_false = '<div data-wp-interactive="test" data-wp-show="state.shouldShow">content</div>';
+		$updated    = $instance->process_directives( $html_false );
+
+		$this->assertStringContainsString( 'display: none', $updated );
+
+		// Also verify the truthy path.
+		$instance->state(
+			'test',
+			array( 'shouldShow' => true )
+		);
+
+		$html_true = '<div data-wp-interactive="test" data-wp-show="state.shouldShow">content</div>';
+		$updated   = $instance->process_directives( $html_true );
+
+		$this->assertStringNotContainsString( 'display: none', $updated );
+	}
+
+	/*
+	 * ── Filter: register a data-wp-show directive ─────────────────────
+	 *
+	 * The same show/hide behaviour is registered via the filter using
+	 * two different callable types.
+	 */
+
+	/**
+	 * Helper: registers a data-wp-show processor via the filter and
+	 * returns the processed HTML.
+	 *
+	 * @param callable $callback The processor callback.
+	 * @param bool     $show     Whether the element should be visible.
+	 * @return string Processed HTML.
+	 */
+	private function process_with_show( $callback, bool $show = true ): string {
+		add_filter(
+			'wp_interactivity_directive_processors',
+			function ( $processors ) use ( $callback ) {
+				$processors['data-wp-show'] = $callback;
+				return $processors;
+			}
+		);
+
+		$json = wp_json_encode( array( 'shouldShow' => $show ) );
+		$html = '<div data-wp-interactive="test" data-wp-context="'
+			. esc_attr( $json )
+			. '" data-wp-show="context.shouldShow">content</div>';
+
+		return $this->interactivity->process_directives( $html );
+	}
+
+	/**
+	 * Tests the filter with a Closure as the processor callable —
+	 * the element should be hidden (display: none) when the
+	 * context value is false.
+	 *
+	 * @ticket 65757
+	 *
+	 * @covers ::_process_directives
+	 */
+	public function test_filter_with_closure_processor_hides() {
+		$show_processor = \Closure::bind(
+			function ( $p, $mode ) {
+				if ( 'enter' !== $mode ) {
+					return;
+				}
+				$entries = $this->get_directive_entries( $p, 'show' );
+				if ( empty( $entries ) ) {
+					return;
+				}
+				$resolved = $this->evaluate( $entries[0] );
+				if ( $resolved ) {
+					$p->remove_attribute( 'style' );
+				} else {
+					$p->set_attribute( 'style', 'display: none' );
+				}
+			},
+			$this->interactivity,
+			WP_Interactivity_API::class
+		);
+
+		$updated = $this->process_with_show( $show_processor, false );
+
+		$this->assertStringContainsString( 'display: none', $updated );
+
+		// Also verify the truthy path.
+		$updated = $this->process_with_show( $show_processor, true );
+
+		$this->assertStringNotContainsString( 'display: none', $updated );
+	}
+
+	/**
+	 * Tests the filter with a named static method as the processor
+	 * callback — the element should be visible (no style attribute)
+	 * when the context value is true.
+	 *
+	 * @ticket 65757
+	 *
+	 * @covers ::_process_directives
+	 */
+	public function test_filter_with_named_function_processor_shows() {
+		$updated = $this->process_with_show( 'show_processor', true );
+
+		$this->assertStringNotContainsString( 'display: none', $updated );
+
+		// Also verify the falsy path.
+		$updated = $this->process_with_show( 'show_processor', false );
+
+		$this->assertStringContainsString( 'display: none', $updated );
+	}
+}


### PR DESCRIPTION


<!-- Insert a description of your changes here -->

Trac ticket: 65757

Remove final from WP_Interactivity_API and change method/property visibilities from private to protected where appropriate, enabling plugins to extend or customize server-side directive processing without forking the entire class.

Changes:
- Remove final from class declaration
- Change evaluate(), _process_directives(), get_directive_entries(), extract_directive_value(), parse_directive_name() to protected
- Change all 8 data_wp_*_processor() methods to protected
- Change $state_data, $namespace_stack, $context_stack, $derived_state_closures, $directive_processors to protected
- Add wp_interactivity_directive_processors filter

## Use of AI Tools


Example disclosure:

AI assistance: Yes
Tool(s): VSCode Chat
Model(s): Deepseek v4 Flash
Used for: iterating on the idea, writing the proposal and making the edits, as directed and reviewed by me


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
