### PR TITLE
Only set absolute positioning in modal

### DIFF
--- a/src/wp-includes/css/media-views.css
+++ b/src/wp-includes/css/media-views.css
@@ -1855,6 +1855,7 @@ select#media-attachment-filters ~ select#media-attachment-date-filters {
 	text-align: right;
 	text-transform: none;
 	font-weight: 400;
+	display: flex;
 }
 
 .attachment-details .settings-save-status .spinner {

--- a/src/wp-includes/css/media-views.css
+++ b/src/wp-includes/css/media-views.css
@@ -365,7 +365,7 @@ select#media-attachment-filters ~ select#media-attachment-date-filters {
 	grid-area: 2 / 2 / 3 / 3;
 }
 
-.media-toolbar-secondary > .spinner {
+.media-modal .media-toolbar-secondary > .spinner {
 	position: absolute;
 	left: calc( 100% + 2px );
 	top: 50%;
@@ -2842,7 +2842,7 @@ select#media-attachment-filters ~ select#media-attachment-date-filters {
 		float: right;
 	}
 
-	.media-frame .media-toolbar-secondary .spinner {
+	.media-modal .media-frame .media-toolbar-secondary .spinner {
 		top: calc( 50% - 8px );
 	}
 
@@ -2877,7 +2877,7 @@ select#media-attachment-filters ~ select#media-attachment-date-filters {
 		bottom: -60px;
 	}
 
-	.media-frame .media-toolbar-secondary .spinner {
+	.media-modal .media-frame .media-toolbar-secondary .spinner {
 		top: 0;
 	}
 
@@ -2900,7 +2900,7 @@ select#media-attachment-filters ~ select#media-attachment-date-filters {
 		position: unset;
 	}
 
-	.media-frame .media-toolbar-secondary .spinner {
+	.media-modal .media-frame .media-toolbar-secondary .spinner {
 		position: absolute;
 		top: 0;
 		bottom: 0;

--- a/src/wp-includes/css/media-views.css
+++ b/src/wp-includes/css/media-views.css
@@ -367,7 +367,7 @@ select#media-attachment-filters ~ select#media-attachment-date-filters {
 
 .media-modal .media-toolbar-secondary > .spinner {
 	position: absolute;
-	left: calc( 100% + 2px );
+	right: -30px;
 	top: 50%;
 	margin: 0;
 }
@@ -2901,12 +2901,8 @@ select#media-attachment-filters ~ select#media-attachment-date-filters {
 	}
 
 	.media-modal .media-frame .media-toolbar-secondary .spinner {
-		position: absolute;
-		top: 0;
 		bottom: 0;
 		margin: auto;
-		left: calc( 100% + 2px );
-		right: 0;
 		z-index: 9;
 	}
 


### PR DESCRIPTION
Limit the spinner absolute positioning to only take effect in the media modal.

Trac ticket: https://core.trac.wordpress.org/ticket/65778

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
