### PR TITLE
#65822 Update PHPCS to 3.13.6 (5.5 branch)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
 	},
 	"require-dev": {
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7.0",
+		"squizlabs/php_codesniffer": "3.13.6",
 		"wp-coding-standards/wpcs": "~2.3.0",
 		"phpcompatibility/phpcompatibility-wp": "^2.1.0",
 		"phpunit/phpunit": "^5.7.21 || ^6.5 || ^7.5",

--- a/src/wp-admin/includes/class-wp-list-table.php
+++ b/src/wp-admin/includes/class-wp-list-table.php
@@ -197,7 +197,7 @@ class WP_List_Table {
 	 */
 	public function __set( $name, $value ) {
 		if ( in_array( $name, $this->compat_fields, true ) ) {
-			return $this->$name = $value;
+			return $this->$name = $value; // phpcs:ignore Squiz.PHP.DisallowMultipleAssignments.Found
 		}
 	}
 

--- a/src/wp-includes/class-wp-object-cache.php
+++ b/src/wp-includes/class-wp-object-cache.php
@@ -100,10 +100,9 @@ class WP_Object_Cache {
 	 *
 	 * @param string $name  Property to set.
 	 * @param mixed  $value Property value.
-	 * @return mixed Newly-set property.
 	 */
 	public function __set( $name, $value ) {
-		return $this->$name = $value;
+		$this->$name = $value;
 	}
 
 	/**

--- a/src/wp-includes/class-wp-text-diff-renderer-table.php
+++ b/src/wp-includes/class-wp-text-diff-renderer-table.php
@@ -518,7 +518,7 @@ class WP_Text_Diff_Renderer_Table extends Text_Diff_Renderer {
 	 */
 	public function __set( $name, $value ) {
 		if ( in_array( $name, $this->compat_fields, true ) ) {
-			return $this->$name = $value;
+			return $this->$name = $value; // phpcs:ignore Squiz.PHP.DisallowMultipleAssignments.Found
 		}
 	}
 

--- a/src/wp-includes/class-wp-user-query.php
+++ b/src/wp-includes/class-wp-user-query.php
@@ -844,7 +844,7 @@ class WP_User_Query {
 	 */
 	public function __set( $name, $value ) {
 		if ( in_array( $name, $this->compat_fields, true ) ) {
-			return $this->$name = $value;
+			return $this->$name = $value; // phpcs:ignore Squiz.PHP.DisallowMultipleAssignments.Found
 		}
 	}
 

--- a/tests/phpunit/includes/class-basic-object.php
+++ b/tests/phpunit/includes/class-basic-object.php
@@ -20,7 +20,7 @@ class Basic_Object {
 	}
 
 	public function __set( $name, $value ) {
-		return $this->$name = $value;
+		return $this->$name = $value; // phpcs:ignore Squiz.PHP.DisallowMultipleAssignments.Found
 	}
 
 	public function __isset( $name ) {


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65822

Note: This is a backport of #12871 to the 5.5 branch. As with the 5.8 branch, this adds a direct `squizlabs/php_codesniffer` dependency (previously transitive via WPCS) and updates `composer.lock`.