### PR TITLE
AI: Return false from support checks when the wrapped builder throws

### DIFF
--- a/src/wp-includes/ai-client/class-wp-ai-client-prompt-builder.php
+++ b/src/wp-includes/ai-client/class-wp-ai-client-prompt-builder.php
@@ -43,7 +43,9 @@ use WordPress\AiClient\Tools\DTO\WebSearch;
  * interface. As soon as any exception is caught in a chain of method calls,
  * the returned instance will be in an error state, and all subsequent method
  * calls will be no-ops that just return the same error state instance. Only
- * when a generating method is called, the WP_Error will be returned.
+ * when a generating method is called, the WP_Error will be returned. The
+ * support check methods are the exception to the no-op behavior: they return
+ * false rather than the error state instance.
  *
  * @since 7.0.0
  *
@@ -79,7 +81,7 @@ use WordPress\AiClient\Tools\DTO\WebSearch;
  * @method self as_output_media_aspect_ratio(string $aspectRatio) Sets the output media aspect ratio.
  * @method self as_output_speech_voice(string $voice) Sets the output speech voice.
  * @method self as_json_response(?array<string, mixed> $schema = null) Configures the prompt for JSON response output.
- * @method bool|WP_Error is_supported(?CapabilityEnum $capability = null) Checks if the prompt is supported for the given capability.
+ * @method bool is_supported(?CapabilityEnum $capability = null) Checks if the prompt is supported for the given capability.
  * @method bool is_supported_for_text_generation() Checks if the prompt is supported for text generation.
  * @method bool is_supported_for_image_generation() Checks if the prompt is supported for image generation.
  * @method bool is_supported_for_text_to_speech_conversion() Checks if the prompt is supported for text to speech conversion.
@@ -282,7 +284,7 @@ class WP_AI_Client_Prompt_Builder {
 	 *
 	 * This allows WordPress developers to use snake_case naming conventions. It catches
 	 * any exceptions thrown, stores them, and returns a WP_Error when a terminate method
-	 * is called.
+	 * is called, or false when a support check method is called.
 	 *
 	 * @since 7.0.0
 	 *

--- a/src/wp-includes/ai-client/class-wp-ai-client-prompt-builder.php
+++ b/src/wp-includes/ai-client/class-wp-ai-client-prompt-builder.php
@@ -364,6 +364,9 @@ class WP_AI_Client_Prompt_Builder {
 			if ( self::is_generating_method( $name ) ) {
 				return $this->error;
 			}
+			if ( self::is_support_check_method( $name ) ) {
+				return false;
+			}
 			return $this;
 		}
 	}

--- a/tests/phpunit/tests/ai-client/wpAiClientPromptBuilder.php
+++ b/tests/phpunit/tests/ai-client/wpAiClientPromptBuilder.php
@@ -2649,6 +2649,28 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that support check methods return false when the wrapped builder throws.
+	 *
+	 * @ticket 65781
+	 */
+	public function test_support_check_methods_return_false_when_builder_throws() {
+		$registry       = AiClient::defaultRegistry();
+		$prompt_builder = new WP_AI_Client_Prompt_Builder( $registry, 'Test text' );
+
+		/*
+		 * The document modality has no capability to infer, so the wrapped builder
+		 * throws while determining whether the prompt is supported.
+		 */
+		$result = $prompt_builder->as_output_modalities( ModalityEnum::document() )->is_supported();
+
+		$this->assertIsBool( $result, 'is_supported should return a boolean' );
+		$this->assertFalse( $result, 'is_supported should return false when the wrapped builder throws' );
+
+		// The error is still recorded, so a generating method returns it.
+		$this->assertWPError( $prompt_builder->generate_text(), 'The caught error should still be returned by generating methods' );
+	}
+
+	/**
 	 * Tests that generating methods return WP_Error when in error state.
 	 *
 	 * @ticket 64591

--- a/tests/phpunit/tests/ai-client/wpAiClientPromptBuilder.php
+++ b/tests/phpunit/tests/ai-client/wpAiClientPromptBuilder.php
@@ -2652,22 +2652,82 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 	 * Tests that support check methods return false when the wrapped builder throws.
 	 *
 	 * @ticket 65781
+	 *
+	 * @dataProvider data_support_check_methods
+	 *
+	 * @param string $method         The support check method on the wrapper.
+	 * @param string $wrapped_method The matching method on the wrapped builder.
 	 */
-	public function test_support_check_methods_return_false_when_builder_throws() {
+	public function test_support_check_methods_return_false_when_builder_throws( $method, $wrapped_method ) {
 		$registry       = AiClient::defaultRegistry();
 		$prompt_builder = new WP_AI_Client_Prompt_Builder( $registry, 'Test text' );
 
-		/*
-		 * The document modality has no capability to infer, so the wrapped builder
-		 * throws while determining whether the prompt is supported.
-		 */
+		$wrapped_builder = $this->createMock( PromptBuilder::class );
+		$wrapped_builder->method( $wrapped_method )
+			->willThrowException( new RuntimeException( 'Thrown by the wrapped builder.' ) );
+
+		$builder_property = new ReflectionProperty( WP_AI_Client_Prompt_Builder::class, 'builder' );
+		self::set_accessible( $builder_property );
+		$builder_property->setValue( $prompt_builder, $wrapped_builder );
+
+		$result = $prompt_builder->{$method}();
+
+		$this->assertIsBool( $result, $method . ' should return a boolean' );
+		$this->assertFalse( $result, $method . ' should return false when the wrapped builder throws' );
+
+		// The error is still recorded, so a generating method returns it.
+		$error = $prompt_builder->generate_text();
+		$this->assertWPError( $error, 'The caught error should still be returned by generating methods' );
+		$this->assertSame(
+			'prompt_builder_error',
+			$error->get_error_code(),
+			'The recorded error should be the one thrown by the wrapped builder'
+		);
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array<string, array{0: string, 1: string}> Support check method names, keyed by the method on the wrapper.
+	 */
+	public static function data_support_check_methods(): array {
+		return array(
+			'is_supported'                               => array( 'is_supported', 'isSupported' ),
+			'is_supported_for_text_generation'           => array( 'is_supported_for_text_generation', 'isSupportedForTextGeneration' ),
+			'is_supported_for_image_generation'          => array( 'is_supported_for_image_generation', 'isSupportedForImageGeneration' ),
+			'is_supported_for_text_to_speech_conversion' => array( 'is_supported_for_text_to_speech_conversion', 'isSupportedForTextToSpeechConversion' ),
+			'is_supported_for_video_generation'          => array( 'is_supported_for_video_generation', 'isSupportedForVideoGeneration' ),
+			'is_supported_for_speech_generation'         => array( 'is_supported_for_speech_generation', 'isSupportedForSpeechGeneration' ),
+			'is_supported_for_music_generation'          => array( 'is_supported_for_music_generation', 'isSupportedForMusicGeneration' ),
+			'is_supported_for_embedding_generation'      => array( 'is_supported_for_embedding_generation', 'isSupportedForEmbeddingGeneration' ),
+		);
+	}
+
+	/**
+	 * Tests that a throw from the bundled client during a support check is handled.
+	 *
+	 * This covers the route reported on the ticket. The document modality has no
+	 * capability to infer, so the wrapped builder throws while determining whether
+	 * the prompt is supported.
+	 *
+	 * @ticket 65781
+	 */
+	public function test_is_supported_returns_false_when_the_bundled_builder_throws() {
+		$registry       = AiClient::defaultRegistry();
+		$prompt_builder = new WP_AI_Client_Prompt_Builder( $registry, 'Test text' );
+
 		$result = $prompt_builder->as_output_modalities( ModalityEnum::document() )->is_supported();
 
 		$this->assertIsBool( $result, 'is_supported should return a boolean' );
 		$this->assertFalse( $result, 'is_supported should return false when the wrapped builder throws' );
 
-		// The error is still recorded, so a generating method returns it.
-		$this->assertWPError( $prompt_builder->generate_text(), 'The caught error should still be returned by generating methods' );
+		$error = $prompt_builder->generate_text();
+		$this->assertWPError( $error, 'The caught error should still be returned by generating methods' );
+		$this->assertSame(
+			'prompt_builder_error',
+			$error->get_error_code(),
+			'The document modality should still throw from the wrapped builder. If it no longer does, this test needs another route to a throw'
+		);
 	}
 
 	/**


### PR DESCRIPTION
`WP_AI_Client_Prompt_Builder::__call()` catches an exception from the wrapped SDK builder, stores it as the error state, and then only special cases the generating methods:

```php
} catch ( Exception $e ) {
	$this->error = $this->exception_to_wp_error( $e );

	if ( self::is_generating_method( $name ) ) {
		return $this->error;
	}
	return $this;
}
```

`is_supported()` and the seven `is_supported_for_*()` methods are not generating methods, so they fall through to the fluent return and give back the builder instance. It is truthy, so a support check that failed reads as a success:

```php
if ( wp_ai_client_prompt( 'Write a haiku' )->is_supported() ) {
	// Runs even though the support check could not be completed.
}
```

Everywhere else in the class this is handled. The error state guard at the top of `__call()` returns `false` for support checks, and so does the prevented prompt path. Only an exception raised during the support check itself takes the wrong branch.

## Reproducing it

`ModalityEnum::document()` is a documented factory, but `PromptBuilder::inferCapabilityFromOutputModalities()` has no branch for it and throws a `RuntimeException` in its else. That call is outside the try block `isSupported()` uses to swallow `InvalidArgumentException`, so it reaches the wrapper.

```php
$result = wp_ai_client_prompt( 'Test text' )
	->as_output_modalities( ModalityEnum::document() )
	->is_supported();

var_dump( $result ); // object(WP_AI_Client_Prompt_Builder), expected bool(false)
```

Any throw from the wrapped builder during a support check behaves the same way. The document modality is just the shortest route to one.

## Fix

Return `false` for support check methods from the catch block, so they match what they already return when the builder was in an error state beforehand. The error is still stored, so a later generating call still gets the `WP_Error`, and the test covers that.

## Not a duplicate of #65505

#65505 is about the catch missing `Error`. Its patch widens `catch ( Exception )` to `catch ( Throwable )` and leaves the return logic untouched, so a support check still comes back as the builder after it lands. The two changes are independent and touch different lines.

## Testing

`test_support_check_methods_return_false_when_builder_throws()` fails on trunk with:

```
Failed asserting that WP_AI_Client_Prompt_Builder Object (... 'error' => WP_Error ...
  'Output modality "document" is not yet supported.') is of type "bool".
```

and passes with the patch. The full `ai-client` group is green, 258 tests. `phpcs` passes on both changed files.

Trac ticket: https://core.trac.wordpress.org/ticket/65781

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Reading through the AI client for places where the code disagrees with its own documented behaviour, which is how this turned up, and drafting this description. I confirmed the throw path in the bundled client myself, wrote and ran the test, checked it fails without the patch, ran `phpcs`, and I take responsibility for the change.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
