### PR TITLE
Editor: order viewport breakpoints only against a comparable base

### DIFF
--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -810,6 +810,22 @@ class WP_Theme_JSON {
 	}
 
 	/**
+	 * Returns the base a viewport breakpoint size is measured against.
+	 *
+	 * Media queries resolve `em` and `rem` against the initial font size, so both
+	 * share a base and can be compared with each other. A `px` length cannot be
+	 * compared with either.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param string $value Valid viewport breakpoint size.
+	 * @return string Either 'px' or 'font-relative'.
+	 */
+	private static function get_viewport_breakpoint_base( $value ) {
+		return str_ends_with( trim( $value ), 'px' ) ? 'px' : 'font-relative';
+	}
+
+	/**
 	 * Sanitizes and normalizes viewport breakpoint settings.
 	 *
 	 * Keeps only supported breakpoint keys, trims valid CSS lengths, and returns
@@ -817,6 +833,9 @@ class WP_Theme_JSON {
 	 * only one breakpoint is valid, it remains keyed by its configured state and
 	 * uses a single max-width media query. When `tablet` is not larger than
 	 * `mobile`, it is removed.
+	 *
+	 * `tablet` is also removed when the two breakpoints are measured against
+	 * different bases, since their order cannot be determined.
 	 *
 	 * @since 7.1.0
 	 *
@@ -836,6 +855,7 @@ class WP_Theme_JSON {
 				$breakpoints[ $breakpoint ] = array(
 					'value' => trim( $value ),
 					'px'    => $px,
+					'base'  => self::get_viewport_breakpoint_base( $value ),
 				);
 			}
 		}
@@ -851,7 +871,11 @@ class WP_Theme_JSON {
 
 		$sanitized = array( 'mobile' => $breakpoints['mobile']['value'] );
 
-		if ( isset( $breakpoints['tablet'] ) && $breakpoints['mobile']['px'] < $breakpoints['tablet']['px'] ) {
+		if (
+			isset( $breakpoints['tablet'] )
+			&& $breakpoints['mobile']['base'] === $breakpoints['tablet']['base']
+			&& $breakpoints['mobile']['px'] < $breakpoints['tablet']['px']
+		) {
 			$sanitized['tablet'] = $breakpoints['tablet']['value'];
 		}
 

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -810,22 +810,6 @@ class WP_Theme_JSON {
 	}
 
 	/**
-	 * Returns the base a viewport breakpoint size is measured against.
-	 *
-	 * Media queries resolve `em` and `rem` against the initial font size, so both
-	 * share a base and can be compared with each other. A `px` length cannot be
-	 * compared with either.
-	 *
-	 * @since 7.1.0
-	 *
-	 * @param string $value Valid viewport breakpoint size.
-	 * @return string Either 'px' or 'font-relative'.
-	 */
-	private static function get_viewport_breakpoint_base( $value ) {
-		return str_ends_with( trim( $value ), 'px' ) ? 'px' : 'font-relative';
-	}
-
-	/**
 	 * Sanitizes and normalizes viewport breakpoint settings.
 	 *
 	 * Keeps only supported breakpoint keys, trims valid CSS lengths, and returns
@@ -855,7 +839,7 @@ class WP_Theme_JSON {
 				$breakpoints[ $breakpoint ] = array(
 					'value' => trim( $value ),
 					'px'    => $px,
-					'base'  => self::get_viewport_breakpoint_base( $value ),
+					'is_px' => str_ends_with( trim( $value ), 'px' ),
 				);
 			}
 		}
@@ -873,7 +857,7 @@ class WP_Theme_JSON {
 
 		if (
 			isset( $breakpoints['tablet'] )
-			&& $breakpoints['mobile']['base'] === $breakpoints['tablet']['base']
+			&& $breakpoints['mobile']['is_px'] === $breakpoints['tablet']['is_px']
 			&& $breakpoints['mobile']['px'] < $breakpoints['tablet']['px']
 		) {
 			$sanitized['tablet'] = $breakpoints['tablet']['value'];

--- a/tests/phpunit/tests/theme/wpThemeJson.php
+++ b/tests/phpunit/tests/theme/wpThemeJson.php
@@ -1249,6 +1249,117 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A `px` breakpoint cannot be ordered against a font-relative one, so the
+	 * tablet range is dropped rather than emitted unordered.
+	 *
+	 * @ticket 65833
+	 *
+	 * @dataProvider data_viewport_breakpoints_with_incomparable_units
+	 *
+	 * @param array $viewport_settings Viewport settings to sanitize.
+	 * @param array $expected          Expected media queries.
+	 */
+	public function test_get_viewport_media_queries_omits_tablet_when_breakpoint_units_are_not_comparable( $viewport_settings, $expected ) {
+		$this->assertSame(
+			$expected,
+			WP_Theme_JSON::get_viewport_media_queries(
+				$viewport_settings,
+				array(
+					'include_desktop' => true,
+				)
+			)
+		);
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_viewport_breakpoints_with_incomparable_units() {
+		return array(
+			'font-relative mobile, pixel tablet' => array(
+				'viewport_settings' => array(
+					'mobile' => '30em',
+					'tablet' => '500px',
+				),
+				'expected'          => array(
+					'@mobile'  => '@media (width <= 30em)',
+					'@desktop' => '@media (width > 30em)',
+				),
+			),
+			'pixel mobile, font-relative tablet' => array(
+				'viewport_settings' => array(
+					'mobile' => '400px',
+					'tablet' => '30em',
+				),
+				'expected'          => array(
+					'@mobile'  => '@media (width <= 400px)',
+					'@desktop' => '@media (width > 400px)',
+				),
+			),
+			'pixel mobile, rem tablet'           => array(
+				'viewport_settings' => array(
+					'mobile' => '400px',
+					'tablet' => '30rem',
+				),
+				'expected'          => array(
+					'@mobile'  => '@media (width <= 400px)',
+					'@desktop' => '@media (width > 400px)',
+				),
+			),
+		);
+	}
+
+	/**
+	 * `em` and `rem` share a base, so they can be ordered against each other.
+	 *
+	 * @ticket 65833
+	 */
+	public function test_get_viewport_media_queries_keeps_tablet_when_breakpoints_mix_em_and_rem() {
+		$this->assertSame(
+			array(
+				'@mobile'  => '@media (width <= 30em)',
+				'@tablet'  => '@media (30em < width <= 40rem)',
+				'@desktop' => '@media (width > 40rem)',
+			),
+			WP_Theme_JSON::get_viewport_media_queries(
+				array(
+					'mobile' => '30em',
+					'tablet' => '40rem',
+				),
+				array(
+					'include_desktop' => true,
+				)
+			)
+		);
+	}
+
+	/**
+	 * @ticket 65833
+	 */
+	public function test_viewport_settings_omit_tablet_when_breakpoint_units_are_not_comparable() {
+		$theme_json = new WP_Theme_JSON(
+			array(
+				'version'  => WP_Theme_JSON::LATEST_SCHEMA,
+				'settings' => array(
+					'viewport' => array(
+						'mobile' => '30em',
+						'tablet' => '500px',
+					),
+				),
+			)
+		);
+
+		$this->assertSame(
+			array(
+				'mobile' => '30em',
+			),
+			$theme_json->get_raw_data()['settings']['viewport']
+		);
+	}
+
+	/**
 	 * @ticket 65596
 	 */
 	public function test_get_stylesheet_uses_custom_viewport_breakpoints_for_responsive_block_styles() {

--- a/tests/phpunit/tests/theme/wpThemeJson.php
+++ b/tests/phpunit/tests/theme/wpThemeJson.php
@@ -1254,12 +1254,12 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 	 *
 	 * @ticket 65833
 	 *
-	 * @dataProvider data_viewport_breakpoints_with_incomparable_units
+	 * @dataProvider data_viewport_breakpoints_without_a_shared_base
 	 *
 	 * @param array $viewport_settings Viewport settings to sanitize.
 	 * @param array $expected          Expected media queries.
 	 */
-	public function test_get_viewport_media_queries_omits_tablet_when_breakpoint_units_are_not_comparable( $viewport_settings, $expected ) {
+	public function test_get_viewport_media_queries_omits_tablet_when_breakpoints_do_not_share_a_base( $viewport_settings, $expected ) {
 		$this->assertSame(
 			$expected,
 			WP_Theme_JSON::get_viewport_media_queries(
@@ -1276,7 +1276,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 	 *
 	 * @return array[]
 	 */
-	public function data_viewport_breakpoints_with_incomparable_units() {
+	public function data_viewport_breakpoints_without_a_shared_base() {
 		return array(
 			'font-relative mobile, pixel tablet' => array(
 				'viewport_settings' => array(
@@ -1298,36 +1298,25 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 					'@desktop' => '@media (width > 400px)',
 				),
 			),
-			'pixel mobile, rem tablet'           => array(
-				'viewport_settings' => array(
-					'mobile' => '400px',
-					'tablet' => '30rem',
-				),
-				'expected'          => array(
-					'@mobile'  => '@media (width <= 400px)',
-					'@desktop' => '@media (width > 400px)',
-				),
-			),
 		);
 	}
 
 	/**
-	 * `em` and `rem` share a base, so they can be ordered against each other.
+	 * `em` and `rem` resolve against the same base in a media query, so they can
+	 * be ordered against each other.
 	 *
 	 * @ticket 65833
+	 *
+	 * @dataProvider data_viewport_breakpoints_with_a_shared_base
+	 *
+	 * @param array $viewport_settings Viewport settings to sanitize.
+	 * @param array $expected          Expected media queries.
 	 */
-	public function test_get_viewport_media_queries_keeps_tablet_when_breakpoints_mix_em_and_rem() {
+	public function test_get_viewport_media_queries_keeps_tablet_when_breakpoints_share_a_base( $viewport_settings, $expected ) {
 		$this->assertSame(
-			array(
-				'@mobile'  => '@media (width <= 30em)',
-				'@tablet'  => '@media (30em < width <= 40rem)',
-				'@desktop' => '@media (width > 40rem)',
-			),
+			$expected,
 			WP_Theme_JSON::get_viewport_media_queries(
-				array(
-					'mobile' => '30em',
-					'tablet' => '40rem',
-				),
+				$viewport_settings,
 				array(
 					'include_desktop' => true,
 				)
@@ -1336,9 +1325,41 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_viewport_breakpoints_with_a_shared_base() {
+		return array(
+			'em mobile, rem tablet' => array(
+				'viewport_settings' => array(
+					'mobile' => '30em',
+					'tablet' => '40rem',
+				),
+				'expected'          => array(
+					'@mobile'  => '@media (width <= 30em)',
+					'@tablet'  => '@media (30em < width <= 40rem)',
+					'@desktop' => '@media (width > 40rem)',
+				),
+			),
+			'rem mobile, em tablet' => array(
+				'viewport_settings' => array(
+					'mobile' => '30rem',
+					'tablet' => '40em',
+				),
+				'expected'          => array(
+					'@mobile'  => '@media (width <= 30rem)',
+					'@tablet'  => '@media (30rem < width <= 40em)',
+					'@desktop' => '@media (width > 40em)',
+				),
+			),
+		);
+	}
+
+	/**
 	 * @ticket 65833
 	 */
-	public function test_viewport_settings_omit_tablet_when_breakpoint_units_are_not_comparable() {
+	public function test_viewport_settings_omit_tablet_when_breakpoints_do_not_share_a_base() {
 		$theme_json = new WP_Theme_JSON(
 			array(
 				'version'  => WP_Theme_JSON::LATEST_SCHEMA,


### PR DESCRIPTION
`WP_Theme_JSON::sanitize_viewport_settings()` proves that `tablet` is larger than `mobile` using values normalized at a hardcoded 16px, but `get_viewport_media_queries()` emits the authored units. A media query resolves `em` and `rem` against the initial font size rather than anything set on the page, so the ordering proven at 16px does not transfer to the browser when the two breakpoints are measured against different bases.

With `mobile: 30em, tablet: 500px` the guard passes because 30 x 16 = 480 < 500, and core emits `@media (30em < width <= 500px)`. Above a 16px base that range is empty, and `@media (width <= 30em)` and `@media (width > 500px)` begin to overlap instead, so two viewport states apply at once.

`em` and `rem` share a base in a media query, so they can be ordered against each other. A `px` length and a font-relative one cannot, at any base. This adds `get_viewport_breakpoint_base()` and keeps `tablet` only when both breakpoints are measured against the same base, dropping it in the mixed case exactly as it is already dropped when it is not larger than `mobile`.

No new string, so it is available after hard string freeze. `settings.viewport` is new in 7.1 and unreleased, so no existing theme depends on the current behavior.

Approach agreed with wildworks in [comment:3](https://core.trac.wordpress.org/ticket/65833#comment:3). The warning message requested there is a follow-up rather than part of this change, since it needs a translatable string.

Gutenberg mirrors this logic in `packages/global-styles-engine/src/utils/viewport.ts` and `lib/class-wp-theme-json-gutenberg.php`, so the editor preview needs the same change upstream. Not part of this PR.

## Testing instructions

In a theme's `theme.json`:

```json
{ "version": 3, "settings": { "viewport": { "mobile": "30em", "tablet": "500px" } } }
```

Add a paragraph with block visibility set to hide on tablet, then view the post. Before this change the page emits `@media (30em < width <= 500px)`. After it, `tablet` is not a configured breakpoint and only the mobile query is emitted. `mobile: 30em, tablet: 40rem` keeps both breakpoints, since those share a base.

Trac ticket: https://core.trac.wordpress.org/ticket/65833

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Investigation, browser measurements, drafting the change and the tests. I
reviewed, tested and take responsibility for everything in this pull request.
