### PR TITLE
Login and Registration: Reference every rendered notice in the login form

### DIFF
--- a/src/wp-login.php
+++ b/src/wp-login.php
@@ -1496,16 +1496,33 @@ switch ( $action ) {
 
 		$rememberme = ! empty( $_POST['rememberme'] );
 
-		$aria_describedby = '';
-		$has_errors       = $errors->has_errors();
+		/*
+		 * login_header() splits the errors into a separate notice per severity and
+		 * can display both at once, so reference every notice that is displayed.
+		 */
+		$has_error_notice   = false;
+		$has_message_notice = false;
 
-		if ( $has_errors ) {
-			$aria_describedby = ' aria-describedby="login_error"';
+		foreach ( $errors->get_error_codes() as $code ) {
+			if ( 'message' === $errors->get_error_data( $code ) ) {
+				$has_message_notice = true;
+			} else {
+				$has_error_notice = true;
+			}
 		}
 
-		if ( $has_errors && 'message' === $errors->get_error_data() ) {
-			$aria_describedby = ' aria-describedby="login-message"';
+		// Ordered to match the order login_header() displays the notices in.
+		$describedby_ids = array();
+
+		if ( $has_error_notice ) {
+			$describedby_ids[] = 'login_error';
 		}
+
+		if ( $has_message_notice ) {
+			$describedby_ids[] = 'login-message';
+		}
+
+		$aria_describedby = $describedby_ids ? ' aria-describedby="' . implode( ' ', $describedby_ids ) . '"' : '';
 
 		wp_enqueue_script( 'user-profile' );
 		wp_enqueue_script( 'wp-tooltip' );

--- a/tests/e2e/specs/login-form-notices.test.js
+++ b/tests/e2e/specs/login-form-notices.test.js
@@ -1,0 +1,77 @@
+/**
+ * WordPress dependencies
+ */
+import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+
+/*
+ * login_header() displays a separate notice per error severity and can display
+ * both at once. Every notice displayed must be referenced by the login fields.
+ */
+test.describe( 'Login form notices', () => {
+	// The login form is only displayed to logged out users.
+	test.use( { storageState: { cookies: [], origins: [] } } );
+
+	async function submitInvalidCredentials( page ) {
+		await page.locator( '#user_login' ).fill( 'admin' );
+		await page.locator( '#user_pass' ).fill( 'incorrect-password' );
+		await page.locator( '#wp-submit' ).click();
+	}
+
+	test( 'should reference both notices when an error and a message are displayed', async ( {
+		page,
+	} ) => {
+		// Redirecting back to the About page after an update adds a message.
+		await page.goto(
+			'/wp-login.php?redirect_to=' +
+				encodeURIComponent( '/wp-admin/about.php?updated' )
+		);
+		await submitInvalidCredentials( page );
+
+		await expect( page.locator( '#login_error' ) ).toBeVisible();
+		await expect( page.locator( '#login-message' ) ).toBeVisible();
+
+		await expect( page.locator( '#user_login' ) ).toHaveAttribute(
+			'aria-describedby',
+			'login_error login-message'
+		);
+		await expect( page.locator( '#user_pass' ) ).toHaveAttribute(
+			'aria-describedby',
+			'login_error login-message'
+		);
+	} );
+
+	test( 'should reference the error notice when only an error is displayed', async ( {
+		page,
+	} ) => {
+		await page.goto( '/wp-login.php' );
+		await submitInvalidCredentials( page );
+
+		await expect( page.locator( '#user_login' ) ).toHaveAttribute(
+			'aria-describedby',
+			'login_error'
+		);
+	} );
+
+	test( 'should reference the message notice when only a message is displayed', async ( {
+		page,
+	} ) => {
+		await page.goto( '/wp-login.php?loggedout=true' );
+
+		await expect( page.locator( '#user_login' ) ).toHaveAttribute(
+			'aria-describedby',
+			'login-message'
+		);
+	} );
+
+	test( 'should not reference a notice when none is displayed', async ( {
+		page,
+	} ) => {
+		await page.goto( '/wp-login.php' );
+
+		expect(
+			await page
+				.locator( '#user_login' )
+				.getAttribute( 'aria-describedby' )
+		).toBeNull();
+	} );
+} );


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

`login_header()` splits the login errors into a separate notice per severity and can display both at the same time. The `aria-describedby` logic assumed only one of them existed, so when both were displayed one notice was left unreferenced.

What the problem was:
- `#login_error` (errors) and `#login-message` (informational messages) can both render at once, but the association logic could only ever emit a single ID, so the other notice was visible on screen and never announced when focus reached the username or password field.
- `WP_Error::get_error_data()` was called without a code, so it fell back to the first error code and ignored the severity of every other item.
- The second branch overwrote the attribute instead of appending to it.

What the fix does:
- Determines the severities the same way `login_header()` does, by passing each error code to `WP_Error::get_error_data()`, and references every notice that is actually displayed.

Approach and why:
- Mirroring `login_header()`'s own partition means the IDs cannot drift from what is rendered.
- IDs are emitted in the order `login_header()` outputs the notices, so the order the descriptions are announced in matches the visual order regardless of error-code order.
- No escaping is applied because both IDs are hardcoded literals, consistent with the code being replaced.

Trac ticket: https://core.trac.wordpress.org/ticket/65777

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Ticket analysis, tests cases and generate ticket and PR. All changes were reviewed and validated by me.
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
