### PR TITLE
Formatting: introduce esc_attr_name() for HTML attribute name sanitization

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -4793,20 +4793,20 @@ function esc_attr( $text ) {
 /**
  * Escaping for HTML attribute names.
  *
- * @since 7.1.0
+ * @since 7.2.0
  *
  * @param string $text The attribute name to escape.
  * @return string The escaped attribute name.
  */
 function esc_attr_name( $text ) {
-	$safe_text = wp_check_invalid_utf8( $text );
+	$safe_text = wp_check_invalid_utf8( $text, true );
 
 	$safe_text = preg_replace( '/[^a-zA-Z0-9_.:\[\]-]+/u', '', $safe_text );
 
 	/**
 	 * Filters a string cleaned and escaped for output as an HTML attribute name.
 	 *
-	 * @since 7.1.0
+	 * @since 7.2.0
 	 *
 	 * @param string $safe_text The attribute name after it has been escaped.
 	 * @param string $text      The attribute name prior to being escaped.

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -4791,6 +4791,30 @@ function esc_attr( $text ) {
 }
 
 /**
+ * Escaping for HTML attribute names.
+ *
+ * @since 7.1.0
+ *
+ * @param string $text The attribute name to escape.
+ * @return string The escaped attribute name.
+ */
+function esc_attr_name( $text ) {
+	$safe_text = wp_check_invalid_utf8( $text );
+
+	$safe_text = preg_replace( '/[^a-zA-Z0-9_.:\[\]-]+/u', '', $safe_text );
+
+	/**
+	 * Filters a string cleaned and escaped for output as an HTML attribute name.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param string $safe_text The attribute name after it has been escaped.
+	 * @param string $text      The attribute name prior to being escaped.
+	 */
+	return apply_filters( 'esc_attr_name', $safe_text, $text );
+}
+
+/**
  * Escaping for textarea values.
  *
  * @since 3.1.0

--- a/tests/phpunit/tests/formatting/escAttrName.php
+++ b/tests/phpunit/tests/formatting/escAttrName.php
@@ -67,7 +67,7 @@ class Tests_Formatting_EscAttrName extends WP_UnitTestCase {
 			array( "\t data-foo \n", 'data-foo' ),
 			array( '', '' ),
 			array( ' "\'><=/', '' ),
-			array( 'data-' . "\xc0\x80" . 'foo', '' ),
+			array( 'data-' . "\xc0\x80" . 'foo', 'data-foo' ),
 			array( 'data-ñame', 'data-ame' ),
 			array( 'data-😀', 'data-' ),
 			array( 'attrф', 'attr' ),

--- a/tests/phpunit/tests/formatting/escAttrName.php
+++ b/tests/phpunit/tests/formatting/escAttrName.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * @group formatting
+ *
+ * @covers ::esc_attr_name
+ */
+class Tests_Formatting_EscAttrName extends WP_UnitTestCase {
+
+	/**
+	 * @dataProvider data_valid_attribute_names
+	 *
+	 * @param string $attr Valid HTML attribute name.
+	 */
+	public function test_valid_attribute_names_are_unchanged( $attr ) {
+		$this->assertSame( $attr, esc_attr_name( $attr ) );
+	}
+
+	/**
+	 * @return array[]
+	 */
+	public function data_valid_attribute_names() {
+		return array(
+			array( 'class' ),
+			array( 'data-my-value' ),
+			array( 'aria-label' ),
+			array( 'my_attr' ),
+			array( 'attr123' ),
+			array( 'name[key]' ),
+			array( 'xml:lang' ),
+			array( 'x-my.attr' ),
+			array( 'MyAttr' ),
+			array( 'data-foo_bar.baz[0]' ),
+		);
+	}
+
+	/**
+	 * @dataProvider data_forbidden_chars
+	 *
+	 * @param string $input    Attribute name containing forbidden characters.
+	 * @param string $expected Expected output after escaping.
+	 */
+	public function test_forbidden_chars_are_removed( $input, $expected ) {
+		$this->assertSame( $expected, esc_attr_name( $input ) );
+	}
+
+	/**
+	 * @return array[]
+	 */
+	public function data_forbidden_chars() {
+		return array(
+			array( 'foo bar', 'foobar' ),
+			array( '"data-foo"', 'data-foo' ),
+			array( "'data-foo'", 'data-foo' ),
+			array( 'foo>bar', 'foobar' ),
+			array( 'foo<bar', 'foobar' ),
+			array( 'foo/bar', 'foobar' ),
+			array( 'foo=bar', 'foobar' ),
+			array( 'foo ="bar\'', 'foobar' ),
+			array( '"attr', 'attr' ),
+			array( 'attr/', 'attr' ),
+			array( "\tdata-foo", 'data-foo' ),
+			array( "data\nfoo", 'datafoo' ),
+			array( "\fdata-foo", 'data-foo' ),
+			array( "data\rfoo", 'datafoo' ),
+			array( "data\x00foo", 'datafoo' ),
+			array( "\t data-foo \n", 'data-foo' ),
+			array( '', '' ),
+			array( ' "\'><=/', '' ),
+			array( 'data-' . "\xc0\x80" . 'foo', '' ),
+			array( 'data-ñame', 'data-ame' ),
+			array( 'data-😀', 'data-' ),
+			array( 'attrф', 'attr' ),
+		);
+	}
+
+	public function test_filter_is_applied() {
+		add_filter( 'esc_attr_name', array( $this, 'filter_attr_name' ), 10, 2 );
+
+		$result = esc_attr_name( 'data-foo' );
+
+		remove_filter( 'esc_attr_name', array( $this, 'filter_attr_name' ) );
+
+		$this->assertSame( 'filtered-data-foo', $result );
+	}
+
+	public function filter_attr_name( $safe_text, $text ) {
+		return 'filtered-' . $safe_text;
+	}
+}


### PR DESCRIPTION
The HTML5 spec allows arbitrarily named attributes (e.g., data-*), but WordPress lacked a dedicated function to escape dynamically generated attribute names. Developers sometimes incorrectly used esc_attr() for this, which only escapes attribute values.

This PR introduces esc_attr_name() in formatting.php to resolve this. It uses a strict allowlist regex ([^a-zA-Z0-9_.:\[\]-]+/u) to strip any characters not explicitly permitted in an HTML attribute name per the HTML5 specification (such as spaces, quotes, control characters, <>, =, etc.).

Trac ticket: [#43010](https://core.trac.wordpress.org/ticket/43010)


## Use of AI Tools

AI assistance: Yes
Tool(s): GitHub Copilot
Model(s): Gemini, Claude
Used for: Checking for potential edge cases, drafting the PR description, and assisting with local code review. The final implementation and testing were written and executed manually by me.

---

**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
