### PR TITLE
Backport: Skip pull_request triggered runs in private repos - 5.4 Branch

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -47,7 +47,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-coding-standards-php.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     with:
       php-version: '7.3'
 
@@ -57,7 +64,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-coding-standards-javascript.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
 
   slack-notifications:
     name: Slack Notifications

--- a/.github/workflows/javascript-tests.yml
+++ b/.github/workflows/javascript-tests.yml
@@ -45,7 +45,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-javascript-tests.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     with:
       disable-apparmor: true
 

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -35,7 +35,14 @@ jobs:
     permissions:
       contents: read
     secrets: inherit
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-build-processes.yml
+++ b/.github/workflows/test-build-processes.yml
@@ -41,7 +41,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-test-core-build-process.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This backports 15c4b048588ee7b286edd846708f57756b4a519e (r63183) to the 5.4 branch.

## Merge Conflict Resolution

The cherry-pick conflicted. The 5.4 branch has only 4 workflow files, so most of the original commit does not apply here.

**Files updated (5 jobs total):**

- `.github/workflows/coding-standards.yml` — `phpcs` and `jshint` jobs.
- `.github/workflows/javascript-tests.yml` — `test-js` job.
- `.github/workflows/phpunit-tests.yml` — `test-php` job.
- `.github/workflows/test-build-processes.yml` — `test-core-build-process` job.

All five received the canonical replacement condition verbatim:

```yaml
    if: |
      github.repository == 'WordPress/wordpress-develop' || (
        github.event_name == 'pull_request' && (
          ! github.event.repository.private ||
          ! github.event.pull_request.draft ||
          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
        )
      )
```

**Hunks dropped because the file does not exist on the 5.4 branch** (these came through the cherry-pick as `modify/delete` conflicts and were `git rm`'d):

- `.github/workflows/end-to-end-tests.yml`
- `.github/workflows/javascript-type-checking.yml`
- `.github/workflows/performance.yml`
- `.github/workflows/php-compatibility.yml`
- `.github/workflows/phpstan-static-analysis.yml`
- `.github/workflows/test-and-zip-default-themes.yml`
- `.github/workflows/upgrade-develop-testing.yml`
- `.github/workflows/workflow-lint.yml`

**Content conflicts and how they were resolved:**

- `coding-standards.yml`, `javascript-tests.yml`, `phpunit-tests.yml` all conflicted textually. In each case the conflict was caused by trailing context that differs on 5.4 (`with: php-version: '7.3'`, `with: disable-apparmor: true`, and `secrets: inherit` respectively) sitting directly adjacent to the `if:` line. These three files were reset to their 5.4 state and the condition was applied by hand so no unrelated trunk-only context leaked in.
- `phpunit-tests.yml` on 5.4 has a single `test-php` job that calls `reusable-phpunit-tests-v2.yml`. Trunk's `prepare-gutenberg`, `test-with-mysql`, `test-with-mariadb`, `test-with-sqlite`, `test-old-branches`, and the fork-only `test-with-mysql-forks` jobs do not exist here, so the `startsWith( github.repository, 'WordPress/' ) && (...)` and `! startsWith( ... )` variants from the original commit have no target on this branch and were dropped.
- `test-build-processes.yml` auto-merged cleanly for `test-core-build-process`. Its `test-core-build-process-macos` job is gated only on `github.repository == 'WordPress/wordpress-develop'` (no `pull_request` clause), so it is not part of the affected family and was deliberately left alone.

**Not carried over:**

- The `uses: WordPress/wordpress-develop/.github/workflows/<x>.yml@trunk` → `uses: ./.github/workflows/<x>.yml` change from `upgrade-develop-testing.yml` and `workflow-lint.yml`: neither file exists on 5.4.
- Slack notification jobs (`slack-notifications`) and `failed-workflow` jobs across all four files: gated on `github.event_name != 'pull_request'`, unaffected by this change.

Nothing outside `.github/workflows/` was touched. All four changed files were verified to parse as valid YAML and contain no conflict markers.

## Use of AI Tools
This pull request was created by an AI agent (Claude Code). Until this PR is marked "Ready for Review", treat it as untrusted, AI-created code that requires a manual review by a human team member.
