### PR TITLE
Networks and Sites: Break out the conditional in allow_subdomain_install()

### DIFF
--- a/src/wp-admin/includes/network.php
+++ b/src/wp-admin/includes/network.php
@@ -35,7 +35,12 @@ function network_domain_check() {
 function allow_subdomain_install() {
 	$home   = get_option( 'home' );
 	$domain = parse_url( $home, PHP_URL_HOST );
-	if ( parse_url( $home, PHP_URL_PATH ) || 'localhost' === $domain || preg_match( '|^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$|', $domain ) ) {
+
+	$has_path      = (bool) parse_url( $home, PHP_URL_PATH );
+	$is_localhost  = 'localhost' === $domain;
+	$is_ip_address = (bool) preg_match( '|^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$|', $domain );
+
+	if ( $has_path || $is_localhost || $is_ip_address ) {
 		return false;
 	}
 

--- a/tests/phpunit/tests/admin/includes/network/AllowSubdomainInstall_Test.php
+++ b/tests/phpunit/tests/admin/includes/network/AllowSubdomainInstall_Test.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * @group admin
+ * @group multisite
+ *
+ * @covers ::allow_subdomain_install
+ */
+class Tests_Admin_Includes_Network_AllowSubdomainInstall_Test extends WP_UnitTestCase {
+
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+
+		require_once ABSPATH . 'wp-admin/includes/network.php';
+	}
+
+	/**
+	 * @ticket 35274
+	 *
+	 * @dataProvider data_allow_subdomain_install
+	 *
+	 * @param string $home     Value to set the 'home' option to.
+	 * @param bool   $expected Expected return value of allow_subdomain_install().
+	 */
+	public function test_allow_subdomain_install( $home, $expected ) {
+		update_option( 'home', $home );
+
+		$this->assertSame( $expected, allow_subdomain_install() );
+	}
+
+	/**
+	 * Data provider for test_allow_subdomain_install().
+	 *
+	 * @return array<string, array{home: string, expected: bool}>
+	 */
+	public function data_allow_subdomain_install() {
+		return array(
+			'a plain domain'              => array(
+				'home'     => 'https://example.com',
+				'expected' => true,
+			),
+			'a domain with a subdomain'   => array(
+				'home'     => 'https://www.example.com',
+				'expected' => true,
+			),
+			'localhost'                   => array(
+				'home'     => 'https://localhost',
+				'expected' => false,
+			),
+			'a domain with a path'        => array(
+				'home'     => 'https://example.com/wordpress',
+				'expected' => false,
+			),
+			'an IPv4 address'             => array(
+				'home'     => 'http://127.0.0.1',
+				'expected' => false,
+			),
+			'an IPv4 address with a port' => array(
+				'home'     => 'http://192.168.1.1:8080',
+				'expected' => false,
+			),
+		);
+	}
+}


### PR DESCRIPTION
Breaks out the compound conditional in `allow_subdomain_install()` into three named boolean variables (`$has_path`, `$is_localhost`, `$is_ip_address`) so the return condition reads as a description of what's being checked rather than a single long expression, and adds unit test coverage, which the function previously had none of.

**What changed**
- `src/wp-admin/includes/network.php`: extracted the path/localhost/IP-address checks into named variables ahead of the `if`, with no change in behavior.
- Added `tests/phpunit/tests/admin/includes/network/AllowSubdomainInstall_Test.php`, covering a plain domain, a subdomain, `localhost`, a domain with a path, and IPv4 addresses (with and without a port).

**Why**
This revives a long-stale 2015 patch on the ticket (the original diff no longer applies since the function has been rewritten since). The core ask — better inline readability — still stands, and the function had zero test coverage to lock in its behavior first.

**Testing**
- `npm run test:php -- --filter Tests_Admin_Includes_Network_AllowSubdomainInstall_Test` — 6 tests, 6 assertions, OK.
- `npm run test:php -- --group multisite` — 38 tests, 49 assertions, OK (no regressions).
- `composer lint:errors` and `npm run typecheck:php` clean on the touched files (the one PHPStan baseline mismatch reported is pre-existing on clean trunk, unrelated to this change).

Trac ticket: https://core.trac.wordpress.org/ticket/35274

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Sonnet 5
Used for: Implementation, tests, and PR description. Reviewed by Igor Rozum.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**