### PR TITLE
Rewrite Rules: Add opt-in support for random content redirects.

### DIFF
--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -489,6 +489,9 @@ add_action( 'attachment_updated', 'wp_check_for_changed_slugs', 12, 3 );
 add_action( 'post_updated', 'wp_check_for_changed_dates', 12, 3 );
 add_action( 'attachment_updated', 'wp_check_for_changed_dates', 12, 3 );
 
+// Redirect random content requests (disabled by default, see 'enable_random_content_redirect').
+add_action( 'template_redirect', 'wp_random_content_redirect' );
+
 // Nonce check for post previews.
 add_action( 'init', '_show_post_preview' );
 

--- a/src/wp-includes/query.php
+++ b/src/wp-includes/query.php
@@ -1251,6 +1251,11 @@ function _find_post_by_old_date( $post_type ) {
  * @since 7.2.0
  */
 function wp_random_content_redirect() {
+	// The `random` parameter is a flag, present with or without a value.
+	if ( ! isset( $_GET['random'] ) ) {
+		return;
+	}
+
 	/**
 	 * Filters whether random content redirects are enabled.
 	 *
@@ -1262,12 +1267,7 @@ function wp_random_content_redirect() {
 		return;
 	}
 
-	// The `random` parameter is a flag, present with or without a value.
-	if ( ! isset( $_GET['random'] ) ) {
-		return;
-	}
-
-	if ( isset( $_SERVER['REQUEST_METHOD'] ) && ! in_array( $_SERVER['REQUEST_METHOD'], array( 'GET', 'HEAD' ), true ) ) {
+	if ( isset( $_SERVER['REQUEST_METHOD'] ) && ! in_array( strtoupper( $_SERVER['REQUEST_METHOD'] ), array( 'GET', 'HEAD' ), true ) ) {
 		return;
 	}
 
@@ -1275,21 +1275,24 @@ function wp_random_content_redirect() {
 
 	if ( isset( $_GET['random_post_type'] ) ) {
 		$post_type = sanitize_key( wp_unslash( $_GET['random_post_type'] ) );
+	}
 
-		if ( ! post_type_exists( $post_type ) || ! is_post_type_viewable( $post_type ) ) {
-			return;
-		}
+	$post_type_object = get_post_type_object( $post_type );
+
+	if ( ! $post_type_object || ! is_post_type_viewable( $post_type_object ) ) {
+		return;
 	}
 
 	$args = array(
-		'post_type'           => $post_type,
-		'post_status'         => 'publish',
-		'has_password'        => false,
-		'fields'              => 'ids',
-		'posts_per_page'      => 1,
-		'orderby'             => 'ID',
-		'order'               => 'ASC',
-		'ignore_sticky_posts' => true,
+		'post_type'              => $post_type,
+		'post_status'            => 'publish',
+		'has_password'           => false,
+		'posts_per_page'         => 1,
+		'orderby'                => 'ID',
+		'order'                  => 'ASC',
+		'ignore_sticky_posts'    => true,
+		'update_post_term_cache' => false,
+		'update_post_meta_cache' => false,
 	);
 
 	if ( isset( $_GET['random_cat_id'] ) ) {
@@ -1307,15 +1310,16 @@ function wp_random_content_redirect() {
 	$query      = new WP_Query( $args );
 	$post_count = (int) $query->found_posts;
 
-	if ( $post_count < 1 ) {
-		return;
-	}
-
 	if ( $post_count > 1 ) {
-		$args['offset']        = wp_rand( 0, $post_count - 1 );
-		$args['no_found_rows'] = true;
+		$offset = wp_rand( 0, $post_count - 1 );
 
-		$query = new WP_Query( $args );
+		if ( $offset > 0 ) {
+			$args['offset']        = $offset;
+			$args['no_found_rows'] = true;
+			$args['cache_results'] = false;
+
+			$query = new WP_Query( $args );
+		}
 	}
 
 	if ( empty( $query->posts ) ) {

--- a/src/wp-includes/query.php
+++ b/src/wp-includes/query.php
@@ -1236,6 +1236,115 @@ function _find_post_by_old_date( $post_type ) {
 }
 
 /**
+ * Redirects requests for random content to a randomly selected published post.
+ *
+ * Handles requests using the `random` query parameter, e.g. `example.com/?random`.
+ * The `random_post_type` parameter restricts the pick to a post type (default `post`),
+ * and the `random_cat_id` parameter restricts it to a category (for post types using
+ * the `category` taxonomy). Only published, non-password-protected content from
+ * viewable post types is considered, and only GET/HEAD requests are handled.
+ *
+ * Disabled by default. To enable:
+ *
+ *     add_filter( 'enable_random_content_redirect', '__return_true' );
+ *
+ * @since 7.2.0
+ */
+function wp_random_content_redirect() {
+	/**
+	 * Filters whether random content redirects are enabled.
+	 *
+	 * @since 7.2.0
+	 *
+	 * @param bool $enabled Whether `?random` requests redirect to random content. Default false.
+	 */
+	if ( ! apply_filters( 'enable_random_content_redirect', false ) ) {
+		return;
+	}
+
+	// The `random` parameter is a flag, present with or without a value.
+	if ( ! isset( $_GET['random'] ) ) {
+		return;
+	}
+
+	if ( isset( $_SERVER['REQUEST_METHOD'] ) && ! in_array( $_SERVER['REQUEST_METHOD'], array( 'GET', 'HEAD' ), true ) ) {
+		return;
+	}
+
+	$post_type = 'post';
+
+	if ( isset( $_GET['random_post_type'] ) ) {
+		$post_type = sanitize_key( wp_unslash( $_GET['random_post_type'] ) );
+
+		if ( ! post_type_exists( $post_type ) || ! is_post_type_viewable( $post_type ) ) {
+			return;
+		}
+	}
+
+	$args = array(
+		'post_type'           => $post_type,
+		'post_status'         => 'publish',
+		'has_password'        => false,
+		'fields'              => 'ids',
+		'posts_per_page'      => 1,
+		'orderby'             => 'ID',
+		'order'               => 'ASC',
+		'ignore_sticky_posts' => true,
+	);
+
+	if ( isset( $_GET['random_cat_id'] ) ) {
+		$cat_id = absint( wp_unslash( $_GET['random_cat_id'] ) );
+
+		if ( $cat_id < 1 ) {
+			return;
+		}
+
+		$args['cat'] = $cat_id;
+	}
+
+	// Pick via COUNT plus a random OFFSET rather than `ORDER BY RAND()`,
+	// which randomizes and sorts every candidate row on each request.
+	$query      = new WP_Query( $args );
+	$post_count = (int) $query->found_posts;
+
+	if ( $post_count < 1 ) {
+		return;
+	}
+
+	if ( $post_count > 1 ) {
+		$args['offset']        = wp_rand( 0, $post_count - 1 );
+		$args['no_found_rows'] = true;
+
+		$query = new WP_Query( $args );
+	}
+
+	if ( empty( $query->posts ) ) {
+		return;
+	}
+
+	$link = get_permalink( $query->posts[0] );
+
+	/**
+	 * Filters the random content redirect URL.
+	 *
+	 * Returning a falsey value cancels the redirect.
+	 *
+	 * @since 7.2.0
+	 *
+	 * @param string $link The redirect URL.
+	 */
+	$link = apply_filters( 'random_content_redirect_url', $link );
+
+	if ( ! $link ) {
+		return;
+	}
+
+	// Temporary redirect, so clients do not cache the randomly picked target.
+	wp_safe_redirect( $link, 302 );
+	exit;
+}
+
+/**
  * Set up global post data.
  *
  * @since 1.5.0

--- a/src/wp-includes/query.php
+++ b/src/wp-includes/query.php
@@ -1267,7 +1267,9 @@ function wp_random_content_redirect() {
 		return;
 	}
 
-	if ( isset( $_SERVER['REQUEST_METHOD'] ) && ! in_array( strtoupper( $_SERVER['REQUEST_METHOD'] ), array( 'GET', 'HEAD' ), true ) ) {
+	$request_method = isset( $_SERVER['REQUEST_METHOD'] ) ? strtoupper( $_SERVER['REQUEST_METHOD'] ) : '';
+
+	if ( ! in_array( $request_method, array( 'GET', 'HEAD' ), true ) ) {
 		return;
 	}
 
@@ -1296,7 +1298,7 @@ function wp_random_content_redirect() {
 	);
 
 	if ( isset( $_GET['random_cat_id'] ) ) {
-		$cat_id = absint( wp_unslash( $_GET['random_cat_id'] ) );
+		$cat_id = (int) wp_unslash( $_GET['random_cat_id'] );
 
 		if ( $cat_id < 1 ) {
 			return;
@@ -1343,7 +1345,8 @@ function wp_random_content_redirect() {
 		return;
 	}
 
-	// Temporary redirect, so clients do not cache the randomly picked target.
+	// Temporary redirect, so clients and intermediary caches do not cache the randomly picked target.
+	nocache_headers();
 	wp_safe_redirect( $link, 302 );
 	exit;
 }

--- a/tests/phpunit/tests/rewrite/randomContentRedirect.php
+++ b/tests/phpunit/tests/rewrite/randomContentRedirect.php
@@ -8,32 +8,13 @@
 class Tests_Rewrite_RandomContentRedirect extends WP_UnitTestCase {
 	protected $random_content_redirect_url;
 
-	protected $original_request_method;
-
 	public function set_up() {
 		parent::set_up();
 
 		add_filter( 'enable_random_content_redirect', '__return_true' );
-		add_filter( 'random_content_redirect_url', array( $this, 'filter_random_content_redirect_url' ), 10, 1 );
+		add_filter( 'random_content_redirect_url', array( $this, 'filter_random_content_redirect_url' ) );
 
-		$this->original_request_method = isset( $_SERVER['REQUEST_METHOD'] ) ? $_SERVER['REQUEST_METHOD'] : null;
-
-		$_GET['random']            = '';
-		$_SERVER['REQUEST_METHOD'] = 'GET';
-	}
-
-	public function tear_down() {
-		$this->random_content_redirect_url = null;
-
-		unset( $_GET['random'], $_GET['random_post_type'], $_GET['random_cat_id'] );
-
-		if ( null === $this->original_request_method ) {
-			unset( $_SERVER['REQUEST_METHOD'] );
-		} else {
-			$_SERVER['REQUEST_METHOD'] = $this->original_request_method;
-		}
-
-		parent::tear_down();
+		$_GET['random'] = '';
 	}
 
 	public function test_hook_is_registered() {

--- a/tests/phpunit/tests/rewrite/randomContentRedirect.php
+++ b/tests/phpunit/tests/rewrite/randomContentRedirect.php
@@ -11,10 +11,14 @@ class Tests_Rewrite_RandomContentRedirect extends WP_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 
-		add_filter( 'enable_random_content_redirect', '__return_true' );
 		add_filter( 'random_content_redirect_url', array( $this, 'filter_random_content_redirect_url' ) );
 
 		$_GET['random'] = '';
+	}
+
+	public function filter_random_content_redirect_url( $url ) {
+		$this->random_content_redirect_url = $url;
+		return false;
 	}
 
 	public function test_hook_is_registered() {
@@ -22,8 +26,6 @@ class Tests_Rewrite_RandomContentRedirect extends WP_UnitTestCase {
 	}
 
 	public function test_disabled_by_default() {
-		remove_filter( 'enable_random_content_redirect', '__return_true' );
-
 		self::factory()->post->create();
 
 		wp_random_content_redirect();
@@ -31,6 +33,8 @@ class Tests_Rewrite_RandomContentRedirect extends WP_UnitTestCase {
 	}
 
 	public function test_no_random_parameter_does_not_redirect() {
+		add_filter( 'enable_random_content_redirect', '__return_true' );
+
 		unset( $_GET['random'] );
 
 		self::factory()->post->create();
@@ -40,6 +44,8 @@ class Tests_Rewrite_RandomContentRedirect extends WP_UnitTestCase {
 	}
 
 	public function test_redirects_to_a_published_post() {
+		add_filter( 'enable_random_content_redirect', '__return_true' );
+
 		$post_ids = self::factory()->post->create_many( 3 );
 
 		wp_random_content_redirect();
@@ -47,6 +53,8 @@ class Tests_Rewrite_RandomContentRedirect extends WP_UnitTestCase {
 	}
 
 	public function test_post_request_does_not_redirect() {
+		add_filter( 'enable_random_content_redirect', '__return_true' );
+
 		$_SERVER['REQUEST_METHOD'] = 'POST';
 
 		self::factory()->post->create();
@@ -55,7 +63,20 @@ class Tests_Rewrite_RandomContentRedirect extends WP_UnitTestCase {
 		$this->assertNull( $this->random_content_redirect_url );
 	}
 
+	public function test_unset_request_method_does_not_redirect() {
+		add_filter( 'enable_random_content_redirect', '__return_true' );
+
+		unset( $_SERVER['REQUEST_METHOD'] );
+
+		self::factory()->post->create();
+
+		wp_random_content_redirect();
+		$this->assertNull( $this->random_content_redirect_url );
+	}
+
 	public function test_head_request_redirects() {
+		add_filter( 'enable_random_content_redirect', '__return_true' );
+
 		$_SERVER['REQUEST_METHOD'] = 'HEAD';
 
 		$post_id = self::factory()->post->create();
@@ -65,6 +86,8 @@ class Tests_Rewrite_RandomContentRedirect extends WP_UnitTestCase {
 	}
 
 	public function test_excludes_password_protected_posts() {
+		add_filter( 'enable_random_content_redirect', '__return_true' );
+
 		$public_id = self::factory()->post->create();
 		self::factory()->post->create_many( 2, array( 'post_password' => 'secret' ) );
 
@@ -73,6 +96,8 @@ class Tests_Rewrite_RandomContentRedirect extends WP_UnitTestCase {
 	}
 
 	public function test_excludes_unpublished_posts() {
+		add_filter( 'enable_random_content_redirect', '__return_true' );
+
 		$public_id = self::factory()->post->create();
 		self::factory()->post->create( array( 'post_status' => 'draft' ) );
 		self::factory()->post->create( array( 'post_status' => 'private' ) );
@@ -82,6 +107,8 @@ class Tests_Rewrite_RandomContentRedirect extends WP_UnitTestCase {
 	}
 
 	public function test_random_post_type_parameter() {
+		add_filter( 'enable_random_content_redirect', '__return_true' );
+
 		self::factory()->post->create();
 		$page_id = self::factory()->post->create( array( 'post_type' => 'page' ) );
 
@@ -92,6 +119,8 @@ class Tests_Rewrite_RandomContentRedirect extends WP_UnitTestCase {
 	}
 
 	public function test_invalid_post_type_does_not_redirect() {
+		add_filter( 'enable_random_content_redirect', '__return_true' );
+
 		self::factory()->post->create();
 
 		$_GET['random_post_type'] = 'nonexistent_type';
@@ -101,6 +130,8 @@ class Tests_Rewrite_RandomContentRedirect extends WP_UnitTestCase {
 	}
 
 	public function test_non_viewable_post_type_does_not_redirect() {
+		add_filter( 'enable_random_content_redirect', '__return_true' );
+
 		register_post_type( 'wptests_hidden', array( 'public' => false ) );
 
 		self::factory()->post->create();
@@ -113,6 +144,8 @@ class Tests_Rewrite_RandomContentRedirect extends WP_UnitTestCase {
 	}
 
 	public function test_random_cat_id_parameter() {
+		add_filter( 'enable_random_content_redirect', '__return_true' );
+
 		$cat_id    = self::factory()->category->create();
 		$in_cat_id = self::factory()->post->create( array( 'post_category' => array( $cat_id ) ) );
 		self::factory()->post->create_many( 3 );
@@ -124,6 +157,8 @@ class Tests_Rewrite_RandomContentRedirect extends WP_UnitTestCase {
 	}
 
 	public function test_nonexistent_category_does_not_redirect() {
+		add_filter( 'enable_random_content_redirect', '__return_true' );
+
 		self::factory()->post->create();
 
 		$_GET['random_cat_id'] = '99999';
@@ -138,6 +173,8 @@ class Tests_Rewrite_RandomContentRedirect extends WP_UnitTestCase {
 	 * @param string $cat_id Invalid category ID value.
 	 */
 	public function test_invalid_category_id_does_not_redirect( $cat_id ) {
+		add_filter( 'enable_random_content_redirect', '__return_true' );
+
 		self::factory()->post->create();
 
 		$_GET['random_cat_id'] = $cat_id;
@@ -149,12 +186,25 @@ class Tests_Rewrite_RandomContentRedirect extends WP_UnitTestCase {
 	public function data_invalid_category_ids() {
 		return array(
 			'zero'        => array( '0' ),
-			'negative'    => array( '-5' ),
 			'non-numeric' => array( 'foo' ),
 		);
 	}
 
+	public function test_negated_category_id_of_existing_category_does_not_redirect() {
+		add_filter( 'enable_random_content_redirect', '__return_true' );
+
+		$cat_id = self::factory()->category->create();
+		self::factory()->post->create( array( 'post_category' => array( $cat_id ) ) );
+
+		$_GET['random_cat_id'] = (string) ( -$cat_id );
+
+		wp_random_content_redirect();
+		$this->assertNull( $this->random_content_redirect_url );
+	}
+
 	public function test_redirect_url_is_filterable() {
+		add_filter( 'enable_random_content_redirect', '__return_true' );
+
 		self::factory()->post->create();
 
 		add_filter(
@@ -170,19 +220,18 @@ class Tests_Rewrite_RandomContentRedirect extends WP_UnitTestCase {
 	}
 
 	public function test_no_posts_does_not_redirect() {
+		add_filter( 'enable_random_content_redirect', '__return_true' );
+
 		wp_random_content_redirect();
 		$this->assertNull( $this->random_content_redirect_url );
 	}
 
 	public function test_single_post_redirects_to_it() {
+		add_filter( 'enable_random_content_redirect', '__return_true' );
+
 		$post_id = self::factory()->post->create();
 
 		wp_random_content_redirect();
 		$this->assertSame( get_permalink( $post_id ), $this->random_content_redirect_url );
-	}
-
-	public function filter_random_content_redirect_url( $url ) {
-		$this->random_content_redirect_url = $url;
-		return false;
 	}
 }

--- a/tests/phpunit/tests/rewrite/randomContentRedirect.php
+++ b/tests/phpunit/tests/rewrite/randomContentRedirect.php
@@ -1,0 +1,207 @@
+<?php
+
+/**
+ * @group rewrite
+ * @ticket 64498
+ * @covers wp_random_content_redirect
+ */
+class Tests_Rewrite_RandomContentRedirect extends WP_UnitTestCase {
+	protected $random_content_redirect_url;
+
+	protected $original_request_method;
+
+	public function set_up() {
+		parent::set_up();
+
+		add_filter( 'enable_random_content_redirect', '__return_true' );
+		add_filter( 'random_content_redirect_url', array( $this, 'filter_random_content_redirect_url' ), 10, 1 );
+
+		$this->original_request_method = isset( $_SERVER['REQUEST_METHOD'] ) ? $_SERVER['REQUEST_METHOD'] : null;
+
+		$_GET['random']            = '';
+		$_SERVER['REQUEST_METHOD'] = 'GET';
+	}
+
+	public function tear_down() {
+		$this->random_content_redirect_url = null;
+
+		unset( $_GET['random'], $_GET['random_post_type'], $_GET['random_cat_id'] );
+
+		if ( null === $this->original_request_method ) {
+			unset( $_SERVER['REQUEST_METHOD'] );
+		} else {
+			$_SERVER['REQUEST_METHOD'] = $this->original_request_method;
+		}
+
+		parent::tear_down();
+	}
+
+	public function test_hook_is_registered() {
+		$this->assertSame( 10, has_action( 'template_redirect', 'wp_random_content_redirect' ) );
+	}
+
+	public function test_disabled_by_default() {
+		remove_filter( 'enable_random_content_redirect', '__return_true' );
+
+		self::factory()->post->create();
+
+		wp_random_content_redirect();
+		$this->assertNull( $this->random_content_redirect_url );
+	}
+
+	public function test_no_random_parameter_does_not_redirect() {
+		unset( $_GET['random'] );
+
+		self::factory()->post->create();
+
+		wp_random_content_redirect();
+		$this->assertNull( $this->random_content_redirect_url );
+	}
+
+	public function test_redirects_to_a_published_post() {
+		$post_ids = self::factory()->post->create_many( 3 );
+
+		wp_random_content_redirect();
+		$this->assertContains( $this->random_content_redirect_url, array_map( 'get_permalink', $post_ids ) );
+	}
+
+	public function test_post_request_does_not_redirect() {
+		$_SERVER['REQUEST_METHOD'] = 'POST';
+
+		self::factory()->post->create();
+
+		wp_random_content_redirect();
+		$this->assertNull( $this->random_content_redirect_url );
+	}
+
+	public function test_head_request_redirects() {
+		$_SERVER['REQUEST_METHOD'] = 'HEAD';
+
+		$post_id = self::factory()->post->create();
+
+		wp_random_content_redirect();
+		$this->assertSame( get_permalink( $post_id ), $this->random_content_redirect_url );
+	}
+
+	public function test_excludes_password_protected_posts() {
+		$public_id = self::factory()->post->create();
+		self::factory()->post->create_many( 2, array( 'post_password' => 'secret' ) );
+
+		wp_random_content_redirect();
+		$this->assertSame( get_permalink( $public_id ), $this->random_content_redirect_url );
+	}
+
+	public function test_excludes_unpublished_posts() {
+		$public_id = self::factory()->post->create();
+		self::factory()->post->create( array( 'post_status' => 'draft' ) );
+		self::factory()->post->create( array( 'post_status' => 'private' ) );
+
+		wp_random_content_redirect();
+		$this->assertSame( get_permalink( $public_id ), $this->random_content_redirect_url );
+	}
+
+	public function test_random_post_type_parameter() {
+		self::factory()->post->create();
+		$page_id = self::factory()->post->create( array( 'post_type' => 'page' ) );
+
+		$_GET['random_post_type'] = 'page';
+
+		wp_random_content_redirect();
+		$this->assertSame( get_permalink( $page_id ), $this->random_content_redirect_url );
+	}
+
+	public function test_invalid_post_type_does_not_redirect() {
+		self::factory()->post->create();
+
+		$_GET['random_post_type'] = 'nonexistent_type';
+
+		wp_random_content_redirect();
+		$this->assertNull( $this->random_content_redirect_url );
+	}
+
+	public function test_non_viewable_post_type_does_not_redirect() {
+		register_post_type( 'wptests_hidden', array( 'public' => false ) );
+
+		self::factory()->post->create();
+		self::factory()->post->create( array( 'post_type' => 'wptests_hidden' ) );
+
+		$_GET['random_post_type'] = 'wptests_hidden';
+
+		wp_random_content_redirect();
+		$this->assertNull( $this->random_content_redirect_url );
+	}
+
+	public function test_random_cat_id_parameter() {
+		$cat_id    = self::factory()->category->create();
+		$in_cat_id = self::factory()->post->create( array( 'post_category' => array( $cat_id ) ) );
+		self::factory()->post->create_many( 3 );
+
+		$_GET['random_cat_id'] = (string) $cat_id;
+
+		wp_random_content_redirect();
+		$this->assertSame( get_permalink( $in_cat_id ), $this->random_content_redirect_url );
+	}
+
+	public function test_nonexistent_category_does_not_redirect() {
+		self::factory()->post->create();
+
+		$_GET['random_cat_id'] = '99999';
+
+		wp_random_content_redirect();
+		$this->assertNull( $this->random_content_redirect_url );
+	}
+
+	/**
+	 * @dataProvider data_invalid_category_ids
+	 *
+	 * @param string $cat_id Invalid category ID value.
+	 */
+	public function test_invalid_category_id_does_not_redirect( $cat_id ) {
+		self::factory()->post->create();
+
+		$_GET['random_cat_id'] = $cat_id;
+
+		wp_random_content_redirect();
+		$this->assertNull( $this->random_content_redirect_url );
+	}
+
+	public function data_invalid_category_ids() {
+		return array(
+			'zero'        => array( '0' ),
+			'negative'    => array( '-5' ),
+			'non-numeric' => array( 'foo' ),
+		);
+	}
+
+	public function test_redirect_url_is_filterable() {
+		self::factory()->post->create();
+
+		add_filter(
+			'random_content_redirect_url',
+			static function () {
+				return home_url( '/custom-target/' );
+			},
+			9
+		);
+
+		wp_random_content_redirect();
+		$this->assertSame( home_url( '/custom-target/' ), $this->random_content_redirect_url );
+	}
+
+	public function test_no_posts_does_not_redirect() {
+		wp_random_content_redirect();
+		$this->assertNull( $this->random_content_redirect_url );
+	}
+
+	public function test_single_post_redirects_to_it() {
+		$post_id = self::factory()->post->create();
+
+		wp_random_content_redirect();
+		$this->assertSame( get_permalink( $post_id ), $this->random_content_redirect_url );
+	}
+
+	public function filter_random_content_redirect_url( $url ) {
+		$this->random_content_redirect_url = $url;
+		return false;
+	}
+}


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/64498

This PR adds a minimal, opt-in implementation of **random content redirects**

## What it does

* Adds `wp_random_content_redirect()` (in `wp-includes/query.php`, alongside its closest sibling `wp_old_slug_redirect()`), hooked on `template_redirect`.
* When enabled, a request to `example.com/?random` issues a 302 redirect to a randomly selected published post. `?random&random_post_type=page` restricts the pick to a post type (viewable types only); `?random&random_cat_id=<term ID>` restricts it to a category. These parameter names match Matt's original [Random Redirect plugin](https://wordpress.org/plugins/random-redirect/) referenced in the ticket, so existing `?random` links keep working.
* **Disabled by default** — per the ticket's request for an opt-in implementation with no user-facing settings or defaults, nothing happens unless a theme or plugin opts in:

  ```php
  add_filter( 'enable_random_content_redirect', '__return_true' );
  ```

* A second filter, `random_content_redirect_url`, allows short-circuiting or rewriting the redirect target (same pattern as `old_slug_redirect_url`).

## Implementation notes

* The random pick uses a COUNT plus a random OFFSET (two `WP_Query` calls) rather than `ORDER BY RAND()`, which randomizes and sorts every candidate row on each request and is uncached.
* Password-protected and non-published posts are never redirect targets. Non-viewable post types are rejected. Only GET/HEAD requests are handled.
* The redirect is a 302 so clients do not cache the randomly picked target.
* Open question for review: the parameters are read from `$_GET` on `template_redirect`, matching the original plugin's addressing. If pretty-URL support (e.g. a `/random/` rewrite endpoint) is desirable, the parameters should instead become registered query vars — happy to rework in that direction if preferred.

## Tests

`tests/phpunit/tests/rewrite/randomContentRedirect.php` covers: disabled-by-default behavior, no-op without the `random` parameter, redirect to a published post, post type and category restriction, exclusion of password-protected/draft/private posts, invalid and non-viewable post types, nonexistent categories, empty result sets, and non-GET requests.



## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Fable 5
Used for: Initial implementation and test suite, ported from the Jetpack Random Redirect module under my direction; reviewed, tested, and edited by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
