### PR TITLE
Set the media attachments query posts per page conditionally.

### DIFF
--- a/src/js/media/models/query.js
+++ b/src/js/media/models/query.js
@@ -171,7 +171,7 @@ Query = Attachments.extend(/** @lends wp.media.model.Query.prototype */{
 	 * @readonly
 	 */
 	defaultArgs: {
-		posts_per_page: 80
+		posts_per_page: 40
 	},
 	/**
 	 * @readonly
@@ -280,6 +280,11 @@ Query = Attachments.extend(/** @lends wp.media.model.Query.prototype */{
 
 			// Fill any other default query args.
 			_.defaults( args, Query.defaultArgs );
+
+			// When 'Load more' is enabled, increase the posts pr page to 80.
+			if ( wp.media && wp.media.view && wp.media.view.settings && wp.media.view.settings.infiniteScrolling === 0 ) {
+				args.posts_per_page = 80;
+			}
 
 			// `props.orderby` does not always map directly to `args.orderby`.
 			// Substitute exceptions specified in orderby.keymap.


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65564, https://core.trac.wordpress.org/ticket/65850

Sets the `posts_per_oage` arg conditionally in the media attachments browser based on whether Infinite scrolling is enabled (40) or the 'Load more' button is enabled instead (80),

Note that the `defaultArgs.posts_per_page` is meant to be static so the logic to set the `posts_per_page` value conditionally is added later where it is used, in the `get()` method.

## Use of AI Tools

None

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
