### PR TITLE
XML-RPC: Return an error when a comment field exceeds the maximum length

### DIFF
--- a/src/wp-includes/class-wp-xmlrpc-server.php
+++ b/src/wp-includes/class-wp-xmlrpc-server.php
@@ -3902,6 +3902,7 @@ class wp_xmlrpc_server extends IXR_Server {
 	 * Creates a new comment.
 	 *
 	 * @since 2.7.0
+	 * @since 7.2.0 Returns an error if a comment field exceeds its maximum length.
 	 *
 	 * @param array $args {
 	 *     Method arguments. Note: arguments must be ordered as documented.
@@ -4026,6 +4027,12 @@ class wp_xmlrpc_server extends IXR_Server {
 
 		if ( ! $allow_empty && '' === $comment['comment_content'] ) {
 			return new IXR_Error( 403, __( 'Comment is required.' ) );
+		}
+
+		$check_max_lengths = wp_check_comment_data_max_lengths( $comment );
+
+		if ( is_wp_error( $check_max_lengths ) ) {
+			return new IXR_Error( 413, __( 'Comment field exceeds maximum length allowed.' ) );
 		}
 
 		/** This action is documented in wp-includes/class-wp-xmlrpc-server.php */

--- a/tests/phpunit/tests/xmlrpc/wp/newComment.php
+++ b/tests/phpunit/tests/xmlrpc/wp/newComment.php
@@ -389,4 +389,107 @@ class Tests_XMLRPC_wp_newComment extends WP_XMLRPC_UnitTestCase {
 			),
 		);
 	}
+
+	/**
+	 * Ensure an error is returned when a comment field exceeds its maximum length.
+	 *
+	 * @ticket 38622
+	 *
+	 * @dataProvider data_new_comment_with_field_exceeding_max_length
+	 *
+	 * @param array $content_struct Content struct with one field exceeding its maximum length.
+	 */
+	public function test_new_comment_with_field_exceeding_max_length( $content_struct ) {
+		add_filter( 'xmlrpc_allow_anonymous_comments', '__return_true' );
+
+		$result = $this->myxmlrpcserver->wp_newComment(
+			array(
+				1,
+				'',
+				'',
+				self::$posts['publish']->ID,
+				$content_struct,
+			)
+		);
+
+		$this->assertIXRError( $result );
+		$this->assertSame( 413, $result->code );
+	}
+
+	/**
+	 * Data provider for test_new_comment_with_field_exceeding_max_length.
+	 *
+	 * @return array[]
+	 */
+	public function data_new_comment_with_field_exceeding_max_length() {
+		$defaults = array(
+			'author'       => 'WordPress',
+			'author_email' => 'noreply@wordpress.org',
+			'content'      => 'Test Comment',
+		);
+
+		return array(
+			'author of 246 characters'       => array(
+				array_merge( $defaults, array( 'author' => str_repeat( 'a', 246 ) ) ),
+			),
+			'author email of 101 characters' => array(
+				array_merge( $defaults, array( 'author_email' => str_repeat( 'a', 89 ) . '@example.com' ) ),
+			),
+			'author URL of 201 characters'   => array(
+				array_merge( $defaults, array( 'author_url' => 'https://example.com/' . str_repeat( 'a', 181 ) ) ),
+			),
+			'content of 65526 characters'    => array(
+				array_merge( $defaults, array( 'content' => str_repeat( 'a', 65526 ) ) ),
+			),
+		);
+	}
+
+	/**
+	 * Ensure an error is returned when a logged-in user's comment content exceeds its maximum length.
+	 *
+	 * @ticket 38622
+	 */
+	public function test_new_comment_with_content_exceeding_max_length_logged_in() {
+		$result = $this->myxmlrpcserver->wp_newComment(
+			array(
+				1,
+				'administrator',
+				'administrator',
+				self::$posts['publish']->ID,
+				array(
+					'content' => str_repeat( 'a', 65526 ),
+				),
+			)
+		);
+
+		$this->assertIXRError( $result );
+		$this->assertSame( 413, $result->code );
+	}
+
+	/**
+	 * Ensure a comment with all fields at their maximum length is accepted.
+	 *
+	 * @ticket 38622
+	 */
+	public function test_new_comment_with_fields_at_max_length() {
+		add_filter( 'xmlrpc_allow_anonymous_comments', '__return_true' );
+
+		$result = $this->myxmlrpcserver->wp_newComment(
+			array(
+				1,
+				'',
+				'',
+				self::$posts['publish']->ID,
+				array(
+					'author'       => str_repeat( 'a', 245 ),
+					'author_email' => str_repeat( 'a', 88 ) . '@example.com',
+					'author_url'   => 'https://example.com/' . str_repeat( 'a', 180 ),
+					'content'      => str_repeat( 'a', 65525 ),
+				),
+			)
+		);
+
+		$this->assertNotIXRError( $result );
+		$this->assertIsInt( $result );
+	}
 }


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/38622

## What

`wp_xmlrpc_server::wp_newComment()` now validates the assembled comment with `wp_check_comment_data_max_lengths()` — after both the logged-in and anonymous flows have filled in the author fields, and before `wp_new_comment()` runs — and returns an `IXR_Error` 413 when any field exceeds its column limit (author 245, author email 100, author URL 200, content 65525 bytes).

## Why

The comment form (`wp_handle_comment_submission()`, #10377) and the REST API comments controller both perform this validation; the XML-RPC path never did. Because `wpdb` strips strict SQL modes, over-long fields were silently truncated at the database layer and the client received a success response with a comment ID.

Design notes:
- The error message reuses the REST controller's existing string (`Comment field exceeds maximum length allowed.`) instead of the form-path messages, which embed `<strong>` markup unsuitable for an XML-RPC fault string. No new translatable strings.
- Fault code 413 follows the ticket's original 2019/2020 patches (this PR supersedes PRs #178/#179/#180/#194 and `38622.diff`, which no longer apply cleanly).
- The check runs on slashed data, matching how the form path validates `wp_magic_quotes()`-slashed `$_POST`.
- `@since 7.2.0` assumes a post-7.1 landing; adjust on commit if milestoned differently.

## Tests

`tests/phpunit/tests/xmlrpc/wp/newComment.php`:
- `test_new_comment_with_field_exceeding_max_length` (data provider: author 246 / email 101 / URL 201 / content 65526) — red on trunk without the src change: each call returns a comment ID and the field is silently truncated.
- `test_new_comment_with_content_exceeding_max_length_logged_in` — same symptom via the authenticated flow.
- `test_new_comment_with_fields_at_max_length` — all fields exactly at their limits are still accepted.

```
npm run test:php -- tests/phpunit/tests/xmlrpc/wp/newComment.php   # 28 tests, 50 assertions, OK
npm run test:php -- --group xmlrpc                                 # 324 tests, 1258 assertions, OK
```

PHPCS reports no issues on either changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
