### PR TITLE
Posts, Post Types: Preserve comment/ping status in Quick Edit when the control isn't rendered

### DIFF
--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -2150,11 +2150,11 @@ function wp_ajax_inline_save() {
 	}
 
 	if ( empty( $data['comment_status'] ) ) {
-		$data['comment_status'] = 'closed';
+		$data['comment_status'] = $post['comment_status'];
 	}
 
 	if ( empty( $data['ping_status'] ) ) {
-		$data['ping_status'] = 'closed';
+		$data['ping_status'] = $post['ping_status'];
 	}
 
 	// Exclude terms from taxonomies that are not supposed to appear in Quick Edit.

--- a/tests/phpunit/tests/ajax/wpAjaxInlineSave.php
+++ b/tests/phpunit/tests/ajax/wpAjaxInlineSave.php
@@ -199,4 +199,53 @@ class Tests_Ajax_wpAjaxInlineSave extends WP_Ajax_UnitTestCase {
 
 		$this->assertSame( '2020-09-11 19:20:11', $post->post_date_gmt );
 	}
+
+	/**
+	 * Quick Edit should not reset ping_status to "closed" for a post type,
+	 * such as "page", that does not render a ping_status control because
+	 * it does not support trackbacks.
+	 *
+	 * @ticket 31977
+	 *
+	 * @covers ::edit_post
+	 */
+	public function test_quick_edit_should_not_reset_ping_status_for_post_type_without_trackback_support() {
+		$this->assertFalse( post_type_supports( 'page', 'trackbacks' ) );
+
+		// Become an administrator.
+		$this->_setRole( 'administrator' );
+
+		$page = self::factory()->post->create_and_get(
+			array(
+				'post_type'   => 'page',
+				'post_author' => get_current_user_id(),
+				'ping_status' => 'open',
+			)
+		);
+
+		$this->assertSame( 'open', $page->ping_status );
+
+		// Set up a request. The ping_status field is intentionally omitted,
+		// as the "page" post type does not render a ping_status control.
+		$_POST['_inline_edit'] = wp_create_nonce( 'inlineeditnonce' );
+		$_POST['post_ID']      = $page->ID;
+		$_POST['post_type']    = $page->post_type;
+		$_POST['content']      = $page->post_content;
+		$_POST['excerpt']      = $page->post_excerpt;
+		$_POST['_status']      = $page->post_status;
+		$_POST['post_status']  = $page->post_status;
+		$_POST['screen']       = 'page';
+		$_POST['post_view']    = 'list';
+
+		// Make the request.
+		try {
+			$this->_handleAjax( 'inline-save' );
+		} catch ( WPAjaxDieContinueException $e ) {
+			unset( $e );
+		}
+
+		$page = get_post( $page->ID );
+
+		$this->assertSame( 'open', $page->ping_status );
+	}
 }


### PR DESCRIPTION
`wp_ajax_inline_save()` unconditionally defaults `comment_status`/`ping_status` to `closed` whenever those fields are absent from the Quick Edit POST data, on the assumption that an absent value means the checkbox was unchecked. That assumption breaks for post types that don't support `comments`/`trackbacks` at all (e.g. `page`, which supports `comments` but not `trackbacks`): the corresponding checkbox is never rendered in the Quick Edit form, so the field is always absent, and every Quick Edit save on such a post type silently resets its `ping_status` to `closed` even if it was previously `open`.

This fixes it by falling back to the post's current `comment_status`/`ping_status` (already fetched into `$post` earlier in the function) instead of hardcoding `closed`, so a status that Quick Edit has no control for is left untouched rather than being overwritten. This also fixes the same issue for Bulk Edit's "— No Change —" option, which submits the same empty value through the same code path.

Added a PHPUnit test reproducing the bug against the `page` post type and asserting `ping_status` is preserved across a Quick Edit save.

Trac ticket: https://core.trac.wordpress.org/ticket/31977

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Sonnet 5
Used for: Implementation, tests, and PR description. Reviewed by irozum.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
