### PR TITLE
Connectors: keep the stored API key when a masked value is submitted

### DIFF
--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -622,10 +622,11 @@ function _wp_connectors_is_ai_api_key_valid( string $key, string $provider_id ):
  *
  * A value matching the mask that `_wp_connectors_rest_settings_dispatch()`
  * places in REST responses keeps the stored key, so a masked settings response
- * can be submitted back to the endpoint unchanged. Pass an empty string to
- * clear the key.
+ * can be submitted back to the endpoint unchanged. The match must be exact; all
+ * other values are sanitized as text, as before. Pass an empty string to clear
+ * the key.
  *
- * @since 7.1.0
+ * @since 7.2.0
  * @access private
  *
  * @param mixed  $value  The submitted setting value.
@@ -766,10 +767,13 @@ function _wp_connectors_rest_settings_dispatch( WP_REST_Response $response, WP_R
 		$value = $data[ $setting_name ];
 
 		// On update, validate AI provider keys submitted in the request before masking.
+		// A request carrying the mask of the stored key submitted no new key, since
+		// wp_connectors_sanitize_api_key() kept the stored one, so there is nothing to validate.
 		// Non-AI connectors accept keys as-is; the service plugin handles its own validation.
 		if ( $is_update
 			&& $request->has_param( $setting_name )
 			&& is_string( $value ) && '' !== $value
+			&& _wp_connectors_mask_api_key( $value ) !== $request->get_param( $setting_name )
 			&& 'ai_provider' === $connector_data['type']
 		) {
 			if ( true !== _wp_connectors_is_ai_api_key_valid( $value, $connector_id ) ) {

--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -618,6 +618,40 @@ function _wp_connectors_is_ai_api_key_valid( string $key, string $provider_id ):
 }
 
 /**
+ * Sanitizes a stored connector API key.
+ *
+ * A value matching the mask that `_wp_connectors_rest_settings_dispatch()`
+ * places in REST responses keeps the stored key, so a masked settings response
+ * can be submitted back to the endpoint unchanged. Pass an empty string to
+ * clear the key.
+ *
+ * @since 7.1.0
+ * @access private
+ *
+ * @param mixed  $value  The submitted setting value.
+ * @param string $option The option name being sanitized. Passed explicitly by the
+ *                       registered sanitize callback; falls back to the current
+ *                       `sanitize_option_{$option}` filter name when omitted.
+ * @return string The sanitized API key.
+ */
+function wp_connectors_sanitize_api_key( $value, string $option = '' ): string {
+	if ( is_string( $value ) && '' !== $value ) {
+		if ( '' === $option ) {
+			$option = str_replace( 'sanitize_option_', '', (string) current_filter() );
+		}
+
+		$stored = get_option( $option );
+
+		// A masked key means a client resubmitted a masked REST response.
+		if ( is_string( $stored ) && '' !== $stored && _wp_connectors_mask_api_key( $stored ) === $value ) {
+			return $stored;
+		}
+	}
+
+	return sanitize_text_field( $value );
+}
+
+/**
  * Sanitizes stored application-password credentials for a connector.
  *
  * Credential fields that are missing or not strings keep their currently
@@ -802,7 +836,9 @@ function _wp_register_default_connector_settings(): void {
 					),
 					'default'           => '',
 					'show_in_rest'      => true,
-					'sanitize_callback' => 'sanitize_text_field',
+					'sanitize_callback' => static function ( $value ) use ( $setting_name ) {
+						return wp_connectors_sanitize_api_key( $value, $setting_name );
+					},
 				)
 			);
 		} elseif ( 'application_password' === $auth['method'] ) {

--- a/tests/phpunit/tests/connectors/wpConnectorsRestSettingsDispatch.php
+++ b/tests/phpunit/tests/connectors/wpConnectorsRestSettingsDispatch.php
@@ -183,4 +183,40 @@ class Tests_Connectors_WpConnectorsRestSettingsDispatch extends WP_UnitTestCase 
 			'The submitted AI provider key should be masked in the response.'
 		);
 	}
+
+	/**
+	 * Ensures a resubmitted mask is not validated, so a read-modify-write client
+	 * cannot wipe a stored AI provider key.
+	 *
+	 * wp_connectors_sanitize_api_key() keeps the stored key when the mask is
+	 * submitted, so the response carries the real key and there is nothing new
+	 * to validate.
+	 *
+	 * @ticket 65821
+	 */
+	public function test_does_not_validate_or_reset_resubmitted_masked_ai_key(): void {
+		$stored_key = 'sk-stored-valid-key';
+		update_option( self::AI_KEY_SETTING_NAME, $stored_key );
+
+		// A provider that would fail validation if it were consulted.
+		self::set_mock_provider_configured( false );
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/settings' );
+		$request->set_param( self::AI_KEY_SETTING_NAME, _wp_connectors_mask_api_key( $stored_key ) );
+		$response = new WP_REST_Response( array( self::AI_KEY_SETTING_NAME => $stored_key ) );
+
+		$result = _wp_connectors_rest_settings_dispatch( $response, rest_get_server(), $request );
+		$data   = $result->get_data();
+
+		$this->assertSame(
+			$stored_key,
+			get_option( self::AI_KEY_SETTING_NAME ),
+			'A resubmitted mask should leave the stored AI provider key in place.'
+		);
+		$this->assertSame(
+			_wp_connectors_mask_api_key( $stored_key ),
+			$data[ self::AI_KEY_SETTING_NAME ],
+			'The stored AI provider key should still be masked in the response.'
+		);
+	}
 }

--- a/tests/phpunit/tests/connectors/wpConnectorsSanitizeApiKey.php
+++ b/tests/phpunit/tests/connectors/wpConnectorsSanitizeApiKey.php
@@ -1,0 +1,208 @@
+<?php
+/**
+ * Tests for wp_connectors_sanitize_api_key().
+ *
+ * @group connectors
+ * @covers ::wp_connectors_sanitize_api_key
+ */
+class Tests_Connectors_WpConnectorsSanitizeApiKey extends WP_UnitTestCase {
+
+	const CONNECTOR_ID    = 'wp_test_api_key_connector';
+	const API_KEY_SETTING = 'connectors_test_service_api_key';
+	const STORED_API_KEY  = 'sk-live-abcdefghijklmnop1234';
+
+	/**
+	 * Administrator user ID.
+	 *
+	 * @var int
+	 */
+	private static $administrator_id;
+
+	/**
+	 * Snapshot of registered settings before each test.
+	 *
+	 * @var array
+	 */
+	private array $original_registered_settings = array();
+
+	/**
+	 * Creates an administrator for REST settings requests.
+	 *
+	 * @param WP_UnitTest_Factory $factory Test factory.
+	 */
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$administrator_id = $factory->user->create( array( 'role' => 'administrator' ) );
+	}
+
+	/**
+	 * Removes the administrator.
+	 */
+	public static function wpTearDownAfterClass() {
+		self::delete_user( self::$administrator_id );
+	}
+
+	/**
+	 * Registers an API key connector and its setting before each test.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		global $wp_registered_settings;
+		$this->original_registered_settings = is_array( $wp_registered_settings ) ? $wp_registered_settings : array();
+
+		WP_Connector_Registry::get_instance()->register(
+			self::CONNECTOR_ID,
+			array(
+				'name'           => 'Test API Key Connector',
+				'type'           => 'content_source',
+				'authentication' => array(
+					'method'       => 'api_key',
+					'setting_name' => self::API_KEY_SETTING,
+				),
+			)
+		);
+
+		_wp_register_default_connector_settings();
+	}
+
+	/**
+	 * Removes the test connector, its option, and restores registered settings.
+	 */
+	public function tear_down(): void {
+		$registry = WP_Connector_Registry::get_instance();
+		if ( null !== $registry && $registry->is_registered( self::CONNECTOR_ID ) ) {
+			$registry->unregister( self::CONNECTOR_ID );
+		}
+
+		delete_option( self::API_KEY_SETTING );
+
+		global $wp_registered_settings;
+		$wp_registered_settings = $this->original_registered_settings;
+
+		parent::tear_down();
+	}
+
+	/**
+	 * @ticket 65821
+	 */
+	public function test_masked_value_preserves_stored_api_key(): void {
+		update_option( self::API_KEY_SETTING, self::STORED_API_KEY );
+
+		update_option( self::API_KEY_SETTING, _wp_connectors_mask_api_key( self::STORED_API_KEY ) );
+
+		$this->assertSame( self::STORED_API_KEY, get_option( self::API_KEY_SETTING ) );
+	}
+
+	/**
+	 * @ticket 65821
+	 */
+	public function test_submitted_key_replaces_stored_api_key(): void {
+		update_option( self::API_KEY_SETTING, self::STORED_API_KEY );
+
+		update_option( self::API_KEY_SETTING, 'sk-live-zyxwvutsrqponmlk9876' );
+
+		$this->assertSame( 'sk-live-zyxwvutsrqponmlk9876', get_option( self::API_KEY_SETTING ) );
+	}
+
+	/**
+	 * @ticket 65821
+	 */
+	public function test_empty_string_clears_stored_api_key(): void {
+		update_option( self::API_KEY_SETTING, self::STORED_API_KEY );
+
+		update_option( self::API_KEY_SETTING, '' );
+
+		$this->assertSame( '', get_option( self::API_KEY_SETTING ) );
+	}
+
+	/**
+	 * A masked value only stands in for the key it was generated from.
+	 *
+	 * @ticket 65821
+	 */
+	public function test_mask_of_a_different_key_does_not_preserve_stored_api_key(): void {
+		update_option( self::API_KEY_SETTING, self::STORED_API_KEY );
+
+		$other_mask = _wp_connectors_mask_api_key( 'sk-live-zyxwvutsrqponmlk9876' );
+		update_option( self::API_KEY_SETTING, $other_mask );
+
+		$this->assertSame( $other_mask, get_option( self::API_KEY_SETTING ) );
+	}
+
+	/**
+	 * @ticket 65821
+	 */
+	public function test_masked_value_with_no_stored_key_is_sanitized_as_text(): void {
+		$mask = _wp_connectors_mask_api_key( self::STORED_API_KEY );
+
+		update_option( self::API_KEY_SETTING, $mask );
+
+		$this->assertSame( $mask, get_option( self::API_KEY_SETTING ) );
+	}
+
+	/**
+	 * A connector plugin may own the setting and register the sanitizer itself, in
+	 * which case only the value is passed and the option name comes from the filter.
+	 *
+	 * @ticket 65821
+	 */
+	public function test_option_name_falls_back_to_the_current_filter(): void {
+		$option = 'connectors_test_plugin_owned_api_key';
+
+		register_setting(
+			'connectors',
+			$option,
+			array(
+				'type'              => 'string',
+				'default'           => '',
+				'sanitize_callback' => 'wp_connectors_sanitize_api_key',
+			)
+		);
+
+		update_option( $option, self::STORED_API_KEY );
+		update_option( $option, _wp_connectors_mask_api_key( self::STORED_API_KEY ) );
+
+		$this->assertSame( self::STORED_API_KEY, get_option( $option ) );
+
+		unregister_setting( 'connectors', $option );
+		delete_option( $option );
+	}
+
+	/**
+	 * @ticket 65821
+	 */
+	public function test_rest_round_trip_of_masked_response_preserves_stored_api_key(): void {
+		wp_set_current_user( self::$administrator_id );
+
+		update_option( self::API_KEY_SETTING, self::STORED_API_KEY );
+
+		$get_request  = new WP_REST_Request( 'GET', '/wp/v2/settings' );
+		$get_response = $this->dispatch_settings_request( $get_request );
+		$masked       = $get_response->get_data()[ self::API_KEY_SETTING ];
+
+		$this->assertSame( _wp_connectors_mask_api_key( self::STORED_API_KEY ), $masked );
+
+		// Submit the masked response back, as a read-modify-write client would.
+		$post_request = new WP_REST_Request( 'POST', '/wp/v2/settings' );
+		$post_request->set_param( self::API_KEY_SETTING, $masked );
+		$post_response = $this->dispatch_settings_request( $post_request );
+
+		$this->assertSame( 200, $post_response->get_status() );
+		$this->assertSame( self::STORED_API_KEY, get_option( self::API_KEY_SETTING ) );
+		$this->assertSame(
+			_wp_connectors_mask_api_key( self::STORED_API_KEY ),
+			$post_response->get_data()[ self::API_KEY_SETTING ]
+		);
+	}
+
+	/**
+	 * Dispatches a settings request through the filter that masks connector credentials.
+	 *
+	 * @param WP_REST_Request $request The request to dispatch.
+	 * @return WP_REST_Response The filtered response.
+	 */
+	private function dispatch_settings_request( WP_REST_Request $request ): WP_REST_Response {
+		$response = rest_do_request( $request );
+		return apply_filters( 'rest_post_dispatch', rest_ensure_response( $response ), rest_get_server(), $request );
+	}
+}

--- a/tests/phpunit/tests/connectors/wpConnectorsSanitizeApplicationPasswordCredentials.php
+++ b/tests/phpunit/tests/connectors/wpConnectorsSanitizeApplicationPasswordCredentials.php
@@ -176,6 +176,40 @@ class Tests_Connectors_WpConnectorsSanitizeApplicationPasswordCredentials extend
 	}
 
 	/**
+	 * Only the exact mask stands in for the stored password.
+	 *
+	 * @ticket 65821
+	 */
+	public function test_bullet_prefixed_password_that_is_not_the_mask_is_stored(): void {
+		update_option(
+			self::CREDENTIALS_SETTING_NAME,
+			array(
+				'username' => 'remote-user',
+				'password' => 'abcd efgh ijkl mnop 1234',
+			)
+		);
+
+		// Starts with bullets, but it is the API key mask rather than the password mask.
+		$submitted = _wp_connectors_mask_api_key( 'abcd efgh ijkl mnop 1234' );
+
+		update_option(
+			self::CREDENTIALS_SETTING_NAME,
+			array(
+				'username' => 'remote-user',
+				'password' => $submitted,
+			)
+		);
+
+		$this->assertSame(
+			array(
+				'username' => 'remote-user',
+				'password' => $submitted,
+			),
+			get_option( self::CREDENTIALS_SETTING_NAME )
+		);
+	}
+
+	/**
 	 * @ticket 64850
 	 */
 	public function test_non_array_value_preserves_stored_credentials(): void {


### PR DESCRIPTION
Connector API keys are masked in `/wp/v2/settings` responses but sanitized with `sanitize_text_field()`, so posting a settings response back unchanged stores the mask in place of the key. For `ai_provider` connectors the value that reaches validation is then the mask rather than the user's key, and it is discarded unless validation returns exactly `true`.

Adds `wp_connectors_sanitize_api_key()`, which keeps the stored key when the submitted value is exactly that key's mask, and uses it as the sanitize callback for API key settings. This mirrors `wp_connectors_sanitize_application_password_credentials()`, which already does this for the `application_password` method.

Also skips the AI provider validation in `_wp_connectors_rest_settings_dispatch()` when the submitted value is the mask of the stored key. Without it, keeping the stored key meant the dispatch filter validated that key against the provider on every settings save and discarded it whenever validation did not return `true`.

Trac ticket: https://core.trac.wordpress.org/ticket/65821

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Drafting the fix and the test file. I reproduced the data loss on a running site and in PHPUnit, confirmed the new assertions fail without the source change, and ran the test groups and linters. I have reviewed the change and take responsibility for it.

