### PR TITLE
Fix: Connectors: AI provider API keys are re-validated on every settings update (/wp/v2/settings), causing needless provider calls and key resets

### DIFF
--- a/src/wp-includes/connectors.php
+++ b/src/wp-includes/connectors.php
@@ -705,6 +705,7 @@ function _wp_connectors_rest_settings_dispatch( WP_REST_Response $response, WP_R
 	}
 
 	$is_update = 'POST' === $request->get_method() || 'PUT' === $request->get_method();
+	$submitted = $is_update ? $request->get_params() : array();
 
 	foreach ( wp_get_connectors() as $connector_id => $connector_data ) {
 		$auth = $connector_data['authentication'];
@@ -731,9 +732,14 @@ function _wp_connectors_rest_settings_dispatch( WP_REST_Response $response, WP_R
 
 		$value = $data[ $setting_name ];
 
-		// On update, validate AI provider keys before masking.
-		// Non-AI connectors accept keys as-is; the service plugin handles its own validation.
-		if ( $is_update && is_string( $value ) && '' !== $value && 'ai_provider' === $connector_data['type'] ) {
+		// On update, validate AI provider keys before masking, but only when the
+		// key was actually submitted in this request. Non-AI connectors accept keys
+		// as-is; the service plugin handles its own validation.
+		if ( $is_update
+			&& array_key_exists( $setting_name, $submitted )
+			&& is_string( $value ) && '' !== $value
+			&& 'ai_provider' === $connector_data['type']
+		) {
 			if ( true !== _wp_connectors_is_ai_api_key_valid( $value, $connector_id ) ) {
 				update_option( $setting_name, '' );
 				$data[ $setting_name ] = '';

--- a/tests/phpunit/tests/connectors/wpConnectorsRestSettingsDispatch.php
+++ b/tests/phpunit/tests/connectors/wpConnectorsRestSettingsDispatch.php
@@ -1,4 +1,7 @@
 <?php
+
+require_once dirname( __DIR__, 2 ) . '/includes/wp-ai-client-mock-provider-trait.php';
+
 /**
  * Tests for _wp_connectors_rest_settings_dispatch().
  *
@@ -7,8 +10,19 @@
  */
 class Tests_Connectors_WpConnectorsRestSettingsDispatch extends WP_UnitTestCase {
 
+	use WP_AI_Client_Mock_Provider_Trait;
+
 	const CONNECTOR_ID             = 'wp_test_application_password_connector';
 	const CREDENTIALS_SETTING_NAME = 'connectors_test_remote_credentials';
+	const AI_KEY_SETTING_NAME      = 'connectors_ai_mock_connectors_test_api_key';
+
+	/**
+	 * Registers the mock AI provider connector once for the class.
+	 */
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+		self::register_mock_connectors_provider();
+	}
 
 	/**
 	 * Registers an application password connector before each test.
@@ -62,5 +76,42 @@ class Tests_Connectors_WpConnectorsRestSettingsDispatch extends WP_UnitTestCase 
 		$this->assertSame( 'remote-user', $data[ self::CREDENTIALS_SETTING_NAME ]['username'] );
 		$this->assertSame( str_repeat( "\u{2022}", 16 ), $data[ self::CREDENTIALS_SETTING_NAME ]['password'] );
 		$this->assertNotSame( $application_password, $data[ self::CREDENTIALS_SETTING_NAME ]['password'] );
+	}
+
+	/**
+	 * Ensures a stored AI provider API key is not re-validated, and therefore not
+	 * reset, when it is not part of the current settings update.
+	 *
+	 * @ticket 65867
+	 */
+	public function test_does_not_validate_or_reset_unsubmitted_ai_key(): void {
+		$stored_key = 'sk-stored-valid-key';
+		update_option( self::AI_KEY_SETTING_NAME, $stored_key );
+
+		self::set_mock_provider_configured( false );
+
+		// An update that does not submit the AI key (e.g. saving another setting).
+		$request = new WP_REST_Request( 'POST', '/wp/v2/settings' );
+		$request->set_param( 'title', 'New Site Title' );
+
+		// The settings endpoint response always contains every registered setting.
+		$response = new WP_REST_Response( array( self::AI_KEY_SETTING_NAME => $stored_key ) );
+
+		$result = _wp_connectors_rest_settings_dispatch( $response, rest_get_server(), $request );
+		$data   = $result->get_data();
+
+		$this->assertSame(
+			$stored_key,
+			get_option( self::AI_KEY_SETTING_NAME ),
+			'An AI provider key that was not submitted should not be reset.'
+		);
+		$this->assertSame(
+			_wp_connectors_mask_api_key( $stored_key ),
+			$data[ self::AI_KEY_SETTING_NAME ],
+			'The stored AI provider key should still be masked in the response.'
+		);
+
+		self::set_mock_provider_configured( true );
+		delete_option( self::AI_KEY_SETTING_NAME );
 	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/65554

## Description

- Fixed the issue related to settings check for API key for all connectors, even if the request does not changes or have connector key.
- This leads to unnecessary calls to provider to check for API key on every settings save via `wp/v2/settings`.

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->
- Yes, Claude Code, Opus 5.
- Used for drafting the ticket mentioned.
- Used for adding the unit test for the changes mentioned. Tested locally and reviewed tests by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
