### PR TITLE
Formatting: Allow CSS transform and SVG shape functions in safecss_filter_attr()

### DIFF
--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -3016,7 +3016,18 @@ function safecss_filter_attr( $css, $deprecated = '' ) {
 			 * Nested functions and parentheses are also removed, so long as the parentheses are balanced.
 			 */
 			$css_test_string = preg_replace(
-				'/\b(?:var|calc|min|max|minmax|clamp|repeat|rotate|rotateX|rotateY|rotateZ|rotate3d|translate|translateX|translateY|translateZ|translate3d|scale|scaleX|scaleY|scaleZ|scale3d|skew|skewX|skewY|matrix|matrix3d|perspective|inset|circle|ellipse|polygon|path)(\((?:[^()]|(?1))*\))/',
+				'/\b(?:'
+					// General purpose value functions.
+					. 'var|calc|min|max|minmax|clamp|repeat'
+					// Transform functions.
+					. '|matrix|matrix3d|perspective'
+					. '|rotate|rotate3d|rotateX|rotateY|rotateZ'
+					. '|scale|scale3d|scaleX|scaleY|scaleZ'
+					. '|skew|skewX|skewY'
+					. '|translate|translate3d|translateX|translateY|translateZ'
+					// Basic shape functions, as used by `clip-path`.
+					. '|circle|ellipse|inset|path|polygon|rect|shape|xywh'
+				. ')(\((?:[^()]|(?1))*\))/',
 				'',
 				$css_test_string
 			);

--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -2906,6 +2906,16 @@ function safecss_filter_attr( $css, $deprecated = '' ) {
 
 		'list-style',
 		'list-style-image',
+
+		// SVG presentation properties that accept url() references.
+		'clip-path',
+		'fill',
+		'marker',
+		'marker-end',
+		'marker-mid',
+		'marker-start',
+		'mask',
+		'stroke',
 	);
 
 	/*
@@ -3004,7 +3014,7 @@ function safecss_filter_attr( $css, $deprecated = '' ) {
 			 * Nested functions and parentheses are also removed, so long as the parentheses are balanced.
 			 */
 			$css_test_string = preg_replace(
-				'/\b(?:var|calc|min|max|minmax|clamp|repeat)(\((?:[^()]|(?1))*\))/',
+				'/\b(?:var|calc|min|max|minmax|clamp|repeat|rotate|rotateX|rotateY|rotateZ|rotate3d|translate|translateX|translateY|translateZ|translate3d|scale|scaleX|scaleY|scaleZ|scale3d|skew|skewX|skewY|matrix|matrix3d|perspective|inset|circle|ellipse|polygon|path)(\((?:[^()]|(?1))*\))/',
 				'',
 				$css_test_string
 			);

--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -2638,6 +2638,8 @@ function kses_init() {
  * @since 6.6.0 Added support for `grid-column`, `grid-row`, and `container-type`.
  * @since 6.9.0 Added support for `white-space`.
  * @since 7.1.0 Extended gradient support to allow any single-level nested function.
+ *              Added support for transform functions, `clip-path` basic shapes,
+ *              and URLs in the SVG element reference properties.
  *
  * @param string $css        A string of CSS rules, decoded from an HTML `style` attribute.
  * @param string $deprecated Not used.

--- a/tests/phpunit/tests/kses.php
+++ b/tests/phpunit/tests/kses.php
@@ -1840,6 +1840,18 @@ EOF;
 				'css'      => 'marker-end: url(#arrowEnd)',
 				'expected' => 'marker-end: url(#arrowEnd)',
 			),
+			array(
+				'css'      => 'marker-mid: url(#arrowMid)',
+				'expected' => 'marker-mid: url(#arrowMid)',
+			),
+			array(
+				'css'      => 'marker: url(#marker1)',
+				'expected' => 'marker: url(#marker1)',
+			),
+			array(
+				'css'      => 'stroke: url(#strokeGradient)',
+				'expected' => 'stroke: url(#strokeGradient)',
+			),
 			// Disallow javascript: URLs in SVG url() references (security regression).
 			array(
 				'css'      => 'fill: url(javascript:alert(1))',

--- a/tests/phpunit/tests/kses.php
+++ b/tests/phpunit/tests/kses.php
@@ -1819,6 +1819,27 @@ EOF;
 				'css'      => 'clip-path: polygon(50% 0%, 100% 100%, 0% 100%)',
 				'expected' => 'clip-path: polygon(50% 0%, 100% 100%, 0% 100%)',
 			),
+			array(
+				'css'      => "clip-path: path('M 0 0 L 100 0 L 50 100 Z')",
+				'expected' => "clip-path: path('M 0 0 L 100 0 L 50 100 Z')",
+			),
+			array(
+				'css'      => 'clip-path: rect(0 100% 100% 0)',
+				'expected' => 'clip-path: rect(0 100% 100% 0)',
+			),
+			array(
+				'css'      => 'clip-path: xywh(0 0 100% 100% round 10px)',
+				'expected' => 'clip-path: xywh(0 0 100% 100% round 10px)',
+			),
+			array(
+				'css'      => 'clip-path: shape(from 0 0, line to 100% 0, line to 50% 100%, close)',
+				'expected' => 'clip-path: shape(from 0 0, line to 100% 0, line to 50% 100%, close)',
+			),
+			// Nested functions within a basic shape are allowed.
+			array(
+				'css'      => 'clip-path: inset(calc(10px + 1em) round var(--radius))',
+				'expected' => 'clip-path: inset(calc(10px + 1em) round var(--radius))',
+			),
 			// SVG url() references for allowlisted properties (ticket #65832).
 			array(
 				'css'      => 'clip-path: url(#myClipper)',

--- a/tests/phpunit/tests/kses.php
+++ b/tests/phpunit/tests/kses.php
@@ -1224,6 +1224,7 @@ EOF;
 	 * @ticket 64414
 	 * @ticket 65457
 	 * @ticket 64974
+	 * @ticket 65832
 	 *
 	 * @dataProvider data_safecss_filter_attr
 	 *
@@ -1765,6 +1766,88 @@ EOF;
 			array(
 				'css'      => 'text-anchor: middle',
 				'expected' => 'text-anchor: middle',
+			),
+			// SVG transform functions (ticket #65832).
+			array(
+				'css'      => 'transform: rotate(45deg)',
+				'expected' => 'transform: rotate(45deg)',
+			),
+			array(
+				'css'      => 'transform: translate(10px, 20px)',
+				'expected' => 'transform: translate(10px, 20px)',
+			),
+			array(
+				'css'      => 'transform: scale(1.5)',
+				'expected' => 'transform: scale(1.5)',
+			),
+			array(
+				'css'      => 'transform: matrix(1, 0, 0, 1, 10, 20)',
+				'expected' => 'transform: matrix(1, 0, 0, 1, 10, 20)',
+			),
+			array(
+				'css'      => 'transform: skewX(30deg)',
+				'expected' => 'transform: skewX(30deg)',
+			),
+			array(
+				'css'      => 'transform: skewY(30deg)',
+				'expected' => 'transform: skewY(30deg)',
+			),
+			// Multiple transform functions chained.
+			array(
+				'css'      => 'transform: rotate(45deg) scale(1.5)',
+				'expected' => 'transform: rotate(45deg) scale(1.5)',
+			),
+			// transform: none is unchanged (regression control).
+			array(
+				'css'      => 'transform: none',
+				'expected' => 'transform: none',
+			),
+			// SVG clip-path shape functions (ticket #65832).
+			array(
+				'css'      => 'clip-path: inset(10px)',
+				'expected' => 'clip-path: inset(10px)',
+			),
+			array(
+				'css'      => 'clip-path: circle(50%)',
+				'expected' => 'clip-path: circle(50%)',
+			),
+			array(
+				'css'      => 'clip-path: ellipse(25% 40% at 50% 50%)',
+				'expected' => 'clip-path: ellipse(25% 40% at 50% 50%)',
+			),
+			array(
+				'css'      => 'clip-path: polygon(50% 0%, 100% 100%, 0% 100%)',
+				'expected' => 'clip-path: polygon(50% 0%, 100% 100%, 0% 100%)',
+			),
+			// SVG url() references for allowlisted properties (ticket #65832).
+			array(
+				'css'      => 'clip-path: url(#myClipper)',
+				'expected' => 'clip-path: url(#myClipper)',
+			),
+			array(
+				'css'      => 'fill: url(#gradient1)',
+				'expected' => 'fill: url(#gradient1)',
+			),
+			array(
+				'css'      => 'mask: url(#myMask)',
+				'expected' => 'mask: url(#myMask)',
+			),
+			array(
+				'css'      => 'marker-start: url(#arrowStart)',
+				'expected' => 'marker-start: url(#arrowStart)',
+			),
+			array(
+				'css'      => 'marker-end: url(#arrowEnd)',
+				'expected' => 'marker-end: url(#arrowEnd)',
+			),
+			// Disallow javascript: URLs in SVG url() references (security regression).
+			array(
+				'css'      => 'fill: url(javascript:alert(1))',
+				'expected' => '',
+			),
+			array(
+				'css'      => 'clip-path: url(javascript:alert(1))',
+				'expected' => '',
 			),
 		);
 	}


### PR DESCRIPTION
Follow-up to #65457 / #12169. Fixes #65832.

## The problem

`#65457` added 20+ SVG presentation properties to the KSES CSS allowlist, but left two internal structures unchanged. This means the new properties are allowlisted in name only — their functional values are still stripped:

| Declaration | Before this PR | Expected |
|---|---|---|
| `transform: rotate(45deg)` | stripped | preserved |
| `transform: translate(10px, 20px)` | stripped | preserved |
| `clip-path: url(#myClipper)` | stripped | preserved |
| `fill: url(#gradient1)` | stripped | preserved |
| `mask: url(#myMask)` | stripped | preserved |
| `transform: none` | preserved ✓ | preserved ✓ |
| `fill: #ff0000` | preserved ✓ | preserved ✓ |

The failure mode is the `(` character check at `kses.php:3015`. After stripping known-safe functions (`var`, `calc`, etc.), any remaining `(` causes the whole declaration to be dropped. Transform functions like `rotate(45deg)` were never added to that strip list.

The second failure: `clip-path: url(#id)` and `fill: url(#gradient)` need the URL-validation code path, which only runs for properties listed in `$css_url_data_types`. Those SVG properties were never added there either.

## The fix

**1. Expand `$css_url_data_types`** (9 lines added) to include `clip-path`, `fill`, `stroke`, `mask`, `marker`, `marker-start`, `marker-mid`, `marker-end`. This routes their `url()` values through the existing URL validator — which already blocks `javascript:`, `vbscript:`, and other bad protocols via `wp_kses_bad_protocol()`. No new security surface; the same gate that protects `background-image: url(...)` now protects these too.

**2. Extend the CSS function strip regex** to cover:
- CSS transform functions: `rotate`, `rotateX/Y/Z`, `rotate3d`, `translate`, `translateX/Y/Z`, `translate3d`, `scale`, `scaleX/Y/Z`, `scale3d`, `skew`, `skewX`, `skewY`, `matrix`, `matrix3d`, `perspective`
- CSS shape functions (for `clip-path`): `inset`, `circle`, `ellipse`, `polygon`, `path`

These are purely geometric/visual — no script execution risk. Precedent: `calc()` added in #46197 (5.8), `min()`/`max()` in #55966 (6.1), CSS custom properties in #56353 (6.1).

## Tests

Added 20 cases to `data_safecss_filter_attr()`:
- Transform functions: `rotate()`, `translate()`, `scale()`, `matrix()`, `skewX()`, `skewY()`
- Chained: `rotate(45deg) scale(1.5)`
- Regression control: `transform: none` (function-free value, was already passing)
- `clip-path` shapes: `inset()`, `circle()`, `ellipse()`, `polygon()`
- SVG `url()` references: `clip-path: url(#id)`, `fill: url(#id)`, `mask: url(#id)`, `marker-start: url(#id)`, `marker-end: url(#id)`
- Security regressions: `fill: url(javascript:alert(1))` → `""`, `clip-path: url(javascript:alert(1))` → `""`

Full kses group: **462 tests, 1537 assertions — all passing**.

---

Trac ticket: https://core.trac.wordpress.org/ticket/65832

---

This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.