### PR TITLE
Privacy: Rename "Complete request" to "Close request" on the Erase Personal Data screen

### DIFF
--- a/src/wp-admin/includes/class-wp-privacy-data-removal-requests-list-table.php
+++ b/src/wp-admin/includes/class-wp-privacy-data-removal-requests-list-table.php
@@ -91,11 +91,11 @@ class WP_Privacy_Data_Removal_Requests_List_Table extends WP_Privacy_Requests_Ta
 				esc_attr(
 					sprintf(
 						/* translators: %s: Request email. */
-						__( 'Mark export request for &#8220;%s&#8221; as completed.' ),
+						__( 'Mark erasure request for &#8220;%s&#8221; as completed.' ),
 						$item->email
 					)
 				),
-				__( 'Complete request' )
+				__( 'Close request' )
 			);
 			$complete_request_markup .= '</span>';
 		}

--- a/tests/phpunit/tests/privacy/wpPrivacyDataRemovalRequestsListTable.php
+++ b/tests/phpunit/tests/privacy/wpPrivacyDataRemovalRequestsListTable.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Test cases for WP_Privacy_Data_Removal_Requests_List_Table::column_email().
+ *
+ * @package WordPress
+ * @subpackage UnitTests
+ * @since 6.9.0
+ *
+ * @group privacy
+ * @group admin
+ * @covers WP_Privacy_Data_Removal_Requests_List_Table::column_email
+ */
+class Tests_Privacy_WpPrivacyDataRemovalRequestsListTable extends WP_UnitTestCase {
+
+	/**
+	 * Request ID.
+	 *
+	 * @var int
+	 */
+	protected static $request_id;
+
+	/**
+	 * List table instance.
+	 *
+	 * @var WP_Privacy_Data_Removal_Requests_List_Table
+	 */
+	protected static $list_table;
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		require_once ABSPATH . 'wp-admin/includes/class-wp-privacy-requests-table.php';
+		require_once ABSPATH . 'wp-admin/includes/class-wp-privacy-data-removal-requests-list-table.php';
+
+		self::$request_id = wp_create_user_request( 'requester@example.com', 'remove_personal_data' );
+		self::$list_table = new WP_Privacy_Data_Removal_Requests_List_Table( array( 'screen' => 'erase-personal-data' ) );
+	}
+
+	/**
+	 * @ticket 65735
+	 */
+	public function test_column_email_close_request_link_text() {
+		$request = wp_get_user_request( self::$request_id );
+		ob_start();
+		echo self::$list_table->column_email( $request );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'Close request', $output, 'Row action should be labelled "Close request".' );
+		$this->assertStringNotContainsString( 'Complete request', $output, 'Row action should not use the ambiguous "Complete request" label.' );
+	}
+
+	/**
+	 * @ticket 65735
+	 */
+	public function test_column_email_aria_label_references_erasure_not_export() {
+		$request = wp_get_user_request( self::$request_id );
+		ob_start();
+		echo self::$list_table->column_email( $request );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'erasure request', $output, 'Aria-label should reference an erasure request, not an export request.' );
+		$this->assertStringNotContainsString( 'export request', $output, 'Aria-label should not reference an export request on the erasure screen.' );
+	}
+}


### PR DESCRIPTION
## Summary

The row action **"Complete request"** on Tools → Erase Personal Data is easily mistaken for an instruction to execute the erasure. In reality it only marks the request as completed (for manually-fulfilled requests) and runs no erasers. A site owner clicking it expecting data to be erased will see a Completed status with data still intact.

Two bugs fixed:

- **Misleading label:** Renamed `Complete request` → `Close request` (per the suggestion in the ticket), making it clear the action does not erase data.
- **Wrong aria-label:** The accessible label read *"Mark export request for…"* on the erasure screen — a copy-paste error from the export list table. Fixed to *"Mark erasure request for…"*

The bulk action in `WP_Privacy_Requests_Table::get_bulk_actions()` already uses the label `Mark requests as completed`, so this row action was the only inconsistency.

## Testing

Added `tests/phpunit/tests/privacy/wpPrivacyDataRemovalRequestsListTable.php` with two assertions:
- Row action output contains `Close request` and not `Complete request`
- Aria-label contains `erasure request` and not `export request`

Fixes https://core.trac.wordpress.org/ticket/65735