### PR TITLE
View config: lowercase dynamic filter names

### DIFF
--- a/src/wp-includes/class-wp-view-config-data.php
+++ b/src/wp-includes/class-wp-view-config-data.php
@@ -121,9 +121,9 @@ class WP_View_Config_Data {
 	 * Applies the entity view configuration filter and returns the result.
 	 *
 	 * Exposes the container through the dynamic
-	 * `get_entity_view_config_{$kind}_{$name}` filter so that core and third
-	 * parties can provide the configuration for a specific entity, then
-	 * reconciles the filtered container back into a plain configuration array,
+	 * `get_entity_view_config_{$kind}_{$name}` filter (with the dynamic portions
+	 * lowercased, so that core and third parties can provide the configuration for a specific entity,
+	 * then reconciles the filtered container back into a plain configuration array,
 	 * limited to the documented configuration keys.
 	 *
 	 * @since 7.1.0
@@ -137,7 +137,9 @@ class WP_View_Config_Data {
 		 * Filters the view configuration for a given entity.
 		 *
 		 * The dynamic portions of the hook name, `$kind` and `$name`, refer to the
-		 * entity kind (e.g. `postType`) and the entity name (e.g. `page`).
+		 * entity kind (e.g. `postType`) and the entity name (e.g. `page`),
+		 * lowercased — so the `postType`/`page` entity maps to the
+		 * `get_entity_view_config_posttype_page` hook.
 		 *
 		 * Callbacks receive a WP_View_Config_Data object and change the
 		 * configuration through its methods. Each write method takes the schema
@@ -183,7 +185,7 @@ class WP_View_Config_Data {
 		 * }
 		 */
 		apply_filters(
-			"get_entity_view_config_{$kind}_{$name}",
+			wp_get_entity_view_config_hook_name( $kind, $name ),
 			$this,
 			array(
 				'kind' => $kind,

--- a/src/wp-includes/class-wp-view-config-data.php
+++ b/src/wp-includes/class-wp-view-config-data.php
@@ -122,7 +122,7 @@ class WP_View_Config_Data {
 	 *
 	 * Exposes the container through the dynamic
 	 * `get_entity_view_config_{$kind}_{$name}` filter (with the dynamic portions
-	 * lowercased, so that core and third parties can provide the configuration for a specific entity,
+	 * lowercased), so that core and third parties can provide the configuration for a specific entity,
 	 * then reconciles the filtered container back into a plain configuration array,
 	 * limited to the documented configuration keys.
 	 *

--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -827,8 +827,8 @@ foreach ( array( 'page', 'wp_block', 'wp_template_part', 'wp_template' ) as $pos
 	// callbacks registered at the default compose on top of them
 	// regardless of registration order.
 	add_filter(
-		"get_entity_view_config_postType_{$post_type}",
-		"_wp_get_entity_view_config_post_type_{$post_type}",
+		"get_entity_view_config_posttype_{$post_type}",
+		"_wp_get_entity_view_config_posttype_{$post_type}",
 		5
 	);
 }

--- a/src/wp-includes/view-config.php
+++ b/src/wp-includes/view-config.php
@@ -4,11 +4,32 @@
  *
  * Builds the default view configuration for an entity and exposes it through
  * the dynamic `get_entity_view_config_{$kind}_{$name}` filter so core and third
- * parties can provide the configuration for a specific entity.
+ * parties can provide the configuration for a specific entity. The dynamic
+ * portions of the hook name are lowercased, e.g.
+ * `get_entity_view_config_posttype_page` for the `page` post type.
  *
  * @package WordPress
  * @since 7.1.0
  */
+
+/**
+ * Builds the name of the dynamic filter that provides the view configuration
+ * for an entity.
+ *
+ * The entity kind and name are embedded in the hook name lowercased, so the
+ * hook follows the WordPress convention of lowercase hook names regardless of
+ * how the entity identifiers are spelled: the `postType`/`page` entity maps to
+ * the `get_entity_view_config_posttype_page` hook.
+ *
+ * @since 7.1.0
+ *
+ * @param string $kind The entity kind (e.g. `postType`).
+ * @param string $name The entity name (e.g. `page`).
+ * @return string The filter name.
+ */
+function wp_get_entity_view_config_hook_name( $kind, $name ) {
+	return strtolower( "get_entity_view_config_{$kind}_{$name}" );
+}
 
 /**
  * Builds the default `form` configuration for post types that don't provide their own.
@@ -27,7 +48,7 @@
  *
  * @return array The default form configuration.
  */
-function _wp_get_default_post_type_form() {
+function _wp_get_default_posttype_form() {
 	return array(
 		'layout' => array( 'type' => 'panel' ),
 		'fields' => array(
@@ -97,8 +118,10 @@ function _wp_get_default_post_type_form() {
  * Returns the view configuration for the given entity.
  *
  * Builds the default configuration shared by all entities and then exposes it
- * through the dynamic `get_entity_view_config_{$kind}_{$name}` filter so that core
- * and third parties can provide the configuration for a specific entity.
+ * through the dynamic `get_entity_view_config_{$kind}_{$name}` filter — with the
+ * dynamic portions lowercased, see wp_get_entity_view_config_hook_name()
+ * — so that core and third parties can provide the configuration for a
+ * specific entity.
  *
  * @since 7.1.0
  *
@@ -148,7 +171,7 @@ function wp_get_entity_view_config( $kind, $name ) {
 		'default_view'    => $default_view,
 		'default_layouts' => $default_layouts,
 		'view_list'       => $view_list,
-		'form'            => 'postType' === $kind ? _wp_get_default_post_type_form() : array(),
+		'form'            => 'postType' === $kind ? _wp_get_default_posttype_form() : array(),
 	);
 
 	$data = new WP_View_Config_Data( $config );
@@ -164,7 +187,7 @@ function wp_get_entity_view_config( $kind, $name ) {
  * @param WP_View_Config_Data $data The view configuration container for the entity.
  * @return WP_View_Config_Data The updated view configuration container.
  */
-function _wp_get_entity_view_config_post_type_page( $data ) {
+function _wp_get_entity_view_config_posttype_page( $data ) {
 	$default_layouts = array(
 		'table' => array(
 			'layout' => array(
@@ -304,7 +327,7 @@ function _wp_get_entity_view_config_post_type_page( $data ) {
  * @param WP_View_Config_Data $data The view configuration container for the entity.
  * @return WP_View_Config_Data The updated view configuration container.
  */
-function _wp_get_entity_view_config_post_type_wp_block( $data ) {
+function _wp_get_entity_view_config_posttype_wp_block( $data ) {
 	$default_layouts = array(
 		'table' => array(
 			'layout' => array(
@@ -422,7 +445,7 @@ function _wp_get_entity_view_config_post_type_wp_block( $data ) {
  * @param WP_View_Config_Data $data The view configuration container for the entity.
  * @return WP_View_Config_Data The updated view configuration container.
  */
-function _wp_get_entity_view_config_post_type_wp_template_part( $data ) {
+function _wp_get_entity_view_config_posttype_wp_template_part( $data ) {
 	$default_layouts = array(
 		'table' => array(
 			'layout' => array(
@@ -524,7 +547,7 @@ function _wp_get_entity_view_config_post_type_wp_template_part( $data ) {
  * @param WP_View_Config_Data $data The view configuration container for the entity.
  * @return WP_View_Config_Data The updated view configuration container.
  */
-function _wp_get_entity_view_config_post_type_wp_template( $data ) {
+function _wp_get_entity_view_config_posttype_wp_template( $data ) {
 	$default_view = array(
 		'type'             => 'grid',
 		'perPage'          => 20,

--- a/tests/phpunit/tests/view-config.php
+++ b/tests/phpunit/tests/view-config.php
@@ -69,7 +69,7 @@ class Tests_View_Config_API extends WP_UnitTestCase {
 	 * Tears down each test.
 	 */
 	public function tear_down() {
-		remove_all_filters( 'get_entity_view_config_postType_unregistered_cpt' );
+		remove_all_filters( 'get_entity_view_config_posttype_unregistered_cpt' );
 		remove_all_filters( 'get_entity_view_config_custom_kind_custom_name' );
 		parent::tear_down();
 	}
@@ -117,6 +117,28 @@ class Tests_View_Config_API extends WP_UnitTestCase {
 		$this->assertSame( 'All Custom Things', $config['view_list'][0]['title'] );
 
 		unregister_post_type( 'view_config_cpt' );
+	}
+
+	/**
+	 * The dynamic filter name lowercases the entity kind and name.
+	 */
+	public function test_filter_hook_name_is_lowercased() {
+		$called = false;
+		add_filter(
+			'get_entity_view_config_posttype_unregistered_cpt',
+			function ( $data ) use ( &$called ) {
+				$called = true;
+				return $data;
+			}
+		);
+
+		wp_get_entity_view_config( 'postType', 'Unregistered_CPT' );
+
+		$this->assertTrue( $called );
+		$this->assertSame(
+			'get_entity_view_config_posttype_unregistered_cpt',
+			wp_get_entity_view_config_hook_name( 'postType', 'Unregistered_CPT' )
+		);
 	}
 
 	/**


### PR DESCRIPTION
Trac ticket https://core.trac.wordpress.org/ticket/65577
Backports https://github.com/WordPress/gutenberg/pull/81068
Follow-up to https://github.com/WordPress/wordpress-develop/pull/12391

## What?

Lowercases the dynamic filter names for view config.

## Why?

Lowercase names match PHP practices, [feedback](https://make.wordpress.org/core/2026/07/31/filtering-site-editor-screens-in-wordpress-7-1/#comment-49084).

## How?

Make the dynamic filter hook name lowercase.

## Testing Instructions

Load the Site Editor screens (Pages, Templates, Patterns&Parts) and verify they still work as before.