### PR TITLE
#65822 Ignore the PHP_CodeSniffer security advisory (CVE-2026-67434) (5.6 branch)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
 		]
 	},
 	"config": {
+		"audit": { "ignore": [ "GHSA-hmqg-cxww-wqhq", "PKSA-rdkp-vv9z-mjkg" ] },
 		"allow-plugins": {
 			"dealerdirect/phpcodesniffer-composer-installer": true
 		}

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d8bcbf1466f6595287a44721f525844d",
+    "content-hash": "f9614943a9127e725997fd4141d940fe",
     "packages": [],
     "packages-dev": [
         {
@@ -1565,12 +1565,12 @@
             "version": "3.5.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
                 "reference": "73e2e7f57d958e7228fce50dc0c61f58f017f9f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/73e2e7f57d958e7228fce50dc0c61f58f017f9f6",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/73e2e7f57d958e7228fce50dc0c61f58f017f9f6",
                 "reference": "73e2e7f57d958e7228fce50dc0c61f58f017f9f6",
                 "shasum": ""
             },
@@ -1738,12 +1738,12 @@
             "version": "1.9.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/webmozart/assert.git",
+                "url": "https://github.com/webmozarts/assert.git",
                 "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/bafc69caeb4d49c39fd0779086c03a3738cbb389",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/bafc69caeb4d49c39fd0779086c03a3738cbb389",
                 "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389",
                 "shasum": ""
             },
@@ -1894,12 +1894,12 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": ">=5.6"
     },
-    "platform-dev": [],
-    "plugin-api-version": "2.1.0"
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65822

Adds an ignore for https://github.com/PHPCSStandards/PHP_CodeSniffer/security/advisories/GHSA-hmqg-cxww-wqhq (CVE-2026-67434), under both its GitHub and Packagist advisory IDs, and refreshes the `composer.lock` content hash.

The advisory has now propagated to Packagist and Composer 2.9+ blocks dependency resolution of affected versions. This branch installs from a committed lock file so `composer install` is unaffected, but any future `composer update` would be blocked while an affected version is locked. This unblocks such operations until the update to 3.13.6 (#12886) lands.

Note: This is a backport of #12888 to the 5.6 branch.