### PR TITLE
Administration: Remove no-JS notices from Fonts and Connectors screens

### DIFF
--- a/src/wp-admin/font-library.php
+++ b/src/wp-admin/font-library.php
@@ -28,25 +28,9 @@ if ( ! function_exists( 'wp_font_library_wp_admin_render_page' ) ) {
 }
 
 // Set the page title
-$title               = _x( 'Fonts', 'Font Library admin page title' );
-$js_required_message = __( 'The Fonts screen requires JavaScript. Please enable JavaScript in your browser settings to install and manage fonts.' );
+$title = _x( 'Fonts', 'Font Library admin page title' );
 
 require_once ABSPATH . 'wp-admin/admin-header.php';
-
-?>
-<div class="wrap hide-if-js">
-	<h1 class="wp-heading-inline"><?php echo esc_html( $title ); ?></h1>
-	<?php
-		wp_admin_notice(
-			$js_required_message,
-			array(
-				'type'               => 'error',
-				'additional_classes' => array( 'hide-if-js' ),
-			)
-		);
-		?>
-</div>
-<?php
 
 // Render the Font Library page
 wp_font_library_wp_admin_render_page();

--- a/src/wp-admin/options-connectors.php
+++ b/src/wp-admin/options-connectors.php
@@ -27,28 +27,12 @@ if ( ! class_exists( '\WordPress\AiClient\AiClient' ) || ! function_exists( 'wp_
 }
 
 // Set the page title.
-$title               = __( 'Connectors' );
-$js_required_message = __( 'The Connectors screen requires JavaScript. Please enable JavaScript in your browser settings to manage your connectors.' );
+$title = __( 'Connectors' );
 
 // Set parent file for menu highlighting.
 $parent_file = 'options-general.php';
 
 require_once ABSPATH . 'wp-admin/admin-header.php';
-
-?>
-<div class="wrap hide-if-js">
-	<h1 class="wp-heading-inline"><?php echo esc_html( $title ); ?></h1>
-	<?php
-		wp_admin_notice(
-			$js_required_message,
-			array(
-				'type'               => 'error',
-				'additional_classes' => array( 'hide-if-js' ),
-			)
-		);
-		?>
-</div>
-<?php
 
 // Render the Connectors page.
 wp_options_connectors_wp_admin_render_page();


### PR DESCRIPTION
Removes the per-page no-JS heading and notice added in [r62954](https://core.trac.wordpress.org/changeset/62954), since the generated `wp-build` page template now renders them for every route-based page.

- Depends on https://github.com/WordPress/gutenberg/pull/81365.
- Trac ticket: https://core.trac.wordpress.org/ticket/65840

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Removing the markup per the ticket; reviewed and verified by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
