### PR TITLE
Menus: Avoid undefined property warning for aria-current in Walker_Nav_Menu

### DIFF
--- a/src/wp-includes/class-walker-nav-menu.php
+++ b/src/wp-includes/class-walker-nav-menu.php
@@ -262,7 +262,7 @@ class Walker_Nav_Menu extends Walker {
 			$atts['href'] = '';
 		}
 
-		$atts['aria-current'] = $menu_item->current ? 'page' : '';
+		$atts['aria-current'] = ! empty( $menu_item->current ) ? 'page' : '';
 
 		// Add title attribute only if it does not match the link text (before or after filtering).
 		if ( ! empty( $menu_item->attr_title )

--- a/tests/phpunit/tests/menu/walker-nav-menu.php
+++ b/tests/phpunit/tests/menu/walker-nav-menu.php
@@ -144,6 +144,39 @@ class Tests_Menu_Walker_Nav_Menu extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that `Walker_Nav_Menu::start_el()` does not trigger a PHP warning
+	 * when the `current` property is not set on the menu item object.
+	 *
+	 * @ticket 65786
+	 *
+	 * @covers Walker_Nav_Menu::start_el
+	 */
+	public function test_start_el_should_not_warn_when_current_property_is_not_set() {
+		$output  = '';
+		$post_id = self::factory()->post->create();
+
+		$item = (object) array(
+			'ID'        => $post_id,
+			'object_id' => $post_id,
+			'title'     => get_the_title( $post_id ),
+			'target'    => '',
+			'xfn'       => '',
+			// Intentionally omitted to replicate menu item objects without a `current` property.
+		);
+
+		$args = (object) array(
+			'before'      => '',
+			'after'       => '',
+			'link_before' => '',
+			'link_after'  => '',
+		);
+
+		$this->walker->start_el( $output, $item, 0, $args );
+
+		$this->assertStringNotContainsString( 'aria-current', $output );
+	}
+
+	/**
 	 * Tests that `Walker_Nav_Menu::start_el()` adds `rel="privacy-policy"`.
 	 *
 	 * @ticket 56345


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65786

## Summary
`Walker_Nav_Menu::start_el()` reads `$menu_item->current` directly to build the `aria-current` attribute. When a menu item object reaches the walker without going through `_wp_menu_item_classes_by_context()` (e.g. custom walkers, filtered or cached menu items), the `current` property is never set, which triggers a `PHP Warning: Undefined property: stdClass::$current` on PHP 8.2+.

This wraps the check in `empty()`, matching how the other optional menu item properties (`target`, `xfn`, `url`, `attr_title`, `classes`) are already handled in this same method.

## Test plan
- Added `test_start_el_should_not_warn_when_current_property_is_not_set()` in `tests/phpunit/tests/menu/walker-nav-menu.php`, which calls `start_el()` with a menu item object that intentionally omits `current` and asserts no `aria-current` attribute is output (fails without the fix, passes with it).