### PR TITLE
Backport: Skip pull_request triggered runs in private repos - 5.7 Branch

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -47,7 +47,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-coding-standards-php.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     with:
       php-version: '7.4'
 
@@ -57,7 +64,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-coding-standards-javascript.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
 
   slack-notifications:
     name: Slack Notifications

--- a/.github/workflows/javascript-tests.yml
+++ b/.github/workflows/javascript-tests.yml
@@ -45,7 +45,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-javascript-tests.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     with:
       disable-apparmor: true
 

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -41,7 +41,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-php-compatibility.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     with:
       php-version: '7.4'
 

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -35,7 +35,14 @@ jobs:
     permissions:
       contents: read
     secrets: inherit
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-build-processes.yml
+++ b/.github/workflows/test-build-processes.yml
@@ -41,7 +41,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-test-core-build-process.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This backports 15c4b048588ee7b286edd846708f57756b4a519e (r63183) to the 5.7 branch.

## Merge Conflict Resolution

The cherry-pick conflicted. The `5.7` branch only has 5 workflow files (`coding-standards.yml`, `javascript-tests.yml`, `php-compatibility.yml`, `phpunit-tests.yml`, `test-build-processes.yml`), so the majority of the original commit does not apply.

**Hunks dropped because the file does not exist on `5.7`** (the cherry-pick tried to create each of these as a new file; all were `git rm`'d):

- `.github/workflows/end-to-end-tests.yml`
- `.github/workflows/javascript-type-checking.yml`
- `.github/workflows/performance.yml`
- `.github/workflows/phpstan-static-analysis.yml`
- `.github/workflows/test-and-zip-default-themes.yml`
- `.github/workflows/upgrade-develop-testing.yml` (no equivalent `upgrade-testing.yml` on this branch either)
- `.github/workflows/workflow-lint.yml`

Because `upgrade-develop-testing.yml` and `workflow-lint.yml` do not exist here, the companion part of the original commit that switched those two workflows from `uses: WordPress/wordpress-develop/.github/workflows/<x>.yml@trunk` to `uses: ./.github/workflows/<x>.yml` was not carried over. No `reusable-*.yml` workflow files exist on this branch, so that change would not have been valid regardless.

**Files that conflicted textually and how they were resolved:**

- `coding-standards.yml` — the `phpcs` job conflicted because `5.7` has an extra `with: php-version: '7.4'` block immediately after the `if:`. Resolved by taking the new multi-line `if:` and keeping the branch's `with:` block. The `jshint` job in the same file merged cleanly.
- `javascript-tests.yml` — the `test-js` job conflicted for the same reason (`5.7` has `with: disable-apparmor: true` after the `if:`). Resolved the same way.
- `php-compatibility.yml` — the `php-compatibility` job conflicted for the same reason (`with: php-version: '7.4'`). Resolved the same way.
- `phpunit-tests.yml` — heavily conflicted. `5.7` has a single `test-php` job using `reusable-phpunit-tests-v2.yml`, while trunk has `prepare-gutenberg`, `test-with-mysql`, `test-with-mariadb`, `test-with-sqlite`, and a fork-only job. The file was restored from `upstream/5.7` and the new condition was applied by hand to the one job in the family, `test-php`. All trunk-only jobs and their conditions were dropped, including the fork-only `! startsWith( github.repository, 'WordPress/' ) && github.event_name == 'pull_request'` variant, which has no counterpart on this branch.
- `test-build-processes.yml` — merged cleanly for the `test-core-build-process` job.

**Intentionally left unchanged:**

- All `slack-notifications` and `failed-workflow` jobs (gated on `github.event_name != 'pull_request'`, unaffected by this change).
- `test-build-processes.yml`'s `test-core-build-process-macos` job, whose condition is `github.repository == 'WordPress/wordpress-develop'` only — it is not in the `|| github.event_name == 'pull_request'` family and was not touched by the original commit.

**Verification:** `git diff upstream/5.7 --stat` shows only the 5 files above, all under `.github/workflows/`. No conflict markers remain, and all 5 changed files parse as valid YAML with their expected job lists intact.

## Use of AI Tools
This pull request was created by an AI agent (Claude Code). Until this PR is marked "Ready for Review", treat it as untrusted, AI-created code that requires a manual review by a human team member.
