### PR TITLE
Media Modal: Fix positioning and spacing on mobile with infinite scroll

### DIFF
--- a/src/wp-includes/css/media-views.css
+++ b/src/wp-includes/css/media-views.css
@@ -2635,6 +2635,7 @@ select#media-attachment-filters ~ select#media-attachment-date-filters {
 	}
 
 	.attachments-browser .attachments,
+	.attachments-browser:not(.has-load-more) .attachments,
 	.attachments-browser .uploader-inline,
 	.attachments-browser .media-toolbar,
 	.attachments-browser .attachments-wrapper,
@@ -2643,13 +2644,14 @@ select#media-attachment-filters ~ select#media-attachment-date-filters {
 	}
 
 	.attachments-browser .media-toolbar {
-		height: 74px;
+		height: 117px;
 	}
 
 	.attachments-browser .attachments,
+	.attachments-browser:not(.has-load-more) .attachments,
 	.attachments-browser .uploader-inline,
 	.media-frame-content .attachments-browser .attachments-wrapper {
-		top: 90px;
+		top: 131px;
 	}
 
 	.media-sidebar .setting,
@@ -2956,6 +2958,7 @@ select#media-attachment-filters ~ select#media-attachment-date-filters {
 	}
 
 	.attachments-browser .attachments,
+	.attachments-browser:not(.has-load-more) .attachments,
 	.attachments-browser .uploader-inline,
 	.attachments-browser .media-toolbar,
 	.media-frame-content .attachments-browser .attachments-wrapper {


### PR DESCRIPTION
## What

This fixes the positioning and spacing of the media modal on mobile when infinite scroll is enabled.

## Why

In the media modal on small screens, the attachment grid collapses to a single narrow column when infinite scrolling is enabled. 

See: https://core.trac.wordpress.org/ticket/65564#comment:25

## Testing instructions:
* Ensure infinite scrolling is enabled (it's enabled by default, make sure the current user is not opted out in Users > Profile)
* Try with various browser widths, like mobile and tablet
* Make sure you have at least 10 images uploaded
* Open a media modal from the post editor (from the Image block for example)
* Verify the attachment grid fills the modal width and shows multiple items per row
* Disable infinite scrolling and verify the layout is identical and still works well. 

## Screenshots

| Before      | After |
| ----------- | ----------- |
| <img width="407" height="468" alt="Screenshot 2026-07-31 at 10 33 44" src="https://github.com/user-attachments/assets/1674178a-eec0-4ef8-8248-8d79d892b489" /> | <img width="409" height="468" alt="Screenshot 2026-07-31 at 10 34 12" src="https://github.com/user-attachments/assets/189d31cb-8e0a-44ca-b596-7e25f21f1c52" />  |

