### PR TITLE
REST API: Correctly store multiple value meta on autosaves

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php
@@ -398,10 +398,30 @@ class WP_REST_Autosaves_Controller extends WP_REST_Revisions_Controller {
 		// Check if meta values have changed.
 		if ( ! empty( $meta ) ) {
 			$revisioned_meta_keys = wp_post_revision_meta_keys( $post->post_type );
+			$registered_meta      = array_merge(
+				get_registered_meta_keys( 'post' ),
+				get_registered_meta_keys( 'post', $post->post_type )
+			);
+
+			/*
+			 * Meta keys registered with 'single' => false store each of their values in a
+			 * separate row, so they must be read, compared, and stored as a list of values.
+			 * Keys without a registration are treated as single, matching previous behavior.
+			 */
+			$is_single_meta = array();
+
+			foreach ( $revisioned_meta_keys as $meta_key ) {
+				$is_single_meta[ $meta_key ] = ! isset( $registered_meta[ $meta_key ]['single'] ) || $registered_meta[ $meta_key ]['single'];
+			}
+
 			foreach ( $revisioned_meta_keys as $meta_key ) {
 				// get_metadata_raw is used to avoid retrieving the default value.
-				$old_meta = get_metadata_raw( 'post', $post_id, $meta_key, true );
-				$new_meta = $meta[ $meta_key ] ?? '';
+				$old_meta = get_metadata_raw( 'post', $post_id, $meta_key, $is_single_meta[ $meta_key ] );
+				$new_meta = $meta[ $meta_key ] ?? ( $is_single_meta[ $meta_key ] ? '' : array() );
+
+				if ( ! $is_single_meta[ $meta_key ] && null === $old_meta ) {
+					$old_meta = array();
+				}
 
 				if ( $new_meta !== $old_meta ) {
 					$autosave_is_different = true;
@@ -441,8 +461,23 @@ class WP_REST_Autosaves_Controller extends WP_REST_Revisions_Controller {
 		// Attached any passed meta values that have revisions enabled.
 		if ( ! empty( $meta ) ) {
 			foreach ( $revisioned_meta_keys as $meta_key ) {
-				if ( isset( $meta[ $meta_key ] ) ) {
+				if ( ! isset( $meta[ $meta_key ] ) ) {
+					continue;
+				}
+
+				if ( $is_single_meta[ $meta_key ] ) {
 					update_metadata( 'post', $revision_id, $meta_key, wp_slash( $meta[ $meta_key ] ) );
+					continue;
+				}
+
+				/*
+				 * update_metadata() would overwrite every row sharing the meta key with the
+				 * same value, so replace the stored values instead, as _wp_copy_post_meta() does.
+				 */
+				delete_metadata( 'post', $revision_id, $meta_key );
+
+				foreach ( (array) $meta[ $meta_key ] as $meta_value ) {
+					add_metadata( 'post', $revision_id, $meta_key, wp_slash( $meta_value ) );
 				}
 			}
 		}

--- a/tests/phpunit/tests/rest-api/rest-autosaves-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-autosaves-controller.php
@@ -516,6 +516,64 @@ class WP_Test_REST_Autosaves_Controller extends WP_Test_REST_Post_Type_Controlle
 		$this->assertNotNull( $values );
 	}
 
+	/**
+	 * @ticket 65754
+	 */
+	public function test_update_item_with_multiple_value_meta() {
+		wp_set_current_user( self::$editor_id );
+
+		register_post_meta(
+			'post',
+			'foo_multi',
+			array(
+				'show_in_rest'      => true,
+				'revisions_enabled' => true,
+				'single'            => false,
+				'type'              => 'string',
+			)
+		);
+
+		$post_id = self::factory()->post->create(
+			array(
+				'post_content' => 'Original content.',
+				'post_author'  => self::$editor_id,
+			)
+		);
+
+		add_post_meta( $post_id, 'foo_multi', 'bar' );
+		add_post_meta( $post_id, 'foo_multi', 'baz' );
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/posts/' . $post_id . '/autosaves' );
+		$request->add_header( 'Content-Type', 'application/x-www-form-urlencoded' );
+		$request->set_body_params(
+			$this->set_post_data(
+				array(
+					'id'      => $post_id,
+					'content' => 'Autosaved content.',
+					'meta'    => array(
+						'foo_multi' => array( 'bar', 'qux' ),
+					),
+				)
+			)
+		);
+
+		$response = rest_get_server()->dispatch( $request );
+		$this->check_create_autosave_response( $response );
+
+		$data = $response->get_data();
+
+		$this->assertSame(
+			array( 'bar', 'qux' ),
+			get_post_meta( $data['id'], 'foo_multi' ),
+			'The autosave revision should store each meta value in its own row.'
+		);
+		$this->assertSame(
+			array( 'bar', 'qux' ),
+			$data['meta']['foo_multi'],
+			'The response should return the autosaved meta values.'
+		);
+	}
+
 	public function test_update_item_nopriv() {
 		wp_set_current_user( self::$contributor_id );
 


### PR DESCRIPTION
## Problem

`WP_REST_Autosaves_Controller::create_post_autosave()` stores every revisioned meta key with a single call:

```php
update_metadata( 'post', $revision_id, $meta_key, wp_slash( $meta[ $meta_key ] ) );
```

`update_metadata()` called without a `$prev_value` updates *every* row that shares the meta key. For a meta key registered with `single => false` the autosave revision already has one row per value, copied there by `_wp_copy_post_meta()`. Each of those rows is then overwritten with the complete array, so a key with two values ends up as:

```
meta_key | meta_value
foo      | a:2:{i:0;s:3:"bar";i:1;s:3:"qux";}
foo      | a:2:{i:0;s:3:"bar";i:1;s:3:"qux";}
```

instead of one row holding `bar` and another holding `qux`.

There is a second, smaller problem in the change detection a few lines above:

```php
$old_meta = get_metadata_raw( 'post', $post_id, $meta_key, true );
$new_meta = $meta[ $meta_key ] ?? '';
```

`$single` is hardcoded to `true`, so for a multiple value key the stored data is read back as a single string and compared against an array. That comparison can never match, so the autosave is always considered different from the post even when nothing actually changed, and a revision is written on every request. This is not in the ticket report, but it has the same cause, so it is fixed here as well. Happy to split it out if that is preferred.

## Fix

Whether a key is single is now taken from the `single` argument it was registered with, rather than from whether the submitted value happens to be an array. That distinction matters: a key registered with `single => true` can legitimately hold an array, and the existing `test_update_item_with_json_meta` covers exactly that case. Keys with no registration keep the previous single behaviour.

For multiple value keys the stored rows are replaced the same way `_wp_copy_post_meta()` writes them in the first place, with `delete_metadata()` followed by one `add_metadata()` per value. The change detection reads back with the matching `$single` argument so the comparison is like for like.

Single value meta is unaffected and still goes through `update_metadata()`.

## Testing instructions

Register a revisionable, multiple value post meta field:

```php
add_action(
	'init',
	function () {
		register_post_meta(
			'post',
			'foo',
			array(
				'show_in_rest'      => true,
				'revisions_enabled' => true,
				'single'            => false,
				'type'              => 'string',
			)
		);
	}
);
```

Add two values to a post, then open it in the block editor, change the content and wait for an autosave:

```
wp post meta add 1 foo bar
wp post meta add 1 foo baz
```

Inspect the `POST /wp-json/wp/v2/posts/1/autosaves` response. Before this change the returned `meta.foo` does not reflect the submitted values and the revision rows each contain the whole serialized array. After it, each value is stored in its own row and comes back correctly.

Automated coverage is included:

```
phpunit --group restapi-autosave
```

`test_update_item_with_multiple_value_meta` fails on trunk with:

```
Failed asserting that two arrays are identical.
-    0 => 'bar'
-    1 => 'qux'
+    0 => Array ( 0 => 'bar', 1 => 'qux' )
+    1 => Array ( 0 => 'bar', 1 => 'qux' )
```

and passes with this change. The full `restapi`, `revision` and `meta` groups pass locally.

Trac ticket: https://core.trac.wordpress.org/ticket/65754

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Locating the cause in `create_post_autosave()`, drafting the fix and the regression test, and drafting this description. I reviewed the change, confirmed the failure and the fix locally against the `restapi`, `restapi-autosave`, `revision` and `meta` groups, and I take responsibility for the code.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
