### PR TITLE
Lint the About page CSS for WordPress 7.1

### DIFF
--- a/src/wp-admin/css/about.css
+++ b/src/wp-admin/css/about.css
@@ -294,7 +294,6 @@
 	}
 
 	.about__section.has-2-columns.has-gutters .column,
-.about__section.has-2-columns.has-gutters .column,
 	.about__section.has-3-columns.has-gutters .column {
 		margin-bottom: var(--gap);
 	}

--- a/src/wp-admin/css/about.css
+++ b/src/wp-admin/css/about.css
@@ -34,7 +34,7 @@
 	--accent-3: #ececec; /* hr background */
 
 	/* Header background on small screens */
-	--accent-gradient: linear-gradient(90deg, #000000 4.7%, var(--accent-1) 83.84%)/*rtl:linear-gradient(-90deg, #000000 4.7%, var(--accent-1) 83.84%)*/;
+	--accent-gradient: linear-gradient(90deg, #000 4.7%, var(--accent-1) 83.84%)/*rtl:linear-gradient(-90deg, #000 4.7%, var(--accent-1) 83.84%)*/;
 
 	/* Navigation colors. */
 	--nav-background: #fff;
@@ -300,7 +300,6 @@
 	}
 
 	.about__section.has-2-columns.has-gutters .column:last-child,
-	.about__section.has-2-columns.has-gutters .column:last-child,
 	.about__section.has-3-columns.has-gutters .column:last-child {
 		margin-bottom: 0;
 	}
@@ -359,12 +358,12 @@
 	}
 
 	.about__section .column.is-left-padding-zero {
-        padding-right: 0;
-    }
+		padding-right: 0;
+	}
 
-    .about__section .column.is-right-padding-zero {
-        padding-left: 0;
-    }
+	.about__section .column.is-right-padding-zero {
+		padding-left: 0;
+	}
 }
 
 @media screen and (max-width: 480px) {
@@ -445,9 +444,6 @@
 
 .about__container p {
 	text-wrap: pretty;
-}
-
-.about__container p {
 	font-size: inherit;
 	line-height: inherit;
 }
@@ -457,7 +453,7 @@
 	margin-bottom: 1rem;
 	font-size: 1.5rem;
 	font-weight: 300;
-	line-height: 160%;
+	line-height: 1.6;
 }
 
 .about__section a {
@@ -608,49 +604,49 @@
 	padding-right: 26rem; /* Space for the background image. */
 	min-height: clamp(10rem, 25vw, 18.75rem);
 	border-radius: var(--border-radius);
-	background-image: url( "https://s.w.org/images/core/7.1/about-header-default.webp?ver=20260804" );
+	background-image: url(https://s.w.org/images/core/7.1/about-header-default.webp?ver=20260804);
 	background-repeat: no-repeat;
 	background-position: right center;
 	background-size: cover;
 	background-color: var(--background);
 	color: var(--text-light);
-	margin-bottom: .25rem;
+	margin-bottom: 0.25rem;
 }
 
-.credits-php  .about__header {
-	background-image: url( "https://s.w.org/images/core/7.1/about-header-credits.webp?ver=20260804" );
+.credits-php .about__header {
+	background-image: url(https://s.w.org/images/core/7.1/about-header-credits.webp?ver=20260804);
 }
 
-.freedoms-php  .about__header {
-	background-image: url( "https://s.w.org/images/core/7.1/about-header-freedoms.webp?ver=20260804" );
+.freedoms-php .about__header {
+	background-image: url(https://s.w.org/images/core/7.1/about-header-freedoms.webp?ver=20260804);
 }
 
-.privacy-php  .about__header {
-	background-image: url( "https://s.w.org/images/core/7.1/about-header-privacy.webp?ver=20260804" );
+.privacy-php .about__header {
+	background-image: url(https://s.w.org/images/core/7.1/about-header-privacy.webp?ver=20260804);
 }
 
 .contribute-php .about__header {
-	background-image: url( "https://s.w.org/images/core/7.1/about-header-get-involved.webp?ver=20260804" );
+	background-image: url(https://s.w.org/images/core/7.1/about-header-get-involved.webp?ver=20260804);
 }
 
 [dir="rtl"] .about__header {
-	background-image: url( "https://s.w.org/images/core/7.1/about-header-default-rtl.webp?ver=20260804" );
+	background-image: url(https://s.w.org/images/core/7.1/about-header-default-rtl.webp?ver=20260804);
 }
 
-[dir="rtl"] .credits-php  .about__header {
-	background-image: url( "https://s.w.org/images/core/7.1/about-header-credits-rtl.webp?ver=20260804" );
+[dir="rtl"] .credits-php .about__header {
+	background-image: url(https://s.w.org/images/core/7.1/about-header-credits-rtl.webp?ver=20260804);
 }
 
-[dir="rtl"] .freedoms-php  .about__header {
-	background-image: url( "https://s.w.org/images/core/7.1/about-header-freedoms-rtl.webp?ver=20260804" );
+[dir="rtl"] .freedoms-php .about__header {
+	background-image: url(https://s.w.org/images/core/7.1/about-header-freedoms-rtl.webp?ver=20260804);
 }
 
-[dir="rtl"] .privacy-php  .about__header {
-	background-image: url( "https://s.w.org/images/core/7.1/about-header-privacy-rtl.webp?ver=20260804" );
+[dir="rtl"] .privacy-php .about__header {
+	background-image: url(https://s.w.org/images/core/7.1/about-header-privacy-rtl.webp?ver=20260804);
 }
 
 [dir="rtl"] .contribute-php .about__header {
-	background-image: url( "https://s.w.org/images/core/7.1/about-header-get-involved-rtl.webp?ver=20260804" );
+	background-image: url(https://s.w.org/images/core/7.1/about-header-get-involved-rtl.webp?ver=20260804);
 }
 
 .about__header-image {
@@ -1082,7 +1078,7 @@
 .about-wrap figcaption {
 	font-size: 13px;
 	text-align: center;
-	color: white;
+	color: #fff;
 	text-overflow: ellipsis;
 }
 

--- a/src/wp-admin/css/about.css
+++ b/src/wp-admin/css/about.css
@@ -294,7 +294,7 @@
 	}
 
 	.about__section.has-2-columns.has-gutters .column,
-	.about__section.has-2-columns.has-gutters .column,
+.about__section.has-2-columns.has-gutters .column,
 	.about__section.has-3-columns.has-gutters .column {
 		margin-bottom: var(--gap);
 	}


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65856

The CSS for the WordPress 7.1 About page contains several [CSS Coding Standards](https://github.com/WordPress/wpcs-docs/blob/a9ffaa51e7c8d3bdf8732deeaea8f38e2d18ab15/wordpress-coding-standards/css.md) errors.

This PR aims to fix _most_ of them.

Importtant for accessibility:

At the moment, the `about.css` file contains [two new order CSS properties](https://github.com/WordPress/wordpress-develop/blob/d6de0ec3090d26362834c4f253e89c21bde15f14/src/wp-admin/css/about.css#L336-L342). They are used for the responsive view at 600 pixels. They should be carefully checked to see if they introduce any accessibility problems.

A list of the errors is available in the attached txt file:

[01 about-page-css-errors.txt](https://github.com/user-attachments/files/30975790/01.about-page-css-errors.txt)

What this PR does _not_ fix:

- It does not fix most of the 'Unexpected duplicate selector'. The duplicate selectors come from the structure of the file that is divided into sections. Still, they are unnecessary duplicate.
- 'Unexpected qualifying type selector' e.g. `h3.is-larger-heading` where the element type selector should not be used. So far, I'm considering this a 'warning' and not a real error although this is explicitly mentioned in the CSS Coding Standards:

> Refrain from using over-qualified selectors, div.container can simply be stated as .container.

## Use of AI Tools

None

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
