### PR TITLE
Try: Build WP once for PHPUnit test suite.

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -156,6 +156,7 @@ jobs:
       report: ${{ matrix.report || false }}
       gutenberg-artifact: ${{ needs.prepare-gutenberg.result != 'skipped' }}
       gutenberg-sha: ${{ needs.prepare-gutenberg.outputs.gutenberg-sha }}
+      wordpress-build-artifact: wordpress-build
 
   #
   # Creates a PHPUnit test job for each PHP/MariaDB combination.
@@ -221,6 +222,7 @@ jobs:
       report: false
       gutenberg-artifact: ${{ needs.prepare-gutenberg.result != 'skipped' }}
       gutenberg-sha: ${{ needs.prepare-gutenberg.outputs.gutenberg-sha }}
+      wordpress-build-artifact: wordpress-build
 
   #
   # Creates PHPUnit test jobs to test MariaDB and MySQL innovation releases.
@@ -280,6 +282,7 @@ jobs:
       report: false
       gutenberg-artifact: ${{ needs.prepare-gutenberg.result != 'skipped' }}
       gutenberg-sha: ${{ needs.prepare-gutenberg.outputs.gutenberg-sha }}
+      wordpress-build-artifact: wordpress-build
 
   #
   # Runs the HTML API test group.
@@ -324,6 +327,7 @@ jobs:
       phpunit-test-groups: ${{ matrix.phpunit-test-groups }}
       gutenberg-artifact: ${{ needs.prepare-gutenberg.result != 'skipped' }}
       gutenberg-sha: ${{ needs.prepare-gutenberg.outputs.gutenberg-sha }}
+      wordpress-build-artifact: wordpress-build
 
   #
   # Runs unit tests for forks.
@@ -395,6 +399,7 @@ jobs:
       phpunit-test-groups: ${{ matrix.phpunit-test-groups || '' }}
       gutenberg-artifact: ${{ needs.prepare-gutenberg.result != 'skipped' }}
       gutenberg-sha: ${{ needs.prepare-gutenberg.outputs.gutenberg-sha }}
+      wordpress-build-artifact: wordpress-build
 
   slack-notifications:
     name: Slack Notifications

--- a/.github/workflows/reusable-phpunit-tests-v3.yml
+++ b/.github/workflows/reusable-phpunit-tests-v3.yml
@@ -82,6 +82,11 @@ on:
         required: false
         type: string
         default: ''
+      wordpress-build-artifact:
+        description: 'The name of a same-workflow artifact containing the pre-built WordPress assets. Optional: callers that omit it build per job.'
+        required: false
+        type: string
+        default: ''
     secrets:
       CODECOV_TOKEN:
         description: 'The Codecov token required for uploading reports.'
@@ -184,7 +189,21 @@ jobs:
       - name: Install npm dependencies
         run: npm ci
 
+      - name: Download WordPress build
+        if: inputs.wordpress-build-artifact != ''
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ inputs.wordpress-build-artifact }}
+          path: /tmp/wordpress-build
+          digest-mismatch: error
+
+      - name: Apply WordPress build
+        if: inputs.wordpress-build-artifact != ''
+        run: |
+          tar -xzf /tmp/wordpress-build/wordpress-build.tar.gz
+
       - name: Build WordPress
+        if: inputs.wordpress-build-artifact == ''
         run: npm run build:dev
         env:
           # The producer resolved this once. Matrix jobs must not re-resolve mutable GHCR tags.

--- a/.github/workflows/reusable-phpunit-tests-v3.yml
+++ b/.github/workflows/reusable-phpunit-tests-v3.yml
@@ -190,6 +190,8 @@ jobs:
         run: npm ci
 
       - name: Download WordPress build
+        id: download-wordpress
+        continue-on-error: ${{ github.run_attempt != '1' }}
         if: inputs.wordpress-build-artifact != ''
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -198,12 +200,12 @@ jobs:
           digest-mismatch: error
 
       - name: Apply WordPress build
-        if: inputs.wordpress-build-artifact != ''
+        if: steps.download-wordpress.outcome == 'success'
         run: |
           tar -xzf /tmp/wordpress-build/wordpress-build.tar.gz
 
       - name: Build WordPress
-        if: inputs.wordpress-build-artifact == ''
+        if: inputs.wordpress-build-artifact == '' || steps.download-wordpress.outcome != 'success'
         run: npm run build:dev
         env:
           # The producer resolved this once. Matrix jobs must not re-resolve mutable GHCR tags.

--- a/.github/workflows/reusable-prepare-gutenberg.yml
+++ b/.github/workflows/reusable-prepare-gutenberg.yml
@@ -38,6 +38,7 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.nvmrc'
+          cache: npm
 
       - name: Download and verify Gutenberg build
         id: download

--- a/.github/workflows/reusable-prepare-gutenberg.yml
+++ b/.github/workflows/reusable-prepare-gutenberg.yml
@@ -58,3 +58,29 @@ jobs:
           if-no-files-found: error
           include-hidden-files: true
           retention-days: 1
+
+      - name: Install npm dependencies
+        run: npm ci
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: true
+
+      - name: Build WordPress
+        run: npm run build:dev
+        env:
+          GUTENBERG_EXPECTED_SHA: ${{ steps.download.outputs.gutenberg-sha }}
+
+      - name: Package WordPress build
+        run: |
+          { git diff --name-only HEAD; git ls-files --others --exclude="/gutenberg/*" --exclude="/vendor/*" --exclude="/node_modules/*"; } \
+            > /tmp/build-manifest.txt
+          echo "Files included in build artifact:"
+          cat /tmp/build-manifest.txt
+          tar -czf wordpress-build.tar.gz --files-from=/tmp/build-manifest.txt
+
+      - name: Upload WordPress build
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: wordpress-build
+          path: wordpress-build.tar.gz
+          if-no-files-found: error
+          retention-days: 1

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -79,6 +79,7 @@ jobs:
       coverage-report: ${{ matrix.coverage-report }}
       gutenberg-artifact: ${{ needs.prepare-gutenberg.result != 'skipped' }}
       gutenberg-sha: ${{ needs.prepare-gutenberg.outputs.gutenberg-sha }}
+      wordpress-build-artifact: wordpress-build
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 


### PR DESCRIPTION
Runs `npm run build:dev` in the newly created `prepare-gutenberg` reusable workflow for the PHPUnit tests.

This allows the step to be bypassed in each test, saving about 30 seconds of runtime.

As the local environment uses NPM for the docker pull and configuration, the `npm ci` step is still required. That can be a project for another time.

Trac ticket: https://core.trac.wordpress.org/ticket/65770

## Use of AI Tools

AI assistance: Yes
Tool(s): GitHub Copilot
Used for: Initial drafting of this in another PR that also included some docker changes. The creation of this PR built upon portions of that but is much reduced in scope. AI was not used for the generation of this PR per se.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
