### PR TITLE
Feeds: Remove deprecated wfw namespace.

### DIFF
--- a/src/wp-admin/includes/export.php
+++ b/src/wp-admin/includes/export.php
@@ -521,7 +521,6 @@ function export_wp( $args = array() ) {
 <rss version="2.0"
 	xmlns:excerpt="http://wordpress.org/export/<?php echo WXR_VERSION; ?>/excerpt/"
 	xmlns:content="http://purl.org/rss/1.0/modules/content/"
-	xmlns:wfw="http://wellformedweb.org/CommentAPI/"
 	xmlns:dc="http://purl.org/dc/elements/1.1/"
 	xmlns:wp="http://wordpress.org/export/<?php echo WXR_VERSION; ?>/"
 >

--- a/src/wp-includes/feed-rss2.php
+++ b/src/wp-includes/feed-rss2.php
@@ -22,7 +22,6 @@ do_action( 'rss_tag_pre', 'rss2' );
 ?>
 <rss version="2.0"
 	xmlns:content="http://purl.org/rss/1.0/modules/content/"
-	xmlns:wfw="http://wellformedweb.org/CommentAPI/"
 	xmlns:dc="http://purl.org/dc/elements/1.1/"
 	xmlns:atom="http://www.w3.org/2005/Atom"
 	xmlns:sy="http://purl.org/rss/1.0/modules/syndication/"
@@ -110,7 +109,6 @@ do_action( 'rss_tag_pre', 'rss2' );
 		<?php endif; ?>
 
 		<?php if ( get_comments_number() || comments_open() ) : ?>
-			<wfw:commentRss><?php echo esc_url( get_post_comments_feed_link( null, 'rss2' ) ); ?></wfw:commentRss>
 			<slash:comments><?php echo get_comments_number(); ?></slash:comments>
 		<?php endif; ?>
 

--- a/tests/phpunit/tests/feed/rss2.php
+++ b/tests/phpunit/tests/feed/rss2.php
@@ -123,7 +123,6 @@ class Tests_Feed_RSS2 extends WP_UnitTestCase {
 
 		$this->assertSame( '2.0', $rss[0]['attributes']['version'] );
 		$this->assertSame( 'http://purl.org/rss/1.0/modules/content/', $rss[0]['attributes']['xmlns:content'] );
-		$this->assertSame( 'http://wellformedweb.org/CommentAPI/', $rss[0]['attributes']['xmlns:wfw'] );
 		$this->assertSame( 'http://purl.org/dc/elements/1.1/', $rss[0]['attributes']['xmlns:dc'] );
 
 		// RSS should have exactly one child element (channel).
@@ -269,10 +268,6 @@ class Tests_Feed_RSS2 extends WP_UnitTestCase {
 				$content = xml_find( $items[ $key ]['child'], 'content:encoded' );
 				$this->assertSame( trim( apply_filters( 'the_content', $post->post_content ) ), trim( $content[0]['content'] ) );
 			}
-
-			// Comment RSS.
-			$comment_rss = xml_find( $items[ $key ]['child'], 'wfw:commentRss' );
-			$this->assertSame( html_entity_decode( get_post_comments_feed_link( $post->ID ) ), $comment_rss[0]['content'] );
 		}
 	}
 
@@ -301,10 +296,6 @@ class Tests_Feed_RSS2 extends WP_UnitTestCase {
 			// Comment link.
 			$comments_link = xml_find( $items[ $key ]['child'], 'comments' );
 			$this->assertEmpty( $comments_link );
-
-			// Comment RSS.
-			$comment_rss = xml_find( $items[ $key ]['child'], 'wfw:commentRss' );
-			$this->assertEmpty( $comment_rss );
 		}
 
 		remove_filter( 'comments_open', '__return_false' );


### PR DESCRIPTION
## Description

Remove the deprecated wfw XML namespace from generated feeds.

The referenced wellformedweb.org domain is no longer maintained.

Trac ticket:
https://core.trac.wordpress.org/ticket/65830


## Testing

Verified generated feeds no longer output the deprecated namespace.