### PR TITLE
Tests: Clean up the `wp_delete_post()` unit tests

### DIFF
--- a/tests/phpunit/tests/post/wpDeletePost.php
+++ b/tests/phpunit/tests/post/wpDeletePost.php
@@ -17,38 +17,6 @@
 class Tests_Post_WpDeletePost extends WP_UnitTestCase {
 
 	/**
-	 * User IDs for the test.
-	 *
-	 * @var array{administrator: int, editor: int, contributor: int}
-	 */
-	protected static $user_ids;
-
-	/**
-	 * Set up before class.
-	 *
-	 * @param WP_UnitTest_Factory $factory The Unit Test Factory.
-	 */
-	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
-		self::$user_ids = array(
-			'administrator' => $factory->user->create(
-				array(
-					'role' => 'administrator',
-				)
-			),
-			'editor'        => $factory->user->create(
-				array(
-					'role' => 'editor',
-				)
-			),
-			'contributor'   => $factory->user->create(
-				array(
-					'role' => 'contributor',
-				)
-			),
-		);
-	}
-
-	/**
 	 * Tests wp_delete_post reassign hierarchical post type.
 	 */
 	public function test_wp_delete_post_reassign_hierarchical_post_type() {
@@ -120,9 +88,9 @@ class Tests_Post_WpDeletePost extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests wp_delete_post() when the post for the post_id has been already deleted.
+	 * Tests that wp_delete_post() returns null when the post has already been deleted.
 	 */
-	public function test_wp_delete_post_returns_false_for_invalid_post() {
+	public function test_wp_delete_post_returns_null_for_already_deleted_post() {
 		$post_id      = self::factory()->post->create();
 		$deleted_post = wp_delete_post( $post_id, true );
 		$this->assertInstanceOf( WP_Post::class, $deleted_post );
@@ -163,7 +131,7 @@ class Tests_Post_WpDeletePost extends WP_UnitTestCase {
 		$deleted_post = wp_delete_post( (string) $post_id, true );
 		$this->assertInstanceOf( WP_Post::class, $deleted_post );
 
-		foreach ( array( 'before_delete_post', 'delete_post_post', 'delete_post', 'deleted_post_post', 'deleted_post', 'after_delete_post' ) as $action ) {
+		foreach ( $actions as $action ) {
 			$this->assertSame( $initial_action_counts[ $action ] + 1, did_action( $action ), "Expected $action action count to increment by 1." );
 			$this->assertCount( 2, $captured_action_args[ $action ], "Expected count for $action action" );
 			$this->assertSame( $post_id, $captured_action_args[ $action ][0], "Expected post ID for $action action" );
@@ -175,7 +143,7 @@ class Tests_Post_WpDeletePost extends WP_UnitTestCase {
 	/**
 	 * Tests short-circuiting wp_delete_post() with pre_delete_post filter.
 	 *
-	 * @ticket @63975
+	 * @ticket 63975
 	 */
 	public function test_wp_delete_post_can_be_short_circuited() {
 		$post_id = self::factory()->post->create();


### PR DESCRIPTION
## Description
Four independent clean-ups in the test file. Follow-up to [[60906](https://core.trac.wordpress.org/changeset/60906)].
- **Remove the unused `$user_ids` fixture.** The property and its `wpSetUpBeforeClass()` method were copied over from the `wp_insert_post()` tests. Nothing in this class references `self::$user_ids`, so the only effect was creating three users for every test in the class.
- **Rename `test_wp_delete_post_returns_false_for_invalid_post()`** to `test_wp_delete_post_returns_null_for_already_deleted_post()`. The test asserts `assertNull()`, and that is the correct expectation: for an ID with no matching row, `wp_delete_post()` returns the `null` coming out of `$wpdb->get_row()`, whereas `false` is only returned by the `$post_id <= 0` guard. The old name described the opposite of what the test covers.
- **Reuse the `$actions` array** in the assertion loop of `test_wp_delete_post_actions()`. The same six action names were spelled out a second time inline, so the registration loop and the assertion loop could drift apart.
- **Fix the `@ticket @63975` annotation.** The stray `@` made the tag invalid, so the test was not associated with the ticket.
No assertion was added, removed or changed, and no test behaviour changes.

Trac ticket: https://core.trac.wordpress.org/ticket/65819



---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
