### PR TITLE
Backport: Skip pull_request triggered runs in private repos - 5.6 Branch

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -47,7 +47,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-coding-standards-php.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     with:
       php-version: '7.4'
 
@@ -57,7 +64,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-coding-standards-javascript.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
 
   slack-notifications:
     name: Slack Notifications

--- a/.github/workflows/javascript-tests.yml
+++ b/.github/workflows/javascript-tests.yml
@@ -45,7 +45,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-javascript-tests.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     with:
       disable-apparmor: true
 

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -41,7 +41,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-php-compatibility.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     with:
       php-version: '7.4'
 

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -35,7 +35,14 @@ jobs:
     permissions:
       contents: read
     secrets: inherit
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-build-processes.yml
+++ b/.github/workflows/test-build-processes.yml
@@ -41,7 +41,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-test-core-build-process.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This backports 15c4b048588ee7b286edd846708f57756b4a519e (r63183) to the 5.6 branch.

## Merge Conflict Resolution

The cherry-pick conflicted. The `5.6` branch only contains 5 workflow files, so most of the original commit did not apply.

**Files updated (6 jobs total, all with the standard replacement condition):**

- `.github/workflows/coding-standards.yml` — `phpcs` and `jshint` jobs. The `phpcs` job conflicted because on `5.6` it is followed by a `with: php-version: '7.4'` block that does not exist on `trunk`; resolved by taking the new `if:` and keeping the existing `with:` block. The `jshint` job merged cleanly.
- `.github/workflows/javascript-tests.yml` — `test-js` job. Conflicted for the same reason (`5.6` has a `with: disable-apparmor: true` block after the `if:`); resolved by taking the new `if:` and keeping `with:`.
- `.github/workflows/php-compatibility.yml` — `php-compatibility` job. Same conflict shape (`with: php-version: '7.4'`); resolved the same way.
- `.github/workflows/phpunit-tests.yml` — `test-php` job. The incoming diff tried to pull in trunk-only jobs (`prepare-gutenberg`, `test-with-mysql`, `test-with-mariadb`, the fork-only job, etc.) that do not exist on `5.6`. The file was reset to the `5.6` version and the condition was applied by hand to the single gated job, `test-php`, preserving the branch's `secrets: inherit` line.
- `.github/workflows/test-build-processes.yml` — `test-core-build-process` job. Merged cleanly.

**Hunks dropped because the file does not exist on `5.6`:**

- `.github/workflows/end-to-end-tests.yml`
- `.github/workflows/javascript-type-checking.yml`
- `.github/workflows/performance.yml`
- `.github/workflows/phpstan-static-analysis.yml`
- `.github/workflows/test-and-zip-default-themes.yml`
- `.github/workflows/upgrade-develop-testing.yml` (no equivalent `upgrade-testing.yml` on this branch either)
- `.github/workflows/workflow-lint.yml`

Each of these was left in the tree by the cherry-pick as a modify/delete conflict and was removed with `git rm`, since creating them on `5.6` is out of scope.

**Other pieces intentionally not carried over:**

- The `uses: WordPress/wordpress-develop/.github/workflows/<x>.yml@trunk` → `uses: ./.github/workflows/<x>.yml` change from the original commit applied only to `upgrade-develop-testing.yml` and `workflow-lint.yml`, neither of which exists on `5.6`. No reusable workflow files exist in this branch's `.github/workflows/` directory, so nothing was converted to a local path.
- The trunk-only condition shapes (the `startsWith( github.repository, 'WordPress/' ) && (...)` wrapper, the `! contains( github.event.before, '00000000' )` clause, the fork-only job variant, and the push-event variant) have no counterpart on `5.6`; every gated job on this branch uses the plain `github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request'` form.
- `test-build-processes.yml`'s `test-core-build-process-macos` job is gated only on `github.repository == 'WordPress/wordpress-develop'` and is not part of the affected family, so it was left alone (matching the original commit, which only touched one job in that file).
- Slack notification and `failed-workflow` jobs are gated on `github.event_name != 'pull_request'` and were not touched.

**Verification:** the diff against `5.6` touches only files under `.github/workflows/`, contains no conflict markers, and all 5 changed YAML files parse successfully.

## Use of AI Tools
This pull request was created by an AI agent (Claude Code). Until this PR is marked "Ready for Review", treat it as untrusted, AI-created code that requires a manual review by a human team member.
