### PR TITLE
Users: Preserve early-authenticated user ID in `determine_current_user` filter chain

### DIFF
--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -774,7 +774,7 @@ if ( ! function_exists( 'wp_validate_auth_cookie' ) ) :
 	 *
 	 * @global int $login_grace_period
 	 *
-	 * @param int|string $cookie Optional. User ID if passed via `determine_current_user` filter,
+	 * @param int|string $cookie Optional. User ID if passed via 'determine_current_user' filter,
 	 *                           or cookie string to validate. Default empty string.
 	 * @param string     $scheme Optional. The cookie scheme to use: 'auth', 'secure_auth', or 'logged_in'.
 	 *                       Note: This does *not* default to 'auth' like other cookie functions.

--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -774,12 +774,18 @@ if ( ! function_exists( 'wp_validate_auth_cookie' ) ) :
 	 *
 	 * @global int $login_grace_period
 	 *
-	 * @param string $cookie Optional. If used, will validate contents instead of cookie's.
-	 * @param string $scheme Optional. The cookie scheme to use: 'auth', 'secure_auth', or 'logged_in'.
+	 * @param int|string $cookie Optional. User ID if passed via `determine_current_user` filter,
+	 *                           or cookie string to validate. Default empty string.
+	 * @param string     $scheme Optional. The cookie scheme to use: 'auth', 'secure_auth', or 'logged_in'.
 	 *                       Note: This does *not* default to 'auth' like other cookie functions.
-	 * @return int|false User ID if valid cookie, false if invalid.
+	 * @return int|false User ID if valid cookie, false if invalid. If a user ID from an earlier filter
+	 *                   callback is received, that value is returned.
 	 */
 	function wp_validate_auth_cookie( $cookie = '', $scheme = '' ) {
+		if ( $cookie && ( ! is_string( $cookie ) || is_numeric( $cookie ) ) ) {
+			return $cookie;
+		}
+
 		$cookie_elements = wp_parse_auth_cookie( $cookie, $scheme );
 		if ( ! $cookie_elements ) {
 			/**

--- a/tests/phpunit/tests/auth.php
+++ b/tests/phpunit/tests/auth.php
@@ -95,7 +95,7 @@ class Tests_Auth extends WP_UnitTestCase {
 		$cookie          = wp_generate_auth_cookie( self::$user_id, time() + 3600, 'auth' );
 		list($a, $b, $c) = explode( '|', $cookie );
 		$cookie          = $a . '|' . ( $b + 1 ) . '|' . $c;
-		$this->assertFalse( wp_validate_auth_cookie( self::$user_id, 'auth' ), 'altered cookie' );
+		$this->assertFalse( wp_validate_auth_cookie( $cookie, 'auth' ), 'altered cookie' );
 	}
 
 	public function test_auth_cookie_scheme() {

--- a/tests/phpunit/tests/user/wpDetermineCurrentUser.php
+++ b/tests/phpunit/tests/user/wpDetermineCurrentUser.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * Tests for the determine_current_user filter.
+ *
+ * @group user
+ * @group auth
+ *
+ * @covers ::wp_validate_auth_cookie
+ */
+class Tests_User_WpDetermineCurrentUser extends WP_UnitTestCase {
+
+	/**
+	 * Tests that determine_current_user filter callbacks with priority < 10 return their user ID
+	 * without being overridden by wp_validate_auth_cookie.
+	 *
+	 * @ticket 28212
+	 */
+	public function test_determine_current_user_early_filter_priority_less_than_10() {
+		$user_id = self::factory()->user->create();
+
+		$callback = function( $current_user_id ) use ( $user_id ) {
+			return $user_id;
+		};
+
+		add_filter( 'determine_current_user', $callback, 5 );
+
+		$determined_user_id = apply_filters( 'determine_current_user', false );
+
+		remove_filter( 'determine_current_user', $callback, 5 );
+
+		$this->assertSame( $user_id, $determined_user_id );
+	}
+}

--- a/tests/phpunit/tests/user/wpDetermineCurrentUser.php
+++ b/tests/phpunit/tests/user/wpDetermineCurrentUser.php
@@ -19,7 +19,7 @@ class Tests_User_WpDetermineCurrentUser extends WP_UnitTestCase {
 	public function test_determine_current_user_early_filter_priority_less_than_10() {
 		$user_id = self::factory()->user->create();
 
-		$callback = function( $current_user_id ) use ( $user_id ) {
+		$callback = function ( $current_user_id ) use ( $user_id ) {
 			return $user_id;
 		};
 


### PR DESCRIPTION

Trac ticket: https://core.trac.wordpress.org/ticket/28212

When a callback registered on the determine_current_user filter at a priority lower than 10 authenticates a user and returns a user ID, wp_validate_auth_cookie (hooked directly at priority 10) receives that user ID as its $cookie argument.

Because wp_validate_auth_cookie expected a cookie string, it failed parsing and returned false, overriding the user ID determined by the earlier filter callback.

Since we cannot wrap wp_validate_auth_cookie in a new filter callback function (like wp_validate_logged_in_cookie) because changing the hook name in default-filters.php would break backward compatibility for countless stateless API plugins that rely on remove_filter( 'determine_current_user', 'wp_validate_auth_cookie' ).

Instead, this PR adds a safeguard inside wp_validate_auth_cookie() in pluggable.php. If a user ID (non-string or numeric value) is passed, it returns it immediately. If no user ID is passed, it falls through to wp_parse_auth_cookie(), preserving the existing is_ssl() auto-detection logic perfectly.
