### PR TITLE
HTTP API: Add wp_remote_put(), wp_remote_delete(), wp_remote_patch() and safe variants

### DIFF
--- a/src/wp-includes/http.php
+++ b/src/wp-includes/http.php
@@ -143,13 +143,106 @@ function wp_safe_remote_head( $url, $args = array() ) {
 }
 
 /**
+ * Retrieves the raw response from a safe HTTP request using the PUT method.
+ *
+ * This function is ideal when the HTTP request is being made to an arbitrary
+ * URL. The URL, and every URL it redirects to, are validated with wp_http_validate_url()
+ * to avoid Server Side Request Forgery attacks (SSRF).
+ *
+ * The only supported protocols are `http` and `https`.
+ *
+ * @since 7.1.0
+ *
+ * @see wp_remote_request() For more information on the response array format.
+ * @see WP_Http::request() For default arguments information.
+ * @see wp_http_validate_url() For more information about how the URL is validated.
+ *
+ * @link https://owasp.org/www-community/attacks/Server_Side_Request_Forgery
+ *
+ * @param string $url  URL to send the request to.
+ * @param array  $args Optional. Request arguments. Default empty array.
+ *                     See WP_Http::request() for information on accepted arguments.
+ * @return array|WP_Error The response or WP_Error on failure.
+ *                        See WP_Http::request() for information on return value.
+ */
+function wp_safe_remote_put( $url, $args = array() ) {
+	$args['reject_unsafe_urls'] = true;
+	$defaults                   = array( 'method' => 'PUT' );
+	$parsed_args                = wp_parse_args( $args, $defaults );
+	return wp_remote_request( $url, $parsed_args );
+}
+
+/**
+ * Retrieves the raw response from a safe HTTP request using the DELETE method.
+ *
+ * This function is ideal when the HTTP request is being made to an arbitrary
+ * URL. The URL, and every URL it redirects to, are validated with wp_http_validate_url()
+ * to avoid Server Side Request Forgery attacks (SSRF).
+ *
+ * The only supported protocols are `http` and `https`.
+ *
+ * @since 7.1.0
+ *
+ * @see wp_remote_request() For more information on the response array format.
+ * @see WP_Http::request() For default arguments information.
+ * @see wp_http_validate_url() For more information about how the URL is validated.
+ *
+ * @link https://owasp.org/www-community/attacks/Server_Side_Request_Forgery
+ *
+ * @param string $url  URL to send the request to.
+ * @param array  $args Optional. Request arguments. Default empty array.
+ *                     See WP_Http::request() for information on accepted arguments.
+ * @return array|WP_Error The response or WP_Error on failure.
+ *                        See WP_Http::request() for information on return value.
+ */
+function wp_safe_remote_delete( $url, $args = array() ) {
+	$args['reject_unsafe_urls'] = true;
+	$defaults                   = array( 'method' => 'DELETE' );
+	$parsed_args                = wp_parse_args( $args, $defaults );
+	return wp_remote_request( $url, $parsed_args );
+}
+
+/**
+ * Retrieves the raw response from a safe HTTP request using the PATCH method.
+ *
+ * This function is ideal when the HTTP request is being made to an arbitrary
+ * URL. The URL, and every URL it redirects to, are validated with wp_http_validate_url()
+ * to avoid Server Side Request Forgery attacks (SSRF).
+ *
+ * The only supported protocols are `http` and `https`.
+ *
+ * @since 7.1.0
+ *
+ * @see wp_remote_request() For more information on the response array format.
+ * @see WP_Http::request() For default arguments information.
+ * @see wp_http_validate_url() For more information about how the URL is validated.
+ *
+ * @link https://owasp.org/www-community/attacks/Server_Side_Request_Forgery
+ *
+ * @param string $url  URL to send the request to.
+ * @param array  $args Optional. Request arguments. Default empty array.
+ *                     See WP_Http::request() for information on accepted arguments.
+ * @return array|WP_Error The response or WP_Error on failure.
+ *                        See WP_Http::request() for information on return value.
+ */
+function wp_safe_remote_patch( $url, $args = array() ) {
+	$args['reject_unsafe_urls'] = true;
+	$defaults                   = array( 'method' => 'PATCH' );
+	$parsed_args                = wp_parse_args( $args, $defaults );
+	return wp_remote_request( $url, $parsed_args );
+}
+
+/**
  * Performs an HTTP request and returns its response.
  *
  * There are other API functions available which abstract away the HTTP method:
  *
- *  - Default 'GET'  for wp_remote_get()
- *  - Default 'POST' for wp_remote_post()
- *  - Default 'HEAD' for wp_remote_head()
+ *  - Default 'GET'    for wp_remote_get()
+ *  - Default 'POST'   for wp_remote_post()
+ *  - Default 'HEAD'   for wp_remote_head()
+ *  - Default 'PUT'    for wp_remote_put()
+ *  - Default 'DELETE' for wp_remote_delete()
+ *  - Default 'PATCH'  for wp_remote_patch()
  *
  * Important: If the URL is user-controlled, use `wp_safe_remote_request()` instead.
  *
@@ -229,6 +322,72 @@ function wp_remote_post( $url, $args = array() ) {
 function wp_remote_head( $url, $args = array() ) {
 	$http = _wp_http_get_object();
 	return $http->head( $url, $args );
+}
+
+/**
+ * Performs an HTTP request using the PUT method and returns its response.
+ *
+ * Important: If the URL is user-controlled, use `wp_safe_remote_put()` instead.
+ *
+ * @since 7.1.0
+ *
+ * @see wp_remote_request() For more information on the response array format.
+ * @see WP_Http::request() For default arguments information.
+ *
+ * @param string $url  URL to send the request to.
+ * @param array  $args Optional. Request arguments. Default empty array.
+ *                     See WP_Http::request() for information on accepted arguments.
+ * @return array|WP_Error The response or WP_Error on failure.
+ *                        See WP_Http::request() for information on return value.
+ */
+function wp_remote_put( $url, $args = array() ) {
+	$defaults    = array( 'method' => 'PUT' );
+	$parsed_args = wp_parse_args( $args, $defaults );
+	return wp_remote_request( $url, $parsed_args );
+}
+
+/**
+ * Performs an HTTP request using the DELETE method and returns its response.
+ *
+ * Important: If the URL is user-controlled, use `wp_safe_remote_delete()` instead.
+ *
+ * @since 7.1.0
+ *
+ * @see wp_remote_request() For more information on the response array format.
+ * @see WP_Http::request() For default arguments information.
+ *
+ * @param string $url  URL to send the request to.
+ * @param array  $args Optional. Request arguments. Default empty array.
+ *                     See WP_Http::request() for information on accepted arguments.
+ * @return array|WP_Error The response or WP_Error on failure.
+ *                        See WP_Http::request() for information on return value.
+ */
+function wp_remote_delete( $url, $args = array() ) {
+	$defaults    = array( 'method' => 'DELETE' );
+	$parsed_args = wp_parse_args( $args, $defaults );
+	return wp_remote_request( $url, $parsed_args );
+}
+
+/**
+ * Performs an HTTP request using the PATCH method and returns its response.
+ *
+ * Important: If the URL is user-controlled, use `wp_safe_remote_patch()` instead.
+ *
+ * @since 7.1.0
+ *
+ * @see wp_remote_request() For more information on the response array format.
+ * @see WP_Http::request() For default arguments information.
+ *
+ * @param string $url  URL to send the request to.
+ * @param array  $args Optional. Request arguments. Default empty array.
+ *                     See WP_Http::request() for information on accepted arguments.
+ * @return array|WP_Error The response or WP_Error on failure.
+ *                        See WP_Http::request() for information on return value.
+ */
+function wp_remote_patch( $url, $args = array() ) {
+	$defaults    = array( 'method' => 'PATCH' );
+	$parsed_args = wp_parse_args( $args, $defaults );
+	return wp_remote_request( $url, $parsed_args );
 }
 
 /**

--- a/tests/phpunit/tests/http/wpRemoteMethods.php
+++ b/tests/phpunit/tests/http/wpRemoteMethods.php
@@ -1,0 +1,321 @@
+<?php
+
+/**
+ * Tests for wp_remote_put(), wp_remote_delete(), wp_remote_patch(),
+ * and their wp_safe_remote_* counterparts.
+ *
+ * @ticket 40142
+ *
+ * @group http
+ */
+class Tests_HTTP_wp_remote_methods extends WP_UnitTestCase {
+
+	/**
+	 * Stores the HTTP request args captured by the filter.
+	 *
+	 * @var array
+	 */
+	private $http_args = array();
+
+	/**
+	 * Intercepts the HTTP request and captures its args without making a real network call.
+	 *
+	 * @param false|array|WP_Error $preempt Whether to preempt the request.
+	 * @param array                $args    HTTP request arguments.
+	 * @return WP_Error Short-circuits the request.
+	 */
+	public function http_catcher( $preempt, $args ) {
+		$this->http_args = $args;
+		return new WP_Error( 'test_short_circuit', 'Request short-circuited for testing.' );
+	}
+
+	/**
+	 * Helper to run a wp_remote_* function with the request intercepted.
+	 *
+	 * @param string $function_name The function to call, e.g. 'wp_remote_put'.
+	 * @param string $url           URL to pass.
+	 * @param array  $args          Additional args to pass.
+	 */
+	private function call_remote_function( $function_name, $url = 'http://example.com/', $args = array() ) {
+		$this->http_args = array();
+
+		add_filter( 'pre_http_request', array( $this, 'http_catcher' ), 10, 2 );
+		call_user_func( $function_name, $url, $args );
+		remove_filter( 'pre_http_request', array( $this, 'http_catcher' ), 10, 2 );
+	}
+
+	/**
+	 * Data provider yielding unsafe wp_remote_* function names and their expected HTTP methods.
+	 *
+	 * @return array[]
+	 */
+	public function data_remote_methods() {
+		return array(
+			'PUT'    => array( 'wp_remote_put', 'PUT' ),
+			'DELETE' => array( 'wp_remote_delete', 'DELETE' ),
+			'PATCH'  => array( 'wp_remote_patch', 'PATCH' ),
+		);
+	}
+
+	/**
+	 * Data provider yielding safe wp_safe_remote_* function names and their expected HTTP methods.
+	 *
+	 * @return array[]
+	 */
+	public function data_safe_remote_methods() {
+		return array(
+			'PUT'    => array( 'wp_safe_remote_put', 'PUT' ),
+			'DELETE' => array( 'wp_safe_remote_delete', 'DELETE' ),
+			'PATCH'  => array( 'wp_safe_remote_patch', 'PATCH' ),
+		);
+	}
+
+	/**
+	 * Data provider yielding only unsafe function names (no expected method needed).
+	 *
+	 * @return array[]
+	 */
+	public function data_remote_function_names() {
+		return array(
+			'wp_remote_put'    => array( 'wp_remote_put' ),
+			'wp_remote_delete' => array( 'wp_remote_delete' ),
+			'wp_remote_patch'  => array( 'wp_remote_patch' ),
+		);
+	}
+
+	/**
+	 * Data provider yielding only safe function names (no expected method needed).
+	 *
+	 * @return array[]
+	 */
+	public function data_safe_remote_function_names() {
+		return array(
+			'wp_safe_remote_put'    => array( 'wp_safe_remote_put' ),
+			'wp_safe_remote_delete' => array( 'wp_safe_remote_delete' ),
+			'wp_safe_remote_patch'  => array( 'wp_safe_remote_patch' ),
+		);
+	}
+
+	/**
+	 * Tests that each wp_remote_* wrapper sets the correct HTTP method.
+	 *
+	 * @ticket 40142
+	 *
+	 * @dataProvider data_remote_methods
+	 *
+	 * @covers ::wp_remote_put
+	 * @covers ::wp_remote_delete
+	 * @covers ::wp_remote_patch
+	 *
+	 * @param string $function_name  The function name to call.
+	 * @param string $expected_method The expected HTTP method string.
+	 */
+	public function test_remote_methods_use_correct_http_method( $function_name, $expected_method ) {
+		$this->call_remote_function( $function_name );
+
+		$this->assertNotEmpty(
+			$this->http_args,
+			"$function_name() did not trigger a request."
+		);
+
+		$this->assertSame(
+			$expected_method,
+			$this->http_args['method'],
+			"$function_name() did not set the expected HTTP method '$expected_method'."
+		);
+	}
+
+	/**
+	 * Tests that each wp_safe_remote_* wrapper sets the correct HTTP method.
+	 *
+	 * @ticket 40142
+	 *
+	 * @dataProvider data_safe_remote_methods
+	 *
+	 * @covers ::wp_safe_remote_put
+	 * @covers ::wp_safe_remote_delete
+	 * @covers ::wp_safe_remote_patch
+	 *
+	 * @param string $function_name  The function name to call.
+	 * @param string $expected_method The expected HTTP method string.
+	 */
+	public function test_safe_remote_methods_use_correct_http_method( $function_name, $expected_method ) {
+		$this->call_remote_function( $function_name );
+
+		$this->assertNotEmpty(
+			$this->http_args,
+			"$function_name() did not trigger a request."
+		);
+
+		$this->assertSame(
+			$expected_method,
+			$this->http_args['method'],
+			"$function_name() did not set the expected HTTP method '$expected_method'."
+		);
+	}
+
+	/**
+	 * Tests that wp_safe_remote_* wrappers set the reject_unsafe_urls flag.
+	 *
+	 * @ticket 40142
+	 *
+	 * @dataProvider data_safe_remote_function_names
+	 *
+	 * @covers ::wp_safe_remote_put
+	 * @covers ::wp_safe_remote_delete
+	 * @covers ::wp_safe_remote_patch
+	 *
+	 * @param string $function_name The function name to call.
+	 */
+	public function test_safe_remote_methods_reject_unsafe_urls( $function_name ) {
+		$this->call_remote_function( $function_name );
+
+		$this->assertNotEmpty(
+			$this->http_args,
+			"$function_name() did not trigger a request."
+		);
+
+		$this->assertTrue(
+			$this->http_args['reject_unsafe_urls'],
+			"$function_name() did not set 'reject_unsafe_urls' to true."
+		);
+	}
+
+	/**
+	 * Tests that the unsafe wp_remote_* wrappers do NOT set reject_unsafe_urls.
+	 *
+	 * @ticket 40142
+	 *
+	 * @dataProvider data_remote_function_names
+	 *
+	 * @covers ::wp_remote_put
+	 * @covers ::wp_remote_delete
+	 * @covers ::wp_remote_patch
+	 *
+	 * @param string $function_name The function name to call.
+	 */
+	public function test_remote_methods_do_not_reject_unsafe_urls( $function_name ) {
+		$this->call_remote_function( $function_name );
+
+		$this->assertNotEmpty(
+			$this->http_args,
+			"$function_name() did not trigger a request."
+		);
+
+		$this->assertEmpty(
+			$this->http_args['reject_unsafe_urls'] ?? '',
+			"$function_name() should NOT set 'reject_unsafe_urls', but it did."
+		);
+	}
+
+	/**
+	 * Tests that caller-supplied args are passed through and merged correctly
+	 * for the unsafe wp_remote_* wrappers.
+	 *
+	 * @ticket 40142
+	 *
+	 * @dataProvider data_remote_methods
+	 *
+	 * @covers ::wp_remote_put
+	 * @covers ::wp_remote_delete
+	 * @covers ::wp_remote_patch
+	 *
+	 * @param string $function_name  The function name to call.
+	 * @param string $expected_method The expected HTTP method string.
+	 */
+	public function test_remote_methods_pass_through_args( $function_name, $expected_method ) {
+		$this->call_remote_function(
+			$function_name,
+			'http://example.com/',
+			array(
+				'timeout' => 42,
+				'headers' => array( 'X-Custom-Header' => 'test-value' ),
+			)
+		);
+
+		$this->assertSame(
+			$expected_method,
+			$this->http_args['method'],
+			"$function_name() did not set the expected HTTP method '$expected_method'."
+		);
+
+		$this->assertSame(
+			42,
+			$this->http_args['timeout'],
+			"$function_name() did not pass through the 'timeout' argument."
+		);
+	}
+
+	/**
+	 * Tests that caller-supplied args are passed through and merged correctly
+	 * for the safe wp_safe_remote_* wrappers.
+	 *
+	 * @ticket 40142
+	 *
+	 * @dataProvider data_safe_remote_methods
+	 *
+	 * @covers ::wp_safe_remote_put
+	 * @covers ::wp_safe_remote_delete
+	 * @covers ::wp_safe_remote_patch
+	 *
+	 * @param string $function_name  The function name to call.
+	 * @param string $expected_method The expected HTTP method string.
+	 */
+	public function test_safe_remote_methods_pass_through_args( $function_name, $expected_method ) {
+		$this->call_remote_function(
+			$function_name,
+			'http://example.com/',
+			array(
+				'timeout' => 99,
+				'headers' => array( 'X-Safe-Header' => 'safe-value' ),
+			)
+		);
+
+		$this->assertSame(
+			$expected_method,
+			$this->http_args['method'],
+			"$function_name() did not set the expected HTTP method '$expected_method'."
+		);
+
+		$this->assertSame(
+			99,
+			$this->http_args['timeout'],
+			"$function_name() did not pass through the 'timeout' argument."
+		);
+
+		$this->assertTrue(
+			$this->http_args['reject_unsafe_urls'],
+			"$function_name() did not set 'reject_unsafe_urls' to true."
+		);
+	}
+
+	/**
+	 * Tests that a caller-supplied 'method' argument overrides the function's default HTTP method.
+	 *
+	 * wp_parse_args() gives caller-supplied values priority over defaults, so this is
+	 * intentional and consistent with the behaviour of wp_remote_get(), wp_remote_post(), etc.
+	 *
+	 * @ticket 40142
+	 *
+	 * @dataProvider data_remote_function_names
+	 *
+	 * @covers ::wp_remote_put
+	 * @covers ::wp_remote_delete
+	 * @covers ::wp_remote_patch
+	 *
+	 * @param string $function_name The function name to call.
+	 */
+	public function test_remote_methods_caller_can_override_method( $function_name ) {
+		$this->call_remote_function(
+			$function_name,
+			'http://example.com/',
+			array( 'method' => 'GET' )
+		);
+
+		$this->assertSame(
+			'GET',
+			$this->http_args['method'],
+			"$function_name() should allow callers to override the HTTP method via \$args, but it did not."
+		);
+	}
+}


### PR DESCRIPTION
Introduces helper functions for the remaining HTTP methods (`PUT`, `DELETE`, and `PATCH`) to complement the existing `wp_remote_get()`, `wp_remote_post()`, and `wp_remote_head()` functions. This makes working with third-party APIs and the REST API much easier. 

The following wrapper functions have been added to `src/wp-includes/http.php`:
* `wp_remote_put()` & `wp_safe_remote_put()`
* `wp_remote_delete()` & `wp_safe_remote_delete()`
* `wp_remote_patch()` & `wp_safe_remote_patch()`

Trac ticket: [#40142](https://core.trac.wordpress.org/ticket/40142)

## Use of AI Tools

AI assistance: Yes
Tool(s): GitHub Copilot
Model(s): Gemini, Claude
Used for: Checking for potential edge cases, drafting the PR description, and assisting with local code review. The final implementation and testing were written and executed manually by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
