### PR TITLE
Build/Test Tools: Add a database healthcheck to the 5.7 Docker environment.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
 
   ##
@@ -25,7 +23,10 @@ services:
     command: /bin/sh -c "envsubst '$$LOCAL_DIR' < /etc/nginx/conf.d/default.template > /etc/nginx/conf.d/default.conf && exec nginx -g 'daemon off;'"
 
     depends_on:
-      - php
+      php:
+        condition: service_started
+      mysql:
+        condition: service_healthy
 
   ##
   # The PHP container.
@@ -47,7 +48,8 @@ services:
       - ./:/var/www
 
     depends_on:
-      - mysql
+      mysql:
+        condition: service_healthy
 
   ##
   # The MySQL container.
@@ -71,6 +73,12 @@ services:
 
     # For compatibility with PHP versions that don't support the caching_sha2_password auth plugin used in MySQL 8.0.
     command: --default-authentication-plugin=mysql_native_password
+
+    healthcheck:
+      test: [ "CMD-SHELL", "if [ \"$LOCAL_DB_TYPE\" = \"mariadb\" ]; then mariadb-admin ping -h localhost; else mysqladmin ping -h localhost; fi" ]
+      timeout: 5s
+      interval: 5s
+      retries: 10
 
   ##
   # The WP CLI container.
@@ -121,7 +129,8 @@ services:
     init: true
 
     depends_on:
-      - mysql
+      mysql:
+        condition: service_healthy
 
 volumes:
   # So that sites aren't wiped every time containers are restarted, MySQL uses a persistent volume.


### PR DESCRIPTION
Trac ticket: [#65799](https://core.trac.wordpress.org/ticket/65799)

The 5.7 branch is the only branch between 4.7 and 7.0 whose `mysql` service has no `healthcheck`. Its `depends_on` therefore waits for the container to start rather than for the database to accept connections.

The healthcheck was added to trunk in [[56464]](https://core.trac.wordpress.org/changeset/56464) and reached 5.6 in [[58605]](https://core.trac.wordpress.org/changeset/58605) and 5.8 in [[58597]](https://core.trac.wordpress.org/changeset/58597). The equivalent 5.7 commit, [[58598]](https://core.trac.wordpress.org/changeset/58598), did not include it.

This ports the healthcheck and the long-form `depends_on` conditions from 5.6 and 5.8, and removes the obsolete `version` property, which prevents those conditions from being honoured.

`start_period` is deliberately not included here—5.7 picks that up with every other branch when [#65752](https://core.trac.wordpress.org/ticket/65752) is backported.
