### PR TITLE
Backport: Skip pull_request triggered runs in private repos - 7.0 Branch

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -50,7 +50,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-coding-standards-php.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
 
   # Runs the JavaScript coding standards checks.
   jshint:
@@ -58,7 +65,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-coding-standards-javascript.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
 
   slack-notifications:
     name: Slack Notifications

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -57,7 +57,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-end-to-end-tests.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/javascript-tests.yml
+++ b/.github/workflows/javascript-tests.yml
@@ -53,7 +53,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-javascript-tests.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
 
   slack-notifications:
     name: Slack Notifications

--- a/.github/workflows/javascript-type-checking.yml
+++ b/.github/workflows/javascript-type-checking.yml
@@ -46,7 +46,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-javascript-type-checking-v1.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
 
   slack-notifications:
     name: Slack Notifications

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -51,7 +51,17 @@ jobs:
   determine-matrix:
     name: Determine Matrix
     runs-on: ubuntu-24.04
-    if: ${{ ( github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' ) && ! contains( github.event.before, '00000000' ) }}
+    if: |
+      (
+        github.repository == 'WordPress/wordpress-develop' || (
+          github.event_name == 'pull_request' && (
+            ! github.event.repository.private ||
+            ! github.event.pull_request.draft ||
+            contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+          )
+        )
+      ) &&
+      ! contains( github.event.before, '00000000' )
     permissions:
       actions: read
     env:

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -42,7 +42,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-php-compatibility.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
 
   slack-notifications:
     name: Slack Notifications

--- a/.github/workflows/phpstan-static-analysis.yml
+++ b/.github/workflows/phpstan-static-analysis.yml
@@ -42,7 +42,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-phpstan-static-analysis-v1.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
 
   slack-notifications:
     name: Slack Notifications

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -57,7 +57,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-prepare-gutenberg.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
 
   #
   # Creates a PHPUnit test job for each PHP/MySQL combination.
@@ -73,7 +80,16 @@ jobs:
     permissions:
       contents: read
     secrets: inherit
-    if: ${{ startsWith( github.repository, 'WordPress/' ) && ( github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' ) }}
+    if: |
+      startsWith( github.repository, 'WordPress/' ) && (
+        github.repository == 'WordPress/wordpress-develop' || (
+          github.event_name == 'pull_request' && (
+            ! github.event.repository.private ||
+            ! github.event.pull_request.draft ||
+            contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+          )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:
@@ -154,7 +170,16 @@ jobs:
     permissions:
       contents: read
     secrets: inherit
-    if: ${{ startsWith( github.repository, 'WordPress/' ) && ( github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' ) }}
+    if: |
+      startsWith( github.repository, 'WordPress/' ) && (
+        github.repository == 'WordPress/wordpress-develop' || (
+          github.event_name == 'pull_request' && (
+            ! github.event.repository.private ||
+            ! github.event.pull_request.draft ||
+            contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+          )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:
@@ -210,7 +235,16 @@ jobs:
     permissions:
       contents: read
     secrets: inherit
-    if: ${{ startsWith( github.repository, 'WordPress/' ) && ( github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' ) }}
+    if: |
+      startsWith( github.repository, 'WordPress/' ) && (
+        github.repository == 'WordPress/wordpress-develop' || (
+          github.event_name == 'pull_request' && (
+            ! github.event.repository.private ||
+            ! github.event.pull_request.draft ||
+            contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+          )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:
@@ -257,7 +291,16 @@ jobs:
     permissions:
       contents: read
     secrets: inherit
-    if: ${{ startsWith( github.repository, 'WordPress/' ) && ( github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' ) }}
+    if: |
+      startsWith( github.repository, 'WordPress/' ) && (
+        github.repository == 'WordPress/wordpress-develop' || (
+          github.event_name == 'pull_request' && (
+            ! github.event.repository.private ||
+            ! github.event.pull_request.draft ||
+            contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+          )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:
@@ -289,7 +332,13 @@ jobs:
     permissions:
       contents: read
     secrets: inherit
-    if: ${{ ! startsWith( github.repository, 'WordPress/' ) && github.event_name == 'pull_request' }}
+    if: |
+      ! startsWith( github.repository, 'WordPress/' ) &&
+      github.event_name == 'pull_request' && (
+        ! github.event.repository.private ||
+        ! github.event.pull_request.draft ||
+        contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+      )
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-build-processes.yml
+++ b/.github/workflows/test-build-processes.yml
@@ -51,7 +51,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-test-core-build-process.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/upgrade-develop-testing.yml
+++ b/.github/workflows/upgrade-develop-testing.yml
@@ -44,7 +44,16 @@ jobs:
   build:
     name: Build
     uses: WordPress/wordpress-develop/.github/workflows/reusable-build-package.yml@trunk
-    if: ${{ startsWith( github.repository, 'WordPress/' ) && ( github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' ) }}
+    if: |
+      startsWith( github.repository, 'WordPress/' ) && (
+        github.repository == 'WordPress/wordpress-develop' || (
+          github.event_name == 'pull_request' && (
+            ! github.event.repository.private ||
+            ! github.event.pull_request.draft ||
+            contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+          )
+        )
+      )
     permissions:
       contents: read
 
@@ -87,7 +96,14 @@ jobs:
   upgrade-tests-develop-forks:
     name: Upgrade from ${{ matrix.wp }}
     uses: WordPress/wordpress-develop/.github/workflows/reusable-upgrade-testing.yml@trunk
-    if: ${{ github.repository != 'WordPress/wordpress-develop' }}
+    # This job also runs for the push event, which has no draft state to check.
+    if: |
+      github.repository != 'WordPress/wordpress-develop' && (
+        github.event_name != 'pull_request' ||
+        ! github.event.repository.private ||
+        ! github.event.pull_request.draft ||
+        contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+      )
     needs: [ build ]
     permissions:
       contents: read

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -33,7 +33,14 @@ jobs:
   lint:
     name: Lint GitHub Action files
     uses: WordPress/wordpress-develop/.github/workflows/reusable-workflow-lint.yml@trunk
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     permissions:
       security-events: write
       actions: read


### PR DESCRIPTION
This backports 15c4b048588ee7b286edd846708f57756b4a519e (r63183) to the 7.0 branch.

## Merge Conflict Resolution

The cherry-pick did not apply cleanly. The following adaptations were made for the `7.0` branch:

### `.github/workflows/test-and-zip-default-themes.yml` — dropped entirely

This file does not exist on the `7.0` branch (it was introduced on `trunk` in [b71a7bfcff], after 7.0 was branched), so the cherry-pick reported a `modify/delete` conflict. The file was `git rm`'d rather than created, since introducing a brand new workflow is out of scope for a backport. The two hunks from the original commit that targeted its `test-default-themes` and `zip-default-themes` jobs were dropped.

### `.github/workflows/phpunit-tests.yml` — 5 content conflicts, all resolved the same way

All five conflicts were caused by unrelated drift between `trunk` and `7.0` in the lines immediately adjacent to the `if:` gates: `trunk` passes secrets explicitly, while `7.0` still uses `secrets: inherit`.

```
<<<<<<< HEAD (7.0)
    secrets: inherit
=======
    secrets:
      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
      WPT_REPORT_API_KEY: ${{ secrets.WPT_REPORT_API_KEY }}
>>>>>>> (trunk)
```

In every case the branch's `secrets: inherit` line was kept unchanged and only the new `if:` condition from r63183 was taken. The affected jobs are:

- `test-with-mysql`
- `test-with-mariadb`
- `test-innovation-releases`
- `html-api-test-groups`

  (the four above all use the `startsWith( github.repository, 'WordPress/' ) && ( ... )` outer wrapper)
- `limited-matrix-for-forks`, the fork-only job gated on `! startsWith( github.repository, 'WordPress/' ) && github.event_name == 'pull_request'`, which received the private/draft/label group appended directly, per the original commit.

The `prepare-gutenberg` job applied cleanly.

### `uses:` changes reverted — reusable workflows do not live on this branch

The original commit also switched two workflows from `uses: WordPress/wordpress-develop/.github/workflows/<x>.yml@trunk` to a local `uses: ./.github/workflows/<x>.yml` reference. The `7.0` branch contains **no** `reusable-*.yml` files at all (verified with `git ls-tree -r --name-only 7.0 .github/workflows/ | grep reusable` → 0 results); every workflow on this branch consumes the reusable workflows from `trunk` in the canonical repo.

Applying the local references would therefore break these workflows, so the `uses:` lines were restored to their `7.0` values after the cherry-pick, and only the `if:` conditions were backported:

- `.github/workflows/upgrade-develop-testing.yml` — `build` job kept `uses: WordPress/wordpress-develop/.github/workflows/reusable-build-package.yml@trunk`; `upgrade-tests-develop-forks` job kept `uses: WordPress/wordpress-develop/.github/workflows/reusable-upgrade-testing.yml@trunk`.
- `.github/workflows/workflow-lint.yml` — `lint` job kept `uses: WordPress/wordpress-develop/.github/workflows/reusable-workflow-lint.yml@trunk`.

The `if:` changes for those three jobs (including the `# This job also runs for the push event, which has no draft state to check.` comment on `upgrade-tests-develop-forks`) were applied in full.

### Applied cleanly, no adaptation needed

`coding-standards.yml` (2 jobs), `end-to-end-tests.yml`, `javascript-tests.yml`, `javascript-type-checking.yml`, `performance.yml` (`determine-matrix`, including the `! contains( github.event.before, '00000000' )` clause), `php-compatibility.yml`, `phpstan-static-analysis.yml`, `test-build-processes.yml`.

### Verification

- `git diff 7.0 --stat` touches only files under `.github/workflows/` (11 files).
- No conflict markers remain.
- All 16 workflow files on the branch parse as valid YAML.
- A sweep for any remaining `github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request'` style gate in the touched files returns nothing. Slack notification jobs (gated on `github.event_name != 'pull_request'`) and untouched workflows (`props-bot.yml`, `pull-request-comments.yml`, `check-built-files.yml`, `cleanup-pull-requests.yml`, `local-docker-environment.yml`) were left alone.

## Use of AI Tools
This pull request was created by an AI agent (Claude Code). Until this PR is marked "Ready for Review", treat it as untrusted, AI-created code that requires a manual review by a human team member.
