### PR TITLE
52220 - Fixed displaying posts from first week of year

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -7171,6 +7171,11 @@ function send_nosniff_header() {
 
 /**
  * Returns a MySQL expression for selecting the week number based on the start_of_week option.
+ * @ticket 52220 - Former used MySQL::WEEK modes 0 and 1 changed to 2 and 3 respectively.
+ * Modes 0 and 1 return weeks numbers from 0 to 53, while modes 2 and 3 return week numbers from 1 to 53 which is corresponds to our documentation:
+ * https://github.com/WordPress/wordpress-develop/blob/de2572b1da20f0fe6f53eebd6b8bf10ae066dd2f/src/wp-includes/class-wp-query.php#L807
+ * Also, WP ignores GET parameter w=0 and didn't allow to select posts from the first week (w=0) of the year correctly with 0 and 1 used modes.
+ * Modes 2 and 3 fix this issue and allow to select posts from the first week of the year correctly.
  *
  * @ignore
  * @since 3.0.0
@@ -7182,16 +7187,16 @@ function _wp_mysql_week( $column ) {
 	$start_of_week = (int) get_option( 'start_of_week' );
 	switch ( $start_of_week ) {
 		case 1:
-			return "WEEK( $column, 1 )";
+			return "WEEK( $column, 3 )";
 		case 2:
 		case 3:
 		case 4:
 		case 5:
 		case 6:
-			return "WEEK( DATE_SUB( $column, INTERVAL $start_of_week DAY ), 0 )";
+			return "WEEK( DATE_SUB( $column, INTERVAL $start_of_week DAY ), 2 )";
 		case 0:
 		default:
-			return "WEEK( $column, 0 )";
+			return "WEEK( $column, 2 )";
 	}
 }
 

--- a/tests/phpunit/tests/functions/wpMysqlWeek.php
+++ b/tests/phpunit/tests/functions/wpMysqlWeek.php
@@ -31,14 +31,14 @@ class Tests_Functions_WpMysqlWeek extends WP_UnitTestCase {
 	 */
 	public function data_wp_mysql_week() {
 		return array(
-			array( '1969-12-25', 0, 'WEEK( col_name, 0 )' ),
-			array( '1969-12-25', 1, 'WEEK( col_name, 1 )' ),
-			array( '1969-12-25', 2, 'WEEK( DATE_SUB( col_name, INTERVAL 2 DAY ), 0 )' ),
-			array( '1969-12-25', 3, 'WEEK( DATE_SUB( col_name, INTERVAL 3 DAY ), 0 )' ),
-			array( '1969-12-25', 4, 'WEEK( DATE_SUB( col_name, INTERVAL 4 DAY ), 0 )' ),
-			array( '1969-12-25', 5, 'WEEK( DATE_SUB( col_name, INTERVAL 5 DAY ), 0 )' ),
-			array( '1969-12-25', 6, 'WEEK( DATE_SUB( col_name, INTERVAL 6 DAY ), 0 )' ),
-			array( '1969-12-25', 9, 'WEEK( col_name, 0 )' ),
+			array( '1969-12-25', 0, 'WEEK( col_name, 2 )' ),
+			array( '1969-12-25', 1, 'WEEK( col_name, 3 )' ),
+			array( '1969-12-25', 2, 'WEEK( DATE_SUB( col_name, INTERVAL 2 DAY ), 2 )' ),
+			array( '1969-12-25', 3, 'WEEK( DATE_SUB( col_name, INTERVAL 3 DAY ), 2 )' ),
+			array( '1969-12-25', 4, 'WEEK( DATE_SUB( col_name, INTERVAL 4 DAY ), 2 )' ),
+			array( '1969-12-25', 5, 'WEEK( DATE_SUB( col_name, INTERVAL 5 DAY ), 2 )' ),
+			array( '1969-12-25', 6, 'WEEK( DATE_SUB( col_name, INTERVAL 6 DAY ), 2 )' ),
+			array( '1969-12-25', 9, 'WEEK( col_name, 2 )' ),
 		);
 	}
 }

--- a/tests/phpunit/tests/query/dateQuery.php
+++ b/tests/phpunit/tests/query/dateQuery.php
@@ -953,8 +953,8 @@ class Tests_Query_DateQuery extends WP_UnitTestCase {
 
 		$this->assertSame( array( $p2 ), wp_list_pluck( $posts, 'ID' ) );
 
-		$this->assertStringContainsString( "WEEK( $wpdb->posts.post_date, 1 ) = 43", $this->q->request );
-		$this->assertStringNotContainsString( "WEEK( $wpdb->posts.post_date, 1 ) = 42", $this->q->request );
+		$this->assertStringContainsString( "WEEK( $wpdb->posts.post_date, 3 ) = 43", $this->q->request );
+		$this->assertStringNotContainsString( "WEEK( $wpdb->posts.post_date, 3 ) = 42", $this->q->request );
 	}
 
 	/**


### PR DESCRIPTION
Posts frow the first week of the year will be selected from DB correctly

Trac ticket: [52220](https://core.trac.wordpress.org/ticket/52220)

## Use of AI Tools
AI assistance: No

