### PR TITLE
Administration: Fix install button icon alignment in the theme preview.

### DIFF
--- a/src/wp-admin/css/themes.css
+++ b/src/wp-admin/css/themes.css
@@ -1976,6 +1976,11 @@ body.full-overlay-active {
 	line-height: 2.30769231; /* 30px for 32px height with 13px font */
 }
 
+.theme-install-overlay .wp-full-overlay-header .button.updating-message:before,
+.theme-install-overlay .wp-full-overlay-header .button.updated-message:before {
+	line-height: 1.5; /* 30px (20px * 1.5) - matches the button above */
+}
+
 .theme-install-overlay .wp-full-overlay-sidebar {
 	background: #f0f0f1;
 	border-right: 1px solid #dcdcde;


### PR DESCRIPTION
Alternatives to [wordpress.patch](https://core.trac.wordpress.org/attachment/ticket/65601/wordpress.patch)

This PR adopts a more restrictive approach.

Trac ticket: https://core.trac.wordpress.org/ticket/65601

| Before | After |
|--------|--------|
| <img width="300" height="51" alt="before" src="https://github.com/user-attachments/assets/bcf2ac19-ca62-4e30-8b16-85eea96186a5" /> | <img width="300" height="47" alt="after" src="https://github.com/user-attachments/assets/d1d45542-2166-40fe-bd7a-6d0bb3db73db" /> |

## Use of AI Tools

None