### PR TITLE
Backport: Skip pull_request triggered runs in private repos - 5.5 Branch

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -47,7 +47,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-coding-standards-php.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     with:
       php-version: '7.4'
 
@@ -57,7 +64,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-coding-standards-javascript.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
 
   slack-notifications:
     name: Slack Notifications

--- a/.github/workflows/javascript-tests.yml
+++ b/.github/workflows/javascript-tests.yml
@@ -45,7 +45,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-javascript-tests.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     with:
       disable-apparmor: true
 

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -41,7 +41,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-php-compatibility.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     with:
       php-version: '7.4'
 

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -35,7 +35,14 @@ jobs:
     permissions:
       contents: read
     secrets: inherit
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-build-processes.yml
+++ b/.github/workflows/test-build-processes.yml
@@ -41,7 +41,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-test-core-build-process.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This backports 15c4b048588ee7b286edd846708f57756b4a519e (r63183) to the 5.5 branch.

## Merge Conflict Resolution

The cherry-pick conflicted. The `5.5` branch contains only 5 of the 12 workflow files touched by the original commit, and the shared files have different surrounding content.

**Jobs updated (6 total, across 5 files) — all were the plain `github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request'` form and received the canonical replacement condition verbatim:**

- `.github/workflows/coding-standards.yml` — `phpcs`, `jshint`
- `.github/workflows/javascript-tests.yml` — `test-js`
- `.github/workflows/php-compatibility.yml` — `php-compatibility`
- `.github/workflows/phpunit-tests.yml` — `test-php`
- `.github/workflows/test-build-processes.yml` — `test-core-build-process`

**Files from the original commit that do not exist on `5.5` — hunks dropped entirely.** The cherry-pick reported these as `modify/delete` conflicts and left the trunk versions in the working tree; each was removed with `git rm` so no new file is introduced by this backport:

- `end-to-end-tests.yml`
- `javascript-type-checking.yml`
- `performance.yml`
- `phpstan-static-analysis.yml`
- `test-and-zip-default-themes.yml`
- `upgrade-develop-testing.yml` (no equivalent on this branch; there is no `upgrade-testing.yml` either)
- `workflow-lint.yml`

**Content conflicts and how they were resolved:**

- `coding-standards.yml` (`phpcs`), `javascript-tests.yml` (`test-js`), `php-compatibility.yml` (`php-compatibility`) — conflicted only because a `with:` block (`php-version: '7.4'` / `disable-apparmor: true`) follows the `if:` line on this branch but not on trunk. Resolved by taking the new `if:` block and keeping this branch's `with:` block. The `jshint` job in `coding-standards.yml` merged cleanly.
- `phpunit-tests.yml` — conflicted badly. On trunk this workflow has `prepare-gutenberg`, `test-with-mysql`, `test-with-mariadb`, `test-with-sqlite` and a fork-only job, none of which exist on `5.5`; the branch has a single `test-php` job using `reusable-phpunit-tests-v2.yml`. The merge attempted to import trunk's job structure. The file was reset to the branch version and the condition was hand-applied to the one in-scope job, `test-php`. All of trunk's `startsWith( github.repository, 'WordPress/' ) && (...)` hunks and the fork-only `! startsWith(...)` hunk were dropped — those jobs do not exist here.
- `test-build-processes.yml` — auto-merged cleanly; verified the result matches the canonical replacement.

**Deliberately not touched:**

- `slack-notifications` and `failed-workflow` jobs in all 5 files — gated on `github.event_name != 'pull_request'` and unaffected.
- `test-core-build-process-macos` in `test-build-processes.yml` — gated on `github.repository == 'WordPress/wordpress-develop'` only, which is not part of the targeted condition family and was not changed by the original commit.
- The trunk `uses: WordPress/wordpress-develop/.github/workflows/<x>.yml@trunk` → `uses: ./.github/workflows/<x>.yml` change was skipped: it applied only to `upgrade-develop-testing.yml` and `workflow-lint.yml`, neither of which exists on `5.5`. This branch has no local reusable workflow files at all.

Verification: `git diff 5.5 --stat` shows only the 5 files above; no conflict markers remain; all 5 changed files parse as valid YAML and each of the 6 jobs was confirmed to carry the new condition.

## Use of AI Tools
This pull request was created by an AI agent (Claude Code). Until this PR is marked "Ready for Review", treat it as untrusted, AI-created code that requires a manual review by a human team member.
