### PR TITLE
AI: Clone the wrapped builder when cloning WP_AI_Client_Prompt_Builder

### DIFF
--- a/src/wp-includes/ai-client/class-wp-ai-client-prompt-builder.php
+++ b/src/wp-includes/ai-client/class-wp-ai-client-prompt-builder.php
@@ -230,7 +230,7 @@ class WP_AI_Client_Prompt_Builder {
 	 * share that state with the original and any change made to one would be
 	 * visible in the other.
 	 *
-	 * @since 7.1.0
+	 * @since 7.2.0
 	 */
 	public function __clone() {
 		$this->builder = clone $this->builder;

--- a/src/wp-includes/ai-client/class-wp-ai-client-prompt-builder.php
+++ b/src/wp-includes/ai-client/class-wp-ai-client-prompt-builder.php
@@ -224,6 +224,23 @@ class WP_AI_Client_Prompt_Builder {
 	}
 
 	/**
+	 * Clones the wrapped prompt builder alongside this instance.
+	 *
+	 * The wrapped builder mutates its own state, so without this a clone would
+	 * share that state with the original and any change made to one would be
+	 * visible in the other.
+	 *
+	 * @since 7.1.0
+	 */
+	public function __clone() {
+		$this->builder = clone $this->builder;
+
+		if ( null !== $this->error ) {
+			$this->error = clone $this->error;
+		}
+	}
+
+	/**
 	 * Registers WordPress abilities as function declarations for the AI model.
 	 *
 	 * Converts each WP_Ability to a FunctionDeclaration using the wpab__ prefix

--- a/tests/phpunit/tests/ai-client/wpAiClientPromptBuilder.php
+++ b/tests/phpunit/tests/ai-client/wpAiClientPromptBuilder.php
@@ -2617,9 +2617,9 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 	 * Returns the text of every message part held by a prompt builder.
 	 *
 	 * @param WP_AI_Client_Prompt_Builder $builder The prompt builder to read.
-	 * @return string The concatenated message text.
+	 * @return string[] The text of each message part, in order.
 	 */
-	private function get_prompt_text( WP_AI_Client_Prompt_Builder $builder ): string {
+	private function get_prompt_parts( WP_AI_Client_Prompt_Builder $builder ): array {
 		$wrapped = new ReflectionProperty( WP_AI_Client_Prompt_Builder::class, 'builder' );
 		self::set_accessible( $wrapped );
 		$inner = $wrapped->getValue( $builder );
@@ -2627,14 +2627,14 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 		$messages = new ReflectionProperty( $inner, 'messages' );
 		self::set_accessible( $messages );
 
-		$text = '';
+		$parts = array();
 		foreach ( $messages->getValue( $inner ) as $message ) {
 			foreach ( $message->getParts() as $part ) {
-				$text .= (string) $part->getText();
+				$parts[] = (string) $part->getText();
 			}
 		}
 
-		return $text;
+		return $parts;
 	}
 
 	/**
@@ -2657,7 +2657,7 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 
 		$clone->with_text( 'Added to the clone' );
 
-		$this->assertSame( 'Original prompt', $this->get_prompt_text( $builder ), 'Changing the clone should not change the original' );
+		$this->assertSame( array( 'Original prompt' ), $this->get_prompt_parts( $builder ), 'Changing the clone should not change the original' );
 	}
 
 	/**
@@ -2679,7 +2679,7 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 		$builder = new WP_AI_Client_Prompt_Builder( AiClient::defaultRegistry(), 'Original prompt' );
 		$builder->is_supported();
 
-		$this->assertSame( 'Original prompt', $this->get_prompt_text( $builder ), 'A filter should not be able to change the prompt' );
+		$this->assertSame( array( 'Original prompt' ), $this->get_prompt_parts( $builder ), 'A filter should not be able to change the prompt' );
 	}
 
 	/**

--- a/tests/phpunit/tests/ai-client/wpAiClientPromptBuilder.php
+++ b/tests/phpunit/tests/ai-client/wpAiClientPromptBuilder.php
@@ -2614,6 +2614,75 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Returns the text of every message part held by a prompt builder.
+	 *
+	 * @param WP_AI_Client_Prompt_Builder $builder The prompt builder to read.
+	 * @return string The concatenated message text.
+	 */
+	private function get_prompt_text( WP_AI_Client_Prompt_Builder $builder ): string {
+		$wrapped = new ReflectionProperty( WP_AI_Client_Prompt_Builder::class, 'builder' );
+		$wrapped->setAccessible( true );
+		$inner = $wrapped->getValue( $builder );
+
+		$messages = new ReflectionProperty( $inner, 'messages' );
+		$messages->setAccessible( true );
+
+		$text = '';
+		foreach ( $messages->getValue( $inner ) as $message ) {
+			foreach ( $message->getParts() as $part ) {
+				$text .= (string) $part->getText();
+			}
+		}
+
+		return $text;
+	}
+
+	/**
+	 * Tests that a clone does not share the wrapped builder with the original.
+	 *
+	 * @ticket 65782
+	 */
+	public function test_clone_does_not_share_the_wrapped_builder() {
+		$builder = new WP_AI_Client_Prompt_Builder( AiClient::defaultRegistry(), 'Original prompt' );
+		$clone   = clone $builder;
+
+		$wrapped = new ReflectionProperty( WP_AI_Client_Prompt_Builder::class, 'builder' );
+		$wrapped->setAccessible( true );
+
+		$this->assertNotSame(
+			$wrapped->getValue( $builder ),
+			$wrapped->getValue( $clone ),
+			'A clone should wrap its own builder instance'
+		);
+
+		$clone->with_text( 'Added to the clone' );
+
+		$this->assertSame( 'Original prompt', $this->get_prompt_text( $builder ), 'Changing the clone should not change the original' );
+	}
+
+	/**
+	 * Tests that the clone passed to the prevent prompt filter cannot change the prompt.
+	 *
+	 * @ticket 65782
+	 */
+	public function test_prevent_prompt_filter_cannot_mutate_the_original_prompt() {
+		add_filter(
+			'wp_ai_client_prevent_prompt',
+			static function ( $prevent, $builder ) {
+				$builder->with_text( 'Added by the filter' );
+				return $prevent;
+			},
+			10,
+			2
+		);
+
+		$builder = new WP_AI_Client_Prompt_Builder( AiClient::defaultRegistry(), 'Original prompt' );
+		$builder->is_supported();
+
+		$this->assertSame( 'Original prompt', $this->get_prompt_text( $builder ), 'A filter should not be able to change the prompt' );
+	}
+
+	/**
 	 * Tests that once in error state, subsequent fluent calls return the same instance.
 	 *
 	 * @ticket 64591

--- a/tests/phpunit/tests/ai-client/wpAiClientPromptBuilder.php
+++ b/tests/phpunit/tests/ai-client/wpAiClientPromptBuilder.php
@@ -2621,11 +2621,11 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 	 */
 	private function get_prompt_text( WP_AI_Client_Prompt_Builder $builder ): string {
 		$wrapped = new ReflectionProperty( WP_AI_Client_Prompt_Builder::class, 'builder' );
-		$wrapped->setAccessible( true );
+		self::set_accessible( $wrapped );
 		$inner = $wrapped->getValue( $builder );
 
 		$messages = new ReflectionProperty( $inner, 'messages' );
-		$messages->setAccessible( true );
+		self::set_accessible( $messages );
 
 		$text = '';
 		foreach ( $messages->getValue( $inner ) as $message ) {
@@ -2647,7 +2647,7 @@ class Tests_AI_Client_PromptBuilder extends WP_UnitTestCase {
 		$clone   = clone $builder;
 
 		$wrapped = new ReflectionProperty( WP_AI_Client_Prompt_Builder::class, 'builder' );
-		$wrapped->setAccessible( true );
+		self::set_accessible( $wrapped );
 
 		$this->assertNotSame(
 			$wrapped->getValue( $builder ),


### PR DESCRIPTION
`WP_AI_Client_Prompt_Builder::__call()` hands a clone of itself to the `wp_ai_client_prevent_prompt` filter, and the hook doc calls it read only:

```php
/**
 * @param bool                        $prevent Whether to prevent the prompt. Default false.
 * @param WP_AI_Client_Prompt_Builder $builder A clone of the prompt builder instance (read-only).
 */
$prevent = (bool) apply_filters( 'wp_ai_client_prevent_prompt', false, clone $this );
```

The class has no `__clone()`, so that is a shallow copy and the clone still points at the same wrapped `PromptBuilder`. The wrapped builder mutates itself rather than returning new instances:

```php
public function withText(string $text): self
{
	$part = new MessagePart($text);
	$this->appendPartToMessages($part);
	return $this;
}
```

So whatever a filter does to the clone lands on the original, and the prompt sent to the provider is not the one the caller built.

```php
add_filter(
	'wp_ai_client_prevent_prompt',
	static function ( $prevent, $builder ) {
		$builder->with_text( 'Added by the filter' );
		return $prevent;
	},
	10,
	2
);

$builder = wp_ai_client_prompt( 'Original prompt' );
$builder->is_supported();

// The prompt is now 'Original promptAdded by the filter'.
```

This runs on every call that reaches the filter, so support checks and generating methods both.

## Fix

Add `__clone()` so the wrapped builder is cloned too. The bundled client already implements `PromptBuilder::__clone()` to deep clone messages, model config and request options. It was written for this, it just never ran because only the wrapper was being cloned.

A stored `WP_Error` is copied as well. Nothing today clones the wrapper while it holds an error, since the filter is only reached when the error is still null, but `__clone()` is a magic method any caller can trigger and leaving half the state shared would be the same bug in a different place.

## Testing

Two tests, both failing on trunk:

```
1) test_clone_does_not_share_the_wrapped_builder
A clone should wrap its own builder instance
Failed asserting that two variables don't reference the same object.

2) test_prevent_prompt_filter_cannot_mutate_the_original_prompt
A filter should not be able to change the prompt
-'Original prompt'
+'Original promptAdded by the filter'
```

Both pass with the patch. The existing `test_prevent_prompt_filter_receives_cloned_builder_instance()` only asserted the outer objects differ, which is why this went unnoticed, and it still passes. The full `ai-client` group is green, 259 tests. `phpcs` passes on both changed files.

Trac ticket: https://core.trac.wordpress.org/ticket/65782

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Reading through the AI client for places where the code disagrees with its own documented behaviour, which is how this turned up, and drafting this description. I confirmed the mutation by hand, checked that the bundled client already has a deep `__clone()`, wrote and ran the tests, checked they fail without the patch, ran `phpcs`, and I take responsibility for the change.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
