### PR TITLE
Options, Meta APIs: Pass $unique to the add_{$meta_type}_meta and added_{$meta_type}_meta actions.

### DIFF
--- a/src/wp-includes/meta.php
+++ b/src/wp-includes/meta.php
@@ -163,7 +163,7 @@ function add_metadata( $meta_type, $object_id, $meta_key, $meta_value, $unique =
 	 * @since 2.9.0
 	 * @since 7.2.0 The `$unique` parameter was added.
 	 *
-	 * @param int    $mid         The meta ID after successful update.
+	 * @param int    $mid         The meta ID after successful addition.
 	 * @param int    $object_id   ID of the object metadata is for.
 	 * @param string $meta_key    Metadata key.
 	 * @param mixed  $_meta_value Metadata value.

--- a/src/wp-includes/meta.php
+++ b/src/wp-includes/meta.php
@@ -120,12 +120,14 @@ function add_metadata( $meta_type, $object_id, $meta_key, $meta_value, $unique =
 	 *  - `add_user_meta`
 	 *
 	 * @since 3.1.0
+	 * @since 7.2.0 The `$unique` parameter was added.
 	 *
 	 * @param int    $object_id   ID of the object metadata is for.
 	 * @param string $meta_key    Metadata key.
 	 * @param mixed  $_meta_value Metadata value.
+	 * @param bool   $unique      Whether the specified meta key should be unique for the object.
 	 */
-	do_action( "add_{$meta_type}_meta", $object_id, $meta_key, $_meta_value );
+	do_action( "add_{$meta_type}_meta", $object_id, $meta_key, $_meta_value, $unique );
 
 	$result = $wpdb->insert(
 		$table,
@@ -159,13 +161,15 @@ function add_metadata( $meta_type, $object_id, $meta_key, $meta_value, $unique =
 	 *  - `added_user_meta`
 	 *
 	 * @since 2.9.0
+	 * @since 7.2.0 The `$unique` parameter was added.
 	 *
 	 * @param int    $mid         The meta ID after successful update.
 	 * @param int    $object_id   ID of the object metadata is for.
 	 * @param string $meta_key    Metadata key.
 	 * @param mixed  $_meta_value Metadata value.
+	 * @param bool   $unique      Whether the specified meta key should be unique for the object.
 	 */
-	do_action( "added_{$meta_type}_meta", $mid, $object_id, $meta_key, $_meta_value );
+	do_action( "added_{$meta_type}_meta", $mid, $object_id, $meta_key, $_meta_value, $unique );
 
 	return $mid;
 }

--- a/tests/phpunit/tests/meta/addMetadata.php
+++ b/tests/phpunit/tests/meta/addMetadata.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * @group meta
+ * @covers ::add_metadata
+ */
+class Tests_Meta_AddMetadata extends WP_UnitTestCase {
+
+	/**
+	 * @ticket 39706
+	 *
+	 * @dataProvider data_actions_should_receive_unique
+	 *
+	 * @param bool $unique Whether the specified meta key should be unique for the object.
+	 */
+	public function test_actions_should_receive_unique( $unique ) {
+		$add_action   = new MockAction();
+		$added_action = new MockAction();
+
+		add_action( 'add_post_meta', array( $add_action, 'action' ), 10, 4 );
+		add_action( 'added_post_meta', array( $added_action, 'action' ), 10, 5 );
+
+		add_metadata( 'post', 123, 'test_key', 'value', $unique );
+
+		$add_args   = $add_action->get_args();
+		$added_args = $added_action->get_args();
+
+		$this->assertSame( $unique, $add_args[0][3], 'The add_post_meta action should receive the value of $unique.' );
+		$this->assertSame( $unique, $added_args[0][4], 'The added_post_meta action should receive the value of $unique.' );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_actions_should_receive_unique() {
+		return array(
+			'unique meta'     => array( true ),
+			'non-unique meta' => array( false ),
+		);
+	}
+}


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/39706

## What

Passes the `$unique` flag given to `add_metadata()` through to the `add_{$meta_type}_meta` and `added_{$meta_type}_meta` action hooks, as an additional (4th respectively 5th) argument.

## Why

Callbacks on these hooks can currently see what metadata is being added, but not whether the caller requested it to be unique for the object, even though that flag changes the semantics of the operation. The related `add_{$meta_type}_metadata` filter already receives `$unique`; this brings the actions in line with it.

The change is backward compatible: existing callbacks declared their accepted argument count against the old signature and continue to receive exactly the arguments they did before. Only callbacks that opt in to the additional argument receive it.

## Testing

New unit tests in `tests/phpunit/tests/meta/addMetadata.php` assert that both actions receive the `$unique` value for both `true` and `false`, using callbacks that opt in to the new argument count.

- New tests: 2 tests, 4 assertions, passing.
- Full `meta` group: 460 tests, 1222 assertions, passing.
- PHPCS: no new issues on changed files.
- PHPStan hook docblock verification: no errors.

## Notes

- `@since 7.2.0` was used because trunk is currently in the 7.1 beta cycle; happy to adjust.
- Comment 1 on the ticket suggests similarly passing `$delete_all` to the `delete_{$meta_type}_meta` hooks. That is left out here to keep this PR scoped to the ticket summary, and could be a follow-up.
