### PR TITLE
Editor: Drop mixed-unit viewport breakpoint pairs in theme.json

### DIFF
--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -816,7 +816,8 @@ class WP_Theme_JSON {
 	 * the default breakpoints when no valid custom breakpoint is provided. When
 	 * only one breakpoint is valid, it remains keyed by its configured state and
 	 * uses a single max-width media query. When `tablet` is not larger than
-	 * `mobile`, it is removed.
+	 * `mobile`, or does not share an absolute or relative unit type with it, it
+	 * is removed.
 	 *
 	 * @since 7.1.0
 	 *
@@ -852,7 +853,17 @@ class WP_Theme_JSON {
 		$sanitized = array( 'mobile' => $breakpoints['mobile']['value'] );
 
 		if ( isset( $breakpoints['tablet'] ) && $breakpoints['mobile']['px'] < $breakpoints['tablet']['px'] ) {
-			$sanitized['tablet'] = $breakpoints['tablet']['value'];
+			/*
+			 * A media query resolves `em` and `rem` against the browser's default
+			 * font size, so the order of a pair that mixes a relative unit with
+			 * `px` only holds at the 16px base assumed above.
+			 */
+			$mobile_is_absolute = str_ends_with( $breakpoints['mobile']['value'], 'px' );
+			$tablet_is_absolute = str_ends_with( $breakpoints['tablet']['value'], 'px' );
+
+			if ( $mobile_is_absolute === $tablet_is_absolute ) {
+				$sanitized['tablet'] = $breakpoints['tablet']['value'];
+			}
 		}
 
 		return $sanitized;

--- a/tests/phpunit/tests/theme/wpThemeJson.php
+++ b/tests/phpunit/tests/theme/wpThemeJson.php
@@ -1249,6 +1249,49 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 65865
+	 */
+	public function test_get_viewport_media_queries_omits_tablet_when_breakpoints_mix_absolute_and_relative_units() {
+		$this->assertSame(
+			array(
+				'@mobile'  => '@media (width <= 30em)',
+				'@desktop' => '@media (width > 30em)',
+			),
+			WP_Theme_JSON::get_viewport_media_queries(
+				array(
+					'mobile' => '30em',
+					'tablet' => '580px',
+				),
+				array(
+					'include_desktop' => true,
+				)
+			)
+		);
+	}
+
+	/**
+	 * @ticket 65865
+	 */
+	public function test_get_viewport_media_queries_keeps_tablet_when_breakpoints_mix_em_and_rem() {
+		$this->assertSame(
+			array(
+				'@mobile'  => '@media (width <= 30em)',
+				'@tablet'  => '@media (30em < width <= 48rem)',
+				'@desktop' => '@media (width > 48rem)',
+			),
+			WP_Theme_JSON::get_viewport_media_queries(
+				array(
+					'mobile' => '30em',
+					'tablet' => '48rem',
+				),
+				array(
+					'include_desktop' => true,
+				)
+			)
+		);
+	}
+
+	/**
 	 * @ticket 65596
 	 */
 	public function test_get_stylesheet_uses_custom_viewport_breakpoints_for_responsive_block_styles() {


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

A `settings.viewport` pair that mixes units, such as `"mobile": "30em"` with `"tablet": "580px"`, produces an empty `@tablet` media query for readers who change their browser's default font size, so the responsive styles and visibility rules bound to it silently stop applying.

`sanitize_viewport_settings()` orders the pair against a fixed 16px base, but the generated query keeps the original units, and a media query resolves `em`/`rem` against the reader's default font size instead. The patch removes `tablet` when it does not share an absolute or relative unit type with `mobile`, alongside the existing not-larger-than check.

`em`/`rem` pairs are kept, since a media query resolves both against the same base; same-unit and default pairs are unaffected.

Trac ticket: https://core.trac.wordpress.org/ticket/65865

## Use of AI Tools
AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Diagnosing the unit-resolution mismatch, drafting the fix and its unit tests. All changes were reviewed and validated by me.
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
