### PR TITLE
Auto approve self pings follow up

### DIFF
--- a/src/wp-includes/comment.php
+++ b/src/wp-includes/comment.php
@@ -194,7 +194,7 @@ function check_comment( $author, $email, $url, $comment, $user_ip, $user_agent, 
 			 *                                 originated from, or 0 if it came from elsewhere.
 			 * @param string $url              The URL the pingback was sent from.
 			 */
-			return (bool) apply_filters( 'auto_approve_pingback', $approve_pingback, $source_id, $url );
+			return (bool) apply_filters( 'wp_auto_approve_pingback', $approve_pingback, $source_id, $url );
 		} else {
 			return false;
 		}

--- a/src/wp-includes/comment.php
+++ b/src/wp-includes/comment.php
@@ -20,13 +20,13 @@
  * If the comment author was approved before, then the comment is automatically
  * approved.
  *
- * Pingbacks originating from this site are automatically approved, as the link
- * they report was created by someone who can already publish here.
+ * Pingbacks originating from the same site are automatically approved, as the
+ * link they report was created by someone who can already publish here.
  *
  * If all checks pass, the function will return true.
  *
  * @since 1.2.0
- * @since 7.1.0 Pingbacks from this site are no longer held for moderation.
+ * @since 7.1.0 Pingbacks from the same site are no longer held for moderation.
  *
  * @global wpdb $wpdb WordPress database abstraction object.
  *
@@ -183,13 +183,13 @@ function check_comment( $author, $email, $url, $comment, $user_ip, $user_agent, 
 			/**
 			 * Filters whether a pingback is approved without being held for moderation.
 			 *
-			 * Defaults to true for pingbacks originating from a published post on this
+			 * Defaults to true for pingbacks originating from a published post on the same
 			 * site, and false for every other pingback. Trackbacks are never considered,
 			 * as they cannot be verified.
 			 *
 			 * @since 7.1.0
 			 *
-			 * @param bool   $approve_pingback Whether to approve the pingback.
+			 * @param bool   $approve_pingback Whether to auto-approve the pingback.
 			 * @param int    $source_id        ID of the post on this site the pingback
 			 *                                 originated from, or 0 if it came from elsewhere.
 			 * @param string $url              The URL the pingback was sent from.

--- a/src/wp-includes/comment.php
+++ b/src/wp-includes/comment.php
@@ -26,7 +26,7 @@
  * If all checks pass, the function will return true.
  *
  * @since 1.2.0
- * @since 7.2.0 Pingbacks from this site are no longer held for moderation.
+ * @since 7.1.0 Pingbacks from this site are no longer held for moderation.
  *
  * @global wpdb $wpdb WordPress database abstraction object.
  *
@@ -187,7 +187,7 @@ function check_comment( $author, $email, $url, $comment, $user_ip, $user_agent, 
 			 * site, and false for every other pingback. Trackbacks are never considered,
 			 * as they cannot be verified.
 			 *
-			 * @since 7.2.0
+			 * @since 7.1.0
 			 *
 			 * @param bool   $approve_pingback Whether to approve the pingback.
 			 * @param int    $source_id        ID of the post on this site the pingback

--- a/src/wp-includes/comment.php
+++ b/src/wp-includes/comment.php
@@ -194,7 +194,7 @@ function check_comment( $author, $email, $url, $comment, $user_ip, $user_agent, 
 			 *                                 originated from, or 0 if it came from elsewhere.
 			 * @param string $url              The URL the pingback was sent from.
 			 */
-			return (bool) apply_filters( 'wp_auto_approve_pingback', $approve_pingback, $source_id, $url );
+			return (bool) apply_filters( 'wp_auto_approve_ping', $approve_pingback, $source_id, $url );
 		} else {
 			return false;
 		}

--- a/tests/phpunit/tests/comment/checkComment.php
+++ b/tests/phpunit/tests/comment/checkComment.php
@@ -330,6 +330,24 @@ class Tests_Comment_CheckComment extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Ensure pingbacks from Multisite sub-sites are not auto approved.
+	 *
+	 * @ticket 65016
+	 * @group ms-required
+	 */
+	public function test_auto_approve_pingback_should_not_approve_from_a_different_ms_site() {
+		update_option( 'comment_previously_approved', '1' );
+
+		$new_blog = self::factory()->blog->create();
+
+		switch_to_blog( $new_blog );
+		$source_url = get_permalink( self::factory()->post->create() );
+		restore_current_blog();
+
+		$this->assertFalse( check_comment( 'Site Title', '', $source_url, 'Excerpt.', '192.168.0.1', '', 'pingback' ) );
+	}
+
+	/**
 	 * @ticket 65016
 	 */
 	public function test_auto_approve_pingback_should_receive_the_source_post_id() {

--- a/tests/phpunit/tests/comment/checkComment.php
+++ b/tests/phpunit/tests/comment/checkComment.php
@@ -373,6 +373,33 @@ class Tests_Comment_CheckComment extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Ensure the `wp_auto_approve_pingback` filter does not receive a post ID for off-site pings.
+	 *
+	 * @ticket 65016
+	 */
+	public function test_auto_approve_pingback_should_receive_the_post_id_zero_for_off_site_pings() {
+		update_option( 'comment_previously_approved', '1' );
+
+		$post_permalink = get_permalink( self::factory()->post->create() );
+		$source_url     = str_replace( home_url( '/' ), 'http://wordpress.org/', $post_permalink );
+
+		$observed = null;
+		add_filter(
+			'wp_auto_approve_pingback',
+			static function ( $approve, $source_id ) use ( &$observed ) {
+				$observed = $source_id;
+				return $approve;
+			},
+			10,
+			2
+		);
+
+		check_comment( 'Site Title', '', $source_url, 'Excerpt.', '192.168.0.1', '', 'pingback' );
+
+		$this->assertSame( 0, $observed );
+	}
+
+	/**
 	 * Data provider.
 	 *
 	 * @return array[]

--- a/tests/phpunit/tests/comment/checkComment.php
+++ b/tests/phpunit/tests/comment/checkComment.php
@@ -315,7 +315,7 @@ class Tests_Comment_CheckComment extends WP_UnitTestCase {
 
 		$source_url = get_permalink( self::factory()->post->create() );
 
-		add_filter( 'wp_auto_approve_pingback', '__return_false' );
+		add_filter( 'wp_auto_approve_ping', '__return_false' );
 
 		$this->assertFalse( check_comment( 'Site Title', '', $source_url, 'Excerpt.', '192.168.0.1', '', 'pingback' ) );
 	}
@@ -328,7 +328,7 @@ class Tests_Comment_CheckComment extends WP_UnitTestCase {
 	public function test_auto_approve_pingback_should_be_able_to_approve_a_pingback_from_another_site() {
 		update_option( 'comment_previously_approved', '1' );
 
-		add_filter( 'wp_auto_approve_pingback', '__return_true' );
+		add_filter( 'wp_auto_approve_ping', '__return_true' );
 
 		$this->assertTrue( check_comment( 'Site Title', '', 'http://example.com/a-post/', 'Excerpt.', '192.168.0.1', '', 'pingback' ) );
 	}
@@ -364,7 +364,7 @@ class Tests_Comment_CheckComment extends WP_UnitTestCase {
 
 		$observed = null;
 		add_filter(
-			'wp_auto_approve_pingback',
+			'wp_auto_approve_ping',
 			static function ( $approve, $source_id ) use ( &$observed ) {
 				$observed = $source_id;
 				return $approve;
@@ -391,7 +391,7 @@ class Tests_Comment_CheckComment extends WP_UnitTestCase {
 
 		$observed = null;
 		add_filter(
-			'wp_auto_approve_pingback',
+			'wp_auto_approve_ping',
 			static function ( $approve, $source_id ) use ( &$observed ) {
 				$observed = $source_id;
 				return $approve;

--- a/tests/phpunit/tests/comment/checkComment.php
+++ b/tests/phpunit/tests/comment/checkComment.php
@@ -313,7 +313,7 @@ class Tests_Comment_CheckComment extends WP_UnitTestCase {
 
 		$source_url = get_permalink( self::factory()->post->create() );
 
-		add_filter( 'auto_approve_pingback', '__return_false' );
+		add_filter( 'wp_auto_approve_pingback', '__return_false' );
 
 		$this->assertFalse( check_comment( 'Site Title', '', $source_url, 'Excerpt.', '192.168.0.1', '', 'pingback' ) );
 	}
@@ -324,7 +324,7 @@ class Tests_Comment_CheckComment extends WP_UnitTestCase {
 	public function test_auto_approve_pingback_should_be_able_to_approve_a_pingback_from_another_site() {
 		update_option( 'comment_previously_approved', '1' );
 
-		add_filter( 'auto_approve_pingback', '__return_true' );
+		add_filter( 'wp_auto_approve_pingback', '__return_true' );
 
 		$this->assertTrue( check_comment( 'Site Title', '', 'http://example.com/a-post/', 'Excerpt.', '192.168.0.1', '', 'pingback' ) );
 	}
@@ -340,7 +340,7 @@ class Tests_Comment_CheckComment extends WP_UnitTestCase {
 
 		$observed = null;
 		add_filter(
-			'auto_approve_pingback',
+			'wp_auto_approve_pingback',
 			static function ( $approve, $source_id ) use ( &$observed ) {
 				$observed = $source_id;
 				return $approve;

--- a/tests/phpunit/tests/comment/checkComment.php
+++ b/tests/phpunit/tests/comment/checkComment.php
@@ -306,6 +306,8 @@ class Tests_Comment_CheckComment extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test auto approvals can be turned off via the `wp_auto_approve_pingback` filter.
+	 *
 	 * @ticket 65016
 	 */
 	public function test_auto_approve_pingback_should_be_able_to_hold_a_pingback_from_this_site() {
@@ -319,6 +321,8 @@ class Tests_Comment_CheckComment extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test auto approvals can be turned on via the `wp_auto_approve_pingback` filter.
+	 *
 	 * @ticket 65016
 	 */
 	public function test_auto_approve_pingback_should_be_able_to_approve_a_pingback_from_another_site() {
@@ -348,6 +352,8 @@ class Tests_Comment_CheckComment extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Ensure the `wp_auto_approve_pingback` filter receives the post ID for same site pings.
+	 *
 	 * @ticket 65016
 	 */
 	public function test_auto_approve_pingback_should_receive_the_source_post_id() {


### PR DESCRIPTION
Makes a few updates:

* Version annotations to 7.1.0
* Clarifies "this site" means "the same site" in various docs.
* Prefixes the new filter with `wp_`.
* Extends the tests:
   * adds test to ensure MS sub-site posts are not auto approved
   * adds test to ensure that post ID sent to filter is zero for external sites.
   * adds docs for each test

Trac ticket: https://core.trac.wordpress.org/ticket/65016

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
