### PR TITLE
Update labelling on reading and discussion

### DIFF
--- a/src/wp-admin/options-discussion.php
+++ b/src/wp-admin/options-discussion.php
@@ -182,15 +182,10 @@ $thread_comments_depth .= '</select>';
 <tr>
 <th scope="row"><?php echo $comment_moderation_title; ?></th>
 <td><fieldset><legend class="screen-reader-text"><span><?php echo $comment_moderation_title; ?></span></legend>
-<p><label for="comment_max_links">
-<?php
-printf(
-	/* translators: %s: Number of links. */
-	__( 'Hold a comment in the queue if it contains %s or more links. (A common characteristic of comment spam is a large number of hyperlinks.)' ),
-	'<input name="comment_max_links" type="number" step="1" min="0" id="comment_max_links" value="' . esc_attr( get_option( 'comment_max_links' ) ) . '" class="small-text" />'
-);
-?>
-</label></p>
+<p><label for="comment_max_links"><?php _e( 'Number of links to allow in a comment before holding for moderation.' ); ?></label>
+<input name="comment_max_links" type="number" step="1" min="0" id="comment_max_links" value="<?php echo esc_attr( get_option( 'comment_max_links' ) ); ?>" class="small-text" aria-describedby="comment_links_moderation_desc" />
+<span id="comment_links_moderation_desc"><?php _e( '(A common characteristic of comment spam is a large number of hyperlinks.)' ); ?></span>
+</p>
 
 <p><label for="moderation_keys"><?php _e( 'When a comment contains any of these words in its content, author name, URL, email, IP address, or browser&#8217;s user agent string, it will be held in the <a href="edit-comments.php?comment_status=moderated">moderation queue</a>. One word or IP address per line. It will match inside words, so &#8220;press&#8221; will match &#8220;WordPress&#8221;.' ); ?></label></p>
 <p>

--- a/src/wp-admin/options-reading.php
+++ b/src/wp-admin/options-reading.php
@@ -175,14 +175,14 @@ else :
 </tr>
 <?php endif; ?>
 <tr>
-<th scope="row"><label for="posts_per_page"><?php _e( 'Blog pages show at most' ); ?></label></th>
+<th scope="row"><label for="posts_per_page"><?php _e( 'Number of recent posts shown on blog pages' ); ?></label></th>
 <td>
-<input name="posts_per_page" type="number" step="1" min="1" id="posts_per_page" value="<?php form_option( 'posts_per_page' ); ?>" class="small-text" /> <?php _e( 'posts' ); ?>
+<input name="posts_per_page" type="number" step="1" min="1" id="posts_per_page" value="<?php form_option( 'posts_per_page' ); ?>" class="small-text" />
 </td>
 </tr>
 <tr>
-<th scope="row"><label for="posts_per_rss"><?php _e( 'Syndication feeds show the most recent' ); ?></label></th>
-<td><input name="posts_per_rss" type="number" step="1" min="1" id="posts_per_rss" value="<?php form_option( 'posts_per_rss' ); ?>" class="small-text" /> <?php _e( 'items' ); ?></td>
+<th scope="row"><label for="posts_per_rss"><?php _e( 'Number of recent items shown in syndication feeds' ); ?></label></th>
+<td><input name="posts_per_rss" type="number" step="1" min="1" id="posts_per_rss" value="<?php form_option( 'posts_per_rss' ); ?>" class="small-text" /></td>
 </tr>
 
 <?php $rss_use_excerpt_title = __( 'For each post in a feed, include' ); ?>

--- a/src/wp-admin/options-reading.php
+++ b/src/wp-admin/options-reading.php
@@ -175,7 +175,7 @@ else :
 </tr>
 <?php endif; ?>
 <tr>
-<th scope="row"><label for="posts_per_page"><?php _e( 'Number of recent posts shown on blog pages' ); ?></label></th>
+<th scope="row"><label for="posts_per_page"><?php _e( 'Number of recent posts shown on archive pages' ); ?></label></th>
 <td>
 <input name="posts_per_page" type="number" step="1" min="1" id="posts_per_page" value="<?php form_option( 'posts_per_page' ); ?>" class="small-text" />
 </td>


### PR DESCRIPTION
Eliminates problems with plural/singular and fixes labeling for screen readers.

Trac ticket: https://core.trac.wordpress.org/ticket/29299

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
