### PR TITLE
General: Bump the pinned hash for Gutenberg to b9743a

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"url": "https://develop.svn.wordpress.org/trunk"
 	},
 	"gutenberg": {
-		"sha": "ea285b45692aed6c4f95353671393402f97f0aa7",
+		"sha": "b9743a015526ac8fd79298fd4e96cf002cee333b",
 		"ghcrRepo": "WordPress/gutenberg/gutenberg-wp-develop-build"
 	},
 	"engines": {

--- a/src/wp-includes/assets/script-loader-packages.php
+++ b/src/wp-includes/assets/script-loader-packages.php
@@ -104,7 +104,7 @@
 			'wp-url',
 			'wp-warning'
 		),
-		'version' => '3e3993ced88d35b1fafc'
+		'version' => 'd3cbb2c45b145b27a5cf'
 	),
 	'block-library.js' => array(
 		'dependencies' => array(
@@ -150,7 +150,7 @@
 				'import' => 'dynamic'
 			)
 		),
-		'version' => '6569ec7523b3693a2b2e'
+		'version' => '2e80403676c10cc0a473'
 	),
 	'block-serialization-default-parser.js' => array(
 		'dependencies' => array(
@@ -224,7 +224,7 @@
 			'wp-theme',
 			'wp-warning'
 		),
-		'version' => '7937a1d6ffdc16e88517'
+		'version' => '9b751f17060211272a5c'
 	),
 	'compose.js' => array(
 		'dependencies' => array(
@@ -452,7 +452,7 @@
 				'import' => 'static'
 			)
 		),
-		'version' => '51385a88f6721b4a849f'
+		'version' => '789f35fae26c8d01c548'
 	),
 	'edit-widgets.js' => array(
 		'dependencies' => array(
@@ -543,7 +543,7 @@
 				'import' => 'static'
 			)
 		),
-		'version' => '6ef3b2a5f3b9e37bb337'
+		'version' => '4849df258387a9077371'
 	),
 	'element.js' => array(
 		'dependencies' => array(

--- a/src/wp-includes/assets/script-modules-packages.php
+++ b/src/wp-includes/assets/script-modules-packages.php
@@ -88,7 +88,7 @@
 				'import' => 'static'
 			)
 		),
-		'version' => 'fb8db6c2fefd8246fa86'
+		'version' => 'e921883a3f8a7b1ead70'
 	),
 	'block-library/query/view.js' => array(
 		'dependencies' => array(
@@ -315,7 +315,7 @@
 			'wp-private-apis',
 			'wp-style-engine'
 		),
-		'version' => '0e40b71e65fda1397a4b'
+		'version' => 'f947bd8281443624c0d0'
 	),
 	'route/index.js' => array(
 		'dependencies' => array(

--- a/src/wp-includes/blocks/cover.php
+++ b/src/wp-includes/blocks/cover.php
@@ -154,7 +154,7 @@ function render_block_core_cover( $attributes, $content ) {
 		if ( in_the_loop() ) {
 			update_post_thumbnail_cache();
 		}
-		$current_featured_image = get_the_post_thumbnail_url( null, $attributes['sizeSlug'] ?? null );
+		$current_featured_image = get_the_post_thumbnail_url( null, $attributes['sizeSlug'] ?? 'full' );
 		if ( ! $current_featured_image ) {
 			return $content;
 		}


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65529

This ticket is for syncing the changes between `ea285b45692aed6c4f95353671393402f97f0aa7` into `wordpress-develop` (`b9743a015526ac8fd79298fd4e96cf002cee333b`).

Diff: https://github.com/WordPress/gutenberg/compare/ea285b45692aed6c4f95353671393402f97f0aa7...b9743a015526ac8fd79298fd4e96cf002cee333b