### PR TITLE
#65822 Ignore the PHP_CodeSniffer security advisory (CVE-2026-67434) (5.5 branch)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
 		"yoast/phpunit-polyfills": "^1.0.1"
 	},
 	"config": {
+		"audit": { "ignore": [ "GHSA-hmqg-cxww-wqhq", "PKSA-rdkp-vv9z-mjkg" ] },
 		"allow-plugins": {
 			"dealerdirect/phpcodesniffer-composer-installer": true
 		}

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9e9eda16834511e20c7fef4c012b6744",
+    "content-hash": "2200b3da9f0e1efee350f52b41cd0f3c",
     "packages": [],
     "packages-dev": [
         {
@@ -1576,12 +1576,12 @@
             "version": "3.5.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
                 "reference": "73e2e7f57d958e7228fce50dc0c61f58f017f9f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/73e2e7f57d958e7228fce50dc0c61f58f017f9f6",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/73e2e7f57d958e7228fce50dc0c61f58f017f9f6",
                 "reference": "73e2e7f57d958e7228fce50dc0c61f58f017f9f6",
                 "shasum": ""
             },
@@ -1899,12 +1899,12 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": ">=5.6"
     },
-    "platform-dev": [],
-    "plugin-api-version": "1.1.0"
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65822

Adds an ignore for https://github.com/PHPCSStandards/PHP_CodeSniffer/security/advisories/GHSA-hmqg-cxww-wqhq (CVE-2026-67434), under both its GitHub and Packagist advisory IDs, and refreshes the `composer.lock` content hash.

The advisory has now propagated to Packagist and Composer 2.9+ blocks dependency resolution of affected versions. This branch installs from a committed lock file so `composer install` is unaffected, but any future `composer update` would be blocked while an affected version is locked.

Note: This is a backport of #12888 to the 5.5 branch. It supersedes #12887.