### PR TITLE
Backport: Skip pull_request triggered runs in private repos - 6.6 Branch

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -47,7 +47,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-coding-standards-php.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
 
   # Runs the JavaScript coding standards checks.
   jshint:
@@ -55,7 +62,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-coding-standards-javascript.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
 
   slack-notifications:
     name: Slack Notifications

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -36,7 +36,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-end-to-end-tests.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/javascript-tests.yml
+++ b/.github/workflows/javascript-tests.yml
@@ -45,7 +45,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-javascript-tests.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
 
   slack-notifications:
     name: Slack Notifications

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -41,7 +41,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-php-compatibility.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
 
   slack-notifications:
     name: Slack Notifications

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -37,7 +37,14 @@ jobs:
     permissions:
       contents: read
     secrets: inherit
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:
@@ -110,7 +117,14 @@ jobs:
     permissions:
       contents: read
     secrets: inherit
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-build-processes.yml
+++ b/.github/workflows/test-build-processes.yml
@@ -31,7 +31,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-test-core-build-process.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:
@@ -79,7 +86,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-test-gutenberg-build-process.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This backports 15c4b048588ee7b286edd846708f57756b4a519e (r63183) to the 6.6 branch.

## Merge Conflict Resolution

The cherry-pick conflicted. The `6.6` branch has a much smaller and differently shaped set of workflow files than `trunk`, so several hunks were dropped and one job was updated by hand. Details:

### Files updated (6 files, 8 jobs)

All 8 jobs received the canonical replacement:

```yaml
    if: |
      github.repository == 'WordPress/wordpress-develop' || (
        github.event_name == 'pull_request' && (
          ! github.event.repository.private ||
          ! github.event.pull_request.draft ||
          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
        )
      )
```

- `.github/workflows/coding-standards.yml` — `phpcs` and `jshint` jobs (clean apply).
- `.github/workflows/end-to-end-tests.yml` — `e2e-tests` job (clean apply).
- `.github/workflows/javascript-tests.yml` — `test-js` job (clean apply).
- `.github/workflows/php-compatibility.yml` — `php-compatibility` job (clean apply).
- `.github/workflows/phpunit-tests.yml` — `test-with-mysql` and `test-with-mariadb` jobs (conflicted, resolved by hand — see below).
- `.github/workflows/test-build-processes.yml` — `test-core-build-process` (clean apply) and `test-gutenberg-build-process` (**hand-applied**, see below).

### Files from the original commit that do not exist on `6.6` (hunks dropped)

The cherry-pick reported `CONFLICT (modify/delete)` for each of these and left the `trunk` version of the file in the tree. Each was removed with `git rm` so that no new workflow file is introduced on this branch:

- `.github/workflows/javascript-type-checking.yml`
- `.github/workflows/performance.yml`
- `.github/workflows/phpstan-static-analysis.yml`
- `.github/workflows/test-and-zip-default-themes.yml`
- `.github/workflows/upgrade-develop-testing.yml`
- `.github/workflows/workflow-lint.yml`

### `phpunit-tests.yml` conflict resolution

`trunk`'s version of this workflow has diverged substantially from `6.6`'s. Four conflict hunks:

1. **`prepare-gutenberg` job** — dropped. This job does not exist on `6.6`; the cherry-pick wanted to add the whole job. Kept the `6.6` side (no job).
2. **`test-with-mysql` `if:`** — `6.6` uses `secrets: inherit` and has **no** `startsWith( github.repository, 'WordPress/' ) && ( ... )` outer wrapper (that wrapper was introduced on `trunk` after 6.6). Kept `secrets: inherit` and applied the plain canonical replacement without the `startsWith()` wrapper.
3. **`test-with-mariadb` `if:`** — same as above.
4. **Tail of `test-with-mariadb` `with:` block** — dropped. `trunk` adds `gutenberg-artifact` / `gutenberg-sha` inputs and an entire additional `test-with-innovation-releases` job; neither exists on `6.6`. Kept the `6.6` side (`report: ${{ matrix.report || false }}`).

Net effect on `phpunit-tests.yml`: only the two `if:` conditions changed; nothing else in the file was altered.

### Hand-applied change

- `.github/workflows/test-build-processes.yml`, job **`test-gutenberg-build-process`** — this job no longer exists on `trunk` (the Gutenberg build-process jobs were removed there), so the cherry-pick had no hunk for it. It carries the same `github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request'` gate, so the same replacement was applied by hand.

### Deliberately not touched

- `.github/workflows/upgrade-testing.yml` — this is **not** the equivalent of `trunk`'s `upgrade-develop-testing.yml`. Its jobs (`upgrade-tests-wp-6x-mysql`, `upgrade-tests-wp-5x-php-7x-mysql`, `upgrade-tests-wp-5x-php-8x-mysql`, `upgrade-tests-wp-4x-php-7x-mysql`, `upgrade-tests-wp-4x-php-8x-mysql`) are the direct ancestors of `trunk`'s `upgrade-testing.yml`, which r63183 did not touch. `trunk`'s `upgrade-develop-testing.yml` was added after 6.6 (in `24a2eacf7d`) and has no counterpart here. Five `if:` gates of the affected family therefore remain unchanged in this file.
- `test-core-build-process-macos` and `test-gutenberg-build-process-macos` in `test-build-processes.yml` — gated on `github.repository == 'WordPress/wordpress-develop'` only, not the affected family.
- All `slack-notifications` and `failed-workflow` jobs — gated on `github.event_name != 'pull_request'`, unaffected.
- `props-bot.yml` and `pull-request-comments.yml` — out of scope.

### `uses:` path changes not carried over

r63183 also switched `upgrade-develop-testing.yml` and `workflow-lint.yml` from `uses: WordPress/wordpress-develop/.github/workflows/<x>.yml@trunk` to `uses: ./.github/workflows/<x>.yml`. Neither file exists on `6.6`, and `6.6` has no local `reusable-*.yml` workflow files at all, so this portion was skipped entirely.

### Verification

- `git diff upstream/6.6 --stat` shows only the 6 files listed above, all under `.github/workflows/`.
- No conflict markers remain (`git grep -n -E '^(<<<<<<<|=======|>>>>>>>)' -- .github` returns nothing).
- All 9 workflow YAML files on the branch parse cleanly with PyYAML.

## Use of AI Tools
This pull request was created by an AI agent (Claude Code). Until this PR is marked "Ready for Review", treat it as untrusted, AI-created code that requires a manual review by a human team member.
