### PR TITLE
REST API: remove `search` and `page` from the view config schema.

### DIFF
--- a/src/wp-includes/class-wp-view-config-data.php
+++ b/src/wp-includes/class-wp-view-config-data.php
@@ -355,13 +355,13 @@ class WP_View_Config_Data {
 	 *
 	 * ```php
 	 * array(
-	 *   'default_view' => array( 'search' => 'new search', 'fields' => array( 'newField' ) ),
+	 *   'default_view' => array( 'titleField' => 'newTitleField', 'fields' => array( 'newField' ) ),
 	 *   'default_layouts' => array( 'grid' => array( 'layout' => array( 'badgeFields' => array( 'newField' ) ) ) ),
 	 *   'view_list' => array( array( 'slug' => 'table', 'title' => 'New title' ) ),
 	 * )
 	 * ```
 	 *
-	 * - default_view will be updated so the search string is 'new search' and the newField is appended to the list of fields.
+	 * - default_view will be updated so the titleField is 'newTitleField' and the newField is appended to the list of fields.
 	 * - default_layouts will be updated so that newField is appended to the badgeFields.
 	 * - view_list will be updated so that the view with slug 'table' has its title changed to 'New title'.
 	 *

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-view-config-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-view-config-controller.php
@@ -391,15 +391,15 @@ class WP_REST_View_Config_Controller extends WP_REST_Controller {
 	/**
 	 * Returns the schema properties shared by all view types (ViewBase), excluding 'type'.
 	 *
+	 * Note that `search` and `page` are not part of the schema: they are managed
+	 * via the URL, which is their only source of truth.
+	 *
 	 * @since 7.1.0
 	 *
 	 * @return array Schema properties for the base view configuration.
 	 */
 	protected function get_view_base_schema() {
 		return array(
-			'search'                => array(
-				'type' => 'string',
-			),
 			'filters'               => array(
 				'type'  => 'array',
 				'items' => array(
@@ -443,9 +443,6 @@ class WP_REST_View_Config_Controller extends WP_REST_Controller {
 						'enum' => array( 'asc', 'desc' ),
 					),
 				),
-			),
-			'page'                  => array(
-				'type' => 'integer',
 			),
 			'perPage'               => array(
 				'type' => 'integer',

--- a/tests/phpunit/tests/rest-api/rest-view-config-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-view-config-controller.php
@@ -385,4 +385,29 @@ class WP_REST_View_Config_Controller_Test extends WP_Test_REST_TestCase {
 			array_keys( $schema['properties'] )
 		);
 	}
+
+	/**
+	 * `search` and `page` are not part of the view schema: they are managed via
+	 * the URL, which is their only source of truth.
+	 *
+	 * @covers ::get_item_schema
+	 */
+	public function test_get_item_schema_excludes_url_managed_view_properties() {
+		$controller = new WP_REST_View_Config_Controller();
+		$schema     = $controller->get_item_schema();
+
+		$views = array(
+			'default_view'             => $schema['properties']['default_view']['properties'],
+			'view_list item view'      => $schema['properties']['view_list']['items']['properties']['view']['properties'],
+			'default_layouts.table'    => $schema['properties']['default_layouts']['properties']['table']['properties'],
+			'default_layouts.grid'     => $schema['properties']['default_layouts']['properties']['grid']['properties'],
+			'default_layouts.list'     => $schema['properties']['default_layouts']['properties']['list']['properties'],
+			'default_layouts.activity' => $schema['properties']['default_layouts']['properties']['activity']['properties'],
+		);
+
+		foreach ( $views as $label => $properties ) {
+			$this->assertArrayNotHasKey( 'search', $properties, "$label should not declare a `search` property." );
+			$this->assertArrayNotHasKey( 'page', $properties, "$label should not declare a `page` property." );
+		}
+	}
 }


### PR DESCRIPTION
Trac ticket https://core.trac.wordpress.org/ticket/65577
Backports https://github.com/WordPress/gutenberg/pull/80832
Follow-up to https://github.com/WordPress/wordpress-develop/pull/12391

`search` and `page` are managed via the URL, which is their only source of truth, so they should not be persisted as part of a view configuration.

Removes both properties from the shared ViewBase schema in `WP_REST_View_Config_Controller`, updates the `WP_View_Config_Data` docblock example that used `search`, and adds a test asserting neither property is declared by any view in the item schema.

