### PR TITLE
#65822 Update PHPCS to 3.13.6 (7.0 branch)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
 	},
 	"require-dev": {
 		"composer/ca-bundle": "1.5.11",
-		"squizlabs/php_codesniffer": "3.13.5",
+		"squizlabs/php_codesniffer": "3.13.6",
 		"wp-coding-standards/wpcs": "~3.3.0",
 		"phpcompatibility/phpcompatibility-wp": "~2.1.3",
 		"phpstan/phpstan": "2.1.39",


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65822

Note: This is a backport of #12871 to the 7.0 branch.