### PR TITLE
Formatting: match CSS function names case-insensitively in safecss_fi…

### DIFF
--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -2554,6 +2554,7 @@ function kses_init() {
  * @since 6.6.0 Added support for `grid-column`, `grid-row`, and `container-type`.
  * @since 6.9.0 Added support for `white-space`.
  * @since 7.1.0 Extended gradient support to allow any single-level nested function.
+ *              CSS function names are now matched case-insensitively.
  *
  * @param string $css        A string of CSS rules, decoded from an HTML `style` attribute.
  * @param string $deprecated Not used.
@@ -2869,19 +2870,22 @@ function safecss_filter_attr( $css, $deprecated = '' ) {
 			}
 
 			if ( $is_custom_var ) {
-				$css_value     = trim( $parts[1] );
-				$url_attr      = str_starts_with( $css_value, 'url(' );
-				$gradient_attr = str_contains( $css_value, '-gradient(' );
+				$css_value = trim( $parts[1] );
+
+				// CSS function names are ASCII case-insensitive.
+				$lowercase_css_value = strtolower( $css_value );
+				$url_attr            = str_starts_with( $lowercase_css_value, 'url(' );
+				$gradient_attr       = str_contains( $lowercase_css_value, '-gradient(' );
 			}
 		}
 
 		if ( $found && $url_attr ) {
 			// Simplified: matches the sequence `url(*)`.
-			preg_match_all( '/url\([^)]+\)/', $parts[1], $url_matches );
+			preg_match_all( '/url\([^)]+\)/i', $parts[1], $url_matches );
 
 			foreach ( $url_matches[0] as $url_match ) {
 				// Clean up the URL from each of the matches above.
-				preg_match( '/^url\(\s*([\'\"]?)(.*)(\g1)\s*\)$/', $url_match, $url_pieces );
+				preg_match( '/^url\(\s*([\'\"]?)(.*)(\g1)\s*\)$/i', $url_match, $url_pieces );
 
 				if ( empty( $url_pieces[2] ) ) {
 					$found = false;
@@ -2906,7 +2910,7 @@ function safecss_filter_attr( $css, $deprecated = '' ) {
 			 * (e.g. rgb(), hsl(), var()). Matching each occurrence, rather than requiring the
 			 * whole value to be a single gradient, lets a gradient combine with a url() image.
 			 */
-			preg_match_all( '/(?:repeating-)?(?:linear|radial|conic)-gradient\((?:[^()]|\([^()]*\))*\)/', $css_test_string, $gradient_matches );
+			preg_match_all( '/(?:repeating-)?(?:linear|radial|conic)-gradient\((?:[^()]|\([^()]*\))*\)/i', $css_test_string, $gradient_matches );
 
 			foreach ( $gradient_matches[0] as $gradient_match ) {
 				// Remove each `gradient()` bit that was matched above from the CSS.
@@ -2918,9 +2922,10 @@ function safecss_filter_attr( $css, $deprecated = '' ) {
 			/*
 			 * Allow CSS functions like var(), calc(), etc. by removing them from the test string.
 			 * Nested functions and parentheses are also removed, so long as the parentheses are balanced.
+			 * Function names are matched case-insensitively, as they are in CSS.
 			 */
 			$css_test_string = preg_replace(
-				'/\b(?:var|calc|min|max|minmax|clamp|repeat)(\((?:[^()]|(?1))*\))/',
+				'/\b(?:var|calc|min|max|minmax|clamp|repeat)(\((?:[^()]|(?1))*\))/i',
 				'',
 				$css_test_string
 			);

--- a/tests/phpunit/tests/kses.php
+++ b/tests/phpunit/tests/kses.php
@@ -1003,6 +1003,7 @@ EOF;
 	 * @ticket 64414
 	 * @ticket 65457
 	 * @ticket 64974
+	 * @ticket 65838
 	 *
 	 * @dataProvider data_safecss_filter_attr
 	 *
@@ -1544,6 +1545,85 @@ EOF;
 			array(
 				'css'      => 'text-anchor: middle',
 				'expected' => 'text-anchor: middle',
+			),
+			/*
+			 * CSS function names are ASCII case-insensitive.
+			 *
+			 * Note that property names remain case-sensitive, so only the
+			 * function part of each value is written in mixed case here.
+			 */
+			array(
+				'css'      => 'width: CALC(100% - 10px)',
+				'expected' => 'width: CALC(100% - 10px)',
+			),
+			array(
+				'css'      => 'margin-top: Calc(Var(--wp-var1) * 3 + 2em)',
+				'expected' => 'margin-top: Calc(Var(--wp-var1) * 3 + 2em)',
+			),
+			array(
+				'css'      => 'width: CLAMP(MIN(100px, 350px), 50%, MAX(200px, 25%))',
+				'expected' => 'width: CLAMP(MIN(100px, 350px), 50%, MAX(200px, 25%))',
+			),
+			array(
+				'css'      => 'grid-template-columns: REPEAT(4, MINMAX(0, 1fr))',
+				'expected' => 'grid-template-columns: REPEAT(4, MINMAX(0, 1fr))',
+			),
+			array(
+				'css'      => 'background-image: URL("foo.jpg")',
+				'expected' => 'background-image: URL("foo.jpg")',
+			),
+			array(
+				'css'      => 'background: LINEAR-GRADIENT(135deg,RGBA(6,147,227,1) 0%,rgb(155,81,224) 100%)',
+				'expected' => 'background: LINEAR-GRADIENT(135deg,RGBA(6,147,227,1) 0%,rgb(155,81,224) 100%)',
+			),
+			array(
+				'css'      => 'background: Repeating-Radial-Gradient(red, blue)',
+				'expected' => 'background: Repeating-Radial-Gradient(red, blue)',
+			),
+			array(
+				'css'      => '--with-url-value: URL("foo.jpg");--with-gradient: CONIC-GRADIENT(red, blue)',
+				'expected' => '--with-url-value: URL("foo.jpg");--with-gradient: CONIC-GRADIENT(red, blue)',
+			),
+			// Case-insensitive matching must not let unsafe or malformed values through.
+			array(
+				'css'      => 'background-image: URL("bad://example.com/invalid.gif")',
+				'expected' => '',
+			),
+			array(
+				'css'      => 'background-image: uRl( "JavaScript:alert(1)" )',
+				'expected' => '',
+			),
+			array(
+				'css'      => 'background: LINEAR-GRADIENT(red, URL(javascript:alert(1)))',
+				'expected' => '',
+			),
+			array(
+				'css'      => 'background-image: URL()',
+				'expected' => '',
+			),
+			array(
+				'css'      => 'width: CALC(3em + 10px',
+				'expected' => '',
+			),
+			array(
+				'css'      => 'width: CALC(3em + (10px * 2)',
+				'expected' => '',
+			),
+			array(
+				'css'      => 'width: EXPRESSION(alert(1))',
+				'expected' => '',
+			),
+			array(
+				'css'      => 'aspect-ratio: EXPRESSION( 16 / 9 )',
+				'expected' => '',
+			),
+			array(
+				'css'      => 'background: UNKNOWN-GRADIENT(135deg,rgba(6,147,227,1) 0%)',
+				'expected' => '',
+			),
+			array(
+				'css'      => 'width: CALCMAX(100px + 50%)',
+				'expected' => '',
 			),
 		);
 	}


### PR DESCRIPTION

CSS function names are ASCII case-insensitive, so `CALC(1px + 2px)`, `URL(foo.jpg)`, and `LINEAR-GRADIENT(red, blue)` are all valid CSS. Every function-matching pattern in `safecss_filter_attr()` was case-sensitive, however, so valid declarations using anything other than all-lowercase function names were silently dropped.

Add the `i` modifier to the `url()`, gradient, and generic function patterns, and lowercase the value before the `url(` / `-gradient(` sniffing done for custom properties.

Only the function names are matched loosely; the grammar each pattern accepts is unchanged, so a mixed-case value is now held to exactly the same standard as its lowercase equivalent. Protocol checking in `wp_kses_bad_protocol()` was already case-insensitive, so `URL()` values are validated the same way `url()` values are.

Property names remain case-sensitive, which is a separate concern.

Fixes #65838. See #64974.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
