### PR TITLE
Backport: Skip pull_request triggered runs in private repos - 5.1 Branch

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -47,7 +47,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-coding-standards-php.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     with:
       php-version: '7.2'
       old-branch: true
@@ -58,7 +65,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-coding-standards-javascript.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
 
   slack-notifications:
     name: Slack Notifications

--- a/.github/workflows/javascript-tests.yml
+++ b/.github/workflows/javascript-tests.yml
@@ -45,7 +45,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-javascript-tests.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     with:
       disable-apparmor: true
 

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -37,7 +37,14 @@ jobs:
     permissions:
       contents: read
     secrets: inherit
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-build-processes.yml
+++ b/.github/workflows/test-build-processes.yml
@@ -41,7 +41,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-test-core-build-process.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This backports 15c4b048588ee7b286edd846708f57756b4a519e (r63183) to the 5.1 branch.

## Merge Conflict Resolution

The direct `git cherry-pick` of 15c4b048588ee7b286edd846708f57756b4a519e produced conflicts in every touched file and wanted to (re)create several workflow files that do not exist on the 5.1 branch (`git-svn` history renamed/restructured many workflow files between 5.1 and trunk). The cherry-pick was aborted and the change was applied by hand, file by file, preserving the original commit message.

The 5.1 branch only has 4 files under `.github/workflows/`: `coding-standards.yml`, `javascript-tests.yml`, `phpunit-tests.yml`, and `test-build-processes.yml`. Each was checked for jobs using the `if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}` gate and updated in place to the canonical replacement:

```yaml
    if: |
      github.repository == 'WordPress/wordpress-develop' || (
        github.event_name == 'pull_request' && (
          ! github.event.repository.private ||
          ! github.event.pull_request.draft ||
          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
        )
      )
```

Jobs updated:
- `.github/workflows/coding-standards.yml`: `phpcs` and `jshint` jobs.
- `.github/workflows/javascript-tests.yml`: `test-js` job.
- `.github/workflows/phpunit-tests.yml`: `test-php` job (this branch has a single PHP/MySQL test job, not the per-combination matrix jobs added later on trunk, so there was only one job to update here).
- `.github/workflows/test-build-processes.yml`: `test-core-build-process` job. The `test-core-build-process-macos` job in the same file was intentionally left untouched — its condition is only `github.repository == 'WordPress/wordpress-develop'` (no `|| github.event_name == 'pull_request'` clause), so it is not part of the affected family and was out of scope.

Files from the original commit that do not exist on the 5.1 branch and were therefore skipped entirely (not created): `end-to-end-tests.yml`, `javascript-type-checking.yml`, `performance.yml`, `php-compatibility.yml`, `phpstan-static-analysis.yml`, `test-and-zip-default-themes.yml`, `upgrade-develop-testing.yml`, `workflow-lint.yml`. None of these have an equivalent under a different name on this branch.

The `slack-notifications` and `failed-workflow` jobs in each of the 4 files were left untouched, as they are gated on `github.event_name != 'pull_request'` and are unaffected by this change.

No files outside `.github/workflows/` were touched.

## Use of AI Tools
This pull request was created by an AI agent (Claude Code). Until this PR is marked "Ready for Review", treat it as untrusted, AI-created code that requires a manual review by a human team member.
