### PR TITLE
Coding Standards: Fix alignment of assignment operators

### DIFF
--- a/src/wp-admin/includes/class-wp-users-list-table.php
+++ b/src/wp-admin/includes/class-wp-users-list-table.php
@@ -635,7 +635,7 @@ class WP_Users_List_Table extends WP_List_Table {
 				if ( $primary === $column_name ) {
 					$row .= $this->row_actions( $actions );
 				}
-				$tag = ( $primary === $column_name ) ? 'th' : 'td';
+				$tag  = ( $primary === $column_name ) ? 'th' : 'td';
 				$row .= "</$tag>";
 			}
 		}

--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -2376,7 +2376,7 @@ if ( ! function_exists( 'wp_new_user_notification' ) ) :
 
 		$switched_locale = switch_to_user_locale( $user_id );
 
-		$message  = __( 'To set your password, visit the following address:' ) . "\r\n\r\n";
+		$message = __( 'To set your password, visit the following address:' ) . "\r\n\r\n";
 
 		/*
 		 * Since some user login names end in a period, this could produce ambiguous URLs that


### PR DESCRIPTION
## Description

`composer run format` currently reports two `Generic.Formatting.MultipleStatementAlignment` warnings. This PR applies the auto-fixes so that a clean checkout of `trunk` passes without pending changes.

## Warnings

```
FILE: src/wp-admin/includes/class-wp-users-list-table.php
 638 | WARNING | [x] Equals sign not aligned with surrounding assignments; expected 2 spaces but found 1 space

FILE: src/wp-includes/pluggable.php
2379 | WARNING | [x] Equals sign not aligned correctly; expected 1 space but found 2 spaces
```

## When were these introduced?

Both were introduced during the 7.1 development cycle, so no released version of WordPress is affected.

| File | Introduced in | Ticket |
| --- | --- | --- |
| `src/wp-admin/includes/class-wp-users-list-table.php` | [r62838](https://core.trac.wordpress.org/changeset/62838) – *Administration: Use post title column as table header in post lists* (2026-07-23) | [#32892](https://core.trac.wordpress.org/ticket/32892) |
| `src/wp-includes/pluggable.php` | [r62590](https://core.trac.wordpress.org/changeset/62590) – *Notifications: Remove the username from the new user notification email* (2026-06-30) | [#63085](https://core.trac.wordpress.org/ticket/63085) |

In [r62838](https://core.trac.wordpress.org/changeset/62838) the new `$tag` assignment was added directly above an existing `$row .=` assignment without aligning the block. In [r62590](https://core.trac.wordpress.org/changeset/62590) the line above `$message` was removed, leaving `$message` with the alignment padding of a block that no longer exists.

These are whitespace-only changes, so no functional testing is required.

Trac ticket: https://core.trac.wordpress.org/ticket/64897

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
