### PR TITLE
Editor: Add text-shadow block support and theme.json presets

### DIFF
--- a/src/wp-includes/block-supports/typography.php
+++ b/src/wp-includes/block-supports/typography.php
@@ -37,6 +37,7 @@ function wp_register_typography_support( $block_type ) {
 	$has_text_decoration_support = $typography_supports['__experimentalTextDecoration'] ?? false;
 	$has_text_transform_support  = $typography_supports['__experimentalTextTransform'] ?? false;
 	$has_text_indent_support     = $typography_supports['textIndent'] ?? false;
+	$has_text_shadow_support     = $typography_supports['textShadow'] ?? false;
 	$has_writing_mode_support    = $typography_supports['__experimentalWritingMode'] ?? false;
 
 	$has_typography_support = $has_font_family_support
@@ -50,6 +51,7 @@ function wp_register_typography_support( $block_type ) {
 		|| $has_text_decoration_support
 		|| $has_text_transform_support
 		|| $has_text_indent_support
+		|| $has_text_shadow_support
 		|| $has_writing_mode_support;
 
 	if ( ! $block_type->attributes ) {
@@ -70,6 +72,12 @@ function wp_register_typography_support( $block_type ) {
 
 	if ( $has_font_family_support && ! array_key_exists( 'fontFamily', $block_type->attributes ) ) {
 		$block_type->attributes['fontFamily'] = array(
+			'type' => 'string',
+		);
+	}
+
+	if ( $has_text_shadow_support && ! array_key_exists( 'textShadow', $block_type->attributes ) ) {
+		$block_type->attributes['textShadow'] = array(
 			'type' => 'string',
 		);
 	}
@@ -115,6 +123,7 @@ function wp_apply_typography_support( $block_type, $block_attributes ) {
 	$has_text_decoration_support = $typography_supports['__experimentalTextDecoration'] ?? false;
 	$has_text_transform_support  = $typography_supports['__experimentalTextTransform'] ?? false;
 	$has_text_indent_support     = $typography_supports['textIndent'] ?? false;
+	$has_text_shadow_support     = $typography_supports['textShadow'] ?? false;
 	$has_writing_mode_support    = $typography_supports['__experimentalWritingMode'] ?? false;
 
 	// Whether to skip individual block support features.
@@ -129,6 +138,7 @@ function wp_apply_typography_support( $block_type, $block_attributes ) {
 	$should_skip_text_transform  = wp_should_skip_block_supports_serialization( $block_type, 'typography', 'textTransform' );
 	$should_skip_letter_spacing  = wp_should_skip_block_supports_serialization( $block_type, 'typography', 'letterSpacing' );
 	$should_skip_text_indent     = wp_should_skip_block_supports_serialization( $block_type, 'typography', 'textIndent' );
+	$should_skip_text_shadow     = wp_should_skip_block_supports_serialization( $block_type, 'typography', 'textShadow' );
 	$should_skip_writing_mode    = wp_should_skip_block_supports_serialization( $block_type, 'typography', 'writingMode' );
 
 	$typography_block_styles = array();
@@ -230,6 +240,12 @@ function wp_apply_typography_support( $block_type, $block_attributes ) {
 
 	if ( $has_text_indent_support && ! $should_skip_text_indent && isset( $block_attributes['style']['typography']['textIndent'] ) ) {
 		$typography_block_styles['textIndent'] = $block_attributes['style']['typography']['textIndent'] ?? null;
+	}
+
+	if ( $has_text_shadow_support && ! $should_skip_text_shadow ) {
+		$preset_text_shadow                    = array_key_exists( 'textShadow', $block_attributes ) ? "var:preset|text-shadow|{$block_attributes['textShadow']}" : null;
+		$custom_text_shadow                    = $block_attributes['style']['typography']['textShadow'] ?? null;
+		$typography_block_styles['textShadow'] = $preset_text_shadow ? $preset_text_shadow : $custom_text_shadow;
 	}
 
 	$attributes = array();

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -127,6 +127,7 @@ class WP_Theme_JSON {
 	 *              Updated the 'prevent_override' value for font size presets to use 'typography.defaultFontSizes'
 	 *              and spacing size presets to use `spacing.defaultSpacingSizes`.
 	 * @since 6.9.0 Added `border.radiusSizes`.
+	 * @since 7.2.0 Added `typography.textShadowPresets`.
 	 * @var array
 	 */
 	const PRESETS_METADATA = array(
@@ -187,6 +188,15 @@ class WP_Theme_JSON {
 			'css_vars'          => '--wp--preset--font-family--$slug',
 			'classes'           => array( '.has-$slug-font-family' => 'font-family' ),
 			'properties'        => array( 'font-family' ),
+		),
+		array(
+			'path'              => array( 'typography', 'textShadowPresets' ),
+			'prevent_override'  => array( 'typography', 'defaultTextShadowPresets' ),
+			'use_default_names' => false,
+			'value_key'         => 'textShadow',
+			'css_vars'          => '--wp--preset--text-shadow--$slug',
+			'classes'           => array( '.has-$slug-text-shadow' => 'text-shadow' ),
+			'properties'        => array( 'text-shadow' ),
 		),
 		array(
 			'path'              => array( 'spacing', 'spacingSizes' ),
@@ -419,6 +429,8 @@ class WP_Theme_JSON {
 	 *              Added support for `typography.textIndent`.
 	 * @since 7.1.0 Added `viewport` property.
 	 *              Added support for `background.gradient`, `dimensions.minWidth` and `blockVisibility.allowEditing`.
+	 * @since 7.2.0 Added support for `typography.textShadow`, `typography.textShadowPresets`,
+	 *              and `typography.defaultTextShadowPresets`.
 	 * @var array
 	 */
 	const VALID_SETTINGS = array(
@@ -496,22 +508,25 @@ class WP_Theme_JSON {
 			'defaultPresets' => null,
 		),
 		'typography'                    => array(
-			'fluid'            => null,
-			'customFontSize'   => null,
-			'defaultFontSizes' => null,
-			'dropCap'          => null,
-			'fontFamilies'     => null,
-			'fontSizes'        => null,
-			'fontStyle'        => null,
-			'fontWeight'       => null,
-			'letterSpacing'    => null,
-			'lineHeight'       => null,
-			'textAlign'        => null,
-			'textColumns'      => null,
-			'textDecoration'   => null,
-			'textIndent'       => null,
-			'textTransform'    => null,
-			'writingMode'      => null,
+			'fluid'                    => null,
+			'customFontSize'           => null,
+			'defaultFontSizes'         => null,
+			'dropCap'                  => null,
+			'fontFamilies'             => null,
+			'fontSizes'                => null,
+			'fontStyle'                => null,
+			'fontWeight'               => null,
+			'letterSpacing'            => null,
+			'lineHeight'               => null,
+			'textAlign'                => null,
+			'textColumns'              => null,
+			'textDecoration'           => null,
+			'textIndent'               => null,
+			'textTransform'            => null,
+			'textShadow'               => null,
+			'defaultTextShadowPresets' => null,
+			'textShadowPresets'        => null,
+			'writingMode'              => null,
 		),
 		'viewport'                      => array(
 			'mobile' => null,

--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -2639,6 +2639,7 @@ function kses_init() {
  * @since 7.1.0 Extended gradient support to allow any single-level nested function.
  *              Added support for transform functions, `clip-path` basic shapes,
  *              and URLs in the SVG element reference properties.
+ * @since 7.2.0 Added support for `text-shadow`.
  *
  * @param string $css        A string of CSS rules, decoded from an HTML `style` attribute.
  * @param string $deprecated Not used.
@@ -2734,6 +2735,7 @@ function safecss_filter_attr( $css, $deprecated = '' ) {
 			'text-align',
 			'text-decoration',
 			'text-indent',
+			'text-shadow',
 			'text-transform',
 			'white-space',
 

--- a/src/wp-includes/style-engine/class-wp-style-engine.php
+++ b/src/wp-includes/style-engine/class-wp-style-engine.php
@@ -27,6 +27,7 @@
  *              background.backgroundRepeat and dimensions.aspectRatio.
  * @since 6.7.0 Added support for typography.writingMode.
  * @since 7.0.0 Added support for typography.textIndent.
+ * @since 7.2.0 Added support for typography.textShadow.
  */
 #[AllowDynamicProperties]
 final class WP_Style_Engine {
@@ -349,6 +350,18 @@ final class WP_Style_Engine {
 					'default' => 'text-indent',
 				),
 				'path'          => array( 'typography', 'textIndent' ),
+			),
+			'textShadow'     => array(
+				'property_keys' => array(
+					'default' => 'text-shadow',
+				),
+				'css_vars'      => array(
+					'text-shadow' => '--wp--preset--text-shadow--$slug',
+				),
+				'path'          => array( 'typography', 'textShadow' ),
+				'classnames'    => array(
+					'has-$slug-text-shadow' => 'text-shadow',
+				),
 			),
 			'textTransform'  => array(
 				'property_keys' => array(

--- a/tests/phpunit/tests/block-supports/typography.php
+++ b/tests/phpunit/tests/block-supports/typography.php
@@ -292,6 +292,39 @@ class Tests_Block_Supports_Typography extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that a classname is generated for a text shadow preset.
+	 *
+	 * @covers ::wp_apply_typography_support
+	 */
+	public function test_should_generate_classname_for_text_shadow() {
+		$this->test_block_name = 'test/text-shadow-with-class';
+		register_block_type(
+			$this->test_block_name,
+			array(
+				'api_version' => 3,
+				'attributes'  => array(
+					'style' => array(
+						'type' => 'object',
+					),
+				),
+				'supports'    => array(
+					'typography' => array(
+						'textShadow' => true,
+					),
+				),
+			)
+		);
+		$registry   = WP_Block_Type_Registry::get_instance();
+		$block_type = $registry->get_registered( $this->test_block_name );
+		$block_atts = array( 'textShadow' => 'light' );
+
+		$actual   = wp_apply_typography_support( $block_type, $block_atts );
+		$expected = array( 'class' => 'has-light-text-shadow' );
+
+		$this->assertSame( $expected, $actual );
+	}
+
+	/**
 	 * Tests generating font size values, including fluid formulae, from fontSizes preset.
 	 *
 	 * @ticket 56467

--- a/tests/phpunit/tests/block-supports/typography.php
+++ b/tests/phpunit/tests/block-supports/typography.php
@@ -289,6 +289,39 @@ class Tests_Block_Supports_Typography extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that a classname is generated for a text shadow preset.
+	 *
+	 * @covers ::wp_apply_typography_support
+	 */
+	public function test_should_generate_classname_for_text_shadow() {
+		$this->test_block_name = 'test/text-shadow-with-class';
+		register_block_type(
+			$this->test_block_name,
+			array(
+				'api_version' => 3,
+				'attributes'  => array(
+					'style' => array(
+						'type' => 'object',
+					),
+				),
+				'supports'    => array(
+					'typography' => array(
+						'textShadow' => true,
+					),
+				),
+			)
+		);
+		$registry   = WP_Block_Type_Registry::get_instance();
+		$block_type = $registry->get_registered( $this->test_block_name );
+		$block_atts = array( 'textShadow' => 'light' );
+
+		$actual   = wp_apply_typography_support( $block_type, $block_atts );
+		$expected = array( 'class' => 'has-light-text-shadow' );
+
+		$this->assertSame( $expected, $actual );
+	}
+
+	/**
 	 * Tests generating font size values, including fluid formulae, from fontSizes preset.
 	 *
 	 * @ticket 56467

--- a/tests/phpunit/tests/kses.php
+++ b/tests/phpunit/tests/kses.php
@@ -1455,6 +1455,23 @@ EOF;
 				'css'      => 'white-space: pre-line',
 				'expected' => 'white-space: pre-line',
 			),
+			// `text-shadow` introduced in 7.2.0.
+			array(
+				'css'      => 'text-shadow: none',
+				'expected' => 'text-shadow: none',
+			),
+			array(
+				'css'      => 'text-shadow: 1px 1px 2px #000000',
+				'expected' => 'text-shadow: 1px 1px 2px #000000',
+			),
+			array(
+				'css'      => 'text-shadow: 1px 1px 2px #000000, 0 0 1em #ff0000',
+				'expected' => 'text-shadow: 1px 1px 2px #000000, 0 0 1em #ff0000',
+			),
+			array(
+				'css'      => 'text-shadow: var(--wp--preset--text-shadow--soft)',
+				'expected' => 'text-shadow: var(--wp--preset--text-shadow--soft)',
+			),
 			// Expressions are not allowed.
 			array(
 				'css'      => 'height: expression( body.scrollTop + 50 + "px" )',


### PR DESCRIPTION
Backports the server-side portion of [Gutenberg PR #79584](https://github.com/WordPress/gutenberg/pull/79584), which adds full `text-shadow` support to the typography block supports and theme.json.

Blocks can now opt in via `supports.typography.textShadow`, and themes can define presets under `settings.typography.textShadowPresets` (with `textShadow` and `defaultTextShadowPresets` to control the UI and default presets). Unlike shadow support, preset values are serialized as a class name (`has-{slug}-text-shadow`) rather than an inline style, so the Style Engine definition registers both `css_vars` and `classnames`.

Notes:

- The Style Engine had no `textShadow` entry at all, so the whole definition is added here rather than only the `css_vars`/`classnames` keys.
- `@since` tags use `7.2.0` to match the current trunk version.
- `theme.json` / `theme-i18n.json` are not touched, since they are copied from the Gutenberg package during the build. The default presets will land with the next package sync.
- The block.json changes for Paragraph and Heading are not included, since those are synced from the Gutenberg package as well.

Trac ticket: https://core.trac.wordpress.org/ticket/65869

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Porting the Gutenberg changes to their Core equivalents. The original Gutenberg implementation and this backport were both reviewed and edited by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
