### PR TITLE
Upgrade/Install: Label the en_US update offer with its own locale

### DIFF
--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -47,6 +47,8 @@ function list_core_update( $update ) {
 		if ( $updates && 1 === count( $updates ) ) {
 			// If the only available update is a partial builds, it doesn't need a language-specific version string.
 			$version_string = $update->current;
+		} else {
+			$version_string = sprintf( '%s&ndash;%s', $update->current, $update->locale );
 		}
 	} elseif ( 'en_US' === $update->locale && 'en_US' !== get_locale() ) {
 		$version_string = sprintf( '%s&ndash;%s', $update->current, $update->locale );


### PR DESCRIPTION
When a localized site is offered both a localized and an en_US core update, and the en_US offer advertises a partial build matching the installed version, both buttons end up with the same label while posting different locales.

The second condition in `list_core_update()` matches for that offer, but only assigns a version string when it is the only update available:

```php
} elseif ( 'en_US' === $update->locale && $update->packages->partial && $wp_version === $update->partial_version ) {
	$updates = get_core_updates();
	if ( $updates && 1 === count( $updates ) ) {
		// If the only available update is a partial builds, it doesn't need a language-specific version string.
		$version_string = $update->current;
	}
}
```

With more than one offer, nothing is assigned, so `$version_string` keeps the default set earlier in the function, which is built from `get_locale()` rather than from the offer's own locale. Because this is an `elseif` chain, the following condition that would have labelled it correctly is never reached.

### Reproduction

On a `de_DE` site, serving two offers, one `de_DE` and one `en_US` with a partial build matching the installed version:

| Button label | Posts `locale` |
| --- | --- |
| Update to version 7.2&ndash;de_DE | `de_DE` |
| Update to version 7.2&ndash;de_DE | `en_US` |

Both buttons read the same, but the second posts `locale=en_US` and would install the English package. With this change:

| Button label | Posts `locale` |
| --- | --- |
| Update to version 7.2&ndash;de_DE | `de_DE` |
| Update to version 7.2&ndash;en_US | `en_US` |

The added branch assigns the same string the following condition already uses for the non-partial case.

### Testing

- Checked the case the branch exists for, a single partial en_US offer, still renders `Update to version 7.2` with no locale suffix.
- `--group upgrade` passes, 183 tests.
- `--group admin` passes, 1016 tests, 0 failures. It reports 10 PHPUnit 10 deprecation warnings, which are identical on unmodified trunk.
- `phpcs` and `php -l` clean.

No unit test is included. `list_core_update()` is defined in `wp-admin/update-core.php`, which runs page logic on include, so it cannot be exercised from PHPUnit without refactoring the function out of the page file. The reproduction above was done against the rendered admin screen.

Trac ticket: https://core.trac.wordpress.org/ticket/65666

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Drafting the patch and this description. I reproduced the mislabelled buttons on the rendered update screen before and after the change, confirmed the single-offer case still renders without a locale suffix, ran the upgrade and admin groups and checked the admin warnings against a trunk baseline, ran phpcs and php -l, and I take responsibility for the result.
