### PR TITLE
Site Health: Send only WordPress cookies with the REST API test

### DIFF
--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -2187,6 +2187,7 @@ class WP_Site_Health {
 	 * This is required for the new block editor to work, so we explicitly test for this.
 	 *
 	 * @since 5.2.0
+	 * @since 7.1.0 Only WordPress' own cookies are sent with the request.
 	 *
 	 * @return array The test results.
 	 */
@@ -2206,7 +2207,16 @@ class WP_Site_Health {
 			'test'        => 'rest_availability',
 		);
 
-		$cookies = wp_unslash( $_COOKIE );
+		/*
+		 * Only WordPress' own cookies have any bearing on this request. Forwarding the rest of
+		 * the browser's cookie jar lets unrelated cookies fail a test that is meant to measure
+		 * the REST API.
+		 */
+		$cookies = array_intersect_key(
+			wp_unslash( $_COOKIE ),
+			array_flip( array( AUTH_COOKIE, SECURE_AUTH_COOKIE, LOGGED_IN_COOKIE, TEST_COOKIE ) )
+		);
+
 		$timeout = 10; // 10 seconds.
 		$headers = array(
 			'Cache-Control' => 'no-cache',

--- a/tests/phpunit/tests/admin/wpSiteHealth.php
+++ b/tests/phpunit/tests/admin/wpSiteHealth.php
@@ -707,4 +707,51 @@ class Tests_Admin_wpSiteHealth extends WP_UnitTestCase {
 			$this->assertStringContainsString( __( 'Enabling this cache can significantly improve the performance of your site.' ), $result['description'] );
 		}
 	}
+
+	/**
+	 * Tests that only WordPress' own cookies are sent with the REST API test request.
+	 *
+	 * @ticket 65839
+	 *
+	 * @covers ::get_test_rest_availability()
+	 */
+	public function test_get_test_rest_availability_sends_only_wordpress_cookies() {
+		$original_cookie = $_COOKIE;
+
+		$_COOKIE = array(
+			LOGGED_IN_COOKIE     => 'admin|1700000000|token|hmac',
+			TEST_COOKIE          => 'WP Cookie check',
+			'_ga'                => 'GA1.1.123456789.1700000000',
+			'wp-settings-time-1' => '1700000000',
+		);
+
+		$sent = null;
+
+		add_filter(
+			'pre_http_request',
+			static function ( $response, $parsed_args ) use ( &$sent ) {
+				$sent = $parsed_args['cookies'];
+
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => '',
+				);
+			},
+			10,
+			2
+		);
+
+		$this->instance->get_test_rest_availability();
+
+		$_COOKIE = $original_cookie;
+
+		$this->assertSame(
+			array(
+				LOGGED_IN_COOKIE => 'admin|1700000000|token|hmac',
+				TEST_COOKIE      => 'WP Cookie check',
+			),
+			$sent,
+			'Only WordPress\' own cookies should be sent with the REST API test request.'
+		);
+	}
 }


### PR DESCRIPTION
Restricts the cookies sent with the Site Health REST API availability test to the cookie names WordPress itself defines, instead of forwarding the visitor's entire browser cookie jar to the loopback request.

What the problem was:

- `WP_Site_Health::get_test_rest_availability()` passed `wp_unslash( $_COOKIE )` straight to `wp_remote_get()`, so every cookie in the visitor's browser — analytics, CDN, cache, commerce, and others — was forwarded to the site's own REST endpoint.

- None of those cookies play any part in authenticating the request, which is done with the WordPress cookies plus the `X-WP-Nonce` header.

- On the reporting site this produced a false `(403) Forbidden` with `rest_cookie_invalid_nonce`, while the same request limited to the WordPress cookies returned `200`.

What the fix does:

- Filters `$cookies` through `array_intersect_key()` so only `AUTH_COOKIE`, `SECURE_AUTH_COOKIE`, `LOGGED_IN_COOKIE`, and `TEST_COOKIE` are forwarded.

- Adds a test asserting that unrelated cookies are dropped and the WordPress cookies are kept.

Approach and why:

- The allowlist uses core's cookie constants rather than a `wordpress_` name prefix. A prefix would keep `wp-settings-*`, which is not an authentication cookie, and would break on sites that redefine the cookie constants in `wp-config.php`. The test covers the `wp-settings-*` case specifically.

- This narrows what is sent, so it is worth stating plainly: a site whose edge or host requires some other cookie to reach the endpoint (for example Cloudflare Access) can restore it through the existing `http_request_args` filter, which runs after this code. No new filter is introduced.

- Only the method named in the ticket is changed. `WP_Site_Health::can_perform_loopback()`, `WP_Automatic_Updater`, and `wp-admin/includes/file.php` use the same `wp_unslash( $_COOKIE )` pattern for different loopback targets and need their own analysis; they are left for a separate ticket.

Testing instructions:

1. Log in as an administrator and add several unrelated cookies for the site in the browser (for example `_ga`, `wp-settings-time-1`, and a large dummy cookie of a few kilobytes).

2. Visit Tools > Site Health. On trunk, inspect the outgoing loopback request and confirm the whole cookie jar is sent; on a site sensitive to this the REST API test reports `(403) Forbidden` with `rest_cookie_invalid_nonce`.

3. Apply the patch, reload Site Health, and confirm the REST API test reports "The REST API is available" and that only the WordPress cookies are sent.

4. Run `phpunit --filter test_get_test_rest_availability_sends_only_wordpress_cookies tests/phpunit/tests/admin/wpSiteHealth.php`. The test fails on trunk and passes with the patch.

Trac ticket: https://core.trac.wordpress.org/ticket/65839

## Use of AI Tools

AI assistance: Yes

Tool(s): Claude Code

Model(s): Claude Opus 5

Used for: Ticket analysis, code implementation, and tests. All changes were reviewed and validated by me.

---

**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
