### PR TITLE
Accessibility: Describe the toggletip dialog with its own text

### DIFF
--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -547,12 +547,13 @@ function wp_get_tooltip_helper( $content, $args = array() ) {
 		/*
 		 * A `span` with `role="dialog"` is used instead of a `dialog` element to keep the
 		 * markup as phrasing content. The `aria-label`, `tabindex`, and `autofocus`
-		 * attributes reproduce the accessible name and focus handling of the native element.
+		 * attributes reproduce the accessible name and focus handling of the native element,
+		 * and `aria-describedby` gives it the help text as its accessible description.
 		 */
 		$markup = sprintf(
 			'<span class="%1$s">
 				' . $button . '
-				<span popover="auto" id="%2$s" class="wp-tooltip__bubble" role="dialog" aria-label="%3$s" tabindex="-1" autofocus>' .
+				<span popover="auto" id="%2$s" class="wp-tooltip__bubble" role="dialog" aria-label="%3$s" aria-describedby="%2$s-text" tabindex="-1" autofocus>' .
 					'<span id="%2$s-text" class="wp-tooltip__text">%5$s</span>' .
 					'<button type="button" class="wp-tooltip__close" popovertarget="%2$s" popovertargetaction="hide" aria-label="%6$s">' .
 						'<span class="dashicons dashicons-no-alt" aria-hidden="true"></span>' .

--- a/tests/phpunit/tests/general/wpGetTooltip.php
+++ b/tests/phpunit/tests/general/wpGetTooltip.php
@@ -167,6 +167,82 @@ class Tests_General_wpGetTooltip extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that the toggletip dialog is described by its own text.
+	 *
+	 * The dialog is named by the toggle button's label, 'Help' by default, so without
+	 * this association the help text is not part of its accessible description.
+	 *
+	 * @ticket 65675
+	 */
+	public function test_wp_get_toggletip_dialog_is_described_by_its_text() {
+		$html = wp_get_toggletip( 'Helpful text.', array( 'id' => 'my-tip' ) );
+
+		$processor = new WP_HTML_Tag_Processor( $html );
+
+		$this->assertTrue(
+			$processor->next_tag( array( 'class_name' => 'wp-tooltip__bubble' ) ),
+			'The toggletip should render a bubble element.'
+		);
+		$this->assertSame(
+			'dialog',
+			$processor->get_attribute( 'role' ),
+			'The toggletip bubble should be a dialog.'
+		);
+		$this->assertSame(
+			'my-tip-text',
+			$processor->get_attribute( 'aria-describedby' ),
+			'The dialog should be described by its text element.'
+		);
+
+		$this->assertTrue(
+			$processor->next_tag( array( 'class_name' => 'wp-tooltip__text' ) ),
+			'The toggletip should render a text element.'
+		);
+		$this->assertSame(
+			'my-tip-text',
+			$processor->get_attribute( 'id' ),
+			'The text element should carry the ID the dialog points at.'
+		);
+	}
+
+	/**
+	 * Tests that the describing ID follows a generated ID.
+	 *
+	 * @ticket 65675
+	 */
+	public function test_wp_get_toggletip_described_by_matches_generated_id() {
+		$html = wp_get_toggletip( 'Helpful text.' );
+
+		$this->assertSame( 1, preg_match( '/id="(wp-tooltip-\d+)"/', $html, $matches ) );
+
+		$processor = new WP_HTML_Tag_Processor( $html );
+		$this->assertTrue( $processor->next_tag( array( 'class_name' => 'wp-tooltip__bubble' ) ) );
+		$this->assertSame(
+			$matches[1] . '-text',
+			$processor->get_attribute( 'aria-describedby' ),
+			'The description should reference the generated ID.'
+		);
+	}
+
+	/**
+	 * Tests that a tooltip is not given a description.
+	 *
+	 * A tooltip already carries its content as the toggle button's accessible name.
+	 *
+	 * @ticket 65675
+	 */
+	public function test_wp_get_tooltip_bubble_has_no_described_by() {
+		$html = wp_get_tooltip( 'Helpful text.', array( 'id' => 'my-tip' ) );
+
+		$processor = new WP_HTML_Tag_Processor( $html );
+		$this->assertTrue( $processor->next_tag( array( 'class_name' => 'wp-tooltip__bubble' ) ) );
+		$this->assertNull(
+			$processor->get_attribute( 'aria-describedby' ),
+			'A tooltip bubble should not describe itself.'
+		);
+	}
+
+	/**
 	 * Tests that the markup consists only of phrasing content so it can be nested
 	 * inside a paragraph (or other phrasing context) without the parser closing
 	 * the enclosing element and leaving a stray empty paragraph behind.


### PR DESCRIPTION
`wp_get_toggletip()` renders the bubble as a `span` with `role="dialog"`, `aria-label` and `autofocus`. The help text sits in a child `span` that already carries an `{id}-text` ID, but nothing referenced that ID, so the dialog received focus with an accessible name of "Help" and no accessible description.

There is no `aria-describedby` anywhere in `general-template.php`, the CSS targets the `.wp-tooltip__text` class rather than the ID, and no JS uses it. The ID is generated on every render and pointed at by nothing.

This points `aria-describedby` at that text element.

On the Remember Me toggletip on `wp-login.php`, Chrome's accessibility tree goes from

```
dialog "Help" focusable focused
```

to

```
dialog "Help" description="Selecting "Remember Me" reduces the number of times you'll be asked to log in using this device. To keep your account secure, use this option only on your personal devices." focusable focused
```

Tooltips are unchanged. A tooltip carries its content as the toggle button's accessible name, so the bubble describing itself would be redundant. There is a test asserting the tooltip branch stays without a description.

### Testing

- `--group tooltip`, `--group general` and `--group template` all pass.
- The two new toggletip assertions fail without the `src` change and pass with it.
- `phpcs` clean on both changed files.
- Checked against the rendered accessibility tree on `wp-login.php`, not only in PHPUnit.

Trac ticket: https://core.trac.wordpress.org/ticket/65675

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Drafting the patch, the tests and this description. I confirmed the missing association on a rendered page by reading Chrome's accessibility tree before and after, checked that the new tests fail without the change, ran the tooltip, general and template groups plus phpcs, and I take responsibility for the result.
