### PR TITLE
Tests: Use `assertNull()` instead of `assertSame()` with `null`

### DIFF
--- a/tests/phpunit/tests/functions/maybeSerialize.php
+++ b/tests/phpunit/tests/functions/maybeSerialize.php
@@ -222,7 +222,7 @@ class Tests_Functions_MaybeSerialize extends WP_UnitTestCase {
 			}
 			$callback_value = $property->getValue( $new_value );
 
-			$this->assertSame( null, $callback_value );
+			$this->assertNull( $callback_value );
 		} else {
 			$this->assertSame( $value->count(), unserialize( $serialized )->count() );
 		}

--- a/tests/phpunit/tests/post/types.php
+++ b/tests/phpunit/tests/post/types.php
@@ -626,7 +626,7 @@ class Tests_Post_Types extends WP_UnitTestCase {
 
 		remove_post_type_support( 'foo', 'autosave' );
 		$post_type_object = get_post_type_object( 'foo' );
-		$this->assertSame( null, $post_type_object->get_autosave_rest_controller(), 'Autosave controller should be removed.' );
+		$this->assertNull( $post_type_object->get_autosave_rest_controller(), 'Autosave controller should be removed.' );
 		_unregister_post_type( 'foo' );
 	}
 

--- a/tests/phpunit/tests/post/wpAfterInsertPost.php
+++ b/tests/phpunit/tests/post/wpAfterInsertPost.php
@@ -157,7 +157,7 @@ class Tests_Post_wpAfterInsertPost extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertSame( null, self::$passed_post_before_status );
+		$this->assertNull( self::$passed_post_before_status );
 		$this->assertSame( 'a new post', self::$passed_post_title );
 	}
 
@@ -197,7 +197,7 @@ class Tests_Post_wpAfterInsertPost extends WP_UnitTestCase {
 		);
 		rest_get_server()->dispatch( $request );
 
-		$this->assertSame( null, self::$passed_post_before_title );
+		$this->assertNull( self::$passed_post_before_title );
 		$this->assertSame( 'new title', self::$passed_post_title );
 	}
 

--- a/tests/phpunit/tests/rest-api/rest-settings-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-settings-controller.php
@@ -794,6 +794,6 @@ class WP_Test_REST_Settings_Controller extends WP_Test_REST_Controller_Testcase 
 		$this->assertSame( 'string', $title['type'] );
 		$this->assertSame( 'Title', $title['title'] );
 		$this->assertSame( 'Site title.', $title['description'] );
-		$this->assertSame( null, $title['default'] );
+		$this->assertNull( $title['default'] );
 	}
 }

--- a/tests/phpunit/tests/theme/wpGetBlockCssSelector.php
+++ b/tests/phpunit/tests/theme/wpGetBlockCssSelector.php
@@ -131,7 +131,7 @@ class Tests_Theme_WpGetBlockCssSelector extends WP_Theme_UnitTestCase {
 		);
 
 		$selector = wp_get_block_css_selector( $block_type, 'typography' );
-		$this->assertSame( null, $selector );
+		$this->assertNull( $selector );
 	}
 
 	/**
@@ -205,7 +205,7 @@ class Tests_Theme_WpGetBlockCssSelector extends WP_Theme_UnitTestCase {
 		);
 
 		$selector = wp_get_block_css_selector( $block_type, 'typography' );
-		$this->assertSame( null, $selector );
+		$this->assertNull( $selector );
 	}
 
 	/**
@@ -262,7 +262,7 @@ class Tests_Theme_WpGetBlockCssSelector extends WP_Theme_UnitTestCase {
 		);
 
 		$selector = wp_get_block_css_selector( $block_type, array( 'typography', 'fontSize' ) );
-		$this->assertSame( null, $selector );
+		$this->assertNull( $selector );
 	}
 
 	/**
@@ -297,7 +297,7 @@ class Tests_Theme_WpGetBlockCssSelector extends WP_Theme_UnitTestCase {
 			$block_type,
 			array( 'typography', 'fontSize' )
 		);
-		$this->assertSame( null, $selector );
+		$this->assertNull( $selector );
 	}
 
 	/**
@@ -311,10 +311,10 @@ class Tests_Theme_WpGetBlockCssSelector extends WP_Theme_UnitTestCase {
 		);
 
 		$selector = wp_get_block_css_selector( $block_type, array() );
-		$this->assertSame( null, $selector );
+		$this->assertNull( $selector );
 
 		$selector = wp_get_block_css_selector( $block_type, '' );
-		$this->assertSame( null, $selector );
+		$this->assertNull( $selector );
 	}
 
 	/**


### PR DESCRIPTION
Using the dedicated `assertNull()` assertion instead of `assertSame( null, $actual )` clarifies intent and produces more descriptive failure messages.

Trac ticket:  https://core.trac.wordpress.org/ticket/64894

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
