### PR TITLE
Backport: Skip pull_request triggered runs in private repos - 5.0 Branch

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -47,7 +47,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-coding-standards-javascript.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
 
   slack-notifications:
     name: Slack Notifications

--- a/.github/workflows/javascript-tests.yml
+++ b/.github/workflows/javascript-tests.yml
@@ -45,7 +45,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-javascript-tests.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     with:
       disable-apparmor: true
 

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -37,7 +37,14 @@ jobs:
     permissions:
       contents: read
     secrets: inherit
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-build-processes.yml
+++ b/.github/workflows/test-build-processes.yml
@@ -41,7 +41,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-test-core-build-process.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This backports 15c4b048588ee7b286edd846708f57756b4a519e (r63183) to the 5.0 branch.

## Merge Conflict Resolution

The cherry-pick conflicted because the `5.0` branch's `.github/workflows/` directory predates most of the workflow files and jobs that existed on `trunk` at the time of the original commit. Conflicts were resolved as follows:

**Files that do not exist on the `5.0` branch — dropped entirely (not created):**
- `.github/workflows/end-to-end-tests.yml`
- `.github/workflows/javascript-type-checking.yml`
- `.github/workflows/performance.yml`
- `.github/workflows/php-compatibility.yml`
- `.github/workflows/phpstan-static-analysis.yml`
- `.github/workflows/test-and-zip-default-themes.yml`
- `.github/workflows/upgrade-develop-testing.yml` (no `upgrade-testing.yml`-style equivalent exists on this branch either)
- `.github/workflows/workflow-lint.yml`

The cherry-pick attempted to recreate each of these (git reported them as modify/delete conflicts), so each was removed with `git rm` to keep them out of scope for this branch.

**`.github/workflows/coding-standards.yml`:** The `5.0` branch only has the `jshint` job in this workflow — the `phpcs` job does not exist yet (PHPCS checking was introduced in WordPress 5.1, per the file's own header comment). The cherry-pick tried to add a new `phpcs` job carrying the updated condition; that whole job addition was dropped since it isn't part of this branch. The `jshint` job's `if:` condition was updated to the canonical replacement (this part applied cleanly, no hand-editing needed).

**`.github/workflows/javascript-tests.yml`:** The `test-js` job conflicted only because this branch has a `with: disable-apparmor: true` block that trunk no longer has. Resolved by keeping the branch's `with:` block and applying the updated `if:` condition ahead of it.

**`.github/workflows/phpunit-tests.yml`:** This branch's version of the workflow only has one test job, `test-php` (using `reusable-phpunit-tests-v1.yml` with the old PHP-only matrix and `secrets: inherit`), plus `slack-notifications` and `failed-workflow`. Trunk's version has since split into several additional jobs (`prepare-gutenberg`, `test-with-mysql`, `test-with-mariadb`, `test-innovation-releases`, `html-api-test-groups`, `limited-matrix-for-forks`) that do not exist on `5.0`. Two conflict hunks resulted:
- The first hunk mixed the `test-php` job's `if:` update together with the entirely new `test-with-mysql` job. Kept `secrets: inherit` and applied the canonical `if:` condition to `test-php`; dropped the `test-with-mysql` job addition (out of scope).
- The second hunk appeared inside the `with:` block of `test-php` and contained trailing `with:` keys (`tests-domain`, `report`, `gutenberg-artifact`, `gutenberg-sha`) that belong to the newer reusable workflow version, immediately followed by the four other new jobs listed above. All of that was dropped since none of it exists on this branch; `test-php`'s existing `with:` block (`os`, `php`, `phpunit`, `multisite`, `split_slow`, `memcached`, `phpunit-config`) was left untouched and the diff proceeds straight to the existing `slack-notifications` job.

**`.github/workflows/test-build-processes.yml`:** Applied cleanly with no conflicts; only the `if:` condition was updated.

No other files were touched. `git diff upstream/5.0 --stat` confirms only these four files under `.github/workflows/` changed, each changed job now carries the canonical private-repo/draft-PR condition, and every changed YAML file parses successfully with PyYAML.

## Use of AI Tools
This pull request was created by an AI agent (Claude Code). Until this PR is marked "Ready for Review", treat it as untrusted, AI-created code that requires a manual review by a human team member.
