### PR TITLE
Plugin Dependencies: Recognize network-active dependencies

### DIFF
--- a/src/wp-admin/includes/plugin-install.php
+++ b/src/wp-admin/includes/plugin-install.php
@@ -914,7 +914,6 @@ function wp_get_plugin_action_button( $name, $data, $compatible_php, $compatible
 
 	// Determine the status of plugin dependencies.
 	$installed_plugins                   = get_plugins();
-	$active_plugins                      = get_option( 'active_plugins', array() );
 	$plugin_dependencies_count           = count( $requires_plugins );
 	$installed_plugin_dependencies_count = 0;
 	$active_plugin_dependencies_count    = 0;
@@ -922,12 +921,10 @@ function wp_get_plugin_action_button( $name, $data, $compatible_php, $compatible
 		foreach ( array_keys( $installed_plugins ) as $installed_plugin_file ) {
 			if ( str_contains( $installed_plugin_file, '/' ) && explode( '/', $installed_plugin_file )[0] === $dependency ) {
 				++$installed_plugin_dependencies_count;
-			}
-		}
 
-		foreach ( $active_plugins as $active_plugin_file ) {
-			if ( str_contains( $active_plugin_file, '/' ) && explode( '/', $active_plugin_file )[0] === $dependency ) {
-				++$active_plugin_dependencies_count;
+				if ( is_plugin_active( $installed_plugin_file ) ) {
+					++$active_plugin_dependencies_count;
+				}
 			}
 		}
 	}

--- a/tests/phpunit/tests/admin/includes/plugin-install/WpGetPluginActionButton_Test.php
+++ b/tests/phpunit/tests/admin/includes/plugin-install/WpGetPluginActionButton_Test.php
@@ -32,6 +32,13 @@ class Admin_Includes_Plugin_Install_WpGetPluginActionButton_Test extends WP_Unit
 	private static $test_plugin;
 
 	/**
+	 * Test dependency plugin data.
+	 *
+	 * @var stdClass
+	 */
+	private static $dependency_plugin;
+
+	/**
 	 * Sets up properties and adds a test plugin before any tests run.
 	 */
 	public static function set_up_before_class() {
@@ -42,12 +49,18 @@ class Admin_Includes_Plugin_Install_WpGetPluginActionButton_Test extends WP_Unit
 		$role_name = 'wp_get_plugin_action_button-test-role';
 		add_role( $role_name, 'Test Role' );
 
-		self::$role        = get_role( $role_name );
-		self::$user_id     = self::factory()->user->create( array( 'role' => $role_name ) );
-		self::$test_plugin = (object) array(
+		self::$role              = get_role( $role_name );
+		self::$user_id           = self::factory()->user->create( array( 'role' => $role_name ) );
+		self::$test_plugin       = (object) array(
 			'name'    => 'My Plugin',
 			'slug'    => 'my-plugin',
 			'version' => '1.0.0',
+		);
+		self::$dependency_plugin = (object) array(
+			'name'    => 'My Dependency Plugin',
+			'slug'    => 'my-dependency-plugin',
+			'version' => '1.0.0',
+			'file'    => 'my-dependency-plugin/my_dependency_plugin.php',
 		);
 
 		mkdir( WP_PLUGIN_DIR . '/' . self::$test_plugin->slug );
@@ -55,6 +68,14 @@ class Admin_Includes_Plugin_Install_WpGetPluginActionButton_Test extends WP_Unit
 			WP_PLUGIN_DIR . '/' . self::$test_plugin->slug . '/my_plugin.php',
 			"<?php\n/**\n* Plugin Name: " . self::$test_plugin->name . "\n* Version: " . self::$test_plugin->version . "\n*/"
 		);
+
+		mkdir( WP_PLUGIN_DIR . '/' . self::$dependency_plugin->slug );
+		file_put_contents(
+			WP_PLUGIN_DIR . '/' . self::$dependency_plugin->file,
+			"<?php\n/**\n* Plugin Name: " . self::$dependency_plugin->name . "\n* Version: " . self::$dependency_plugin->version . "\n*/"
+		);
+
+		wp_clean_plugins_cache( false );
 	}
 
 	/**
@@ -67,6 +88,11 @@ class Admin_Includes_Plugin_Install_WpGetPluginActionButton_Test extends WP_Unit
 
 		unlink( WP_PLUGIN_DIR . '/' . self::$test_plugin->slug . '/my_plugin.php' );
 		rmdir( WP_PLUGIN_DIR . '/' . self::$test_plugin->slug );
+
+		unlink( WP_PLUGIN_DIR . '/' . self::$dependency_plugin->file );
+		rmdir( WP_PLUGIN_DIR . '/' . self::$dependency_plugin->slug );
+
+		wp_clean_plugins_cache( false );
 	}
 
 	/**
@@ -151,5 +177,36 @@ class Admin_Includes_Plugin_Install_WpGetPluginActionButton_Test extends WP_Unit
 
 		$this->assertIsString( $actual, 'A string should be returned.' );
 		$this->assertNotEmpty( $actual, 'An empty string should not be returned.' );
+	}
+
+	/**
+	 * Tests that the Activate button is enabled when a dependency is network-active.
+	 *
+	 * @ticket 65759
+	 *
+	 * @group ms-required
+	 */
+	public function test_should_enable_activate_button_when_dependency_is_network_active() {
+		$test_plugin                   = clone self::$test_plugin;
+		$test_plugin->requires_plugins = array( self::$dependency_plugin->slug );
+
+		wp_set_current_user( self::$user_id );
+		grant_super_admin( self::$user_id );
+
+		$activation_result = activate_plugin( self::$dependency_plugin->file, '', true );
+
+		$actual = wp_get_plugin_action_button(
+			$test_plugin->name,
+			$test_plugin,
+			true,
+			true
+		);
+
+		deactivate_plugins( self::$dependency_plugin->file, true, true );
+		revoke_super_admin( self::$user_id );
+
+		$this->assertNull( $activation_result, 'The dependency plugin should be network-activated.' );
+		$this->assertStringContainsString( 'activate-now', $actual, 'An enabled Activate button should be returned.' );
+		$this->assertStringNotContainsString( 'button-disabled', $actual, 'The Activate button should not be disabled.' );
 	}
 }


### PR DESCRIPTION
## Summary

`wp_get_plugin_action_button()` only checked the per-site `active_plugins` option when determining whether plugin dependencies were active. On multisite, this caused the Activate button to remain disabled when a dependency was network-active.

This changes the dependency check to use `is_plugin_active()`, which recognizes both per-site and network activation, and adds a multisite regression test.

Trac ticket: https://core.trac.wordpress.org/ticket/65759

## Testing

- Focused multisite regression test: 1 test, 3 assertions
- Complete action-button test class on multisite: 3 tests, 7 assertions
- Complete action-button test class on single site: 3 tests, 6 assertions
- PHP coding standards on both changed files
- `git diff --check`

## Use of AI Tools

AI assistance: Codex assisted with drafting the code and tests. I reviewed and validated the changes and completed the remaining contribution work.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
