### PR TITLE
#13655 fix: stripslash passwords on login and user edit

### DIFF
--- a/src/wp-admin/includes/user.php
+++ b/src/wp-admin/includes/user.php
@@ -49,10 +49,10 @@ function edit_user( $user_id = 0 ) {
 	$pass1 = '';
 	$pass2 = '';
 	if ( isset( $_POST['pass1'] ) ) {
-		$pass1 = trim( $_POST['pass1'] );
+		$pass1 = trim( wp_unslash( $_POST['pass1'] ) );
 	}
 	if ( isset( $_POST['pass2'] ) ) {
-		$pass2 = trim( $_POST['pass2'] );
+		$pass2 = trim( wp_unslash( $_POST['pass2'] ) );
 	}
 
 	if ( isset( $_POST['role'] ) && current_user_can( 'promote_users' ) && ( ! $user_id || current_user_can( 'promote_user', $user_id ) ) ) {

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -52,7 +52,7 @@ function wp_signon( $credentials = array(), $secure_cookie = '' ) {
 			$credentials['user_login'] = wp_unslash( $_POST['log'] );
 		}
 		if ( ! empty( $_POST['pwd'] ) && is_string( $_POST['pwd'] ) ) {
-			$credentials['user_password'] = $_POST['pwd'];
+			$credentials['user_password'] = wp_unslash( $_POST['pwd'] );
 		}
 		if ( ! empty( $_POST['rememberme'] ) ) {
 			$credentials['remember'] = $_POST['rememberme'];
@@ -208,6 +208,19 @@ function wp_authenticate_username_password(
 	$valid = wp_check_password( $password, $user->user_pass, $user->ID );
 
 	if ( ! $valid ) {
+		/*
+		 * Back-compat for users whose password was hashed with magic-quote slashes
+		 * intact. If the slashed version matches, migrate the hash to the
+		 * unslashed password.
+		 */
+		$valid = wp_check_password( wp_slash( $password ), $user->user_pass, $user->ID );
+
+		if ( $valid ) {
+			wp_set_password( $password, $user->ID );
+		}
+	}
+
+	if ( ! $valid ) {
 		return new WP_Error(
 			'incorrect_password',
 			sprintf(
@@ -289,6 +302,19 @@ function wp_authenticate_email_password(
 	}
 
 	$valid = wp_check_password( $password, $user->user_pass, $user->ID );
+
+	if ( ! $valid ) {
+		/*
+		 * Back-compat for users whose password was hashed with magic-quote slashes
+		 * intact. If the slashed version matches, migrate the hash to the
+		 * unslashed password.
+		 */
+		$valid = wp_check_password( wp_slash( $password ), $user->user_pass, $user->ID );
+
+		if ( $valid ) {
+			wp_set_password( $password, $user->ID );
+		}
+	}
 
 	if ( ! $valid ) {
 		return new WP_Error(

--- a/src/wp-login.php
+++ b/src/wp-login.php
@@ -970,7 +970,7 @@ switch ( $action ) {
 
 		// Check if password is one or all empty spaces.
 		if ( ! empty( $_POST['pass1'] ) ) {
-			$_POST['pass1'] = trim( $_POST['pass1'] );
+			$_POST['pass1'] = trim( wp_unslash( $_POST['pass1'] ) );
 
 			if ( empty( $_POST['pass1'] ) ) {
 				$errors->add( 'password_reset_empty_space', __( 'The password cannot be a space or all spaces.' ) );
@@ -978,7 +978,7 @@ switch ( $action ) {
 		}
 
 		// Check if password fields do not match.
-		if ( ! empty( $_POST['pass1'] ) && trim( $_POST['pass2'] ) !== $_POST['pass1'] ) {
+		if ( ! empty( $_POST['pass1'] ) && trim( wp_unslash( $_POST['pass2'] ) ) !== $_POST['pass1'] ) {
 			$errors->add( 'password_reset_mismatch', __( '<strong>Error:</strong> The passwords do not match.' ) );
 		}
 

--- a/tests/phpunit/tests/auth.php
+++ b/tests/phpunit/tests/auth.php
@@ -155,6 +155,55 @@ class Tests_Auth extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that wp_signon() unslashes the password from $_POST.
+	 *
+	 * @ticket 13655
+	 */
+	public function test_wp_signon_unslashes_password() {
+		$password = "pa'ss";
+		wp_set_password( $password, $this->user->ID );
+
+		$_POST['log']  = $this->user->user_login;
+		$_POST['pwd']  = wp_slash( $password );
+		$_POST['test'] = 1;
+
+		$authed_user = wp_signon();
+
+		unset( $_POST['log'], $_POST['pwd'], $_POST['test'] );
+
+		$this->assertNotWPError( $authed_user );
+		$this->assertInstanceOf( 'WP_User', $authed_user );
+		$this->assertSame( $this->user->ID, $authed_user->ID );
+	}
+
+	/**
+	 * Tests that a password hashed with slashes intact is migrated on login.
+	 *
+	 * @ticket 13655
+	 */
+	public function test_slashed_password_hash_is_migrated_on_login() {
+		$password = "pa'ss";
+
+		// Simulate a legacy hash of the slashed password.
+		$slashed_hash = wp_hash_password( wp_slash( $password ) );
+		wp_update_user(
+			array(
+				'ID'        => $this->user->ID,
+				'user_pass' => $slashed_hash,
+			)
+		);
+
+		$authed_user = wp_authenticate( $this->user->user_login, $password );
+
+		$this->assertNotWPError( $authed_user );
+		$this->assertSame( $this->user->ID, $authed_user->ID );
+
+		// The hash should now be of the unslashed password.
+		$user = get_user_by( 'id', $this->user->ID );
+		$this->assertTrue( wp_check_password( $password, $user->user_pass, $user->ID ) );
+	}
+
+	/**
 	 * Tests hooking into wp_set_password().
 	 *
 	 * @ticket 57436


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->
Current state on trunk: wp_insert_user() already stripslashes user_pass before hashing (the data compaction unslashes the whole user record at the end of the function), so new hashes are of the unslashed password. The remaining gaps are the input paths that pass the slashed value around:

- wp_signon() reads $_POST['pwd'] without unslashing (wp-includes/user.php)
- edit_user() in wp-admin/includes/user.php reads $_POST['pass1']/$_POST['pass2'] raw
- the lost-password flow in wp-login.php passes $_POST['pass1'] raw into reset_password()


Trac ticket: https://core.trac.wordpress.org/ticket/13655 <!-- insert a link to the WordPress Trac ticket here -->

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->
AI assistance: Yes
Tool(s): Claude
Model(s): Sonnet
Used for: Writing test cases

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
