### PR TITLE
Bundled themes: Version bumps for version 7.2

### DIFF
--- a/src/wp-content/themes/twentyeleven/header.php
+++ b/src/wp-content/themes/twentyeleven/header.php
@@ -43,7 +43,7 @@ if ( ( $paged >= 2 || $page >= 2 ) && ! is_404() ) {
 ?>
 	</title>
 <link rel="profile" href="https://gmpg.org/xfn/11" />
-<link rel="stylesheet" media="all" href="<?php echo esc_url( get_stylesheet_uri() ); ?>?ver=20260819" />
+<link rel="stylesheet" media="all" href="<?php echo esc_url( get_stylesheet_uri() ); ?>?ver=20261209" />
 <link rel="pingback" href="<?php echo esc_url( get_bloginfo( 'pingback_url' ) ); ?>">
 <?php
 	/*

--- a/src/wp-content/themes/twentyeleven/readme.txt
+++ b/src/wp-content/themes/twentyeleven/readme.txt
@@ -1,9 +1,9 @@
 === Twenty Eleven ===
 Contributors: wordpressdotorg
 Requires at least: 3.2
-Tested up to: 7.1
+Tested up to: 7.2
 Requires PHP: 5.2.4
-Stable tag: 5.2
+Stable tag: 5.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Tags: blog, one-column, two-columns, left-sidebar, right-sidebar, custom-background, custom-colors, custom-header, custom-menu, editor-style, featured-image-header, featured-images, flexible-header, footer-widgets, full-width-template, microformats, post-formats, rtl-language-support, sticky-post, theme-options, translation-ready, block-patterns
@@ -43,6 +43,11 @@ Images
 "People Woman Photo" by Brooke Cagle. CC0. https://stocksnap.io/photo/people-woman-MU7G67710S
 
 == Changelog ==
+
+= 5.3 =
+* Released: December 9, 2026
+
+https://wordpress.org/documentation/article/twenty-eleven-changelog/#Version_5.3
 
 = 5.2 =
 * Released: August 19, 2026

--- a/src/wp-content/themes/twentyeleven/style.css
+++ b/src/wp-content/themes/twentyeleven/style.css
@@ -4,9 +4,9 @@ Theme URI: https://wordpress.org/themes/twentyeleven/
 Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: The 2011 theme for WordPress is sophisticated, lightweight, and adaptable. Make it yours with a custom menu, header image, and background -- then go further with available theme options for light or dark color scheme, custom link colors, and three layout choices. Twenty Eleven comes equipped with a Showcase page template that transforms your front page into a showcase to show off your best content, widget support galore (sidebar, three footer areas, and a Showcase page widget area), and a custom "Ephemera" widget to display your Aside, Link, Quote, or Status posts. Included are styles for print and for the admin editor, support for featured images (as custom header images on posts and pages and as large images on featured "sticky" posts), and special styles for six different post formats.
-Version: 5.2
+Version: 5.3
 Requires at least: 3.2
-Tested up to: 7.1
+Tested up to: 7.2
 Requires PHP: 5.2.4
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/src/wp-content/themes/twentyfifteen/functions.php
+++ b/src/wp-content/themes/twentyfifteen/functions.php
@@ -441,7 +441,7 @@ function twentyfifteen_scripts() {
 	wp_enqueue_style( 'genericons', get_template_directory_uri() . '/genericons/genericons.css', array(), '20251101' );
 
 	// Load our main stylesheet.
-	wp_enqueue_style( 'twentyfifteen-style', get_stylesheet_uri(), array(), '20260819' );
+	wp_enqueue_style( 'twentyfifteen-style', get_stylesheet_uri(), array(), '20261209' );
 
 	// Theme block stylesheet.
 	wp_enqueue_style( 'twentyfifteen-block-style', get_template_directory_uri() . '/css/blocks.css', array( 'twentyfifteen-style' ), '20240715' );

--- a/src/wp-content/themes/twentyfifteen/readme.txt
+++ b/src/wp-content/themes/twentyfifteen/readme.txt
@@ -1,9 +1,9 @@
 === Twenty Fifteen ===
 Contributors: wordpressdotorg
 Requires at least: 4.1
-Tested up to: 7.1
+Tested up to: 7.2
 Requires PHP: 5.2.4
-Version: 4.3
+Version: 4.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Tags: blog, two-columns, left-sidebar, accessibility-ready, custom-background, custom-colors, custom-header, custom-logo, custom-menu, editor-style, featured-images, microformats, post-formats, rtl-language-support, sticky-post, threaded-comments, translation-ready, block-patterns
@@ -72,6 +72,11 @@ Source: https://stocksnap.io/photo/purple-yellow-ACF0693B9C
         https://stocksnap.io/photo/sunset-pier-77F43EA43C
 
 == Changelog ==
+
+= 4.4 =
+* Released: December 9, 2026
+
+https://wordpress.org/documentation/article/twenty-fifteen-changelog/#Version_4.4
 
 = 4.3 =
 * Released: August 19, 2026

--- a/src/wp-content/themes/twentyfifteen/style.css
+++ b/src/wp-content/themes/twentyfifteen/style.css
@@ -4,9 +4,9 @@ Theme URI: https://wordpress.org/themes/twentyfifteen/
 Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: Our 2015 default theme is clean, blog-focused, and designed for clarity. Twenty Fifteen's simple, straightforward typography is readable on a wide variety of screen sizes, and suitable for multiple languages. We designed it using a mobile-first approach, meaning your content takes center-stage, regardless of whether your visitors arrive by smartphone, tablet, laptop, or desktop computer.
-Version: 4.3
+Version: 4.4
 Requires at least: 4.1
-Tested up to: 7.1
+Tested up to: 7.2
 Requires PHP: 5.2.4
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/src/wp-content/themes/twentyfourteen/functions.php
+++ b/src/wp-content/themes/twentyfourteen/functions.php
@@ -351,7 +351,7 @@ function twentyfourteen_scripts() {
 	wp_enqueue_style( 'genericons', get_template_directory_uri() . '/genericons/genericons.css', array(), '20251101' );
 
 	// Load our main stylesheet.
-	wp_enqueue_style( 'twentyfourteen-style', get_stylesheet_uri(), array(), '20260819' );
+	wp_enqueue_style( 'twentyfourteen-style', get_stylesheet_uri(), array(), '20261209' );
 
 	// Theme block stylesheet.
 	wp_enqueue_style( 'twentyfourteen-block-style', get_template_directory_uri() . '/css/blocks.css', array( 'twentyfourteen-style' ), '20250715' );

--- a/src/wp-content/themes/twentyfourteen/readme.txt
+++ b/src/wp-content/themes/twentyfourteen/readme.txt
@@ -1,9 +1,9 @@
 === Twenty Fourteen ===
 Contributors: wordpressdotorg
 Requires at least: 3.6
-Tested up to: 7.1
+Tested up to: 7.2
 Requires PHP: 5.2.4
-Stable tag: 4.6
+Stable tag: 4.7
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Tags: blog, news, two-columns, three-columns, left-sidebar, right-sidebar, custom-background, custom-header, custom-menu, editor-style, featured-images, flexible-header, footer-widgets, full-width-template, microformats, post-formats, rtl-language-support, sticky-post, theme-options, translation-ready, accessibility-ready, block-patterns
@@ -59,6 +59,11 @@ Source: https://stocksnap.io/photo/fog-mountain-ZKN6UKFKEO
         https://stocksnap.io/photo/guy-man-7CFLDIWXK5
 
 == Changelog ==
+
+= 4.7 =
+* Released: December 9, 2026
+
+https://wordpress.org/documentation/article/twenty-fourteen-changelog/#Version_4.7
 
 = 4.6 =
 * Released: August 19, 2026

--- a/src/wp-content/themes/twentyfourteen/style.css
+++ b/src/wp-content/themes/twentyfourteen/style.css
@@ -4,9 +4,9 @@ Theme URI: https://wordpress.org/themes/twentyfourteen/
 Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: In 2014, our default theme lets you create a responsive magazine website with a sleek, modern design. Feature your favorite homepage content in either a grid or a slider. Use the three widget areas to customize your website, and change your content's layout with a full-width page template and a contributor page to show off your authors. Creating a magazine website with WordPress has never been easier.
-Version: 4.6
+Version: 4.7
 Requires at least: 3.6
-Tested up to: 7.1
+Tested up to: 7.2
 Requires PHP: 5.2.4
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/src/wp-content/themes/twentynineteen/package-lock.json
+++ b/src/wp-content/themes/twentynineteen/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "twentynineteen",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "twentynineteen",
-      "version": "3.4.0",
+      "version": "3.5.0",
       "devDependencies": {
         "@wordpress/browserslist-config": "^6.34.0",
         "autoprefixer": "^10.4.22",

--- a/src/wp-content/themes/twentynineteen/package.json
+++ b/src/wp-content/themes/twentynineteen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twentynineteen",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "Default WP Theme",
   "bugs": {
     "url": "https://core.trac.wordpress.org/"

--- a/src/wp-content/themes/twentynineteen/readme.txt
+++ b/src/wp-content/themes/twentynineteen/readme.txt
@@ -2,9 +2,9 @@
 Contributors: wordpressdotorg
 Tags: one-column, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, block-patterns
 Requires at least: 4.7
-Tested up to: 7.1
+Tested up to: 7.2
 Requires PHP: 5.2.4
-Stable tag: 3.4
+Stable tag: 3.5
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -39,6 +39,11 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
 
 == Changelog ==
+
+= 3.5 =
+* Released: December 9, 2026
+
+https://wordpress.org/documentation/article/twenty-nineteen-changelog/#Version_3.5
 
 = 3.4 =
 * Released: August 19, 2026

--- a/src/wp-content/themes/twentynineteen/style-rtl.css
+++ b/src/wp-content/themes/twentynineteen/style-rtl.css
@@ -5,10 +5,10 @@ Theme URI: https://wordpress.org/themes/twentynineteen/
 Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: Our 2019 default theme is designed to show off the power of the block editor. It features custom styles for all the default blocks, and is built so that what you see in the editor looks like what you'll see on your website. Twenty Nineteen is designed to be adaptable to a wide range of websites, whether you’re running a photo blog, launching a new business, or supporting a non-profit. Featuring ample whitespace and modern sans-serif headlines paired with classic serif body text, it's built to be beautiful on all screen sizes.
-Tested up to: 7.1
+Tested up to: 7.2
 Requires at least: 4.7
 Requires PHP: 5.2.4
-Version: 3.4
+Version: 3.5
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: twentynineteen

--- a/src/wp-content/themes/twentynineteen/style.css
+++ b/src/wp-content/themes/twentynineteen/style.css
@@ -5,10 +5,10 @@ Theme URI: https://wordpress.org/themes/twentynineteen/
 Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: Our 2019 default theme is designed to show off the power of the block editor. It features custom styles for all the default blocks, and is built so that what you see in the editor looks like what you'll see on your website. Twenty Nineteen is designed to be adaptable to a wide range of websites, whether you’re running a photo blog, launching a new business, or supporting a non-profit. Featuring ample whitespace and modern sans-serif headlines paired with classic serif body text, it's built to be beautiful on all screen sizes.
-Tested up to: 7.1
+Tested up to: 7.2
 Requires at least: 4.7
 Requires PHP: 5.2.4
-Version: 3.4
+Version: 3.5
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: twentynineteen

--- a/src/wp-content/themes/twentynineteen/style.scss
+++ b/src/wp-content/themes/twentynineteen/style.scss
@@ -4,10 +4,10 @@ Theme URI: https://wordpress.org/themes/twentynineteen/
 Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: Our 2019 default theme is designed to show off the power of the block editor. It features custom styles for all the default blocks, and is built so that what you see in the editor looks like what you'll see on your website. Twenty Nineteen is designed to be adaptable to a wide range of websites, whether you’re running a photo blog, launching a new business, or supporting a non-profit. Featuring ample whitespace and modern sans-serif headlines paired with classic serif body text, it's built to be beautiful on all screen sizes.
-Tested up to: 7.1
+Tested up to: 7.2
 Requires at least: 4.7
 Requires PHP: 5.2.4
-Version: 3.4
+Version: 3.5
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: twentynineteen

--- a/src/wp-content/themes/twentyseventeen/functions.php
+++ b/src/wp-content/themes/twentyseventeen/functions.php
@@ -467,7 +467,7 @@ function twentyseventeen_scripts() {
 	wp_enqueue_style( 'twentyseventeen-fonts', twentyseventeen_fonts_url(), array(), $font_version );
 
 	// Theme stylesheet.
-	wp_enqueue_style( 'twentyseventeen-style', get_stylesheet_uri(), array(), '20260819' );
+	wp_enqueue_style( 'twentyseventeen-style', get_stylesheet_uri(), array(), '20261209' );
 
 	// Theme block stylesheet.
 	wp_enqueue_style( 'twentyseventeen-block-style', get_theme_file_uri( '/assets/css/blocks.css' ), array( 'twentyseventeen-style' ), '20240729' );

--- a/src/wp-content/themes/twentyseventeen/readme.txt
+++ b/src/wp-content/themes/twentyseventeen/readme.txt
@@ -1,9 +1,9 @@
 === Twenty Seventeen ===
 Contributors: wordpressdotorg
 Requires at least: 4.7
-Tested up to: 7.1
+Tested up to: 7.2
 Requires PHP: 5.2.4
-Version: 4.2
+Version: 4.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Tags: one-column, two-columns, right-sidebar, flexible-header, accessibility-ready, custom-colors, custom-header, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, post-formats, rtl-language-support, sticky-post, theme-options, threaded-comments, translation-ready, block-patterns
@@ -70,6 +70,11 @@ License: CC0 1.0 Universal (CC0 1.0)
 Source: https://stocksnap.io/photo/striped-fabric-9CBVWF2CDU
 
 == Changelog ==
+
+= 4.3 =
+* Released: December 9, 2026
+
+https://wordpress.org/documentation/article/twenty-seventeen-changelog/#Version_4.3
 
 = 4.2 =
 * Released: August 19, 2026

--- a/src/wp-content/themes/twentyseventeen/style.css
+++ b/src/wp-content/themes/twentyseventeen/style.css
@@ -4,8 +4,8 @@ Theme URI: https://wordpress.org/themes/twentyseventeen/
 Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: Twenty Seventeen brings your site to life with header video and immersive featured images. With a focus on business sites, it features multiple sections on the front page as well as widgets, navigation and social menus, a logo, and more. Personalize its asymmetrical grid with a custom color scheme and showcase your multimedia content with post formats. Our default theme for 2017 works great in many languages, for any abilities, and on any device.
-Version: 4.2
-Tested up to: 7.1
+Version: 4.3
+Tested up to: 7.2
 Requires at least: 4.7
 Requires PHP: 5.2.4
 License: GNU General Public License v2 or later

--- a/src/wp-content/themes/twentysixteen/functions.php
+++ b/src/wp-content/themes/twentysixteen/functions.php
@@ -409,7 +409,7 @@ function twentysixteen_scripts() {
 	wp_enqueue_style( 'genericons', get_template_directory_uri() . '/genericons/genericons.css', array(), '20251101' );
 
 	// Theme stylesheet.
-	wp_enqueue_style( 'twentysixteen-style', get_stylesheet_uri(), array(), '20260819' );
+	wp_enqueue_style( 'twentysixteen-style', get_stylesheet_uri(), array(), '20261209' );
 
 	// Theme block stylesheet.
 	wp_enqueue_style( 'twentysixteen-block-style', get_template_directory_uri() . '/css/blocks.css', array( 'twentysixteen-style' ), '20260105' );

--- a/src/wp-content/themes/twentysixteen/readme.txt
+++ b/src/wp-content/themes/twentysixteen/readme.txt
@@ -1,9 +1,9 @@
 === Twenty Sixteen ===
 Contributors: wordpressdotorg
 Requires at least: 4.4
-Tested up to: 7.1
+Tested up to: 7.2
 Requires PHP: 5.2.4
-Version: 3.9
+Version: 4.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Tags: one-column, two-columns, right-sidebar, accessibility-ready, custom-background, custom-colors, custom-header, custom-menu, editor-style, featured-images, flexible-header, microformats, post-formats, rtl-language-support, sticky-post, threaded-comments, translation-ready, blog, block-patterns
@@ -67,6 +67,11 @@ Source: https://fontsource.org/fonts/inconsolata
 Image used in screenshot.png: A photo by Austin Schmid (https://unsplash.com/schmidy/), licensed under Creative Commons Zero(http://creativecommons.org/publicdomain/zero/1.0/)
 
 == Changelog ==
+
+= 4.0 =
+* Released: December 9, 2026
+
+https://wordpress.org/documentation/article/twenty-sixteen-changelog/#Version_4.0
 
 = 3.9 =
 * Released: August 19, 2026

--- a/src/wp-content/themes/twentysixteen/style.css
+++ b/src/wp-content/themes/twentysixteen/style.css
@@ -4,8 +4,8 @@ Theme URI: https://wordpress.org/themes/twentysixteen/
 Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: Twenty Sixteen is a modernized take on an ever-popular WordPress layout — the horizontal masthead with an optional right sidebar that works perfectly for blogs and websites. It has custom color options with beautiful default color schemes, a harmonious fluid grid using a mobile-first approach, and impeccable polish in every detail. Twenty Sixteen will make your WordPress look beautiful everywhere.
-Version: 3.9
-Tested up to: 7.1
+Version: 4.0
+Tested up to: 7.2
 Requires at least: 4.4
 Requires PHP: 5.2.4
 License: GNU General Public License v2 or later

--- a/src/wp-content/themes/twentyten/header.php
+++ b/src/wp-content/themes/twentyten/header.php
@@ -42,7 +42,7 @@ if ( ( $paged >= 2 || $page >= 2 ) && ! is_404() ) {
 ?>
 	</title>
 <link rel="profile" href="https://gmpg.org/xfn/11" />
-<link rel="stylesheet" media="all" href="<?php echo esc_url( get_stylesheet_uri() ); ?>?ver=20260819" />
+<link rel="stylesheet" media="all" href="<?php echo esc_url( get_stylesheet_uri() ); ?>?ver=20261209" />
 <link rel="pingback" href="<?php echo esc_url( get_bloginfo( 'pingback_url' ) ); ?>">
 <?php
 	/*

--- a/src/wp-content/themes/twentyten/readme.txt
+++ b/src/wp-content/themes/twentyten/readme.txt
@@ -1,9 +1,9 @@
 === Twenty Ten ===
 Contributors: wordpressdotorg
 Requires at least: 3.0
-Tested up to: 7.1
+Tested up to: 7.2
 Requires PHP: 5.2.4
-Stable tag: 4.7
+Stable tag: 4.8
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Tags: blog, two-columns, custom-header, custom-background, threaded-comments, sticky-post, translation-ready, microformats, rtl-language-support, editor-style, custom-menu, flexible-header, featured-images, footer-widgets, featured-image-header, block-patterns
@@ -43,6 +43,11 @@ Images
 “Old Barn Photo” by Bonnie Moreland. CC0. https://stocksnap.io/photo/old-barn-4HMJ2KQVX9
 
 == Changelog ==
+
+= 4.8 =
+* Released: December 9, 2026
+
+https://wordpress.org/documentation/article/twenty-ten-changelog/#Version_4.8
 
 = 4.7 =
 * Released: August 19, 2026

--- a/src/wp-content/themes/twentyten/style.css
+++ b/src/wp-content/themes/twentyten/style.css
@@ -4,8 +4,8 @@ Theme URI: https://wordpress.org/themes/twentyten/
 Description: The 2010 theme for WordPress is stylish, customizable, simple, and readable -- make it yours with a custom menu, header image, and background. Twenty Ten supports six widgetized areas (two in the sidebar, four in the footer) and featured images (thumbnails for gallery posts and custom header images for posts and pages). It includes stylesheets for print and the admin Visual Editor, special styles for posts in the "Asides" and "Gallery" categories, and has an optional one-column page template that removes the sidebar.
 Author: the WordPress team
 Author URI: https://wordpress.org/
-Version: 4.7
-Tested up to: 7.1
+Version: 4.8
+Tested up to: 7.2
 Requires at least: 3.0
 Requires PHP: 5.2.4
 License: GNU General Public License v2 or later

--- a/src/wp-content/themes/twentythirteen/functions.php
+++ b/src/wp-content/themes/twentythirteen/functions.php
@@ -348,7 +348,7 @@ function twentythirteen_scripts_styles() {
 	wp_enqueue_style( 'genericons', get_template_directory_uri() . '/genericons/genericons.css', array(), '20251101' );
 
 	// Loads our main stylesheet.
-	wp_enqueue_style( 'twentythirteen-style', get_stylesheet_uri(), array(), '20260819' );
+	wp_enqueue_style( 'twentythirteen-style', get_stylesheet_uri(), array(), '20261209' );
 
 	// Theme block stylesheet.
 	wp_enqueue_style( 'twentythirteen-block-style', get_template_directory_uri() . '/css/blocks.css', array( 'twentythirteen-style' ), '20240520' );

--- a/src/wp-content/themes/twentythirteen/readme.txt
+++ b/src/wp-content/themes/twentythirteen/readme.txt
@@ -1,9 +1,9 @@
 === Twenty Thirteen ===
 Contributors: wordpressdotorg
 Requires at least: 3.6
-Tested up to: 7.1
+Tested up to: 7.2
 Requires PHP: 5.2.4
-Stable tag: 4.7
+Stable tag: 4.8
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Tags: blog, one-column, two-columns, right-sidebar, custom-header, custom-menu, editor-style, featured-images, footer-widgets, microformats, post-formats, rtl-language-support, sticky-post, translation-ready, accessibility-ready, block-patterns
@@ -59,6 +59,11 @@ Torus Interior: https://www.flickr.com/photos/nasacommons/14076102195/in/album-7
 Toroidal Colony: https://www.flickr.com/photos/nasacommons/13889485757/in/album-72157644439092941/ Rick Guidice, NASA Ames Research Center.
 
 == Changelog ==
+
+= 4.8 =
+* Released: December 9, 2026
+
+https://wordpress.org/documentation/article/twenty-thirteen-changelog/#Version_4.8
 
 = 4.7 =
 * Released: August 19, 2026

--- a/src/wp-content/themes/twentythirteen/style.css
+++ b/src/wp-content/themes/twentythirteen/style.css
@@ -4,8 +4,8 @@ Theme URI: https://wordpress.org/themes/twentythirteen/
 Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: The 2013 theme for WordPress takes us back to the blog, featuring a full range of post formats, each displayed beautifully in their own unique way. Design details abound, starting with a vibrant color scheme and matching header images, beautiful typography and icons, and a flexible layout that looks great on any device, big or small.
-Version: 4.7
-Tested up to: 7.1
+Version: 4.8
+Tested up to: 7.2
 Requires at least: 3.6
 Requires PHP: 5.2.4
 License: GNU General Public License v2 or later

--- a/src/wp-content/themes/twentytwelve/functions.php
+++ b/src/wp-content/themes/twentytwelve/functions.php
@@ -216,7 +216,7 @@ function twentytwelve_scripts_styles() {
 	}
 
 	// Loads our main stylesheet.
-	wp_enqueue_style( 'twentytwelve-style', get_stylesheet_uri(), array(), '20260819' );
+	wp_enqueue_style( 'twentytwelve-style', get_stylesheet_uri(), array(), '20261209' );
 
 	// Theme block stylesheet.
 	wp_enqueue_style( 'twentytwelve-block-style', get_template_directory_uri() . '/css/blocks.css', array( 'twentytwelve-style' ), '20251031' );

--- a/src/wp-content/themes/twentytwelve/readme.txt
+++ b/src/wp-content/themes/twentytwelve/readme.txt
@@ -1,9 +1,9 @@
 === Twenty Twelve ===
 Contributors: wordpressdotorg
 Requires at least: 3.5
-Tested up to: 7.1
+Tested up to: 7.2
 Requires PHP: 5.2.4
-Stable tag: 4.9
+Stable tag: 5.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Tags: blog, one-column, two-columns, right-sidebar, custom-background, custom-header, custom-menu, editor-style, featured-images, flexible-header, footer-widgets, full-width-template, microformats, post-formats, rtl-language-support, sticky-post, theme-options, translation-ready, block-patterns
@@ -48,6 +48,11 @@ Source: https://fontsource.org/fonts/open-sans
 "Autumn City Photo" by Oleg Prokopenko. CC0. https://stocksnap.io/photo/autumn-city-PZP8EWR5MR
 
 == Changelog ==
+
+= 5.0 =
+* Released: December 9, 2026
+
+https://wordpress.org/documentation/article/twenty-twelve-changelog/#Version_5.0
 
 = 4.9 =
 * Released: August 19, 2026

--- a/src/wp-content/themes/twentytwelve/style.css
+++ b/src/wp-content/themes/twentytwelve/style.css
@@ -4,8 +4,8 @@ Theme URI: https://wordpress.org/themes/twentytwelve/
 Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: The 2012 theme for WordPress is a fully responsive theme that looks great on any device. Features include a front page template with its own widgets, an optional display font, styling for post formats on both index and single views, and an optional no-sidebar page template. Make it yours with a custom menu, header image, and background.
-Version: 4.9
-Tested up to: 7.1
+Version: 5.0
+Tested up to: 7.2
 Requires at least: 3.5
 Requires PHP: 5.2.4
 License: GNU General Public License v2 or later

--- a/src/wp-content/themes/twentytwenty/package-lock.json
+++ b/src/wp-content/themes/twentytwenty/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "twentytwenty",
-	"version": "3.2.0",
+	"version": "3.3.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "twentytwenty",
-			"version": "3.2.0",
+			"version": "3.3.0",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
 				"@wordpress/browserslist-config": "^6.34.0",

--- a/src/wp-content/themes/twentytwenty/package.json
+++ b/src/wp-content/themes/twentytwenty/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "twentytwenty",
-	"version": "3.2.0",
+	"version": "3.3.0",
 	"description": "Default WP Theme",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/src/wp-content/themes/twentytwenty/readme.txt
+++ b/src/wp-content/themes/twentytwenty/readme.txt
@@ -1,9 +1,9 @@
 === Twenty Twenty ===
 Contributors: the WordPress team
 Requires at least: 4.7
-Tested up to: 7.1
+Tested up to: 7.2
 Requires PHP: 5.2.4
-Stable tag: 3.2
+Stable tag: 3.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -23,6 +23,11 @@ all elements on your site are automatically calculated based on the colors
 you pick, ensuring a high, accessible color contrast for your visitors.
 
 == Changelog ==
+
+= 3.3 =
+* Released: December 9, 2026
+
+https://wordpress.org/documentation/article/twenty-twenty-changelog/#Version_3.3
 
 = 3.2 =
 * Released: August 19, 2026

--- a/src/wp-content/themes/twentytwenty/style-rtl.css
+++ b/src/wp-content/themes/twentytwenty/style-rtl.css
@@ -1,8 +1,8 @@
 /*
 Theme Name: Twenty Twenty
 Text Domain: twentytwenty
-Version: 3.2
-Tested up to: 7.1
+Version: 3.3
+Tested up to: 7.2
 Requires at least: 4.7
 Requires PHP: 5.2.4
 Description: Our default theme for 2020 is designed to take full advantage of the flexibility of the block editor. Organizations and businesses have the ability to create dynamic landing pages with endless layouts using the group and column blocks. The centered content column and fine-tuned typography also makes it perfect for traditional blogs. Complete editor styles give you a good idea of what your content will look like, even before you publish. You can give your site a personal touch by changing the background colors and the accent color in the Customizer. The colors of all elements on your site are automatically calculated based on the colors you pick, ensuring a high, accessible color contrast for your visitors.

--- a/src/wp-content/themes/twentytwenty/style.css
+++ b/src/wp-content/themes/twentytwenty/style.css
@@ -1,8 +1,8 @@
 /*
 Theme Name: Twenty Twenty
 Text Domain: twentytwenty
-Version: 3.2
-Tested up to: 7.1
+Version: 3.3
+Tested up to: 7.2
 Requires at least: 4.7
 Requires PHP: 5.2.4
 Description: Our default theme for 2020 is designed to take full advantage of the flexibility of the block editor. Organizations and businesses have the ability to create dynamic landing pages with endless layouts using the group and column blocks. The centered content column and fine-tuned typography also makes it perfect for traditional blogs. Complete editor styles give you a good idea of what your content will look like, even before you publish. You can give your site a personal touch by changing the background colors and the accent color in the Customizer. The colors of all elements on your site are automatically calculated based on the colors you pick, ensuring a high, accessible color contrast for your visitors.

--- a/src/wp-content/themes/twentytwentyfive/package-lock.json
+++ b/src/wp-content/themes/twentytwentyfive/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "twentytwentyfive",
-	"version": "1.5.0",
+	"version": "1.6.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "twentytwentyfive",
-			"version": "1.5.0",
+			"version": "1.6.0",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
 				"@wordpress/browserslist-config": "^6.34.0",

--- a/src/wp-content/themes/twentytwentyfive/package.json
+++ b/src/wp-content/themes/twentytwentyfive/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "twentytwentyfive",
-	"version": "1.5.0",
+	"version": "1.6.0",
 	"description": "Default WP Theme",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/src/wp-content/themes/twentytwentyfive/readme.txt
+++ b/src/wp-content/themes/twentytwentyfive/readme.txt
@@ -1,9 +1,9 @@
 === Twenty Twenty-Five ===
 Contributors: wordpressdotorg
 Requires at least: 6.7
-Tested up to: 7.1
+Tested up to: 7.2
 Requires PHP: 7.2
-Stable tag: 1.5
+Stable tag: 1.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -13,6 +13,11 @@ Twenty Twenty-Five emphasizes simplicity and adaptability. It offers flexible de
 
 
 == Changelog ==
+
+= 1.6 =
+* Released: December 9, 2026
+
+https://wordpress.org/documentation/article/twenty-twenty-five-changelog/#Version_1.6
 
 = 1.5 =
 * Released: May 20, 2026

--- a/src/wp-content/themes/twentytwentyfive/style.css
+++ b/src/wp-content/themes/twentytwentyfive/style.css
@@ -5,9 +5,9 @@ Author: the WordPress team
 Author URI: https://wordpress.org
 Description: Twenty Twenty-Five emphasizes simplicity and adaptability. It offers flexible design options, supported by a variety of patterns for different page types, such as services and landing pages, making it ideal for building personal blogs, professional portfolios, online magazines, or business websites. Its templates cater to various blog styles, from text-focused to image-heavy layouts. Additionally, it supports international typography and diverse color palettes, ensuring accessibility and customization for users worldwide.
 Requires at least: 6.7
-Tested up to: 7.1
+Tested up to: 7.2
 Requires PHP: 7.2
-Version: 1.5
+Version: 1.6
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: twentytwentyfive

--- a/src/wp-content/themes/twentytwentyfour/readme.txt
+++ b/src/wp-content/themes/twentytwentyfour/readme.txt
@@ -1,9 +1,9 @@
 === Twenty Twenty-Four ===
 Contributors: wordpressdotorg
 Requires at least: 6.4
-Tested up to: 7.1
+Tested up to: 7.2
 Requires PHP: 7.0
-Stable tag: 1.6
+Stable tag: 1.7
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -12,6 +12,11 @@ License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Twenty Twenty-Four is designed to be flexible, versatile and applicable to any website. Its collection of templates and patterns tailor to different needs, such as presenting a business, blogging and writing or showcasing work. A multitude of possibilities open up with just a few adjustments to color and typography. Twenty Twenty-Four comes with style variations and full page designs to help speed up the site building process, is fully compatible with the site editor, and takes advantage of new design tools introduced in WordPress 6.4.
 
 == Changelog ==
+
+= 1.7 =
+* Released: December 9, 2026
+
+https://wordpress.org/documentation/article/twenty-twenty-four-changelog/#Version_1.7
 
 = 1.6 =
 * Released: August 19, 2026

--- a/src/wp-content/themes/twentytwentyfour/style.css
+++ b/src/wp-content/themes/twentytwentyfour/style.css
@@ -5,9 +5,9 @@ Author: the WordPress team
 Author URI: https://wordpress.org
 Description: Twenty Twenty-Four is designed to be flexible, versatile and applicable to any website. Its collection of templates and patterns tailor to different needs, such as presenting a business, blogging and writing or showcasing work. A multitude of possibilities open up with just a few adjustments to color and typography. Twenty Twenty-Four comes with style variations and full page designs to help speed up the site building process, is fully compatible with the site editor, and takes advantage of new design tools introduced in WordPress 6.4.
 Requires at least: 6.4
-Tested up to: 7.1
+Tested up to: 7.2
 Requires PHP: 7.0
-Version: 1.6
+Version: 1.7
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: twentytwentyfour

--- a/src/wp-content/themes/twentytwentyone/assets/sass/01-settings/file-header.scss
+++ b/src/wp-content/themes/twentytwentyone/assets/sass/01-settings/file-header.scss
@@ -5,9 +5,9 @@ Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: Twenty Twenty-One is a blank canvas for your ideas and it makes the block editor your best brush. With new block patterns, which allow you to create a beautiful layout in a matter of seconds, this theme’s soft colors and eye-catching — yet timeless — design will let your work shine. Take it for a spin! See how Twenty Twenty-One elevates your portfolio, business website, or personal blog.
 Requires at least: 5.3
-Tested up to: 7.1
+Tested up to: 7.2
 Requires PHP: 5.6
-Version: 2.9
+Version: 3.0
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: twentytwentyone

--- a/src/wp-content/themes/twentytwentyone/package-lock.json
+++ b/src/wp-content/themes/twentytwentyone/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "twentytwentyone",
-	"version": "2.9.0",
+	"version": "3.0.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "twentytwentyone",
-			"version": "2.9.0",
+			"version": "3.0.0",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
 				"@wordpress/browserslist-config": "^6.34.0",

--- a/src/wp-content/themes/twentytwentyone/package.json
+++ b/src/wp-content/themes/twentytwentyone/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "twentytwentyone",
-	"version": "2.9.0",
+	"version": "3.0.0",
 	"description": "Default WP Theme",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/src/wp-content/themes/twentytwentyone/readme.txt
+++ b/src/wp-content/themes/twentytwentyone/readme.txt
@@ -1,9 +1,9 @@
 === Twenty Twenty-One ===
 Contributors: wordpressdotorg
 Requires at least: 5.3
-Tested up to: 7.1
+Tested up to: 7.2
 Requires PHP: 5.6
-Stable tag: 2.9
+Stable tag: 3.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -29,6 +29,11 @@ LocalStorage is necessary for the setting to work and is only used when a user c
 No data is saved in the database or transferred.
 
 == Changelog ==
+
+= 3.0 =
+* Released: December 9, 2026
+
+https://wordpress.org/documentation/article/twenty-twenty-one-changelog/#Version_3.0
 
 = 2.9 =
 * Released: August 19, 2026

--- a/src/wp-content/themes/twentytwentyone/style-rtl.css
+++ b/src/wp-content/themes/twentytwentyone/style-rtl.css
@@ -7,9 +7,9 @@ Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: Twenty Twenty-One is a blank canvas for your ideas and it makes the block editor your best brush. With new block patterns, which allow you to create a beautiful layout in a matter of seconds, this theme’s soft colors and eye-catching — yet timeless — design will let your work shine. Take it for a spin! See how Twenty Twenty-One elevates your portfolio, business website, or personal blog.
 Requires at least: 5.3
-Tested up to: 7.1
+Tested up to: 7.2
 Requires PHP: 5.6
-Version: 2.9
+Version: 3.0
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: twentytwentyone

--- a/src/wp-content/themes/twentytwentyone/style.css
+++ b/src/wp-content/themes/twentytwentyone/style.css
@@ -7,9 +7,9 @@ Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: Twenty Twenty-One is a blank canvas for your ideas and it makes the block editor your best brush. With new block patterns, which allow you to create a beautiful layout in a matter of seconds, this theme’s soft colors and eye-catching — yet timeless — design will let your work shine. Take it for a spin! See how Twenty Twenty-One elevates your portfolio, business website, or personal blog.
 Requires at least: 5.3
-Tested up to: 7.1
+Tested up to: 7.2
 Requires PHP: 5.6
-Version: 2.9
+Version: 3.0
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: twentytwentyone

--- a/src/wp-content/themes/twentytwentythree/readme.txt
+++ b/src/wp-content/themes/twentytwentythree/readme.txt
@@ -1,9 +1,9 @@
 === Twenty Twenty-Three ===
 Contributors: wordpressdotorg
 Requires at least: 6.1
-Tested up to: 7.1
+Tested up to: 7.2
 Requires PHP: 5.6
-Stable tag: 1.7
+Stable tag: 1.8
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -14,6 +14,11 @@ Twenty Twenty-Three is designed to take advantage of the new design tools introd
 Whether you want to build a complex or incredibly simple website, you can do it quickly and intuitively through the bundled styles or dive into creation and full customization yourself.
 
 == Changelog ==
+
+= 1.8 =
+* Released: December 9, 2026
+
+https://wordpress.org/documentation/article/twenty-twenty-three-changelog/#Version_1.8
 
 = 1.7 =
 * Released: August 19, 2026

--- a/src/wp-content/themes/twentytwentythree/style.css
+++ b/src/wp-content/themes/twentytwentythree/style.css
@@ -5,9 +5,9 @@ Author: the WordPress team
 Author URI: https://wordpress.org
 Description: Twenty Twenty-Three is designed to take advantage of the new design tools introduced in WordPress 6.1. With a clean, blank base as a starting point, this default theme includes ten diverse style variations created by members of the WordPress community. Whether you want to build a complex or incredibly simple website, you can do it quickly and intuitively through the bundled styles or dive into creation and full customization yourself.
 Requires at least: 6.1
-Tested up to: 7.1
+Tested up to: 7.2
 Requires PHP: 5.6
-Version: 1.7
+Version: 1.8
 License: GNU General Public License v2 or later
 License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 Text Domain: twentytwentythree

--- a/src/wp-content/themes/twentytwentytwo/package-lock.json
+++ b/src/wp-content/themes/twentytwentytwo/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "twentytwentytwo",
-	"version": "2.2.0",
+	"version": "2.3.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "twentytwentytwo",
-			"version": "2.2.0",
+			"version": "2.3.0",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
 				"@wordpress/browserslist-config": "^6.34.0",

--- a/src/wp-content/themes/twentytwentytwo/package.json
+++ b/src/wp-content/themes/twentytwentytwo/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "twentytwentytwo",
-	"version": "2.2.0",
+	"version": "2.3.0",
 	"description": "Default WP Theme",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/src/wp-content/themes/twentytwentytwo/readme.txt
+++ b/src/wp-content/themes/twentytwentytwo/readme.txt
@@ -1,9 +1,9 @@
 === Twenty Twenty-Two ===
 Contributors: wordpressdotorg
 Requires at least: 5.9
-Tested up to: 7.1
+Tested up to: 7.2
 Requires PHP: 5.6
-Stable tag: 2.2
+Stable tag: 2.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -38,6 +38,11 @@ Follow these instructions for each of the following templates:
 - Single Post (No Separators)
 
 == Changelog ==
+
+= 2.3 =
+* Released: December 9, 2026
+
+https://wordpress.org/documentation/article/twenty-twenty-two-changelog/#Version_2.3
 
 = 2.2 =
 * Released: August 19, 2026

--- a/src/wp-content/themes/twentytwentytwo/style.css
+++ b/src/wp-content/themes/twentytwentytwo/style.css
@@ -5,9 +5,9 @@ Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: Built on a solidly designed foundation, Twenty Twenty-Two embraces the idea that everyone deserves a truly unique website. The theme’s subtle styles are inspired by the diversity and versatility of birds: its typography is lightweight yet strong, its color palette is drawn from nature, and its layout elements sit gently on the page. The true richness of Twenty Twenty-Two lies in its opportunity for customization. The theme is built to take advantage of the Site Editor features introduced in WordPress 5.9, which means that colors, typography, and the layout of every single page on your site can be customized to suit your vision. It also includes dozens of block patterns, opening the door to a wide range of professionally designed layouts in just a few clicks. Whether you’re building a single-page website, a blog, a business website, or a portfolio, Twenty Twenty-Two will help you create a site that is uniquely yours.
 Requires at least: 5.9
-Tested up to: 7.1
+Tested up to: 7.2
 Requires PHP: 5.6
-Version: 2.2
+Version: 2.3
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: twentytwentytwo


### PR DESCRIPTION
This bumps the version for the upcoming release WordPress 7.2. 
Twenty Ten: 4.8.
Twenty Eleven: 5.3.
Twenty Twelve: 5.0.
Twenty Thirteen: 4.8.
Twenty Fourteen: 4.7.
Twenty Fifteen: 4.4.
Twenty Sixteen: 4.0.
Twenty Seventeen: 4.3.
Twenty Nineteen: 3.5.
Twenty Twenty: 3.3.
Twenty Twenty-One: 3.0.
Twenty Twenty-Two: 2.3.
Twenty Twenty-Three: 1.8.
Twenty Twenty-Four: 1.7.
Twenty Twenty-Five: 1.6.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

Bundled theme versions still point at 7.1 and need bumping for the 7.2 release.

This updates `Version`/`Stable tag` and `Tested up to: 7.2` in each theme's `style.css` and `readme.txt`, adds a changelog entry dated December 9, 2026 (the proposed 7.2 date), bumps the main stylesheet cache-busting strings from `20260819` to `20261209`, and updates `package.json`/`package-lock.json` for Twenty Nineteen, Twenty Twenty, Twenty Twenty-One, Twenty Twenty-Two, and Twenty Twenty-Five. Twenty Twelve, Twenty Sixteen, and Twenty Twenty-One roll over to 5.0, 4.0, and 3.0, as no bundled theme has used a two-digit minor.

No theme has changes yet this cycle; as in #65322, any still unedited at RC should drop to a `Tested up to` change only.

Trac ticket: https://core.trac.wordpress.org/ticket/65875

## Use of AI Tools
AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Applying the version, date, and changelog updates across the theme files, and checking header consistency. All changes were reviewed and validated by me.
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
