### PR TITLE
Privacy: Fix the color contrast of request row action text

### DIFF
--- a/src/wp-admin/css/forms.css
+++ b/src/wp-admin/css/forms.css
@@ -1499,10 +1499,6 @@ table.form-table td .updated p {
 	box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.1);
 }
 
-.privacy_requests .row-actions {
-	color: #787c82;
-}
-
 .privacy_requests .row-actions.processing {
 	position: static;
 }


### PR DESCRIPTION
The Export and Erase Personal Data tables render their progress and result text inside the row actions, where `forms.css` sets a privacy specific color:

```css
.privacy_requests .row-actions {
	color: #787c82;
}
```

Against the `#fff` cell background that is **4.19:1**, below the 4.5:1 minimum for normal text. The strings are built into `$row_actions` in the two list tables, so they inherit a color meant for links:

```php
'<span class="remove-personal-data-processing hidden">' . __( 'Erasing data...' ) . ' <span class="erasure-progress"></span></span>' .
'<span class="remove-personal-data-success hidden">' . __( 'Erasure completed.' ) . '</span>' .
```

This removes the override so the text inherits the standard `.row-actions` color, `#646970` from `list-tables.css`, which is **5.53:1** against the same background. Every other list table in the admin already uses it, so this introduces no new color, which is what the ticket asks for.

The color was never chosen for its contrast. It arrived as `#72777c` in [46264] and became `#787c82` in [50025], when admin colors were standardized on a single palette.

### Measured, before and after

Computed styles on the rendered screens at `/wp-admin/export-personal-data.php` and `/wp-admin/erase-personal-data.php`, with requests present in all four states (pending, confirmed, failed, completed). The row action states that are hidden until JS runs were unhidden in order to measure them.

| String | Before | After |
| --- | --- | --- |
| Downloading data... | 4.19:1 | 5.53:1 |
| Download failed. | 4.19:1 | 5.53:1 |
| Erasing data... | 4.19:1 | 5.53:1 |
| Erasure completed. | 4.19:1 | 5.53:1 |
| Force erasure has failed. | 4.19:1 | 5.53:1 |
| Separator between actions | 4.19:1 | 5.53:1 |

Auditing every text bearing element inside both tables: 7 failures before, **0 after**. The lowest remaining ratio in either table is 4.73:1, the `#d63638` "Failed" status label, which passes.

Note the ticket names two strings; there are five. "Force erasure has failed." and "Download failed." come from the same rule, as do the `|` separators.

### On the striping question

The ticket asks whether zebra striping puts this text on a gray background, which would lower the ratio further. It does not. The table carries the `striped` class, but `forms.css` overrides the backgrounds, and measured on the rendered page every text bearing cell computes to `#fff` in all four request states. The only gray is `#f6f7f7` on `td.check-column` of a failed request, which contains just the checkbox and no text. So 4.19:1 was the worst case, not the best case.

### Testing

- Measured computed color and effective background for every text bearing element in both tables, in all four request states, before and after.
- No RTL change is needed: `forms-rtl.css` is generated at build time and is not tracked.
- CSS only, no markup or PHP change, so no unit test accompanies this.

Trac ticket: https://core.trac.wordpress.org/ticket/65807

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Drafting the patch and this description. I measured the contrast ratios from computed styles on the rendered admin screens before and after the change, created privacy requests in all four states to cover every row variant, audited every text bearing element in both tables rather than only the strings named in the ticket, checked the striping question against the rendered page, traced the color back through [46264] and [50025], and I take responsibility for the result.
