### PR TITLE
Editor: Trigger a notice when the tablet viewport breakpoint is dropped

### DIFF
--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -816,9 +816,10 @@ class WP_Theme_JSON {
 	 * the default breakpoints when no valid custom breakpoint is provided. When
 	 * only one breakpoint is valid, it remains keyed by its configured state and
 	 * uses a single max-width media query. When `tablet` is not larger than
-	 * `mobile`, it is removed.
+	 * `mobile`, it is removed and a notice is triggered.
 	 *
 	 * @since 7.1.0
+	 * @since 7.2.0 A notice is triggered when `tablet` is dropped because it is not larger than `mobile`.
 	 *
 	 * @param mixed $viewport_settings Viewport settings from theme.json.
 	 * @return array Sanitized viewport breakpoint settings.
@@ -853,6 +854,17 @@ class WP_Theme_JSON {
 
 		if ( isset( $breakpoints['tablet'] ) && $breakpoints['mobile']['px'] < $breakpoints['tablet']['px'] ) {
 			$sanitized['tablet'] = $breakpoints['tablet']['value'];
+		} elseif ( isset( $breakpoints['tablet'] ) ) {
+			wp_trigger_error(
+				__METHOD__,
+				sprintf(
+					/* translators: 1: theme.json, 2: settings.viewport */
+					__( 'The %1$s %2$s "tablet" breakpoint value must be larger than the "mobile" value. The "tablet" breakpoint was removed.' ),
+					'theme.json',
+					'settings.viewport'
+				),
+				E_USER_NOTICE
+			);
 		}
 
 		return $sanitized;

--- a/tests/phpunit/tests/theme/wpThemeJson.php
+++ b/tests/phpunit/tests/theme/wpThemeJson.php
@@ -1249,6 +1249,42 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that a notice is triggered when the tablet breakpoint is dropped because it is not larger than mobile.
+	 *
+	 * @ticket 65841
+	 */
+	public function test_sanitize_viewport_settings_triggers_notice_when_tablet_is_not_larger_than_mobile() {
+		$notice_triggered = false;
+		$notice_message   = '';
+
+		add_action(
+			'wp_trigger_error_run',
+			static function ( $function_name, $message ) use ( &$notice_triggered, &$notice_message ) {
+				$notice_triggered = true;
+				$notice_message   = $message;
+			},
+			10,
+			2
+		);
+
+		// Suppress the actual PHP notice so it doesn't fail the test.
+		add_filter( 'wp_trigger_error_trigger_error', '__return_false' );
+
+		WP_Theme_JSON::get_viewport_media_queries(
+			array(
+				'mobile' => '64rem',
+				'tablet' => '40rem',
+			)
+		);
+
+		remove_filter( 'wp_trigger_error_trigger_error', '__return_false' );
+
+		$this->assertTrue( $notice_triggered, 'A notice should be triggered when the tablet breakpoint is not larger than mobile.' );
+		$this->assertStringContainsString( '"tablet"', $notice_message );
+		$this->assertStringContainsString( '"mobile"', $notice_message );
+	}
+
+	/**
 	 * @ticket 65596
 	 */
 	public function test_get_stylesheet_uses_custom_viewport_breakpoints_for_responsive_block_styles() {


### PR DESCRIPTION
Fixes the silent failure described in #65841.

When `WP_Theme_JSON::sanitize_viewport_settings()` drops the `tablet` breakpoint because its value is not larger than `mobile`, it now triggers a `wp_trigger_error()` `E_USER_NOTICE` informing theme authors of the reason.

**What the problem was:**
When a theme.json sets a `tablet` viewport breakpoint whose value is equal to or smaller than `mobile`, the `tablet` key is silently removed. The theme gets a two-state layout instead of the three states it configured, with no indication of why.

**What the fix does:**
Adds an `elseif` branch in `sanitize_viewport_settings()` that fires `wp_trigger_error()` with `E_USER_NOTICE` when `tablet` is present but not larger than `mobile`. This matches the pattern already used in `compute_spacing_sizes()` for invalid `spacingScale` values.

**Testing:**
- Adds a unit test that hooks `wp_trigger_error_run` and asserts the notice fires with the correct message content when `tablet` ≤ `mobile`.
- Existing test `test_get_viewport_media_queries_omits_tablet_when_its_breakpoint_is_not_larger_than_mobile()` continues to verify the sanitized output is correct.

**Notes:**
The ticket also describes a second case (mixed em/px bases, added by #65833) that cannot be addressed here until #65833 lands. This PR covers only Case 1 from the ticket description.

See https://core.trac.wordpress.org/ticket/65841