### PR TITLE
Pings/Trackbacks: Auto-approve pingbacks from the same site

### DIFF
--- a/src/wp-includes/comment.php
+++ b/src/wp-includes/comment.php
@@ -20,9 +20,13 @@
  * If the comment author was approved before, then the comment is automatically
  * approved.
  *
+ * Pingbacks originating from this site are automatically approved, as the link
+ * they report was created by someone who can already publish here.
+ *
  * If all checks pass, the function will return true.
  *
  * @since 1.2.0
+ * @since 7.2.0 Pingbacks from this site are no longer held for moderation.
  *
  * @global wpdb $wpdb WordPress database abstraction object.
  *
@@ -161,6 +165,36 @@ function check_comment( $author, $email, $url, $comment, $user_ip, $user_agent, 
 			} else {
 				return false;
 			}
+		} elseif ( 'pingback' === $comment_type ) {
+			/*
+			 * Only pingbacks are considered. A pingback is verified before it reaches
+			 * this point: the source page is fetched, it must link to the target, and
+			 * the comment is built from that fetched page. A trackback carries no such
+			 * proof. Its source URL, title, and excerpt are unverified request data, so
+			 * a forged trackback naming a local post as its source would be approved.
+			 */
+
+			// url_to_postid() compares hostnames, so it returns 0 for any URL that only appears to be local.
+			$source_id = url_to_postid( wp_unslash( $url ) );
+
+			// Approve pingbacks reporting a link that someone who can already publish here created.
+			$approve_pingback = $source_id > 0 && 'publish' === get_post_status( $source_id );
+
+			/**
+			 * Filters whether a pingback is approved without being held for moderation.
+			 *
+			 * Defaults to true for pingbacks originating from a published post on this
+			 * site, and false for every other pingback. Trackbacks are never considered,
+			 * as they cannot be verified.
+			 *
+			 * @since 7.2.0
+			 *
+			 * @param bool   $approve_pingback Whether to approve the pingback.
+			 * @param int    $source_id        ID of the post on this site the pingback
+			 *                                 originated from, or 0 if it came from elsewhere.
+			 * @param string $url              The URL the pingback was sent from.
+			 */
+			return (bool) apply_filters( 'auto_approve_pingback', $approve_pingback, $source_id, $url );
 		} else {
 			return false;
 		}

--- a/tests/phpunit/tests/comment/checkComment.php
+++ b/tests/phpunit/tests/comment/checkComment.php
@@ -205,4 +205,164 @@ class Tests_Comment_CheckComment extends WP_UnitTestCase {
 		$results = check_comment( 'bar', 'zag@example.com', 'http://example.com', 'This is my first comment.', '66.155.40.249', 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:35.0) Gecko/20100101 Firefox/35.0', 'comment', 4 );
 		$this->assertFalse( $results );
 	}
+
+	/**
+	 * @ticket 65016
+	 */
+	public function test_should_return_true_for_a_pingback_from_this_site() {
+		update_option( 'comment_previously_approved', '1' );
+
+		$source_url = get_permalink( self::factory()->post->create() );
+
+		$this->assertTrue( check_comment( 'Site Title', '', $source_url, 'Excerpt.', '192.168.0.1', '', 'pingback' ) );
+	}
+
+	/**
+	 * Trackbacks are never approved automatically.
+	 *
+	 * A trackback's source URL, title, and excerpt are unverified request data. Were
+	 * they trusted, anyone could POST a trackback naming a local post as its source
+	 * and have arbitrary content approved without moderation.
+	 *
+	 * @ticket 65016
+	 */
+	public function test_should_return_false_for_a_trackback_claiming_a_local_source() {
+		update_option( 'comment_previously_approved', '1' );
+
+		$source_url = get_permalink( self::factory()->post->create() );
+
+		$this->assertFalse( check_comment( 'ForgedSite', '', $source_url, 'Spam.', '192.168.0.1', '', 'trackback' ) );
+	}
+
+	/**
+	 * @ticket 65016
+	 *
+	 * @dataProvider data_ping_types
+	 *
+	 * @param string $comment_type The comment type.
+	 */
+	public function test_should_return_false_for_a_ping_from_another_site( $comment_type ) {
+		update_option( 'comment_previously_approved', '1' );
+
+		$this->assertFalse( check_comment( 'Site Title', '', 'http://example.com/a-post/', 'Excerpt.', '192.168.0.1', '', $comment_type ) );
+	}
+
+	/**
+	 * A URL is only local when its host matches, not when it merely contains the home URL.
+	 *
+	 * @ticket 65016
+	 *
+	 * @dataProvider data_ping_types
+	 *
+	 * @param string $comment_type The comment type.
+	 */
+	public function test_should_return_false_for_a_ping_from_a_url_spoofing_this_site( $comment_type ) {
+		update_option( 'comment_previously_approved', '1' );
+
+		$post_id    = self::factory()->post->create();
+		$source_url = 'http://example.com/?ref=' . rawurlencode( get_permalink( $post_id ) );
+
+		$this->assertFalse( check_comment( 'Site Title', '', $source_url, 'Excerpt.', '192.168.0.1', '', $comment_type ) );
+	}
+
+	/**
+	 * Manually approving every comment must not be bypassed by a self-pingback.
+	 *
+	 * @ticket 65016
+	 */
+	public function test_should_return_false_for_a_pingback_from_this_site_when_comment_moderation_is_enabled() {
+		update_option( 'comment_moderation', '1' );
+
+		$source_url = get_permalink( self::factory()->post->create() );
+
+		$this->assertFalse( check_comment( 'Site Title', '', $source_url, 'Excerpt.', '192.168.0.1', '', 'pingback' ) );
+	}
+
+	/**
+	 * The source post must be published, not a draft that happens to resolve.
+	 *
+	 * @ticket 65016
+	 */
+	public function test_should_return_false_for_a_pingback_from_an_unpublished_post_on_this_site() {
+		update_option( 'comment_previously_approved', '1' );
+
+		$post_id    = self::factory()->post->create( array( 'post_status' => 'draft' ) );
+		$source_url = add_query_arg( 'p', $post_id, home_url( '/' ) );
+
+		$this->assertFalse( check_comment( 'Site Title', '', $source_url, 'Excerpt.', '192.168.0.1', '', 'pingback' ) );
+	}
+
+	/**
+	 * Only pings are exempt. A regular comment linking to a local post is still moderated.
+	 *
+	 * @ticket 65016
+	 */
+	public function test_should_return_false_for_a_comment_whose_author_url_is_a_post_on_this_site() {
+		update_option( 'comment_previously_approved', '1' );
+
+		$source_url = get_permalink( self::factory()->post->create() );
+
+		$this->assertFalse( check_comment( 'Bob', 'bob@example.com', $source_url, 'A comment.', '192.168.0.1', '', 'comment' ) );
+	}
+
+	/**
+	 * @ticket 65016
+	 */
+	public function test_auto_approve_pingback_should_be_able_to_hold_a_pingback_from_this_site() {
+		update_option( 'comment_previously_approved', '1' );
+
+		$source_url = get_permalink( self::factory()->post->create() );
+
+		add_filter( 'auto_approve_pingback', '__return_false' );
+
+		$this->assertFalse( check_comment( 'Site Title', '', $source_url, 'Excerpt.', '192.168.0.1', '', 'pingback' ) );
+	}
+
+	/**
+	 * @ticket 65016
+	 */
+	public function test_auto_approve_pingback_should_be_able_to_approve_a_pingback_from_another_site() {
+		update_option( 'comment_previously_approved', '1' );
+
+		add_filter( 'auto_approve_pingback', '__return_true' );
+
+		$this->assertTrue( check_comment( 'Site Title', '', 'http://example.com/a-post/', 'Excerpt.', '192.168.0.1', '', 'pingback' ) );
+	}
+
+	/**
+	 * @ticket 65016
+	 */
+	public function test_auto_approve_pingback_should_receive_the_source_post_id() {
+		update_option( 'comment_previously_approved', '1' );
+
+		$post_id    = self::factory()->post->create();
+		$source_url = get_permalink( $post_id );
+
+		$observed = null;
+		add_filter(
+			'auto_approve_pingback',
+			static function ( $approve, $source_id ) use ( &$observed ) {
+				$observed = $source_id;
+				return $approve;
+			},
+			10,
+			2
+		);
+
+		check_comment( 'Site Title', '', $source_url, 'Excerpt.', '192.168.0.1', '', 'pingback' );
+
+		$this->assertSame( $post_id, $observed );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_ping_types() {
+		return array(
+			'pingback'  => array( 'pingback' ),
+			'trackback' => array( 'trackback' ),
+		);
+	}
 }

--- a/tests/phpunit/tests/comment/wpAllowComment.php
+++ b/tests/phpunit/tests/comment/wpAllowComment.php
@@ -71,4 +71,47 @@ class Tests_Comment_WpAllowComment extends WP_UnitTestCase {
 
 		$result = wp_allow_comment( $comment_data );
 	}
+
+	/**
+	 * @ticket 65016
+	 *
+	 * @dataProvider data_should_approve_a_pingback_only_when_it_comes_from_this_site
+	 *
+	 * @param bool $is_self_ping Whether the pingback should come from this site.
+	 * @param int  $expected     The expected approval status.
+	 */
+	public function test_should_approve_a_pingback_only_when_it_comes_from_this_site( $is_self_ping, $expected ) {
+		update_option( 'comment_previously_approved', '1' );
+
+		$source_url = $is_self_ping
+			? get_permalink( self::factory()->post->create() )
+			: 'http://example.com/their-post/';
+
+		$comment_data = array(
+			'comment_post_ID'      => self::$post_id,
+			'comment_author'       => 'The Linking Post',
+			'comment_author_email' => '',
+			'comment_author_url'   => $source_url,
+			'comment_content'      => '[&#8230;] an earlier post of mine [&#8230;]',
+			'comment_author_IP'    => '192.168.0.1',
+			'comment_parent'       => 0,
+			'comment_date_gmt'     => gmdate( 'Y-m-d H:i:s' ),
+			'comment_agent'        => 'WordPress/6.8',
+			'comment_type'         => 'pingback',
+		);
+
+		$this->assertSame( $expected, wp_allow_comment( $comment_data ) );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_should_approve_a_pingback_only_when_it_comes_from_this_site() {
+		return array(
+			'a pingback from this site'    => array( true, 1 ),
+			'a pingback from another site' => array( false, 0 ),
+		);
+	}
 }


### PR DESCRIPTION
Pingbacks carry no email address, so they can never satisfy the `comment_previously_approved` option in `check_comment()` — they always fall through to `return false`. That option is on by default, so every pingback is held for moderation indefinitely, including the ones a site sends to itself when a new post links to an older one. The only existing workaround is to disable the option, which also auto-approves pingbacks from every other site.

Trac ticket: https://core.trac.wordpress.org/ticket/65016

## Changes

`check_comment()` now approves a pingback whose source URL resolves to a published post on this site. No new function and no new setting.

The decision is exposed as `auto_approve_pingback`, defaulting to true for pingbacks from this site and false for all others:

```php
apply_filters( 'auto_approve_pingback', $approve_pingback, $source_id, $url );
```

Two things worth checking in review:

- Host matching is delegated to `url_to_postid()`, which compares parsed hostnames, so a URL that merely *contains* the home URL is not treated as local.
- The check sits after the existing gates, so manual moderation, moderation keywords, and the max link count still take precedence.

### Why pingbacks only

An earlier revision of this PR also covered trackbacks. That was wrong, and it is worth stating why so the exclusion is not "fixed" later.

A pingback is verified before it is stored: `pingback_ping()` fetches the source page, requires it to contain a link to the target, rejects source == target, and builds the comment from the fetched page. A trackback has none of that. `wp-trackback.php` takes the source URL, title, excerpt, and blog name straight from `$_POST` and never contacts the source.

So trusting a trackback's claimed source means anyone can POST arbitrary content naming a local post and have it approved:

```sh
curl -s "https://example.com/2026/08/a-post/trackback/" \
  --data-urlencode "url=https://example.com/2026/08/a-post/#x1" \
  --data-urlencode "title=Cheap X" \
  --data-urlencode "excerpt=BUY https://spam.tld" \
  --data-urlencode "blog_name=ForgedSite"
```

The trackback dedup is an exact string match on `comment_author_url`, while `url_to_postid()` strips the fragment, so `#x1`, `#x2`, … all resolve to the same post and all pass. `wp_check_comment_flood()` throttles this to one per 15 seconds per IP, which is a rate limit rather than an authorization control. Verified locally: unauthenticated, approved on arrival, and held again once trackbacks were excluded. There is a regression test covering it.

## Testing

Verified end to end on a real site: publishing a post that links to an older one produces a pingback that lands approved, with an empty moderation queue. Adding `add_filter( 'auto_approve_pingback', '__return_false' )` puts the same pingback back at `comment_approved = '0'`, and the forged trackback above is held.

Three things unrelated to this patch get in the way of reproducing that in the standard Docker environment, in case anyone else hits them:

- Pings are disabled outside production as of 7.1, so `wp_should_disable_pings_for_environment` needs filtering to false.
- `wp_extract_urls()` requires a literal `.` in the URL, so nothing is extracted with the default `localhost:8889` site URL. Using `127.0.0.1:8889` works.
- The site pings itself over HTTP, and `localhost:8889` from inside the php container is that container. Requests need routing to the nginx service, keeping the original `Host` header so WordPress does not issue a canonical redirect.

Pingbacks are dispatched from a `do_pings` cron event, so a manual `wp cron event run do_pings` avoids waiting for a subsequent request.

```sh
npm run test:php -- --group comment    # 610 tests, 1498 assertions
npm run test:php -- --group xmlrpc     # 318 tests, 1246 assertions
```

## Open question

The ticket asks whether this should be a setting or automatic; this is the automatic version. Related: [#24241](https://core.trac.wordpress.org/ticket/24241), where the opposite preference is argued, and which also asks for trackbacks — see above for why they are excluded.

On multi-author sites, any published post can trigger an auto-approved self-pingback. Restricting this to source posts whose author is the target's author or can `moderate_comments` would close that, reusing the trust rule already in `wp_check_comment_data()`. Left out for now — happy to add it if preferred over leaving it to the filter.

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Research, implementation, and tests; reviewed and edited by me.
