### PR TITLE
Administration: Guard network admin bootstrap on single sites

### DIFF
--- a/src/wp-admin/network/admin.php
+++ b/src/wp-admin/network/admin.php
@@ -9,14 +9,15 @@
 
 define( 'WP_NETWORK_ADMIN', true );
 
-/** Load WordPress Administration Bootstrap */
-require_once dirname( __DIR__ ) . '/admin.php';
-
+/** Load WordPress Bootstrap */
+require_once dirname( __DIR__, 2 ) . '/wp-load.php';
 // Do not remove this check. It is required by individual network admin pages.
 if ( ! is_multisite() ) {
 	wp_die( __( 'Multisite support is not enabled.' ) );
 }
 
+/** Load WordPress Administration Bootstrap */
+require_once dirname( __DIR__ ) . '/admin.php';
 $redirect_network_admin_request = ( 0 !== strcasecmp( $current_blog->domain, $current_site->domain ) || 0 !== strcasecmp( $current_blog->path, $current_site->path ) );
 
 /**

--- a/src/wp-admin/network/admin.php
+++ b/src/wp-admin/network/admin.php
@@ -9,8 +9,10 @@
 
 define( 'WP_NETWORK_ADMIN', true );
 
-/** Load WordPress Bootstrap */
-require_once dirname( __DIR__, 2 ) . '/wp-load.php';
+if ( ! defined( 'ABSPATH' ) ) {
+	/** Load WordPress Bootstrap */
+	require_once dirname( __DIR__, 2 ) . '/wp-load.php';
+}
 // Do not remove this check. It is required by individual network admin pages.
 if ( ! is_multisite() ) {
 	wp_die( __( 'Multisite support is not enabled.' ) );

--- a/tests/phpunit/tests/admin/wpNetworkAdmin.php
+++ b/tests/phpunit/tests/admin/wpNetworkAdmin.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * Tests for the network administration bootstrap.
+ *
+ * @package WordPress
+ * @subpackage Administration
+ */
+
+/**
+ * Tests for the network administration bootstrap.
+ */
+class Tests_Admin_NetworkAdmin extends WP_UnitTestCase {
+
+	/**
+	 * Tests that plugin pages are not loaded on a single site.
+	 *
+	 * @ticket 38076
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_plugin_pages_are_not_loaded_on_a_single_site() {
+		if ( is_multisite() ) {
+			$this->markTestSkipped( 'This test is for single site installations.' );
+		}
+
+		$plugin_page_loaded = false;
+		add_action(
+			'network_admin_menu',
+			function () use ( &$plugin_page_loaded ) {
+				add_menu_page(
+					'Test Plugin Page',
+					'Test Plugin Page',
+					'manage_options',
+					'test-plugin-page',
+					function () use ( &$plugin_page_loaded ) {
+						$plugin_page_loaded = true;
+					}
+				);
+			}
+		);
+
+		$_GET['page'] = 'test-plugin-page';
+
+		try {
+			require ABSPATH . 'wp-admin/network/admin.php';
+			$this->fail( 'The network administration bootstrap should stop on a single site.' );
+		} catch ( WPDieException $exception ) {
+			$this->assertSame( 'Multisite support is not enabled.', $exception->getMessage() );
+		}
+
+		$this->assertFalse( $plugin_page_loaded );
+	}
+}


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

Load the network administration bootstrap only after confirming that the request is running on a multisite installation.`n`n## Description

On single-site installations, `wp-admin/network/admin.php` previously loaded `wp-admin/admin.php` before the multisite guard ran. This allowed plugin-generated network-admin pages to be dispatched before the request was rejected.

This change:

- Moves the WordPress bootstrap before the network-admin dispatch path.
- Rejects network-admin requests on single-site installations before plugin-page dispatch.
- Adds regression coverage for the single-site bootstrap path.

## Testing

- `php -l src/wp-admin/network/admin.php`
- `php -l tests/phpunit/tests/admin/wpNetworkAdmin.php`
- `php vendor/bin/phpcbf --standard=phpcs.xml.dist src/wp-admin/network/admin.php tests/phpunit/tests/admin/wpNetworkAdmin.php`
- `php vendor/bin/phpcs --standard=phpcs.xml.dist src/wp-admin/network/admin.php tests/phpunit/tests/admin/wpNetworkAdmin.php`
- The PR's CI follow-up addressed the shared `DB_NAME already defined` bootstrap failure; the current CI status should be reviewed separately.

## Use of AI Tools

AI assistance: Yes
Tool(s): ChatGPT
Model(s): GPT-5
Used for: Reviewing the Trac ticket and current source, identifying the initial implementation and regression-test approach, assisting with the initial draft of the PR description and validation. The final implementation, test changes, validation commands, and submitted description were reviewed and accepted by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**

Trac ticket: https://core.trac.wordpress.org/ticket/38076

## Use of AI Tools

AI assistance: Yes
Tool(s): OpenAI Codex
Model(s): GPT-5
Used for: Reviewing the Trac ticket and relevant code, helping with the initial implementation and regression-test approach, and assisting with validation and PR-description drafting. The final implementation, tests, validation results, and description were reviewed and accepted by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**