### PR TITLE
Backport: Skip pull_request triggered runs in private repos - 6.8 Branch

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -48,7 +48,15 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-coding-standards-php.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || ( github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' ) }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' &&
+        github.actor != 'dependabot[bot]' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
 
   # Runs the JavaScript coding standards checks.
   jshint:
@@ -56,7 +64,15 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-coding-standards-javascript.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || ( github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' ) }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' &&
+        github.actor != 'dependabot[bot]' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
 
   slack-notifications:
     name: Slack Notifications

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -53,7 +53,15 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-end-to-end-tests.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || ( github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' ) }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' &&
+        github.actor != 'dependabot[bot]' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/javascript-tests.yml
+++ b/.github/workflows/javascript-tests.yml
@@ -49,7 +49,15 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-javascript-tests.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || ( github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' ) }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' &&
+        github.actor != 'dependabot[bot]' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
 
   slack-notifications:
     name: Slack Notifications

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -46,7 +46,18 @@ jobs:
   determine-matrix:
     name: Determine Matrix
     runs-on: ubuntu-24.04
-    if: ${{ ( github.repository == 'WordPress/wordpress-develop' || ( github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' ) ) && ! contains( github.event.before, '00000000' ) }}
+    if: |
+      (
+        github.repository == 'WordPress/wordpress-develop' || (
+          github.event_name == 'pull_request' &&
+          github.actor != 'dependabot[bot]' && (
+            ! github.event.repository.private ||
+            ! github.event.pull_request.draft ||
+            contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+          )
+        )
+      ) &&
+      ! contains( github.event.before, '00000000' )
     permissions:
       actions: read
     env:

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -42,7 +42,15 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-php-compatibility.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || ( github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' ) }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' &&
+        github.actor != 'dependabot[bot]' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
 
   slack-notifications:
     name: Slack Notifications

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -56,7 +56,15 @@ jobs:
     permissions:
       contents: read
     secrets: inherit
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || ( github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' ) }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' &&
+        github.actor != 'dependabot[bot]' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:
@@ -127,7 +135,15 @@ jobs:
     permissions:
       contents: read
     secrets: inherit
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || ( github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' ) }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' &&
+        github.actor != 'dependabot[bot]' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:
@@ -177,7 +193,15 @@ jobs:
     permissions:
       contents: read
     secrets: inherit
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || ( github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' ) }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' &&
+        github.actor != 'dependabot[bot]' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:
@@ -218,7 +242,15 @@ jobs:
     permissions:
       contents: read
     secrets: inherit
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || ( github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' ) }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' &&
+        github.actor != 'dependabot[bot]' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-build-processes.yml
+++ b/.github/workflows/test-build-processes.yml
@@ -48,7 +48,15 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-test-core-build-process.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || ( github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' ) }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' &&
+        github.actor != 'dependabot[bot]' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:
@@ -100,7 +108,15 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-test-gutenberg-build-process.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || ( github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' ) }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' &&
+        github.actor != 'dependabot[bot]' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/upgrade-develop-testing.yml
+++ b/.github/workflows/upgrade-develop-testing.yml
@@ -51,7 +51,15 @@ jobs:
   upgrade-tests-develop:
     name: Upgrade from ${{ matrix.wp }}
     uses: WordPress/wordpress-develop/.github/workflows/reusable-upgrade-testing.yml@trunk
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || ( github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' ) }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' &&
+        github.actor != 'dependabot[bot]' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     needs: [ build ]
     permissions:
       contents: read

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -33,7 +33,15 @@ jobs:
   lint:
     name: Lint GitHub Action files
     uses: WordPress/wordpress-develop/.github/workflows/reusable-workflow-lint.yml@trunk
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || ( github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' ) }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' &&
+        github.actor != 'dependabot[bot]' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     permissions:
       security-events: write
       actions: read


### PR DESCRIPTION
This backports 15c4b048588ee7b286edd846708f57756b4a519e (r63183) to the 6.8 branch.

## Merge Conflict Resolution

The cherry-pick conflicted in every file it touched. The `if:` gate on the 6.8 branch carries an
extra `github.actor != 'dependabot[bot]'` clause that no longer exists on `trunk`, so no hunk applied
cleanly. Additionally, `phpunit-tests.yml` on 6.8 differs substantially from `trunk` (no
`prepare-gutenberg` job, `secrets: inherit` instead of explicit secrets, no
`startsWith( github.repository, 'WordPress/' )` gating, no fork-only job), which made that file's
conflicts unusable.

Rather than hand-editing conflict hunks that contained unrelated `trunk`-only content, every
conflicted file was reset to its 6.8 content and the condition change was applied by hand to each
qualifying job.

### Adapted condition shape

Because 6.8 gates on dependabot as well, the standard replacement used here preserves that clause:

```yaml
    if: |
      github.repository == 'WordPress/wordpress-develop' || (
        github.event_name == 'pull_request' &&
        github.actor != 'dependabot[bot]' && (
          ! github.event.repository.private ||
          ! github.event.pull_request.draft ||
          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
        )
      )
```

### Jobs updated by hand (14 total)

| File | Job(s) |
| --- | --- |
| `.github/workflows/coding-standards.yml` | `phpcs`, `jshint` |
| `.github/workflows/end-to-end-tests.yml` | `e2e-tests` |
| `.github/workflows/javascript-tests.yml` | `test-js` |
| `.github/workflows/performance.yml` | `determine-matrix` |
| `.github/workflows/php-compatibility.yml` | `php-compatibility` |
| `.github/workflows/phpunit-tests.yml` | `test-with-mysql`, `test-with-mariadb`, `test-innovation-releases`, `specific-test-groups` |
| `.github/workflows/test-build-processes.yml` | `test-core-build-process`, `test-gutenberg-build-process` |
| `.github/workflows/upgrade-develop-testing.yml` | `upgrade-tests-develop` |
| `.github/workflows/workflow-lint.yml` | `lint` |

`performance.yml`'s `determine-matrix` job additionally keeps its
`&& ! contains( github.event.before, '00000000' )` clause, matching the shape used on `trunk`:

```yaml
    if: |
      (
        github.repository == 'WordPress/wordpress-develop' || (
          github.event_name == 'pull_request' &&
          github.actor != 'dependabot[bot]' && (
            ! github.event.repository.private ||
            ! github.event.pull_request.draft ||
            contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
          )
        )
      ) &&
      ! contains( github.event.before, '00000000' )
```

### Hunks dropped

- `.github/workflows/javascript-type-checking.yml` — does not exist on 6.8. The cherry-pick left the
  `trunk` version of the whole file in the tree; it was `git rm`'d rather than created.
- `.github/workflows/phpstan-static-analysis.yml` — does not exist on 6.8. Same handling as above.
- `.github/workflows/test-and-zip-default-themes.yml` — does not exist on 6.8. Same handling as above.
- `phpunit-tests.yml`: the `prepare-gutenberg` job, the `gutenberg-artifact`/`gutenberg-sha` inputs,
  the explicit `CODECOV_TOKEN`/`WPT_REPORT_API_KEY` secrets blocks, the
  `startsWith( github.repository, 'WordPress/' ) && ( ... )` outer wrapper, and the fork-only
  `test-with-mysql` variant job all came along with the conflict but do not exist on 6.8. None were
  introduced. Only the `if:` lines on the four existing jobs were changed.
- The `uses: WordPress/wordpress-develop/.github/workflows/<x>.yml@trunk` →
  `uses: ./.github/workflows/<x>.yml` change from the original commit was **not** carried over for
  `upgrade-develop-testing.yml` or `workflow-lint.yml`. The 6.8 branch contains no `reusable-*.yml`
  workflow files at all, so the local references would not resolve.
- `upgrade-develop-testing.yml`: the original commit also updated the `build` job and the
  `upgrade-tests-develop-forks` job. Neither has an `if:` gate (the `build` job) or exists at all
  (`upgrade-tests-develop-forks`) on 6.8, so those hunks were dropped.

### Deliberately left untouched

- `.github/workflows/upgrade-testing.yml` — exists on both `trunk` and 6.8 and was not touched by the
  original commit. Note that its jobs on 6.8 *do* carry the `|| ( pull_request && ! dependabot )`
  family gate (on `trunk` they are gated on `github.repository == 'WordPress/wordpress-develop'`
  only). Flagging this in case it should be included; it was left alone to match the scope of r63183.
- `.github/workflows/local-docker-environment.yml` — same situation: has the family gate on 6.8, but
  the original commit did not touch this workflow on `trunk`.
- All Slack notification jobs (gated on `github.event_name != 'pull_request'`, unaffected).
- `props-bot.yml`, `pull-request-comments.yml`, `cleanup-pull-requests.yml`, `check-built-files.yml`.

### Verification

- `git diff upstream/6.8 --stat` shows only files under `.github/workflows/` (9 files, +129/-14).
- `git grep -n -E '^(<<<<<<<|=======|>>>>>>>)' -- .github` returns nothing.
- All 15 workflow files on the branch parse with PyYAML; the 14 updated `if:` expressions were
  re-serialized and inspected to confirm the boolean grouping is correct.

## Use of AI Tools
This pull request was created by an AI agent (Claude Code). Until this PR is marked "Ready for Review", treat it as untrusted, AI-created code that requires a manual review by a human team member.
