### PR TITLE
Backport: Skip pull_request triggered runs in private repos - 6.0 Branch

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -47,7 +47,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-coding-standards-php.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     with:
       php-version: '7.4'
 
@@ -57,7 +64,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-coding-standards-javascript.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
 
   slack-notifications:
     name: Slack Notifications

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -35,7 +35,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-end-to-end-tests.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/javascript-tests.yml
+++ b/.github/workflows/javascript-tests.yml
@@ -45,7 +45,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-javascript-tests.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     with:
       disable-apparmor: true
 

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -41,7 +41,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-php-compatibility.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     with:
       php-version: '7.4'
 

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -38,7 +38,14 @@ jobs:
     permissions:
       contents: read
     secrets: inherit
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-build-processes.yml
+++ b/.github/workflows/test-build-processes.yml
@@ -41,7 +41,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-test-core-build-process.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This backports 15c4b048588ee7b286edd846708f57756b4a519e (r63183) to the 6.0 branch.

## Merge Conflict Resolution

The cherry-pick conflicted. The 6.0 branch has a much smaller set of workflow files and older job definitions, so the following adaptations were made.

**Files from the original commit that do not exist on the 6.0 branch (dropped entirely, `git rm`'d after the cherry-pick left them in the tree):**

- `.github/workflows/javascript-type-checking.yml`
- `.github/workflows/performance.yml`
- `.github/workflows/phpstan-static-analysis.yml`
- `.github/workflows/test-and-zip-default-themes.yml`
- `.github/workflows/upgrade-develop-testing.yml` (no equivalent `upgrade-testing.yml` exists on 6.0 either)
- `.github/workflows/workflow-lint.yml`

Because `upgrade-develop-testing.yml` and `workflow-lint.yml` do not exist on this branch, the `uses: WordPress/wordpress-develop/.github/workflows/<x>.yml@trunk` → `uses: ./.github/workflows/<x>.yml` portion of the original commit was not carried over. The 6.0 branch also has no `reusable-*.yml` workflow files of its own, so local `uses:` references would not resolve.

**Files that applied cleanly (no conflict):**

- `.github/workflows/end-to-end-tests.yml` — `e2e-tests` job.
- `.github/workflows/test-build-processes.yml` — `test-core-build-process` job.

**Conflicts resolved by hand:**

- `.github/workflows/coding-standards.yml` — the `phpcs` job conflicted because 6.0 has a `with: php-version: '7.4'` block immediately after the `if:`, which trunk no longer has. Resolution: took the new multi-line `if:` condition from the commit and kept 6.0's `with:` block after it. The `jshint` job in the same file merged cleanly.
- `.github/workflows/javascript-tests.yml` — the `test-js` job conflicted for the same reason (6.0 has `with: disable-apparmor: true` after the `if:`). Resolution: new `if:` condition followed by 6.0's existing `with:` block.
- `.github/workflows/php-compatibility.yml` — the `php-compatibility` job conflicted for the same reason (`with: php-version: '7.4'`). Resolution: new `if:` condition followed by 6.0's existing `with:` block.
- `.github/workflows/phpunit-tests.yml` — three conflict hunks:
  1. The commit wanted to add a new `prepare-gutenberg` job (and its `jobs:` key). That job does not exist on 6.0 and the reusable workflow it calls is not applicable here, so the hunk was dropped.
  2. The `test-php` job conflicted: 6.0 uses `secrets: inherit` (trunk lists individual secrets) and 6.0's condition is the plain `github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request'` form without trunk's `startsWith( github.repository, 'WordPress/' ) && ( ... )` wrapper. Resolution: kept 6.0's `secrets: inherit`, and applied the canonical replacement condition **without** the `startsWith( ... )` wrapper, since that wrapper is not part of the 6.0 gate and adding it would change which repos run the job.
  3. A large hunk that would have pulled in trunk-only jobs (`test-with-mariadb`, the SQLite/fork jobs, Gutenberg artifact inputs, etc.) into 6.0. Dropped entirely; 6.0's `test-php` job body is unchanged.

**Intentionally not touched:**

- All `slack-notifications` jobs (gated on `github.event_name != 'pull_request'`) and all `failed-workflow` jobs.
- `.github/workflows/test-build-processes.yml` → `test-core-build-process-macos`, which is gated only on `github.repository == 'WordPress/wordpress-develop'` and is not part of the `|| github.event_name == 'pull_request'` family.
- `.github/workflows/welcome-new-contributors.yml`, which the original commit did not touch.

**Verification performed:** the diff against `6.0` touches only files under `.github/workflows/`; no conflict markers remain; all six changed YAML files parse with PyYAML and expose the expected job keys.

## Use of AI Tools
This pull request was created by an AI agent (Claude Code). Until this PR is marked "Ready for Review", treat it as untrusted, AI-created code that requires a manual review by a human team member.
