### PR TITLE
Prevent duplicate Quick Edit save requests

### DIFF
--- a/src/js/_enqueues/admin/inline-edit-post.js
+++ b/src/js/_enqueues/admin/inline-edit-post.js
@@ -20,6 +20,7 @@ window.wp = window.wp || {};
  *
  * @property {string} type The type of inline editor.
  * @property {string} what The prefix before the post ID.
+ * @property {boolean} saving Whether a save request is active.
  *
  */
 ( function( $, wp ) {

--- a/src/js/_enqueues/admin/inline-edit-post.js
+++ b/src/js/_enqueues/admin/inline-edit-post.js
@@ -26,6 +26,13 @@ window.wp = window.wp || {};
 
 	window.inlineEditPost = {
 
+		/**
+		 * Whether a save request is active.
+		 *
+		 * @type {boolean}
+		 */
+		saving: false,
+
 	/**
 	 * Initializes the inline and bulk post editor.
 	 *
@@ -488,6 +495,11 @@ window.wp = window.wp || {};
 	save : function(id) {
 		var params, fields, page = $('.post_status_page').val() || '';
 
+		if ( this.saving ) {
+			return false;
+		}
+		this.saving = true;
+
 		if ( typeof(id) === 'object' ) {
 			id = this.getId(id);
 		}
@@ -536,7 +548,10 @@ window.wp = window.wp || {};
 					wp.a11y.speak( wp.i18n.__( 'Error while saving the changes.' ) );
 				}
 			},
-		'html');
+			'html'
+		).always( function() {
+			inlineEditPost.saving = false;
+		} );
 
 		// Prevent submitting the form when pressing Enter on a focused field.
 		return false;

--- a/src/js/_enqueues/admin/inline-edit-tax.js
+++ b/src/js/_enqueues/admin/inline-edit-tax.js
@@ -20,6 +20,12 @@ window.wp = window.wp || {};
 ( function( $, wp ) {
 
 window.inlineEditTax = {
+	/**
+	 * Whether a save request is active.
+	 *
+	 * @type {boolean}
+	 */
+	saving: false,
 
 	/**
 	 * Initializes the inline taxonomy editor by adding event handlers to be able to
@@ -167,6 +173,11 @@ window.inlineEditTax = {
 	save : function(id) {
 		var params, fields, tax = $('input[name="taxonomy"]').val() || '';
 
+		if ( this.saving ) {
+			return false;
+		}
+		this.saving = true;
+
 		// Makes sure we can pass an HTMLElement as the ID.
 		if( typeof(id) === 'object' ) {
 			id = this.getId(id);
@@ -242,7 +253,9 @@ window.inlineEditTax = {
 					wp.a11y.speak( wp.i18n.__( 'Error while saving the changes.' ) );
 				}
 			}
-		);
+		).always( function() {
+			inlineEditTax.saving = false;
+		} );
 
 		// Prevent submitting the form when pressing Enter on a focused field.
 		return false;

--- a/tests/qunit/index.html
+++ b/tests/qunit/index.html
@@ -76,6 +76,7 @@
 	<body>
 		<div id="qunit"></div>
 		<div id="qunit-fixture">
+			<table id="the-list" data-wp-lists="list:tag"><tbody></tbody></table>
 			<script src="fixtures/customize-header.js"></script>
 			<script src="fixtures/customize-settings.js"></script>
 			<script src="fixtures/customize-menus.js"></script>
@@ -90,6 +91,8 @@
 		<script src="../../build/wp-admin/js/dashboard.js"></script>
 		<script src="../../build/wp-admin/js/password-strength-meter.js"></script>
 		<script src="../../build/wp-admin/js/postbox.js"></script>
+		<script src="../../build/wp-admin/js/inline-edit-post.js"></script>
+		<script src="../../build/wp-admin/js/inline-edit-tax.js"></script>
 		<script src="../../build/wp-includes/js/dist/vendor/moment.js"></script>
 		<script src="../../build/wp-includes/js/dist/date.js"></script>
 		<script src="../../build/wp-includes/js/dist/i18n.js"></script>
@@ -147,6 +150,7 @@
 
 		<!-- Unit tests -->
 		<script src="wp-admin/js/password-strength-meter.js"></script>
+		<script src="wp-admin/js/inline-edit.js"></script>
 		<script src="wp-admin/js/theme.js"></script>
 		<script src="wp-admin/js/customize-base.js"></script>
 		<script src="wp-admin/js/customize-header.js"></script>

--- a/tests/qunit/wp-admin/js/inline-edit.js
+++ b/tests/qunit/wp-admin/js/inline-edit.js
@@ -1,0 +1,19 @@
+/* global QUnit, inlineEditPost, inlineEditTax */
+
+( function() {
+	'use strict';
+
+	QUnit.module( 'wp.inlineEdit' );
+
+	QUnit.test( 'Duplicate post saves are ignored while a request is active', function( assert ) {
+		inlineEditPost.saving = true;
+		assert.strictEqual( inlineEditPost.save( 1 ), false, 'A duplicate post save is ignored.' );
+		inlineEditPost.saving = false;
+	} );
+
+	QUnit.test( 'Duplicate taxonomy saves are ignored while a request is active', function( assert ) {
+		inlineEditTax.saving = true;
+		assert.strictEqual( inlineEditTax.save( 1 ), false, 'A duplicate taxonomy save is ignored.' );
+		inlineEditTax.saving = false;
+	} );
+} )();


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

## What changed

- Ignore repeated post and taxonomy Quick Edit saves while the current AJAX request is active.
- Clear the guard when the request completes, including failed requests.
- Add QUnit coverage for both editors.

## Why

Double-clicking Quick Edit can submit duplicate requests. The first response removes the inline-edit row, while the second response then operates on missing markup.

## Validation

- QUnit tests pass.
- JavaScript coding standards pass.
- JavaScript type checking passes.
- Built-files check passes.
- PHP coding standards checks pass in CI.

Trac ticket: https://core.trac.wordpress.org/ticket/25696

## Use of AI Tools

AI assistance: Yes
Tool(s): OpenAI Codex
Model(s): GPT-5
Used for: Reviewing the Trac ticket and relevant code, helping with the initial implementation and regression-test approach, and assisting with validation and PR-description drafting. The final implementation, tests, validation results, and description were reviewed and accepted by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**