### PR TITLE
REST API: Check for a missing post before the comment status capability.

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
@@ -568,6 +568,14 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 			);
 		}
 
+		if ( empty( $request['post'] ) ) {
+			return new WP_Error(
+				'rest_comment_invalid_post_id',
+				__( 'Sorry, you are not allowed to create this comment without a post.' ),
+				array( 'status' => 403 )
+			);
+		}
+
 		$edit_cap = $is_note ? array( 'edit_post', (int) $request['post'] ) : array( 'moderate_comments' );
 		if ( isset( $request['status'] ) && ! current_user_can( ...$edit_cap ) ) {
 			return new WP_Error(
@@ -575,14 +583,6 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 				/* translators: %s: Request parameter. */
 				sprintf( __( "Sorry, you are not allowed to edit '%s' for comments." ), 'status' ),
 				array( 'status' => rest_authorization_required_code() )
-			);
-		}
-
-		if ( empty( $request['post'] ) ) {
-			return new WP_Error(
-				'rest_comment_invalid_post_id',
-				__( 'Sorry, you are not allowed to create this comment without a post.' ),
-				array( 'status' => 403 )
 			);
 		}
 

--- a/tests/phpunit/tests/rest-api/rest-comments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-comments-controller.php
@@ -3839,6 +3839,36 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 	}
 
 	/**
+	 * A missing post should be reported as a missing post for notes too.
+	 *
+	 * Without a post, the `status` capability check falls back to
+	 * `current_user_can( 'edit_post', 0 )`, which no role can satisfy. An
+	 * administrator is used here to show the missing post is reported even for a
+	 * user holding every capability.
+	 *
+	 * @ticket 65761
+	 */
+	public function test_create_note_status_and_no_post_id() {
+		wp_set_current_user( self::$admin_id );
+
+		$params = array(
+			'author_name'  => 'Ishmael',
+			'author_email' => 'herman-melville@earthlink.net',
+			'author_url'   => 'https://en.wikipedia.org/wiki/Herman_Melville',
+			'content'      => 'Comic Book Guy',
+			'type'         => 'note',
+			'status'       => 'hold',
+		);
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/comments' );
+		$request->add_header( 'Content-Type', 'application/json' );
+		$request->set_body( wp_json_encode( $params ) );
+
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertErrorResponse( 'rest_comment_invalid_post_id', $response, 403 );
+	}
+
+	/**
 	 * @ticket 64096
 	 */
 	public function test_cannot_create_with_non_valid_comment_type() {

--- a/tests/phpunit/tests/rest-api/rest-comments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-comments-controller.php
@@ -2024,6 +2024,31 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 		$this->assertErrorResponse( 'rest_comment_invalid_post_id', $response, 403 );
 	}
 
+	/**
+	 * A missing post should be reported as a missing post, even when the request
+	 * also sets `status` and the user is not allowed to set it.
+	 *
+	 * @ticket 65761
+	 */
+	public function test_create_comment_status_and_no_post_id_no_permission() {
+		wp_set_current_user( self::$author_id );
+
+		$params = array(
+			'author_name'  => 'Homer Jay Simpson',
+			'author_email' => 'chunkylover53@aol.com',
+			'author_url'   => 'http://compuglobalhypermeganet.com',
+			'content'      => 'Here\’s to alcohol: the cause of, and solution to, all of life\’s problems.',
+			'status'       => 'approved',
+		);
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/comments' );
+		$request->add_header( 'Content-Type', 'application/json' );
+		$request->set_body( wp_json_encode( $params ) );
+
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertErrorResponse( 'rest_comment_invalid_post_id', $response, 403 );
+	}
+
 	public function test_create_comment_invalid_post_id() {
 		wp_set_current_user( self::$admin_id );
 


### PR DESCRIPTION
## What



`WP_REST_Comments_Controller::create_item_permissions_check()` checks whether the caller is allowed to set the `status` parameter before it checks that a `post` was supplied at all. A request that carries a `status` but no `post` is therefore rejected with `rest_comment_invalid_status`, "Sorry, you are not allowed to edit 'status' for comments", which points at the wrong parameter. The actual problem is the missing post.

This moves the missing-post guard above the status capability check. It is a pure move of about seven lines; no logic changes.

Trac ticket: https://core.trac.wordpress.org/ticket/65761

## Why the wrong error appears

The status check consults `moderate_comments` for ordinary comments. An Administrator has it, so the check passes and execution reaches the missing-post guard, producing the correct error. A Subscriber, Contributor or Author does not, so it stops one guard early and reports the status problem instead. That asymmetry between roles is the bug.

## Behaviour changes

The reorder flips the reported error code in two situations. Both remain HTTP 403 and both remain rejected. Only the reason changes. 

| Request | Before | After |
| --- | --- | --- |
| `status` set, no `post`, caller lacks `moderate_comments` | `rest_comment_invalid_status` | `rest_comment_invalid_post_id` |
| `type: note`, `status` set, no `post`, any caller | `rest_comment_invalid_status` | `rest_comment_invalid_post_id` |

The second row is easy to miss. For a note, `$edit_cap` becomes `array( 'edit_post', (int) $request['post'] )`, which is `array( 'edit_post', 0 )` when no post is supplied. `map_meta_cap()` returns `do_not_allow` for `edit_post` whenever `get_post()` finds nothing, so that check failed for every caller, including Administrators, before this change.

Because a response code changes, this belongs in a major release rather than a point release, hence 7.2.

## Testing instructions

To check by hand, as an Author with a published post open in the block editor:


```js
wp.apiFetch( {
	path: '/wp/v2/comments',
	method: 'POST',
	data: { content: 'AUTHOR_YOLO', status: 'approved' },
} ).then( console.log ).catch( console.log );

/*

// Before


{
    "code": "rest_comment_invalid_status",
    "message": "Sorry, you are not allowed to edit 'status' for comments.",
    "data": {
        "status": 403
    }
}


// After

{
    "code": "rest_comment_invalid_post_id",
    "message": "Sorry, you are not allowed to create this comment without a post.",
    "data": {
        "status": 403
    }
}

*/


```


Still as an Author, check that you get the right "status" error when you do provide a post id:

```js
const post = wp.data.select( 'core/editor' ).getCurrentPostId();
wp.apiFetch( { path: '/wp/v2/comments', method: 'POST', data: { post, content: 'happy path', status: 'approved' } } ).then( console.log ).catch( console.log );

/*

{
    "code": "rest_comment_invalid_status",
    "message": "Sorry, you are not allowed to edit 'status' for comments.",
    "data": {
        "status": 403
    }
}

*/


```

Then do a happy path as an Admin in a post:

```js
const post = wp.data.select( 'core/editor' ).getCurrentPostId();
wp.apiFetch( {
	path: '/wp/v2/comments',
	method: 'POST',
	data: { post, content: 'happy path', status: 'approved' },
} ).then( console.log ).catch( console.log );

/*
Expect 201 with "status": "approved"
*/

```


Tests

```
npm run test:php -- --filter WP_Test_REST_Comments_Controller
npm run test:php -- --group comment
```