### PR TITLE
6.9 Branch: Update `php_codesniffer`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,13 +20,13 @@
 	},
 	"require-dev": {
 		"composer/ca-bundle": "1.5.9",
-		"squizlabs/php_codesniffer": "3.13.2",
+		"squizlabs/php_codesniffer": "3.13.6",
 		"wp-coding-standards/wpcs": "~3.2.0",
 		"phpcompatibility/phpcompatibility-wp": "~2.1.3",
 		"yoast/phpunit-polyfills": "^1.1.0"
 	},
 	"config": {
-		"audit": { "ignore": [ "GHSA-3pwp-g2mj-5p3v", "GHSA-hmqg-cxww-wqhq", "PKSA-rdkp-vv9z-mjkg" ] },
+		"audit": { "ignore": [ "GHSA-3pwp-g2mj-5p3v" ] },
 		"allow-plugins": {
 			"dealerdirect/phpcodesniffer-composer-installer": true
 		},


### PR DESCRIPTION
This updates the `php_codesniffer` Composer dependency to version 3.13.6 in the 6.9 branch. The previous direct dependency version pinned was incompatible with a transitive dependency floor after a recent security update, which prevented Composer from resolving the dependency list successfully.

## Use of AI Tools
This pull request was created by an AI agent (Cursor w/Composer 2.5). Until this PR is marked "Ready for Review", treat it as untrusted, AI-created code that requires a manual review by a human team member.