### PR TITLE
Comments: Store comment_modified and comment_modified_gmt as meta on wp_update_comment().

### DIFF
--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -644,6 +644,125 @@ function comment_date( $format = '', $comment_id = 0 ) {
 }
 
 /**
+ * Retrieves the last modified date of the given comment.
+ *
+ * Returns the date the comment was last updated via wp_update_comment(),
+ * stored as comment meta under the 'comment_modified' key. Returns an empty
+ * string if the comment has never been modified.
+ *
+ * @since 6.9.0
+ *
+ * @param string         $format     Optional. PHP date format. Defaults to the 'date_format' option.
+ * @param int|WP_Comment $comment_id Optional. WP_Comment or ID of the comment for which to get the
+ *                                   last modified date. Default current comment.
+ * @return string Formatted date string, or empty string if the comment has never been modified.
+ */
+function get_comment_modified_date( $format = '', $comment_id = 0 ) {
+	$comment = get_comment( $comment_id );
+
+	if ( null === $comment ) {
+		return '';
+	}
+
+	$modified = get_comment_meta( $comment->comment_ID, 'comment_modified', true );
+
+	if ( ! $modified ) {
+		return '';
+	}
+
+	$_format = ! empty( $format ) ? $format : get_option( 'date_format' );
+
+	$comment_modified_date = mysql2date( $_format, $modified );
+
+	/**
+	 * Filters the returned comment last modified date.
+	 *
+	 * @since 6.9.0
+	 *
+	 * @param string|int $comment_modified_date Formatted date string or Unix timestamp.
+	 * @param string     $format                PHP date format.
+	 * @param WP_Comment $comment               The comment object.
+	 */
+	return apply_filters( 'get_comment_modified_date', $comment_modified_date, $format, $comment );
+}
+
+/**
+ * Displays the last modified date of the current comment.
+ *
+ * @since 6.9.0
+ *
+ * @param string         $format     Optional. PHP date format. Defaults to the 'date_format' option.
+ * @param int|WP_Comment $comment_id Optional. WP_Comment or ID of the comment for which to print the
+ *                                   last modified date. Default current comment.
+ */
+function comment_modified_date( $format = '', $comment_id = 0 ) {
+	echo get_comment_modified_date( $format, $comment_id );
+}
+
+/**
+ * Retrieves the last modified time of the given comment.
+ *
+ * Returns the time the comment was last updated via wp_update_comment(),
+ * stored as comment meta under the 'comment_modified' (local) or
+ * 'comment_modified_gmt' (GMT) key. Returns an empty string if the comment
+ * has never been modified.
+ *
+ * @since 6.9.0
+ *
+ * @param string         $format     Optional. PHP date format. Defaults to the 'time_format' option.
+ * @param bool           $gmt        Optional. Whether to use the GMT date. Default false.
+ * @param bool           $translate  Optional. Whether to translate the time (for use in feeds).
+ *                                   Default true.
+ * @param int|WP_Comment $comment_id Optional. WP_Comment or ID of the comment for which to get the
+ *                                   last modified time. Default current comment.
+ * @return string Formatted time string, or empty string if the comment has never been modified.
+ */
+function get_comment_modified_time( $format = '', $gmt = false, $translate = true, $comment_id = 0 ) {
+	$comment = get_comment( $comment_id );
+
+	if ( null === $comment ) {
+		return '';
+	}
+
+	$meta_key = $gmt ? 'comment_modified_gmt' : 'comment_modified';
+	$modified = get_comment_meta( $comment->comment_ID, $meta_key, true );
+
+	if ( ! $modified ) {
+		return '';
+	}
+
+	$_format = ! empty( $format ) ? $format : get_option( 'time_format' );
+
+	$comment_modified_time = mysql2date( $_format, $modified, $translate );
+
+	/**
+	 * Filters the returned comment last modified time.
+	 *
+	 * @since 6.9.0
+	 *
+	 * @param string|int $comment_modified_time The comment last modified time, formatted as a date string or Unix timestamp.
+	 * @param string     $format                PHP date format.
+	 * @param bool       $gmt                   Whether the GMT date is in use.
+	 * @param bool       $translate             Whether the time is translated.
+	 * @param WP_Comment $comment               The comment object.
+	 */
+	return apply_filters( 'get_comment_modified_time', $comment_modified_time, $format, $gmt, $translate, $comment );
+}
+
+/**
+ * Displays the last modified time of the current comment.
+ *
+ * @since 6.9.0
+ *
+ * @param string         $format     Optional. PHP time format. Defaults to the 'time_format' option.
+ * @param int|WP_Comment $comment_id Optional. WP_Comment or ID of the comment for which to print the
+ *                                   last modified time. Default current comment.
+ */
+function comment_modified_time( $format = '', $comment_id = 0 ) {
+	echo get_comment_modified_time( $format, false, true, $comment_id );
+}
+
+/**
  * Retrieves the excerpt of the given comment.
  *
  * Returns a maximum of 20 words with an ellipsis appended if necessary.

--- a/src/wp-includes/comment.php
+++ b/src/wp-includes/comment.php
@@ -2776,6 +2776,10 @@ function wp_update_comment( $commentarr, $wp_error = false ) {
 		}
 	}
 
+	// Store last modified timestamps as comment meta.
+	update_comment_meta( $comment_id, 'comment_modified', current_time( 'mysql' ) );
+	update_comment_meta( $comment_id, 'comment_modified_gmt', current_time( 'mysql', true ) );
+
 	clean_comment_cache( $comment_id );
 	wp_update_comment_count( $comment_post_id );
 

--- a/tests/phpunit/tests/comment/wpUpdateComment.php
+++ b/tests/phpunit/tests/comment/wpUpdateComment.php
@@ -1,0 +1,171 @@
+<?php
+
+/**
+ * @group comment
+ *
+ * @covers ::wp_update_comment
+ */
+class Tests_Comment_WpUpdateComment extends WP_UnitTestCase {
+
+	protected static $post_id;
+	protected static $comment_id;
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$post_id    = $factory->post->create();
+		self::$comment_id = $factory->comment->create(
+			array(
+				'comment_post_ID' => self::$post_id,
+			)
+		);
+	}
+
+	/**
+	 * @ticket 36564
+	 *
+	 * @covers ::wp_update_comment
+	 */
+	public function test_wp_update_comment_modified_meta_is_valid_mysql_datetime() {
+		wp_update_comment(
+			array(
+				'comment_ID'      => self::$comment_id,
+				'comment_content' => 'Check datetime format.',
+			)
+		);
+
+		$comment_modified     = get_comment_meta( self::$comment_id, 'comment_modified', true );
+		$comment_modified_gmt = get_comment_meta( self::$comment_id, 'comment_modified_gmt', true );
+
+		// MySQL datetime format: YYYY-MM-DD HH:MM:SS
+		$this->assertMatchesRegularExpression(
+			'/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/',
+			$comment_modified,
+			'comment_modified should be in MySQL datetime format.'
+		);
+		$this->assertMatchesRegularExpression(
+			'/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/',
+			$comment_modified_gmt,
+			'comment_modified_gmt should be in MySQL datetime format.'
+		);
+	}
+
+	/**
+	 * @ticket 36564
+	 *
+	 * @covers ::wp_update_comment
+	 */
+	public function test_wp_update_comment_does_not_store_modified_meta_on_invalid_comment() {
+		// Use a non-existent comment ID.
+		$result = wp_update_comment(
+			array(
+				'comment_ID'      => 999999,
+				'comment_content' => 'Should not be stored.',
+			)
+		);
+
+		$this->assertFalse( $result, 'wp_update_comment() should return false for an invalid comment ID.' );
+
+		$comment_modified = get_comment_meta( 999999, 'comment_modified', true );
+		$this->assertEmpty( $comment_modified, 'comment_modified meta should not be set for an invalid comment.' );
+	}
+
+	/**
+	 * @ticket 36564
+	 *
+	 * @covers ::get_comment_modified_date
+	 */
+	public function test_get_comment_modified_date_returns_formatted_date() {
+		wp_update_comment(
+			array(
+				'comment_ID'      => self::$comment_id,
+				'comment_content' => 'For modified date test.',
+			)
+		);
+
+		$date = get_comment_modified_date( 'Y-m-d', self::$comment_id );
+
+		$this->assertMatchesRegularExpression(
+			'/^\d{4}-\d{2}-\d{2}$/',
+			$date,
+			'get_comment_modified_date() should return a date formatted as Y-m-d.'
+		);
+	}
+
+	/**
+	 * @ticket 36564
+	 *
+	 * @covers ::get_comment_modified_date
+	 */
+	public function test_get_comment_modified_date_returns_empty_for_unmodified_comment() {
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID' => self::$post_id,
+			)
+		);
+
+		// Do not call wp_update_comment() — no meta should exist.
+		$date = get_comment_modified_date( 'Y-m-d', $comment_id );
+
+		$this->assertSame( '', $date, 'get_comment_modified_date() should return empty string when the comment has never been modified.' );
+	}
+
+	/**
+	 * @ticket 36564
+	 *
+	 * @covers ::get_comment_modified_time
+	 */
+	public function test_get_comment_modified_time_returns_formatted_time() {
+		wp_update_comment(
+			array(
+				'comment_ID'      => self::$comment_id,
+				'comment_content' => 'For modified time test.',
+			)
+		);
+
+		$time = get_comment_modified_time( 'H:i:s', false, false, self::$comment_id );
+
+		$this->assertMatchesRegularExpression(
+			'/^\d{2}:\d{2}:\d{2}$/',
+			$time,
+			'get_comment_modified_time() should return a time formatted as H:i:s.'
+		);
+	}
+
+	/**
+	 * @ticket 36564
+	 *
+	 * @covers ::get_comment_modified_time
+	 */
+	public function test_get_comment_modified_time_gmt_uses_gmt_meta() {
+		wp_update_comment(
+			array(
+				'comment_ID'      => self::$comment_id,
+				'comment_content' => 'For modified time GMT test.',
+			)
+		);
+
+		$time_gmt   = get_comment_modified_time( 'U', true, false, self::$comment_id );
+		$time_local = get_comment_modified_time( 'U', false, false, self::$comment_id );
+
+		// Both should be numeric timestamps.
+		$this->assertIsNumeric( $time_gmt, 'GMT timestamp should be numeric.' );
+		$this->assertIsNumeric( $time_local, 'Local timestamp should be numeric.' );
+	}
+
+	/**
+	 * @ticket 36564
+	 *
+	 * @covers ::get_comment_modified_time
+	 */
+	public function test_get_comment_modified_time_returns_empty_for_unmodified_comment() {
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID' => self::$post_id,
+			)
+		);
+
+		// Do not call wp_update_comment() — no meta should exist.
+		$time = get_comment_modified_time( 'H:i:s', false, false, $comment_id );
+
+		$this->assertSame( '', $time, 'get_comment_modified_time() should return empty string when the comment has never been modified.' );
+	}
+}


### PR DESCRIPTION
Posts in WordPress have post_modified and post_modified_gmt fields, but comments historically lacked a way to track when they were last updated. This PR introduces a low-impact solution to track the last modified date of a comment using comment meta.

Trac ticket: [#36564](https://core.trac.wordpress.org/ticket/36564)

## Use of AI Tools

AI assistance: Yes
Tool(s): GitHub Copilot
Model(s): Gemini, Claude
Used for: Checking for potential edge cases, drafting the PR description, and assisting with local code review. The final implementation and testing were written and executed manually by me.

---

**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
