### PR TITLE
Backport: Skip pull_request triggered runs in private repos - 5.8 Branch

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -47,7 +47,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-coding-standards-php.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     with:
       php-version: '7.4'
 
@@ -57,7 +64,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-coding-standards-javascript.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
 
   slack-notifications:
     name: Slack Notifications

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -35,7 +35,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-end-to-end-tests.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/javascript-tests.yml
+++ b/.github/workflows/javascript-tests.yml
@@ -45,7 +45,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-javascript-tests.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     with:
       disable-apparmor: true
 

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -41,7 +41,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-php-compatibility.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     with:
       php-version: '7.4'
 

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -35,7 +35,14 @@ jobs:
     permissions:
       contents: read
     secrets: inherit
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-build-processes.yml
+++ b/.github/workflows/test-build-processes.yml
@@ -41,7 +41,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-test-core-build-process.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This backports 15c4b048588ee7b286edd846708f57756b4a519e (r63183) to the 5.8 branch.

## Merge Conflict Resolution

The cherry-pick conflicted. The 5.8 branch only has 6 workflow files, and the ones it does have are shaped differently than on `trunk`. Here is exactly what was done:

**Files that do not exist on 5.8 (hunks dropped entirely).** The cherry-pick reported these as `modify/delete` conflicts and left the `trunk` version of each file in the tree. Each was removed with `git rm` so no new workflow files are introduced to this branch:

- `.github/workflows/javascript-type-checking.yml`
- `.github/workflows/performance.yml`
- `.github/workflows/phpstan-static-analysis.yml`
- `.github/workflows/test-and-zip-default-themes.yml`
- `.github/workflows/upgrade-develop-testing.yml`
- `.github/workflows/workflow-lint.yml`

Because `upgrade-develop-testing.yml` and `workflow-lint.yml` (and their `reusable-*` counterparts) do not exist on 5.8, the `uses: WordPress/wordpress-develop/.github/workflows/<x>.yml@trunk` → `uses: ./.github/workflows/<x>.yml` portion of the original commit was **not** carried over.

**Files that applied cleanly:**

- `end-to-end-tests.yml` (`e2e-tests` job)
- `test-build-processes.yml` (`test-core-build-process` job)

**Files with content conflicts, resolved by hand:**

- `coding-standards.yml` — the `phpcs` job conflicted because 5.8 passes `with: php-version: '7.4'` immediately after the `if:` line. Resolved by keeping the branch's `with:` block and replacing only the `if:` condition. The `jshint` job merged cleanly.
- `javascript-tests.yml` — the `test-js` job conflicted because 5.8 passes `with: disable-apparmor: true` after the `if:` line. Resolved by keeping the branch's `with:` block and replacing only the `if:` condition.
- `php-compatibility.yml` — the `php-compatibility` job conflicted for the same reason as `phpcs` (`with: php-version: '7.4'`). Resolved the same way.
- `phpunit-tests.yml` — large conflict. On `trunk` this file has `prepare-gutenberg`, `test-with-mysql`, `test-with-mariadb`, `test-innovation-releases`, `html-api-test-groups`, and `limited-matrix-for-forks` jobs. On 5.8 there is a single `test-php` job that calls `reusable-phpunit-tests-v2.yml` and uses `secrets: inherit`. All incoming job definitions from `trunk` were dropped, the branch's `secrets: inherit` line was preserved, and the new condition was applied only to the existing `test-php` job. The `startsWith( github.repository, 'WordPress/' ) && (...)` and fork-only (`! startsWith(...)`) variants from the original commit have no equivalent on 5.8, so those shapes were not needed here.

**Jobs deliberately left untouched:**

- All `slack-notifications` and `failed-workflow` jobs (gated on `github.event_name != 'pull_request'`, unaffected).
- `test-build-processes.yml` → `test-core-build-process-macos`, which is gated on `github.repository == 'WordPress/wordpress-develop'` only and is not part of the condition family this commit changes.

**Verification performed:** the diff against `5.8` touches only `.github/workflows/`; no conflict markers remain; all six workflow files parse as valid YAML.

## Use of AI Tools
This pull request was created by an AI agent (Claude Code). Until this PR is marked "Ready for Review", treat it as untrusted, AI-created code that requires a manual review by a human team member.
