### PR TITLE
Media: use updated file path for attachment metadata

### DIFF
--- a/src/wp-admin/includes/media.php
+++ b/src/wp-admin/includes/media.php
@@ -444,6 +444,7 @@ function media_handle_upload( $file_id, $post_id, $post_data = array(), $overrid
 		 * The image sub-sizes are created during wp_generate_attachment_metadata().
 		 * This is generally slow and may cause timeouts or out of memory errors.
 		 */
+		$file = get_attached_file( $attachment_id );
 		wp_update_attachment_metadata( $attachment_id, wp_generate_attachment_metadata( $attachment_id, $file ) );
 	}
 
@@ -532,6 +533,7 @@ function media_handle_sideload( $file_array, $post_id = 0, $desc = null, $post_d
 	}
 
 	if ( ! is_wp_error( $attachment_id ) ) {
+		$file = get_attached_file( $attachment_id );
 		wp_update_attachment_metadata( $attachment_id, wp_generate_attachment_metadata( $attachment_id, $file ) );
 	}
 

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -1644,6 +1644,95 @@ VIDEO;
 	}
 
 	/**
+	 * @ticket 35593
+	 */
+	public function test_media_handle_upload_generates_metadata_for_updated_file() {
+		$test_file = DIR_TESTDATA . '/images/test-image.jpg';
+		$tmp_name  = wp_tempnam( $test_file );
+
+		copy( $test_file, $tmp_name );
+
+		$_FILES['upload'] = array(
+			'tmp_name' => $tmp_name,
+			'name'     => 'test-image.jpg',
+			'type'     => 'image/jpeg',
+			'error'    => 0,
+			'size'     => filesize( $test_file ),
+		);
+
+		$updated_file = null;
+		$action       = function ( $attachment_id ) use ( &$updated_file ) {
+			$original_file = get_attached_file( $attachment_id );
+			$updated_file  = $original_file . '-updated.jpg';
+
+			rename( $original_file, $updated_file );
+			update_attached_file( $attachment_id, $updated_file );
+		};
+		add_action( 'add_attachment', $action );
+
+		$attachment_id = media_handle_upload(
+			'upload',
+			0,
+			array(),
+			array(
+				'action'    => 'test_upload_updated_file',
+				'test_form' => false,
+			)
+		);
+
+		remove_action( 'add_attachment', $action );
+		unset( $_FILES['upload'] );
+
+		$metadata = wp_get_attachment_metadata( $attachment_id );
+
+		$this->assertFileExists( $updated_file );
+		$this->assertIsArray( $metadata );
+		$this->assertSame( wp_basename( $updated_file ), wp_basename( $metadata['file'] ) );
+
+		wp_delete_attachment( $attachment_id, true );
+	}
+
+	/**
+	 * @ticket 35593
+	 */
+	public function test_media_handle_sideload_generates_metadata_for_updated_file() {
+		$test_file = DIR_TESTDATA . '/images/test-image.jpg';
+		$tmp_name  = wp_tempnam( $test_file );
+
+		copy( $test_file, $tmp_name );
+
+		$file_array = array(
+			'tmp_name' => $tmp_name,
+			'name'     => 'test-image.jpg',
+			'type'     => 'image/jpeg',
+			'error'    => 0,
+			'size'     => filesize( $test_file ),
+		);
+
+		$updated_file = null;
+		$action       = function ( $attachment_id ) use ( &$updated_file ) {
+			$original_file = get_attached_file( $attachment_id );
+			$updated_file  = $original_file . '-updated.jpg';
+
+			rename( $original_file, $updated_file );
+			update_attached_file( $attachment_id, $updated_file );
+		};
+		add_action( 'add_attachment', $action );
+
+		$attachment_id = media_handle_sideload( $file_array );
+
+		remove_action( 'add_attachment', $action );
+
+		$metadata = wp_get_attachment_metadata( $attachment_id );
+
+		$this->assertFileExists( $updated_file );
+		$this->assertIsArray( $metadata );
+		$this->assertSame( wp_basename( $updated_file ), wp_basename( $metadata['file'] ) );
+
+		wp_delete_attachment( $attachment_id, true );
+	}
+
+	/**
 	 * @ticket 33016
 	 */
 	public function test_multiline_cdata() {


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

## Description

When an `add_attachment` callback changes an attachment's file, media metadata generation currently uses the stale pre-insert path. Use `get_attached_file()` after insertion so uploads and sideloads generate metadata for the current file.

Includes regression tests for both paths.`n`n## Testing

- PHP lint
- PHPCBF
- PHPCS

Trac ticket: https://core.trac.wordpress.org/ticket/35593

## Use of AI Tools

AI assistance: Yes
Tool(s): OpenAI Codex
Model(s): GPT-5
Used for: Reviewing the Trac ticket and relevant code, helping with the initial implementation and regression-test approach, and assisting with validation and PR-description drafting. The final implementation, tests, validation results, and description were reviewed and accepted by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**