### PR TITLE
Revert "Docs: Indicate `absint()` returns `non-negative-int` for static analysis.

### DIFF
--- a/src/wp-includes/load.php
+++ b/src/wp-includes/load.php
@@ -1464,9 +1464,8 @@ function is_multisite() {
  *
  * @param mixed $maybeint Data you wish to have converted to a non-negative integer.
  * @return int A non-negative integer.
- * @phpstan-return non-negative-int
  */
-function absint( $maybeint ): int {
+function absint( $maybeint ) {
 	return abs( (int) $maybeint );
 }
 

--- a/tests/phpstan/baselines/argument.type.neon
+++ b/tests/phpstan/baselines/argument.type.neon
@@ -56,12 +56,7 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$text of function esc_attr expects string, int given\.$#'
 			identifier: argument.type
-			count: 3
-			path: ../../../src/wp-admin/edit-comments.php
-		-
-			message: '#^Parameter \#1 \$text of function esc_attr expects string, int\<0, max\> given\.$#'
-			identifier: argument.type
-			count: 1
+			count: 4
 			path: ../../../src/wp-admin/edit-comments.php
 		-
 			message: '#^Parameter \#1 \$text of function esc_attr expects string, int\<min, \-1\>\|int\<1, max\> given\.$#'
@@ -574,7 +569,7 @@ parameters:
 			count: 5
 			path: ../../../src/wp-admin/nav-menus.php
 		-
-			message: '#^Parameter \#2 \$menu_data of function wp_save_nav_menu_items expects array\<array\>, int\<0, max\> given\.$#'
+			message: '#^Parameter \#2 \$menu_data of function wp_save_nav_menu_items expects array\<array\>, int given\.$#'
 			identifier: argument.type
 			count: 1
 			path: ../../../src/wp-admin/nav-menus.php
@@ -714,7 +709,7 @@ parameters:
 			count: 1
 			path: ../../../src/wp-content/themes/twentyeleven/inc/theme-options.php
 		-
-			message: '#^Parameter \#1 \$text of function esc_attr expects string, int\<0, max\> given\.$#'
+			message: '#^Parameter \#1 \$text of function esc_attr expects string, int given\.$#'
 			identifier: argument.type
 			count: 1
 			path: ../../../src/wp-content/themes/twentyeleven/inc/widgets.php
@@ -779,7 +774,7 @@ parameters:
 			count: 1
 			path: ../../../src/wp-content/themes/twentyfourteen/inc/widgets.php
 		-
-			message: '#^Parameter \#1 \$text of function esc_attr expects string, int\<0, max\> given\.$#'
+			message: '#^Parameter \#1 \$text of function esc_attr expects string, int given\.$#'
 			identifier: argument.type
 			count: 1
 			path: ../../../src/wp-content/themes/twentyfourteen/inc/widgets.php
@@ -809,7 +804,7 @@ parameters:
 			count: 1
 			path: ../../../src/wp-content/themes/twentynineteen/template-parts/post/author-bio.php
 		-
-			message: '#^Parameter \#1 \$text of function esc_attr expects string, int\<0, max\> given\.$#'
+			message: '#^Parameter \#1 \$text of function esc_attr expects string, int given\.$#'
 			identifier: argument.type
 			count: 1
 			path: ../../../src/wp-content/themes/twentyseventeen/inc/color-patterns.php

--- a/tests/phpstan/baselines/notIdentical.alwaysTrue.neon
+++ b/tests/phpstan/baselines/notIdentical.alwaysTrue.neon
@@ -19,11 +19,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: '#^Strict comparison using \!\=\= between ''all'' and int will always evaluate to true\.$#'
-			identifier: notIdentical.alwaysTrue
-			count: 1
-			path: ../../../src/wp-admin/includes/class-wp-links-list-table.php
-		-
 			message: '#^Strict comparison using \!\=\= between null and string will always evaluate to true\.$#'
 			identifier: notIdentical.alwaysTrue
 			count: 1


### PR DESCRIPTION
Trac ticket: Core-65826
Replaces #12917

This reverts commit 395dd7422b1b569936bb8c0f9b90bf44d2044095.

When the return-type annotation was added to `absint()` it failed to recoginize that the function can return `float` as well. In the cases where it does this, WordPress started crashing requests.

Reverting remove the type constraint where PHP enforces it in order to avoid the fatal errors.