### PR TITLE
Query: Add unit test for redirect_guess_404_permalink() post_type array leak

### DIFF
--- a/tests/phpunit/tests/canonical.php
+++ b/tests/phpunit/tests/canonical.php
@@ -378,6 +378,7 @@ class Tests_Canonical extends WP_Canonical_UnitTestCase {
 	 *
 	 * @ticket 43056
 	 * @ticket 59795
+	 * @ticket 44964
 	 *
 	 * @dataProvider data_redirect_guess_404_permalink_post_types
 	 */
@@ -412,6 +413,10 @@ class Tests_Canonical extends WP_Canonical_UnitTestCase {
 			'do not redirect to private post type' => array(
 				'original_url' => '/?name=private-cpt-po&post_type[]=wp_tests_private',
 				'expected'     => '/?name=private-cpt-po&post_type[]=wp_tests_private',
+			),
+			'do not leak private post type mixed in with a public one' => array(
+				'original_url' => '/?name=private-cpt-po&post_type[]=page&post_type[]=wp_tests_private',
+				'expected'     => '/?name=private-cpt-po&post_type[]=page&post_type[]=wp_tests_private',
 			),
 		);
 	}


### PR DESCRIPTION
**What this adds:** a new data-provider case for `Tests_Canonical::test_redirect_guess_404_permalink_post_types()` in `tests/phpunit/tests/canonical.php`, covering `redirect_guess_404_permalink()` in `src/wp-includes/canonical.php`.

**Function under test:** `redirect_guess_404_permalink()`, specifically the branch that builds the SQL `post_type IN (...)` clause when `post_type` is queried as an array (`src/wp-includes/canonical.php`, around line 985-989).

**Case covered and why:** a mix of one publicly viewable post type (`page`) and one non-viewable post type (`wp_tests_private`) in the `post_type` array, where a post of the *non-viewable* type matches the requested `name` prefix. Before the fix landed in trunk (`efa21b21dd`, ticket #44964), this branch built the SQL `IN (...)` clause from the raw, unfiltered `get_query_var( 'post_type' )` array instead of the `$post_types` list already intersected against publicly viewable types two lines above — so a private/non-viewable post could be found and its permalink leaked as the guessed 404 redirect target, even though it should never have been considered. The existing data set already covered a *single* private post type (which short-circuits via the `empty( $post_types )` guard before ever reaching the vulnerable SQL line) and a single public type, but nothing exercised the mixed-array path where the bug actually lived. I verified this test fails against the pre-fix code (reverting the one-line fix locally reproduces the leak and turns this exact case red) and passes against current trunk.

This is test-only — it adds no production behaviour. `git diff trunk` for this branch touches only `tests/phpunit/tests/canonical.php`.

Trac ticket: https://core.trac.wordpress.org/ticket/44964

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Sonnet 5
Used for: Surveying Trac for a coverage candidate, verifying the fix had landed in trunk and no test existed for it, drafting the test case and data-provider entry, and running the red/green verification loop (breaking the fix locally to confirm the new test fails, then reverting). I reviewed the diff, ticket, and test output before submitting.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**