### PR TITLE
Emit valid values for aria-pressed on the Customizer device buttons

### DIFF
--- a/src/wp-admin/customize.php
+++ b/src/wp-admin/customize.php
@@ -288,7 +288,7 @@ do_action( 'customize_controls_head' );
 							$class .= ' active';
 						}
 						?>
-						<button type="button" class="<?php echo esc_attr( $class ); ?>" aria-pressed="<?php echo esc_attr( $active ); ?>" data-device="<?php echo esc_attr( $device ); ?>">
+						<button type="button" class="<?php echo esc_attr( $class ); ?>" aria-pressed="<?php echo $active ? 'true' : 'false'; ?>" data-device="<?php echo esc_attr( $device ); ?>">
 							<span class="devices__preview-label"><?php echo esc_html( $settings['label'] ); ?></span>
 						</button>
 					<?php endforeach; ?>

--- a/src/wp-admin/options-general.php
+++ b/src/wp-admin/options-general.php
@@ -190,7 +190,7 @@ $tagline_description = sprintf(
 			data-choose-text="<?php esc_attr_e( 'Choose a Site Icon' ); ?>"
 			data-update-text="<?php esc_attr_e( 'Change Site Icon' ); ?>"
 			data-update="<?php esc_attr_e( 'Set as Site Icon' ); ?>"
-			data-state="<?php echo esc_attr( has_site_icon() ); ?>"
+			data-state="<?php echo has_site_icon() ? '1' : ''; ?>"
 
 		>
 			<?php if ( has_site_icon() ) : ?>

--- a/tests/phpstan/baselines/argument.type.neon
+++ b/tests/phpstan/baselines/argument.type.neon
@@ -44,11 +44,6 @@ parameters:
 			count: 2
 			path: ../../../src/wp-admin/comment.php
 		-
-			message: '#^Parameter \#1 \$text of function esc_attr expects float\|int\|string, bool given\.$#'
-			identifier: argument.type
-			count: 1
-			path: ../../../src/wp-admin/customize.php
-		-
 			message: '#^Parameter \#1 \$position of function wp_comment_reply expects int, string given\.$#'
 			identifier: argument.type
 			count: 1
@@ -448,11 +443,6 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: ../../../src/wp-admin/network/site-users.php
-		-
-			message: '#^Parameter \#1 \$text of function esc_attr expects float\|int\|string, bool given\.$#'
-			identifier: argument.type
-			count: 1
-			path: ../../../src/wp-admin/options-general.php
 		-
 			message: '#^Parameter \#2 \$callback of function array_filter expects \(callable\(mixed\)\: bool\)\|null, ''validate_file'' given\.$#'
 			identifier: argument.type


### PR DESCRIPTION
✅  Committed in r63352 (f8d305313c90975c8eaa7ee06fb6a5a144ca9ca9)

----
The responsive-preview buttons in the Customizer emit invalid values for `aria-pressed`, so none of the three is exposed to assistive technology as a toggle button on initial render.

## The defect

`wp-admin/customize.php` rendered the attribute through `esc_attr()` with a bool:

```php
$active = ! empty( $settings['default'] );
...
<button type="button" ... aria-pressed="<?php echo esc_attr( $active ); ?>" ...>
```

PHP casts `true` to `'1'` and `false` to the empty string. Since only the Desktop device carries `'default' => true`, the markup came out as:

```html
<button ... aria-pressed="1"  data-device="desktop">
<button ... aria-pressed=""   data-device="tablet">
<button ... aria-pressed=""   data-device="mobile">
```

`aria-pressed` is a tristate attribute whose only valid values are `true`, `false`, `mixed`, and `undefined`. Both `1` and the empty string are invalid, and an invalid or empty value is treated as `undefined`, which means the element is not exposed as a toggle button at all. So on page load the pressed state of all three buttons was unavailable to screen reader users, and the currently selected preview size was not announced.

The state does become correct after the first interaction, because `customize-controls.js` sets it via jQuery:

```js
.attr( 'aria-pressed', false );
...
.attr( 'aria-pressed', true );
```

jQuery stringifies those to `"false"` and `"true"`, which are valid. So the JavaScript was always right and the server render disagreed with it — the markup only repaired itself once the user clicked something.

## The fix

Emit the literals directly, so the initial render agrees with what the JavaScript later writes:

```php
aria-pressed="<?php echo $active ? 'true' : 'false'; ?>"
```

No escaping is needed since both values are literals. This matches the existing pattern for `aria-expanded` in `wp-admin/includes/template.php`, which assigns `'true'`/`'false'` as strings.

Every `aria-pressed`, `aria-expanded`, `aria-selected`, `aria-checked`, `aria-disabled`, `aria-current`, and `aria-invalid` value rendered from PHP across `src/wp-admin`, `src/wp-includes`, and `src/wp-content/themes` was checked. This was the only one not already a valid literal.

## Also included

`wp-admin/options-general.php` used the same bool-to-string cast for the Site Icon button's `data-state`:

```php
data-state="<?php echo esc_attr( has_site_icon() ); ?>"
```

That one is **not** a defect. `site-icon.js` compares against the literal `'1'` and writes back `'1'`/`''`, so the cast happened to produce exactly the sentinels the script expects. It is changed to `has_site_icon() ? '1' : ''` purely to state that contract rather than leave it resting on PHP's cast rules. Behaviour is identical.

It is included here because these were the only two places in core passing a bool to an escaping function. Commit r63296 widened the `esc_*()` annotations to `string|int|float` and deliberately excluded `bool` so that both call sites stayed visible rather than being silently permitted by the signature; resolving them empties the last of the `esc_*()` entries from `tests/phpstan/baselines/argument.type.neon`.

Trac ticket: Core-65817

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Identifying the invalid attribute values, sweeping core for other occurrences, the fix itself, and drafting this description. Reviewed by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**