### PR TITLE
REST API: Prevent taxonomy REST bases from overwriting post item properties

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-menu-items-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-menu-items-controller.php
@@ -601,7 +601,7 @@ class WP_REST_Menu_Items_Controller extends WP_REST_Posts_Controller {
 			$data['meta'] = $this->meta->get_value( $menu_item->ID, $request );
 		}
 
-		$taxonomies = wp_list_filter( get_object_taxonomies( $this->post_type, 'objects' ), array( 'show_in_rest' => true ) );
+		$taxonomies = $this->get_rest_taxonomies();
 
 		foreach ( $taxonomies as $taxonomy ) {
 			$base = ! empty( $taxonomy->rest_base ) ? $taxonomy->rest_base : $taxonomy->name;
@@ -907,7 +907,7 @@ class WP_REST_Menu_Items_Controller extends WP_REST_Posts_Controller {
 			'readonly'    => true,
 		);
 
-		$taxonomies = wp_list_filter( get_object_taxonomies( $this->post_type, 'objects' ), array( 'show_in_rest' => true ) );
+		$taxonomies = $this->get_rest_taxonomies( $schema['properties'] );
 
 		foreach ( $taxonomies as $taxonomy ) {
 			$base                          = ! empty( $taxonomy->rest_base ) ? $taxonomy->rest_base : $taxonomy->name;

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -48,6 +48,18 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 	protected $allow_batch = array( 'v1' => true );
 
 	/**
+	 * Taxonomies exposed as properties on the REST API item resource.
+	 *
+	 * The list is initialized while building the item schema so taxonomy REST
+	 * bases that conflict with existing properties are excluded consistently
+	 * from item reads, writes, permissions, and action links.
+	 *
+	 * @since 7.2.0
+	 * @var WP_Taxonomy[]|null
+	 */
+	protected $rest_taxonomies = null;
+
+	/**
 	 * Constructor.
 	 *
 	 * @since 4.7.0
@@ -1691,6 +1703,61 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 	}
 
 	/**
+	 * Retrieves taxonomies exposed as properties on the REST API item resource.
+	 *
+	 * When schema properties are provided, taxonomy REST bases that conflict
+	 * with an existing property are excluded and the resulting list is cached.
+	 * Calling this method without schema properties never triggers schema
+	 * generation, avoiding recursion in controllers that override
+	 * get_item_schema().
+	 *
+	 * @since 7.2.0
+	 *
+	 * @param array|null $properties Existing item schema properties, or null to use the cached list.
+	 * @return WP_Taxonomy[] Taxonomies available as item resource properties.
+	 */
+	protected function get_rest_taxonomies( $properties = null ) {
+		if ( null !== $this->rest_taxonomies ) {
+			return $this->rest_taxonomies;
+		}
+
+		$taxonomies = wp_list_filter( get_object_taxonomies( $this->post_type, 'objects' ), array( 'show_in_rest' => true ) );
+
+		if ( null === $properties ) {
+			return $taxonomies;
+		}
+
+		$rest_taxonomies = array();
+
+		foreach ( $taxonomies as $taxonomy_name => $taxonomy ) {
+			$base = ! empty( $taxonomy->rest_base ) ? $taxonomy->rest_base : $taxonomy->name;
+
+			if ( array_key_exists( $base, $properties ) ) {
+				$taxonomy_field_name_with_conflict = ! empty( $taxonomy->rest_base ) ? 'rest_base' : 'name';
+				_doing_it_wrong(
+					'register_taxonomy',
+					sprintf(
+						/* translators: 1: The taxonomy name, 2: The property name, either 'rest_base' or 'name', 3: The conflicting value. */
+						__( 'The "%1$s" taxonomy "%2$s" property (%3$s) conflicts with an existing property on the REST API Posts Controller. Specify a custom "rest_base" when registering the taxonomy to avoid this error.' ),
+						$taxonomy->name,
+						$taxonomy_field_name_with_conflict,
+						$base
+					),
+					'5.4.0'
+				);
+				continue;
+			}
+
+			$rest_taxonomies[ $taxonomy_name ] = $taxonomy;
+			$properties[ $base ]               = true;
+		}
+
+		$this->rest_taxonomies = $rest_taxonomies;
+
+		return $this->rest_taxonomies;
+	}
+
+	/**
 	 * Updates the post's terms from a REST request.
 	 *
 	 * @since 4.7.0
@@ -1700,7 +1767,8 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 	 * @return null|WP_Error WP_Error on an error assigning any of the terms, otherwise null.
 	 */
 	protected function handle_terms( $post_id, $request ) {
-		$taxonomies = wp_list_filter( get_object_taxonomies( $this->post_type, 'objects' ), array( 'show_in_rest' => true ) );
+		$this->get_item_schema();
+		$taxonomies = $this->get_rest_taxonomies();
 
 		foreach ( $taxonomies as $taxonomy ) {
 			$base = ! empty( $taxonomy->rest_base ) ? $taxonomy->rest_base : $taxonomy->name;
@@ -1728,7 +1796,8 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 	 * @return bool Whether the current user can assign the provided terms.
 	 */
 	protected function check_assign_terms_permission( $request ) {
-		$taxonomies = wp_list_filter( get_object_taxonomies( $this->post_type, 'objects' ), array( 'show_in_rest' => true ) );
+		$this->get_item_schema();
+		$taxonomies = $this->get_rest_taxonomies();
 		foreach ( $taxonomies as $taxonomy ) {
 			$base = ! empty( $taxonomy->rest_base ) ? $taxonomy->rest_base : $taxonomy->name;
 
@@ -2103,7 +2172,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			$data['meta'] = $this->meta->get_value( $post->ID, $request );
 		}
 
-		$taxonomies = wp_list_filter( get_object_taxonomies( $this->post_type, 'objects' ), array( 'show_in_rest' => true ) );
+		$taxonomies = $this->get_rest_taxonomies();
 
 		foreach ( $taxonomies as $taxonomy ) {
 			$base = ! empty( $taxonomy->rest_base ) ? $taxonomy->rest_base : $taxonomy->name;
@@ -2369,7 +2438,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			}
 		}
 
-		$taxonomies = wp_list_filter( get_object_taxonomies( $this->post_type, 'objects' ), array( 'show_in_rest' => true ) );
+		$taxonomies = $this->get_rest_taxonomies();
 
 		foreach ( $taxonomies as $tax ) {
 			$tax_base   = ! empty( $tax->rest_base ) ? $tax->rest_base : $tax->name;
@@ -2759,25 +2828,10 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			),
 		);
 
-		$taxonomies = wp_list_filter( get_object_taxonomies( $this->post_type, 'objects' ), array( 'show_in_rest' => true ) );
+		$taxonomies = $this->get_rest_taxonomies( $schema['properties'] );
 
 		foreach ( $taxonomies as $taxonomy ) {
 			$base = ! empty( $taxonomy->rest_base ) ? $taxonomy->rest_base : $taxonomy->name;
-
-			if ( array_key_exists( $base, $schema['properties'] ) ) {
-				$taxonomy_field_name_with_conflict = ! empty( $taxonomy->rest_base ) ? 'rest_base' : 'name';
-				_doing_it_wrong(
-					'register_taxonomy',
-					sprintf(
-						/* translators: 1: The taxonomy name, 2: The property name, either 'rest_base' or 'name', 3: The conflicting value. */
-						__( 'The "%1$s" taxonomy "%2$s" property (%3$s) conflicts with an existing property on the REST API Posts Controller. Specify a custom "rest_base" when registering the taxonomy to avoid this error.' ),
-						$taxonomy->name,
-						$taxonomy_field_name_with_conflict,
-						$base
-					),
-					'5.4.0'
-				);
-			}
 
 			$schema['properties'][ $base ] = array(
 				/* translators: %s: Taxonomy name. */
@@ -2914,7 +2968,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			);
 		}
 
-		$taxonomies = wp_list_filter( get_object_taxonomies( $this->post_type, 'objects' ), array( 'show_in_rest' => true ) );
+		$taxonomies = $this->get_rest_taxonomies();
 
 		foreach ( $taxonomies as $tax ) {
 			$tax_base = ! empty( $tax->rest_base ) ? $tax->rest_base : $tax->name;

--- a/tests/phpunit/tests/rest-api/rest-posts-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-posts-controller.php
@@ -4919,6 +4919,62 @@ Shankle pork chop prosciutto ribeye ham hock pastrami. T-bone shank brisket baco
 	}
 
 	/**
+	 * @ticket 65855
+	 */
+	public function test_get_item_schema_does_not_overwrite_existing_property_when_taxonomy_name_conflicts() {
+		$this->setExpectedIncorrectUsage( 'register_taxonomy' );
+
+		register_taxonomy(
+			'type',
+			'post',
+			array(
+				'show_in_rest' => true,
+			)
+		);
+
+		$controller = new WP_REST_Posts_Controller( 'post' );
+		$schema     = $controller->get_item_schema();
+
+		unregister_taxonomy( 'type' );
+
+		$this->assertSame( 'string', $schema['properties']['type']['type'] );
+		$this->assertTrue( $schema['properties']['type']['readonly'] );
+	}
+
+	/**
+	 * @ticket 65855
+	 */
+	public function test_prepare_item_for_response_does_not_overwrite_existing_property_when_taxonomy_name_conflicts() {
+		$this->setExpectedIncorrectUsage( 'register_taxonomy' );
+
+		register_taxonomy(
+			'type',
+			'post',
+			array(
+				'show_in_rest' => true,
+			)
+		);
+
+		$controller = new WP_REST_Posts_Controller( 'post' );
+		$request    = new WP_REST_Request(
+			'GET',
+			sprintf( '/wp/v2/posts/%d', self::$post_id )
+		);
+		$request->set_param( 'context', 'view' );
+		$request->set_param( '_fields', 'type' );
+
+		$response = $controller->prepare_item_for_response(
+			get_post( self::$post_id ),
+			$request
+		);
+		$data     = $response->get_data();
+
+		unregister_taxonomy( 'type' );
+
+		$this->assertSame( 'post', $data['type'] );
+	}
+
+	/**
 	 * @ticket 39805
 	 */
 	public function test_get_post_view_context_properties() {

--- a/tests/phpunit/tests/rest-api/wpRestMenuItemsController.php
+++ b/tests/phpunit/tests/rest-api/wpRestMenuItemsController.php
@@ -787,6 +787,29 @@ class Tests_REST_WpRestMenuItemsController extends WP_Test_REST_Post_Type_Contro
 	}
 
 	/**
+	 * @ticket 65855
+	 * @covers ::get_item_schema
+	 */
+	public function test_get_item_schema_does_not_overwrite_existing_property_when_taxonomy_name_conflicts() {
+		$this->setExpectedIncorrectUsage( 'register_taxonomy' );
+
+		register_taxonomy(
+			'type',
+			'nav_menu_item',
+			array(
+				'show_in_rest' => true,
+			)
+		);
+
+		$controller = new WP_REST_Menu_Items_Controller( 'nav_menu_item' );
+		$schema     = $controller->get_item_schema();
+
+		unregister_taxonomy( 'type' );
+
+		$this->assertSame( 'string', $schema['properties']['type']['type'] );
+	}
+
+	/**
 	 * @ticket 40878
 	 * @covers ::get_items_permissions_check
 	 */


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65855

This PR prevents taxonomies with conflicting REST bases from overwriting existing post item properties.

The existing `_doing_it_wrong()` warning added for #48401 is preserved, but conflicting taxonomies are excluded from the item-level REST taxonomy set so they no longer participate in:

- item schema properties;
- prepared item responses;
- term assignment;
- term assignment permission checks;
- REST action links; and
- schema links.

The conflict-free taxonomy list is initialized while building the item schema and reused by the relevant item-level paths. This avoids lazily calling `get_item_schema()` from the helper, which could introduce recursion in subclasses such as `WP_REST_Menu_Items_Controller`.

Collection-level taxonomy query behavior is intentionally unchanged.

Tests added for:
- preserving the existing `type` schema property when a taxonomy name conflicts;
- preserving the existing `type` response property;
- the `WP_REST_Menu_Items_Controller` subclass schema path.

Testing:
- `npm run test:php -- --group 65855`
  - OK (3 tests, 7 assertions)
- `npm run test:php -- --filter WP_Test_REST_Posts_Controller`
  - OK (283 tests, 2637 assertions)
- `npm run test:php -- --filter Tests_REST_WpRestMenuItemsController`
  - OK (41 tests, 441 assertions)
- PHPCS passes for all four modified files.
- `git diff --check` reports no whitespace errors.