### PR TITLE
Backport: Skip pull_request triggered runs in private repos - 5.3 Branch

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -47,7 +47,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-coding-standards-php.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     with:
       php-version: '7.3'
       old-branch: true
@@ -58,7 +65,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-coding-standards-javascript.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
 
   slack-notifications:
     name: Slack Notifications

--- a/.github/workflows/javascript-tests.yml
+++ b/.github/workflows/javascript-tests.yml
@@ -45,7 +45,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-javascript-tests.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     with:
       disable-apparmor: true
 

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -35,7 +35,14 @@ jobs:
     permissions:
       contents: read
     secrets: inherit
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-build-processes.yml
+++ b/.github/workflows/test-build-processes.yml
@@ -41,7 +41,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-test-core-build-process.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This backports 15c4b048588ee7b286edd846708f57756b4a519e (r63183) to the 5.3 branch.

## Merge Conflict Resolution

The cherry-pick conflicted. The 5.3 branch has only four workflow files in `.github/workflows/`: `coding-standards.yml`, `javascript-tests.yml`, `phpunit-tests.yml`, and `test-build-processes.yml`. Eight of the twelve files touched by the original commit do not exist on this branch, and the two files that conflicted textually differ structurally from trunk.

### Files dropped entirely (do not exist on 5.3, and have no equivalent here)

The cherry-pick tried to create these as new files because they are absent on 5.3. Each was `git rm`'d so no new workflow file is introduced by this backport:

- `end-to-end-tests.yml`
- `javascript-type-checking.yml`
- `performance.yml`
- `php-compatibility.yml`
- `phpstan-static-analysis.yml`
- `test-and-zip-default-themes.yml`
- `upgrade-develop-testing.yml` (5.3 has no `upgrade-testing.yml` equivalent either)
- `workflow-lint.yml`

Because `upgrade-develop-testing.yml` and `workflow-lint.yml` do not exist here, the original commit's change from `uses: WordPress/wordpress-develop/.github/workflows/<x>.yml@trunk` to `uses: ./.github/workflows/<x>.yml` was not carried over. 5.3 has no local `reusable-*.yml` files at all, so that piece is not applicable to this branch.

### `coding-standards.yml` — conflicted (content)

Both the `phpcs` and `jshint` jobs matched the target pattern and both received the new condition.

The `phpcs` job conflicted because on 5.3 the `if:` line is immediately followed by a `with:` block that does not exist on trunk:

```yaml
    with:
      php-version: '7.3'
      old-branch: true
```

Resolved by replacing only the `if:` expression and preserving that `with:` block unchanged. The `jshint` job merged cleanly.

### `javascript-tests.yml` — conflicted (content)

The `test-js` job conflicted for the same reason: on 5.3 the `if:` line is followed by a `with: disable-apparmor: true` block not present on trunk. Resolved by replacing only the `if:` expression and preserving the `with:` block.

### `phpunit-tests.yml` — conflicted (content), resolved by hand

This was the largest divergence. Trunk has six jobs in this file (`prepare-gutenberg`, `test-with-mysql`, `test-with-mariadb`, `test-with-sqlite`, a fork-only job, plus notifications); 5.3 has a single `test-php` job that calls `reusable-phpunit-tests-v2.yml`. The three-way merge tried to splice trunk's job structure into this file.

Resolution: the 5.3 version of the file was restored in full (`git checkout HEAD -- .github/workflows/phpunit-tests.yml`) and the condition was applied by hand to the one job that matches the target pattern, `test-php`. Its `secrets: inherit` line (5.3-only) is preserved above the new `if:`. The trunk hunks for `test-with-mysql`, `test-with-mariadb`, `test-with-sqlite`, and the fork-only `! startsWith( github.repository, 'WordPress/' )` job were dropped because none of those jobs exist on this branch. Consequently no `startsWith( github.repository, 'WordPress/' ) && ( ... )` variant appears in this backport.

### `test-build-processes.yml` — merged cleanly

The `test-core-build-process` job merged without conflict. The `test-core-build-process-macos` job was deliberately left alone: its gate is `if: ${{ github.repository == 'WordPress/wordpress-develop' }}`, which is not part of the `|| github.event_name == 'pull_request'` family and is unaffected by the original commit.

### Not touched

`slack-notifications` and `failed-workflow` jobs in all four files are gated on `github.event_name != 'pull_request'` and were left unchanged, per the original commit.

### Verification

- `git diff upstream/5.3 --stat` shows only the four files above, all under `.github/workflows/`.
- No conflict markers remain in `.github`.
- All four changed files parse as valid YAML, and their job lists are unchanged from the 5.3 originals.

## Use of AI Tools
This pull request was created by an AI agent (Claude Code). Until this PR is marked "Ready for Review", treat it as untrusted, AI-created code that requires a manual review by a human team member.
