### PR TITLE
Build/Test Tools: Add a start period to the MySQL healthcheck on the 6.9 branch.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,6 +90,7 @@ services:
       timeout: 5s
       interval: 5s
       retries: 10
+      start_period: 60s
 
   ##
   # The WP CLI container.


### PR DESCRIPTION
Backport of r62937 to the 6.9 branch. Developed in #12753.

The `mysql` healthcheck sets `interval`, `timeout`, and `retries`, but not `start_period`. Docker therefore counts the checks that run while the database initializes against the retry budget of `interval` × `retries`, which is 50 seconds.

The first start of a database volume creates the data directory and runs the files in `/docker-entrypoint-initdb.d`. On a loaded CI runner that work can take longer than 50 seconds. Docker then marks the container unhealthy, every service that declares `mysql: condition: service_healthy` fails to start, and `docker compose up` fails:

```
09:33:37  Container wordpress-develop-mysql-1  Started
09:33:37  Container wordpress-develop-mysql-1  Waiting
09:34:27  Container wordpress-develop-mysql-1  Error
          dependency failed to start: container wordpress-develop-mysql-1 is unhealthy
```

Example run: https://github.com/WordPress/wordpress-develop/actions/runs/30439797855/job/90536164263

This patch adds `start_period: 60s`.

## Testing instructions

The failure needs a first start that takes more than 50 seconds. A fast machine initializes the volume in about 10 seconds, so the failure does not appear locally. Measure the margin instead:

```
npm run env:stop
docker compose down -v
docker compose up -d mysql
docker inspect --format '{{.State.Health.Status}}' $(docker compose ps -q mysql)
```

Repeat the `inspect` command and record how long the container stays `starting`. Compare that time to the 50 second budget.

Then confirm that the start period does not delay a healthy start: on this branch the container still reports `healthy` at the same point it did before, not 60 seconds later.

Trac ticket: https://core.trac.wordpress.org/ticket/65752


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
