### PR TITLE
Backport: Skip pull_request triggered runs in private repos - 6.3 Branch

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -47,7 +47,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-coding-standards-php.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     with:
       php-version: '7.4'
 
@@ -57,7 +64,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-coding-standards-javascript.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
 
   slack-notifications:
     name: Slack Notifications

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -35,7 +35,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-end-to-end-tests.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/javascript-tests.yml
+++ b/.github/workflows/javascript-tests.yml
@@ -45,7 +45,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-javascript-tests.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
 
   slack-notifications:
     name: Slack Notifications

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -41,7 +41,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-php-compatibility.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     with:
       php-version: '7.4'
 

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -37,7 +37,14 @@ jobs:
     permissions:
       contents: read
     secrets: inherit
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-build-processes.yml
+++ b/.github/workflows/test-build-processes.yml
@@ -41,7 +41,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-test-core-build-process.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This backports 15c4b048588ee7b286edd846708f57756b4a519e (r63183) to the 6.3 branch.

## Merge Conflict Resolution

The cherry-pick conflicted because the 6.3 branch has a much smaller and older set of workflow files than `trunk`. All resolutions were confined to `.github/workflows/`.

### Jobs updated (7 jobs across 6 files)

The canonical replacement condition was applied to every job on this branch whose gate was `if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}`:

- `coding-standards.yml` → `phpcs`, `jshint`
- `end-to-end-tests.yml` → `e2e-tests`
- `javascript-tests.yml` → `test-js`
- `php-compatibility.yml` → `php-compatibility`
- `phpunit-tests.yml` → `test-php`
- `test-build-processes.yml` → `test-core-build-process`

None of these jobs exist on 6.3 in the `startsWith( github.repository, 'WordPress/' ) && ( ... )` wrapped form used on `trunk`, so the plain (unwrapped) canonical condition was used for all of them.

### Conflicts and how they were resolved

- **`coding-standards.yml` (`phpcs`) and `php-compatibility.yml` (`php-compatibility`)** — content conflicts. On 6.3 these jobs have a `with: php-version: '7.4'` block immediately after the `if:` key, which `trunk` no longer has. Resolved by taking the new multi-line `if:` from the cherry-pick and re-appending the branch's existing `with: php-version: '7.4'` block below it. No other changes to these jobs.
- **`phpunit-tests.yml`** — content conflict. The incoming change wanted to add the `prepare-gutenberg` job and rewrite `test-php` to use `secrets: CODECOV_TOKEN` / `WPT_REPORT_API_KEY`, plus pull in the `test-with-mariadb` / `test-with-sqlite` / fork-specific jobs, none of which exist on 6.3. Resolved by restoring the branch's version of the file in full and hand-applying only the new `if:` condition to the single `test-php` job. The branch's `secrets: inherit` line and the rest of the job were left untouched. No new jobs were introduced.
- **`end-to-end-tests.yml`, `javascript-tests.yml`, `test-build-processes.yml`** — auto-merged cleanly; no manual intervention.

### Hunks dropped (file does not exist on 6.3)

These files from the original commit do not exist on this branch, so their hunks were dropped and the files were `git rm`'d from the cherry-pick so they are not created here:

- `javascript-type-checking.yml`
- `performance.yml`
- `phpstan-static-analysis.yml`
- `test-and-zip-default-themes.yml`
- `upgrade-develop-testing.yml` (no equivalent `upgrade-testing.yml` exists on 6.3 either)
- `workflow-lint.yml`

### Other pieces of the original commit intentionally not carried over

- The `uses: WordPress/wordpress-develop/.github/workflows/<x>.yml@trunk` → `uses: ./.github/workflows/<x>.yml` switch applied only to `upgrade-develop-testing.yml` and `workflow-lint.yml`, neither of which exists on 6.3. Skipped.
- `test-build-processes.yml` → `test-core-build-process-macos` was **not** changed. It is gated on `if: ${{ github.repository == 'WordPress/wordpress-develop' }}` only, which is not part of the condition family this commit modifies (it already never runs in forks or mirrors), and the equivalent job was not touched by the original commit.
- The `slack-notifications` and `failed-workflow` jobs in all six files were left untouched, as they are gated on `github.event_name != 'pull_request'` and are unaffected.
- `welcome-new-contributors.yml` was not touched.

### Verification performed

- `git diff upstream/6.3 --stat` shows only the six files above (56 insertions, 7 deletions).
- No conflict markers remain anywhere under `.github`.
- All six changed workflow files parse as valid YAML, and each job's resolved `if:` expression was dumped and inspected to confirm correct structure and indentation.

## Use of AI Tools
This pull request was created by an AI agent (Claude Code). Until this PR is marked "Ready for Review", treat it as untrusted, AI-created code that requires a manual review by a human team member.
