### PR TITLE
Posts list table: Add Standard option to Formats filter dropdown

### DIFF
--- a/src/wp-admin/includes/class-wp-posts-list-table.php
+++ b/src/wp-admin/includes/class-wp-posts-list-table.php
@@ -541,7 +541,7 @@ class WP_Posts_List_Table extends WP_List_Table {
 		</label>
 		<select name="post_format" id="filter-by-format">
 			<option<?php selected( $displayed_post_format, '' ); ?> value=""><?php _e( 'All formats' ); ?></option>
-			<option<?php selected( $displayed_post_format, 'standard' ); ?> value="standard"><?php echo get_post_format_string( 'standard' ); ?></option>
+			<option<?php selected( $displayed_post_format, 'standard' ); ?> value="standard"><?php echo esc_html( get_post_format_string( 'standard' ) ); ?></option>
 			<?php
 			foreach ( $used_post_formats as $used_post_format ) {
 				// Post format slug.

--- a/src/wp-admin/includes/class-wp-posts-list-table.php
+++ b/src/wp-admin/includes/class-wp-posts-list-table.php
@@ -541,6 +541,7 @@ class WP_Posts_List_Table extends WP_List_Table {
 		</label>
 		<select name="post_format" id="filter-by-format">
 			<option<?php selected( $displayed_post_format, '' ); ?> value=""><?php _e( 'All formats' ); ?></option>
+			<option<?php selected( $displayed_post_format, 'standard' ); ?> value="standard"><?php echo get_post_format_string( 'standard' ); ?></option>
 			<?php
 			foreach ( $used_post_formats as $used_post_format ) {
 				// Post format slug.

--- a/src/wp-includes/post-formats.php
+++ b/src/wp-includes/post-formats.php
@@ -178,8 +178,8 @@ function _post_format_request( $qvs ) {
 		} else {
 			$qvs['post_format'] = 'post-format-' . $slugs[ $qvs['post_format'] ];
 		}
+	}
 	$tax = get_taxonomy( 'post_format' );
-	if ( ! is_admin() ) {
 		$qvs['post_type'] = $tax->object_type;
 	}
 	return $qvs;

--- a/src/wp-includes/post-formats.php
+++ b/src/wp-includes/post-formats.php
@@ -174,12 +174,10 @@ function _post_format_request( $qvs ) {
 			$qvs['tax_query'][] = array(
 				'taxonomy' => 'post_format',
 				'operator' => 'NOT EXISTS',
-				'field'    => 'slug',
 			);
-			return $qvs;
+		} else {
+			$qvs['post_format'] = 'post-format-' . $slugs[ $qvs['post_format'] ];
 		}
-		$qvs['post_format'] = 'post-format-' . $slugs[ $qvs['post_format'] ];
-	}
 	$tax = get_taxonomy( 'post_format' );
 	if ( ! is_admin() ) {
 		$qvs['post_type'] = $tax->object_type;

--- a/src/wp-includes/post-formats.php
+++ b/src/wp-includes/post-formats.php
@@ -169,6 +169,15 @@ function _post_format_request( $qvs ) {
 	}
 	$slugs = get_post_format_slugs();
 	if ( isset( $slugs[ $qvs['post_format'] ] ) ) {
+		if ( 'standard' === $qvs['post_format'] ) {
+			unset( $qvs['post_format'] );
+			$qvs['tax_query'][] = array(
+				'taxonomy' => 'post_format',
+				'operator' => 'NOT EXISTS',
+				'field'    => 'slug',
+			);
+			return $qvs;
+		}
 		$qvs['post_format'] = 'post-format-' . $slugs[ $qvs['post_format'] ];
 	}
 	$tax = get_taxonomy( 'post_format' );

--- a/src/wp-includes/post-formats.php
+++ b/src/wp-includes/post-formats.php
@@ -180,6 +180,7 @@ function _post_format_request( $qvs ) {
 		}
 	}
 	$tax = get_taxonomy( 'post_format' );
+	if ( ! is_admin() ) {
 		$qvs['post_type'] = $tax->object_type;
 	}
 	return $qvs;


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->
The Formats filter dropdown in the admin posts list table did not have a "Standard" option, so users could not filter for posts without an assigned post format. This was inconsistent with the Categories filter (which has an "Uncategorized" option) and removed a workflow that existed before the formats dropdown was introduced — distinguishing standard posts from formatted ones.

Added a "Standard" option that uses a NOT EXISTS tax_query to correctly find posts without a format.

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->
https://core.trac.wordpress.org/ticket/47675

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->
AI assistance: Yes
Tool(s): Opencode
Model(s): DeepSeek V4 Flash
Used for: Initial code skeleton; final implementation was edited and tested by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
