### PR TITLE
Build/Test Tools: Add Stylelint checks to CSS precommit

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,0 +1,7 @@
+{
+	"rules": {
+		"block-no-empty": true,
+		"length-zero-no-unit": true,
+		"property-no-unknown": true
+	}
+}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1760,7 +1760,29 @@ module.exports = function(grunt) {
 		'qunit:compiled'
 	] );
 
+	grunt.registerTask( 'lint:css', 'Runs Stylelint on core CSS.', function() {
+		var done = this.async();
+
+		grunt.util.spawn( {
+			cmd: 'npx',
+			args: [
+				'wp-scripts',
+				'lint-style',
+				SOURCE_DIR + 'wp-admin/css/*.css',
+				SOURCE_DIR + 'wp-includes/css/*.css',
+				'--ignore-pattern',
+				'**/*.min.css',
+				'--ignore-pattern',
+				'**/*-rtl.css'
+			],
+			opts: { stdio: 'inherit' }
+		}, function( error ) {
+			done( ! error );
+		} );
+	} );
+
 	grunt.registerTask( 'precommit:css', [
+		'lint:css',
 		'postcss:core'
 	] );
 
@@ -1835,7 +1857,7 @@ module.exports = function(grunt) {
 				}
 
 				if ( code === 0 ) {
-					if ( [ 'package.json', 'Gruntfile.js', 'composer.json' ].some( testPath ) ) {
+					if ( [ 'package.json', 'Gruntfile.js', 'composer.json', '.stylelintrc.json' ].some( testPath ) ) {
 						grunt.log.writeln( 'Configuration files modified. Running `prerelease`.' );
 						taskList.push( 'prerelease' );
 					} else {

--- a/src/wp-admin/css/list-tables.css
+++ b/src/wp-admin/css/list-tables.css
@@ -1986,7 +1986,7 @@ div.action-links,
 
 	.plugins .active th.check-column input,
 	.plugins .active td.check-column input {
-		margin-left: 0px;
+		margin-left: 0;
 	}
 
 	.plugins tr.active,

--- a/src/wp-includes/css/media-views.css
+++ b/src/wp-includes/css/media-views.css
@@ -336,7 +336,7 @@
 	grid-template-columns: repeat( 2, 1fr );
 	grid-template-rows: repeat( 2, 1fr );
 	grid-column-gap: 12px;
-	grid-row-gap: 0px;
+	grid-row-gap: 0;
 	align-items: end;
 }
 
@@ -564,7 +564,7 @@ select#media-attachment-filters ~ select#media-attachment-date-filters {
 	width: 16px;
 	height: 16px;
 	font-size: 16px;
-	margin-top: 0px;
+	margin-top: 0;
 }
 
 .media-sidebar .setting .value,


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

This PR adds Stylelint checks to the CSS pre-commit workflow, as discussed in Trac ticket https://core.trac.wordpress.org/ticket/29792

The new lint:css task checks core CSS for:
 - Empty blocks.
 - Unknown properties.
 - Units on zero-length values.
 The task runs before postcss:core as part of precommit:css. Generated minified and RTL files are excluded.

Testing
- Verified the pre-commit workflow locally
- Confirmed Stylelint runs against the expected CSS files
- Tested the changes with both valid CSS and CSS containing linting errors

## Use of AI Tools

AI assistance: Yes
Tool(s): Pi
Model(s): GPT-5.6
Used for: Initial code skeleton, code review and PR description generation; final implementation and tests were reviewed and edited by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
