### PR TITLE
Toolbar: Show the item indicator on hover as well as on focus.

### DIFF
--- a/src/wp-includes/css/admin-bar.css
+++ b/src/wp-includes/css/admin-bar.css
@@ -82,11 +82,19 @@ html:lang(he-il) .rtl #wpadminbar * {
 	outline-offset: -2px;
 	/* Only visible in Windows High Contrast mode */
 	outline: 2px solid transparent;
+}
+
+#wpadminbar a:hover,
+#wpadminbar a:focus,
+#wpadminbar .ab-item[tabindex="0"]:hover,
+#wpadminbar .ab-item[tabindex="0"]:focus {
 	box-shadow: inset 0 -4px 0 0 currentColor;
 	transition: box-shadow 0.1s linear;
 }
 
+#wpadminbar .ab-submenu a:hover,
 #wpadminbar .ab-submenu a:focus,
+#wpadminbar .ab-submenu .ab-item[tabindex="0"]:hover,
 #wpadminbar .ab-submenu .ab-item[tabindex="0"]:focus {
 	box-shadow: inset 4px 0 0 0 currentColor;
 }


### PR DESCRIPTION
A visual indicator now appears when elements in the admin bar are focused, thanks to [r63009](https://core.trac.wordpress.org/changeset/63009). However, this results in a similar bar appearing when clicking with the mouse, which feels slightly unnatural.




I came up with two approaches:

- Use focus-visible to display the indicator only when an element is focused via keyboard.
- Display the indicator not only on focus but also on hover.

I chose the latter approach for consistency with the sidebar.

Trac ticket: https://core.trac.wordpress.org/ticket/65849

https://github.com/user-attachments/assets/b9081a2b-95f7-412e-9c93-cfe46cb68187

https://github.com/user-attachments/assets/3412aae9-9b19-4e95-a61f-382414b8b638

## Use of AI Tools

Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.