### PR TITLE
Code Modernization: Use is_iterable() instead of manual array or Traversable checks

### DIFF
--- a/src/wp-includes/ai-client/adapters/class-wp-ai-client-http-client.php
+++ b/src/wp-includes/ai-client/adapters/class-wp-ai-client-http-client.php
@@ -211,7 +211,7 @@ class WP_AI_Client_HTTP_Client implements ClientInterface, ClientWithOptionsInte
 			$headers = $headers->get_headers();
 		}
 
-		if ( is_array( $headers ) || $headers instanceof Traversable ) {
+		if ( is_iterable( $headers ) ) {
 			foreach ( $headers as $name => $value ) {
 				$response = $response->withHeader( $name, $value );
 			}


### PR DESCRIPTION
## Description

PHP offers `is_iterable()` for the "array or `Traversable`" test that is otherwise written as a compound condition:

```php
// Before
if ( is_array( $value ) || $value instanceof Traversable ) {

// After
if ( is_iterable( $value ) ) {
```

This replaces that idiom where it occurs.

## Why this is safe

`is_iterable()` returns `true` for arrays and for objects implementing `Traversable`, and `false` for everything else, the same set the compound condition described, with no edge cases in between. It has been available since PHP 7.1, and WordPress currently requires PHP 7.4 or greater, so no compatibility shim is needed. Only the conditions themselves change; no surrounding logic is touched.

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
