### PR TITLE
Accept non-string scalars in the esc_*() escaping functions

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -4716,11 +4716,13 @@ function htmlentities2( $text ) {
  * be in single quotes. The {@see 'js_escape'} filter is also applied here.
  *
  * @since 2.8.0
+ * @since 7.2.0 Non-string scalars are cast to string before escaping.
  *
- * @param string $text The text to be escaped.
+ * @param string|int|float $text The text to be escaped.
  * @return string Escaped text.
  */
 function esc_js( $text ) {
+	$text      = (string) $text;
 	$safe_text = wp_check_invalid_utf8( $text );
 	$safe_text = _wp_specialchars( $safe_text, ENT_COMPAT );
 	$safe_text = preg_replace( '/&#(x)?0*(?(1)27|39);?/i', "'", stripslashes( $safe_text ) );
@@ -4744,11 +4746,13 @@ function esc_js( $text ) {
  * Escaping for HTML blocks.
  *
  * @since 2.8.0
+ * @since 7.2.0 Non-string scalars are cast to string before escaping.
  *
- * @param string $text
+ * @param string|int|float $text The text to be escaped.
  * @return string Escaped text.
  */
 function esc_html( $text ) {
+	$text      = (string) $text;
 	$safe_text = wp_check_invalid_utf8( $text );
 	$safe_text = _wp_specialchars( $safe_text, ENT_QUOTES );
 	/**
@@ -4769,11 +4773,13 @@ function esc_html( $text ) {
  * Escaping for HTML attributes.
  *
  * @since 2.8.0
+ * @since 7.2.0 Non-string scalars are cast to string before escaping.
  *
- * @param string $text
+ * @param string|int|float $text The text to be escaped.
  * @return string Escaped text.
  */
 function esc_attr( $text ) {
+	$text      = (string) $text;
 	$safe_text = wp_check_invalid_utf8( $text );
 	$safe_text = _wp_specialchars( $safe_text, ENT_QUOTES );
 	/**
@@ -4794,11 +4800,13 @@ function esc_attr( $text ) {
  * Escaping for textarea values.
  *
  * @since 3.1.0
+ * @since 7.2.0 Non-string scalars are cast to string before escaping.
  *
- * @param string $text
+ * @param string|int|float $text The text to be escaped.
  * @return string Escaped text.
  */
 function esc_textarea( $text ) {
+	$text      = (string) $text;
 	$safe_text = htmlspecialchars( $text, ENT_QUOTES, get_option( 'blog_charset' ) );
 	/**
 	 * Filters a string cleaned and escaped for output in a textarea element.
@@ -4815,11 +4823,13 @@ function esc_textarea( $text ) {
  * Escaping for XML blocks.
  *
  * @since 5.5.0
+ * @since 7.2.0 Non-string scalars are cast to string before escaping.
  *
- * @param string $text Text to escape.
+ * @param string|int|float $text The text to be escaped.
  * @return string Escaped text.
  */
 function esc_xml( $text ) {
+	$text      = (string) $text;
 	$safe_text = wp_check_invalid_utf8( $text );
 
 	$cdata_regex = '\<\!\[CDATA\[.*?\]\]\>';

--- a/tests/phpstan/baselines/argument.type.neon
+++ b/tests/phpstan/baselines/argument.type.neon
@@ -44,7 +44,7 @@ parameters:
 			count: 2
 			path: ../../../src/wp-admin/comment.php
 		-
-			message: '#^Parameter \#1 \$text of function esc_attr expects string, bool given\.$#'
+			message: '#^Parameter \#1 \$text of function esc_attr expects float\|int\|string, bool given\.$#'
 			identifier: argument.type
 			count: 1
 			path: ../../../src/wp-admin/customize.php
@@ -54,24 +54,9 @@ parameters:
 			count: 1
 			path: ../../../src/wp-admin/edit-comments.php
 		-
-			message: '#^Parameter \#1 \$text of function esc_attr expects string, int given\.$#'
-			identifier: argument.type
-			count: 4
-			path: ../../../src/wp-admin/edit-comments.php
-		-
-			message: '#^Parameter \#1 \$text of function esc_attr expects string, int\<min, \-1\>\|int\<1, max\> given\.$#'
-			identifier: argument.type
-			count: 1
-			path: ../../../src/wp-admin/edit-comments.php
-		-
 			message: '#^Parameter \#1 \$screen of function do_meta_boxes expects string\|WP_Screen, null given\.$#'
 			identifier: argument.type
 			count: 2
-			path: ../../../src/wp-admin/edit-form-advanced.php
-		-
-			message: '#^Parameter \#1 \$text of function esc_attr expects string, int\<0, max\> given\.$#'
-			identifier: argument.type
-			count: 1
 			path: ../../../src/wp-admin/edit-form-advanced.php
 		-
 			message: '#^Parameter \#1 \$post of function get_edit_post_link expects int\|WP_Post, string given\.$#'
@@ -119,16 +104,6 @@ parameters:
 			count: 2
 			path: ../../../src/wp-admin/includes/ajax-actions.php
 		-
-			message: '#^Parameter \#1 \$text of function esc_attr expects string, int given\.$#'
-			identifier: argument.type
-			count: 1
-			path: ../../../src/wp-admin/includes/ajax-actions.php
-		-
-			message: '#^Parameter \#1 \$text of function esc_attr expects string, int\<0, max\> given\.$#'
-			identifier: argument.type
-			count: 1
-			path: ../../../src/wp-admin/includes/ajax-actions.php
-		-
 			message: '#^Parameter \#2 \$compare_from of function wp_get_revision_ui_diff expects int, string given\.$#'
 			identifier: argument.type
 			count: 1
@@ -149,30 +124,10 @@ parameters:
 			count: 1
 			path: ../../../src/wp-admin/includes/class-automatic-upgrader-skin.php
 		-
-			message: '#^Parameter \#1 \$text of function esc_attr expects string, int given\.$#'
-			identifier: argument.type
-			count: 2
-			path: ../../../src/wp-admin/includes/class-bulk-upgrader-skin.php
-		-
-			message: '#^Parameter \#1 \$text of function esc_js expects string, int given\.$#'
-			identifier: argument.type
-			count: 4
-			path: ../../../src/wp-admin/includes/class-bulk-upgrader-skin.php
-		-
 			message: '#^Parameter \#1 \$text of function submit_button expects string, null given\.$#'
 			identifier: argument.type
 			count: 1
 			path: ../../../src/wp-admin/includes/class-custom-background.php
-		-
-			message: '#^Parameter \#1 \$text of function esc_attr expects string, \(float\|int\) given\.$#'
-			identifier: argument.type
-			count: 1
-			path: ../../../src/wp-admin/includes/class-custom-image-header.php
-		-
-			message: '#^Parameter \#1 \$text of function esc_attr expects string, float\|int given\.$#'
-			identifier: argument.type
-			count: 4
-			path: ../../../src/wp-admin/includes/class-custom-image-header.php
 		-
 			message: '#^Parameter \#1 \$text of function submit_button expects string, null given\.$#'
 			identifier: argument.type
@@ -183,16 +138,6 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: ../../../src/wp-admin/includes/class-language-pack-upgrader.php
-		-
-			message: '#^Parameter \#1 \$text of function esc_attr expects string, int given\.$#'
-			identifier: argument.type
-			count: 1
-			path: ../../../src/wp-admin/includes/class-walker-nav-menu-edit.php
-		-
-			message: '#^Parameter \#1 \$text of function esc_attr expects string, int\<0, max\> given\.$#'
-			identifier: argument.type
-			count: 1
-			path: ../../../src/wp-admin/includes/class-walker-nav-menu-edit.php
 		-
 			message: '#^Parameter \#1 \$str of function md5 expects string, int given\.$#'
 			identifier: argument.type
@@ -209,55 +154,10 @@ parameters:
 			count: 1
 			path: ../../../src/wp-admin/includes/class-wp-comments-list-table.php
 		-
-			message: '#^Parameter \#1 \$text of function esc_attr expects string, int given\.$#'
-			identifier: argument.type
-			count: 1
-			path: ../../../src/wp-admin/includes/class-wp-ms-users-list-table.php
-		-
 			message: '#^Parameter \#3 \$number of function _nx expects int, float given\.$#'
 			identifier: argument.type
 			count: 1
 			path: ../../../src/wp-admin/includes/class-wp-plugin-install-list-table.php
-		-
-			message: '#^Parameter \#1 \$text of function esc_attr expects string, int given\.$#'
-			identifier: argument.type
-			count: 1
-			path: ../../../src/wp-admin/includes/class-wp-plugins-list-table.php
-		-
-			message: '#^Parameter \#1 \$text of function esc_attr expects string, int given\.$#'
-			identifier: argument.type
-			count: 2
-			path: ../../../src/wp-admin/includes/class-wp-privacy-data-export-requests-list-table.php
-		-
-			message: '#^Parameter \#1 \$text of function esc_attr expects string, int\<0, max\> given\.$#'
-			identifier: argument.type
-			count: 2
-			path: ../../../src/wp-admin/includes/class-wp-privacy-data-export-requests-list-table.php
-		-
-			message: '#^Parameter \#1 \$text of function esc_attr expects string, int given\.$#'
-			identifier: argument.type
-			count: 2
-			path: ../../../src/wp-admin/includes/class-wp-privacy-data-removal-requests-list-table.php
-		-
-			message: '#^Parameter \#1 \$text of function esc_attr expects string, int\<0, max\> given\.$#'
-			identifier: argument.type
-			count: 2
-			path: ../../../src/wp-admin/includes/class-wp-privacy-data-removal-requests-list-table.php
-		-
-			message: '#^Parameter \#1 \$text of function esc_attr expects string, int given\.$#'
-			identifier: argument.type
-			count: 2
-			path: ../../../src/wp-admin/includes/class-wp-privacy-requests-table.php
-		-
-			message: '#^Parameter \#1 \$text of function esc_attr expects string, int given\.$#'
-			identifier: argument.type
-			count: 1
-			path: ../../../src/wp-admin/includes/class-wp-screen.php
-		-
-			message: '#^Parameter \#1 \$text of function esc_attr expects string, int\<1, max\> given\.$#'
-			identifier: argument.type
-			count: 1
-			path: ../../../src/wp-admin/includes/class-wp-screen.php
 		-
 			message: '#^Parameter \#1 \$version of function get_core_checksums expects string, float given\.$#'
 			identifier: argument.type
@@ -329,11 +229,6 @@ parameters:
 			count: 1
 			path: ../../../src/wp-admin/includes/image-edit.php
 		-
-			message: '#^Parameter \#1 \$text of function esc_attr expects string, int given\.$#'
-			identifier: argument.type
-			count: 2
-			path: ../../../src/wp-admin/includes/image-edit.php
-		-
 			message: '#^Parameter \#1 \$width of function wp_imagecreatetruecolor expects int, float given\.$#'
 			identifier: argument.type
 			count: 1
@@ -379,35 +274,10 @@ parameters:
 			count: 1
 			path: ../../../src/wp-admin/includes/media.php
 		-
-			message: '#^Parameter \#1 \$text of function esc_attr expects string, int given\.$#'
-			identifier: argument.type
-			count: 2
-			path: ../../../src/wp-admin/includes/media.php
-		-
 			message: '#^Parameter \#2 \$result of function wp_parse_str expects array, \(string\|false\) given\.$#'
 			identifier: argument.type
 			count: 1
 			path: ../../../src/wp-admin/includes/menu.php
-		-
-			message: '#^Parameter \#1 \$text of function esc_attr expects string, int given\.$#'
-			identifier: argument.type
-			count: 1
-			path: ../../../src/wp-admin/includes/meta-boxes.php
-		-
-			message: '#^Parameter \#1 \$text of function esc_attr expects string, int given\.$#'
-			identifier: argument.type
-			count: 8
-			path: ../../../src/wp-admin/includes/misc.php
-		-
-			message: '#^Parameter \#1 \$text of function esc_attr expects string, int\<0, max\> given\.$#'
-			identifier: argument.type
-			count: 2
-			path: ../../../src/wp-admin/includes/misc.php
-		-
-			message: '#^Parameter \#1 \$text of function esc_attr expects string, int\<1, max\> given\.$#'
-			identifier: argument.type
-			count: 2
-			path: ../../../src/wp-admin/includes/misc.php
 		-
 			message: '#^Parameter \#1 \$link_id of function wp_delete_link expects int, string\|null given\.$#'
 			identifier: argument.type
@@ -464,11 +334,6 @@ parameters:
 			count: 4
 			path: ../../../src/wp-admin/includes/plugin.php
 		-
-			message: '#^Parameter \#1 \$text of function esc_attr expects string, int\<0, max\> given\.$#'
-			identifier: argument.type
-			count: 1
-			path: ../../../src/wp-admin/includes/post.php
-		-
 			message: '#^Parameter \#2 \$fallback_title of function sanitize_title expects string, int\<0, max\> given\.$#'
 			identifier: argument.type
 			count: 2
@@ -513,11 +378,6 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: ../../../src/wp-admin/includes/update-core.php
-		-
-			message: '#^Parameter \#1 \$text of function esc_attr expects string, int given\.$#'
-			identifier: argument.type
-			count: 1
-			path: ../../../src/wp-admin/includes/update.php
 		-
 			message: '#^Parameter \#1 \$timestamp of function wp_schedule_event expects int, float given\.$#'
 			identifier: argument.type
@@ -564,11 +424,6 @@ parameters:
 			count: 1
 			path: ../../../src/wp-admin/install.php
 		-
-			message: '#^Parameter \#1 \$text of function esc_attr expects string, int given\.$#'
-			identifier: argument.type
-			count: 5
-			path: ../../../src/wp-admin/nav-menus.php
-		-
 			message: '#^Parameter \#2 \$menu_data of function wp_save_nav_menu_items expects array\<array\>, int given\.$#'
 			identifier: argument.type
 			count: 1
@@ -579,17 +434,7 @@ parameters:
 			count: 1
 			path: ../../../src/wp-admin/network/site-info.php
 		-
-			message: '#^Parameter \#1 \$text of function esc_attr expects string, int\<min, \-1\>\|int\<1, max\> given\.$#'
-			identifier: argument.type
-			count: 1
-			path: ../../../src/wp-admin/network/site-info.php
-		-
 			message: '#^Parameter \#1 \$network_id of function can_edit_network expects int, string given\.$#'
-			identifier: argument.type
-			count: 1
-			path: ../../../src/wp-admin/network/site-settings.php
-		-
-			message: '#^Parameter \#1 \$text of function esc_attr expects string, int\<min, \-1\>\|int\<1, max\> given\.$#'
 			identifier: argument.type
 			count: 1
 			path: ../../../src/wp-admin/network/site-settings.php
@@ -599,37 +444,12 @@ parameters:
 			count: 1
 			path: ../../../src/wp-admin/network/site-themes.php
 		-
-			message: '#^Parameter \#1 \$text of function esc_attr expects string, int\<min, \-1\>\|int\<1, max\> given\.$#'
-			identifier: argument.type
-			count: 2
-			path: ../../../src/wp-admin/network/site-themes.php
-		-
 			message: '#^Parameter \#1 \$network_id of function can_edit_network expects int, string given\.$#'
 			identifier: argument.type
 			count: 1
 			path: ../../../src/wp-admin/network/site-users.php
 		-
-			message: '#^Parameter \#1 \$text of function esc_attr expects string, int\<min, \-1\>\|int\<1, max\> given\.$#'
-			identifier: argument.type
-			count: 4
-			path: ../../../src/wp-admin/network/site-users.php
-		-
-			message: '#^Parameter \#1 \$text of function esc_attr expects string, int given\.$#'
-			identifier: argument.type
-			count: 2
-			path: ../../../src/wp-admin/network/sites.php
-		-
-			message: '#^Parameter \#1 \$text of function esc_attr expects string, int\<2, max\> given\.$#'
-			identifier: argument.type
-			count: 1
-			path: ../../../src/wp-admin/options-discussion.php
-		-
-			message: '#^Parameter \#1 \$text of function esc_attr expects string, bool given\.$#'
-			identifier: argument.type
-			count: 1
-			path: ../../../src/wp-admin/options-general.php
-		-
-			message: '#^Parameter \#1 \$text of function esc_attr expects string, int\<0, 6\> given\.$#'
+			message: '#^Parameter \#1 \$text of function esc_attr expects float\|int\|string, bool given\.$#'
 			identifier: argument.type
 			count: 1
 			path: ../../../src/wp-admin/options-general.php
@@ -648,16 +468,6 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: ../../../src/wp-admin/update.php
-		-
-			message: '#^Parameter \#1 \$text of function esc_attr expects string, int given\.$#'
-			identifier: argument.type
-			count: 1
-			path: ../../../src/wp-admin/user-edit.php
-		-
-			message: '#^Parameter \#1 \$text of function esc_attr expects string, int given\.$#'
-			identifier: argument.type
-			count: 10
-			path: ../../../src/wp-admin/users.php
 		-
 			message: '#^Parameter \#1 \$author_id of function get_author_posts_url expects int, string given\.$#'
 			identifier: argument.type
@@ -709,16 +519,6 @@ parameters:
 			count: 1
 			path: ../../../src/wp-content/themes/twentyeleven/inc/theme-options.php
 		-
-			message: '#^Parameter \#1 \$text of function esc_attr expects string, int given\.$#'
-			identifier: argument.type
-			count: 1
-			path: ../../../src/wp-content/themes/twentyeleven/inc/widgets.php
-		-
-			message: '#^Parameter \#1 \$text of function esc_attr expects string, int\<1, max\> given\.$#'
-			identifier: argument.type
-			count: 1
-			path: ../../../src/wp-content/themes/twentyeleven/showcase.php
-		-
 			message: '#^Parameter \#2 \$instance of function the_widget expects array, string given\.$#'
 			identifier: argument.type
 			count: 1
@@ -759,22 +559,12 @@ parameters:
 			count: 1
 			path: ../../../src/wp-content/themes/twentyfourteen/image.php
 		-
-			message: '#^Parameter \#1 \$text of function esc_html expects string, int\<1, max\> given\.$#'
-			identifier: argument.type
-			count: 2
-			path: ../../../src/wp-content/themes/twentyfourteen/image.php
-		-
 			message: '#^Parameter \#1 \$author_id of function get_author_posts_url expects int, string given\.$#'
 			identifier: argument.type
 			count: 1
 			path: ../../../src/wp-content/themes/twentyfourteen/inc/template-tags.php
 		-
 			message: '#^Parameter \#1 \$author_id of function get_author_posts_url expects int, string given\.$#'
-			identifier: argument.type
-			count: 1
-			path: ../../../src/wp-content/themes/twentyfourteen/inc/widgets.php
-		-
-			message: '#^Parameter \#1 \$text of function esc_attr expects string, int given\.$#'
 			identifier: argument.type
 			count: 1
 			path: ../../../src/wp-content/themes/twentyfourteen/inc/widgets.php
@@ -804,25 +594,10 @@ parameters:
 			count: 1
 			path: ../../../src/wp-content/themes/twentynineteen/template-parts/post/author-bio.php
 		-
-			message: '#^Parameter \#1 \$text of function esc_attr expects string, int given\.$#'
-			identifier: argument.type
-			count: 1
-			path: ../../../src/wp-content/themes/twentyseventeen/inc/color-patterns.php
-		-
 			message: '#^Parameter \#1 \$author_id of function get_author_posts_url expects int, string given\.$#'
 			identifier: argument.type
 			count: 1
 			path: ../../../src/wp-content/themes/twentyseventeen/inc/template-tags.php
-		-
-			message: '#^Parameter \#1 \$text of function esc_attr expects string, \(float\|int\) given\.$#'
-			identifier: argument.type
-			count: 1
-			path: ../../../src/wp-content/themes/twentyseventeen/template-parts/page/content-front-page-panels.php
-		-
-			message: '#^Parameter \#1 \$text of function esc_attr expects string, \(float\|int\) given\.$#'
-			identifier: argument.type
-			count: 1
-			path: ../../../src/wp-content/themes/twentyseventeen/template-parts/page/content-front-page.php
 		-
 			message: '#^Parameter \#1 \$size of function next_image_link expects array\<int\>\|string, false given\.$#'
 			identifier: argument.type
@@ -949,11 +724,6 @@ parameters:
 			count: 1
 			path: ../../../src/wp-content/themes/twentytwenty/classes/class-twentytwenty-non-latin-languages.php
 		-
-			message: '#^Parameter \#1 \$text of function esc_attr expects string, int given\.$#'
-			identifier: argument.type
-			count: 2
-			path: ../../../src/wp-content/themes/twentytwenty/functions.php
-		-
 			message: '#^Parameter \#3 \$deps of function wp_enqueue_style expects array\<string\>, null given\.$#'
 			identifier: argument.type
 			count: 1
@@ -968,11 +738,6 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: ../../../src/wp-content/themes/twentytwenty/template-parts/entry-author-bio.php
-		-
-			message: '#^Parameter \#1 \$text of function esc_attr expects string, int\|false given\.$#'
-			identifier: argument.type
-			count: 1
-			path: ../../../src/wp-content/themes/twentytwentyone/inc/template-functions.php
 		-
 			message: '#^Parameter \#1 \$author_id of function get_author_posts_url expects int, string given\.$#'
 			identifier: argument.type
@@ -1044,11 +809,6 @@ parameters:
 			count: 1
 			path: ../../../src/wp-includes/class-wp-comment-query.php
 		-
-			message: '#^Parameter \#1 \$text of function esc_attr expects string, int\<0, max\> given\.$#'
-			identifier: argument.type
-			count: 1
-			path: ../../../src/wp-includes/class-wp-customize-control.php
-		-
 			message: '#^Parameter \#1 \$ajax_message of method WP_Customize_Manager\:\:wp_die\(\) expects string\|WP_Error, int given\.$#'
 			identifier: argument.type
 			count: 6
@@ -1068,11 +828,6 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: ../../../src/wp-includes/class-wp-customize-manager.php
-		-
-			message: '#^Parameter \#1 \$text of function esc_html expects string, int given\.$#'
-			identifier: argument.type
-			count: 1
-			path: ../../../src/wp-includes/class-wp-date-query.php
 		-
 			message: '#^Parameter \#2 \$parent_query of method WP_Date_Query\:\:get_sql_for_clause\(\) expects array, string given\.$#'
 			identifier: argument.type
@@ -1384,11 +1139,6 @@ parameters:
 			count: 2
 			path: ../../../src/wp-includes/general-template.php
 		-
-			message: '#^Parameter \#1 \$text of function esc_attr expects string, float given\.$#'
-			identifier: argument.type
-			count: 2
-			path: ../../../src/wp-includes/general-template.php
-		-
 			message: '#^Parameter \#2 \$replace of function str_replace expects array\<string\>\|string, int\<1, max\> given\.$#'
 			identifier: argument.type
 			count: 2
@@ -1438,16 +1188,6 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: ../../../src/wp-includes/load.php
-		-
-			message: '#^Parameter \#1 \$text of function esc_attr expects string, int\<1, 9\> given\.$#'
-			identifier: argument.type
-			count: 1
-			path: ../../../src/wp-includes/media-template.php
-		-
-			message: '#^Parameter \#1 \$text of function esc_html expects string, int\<1, 9\> given\.$#'
-			identifier: argument.type
-			count: 1
-			path: ../../../src/wp-includes/media-template.php
 		-
 			message: '#^Parameter \#5 \$text of function wp_get_attachment_link expects string\|false, bool given\.$#'
 			identifier: argument.type
@@ -1854,17 +1594,7 @@ parameters:
 			count: 1
 			path: ../../../src/wp-includes/widgets.php
 		-
-			message: '#^Parameter \#1 \$text of function esc_attr expects string, int given\.$#'
-			identifier: argument.type
-			count: 1
-			path: ../../../src/wp-includes/widgets/class-wp-nav-menu-widget.php
-		-
 			message: '#^Parameter \#1 \$post of function get_the_title expects int\|WP_Post, string given\.$#'
 			identifier: argument.type
 			count: 1
 			path: ../../../src/wp-includes/widgets/class-wp-widget-recent-comments.php
-		-
-			message: '#^Parameter \#1 \$text of function esc_html expects string, int given\.$#'
-			identifier: argument.type
-			count: 1
-			path: ../../../src/wp-mail.php


### PR DESCRIPTION
✅  Committed in r63296 (abc50fe).

----

Widens the `@param` annotation on the `esc_*()` escaping functions from `string` to `string|int|float`, and adds an explicit `(string)` cast to each.

This clears **54 baseline entries covering 101 errors** from `tests/phpstan/baselines/argument.type.neon`. `esc_attr()` alone accounted for 94 of them — the largest single cluster in that file.

## Background

`esc_attr()`, `esc_html()`, `esc_js()`, `esc_textarea()`, and `esc_xml()` were all annotated `@param string $text`, but none of them has ever required a string at runtime. The two helpers they delegate to each open by coercing:

- `_wp_specialchars()` — `$text = (string) $text;`
- `wp_check_invalid_utf8()` — the same

Tracing that cast back through r11380 (which deprecated `wp_specialchars()` in favour of `esc_html()`) to r10298 puts it in 2009. Since `esc_attr()` and `esc_html()` are `@since 2.8.0`, also 2009, the coercion is as old as the functions themselves. Only the annotation ever claimed otherwise — which is why passing an `int`, overwhelmingly a post ID, a term ID, or a count, has always worked while still registering as a static analysis error.

Confirmed against the current codebase (PHP 8.5):

| input | `esc_attr()` | `esc_html()` | `esc_js()` | `esc_textarea()` |
|---|---|---|---|---|
| `42` | `'42'` | `'42'` | `'42'` | `'42'` |
| `-7` | `'-7'` | `'-7'` | `'-7'` | `'-7'` |
| `1.5` | `'1.5'` | `'1.5'` | `'1.5'` | `'1.5'` |
| `true` | `'1'` | `'1'` | `'1'` | `'1'` |
| `false` | `''` | `''` | `''` | `''` |

## Why the cast is not redundant

For `esc_attr()`, `esc_html()`, and `esc_js()` the value is already coerced downstream, so the new cast does not change what gets escaped. What it does change is the second argument handed to the `attribute_escape`, `esc_html`, and `js_escape` filters. Each is documented as `@param string $text The text prior to being escaped`, but callbacks previously received the raw `int` or `float`. The cast makes that documented contract true.

`esc_textarea()` is the one case where the cast also affects escaping: it passed `$text` straight to `htmlspecialchars()`, so `esc_textarea( null )` emitted a PHP 8.1+ deprecation. That no longer happens.

## Why `bool` is excluded

`bool` is accepted at runtime, and the cast handles it, but it is deliberately left out of the annotation. Casting `true` yields `'1'` while `false` yields `''`, and an empty string is indistinguishable from a missing value, an empty option, or a failed lookup in any output context. There is no output context where `''` is a meaningful rendering of *false*.

Core has exactly two call sites passing a `bool`, and they split evenly:

- `wp-admin/options-general.php:193` — `data-state="<?php echo esc_attr( has_site_icon() ); ?>"`. This works, because `site-icon.js` compares against the literal `'1'` and writes back `'1'`/`''`. The convention is real but implicit.
- `wp-admin/customize.php:291` — `aria-pressed="<?php echo esc_attr( $active ); ?>"`. This renders `aria-pressed="1"` for the desktop button and `aria-pressed=""` for tablet and mobile. Valid ARIA tristate values are only `"true"`, `"false"`, `"mixed"`, and `"undefined"`, so all three buttons are exposed as non-toggles until `controls.js` (which correctly writes `"true"`/`"false"`) runs.

Admitting `bool` to the signature would permanently silence the second one. Both stay baselined instead, so they remain visible as outstanding work. The accessibility fix is intentionally **not** in this PR and will be handled separately.

## Scope

`esc_textarea()` and `esc_xml()` had no baselined errors and are included only to keep the family consistent — five functions with identical semantics should not carry three different parameter annotations.

Call sites are not touched. Nothing here changes escaping behaviour for any input that was already a string.

Trac ticket: https://core.trac.wordpress.org/ticket/65817

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Investigating the runtime coercion behaviour and its history, the docblock and cast changes, regenerating the baselines, and drafting this description. The decision to exclude `bool` and to defer the accessibility fix was mine, as was review of the result.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**