### PR TITLE
Widgets: Cap 'On This Day' posts per year instead of overall

### DIFF
--- a/src/wp-admin/css/dashboard.css
+++ b/src/wp-admin/css/dashboard.css
@@ -1054,6 +1054,11 @@ body #dashboard-widgets .postbox form .submit {
 	color: #646970;
 }
 
+#wp_dashboard_on_this_day .wp-on-this-day-more {
+	list-style: none;
+	color: #646970;
+}
+
 /* Browse happy box */
 
 #dashboard-widgets #dashboard_browser_nag.postbox .inside {

--- a/src/wp-admin/includes/dashboard-on-this-day.php
+++ b/src/wp-admin/includes/dashboard-on-this-day.php
@@ -57,26 +57,19 @@ function wp_dashboard_on_this_day_postbox_classes( $classes ) {
  * @since 7.1.0
  */
 function wp_dashboard_on_this_day() {
-	$posts = wp_dashboard_on_this_day_get_posts();
+	$posts_by_year = wp_dashboard_on_this_day_get_posts();
 
-	if ( empty( $posts ) ) {
+	if ( empty( $posts_by_year ) ) {
 		// Placeholder shown when a user reveals the hidden widget via Screen
 		// Options on a day with no matching posts.
 		echo '<p>' . esc_html__( 'No posts were published on this day in previous years.' ) . '</p>';
 		return;
 	}
 
-	$posts_by_year = array();
-	$post_count    = count( $posts );
+	$post_count = 0;
 
-	foreach ( $posts as $post ) {
-		$year = get_the_date( 'Y', $post );
-
-		if ( ! isset( $posts_by_year[ $year ] ) ) {
-			$posts_by_year[ $year ] = array();
-		}
-
-		$posts_by_year[ $year ][] = $post;
+	foreach ( $posts_by_year as $year_data ) {
+		$post_count += $year_data['total'];
 	}
 
 	/* translators: Date format for the On This Day widget date, without year. See https://www.php.net/manual/datetime.format.php */
@@ -108,11 +101,11 @@ function wp_dashboard_on_this_day() {
 			?>
 		</p>
 		<ul>
-			<?php foreach ( $posts_by_year as $year => $year_posts ) : ?>
+			<?php foreach ( $posts_by_year as $year => $year_data ) : ?>
 				<li>
 					<h3><?php echo esc_html( $year ); ?></h3>
 					<ul>
-						<?php foreach ( $year_posts as $year_post ) : ?>
+						<?php foreach ( $year_data['posts'] as $year_post ) : ?>
 							<?php
 							$title = get_the_title( $year_post );
 
@@ -139,6 +132,24 @@ function wp_dashboard_on_this_day() {
 								<?php endif; ?>
 							</li>
 						<?php endforeach; ?>
+						<?php
+						$remaining = $year_data['total'] - count( $year_data['posts'] );
+
+						if ( $remaining > 0 ) :
+							$remaining_text = sprintf(
+								/* translators: %s: Number of additional posts published in that year. */
+								_n( '%s more post', '%s more posts', $remaining ),
+								number_format_i18n( $remaining )
+							);
+							?>
+							<li class="wp-on-this-day-more">
+								<?php if ( '' !== $year_data['archive_link'] ) : ?>
+									<a href="<?php echo esc_url( $year_data['archive_link'] ); ?>"><?php echo esc_html( $remaining_text ); ?></a>
+								<?php else : ?>
+									<?php echo esc_html( $remaining_text ); ?>
+								<?php endif; ?>
+							</li>
+						<?php endif; ?>
 					</ul>
 				</li>
 			<?php endforeach; ?>
@@ -149,53 +160,143 @@ function wp_dashboard_on_this_day() {
 
 /**
  * Retrieves published posts from all authors that were published on this
- * calendar day in previous years.
+ * calendar day in previous years, grouped by publication year.
  *
- * The date constraint matches today's month and day, combined with a
- * `before` clause anchored to January 1 of the current year. Up to ten posts
- * are returned; use the `wp_dashboard_on_this_day_query_args` filter to change
- * the limit. Results are cached by WP_Query's native query caching.
+ * The date constraint matches today's month and day, combined with a `before`
+ * clause anchored to January 1 of the current year. Rather than capping the
+ * widget as a whole — which lets recent, prolific years crowd out older ones
+ * entirely — a small number of posts is kept for each year that has any,
+ * newest year first.
+ *
+ * A single query reads the ID and publication date of every matching post,
+ * which is what allows the per-year totals to be accurate even when only a
+ * few posts from a year are displayed. Only the posts that will be displayed
+ * are then loaded in full. Use the `wp_dashboard_on_this_day_query_args`
+ * filter to change the post types, statuses, or per-year limit.
  *
  * @since 7.1.0
  *
- * @return WP_Post[] Array of posts ordered by newest first.
+ * @global wpdb $wpdb WordPress database abstraction object.
+ *
+ * @return array[] Array of per-year data keyed by four-digit year, newest year
+ *                 first. Each entry is an array with the following keys:
+ *
+ *     @type WP_Post[] $posts        The posts to display, newest first.
+ *     @type int       $total        Total number of matching posts that year,
+ *                                   including those not in `$posts`.
+ *     @type string    $archive_link URL of the day archive listing every post
+ *                                   from that day, or an empty string when no
+ *                                   single day archive covers the year's posts.
  */
 function wp_dashboard_on_this_day_get_posts() {
-	$today      = current_datetime();
-	$year       = (int) $today->format( 'Y' );
-	$date_query = array(
-		'relation' => 'AND',
-		array(
-			'before' => array( 'year' => $year ),
-		),
-		_wp_dashboard_on_this_day_date_query_clause( $today ),
-	);
+	global $wpdb;
+
+	$today = current_datetime();
 
 	$args = array(
-		'post_type'              => 'post',
-		'post_status'            => array( 'publish' ),
-		'posts_per_page'         => 10,
-		'ignore_sticky_posts'    => true,
-		'orderby'                => 'date',
-		'order'                  => 'DESC',
-		'no_found_rows'          => true,
-		'update_post_term_cache' => false,
-		'update_post_meta_cache' => false,
-		'date_query'             => $date_query,
+		'post_type'      => 'post',
+		'post_status'    => array( 'publish' ),
+		'posts_per_year' => 5,
 	);
 
 	/**
-	 * Filters the arguments used to query posts for the On This Day dashboard widget.
+	 * Filters the arguments used to gather posts for the On This Day dashboard widget.
 	 *
 	 * @since 7.1.0
 	 *
-	 * @param array $args WP_Query arguments.
+	 * @param array $args {
+	 *     Arguments for the widget's query.
+	 *
+	 *     @type string|string[] $post_type      Post type or types to include. Default 'post'.
+	 *     @type string|string[] $post_status    Post status or statuses to include. Default 'publish'.
+	 *     @type int             $posts_per_year Maximum posts to display for each year. Any
+	 *                                           further posts from that year are summarized
+	 *                                           with a link to the day archive. Default 5.
+	 * }
 	 */
 	$args = apply_filters( 'wp_dashboard_on_this_day_query_args', $args );
 
-	$query = new WP_Query( $args );
+	$post_types     = array_filter( array_map( 'strval', (array) ( $args['post_type'] ?? 'post' ) ) );
+	$post_statuses  = array_filter( array_map( 'strval', (array) ( $args['post_status'] ?? 'publish' ) ) );
+	$posts_per_year = (int) ( $args['posts_per_year'] ?? 5 );
 
-	return $query->posts;
+	if ( empty( $post_types ) || empty( $post_statuses ) || $posts_per_year < 1 ) {
+		return array();
+	}
+
+	$clause = _wp_dashboard_on_this_day_date_query_clause( $today );
+
+	$date_query = new WP_Date_Query(
+		array(
+			'relation' => 'AND',
+			array(
+				'before' => array( 'year' => (int) $today->format( 'Y' ) ),
+			),
+			$clause,
+		),
+		"{$wpdb->posts}.post_date"
+	);
+
+	$sql = $wpdb->prepare(
+		"SELECT ID, post_date FROM {$wpdb->posts}
+		WHERE post_type IN (" . implode( ',', array_fill( 0, count( $post_types ), '%s' ) ) . ')
+		AND post_status IN (' . implode( ',', array_fill( 0, count( $post_statuses ), '%s' ) ) . ')',
+		array_merge( $post_types, $post_statuses )
+	) . $date_query->get_sql() . " ORDER BY {$wpdb->posts}.post_date DESC";
+
+	// A merged leap day clause spans two calendar days, so no single day archive covers it.
+	$archive_month = isset( $clause['relation'] ) ? 0 : (int) $today->format( 'm' );
+	$archive_day   = isset( $clause['relation'] ) ? 0 : (int) $today->format( 'd' );
+
+	$last_changed  = wp_cache_get_last_changed( 'posts' );
+	$cache_key     = 'on_this_day:' . md5( "$sql|$posts_per_year" ) . ":$last_changed";
+	$posts_by_year = wp_cache_get( $cache_key, 'post-queries' );
+
+	if ( false === $posts_by_year ) {
+		$posts_by_year = array();
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Both clauses above are prepared.
+		$rows = $wpdb->get_results( $sql );
+
+		// Rows arrive newest first, so each year is filled in display order.
+		foreach ( $rows as $row ) {
+			$year = (int) substr( $row->post_date, 0, 4 );
+
+			if ( ! isset( $posts_by_year[ $year ] ) ) {
+				$posts_by_year[ $year ] = array(
+					'post_ids'     => array(),
+					'total'        => 0,
+					'archive_link' => $archive_month > 0 ? get_day_link( $year, $archive_month, $archive_day ) : '',
+				);
+			}
+
+			++$posts_by_year[ $year ]['total'];
+
+			if ( count( $posts_by_year[ $year ]['post_ids'] ) < $posts_per_year ) {
+				$posts_by_year[ $year ]['post_ids'][] = (int) $row->ID;
+			}
+		}
+
+		wp_cache_set( $cache_key, $posts_by_year, 'post-queries' );
+	}
+
+	if ( empty( $posts_by_year ) ) {
+		return array();
+	}
+
+	$post_ids = array_merge( ...array_column( $posts_by_year, 'post_ids' ) );
+
+	_prime_post_caches( $post_ids, false, false );
+
+	foreach ( $posts_by_year as $year => $year_data ) {
+		$posts = array_values( array_filter( array_map( 'get_post', $year_data['post_ids'] ) ) );
+
+		unset( $posts_by_year[ $year ]['post_ids'] );
+
+		$posts_by_year[ $year ]['posts'] = $posts;
+	}
+
+	return $posts_by_year;
 }
 
 /**

--- a/tests/phpunit/tests/admin/wpDashboardOnThisDay.php
+++ b/tests/phpunit/tests/admin/wpDashboardOnThisDay.php
@@ -337,11 +337,12 @@ class Tests_Admin_wpDashboardOnThisDay extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 65116
+	 * @ticket 65783
 	 *
 	 * @covers ::wp_dashboard_on_this_day
 	 * @covers ::wp_dashboard_on_this_day_get_posts
 	 */
-	public function test_widget_limits_posts_to_ten() {
+	public function test_widget_shows_every_year_that_has_posts() {
 		wp_set_current_user( self::$user_id );
 
 		for ( $years_ago = 1; $years_ago <= 11; $years_ago++ ) {
@@ -352,9 +353,205 @@ class Tests_Admin_wpDashboardOnThisDay extends WP_UnitTestCase {
 		wp_dashboard_on_this_day();
 		$output = ob_get_clean();
 
-		$this->assertStringContainsString( '10 posts have been published on <strong>' . wp_date( 'F jS' ) . '</strong>:', $output );
-		$this->assertStringContainsString( 'Anniversary post 1<', $output );
-		$this->assertStringContainsString( 'Anniversary post 10<', $output );
-		$this->assertStringNotContainsString( 'Anniversary post 11', $output );
+		$this->assertStringContainsString( '11 posts have been published on <strong>' . wp_date( 'F jS' ) . '</strong>:', $output );
+
+		for ( $years_ago = 1; $years_ago <= 11; $years_ago++ ) {
+			$this->assertStringContainsString( 'Anniversary post ' . $years_ago . '<', $output );
+			$this->assertStringContainsString(
+				'<h3>' . current_datetime()->modify( "-$years_ago years" )->format( 'Y' ) . '</h3>',
+				$output
+			);
+		}
+	}
+
+	/**
+	 * @ticket 65783
+	 *
+	 * @covers ::wp_dashboard_on_this_day
+	 * @covers ::wp_dashboard_on_this_day_get_posts
+	 */
+	public function test_widget_limits_posts_per_year() {
+		wp_set_current_user( self::$user_id );
+
+		for ( $hour = 1; $hour <= 7; $hour++ ) {
+			$this->create_matching_post( self::$user_id, 'Busy day post ' . $hour, 1, sprintf( '%02d:00:00', $hour ) );
+		}
+
+		$this->create_matching_post( self::$user_id, 'A quiet older day', 2 );
+
+		ob_start();
+		wp_dashboard_on_this_day();
+		$output = ob_get_clean();
+
+		// The header reports every matching post, not just the displayed ones.
+		$this->assertStringContainsString( '8 posts have been published on <strong>' . wp_date( 'F jS' ) . '</strong>:', $output );
+
+		// The five newest posts of the busy year are shown, the two oldest are not.
+		foreach ( array( 7, 6, 5, 4, 3 ) as $hour ) {
+			$this->assertStringContainsString( 'Busy day post ' . $hour . '<', $output );
+		}
+		$this->assertStringNotContainsString( 'Busy day post 2<', $output );
+		$this->assertStringNotContainsString( 'Busy day post 1<', $output );
+
+		// The remainder is summarized, and the quieter year is untouched.
+		$this->assertStringContainsString( '2 more posts', $output );
+		$this->assertStringContainsString( 'A quiet older day', $output );
+	}
+
+	/**
+	 * @ticket 65783
+	 *
+	 * @covers ::wp_dashboard_on_this_day_get_posts
+	 */
+	public function test_posts_per_year_is_filterable_via_query_args() {
+		wp_set_current_user( self::$user_id );
+
+		for ( $hour = 1; $hour <= 3; $hour++ ) {
+			$this->create_matching_post( self::$user_id, 'Busy day post ' . $hour, 1, sprintf( '%02d:00:00', $hour ) );
+		}
+
+		add_filter(
+			'wp_dashboard_on_this_day_query_args',
+			static function ( $args ) {
+				$args['posts_per_year'] = 2;
+
+				return $args;
+			}
+		);
+
+		$posts_by_year = wp_dashboard_on_this_day_get_posts();
+		$year          = (int) current_datetime()->modify( '-1 year' )->format( 'Y' );
+
+		$this->assertSame( array( $year ), array_keys( $posts_by_year ) );
+		$this->assertCount( 2, $posts_by_year[ $year ]['posts'] );
+		$this->assertSame( 3, $posts_by_year[ $year ]['total'] );
+	}
+
+	/**
+	 * @ticket 65783
+	 *
+	 * @covers ::wp_dashboard_on_this_day
+	 * @covers ::wp_dashboard_on_this_day_get_posts
+	 */
+	public function test_widget_does_not_summarize_a_year_that_is_fully_shown() {
+		wp_set_current_user( self::$user_id );
+
+		$this->create_matching_post( self::$user_id, 'The only memory' );
+
+		ob_start();
+		wp_dashboard_on_this_day();
+		$output = ob_get_clean();
+
+		$this->assertStringNotContainsString( 'wp-on-this-day-more', $output );
+	}
+
+	/**
+	 * @ticket 65783
+	 *
+	 * @covers ::wp_dashboard_on_this_day_get_posts
+	 */
+	public function test_get_posts_groups_years_newest_first_with_accurate_totals() {
+		$this->create_matching_post( self::$user_id, 'Two years ago', 2 );
+		$this->create_matching_post( self::$user_id, 'Last year, morning', 1, '09:00:00' );
+		$this->create_matching_post( self::$user_id, 'Last year, evening', 1, '19:00:00' );
+		$this->create_nearby_post( self::$user_id, 'Not today' );
+
+		$today         = current_datetime();
+		$last_year     = (int) $today->modify( '-1 year' )->format( 'Y' );
+		$two_years_ago = (int) $today->modify( '-2 years' )->format( 'Y' );
+
+		$posts_by_year = wp_dashboard_on_this_day_get_posts();
+
+		$this->assertSame( array( $last_year, $two_years_ago ), array_keys( $posts_by_year ) );
+		$this->assertSame( 2, $posts_by_year[ $last_year ]['total'] );
+		$this->assertSame( 1, $posts_by_year[ $two_years_ago ]['total'] );
+		$this->assertSame(
+			'Last year, evening',
+			get_the_title( $posts_by_year[ $last_year ]['posts'][0] ),
+			'Posts within a year should be newest first.'
+		);
+	}
+
+	/**
+	 * @ticket 65783
+	 *
+	 * @covers ::wp_dashboard_on_this_day_get_posts
+	 */
+	public function test_get_posts_excludes_the_current_year() {
+		$post_date = current_datetime()->format( 'Y-m-d' ) . ' 00:00:01';
+
+		self::factory()->post->create(
+			array(
+				'post_author'   => self::$user_id,
+				'post_date'     => $post_date,
+				'post_date_gmt' => get_gmt_from_date( $post_date ),
+				'post_status'   => 'publish',
+				'post_title'    => 'Published today',
+			)
+		);
+
+		$this->assertSame( array(), wp_dashboard_on_this_day_get_posts() );
+	}
+
+	/**
+	 * @ticket 65783
+	 *
+	 * @covers ::wp_dashboard_on_this_day_get_posts
+	 */
+	public function test_get_posts_ignores_unpublished_posts() {
+		$post_date = current_datetime()->modify( '-1 year' )->format( 'Y-m-d' ) . ' 12:00:00';
+
+		foreach ( array( 'draft', 'pending', 'private' ) as $status ) {
+			self::factory()->post->create(
+				array(
+					'post_author'   => self::$user_id,
+					'post_date'     => $post_date,
+					'post_date_gmt' => get_gmt_from_date( $post_date ),
+					'post_status'   => $status,
+					'post_title'    => "A $status memory",
+				)
+			);
+		}
+
+		$this->assertSame( array(), wp_dashboard_on_this_day_get_posts() );
+	}
+
+	/**
+	 * @ticket 65783
+	 *
+	 * @covers ::wp_dashboard_on_this_day_get_posts
+	 */
+	public function test_get_posts_scans_once_regardless_of_year_count() {
+		global $wpdb;
+
+		for ( $years_ago = 1; $years_ago <= 6; $years_ago++ ) {
+			$this->create_matching_post( self::$user_id, 'Anniversary ' . $years_ago, $years_ago );
+		}
+
+		wp_cache_flush();
+
+		$post_queries = array();
+
+		add_filter(
+			'query',
+			static function ( $query ) use ( &$post_queries, $wpdb ) {
+				if ( str_contains( $query, $wpdb->posts ) ) {
+					$post_queries[] = $query;
+				}
+
+				return $query;
+			}
+		);
+
+		$posts_by_year = wp_dashboard_on_this_day_get_posts();
+
+		$this->assertCount( 6, $posts_by_year );
+		$this->assertCount(
+			2,
+			$post_queries,
+			"Gathering posts should take one scan plus one cache prime, not one query per year. Ran:\n" . implode( "\n", $post_queries )
+		);
+		$this->assertStringContainsString( 'ORDER BY', $post_queries[0] );
+		$this->assertStringNotContainsString( 'YEAR(', $post_queries[0], 'The scan must stay sargable on type_status_date.' );
 	}
 }


### PR DESCRIPTION
## What?

Changes the "On This Day" dashboard widget from a cap of ten posts overall to five posts per year, and makes the summary line report the true number of matching posts.

## Ticket

Trac ticket: https://core.trac.wordpress.org/ticket/65783

## Why?

**Older years disappear entirely.** Because `orderby => date` is global rather than per year, one prolific year exhausts the ten-post budget before an older year is reached. The limit isn't ten posts per day — it's ten posts on that calendar date across the site's whole history:

| Posts on that date per year | Oldest year that can appear |
| --- | --- |
| 1 | 10 years back |
| 2 | 5 years back |
| 3 | 3 years back |

A blog that posts twice on August 1st each year can't see past 2020. The report on the ticket is about a 2002 post vanishing for exactly this reason.

**The count was wrong.** `$post_count` was `count( $posts )` on an already-capped array, so a day with 15 matching posts rendered "10 posts have been published on August 1st".

## How?

One query reads `ID` and `post_date` for every matching post, which is what makes the per-year totals accurate. Grouping and capping happen in PHP, then only the posts that will be displayed are loaded in full via `_prime_post_caches()`. 
Results are cached in the `post-queries` group keyed on `wp_cache_get_last_changed( 'posts' )`, since the widget queries twice per dashboard load.

Years with more than five matches get a "N more posts" link to that day's archive, so nothing becomes unreachable. That link is suppressed on February 28th in a non-leap year, because the existing leap-day merge means the group spans two
calendar days and no single archive covers both.

**Deliberately avoided:** one query per year. `WP_Date_Query` renders a year constraint as `YEAR( post_date ) = 2019`, which can't use `type_status_date`, so each per-year query degrades to a full filter over every published post. That
shape measured 48.1 ms against 3.19 ms for the single scan. There's a test asserting the scan contains no `YEAR(` to stop it creeping back in.

## Notable changes

- `wp_dashboard_on_this_day_get_posts()` returns per-year data keyed by year rather than a flat `WP_Post[]`.
- `wp_dashboard_on_this_day_query_args` keeps its name and now carries `post_type`, `post_status` and `posts_per_year`.

## Performance

10k posts spanning 28 years, cold cache, ten runs:

| | Sparse day (21 matches) | Dense day (421 matches) |
| --- | --- | --- |
| trunk | 1.41 ms | 0.76 ms |
| this PR | 3.03 ms | 3.19 ms |

trunk is fast because `LIMIT 10` lets it stop after ten index entries — it's quick precisely because it isn't looking. Reporting an accurate total means scanning, since `MONTH()`/`DAYOFMONTH()` can't use `type_status_date`. The cost is ~1.6–2.4 ms on a dashboard load, and the result is cached for the widget's second query in the same request.

## Screenshots

| Before | After |
| --- | --- |
| <img width="587" height="382" alt="before" src="https://github.com/user-attachments/assets/bd6bfbb9-5960-4687-b2af-b8d360885964" /> | <img width="526" height="433" alt="after-singlescan" src="https://github.com/user-attachments/assets/cc9ac16e-2956-48ec-b7c2-975ee3143a00" /> |

## Testing Instructions

1. Publish 12 posts dated today's month/day in 2024, 2 in 2011, and 1 in 2002 or use this https://codeshare.io/5o1E1o in testing on wordpress-dev site.
2. Load the dashboard.
3. **Before:** one `2024` group of ten entries, no 2011 or 2002, header reads "10 posts have been published".
4. **After:** `2024` shows five entries plus a "7 more posts" link, `2011` shows both, `2002` shows one, header reads "15 posts have been published".
5. Click "7 more posts" — it should land on that day's archive.
6. `npm run test:php -- --filter Tests_Admin_wpDashboardOnThisDay`

### Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Implementation, unit tests, and inline documentation; benchmarking the query shapes against a 10k-post fixture; drafting PR description.