### PR TITLE
Build/Test Tools: Correct `@var` annotation in REST users controller tests

### DIFF
--- a/tests/phpunit/tests/rest-api/rest-users-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-users-controller.php
@@ -3283,7 +3283,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->assertTrue( isset( $args[0][0] ), 'Query parameters were not captured.' );
 		$this->assertInstanceOf( WP_User_Query::class, $args[0][0], 'Query parameters were not captured.' );
 
-		/** @var WP_User $query */
+		/** @var WP_User_Query $query */
 		$query = $args[0][0];
 
 		if ( $is_head_request ) {


### PR DESCRIPTION
## What

Fixes an incorrect inline `@var` annotation in `WP_Test_REST_Users_Controller::test_get_items_only_fetches_ids_for_head_requests()`.

The `$query` variable comes from the `pre_user_query` filter args and is a `WP_User_Query` instance, the `assertInstanceOf( WP_User_Query::class, ... )` on the line above asserts exactly that. The docblock incorrectly declared it as `WP_User`.

## Why

`WP_User` has no `query_vars` property, so the wrong annotation causes static analysis tools (PHPStan) and IDEs to report false errors on the following `$query->query_vars` accesses, and it misleads anyone reading the test

Trac ticket: https://core.trac.wordpress.org/ticket/64894

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
