### PR TITLE
Build/Test Tools: Add unit test for send_frame_options_header()

### DIFF
--- a/tests/phpunit/tests/functions/sendFrameOptionsHeader.php
+++ b/tests/phpunit/tests/functions/sendFrameOptionsHeader.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * Test send_frame_options_header().
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ *
+ * @group functions
+ *
+ * @covers ::send_frame_options_header
+ */
+class Tests_Functions_sendFrameOptionsHeader extends WP_UnitTestCase {
+
+	/**
+	 * @ticket 59851
+	 *
+	 * @requires function xdebug_get_headers
+	 */
+	public function test_send_frame_options_header_sends_expected_headers() {
+		send_frame_options_header();
+
+		$headers = xdebug_get_headers();
+
+		$this->assertContains( 'X-Frame-Options: SAMEORIGIN', $headers );
+		$this->assertContains( "Content-Security-Policy: frame-ancestors 'self';", $headers );
+	}
+}


### PR DESCRIPTION
Adds PHPUnit coverage for `send_frame_options_header()` in `wp-includes/functions.php`, which currently has no test coverage. **This change is test-only and adds no production behaviour** — it does not touch any file under `src/`. The new test calls the function directly and asserts, via `xdebug_get_headers()`, that both the `X-Frame-Options: SAMEORIGIN` and `Content-Security-Policy: frame-ancestors 'self';` headers are sent — the function's entire observable behaviour, since it takes no parameters and returns nothing. The test is marked `@requires function xdebug_get_headers` and runs in a separate process (`@runTestsInSeparateProcesses`), following the existing precedent for header assertions in `tests/phpunit/tests/oembed/headers.php`, so it is skipped rather than failing on environments without the Xdebug extension loaded. I verified the test is meaningful by temporarily changing the `X-Frame-Options` value sent in `send_frame_options_header()` and confirming the test failed, then reverted the change and confirmed it passes again. I did not add a test for the `headers_sent()` guard clause (the early return when headers were already sent) — PHPUnit's `beStrictAboutOutputDuringTests` buffers test output internally, so producing real output from within a test does not actually flip `headers_sent()` to true in this harness, and I did not want to force a fragile workaround for that branch.

Trac ticket: https://core.trac.wordpress.org/ticket/59851

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Sonnet 5
Used for: Ticket triage/selection, reading the existing implementation and test conventions, writing the test file, and running the verification loop (green/red/green). All output was reviewed by me before committing.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**