### PR TITLE
Docs: Document three missing parameters in core classes

### DIFF
--- a/src/wp-includes/class-wp-http-ixr-client.php
+++ b/src/wp-includes/class-wp-http-ixr-client.php
@@ -47,10 +47,13 @@ class WP_HTTP_IXR_Client extends IXR_Client {
 	}
 
 	/**
+	 * Sends an XML-RPC request.
+	 *
 	 * @since 3.1.0
 	 * @since 5.5.0 Formalized the existing `...$args` parameter by adding it
 	 *              to the function signature.
 	 *
+	 * @param mixed ...$args The method name, followed by the arguments to pass to it.
 	 * @return bool True if the request succeeded, false otherwise.
 	 */
 	public function query( ...$args ) {

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-font-collections-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-font-collections-controller.php
@@ -335,7 +335,8 @@ class WP_REST_Font_Collections_Controller extends WP_REST_Controller {
 	 *
 	 * @since 6.5.0
 	 *
-	 * @return true|WP_Error True if the request has write access for the item, WP_Error object otherwise.
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
 	 */
 	public function get_items_permissions_check( $request ) {
 		if ( current_user_can( 'edit_theme_options' ) ) {

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-font-families-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-font-families-controller.php
@@ -427,6 +427,7 @@ class WP_REST_Font_Families_Controller extends WP_REST_Posts_Controller {
 	 *
 	 * @since 6.5.0
 	 *
+	 * @param string $method Optional. HTTP method of the request. Default WP_REST_Server::CREATABLE.
 	 * @return array Font family create/edit arguments.
 	 */
 	public function get_endpoint_args_for_item_schema( $method = WP_REST_Server::CREATABLE ) {


### PR DESCRIPTION
Three core-owned methods are missing a `@param` tag.

**`WP_HTTP_IXR_Client::query()`**

The docblock already records that the `...$args` parameter was formalized in 5.5.0 by adding it to the signature, but the parameter itself was never documented. `WP_Dependency::__construct()` carries the same `@since` wording and does document it as `@param mixed ...$args Dependency information.`, so this brings the two back in line.

The description matches what the method does with the value: `array_shift( $args )` takes the method name, and the remainder are the arguments passed to it.

**`WP_REST_Font_Collections_Controller::get_items_permissions_check()`**

Has `@since` and `@return` but no `@param` for `$request`.

**`WP_REST_Font_Families_Controller::get_endpoint_args_for_item_schema()`**

Has `@since` and `@return` but no `@param` for `$method`.

### Testing

- `--group xmlrpc` passes, 318 tests.
- The font controller REST tests pass, 143 tests.
- `phpcs` clean on all three files.
- `php -l` clean on all three files.

Documentation only, no behaviour change.

Trac ticket: https://core.trac.wordpress.org/ticket/65860

Originally opened against #64896, which was closed when 7.1 reached RC3
without this being committed. Moved to the 7.2 docblock ticket.

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Drafting the tags and this description. I confirmed each gap against the current file, checked the variadic wording against how core documents the same parameter on `WP_Dependency::__construct()`, verified the `...$args` description against the method body, confirmed no existing ticket or pull request already covers these three, ran the xmlrpc and font REST tests plus phpcs, and I take responsibility for the result.

