### PR TITLE
Query: Add is_post_format_archive() conditional tag

### DIFF
--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -4409,6 +4409,27 @@ class WP_Query {
 	}
 
 	/**
+	 * Is the query for an existing post format archive page?
+	 *
+	 * @since 7.2.0
+	 *
+	 * @param string|string[] $post_formats Optional. Post format or array of post formats
+	 *                                      to check against. Default empty.
+	 * @return bool Whether the query is for an existing post format archive page.
+	 */
+	public function is_post_format_archive( $post_formats = '' ) {
+		$prefixed_formats = array();
+
+		if ( $post_formats ) {
+			foreach ( (array) $post_formats as $post_format ) {
+				$prefixed_formats[] = 'post-format-' . sanitize_key( $post_format );
+			}
+		}
+
+		return $this->is_tax( 'post_format', $prefixed_formats );
+	}
+
+	/**
 	 * Determines whether the current URL is within the comments popup window.
 	 *
 	 * @since 3.1.0

--- a/src/wp-includes/query.php
+++ b/src/wp-includes/query.php
@@ -346,6 +346,35 @@ function is_tax( $taxonomy = '', $term = '' ) {
 }
 
 /**
+ * Determines whether the query is for an existing post format archive page.
+ *
+ * If the $post_formats parameter is specified, this function will additionally
+ * check if the query is for one of the post formats specified.
+ *
+ * For more information on this and similar theme functions, check out
+ * the {@link https://developer.wordpress.org/themes/basics/conditional-tags/
+ * Conditional Tags} article in the Theme Developer Handbook.
+ *
+ * @since 7.2.0
+ *
+ * @global WP_Query $wp_query WordPress Query object.
+ *
+ * @param string|string[] $post_formats Optional. Post format or array of post formats
+ *                                      to check against. Default empty.
+ * @return bool Whether the query is for an existing post format archive page.
+ */
+function is_post_format_archive( $post_formats = '' ) {
+	global $wp_query;
+
+	if ( ! isset( $wp_query ) ) {
+		_doing_it_wrong( __FUNCTION__, __( 'Conditional query tags do not work before the query is run. Before then, they always return false.' ), '3.1.0' );
+		return false;
+	}
+
+	return $wp_query->is_post_format_archive( $post_formats );
+}
+
+/**
  * Determines whether the query is for an existing date archive.
  *
  * For more information on this and similar theme functions, check out

--- a/tests/phpunit/includes/abstract-testcase.php
+++ b/tests/phpunit/includes/abstract-testcase.php
@@ -1186,6 +1186,7 @@ abstract class WP_UnitTestCase_Base extends PHPUnit_Adapter_TestCase {
 			'is_month',
 			'is_page',
 			'is_paged',
+			'is_post_format_archive',
 			'is_post_type_archive',
 			'is_posts_page',
 			'is_preview',

--- a/tests/phpunit/tests/query/conditionals.php
+++ b/tests/phpunit/tests/query/conditionals.php
@@ -1599,6 +1599,35 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 23749
+	 */
+	public function test_is_post_format_archive() {
+		$post_id = self::factory()->post->create();
+		set_post_format( $post_id, 'aside' );
+
+		$this->go_to( '/?post_format=aside' );
+
+		$this->assertQueryTrue( 'is_archive', 'is_tax', 'is_post_format_archive' );
+		$this->assertTrue( is_post_format_archive() );
+		$this->assertTrue( is_post_format_archive( 'aside' ) );
+		$this->assertTrue( is_post_format_archive( array( 'gallery', 'aside' ) ) );
+		$this->assertFalse( is_post_format_archive( 'gallery' ) );
+	}
+
+	/**
+	 * @ticket 23749
+	 */
+	public function test_is_post_format_archive_false_outside_a_post_format_archive() {
+		$post_id = self::factory()->post->create();
+		set_post_format( $post_id, 'aside' );
+
+		$this->go_to( get_permalink( $post_id ) );
+
+		$this->assertFalse( is_post_format_archive() );
+		$this->assertFalse( is_post_format_archive( 'aside' ) );
+	}
+
+	/**
 	 * @ticket 44005
 	 * @group privacy
 	 */


### PR DESCRIPTION
Adds a new `is_post_format_archive( $post_formats = '' )` conditional tag, plus the matching `WP_Query::is_post_format_archive()` method, so themes and plugins can check whether the current query is for a post format archive without going through the less-intuitive `is_tax( 'post-format', 'post-format-image' )` call and manually prefixing term slugs.

The implementation mirrors the existing `has_post_format()` helper's slug-prefixing pattern and follows the exact structure of sibling conditional tags like `is_category()`/`is_tag()`/`is_tax()`: a thin `WP_Query` method delegating to `is_tax( 'post_format', ... )`, plus a global wrapper function in `query.php` with the standard "query hasn't run yet" `_doing_it_wrong()` guard. `is_post_format_archive` was also added to the shared `assertQueryTrue()` conditional list in `abstract-testcase.php` (alongside `is_post_type_archive`) so it participates in the existing cross-conditional assertions, and it's automatically covered by the existing `data_conditional_tags_trigger_doing_it_wrong_and_return_false_if_wp_query_is_not_set` data provider since that discovers all `is_*` methods on `WP_Query` dynamically.

`$post_formats` accepts a single format string (e.g. `'aside'`) or an array of formats, without the `post-format-` slug prefix, matching the ergonomics of `has_post_format()`.

Trac ticket: https://core.trac.wordpress.org/ticket/23749

## Use of AI Tools
AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Implementation, tests, and PR description. Reviewed by Igor Rozum.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
