### PR TITLE
Tests: Use `assertIsCallable()` for callable assertions.

### DIFF
--- a/tests/phpunit/tests/customize/widgets.php
+++ b/tests/phpunit/tests/customize/widgets.php
@@ -397,8 +397,8 @@ class Tests_WP_Customize_Widgets extends WP_UnitTestCase {
 		foreach ( $default_args as $key => $default_value ) {
 			$this->assertSame( $default_value, $args[ $key ] );
 		}
-		$this->assertTrue( is_callable( $args['sanitize_callback'] ), 'sanitize_callback is callable' );
-		$this->asserttrue( is_callable( $args['sanitize_js_callback'] ), 'sanitize_js_callback is callable' );
+		$this->assertIsCallable( $args['sanitize_callback'], 'sanitize_callback is callable' );
+		$this->assertIsCallable( $args['sanitize_js_callback'], 'sanitize_js_callback is callable' );
 		$this->assertSame( 'WIDGET_FOO[2]', $args['uppercase_id_set_by_filter'] );
 
 		$default_args = array(
@@ -411,8 +411,8 @@ class Tests_WP_Customize_Widgets extends WP_UnitTestCase {
 		foreach ( $default_args as $key => $default_value ) {
 			$this->assertSame( $default_value, $args[ $key ] );
 		}
-		$this->assertTrue( is_callable( $args['sanitize_callback'] ), 'sanitize_callback is callable' );
-		$this->asserttrue( is_callable( $args['sanitize_js_callback'] ), 'sanitize_js_callback is callable' );
+		$this->assertIsCallable( $args['sanitize_callback'], 'sanitize_callback is callable' );
+		$this->assertIsCallable( $args['sanitize_js_callback'], 'sanitize_js_callback is callable' );
 
 		remove_theme_support( 'customize-selective-refresh-widgets' );
 		$args = $this->manager->widgets->get_setting_args( 'widget_search[2]' );
@@ -443,8 +443,8 @@ class Tests_WP_Customize_Widgets extends WP_UnitTestCase {
 		foreach ( $default_args as $key => $default_value ) {
 			$this->assertSame( $default_value, $args[ $key ] );
 		}
-		$this->assertTrue( is_callable( $args['sanitize_callback'] ), 'sanitize_callback is callable' );
-		$this->asserttrue( is_callable( $args['sanitize_js_callback'] ), 'sanitize_js_callback is callable' );
+		$this->assertIsCallable( $args['sanitize_callback'], 'sanitize_callback is callable' );
+		$this->assertIsCallable( $args['sanitize_js_callback'], 'sanitize_js_callback is callable' );
 		$this->assertSame( 'SIDEBARS_WIDGETS[SIDEBAR-1]', $args['uppercase_id_set_by_filter'] );
 
 		$override_args = array(

--- a/tests/phpunit/tests/multisite/wpCacheSwitchToBlogFallback.php
+++ b/tests/phpunit/tests/multisite/wpCacheSwitchToBlogFallback.php
@@ -121,8 +121,8 @@ class Tests_Multisite_WpCacheSwitchToBlogFallback extends WP_UnitTestCase {
 		$this->assertTrue( function_exists( 'wp_cache_switch_to_blog_fallback' ), 'wp_cache_switch_to_blog_fallback() should always exist' );
 
 		// Both should be callable.
-		$this->assertTrue( is_callable( 'wp_cache_switch_to_blog' ) );
-		$this->assertTrue( is_callable( 'wp_cache_switch_to_blog_fallback' ) );
+		$this->assertIsCallable( 'wp_cache_switch_to_blog' );
+		$this->assertIsCallable( 'wp_cache_switch_to_blog_fallback' );
 	}
 
 	/**


### PR DESCRIPTION
Replaces eight generic `assertTrue( is_callable() )` assertions with
PHPUnit's dedicated `assertIsCallable()` assertion in:

- `tests/phpunit/tests/customize/widgets.php`
- `tests/phpunit/tests/multisite/wpCacheSwitchToBlogFallback.php`

This is a test-only cleanup and does not change WordPress runtime behavior.

The multisite assertions were added as a review-driven follow-up after the
same pattern was identified in `Tests_Multisite_WpCacheSwitchToBlogFallback`.

Trac ticket: https://core.trac.wordpress.org/ticket/65819

## Testing

- `npm run test:php -- --filter Tests_WP_Customize_Widgets --colors=never --do-not-cache-result`
  - PASS: 28 tests, 410 assertions

- `npm run test:php -- -c tests/phpunit/multisite.xml --filter Tests_Multisite_WpCacheSwitchToBlogFallback::test_wp_cache_switch_to_blog_function_exists --colors=never --do-not-cache-result`
  - PASS: 1 test, 4 assertions

- `npm run test:php -- -c tests/phpunit/multisite.xml --filter Tests_Multisite_WpCacheSwitchToBlogFallback --colors=never --do-not-cache-result`
  - PASS: 25 tests, 136 assertions

- `npm run env:composer -- lint tests/phpunit/tests/multisite/wpCacheSwitchToBlogFallback.php`
  - PASS

Fresh upstream verification confirmed that neither changed test file has
changed upstream since the candidate parent.

## Use of AI Tools

AI assistance: Yes
Tool(s): ChatGPT
Model(s): GPT-5.6 Sol
Used for: Investigation support, contribution workflow and validation
planning, and drafting assistance. The change was reviewed, understood,
signed, and tested by me.

---
**This Pull Request is for code review only. Please keep all other
discussion in the Trac ticket. Do not merge this Pull Request. See
[GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/)
in the Core Handbook for more details.**