### PR TITLE
Media: Add a checkbox to toggle infinite scrolling in the media modal

### DIFF
--- a/src/js/media/views/attachments.js
+++ b/src/js/media/views/attachments.js
@@ -90,13 +90,11 @@ Attachments = View.extend(/** @lends wp.media.view.Attachments.prototype */{
 
 		this.controller.on( 'library:selection:add', this.attachmentFocus, this );
 
-		if ( this.options.infiniteScrolling ) {
-			// Throttle the scroll handler and bind this.
-			this.scroll = _.chain( this.scroll ).bind( this ).throttle( this.options.refreshSensitivity ).value();
+		// Throttle the scroll handler and bind this.
+		this.scroll = _.chain( this.scroll ).bind( this ).throttle( this.options.refreshSensitivity ).value();
 
-			this.options.scrollElement = this.options.scrollElement || this.el;
-			$( this.options.scrollElement ).on( 'scroll', this.scroll );
-		}
+		this.options.scrollElement = this.options.scrollElement || this.el;
+		$( this.options.scrollElement ).on( 'scroll', this.scroll );
 
 		this.initSortable();
 
@@ -422,6 +420,7 @@ Attachments = View.extend(/** @lends wp.media.view.Attachments.prototype */{
 	 * server if we're {refreshThreshold} times away from the bottom.
 	 *
 	 * @since 3.5.0
+	 * @since 7.1.0 Bails out when infinite scrolling is disabled.
 	 *
 	 * @return {void}
 	 */
@@ -430,6 +429,10 @@ Attachments = View.extend(/** @lends wp.media.view.Attachments.prototype */{
 			el = this.options.scrollElement,
 			scrollTop = el.scrollTop,
 			toolbar;
+
+		if ( ! this.options.infiniteScrolling ) {
+			return;
+		}
 
 		/*
 		 * The scroll event occurs on the document, but the element that should be

--- a/src/js/media/views/attachments/browser.js
+++ b/src/js/media/views/attachments/browser.js
@@ -43,6 +43,8 @@ AttachmentsBrowser = View.extend(/** @lends wp.media.view.AttachmentsBrowser.pro
 			AttachmentView: wp.media.view.Attachment.Library
 		});
 
+		this.infiniteScrolling = !! infiniteScrolling;
+
 		this.controller.on( 'toggle:upload:attachment', this.toggleUploader, this );
 		this.controller.on( 'edit:selection', this.editSelection );
 
@@ -77,7 +79,7 @@ AttachmentsBrowser = View.extend(/** @lends wp.media.view.AttachmentsBrowser.pro
 		// Create the attachments wrapper view.
 		this.createAttachmentsWrapperView();
 
-		if ( ! infiniteScrolling ) {
+		if ( ! this.infiniteScrolling ) {
 			this.$el.addClass( 'has-load-more' );
 			this.createLoadMoreView();
 		}
@@ -89,7 +91,7 @@ AttachmentsBrowser = View.extend(/** @lends wp.media.view.AttachmentsBrowser.pro
 
 		this.updateContent();
 
-		if ( ! infiniteScrolling ) {
+		if ( ! this.infiniteScrolling ) {
 			this.updateLoadMoreView();
 		}
 
@@ -102,10 +104,7 @@ AttachmentsBrowser = View.extend(/** @lends wp.media.view.AttachmentsBrowser.pro
 		}
 
 		this.collection.on( 'add remove reset', this.updateContent, this );
-
-		if ( ! infiniteScrolling ) {
-			this.collection.on( 'add remove reset', this.updateLoadMoreView, this );
-		}
+		this.collection.on( 'add remove reset', this.updateLoadMoreView, this );
 
 		// The non-cached or cached attachments query has completed.
 		this.collection.on( 'attachments:received', this.announceSearchResults, this );
@@ -125,7 +124,7 @@ AttachmentsBrowser = View.extend(/** @lends wp.media.view.AttachmentsBrowser.pro
 			/* translators: Accessibility text. %d: Number of attachments found in a search. */
 			mediaFoundHasMoreResultsMessage = __( 'Number of media items displayed: %d. Click load more for more results.' );
 
-		if ( infiniteScrolling ) {
+		if ( this.infiniteScrolling ) {
 			/* translators: Accessibility text. %d: Number of attachments found in a search. */
 			mediaFoundHasMoreResultsMessage = __( 'Number of media items displayed: %d. Scroll the page for more results.' );
 		}
@@ -472,9 +471,76 @@ AttachmentsBrowser = View.extend(/** @lends wp.media.view.AttachmentsBrowser.pro
 			className: 'attachments-wrapper'
 		} );
 
-		// Create the list of attachments.
 		this.views.add( this.attachmentsWrapper );
+
+		// Place the infinite scrolling toggle before the list of attachments.
+		this.createInfiniteScrollingToggle();
+
+		// Create the list of attachments.
 		this.createAttachments();
+	},
+
+	/**
+	 * Creates the checkbox that turns infinite scrolling on and off.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @return {void}
+	 */
+	createInfiniteScrollingToggle: function() {
+		var view = this,
+			id = _.uniqueId( 'media-infinite-scrolling-' ),
+			checkbox = $( '<input />', {
+				type:    'checkbox',
+				id:      id,
+				checked: this.infiniteScrolling
+			} ),
+			label = $( '<label />', {
+				'for': id,
+				text:  __( 'Enable infinite scrolling' )
+			} );
+
+		checkbox.on( 'change', function() {
+			view.toggleInfiniteScrolling( this.checked );
+		} );
+
+		this.infiniteScrollingToggle = new View( {
+			controller: this.controller,
+			className:  'media-infinite-scrolling'
+		} );
+
+		this.infiniteScrollingToggle.$el.append( checkbox, label );
+
+		this.views.add( '.attachments-wrapper', this.infiniteScrollingToggle );
+	},
+
+	/**
+	 * Turns infinite scrolling of the attachments list on and off.
+	 *
+	 * When infinite scrolling is off, the "Load more" button is used instead.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param {boolean} infiniteScrolling Whether the attachments list has infinite scrolling.
+	 *
+	 * @return {void}
+	 */
+	toggleInfiniteScrolling: function( infiniteScrolling ) {
+		this.infiniteScrolling = infiniteScrolling;
+		this.attachments.options.infiniteScrolling = infiniteScrolling;
+		this.$el.toggleClass( 'has-load-more', ! infiniteScrolling );
+
+		if ( ! this.loadMoreWrapper ) {
+			this.createLoadMoreView();
+		}
+
+		this.loadMoreWrapper.$el.toggleClass( 'hidden', infiniteScrolling );
+
+		if ( infiniteScrolling ) {
+			this.attachments.scroll();
+		} else {
+			this.updateLoadMoreView();
+		}
 	},
 
 	createAttachments: function() {
@@ -484,7 +550,8 @@ AttachmentsBrowser = View.extend(/** @lends wp.media.view.AttachmentsBrowser.pro
 			selection:            this.options.selection,
 			model:                this.model,
 			sortable:             this.options.sortable,
-			scrollElement:        this.options.scrollElement,
+			infiniteScrolling:    this.infiniteScrolling,
+			scrollElement:        this.options.scrollElement || this.attachmentsWrapper.el,
 			idealColumnWidth:     this.options.idealColumnWidth,
 
 			// The single `Attachment` view to be used in the `Attachments` view.
@@ -565,10 +632,15 @@ AttachmentsBrowser = View.extend(/** @lends wp.media.view.AttachmentsBrowser.pro
 	 * We need it to run only once, after all attachments are added or removed.
 	 *
 	 * @since 5.8.0
+	 * @since 7.1.0 Bails out when infinite scrolling is enabled.
 	 *
 	 * @return {void}
 	 */
 	updateLoadMoreView: _.debounce( function() {
+		if ( this.infiniteScrolling ) {
+			return;
+		}
+
 		// Ensure the load more view elements are initially hidden at each update.
 		this.loadMoreButton.$el.addClass( 'hidden' );
 		this.loadMoreCount.$el.addClass( 'hidden' );

--- a/src/js/media/views/attachments/browser.js
+++ b/src/js/media/views/attachments/browser.js
@@ -4,6 +4,7 @@ var View = wp.media.View,
 	$ = jQuery,
 	AttachmentsBrowser,
 	infiniteScrolling = wp.media.view.settings.infiniteScrolling,
+	canToggleInfiniteScrolling = wp.media.view.settings.canToggleInfiniteScrolling,
 	__ = wp.i18n.__,
 	sprintf = wp.i18n.sprintf;
 
@@ -473,8 +474,14 @@ AttachmentsBrowser = View.extend(/** @lends wp.media.view.AttachmentsBrowser.pro
 
 		this.views.add( this.attachmentsWrapper );
 
-		// Place the infinite scrolling toggle before the list of attachments.
-		this.createInfiniteScrollingToggle();
+		/*
+		 * Place the infinite scrolling toggle before the list of attachments. It
+		 * saves the personal option, so it is only offered when wp_enqueue_media()
+		 * reports that saving that option takes effect.
+		 */
+		if ( canToggleInfiniteScrolling ) {
+			this.createInfiniteScrollingToggle();
+		}
 
 		// Create the list of attachments.
 		this.createAttachments();
@@ -497,11 +504,17 @@ AttachmentsBrowser = View.extend(/** @lends wp.media.view.AttachmentsBrowser.pro
 			} ),
 			label = $( '<label />', {
 				'for': id,
-				text:  __( 'Enable infinite scrolling' )
+				text:  __( 'Infinite scrolling' )
 			} );
+
+		// Not a live region: the same message is sent to `speak()` when it changes.
+		this.infiniteScrollingStatus = $( '<span />', {
+			'class': 'media-infinite-scrolling-status'
+		} );
 
 		checkbox.on( 'change', function() {
 			view.toggleInfiniteScrolling( this.checked );
+			view.saveInfiniteScrolling( this.checked );
 		} );
 
 		this.infiniteScrollingToggle = new View( {
@@ -509,9 +522,52 @@ AttachmentsBrowser = View.extend(/** @lends wp.media.view.AttachmentsBrowser.pro
 			className:  'media-infinite-scrolling'
 		} );
 
-		this.infiniteScrollingToggle.$el.append( checkbox, label );
+		this.infiniteScrollingToggle.$el.append( checkbox, label, this.infiniteScrollingStatus );
 
 		this.views.add( '.attachments-wrapper', this.infiniteScrollingToggle );
+	},
+
+	/**
+	 * Saves the infinite scrolling preference for the current user.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param {boolean} infiniteScrolling Whether the attachments list has infinite scrolling.
+	 *
+	 * @return {void}
+	 */
+	saveInfiniteScrolling: function( infiniteScrolling ) {
+		var view = this;
+
+		wp.ajax.post( 'save-media-infinite-scrolling', {
+			nonce:             wp.media.view.settings.nonce.saveInfiniteScrolling,
+			infiniteScrolling: infiniteScrolling
+		} ).done( function() {
+			view.updateInfiniteScrollingStatus(
+				infiniteScrolling ?
+					__( 'Infinite scrolling enabled. Preference saved.' ) :
+					__( 'Infinite scrolling disabled. Load more button displayed. Preference saved.' )
+			);
+		} ).fail( function() {
+			view.updateInfiniteScrollingStatus( __( 'The infinite scrolling preference could not be saved.' ) );
+		} );
+	},
+
+	/**
+	 * Displays and announces the result of changing the infinite scrolling preference.
+	 *
+	 * The controls it affects are at the end of the list of attachments, so the
+	 * result is usually out of view when the checkbox changes.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param {string} message The message to display and announce.
+	 *
+	 * @return {void}
+	 */
+	updateInfiniteScrollingStatus: function( message ) {
+		this.infiniteScrollingStatus.text( message );
+		wp.a11y.speak( message );
 	},
 
 	/**

--- a/src/wp-admin/admin-ajax.php
+++ b/src/wp-admin/admin-ajax.php
@@ -106,6 +106,7 @@ $core_actions_post = array(
 	'send-link-to-editor',
 	'send-attachment-to-editor',
 	'save-attachment-order',
+	'save-media-infinite-scrolling',
 	'media-create-image-subsizes',
 	'heartbeat',
 	'get-revision-diffs',

--- a/src/wp-admin/css/media.css
+++ b/src/wp-admin/css/media.css
@@ -457,8 +457,7 @@ border color while dragging a file over the uploader drop area */
 
 .media-frame.mode-grid,
 .media-frame.mode-grid .media-frame-content,
-.media-frame.mode-grid .attachments-browser:not(.has-load-more) .attachments,
-.media-frame.mode-grid .attachments-browser.has-load-more .attachments-wrapper,
+.media-frame.mode-grid .attachments-browser .attachments-wrapper,
 .media-frame.mode-grid .uploader-inline-content {
 	position: static;
 }
@@ -518,8 +517,7 @@ border color while dragging a file over the uploader drop area */
 	border: 4px dashed #c3c4c7;
 }
 
-.media-frame.mode-select .attachments-browser.fixed:not(.has-load-more) .attachments,
-.media-frame.mode-select .attachments-browser.has-load-more.fixed .attachments-wrapper {
+.media-frame.mode-select .attachments-browser.fixed .attachments-wrapper {
 	position: relative;
 	top: 94px; /* prevent jumping up when the toolbar becomes fixed */
 	padding-bottom: 94px; /* offset for above so the bottom doesn't get cut off */

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -3318,6 +3318,29 @@ function wp_ajax_save_attachment_order() {
 }
 
 /**
+ * Handles saving the current user's Media Library infinite scrolling preference via AJAX.
+ *
+ * Writes the same personal option as the "Infinite Scrolling" checkbox on the
+ * profile screen, so that the preference set from the attachments browser
+ * persists beyond the current view.
+ *
+ * @since 7.1.0
+ */
+function wp_ajax_save_media_infinite_scrolling() {
+	check_ajax_referer( 'save-media-infinite-scrolling', 'nonce' );
+
+	if ( ! isset( $_POST['infiniteScrolling'] ) ) {
+		wp_send_json_error();
+	}
+
+	$infinite_scrolling = wp_validate_boolean( wp_unslash( $_POST['infiniteScrolling'] ) );
+
+	update_user_meta( get_current_user_id(), 'infinite_scrolling', $infinite_scrolling ? 'true' : 'false' );
+
+	wp_send_json_success();
+}
+
+/**
  * Handles sending an attachment to the editor via AJAX.
  *
  * Generates the HTML to send an attachment to the editor.

--- a/src/wp-includes/css/media-views.css
+++ b/src/wp-includes/css/media-views.css
@@ -1291,6 +1291,11 @@ select#media-attachment-filters ~ select#media-attachment-date-filters {
 	padding: 8px 16px 12px;
 }
 
+.attachments-browser .media-infinite-scrolling-status {
+	margin-left: 12px;
+	color: #50575e;
+}
+
 /* In the modal, the media items list scrolls: keep the toggle in view. */
 .media-modal .attachments-browser .media-infinite-scrolling {
 	position: sticky;

--- a/src/wp-includes/css/media-views.css
+++ b/src/wp-includes/css/media-views.css
@@ -1276,8 +1276,7 @@ select#media-attachment-filters ~ select#media-attachment-date-filters {
 	padding: 2px 8px 8px;
 }
 
-.attachments-browser:not(.has-load-more) .attachments,
-.attachments-browser.has-load-more .attachments-wrapper,
+.attachments-browser .attachments-wrapper,
 .attachments-browser .uploader-inline {
 	position: absolute;
 	top: 72px;
@@ -1286,6 +1285,22 @@ select#media-attachment-filters ~ select#media-attachment-date-filters {
 	bottom: 0;
 	overflow: auto;
 	outline: none;
+}
+
+.attachments-browser .media-infinite-scrolling {
+	padding: 12px 8px;
+}
+
+/* In the modal, the media items list scrolls: keep the toggle in view. */
+.media-modal .attachments-browser .media-infinite-scrolling {
+	position: sticky;
+	top: 0;
+	z-index: 1;
+	background: #fff;
+}
+
+.attachments-browser .load-more-wrapper.hidden {
+	display: none;
 }
 
 .attachments-browser .uploader-inline.hidden {
@@ -1341,7 +1356,7 @@ select#media-attachment-filters ~ select#media-attachment-date-filters {
 	box-shadow: 0 0 3px rgba(var(--wp-admin-theme-color--rgb, 56, 88, 233), 0.8);
 }
 
-.attachments-browser.hide-sidebar .attachments,
+.attachments-browser.hide-sidebar .attachments-wrapper,
 .attachments-browser.hide-sidebar .uploader-inline {
 	right: 0;
 	margin-right: 0;

--- a/src/wp-includes/css/media-views.css
+++ b/src/wp-includes/css/media-views.css
@@ -1288,7 +1288,7 @@ select#media-attachment-filters ~ select#media-attachment-date-filters {
 }
 
 .attachments-browser .media-infinite-scrolling {
-	padding: 12px 8px;
+	padding: 8px 16px 12px;
 }
 
 /* In the modal, the media items list scrolls: keep the toggle in view. */
@@ -2669,6 +2669,10 @@ select#media-attachment-filters ~ select#media-attachment-date-filters {
 		top: 131px;
 	}
 
+	.attachments-browser .media-infinite-scrolling {
+		padding: 14px 16px 0px;
+	}
+
 	.media-sidebar .setting,
 	.attachment-details .setting {
 		margin: 6px 0;
@@ -2773,6 +2777,7 @@ select#media-attachment-filters ~ select#media-attachment-date-filters {
 		font-size: 16px;
 		line-height: 1.625;
 		padding: 5px 24px 5px 8px;
+		margin: 0;
 	}
 
 	.image-details .column-image {

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -5076,31 +5076,40 @@ function wp_enqueue_media( $args = array() ) {
 	 */
 	$infinite_scrolling = apply_filters( 'media_library_infinite_scrolling', $infinite_scrolling );
 
+	/*
+	 * The control that turns infinite scrolling on and off saves the personal
+	 * option, so it is only offered when saving that option takes effect: there
+	 * has to be a user to save it for, and no filter callback overriding it.
+	 */
+	$can_toggle_infinite_scrolling = is_user_logged_in() && ! has_filter( 'media_library_infinite_scrolling' );
+
 	$settings = array(
-		'tabs'              => $tabs,
-		'tabUrl'            => add_query_arg( array( 'chromeless' => true ), admin_url( 'media-upload.php' ) ),
-		'mimeTypes'         => wp_list_pluck( get_post_mime_types(), 0 ),
+		'tabs'                       => $tabs,
+		'tabUrl'                     => add_query_arg( array( 'chromeless' => true ), admin_url( 'media-upload.php' ) ),
+		'mimeTypes'                  => wp_list_pluck( get_post_mime_types(), 0 ),
 		/** This filter is documented in wp-admin/includes/media.php */
-		'captions'          => ! apply_filters( 'disable_captions', '' ),
-		'nonce'             => array(
+		'captions'                   => ! apply_filters( 'disable_captions', '' ),
+		'nonce'                      => array(
 			'sendToEditor'           => wp_create_nonce( 'media-send-to-editor' ),
 			'setAttachmentThumbnail' => wp_create_nonce( 'set-attachment-thumbnail' ),
+			'saveInfiniteScrolling'  => wp_create_nonce( 'save-media-infinite-scrolling' ),
 		),
-		'post'              => array(
+		'post'                       => array(
 			'id' => 0,
 		),
-		'defaultProps'      => $props,
-		'attachmentCounts'  => array(
+		'defaultProps'               => $props,
+		'attachmentCounts'           => array(
 			'audio' => ( $show_audio_playlist ) ? 1 : 0,
 			'video' => ( $show_video_playlist ) ? 1 : 0,
 		),
-		'oEmbedProxyUrl'    => rest_url( 'oembed/1.0/proxy' ),
-		'embedExts'         => $exts,
-		'embedMimes'        => $ext_mimes,
-		'contentWidth'      => $content_width,
-		'months'            => $months,
-		'mediaTrash'        => MEDIA_TRASH ? 1 : 0,
-		'infiniteScrolling' => ( $infinite_scrolling ) ? 1 : 0,
+		'oEmbedProxyUrl'             => rest_url( 'oembed/1.0/proxy' ),
+		'embedExts'                  => $exts,
+		'embedMimes'                 => $ext_mimes,
+		'contentWidth'               => $content_width,
+		'months'                     => $months,
+		'mediaTrash'                 => MEDIA_TRASH ? 1 : 0,
+		'infiniteScrolling'          => ( $infinite_scrolling ) ? 1 : 0,
+		'canToggleInfiniteScrolling' => ( $can_toggle_infinite_scrolling ) ? 1 : 0,
 	);
 
 	$post = null;

--- a/tests/phpunit/includes/testcase-ajax.php
+++ b/tests/phpunit/includes/testcase-ajax.php
@@ -86,6 +86,7 @@ abstract class WP_Ajax_UnitTestCase extends WP_UnitTestCase {
 		'wp-remove-post-lock',
 		'dismiss-wp-pointer',
 		'send-attachment-to-editor',
+		'save-media-infinite-scrolling',
 		'heartbeat',
 		'nopriv_heartbeat',
 		'get-revision-diffs',

--- a/tests/phpunit/tests/ajax/wpAjaxSaveMediaInfiniteScrolling.php
+++ b/tests/phpunit/tests/ajax/wpAjaxSaveMediaInfiniteScrolling.php
@@ -1,0 +1,111 @@
+<?php
+
+/**
+ * Admin Ajax functions to be tested.
+ */
+require_once ABSPATH . 'wp-admin/includes/ajax-actions.php';
+
+/**
+ * Testing the AJAX handler that saves the Media Library infinite scrolling preference.
+ *
+ * @group ajax
+ *
+ * @covers ::wp_ajax_save_media_infinite_scrolling
+ */
+class Tests_Ajax_wpAjaxSaveMediaInfiniteScrolling extends WP_Ajax_UnitTestCase {
+
+	/**
+	 * Tests that the preference is stored in the same personal option the profile screen uses.
+	 *
+	 * @ticket 65775
+	 *
+	 * @dataProvider data_save_media_infinite_scrolling
+	 *
+	 * @param string $sent     The value posted for the `infiniteScrolling` parameter.
+	 * @param string $expected The expected value of the `infinite_scrolling` user meta.
+	 */
+	public function test_save_media_infinite_scrolling( $sent, $expected ) {
+		$this->_setRole( 'administrator' );
+
+		$_POST = array(
+			'nonce'             => wp_create_nonce( 'save-media-infinite-scrolling' ),
+			'infiniteScrolling' => $sent,
+		);
+
+		try {
+			$this->_handleAjax( 'save-media-infinite-scrolling' );
+		} catch ( WPAjaxDieContinueException $e ) {
+			unset( $e );
+		}
+
+		$response = json_decode( $this->_last_response, true );
+
+		$this->assertTrue( $response['success'], 'The request should have succeeded.' );
+		$this->assertSame(
+			$expected,
+			get_user_meta( get_current_user_id(), 'infinite_scrolling', true ),
+			'The personal option should match the posted preference.'
+		);
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_save_media_infinite_scrolling() {
+		return array(
+			'enabled'  => array( 'true', 'true' ),
+			'disabled' => array( 'false', 'false' ),
+		);
+	}
+
+	/**
+	 * Tests that the request fails when the nonce is invalid.
+	 *
+	 * @ticket 65775
+	 */
+	public function test_save_media_infinite_scrolling_requires_a_valid_nonce() {
+		$this->_setRole( 'administrator' );
+
+		$_POST = array(
+			'nonce'             => 'invalid-nonce',
+			'infiniteScrolling' => 'false',
+		);
+
+		$this->expectException( 'WPAjaxDieStopException' );
+		$this->expectExceptionMessage( '-1' );
+
+		$this->_handleAjax( 'save-media-infinite-scrolling' );
+	}
+
+	/**
+	 * Tests that the preference is left alone when no value is posted.
+	 *
+	 * @ticket 65775
+	 */
+	public function test_save_media_infinite_scrolling_requires_a_value() {
+		$this->_setRole( 'administrator' );
+
+		update_user_meta( get_current_user_id(), 'infinite_scrolling', 'true' );
+
+		$_POST = array(
+			'nonce' => wp_create_nonce( 'save-media-infinite-scrolling' ),
+		);
+
+		try {
+			$this->_handleAjax( 'save-media-infinite-scrolling' );
+		} catch ( WPAjaxDieContinueException $e ) {
+			unset( $e );
+		}
+
+		$response = json_decode( $this->_last_response, true );
+
+		$this->assertFalse( $response['success'], 'The request should not have succeeded.' );
+		$this->assertSame(
+			'true',
+			get_user_meta( get_current_user_id(), 'infinite_scrolling', true ),
+			'The personal option should not have changed.'
+		);
+	}
+}

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -127,7 +127,7 @@ CAP;
 		// Default: no user preference and no filter, infinite scrolling is enabled.
 		$this->assertSame(
 			1,
-			$this->get_media_infinite_scrolling_setting(),
+			$this->get_media_view_setting( 'infiniteScrolling' ),
 			'Infinite scrolling should be enabled by default.'
 		);
 
@@ -135,7 +135,7 @@ CAP;
 		update_user_meta( $user_id, 'infinite_scrolling', 'false' );
 		$this->assertSame(
 			0,
-			$this->get_media_infinite_scrolling_setting(),
+			$this->get_media_view_setting( 'infiniteScrolling' ),
 			'The user preference should disable infinite scrolling.'
 		);
 
@@ -143,25 +143,58 @@ CAP;
 		add_filter( 'media_library_infinite_scrolling', '__return_true' );
 		$this->assertSame(
 			1,
-			$this->get_media_infinite_scrolling_setting(),
+			$this->get_media_view_setting( 'infiniteScrolling' ),
 			'The filter should take precedence over the user preference.'
 		);
 	}
 
 	/**
-	 * Helper that runs wp_enqueue_media() and returns the computed
-	 * `infiniteScrolling` media view setting.
+	 * Tests that the infinite scrolling control is only offered when saving the
+	 * personal option takes effect.
 	 *
-	 * @return int The infiniteScrolling setting: 1 when enabled, 0 when disabled.
+	 * @ticket 65775
+	 *
+	 * @covers ::wp_enqueue_media
 	 */
-	private function get_media_infinite_scrolling_setting() {
+	public function test_wp_enqueue_media_can_toggle_infinite_scrolling() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+
+		$this->assertSame(
+			1,
+			$this->get_media_view_setting( 'canToggleInfiniteScrolling' ),
+			'The control should be offered when no filter callback is attached.'
+		);
+
+		add_filter( 'media_library_infinite_scrolling', '__return_true' );
+		$this->assertSame(
+			0,
+			$this->get_media_view_setting( 'canToggleInfiniteScrolling' ),
+			'The control should not be offered when a filter callback takes precedence.'
+		);
+
+		remove_filter( 'media_library_infinite_scrolling', '__return_true' );
+		wp_set_current_user( 0 );
+		$this->assertSame(
+			0,
+			$this->get_media_view_setting( 'canToggleInfiniteScrolling' ),
+			'The control should not be offered when there is no logged-in user.'
+		);
+	}
+
+	/**
+	 * Helper that runs wp_enqueue_media() and returns one of the computed media view settings.
+	 *
+	 * @param string $setting The name of the setting to return.
+	 * @return mixed The setting as passed through the `media_view_settings` filter.
+	 */
+	private function get_media_view_setting( $setting ) {
 		// wp_enqueue_media() only runs once per request; reset the guard so it
 		// can be invoked again for each scenario.
 		unset( $GLOBALS['wp_actions']['wp_enqueue_media'] );
 
-		$infinite_scrolling = null;
-		$capture            = static function ( $settings ) use ( &$infinite_scrolling ) {
-			$infinite_scrolling = $settings['infiniteScrolling'];
+		$value   = null;
+		$capture = static function ( $settings ) use ( &$value, $setting ) {
+			$value = $settings[ $setting ];
 			return $settings;
 		};
 
@@ -169,7 +202,7 @@ CAP;
 		wp_enqueue_media();
 		remove_filter( 'media_view_settings', $capture );
 
-		return $infinite_scrolling;
+		return $value;
 	}
 
 	public function test_img_caption_shortcode_with_empty_params() {


### PR DESCRIPTION
Adds a point-of-use control for infinite scrolling in the attachments browser, as a follow-up to #65564.

What the problem was:
- Infinite scrolling is enabled by default as of [62632], but the only way to change it is the "Infinite Scrolling" option on the user profile screen. Users who need the "Load more" button for accessibility, or who want to avoid loading a large library, have to leave the modal, change their profile, and come back.

What the fix does:
- Renders an "Infinite scrolling" checkbox before the list of media items, in both the media modal and the Media Library grid view, that turns infinite scrolling on and off immediately.
- Saves the change as the user's preference, so it persists beyond the current view. A new `save-media-infinite-scrolling` AJAX action writes the same `infinite_scrolling` personal option as the profile screen, and the two stay in sync in both directions.
- Confirms the change next to the checkbox and sends the same message to `wp.a11y.speak()`, because the controls that change are at the end of the list and usually out of view.
- Unchecking it reveals the "Load more" button and the item count and stops the scroll handler from requesting more attachments. Checking it hides them and resumes loading on scroll.
- Keeps the screen reader search-results message in sync with the active mode.

Approach and why:
- The checkbox is only rendered when saving the personal option takes effect. `wp_enqueue_media()` passes a new `canToggleInfiniteScrolling` setting, which is false when a `media_library_infinite_scrolling` filter callback overrides the option, or when there is no user to save it for. Announcing "Preference saved" for a value a filter overrides on the next page load would be misleading, so no control is offered in that case. This is deliberately blunt: any callback on the filter hides the control, even one that only applies conditionally.
- The `media_library_infinite_scrolling` filter and the profile option still determine the initial state, and their documented precedence is unchanged.
- `infiniteScrolling` moves from a module-level constant to per-instance state on `AttachmentsBrowser`, and is passed down to the `Attachments` view rather than read from the global a second time.
- The scroll handler is now always bound and bails when infinite scrolling is off, so it is live if the user turns scrolling on mid-session.
- To make room for a control before the list, `.attachments-wrapper` is now the positioned, scrolling region in both modes rather than only when the "Load more" button is present. This reuses the offsets that already applied to the wrapper at every breakpoint, so no per-breakpoint pixel values change.

Trac ticket: https://core.trac.wordpress.org/ticket/65775

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Ticket analysis, tests and generate PR. All changes were reviewed and validated by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
