### PR TITLE
Networks and Sites: Add update_welcome_user_headers filter to wpmu_welcome_user_notification()

### DIFF
--- a/src/wp-includes/ms-functions.php
+++ b/src/wp-includes/ms-functions.php
@@ -1886,6 +1886,8 @@ Name: %3$s'
  * Filter {@see 'update_welcome_user_email'} and {@see 'update_welcome_user_subject'} to
  * modify the content and subject line of the notification email.
  *
+ * Filter {@see 'update_welcome_user_headers'} to modify the notification email's headers.
+ *
  * @since MU (3.0.0)
  *
  * @param int    $user_id  User ID.
@@ -1946,9 +1948,27 @@ function wpmu_welcome_user_notification(
 		$admin_email = 'support@' . wp_parse_url( network_home_url(), PHP_URL_HOST );
 	}
 
-	$from_name       = ( '' !== get_site_option( 'site_name' ) ) ? esc_html( get_site_option( 'site_name' ) ) : 'WordPress';
-	$message_headers = "From: \"{$from_name}\" <{$admin_email}>\n" . 'Content-Type: text/plain; charset="' . get_option( 'blog_charset' ) . "\"\n";
-	$message         = $welcome_email;
+	$from_name = ( '' !== get_site_option( 'site_name' ) ) ? esc_html( get_site_option( 'site_name' ) ) : 'WordPress';
+
+	$message_headers = array(
+		"From: \"{$from_name}\" <{$admin_email}>\n",
+		'Content-Type: text/plain; charset="' . get_option( 'blog_charset' ) . "\"\n",
+	);
+
+	/**
+	 * Filters the headers of the welcome email after user activation.
+	 *
+	 * @since 7.2.0
+	 *
+	 * @param string[] $message_headers Array of headers to send with the email, formatted for
+	 *                                  transmission via wp_mail().
+	 * @param int      $user_id         User ID.
+	 * @param string   $password        User password.
+	 * @param array    $meta            Signup meta data. Default empty array.
+	 */
+	$message_headers = apply_filters( 'update_welcome_user_headers', $message_headers, $user_id, $password, $meta );
+
+	$message = $welcome_email;
 
 	if ( empty( $current_network->site_name ) ) {
 		$current_network->site_name = 'WordPress';

--- a/tests/phpunit/tests/multisite/wpmuWelcomeUserNotification.php
+++ b/tests/phpunit/tests/multisite/wpmuWelcomeUserNotification.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * @group ms-required
+ * @group multisite
+ *
+ * @covers ::wpmu_welcome_user_notification
+ */
+class Tests_Multisite_wpmuWelcomeUserNotification extends WP_UnitTestCase {
+
+	protected static $user_id;
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$user_id = $factory->user->create(
+			array(
+				'user_email' => 'welcome-user-notification@example.com',
+			)
+		);
+	}
+
+	public function set_up() {
+		parent::set_up();
+
+		reset_phpmailer_instance();
+	}
+
+	public function tear_down() {
+		reset_phpmailer_instance();
+
+		parent::tear_down();
+	}
+
+	/**
+	 * @ticket 49564
+	 */
+	public function test_email_headers_should_be_filterable() {
+		add_filter( 'update_welcome_user_headers', array( $this, 'filter_email_headers' ) );
+		wpmu_welcome_user_notification( self::$user_id, 'password' );
+
+		$mailer = tests_retrieve_phpmailer_instance();
+
+		$this->assertStringContainsString( 'From: Tester <tester@example.com>', $mailer->get_sent()->header );
+	}
+
+	/**
+	 * @ticket 49564
+	 */
+	public function test_email_headers_filter_should_receive_the_default_headers_and_call_args() {
+		$received = null;
+
+		add_filter(
+			'update_welcome_user_headers',
+			function ( $headers, $user_id, $password, $meta ) use ( &$received ) {
+				$received = array( $headers, $user_id, $password, $meta );
+
+				return $headers;
+			},
+			10,
+			4
+		);
+
+		wpmu_welcome_user_notification( self::$user_id, 'password', array( 'foo' => 'bar' ) );
+
+		$this->assertIsArray( $received[0] );
+		$this->assertNotEmpty( $received[0] );
+		$this->assertSame( self::$user_id, $received[1] );
+		$this->assertSame( 'password', $received[2] );
+		$this->assertSame( array( 'foo' => 'bar' ), $received[3] );
+	}
+
+	/**
+	 * @ticket 49564
+	 */
+	public function test_default_headers_should_still_be_sent_without_the_filter() {
+		update_site_option( 'site_name', 'Test Network' );
+
+		wpmu_welcome_user_notification( self::$user_id, 'password' );
+
+		$mailer = tests_retrieve_phpmailer_instance();
+
+		$this->assertStringContainsString( 'From: Test Network <', $mailer->get_sent()->header );
+	}
+
+	public function filter_email_headers( $headers ) {
+		return array( 'From: Tester <tester@example.com>' );
+	}
+}


### PR DESCRIPTION
Adds a new `update_welcome_user_headers` filter to `wpmu_welcome_user_notification()`, letting developers customize the headers of the Multisite "account activation successful" welcome email — for example to send it as HTML (`Content-Type: text/html`) or override the `From` address — the same way `update_welcome_user_email` already lets them customize the message body. Previously the headers were built as a single hardcoded string with no filter hook, so a plugin could change the email content but not its headers. The header construction now builds a `$message_headers` array (still fully compatible with `wp_mail()`, which accepts either a string or an array of header lines) and runs it through the new filter before sending, mirroring the existing `new_site_email` array-filter pattern already used by `wpmu_new_site_admin_notification()` elsewhere in this file.

Trac ticket: https://core.trac.wordpress.org/ticket/49564

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Sonnet 5
Used for: Implementation, tests, and PR description. Reviewed by Igor Rozum.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
