### PR TITLE
Editor: Restore contrast of active TinyMCE toolbar button icons

### DIFF
--- a/src/wp-includes/css/editor.css
+++ b/src/wp-includes/css/editor.css
@@ -425,11 +425,16 @@ div.mce-path {
 	border-color: #50575e;
 }
 
-.mce-btn.mce-active,
-.mce-btn.mce-active button,
-.mce-btn.mce-active:hover button,
-.mce-btn.mce-active i,
-.mce-btn.mce-active:hover i {
+/*
+ * TinyMCE appends its skin stylesheet when the editor initializes, so it can be
+ * parsed after this file. The extra class gives these rules a higher specificity
+ * than the skin's white active state, so they no longer depend on source order.
+ */
+.mce-widget.mce-btn.mce-active,
+.mce-widget.mce-btn.mce-active button,
+.mce-widget.mce-btn.mce-active:hover button,
+.mce-widget.mce-btn.mce-active i,
+.mce-widget.mce-btn.mce-active:hover i {
 	color: inherit;
 }
 

--- a/src/wp-includes/css/editor.css
+++ b/src/wp-includes/css/editor.css
@@ -426,15 +426,16 @@ div.mce-path {
 }
 
 /*
- * TinyMCE appends its skin stylesheet when the editor initializes, so it can be
- * parsed after this file. The extra class gives these rules a higher specificity
- * than the skin's white active state, so they no longer depend on source order.
+ * TinyMCE appends its skin stylesheet when the editor initializes. The skin may
+ * be parsed after this stylesheet. The extra `mce-toolbar` class gives these
+ * selectors a higher specificity than the skin's white active state, so that
+ * the styling no longer depend on source order.
  */
-.mce-widget.mce-btn.mce-active,
-.mce-widget.mce-btn.mce-active button,
-.mce-widget.mce-btn.mce-active:hover button,
-.mce-widget.mce-btn.mce-active i,
-.mce-widget.mce-btn.mce-active:hover i {
+.mce-toolbar .mce-btn.mce-active,
+.mce-toolbar .mce-btn.mce-active button,
+.mce-toolbar .mce-btn.mce-active:hover button,
+.mce-toolbar .mce-btn.mce-active i,
+.mce-toolbar .mce-btn.mce-active:hover i {
 	color: inherit;
 }
 


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

TinyMCE's lightgray skin styles active toolbar buttons as white icons on a dark background. `editor.css` overrides both halves — the background becomes light gray and the icon colour reverts to `inherit` — but the colour override used the same selectors as the skin, so it only won the cascade when parsed later.

What the problem was:
- TinyMCE appends its skin stylesheet when the editor initializes. When the editor is initialized after page load, as the Classic block does, the skin is parsed after `editor.css` and its white icon colour wins the tie.
- The classic editor is unaffected because `wp_editor()` prints `editor-buttons` inline in the body, after the skin.
- Result: active buttons render a white icon on the `#f0f0f1` background — 1.1:1 contrast.

What the fix does:
- Adds the `mce-widget` class, which TinyMCE puts on every button alongside `mce-btn`, to the five existing override selectors.

Approach and why:
- The override already expresses the correct intent; it just needed to stop depending on source order. Adding a class TinyMCE always emits raises specificity above the skin without narrowing scope.
- Scoping to `.mce-toolbar .mce-btn-group` would also have worked but would drop menubar buttons, which plugins can enable via `tiny_mce_before_init`.

Trac ticket: https://core.trac.wordpress.org/ticket/65768

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Ticket analysis, tests and writing PR. All changes were reviewed and validated by me.
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
