### PR TITLE
Networks and Sites: Document that wp_delete_site() does not guard against deleting the main site

### DIFF
--- a/src/wp-includes/ms-site.php
+++ b/src/wp-includes/ms-site.php
@@ -202,6 +202,11 @@ function wp_update_site( $site_id, array $data ) {
 /**
  * Deletes a site from the database.
  *
+ * This function does not protect against deleting the main site of a network, or a site
+ * whose domain and path match the network's own. That guard lives in wpmu_delete_blog(),
+ * which the Network Admin's delete-site screen calls; a caller invoking wp_delete_site()
+ * directly is responsible for performing an equivalent check first.
+ *
  * @since 5.1.0
  *
  * @global wpdb $wpdb WordPress database abstraction object.


### PR DESCRIPTION
`wp_delete_site()` validates only that the `$site_id` is non-empty and that the site exists, then fires the `wp_validate_site_deletion` action and proceeds — core registers no callback on that action, so a direct call to `wp_delete_site( 1 )` uninitializes and deletes a network's main site with no error returned. The equivalent protection (blocking deletion of site ID 1, the main site, or the network's own domain/path root) lives only in `wpmu_delete_blog()` in `wp-admin/includes/ms.php`, which the Network Admin UI routes through, so the admin screens are safe. `wp_delete_site()` is the newer CRUD-style API (introduced in #41333) that plugin authors, migration scripts, and custom WP-CLI tooling are pointed toward, so someone calling it directly gets no protection against destroying the primary site, and the result is unrecoverable without a backup.

As discussed on the ticket, a behavior change to `wp_delete_site()` itself would affect any code currently relying on the unguarded call, so this PR takes the documentation-only route the ticket comments converged on: it adds a paragraph to the function's docblock in `src/wp-includes/ms-site.php` stating plainly that `wp_delete_site()` does not guard against deleting the main site, and pointing to `wpmu_delete_blog()` as where that guard lives for callers who need it. No behavior changes.

Trac ticket: https://core.trac.wordpress.org/ticket/65760

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Sonnet 5
Used for: Implementation and PR description. Reviewed by irozum.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
