### PR TITLE
Backport: Skip pull_request triggered runs in private repos - 4.8 Branch

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -47,7 +47,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-coding-standards-javascript.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
 
   slack-notifications:
     name: Slack Notifications

--- a/.github/workflows/javascript-tests.yml
+++ b/.github/workflows/javascript-tests.yml
@@ -45,7 +45,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-javascript-tests.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     with:
       disable-apparmor: true
 

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -37,7 +37,14 @@ jobs:
     permissions:
       contents: read
     secrets: inherit
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-build-processes.yml
+++ b/.github/workflows/test-build-processes.yml
@@ -41,7 +41,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-test-core-build-process.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This backports 15c4b048588ee7b286edd846708f57756b4a519e (r63183) to the 4.8 branch.

## Merge Conflict Resolution

`git cherry-pick` was aborted because the vast majority of the workflow files touched by the
original commit do not exist on the 4.8 branch, which only has four workflow files at all:
`coding-standards.yml`, `javascript-tests.yml`, `phpunit-tests.yml`, and `test-build-processes.yml`.
The change was applied by hand to those four files instead, reusing the original commit message.

- **Skipped entirely (file does not exist on 4.8):** `end-to-end-tests.yml`,
  `javascript-type-checking.yml`, `performance.yml`, `php-compatibility.yml`,
  `phpstan-static-analysis.yml`, `test-and-zip-default-themes.yml`,
  `upgrade-develop-testing.yml`, `workflow-lint.yml`. None of these workflows, or an equivalent
  of them, exist in the 4.8 branch, so there was nothing to update.
- **`coding-standards.yml`:** updated the `jshint` job's `if:` condition to the new
  private-repo/draft/label-gated form. The `slack-notifications` and `failed-workflow` jobs are
  gated on `github.event_name != 'pull_request'` and were left untouched, matching the original
  commit's scope.
- **`javascript-tests.yml`:** updated the `test-js` job's `if:` condition the same way. The
  `slack-notifications` and `failed-workflow` jobs were left untouched for the same reason as above.
- **`phpunit-tests.yml`:** updated the `test-php` job's `if:` condition the same way. On this
  branch, `test-php` only uses the simple
  `github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request'`
  gate (the `startsWith( github.repository, 'WordPress/' ) && (...)` wrapper seen in trunk's
  `phpunit-tests.yml` for its matrix jobs does not exist on 4.8, since this branch predates the
  per-PHP-version reusable-workflow matrix split), so the canonical replacement condition was
  used as-is. The `slack-notifications` and `failed-workflow` jobs were left untouched.
- **`test-build-processes.yml`:** updated the `test-core-build-process` job's `if:` condition the
  same way. The `test-core-build-process-macos` job uses a stricter, unrelated condition
  (`github.repository == 'WordPress/wordpress-develop'`, with no `pull_request` allowance at all,
  to limit consumption of the higher-cost macOS runner minutes) and was intentionally left
  untouched, since it is not a member of the `... || github.event_name == 'pull_request'` family
  the original commit targeted. The `slack-notifications` and `failed-workflow` jobs were left
  untouched as well.

No files outside `.github/workflows/` were touched, and no file was created or deleted.

## Use of AI Tools
This pull request was created by an AI agent (Claude Code). Until this PR is marked "Ready for Review", treat it as untrusted, AI-created code that requires a manual review by a human team member.
