### PR TITLE
Docs: Restore the `@return` tag for `WP_Duotone::is_preset()`

### DIFF
--- a/src/wp-includes/class-wp-duotone.php
+++ b/src/wp-includes/class-wp-duotone.php
@@ -569,8 +569,8 @@ class WP_Duotone {
 	 *
 	 * @since 6.3.0
 	 *
-	 * @param string $duotone_attr The duotone attribute from a block.
 	 * @param string|string[] $duotone_attr The duotone attribute from a block.
+	 * @return bool True if the duotone preset present and valid.
 	 */
 	private static function is_preset( $duotone_attr ) {
 		if ( ! is_string( $duotone_attr ) ) {


### PR DESCRIPTION
`WP_Duotone::is_preset()` carries two `@param` tags for the same variable, giving contradictory types, and documents no return value at all:

```php
 * @param string $duotone_attr The duotone attribute from a block.
 * @param string|string[] $duotone_attr The duotone attribute from a block.
 */
private static function is_preset( $duotone_attr ) {
```

In [61603] the type was widened from `string` to `string|string[]`, but the new tag replaced the `@return` line rather than the old `@param`:

```diff
-	 * @return bool True if the duotone preset present and valid.
+	 * @param string|string[] $duotone_attr The duotone attribute from a block.
```

So the method lost its return documentation and kept a stale parameter type in the same edit.

## Fix

Drop the stale `@param` and restore the `@return`. The wording is the one [61603] removed, so nothing here is invented. Two independent references confirm it:

- `WP_Duotone::get_slug_from_attribute()`, immediately above, was updated by that same changeset and got it right: `@param string|string[]` **and** a `@return`.
- The Gutenberg counterpart, `lib/class-wp-duotone-gutenberg.php`, still reads `@param string|string[] $duotone_attr` and `@return bool True if the duotone preset present and valid.`

`string|string[]` is the correct type. The method guards with `! is_string( $duotone_attr )` and returns `false`, which is exactly the array case [61603] was written to handle.

No functional change. `phpcs` passes on the file.

Trac ticket: https://core.trac.wordpress.org/ticket/64896

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Scanning `src/` for docblock and signature disagreements, which is how this was found, and drafting this description. I confirmed the cause in the changeset history, checked the wording against the sibling method and the Gutenberg copy, ran `phpcs`, and I take responsibility for the change.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
