### PR TITLE
Formatting: make get_tag_regex() match tags non-greedily (#26674)

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -7679,7 +7679,7 @@ function get_tag_regex( $tag ) {
 	if ( empty( $tag ) ) {
 		return '';
 	}
-	return sprintf( '<%1$s[^<]*(?:>[\s\S]*<\/%1$s>|\s*\/>)', tag_escape( $tag ) );
+	return sprintf( '<%1$s[^<]*?(?:>[\s\S]*?<\/%1$s>|\s*\/>)', tag_escape( $tag ) );
 }
 
 /**

--- a/tests/phpunit/tests/functions/getTagRegex.php
+++ b/tests/phpunit/tests/functions/getTagRegex.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * Tests for the get_tag_regex() function.
+ *
+ * @group functions
+ *
+ * @covers ::get_tag_regex
+ */
+class Tests_Functions_GetTagRegex extends WP_UnitTestCase {
+
+	/**
+	 * @ticket 26674
+	 *
+	 * @dataProvider data_get_tag_regex_matches
+	 *
+	 * @param string   $tag      Tag name to build the regex for.
+	 * @param string   $content  Content to match against.
+	 * @param string[] $expected Expected full matches, in order.
+	 */
+	public function test_get_tag_regex_matches( $tag, $content, $expected ) {
+		preg_match_all( '#' . get_tag_regex( $tag ) . '#', $content, $matches );
+		$this->assertSame( $expected, $matches[0] );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_get_tag_regex_matches() {
+		return array(
+			'a single tag with a body'                  => array(
+				'iframe',
+				'<iframe src="https://example.com/a"></iframe>',
+				array( '<iframe src="https://example.com/a"></iframe>' ),
+			),
+
+			// The regression: a greedy match ran from the first opening tag to
+			// the last closing tag, merging both embeds and the text between
+			// them into a single match. See #26674.
+			'two adjacent tags are matched separately'  => array(
+				'iframe',
+				'<iframe src="https://example.com/a"></iframe> text <iframe src="https://example.com/b"></iframe>',
+				array(
+					'<iframe src="https://example.com/a"></iframe>',
+					'<iframe src="https://example.com/b"></iframe>',
+				),
+			),
+
+			'a self-closing tag'                        => array(
+				'iframe',
+				'<iframe src="https://example.com/a" />',
+				array( '<iframe src="https://example.com/a" />' ),
+			),
+
+			'a tag with a multiline body'               => array(
+				'video',
+				"<video>\n<source src=\"a.mp4\">\n</video>",
+				array( "<video>\n<source src=\"a.mp4\">\n</video>" ),
+			),
+
+			'no match when the tag is absent'           => array(
+				'iframe',
+				'<p>No embeds here.</p>',
+				array(),
+			),
+		);
+	}
+
+	/**
+	 * @ticket 26674
+	 */
+	public function test_get_tag_regex_returns_empty_string_for_empty_tag() {
+		$this->assertSame( '', get_tag_regex( '' ) );
+	}
+
+	/**
+	 * The tag name is passed through tag_escape(), so casing and invalid
+	 * characters do not change the generated pattern.
+	 *
+	 * @ticket 26674
+	 */
+	public function test_get_tag_regex_escapes_the_tag_name() {
+		$this->assertSame( get_tag_regex( 'iframe' ), get_tag_regex( 'IFRAME' ) );
+	}
+}

--- a/tests/phpunit/tests/functions/getTagRegex.php
+++ b/tests/phpunit/tests/functions/getTagRegex.php
@@ -48,10 +48,18 @@ class Tests_Functions_GetTagRegex extends WP_UnitTestCase {
 				),
 			),
 
-			'a self-closing tag'                       => array(
-				'iframe',
-				'<iframe src="https://example.com/a" />',
-				array( '<iframe src="https://example.com/a" />' ),
+			// A self-closing void element (an iframe cannot self-close), matched
+			// both with and without the space before the slash (comment:16).
+			'a self-closing tag with a space'          => array(
+				'input',
+				'<input type="text" />',
+				array( '<input type="text" />' ),
+			),
+
+			'a self-closing tag without a space'       => array(
+				'input',
+				'<input type="text"/>',
+				array( '<input type="text"/>' ),
 			),
 
 			'a tag with a multiline body'              => array(

--- a/tests/phpunit/tests/functions/getTagRegex.php
+++ b/tests/phpunit/tests/functions/getTagRegex.php
@@ -1,18 +1,24 @@
 <?php
-
 /**
  * Tests for the get_tag_regex() function.
  *
- * @group functions
+ * @package WordPress\UnitTests
  *
+ * @since 7.2.0
+ *
+ * @group functions
  * @covers ::get_tag_regex
  */
 class Tests_Functions_GetTagRegex extends WP_UnitTestCase {
 
 	/**
+	 * Tests that get_tag_regex() properly generates regex patterns for various HTML tags.
+	 *
 	 * @ticket 26674
 	 *
 	 * @dataProvider data_get_tag_regex_matches
+	 *
+	 * @since 7.2.0
 	 *
 	 * @param string   $tag      Tag name to build the regex for.
 	 * @param string   $content  Content to match against.
@@ -25,6 +31,8 @@ class Tests_Functions_GetTagRegex extends WP_UnitTestCase {
 
 	/**
 	 * Data provider.
+	 *
+	 * @since 7.2.0
 	 *
 	 * @return array[]
 	 */
@@ -81,17 +89,23 @@ class Tests_Functions_GetTagRegex extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that calling get_tag_regex() with an empty tag name returns an empty string.
+	 *
 	 * @ticket 26674
+	 *
+	 * @since 7.2.0
 	 */
 	public function test_get_tag_regex_returns_empty_string_for_empty_tag() {
 		$this->assertSame( '', get_tag_regex( '' ) );
 	}
 
 	/**
-	 * The tag name is passed through tag_escape(), so casing and invalid
-	 * characters do not change the generated pattern.
+	 * Tests that the tag name is passed through tag_escape(), so casing and
+	 * invalid characters do not change the generated pattern.
 	 *
 	 * @ticket 26674
+	 *
+	 * @since 7.2.0
 	 */
 	public function test_get_tag_regex_escapes_the_tag_name() {
 		$this->assertSame( get_tag_regex( 'iframe' ), get_tag_regex( 'IFRAME' ) );

--- a/tests/phpunit/tests/functions/getTagRegex.php
+++ b/tests/phpunit/tests/functions/getTagRegex.php
@@ -29,10 +29,14 @@ class Tests_Functions_GetTagRegex extends WP_UnitTestCase {
 	 * @return array[]
 	 */
 	public function data_get_tag_regex_matches() {
+		// Each case embeds the element(s) within surrounding HTML, mirroring the
+		// original usage in get_media_embedded_in_content(), which is passed a
+		// string of HTML that may contain media elements rather than the bare
+		// element on its own.
 		return array(
 			'a single tag with a body'                 => array(
 				'iframe',
-				'<iframe src="https://example.com/a"></iframe>',
+				'<div><p>Before.</p><iframe src="https://example.com/a"></iframe><p>After.</p></div>',
 				array( '<iframe src="https://example.com/a"></iframe>' ),
 			),
 
@@ -41,7 +45,7 @@ class Tests_Functions_GetTagRegex extends WP_UnitTestCase {
 			// them into a single match. See #26674.
 			'two adjacent tags are matched separately' => array(
 				'iframe',
-				'<iframe src="https://example.com/a"></iframe> text <iframe src="https://example.com/b"></iframe>',
+				'<div><p>Intro.</p><iframe src="https://example.com/a"></iframe> text <iframe src="https://example.com/b"></iframe><p>Outro.</p></div>',
 				array(
 					'<iframe src="https://example.com/a"></iframe>',
 					'<iframe src="https://example.com/b"></iframe>',
@@ -52,25 +56,25 @@ class Tests_Functions_GetTagRegex extends WP_UnitTestCase {
 			// both with and without the space before the slash (comment:16).
 			'a self-closing tag with a space'          => array(
 				'input',
-				'<input type="text" />',
+				'<div>A form field: <input type="text" /> and more text.</div>',
 				array( '<input type="text" />' ),
 			),
 
 			'a self-closing tag without a space'       => array(
 				'input',
-				'<input type="text"/>',
+				'<div>A form field: <input type="text"/> and more text.</div>',
 				array( '<input type="text"/>' ),
 			),
 
 			'a tag with a multiline body'              => array(
 				'video',
-				"<video>\n<source src=\"a.mp4\">\n</video>",
+				"<div><p>Watch:</p>\n<video>\n<source src=\"a.mp4\">\n</video>\n<p>End.</p></div>",
 				array( "<video>\n<source src=\"a.mp4\">\n</video>" ),
 			),
 
 			'no match when the tag is absent'          => array(
 				'iframe',
-				'<p>No embeds here.</p>',
+				'<div><p>No embeds here.</p></div>',
 				array(),
 			),
 		);

--- a/tests/phpunit/tests/functions/getTagRegex.php
+++ b/tests/phpunit/tests/functions/getTagRegex.php
@@ -30,7 +30,7 @@ class Tests_Functions_GetTagRegex extends WP_UnitTestCase {
 	 */
 	public function data_get_tag_regex_matches() {
 		return array(
-			'a single tag with a body'                  => array(
+			'a single tag with a body'                 => array(
 				'iframe',
 				'<iframe src="https://example.com/a"></iframe>',
 				array( '<iframe src="https://example.com/a"></iframe>' ),
@@ -39,7 +39,7 @@ class Tests_Functions_GetTagRegex extends WP_UnitTestCase {
 			// The regression: a greedy match ran from the first opening tag to
 			// the last closing tag, merging both embeds and the text between
 			// them into a single match. See #26674.
-			'two adjacent tags are matched separately'  => array(
+			'two adjacent tags are matched separately' => array(
 				'iframe',
 				'<iframe src="https://example.com/a"></iframe> text <iframe src="https://example.com/b"></iframe>',
 				array(
@@ -48,19 +48,19 @@ class Tests_Functions_GetTagRegex extends WP_UnitTestCase {
 				),
 			),
 
-			'a self-closing tag'                        => array(
+			'a self-closing tag'                       => array(
 				'iframe',
 				'<iframe src="https://example.com/a" />',
 				array( '<iframe src="https://example.com/a" />' ),
 			),
 
-			'a tag with a multiline body'               => array(
+			'a tag with a multiline body'              => array(
 				'video',
 				"<video>\n<source src=\"a.mp4\">\n</video>",
 				array( "<video>\n<source src=\"a.mp4\">\n</video>" ),
 			),
 
-			'no match when the tag is absent'           => array(
+			'no match when the tag is absent'          => array(
 				'iframe',
 				'<p>No embeds here.</p>',
 				array(),


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/26674

## What

`get_tag_regex()` builds a pattern with a greedy body match:

```
<iframe[^<]*(?:>[\s\S]*<\/iframe>|\s*\/>)
```

Because `[\s\S]*` is greedy, content with more than one tag of the same type matches from the **first** opening tag all the way to the **last** closing tag, so both tags — and everything between them — collapse into a single match:

```php
$content = '<iframe src="a"></iframe> text <iframe src="b"></iframe>';
preg_match_all( '#' . get_tag_regex( 'iframe' ) . '#', $content, $m );
// $m[0] currently has ONE entry containing both iframes and the text between.
```

## Fix

Make the attribute and body matches lazy:

```
<iframe[^<]*?(?:>[\s\S]*?<\/iframe>|\s*\/>)
```

This is the same pattern core already uses inline in `get_media_embedded_in_content()` (`[^<]*?` … `[\s\S]*?`), so this really just brings the standalone `get_tag_regex()` back in line with it. With the change, the two iframes above match as two separate entries, and single-tag, multiline-body, and self-closing cases keep matching as before.

`get_tag_regex()` has no callers in core today (`get_media_embedded_in_content()` carries its own copy of the pattern), but it's a public function since 3.6.0, so the greedy behavior affects anything outside core that relies on it.

## Tests

`get_tag_regex()` had no test coverage, so this adds `tests/phpunit/tests/functions/getTagRegex.php` covering a single tag with a body, two adjacent tags matched separately (the regression), a self-closing tag, a multiline body, and the no-match and empty-tag cases. The two-adjacent-tags case fails against the current greedy pattern and passes with the fix.

## Notes

This refreshes the long-stale patch on the ticket (it no longer applied against trunk). I kept the self-closing branch as `\s*\/>` to match the pattern in `get_media_embedded_in_content()`; @afercia's earlier suggestion to also make the slash optional (`\s*?\/?>`) would broaden what counts as self-closing, so that feels like a separate decision from the greedy fix and I left it out here.

Props @kopepasah for the report and original patch, and @afercia for the regex review.
