### PR TITLE
Posts: Prevent private posts from becoming sticky in Quick and Bulk Edit

### DIFF
--- a/src/js/_enqueues/admin/inline-edit-post.js
+++ b/src/js/_enqueues/admin/inline-edit-post.js
@@ -149,6 +149,15 @@ window.wp = window.wp || {};
 
 		$('select[name="_status"] option[value="future"]', bulkRow).remove();
 
+		// Disable sticky option when the status is set to 'Private' in bulk edit.
+		$( '#bulk-edit' ).on( 'change', 'select[name="_status"]', function() {
+			if ( 'private' === $( this ).val() ) {
+				$( '#bulk-edit select[name="sticky"]' ).val( '-1' ).prop( 'disabled', true );
+			} else {
+				$( '#bulk-edit select[name="sticky"]' ).prop( 'disabled', false );
+			}
+		});
+
 		/**
 		 * Adds onclick events to the apply buttons.
 		 */

--- a/src/js/_enqueues/admin/inline-edit-post.js
+++ b/src/js/_enqueues/admin/inline-edit-post.js
@@ -109,14 +109,19 @@ window.wp = window.wp || {};
 		});
 
 		/**
-		 * Disables the password input field when the private post checkbox is checked.
+		 * Disables the password input field and sticky option when the private post checkbox is checked.
 		 */
-		$('#inline-edit .inline-edit-private input[value="private"]').on( 'click', function(){
-			var pw = $('input.inline-edit-password-input');
-			if ( $(this).prop('checked') ) {
-				pw.val('').prop('disabled', true);
+		$( 'table.widefat' ).on( 'change', '.inline-edit-private input[value="private"]', function() {
+			var editRow = $( this ).closest( 'tr' ),
+				pw = $( 'input.inline-edit-password-input', editRow ),
+				sticky = $( 'input[name="sticky"]', editRow );
+
+			if ( $( this ).prop( 'checked' ) ) {
+				pw.val( '' ).prop( 'disabled', true );
+				sticky.prop( 'checked', false ).prop( 'disabled', true );
 			} else {
-				pw.prop('disabled', false);
+				pw.prop( 'disabled', false );
+				sticky.prop( 'disabled', false );
 			}
 		});
 

--- a/src/js/_enqueues/admin/inline-edit-post.js
+++ b/src/js/_enqueues/admin/inline-edit-post.js
@@ -463,6 +463,7 @@ window.wp = window.wp || {};
 		if ( 'private' === status ) {
 			$('input[name="keep_private"]', editRow).prop('checked', true);
 			pw.val( '' ).prop( 'disabled', true );
+			$('input[name="sticky"]', editRow).prop('checked', false).prop('disabled', true);
 		}
 
 		// Remove the current page and children from the parent dropdown.

--- a/src/wp-admin/includes/post.php
+++ b/src/wp-admin/includes/post.php
@@ -706,7 +706,11 @@ function bulk_edit_posts( $post_data = null ) {
 		update_post_meta( $post_id, '_edit_last', get_current_user_id() );
 		$updated[] = $post_id;
 
-		if ( isset( $post_data['sticky'] ) && current_user_can( $ptype->cap->edit_others_posts ) ) {
+		$post_status = ! empty( $post_data['post_status'] ) ? $post_data['post_status'] : $post->post_status;
+
+		if ( 'private' === $post_status ) {
+			unstick_post( $post_id );
+		} elseif ( isset( $post_data['sticky'] ) && current_user_can( $ptype->cap->edit_others_posts ) ) {
 			if ( 'sticky' === $post_data['sticky'] ) {
 				stick_post( $post_id );
 			} else {

--- a/src/wp-admin/includes/post.php
+++ b/src/wp-admin/includes/post.php
@@ -708,6 +708,7 @@ function bulk_edit_posts( $post_data = null ) {
 
 		$post_status = ! empty( $post_data['post_status'] ) ? $post_data['post_status'] : $post->post_status;
 
+		// Private posts cannot be sticky.
 		if ( 'private' === $post_status ) {
 			unstick_post( $post_id );
 		} elseif ( isset( $post_data['sticky'] ) && current_user_can( $ptype->cap->edit_others_posts ) ) {

--- a/tests/phpunit/tests/admin/includesPost.php
+++ b/tests/phpunit/tests/admin/includesPost.php
@@ -313,6 +313,32 @@ class Tests_Admin_IncludesPost extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Non-private posts should be made sticky during bulk edit.
+	 *
+	 * @ticket 39946
+	 */
+	public function test_bulk_edit_posts_should_make_non_private_posts_sticky() {
+		wp_set_current_user( self::$admin_id );
+
+		$post_id = self::factory()->post->create(
+			array(
+				'post_status' => 'publish',
+			)
+		);
+
+		$request = array(
+			'post_type' => 'post',
+			'sticky'    => 'sticky',
+			'_status'   => '-1',
+			'post'      => array( $post_id ),
+		);
+
+		bulk_edit_posts( $request );
+
+		$this->assertTrue( is_sticky( $post_id ) );
+	}
+
+	/**
 	 * The bulk_edit_posts() function should preserve the post format
 	 * when it's unchanged.
 	 *

--- a/tests/phpunit/tests/admin/includesPost.php
+++ b/tests/phpunit/tests/admin/includesPost.php
@@ -286,6 +286,33 @@ class Tests_Admin_IncludesPost extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Existing private posts should not be made sticky during bulk edit.
+	 *
+	 * @ticket 39946
+	 */
+	public function test_bulk_edit_posts_should_unstick_existing_private_posts() {
+		wp_set_current_user( self::$admin_id );
+
+		$post_id = self::factory()->post->create(
+			array(
+				'post_status' => 'private',
+			)
+		);
+		stick_post( $post_id );
+
+		$request = array(
+			'post_type' => 'post',
+			'sticky'    => 'sticky',
+			'_status'   => '-1',
+			'post'      => array( $post_id ),
+		);
+
+		bulk_edit_posts( $request );
+
+		$this->assertFalse( is_sticky( $post_id ) );
+	}
+
+	/**
 	 * The bulk_edit_posts() function should preserve the post format
 	 * when it's unchanged.
 	 *

--- a/tests/phpunit/tests/admin/includesPost.php
+++ b/tests/phpunit/tests/admin/includesPost.php
@@ -259,6 +259,33 @@ class Tests_Admin_IncludesPost extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Private posts should not be made sticky during bulk edit.
+	 *
+	 * @ticket 39946
+	 */
+	public function test_bulk_edit_posts_should_not_make_private_posts_sticky() {
+		wp_set_current_user( self::$admin_id );
+
+		$post_id = self::factory()->post->create(
+			array(
+				'post_status' => 'publish',
+			)
+		);
+
+		$request = array(
+			'post_type' => 'post',
+			'sticky'    => 'sticky',
+			'_status'   => 'private',
+			'post'      => array( $post_id ),
+		);
+
+		bulk_edit_posts( $request );
+
+		$this->assertSame( 'private', get_post_status( $post_id ) );
+		$this->assertFalse( is_sticky( $post_id ) );
+	}
+
+	/**
 	 * The bulk_edit_posts() function should preserve the post format
 	 * when it's unchanged.
 	 *


### PR DESCRIPTION

Trac ticket: https://core.trac.wordpress.org/ticket/39946

Private posts are only visible to authorized users and do not appear in public front page queries (`is_home()`). Consequently, private posts cannot and should not be made sticky.

While single post editing (`edit_post()`) correctly enforces this constraint by unsticking private posts, `wp-admin/edit.php` previously allowed private posts to become sticky via Bulk Edit both in the UI and in the `bulk_edit_posts()` backend handler. Quick Edit UI also left the sticky checkbox active when Private status was checked.

This PR resolves ticket #39946 by:
1. Updating `bulk_edit_posts()` in `src/wp-admin/includes/post.php` to automatically call `unstick_post()` whenever a post's status is or becomes `private`.
2. Updating `src/js/_enqueues/admin/inline-edit-post.js` to disable and reset the "Sticky" dropdown when "Private" status is selected in Bulk Edit.
3. Updating `inline-edit-post.js` to delegate event handling on `table.widefat` so Quick Edit rows properly uncheck and disable the "Sticky" checkbox when "Private" is selected.
4. Adding PHPUnit test coverage in `tests/phpunit/tests/admin/includesPost.php`.

### Testing Instructions
1. Navigate to **Posts > All Posts** (`wp-admin/edit.php`).
2. Open **Quick Edit** on any post and check "Private". Verify that "Make this post sticky" becomes disabled and unchecked immediately.
3. Select multiple posts and open **Bulk Edit**. Change **Status** to "Private". Verify that the "Sticky" select dropdown resets to "— No Change —" and is disabled.
4. Run the PHPUnit test suite: `npm run test:php -- --filter=Tests_Admin_IncludesPost`.

