### PR TITLE
Build/Test Tools: Format copied Gutenberg style registry

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -751,6 +751,36 @@ module.exports = function(grunt) {
 				} ],
 			},
 			'gutenberg-styles': {
+				options: {
+					process: function( content, srcpath ) {
+						if ( path.basename( srcpath ) !== 'registry.php' ) {
+							return content;
+						}
+
+						/*
+						 * Gutenberg's generated style registry does not currently
+						 * meet Core's PHP coding standards. Format its known keys
+						 * while copying it so build jobs do not require PHP tooling.
+						 *
+						 * @ticket 65278
+						 */
+						return content.replace(
+							/^(\t\t)'(handle|path|dependencies)'\s*=>\s*([^\r\n]*)$/gm,
+							function( match, indentation, key, value ) {
+								const padding = ' '.repeat( 13 - key.length );
+
+								if ( key === 'dependencies' ) {
+									value = value.replace(
+										/^array\((.+)\),$/,
+										'array( $1 ),'
+									);
+								}
+
+								return indentation + '\'' + key + '\'' + padding + '=> ' + value;
+							}
+						);
+					}
+				},
 				files: [ {
 					expand: true,
 					cwd: 'gutenberg/build/styles',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -764,15 +764,21 @@ module.exports = function(grunt) {
 						 *
 						 * @ticket 65278
 						 */
+						const longestKey = 'dependencies';
+
 						return content.replace(
 							/^(\t\t)'(handle|path|dependencies)'\s*=>\s*([^\r\n]*)$/gm,
 							function( match, indentation, key, value ) {
-								const padding = ' '.repeat( 13 - key.length );
+								const padding = ' '.repeat( longestKey.length - key.length + 1 );
 
 								if ( key === 'dependencies' ) {
 									value = value.replace(
-										/^array\((.+)\),$/,
-										'array( $1 ),'
+										/^array\((.*)\),$/,
+										function( array, dependencies ) {
+											dependencies = dependencies.trim();
+
+											return dependencies ? 'array( ' + dependencies + ' ),' : 'array(),';
+										}
 									);
 								}
 


### PR DESCRIPTION
Formats the generated Gutenberg style registry while it is copied into Core.

Gutenberg currently outputs `registry.php` with unaligned array operators and missing spaces inside non-empty dependency arrays. Running `build:dev` followed by a Core PHPCS scan therefore reports coding standards violations. The copy step now normalizes those known fields without requiring PHP or Composer in build-only jobs.

Trac ticket: https://core.trac.wordpress.org/ticket/65278

## Testing

- `npm run build:dev`
- `npm run grunt jshint:grunt`
- `php -l src/wp-includes/css/dist/registry.php`
- `php ./vendor/squizlabs/php_codesniffer/bin/phpcs --standard=phpcs.xml.dist src/wp-includes/css/dist/registry.php`
- `php ./vendor/squizlabs/php_codesniffer/bin/phpcs --standard=phpcompat.xml.dist src/wp-includes/css/dist/registry.php`
- `git diff --check`

Before the change, PHPCS reported 34 errors and 38 warnings in the generated registry. After the change, both PHPCS rulesets pass.

## Use of AI Tools

AI assistance: Yes
Tool(s): OpenAI Codex
Model(s): GPT-5
Used for: Issue research, implementation, and local validation.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
