### PR TITLE
Backport: Skip pull_request triggered runs in private repos - 5.2 Branch

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -47,7 +47,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-coding-standards-php.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     with:
       php-version: '7.3'
       old-branch: true
@@ -58,7 +65,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-coding-standards-javascript.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
 
   slack-notifications:
     name: Slack Notifications

--- a/.github/workflows/javascript-tests.yml
+++ b/.github/workflows/javascript-tests.yml
@@ -45,7 +45,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-javascript-tests.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     with:
       disable-apparmor: true
 

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -35,7 +35,14 @@ jobs:
     permissions:
       contents: read
     secrets: inherit
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-build-processes.yml
+++ b/.github/workflows/test-build-processes.yml
@@ -41,7 +41,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-test-core-build-process.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This backports 15c4b048588ee7b286edd846708f57756b4a519e (r63183) to the 5.2 branch.

## Merge Conflict Resolution

The cherry-pick conflicted. The `5.2` branch only contains four workflow files (`coding-standards.yml`, `javascript-tests.yml`, `phpunit-tests.yml`, `test-build-processes.yml`), while the original commit touched twelve. Details of what was applied, dropped, and hand-adapted:

### Jobs the condition was applied to (5 total)

| File | Job |
| --- | --- |
| `.github/workflows/coding-standards.yml` | `phpcs` |
| `.github/workflows/coding-standards.yml` | `jshint` |
| `.github/workflows/javascript-tests.yml` | `test-js` |
| `.github/workflows/phpunit-tests.yml` | `test-php` |
| `.github/workflows/test-build-processes.yml` | `test-core-build-process` |

All five previously used the identical gate `if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}` and were replaced with the canonical multi-line form from the source commit. No `startsWith( github.repository, 'WordPress/' )` variants, no `github.event.before` clause, and no fork-only (`! startsWith(...)`) jobs exist on this branch, so none of the other shapes from the original commit were needed.

### Files dropped (do not exist on the `5.2` branch)

These came through the cherry-pick as `modify/delete` conflicts and were removed with `git rm` so they are not newly created on this branch:

- `.github/workflows/end-to-end-tests.yml`
- `.github/workflows/javascript-type-checking.yml`
- `.github/workflows/performance.yml`
- `.github/workflows/php-compatibility.yml`
- `.github/workflows/phpstan-static-analysis.yml`
- `.github/workflows/test-and-zip-default-themes.yml`
- `.github/workflows/upgrade-develop-testing.yml` (no `upgrade-testing.yml` equivalent exists on this branch either)
- `.github/workflows/workflow-lint.yml`

### Conflict resolution per file

- **`coding-standards.yml`** — content conflict on the `phpcs` job only, because on this branch the `if:` is followed by a `with:` block (`php-version: '7.3'`, `old-branch: true`) that does not exist on trunk. Resolved by taking the new multi-line `if:` and preserving this branch's `with:` block beneath it. The `jshint` job merged cleanly.
- **`javascript-tests.yml`** — same shape of conflict on `test-js`, whose `if:` is followed by `with: disable-apparmor: true` on this branch. Resolved by taking the new `if:` and preserving the `with:` block.
- **`phpunit-tests.yml`** — the largest divergence. Trunk has `prepare-gutenberg`, `test-with-mysql`, `test-with-mariadb`, `test-with-sqlite`, and a fork-only job; `5.2` has a single `test-php` job using `reusable-phpunit-tests-v2.yml`. The conflict attempted to import those trunk-only jobs wholesale. The file was restored to the `upstream/5.2` version and the new `if:` was hand-applied to `test-php` only (the sole job on this branch matching the gate family). No trunk-only jobs were introduced.
- **`test-build-processes.yml`** — auto-merged cleanly onto `test-core-build-process`; verified the condition landed on the correct job.

### Intentionally left untouched

- All `slack-notifications` and `failed-workflow` jobs in the four files — gated on `github.event_name != 'pull_request'` and unaffected.
- `test-build-processes.yml` → `test-core-build-process-macos`, gated on `if: ${{ github.repository == 'WordPress/wordpress-develop' }}` only. It never runs for fork `pull_request` events, so it is not part of the gate family the commit targets.
- The `uses: WordPress/wordpress-develop/.github/workflows/<x>.yml@trunk` → `uses: ./.github/workflows/<x>.yml` portion of the original commit was skipped: it applied only to `upgrade-develop-testing.yml` and `workflow-lint.yml`, neither of which exists on this branch, and this branch has no local `reusable-*.yml` files to reference.

### Verification

- `git diff upstream/5.2 --stat` shows only the four files above (40 insertions, 5 deletions).
- No conflict markers remain under `.github`.
- All four changed files parse as valid YAML via PyYAML, with their job lists intact.

## Use of AI Tools
This pull request was created by an AI agent (Claude Code). Until this PR is marked "Ready for Review", treat it as untrusted, AI-created code that requires a manual review by a human team member.
