### PR TITLE
Privacy: Surface email-send failures when initiating a personal data request

### DIFF
--- a/src/wp-admin/includes/privacy-tools.php
+++ b/src/wp-admin/includes/privacy-tools.php
@@ -166,7 +166,17 @@ function _wp_personal_data_handle_actions() {
 				}
 
 				if ( 'pending' === $status ) {
-					wp_send_user_request( $request_id );
+					$send_request_result = wp_send_user_request( $request_id );
+
+					if ( is_wp_error( $send_request_result ) ) {
+						add_settings_error(
+							'username_or_email_for_privacy_request',
+							'username_or_email_for_privacy_request',
+							$send_request_result->get_error_message(),
+							'error'
+						);
+						break;
+					}
 
 					$message = __( 'Confirmation request initiated successfully.' );
 				} elseif ( 'confirmed' === $status ) {

--- a/tests/phpunit/tests/privacy/wpPersonalDataHandleActions.php
+++ b/tests/phpunit/tests/privacy/wpPersonalDataHandleActions.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Test cases for the `_wp_personal_data_handle_actions()` function.
+ *
+ * @package WordPress
+ * @subpackage UnitTests
+ *
+ * @group privacy
+ * @group admin
+ * @covers ::_wp_personal_data_handle_actions
+ */
+class Tests_Privacy_wpPersonalDataHandleActions extends WP_UnitTestCase {
+
+	/**
+	 * Reset the mocked phpmailer instance before each test.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		reset_phpmailer_instance();
+	}
+
+	/**
+	 * Clean up superglobals and settings errors after each test.
+	 */
+	public function tear_down() {
+		unset(
+			$_POST['action'],
+			$_POST['_wpnonce'],
+			$_POST['type_of_action'],
+			$_POST['username_or_email_for_privacy_request'],
+			$_POST['send_confirmation_email'],
+			$_REQUEST['_wpnonce']
+		);
+
+		$GLOBALS['wp_settings_errors'] = array();
+
+		reset_phpmailer_instance();
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Populates $_POST with a valid "add personal data request" submission.
+	 *
+	 * @param string $email Email address for the request.
+	 */
+	private function set_up_add_request_post_data( $email ) {
+		$_POST['action']                                = 'add_export_personal_data_request';
+		$_POST['_wpnonce']                               = wp_create_nonce( 'personal-data-request' );
+		$_POST['type_of_action']                         = 'export_personal_data';
+		$_POST['username_or_email_for_privacy_request']  = $email;
+		$_POST['send_confirmation_email']                = '1';
+
+		// check_admin_referer() reads the nonce from $_REQUEST, which the test bootstrap resets per test.
+		$_REQUEST['_wpnonce'] = $_POST['_wpnonce'];
+	}
+
+	/**
+	 * A confirmation email failing to send should surface as an error, not a false success message.
+	 *
+	 * @ticket 54442
+	 */
+	public function test_should_add_error_when_confirmation_email_fails_to_send() {
+		$this->set_up_add_request_post_data( 'requester@example.com' );
+
+		// Cause `wp_mail()` to return false.
+		add_filter( 'wp_mail_from', '__return_empty_string' );
+
+		_wp_personal_data_handle_actions();
+
+		$errors = get_settings_errors( 'username_or_email_for_privacy_request' );
+
+		$this->assertNotEmpty( $errors, 'An error should be recorded when the confirmation email fails to send.' );
+		$this->assertSame( 'error', $errors[0]['type'] );
+		$this->assertSame( 'Unable to send personal data export confirmation email.', $errors[0]['message'] );
+	}
+
+	/**
+	 * A successfully sent confirmation email should still report success.
+	 *
+	 * @ticket 54442
+	 */
+	public function test_should_add_success_message_when_confirmation_email_sends() {
+		$this->set_up_add_request_post_data( 'requester@example.com' );
+
+		_wp_personal_data_handle_actions();
+
+		$errors = get_settings_errors( 'username_or_email_for_privacy_request' );
+
+		$this->assertNotEmpty( $errors );
+		$this->assertSame( 'success', $errors[0]['type'] );
+		$this->assertSame( 'Confirmation request initiated successfully.', $errors[0]['message'] );
+	}
+}


### PR DESCRIPTION
**What:** When an admin adds a new personal data export/erasure request with "send confirmation email" checked, `_wp_personal_data_handle_actions()` calls `wp_send_user_request()` but discards its return value, then unconditionally shows "Confirmation request initiated successfully." Since `wp_send_user_request()` returns a `WP_Error` on mail failure, the admin gets a false success message even when the confirmation email never went out — leaving the request stuck pending with no obvious explanation.

**Fix:** Check the return value of `wp_send_user_request()` and, if it's a `WP_Error`, surface the actual error message via `add_settings_error()` (type `error`) instead of the canned success string — mirroring the existing pattern used a few lines above for `wp_create_user_request()` failures and in `_wp_privacy_resend_request()`'s retry path.

**Tests:** Added `tests/phpunit/tests/privacy/wpPersonalDataHandleActions.php`, covering both the failure path (forcing `wp_mail()` to fail via the `wp_mail_from` filter, per the existing pattern in `Tests_User_wpSendUserRequest`) and the existing success path as a regression guard.

Trac ticket: https://core.trac.wordpress.org/ticket/54442

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Sonnet 5
Used for: Implementation, tests, and PR description. Reviewed by Igor Rozum.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
