### PR TITLE
Administration: Fix responsive list table toggle-row button positioning

### DIFF
--- a/src/wp-admin/css/list-tables.css
+++ b/src/wp-admin/css/list-tables.css
@@ -1939,7 +1939,8 @@ div.action-links,
 		display: block;
 	}
 
-	.wp-list-table tr:not(.inline-edit-row):not(.no-items) td:not(.check-column) {
+	.wp-list-table tr:not(.inline-edit-row):not(.no-items) td:not(.check-column),
+	.wp-list-table tbody tr:not(.inline-edit-row):not(.no-items) th:not(.check-column) {
 		position: relative;
 		clear: both;
 		width: auto !important; /* needs to override some columns that are more specifically targeted */
@@ -1966,7 +1967,8 @@ div.action-links,
 		text-overflow: ellipsis;
 	}
 
-	.wp-list-table .is-expanded td:not(.hidden) {
+	.wp-list-table .is-expanded td:not(.hidden):not(.check-column),
+	.wp-list-table .is-expanded th:not(.hidden):not(.check-column) {
 		display: block !important;
 		overflow: hidden; /* clearfix */
 	}


### PR DESCRIPTION
[62838] / #32892 made the primary column a `<th scope="row">` and the checkbox column a `<td>`, but two selectors in the `@media screen and (max-width: 782px)` block of `wp-admin/css/list-tables.css` still only match `td`.

As a result the primary cell never gets `position: relative`, so the absolutely positioned `.toggle-row` button resolves against `#wpbody` and every row's button stacks on the Help and Screen Options tabs (measured `top: 56, left: 734` on `edit.php` at 782px). Clicking Help expands a row instead. On expand, the primary `th` also stays `table-cell` while the sibling `td`s collapse to 8px blocks.

This adds a `th` selector to both rules, scoped to `tbody` so `thead`/`tfoot` are untouched, and excludes `.check-column` from the `.is-expanded` rule so the checkbox cell stays `table-cell`.

To test: at a viewport of 782px or narrower, open Posts, Pages, Comments, Users or Media (list mode). Each row should have its own chevron at the right edge of the title cell, the Help and Screen Options tabs should work, and expanding a row should stack its columns full width with their labels.

Trac ticket: https://core.trac.wordpress.org/ticket/65763

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Reproducing the bug at the 782px breakpoint, tracing it to [62838], and drafting the CSS change. I reviewed the diff, directed the scoping decisions, and verified the behaviour in the browser across the affected screens.
