### PR TITLE
Trim the PHPUnit matrix to boundary PHP versions in the 6.9 branch

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -209,8 +209,6 @@ jobs:
           # MySQL 9.0+ will not work on PHP <= 7.3 because mysql_native_password was removed. See https://core.trac.wordpress.org/ticket/61218.
           - php: '7.2'
             db-version: '9.4'
-          - php: '7.3'
-            db-version: '9.4'
           # Exclude version combinations that don't exist.
           - db-type: 'mariadb'
             db-version: '9.4'

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -69,7 +69,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-24.04 ]
-        php: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5' ]
+        php: [ '7.2', '7.4', '8.0', '8.5' ]
         db-type: [ 'mysql' ]
         db-version: [ '5.7', '8.0', '8.4' ]
         tests-domain: [ 'example.org' ]
@@ -146,7 +146,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-24.04 ]
-        php: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5' ]
+        php: [ '7.2', '7.4', '8.0', '8.5' ]
         db-type: [ 'mariadb' ]
         db-version: [ '5.5', '10.3', '10.5', '10.6', '10.11', '11.4', '11.8' ]
         multisite: [ false, true ]
@@ -198,7 +198,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-24.04 ]
-        php: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5' ]
+        php: [ '7.2', '7.4', '8.0', '8.5' ]
         db-type: [ 'mysql', 'mariadb' ]
         db-version: [ '9.4', '12.0' ]
         multisite: [ false, true ]


### PR DESCRIPTION
This applies the PHPUnit matrix trimming to the 6.9 branch.

Trac ticket: Core-65736