### PR TITLE
Backport: Skip pull_request triggered runs in private repos - 4.9 Branch

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -47,7 +47,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-coding-standards-javascript.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
 
   slack-notifications:
     name: Slack Notifications

--- a/.github/workflows/javascript-tests.yml
+++ b/.github/workflows/javascript-tests.yml
@@ -45,7 +45,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-javascript-tests.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     with:
       disable-apparmor: true
 

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -37,7 +37,14 @@ jobs:
     permissions:
       contents: read
     secrets: inherit
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-build-processes.yml
+++ b/.github/workflows/test-build-processes.yml
@@ -41,7 +41,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-test-core-build-process.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This backports 15c4b048588ee7b286edd846708f57756b4a519e (r63183) to the 4.9 branch.

## Merge Conflict Resolution

`git cherry-pick` produced conflicts on every touched file (4 content conflicts plus 8 modify/delete conflicts), so the cherry-pick was aborted and the change was applied by hand with the original commit message instead.

The 4.9 branch only has 4 workflow files under `.github/workflows/` (`coding-standards.yml`, `javascript-tests.yml`, `phpunit-tests.yml`, `test-build-processes.yml`). Each contains exactly one job whose `if:` gate matches the `github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request'` pattern from the original commit, and each was updated to the canonical replacement condition:

```yaml
    if: |
      github.repository == 'WordPress/wordpress-develop' || (
        github.event_name == 'pull_request' && (
          ! github.event.repository.private ||
          ! github.event.pull_request.draft ||
          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
        )
      )
```

- `.github/workflows/coding-standards.yml` — `jshint` job.
- `.github/workflows/javascript-tests.yml` — `test-js` job.
- `.github/workflows/phpunit-tests.yml` — `test-php` job. (This branch has only a single PHP-matrix job here, unlike trunk's multiple PHP/MySQL jobs gated with the `startsWith( github.repository, 'WordPress/' )` variant, so only the simple form was needed.)
- `.github/workflows/test-build-processes.yml` — `test-core-build-process` job. (The `test-core-build-process-macos` job on this branch is gated only on `github.repository == 'WordPress/wordpress-develop'`, with no `pull_request` clause, so it was left untouched — it is not an equivalent of any job the original commit touched.)

The following files from the original commit do not exist on the 4.9 branch, so their hunks were dropped entirely (nothing to do, nothing created):

- `.github/workflows/end-to-end-tests.yml`
- `.github/workflows/javascript-type-checking.yml`
- `.github/workflows/performance.yml`
- `.github/workflows/php-compatibility.yml`
- `.github/workflows/phpstan-static-analysis.yml`
- `.github/workflows/test-and-zip-default-themes.yml`
- `.github/workflows/upgrade-develop-testing.yml`
- `.github/workflows/workflow-lint.yml`

No `uses: WordPress/wordpress-develop/.github/workflows/<x>.yml@trunk` → `uses: ./.github/workflows/<x>.yml` conversions were carried over: `upgrade-develop-testing.yml` and `workflow-lint.yml` do not exist on this branch.

Slack-notification and `failed-workflow` jobs were left untouched, as they are gated on `github.event_name != 'pull_request'` and are unaffected by this change.

## Use of AI Tools
This pull request was created by an AI agent (Claude Code). Until this PR is marked "Ready for Review", treat it as untrusted, AI-created code that requires a manual review by a human team member.
