### PR TITLE
Toolbar: Fix missing focus style on the home icon in mobile layouts

### DIFF
--- a/src/wp-admin/css/colors/_admin.scss
+++ b/src/wp-admin/css/colors/_admin.scss
@@ -477,7 +477,8 @@ ul#adminmenu > li.current > a.current:after {
 #wpadminbar .quicklinks .ab-sub-wrapper .menupop.hover > a .blavatar,
 #wpadminbar .menupop .menupop > .ab-item:hover:before,
 #wpadminbar.mobile .quicklinks .hover .ab-icon:before,
-#wpadminbar.mobile .quicklinks .hover .ab-item:before {
+#wpadminbar.mobile .quicklinks .hover .ab-item:before,
+#wpadminbar.mobile .quicklinks .ab-item:focus:before {
 	color: variables.$menu-submenu-focus-text;
 }
 

--- a/src/wp-includes/css/admin-bar.css
+++ b/src/wp-includes/css/admin-bar.css
@@ -304,7 +304,8 @@ html:lang(he-il) .rtl #wpadminbar * {
 }
 
 #wpadminbar.mobile .quicklinks .hover .ab-icon:before,
-#wpadminbar.mobile .quicklinks .hover .ab-item:before {
+#wpadminbar.mobile .quicklinks .hover .ab-item:before,
+#wpadminbar.mobile .quicklinks .ab-item:focus:before {
 	color: #72aee6;
 }
 


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65765

The home icon is drawn on `.ab-item::before` and has no nested `.ab-icon` span. In mobile layouts its resting colour is more specific than its focus colour, so focusing the link never changes the icon:

    resting   #wpadminbar.mobile .quicklinks .ab-item:before   (1,3,1)
    focus     #wpadminbar li .ab-item:focus:before             (1,2,2)

This adds a focus selector next to the existing `.hover` rule, at matching specificity (1,4,1).

Both files are needed. `colors/_admin.scss` generates the admin colour schemes. `admin-bar.css` handles the two cases that load no colour scheme file at all: the Fresh scheme, and the toolbar on the front end of the site.

> [!NOTE]
> `#wpadminbar` only gets the `mobile` class when `wp_is_mobile()` returns true, so reproducing needs a device preset in DevTools or a real device — narrowing the browser window is not enough.

## Screenshots

| | Before | After |
|---|---|---|
| **Admin** | <img width="500" alt="admin-before" src="https://github.com/user-attachments/assets/d42e17bf-a7e8-48b1-bc0b-1c04a80df892" /> | <img width="500" alt="admin-after" src="https://github.com/user-attachments/assets/5e87aa38-c2f0-4e12-aaef-92a024a79b64" /> |
| **Front end** |<img width="500" height="269" alt="frontend-before" src="https://github.com/user-attachments/assets/856c4318-6e9b-445f-8c3c-760720d39d5e" /> |<img width="500" height="269" alt="frontend-after" src="https://github.com/user-attachments/assets/88862fda-e839-40e2-9851-ecadc6cf88fc" /> |

The front-end pair also shows the mechanism: `site-name` and `site-editor` draw their icons on `.ab-item::before` and gain a focus colour with the patch, while `comments` uses a nested `.ab-icon` and was already working.

## Use of AI Tools

- **AI assistance:** Yes
- **Tool(s):** Claude Code
- **Model(s):** Claude Opus 5
- **Used for:** Investigating the CSS specificity conflict, verifying the behaviour across the admin colour schemes and the front-end toolbar, and drafting the commit message and this description. The final change was reduced, tested and confirmed by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
