### PR TITLE
#14439 fix: filter associated nav menu items by menu

### DIFF
--- a/src/wp-includes/nav-menu.php
+++ b/src/wp-includes/nav-menu.php
@@ -1049,11 +1049,18 @@ function wp_setup_nav_menu_item( $menu_item ) {
  *                            Default 'post_type'.
  * @param string $taxonomy    Optional. If $object_type is 'taxonomy', $taxonomy is the name
  *                            of the tax that $object_id belongs to. Default empty.
+ * @param int    $menu_id     Optional. The ID of the menu. Default 0.
  * @return int[] The array of menu item IDs; empty array if none.
  */
-function wp_get_associated_nav_menu_items( $object_id = 0, $object_type = 'post_type', $taxonomy = '' ) {
+function wp_get_associated_nav_menu_items( $object_id = 0, $object_type = 'post_type', $taxonomy = '', $menu_id = 0 ) {
 	$object_id     = (int) $object_id;
+	$menu_id       = (int) $menu_id;
 	$menu_item_ids = array();
+
+	// Bail out if the menu ID does not exist.
+	if ( 0 !== $menu_id && ! term_exists( $menu_id, 'nav_menu' ) ) {
+		return $menu_item_ids;
+	}
 
 	$query      = new WP_Query();
 	$menu_items = $query->query(
@@ -1067,6 +1074,14 @@ function wp_get_associated_nav_menu_items( $object_id = 0, $object_type = 'post_
 	);
 	foreach ( (array) $menu_items as $menu_item ) {
 		if ( isset( $menu_item->ID ) && is_nav_menu_item( $menu_item->ID ) ) {
+			// If a menu ID is given, only consider menu items that belong to that menu.
+			if ( 0 !== $menu_id ) {
+				$menu_item_terms = wp_get_post_terms( $menu_item->ID, 'nav_menu' );
+				if ( ! in_array( $menu_id, wp_list_pluck( $menu_item_terms, 'term_id' ), true ) ) {
+					continue;
+				}
+			}
+
 			$menu_item_type = get_post_meta( $menu_item->ID, '_menu_item_type', true );
 			if (
 				'post_type' === $object_type &&

--- a/tests/phpunit/tests/post/nav-menu.php
+++ b/tests/phpunit/tests/post/nav-menu.php
@@ -182,6 +182,48 @@ class Tests_Post_Nav_Menu extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 14439
+	 */
+	public function test_wp_get_associated_nav_menu_items_menu_id() {
+		$menu_2_id = wp_create_nav_menu( 'bar' );
+		$post_id   = self::factory()->post->create();
+
+		$menu_1_item = wp_update_nav_menu_item(
+			$this->menu_id,
+			0,
+			array(
+				'menu-item-type'      => 'post_type',
+				'menu-item-object'    => 'post',
+				'menu-item-object-id' => $post_id,
+				'menu-item-status'    => 'publish',
+			)
+		);
+
+		$menu_2_item = wp_update_nav_menu_item(
+			$menu_2_id,
+			0,
+			array(
+				'menu-item-type'      => 'post_type',
+				'menu-item-object'    => 'post',
+				'menu-item-object-id' => $post_id,
+				'menu-item-status'    => 'publish',
+			)
+		);
+
+		// Without a menu ID, menu items from all menus are returned.
+		$items = wp_get_associated_nav_menu_items( $post_id );
+		$this->assertSameSets( array( $menu_1_item, $menu_2_item ), $items );
+
+		// With a menu ID, only the menu items of that menu are returned.
+		$items = wp_get_associated_nav_menu_items( $post_id, 'post_type', '', $menu_2_id );
+		$this->assertSameSets( array( $menu_2_item ), $items );
+
+		// An invalid menu ID returns an empty array.
+		$items = wp_get_associated_nav_menu_items( $post_id, 'post_type', '', 999999 );
+		$this->assertSameSets( array(), $items );
+	}
+
+	/**
 	 * @ticket 27113
 	 */
 	public function test_orphan_nav_menu_item() {


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

## Changes:
1. Adds a new optional $menu_id parameter (default 0, appended after $taxonomy so all existing calls are unaffected). When set, only menu items belonging to that menu are returned.
2. Validates the menu ID up front: if a non-zero $menu_id does not correspond to an existing nav_menu term, the function returns an empty array. This covers the invalid-ID case from the 2015 refresh.
3. Filters by the item's nav_menu term assignment (wp_get_post_terms()) inside the existing loop, so the query shape is unchanged and behavior for the existing object types is identical.

Backward compatibility is preserved: calls without $menu_id return items from all menus exactly as before, which the included unit test asserts explicitly.

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/14439 <!-- insert a link to the WordPress Trac ticket here -->

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

AI assistance: Yes
Tool(s): Claude
Model(s): Sonnet
Used for: Writing test cases

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
