### PR TITLE
Toolbar: Restore the color scheme text color on top-level label hover.

### DIFF
--- a/src/wp-includes/css/admin-bar.css
+++ b/src/wp-includes/css/admin-bar.css
@@ -231,7 +231,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 	color: #72aee6;
 }
 
-#wpadminbar:not(.mobile) > #wp-toolbar li:hover span.ab-label,
+#wpadminbar > #wp-toolbar li:hover span.ab-label,
 #wpadminbar > #wp-toolbar li.hover span.ab-label,
 /* The adminbar menu may output either links or focusable div elements. */
 /* As such, we target the focus state without specifying the element type. */


### PR DESCRIPTION
Fixes admin bar top-level labels (+ New, Command Palette, Comments, Updates) using the hardcoded #72aee6 hover color instead of the active admin color scheme.

The issue was a specificity mismatch: admin-bar.css still had span.ab-label:hover:not(.mobile), while the color scheme rule no longer excludes .mobile since [63009]. Removing :not(.mobile) aligns both selectors, allowing the color scheme rule to win by cascade order as intended.

No new mobile behavior is introduced; this simply restores consistency between the default and color scheme styles.

Trac ticket: https://core.trac.wordpress.org/ticket/65848

## Use of AI Tools
AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Ticket analysis and code implementation. All changes were reviewed and validated by me.

---

**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
