### PR TITLE
Administration: Remove unreachable "All selected plugins are up to date." notice in plugins.php

### DIFF
--- a/src/wp-admin/plugins.php
+++ b/src/wp-admin/plugins.php
@@ -740,8 +740,6 @@ if ( isset( $_GET['error'] ) ) {
 	wp_admin_notice( __( 'Plugin deactivated.' ), $updated_notice_args );
 } elseif ( isset( $_GET['deactivate-multi'] ) ) {
 	wp_admin_notice( __( 'Selected plugins deactivated.' ), $updated_notice_args );
-} elseif ( 'update-selected' === $action ) {
-	wp_admin_notice( __( 'All selected plugins are up to date.' ), $updated_notice_args );
 } elseif ( isset( $_GET['resume'] ) ) {
 	wp_admin_notice( __( 'Plugin resumed.' ), $updated_notice_args );
 } elseif ( isset( $_GET['enabled-auto-update'] ) ) {

--- a/tests/phpstan/baselines/identical.alwaysFalse.neon
+++ b/tests/phpstan/baselines/identical.alwaysFalse.neon
@@ -19,11 +19,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: '#^Strict comparison using \=\=\= between ''update\-selected'' and mixed~\(''activate''\|''activate\-selected''\|''deactivate''\|''deactivate\-selected''\|''delete\-selected''\|''disable\-auto\-update''\|''disable\-auto\-update\-selected''\|''enable\-auto\-update''\|''enable\-auto\-update\-selected''\|''error_scrape''\|''resume''\|''update\-selected''\) will always evaluate to false\.$#'
-			identifier: identical.alwaysFalse
-			count: 1
-			path: ../../../src/wp-admin/plugins.php
-		-
 			message: '#^Strict comparison using \=\=\= between ''exceeded\-max…'' and null will always evaluate to false\.$#'
 			identifier: identical.alwaysFalse
 			count: 1


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65812

## Summary

Removes an unreachable admin-notice branch on the Plugins screen (`wp-admin/plugins.php`). The `elseif ( 'update-selected' === $action )` branch that prints _"All selected plugins are up to date."_ can never execute.

## Why it is unreachable

- `$action` is assigned once, from `WP_Plugins_List_Table::current_action()`, and is never reassigned.
- When `$action === 'update-selected'`, the earlier `switch ( $action )` enters `case 'update-selected':`, which renders the bulk-update iframe and ends in an **unconditional `exit;`**.
- Execution therefore never reaches the notice chain while `$action === 'update-selected'`, so the `elseif` is always false. PHPStan reports the comparison as _"will always evaluate to false."_

The string `"All selected plugins are up to date."` exists nowhere else in `wp-admin`, and the iframe update screen (`update.php?action=update-selected`) already reports the up-to-date outcome.

## History

The branch was reachable when introduced in [11542] (2010): the handler filtered the selection to out-of-date plugins and `break`ed (not `exit`) when all were current, falling through to the notice. The iframe rewrite in [11232] removed that filtering and the `break`, leaving the notice behind. It has been dead code ever since.

## Testing

- On the Plugins screen, no user action produces the notice; bulk **Update** always renders the iframe screen.
- `php -l` passes; no functional change (removed code was never reached).