### PR TITLE
Build/Test Tools: Extend the PHPUnit runner variable to the v1 and v2 workflows

### DIFF
--- a/.github/workflows/reusable-phpunit-tests-v1.yml
+++ b/.github/workflows/reusable-phpunit-tests-v1.yml
@@ -85,7 +85,7 @@ jobs:
   # - Run the PHPUnit tests.
   test-php:
     name: PHP ${{ inputs.php }} / ${{ inputs.multisite && ' Multisite' || 'Single site' }}${{ inputs.split_slow && ' slow tests' || '' }}${{ inputs.memcached && ' with memcached' || '' }}
-    runs-on: ${{ inputs.os }}
+    runs-on: ${{ vars.RUNNERS_NAME || inputs.os }}
     timeout-minutes: 20
     permissions:
       contents: read

--- a/.github/workflows/reusable-phpunit-tests-v2.yml
+++ b/.github/workflows/reusable-phpunit-tests-v2.yml
@@ -87,7 +87,7 @@ jobs:
   # - Ensures version-controlled files are not modified or deleted.
   test-php:
     name: PHP ${{ inputs.php }} / ${{ inputs.multisite && ' Multisite' || 'Single Site' }}${{ inputs.split_slow && ' slow tests' || '' }}${{ inputs.memcached && ' with memcached' || '' }}
-    runs-on: ${{ inputs.os }}
+    runs-on: ${{ vars.RUNNERS_NAME || inputs.os }}
     timeout-minutes: 20
     permissions:
       contents: read


### PR DESCRIPTION
Extends [r62891](https://core.trac.wordpress.org/changeset/62891) to the two older reusable PHPUnit workflows.

That change added the `runs-on` override to `reusable-phpunit-tests-v3.yml` alone, so only branches calling that workflow can be redirected.

Branches 4.7 through 5.1 call `reusable-phpunit-tests-v1.yml`, and branches 5.2 through 5.8 call `reusable-phpunit-tests-v2.yml`, both at `@trunk`. Neither reads the variable, so setting `RUNNERS_NAME` at the repository or organization level has no effect on those twelve branches.

This applies the same one-line change to both files. With the variable unset, jobs run on `inputs.os` exactly as before, so there is no change by default.

Each of the three reusable PHPUnit workflows contains exactly one `runs-on`, so no other line in these files needs the same treatment.

Trac ticket: https://core.trac.wordpress.org/ticket/65749

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Identifying the gap by comparing which branches call which reusable workflow, drafting the two-line change, and drafting this description. Reviewed and verified by me before opening.
