### PR TITLE
Build/Test Tools: Cancel old CI runs when a newer commit is pushed

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -32,12 +32,13 @@ on:
       - '.github/workflows/reusable-coding-standards-*.yml'
   workflow_dispatch:
 
-# Cancels all previous workflow runs for pull requests that have not completed.
+# Cancels previous incomplete runs on the same branch for pull requests and pushes.
 concurrency:
-  # The concurrency group contains the workflow name and the branch name for pull requests
-  # or the commit hash for any other events.
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
-  cancel-in-progress: true
+  # Group by branch for pull requests and pushes, so a newer run cancels an older
+  # one on the same branch. Scheduled and manual runs get a unique group and are
+  # never cancelled.
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.number || github.event_name == 'push' && github.ref || format('{0}-{1}', github.run_id, github.run_attempt) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
 
 # Disable permissions for all available scopes by default.
 # Any needed permissions should be configured at the job level.

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -32,11 +32,11 @@ on:
       - '.github/workflows/reusable-coding-standards-*.yml'
   workflow_dispatch:
 
-# Cancels previous incomplete runs on the same branch for pull requests and pushes.
+# Cancel an older in-progress run when a newer one starts for the same pull request or branch.
 concurrency:
-  # Group by branch for pull requests and pushes, so a newer run cancels an older
-  # one on the same branch. Scheduled and manual runs get a unique group and are
-  # never cancelled.
+  # Pull requests group by PR number and pushes group by branch (github.ref), so a
+  # newer run cancels the older one. Manual runs (workflow_dispatch) get a unique
+  # group and are never cancelled.
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.number || github.event_name == 'push' && github.ref || format('{0}-{1}', github.run_id, github.run_attempt) }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
 
@@ -68,7 +68,9 @@ jobs:
       actions: read
       contents: read
     needs: [ phpcs, jshint ]
-    if: ${{ github.repository == 'WordPress/wordpress-develop' && github.event_name != 'pull_request' && always() }}
+    # Skip on cancellation: a cancelled run is usually superseded by a newer push,
+    # so notifying would be noise. Genuine failures still notify.
+    if: ${{ github.repository == 'WordPress/wordpress-develop' && github.event_name != 'pull_request' && !cancelled() }}
     with:
       calling_status: ${{ contains( needs.*.result, 'cancelled' ) && 'cancelled' || contains( needs.*.result, 'failure' ) && 'failure' || 'success' }}
     secrets:
@@ -83,8 +85,10 @@ jobs:
     permissions:
       actions: write
     needs: [ phpcs, jshint, slack-notifications ]
+    # Skip on cancellation: a superseded run must not dispatch a retry for its
+    # now-obsolete commit. Genuine failures still retry.
     if: |
-      always() &&
+      !cancelled() &&
       github.repository == 'WordPress/wordpress-develop' &&
       github.event_name != 'pull_request' &&
       github.run_attempt < 2 &&

--- a/.github/workflows/slack-notifications.yml
+++ b/.github/workflows/slack-notifications.yml
@@ -178,13 +178,17 @@ jobs:
           payload: ${{ needs.prepare.outputs.payload }}
 
   # Posts notifications the first time a workflow run succeeds after previously failing.
+  #
+  # A cancelled previous run is inconclusive (e.g. superseded by a newer push), so it
+  # is not treated as a prior failure here. Otherwise a routine cancel-then-succeed
+  # sequence would post a false "fixed" notification.
   fixed:
     name: Fixed notifications
     permissions: {}
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     needs: [ prepare ]
-    if: ${{ contains( fromJson( '["failure", "cancelled", "none"]' ), needs.prepare.outputs.previous_conclusion ) && inputs.calling_status == 'success' && success() }}
+    if: ${{ contains( fromJson( '["failure", "none"]' ), needs.prepare.outputs.previous_conclusion ) && inputs.calling_status == 'success' && success() }}
 
     steps:
       - name: Post failure notifications to Slack


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65769

----

**Why:** Redundant runs compete for the shared runner pool, so feedback slows for everyone and runner minutes go to commits no one is waiting on. The pressure is worst during releases, when many branches build at once.

**What:** A new push now cancels the still-running older run on the same branch (pull request runs already work this way). Manual runs get their own group and are never cancelled.

Cancelling a superseded run makes `cancelled` routine, so the follow-up jobs no longer treat it as a real problem: the superseded run doesn't dispatch a retry for its obsolete commit, and the replacement run doesn't post a false "fixed" Slack notification. Genuine failures still notify and retry.

Pilot on one workflow. If it behaves as expected, the same change applies to the other push-triggered workflows.

_Use of AI Tools: Claude Code—used to draft the change and description._