### PR TITLE
Using is_feed() does not always work: wp_is_serving_feed_request()

### DIFF
--- a/src/wp-includes/feed.php
+++ b/src/wp-includes/feed.php
@@ -908,3 +908,83 @@ function fetch_feed( $url ) {
 
 	return $feed;
 }
+
+/**
+ * Determines whether the current request looks like a syndication feed request.
+ *
+ * Unlike {@see is_feed()}, this function may be called before the main query has been
+ * parsed, e.g. during the {@see 'init'} action. Only the raw request is examined: the
+ * `feed` query string parameter, and, on sites using pretty permalinks, whether the
+ * final path segment is a registered feed name, as rewrite-based feed URLs always end
+ * in one, e.g. `/feed/` or `/category/foo/feed/atom/`.
+ * See WP_Rewrite::generate_rewrite_rules().
+ *
+ * The parsed main query is intentionally never consulted, so that callers checking
+ * both before and after the query is parsed always receive the same answer for a given
+ * request. Use `is_feed()` instead when the main query is available and authoritative.
+ *
+ * The check is conservative in both directions. Rewrite-based detection requires the
+ * feed base segment, e.g. `/feed/`, `/feed/atom/`, `/category/foo/feed/`, or a
+ * root-level feed name, e.g. `/atom/`, which cannot belong to a post or page because
+ * {@see wp_unique_post_slug()} reserves feed names as slugs. Working but unadvertised
+ * shorthands, e.g. `/category/foo/atom/`, are not detected — a false negative just
+ * means callers keep their pre-query behavior. A false positive remains possible only
+ * when a URL ends in a path segment equal to the feed base itself, e.g. an archive for
+ * a term with the slug `feed`.
+ *
+ * @since 7.2.0
+ *
+ * @global WP_Rewrite $wp_rewrite WordPress rewrite component.
+ *
+ * @return bool True if the request has the pattern of a feed request, false otherwise.
+ */
+function wp_is_serving_feed_request() {
+	global $wp_rewrite;
+
+	// Plain permalink style feed request, e.g. `/?feed=rss2`.
+	$is_feed_request = ! empty( $_GET['feed'] );
+
+	// Pretty permalinks, look for a registered feed name, e.g. `/feed/`.
+	if ( ! $is_feed_request
+		&& $wp_rewrite instanceof WP_Rewrite && $wp_rewrite->using_permalinks()
+		&& isset( $_SERVER['REQUEST_URI'] )
+	) {
+		$path = (string) wp_parse_url( $_SERVER['REQUEST_URI'], PHP_URL_PATH );
+		$path = trim( $path, '/' );
+
+		if ( '' !== $path ) {
+			$segments     = explode( '/', $path );
+			$last_segment = end( $segments );
+
+			if ( $last_segment === $wp_rewrite->feed_base ) {
+				// A default feed, e.g. `/feed/`, `/category/foo/feed/`, `/2024/01/hello-world/feed/`.
+				$is_feed_request = true;
+			} elseif ( in_array( $last_segment, (array) $wp_rewrite->feeds, true ) ) {
+				/*
+				 * A specific feed type is only recognized directly after the feed base,
+				 * e.g. `/feed/atom/`, or as the whole path, e.g. `/atom/`. Requiring
+				 * this structure avoids false positives for archives whose slug equals
+				 * a feed name, e.g. a category with the slug `atom`, while root-level
+				 * slugs are already reserved by wp_unique_post_slug().
+				 */
+				$segment_count    = count( $segments );
+				$previous_segment = ( $segment_count > 1 ) ? $segments[ $segment_count - 2 ] : '';
+
+				$is_feed_request = ( 1 === $segment_count || $previous_segment === $wp_rewrite->feed_base );
+			}
+		}
+	}
+
+	/**
+	 * Filters whether the current request looks like a syndication feed request.
+	 *
+	 * The value passed to the filter is based solely on examining the raw request,
+	 * regardless of whether the main query has been parsed yet. Filter callbacks
+	 * should likewise return a consistent value for the duration of a request.
+	 *
+	 * @since 7.2.0
+	 *
+	 * @param bool $is_feed_request Whether the request has the pattern of a feed request.
+	 */
+	return apply_filters( 'wp_is_serving_feed_request', $is_feed_request );
+}

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2695,6 +2695,8 @@ function wp_should_load_block_editor_scripts_and_styles() {
  * This only affects front end and not the block editor screens.
  *
  * @since 5.8.0
+ * @since 7.2.0 Uses wp_is_serving_feed_request() instead of is_feed(), so that feed
+ *              requests are correctly detected before the main query is parsed.
  * @see wp_should_load_block_assets_on_demand()
  * @see wp_enqueue_registered_block_scripts_and_styles()
  * @see register_block_style_handle()
@@ -2702,7 +2704,7 @@ function wp_should_load_block_editor_scripts_and_styles() {
  * @return bool Whether separate core block assets will be loaded.
  */
 function wp_should_load_separate_core_block_assets() {
-	if ( is_admin() || is_feed() || wp_is_rest_endpoint() ) {
+	if ( is_admin() || wp_is_serving_feed_request() || wp_is_rest_endpoint() ) {
 		return false;
 	}
 
@@ -2732,12 +2734,14 @@ function wp_should_load_separate_core_block_assets() {
  * This only affects front end and not the block editor screens.
  *
  * @since 6.8.0
+ * @since 7.2.0 Uses wp_is_serving_feed_request() instead of is_feed(), so that feed
+ *              requests are correctly detected before the main query is parsed.
  * @see wp_should_load_separate_core_block_assets()
  *
  * @return bool Whether to load block assets only when they are rendered.
  */
 function wp_should_load_block_assets_on_demand() {
-	if ( is_admin() || is_feed() || wp_is_rest_endpoint() ) {
+	if ( is_admin() || wp_is_serving_feed_request() || wp_is_rest_endpoint() ) {
 		return false;
 	}
 

--- a/tests/phpunit/tests/dependencies/wpShouldLoadBlockAssets.php
+++ b/tests/phpunit/tests/dependencies/wpShouldLoadBlockAssets.php
@@ -1,0 +1,194 @@
+<?php
+
+/**
+ * Tests for wp_should_load_separate_core_block_assets() and
+ * wp_should_load_block_assets_on_demand().
+ *
+ * Both functions must bail for feed requests — including before the main query is
+ * parsed, e.g. during 'init', which is when block styles are registered — while
+ * behaving normally for all other front end requests. See wp_is_serving_feed_request().
+ *
+ * @group dependencies
+ * @group scripts
+ * @group feed
+ *
+ * @ticket 65853
+ *
+ * @covers ::wp_should_load_separate_core_block_assets
+ * @covers ::wp_should_load_block_assets_on_demand
+ */
+class Tests_Dependencies_WpShouldLoadBlockAssets extends WP_UnitTestCase {
+
+	/**
+	 * Backup of the original request URI, restored on tear down.
+	 */
+	private string $request_uri = '';
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->request_uri = isset( $_SERVER['REQUEST_URI'] ) ? $_SERVER['REQUEST_URI'] : '';
+
+		// Start each test with an unparsed main query, as on a real request during 'init'.
+		$GLOBALS['wp_the_query'] = new WP_Query();
+		$GLOBALS['wp_query']     = $GLOBALS['wp_the_query'];
+	}
+
+	public function tear_down() {
+		$_SERVER['REQUEST_URI'] = $this->request_uri;
+		unset( $_GET['feed'] );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Simulates the raw request for a URL under the given permalink mode: sets the
+	 * permalink structure and request URI, and mirrors the query string into $_GET,
+	 * as PHP does on a real request.
+	 */
+	private function simulate_request( string $permalink_mode, string $request_uri ): void {
+		if ( 'pretty' === $permalink_mode ) {
+			$this->set_permalink_structure( '/%year%/%monthnum%/%postname%/' );
+		}
+
+		$_SERVER['REQUEST_URI'] = $request_uri;
+
+		$query = wp_parse_url( $request_uri, PHP_URL_QUERY );
+		if ( is_string( $query ) && '' !== $query ) {
+			parse_str( $query, $_GET );
+		}
+	}
+
+	/**
+	 * Data provider shared by both functions: feed and non-feed URLs in both
+	 * permalink modes, with whether the URL is a feed request.
+	 *
+	 * @return array[]
+	 */
+	public function data_urls_for_both_permalink_modes(): array {
+		return array(
+			// Pretty permalinks, feed URLs.
+			'pretty: site feed'              => array( 'pretty', '/feed/', true ),
+			'pretty: site atom feed'         => array( 'pretty', '/feed/atom/', true ),
+			'pretty: category feed'          => array( 'pretty', '/category/uncategorized/feed/', true ),
+			'pretty: comments feed'          => array( 'pretty', '/comments/feed/', true ),
+			'pretty: post comments feed'     => array( 'pretty', '/2024/01/hello-world/feed/', true ),
+
+			// Pretty permalinks, non-feed URLs.
+			'pretty: home page'              => array( 'pretty', '/', false ),
+			'pretty: single post'            => array( 'pretty', '/2024/01/hello-world/', false ),
+			'pretty: page'                   => array( 'pretty', '/sample-page/', false ),
+			'pretty: category archive'       => array( 'pretty', '/category/uncategorized/', false ),
+			'pretty: search results'         => array( 'pretty', '/search/example/', false ),
+			'pretty: feed-like page slug'    => array( 'pretty', '/feedback/', false ),
+
+			// Plain permalinks, feed URLs.
+			'plain: rss2 feed'               => array( 'plain', '/?feed=rss2', true ),
+			'plain: atom feed'               => array( 'plain', '/?feed=atom', true ),
+			'plain: category feed'           => array( 'plain', '/?cat=1&feed=rss2', true ),
+			'plain: post comments feed'      => array( 'plain', '/?p=123&feed=rss2', true ),
+
+			// Plain permalinks, non-feed URLs.
+			'plain: home page'               => array( 'plain', '/', false ),
+			'plain: single post'             => array( 'plain', '/?p=123', false ),
+			'plain: page'                    => array( 'plain', '/?page_id=2', false ),
+			'plain: search for word feed'    => array( 'plain', '/?s=feed', false ),
+			'plain: feed-shaped path is 404' => array( 'plain', '/feed/', false ),
+		);
+	}
+
+	/**
+	 * Tests that wp_should_load_separate_core_block_assets() bails for feed requests
+	 * and honors its filter for all other requests, before the main query is parsed.
+	 *
+	 * @dataProvider data_urls_for_both_permalink_modes
+	 *
+	 * @param string $permalink_mode Either 'pretty' or 'plain'.
+	 * @param string $request_uri    The raw request URI.
+	 * @param bool   $is_feed_url    Whether the URL is a feed request.
+	 */
+	public function test_wp_should_load_separate_core_block_assets( string $permalink_mode, string $request_uri, bool $is_feed_url ): void {
+		$this->simulate_request( $permalink_mode, $request_uri );
+
+		add_filter( 'should_load_separate_core_block_assets', '__return_true' );
+
+		$this->assertSame(
+			! $is_feed_url,
+			wp_should_load_separate_core_block_assets(),
+			$is_feed_url
+				? 'Should return false for a feed request even when enabled via the filter.'
+				: 'Should return true for a non-feed request when enabled via the filter.'
+		);
+
+		remove_filter( 'should_load_separate_core_block_assets', '__return_true' );
+		add_filter( 'should_load_separate_core_block_assets', '__return_false' );
+
+		$this->assertFalse(
+			wp_should_load_separate_core_block_assets(),
+			'Should return false when disabled via the filter, regardless of the request.'
+		);
+	}
+
+	/**
+	 * Tests that wp_should_load_block_assets_on_demand() bails for feed requests
+	 * and honors its filter for all other requests, before the main query is parsed.
+	 *
+	 * @dataProvider data_urls_for_both_permalink_modes
+	 *
+	 * @param string $permalink_mode Either 'pretty' or 'plain'.
+	 * @param string $request_uri    The raw request URI.
+	 * @param bool   $is_feed_url    Whether the URL is a feed request.
+	 */
+	public function test_wp_should_load_block_assets_on_demand( string $permalink_mode, string $request_uri, bool $is_feed_url ): void {
+		$this->simulate_request( $permalink_mode, $request_uri );
+
+		add_filter( 'should_load_block_assets_on_demand', '__return_true' );
+
+		$this->assertSame(
+			! $is_feed_url,
+			wp_should_load_block_assets_on_demand(),
+			$is_feed_url
+				? 'Should return false for a feed request even when enabled via the filter.'
+				: 'Should return true for a non-feed request when enabled via the filter.'
+		);
+
+		remove_filter( 'should_load_block_assets_on_demand', '__return_true' );
+		add_filter( 'should_load_block_assets_on_demand', '__return_false' );
+
+		$this->assertFalse(
+			wp_should_load_block_assets_on_demand(),
+			'Should return false when disabled via the filter, regardless of the request.'
+		);
+	}
+
+	/**
+	 * Tests that wp_should_load_block_assets_on_demand() still defaults to the value of
+	 * wp_should_load_separate_core_block_assets() for non-feed requests.
+	 *
+	 * @dataProvider data_permalink_modes
+	 *
+	 * @param string $permalink_mode Either 'pretty' or 'plain'.
+	 */
+	public function test_on_demand_default_follows_separate_assets( string $permalink_mode ): void {
+		$this->simulate_request( $permalink_mode, '/' );
+
+		add_filter( 'should_load_separate_core_block_assets', '__return_true' );
+
+		$this->assertTrue(
+			wp_should_load_block_assets_on_demand(),
+			'Enabling separate core block assets should enable on-demand loading by default.'
+		);
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_permalink_modes(): array {
+		return array(
+			'pretty permalinks' => array( 'pretty' ),
+			'plain permalinks'  => array( 'plain' ),
+		);
+	}
+}

--- a/tests/phpunit/tests/feed/wpIsServingFeedRequest.php
+++ b/tests/phpunit/tests/feed/wpIsServingFeedRequest.php
@@ -1,0 +1,355 @@
+<?php
+
+/**
+ * Tests for the wp_is_serving_feed_request() function.
+ *
+ * @group feed
+ *
+ * @ticket 65853
+ *
+ * @covers ::wp_is_serving_feed_request
+ */
+class Tests_Feed_WpIsServingFeedRequest extends WP_UnitTestCase {
+
+	/**
+	 * Backup of the original request URI, restored on tear down.
+	 */
+	private string $request_uri = '';
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->request_uri = isset( $_SERVER['REQUEST_URI'] ) ? $_SERVER['REQUEST_URI'] : '';
+
+		// Start each test with an unparsed main query, as on a real request during 'init'.
+		$GLOBALS['wp_the_query'] = new WP_Query();
+		$GLOBALS['wp_query']     = $GLOBALS['wp_the_query'];
+	}
+
+	public function tear_down() {
+		$_SERVER['REQUEST_URI'] = $this->request_uri;
+		unset( $_GET['feed'] );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Sets a pretty permalink structure, as feed rewrite endpoints require one.
+	 */
+	private function use_pretty_permalinks(): void {
+		$this->set_permalink_structure( '/%year%/%monthnum%/%postname%/' );
+	}
+
+	/**
+	 * Simulates the raw request for a URL: sets the request URI and mirrors the
+	 * query string into $_GET, as PHP does on a real request.
+	 */
+	private function simulate_request( string $request_uri ): void {
+		$_SERVER['REQUEST_URI'] = $request_uri;
+
+		$query = wp_parse_url( $request_uri, PHP_URL_QUERY );
+		if ( is_string( $query ) && '' !== $query ) {
+			parse_str( $query, $_GET );
+		}
+	}
+
+	/**
+	 * Tests that the main query has not been parsed when the tests run their checks.
+	 */
+	public function test_main_query_is_not_parsed_before_go_to(): void {
+		$this->assertFalse( isset( $GLOBALS['wp_query']->query ), 'The main query should not be parsed yet.' );
+		$this->assertFalse( is_feed(), 'is_feed() should return false before the main query is parsed.' );
+	}
+
+	/**
+	 * Tests that an empty feed query var is not treated as a feed request.
+	 */
+	public function test_should_ignore_empty_feed_query_var(): void {
+		$_SERVER['REQUEST_URI'] = '/';
+		$_GET['feed']           = '';
+
+		$this->assertFalse( wp_is_serving_feed_request() );
+	}
+
+	/**
+	 * Tests that feed and non-feed requests are detected with pretty permalinks enabled.
+	 *
+	 * @dataProvider data_pretty_permalink_request_uris
+	 *
+	 * @param string $request_uri The raw request URI.
+	 * @param bool   $expected    Expected return value.
+	 */
+	public function test_should_detect_feed_requests_with_pretty_permalinks( string $request_uri, bool $expected ): void {
+		$this->use_pretty_permalinks();
+		$this->simulate_request( $request_uri );
+
+		$this->assertSame( $expected, wp_is_serving_feed_request() );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_pretty_permalink_request_uris(): array {
+		return array(
+			// Site feeds, all feed types.
+			'site default feed'                => array( '/feed/', true ),
+			'site feed without trailing slash' => array( '/feed', true ),
+			'site rss feed'                    => array( '/feed/rss/', true ),
+			'site rss2 feed'                   => array( '/feed/rss2/', true ),
+			'site atom feed'                   => array( '/feed/atom/', true ),
+			'site rdf feed'                    => array( '/feed/rdf/', true ),
+			'root rss2 endpoint'               => array( '/rss2/', true ),
+			'root atom endpoint'               => array( '/atom/', true ),
+
+			// Comments feeds.
+			'site comments feed'               => array( '/comments/feed/', true ),
+			'site comments atom feed'          => array( '/comments/feed/atom/', true ),
+
+			// Archive feeds.
+			'category feed'                    => array( '/category/uncategorized/feed/', true ),
+			'category rss2 feed'               => array( '/category/uncategorized/feed/rss2/', true ),
+			'tag feed'                         => array( '/tag/example/feed/', true ),
+			'tag atom feed'                    => array( '/tag/example/feed/atom/', true ),
+			'author feed'                      => array( '/author/admin/feed/', true ),
+			'year archive feed'                => array( '/2024/feed/', true ),
+			'month archive feed'               => array( '/2024/01/feed/', true ),
+			'day archive feed'                 => array( '/2024/01/05/feed/', true ),
+			'search feed'                      => array( '/search/example/feed/', true ),
+
+			// Single post and page comments feeds.
+			'post comments feed'               => array( '/2024/01/hello-world/feed/', true ),
+			'post comments atom feed'          => array( '/2024/01/hello-world/feed/atom/', true ),
+			'page comments feed'               => array( '/sample-page/feed/', true ),
+
+			// Feed URL variations.
+			'paged feed with query string'     => array( '/feed/?paged=2', true ),
+			'feed in subdirectory install'     => array( '/blog/feed/', true ),
+			'pathinfo permalink feed'          => array( '/index.php/feed/', true ),
+
+			// Non-feed content URLs.
+			'home page'                        => array( '/', false ),
+			'paged home page'                  => array( '/page/2/', false ),
+			'single post'                      => array( '/2024/01/hello-world/', false ),
+			'page'                             => array( '/sample-page/', false ),
+			'category archive'                 => array( '/category/uncategorized/', false ),
+			'paged category archive'           => array( '/category/uncategorized/page/2/', false ),
+			'tag archive'                      => array( '/tag/example/', false ),
+			'author archive'                   => array( '/author/admin/', false ),
+			'year archive'                     => array( '/2024/', false ),
+			'month archive'                    => array( '/2024/01/', false ),
+			'day archive'                      => array( '/2024/01/05/', false ),
+			'search results'                   => array( '/search/example/', false ),
+			'post embed'                       => array( '/2024/01/hello-world/embed/', false ),
+			'post trackback'                   => array( '/2024/01/hello-world/trackback/', false ),
+			'post comment page'                => array( '/2024/01/hello-world/comment-page-2/', false ),
+			'plain style post on pretty site'  => array( '/?p=123', false ),
+
+			// Non-feed system URLs.
+			'REST API request'                 => array( '/wp-json/wp/v2/posts', false ),
+			'sitemap'                          => array( '/wp-sitemap.xml', false ),
+			'robots'                           => array( '/robots.txt', false ),
+			'favicon'                          => array( '/favicon.ico', false ),
+			'login page'                       => array( '/wp-login.php', false ),
+
+			// Near misses that must not be detected as feeds.
+			'page slug starting with feed'     => array( '/feedback/', false ),
+			'category slug containing feed'    => array( '/category/feed-reviews/', false ),
+			'feed base with unknown feed'      => array( '/feed/hello/', false ),
+			'feed as non-final path segment'   => array( '/feed/hello-world/comments/', false ),
+
+			/*
+			 * Archives whose slug equals a feed type name. Term slugs and author
+			 * nicenames are not reserved by wp_unique_post_slug(), so these are real
+			 * archive URLs and must not be detected as feeds.
+			 */
+			'category slug equal to feed type' => array( '/category/atom/', false ),
+			'tag slug equal to feed type'      => array( '/tag/rss2/', false ),
+			'author slug equal to feed type'   => array( '/author/atom/', false ),
+			'nested slug equal to feed type'   => array( '/docs/atom/', false ),
+
+			/*
+			 * Working but unadvertised feed URL shorthands are conservative false
+			 * negatives: core never generates links to them, and missing them only
+			 * means callers keep their pre-query behavior.
+			 */
+			'search rss2 shorthand'            => array( '/search/example/rss2/', false ),
+			'category atom shorthand'          => array( '/category/uncategorized/atom/', false ),
+
+			/*
+			 * Known limitation: a term with the literal slug `feed` produces an archive
+			 * URL indistinguishable from a default feed URL by path alone. This
+			 * documents the accepted false positive.
+			 */
+			'category slug equal to feed base' => array( '/category/feed/', true ),
+		);
+	}
+
+	/**
+	 * Tests that feed and non-feed requests are detected with plain permalinks.
+	 *
+	 * With plain permalinks, only the `feed` query string parameter identifies a feed
+	 * request. Feed rewrite endpoints do not exist, so a path like `/feed/` would
+	 * result in a 404 rather than a feed and must not be matched.
+	 *
+	 * @dataProvider data_plain_permalink_request_uris
+	 *
+	 * @param string $request_uri The raw request URI.
+	 * @param bool   $expected    Expected return value.
+	 */
+	public function test_should_detect_feed_requests_with_plain_permalinks( string $request_uri, bool $expected ): void {
+		$this->simulate_request( $request_uri );
+
+		$this->assertSame( $expected, wp_is_serving_feed_request() );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_plain_permalink_request_uris(): array {
+		return array(
+			// Site feeds, all feed types.
+			'default feed query var'       => array( '/?feed=feed', true ),
+			'rss feed query var'           => array( '/?feed=rss', true ),
+			'rss2 feed query var'          => array( '/?feed=rss2', true ),
+			'atom feed query var'          => array( '/?feed=atom', true ),
+			'rdf feed query var'           => array( '/?feed=rdf', true ),
+			'feed query var via index.php' => array( '/index.php?feed=rss2', true ),
+
+			// Comments feeds.
+			'site comments feed'           => array( '/?feed=comments-rss2', true ),
+			'post comments feed'           => array( '/?p=123&feed=rss2', true ),
+			'page comments feed'           => array( '/?page_id=2&feed=atom', true ),
+
+			// Archive feeds.
+			'category feed'                => array( '/?cat=1&feed=rss2', true ),
+			'tag feed'                     => array( '/?tag=example&feed=atom', true ),
+			'author feed'                  => array( '/?author=1&feed=rss2', true ),
+			'month archive feed'           => array( '/?m=202401&feed=rss2', true ),
+			'search feed'                  => array( '/?s=example&feed=rss2', true ),
+
+			// Non-feed content URLs.
+			'home page'                    => array( '/', false ),
+			'single post'                  => array( '/?p=123', false ),
+			'page'                         => array( '/?page_id=2', false ),
+			'category archive'             => array( '/?cat=1', false ),
+			'tag archive'                  => array( '/?tag=example', false ),
+			'author archive'               => array( '/?author=1', false ),
+			'month archive'                => array( '/?m=202401', false ),
+			'paged home page'              => array( '/?paged=2', false ),
+			'post comment page'            => array( '/?p=123&cpage=2', false ),
+			'attachment'                   => array( '/?attachment_id=9', false ),
+			'search for the word feed'     => array( '/?s=feed', false ),
+
+			// Non-feed system URLs.
+			'REST API request'             => array( '/?rest_route=/wp/v2/posts', false ),
+			'sitemap'                      => array( '/wp-sitemap.xml', false ),
+			'robots'                       => array( '/robots.txt', false ),
+			'login page'                   => array( '/wp-login.php', false ),
+
+			// Feed-shaped paths are 404s with plain permalinks, not feeds.
+			'feed-shaped path is a 404'    => array( '/feed/', false ),
+			'category feed path is a 404'  => array( '/category/uncategorized/feed/', false ),
+		);
+	}
+
+	/**
+	 * Tests that a custom feed registered via add_feed() is detected.
+	 */
+	public function test_should_detect_custom_feed_registered_via_add_feed(): void {
+		global $wp_rewrite;
+
+		$this->use_pretty_permalinks();
+
+		$original_feeds = $wp_rewrite->feeds;
+
+		add_feed( 'json', '__return_empty_string' );
+
+		$this->simulate_request( '/feed/json/' );
+		$detected = wp_is_serving_feed_request();
+
+		$wp_rewrite->feeds = $original_feeds;
+
+		$this->assertTrue( $detected );
+	}
+
+	/**
+	 * Tests that the value does not change once the main query has been parsed.
+	 *
+	 * Callers consult this function both before the main query is parsed (e.g. during
+	 * 'init') and during template rendering, so the answer must be constant for the
+	 * duration of a request.
+	 *
+	 * @dataProvider data_request_lifecycle_urls
+	 *
+	 * @param string $url      The URL to test, passed to go_to().
+	 * @param bool   $expected Expected return value, both before and after parsing.
+	 */
+	public function test_should_return_same_value_before_and_after_query_is_parsed( string $url, bool $expected ): void {
+		$this->use_pretty_permalinks();
+		self::factory()->post->create();
+
+		$this->simulate_request( $url );
+
+		$this->assertSame( $expected, wp_is_serving_feed_request(), 'Unexpected value before the main query is parsed.' );
+
+		$this->go_to( $url );
+
+		/*
+		 * go_to() clears $_GET for scheme-less URLs rather than populating it from the
+		 * query string. On a real request $_GET always mirrors the request URL, so
+		 * restore it to model one faithfully.
+		 */
+		$this->simulate_request( $url );
+
+		$this->assertSame( $expected, is_feed(), 'is_feed() should agree once the main query is parsed.' );
+		$this->assertSame( $expected, wp_is_serving_feed_request(), 'The value should not change after the main query is parsed.' );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_request_lifecycle_urls(): array {
+		return array(
+			'site feed'      => array( '/feed/', true ),
+			'atom feed'      => array( '/feed/atom/', true ),
+			'feed query var' => array( '/?feed=rss2', true ),
+			'home page'      => array( '/', false ),
+		);
+	}
+
+	/**
+	 * Tests that the result can be overridden with the 'wp_is_serving_feed_request' filter.
+	 *
+	 * @dataProvider data_filter_overrides
+	 *
+	 * @param string $request_uri The raw request URI.
+	 * @param string $callback    Filter callback to hook.
+	 * @param bool   $expected    Expected return value.
+	 */
+	public function test_should_be_filterable( string $request_uri, string $callback, bool $expected ): void {
+		$this->use_pretty_permalinks();
+		$this->simulate_request( $request_uri );
+
+		add_filter( 'wp_is_serving_feed_request', $callback );
+
+		$this->assertSame( $expected, wp_is_serving_feed_request() );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_filter_overrides(): array {
+		return array(
+			'forced on for a non-feed URL' => array( '/', '__return_true', true ),
+			'forced off for a feed URL'    => array( '/feed/', '__return_false', false ),
+		);
+	}
+}


### PR DESCRIPTION
https://core.trac.wordpress.org/ticket/65853

This adds the `wp_is_serving_feed_request()` function, which can be used instead of `is_feed()` in cases where the query parser has not run yet.  Code that runs off of the `init` action falls into that category.

Included are updates to `wp_should_load_separate_core_block_assets()` and `wp_should_load_block_assets_on_demand()` to replace their use of `is_feed()`.  Because they were both using `is_feed()` before the query was parsed `is_feed()` always returned `false`.  Which means the early return didn't actually happen.

All this results in WordPress feed requests doing more work than they needed to.  In my local testing this reduced TTFB for the site feed from 39.3 ms to 37.8 ms at p75.  That is a savings of ~1.5 ms or 3.9%.

See https://core.trac.wordpress.org/changeset/50836 for the original work on `should_load_separate_core_block_assets()` - more than 5 years ago.


AI assistance: Yes
Tool(s): Claude
Model(s): Fable 5
Used for: The code was a joint effort between myself and Claude.  The tests were written by Claude.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
