### PR TITLE
Backport: Skip pull_request triggered runs in private repos - 6.7 Branch

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -48,7 +48,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-coding-standards-php.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
 
   # Runs the JavaScript coding standards checks.
   jshint:
@@ -56,7 +63,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-coding-standards-javascript.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
 
   slack-notifications:
     name: Slack Notifications

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -36,7 +36,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-end-to-end-tests.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/javascript-tests.yml
+++ b/.github/workflows/javascript-tests.yml
@@ -46,7 +46,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-javascript-tests.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
 
   slack-notifications:
     name: Slack Notifications

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -42,7 +42,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-php-compatibility.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
 
   slack-notifications:
     name: Slack Notifications

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -37,7 +37,14 @@ jobs:
     permissions:
       contents: read
     secrets: inherit
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:
@@ -109,7 +116,14 @@ jobs:
     permissions:
       contents: read
     secrets: inherit
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-build-processes.yml
+++ b/.github/workflows/test-build-processes.yml
@@ -31,7 +31,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-test-core-build-process.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:
@@ -79,7 +86,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-test-gutenberg-build-process.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -36,7 +36,14 @@ jobs:
   upgrade-tests-wp-6x-mysql:
     name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || 'latest' }}
     uses: WordPress/wordpress-develop/.github/workflows/reusable-upgrade-testing.yml@trunk
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     permissions:
       contents: read
     strategy:
@@ -61,7 +68,14 @@ jobs:
   upgrade-tests-wp-5x-php-7x-mysql:
     name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || 'latest' }}
     uses: WordPress/wordpress-develop/.github/workflows/reusable-upgrade-testing.yml@trunk
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:
@@ -88,7 +102,14 @@ jobs:
   upgrade-tests-wp-5x-php-8x-mysql:
     name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || 'latest' }}
     uses: WordPress/wordpress-develop/.github/workflows/reusable-upgrade-testing.yml@trunk
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:
@@ -111,7 +132,14 @@ jobs:
   upgrade-tests-wp-4x-php-7x-mysql:
     name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || 'latest' }}
     uses: WordPress/wordpress-develop/.github/workflows/reusable-upgrade-testing.yml@trunk
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:
@@ -138,7 +166,14 @@ jobs:
   upgrade-tests-wp-4x-php-8x-mysql:
     name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || 'latest' }}
     uses: WordPress/wordpress-develop/.github/workflows/reusable-upgrade-testing.yml@trunk
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This backports 15c4b048588ee7b286edd846708f57756b4a519e (r63183) to the 6.7 branch.

## Merge Conflict Resolution

The cherry-pick conflicted. The 6.7 branch has a much smaller and differently shaped set of workflow files than `trunk`, so most of the commit had to be adapted by hand. Details below.

### Files updated (14 job gates in total)

| File | Jobs updated |
| --- | --- |
| `.github/workflows/coding-standards.yml` | `phpcs`, `jshint` |
| `.github/workflows/end-to-end-tests.yml` | `e2e-tests` |
| `.github/workflows/javascript-tests.yml` | `test-js` |
| `.github/workflows/php-compatibility.yml` | `php-compatibility` |
| `.github/workflows/phpunit-tests.yml` | `test-with-mysql`, `test-with-mariadb` |
| `.github/workflows/test-build-processes.yml` | `test-core-build-process`, `test-gutenberg-build-process` |
| `.github/workflows/upgrade-testing.yml` | `upgrade-tests-wp-6x-mysql`, `upgrade-tests-wp-5x-php-7x-mysql`, `upgrade-tests-wp-5x-php-8x-mysql`, `upgrade-tests-wp-4x-php-7x-mysql`, `upgrade-tests-wp-4x-php-8x-mysql` |

Every one of these was previously gated with the plain `if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}` and now uses the canonical replacement:

```yaml
    if: |
      github.repository == 'WordPress/wordpress-develop' || (
        github.event_name == 'pull_request' && (
          ! github.event.repository.private ||
          ! github.event.pull_request.draft ||
          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
        )
      )
```

`coding-standards.yml`, `end-to-end-tests.yml`, `javascript-tests.yml`, and `php-compatibility.yml` merged cleanly with no manual intervention.

### Hunks dropped — files that do not exist on 6.7

The cherry-pick reported `modify/delete` conflicts for six workflow files that exist on `trunk` but not on 6.7. All six were `git rm`'d so that this backport does not introduce brand new workflows to a security-only branch:

- `.github/workflows/javascript-type-checking.yml`
- `.github/workflows/performance.yml`
- `.github/workflows/phpstan-static-analysis.yml`
- `.github/workflows/test-and-zip-default-themes.yml`
- `.github/workflows/upgrade-develop-testing.yml`
- `.github/workflows/workflow-lint.yml`

### Manual adaptations

- **`phpunit-tests.yml`** — content conflict. The `trunk` version of this workflow has diverged substantially (a `prepare-gutenberg` job, per-secret `secrets:` blocks, `startsWith( github.repository, 'WordPress/' ) && (...)` wrappers, a `test-innovation-releases` job, and a separate fork-only job). None of that exists on 6.7. Resolution:
  - Dropped the incoming `prepare-gutenberg` job entirely — it does not exist on this branch.
  - Dropped the incoming `test-innovation-releases` job and the fork-only PHPUnit job — neither exists on this branch.
  - Kept 6.7's `secrets: inherit` rather than taking `trunk`'s explicit `CODECOV_TOKEN` / `WPT_REPORT_API_KEY` block.
  - Kept 6.7's `with:` inputs (`report: ${{ matrix.report || false }}`) rather than `trunk`'s `gutenberg-artifact` / `gutenberg-sha` inputs.
  - Because 6.7's `test-with-mysql` and `test-with-mariadb` jobs are **not** wrapped in `startsWith( github.repository, 'WordPress/' ) && (...)`, the plain canonical form was applied to both rather than the `startsWith()` variant used on `trunk`. This preserves the existing behavior on this branch and only adds the private/draft/label narrowing.

- **`test-build-processes.yml`** — the `test-core-build-process` job merged cleanly. The `test-gutenberg-build-process` job was updated **by hand**: that job no longer exists on `trunk`, so there was no corresponding hunk in the source commit, but its gate is of the same family and it runs on `pull_request`. The two macOS jobs (`test-core-build-process-macos`, `test-gutenberg-build-process-macos`) were left alone — they are gated `github.repository == 'WordPress/wordpress-develop'` only and never run on forks.

- **`upgrade-testing.yml`** — all five gates applied **by hand**; there was no corresponding hunk in the source commit. Worth a careful look from a reviewer: on `trunk`, the touched workflow is `upgrade-develop-testing.yml` (added later in 24a2eacf7d and never backported), while `trunk`'s own `upgrade-testing.yml` was left untouched by r63183 because its jobs have since been narrowed to `github.repository == 'WordPress/wordpress-develop'` only. On 6.7 that narrowing never happened, so all five jobs still carry the `|| github.event_name == 'pull_request'` gate and do fire for `pull_request` events (the workflow has a `pull_request` trigger with a `paths` filter on the workflow files themselves). Applying the change here is what preserves the intent of r63183 on this branch. If the preference is instead to leave this file untouched, that hunk can be dropped independently of the rest.

### Not touched

- All `slack-notifications` and `failed-workflow` jobs — gated on `github.event_name != 'pull_request'` and unaffected.
- `props-bot.yml` and `pull-request-comments.yml` — not touched by the source commit and not equivalents of anything it touched.
- The source commit also switched `upgrade-develop-testing.yml` and `workflow-lint.yml` from `uses: WordPress/wordpress-develop/.github/workflows/<x>.yml@trunk` to `uses: ./.github/workflows/<x>.yml`. Neither file exists on 6.7, so that part was skipped entirely. No other `uses:` line was changed.

### Verification

- `git diff 6.7 --stat` shows changes only under `.github/workflows/` (7 files, +112/-14).
- No conflict markers remain anywhere under `.github`.
- All seven changed files parse as valid YAML, and the job count in each file is unchanged from 6.7.

## Use of AI Tools
This pull request was created by an AI agent (Claude Code). Until this PR is marked "Ready for Review", treat it as untrusted, AI-created code that requires a manual review by a human team member.
