### PR TITLE
General: Replace core's remaining `utf8_encode()` calls.

### DIFF
--- a/src/wp-admin/includes/export.php
+++ b/src/wp-admin/includes/export.php
@@ -243,8 +243,11 @@ function export_wp( $args = array() ) {
 	 * @return string
 	 */
 	function wxr_cdata( $str ) {
-		$str = wp_scrub_utf8( (string) $str );
+		$str = (string) $str;
 
+		if ( ! wp_is_valid_utf8( $str ) ) {
+			$str = _wp_iso_8859_1_to_utf8( $str );
+		}
 		// $str = ent2ncr(esc_html($str));
 		$str = '<![CDATA[' . str_replace( ']]>', ']]]]><![CDATA[>', $str ) . ']]>';
 

--- a/src/wp-admin/includes/export.php
+++ b/src/wp-admin/includes/export.php
@@ -246,7 +246,7 @@ function export_wp( $args = array() ) {
 		$str = (string) $str;
 
 		if ( ! wp_is_valid_utf8( $str ) ) {
-			$str = utf8_encode( $str );
+			$str = wp_scrub_utf8( $str );
 		}
 		// $str = ent2ncr(esc_html($str));
 		$str = '<![CDATA[' . str_replace( ']]>', ']]]]><![CDATA[>', $str ) . ']]>';

--- a/src/wp-admin/includes/export.php
+++ b/src/wp-admin/includes/export.php
@@ -243,11 +243,8 @@ function export_wp( $args = array() ) {
 	 * @return string
 	 */
 	function wxr_cdata( $str ) {
-		$str = (string) $str;
+		$str = wp_scrub_utf8( (string) $str );
 
-		if ( ! wp_is_valid_utf8( $str ) ) {
-			$str = wp_scrub_utf8( $str );
-		}
 		// $str = ent2ncr(esc_html($str));
 		$str = '<![CDATA[' . str_replace( ']]>', ']]]]><![CDATA[>', $str ) . ']]>';
 

--- a/src/wp-admin/includes/image.php
+++ b/src/wp-admin/includes/image.php
@@ -1048,12 +1048,16 @@ function wp_read_image_metadata( $file ) {
 	}
 
 	foreach ( array( 'title', 'caption', 'credit', 'copyright', 'camera', 'iso' ) as $key ) {
-		if ( $meta[ $key ] ) {
-			$meta[ $key ] = wp_scrub_utf8( $meta[ $key ] );
+		if ( $meta[ $key ] && ! wp_is_valid_utf8( $meta[ $key ] ) ) {
+			$meta[ $key ] = _wp_iso_8859_1_to_utf8( $meta[ $key ] );
 		}
 	}
 
-	$meta['keywords'] = array_map( 'wp_scrub_utf8', $meta['keywords'] );
+	foreach ( $meta['keywords'] as $key => $keyword ) {
+		if ( ! wp_is_valid_utf8( $keyword ) ) {
+			$meta['keywords'][ $key ] = _wp_iso_8859_1_to_utf8( $keyword );
+		}
+	}
 
 	$meta = wp_kses_post_deep( $meta );
 

--- a/src/wp-admin/includes/image.php
+++ b/src/wp-admin/includes/image.php
@@ -1048,16 +1048,12 @@ function wp_read_image_metadata( $file ) {
 	}
 
 	foreach ( array( 'title', 'caption', 'credit', 'copyright', 'camera', 'iso' ) as $key ) {
-		if ( $meta[ $key ] && ! wp_is_valid_utf8( $meta[ $key ] ) ) {
+		if ( $meta[ $key ] ) {
 			$meta[ $key ] = wp_scrub_utf8( $meta[ $key ] );
 		}
 	}
 
-	foreach ( $meta['keywords'] as $key => $keyword ) {
-		if ( ! wp_is_valid_utf8( $keyword ) ) {
-			$meta['keywords'][ $key ] = wp_scrub_utf8( $keyword );
-		}
-	}
+	$meta['keywords'] = array_map( 'wp_scrub_utf8', $meta['keywords'] );
 
 	$meta = wp_kses_post_deep( $meta );
 

--- a/src/wp-admin/includes/image.php
+++ b/src/wp-admin/includes/image.php
@@ -1049,13 +1049,13 @@ function wp_read_image_metadata( $file ) {
 
 	foreach ( array( 'title', 'caption', 'credit', 'copyright', 'camera', 'iso' ) as $key ) {
 		if ( $meta[ $key ] && ! wp_is_valid_utf8( $meta[ $key ] ) ) {
-			$meta[ $key ] = utf8_encode( $meta[ $key ] );
+			$meta[ $key ] = wp_scrub_utf8( $meta[ $key ] );
 		}
 	}
 
 	foreach ( $meta['keywords'] as $key => $keyword ) {
 		if ( ! wp_is_valid_utf8( $keyword ) ) {
-			$meta['keywords'][ $key ] = utf8_encode( $keyword );
+			$meta['keywords'][ $key ] = wp_scrub_utf8( $keyword );
 		}
 	}
 

--- a/src/wp-includes/utf8.php
+++ b/src/wp-includes/utf8.php
@@ -134,6 +134,48 @@ else :
 	}
 endif;
 
+if ( extension_loaded( 'mbstring' ) ) :
+	/**
+	 * Converts a string from ISO-8859-1 (latin1) to UTF-8.
+	 *
+	 * This is a last resort for text whose encoding is unknown and which has already
+	 * failed to validate as UTF-8. Interpreting those bytes as ISO-8859-1 is a guess:
+	 * it is correct when the text really is ISO-8859-1, and produces mojibake for any
+	 * other single-byte or multi-byte encoding. Call sites which do know the encoding
+	 * of their text should decode it with {@see \mb_convert_encoding()} instead.
+	 *
+	 * Every byte maps to a code point, so the return value is always valid UTF-8.
+	 *
+	 * This function exists so that the call sites which historically relied on PHP’s
+	 * `utf8_encode()` can keep their behavior after that function’s removal in PHP 9.0.
+	 * It is not a replacement for {@see \wp_scrub_utf8()}, which neutralizes invalid
+	 * bytes instead of reinterpreting them.
+	 *
+	 * @ignore
+	 * @private
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param string $text Text treated as ISO-8859-1 (latin1) bytes.
+	 * @return string Text converted into UTF-8.
+	 */
+	function _wp_iso_8859_1_to_utf8( $text ) {
+		return mb_convert_encoding( (string) $text, 'UTF-8', 'ISO-8859-1' );
+	}
+else :
+	/**
+	 * Fallback function for converting ISO-8859-1 into UTF-8.
+	 *
+	 * @ignore
+	 * @private
+	 *
+	 * @since 7.1.0
+	 */
+	function _wp_iso_8859_1_to_utf8( $text ) {
+		return _wp_utf8_encode_fallback( $text );
+	}
+endif;
+
 /**
  * Returns whether the given string contains Unicode noncharacters.
  *

--- a/tests/phpunit/tests/admin/exportWp.php
+++ b/tests/phpunit/tests/admin/exportWp.php
@@ -476,35 +476,37 @@ class Tests_Admin_ExportWp extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Ensures the WXR export always emits valid UTF-8.
+	 * Ensures the WXR export converts non-UTF-8 text into UTF-8.
 	 *
-	 * Byte spans which cannot decode as UTF-8 are replaced with the Unicode replacement
-	 * character. This covers both malformed UTF-8 and text supplied in some other
-	 * encoding entirely; core has no way to know which, so the bytes are neutralized
-	 * rather than reinterpreted as any particular encoding.
+	 * The export declares itself as UTF-8, so `wxr_cdata()` has to hand back a valid
+	 * UTF-8 string. Text which fails to validate is decoded as ISO-8859-1 (latin1),
+	 * which is a guess: correct when the text really is latin1, mojibake otherwise.
+	 * Core has no encoding declaration to consult here, so the guess stands.
+	 *
+	 * These cases pin that behavior so it cannot change silently.
 	 *
 	 * @ticket 65828
 	 *
-	 * @dataProvider data_invalid_utf8_strings
+	 * @dataProvider data_non_utf8_strings
 	 *
 	 * @param string $input    Bytes which are not valid UTF-8.
 	 * @param string $expected Expected CDATA contents.
 	 */
-	public function test_wxr_cdata_scrubs_invalid_utf8( $input, $expected ) {
+	public function test_wxr_cdata_converts_non_utf8_text( $input, $expected ) {
 		// Running an export defines the nested WXR helper functions.
 		$this->get_the_export( array( 'content' => 'post' ) );
 
 		$actual = wxr_cdata( $input );
 		$inner  = substr( $actual, strlen( '<![CDATA[' ), -strlen( ']]>' ) );
 
-		$this->assertTrue(
-			wp_is_valid_utf8( $inner ),
-			'The exported CDATA section should always contain valid UTF-8.'
-		);
 		$this->assertSame(
 			$expected,
 			$inner,
-			'Byte spans which cannot decode as UTF-8 should be replaced.'
+			'Non-UTF-8 bytes should be decoded as ISO-8859-1.'
+		);
+		$this->assertTrue(
+			wp_is_valid_utf8( $inner ),
+			'The exported CDATA section should always contain valid UTF-8.'
 		);
 	}
 
@@ -513,31 +515,37 @@ class Tests_Admin_ExportWp extends WP_UnitTestCase {
 	 *
 	 * @return array[]
 	 */
-	public function data_invalid_utf8_strings() {
+	public function data_non_utf8_strings() {
 		return array(
-			// Malformed UTF-8.
-			'Never-valid byte'        => array( "a\xC0b", "a\u{FFFD}b" ),
-			'Truncated sequence'      => array( "a\xE2\x9Cb", "a\u{FFFD}b" ),
-			'Overlong sequence'       => array( "a\xC1\xBFb", "a\u{FFFD}\u{FFFD}b" ),
-			'Surrogate half'          => array( "a\xED\xA0\x80b", "a\u{FFFD}\u{FFFD}\u{FFFD}b" ),
-
 			// Text which is well-formed, but in some encoding other than UTF-8.
-			'ISO-8859-1 text'         => array(
+			'ISO-8859-1 text'                 => array(
 				mb_convert_encoding( 'Café', 'ISO-8859-1', 'UTF-8' ),
-				"Caf\u{FFFD}",
+				'Café',
 			),
-			'ISO-8859-2 text'         => array(
+			'ISO-8859-2 text'                 => array(
 				mb_convert_encoding( 'wyróżnij', 'ISO-8859-2', 'UTF-8' ),
-				"wyr\u{FFFD}nij",
+				'wyró¿nij',
 			),
-			'Windows-1251 text'       => array(
+			'Windows-1251 text'               => array(
 				mb_convert_encoding( 'Привет', 'Windows-1251', 'UTF-8' ),
-				str_repeat( "\u{FFFD}", 6 ),
+				'Ïðèâåò',
 			),
-			'Windows-1252 quotations' => array(
+			'Windows-1252 quotations'         => array(
 				mb_convert_encoding( '“quoted”', 'Windows-1252', 'UTF-8' ),
-				"\u{FFFD}quoted\u{FFFD}",
+				"\u{0093}quoted\u{0094}",
 			),
+
+			// Malformed UTF-8.
+			'Never-valid byte'                => array( "a\xC0b", 'aÀb' ),
+			'Truncated sequence'              => array( "a\xE2\x9Cb", "aâ\u{009C}b" ),
+			'Overlong sequence'               => array( "a\xC1\xBFb", 'aÁ¿b' ),
+			'Surrogate half'                  => array( "a\xED\xA0\x80b", "a\u{00ED}\u{00A0}\u{0080}b" ),
+
+			/*
+			 * The guard inspects the whole string, so a single stray byte sends the
+			 * valid portions through the conversion as well and double-encodes them.
+			 */
+			'Valid UTF-8 with one stray byte' => array( "Pi\xC3\xB1a \xC0", 'PiÃ±a À' ),
 		);
 	}
 

--- a/tests/phpunit/tests/admin/exportWp.php
+++ b/tests/phpunit/tests/admin/exportWp.php
@@ -476,6 +476,68 @@ class Tests_Admin_ExportWp extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Ensures the WXR export neutralizes invalid UTF-8 instead of reinterpreting it as ISO-8859-1.
+	 *
+	 * `wxr_cdata()` previously called the deprecated `utf8_encode()`, which assumed any
+	 * string that failed UTF-8 validation was ISO-8859-1 and re-encoded the raw bytes on
+	 * that assumption. That guess is wrong for every other single-byte encoding, so the
+	 * invalid spans are now replaced with the Unicode replacement character instead.
+	 *
+	 * @ticket 65828
+	 *
+	 * @dataProvider data_invalid_utf8_strings
+	 *
+	 * @param string $input    Bytes which are not valid UTF-8.
+	 * @param string $expected Expected CDATA contents.
+	 */
+	public function test_wxr_cdata_scrubs_invalid_utf8( $input, $expected ) {
+		// Running an export defines the nested WXR helper functions.
+		$this->get_the_export( array( 'content' => 'post' ) );
+
+		$actual = wxr_cdata( $input );
+		$inner  = substr( $actual, strlen( '<![CDATA[' ), -strlen( ']]>' ) );
+
+		$this->assertTrue(
+			wp_is_valid_utf8( $inner ),
+			'The exported CDATA section should always contain valid UTF-8.'
+		);
+		$this->assertSame(
+			$expected,
+			$inner,
+			'Invalid bytes should be replaced, not reinterpreted as ISO-8859-1.'
+		);
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_invalid_utf8_strings() {
+		return array(
+			'Lone high byte'     => array( "Caf\xE9", "Caf\u{FFFD}" ),
+			'Never-valid byte'   => array( "a\xC0b", "a\u{FFFD}b" ),
+			'Truncated sequence' => array( "a\xE2\x9Cb", "a\u{FFFD}b" ),
+			'Overlong sequence'  => array( "a\xC1\xBFb", "a\u{FFFD}\u{FFFD}b" ),
+			'Surrogate half'     => array( "a\xED\xA0\x80b", "a\u{FFFD}\u{FFFD}\u{FFFD}b" ),
+		);
+	}
+
+	/**
+	 * Ensures valid UTF-8, including multibyte text, survives the export untouched.
+	 *
+	 * @ticket 65828
+	 */
+	public function test_wxr_cdata_preserves_valid_utf8() {
+		$this->get_the_export( array( 'content' => 'post' ) );
+
+		$valid = 'Это комментарий. / Βλέπετε ένα σχόλιο. / 🅰';
+		$inner = substr( wxr_cdata( $valid ), strlen( '<![CDATA[' ), -strlen( ']]>' ) );
+
+		$this->assertSame( $valid, $inner, 'Valid UTF-8 should pass through unchanged.' );
+	}
+
+	/**
 	 * Ensure that posts types with 'can_export' set to false are not included in the export.
 	 *
 	 * @ticket 64964

--- a/tests/phpunit/tests/admin/exportWp.php
+++ b/tests/phpunit/tests/admin/exportWp.php
@@ -476,12 +476,12 @@ class Tests_Admin_ExportWp extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Ensures the WXR export neutralizes invalid UTF-8 instead of reinterpreting it as ISO-8859-1.
+	 * Ensures the WXR export always emits valid UTF-8.
 	 *
-	 * `wxr_cdata()` previously called the deprecated `utf8_encode()`, which assumed any
-	 * string that failed UTF-8 validation was ISO-8859-1 and re-encoded the raw bytes on
-	 * that assumption. That guess is wrong for every other single-byte encoding, so the
-	 * invalid spans are now replaced with the Unicode replacement character instead.
+	 * Byte spans which cannot decode as UTF-8 are replaced with the Unicode replacement
+	 * character. This covers both malformed UTF-8 and text supplied in some other
+	 * encoding entirely; core has no way to know which, so the bytes are neutralized
+	 * rather than reinterpreted as any particular encoding.
 	 *
 	 * @ticket 65828
 	 *
@@ -504,7 +504,7 @@ class Tests_Admin_ExportWp extends WP_UnitTestCase {
 		$this->assertSame(
 			$expected,
 			$inner,
-			'Invalid bytes should be replaced, not reinterpreted as ISO-8859-1.'
+			'Byte spans which cannot decode as UTF-8 should be replaced.'
 		);
 	}
 
@@ -515,11 +515,29 @@ class Tests_Admin_ExportWp extends WP_UnitTestCase {
 	 */
 	public function data_invalid_utf8_strings() {
 		return array(
-			'Lone high byte'     => array( "Caf\xE9", "Caf\u{FFFD}" ),
-			'Never-valid byte'   => array( "a\xC0b", "a\u{FFFD}b" ),
-			'Truncated sequence' => array( "a\xE2\x9Cb", "a\u{FFFD}b" ),
-			'Overlong sequence'  => array( "a\xC1\xBFb", "a\u{FFFD}\u{FFFD}b" ),
-			'Surrogate half'     => array( "a\xED\xA0\x80b", "a\u{FFFD}\u{FFFD}\u{FFFD}b" ),
+			// Malformed UTF-8.
+			'Never-valid byte'        => array( "a\xC0b", "a\u{FFFD}b" ),
+			'Truncated sequence'      => array( "a\xE2\x9Cb", "a\u{FFFD}b" ),
+			'Overlong sequence'       => array( "a\xC1\xBFb", "a\u{FFFD}\u{FFFD}b" ),
+			'Surrogate half'          => array( "a\xED\xA0\x80b", "a\u{FFFD}\u{FFFD}\u{FFFD}b" ),
+
+			// Text which is well-formed, but in some encoding other than UTF-8.
+			'ISO-8859-1 text'         => array(
+				mb_convert_encoding( 'Café', 'ISO-8859-1', 'UTF-8' ),
+				"Caf\u{FFFD}",
+			),
+			'ISO-8859-2 text'         => array(
+				mb_convert_encoding( 'wyróżnij', 'ISO-8859-2', 'UTF-8' ),
+				"wyr\u{FFFD}nij",
+			),
+			'Windows-1251 text'       => array(
+				mb_convert_encoding( 'Привет', 'Windows-1251', 'UTF-8' ),
+				str_repeat( "\u{FFFD}", 6 ),
+			),
+			'Windows-1252 quotations' => array(
+				mb_convert_encoding( '“quoted”', 'Windows-1252', 'UTF-8' ),
+				"\u{FFFD}quoted\u{FFFD}",
+			),
 		);
 	}
 

--- a/tests/phpunit/tests/image/meta.php
+++ b/tests/phpunit/tests/image/meta.php
@@ -150,12 +150,12 @@ class Tests_Image_Meta extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Ensures invalid UTF-8 in IPTC fields is neutralized rather than assumed to be ISO-8859-1.
+	 * Ensures image metadata is always returned as valid UTF-8.
 	 *
-	 * `wp_read_image_metadata()` previously passed any field that failed UTF-8 validation
-	 * through the deprecated `utf8_encode()`, which reinterpreted the raw bytes as
-	 * ISO-8859-1. IPTC carries no reliable encoding declaration, so the invalid spans are
-	 * now replaced with the Unicode replacement character instead of being guessed at.
+	 * Core does not read the IPTC coded character set, so the encoding of these fields is
+	 * unknown. Byte spans which cannot decode as UTF-8 are replaced with the Unicode
+	 * replacement character rather than reinterpreted as any particular encoding. Both
+	 * malformed UTF-8 and text in another encoding are covered here.
 	 *
 	 * @ticket 65828
 	 */
@@ -166,8 +166,8 @@ class Tests_Image_Meta extends WP_UnitTestCase {
 
 		$block = $this->build_iptc_block(
 			array(
-				105 => "Headline \xE9",
-				120 => "Caf\xE9 by the r\xEDver",
+				105 => mb_convert_encoding( 'wyróżnij', 'ISO-8859-2', 'UTF-8' ),
+				120 => mb_convert_encoding( 'Café', 'ISO-8859-1', 'UTF-8' ),
 				110 => "Credit \xC0",
 				116 => "Copyright \xE9",
 				25  => array( 'valid keyword', "sunset\xC0" ),
@@ -191,9 +191,15 @@ class Tests_Image_Meta extends WP_UnitTestCase {
 		}
 
 		$this->assertSame(
-			"Caf\u{FFFD} by the r\u{FFFD}ver",
+			"Caf\u{FFFD}",
 			$out['caption'],
-			'Invalid bytes should be replaced, not reinterpreted as ISO-8859-1.'
+			'ISO-8859-1 text should be neutralized, not reinterpreted.'
+		);
+
+		$this->assertSame(
+			"wyr\u{FFFD}nij",
+			$out['title'],
+			'ISO-8859-2 text should be neutralized, not reinterpreted.'
 		);
 
 		$this->assertSame(

--- a/tests/phpunit/tests/image/meta.php
+++ b/tests/phpunit/tests/image/meta.php
@@ -152,14 +152,18 @@ class Tests_Image_Meta extends WP_UnitTestCase {
 	/**
 	 * Ensures image metadata is always returned as valid UTF-8.
 	 *
-	 * Core does not read the IPTC coded character set, so the encoding of these fields is
-	 * unknown. Byte spans which cannot decode as UTF-8 are replaced with the Unicode
-	 * replacement character rather than reinterpreted as any particular encoding. Both
-	 * malformed UTF-8 and text in another encoding are covered here.
+	 * Core does not read the IPTC coded character set, so the encoding of these fields
+	 * is unknown. Fields which fail to validate as UTF-8 are decoded as ISO-8859-1
+	 * (latin1): correct when the text really is latin1, mojibake otherwise. Invalid
+	 * UTF-8 reaching the database is stripped by `strip_invalid_text()`, which is why
+	 * the conversion has to happen at all. See #35316.
+	 *
+	 * These cases pin that behavior so it cannot change silently.
 	 *
 	 * @ticket 65828
+	 * @ticket 35316
 	 */
-	public function test_iptc_invalid_utf8_is_scrubbed() {
+	public function test_iptc_non_utf8_text_is_converted() {
 		if ( ! is_callable( 'iptcembed' ) || ! is_callable( 'iptcparse' ) ) {
 			$this->markTestSkipped( 'The iptcembed() and iptcparse() functions are required.' );
 		}
@@ -170,11 +174,16 @@ class Tests_Image_Meta extends WP_UnitTestCase {
 				120 => mb_convert_encoding( 'Café', 'ISO-8859-1', 'UTF-8' ),
 				110 => "Credit \xC0",
 				116 => "Copyright \xE9",
-				25  => array( 'valid keyword', "sunset\xC0" ),
+				25  => array(
+					'valid keyword',
+					"sunset\xC0",
+					// The Slovak keywords from the image attached to #35316.
+					mb_convert_encoding( 'Vodná elektráreň Gabčíkovo', 'ISO-8859-2', 'UTF-8' ),
+				),
 			)
 		);
 
-		$file = wp_tempnam( 'iptc-invalid-utf8.jpg' );
+		$file = wp_tempnam( 'iptc-non-utf8.jpg' );
 		file_put_contents( $file, iptcembed( $block, DIR_TESTDATA . '/images/test-image.jpg' ) );
 
 		$out = wp_read_image_metadata( $file );
@@ -191,21 +200,21 @@ class Tests_Image_Meta extends WP_UnitTestCase {
 		}
 
 		$this->assertSame(
-			"Caf\u{FFFD}",
+			'Café',
 			$out['caption'],
-			'ISO-8859-1 text should be neutralized, not reinterpreted.'
+			'ISO-8859-1 text should round-trip unchanged.'
 		);
 
 		$this->assertSame(
-			"wyr\u{FFFD}nij",
+			'wyró¿nij',
 			$out['title'],
-			'ISO-8859-2 text should be neutralized, not reinterpreted.'
+			'Text in another single-byte encoding should be decoded as ISO-8859-1.'
 		);
 
 		$this->assertSame(
-			array( 'valid keyword', "sunset\u{FFFD}" ),
+			array( 'valid keyword', 'sunsetÀ', 'Vodná elektráreò Gabèíkovo' ),
 			$out['keywords'],
-			'Keywords should be scrubbed individually while valid entries are left alone.'
+			'Keywords should be converted individually while valid entries are left alone.'
 		);
 	}
 

--- a/tests/phpunit/tests/image/meta.php
+++ b/tests/phpunit/tests/image/meta.php
@@ -150,6 +150,81 @@ class Tests_Image_Meta extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Ensures invalid UTF-8 in IPTC fields is neutralized rather than assumed to be ISO-8859-1.
+	 *
+	 * `wp_read_image_metadata()` previously passed any field that failed UTF-8 validation
+	 * through the deprecated `utf8_encode()`, which reinterpreted the raw bytes as
+	 * ISO-8859-1. IPTC carries no reliable encoding declaration, so the invalid spans are
+	 * now replaced with the Unicode replacement character instead of being guessed at.
+	 *
+	 * @ticket 65828
+	 */
+	public function test_iptc_invalid_utf8_is_scrubbed() {
+		if ( ! is_callable( 'iptcembed' ) || ! is_callable( 'iptcparse' ) ) {
+			$this->markTestSkipped( 'The iptcembed() and iptcparse() functions are required.' );
+		}
+
+		$block = $this->build_iptc_block(
+			array(
+				105 => "Headline \xE9",
+				120 => "Caf\xE9 by the r\xEDver",
+				110 => "Credit \xC0",
+				116 => "Copyright \xE9",
+				25  => array( 'valid keyword', "sunset\xC0" ),
+			)
+		);
+
+		$file = wp_tempnam( 'iptc-invalid-utf8.jpg' );
+		file_put_contents( $file, iptcembed( $block, DIR_TESTDATA . '/images/test-image.jpg' ) );
+
+		$out = wp_read_image_metadata( $file );
+
+		unlink( $file );
+
+		$this->assertIsArray( $out, 'Metadata should have been read from the image.' );
+
+		foreach ( array( 'title', 'caption', 'credit', 'copyright' ) as $key ) {
+			$this->assertTrue(
+				wp_is_valid_utf8( $out[ $key ] ),
+				"The '{$key}' field should always be valid UTF-8."
+			);
+		}
+
+		$this->assertSame(
+			"Caf\u{FFFD} by the r\u{FFFD}ver",
+			$out['caption'],
+			'Invalid bytes should be replaced, not reinterpreted as ISO-8859-1.'
+		);
+
+		$this->assertSame(
+			array( 'valid keyword', "sunset\u{FFFD}" ),
+			$out['keywords'],
+			'Keywords should be scrubbed individually while valid entries are left alone.'
+		);
+	}
+
+	/**
+	 * Builds a raw IPTC APP13 block for the given record 2 datasets.
+	 *
+	 * @param array $tags Map of dataset number to a string value or list of string values.
+	 * @return string Binary IPTC block suitable for iptcembed().
+	 */
+	private function build_iptc_block( array $tags ) {
+		$block = '';
+
+		foreach ( $tags as $dataset => $values ) {
+			foreach ( (array) $values as $value ) {
+				$length = strlen( $value );
+				$block .= chr( 0x1C ) . chr( 2 ) . chr( $dataset )
+					. chr( ( $length >> 8 ) & 0xFF ) . chr( $length & 0xFF )
+					. $value;
+			}
+		}
+
+		return $block;
+	}
+
+	/**
 	 * wp_read_image_metadata() should return false if the image file doesn't exist.
 	 */
 	public function test_missing_image_file() {


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

`wxr_cdata()` and `wp_read_image_metadata()` hold the last three calls to `utf8_encode()` in core, which PHP deprecated in 8.2 and removes in 9.0, and which core polyfilled with its own `_deprecated_function()` notice in [60950] — so these call sites emit a deprecation notice from core's own code on every affected export and image upload.

This points them at a new private `_wp_iso_8859_1_to_utf8()` in `wp-includes/utf8.php`, following the mbstring/fallback split that file already uses.

There is no behaviour change: `mb_convert_encoding( $text, 'UTF-8', 'ISO-8859-1' )` is byte-identical to `utf8_encode()` across all 256 byte values, the no-mbstring branch reuses the existing `_wp_utf8_encode_fallback()`, and the `wp_is_valid_utf8()` guards are unchanged.

The tests pin that preserved output, including the keywords from the image attached to #35316.

Verified: 36/36 in the two touched test classes, no failures in the `image`, `unicode`, `formatting`, `export` and `admin` groups, and PHPCS reports no new errors or warnings.

Trac ticket: https://core.trac.wordpress.org/ticket/65828

## Use of AI Tools

AI assistance: Yes

Tool(s): Claude

Model(s): Opus 5

Used for: initial exploration, tests, and ticket and PR details. All changes are reviewed and validated by me.

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**

