### PR TITLE
Backport: Skip pull_request triggered runs in private repos - 6.2 Branch

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -47,7 +47,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-coding-standards-php.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     with:
       php-version: '7.4'
 
@@ -57,7 +64,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-coding-standards-javascript.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
 
   slack-notifications:
     name: Slack Notifications

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -35,7 +35,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-end-to-end-tests.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/javascript-tests.yml
+++ b/.github/workflows/javascript-tests.yml
@@ -45,7 +45,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-javascript-tests.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
 
   slack-notifications:
     name: Slack Notifications

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -41,7 +41,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-php-compatibility.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     with:
       php-version: '7.4'
 

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -38,7 +38,14 @@ jobs:
     permissions:
       contents: read
     secrets: inherit
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-build-processes.yml
+++ b/.github/workflows/test-build-processes.yml
@@ -41,7 +41,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-test-core-build-process.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This backports 15c4b048588ee7b286edd846708f57756b4a519e (r63183) to the 6.2 branch.

## Merge Conflict Resolution

The cherry-pick conflicted. The `6.2` branch has only 7 workflow files, and the ones it shares with `trunk` are structured differently, so a number of hunks had to be dropped or hand-applied.

### Files from the original commit that do not exist on `6.2` (dropped entirely)

These came through as `modify/delete` conflicts and were `git rm`'d, since the files have never existed on this branch:

* `.github/workflows/javascript-type-checking.yml`
* `.github/workflows/performance.yml`
* `.github/workflows/phpstan-static-analysis.yml`
* `.github/workflows/test-and-zip-default-themes.yml`
* `.github/workflows/upgrade-develop-testing.yml` — no equivalent (there is no `upgrade-testing.yml` on this branch either)
* `.github/workflows/workflow-lint.yml`

Because `upgrade-develop-testing.yml` and `workflow-lint.yml` do not exist here, the part of the original commit that switched those two workflows from `uses: WordPress/wordpress-develop/.github/workflows/<x>.yml@trunk` to `uses: ./.github/workflows/<x>.yml` was not carried over. `6.2` has no `reusable-*.yml` workflow files of its own, so that change would not have been valid on this branch regardless.

### Conflicts resolved in shared files

* **`coding-standards.yml`** (`phpcs` job) — content conflict. On `6.2` the `if:` is immediately followed by a `with: php-version: '7.4'` block that does not exist on `trunk`. Resolved by taking the new multi-line `if:` from the commit and keeping the branch's existing `with:` block after it. The second job in this file, `jshint`, merged cleanly.
* **`php-compatibility.yml`** (`php-compatibility` job) — same conflict and same resolution: new `if:`, existing `with: php-version: '7.4'` retained.
* **`phpunit-tests.yml`** — large content conflict. `trunk` has since been restructured into `prepare-gutenberg`, `test-with-mysql`, `test-with-mariadb`, `test-innovation-releases`, `html-api-test-groups`, and `limited-matrix-for-forks` jobs; `6.2` has a single `test-php` job using `secrets: inherit`. The cherry-pick tried to import trunk's entire job structure into this branch. The file was reset to the `6.2` version and the condition was hand-applied to the one job that carries the target gate (`test-php`), using the canonical replacement form. The `startsWith( github.repository, 'WordPress/' )` wrapper and the fork-only `limited-matrix-for-forks` variant from the original commit do not apply here, because `6.2` has no such job split.

### Files that merged cleanly

`end-to-end-tests.yml` (`e2e-tests`), `javascript-tests.yml` (`test-js`), and `test-build-processes.yml` (`test-core-build-process`).

### Deliberately left untouched

* All `slack-notifications` and `failed-workflow` jobs — these are gated on `github.event_name != 'pull_request'` and are unaffected.
* `test-build-processes.yml` → `test-core-build-process-macos`, gated only on `github.repository == 'WordPress/wordpress-develop'`, which is not the condition family this commit changes.
* `welcome-new-contributors.yml`, which the original commit did not touch.

### Net result

7 jobs across 6 files now carry the new condition: `coding-standards.yml` (`phpcs`, `jshint`), `end-to-end-tests.yml` (`e2e-tests`), `javascript-tests.yml` (`test-js`), `php-compatibility.yml` (`php-compatibility`), `phpunit-tests.yml` (`test-php`), and `test-build-processes.yml` (`test-core-build-process`). All six changed files were confirmed to parse as valid YAML, and the diff touches nothing outside `.github/workflows/`.

## Use of AI Tools
This pull request was created by an AI agent (Claude Code). Until this PR is marked "Ready for Review", treat it as untrusted, AI-created code that requires a manual review by a human team member.
