### PR TITLE
Backport: Skip pull_request triggered runs in private repos - 6.9 Branch

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -50,7 +50,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-coding-standards-php.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
 
   # Runs the JavaScript coding standards checks.
   jshint:
@@ -58,7 +65,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-coding-standards-javascript.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
 
   slack-notifications:
     name: Slack Notifications

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -55,7 +55,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-end-to-end-tests.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/javascript-tests.yml
+++ b/.github/workflows/javascript-tests.yml
@@ -51,7 +51,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-javascript-tests.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
 
   slack-notifications:
     name: Slack Notifications

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -49,7 +49,17 @@ jobs:
   determine-matrix:
     name: Determine Matrix
     runs-on: ubuntu-24.04
-    if: ${{ ( github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' ) && ! contains( github.event.before, '00000000' ) }}
+    if: |
+      (
+        github.repository == 'WordPress/wordpress-develop' || (
+          github.event_name == 'pull_request' && (
+            ! github.event.repository.private ||
+            ! github.event.pull_request.draft ||
+            contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+          )
+        )
+      ) &&
+      ! contains( github.event.before, '00000000' )
     permissions:
       actions: read
     env:

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -42,7 +42,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-php-compatibility.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
 
   slack-notifications:
     name: Slack Notifications

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -64,7 +64,16 @@ jobs:
     permissions:
       contents: read
     secrets: inherit
-    if: ${{ startsWith( github.repository, 'WordPress/' ) && ( github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' ) }}
+    if: |
+      startsWith( github.repository, 'WordPress/' ) && (
+        github.repository == 'WordPress/wordpress-develop' || (
+          github.event_name == 'pull_request' && (
+            ! github.event.repository.private ||
+            ! github.event.pull_request.draft ||
+            contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+          )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:
@@ -141,7 +150,16 @@ jobs:
     permissions:
       contents: read
     secrets: inherit
-    if: ${{ startsWith( github.repository, 'WordPress/' ) && ( github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' ) }}
+    if: |
+      startsWith( github.repository, 'WordPress/' ) && (
+        github.repository == 'WordPress/wordpress-develop' || (
+          github.event_name == 'pull_request' && (
+            ! github.event.repository.private ||
+            ! github.event.pull_request.draft ||
+            contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+          )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:
@@ -193,7 +211,16 @@ jobs:
     permissions:
       contents: read
     secrets: inherit
-    if: ${{ startsWith( github.repository, 'WordPress/' ) && ( github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' ) }}
+    if: |
+      startsWith( github.repository, 'WordPress/' ) && (
+        github.repository == 'WordPress/wordpress-develop' || (
+          github.event_name == 'pull_request' && (
+            ! github.event.repository.private ||
+            ! github.event.pull_request.draft ||
+            contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+          )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:
@@ -241,7 +268,16 @@ jobs:
     permissions:
       contents: read
     secrets: inherit
-    if: ${{ startsWith( github.repository, 'WordPress/' ) && ( github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' ) }}
+    if: |
+      startsWith( github.repository, 'WordPress/' ) && (
+        github.repository == 'WordPress/wordpress-develop' || (
+          github.event_name == 'pull_request' && (
+            ! github.event.repository.private ||
+            ! github.event.pull_request.draft ||
+            contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+          )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:
@@ -270,7 +306,13 @@ jobs:
     permissions:
       contents: read
     secrets: inherit
-    if: ${{ ! startsWith( github.repository, 'WordPress/' ) && github.event_name == 'pull_request' }}
+    if: |
+      ! startsWith( github.repository, 'WordPress/' ) &&
+      github.event_name == 'pull_request' && (
+        ! github.event.repository.private ||
+        ! github.event.pull_request.draft ||
+        contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+      )
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-build-processes.yml
+++ b/.github/workflows/test-build-processes.yml
@@ -50,7 +50,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-test-core-build-process.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/upgrade-develop-testing.yml
+++ b/.github/workflows/upgrade-develop-testing.yml
@@ -44,7 +44,16 @@ jobs:
   build:
     name: Build
     uses: WordPress/wordpress-develop/.github/workflows/reusable-build-package.yml@trunk
-    if: ${{ startsWith( github.repository, 'WordPress/' ) && ( github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' ) }}
+    if: |
+      startsWith( github.repository, 'WordPress/' ) && (
+        github.repository == 'WordPress/wordpress-develop' || (
+          github.event_name == 'pull_request' && (
+            ! github.event.repository.private ||
+            ! github.event.pull_request.draft ||
+            contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+          )
+        )
+      )
     permissions:
       contents: read
 
@@ -87,7 +96,14 @@ jobs:
   upgrade-tests-develop-forks:
     name: Upgrade from ${{ matrix.wp }}
     uses: WordPress/wordpress-develop/.github/workflows/reusable-upgrade-testing.yml@trunk
-    if: ${{ github.repository != 'WordPress/wordpress-develop' }}
+    # This job also runs for the push event, which has no draft state to check.
+    if: |
+      github.repository != 'WordPress/wordpress-develop' && (
+        github.event_name != 'pull_request' ||
+        ! github.event.repository.private ||
+        ! github.event.pull_request.draft ||
+        contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+      )
     needs: [ build ]
     permissions:
       contents: read

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -33,7 +33,14 @@ jobs:
   lint:
     name: Lint GitHub Action files
     uses: WordPress/wordpress-develop/.github/workflows/reusable-workflow-lint.yml@trunk
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     permissions:
       security-events: write
       actions: read


### PR DESCRIPTION
This backports 15c4b048588ee7b286edd846708f57756b4a519e (r63183) to the 6.9 branch.

## Merge Conflict Resolution

The cherry-pick conflicted. Details of every adaptation:

### Files from the original commit that do not exist on `6.9` (hunks dropped entirely)

These three workflow files were reported as `modify/delete` conflicts (deleted in `HEAD`, modified by the cherry-pick). The cherry-pick left the trunk version in the tree; each was `git rm`'d because the file does not exist on this branch and has no differently-named equivalent here:

* `.github/workflows/javascript-type-checking.yml`
* `.github/workflows/phpstan-static-analysis.yml`
* `.github/workflows/test-and-zip-default-themes.yml`

### `.github/workflows/phpunit-tests.yml` (content conflict, 6 hunks)

* **`prepare-gutenberg` job — dropped.** Trunk added the new `if:` to a `prepare-gutenberg` job that calls `reusable-prepare-gutenberg.yml`. That job does not exist on `6.9`, so the hunk was dropped rather than introducing a new job.
* **`secrets:` blocks — kept the `6.9` version.** Trunk lists `CODECOV_TOKEN` / `WPT_REPORT_API_KEY` explicitly; `6.9` uses `secrets: inherit`. `secrets: inherit` was preserved unchanged in all five jobs — only the `if:` expression was replaced.
* The new condition was applied to `test-with-mysql`, `test-with-mariadb`, `test-innovation-releases`, `html-api-test-groups` (all `startsWith( github.repository, 'WordPress/' ) && ( ... )` shape) and to `limited-matrix-for-forks` (the fork-only `! startsWith( ... ) && github.event_name == 'pull_request'` shape).

### `uses:` changes reverted (out of scope for this branch)

The original commit also switched three `uses:` references from `WordPress/wordpress-develop/.github/workflows/<x>.yml@trunk` to the local `./.github/workflows/<x>.yml` form. The `6.9` branch contains **no** `reusable-*.yml` workflow files at all, so those local paths would not resolve. All three were reverted to the `@trunk` form; only the `if:` conditions were carried over:

* `.github/workflows/upgrade-develop-testing.yml` — `reusable-build-package.yml`
* `.github/workflows/upgrade-develop-testing.yml` — `reusable-upgrade-testing.yml`
* `.github/workflows/workflow-lint.yml` — `reusable-workflow-lint.yml`

### Applied cleanly (no adaptation needed)

`coding-standards.yml` (2 jobs), `end-to-end-tests.yml`, `javascript-tests.yml`, `performance.yml` (`determine-matrix`, including the `! contains( github.event.before, '00000000' )` clause), `php-compatibility.yml`, `test-build-processes.yml`, `workflow-lint.yml` (`if:` only), and `upgrade-develop-testing.yml` (`if:` only).

### Verification

* `git diff upstream/6.9 --stat` touches only `.github/workflows/` (9 files).
* No conflict markers remain (`git grep -E '^(<<<<<<<|=======|>>>>>>>)' -- .github` returns nothing).
* All 9 changed YAML files parse successfully with PyYAML.
* Every `if:` gate of the affected family on `6.9` was audited via grep; no job in the in-scope files was missed. Slack-notification jobs and workflows the original commit did not touch (`check-built-files.yml`, `cleanup-pull-requests.yml`, `local-docker-environment.yml`, `props-bot.yml`, `pull-request-comments.yml`) were left alone.

## Use of AI Tools
This pull request was created by an AI agent (Claude Code). Until this PR is marked "Ready for Review", treat it as untrusted, AI-created code that requires a manual review by a human team member.
