### PR TITLE
Backport: Skip pull_request triggered runs in private repos - 5.9 Branch

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -47,7 +47,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-coding-standards-php.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     with:
       php-version: '7.4'
 
@@ -57,7 +64,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-coding-standards-javascript.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
 
   slack-notifications:
     name: Slack Notifications

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -35,7 +35,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-end-to-end-tests.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/javascript-tests.yml
+++ b/.github/workflows/javascript-tests.yml
@@ -45,7 +45,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-javascript-tests.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     with:
       disable-apparmor: true
 

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -41,7 +41,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-php-compatibility.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     with:
       php-version: '7.4'
 

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -37,7 +37,14 @@ jobs:
     permissions:
       contents: read
     secrets: inherit
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-build-processes.yml
+++ b/.github/workflows/test-build-processes.yml
@@ -41,7 +41,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-test-core-build-process.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This backports 15c4b048588ee7b286edd846708f57756b4a519e (r63183) to the 5.9 branch.

## Merge Conflict Resolution

The 5.9 branch has a much smaller and older set of workflow files than `trunk`, so the cherry-pick conflicted. Notes on exactly what was applied, dropped, and hand-edited:

### Files from the original commit that do not exist on 5.9 (dropped entirely)

These came through as `modify/delete` conflicts (the commit modified them, 5.9 does not have them). They were `git rm`'d so that the backport does not introduce brand new workflow files onto this branch:

* `.github/workflows/javascript-type-checking.yml`
* `.github/workflows/performance.yml`
* `.github/workflows/phpstan-static-analysis.yml`
* `.github/workflows/test-and-zip-default-themes.yml`
* `.github/workflows/upgrade-develop-testing.yml`
* `.github/workflows/workflow-lint.yml`

Because `upgrade-develop-testing.yml` and `workflow-lint.yml` do not exist on 5.9, the part of the original commit that switched those two workflows from `uses: WordPress/wordpress-develop/.github/workflows/<x>.yml@trunk` to `uses: ./.github/workflows/<x>.yml` was not carried over. No `reusable-build-package.yml`, `reusable-upgrade-testing.yml`, or `reusable-workflow-lint.yml` exists on this branch either, so no local `uses:` reference would resolve.

### Files that applied cleanly

* `.github/workflows/end-to-end-tests.yml` – `e2e-tests` job.
* `.github/workflows/test-build-processes.yml` – `test-core-build-process` job.

### Files that conflicted and were resolved by hand

In each of these, the 5.9 version of the job differs from `trunk` (extra `with:` blocks, `secrets: inherit` instead of named secrets, different job names/structure), so the surrounding lines did not match. The 5.9 content was kept as-is and only the `if:` expression was replaced with the new condition:

* `.github/workflows/coding-standards.yml` – `phpcs` job (conflicted because 5.9 has a `with: php-version: '7.4'` block immediately after the `if:`) and `jshint` job.
* `.github/workflows/javascript-tests.yml` – `test-js` job (conflicted because 5.9 has a `with: disable-apparmor: true` block after the `if:`).
* `.github/workflows/php-compatibility.yml` – `php-compatibility` job (conflicted because 5.9 has a `with: php-version: '7.4'` block after the `if:`).
* `.github/workflows/phpunit-tests.yml` – `test-php` job. This file conflicted heavily: 5.9 has a single `test-php` job with `secrets: inherit`, while `trunk` has `prepare-gutenberg`, `test-with-mysql`, `test-with-mariadb`, `test-innovation-releases`, `html-api-test-groups`, and `limited-matrix-for-forks`. Only the existing `test-php` job was updated. None of the `trunk`-only jobs were added, so the `startsWith( github.repository, 'WordPress/' ) && (...)` variant and the fork-only `limited-matrix-for-forks` variant of the condition do not appear on this branch — 5.9's `test-php` uses the plain `github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request'` form and therefore received the plain replacement condition.

### Intentionally left untouched

* All `slack-notifications` and `failed-workflow` jobs — they are gated on `github.event_name != 'pull_request'` and are unaffected.
* `.github/workflows/test-build-processes.yml` – the `test-core-build-process-macos` job is gated only on `github.repository == 'WordPress/wordpress-develop'`, which is not part of the condition family this commit changes.
* `.github/workflows/welcome-new-contributors.yml` — not touched by the original commit.

### Net result

6 files changed, all under `.github/workflows/`. Seven job `if:` gates updated in total. All changed files were verified to parse as valid YAML and contain no conflict markers.

## Use of AI Tools
This pull request was created by an AI agent (Claude Code). Until this PR is marked "Ready for Review", treat it as untrusted, AI-created code that requires a manual review by a human team member.
