### PR TITLE
Rewrite Rules: Fix rewrite rules breaking for taxonomies with URL-encoded Unicode slugs

### DIFF
--- a/src/wp-includes/class-wp-rewrite.php
+++ b/src/wp-includes/class-wp-rewrite.php
@@ -1847,7 +1847,8 @@ class WP_Rewrite {
 		$args['struct'] = preg_replace_callback(
 			'/(?:%[0-9A-F]{2})+/',
 			static function ( $matches ) {
-				return rawurldecode( $matches[0] );
+				$decoded = rawurldecode( $matches[0] );
+				return wp_is_valid_utf8( $decoded ) ? $decoded : $matches[0];
 			},
 			$struct
 		);

--- a/src/wp-includes/class-wp-rewrite.php
+++ b/src/wp-includes/class-wp-rewrite.php
@@ -1844,7 +1844,13 @@ class WP_Rewrite {
 			$struct = $this->root . $struct;
 		}
 
-		$args['struct'] = $struct;
+		$args['struct'] = preg_replace_callback(
+			'/(?:%[0-9A-F]{2})+/',
+			static function ( $matches ) {
+				return rawurldecode( $matches[0] );
+			},
+			$struct
+		);
 
 		$this->extra_permastructs[ $name ] = $args;
 	}

--- a/tests/phpunit/tests/rewrite/permastructs.php
+++ b/tests/phpunit/tests/rewrite/permastructs.php
@@ -81,4 +81,25 @@ class Tests_Rewrite_Permastructs extends WP_UnitTestCase {
 		$rules = $wp_rewrite->generate_rewrite_rules( $stored_struct );
 		$this->assertContains( 'index.php?wptests_cert=$matches[1]', array_values( $rules ) );
 	}
+
+	/**
+	 * Tests that percent-encoded sequences that do not decode to valid UTF-8 are left intact
+	 * so that plugin-registered tag placeholders shaped like hex sequences are never silently mangled.
+	 *
+	 * @ticket 41791
+	 */
+	public function test_add_permastruct_preserves_non_utf8_encoded_sequences() {
+		global $wp_rewrite;
+
+		// %80%81 decodes to two lone continuation bytes — invalid UTF-8.
+		$invalid_sequence = '%80%81';
+		add_permastruct( 'foo_invalid', "bar/{$invalid_sequence}/%foo_invalid%" );
+
+		$stored_struct = $wp_rewrite->extra_permastructs['foo_invalid']['struct'];
+
+		// The invalid sequence must be preserved as-is.
+		$this->assertStringContainsString( $invalid_sequence, $stored_struct );
+
+		remove_permastruct( 'foo_invalid' );
+	}
 }

--- a/tests/phpunit/tests/rewrite/permastructs.php
+++ b/tests/phpunit/tests/rewrite/permastructs.php
@@ -14,6 +14,13 @@ class Tests_Rewrite_Permastructs extends WP_UnitTestCase {
 		$this->set_permalink_structure( '/%postname%/' );
 	}
 
+	public function tear_down() {
+		remove_permastruct( 'wptests_cert' );
+		unregister_taxonomy( 'wptests_cert' );
+
+		parent::tear_down();
+	}
+
 	public function test_add_permastruct() {
 		global $wp_rewrite;
 
@@ -31,6 +38,7 @@ class Tests_Rewrite_Permastructs extends WP_UnitTestCase {
 			),
 			$wp_rewrite->extra_permastructs['foo']
 		);
+		remove_permastruct( 'foo' );
 	}
 
 	public function test_remove_permastruct() {
@@ -42,5 +50,35 @@ class Tests_Rewrite_Permastructs extends WP_UnitTestCase {
 
 		remove_permastruct( 'foo' );
 		$this->assertArrayNotHasKey( 'foo', $wp_rewrite->extra_permastructs );
+	}
+
+	/**
+	 * Tests that a URL-encoded Unicode taxonomy slug is decoded in the permastruct and
+	 * that the generated rewrite rules correctly map the taxonomy query var to $matches[1].
+	 *
+	 * @ticket 41791
+	 */
+	public function test_add_permastruct_with_url_encoded_unicode_slug() {
+		global $wp_rewrite;
+
+		register_taxonomy(
+			'wptests_cert',
+			'post',
+			array(
+				'rewrite' => array(
+					'slug' => urlencode( 'Сертификат' ),
+				),
+			)
+		);
+
+		$stored_struct = $wp_rewrite->extra_permastructs['wptests_cert']['struct'];
+
+		// The struct must store decoded Unicode, not percent-encoded sequences.
+		$this->assertStringContainsString( 'Сертификат', $stored_struct );
+		$this->assertStringNotContainsString( urlencode( 'Сертификат' ), $stored_struct );
+
+		// The generated rules must map the taxonomy var to $matches[1], not a shifted index.
+		$rules = $wp_rewrite->generate_rewrite_rules( $stored_struct );
+		$this->assertContains( 'index.php?wptests_cert=$matches[1]', array_values( $rules ) );
 	}
 }


### PR DESCRIPTION
This PR intercepts the permastruct inside `WP_Rewrite::add_permastruct()` and decodes the URL-encoded slug back into standard UTF-8 text before saving it. 
To ensure we don't accidentally corrupt real rewrite tags (where `%ca` in `%category%` could be decoded by a naive `urldecode`), we use a `preg_replace_callback` that strictly decodes only uppercase hex strings (`[0-9A-F]`). WordPress's URL encoding always uses uppercase, while built-in rewrite tags use lowercase, making this a safe and robust fix.


Trac ticket: [#41791](https://core.trac.wordpress.org/ticket/41791)


## Use of AI Tools

AI assistance: Yes
Tool(s): GitHub Copilot
Model(s): Gemini, Claude
Used for: Checking for potential edge cases, drafting the PR description, and assisting with local code review. The final implementation and testing were written and executed manually by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
