### PR TITLE
Backport: Skip pull_request triggered runs in private repos - 4.7 Branch

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -47,7 +47,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-coding-standards-javascript.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
 
   slack-notifications:
     name: Slack Notifications

--- a/.github/workflows/javascript-tests.yml
+++ b/.github/workflows/javascript-tests.yml
@@ -45,7 +45,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-javascript-tests.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     with:
       disable-apparmor: true
 

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -37,7 +37,14 @@ jobs:
     permissions:
       contents: read
     secrets: inherit
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-build-processes.yml
+++ b/.github/workflows/test-build-processes.yml
@@ -41,7 +41,14 @@ jobs:
     uses: WordPress/wordpress-develop/.github/workflows/reusable-test-core-build-process.yml@trunk
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: |
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+        )
+      )
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This backports 15c4b048588ee7b286edd846708f57756b4a519e (r63183) to the 4.7 branch.

## Merge Conflict Resolution

The 4.7 branch's `.github/workflows/` directory only contains four of the twelve workflow files touched by the original commit: `coding-standards.yml`, `javascript-tests.yml`, `phpunit-tests.yml`, and `test-build-processes.yml`. `git cherry-pick` produced conflicts on every file (content conflicts on the four present files, plus modify/delete conflicts on the eight files that don't exist on this branch), so the cherry-pick was aborted and the change was applied by hand to only the jobs that exist here, using the original commit message.

- `coding-standards.yml`: updated the `if:` condition on the `jshint` job (the `phpcs` job present on trunk does not exist on this branch).
- `javascript-tests.yml`: updated the `if:` condition on the `test-js` job.
- `phpunit-tests.yml`: updated the `if:` condition on the `test-php` job. This branch's `phpunit-tests.yml` has a single PHP-version job (no `startsWith( github.repository, 'WordPress/' )` wrapper and no fork-only job), so only the simple form of the condition applies.
- `test-build-processes.yml`: updated the `if:` condition on the `test-core-build-process` job. The `test-core-build-process-macos` job in this file uses a different, unrelated condition (`github.repository == 'WordPress/wordpress-develop'` only, no `pull_request` fallback) and was left untouched, per the scope rules.

The following files from the original commit do not exist on the 4.7 branch at all and were skipped entirely: `end-to-end-tests.yml`, `javascript-type-checking.yml`, `performance.yml`, `php-compatibility.yml`, `phpstan-static-analysis.yml`, `test-and-zip-default-themes.yml`, `upgrade-develop-testing.yml`, `workflow-lint.yml`. None of these (or an equivalent under a different name) exist on this branch, so there was nothing to map the change to. The `uses: .../@trunk` to `uses: ./...` conversion (originally done in `upgrade-develop-testing.yml` and `workflow-lint.yml`) does not apply here since neither file exists on this branch.

No Slack-notification jobs, and no workflows outside the scope of the original commit, were modified.

## Use of AI Tools
This pull request was created by an AI agent (Claude Code). Until this PR is marked "Ready for Review", treat it as untrusted, AI-created code that requires a manual review by a human team member.
