### PR TITLE
Backport: Skip pull_request triggered runs in private repos - 6.5 Branch

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -47,7 +47,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-coding-standards-php.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
 
   # Runs the JavaScript coding standards checks.
   jshint:
@@ -55,7 +62,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-coding-standards-javascript.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
 
   slack-notifications:
     name: Slack Notifications

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -36,7 +36,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-end-to-end-tests.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/javascript-tests.yml
+++ b/.github/workflows/javascript-tests.yml
@@ -45,7 +45,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-javascript-tests.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
 
   slack-notifications:
     name: Slack Notifications

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -41,7 +41,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-php-compatibility.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
 
   slack-notifications:
     name: Slack Notifications

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -35,7 +35,14 @@ jobs:
     permissions:
       contents: read
     secrets: inherit
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:
@@ -86,7 +93,14 @@ jobs:
     permissions:
       contents: read
     secrets: inherit
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-build-processes.yml
+++ b/.github/workflows/test-build-processes.yml
@@ -31,7 +31,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-test-core-build-process.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:
@@ -79,7 +86,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-test-gutenberg-build-process.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -36,7 +36,14 @@ jobs:
   upgrade-tests-wp-6x-mysql:
     name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || 'latest' }}
     uses: WordPress/wordpress-develop/.github/workflows/upgrade-testing-run.yml@trunk
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     permissions:
       contents: read
     strategy:
@@ -61,7 +68,14 @@ jobs:
   upgrade-tests-wp-5x-php-7x-mysql:
     name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || 'latest' }}
     uses: WordPress/wordpress-develop/.github/workflows/upgrade-testing-run.yml@trunk
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:
@@ -88,7 +102,14 @@ jobs:
   upgrade-tests-wp-5x-php-8x-mysql:
     name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || 'latest' }}
     uses: WordPress/wordpress-develop/.github/workflows/upgrade-testing-run.yml@trunk
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:
@@ -111,7 +132,14 @@ jobs:
   upgrade-tests-wp-4x-php-7x-mysql:
     name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || 'latest' }}
     uses: WordPress/wordpress-develop/.github/workflows/upgrade-testing-run.yml@trunk
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:
@@ -138,7 +166,14 @@ jobs:
   upgrade-tests-wp-4x-php-8x-mysql:
     name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || 'latest' }}
     uses: WordPress/wordpress-develop/.github/workflows/upgrade-testing-run.yml@trunk
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This backports 15c4b048588ee7b286edd846708f57756b4a519e (r63183) to the 6.5 branch.

## Merge Conflict Resolution

The cherry-pick conflicted. The 6.5 branch has a much smaller and older set of workflow files than `trunk`, so several hunks had no destination and a few jobs needed the condition applied by hand. Details below.

### Applied cleanly (auto-merged by the cherry-pick)

The canonical replacement was applied verbatim to these jobs:

- `.github/workflows/coding-standards.yml` — `phpcs`, `jshint`
- `.github/workflows/end-to-end-tests.yml` — `e2e-tests`
- `.github/workflows/javascript-tests.yml` — `test-js`
- `.github/workflows/php-compatibility.yml` — `php-compatibility`
- `.github/workflows/test-build-processes.yml` — `test-core-build-process`

### Hunks dropped — file does not exist on the 6.5 branch

These files were modified by r63183 but do not exist on 6.5. The cherry-pick left them as modify/delete conflicts; they were `git rm`'d so that no new files are introduced by this backport:

- `.github/workflows/javascript-type-checking.yml`
- `.github/workflows/performance.yml`
- `.github/workflows/phpstan-static-analysis.yml`
- `.github/workflows/test-and-zip-default-themes.yml`
- `.github/workflows/upgrade-develop-testing.yml`
- `.github/workflows/workflow-lint.yml`

Because `upgrade-develop-testing.yml` and `workflow-lint.yml` do not exist here, the accompanying `uses: WordPress/wordpress-develop/.github/workflows/<x>.yml@trunk` → `uses: ./.github/workflows/<x>.yml` change from r63183 was **not** carried over. The 6.5 branch also has no `reusable-*.yml` workflow files at all, so a local `./` reference would not resolve. All `uses:` lines in this branch are left pointing at `@trunk`, unchanged.

### Hand-applied — content conflict

- `.github/workflows/phpunit-tests.yml` conflicted heavily. The trunk version of this file has since grown a `prepare-gutenberg` job, `test-innovation-releases`, `html-api-test-groups`, and `limited-matrix-for-forks`, plus `startsWith( github.repository, 'WordPress/' ) && (...)` wrappers and explicit `secrets:` blocks — none of which exist on 6.5. The file was reset to the 6.5 version and the canonical condition was applied by hand to the only two jobs that carry the gate:
  - `test-with-mysql`
  - `test-with-mariadb`

  The `startsWith( github.repository, 'WordPress/' ) && ( ... )` outer wrapper from trunk was intentionally **not** introduced, since 6.5 never had it and adding it would change which repositories run these jobs (a behavior change unrelated to this backport). The fork-only `limited-matrix-for-forks` job that r63183 also updated does not exist on 6.5, so that hunk was dropped.

### Hand-applied — jobs with the same gate that r63183 did not touch textually

Per the intent of r63183 (no `pull_request` runs in private mirrors while a PR is in draft), the same condition was applied to the remaining jobs in the touched/equivalent workflow files that still carry the `github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request'` gate:

- `.github/workflows/test-build-processes.yml` — `test-gutenberg-build-process`. This job was removed from `trunk` some time ago, so r63183 had no corresponding hunk, but it lives in a file the commit touched and carries the exact gate.
- `.github/workflows/upgrade-testing.yml` — `upgrade-tests-wp-6x-mysql`, `upgrade-tests-wp-5x-php-7x-mysql`, `upgrade-tests-wp-5x-php-8x-mysql`, `upgrade-tests-wp-4x-php-7x-mysql`, `upgrade-tests-wp-4x-php-8x-mysql`.

  **Please review this file specifically.** `upgrade-testing.yml` on 6.5 is the ancestor of `trunk`'s `upgrade-testing.yml` (upgrades from released WordPress.org versions), not of `upgrade-develop-testing.yml` (which was introduced later as a new file, not a rename). On `trunk`, `upgrade-testing.yml` was not touched by r63183 because its gates have since been narrowed to `github.repository == 'WordPress/wordpress-develop'` alone. On 6.5 those jobs still carry the `|| github.event_name == 'pull_request'` gate and do run for pull requests, so the condition was applied here to match the intent of the commit. If reviewers would rather leave this file untouched, dropping the `upgrade-testing.yml` hunks is safe and independent of the rest of the diff.

### Explicitly left alone

- Slack notification jobs and `failed-workflow` jobs in every file — gated on `github.event_name != 'pull_request'`, unaffected.
- `.github/workflows/test-build-processes.yml` — `test-core-build-process-macos`, `test-gutenberg-build-process-macos` (`github.repository == 'WordPress/wordpress-develop'` only) and `playground-comment` (`github.repository == 'WordPress/wordpress-develop' && github.event_name == 'pull_request'`). None are in the affected condition family; all are already restricted to the canonical public repo.
- `.github/workflows/props-bot.yml` and `.github/workflows/pull-request-comments.yml` — not touched by r63183 and not equivalents of anything it touched.

### Verification

- `git diff 6.5 --stat` touches only files under `.github/workflows/`; no files added or removed.
- No conflict markers remain (`git grep -E '^(<<<<<<<|=======|>>>>>>>)' -- .github` returns nothing).
- All nine workflow files on the branch parse cleanly with PyYAML.

## Use of AI Tools
This pull request was created by an AI agent (Claude Code). Until this PR is marked "Ready for Review", treat it as untrusted, AI-created code that requires a manual review by a human team member.
