### PR TITLE
#65822 Update PHPCS to 3.13.6 (6.5 branch)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 		"ext-dom": "*"
 	},
 	"require-dev": {
-		"squizlabs/php_codesniffer": "3.8.1",
+		"squizlabs/php_codesniffer": "3.13.6",
 		"wp-coding-standards/wpcs": "~3.0.1",
 		"phpcompatibility/phpcompatibility-wp": "~2.1.3",
 		"yoast/phpunit-polyfills": "^1.1.0"

--- a/src/wp-includes/class-wp-object-cache.php
+++ b/src/wp-includes/class-wp-object-cache.php
@@ -101,10 +101,9 @@ class WP_Object_Cache {
 	 *
 	 * @param string $name  Property to set.
 	 * @param mixed  $value Property value.
-	 * @return mixed Newly-set property.
 	 */
 	public function __set( $name, $value ) {
-		return $this->$name = $value;
+		$this->$name = $value;
 	}
 
 	/**


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65822

Note: This is a backport of #12871 to the 6.5 branch.