### PR TITLE
Build/Test Tools: Improve performance of bcrypt related unit tests in the 6.8 branch

### DIFF
--- a/tests/phpunit/includes/abstract-testcase.php
+++ b/tests/phpunit/includes/abstract-testcase.php
@@ -136,6 +136,21 @@ abstract class WP_UnitTestCase_Base extends PHPUnit_Adapter_TestCase {
 		$this->start_transaction();
 		$this->expectDeprecated();
 		add_filter( 'wp_die_handler', array( $this, 'get_wp_die_handler' ) );
+		add_filter( 'wp_hash_password_options', array( $this, 'wp_hash_password_options' ), 1, 2 );
+	}
+
+	/**
+	 * Sets the bcrypt cost option for password hashing during tests.
+	 *
+	 * @param array      $options   The options for password hashing.
+	 * @param string|int $algorithm The algorithm to use for hashing. This is a string in PHP 7.4+ and an integer in PHP 7.3 and earlier.
+	 */
+	public function wp_hash_password_options( array $options, $algorithm ): array {
+		if ( PASSWORD_BCRYPT === $algorithm ) {
+			$options['cost'] = 5;
+		}
+
+		return $options;
 	}
 
 	/**

--- a/tests/phpunit/tests/admin/includesPlugin.php
+++ b/tests/phpunit/tests/admin/includesPlugin.php
@@ -4,7 +4,16 @@
  * @group admin
  */
 class Tests_Admin_IncludesPlugin extends WP_UnitTestCase {
+
+	/**
+	 * Admin user ID.
+	 *
+	 * @var int $admin_id
+	 */
+	public static $admin_id;
+
 	public static function wpSetUpBeforeClass( $factory ) {
+		self::$admin_id = $factory->user->create( array( 'role' => 'administrator' ) );
 		self::_back_up_mu_plugins();
 	}
 
@@ -37,7 +46,7 @@ class Tests_Admin_IncludesPlugin extends WP_UnitTestCase {
 
 	public function test_menu_page_url() {
 		$current_user = get_current_user_id();
-		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		wp_set_current_user( self::$admin_id );
 		update_option( 'siteurl', 'http://example.com' );
 
 		// Add some pages.
@@ -81,7 +90,7 @@ class Tests_Admin_IncludesPlugin extends WP_UnitTestCase {
 		global $submenu;
 		global $menu;
 		$current_user = get_current_user_id();
-		$admin_user   = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$admin_user   = self::$admin_id;
 		wp_set_current_user( $admin_user );
 		set_current_screen( 'dashboard' );
 
@@ -134,7 +143,7 @@ class Tests_Admin_IncludesPlugin extends WP_UnitTestCase {
 		$menu    = array();
 
 		$current_user = get_current_user_id();
-		$admin_user   = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$admin_user   = self::$admin_id;
 		wp_set_current_user( $admin_user );
 		set_current_screen( 'dashboard' );
 
@@ -283,7 +292,7 @@ class Tests_Admin_IncludesPlugin extends WP_UnitTestCase {
 		$submenu      = array();
 		$menu         = array();
 		$current_user = get_current_user_id();
-		$admin_user   = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$admin_user   = self::$admin_id;
 		wp_set_current_user( $admin_user );
 		set_current_screen( 'dashboard' );
 
@@ -316,7 +325,7 @@ class Tests_Admin_IncludesPlugin extends WP_UnitTestCase {
 		$submenu      = array();
 		$menu         = array();
 		$current_user = get_current_user_id();
-		$admin_user   = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$admin_user   = self::$admin_id;
 		wp_set_current_user( $admin_user );
 		set_current_screen( 'dashboard' );
 
@@ -344,7 +353,7 @@ class Tests_Admin_IncludesPlugin extends WP_UnitTestCase {
 		$submenu      = array();
 		$menu         = array();
 		$current_user = get_current_user_id();
-		$admin_user   = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$admin_user   = self::$admin_id;
 		wp_set_current_user( $admin_user );
 		set_current_screen( 'dashboard' );
 

--- a/tests/phpunit/tests/admin/includesTemplate.php
+++ b/tests/phpunit/tests/admin/includesTemplate.php
@@ -3,6 +3,16 @@
  * @group admin
  */
 class Tests_Admin_IncludesTemplate extends WP_UnitTestCase {
+	/**
+	 * Editor user ID.
+	 *
+	 * @var int $editor_id
+	 */
+	public static $editor_id;
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$editor_id = $factory->user->create( array( 'role' => 'editor' ) );
+	}
 
 	/**
 	 * @ticket 51137
@@ -64,7 +74,7 @@ class Tests_Admin_IncludesTemplate extends WP_UnitTestCase {
 		wp_set_object_terms( $post->ID, $term['term_id'], 'wptests_tax_1' );
 
 		// Test that get_inline_data() has `post_category` div containing the assigned term.
-		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+		wp_set_current_user( self::$editor_id );
 		get_inline_data( $post );
 		$this->expectOutputRegex( '/<div class="post_category" id="wptests_tax_1_' . $post->ID . '">' . $term['term_id'] . '<\/div>/' );
 	}
@@ -90,7 +100,7 @@ class Tests_Admin_IncludesTemplate extends WP_UnitTestCase {
 		wp_set_object_terms( $post->ID, $term['term_id'], 'wptests_tax_1' );
 
 		// Test that get_inline_data() has `tags_input` div containing the assigned term.
-		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+		wp_set_current_user( self::$editor_id );
 		get_inline_data( $post );
 		$this->expectOutputRegex( '/<div class="tags_input" id="wptests_tax_1_' . $post->ID . '">Test<\/div>/' );
 	}

--- a/tests/phpunit/tests/ajax/wpAjaxSendAttachmentToEditor.php
+++ b/tests/phpunit/tests/ajax/wpAjaxSendAttachmentToEditor.php
@@ -14,6 +14,28 @@ require_once ABSPATH . 'wp-admin/includes/ajax-actions.php';
 class Tests_Ajax_wpAjaxSendAttachmentToEditor extends WP_Ajax_UnitTestCase {
 
 	/**
+	 * Shared user ID for the tests.
+	 *
+	 * @var int
+	 */
+	public static $user_id = 0;
+
+	/**
+	 * Set up shared fixtures.
+	 *
+	 * @param WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$user_id = $factory->user->create(
+			array(
+				'role'       => 'administrator',
+				'user_login' => 'user_36578_administrator',
+				'user_email' => 'user_36578_administrator@example.com',
+			)
+		);
+	}
+
+	/**
 	 * @ticket 36578
 	 *
 	 * @covers ::get_image_send_to_editor
@@ -105,13 +127,7 @@ class Tests_Ajax_wpAjaxSendAttachmentToEditor extends WP_Ajax_UnitTestCase {
 	public function test_wp_ajax_set_attachment_thumbnail_success() {
 		// Become an administrator.
 		$post    = $_POST;
-		$user_id = self::factory()->user->create(
-			array(
-				'role'       => 'administrator',
-				'user_login' => 'user_36578_administrator',
-				'user_email' => 'user_36578_administrator@example.com',
-			)
-		);
+		$user_id = self::$user_id;
 		wp_set_current_user( $user_id );
 		$_POST = array_merge( $_POST, $post );
 
@@ -151,13 +167,7 @@ class Tests_Ajax_wpAjaxSendAttachmentToEditor extends WP_Ajax_UnitTestCase {
 	public function test_wp_ajax_set_attachment_thumbnail_missing_nonce() {
 		// Become an administrator.
 		$post    = $_POST;
-		$user_id = self::factory()->user->create(
-			array(
-				'role'       => 'administrator',
-				'user_login' => 'user_36578_administrator',
-				'user_email' => 'user_36578_administrator@example.com',
-			)
-		);
+		$user_id = self::$user_id;
 		wp_set_current_user( $user_id );
 		$_POST = array_merge( $_POST, $post );
 

--- a/tests/phpunit/tests/auth.php
+++ b/tests/phpunit/tests/auth.php
@@ -2089,9 +2089,6 @@ class Tests_Auth extends WP_UnitTestCase {
 	}
 
 	private static function get_default_bcrypt_cost(): int {
-		$hash = password_hash( 'password', PASSWORD_BCRYPT );
-		$info = password_get_info( $hash );
-
-		return $info['options']['cost'];
+		return 5;
 	}
 }

--- a/tests/phpunit/tests/auth.php
+++ b/tests/phpunit/tests/auth.php
@@ -1579,12 +1579,7 @@ class Tests_Auth extends WP_UnitTestCase {
 	 * @covers ::wp_validate_application_password
 	 */
 	public function test_application_password_authentication() {
-		$user_id = self::factory()->user->create(
-			array(
-				'user_login' => 'http_auth_login',
-				'user_pass'  => 'http_auth_pass', // Shouldn't be allowed for API login.
-			)
-		);
+		$user_id = self::$_user->ID;
 
 		// Create a new app-only password.
 		list( $user_app_password, $item ) = WP_Application_Passwords::create_new_application_password( $user_id, array( 'name' => 'phpunit' ) );
@@ -1594,8 +1589,8 @@ class Tests_Auth extends WP_UnitTestCase {
 		add_filter( 'wp_is_application_passwords_available', '__return_true' );
 
 		// Fake an HTTP Auth request with the regular account password first.
-		$_SERVER['PHP_AUTH_USER'] = 'http_auth_login';
-		$_SERVER['PHP_AUTH_PW']   = 'http_auth_pass';
+		$_SERVER['PHP_AUTH_USER'] = self::USER_LOGIN;
+		$_SERVER['PHP_AUTH_PW']   = self::USER_PASS;
 
 		$this->assertNull(
 			wp_validate_application_password( null ),

--- a/tests/phpunit/tests/comment/wpHandleCommentSubmission.php
+++ b/tests/phpunit/tests/comment/wpHandleCommentSubmission.php
@@ -9,6 +9,7 @@ class Tests_Comment_wpHandleCommentSubmission extends WP_UnitTestCase {
 
 	protected static $post;
 	protected static $author_id;
+	protected static $author_id2;
 	protected static $editor_id;
 
 	protected $preprocess_comment_data = array();
@@ -19,6 +20,13 @@ class Tests_Comment_wpHandleCommentSubmission extends WP_UnitTestCase {
 		self::$author_id = $factory->user->create(
 			array(
 				'role' => 'author',
+			)
+		);
+
+		self::$author_id2 = $factory->user->create(
+			array(
+				'role'     => 'author',
+				'user_url' => 'http://user.example.org',
 			)
 		);
 
@@ -223,11 +231,7 @@ class Tests_Comment_wpHandleCommentSubmission extends WP_UnitTestCase {
 
 	public function test_submitting_valid_comment_as_logged_in_user_succeeds() {
 
-		$user = self::factory()->user->create_and_get(
-			array(
-				'user_url' => 'http://user.example.org',
-			)
-		);
+		$user = get_user_by( 'id', self::$author_id2 );
 
 		wp_set_current_user( $user->ID );
 
@@ -314,11 +318,7 @@ class Tests_Comment_wpHandleCommentSubmission extends WP_UnitTestCase {
 
 		$error = 'comment_id_not_found';
 
-		$user = self::factory()->user->create_and_get(
-			array(
-				'role' => 'author',
-			)
-		);
+		$user = get_user_by( 'id', self::$author_id2 );
 
 		wp_set_current_user( $user->ID );
 
@@ -343,11 +343,7 @@ class Tests_Comment_wpHandleCommentSubmission extends WP_UnitTestCase {
 
 		$error = 'comment_id_not_found';
 
-		$user = self::factory()->user->create_and_get(
-			array(
-				'role' => 'author',
-			)
-		);
+		$user = get_user_by( 'id', self::$author_id2 );
 
 		wp_set_current_user( $user->ID );
 
@@ -834,12 +830,8 @@ class Tests_Comment_wpHandleCommentSubmission extends WP_UnitTestCase {
 	/**
 	 * @ticket 36901
 	 */
-	public function test_comments_flood_user_is_admin() {
-		$user = self::factory()->user->create_and_get(
-			array(
-				'role' => 'administrator',
-			)
-		);
+	public function test_comments_flood_user_can_moderate_comments() {
+		$user = get_user_by( 'id', self::$editor_id );
 		wp_set_current_user( $user->ID );
 
 		$data          = array(
@@ -853,8 +845,9 @@ class Tests_Comment_wpHandleCommentSubmission extends WP_UnitTestCase {
 		$data['comment'] = 'Wow! I am quick!';
 		$second_comment  = wp_handle_comment_submission( $data );
 
-		$this->assertNotWPError( $second_comment );
-		$this->assertSame( (string) self::$post->ID, $second_comment->comment_post_ID );
+		$this->assertTrue( current_user_can( 'moderate_comments' ), 'Test user should have the moderate_comments capability' );
+		$this->assertNotWPError( $second_comment, 'Second comment should not trigger comment flooding error.' );
+		$this->assertSame( (string) self::$post->ID, $second_comment->comment_post_ID, 'Second comment should be made against initial post.' );
 	}
 
 	/**

--- a/tests/phpunit/tests/customize/control.php
+++ b/tests/phpunit/tests/customize/control.php
@@ -18,11 +18,27 @@ class Test_WP_Customize_Control extends WP_UnitTestCase {
 	public $wp_customize;
 
 	/**
+	 * Shared user ID for the tests.
+
+	 * @var int
+	 */
+	public static $user_id = 0;
+
+	/**
+	 * Set up shared fixtures.
+	 *
+	 * @param WP_UnitTest_Factory $factory Factory.
+	 */
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$user_id = $factory->user->create( array( 'role' => 'administrator' ) );
+	}
+
+	/**
 	 * Set up.
 	 */
 	public function set_up() {
 		parent::set_up();
-		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		wp_set_current_user( self::$user_id );
 		require_once ABSPATH . WPINC . '/class-wp-customize-manager.php';
 		$GLOBALS['wp_customize'] = new WP_Customize_Manager();
 		$this->wp_customize      = $GLOBALS['wp_customize'];

--- a/tests/phpunit/tests/customize/custom-css-setting.php
+++ b/tests/phpunit/tests/customize/custom-css-setting.php
@@ -23,6 +23,31 @@ class Test_WP_Customize_Custom_CSS_Setting extends WP_UnitTestCase {
 	public $setting;
 
 	/**
+	 * The user ID to use for the tests.
+	 *
+	 * @var int
+	 */
+	public static $user_id = 0;
+
+	/**
+	 * Set up the test case.
+	 *
+	 * @see WP_UnitTestCase::set_up()
+	 */
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		// Create a user to use for the tests.
+		self::$user_id = $factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+
+		if ( is_multisite() ) {
+			grant_super_admin( self::$user_id );
+		}
+	}
+
+	/**
 	 * Set up the test case.
 	 *
 	 * @see WP_UnitTestCase_Base::set_up()
@@ -31,16 +56,7 @@ class Test_WP_Customize_Custom_CSS_Setting extends WP_UnitTestCase {
 		parent::set_up();
 		require_once ABSPATH . WPINC . '/class-wp-customize-manager.php';
 
-		$user_id = self::factory()->user->create(
-			array(
-				'role' => 'administrator',
-			)
-		);
-		if ( is_multisite() ) {
-			grant_super_admin( $user_id );
-		}
-
-		wp_set_current_user( $user_id );
+		wp_set_current_user( self::$user_id );
 
 		global $wp_customize;
 		$this->wp_customize = new WP_Customize_Manager();

--- a/tests/phpunit/tests/customize/manager.php
+++ b/tests/phpunit/tests/customize/manager.php
@@ -27,6 +27,13 @@ class Tests_WP_Customize_Manager extends WP_UnitTestCase {
 	protected static $admin_user_id;
 
 	/**
+	 * Second admin user ID.
+	 *
+	 * @var int
+	 */
+	protected static $other_admin_user_id;
+
+	/**
 	 * Subscriber user ID.
 	 *
 	 * @var int
@@ -46,8 +53,9 @@ class Tests_WP_Customize_Manager extends WP_UnitTestCase {
 	 * @param WP_UnitTest_Factory $factory Factory.
 	 */
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
-		self::$subscriber_user_id = $factory->user->create( array( 'role' => 'subscriber' ) );
-		self::$admin_user_id      = $factory->user->create( array( 'role' => 'administrator' ) );
+		self::$subscriber_user_id  = $factory->user->create( array( 'role' => 'subscriber' ) );
+		self::$admin_user_id       = $factory->user->create( array( 'role' => 'administrator' ) );
+		self::$other_admin_user_id = $factory->user->create( array( 'role' => 'administrator' ) );
 	}
 
 	/**
@@ -153,7 +161,7 @@ class Tests_WP_Customize_Manager extends WP_UnitTestCase {
 	 */
 	public function test_constructor_deferred_changeset_uuid() {
 		wp_set_current_user( self::$admin_user_id );
-		$other_admin_user_id = self::factory()->user->create( array( 'role' => 'admin' ) );
+		$other_admin_user_id = self::$other_admin_user_id;
 
 		$data = array(
 			'blogname' => array(
@@ -1254,7 +1262,7 @@ class Tests_WP_Customize_Manager extends WP_UnitTestCase {
 	 */
 	public function test_save_changeset_post_without_kses_corrupting_json() {
 		global $wp_customize;
-		$lesser_admin_user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$lesser_admin_user_id = self::$other_admin_user_id;
 
 		$uuid         = wp_generate_uuid4();
 		$wp_customize = new WP_Customize_Manager(
@@ -1499,7 +1507,7 @@ class Tests_WP_Customize_Manager extends WP_UnitTestCase {
 
 		add_theme_support( 'custom-background' );
 		wp_set_current_user( self::$admin_user_id );
-		$other_admin_user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$other_admin_user_id = self::$other_admin_user_id;
 
 		$uuid         = wp_generate_uuid4();
 		$wp_customize = $this->create_test_manager( $uuid );
@@ -1714,7 +1722,7 @@ class Tests_WP_Customize_Manager extends WP_UnitTestCase {
 
 		add_theme_support( 'custom-background' );
 		wp_set_current_user( self::$admin_user_id );
-		$other_admin_user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$other_admin_user_id = self::$other_admin_user_id;
 
 		$uuid         = wp_generate_uuid4();
 		$wp_customize = $this->create_test_manager( $uuid );
@@ -1877,7 +1885,7 @@ class Tests_WP_Customize_Manager extends WP_UnitTestCase {
 		$r = $wp_customize->save_changeset_post(
 			array(
 				'autosave' => true,
-				'user_id'  => self::factory()->user->create( array( 'role' => 'administrator' ) ),
+				'user_id'  => self::$other_admin_user_id,
 			)
 		);
 		$this->assertSame( 'illegal_autosave_with_non_current_user', $r->get_error_code() );
@@ -3009,7 +3017,7 @@ class Tests_WP_Customize_Manager extends WP_UnitTestCase {
 	 * @see WP_Customize_Manager::set_return_url()
 	 */
 	public function test_return_url() {
-		wp_set_current_user( self::factory()->user->create( array( 'role' => 'author' ) ) );
+		wp_set_current_user( self::$subscriber_user_id );
 		$this->assertSame( home_url( '/' ), $this->manager->get_return_url() );
 
 		wp_set_current_user( self::$admin_user_id );

--- a/tests/phpunit/tests/customize/nav-menu-item-setting.php
+++ b/tests/phpunit/tests/customize/nav-menu-item-setting.php
@@ -14,6 +14,22 @@ class Test_WP_Customize_Nav_Menu_Item_Setting extends WP_UnitTestCase {
 	public $wp_customize;
 
 	/**
+	 * ID of the administrator user.
+	 *
+	 * @var int
+	 */
+	public static $administrator_id;
+
+	/**
+	 * Set up the shared fixture.
+	 *
+	 * @param WP_UnitTest_Factory $factory Factory instance.
+	 */
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$administrator_id = $factory->user->create( array( 'role' => 'administrator' ) );
+	}
+
+	/**
 	 * Set up a test case.
 	 *
 	 * @see WP_UnitTestCase_Base::set_up()
@@ -21,7 +37,7 @@ class Test_WP_Customize_Nav_Menu_Item_Setting extends WP_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 		require_once ABSPATH . WPINC . '/class-wp-customize-manager.php';
-		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		wp_set_current_user( self::$administrator_id );
 
 		global $wp_customize;
 		$this->wp_customize = new WP_Customize_Manager();

--- a/tests/phpunit/tests/customize/nav-menu-setting.php
+++ b/tests/phpunit/tests/customize/nav-menu-setting.php
@@ -15,6 +15,22 @@ class Test_WP_Customize_Nav_Menu_Setting extends WP_UnitTestCase {
 	public $wp_customize;
 
 	/**
+	 * ID of the administrator user.
+	 *
+	 * @var int
+	 */
+	public static $administrator_id;
+
+	/**
+	 * Set up the shared fixture.
+	 *
+	 * @param WP_UnitTest_Factory $factory Factory instance.
+	 */
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$administrator_id = $factory->user->create( array( 'role' => 'administrator' ) );
+	}
+
+	/**
 	 * Set up a test case.
 	 *
 	 * @see WP_UnitTestCase_Base::set_up()
@@ -22,7 +38,7 @@ class Test_WP_Customize_Nav_Menu_Setting extends WP_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 		require_once ABSPATH . WPINC . '/class-wp-customize-manager.php';
-		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		wp_set_current_user( self::$administrator_id );
 
 		global $wp_customize;
 		$this->wp_customize = new WP_Customize_Manager();

--- a/tests/phpunit/tests/customize/nav-menus.php
+++ b/tests/phpunit/tests/customize/nav-menus.php
@@ -15,6 +15,22 @@ class Test_WP_Customize_Nav_Menus extends WP_UnitTestCase {
 	public $wp_customize;
 
 	/**
+	 * ID of the administrator user.
+	 *
+	 * @var int
+	 */
+	public static $administrator_id;
+
+	/**
+	 * Set up the shared fixture.
+	 *
+	 * @param WP_UnitTest_Factory $factory Factory instance.
+	 */
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$administrator_id = $factory->user->create( array( 'role' => 'administrator' ) );
+	}
+
+	/**
 	 * Set up a test case.
 	 *
 	 * @see WP_UnitTestCase_Base::set_up()
@@ -22,7 +38,7 @@ class Test_WP_Customize_Nav_Menus extends WP_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 		require_once ABSPATH . WPINC . '/class-wp-customize-manager.php';
-		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		wp_set_current_user( self::$administrator_id );
 		global $wp_customize;
 		$this->wp_customize = new WP_Customize_Manager();
 		$wp_customize       = $this->wp_customize;
@@ -856,7 +872,7 @@ class Test_WP_Customize_Nav_Menus extends WP_UnitTestCase {
 		$menus                 = new WP_Customize_Nav_Menus( $this->wp_customize );
 		$contributor_user_id   = self::factory()->user->create( array( 'role' => 'contributor' ) );
 		$author_user_id        = self::factory()->user->create( array( 'role' => 'author' ) );
-		$administrator_user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$administrator_user_id = self::$administrator_id;
 
 		$contributor_post_id   = self::factory()->post->create(
 			array(

--- a/tests/phpunit/tests/customize/panel.php
+++ b/tests/phpunit/tests/customize/panel.php
@@ -8,6 +8,22 @@
 class Tests_WP_Customize_Panel extends WP_UnitTestCase {
 
 	/**
+	 * ID of the administrator user.
+	 *
+	 * @var int
+	 */
+	public static $administrator_id;
+
+	/**
+	 * Set up the shared fixture.
+	 *
+	 * @param WP_UnitTest_Factory $factory Factory instance.
+	 */
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$administrator_id = $factory->user->create( array( 'role' => 'administrator' ) );
+	}
+
+	/**
 	 * @var WP_Customize_Manager
 	 */
 	protected $manager;
@@ -131,8 +147,7 @@ class Tests_WP_Customize_Panel extends WP_UnitTestCase {
 	 * @see WP_Customize_Panel::check_capabilities()
 	 */
 	public function test_check_capabilities() {
-		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
-		wp_set_current_user( $user_id );
+		wp_set_current_user( self::$administrator_id );
 
 		$panel = new WP_Customize_Panel( $this->manager, 'foo' );
 		$this->assertTrue( $panel->check_capabilities() );
@@ -157,7 +172,7 @@ class Tests_WP_Customize_Panel extends WP_UnitTestCase {
 	 * @see WP_Customize_Panel::maybe_render()
 	 */
 	public function test_maybe_render() {
-		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		wp_set_current_user( self::$administrator_id );
 		$panel                        = new WP_Customize_Panel( $this->manager, 'bar' );
 		$customize_render_panel_count = did_action( 'customize_render_panel' );
 		add_action( 'customize_render_panel', array( $this, 'action_customize_render_panel_test' ) );
@@ -182,7 +197,7 @@ class Tests_WP_Customize_Panel extends WP_UnitTestCase {
 	 * @see WP_Customize_Panel::print_template()
 	 */
 	public function test_print_templates_standard() {
-		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		wp_set_current_user( self::$administrator_id );
 
 		$panel = new WP_Customize_Panel( $this->manager, 'baz' );
 		ob_start();
@@ -200,7 +215,7 @@ class Tests_WP_Customize_Panel extends WP_UnitTestCase {
 	 * @see WP_Customize_Panel::print_template()
 	 */
 	public function test_print_templates_custom() {
-		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		wp_set_current_user( self::$administrator_id );
 
 		$panel = new Custom_Panel_Test( $this->manager, 'baz' );
 		ob_start();

--- a/tests/phpunit/tests/customize/selective-refresh-ajax.php
+++ b/tests/phpunit/tests/customize/selective-refresh-ajax.php
@@ -29,6 +29,22 @@ class Test_WP_Customize_Selective_Refresh_Ajax extends WP_UnitTestCase {
 	public $selective_refresh;
 
 	/**
+	 * Shared user ID for the tests.
+	 *
+	 * @var int
+	 */
+	public static $user_id = 0;
+
+	/**
+	 * Set up shared fixtures.
+	 *
+	 * @param WP_UnitTest_Factory $factory Factory.
+	 */
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$user_id = $factory->user->create( array( 'role' => 'administrator' ) );
+	}
+
+	/**
 	 * Set up the test fixture.
 	 */
 	public function set_up() {
@@ -79,7 +95,7 @@ class Test_WP_Customize_Selective_Refresh_Ajax extends WP_UnitTestCase {
 		$this->assertSame( 'expected_customize_preview', $output['data'] );
 
 		// Check expected_customize_preview.
-		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		wp_set_current_user( self::$user_id );
 		$_REQUEST['nonce'] = wp_create_nonce( 'preview-customize_' . $this->wp_customize->theme()->get_stylesheet() );
 		ob_start();
 		try {
@@ -121,7 +137,7 @@ class Test_WP_Customize_Selective_Refresh_Ajax extends WP_UnitTestCase {
 	 * Set the current user to be an admin, add the preview nonce, and set the query var.
 	 */
 	private function setup_valid_render_partials_request_environment() {
-		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		wp_set_current_user( self::$user_id );
 		$_REQUEST['nonce'] = wp_create_nonce( 'preview-customize_' . $this->wp_customize->theme()->get_stylesheet() );
 		$_POST[ WP_Customize_Selective_Refresh::RENDER_QUERY_VAR ] = '1';
 		$this->do_customize_boot_actions();
@@ -171,7 +187,7 @@ class Test_WP_Customize_Selective_Refresh_Ajax extends WP_UnitTestCase {
 	 */
 	public function test_handle_render_partials_request_for_non_rendering_partial() {
 		$this->setup_valid_render_partials_request_environment();
-		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		wp_set_current_user( self::$user_id );
 		$this->wp_customize->add_setting( 'home' );
 		$this->wp_customize->selective_refresh->add_partial( 'foo', array( 'settings' => array( 'home' ) ) );
 		$context_data = array();
@@ -208,7 +224,7 @@ class Test_WP_Customize_Selective_Refresh_Ajax extends WP_UnitTestCase {
 	 */
 	public function test_handle_rendering_disallowed_partial() {
 		$this->setup_valid_render_partials_request_environment();
-		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		wp_set_current_user( self::$user_id );
 		$this->wp_customize->add_setting(
 			'secret_message',
 			array(
@@ -244,7 +260,7 @@ class Test_WP_Customize_Selective_Refresh_Ajax extends WP_UnitTestCase {
 	 */
 	public function test_handle_rendering_partial_with_missing_settings() {
 		$this->setup_valid_render_partials_request_environment();
-		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		wp_set_current_user( self::$user_id );
 		$this->wp_customize->selective_refresh->add_partial( 'bar', array( 'settings' => 'bar' ) );
 
 		$context_data      = array();

--- a/tests/phpunit/tests/customize/setting.php
+++ b/tests/phpunit/tests/customize/setting.php
@@ -17,6 +17,22 @@ class Tests_WP_Customize_Setting extends WP_UnitTestCase {
 	 */
 	public $undefined;
 
+	/**
+	 * Shared admin user ID for the tests.
+	 *
+	 * @var int
+	 */
+	public static $admin_id = 0;
+
+	/**
+	 * Set up shared fixtures.
+	 *
+	 * @param WP_UnitTest_Factory $factory Factory.
+	 */
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$admin_id = $factory->user->create( array( 'role' => 'administrator' ) );
+	}
+
 	public function set_up() {
 		parent::set_up();
 		require_once ABSPATH . WPINC . '/class-wp-customize-manager.php';
@@ -137,7 +153,7 @@ class Tests_WP_Customize_Setting extends WP_UnitTestCase {
 	 * @see WP_Customize_Setting::value()
 	 */
 	public function test_preview_standard_types_non_multidimensional() {
-		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		wp_set_current_user( self::$admin_id );
 		$_POST['customized'] = wp_slash( wp_json_encode( $this->post_data_overrides ) );
 
 		// Try non-multidimensional settings.
@@ -216,7 +232,7 @@ class Tests_WP_Customize_Setting extends WP_UnitTestCase {
 	 * @see WP_Customize_Setting::value()
 	 */
 	public function test_preview_standard_types_multidimensional() {
-		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		wp_set_current_user( self::$admin_id );
 		$_POST['customized'] = wp_slash( wp_json_encode( $this->post_data_overrides ) );
 
 		foreach ( $this->standard_type_configs as $type => $type_options ) {
@@ -362,7 +378,7 @@ class Tests_WP_Customize_Setting extends WP_UnitTestCase {
 	 * @see WP_Customize_Setting::preview()
 	 */
 	public function test_preview_custom_type() {
-		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		wp_set_current_user( self::$admin_id );
 		$type                = 'custom_type';
 		$post_data_overrides = array(
 			"unset_{$type}_with_post_value" => "unset_{$type}_without_post_value\\o/",
@@ -513,7 +529,7 @@ class Tests_WP_Customize_Setting extends WP_UnitTestCase {
 		$this->assertTrue( 0 === did_action( 'customize_save_foo' ) );
 
 		// Satisfy all requirements for save to happen.
-		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		wp_set_current_user( self::$admin_id );
 		$this->assertNotFalse( $setting->save() );
 		$this->assertTrue( 1 === did_action( 'customize_update_custom' ) );
 		$this->assertTrue( 1 === did_action( 'customize_save_foo' ) );
@@ -551,7 +567,7 @@ class Tests_WP_Customize_Setting extends WP_UnitTestCase {
 	 * @ticket 31428
 	 */
 	public function test_is_current_blog_previewed() {
-		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		wp_set_current_user( self::$admin_id );
 		$type       = 'option';
 		$name       = 'blogname';
 		$post_value = __FUNCTION__;
@@ -573,7 +589,7 @@ class Tests_WP_Customize_Setting extends WP_UnitTestCase {
 	 * @group ms-required
 	 */
 	public function test_previewing_with_switch_to_blog() {
-		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		wp_set_current_user( self::$admin_id );
 		$type       = 'option';
 		$name       = 'blogdescription';
 		$post_value = __FUNCTION__;
@@ -596,7 +612,7 @@ class Tests_WP_Customize_Setting extends WP_UnitTestCase {
 	 */
 	public function test_option_autoloading() {
 		global $wpdb;
-		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		wp_set_current_user( self::$admin_id );
 
 		$name    = 'autoloaded1';
 		$setting = new WP_Customize_Setting(
@@ -743,7 +759,7 @@ class Tests_WP_Customize_Setting extends WP_UnitTestCase {
 	 * @ticket 37294
 	 */
 	public function test_multidimensional_value_when_previewed() {
-		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		wp_set_current_user( self::$admin_id );
 		WP_Customize_Setting::reset_aggregated_multidimensionals();
 
 		$initial_value = 456;

--- a/tests/phpunit/tests/customize/widgets.php
+++ b/tests/phpunit/tests/customize/widgets.php
@@ -20,6 +20,22 @@ class Tests_WP_Customize_Widgets extends WP_UnitTestCase {
 	 */
 	protected $backup_registered_sidebars;
 
+	/**
+	 * ID of the administrator user.
+	 *
+	 * @var int
+	 */
+	public static $administrator_id;
+
+	/**
+	 * Set up the shared fixture.
+	 *
+	 * @param WP_UnitTest_Factory $factory Factory instance.
+	 */
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$administrator_id = $factory->user->create( array( 'role' => 'administrator' ) );
+	}
+
 	public function set_up() {
 		parent::set_up();
 		require_once ABSPATH . WPINC . '/class-wp-customize-manager.php';
@@ -27,8 +43,7 @@ class Tests_WP_Customize_Widgets extends WP_UnitTestCase {
 		add_theme_support( 'customize-selective-refresh-widgets' );
 		add_action( 'widgets_init', array( $this, 'remove_widgets_block_editor' ) );
 
-		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
-		wp_set_current_user( $user_id );
+		wp_set_current_user( self::$administrator_id );
 
 		update_option(
 			'widget_search',

--- a/tests/phpunit/tests/general/template.php
+++ b/tests/phpunit/tests/general/template.php
@@ -32,7 +32,29 @@ class Tests_General_Template extends WP_UnitTestCase {
 	 */
 	public static $home_page_id;
 
+	/**
+	 * ID of the administrator user.
+	 *
+	 * @var int
+	 */
+	public static $administrator_id;
+
+	/**
+	 * ID of the author user.
+	 *
+	 * @var int
+	 */
+	public static $author_id;
+
+	/**
+	 * Set up the shared fixtures.
+	 *
+	 * @param WP_UnitTest_Factory $factory Factory instance.
+	 */
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$administrator_id = $factory->user->create( array( 'role' => 'administrator' ) );
+		self::$author_id        = $factory->user->create( array( 'role' => 'author' ) );
+
 		/*
 		 * Declare theme support for custom logo.
 		 *
@@ -212,7 +234,7 @@ class Tests_General_Template extends WP_UnitTestCase {
 	 */
 	public function test_customize_preview_wp_site_icon_empty() {
 		global $wp_customize;
-		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		wp_set_current_user( self::$administrator_id );
 
 		require_once ABSPATH . WPINC . '/class-wp-customize-manager.php';
 		$wp_customize = new WP_Customize_Manager();
@@ -230,7 +252,7 @@ class Tests_General_Template extends WP_UnitTestCase {
 	 */
 	public function test_customize_preview_wp_site_icon_dirty() {
 		global $wp_customize;
-		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		wp_set_current_user( self::$administrator_id );
 
 		require_once ABSPATH . WPINC . '/class-wp-customize-manager.php';
 		$wp_customize = new WP_Customize_Manager();
@@ -763,16 +785,8 @@ class Tests_General_Template extends WP_UnitTestCase {
 	 * @covers ::get_the_archive_title
 	 */
 	public function test_get_the_archive_title_is_correct_for_author_queries() {
-		$user_with_posts    = self::factory()->user->create_and_get(
-			array(
-				'role' => 'author',
-			)
-		);
-		$user_with_no_posts = self::factory()->user->create_and_get(
-			array(
-				'role' => 'author',
-			)
-		);
+		$user_with_posts    = get_user_by( 'id', self::$administrator_id );
+		$user_with_no_posts = get_user_by( 'id', self::$author_id );
 
 		self::factory()->post->create(
 			array(

--- a/tests/phpunit/tests/l10n.php
+++ b/tests/phpunit/tests/l10n.php
@@ -16,6 +16,17 @@ class Tests_L10n extends WP_UnitTestCase {
 	private $long_text = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.';
 
 	/**
+	 * Editor user ID.
+	 *
+	 * @var int $editor_id
+	 */
+	public static $editor_id;
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$editor_id = $factory->user->create( array( 'role' => 'editor' ) );
+	}
+
+	/**
 	 * @ticket 35961
 	 *
 	 * @covers ::_n_noop
@@ -464,7 +475,7 @@ class Tests_L10n extends WP_UnitTestCase {
 		 * and return a string instead of null, which would otherwise cause a PHP 8.1
 		 * "passing null to non-nullable" deprecation notice.
 		 */
-		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+		wp_set_current_user( self::$editor_id );
 
 		$args = array(
 			'post_content' => $this->long_text,
@@ -503,7 +514,7 @@ class Tests_L10n extends WP_UnitTestCase {
 		 * and return a string instead of null, which would otherwise cause a PHP 8.1
 		 * "passing null to non-nullable" deprecation notice.
 		 */
-		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+		wp_set_current_user( self::$editor_id );
 
 		$args = array(
 			'post_content' => $this->long_text,
@@ -542,7 +553,7 @@ class Tests_L10n extends WP_UnitTestCase {
 		 * and return a string instead of null, which would otherwise cause a PHP 8.1
 		 * "passing null to non-nullable" deprecation notice.
 		 */
-		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+		wp_set_current_user( self::$editor_id );
 
 		$args = array(
 			'post_content' => str_repeat( 'あ', 200 ),

--- a/tests/phpunit/tests/l10n/getUserLocale.php
+++ b/tests/phpunit/tests/l10n/getUserLocale.php
@@ -9,34 +9,61 @@
 class Tests_L10n_GetUserLocale extends WP_UnitTestCase {
 	protected $user_id;
 
-	public function set_up() {
-		parent::set_up();
+	/**
+	 * ID of the administrator user with de_DE local.
+	 *
+	 * @var int
+	 */
+	public static $administrator_de_de;
 
-		$this->user_id = self::factory()->user->create(
+	/**
+	 * ID of the user with es_ES local.
+	 *
+	 * @var int
+	 */
+	public static $user_es_es;
+
+	/**
+	 * Set up the shared fixtures.
+	 *
+	 * @param WP_UnitTest_Factory $factory Factory instance.
+	 */
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$administrator_de_de = $factory->user->create(
 			array(
 				'role'   => 'administrator',
 				'locale' => 'de_DE',
 			)
 		);
 
-		wp_set_current_user( $this->user_id );
+		self::$user_es_es = self::factory()->user->create(
+			array(
+				'locale' => 'es_ES',
+			)
+		);
+	}
+
+	public function set_up() {
+		parent::set_up();
+
+		wp_set_current_user( self::$administrator_de_de );
 	}
 
 	public function test_user_locale_property() {
 		set_current_screen( 'dashboard' );
 		$this->assertSame( 'de_DE', get_user_locale() );
-		$this->assertSame( get_user_by( 'id', $this->user_id )->locale, get_user_locale() );
+		$this->assertSame( get_user_by( 'id', self::$administrator_de_de )->locale, get_user_locale() );
 	}
 
 	public function test_update_user_locale() {
 		set_current_screen( 'dashboard' );
-		update_user_meta( $this->user_id, 'locale', 'fr_FR' );
+		update_user_meta( self::$administrator_de_de, 'locale', 'fr_FR' );
 		$this->assertSame( 'fr_FR', get_user_locale() );
 	}
 
 	public function test_returns_site_locale_if_empty() {
 		set_current_screen( 'dashboard' );
-		update_user_meta( $this->user_id, 'locale', '' );
+		update_user_meta( self::$administrator_de_de, 'locale', '' );
 		$this->assertSame( get_locale(), get_user_locale() );
 	}
 
@@ -78,11 +105,7 @@ class Tests_L10n_GetUserLocale extends WP_UnitTestCase {
 	}
 
 	public function test_user_id_argument_with_id() {
-		$user_id = self::factory()->user->create(
-			array(
-				'locale' => 'es_ES',
-			)
-		);
+		$user_id = self::$user_es_es;
 
 		$user_locale1 = get_user_locale( $user_id );
 
@@ -95,11 +118,7 @@ class Tests_L10n_GetUserLocale extends WP_UnitTestCase {
 	}
 
 	public function test_user_id_argument_with_wp_user_object() {
-		$user_id = self::factory()->user->create(
-			array(
-				'locale' => 'es_ES',
-			)
-		);
+		$user_id = self::$user_es_es;
 
 		$user = get_user_by( 'id', $user_id );
 

--- a/tests/phpunit/tests/meta.php
+++ b/tests/phpunit/tests/meta.php
@@ -9,16 +9,15 @@ class Tests_Meta extends WP_UnitTestCase {
 	/**
 	 * @var \WP_User
 	 */
-	private $author;
+	private static $author;
 
-	private $meta_id;
-	private $delete_meta_id;
+	private static $meta_id;
+	private static $delete_meta_id;
 
-	public function set_up() {
-		parent::set_up();
-		$this->author         = new WP_User( self::factory()->user->create( array( 'role' => 'author' ) ) );
-		$this->meta_id        = add_metadata( 'user', $this->author->ID, 'meta_key', 'meta_value' );
-		$this->delete_meta_id = add_metadata( 'user', $this->author->ID, 'delete_meta_key', 'delete_meta_value' );
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$author         = new WP_User( $factory->user->create( array( 'role' => 'author' ) ) );
+		self::$meta_id        = add_metadata( 'user', self::$author->ID, 'meta_key', 'meta_value' );
+		self::$delete_meta_id = add_metadata( 'user', self::$author->ID, 'delete_meta_key', 'delete_meta_value' );
 	}
 
 	public function meta_sanitize_cb( $meta_value, $meta_key, $meta_type ) {
@@ -37,51 +36,51 @@ class Tests_Meta extends WP_UnitTestCase {
 	public function test_delete_metadata_by_mid() {
 		// Let's try and delete a non-existing ID, non existing meta.
 		$this->assertFalse( delete_metadata_by_mid( 'user', 0 ) );
-		$this->assertFalse( delete_metadata_by_mid( 'non_existing_meta', $this->delete_meta_id ) );
+		$this->assertFalse( delete_metadata_by_mid( 'non_existing_meta', self::$delete_meta_id ) );
 
 		// Now let's delete the real meta data.
-		$this->assertTrue( delete_metadata_by_mid( 'user', $this->delete_meta_id ) );
+		$this->assertTrue( delete_metadata_by_mid( 'user', self::$delete_meta_id ) );
 
 		// And make sure it's been deleted.
-		$this->assertFalse( get_metadata_by_mid( 'user', $this->delete_meta_id ) );
+		$this->assertFalse( get_metadata_by_mid( 'user', self::$delete_meta_id ) );
 
 		// Make sure the caches are cleared.
-		$this->assertFalse( (bool) get_user_meta( $this->author->ID, 'delete_meta_key' ) );
+		$this->assertFalse( (bool) get_user_meta( self::$author->ID, 'delete_meta_key' ) );
 	}
 
 	public function test_update_metadata_by_mid() {
 		// Setup.
-		$meta = get_metadata_by_mid( 'user', $this->meta_id );
+		$meta = get_metadata_by_mid( 'user', self::$meta_id );
 
 		// Update the meta value.
-		$this->assertTrue( update_metadata_by_mid( 'user', $this->meta_id, 'meta_new_value' ) );
-		$meta = get_metadata_by_mid( 'user', $this->meta_id );
+		$this->assertTrue( update_metadata_by_mid( 'user', self::$meta_id, 'meta_new_value' ) );
+		$meta = get_metadata_by_mid( 'user', self::$meta_id );
 		$this->assertSame( 'meta_new_value', $meta->meta_value );
 
 		// Update the meta value.
-		$this->assertTrue( update_metadata_by_mid( 'user', $this->meta_id, 'meta_new_value', 'meta_new_key' ) );
-		$meta = get_metadata_by_mid( 'user', $this->meta_id );
+		$this->assertTrue( update_metadata_by_mid( 'user', self::$meta_id, 'meta_new_value', 'meta_new_key' ) );
+		$meta = get_metadata_by_mid( 'user', self::$meta_id );
 		$this->assertSame( 'meta_new_key', $meta->meta_key );
 
 		// Update the key and value.
-		$this->assertTrue( update_metadata_by_mid( 'user', $this->meta_id, 'meta_value', 'meta_key' ) );
-		$meta = get_metadata_by_mid( 'user', $this->meta_id );
+		$this->assertTrue( update_metadata_by_mid( 'user', self::$meta_id, 'meta_value', 'meta_key' ) );
+		$meta = get_metadata_by_mid( 'user', self::$meta_id );
 		$this->assertSame( 'meta_key', $meta->meta_key );
 		$this->assertSame( 'meta_value', $meta->meta_value );
 
 		// Update the value that has to be serialized.
-		$this->assertTrue( update_metadata_by_mid( 'user', $this->meta_id, array( 'first', 'second' ) ) );
-		$meta = get_metadata_by_mid( 'user', $this->meta_id );
+		$this->assertTrue( update_metadata_by_mid( 'user', self::$meta_id, array( 'first', 'second' ) ) );
+		$meta = get_metadata_by_mid( 'user', self::$meta_id );
 		$this->assertSame( array( 'first', 'second' ), $meta->meta_value );
 
 		// Let's try some invalid meta data.
 		$this->assertFalse( update_metadata_by_mid( 'user', 0, 'meta_value' ) );
-		$this->assertFalse( update_metadata_by_mid( 'user', $this->meta_id, 'meta_value', array( 'invalid', 'key' ) ) );
+		$this->assertFalse( update_metadata_by_mid( 'user', self::$meta_id, 'meta_value', array( 'invalid', 'key' ) ) );
 
 		// Let's see if caches get cleared after updates.
-		$meta  = get_metadata_by_mid( 'user', $this->meta_id );
+		$meta  = get_metadata_by_mid( 'user', self::$meta_id );
 		$first = get_user_meta( $meta->user_id, $meta->meta_key );
-		$this->assertTrue( update_metadata_by_mid( 'user', $this->meta_id, 'other_meta_value' ) );
+		$this->assertTrue( update_metadata_by_mid( 'user', self::$meta_id, 'other_meta_value' ) );
 		$second = get_user_meta( $meta->user_id, $meta->meta_key );
 		$this->assertFalse( $first === $second );
 	}
@@ -113,8 +112,8 @@ class Tests_Meta extends WP_UnitTestCase {
 	}
 
 	public function test_metadata_exists() {
-		$this->assertFalse( metadata_exists( 'user', $this->author->ID, 'foobarbaz' ) );
-		$this->assertTrue( metadata_exists( 'user', $this->author->ID, 'meta_key' ) );
+		$this->assertFalse( metadata_exists( 'user', self::$author->ID, 'foobarbaz' ) );
+		$this->assertTrue( metadata_exists( 'user', self::$author->ID, 'meta_key' ) );
 		$this->assertFalse( metadata_exists( 'user', 1234567890, 'foobarbaz' ) );
 		$this->assertFalse( metadata_exists( 'user', 1234567890, 'meta_key' ) );
 	}
@@ -125,7 +124,7 @@ class Tests_Meta extends WP_UnitTestCase {
 	public function test_metadata_exists_with_filter() {
 		// Let's see if it returns the correct value when adding a filter.
 		add_filter( 'get_user_metadata', '__return_zero' );
-		$this->assertFalse( metadata_exists( 'user', $this->author->ID, 'meta_key' ) ); // Existing meta key.
+		$this->assertFalse( metadata_exists( 'user', self::$author->ID, 'meta_key' ) ); // Existing meta key.
 		$this->assertFalse( metadata_exists( 'user', 1234567890, 'meta_key' ) );
 		remove_filter( 'get_user_metadata', '__return_zero' );
 	}
@@ -148,7 +147,7 @@ class Tests_Meta extends WP_UnitTestCase {
 		$this->assertCount( 1, $u );
 
 		// User found is not locally defined author (it's the admin).
-		$this->assertNotEquals( $this->author->user_login, $u[0]->user_login );
+		$this->assertNotEquals( self::$author->user_login, $u[0]->user_login );
 
 		// Test EXISTS and NOT EXISTS together, no users should be found.
 		$this->assertCount(
@@ -183,7 +182,7 @@ class Tests_Meta extends WP_UnitTestCase {
 			)
 		);
 
-		delete_metadata( 'user', $this->author->ID, 'meta_key' );
+		delete_metadata( 'user', self::$author->ID, 'meta_key' );
 
 		$this->assertCount(
 			2,
@@ -206,28 +205,28 @@ class Tests_Meta extends WP_UnitTestCase {
 		$expected  = 'Testsingleslash';
 		$value2    = 'Test\\\\doubleslash';
 		$expected2 = 'Test\\doubleslash';
-		$this->assertFalse( metadata_exists( 'user', $this->author->ID, $key ) );
-		$this->assertFalse( delete_metadata( 'user', $this->author->ID, $key ) );
-		$this->assertSame( '', get_metadata( 'user', $this->author->ID, $key, true ) );
-		$this->assertIsInt( add_metadata( 'user', $this->author->ID, $key, $value ) );
-		$this->assertSame( $expected, get_metadata( 'user', $this->author->ID, $key, true ) );
-		$this->assertTrue( delete_metadata( 'user', $this->author->ID, $key ) );
-		$this->assertSame( '', get_metadata( 'user', $this->author->ID, $key, true ) );
-		$this->assertIsInt( update_metadata( 'user', $this->author->ID, $key, $value ) );
-		$this->assertSame( $expected, get_metadata( 'user', $this->author->ID, $key, true ) );
-		$this->assertTrue( update_metadata( 'user', $this->author->ID, $key, 'blah' ) );
-		$this->assertSame( 'blah', get_metadata( 'user', $this->author->ID, $key, true ) );
-		$this->assertTrue( delete_metadata( 'user', $this->author->ID, $key ) );
-		$this->assertSame( '', get_metadata( 'user', $this->author->ID, $key, true ) );
-		$this->assertFalse( metadata_exists( 'user', $this->author->ID, $key ) );
+		$this->assertFalse( metadata_exists( 'user', self::$author->ID, $key ) );
+		$this->assertFalse( delete_metadata( 'user', self::$author->ID, $key ) );
+		$this->assertSame( '', get_metadata( 'user', self::$author->ID, $key, true ) );
+		$this->assertIsInt( add_metadata( 'user', self::$author->ID, $key, $value ) );
+		$this->assertSame( $expected, get_metadata( 'user', self::$author->ID, $key, true ) );
+		$this->assertTrue( delete_metadata( 'user', self::$author->ID, $key ) );
+		$this->assertSame( '', get_metadata( 'user', self::$author->ID, $key, true ) );
+		$this->assertIsInt( update_metadata( 'user', self::$author->ID, $key, $value ) );
+		$this->assertSame( $expected, get_metadata( 'user', self::$author->ID, $key, true ) );
+		$this->assertTrue( update_metadata( 'user', self::$author->ID, $key, 'blah' ) );
+		$this->assertSame( 'blah', get_metadata( 'user', self::$author->ID, $key, true ) );
+		$this->assertTrue( delete_metadata( 'user', self::$author->ID, $key ) );
+		$this->assertSame( '', get_metadata( 'user', self::$author->ID, $key, true ) );
+		$this->assertFalse( metadata_exists( 'user', self::$author->ID, $key ) );
 
 		// Test overslashing.
-		$this->assertIsInt( add_metadata( 'user', $this->author->ID, $key, $value2 ) );
-		$this->assertSame( $expected2, get_metadata( 'user', $this->author->ID, $key, true ) );
-		$this->assertTrue( delete_metadata( 'user', $this->author->ID, $key ) );
-		$this->assertSame( '', get_metadata( 'user', $this->author->ID, $key, true ) );
-		$this->assertIsInt( update_metadata( 'user', $this->author->ID, $key, $value2 ) );
-		$this->assertSame( $expected2, get_metadata( 'user', $this->author->ID, $key, true ) );
+		$this->assertIsInt( add_metadata( 'user', self::$author->ID, $key, $value2 ) );
+		$this->assertSame( $expected2, get_metadata( 'user', self::$author->ID, $key, true ) );
+		$this->assertTrue( delete_metadata( 'user', self::$author->ID, $key ) );
+		$this->assertSame( '', get_metadata( 'user', self::$author->ID, $key, true ) );
+		$this->assertIsInt( update_metadata( 'user', self::$author->ID, $key, $value2 ) );
+		$this->assertSame( $expected2, get_metadata( 'user', self::$author->ID, $key, true ) );
 	}
 
 	/**
@@ -344,7 +343,7 @@ class Tests_Meta extends WP_UnitTestCase {
 	 * @ticket 37746
 	 */
 	public function test_negative_meta_id() {
-		$negative_mid = $this->meta_id * -1;
+		$negative_mid = self::$meta_id * -1;
 
 		$this->assertLessThan( 0, $negative_mid );
 		$this->assertFalse( get_metadata_by_mid( 'user', $negative_mid ) );
@@ -356,7 +355,7 @@ class Tests_Meta extends WP_UnitTestCase {
 	 * @ticket 37746
 	 */
 	public function test_floating_meta_id() {
-		$floating_mid = $this->meta_id + 0.1337;
+		$floating_mid = self::$meta_id + 0.1337;
 
 		$this->assertTrue( floor( $floating_mid ) !== $floating_mid );
 		$this->assertFalse( get_metadata_by_mid( 'user', $floating_mid ) );
@@ -368,7 +367,7 @@ class Tests_Meta extends WP_UnitTestCase {
 	 * @ticket 37746
 	 */
 	public function test_string_point_zero_meta_id() {
-		$meta_id = add_metadata( 'user', $this->author->ID, 'meta_key', 'meta_value_2' );
+		$meta_id = add_metadata( 'user', self::$author->ID, 'meta_key', 'meta_value_2' );
 
 		$string_mid = "{$meta_id}.0";
 
@@ -385,8 +384,8 @@ class Tests_Meta extends WP_UnitTestCase {
 	public function test_get_metadata_with_empty_key_array_value() {
 		$data  = array( 1, 2 );
 		$value = serialize( $data );
-		add_metadata( 'user', $this->author->ID, 'foo', $data );
-		$found = get_metadata( 'user', $this->author->ID );
+		add_metadata( 'user', self::$author->ID, 'foo', $data );
+		$found = get_metadata( 'user', self::$author->ID );
 
 		$this->assertSame( array( $value ), $found['foo'] );
 	}
@@ -398,8 +397,8 @@ class Tests_Meta extends WP_UnitTestCase {
 		$data      = new stdClass();
 		$data->foo = 'bar';
 		$value     = serialize( $data );
-		add_metadata( 'user', $this->author->ID, 'foo', $data );
-		$found = get_metadata( 'user', $this->author->ID );
+		add_metadata( 'user', self::$author->ID, 'foo', $data );
+		$found = get_metadata( 'user', self::$author->ID );
 
 		$this->assertSame( array( $value ), $found['foo'] );
 	}
@@ -413,8 +412,8 @@ class Tests_Meta extends WP_UnitTestCase {
 			array( 3, 4 ),
 		);
 		$value = serialize( $data );
-		add_metadata( 'user', $this->author->ID, 'foo', $data );
-		$found = get_metadata( 'user', $this->author->ID );
+		add_metadata( 'user', self::$author->ID, 'foo', $data );
+		$found = get_metadata( 'user', self::$author->ID );
 
 		$this->assertSame( array( $value ), $found['foo'] );
 	}

--- a/tests/phpunit/tests/oembed/controller.php
+++ b/tests/phpunit/tests/oembed/controller.php
@@ -304,11 +304,7 @@ class Test_oEmbed_Controller extends WP_UnitTestCase {
 	}
 
 	public function test_request_json() {
-		$user = self::factory()->user->create_and_get(
-			array(
-				'display_name' => 'John Doe',
-			)
-		);
+		$user = get_user_by( 'id', self::$subscriber );
 		$post = self::factory()->post->create_and_get(
 			array(
 				'post_author' => $user->ID,
@@ -391,11 +387,7 @@ class Test_oEmbed_Controller extends WP_UnitTestCase {
 	}
 
 	public function test_request_xml() {
-		$user = self::factory()->user->create_and_get(
-			array(
-				'display_name' => 'John Doe',
-			)
-		);
+		$user = get_user_by( 'id', self::$subscriber );
 		$post = self::factory()->post->create_and_get(
 			array(
 				'post_author' => $user->ID,
@@ -461,11 +453,7 @@ class Test_oEmbed_Controller extends WP_UnitTestCase {
 	}
 
 	public function test_rest_pre_serve_request() {
-		$user = self::factory()->user->create_and_get(
-			array(
-				'display_name' => 'John Doe',
-			)
-		);
+		$user = get_user_by( 'id', self::$subscriber );
 		$post = self::factory()->post->create_and_get(
 			array(
 				'post_author' => $user->ID,
@@ -677,11 +665,7 @@ class Test_oEmbed_Controller extends WP_UnitTestCase {
 	public function test_proxy_with_internal_url() {
 		wp_set_current_user( self::$editor );
 
-		$user = self::factory()->user->create_and_get(
-			array(
-				'display_name' => 'John Doe',
-			)
-		);
+		$user = get_user_by( 'id', self::$subscriber );
 		$post = self::factory()->post->create_and_get(
 			array(
 				'post_author' => $user->ID,

--- a/tests/phpunit/tests/oembed/wpOembed.php
+++ b/tests/phpunit/tests/oembed/wpOembed.php
@@ -11,6 +11,22 @@ class Tests_WP_oEmbed extends WP_UnitTestCase {
 
 	public $pre_oembed_result_filtered = false;
 
+	/**
+	 * ID of the user.
+	 *
+	 * @var int
+	 */
+	public static $user_id;
+
+	/**
+	 * Set up the shared fixture.
+	 *
+	 * @param WP_UnitTest_Factory $factory Factory instance.
+	 */
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$user_id = $factory->user->create();
+	}
+
 	public function set_up() {
 		parent::set_up();
 
@@ -96,7 +112,7 @@ class Tests_WP_oEmbed extends WP_UnitTestCase {
 	 * @group ms-required
 	 */
 	public function test_wp_filter_pre_oembed_result_multisite_sub_samesub() {
-		$user_id = self::factory()->user->create();
+		$user_id = self::$user_id;
 
 		$blog_id = self::factory()->blog->create(
 			array(
@@ -125,7 +141,7 @@ class Tests_WP_oEmbed extends WP_UnitTestCase {
 	 * @group ms-required
 	 */
 	public function test_wp_filter_pre_oembed_result_multisite_sub_othersub() {
-		$user_id = self::factory()->user->create();
+		$user_id = self::$user_id;
 
 		$blog_id = self::factory()->blog->create(
 			array(
@@ -164,7 +180,7 @@ class Tests_WP_oEmbed extends WP_UnitTestCase {
 	public function test_wp_filter_pre_oembed_result_multisite_sub_main() {
 		$post_id   = self::factory()->post->create();
 		$permalink = get_permalink( $post_id );
-		$user_id   = self::factory()->user->create();
+		$user_id   = self::$user_id;
 		$blog_id   = self::factory()->blog->create(
 			array(
 				'user_id' => $user_id,
@@ -189,7 +205,7 @@ class Tests_WP_oEmbed extends WP_UnitTestCase {
 	 * @group ms-required
 	 */
 	public function test_wp_filter_pre_oembed_result_multisite_preserves_switched_state() {
-		$user_id = self::factory()->user->create();
+		$user_id = self::$user_id;
 
 		$blog_id = self::factory()->blog->create( array( 'user_id' => $user_id ) );
 		switch_to_blog( $blog_id );
@@ -220,7 +236,7 @@ class Tests_WP_oEmbed extends WP_UnitTestCase {
 	public function test_wp_filter_pre_oembed_result_multisite_restores_state_if_no_post_is_found() {
 		$current_blog_id = get_current_blog_id();
 
-		$user_id = self::factory()->user->create();
+		$user_id = self::$user_id;
 		$blog_id = self::factory()->blog->create(
 			array(
 				'user_id' => $user_id,

--- a/tests/phpunit/tests/post/getPages.php
+++ b/tests/phpunit/tests/post/getPages.php
@@ -6,6 +6,42 @@
  * @covers ::get_pages
  */
 class Tests_Post_GetPages extends WP_UnitTestCase {
+
+	/**
+	 * ID of the first author.
+	 *
+	 * @var int
+	 */
+	public static $author_id_1;
+
+	/**
+	 * ID of the second author.
+	 *
+	 * @var int
+	 */
+	public static $author_id_2;
+
+	/**
+	 * Set up the shared fixture.
+	 *
+	 * @param WP_UnitTest_Factory $factory Factory instance.
+	 */
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$author_id_1 = $factory->user->create(
+			array(
+				'user_login' => 'author1',
+				'role'       => 'author',
+			)
+		);
+
+		self::$author_id_2 = $factory->user->create(
+			array(
+				'user_login' => 'author2',
+				'role'       => 'author',
+			)
+		);
+	}
+
 	/**
 	 * @ticket 23167
 	 */
@@ -963,12 +999,7 @@ class Tests_Post_GetPages extends WP_UnitTestCase {
 	 * @ticket 12821
 	 */
 	public function test_get_pages_author() {
-		$author_1 = self::factory()->user->create(
-			array(
-				'user_login' => 'author1',
-				'role'       => 'author',
-			)
-		);
+		$author_1 = self::$author_id_1;
 		$posts    = self::factory()->post->create_many(
 			2,
 			array(
@@ -989,12 +1020,7 @@ class Tests_Post_GetPages extends WP_UnitTestCase {
 	 * @ticket 12821
 	 */
 	public function test_get_pages_multiple_authors() {
-		$author_1 = self::factory()->user->create(
-			array(
-				'user_login' => 'author1',
-				'role'       => 'author',
-			)
-		);
+		$author_1 = self::$author_id_1;
 		$post_1   = self::factory()->post->create(
 			array(
 				'post_title'  => 'Page 1',
@@ -1004,12 +1030,7 @@ class Tests_Post_GetPages extends WP_UnitTestCase {
 			)
 		);
 
-		$author_2 = self::factory()->user->create(
-			array(
-				'user_login' => 'author2',
-				'role'       => 'author',
-			)
-		);
+		$author_2 = self::$author_id_2;
 		$post_2   = self::factory()->post->create(
 			array(
 				'post_title'  => 'Page 2',
@@ -1031,12 +1052,7 @@ class Tests_Post_GetPages extends WP_UnitTestCase {
 	 * @ticket 12821
 	 */
 	public function test_get_pages_multiple_authors_by_user_login() {
-		$author_1 = self::factory()->user->create(
-			array(
-				'user_login' => 'author1',
-				'role'       => 'author',
-			)
-		);
+		$author_1 = self::$author_id_1;
 		$post_1   = self::factory()->post->create(
 			array(
 				'post_title'  => 'Page 1',
@@ -1046,12 +1062,7 @@ class Tests_Post_GetPages extends WP_UnitTestCase {
 			)
 		);
 
-		$author_2 = self::factory()->user->create(
-			array(
-				'user_login' => 'author2',
-				'role'       => 'author',
-			)
-		);
+		$author_2 = self::$author_id_2;
 		$post_2   = self::factory()->post->create(
 			array(
 				'post_title'  => 'Page 2',

--- a/tests/phpunit/tests/post/getPostsByAuthorSql.php
+++ b/tests/phpunit/tests/post/getPostsByAuthorSql.php
@@ -5,6 +5,30 @@
  */
 class Tests_Post_GetPostsByAuthorSql extends WP_UnitTestCase {
 
+	/**
+	 * ID of the first user.
+	 *
+	 * @var int
+	 */
+	public static $user_id_1;
+
+	/**
+	 * ID of the second user.
+	 *
+	 * @var int
+	 */
+	public static $user_id_2;
+
+	/**
+	 * Set up the shared fixture.
+	 *
+	 * @param WP_UnitTest_Factory $factory Factory instance.
+	 */
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$user_id_1 = $factory->user->create();
+		self::$user_id_2 = $factory->user->create();
+	}
+
 	public function test_post_type_post() {
 		$maybe_string = get_posts_by_author_sql( 'post' );
 		$this->assertStringContainsString( "post_type = 'post'", $maybe_string );
@@ -59,7 +83,7 @@ class Tests_Post_GetPostsByAuthorSql extends WP_UnitTestCase {
 
 	public function test_public_only_true_should_not_allow_any_private_posts_for_loggedin_user() {
 		$current_user = get_current_user_id();
-		$u            = self::factory()->user->create();
+		$u            = self::$user_id_1;
 		wp_set_current_user( $u );
 
 		$maybe_string = get_posts_by_author_sql( 'post', true, $u, true );
@@ -70,7 +94,7 @@ class Tests_Post_GetPostsByAuthorSql extends WP_UnitTestCase {
 
 	public function test_public_only_should_default_to_false() {
 		$current_user = get_current_user_id();
-		$u            = self::factory()->user->create();
+		$u            = self::$user_id_1;
 		wp_set_current_user( $u );
 
 		$this->assertSame( get_posts_by_author_sql( 'post', true, $u, false ), get_posts_by_author_sql( 'post', true, $u ) );
@@ -80,7 +104,7 @@ class Tests_Post_GetPostsByAuthorSql extends WP_UnitTestCase {
 
 	public function test_public_only_false_should_allow_current_user_access_to_own_private_posts_when_current_user_matches_post_author() {
 		$current_user = get_current_user_id();
-		$u            = self::factory()->user->create();
+		$u            = self::$user_id_1;
 		wp_set_current_user( $u );
 
 		$maybe_string = get_posts_by_author_sql( 'post', true, $u, false );
@@ -91,8 +115,8 @@ class Tests_Post_GetPostsByAuthorSql extends WP_UnitTestCase {
 
 	public function test_public_only_false_should_not_allow_access_to_private_posts_if_current_user_is_not_post_author() {
 		$current_user = get_current_user_id();
-		$u1           = self::factory()->user->create();
-		$u2           = self::factory()->user->create();
+		$u1           = self::$user_id_1;
+		$u2           = self::$user_id_2;
 		wp_set_current_user( $u1 );
 
 		$maybe_string = get_posts_by_author_sql( 'post', true, $u2, false );
@@ -103,7 +127,7 @@ class Tests_Post_GetPostsByAuthorSql extends WP_UnitTestCase {
 
 	public function test_public_only_false_should_allow_current_user_access_to_own_private_posts_when_post_author_is_not_provided() {
 		$current_user = get_current_user_id();
-		$u            = self::factory()->user->create();
+		$u            = self::$user_id_1;
 		wp_set_current_user( $u );
 
 		$maybe_string = get_posts_by_author_sql( 'post', true, $u, false );

--- a/tests/phpunit/tests/query/conditionals.php
+++ b/tests/phpunit/tests/query/conditionals.php
@@ -14,6 +14,22 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 	protected $page_ids;
 	protected $post_ids;
 
+	/**
+	 * ID of the user-a.
+	 *
+	 * @var int
+	 */
+	public static $user_a_id;
+
+	/**
+	 * Set up the shared fixture.
+	 *
+	 * @param WP_UnitTest_Factory $factory Factory instance.
+	 */
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$user_a_id = $factory->user->create( array( 'user_login' => 'user-a' ) );
+	}
+
 	public function set_up() {
 		parent::set_up();
 
@@ -588,7 +604,6 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 	// 'author/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$' => 'index.php?author_name=$matches[1]&feed=$matches[2]',
 	// 'author/([^/]+)/(feed|rdf|rss|rss2|atom)/?$' => 'index.php?author_name=$matches[1]&feed=$matches[2]',
 	public function test_author_feed() {
-		self::factory()->user->create( array( 'user_login' => 'user-a' ) );
 		// Check the long form.
 		$types = array( 'feed', 'rdf', 'rss', 'rss2', 'atom' );
 		foreach ( $types as $type ) {
@@ -607,7 +622,7 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 	// 'author/([^/]+)/page/?([0-9]{1,})/?$' => 'index.php?author_name=$matches[1]&paged=$matches[2]',
 	public function test_author_paged() {
 		update_option( 'posts_per_page', 2 );
-		$user_id = self::factory()->user->create( array( 'user_login' => 'user-a' ) );
+		$user_id = self::$user_a_id;
 		self::factory()->post->create_many( 3, array( 'post_author' => $user_id ) );
 		$this->go_to( '/author/user-a/page/2/' );
 		$this->assertQueryTrue( 'is_archive', 'is_author', 'is_paged' );
@@ -615,14 +630,13 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 
 	// 'author/([^/]+)/?$' => 'index.php?author_name=$matches[1]',
 	public function test_author() {
-		$user_id = self::factory()->user->create( array( 'user_login' => 'user-a' ) );
+		$user_id = self::$user_a_id;
 		self::factory()->post->create( array( 'post_author' => $user_id ) );
 		$this->go_to( '/author/user-a/' );
 		$this->assertQueryTrue( 'is_archive', 'is_author' );
 	}
 
 	public function test_author_with_no_posts() {
-		$user_id = self::factory()->user->create( array( 'user_login' => 'user-a' ) );
 		$this->go_to( '/author/user-a/' );
 		$this->assertQueryTrue( 'is_archive', 'is_author' );
 	}
@@ -1122,7 +1136,7 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 	 * @ticket 24674
 	 */
 	public function test_is_author_with_nicename_that_begins_with_a_number_that_clashes_with_another_author_id() {
-		$u1 = self::factory()->user->create();
+		$u1 = self::$user_a_id;
 
 		$u2_name = $u1 . '_user';
 		$u2      = self::factory()->user->create(
@@ -1279,7 +1293,7 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 		global $wpdb;
 
 		// We need a non-post that shares an ID with a post assigned a template.
-		$user_id = self::factory()->user->create();
+		$user_id = self::$user_a_id;
 		if ( ! get_post( $user_id ) ) {
 			$post_id = self::factory()->post->create( array( 'post_type' => 'post' ) );
 			$wpdb->update( $wpdb->posts, array( 'ID' => $user_id ), array( 'ID' => $post_id ), array( '%d' ) );
@@ -1352,12 +1366,7 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 	 * @ticket 35902
 	 */
 	public function test_is_author_should_not_match_numeric_id_to_nickname_beginning_with_id() {
-		$u1 = self::factory()->user->create(
-			array(
-				'nickname'      => 'Foo',
-				'user_nicename' => 'foo',
-			)
-		);
+		$u1 = self::$user_a_id;
 		$u2 = self::factory()->user->create(
 			array(
 				'nickname'      => "$u1 Foo",
@@ -1375,12 +1384,7 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 	 * @ticket 35902
 	 */
 	public function test_is_author_should_not_match_numeric_id_to_user_nicename_beginning_with_id() {
-		$u1 = self::factory()->user->create(
-			array(
-				'nickname'      => 'Foo',
-				'user_nicename' => 'foo',
-			)
-		);
+		$u1 = self::$user_a_id;
 		$u2 = self::factory()->user->create(
 			array(
 				'nickname'      => 'Foo',

--- a/tests/phpunit/tests/taxonomy.php
+++ b/tests/phpunit/tests/taxonomy.php
@@ -4,6 +4,18 @@
  * @group taxonomy
  */
 class Tests_Taxonomy extends WP_UnitTestCase {
+
+	/**
+	 * Editor user ID.
+	 *
+	 * @var int $editor_id
+	 */
+	public static $editor_id;
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$editor_id = $factory->user->create( array( 'role' => 'editor' ) );
+	}
+
 	public function test_get_post_taxonomies() {
 		$this->assertSame( array( 'category', 'post_tag', 'post_format' ), get_object_taxonomies( 'post' ) );
 	}
@@ -1002,7 +1014,7 @@ class Tests_Taxonomy extends WP_UnitTestCase {
 			)
 		);
 
-		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+		wp_set_current_user( self::$editor_id );
 		$updated_post_id = edit_post(
 			array(
 				'post_ID'   => $post->ID,
@@ -1028,7 +1040,7 @@ class Tests_Taxonomy extends WP_UnitTestCase {
 	 */
 	public function test_default_term_for_custom_taxonomy() {
 
-		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+		wp_set_current_user( self::$editor_id );
 
 		$tax = 'custom-tax';
 

--- a/tests/phpunit/tests/url.php
+++ b/tests/phpunit/tests/url.php
@@ -7,6 +7,17 @@
  */
 class Tests_URL extends WP_UnitTestCase {
 
+	/**
+	 * Author user ID.
+	 *
+	 * @var int $author_id
+	 */
+	public static $author_id;
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$author_id = $factory->user->create( array( 'role' => 'author' ) );
+	}
+
 	public function set_up() {
 		parent::set_up();
 		$GLOBALS['pagenow'] = '';
@@ -386,7 +397,7 @@ class Tests_URL extends WP_UnitTestCase {
 	 * @covers ::get_adjacent_post
 	 */
 	public function test_get_adjacent_post_should_return_private_posts_belonging_to_the_current_user() {
-		$u       = self::factory()->user->create( array( 'role' => 'author' ) );
+		$u       = self::$author_id;
 		$old_uid = get_current_user_id();
 		wp_set_current_user( $u );
 
@@ -425,7 +436,7 @@ class Tests_URL extends WP_UnitTestCase {
 	 * @covers ::get_adjacent_post
 	 */
 	public function test_get_adjacent_post_should_return_private_posts_belonging_to_other_users_if_the_current_user_can_read_private_posts() {
-		$u1      = self::factory()->user->create( array( 'role' => 'author' ) );
+		$u1      = self::$author_id;
 		$u2      = self::factory()->user->create( array( 'role' => 'administrator' ) );
 		$old_uid = get_current_user_id();
 		wp_set_current_user( $u2 );
@@ -465,7 +476,7 @@ class Tests_URL extends WP_UnitTestCase {
 	 * @covers ::get_adjacent_post
 	 */
 	public function test_get_adjacent_post_should_not_return_private_posts_belonging_to_other_users_if_the_current_user_cannot_read_private_posts() {
-		$u1      = self::factory()->user->create( array( 'role' => 'author' ) );
+		$u1      = self::$author_id;
 		$u2      = self::factory()->user->create( array( 'role' => 'author' ) );
 		$old_uid = get_current_user_id();
 		wp_set_current_user( $u2 );

--- a/tests/phpunit/tests/user.php
+++ b/tests/phpunit/tests/user.php
@@ -1083,7 +1083,7 @@ class Tests_User extends WP_UnitTestCase {
 	 * @ticket 35750
 	 */
 	public function test_wp_update_user_should_delete_userslugs_cache() {
-		$u    = self::factory()->user->create();
+		$u    = self::$sub_id;
 		$user = get_userdata( $u );
 
 		wp_update_user(
@@ -1939,11 +1939,7 @@ class Tests_User extends WP_UnitTestCase {
 		$_GET     = array();
 		$_REQUEST = array();
 
-		$administrator = self::factory()->user->create(
-			array(
-				'role' => 'administrator',
-			)
-		);
+		$administrator = self::$admin_id;
 
 		wp_set_current_user( $administrator );
 
@@ -1957,11 +1953,7 @@ class Tests_User extends WP_UnitTestCase {
 		$this->assertSame( array( 'administrator' ), get_userdata( $administrator )->roles );
 
 		// Promote an editor to an administrator.
-		$editor = self::factory()->user->create(
-			array(
-				'role' => 'editor',
-			)
-		);
+		$editor = self::$editor_id;
 
 		$_POST['role']     = 'administrator';
 		$_POST['email']    = 'administrator@administrator.test';


### PR DESCRIPTION
6.8 branched on 2025-03-25, before [60253] and [60298] landed on trunk under [#63026](https://core.trac.wordpress.org/ticket/63026), so it's the only branch that ships bcrypt password hashing without the accompanying test suite cost reductions. 6.7 and earlier predate bcrypt; 6.9 and later inherited both changesets.

Every PHP version pays for it. Median job duration, run 31596990187 on 6.8 against run 31600298705 on 6.9, an hour apart on matrices of the same size:

| PHP | 6.8 | 6.9 |
|---|---|---|
| 7.2 | 818s | 754s |
| 7.4 | 807s | 768s |
| 8.0 | 825s | 752s |
| 8.3 | 855s | 790s |

PHP 8.4 is worse again, because it raised the default bcrypt cost from 10 to 12 while [60298] pins the test cost to 5. On `PHP 8.4 / MySQL 8.4 example.org:8889`, the one job name common to both branches, the `Run PHPUnit tests` step takes 999s on 6.8 and 701s on 6.9. That job is left out of the table above because 6.9 runs PHP 8.4 only on the two `example.org:8889` variants, so a median would compare 26 jobs against 2.

That tail is what breaks the run. Three jobs exceeded `timeout-minutes` and were cancelled, which dispatched `failed-workflow.yml` and reran the run, for 51m18s of wall clock against 18m32s for 6.9. p90 was 1134s against 829s.

This merges both trunk changes so 6.8's suite matches 6.9's:

- [[60253]](https://core.trac.wordpress.org/changeset/60253), developed in #8657, moves per-test user creation into shared fixtures. Users created in `wpSetUpBeforeClass` hash at PHP's full default cost, since the cost filter is registered in `set_up()`.
- [[60298]](https://core.trac.wordpress.org/changeset/60298), developed in #8453, pins the bcrypt cost to 5 for the hashes that filter does cover.

Both applied without conflict.

Two things for review:

`reduce_hash_cost()` now produces cost 4, PHP's minimum, which is why the pinned cost is 5 and not 4.

[60253] touches 28 test files that have had 16 months to drift on this branch. The merge was clean, but that only means the text lined up. The CI run on this PR is the real check, and breakage would most likely show as order dependence in the customize and meta suites.

Trac ticket: https://core.trac.wordpress.org/ticket/65861

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
