### PR TITLE
Block Supports: Reuse block style variation instance for consecutive blocks

### DIFF
--- a/src/wp-includes/block-supports/block-style-variations.php
+++ b/src/wp-includes/block-supports/block-style-variations.php
@@ -104,6 +104,33 @@ function wp_render_block_style_variation_support_styles( $parsed_block ) {
 	}
 
 	/*
+	 * A block style variation resolves to the same data every time it is
+	 * encountered, so consecutive blocks using the same variation generate
+	 * byte-identical CSS. Reuse the previous instance's class name in that case
+	 * so the stylesheet is only generated and enqueued once.
+	 *
+	 * Reuse is deliberately limited to the immediately preceding instance.
+	 * Variation selectors are wrapped in `:where()`, so every variation rule has
+	 * the same specificity and source order alone decides which one wins. Sharing
+	 * a class across an intervening variation would move it in the cascade and
+	 * reintroduce the conflicting styles fixed in #61877.
+	 */
+	static $last_variation_key   = null;
+	static $last_variation_class = null;
+
+	$variation_key = $parsed_block['blockName'] . '|' . $variation;
+
+	if ( null !== $last_variation_class && $last_variation_key === $variation_key ) {
+		_wp_array_set(
+			$parsed_block,
+			array( 'attrs', 'className' ),
+			$parsed_block['attrs']['className'] . " $last_variation_class"
+		);
+
+		return $parsed_block;
+	}
+
+	/*
 	 * Recursively resolve any ref values with the appropriate value within the
 	 * theme_json data.
 	 */
@@ -193,6 +220,13 @@ function wp_render_block_style_variation_support_styles( $parsed_block ) {
 
 	wp_register_style( 'block-style-variation-styles', false, array( 'wp-block-library', 'global-styles' ) );
 	wp_add_inline_style( 'block-style-variation-styles', $variation_styles );
+
+	/*
+	 * Record the instance so an immediately following block using the same
+	 * variation can reuse it instead of emitting a duplicate stylesheet.
+	 */
+	$last_variation_key   = $variation_key;
+	$last_variation_class = $class_name;
 
 	/*
 	 * Add variation instance class name to block's className string so it can

--- a/tests/phpunit/tests/block-supports/block-style-variations.php
+++ b/tests/phpunit/tests/block-supports/block-style-variations.php
@@ -322,6 +322,92 @@ class Tests_Block_Supports_BlockStyleVariations extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Renders a group block with the given block style variation applied.
+	 *
+	 * @param string $variation Block style variation slug.
+	 *
+	 * @return array The parsed block after the block style variation support has run.
+	 */
+	private function render_group_with_variation( $variation ) {
+		return wp_render_block_style_variation_support_styles(
+			array(
+				'blockName' => 'core/group',
+				'attrs'     => array( 'className' => "is-style-$variation" ),
+			)
+		);
+	}
+
+	/**
+	 * Tests that consecutive blocks using the same block style variation share a
+	 * single instance class, so the identical stylesheet is only emitted once.
+	 *
+	 * @ticket 65876
+	 *
+	 * @covers ::wp_render_block_style_variation_support_styles
+	 */
+	public function test_block_style_variation_reuses_instance_for_consecutive_blocks() {
+		switch_theme( 'block-theme' );
+
+		/*
+		 * Render a different variation first so the reuse cache is primed with a
+		 * known value regardless of what earlier tests left behind.
+		 */
+		$this->render_group_with_variation( 'block-style-variation-b' );
+
+		// Start counting emitted stylesheets from here.
+		$GLOBALS['wp_styles'] = null;
+
+		$first  = $this->render_group_with_variation( 'block-style-variation-a' );
+		$second = $this->render_group_with_variation( 'block-style-variation-a' );
+
+		$this->assertSame(
+			$first['attrs']['className'],
+			$second['attrs']['className'],
+			'Consecutive blocks using the same variation should share one instance class'
+		);
+
+		$this->assertCount(
+			1,
+			wp_styles()->get_data( 'block-style-variation-styles', 'after' ),
+			'The variation stylesheet should only be emitted once for consecutive identical variations'
+		);
+	}
+
+	/**
+	 * Tests that a variation interrupted by a different one gets a fresh instance
+	 * class.
+	 *
+	 * Variation selectors are wrapped in `:where()`, so they all share the same
+	 * specificity and source order alone decides which rule wins. Sharing a class
+	 * across an intervening variation would move it in the cascade and
+	 * reintroduce the conflicting styles fixed in #61877.
+	 *
+	 * @ticket 65876
+	 * @ticket 61877
+	 *
+	 * @covers ::wp_render_block_style_variation_support_styles
+	 */
+	public function test_block_style_variation_does_not_reuse_instance_across_a_different_variation() {
+		switch_theme( 'block-theme' );
+
+		$first  = $this->render_group_with_variation( 'block-style-variation-a' );
+		$second = $this->render_group_with_variation( 'block-style-variation-b' );
+		$third  = $this->render_group_with_variation( 'block-style-variation-a' );
+
+		$this->assertNotSame(
+			$first['attrs']['className'],
+			$third['attrs']['className'],
+			'A variation separated by a different variation should get a fresh instance class'
+		);
+
+		$this->assertNotSame(
+			$first['attrs']['className'],
+			$second['attrs']['className'],
+			'Different variations should never share an instance class'
+		);
+	}
+
+	/**
 	 * Tests that a non-string `className` attribute does not cause a fatal
 	 * error and the block content is returned unmodified.
 	 *


### PR DESCRIPTION
`wp_render_block_style_variation_support_styles()` mints a fresh instance class for every block that uses a block style variation, and enqueues a complete copy of that variation's CSS for each one. The generated CSS is identical apart from the instance number, so a page with N blocks sharing a variation ships N copies of the same rules.

With Twenty Twenty-Five and repeated Outline buttons:

| Outline buttons on page | Inline CSS | Rules emitted | Distinct rules |
| --- | --- | --- | --- |
| 3 | 1,663 bytes | 6 | 2 |
| 20 | 10,782 bytes | 40 | 2 |

Growth is linear and unbounded. There is no rendering difference — computed border colour, width, background and padding are identical regardless of how many copies are emitted — so this is purely wasted payload.

This reuses the previous instance **only when the immediately preceding variation instance is the same one**. Nothing else was emitted in between, so re-emitting would be a no-op in cascade terms and the class can safely be shared. Anything interleaved forces a fresh instance, so current ordering is preserved exactly.

### Why not cache by variation slug for the whole request

That would reintroduce #61877, which is why [0a9dcb4](https://github.com/WordPress/wordpress-develop/commit/0a9dcb4bfcdd9d01373e4396c209c1b88d384375) replaced `md5( serialize( $block ) )` with `wp_unique_id()` in the first place.

Variation selectors are wrapped in `:where()`, so every variation rule has the same specificity and source order alone decides which one wins. The per-instance class is what places a nested variation's styles after its ancestor's. Tested with two `core/group` variations styling paragraphs differently — `demo-a` red, `demo-b` blue — laid out as a standalone A followed by a B containing an A:

| Implementation | Emission order | Inner paragraph |
| --- | --- | --- |
| trunk today | `demo-a--2 -> demo-b--3 -> demo-a--4` | red (correct) |
| cache by slug | `demo-a--2 -> demo-b--3` | blue (wrong) |

Limiting reuse to the immediately preceding instance keeps that safe: a nested block always has its ancestor's variation emitted in between, so it never shares a class with an earlier one.

`test_block_style_variation_does_not_reuse_instance_across_a_different_variation` guards this and is annotated with both tickets.

### Results

| Case | Before | After |
| --- | --- | --- |
| 3 outline buttons | 1,663 bytes / 6 rules | 593 bytes / 2 rules |
| 20 outline buttons | 10,782 bytes / 40 rules | 593 bytes / 2 rules |
| Nested section styles | 6,130 bytes / 58 rules | unchanged, byte for byte |
| Nested `demo-a` / `demo-b` | inner paragraph red | still red |

Known limitation: an alternating `A B A B` sequence still emits a copy per instance. Fully deduplicating would require collecting variations during render and emitting them ordered by nesting depth rather than document order, which is a considerably larger change.

### Testing

```
npm run test:php -- --filter Tests_Block_Supports_BlockStyleVariations
```

`test_block_style_variation_reuses_instance_for_consecutive_blocks` fails on trunk without this change.

Note when verifying manually: Twenty Twenty-Five's own section styles set descendant colours with `currentColor`, so nesting `section-1` inside `section-2` produces byte-identical descendant rules and shows no visible change even when ordering is broken. A cascade regression only surfaces with variations that set absolute values.

The same change is proposed for the Gutenberg plugin in https://github.com/WordPress/gutenberg/pull/81609, for https://github.com/WordPress/gutenberg/issues/81583.

Trac ticket: https://core.trac.wordpress.org/ticket/65876

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Investigating the cause, drafting the implementation and the unit tests. All changes, measurements and test results were reviewed and verified by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
