### PR TITLE
Multisite: sync signups email for the edited user

### DIFF
--- a/src/wp-admin/user-edit.php
+++ b/src/wp-admin/user-edit.php
@@ -163,7 +163,7 @@ switch ( $action ) {
 			$user = get_userdata( $user_id );
 
 			if ( $user->user_login && isset( $_POST['email'] ) && is_email( $_POST['email'] ) && $wpdb->get_var( $wpdb->prepare( "SELECT user_login FROM {$wpdb->signups} WHERE user_login = %s", $user->user_login ) ) ) {
-				$wpdb->query( $wpdb->prepare( "UPDATE {$wpdb->signups} SET user_email = %s WHERE user_login = %s", $_POST['email'], $user_login ) );
+				$wpdb->query( $wpdb->prepare( "UPDATE {$wpdb->signups} SET user_email = %s WHERE user_login = %s", $_POST['email'], $user->user_login ) );
 			}
 		}
 


### PR DESCRIPTION
## Summary
- Fixes Multisite email sync in `wp-admin/user-edit.php` where updating another user incorrectly used the global `$user_login` (current user) instead of `$user->user_login` (edited user) when writing to `{$wpdb->signups}`.
- Own-profile updates appeared fine; admin edits of another user with a signup row left signups stale or updated the wrong login.

## Issue
- Fork tracking: https://github.com/Sakanweb/wordpress-develop/issues/1
- Upstream GitHub Issues are disabled; a WordPress Trac ticket should be filed at https://core.trac.wordpress.org/newticket and referenced here (e.g. `Fixes #XXXXX`).

## Test plan
- [ ] Multisite: as admin, edit another user who has a `signups` row; change email; confirm that user's signup `user_email` updates.
- [ ] Multisite: edit own profile email; confirm signup email still updates.
- [ ] Multisite: confirm-email flow (`?newuseremail=`) still works (unchanged path).
- [ ] Single-site: no behavioral change (block is Multisite-only).