### PR TITLE
#65822 Ignore the PHP_CodeSniffer security advisory (CVE-2026-67434)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,6 +56,7 @@
 		"yoast/phpunit-polyfills": "^1.1.0"
 	},
 	"config": {
+		"audit": { "ignore": [ "GHSA-hmqg-cxww-wqhq", "PKSA-rdkp-vv9z-mjkg" ] },
 		"allow-plugins": {
 			"dealerdirect/phpcodesniffer-composer-installer": true
 		},


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65822

Adds an ignore for https://github.com/PHPCSStandards/PHP_CodeSniffer/security/advisories/GHSA-hmqg-cxww-wqhq (CVE-2026-67434), under both its GitHub and Packagist advisory IDs.

The advisory has now propagated to Packagist and Composer 2.9+ blocks dependency resolution of affected versions, so `composer install` fails on branches that pin PHPCS 3.13.5 or older. This unblocks installs on trunk until the update to 3.13.6 (#12871) lands. WordPress's tooling does not use the vulnerable `Gitblame`/`Hgblame`/`Svnblame` report formats, so the pinned version poses no practical risk here.