### PR TITLE
Comments: Update the "Mine" count after AJAX moderation and reply actions.

### DIFF
--- a/src/js/_enqueues/admin/edit-comments.js
+++ b/src/js/_enqueues/admin/edit-comments.js
@@ -480,12 +480,13 @@ window.setCommentsList = function() {
 			response = true === settings.parsed ? {} : settings.parsed.responses[0],
 			commentStatus = true === settings.parsed ? '' : response.supplemental.status,
 			commentPostId = true === settings.parsed ? '' : response.supplemental.postId,
+			isCurrentUserComment = true === settings.parsed ? false : !! parseInt( response.supplemental.isCurrentUserComment, 10 ),
 			newTotal = true === settings.parsed ? '' : response.supplemental,
 
 			targetParent = $( settings.target ).parent(),
 			commentRow = $('#' + settings.element),
 
-			spamDiff, trashDiff, pendingDiff, approvedDiff,
+			spamDiff, trashDiff, pendingDiff, approvedDiff, mineDiff,
 
 			/*
 			 * As `wpList` toggles only the `unapproved` class, the approved comment
@@ -621,6 +622,11 @@ window.setCommentsList = function() {
 			} else if ( trashed ) {
 				trashDiff = -1;
 			}
+		}
+
+		mineDiff = ( pendingDiff || 0 ) + ( approvedDiff || 0 );
+		if ( mineDiff && isCurrentUserComment ) {
+			updateCountText( 'span.mine-count', mineDiff );
 		}
 
 		if ( pendingDiff ) {
@@ -1155,6 +1161,7 @@ window.commentReply = {
 			updateInModerationText( r.supplemental );
 			updateApproved( 1, r.supplemental.parent_post_id );
 			updateCountText( 'span.all-count', 1 );
+			updateCountText( 'span.mine-count', 1 );
 		}
 
 		r.data = r.data || '';

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -488,6 +488,7 @@ function _wp_ajax_delete_comment_response( $comment_id, $delta = -1 ) {
 				'supplemental' => array(
 					'status'               => $comment_status,
 					'postId'               => $comment ? $comment->comment_post_ID : '',
+					'isCurrentUserComment' => (int) ( $comment && get_current_user_id() === (int) $comment->user_id ),
 					'time'                 => $time,
 					'in_moderation'        => $counts->moderated,
 					'i18n_comments_text'   => sprintf(
@@ -559,6 +560,7 @@ function _wp_ajax_delete_comment_response( $comment_id, $delta = -1 ) {
 			'supplemental' => array(
 				'status'               => $comment ? $comment->comment_approved : '',
 				'postId'               => $comment ? $comment->comment_post_ID : '',
+				'isCurrentUserComment' => (int) ( $comment && get_current_user_id() === (int) $comment->user_id ),
 				/* translators: %s: Number of comments. */
 				'total_items_i18n'     => sprintf( _n( '%s item', '%s items', $total ), number_format_i18n( $total ) ),
 				'total_pages'          => (int) ceil( $total / $per_page ),


### PR DESCRIPTION
## Summary
- The comments list table updates the All, Approved, Pending, Spam, and Trash counts via AJAX after replying to or moderating a comment, but the "Mine" count never updates.
- Adds an `isCurrentUserComment` flag to the `supplemental` data returned by `_wp_ajax_delete_comment_response()` (used by both `wp_ajax_delete_comment()` for trash/untrash/spam/unspam/delete, and `wp_ajax_dim_comment()` for approve/unapprove).
- `edit-comments.js` uses that flag to bump `span.mine-count` by the same delta as Pending/Approved when the affected comment belongs to the current user, and unconditionally bumps it by 1 after a reply is added (a reply is always authored by the current user).

## Why
"Mine" (`class-wp-comments-list-table.php`) counts comments where `comment->user_id === get_current_user_id()`, independent of moderation. Approve/Unapprove alone never changes this count since Mine already includes both pending and approved comments; only entering/leaving Spam/Trash does — which is what the JS change reflects.

Fixes https://core.trac.wordpress.org/ticket/46017

## Testing
- `php -l` on the touched PHP file.
- `node --check` on the touched JS file.
- Manually verified in the browser: replying to and moderating (approve/unapprove/spam/unspam/trash/untrash) a comment authored by the current user updates the "Mine" tab count; actions on other users' comments leave it unchanged.

## Test plan
- [x] Visit `/wp-admin/edit-comments.php` as a user who has authored comments.
- [x] Reply to one of your own comments — "Mine" count increments.
- [x] Approve/Unapprove one of your own comments — "Mine" count stays the same (comment just moves between Pending/Approved).
- [x] Spam, Trash, and their Undo actions on your own comments — "Mine" count decrements/increments accordingly.
- [x] Moderate a comment authored by a different user — "Mine" count does not change.
