### PR TITLE
KSES: Allow filter function values in inline styles.

### DIFF
--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -2640,6 +2640,7 @@ function kses_init() {
  * @since 7.1.0 Extended gradient support to allow any single-level nested function.
  *              Added support for transform functions, `clip-path` basic shapes,
  *              and URLs in the SVG element reference properties.
+ * @since 7.2.0 Added support for filter functions.
  *
  * @param string $css        A string of CSS rules, decoded from an HTML `style` attribute.
  * @param string $deprecated Not used.
@@ -3027,6 +3028,9 @@ function safecss_filter_attr( $css, $deprecated = '' ) {
 					. '|translate|translate3d|translateX|translateY|translateZ'
 					// Basic shape functions, as used by `clip-path`.
 					. '|circle|ellipse|inset|path|polygon|rect|shape|xywh'
+					// Filter functions.
+					. '|blur|brightness|contrast|drop-shadow|grayscale'
+					. '|hue-rotate|invert|opacity|saturate|sepia'
 				. ')(\((?:[^()]|(?1))*\))/',
 				'',
 				$css_test_string

--- a/tests/phpunit/tests/kses.php
+++ b/tests/phpunit/tests/kses.php
@@ -1225,6 +1225,7 @@ EOF;
 	 * @ticket 65457
 	 * @ticket 64974
 	 * @ticket 65832
+	 * @ticket 65871
 	 *
 	 * @dataProvider data_safecss_filter_attr
 	 *
@@ -1881,6 +1882,80 @@ EOF;
 			array(
 				'css'      => 'clip-path: url(javascript:alert(1))',
 				'expected' => '',
+			),
+			// Filter functions (ticket #65871).
+			array(
+				'css'      => 'filter: blur(5px)',
+				'expected' => 'filter: blur(5px)',
+			),
+			array(
+				'css'      => 'filter: brightness(0.4)',
+				'expected' => 'filter: brightness(0.4)',
+			),
+			array(
+				'css'      => 'filter: contrast(200%)',
+				'expected' => 'filter: contrast(200%)',
+			),
+			array(
+				'css'      => 'filter: drop-shadow(16px 16px 20px blue)',
+				'expected' => 'filter: drop-shadow(16px 16px 20px blue)',
+			),
+			array(
+				'css'      => 'filter: grayscale(50%)',
+				'expected' => 'filter: grayscale(50%)',
+			),
+			array(
+				'css'      => 'filter: hue-rotate(90deg)',
+				'expected' => 'filter: hue-rotate(90deg)',
+			),
+			array(
+				'css'      => 'filter: invert(75%)',
+				'expected' => 'filter: invert(75%)',
+			),
+			array(
+				'css'      => 'filter: opacity(25%)',
+				'expected' => 'filter: opacity(25%)',
+			),
+			array(
+				'css'      => 'filter: saturate(30%)',
+				'expected' => 'filter: saturate(30%)',
+			),
+			array(
+				'css'      => 'filter: sepia(60%)',
+				'expected' => 'filter: sepia(60%)',
+			),
+			// Multiple filter functions chained.
+			array(
+				'css'      => 'filter: blur(5px) brightness(0.4)',
+				'expected' => 'filter: blur(5px) brightness(0.4)',
+			),
+			// Nested functions within a filter function are allowed.
+			array(
+				'css'      => 'filter: blur(calc(2px + 3px))',
+				'expected' => 'filter: blur(calc(2px + 3px))',
+			),
+			array(
+				'css'      => 'filter: drop-shadow(0 0 var(--shadow-size) black)',
+				'expected' => 'filter: drop-shadow(0 0 var(--shadow-size) black)',
+			),
+			// filter: none and filter: url() are unchanged (regression control).
+			array(
+				'css'      => 'filter: none',
+				'expected' => 'filter: none',
+			),
+			array(
+				'css'      => 'filter: url(#svgBlur)',
+				'expected' => 'filter: url(#svgBlur)',
+			),
+			// Disallow javascript: URLs in filter url() references (security regression).
+			array(
+				'css'      => 'filter: url(javascript:alert(1))',
+				'expected' => '',
+			),
+			// The opacity property is unaffected by the opacity() filter function.
+			array(
+				'css'      => 'opacity: 0.5',
+				'expected' => 'opacity: 0.5',
 			),
 		);
 	}


### PR DESCRIPTION
`filter` has been in the `safecss_filter_attr()` property allowlist since [52049], and
[55564] made `url()` values survive, but the CSS filter functions were never added to the
function-stripping expression at `wp-includes/kses.php:3018`. A declaration using one still
contains a `(` when it reaches the check below it, so it is dropped in full and the property
is unusable in its canonical form for anyone without `unfiltered_html`.

Measured on trunk at [63180], PHP 8.3:

| Declaration | Before | After |
| --- | --- | --- |
| `filter: blur(5px)` | dropped | kept |
| `filter: brightness(0.4)` | dropped | kept |
| `filter: contrast(200%)` | dropped | kept |
| `filter: drop-shadow(16px 16px 20px blue)` | dropped | kept |
| `filter: grayscale(50%)` | dropped | kept |
| `filter: hue-rotate(90deg)` | kept | kept |
| `filter: invert(75%)` | dropped | kept |
| `filter: opacity(25%)` | dropped | kept |
| `filter: saturate(30%)` | dropped | kept |
| `filter: sepia(60%)` | dropped | kept |
| `filter: blur(5px) brightness(0.4)` | dropped | kept |
| `filter: url(#svg-blur)` | kept | kept |
| `filter: none` | kept | kept |

`hue-rotate()` already passed, but not by design: [63180] added `rotate` for the transform
functions and `\brotate(` matches inside `hue-rotate(90deg)` because the hyphen is a word
boundary, leaving `filter: hue-` in the test string. It is now matched by its own name.

This is the same change [63180] made for the transform and basic shape functions. The value
is still re-emitted from the original declaration, `url()` values still go through
`wp_kses_bad_protocol()`, and the test string check is unchanged, so the security model is
the same.

Not in scope: `backdrop-filter` is not allowlisted at all, and the colour functions `rgb()`,
`rgba()`, `hsl()` and `color-mix()` are dropped everywhere, which is #56391.

## Testing

12 of the new cases fail on trunk without the `kses.php` change:

```
1) Tests_Kses::test_safecss_filter_attr with data set #138 ('filter: blur(5px)', 'filter: blur(5px)')
...
FAILURES!
Tests: 163, Assertions: 163, Failures: 12.
```

With the patch the full `kses` group is green, 487 tests / 1562 assertions, and `phpcs`
passes on both changed files.

Trac ticket: https://core.trac.wordpress.org/ticket/65871

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Drafting this description and a first pass at the test cases. I measured the
before and after behaviour myself, confirmed the tests fail without the patch, ran the
`kses` group and `phpcs`, and I take responsibility for the change.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
