### PR TITLE
Media: Assign the HEIC upload error flag to the Plupload settings

### DIFF
--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -5879,7 +5879,7 @@ function _wp_add_additional_image_sizes() {
 function wp_show_heic_upload_error( $plupload_settings ) {
 	// Check if HEIC images can be edited.
 	if ( ! wp_image_editor_supports( array( 'mime_type' => 'image/heic' ) ) ) {
-		$plupload_init['heic_upload_error'] = true;
+		$plupload_settings['heic_upload_error'] = true;
 	}
 	return $plupload_settings;
 }

--- a/tests/phpunit/tests/media/wpShowHeicUploadError.php
+++ b/tests/phpunit/tests/media/wpShowHeicUploadError.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * Tests for the `wp_show_heic_upload_error()` function.
+ *
+ * @group media
+ * @covers ::wp_show_heic_upload_error
+ */
+class Tests_Media_wpShowHeicUploadError extends WP_UnitTestCase {
+
+	/**
+	 * @ticket 65802
+	 */
+	public function test_adds_error_flag_to_the_given_settings_when_heic_is_not_editable() {
+		add_filter( 'wp_image_editors', '__return_empty_array' );
+
+		$this->assertSame(
+			array(
+				'existing'          => 'value',
+				'heic_upload_error' => true,
+			),
+			wp_show_heic_upload_error( array( 'existing' => 'value' ) )
+		);
+	}
+}


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

`wp_show_heic_upload_error()` assigned the `heic_upload_error` flag to an undeclared `$plupload_init` variable instead of the `$plupload_settings` parameter it receives, so the callback returned the settings untouched and the flag was never added.

What the problem was:
- The typo was introduced in [58849] (#53645, shipped in 6.7.0); before that changeset the function assigned to `$plupload_settings` correctly.
- The `plupload_default_settings` path is unaffected in practice, because `wp_plupload_default_settings()` already sets the flag inline.
- The `plupload_init` path is broken: `media_upload_form()` sets the WebP and AVIF flags inline but relies on this callback for HEIC, so no error was shown on `media-new.php` or in the `media-upload.php` iframe when the server could not edit HEIC images.

What the fix does:
- Assigns to `$plupload_settings`, restoring the behaviour the function has documented since 5.5.0.
- Adds a regression test for the callback.

Approach and why:
- One-character-scope fix on the assignment target — nothing else in the function or its two callers needs to change.
- The `heic_upload_error` flag is a non-blocking notice in `handlers.js`; unlike WebP and AVIF it does not remove the file from the queue, so restoring it warns the user without preventing the upload.
- The redundant inline HEIC check in `wp_plupload_default_settings()` was deliberately left alone: it is harmless (the callback assigns the same `true`) and removing it would change behaviour for anyone who has unhooked the callback.

Trac ticket: https://core.trac.wordpress.org/ticket/65802

## Use of AI Tools
AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Generate PR.
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
