### PR TITLE
#65822 Update PHPCS to 3.13.6 (6.7 branch)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 		"ext-dom": "*"
 	},
 	"require-dev": {
-		"squizlabs/php_codesniffer": "3.10.3",
+		"squizlabs/php_codesniffer": "3.13.6",
 		"wp-coding-standards/wpcs": "~3.1.0",
 		"phpcompatibility/phpcompatibility-wp": "~2.1.3",
 		"yoast/phpunit-polyfills": "^1.1.0"


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65822

Note: This is a backport of #12871 to the 6.7 branch.