### PR TITLE
Restore the home path fallback when realpath() fails

### DIFF
--- a/src/wp-admin/includes/network.php
+++ b/src/wp-admin/includes/network.php
@@ -415,9 +415,12 @@ function network_step2( $errors = false ) {
 	$hostname          = get_clean_basedomain();
 	$slashed_home      = trailingslashit( get_option( 'home' ) );
 	$base              = parse_url( $slashed_home, PHP_URL_PATH );
-	$document_root_fix = str_replace( '\\', '/', realpath( $_SERVER['DOCUMENT_ROOT'] ) );
+	$document_root     = isset( $_SERVER['DOCUMENT_ROOT'] ) ? realpath( $_SERVER['DOCUMENT_ROOT'] ) : false;
+	$document_root_fix = $document_root ? str_replace( '\\', '/', $document_root ) : '';
 	$abspath_fix       = str_replace( '\\', '/', ABSPATH );
-	$home_path         = str_starts_with( $abspath_fix, $document_root_fix ) ? $document_root_fix . $base : get_home_path();
+	$home_path         = ( '' !== $document_root_fix && str_starts_with( $abspath_fix, $document_root_fix ) )
+		? $document_root_fix . $base
+		: get_home_path();
 	$wp_siteurl_subdir = preg_replace( '#^' . preg_quote( $home_path, '#' ) . '#', '', $abspath_fix );
 	$rewrite_base      = ! empty( $wp_siteurl_subdir ) ? ltrim( trailingslashit( $wp_siteurl_subdir ), '/' ) : '';
 


### PR DESCRIPTION
https://core.trac.wordpress.org/ticket/38312

When `realpath( $_SERVER['DOCUMENT_ROOT'] )` returns false, `$document_root_fix` was an empty string, and `str_starts_with()` with an empty needle always returns `true`. This made the `get_home_path()` fallback unreachable in precisely the scenario it was intended for, leaving `$home_path` set to just the base path.

Also guards against `$_SERVER['DOCUMENT_ROOT']` being unset, which triggered an undefined array key notice and a `realpath( null )` deprecation on PHP 8.1+.