### PR TITLE
Backport: Skip pull_request triggered runs in private repos - 7.1 Branch

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -50,7 +50,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-coding-standards-php.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
 
   # Runs the JavaScript coding standards checks.
   jshint:
@@ -58,7 +65,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-coding-standards-javascript.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
 
   slack-notifications:
     name: Slack Notifications

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -57,7 +57,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-end-to-end-tests.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/javascript-tests.yml
+++ b/.github/workflows/javascript-tests.yml
@@ -53,7 +53,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-javascript-tests.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
 
   slack-notifications:
     name: Slack Notifications

--- a/.github/workflows/javascript-type-checking.yml
+++ b/.github/workflows/javascript-type-checking.yml
@@ -46,7 +46,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-javascript-type-checking-v1.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
 
   slack-notifications:
     name: Slack Notifications

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -50,7 +50,17 @@ jobs:
   determine-matrix:
     name: Determine Matrix
     runs-on: ubuntu-24.04
-    if: ${{ ( github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' ) && ! contains( github.event.before, '00000000' ) }}
+    if: |
+      (
+        github.repository == 'WordPress/wordpress-develop' || (
+          github.event_name == 'pull_request' && (
+            ! github.event.repository.private ||
+            ! github.event.pull_request.draft ||
+            contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+          )
+        )
+      ) &&
+      ! contains( github.event.before, '00000000' )
     permissions:
       actions: read
     env:

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -42,7 +42,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-php-compatibility.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
 
   slack-notifications:
     name: Slack Notifications

--- a/.github/workflows/phpstan-static-analysis.yml
+++ b/.github/workflows/phpstan-static-analysis.yml
@@ -42,7 +42,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-phpstan-static-analysis-v1.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
 
   slack-notifications:
     name: Slack Notifications

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -58,7 +58,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-prepare-gutenberg.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
 
   #
   # Creates a PHPUnit test job for each PHP/MySQL combination.
@@ -76,7 +83,16 @@ jobs:
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       WPT_REPORT_API_KEY: ${{ secrets.WPT_REPORT_API_KEY }}
-    if: ${{ startsWith( github.repository, 'WordPress/' ) && ( github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' ) }}
+    if: |
+      startsWith( github.repository, 'WordPress/' ) && (
+        github.repository == 'WordPress/wordpress-develop' || (
+          github.event_name == 'pull_request' && (
+            ! github.event.repository.private ||
+            ! github.event.pull_request.draft ||
+            contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+          )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:
@@ -159,7 +175,16 @@ jobs:
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       WPT_REPORT_API_KEY: ${{ secrets.WPT_REPORT_API_KEY }}
-    if: ${{ startsWith( github.repository, 'WordPress/' ) && ( github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' ) }}
+    if: |
+      startsWith( github.repository, 'WordPress/' ) && (
+        github.repository == 'WordPress/wordpress-develop' || (
+          github.event_name == 'pull_request' && (
+            ! github.event.repository.private ||
+            ! github.event.pull_request.draft ||
+            contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+          )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:
@@ -217,7 +242,16 @@ jobs:
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       WPT_REPORT_API_KEY: ${{ secrets.WPT_REPORT_API_KEY }}
-    if: ${{ startsWith( github.repository, 'WordPress/' ) && ( github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' ) }}
+    if: |
+      startsWith( github.repository, 'WordPress/' ) && (
+        github.repository == 'WordPress/wordpress-develop' || (
+          github.event_name == 'pull_request' && (
+            ! github.event.repository.private ||
+            ! github.event.pull_request.draft ||
+            contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+          )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:
@@ -264,7 +298,16 @@ jobs:
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       WPT_REPORT_API_KEY: ${{ secrets.WPT_REPORT_API_KEY }}
-    if: ${{ startsWith( github.repository, 'WordPress/' ) && ( github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' ) }}
+    if: |
+      startsWith( github.repository, 'WordPress/' ) && (
+        github.repository == 'WordPress/wordpress-develop' || (
+          github.event_name == 'pull_request' && (
+            ! github.event.repository.private ||
+            ! github.event.pull_request.draft ||
+            contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+          )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:
@@ -298,7 +341,13 @@ jobs:
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       WPT_REPORT_API_KEY: ${{ secrets.WPT_REPORT_API_KEY }}
-    if: ${{ ! startsWith( github.repository, 'WordPress/' ) && github.event_name == 'pull_request' }}
+    if: |
+      ! startsWith( github.repository, 'WordPress/' ) &&
+      github.event_name == 'pull_request' && (
+        ! github.event.repository.private ||
+        ! github.event.pull_request.draft ||
+        contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+      )
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-build-processes.yml
+++ b/.github/workflows/test-build-processes.yml
@@ -51,7 +51,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-test-core-build-process.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/upgrade-develop-testing.yml
+++ b/.github/workflows/upgrade-develop-testing.yml
@@ -44,7 +44,16 @@ jobs:
   build:
     name: Build
     uses: WordPress/wordpress-develop/.github/workflows/reusable-build-package.yml@trunk
-    if: ${{ startsWith( github.repository, 'WordPress/' ) && ( github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' ) }}
+    if: |
+      startsWith( github.repository, 'WordPress/' ) && (
+        github.repository == 'WordPress/wordpress-develop' || (
+          github.event_name == 'pull_request' && (
+            ! github.event.repository.private ||
+            ! github.event.pull_request.draft ||
+            contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+          )
+        )
+      )
     permissions:
       contents: read
 
@@ -87,7 +96,14 @@ jobs:
   upgrade-tests-develop-forks:
     name: Upgrade from ${{ matrix.wp }}
     uses: WordPress/wordpress-develop/.github/workflows/reusable-upgrade-testing.yml@trunk
-    if: ${{ github.repository != 'WordPress/wordpress-develop' }}
+    # This job also runs for the push event, which has no draft state to check.
+    if: |
+      github.repository != 'WordPress/wordpress-develop' && (
+        github.event_name != 'pull_request' ||
+        ! github.event.repository.private ||
+        ! github.event.pull_request.draft ||
+        contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+      )
     needs: [ build ]
     permissions:
       contents: read

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -33,7 +33,14 @@ jobs:
   lint:
     name: Lint GitHub Action files
     uses: WordPress/wordpress-develop/.github/workflows/reusable-workflow-lint.yml@trunk
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     permissions:
       security-events: write
       actions: read


### PR DESCRIPTION
This backports 15c4b048588ee7b286edd846708f57756b4a519e (r63183) to the 7.1 branch.

## Merge Conflict Resolution

The cherry-pick applied cleanly to 10 of the 12 files. Two adaptations were required:

### 1. `.github/workflows/test-and-zip-default-themes.yml` — dropped entirely

This file does not exist on the `7.1` branch. It is intentionally deleted from numbered release branches by the "Post 7.1 branching changes for the 7.1 branch" commit (`dfdd339309`), since default theme testing/zipping is only performed on `trunk`. The cherry-pick reported a `modify/delete` conflict and left `trunk`'s version of the file in the tree; it was removed with `git rm` so the file is **not** created on this branch. Both `if:` conditions the original commit changed in that file (`test-and-zip-themes` and the second theme job) were therefore dropped.

There is no equivalent renamed file on `7.1` — no workflow on this branch handles default theme testing or zipping.

### 2. `uses:` changes to local reusable workflow paths — not carried over

The original commit also switched three `uses:` references from `WordPress/wordpress-develop/.github/workflows/<x>.yml@trunk` to the local `./.github/workflows/<x>.yml` form:

- `upgrade-develop-testing.yml` → `reusable-build-package.yml`
- `upgrade-develop-testing.yml` → `reusable-upgrade-testing.yml`
- `workflow-lint.yml` → `reusable-workflow-lint.yml`

The `7.1` branch contains **no** `reusable-*.yml` files in `.github/workflows/` at all — numbered branches deliberately consume the reusable workflows from `trunk`. Switching to a local path would break these workflows. Per the backport scope rules, these three `uses:` lines were reverted to their original `@trunk` form after the cherry-pick, and only the `if:` condition changes were kept in those two files.

### Everything else

All remaining hunks applied without modification. No job condition had to be hand-written from scratch — every `if:` gate in the family `github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request'` (including the `startsWith( github.repository, 'WordPress/' ) && (...)` variants, the `&& ! contains( github.event.before, '00000000' )` variant in `performance.yml`, the fork-only variant in `phpunit-tests.yml`, and the push-inclusive variant in `upgrade-develop-testing.yml`) was a clean textual match on this branch.

A post-application sweep of `.github/workflows/` confirmed no jobs of that condition family remain unconverted on `7.1`. Slack notification jobs (gated on `github.event_name != 'pull_request'`) were left untouched, as were `props-bot.yml`, `pull-request-comments.yml`, `cleanup-pull-requests.yml`, `check-built-files.yml`, and `local-docker-environment.yml`, none of which the original commit touched.

All 16 workflow files on this branch were verified to parse as valid YAML after the change.

## Use of AI Tools
This pull request was created by an AI agent (Claude Code). Until this PR is marked "Ready for Review", treat it as untrusted, AI-created code that requires a manual review by a human team member.
