### PR TITLE
Taxonomy: Guard _pad_term_counts() against an empty term list

### DIFF
--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -4105,6 +4105,10 @@ function _pad_term_counts( &$terms, $taxonomy ) {
 		$term_ids[ $term->term_taxonomy_id ] = $term->term_id;
 	}
 
+	if ( empty( $term_ids ) ) {
+		return;
+	}
+
 	// Get the object and term IDs and stick them in a lookup table.
 	$tax_obj      = get_taxonomy( $taxonomy );
 	$object_types = esc_sql( $tax_obj->object_type );

--- a/tests/phpunit/tests/term/getTerms.php
+++ b/tests/phpunit/tests/term/getTerms.php
@@ -2746,6 +2746,39 @@ class Tests_Term_getTerms extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 41867
+	 */
+	public function test_pad_counts_should_not_generate_a_query_error_when_child_of_and_exclude_empty_the_result() {
+		global $wpdb;
+
+		register_taxonomy( 'wptests_tax_padcounts', 'post', array( 'hierarchical' => true ) );
+
+		$parent = self::factory()->term->create( array( 'taxonomy' => 'wptests_tax_padcounts' ) );
+		$child  = self::factory()->term->create(
+			array(
+				'taxonomy' => 'wptests_tax_padcounts',
+				'parent'   => $parent,
+			)
+		);
+
+		$post = self::factory()->post->create();
+		wp_set_object_terms( $post, array( $child ), 'wptests_tax_padcounts' );
+
+		// $parent's only child is excluded, so the padded term list ends up empty.
+		get_terms(
+			array(
+				'taxonomy'   => 'wptests_tax_padcounts',
+				'child_of'   => $parent,
+				'exclude'    => array( $child ),
+				'pad_counts' => true,
+				'hide_empty' => false,
+			)
+		);
+
+		$this->assertEmpty( $wpdb->last_error );
+	}
+
+	/**
 	 * @ticket 10142
 	 */
 	public function test_termmeta_cache_should_be_lazy_loaded_by_default() {


### PR DESCRIPTION
`_pad_term_counts()` (`wp-includes/taxonomy.php`) builds a `term_taxonomy_id IN (...)` SQL clause from `implode( ',', array_keys( $term_ids ) )` with no guard for `$term_ids` being empty. When `wp_list_categories()` is called with `child_of` + `exclude` args that exclude every matching child category, the term list passed into `_pad_term_counts()` ends up empty, and the query becomes literally `... WHERE term_taxonomy_id IN () AND ...` — a WordPress database error, visible to end users when `WP_DEBUG_DISPLAY` is on.

Repro:
```php
$parent = wp_insert_term( 'Parent Cat', 'category' );
$child  = wp_insert_term( 'Only Child', 'category', array( 'parent' => $parent['term_id'] ) );
// ...a published post in $child...
wp_list_categories( array(
	'child_of'     => $parent['term_id'],
	'depth'        => 1,
	'exclude'      => $child['term_id'],
	'hierarchical' => true,
	'hide_empty'   => false,
	'show_count'   => 1,
) );
```

Fix is a one-line guard, matching the existing `empty( $term_hier )` early-return already in the function:
```php
if ( empty( $term_ids ) ) {
	return;
}
```

Added `test_pad_counts_should_not_generate_a_query_error_when_child_of_and_exclude_empty_the_result()` to `Tests_Term_getTerms`, reproducing the same underlying condition through a custom hierarchical taxonomy and `get_terms()` directly (the bug isn't category-specific — it's in `_pad_term_counts()`, which any hierarchical taxonomy with `pad_counts` goes through).

Verified the test is real regression coverage: reverted just the `src/` change and confirmed the test fails with the exact malformed-SQL error, then restored the fix and confirmed green. Ran the full `getTerms.php` file (115 tests) and the whole `taxonomy` group (879 tests) after — no regressions. Lint and PHPStan clean.

This is the same root cause a WordPress Emeritus Committer (`boonebgorges`) already pointed at in the ticket's comment history — `_pad_term_counts()` — this PR implements the one-line fix the original reporter suggested nine years ago.

Trac ticket: https://core.trac.wordpress.org/ticket/41867

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Root-cause tracing, implementation, test authoring, and mutation-testing verification. Reviewed by @irozum.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
