### PR TITLE
Editor: Enhance classic editor timestamp fields with native controls (continues #12275)

### DIFF
--- a/src/js/_enqueues/admin/post.js
+++ b/src/js/_enqueues/admin/post.js
@@ -786,7 +786,7 @@ jQuery( function($) {
 				attemptedDate.getDate() != jj ||
 				attemptedDate.getMinutes() != mn
 			) {
-				$timestampdiv.find( '.timestamp-wrap, #publish-date-native' ).addClass( 'form-invalid' );
+				$timestampdiv.find( '.timestamp-wrap, .timestamp-native-wrap input' ).addClass( 'form-invalid' );
 				return false;
 			} else {
 				$timestampdiv.find( '.timestamp-wrap, .timestamp-native-wrap input' ).removeClass( 'form-invalid' );

--- a/src/js/_enqueues/admin/post.js
+++ b/src/js/_enqueues/admin/post.js
@@ -303,6 +303,7 @@ window.wp = window.wp || {};
  */
 jQuery( function($) {
 	var stamp, visibility, $submitButtons, updateVisibility, updateText,
+		updateFieldsFromNativeTimestamp, setupNativeTimestampFields, updateNativeTimestampFields,
 		$textarea = $('#content'),
 		$document = $(document),
 		postId = $('#post_ID').val() || 0,
@@ -310,6 +311,7 @@ jQuery( function($) {
 		releaseLock = true,
 		$postVisibilitySelect = $('#post-visibility-select'),
 		$timestampdiv = $('#timestampdiv'),
+		$timestampEdit = $timestampdiv.closest( '.misc-pub-curtime' ).find( 'a.edit-timestamp' ),
 		$postStatusSelect = $('#post-status-select'),
 		isMac = window.navigator.platform ? window.navigator.platform.indexOf( 'Mac' ) !== -1 : false,
 		copyAttachmentURLClipboard = new ClipboardJS( '.copy-attachment-url.edit-media' ),
@@ -784,10 +786,10 @@ jQuery( function($) {
 				attemptedDate.getDate() != jj ||
 				attemptedDate.getMinutes() != mn
 			) {
-				$timestampdiv.find('.timestamp-wrap').addClass('form-invalid');
+				$timestampdiv.find( '.timestamp-wrap, #publish-date-native' ).addClass( 'form-invalid' );
 				return false;
 			} else {
-				$timestampdiv.find('.timestamp-wrap').removeClass('form-invalid');
+				$timestampdiv.find( '.timestamp-wrap, .timestamp-native-wrap input' ).removeClass( 'form-invalid' );
 			}
 
 			// Determine what the publish should be depending on the date and post status.
@@ -866,6 +868,79 @@ jQuery( function($) {
 			return true;
 		};
 
+		updateFieldsFromNativeTimestamp = updateText;
+		updateNativeTimestampFields = function() {};
+
+		setupNativeTimestampFields = function() {
+			var dateInput = document.createElement( 'input' ),
+				timeInput = document.createElement( 'input' ),
+				$timestampwrap = $timestampdiv.find( '.timestamp-wrap' ),
+				$nativeTimestampWrap = $timestampdiv.find( '.timestamp-native-wrap' ),
+				$dateInput, $timeInput,
+				toDateValue, toTimeValue;
+
+			dateInput.setAttribute( 'type', 'date' );
+			timeInput.setAttribute( 'type', 'time' );
+			if (
+				'date' !== dateInput.type ||
+				'time' !== timeInput.type ||
+				! $timestampwrap.length ||
+				! $nativeTimestampWrap.length
+			) {
+				return;
+			}
+
+			toDateValue = function() {
+				return $( '#aa' ).val() + '-' +
+					( '00' + $( '#mm' ).val() ).slice( -2 ) + '-' +
+					( '00' + $( '#jj' ).val() ).slice( -2 );
+			};
+
+			toTimeValue = function() {
+				return ( '00' + $( '#hh' ).val() ).slice( -2 ) + ':' +
+					( '00' + $( '#mn' ).val() ).slice( -2 );
+			};
+
+			$dateInput = $nativeTimestampWrap.find( '#publish-date-native' );
+			$timeInput = $nativeTimestampWrap.find( '#publish-time-native' );
+
+			updateFieldsFromNativeTimestamp = function() {
+				var dateMatches = $dateInput.val().match( /^(\d{4})-(\d{2})-(\d{2})$/ ),
+					timeMatches = $timeInput.val().match( /^(\d{2}):(\d{2})$/ );
+
+				$dateInput.toggleClass( 'form-invalid', ! dateMatches );
+				$timeInput.toggleClass( 'form-invalid', ! timeMatches );
+
+				if ( ! dateMatches || ! timeMatches ) {
+					$timestampwrap.addClass( 'form-invalid' );
+					return false;
+				}
+
+				$( '#aa' ).val( dateMatches[1] );
+				$( '#mm' ).val( dateMatches[2] );
+				$( '#jj' ).val( dateMatches[3] );
+				$( '#hh' ).val( timeMatches[1] );
+				$( '#mn' ).val( timeMatches[2] );
+
+				// Seconds remain in the existing hidden field, matching the legacy timestamp UI.
+				return updateText();
+			};
+
+			updateNativeTimestampFields = function() {
+				$dateInput.val( toDateValue() );
+				$timeInput.val( toTimeValue() );
+			};
+
+			updateNativeTimestampFields();
+			$timestampdiv.addClass( 'has-native-timestamp-fields' );
+			$timestampwrap.hide();
+			$nativeTimestampWrap.removeAttr( 'hidden' );
+			$nativeTimestampWrap.find( 'input' ).on( 'change', updateFieldsFromNativeTimestamp );
+			$timestampwrap.find( 'input, select' ).on( 'change', updateNativeTimestampFields );
+		};
+
+		setupNativeTimestampFields();
+
 		// Show the visibility options and hide the toggle button when opened.
 		$( '#visibility .edit-visibility').on( 'click', function( e ) {
 			e.preventDefault();
@@ -924,10 +999,13 @@ jQuery( function($) {
 		});
 
 		// Edit publish time click.
-		$timestampdiv.siblings('a.edit-timestamp').on( 'click', function( event ) {
+		$timestampEdit.on( 'click', function( event ) {
 			if ( $timestampdiv.is( ':hidden' ) ) {
 				$timestampdiv.slideDown( 'fast', function() {
-					$( 'input, select', $timestampdiv.find( '.timestamp-wrap' ) ).first().trigger( 'focus' );
+					$timestampdiv.find( '.timestamp-native-wrap input, .timestamp-wrap input, .timestamp-wrap select' )
+						.filter( ':visible' )
+						.first()
+						.trigger( 'focus' );
 				} );
 				$(this).hide();
 			}
@@ -936,21 +1014,23 @@ jQuery( function($) {
 
 		// Cancel editing the publish time and hide the settings.
 		$timestampdiv.find('.cancel-timestamp').on( 'click', function( event ) {
-			$timestampdiv.slideUp('fast').siblings('a.edit-timestamp').show().trigger( 'focus' );
+			$timestampdiv.slideUp('fast');
+			$timestampEdit.show().trigger( 'focus' );
 			$('#mm').val($('#hidden_mm').val());
 			$('#jj').val($('#hidden_jj').val());
 			$('#aa').val($('#hidden_aa').val());
 			$('#hh').val($('#hidden_hh').val());
 			$('#mn').val($('#hidden_mn').val());
+			updateNativeTimestampFields();
 			updateText();
 			event.preventDefault();
 		});
 
 		// Save the changed timestamp.
 		$timestampdiv.find('.save-timestamp').on( 'click', function( event ) { // Crazyhorse branch - multiple OK cancels.
-			if ( updateText() ) {
+			if ( updateFieldsFromNativeTimestamp() ) {
 				$timestampdiv.slideUp('fast');
-				$timestampdiv.siblings('a.edit-timestamp').show().trigger( 'focus' );
+				$timestampEdit.show().trigger( 'focus' );
 			}
 			event.preventDefault();
 		});

--- a/src/wp-admin/css/edit.css
+++ b/src/wp-admin/css/edit.css
@@ -481,11 +481,12 @@ form#tags-filter {
 
 .misc-pub-curtime {
 	display: grid;
-	grid-template-columns: auto minmax( 0, 1fr );
+	grid-template-columns: auto minmax( 0, max-content ) minmax( 0, 1fr );
 }
 
-.misc-pub-curtime .timestamp-display {
+.misc-pub-curtime #timestamp {
 	grid-column: 2;
+	grid-row: 1;
 	min-width: 0;
 }
 
@@ -504,7 +505,9 @@ form#tags-filter {
 }
 
 .misc-pub-curtime .edit-timestamp {
-	margin-left: 0;
+	grid-column: 3;
+	grid-row: 1;
+	margin-left: 4px;
 }
 
 .misc-pub-curtime .edit-timestamp-label {

--- a/src/wp-admin/css/edit.css
+++ b/src/wp-admin/css/edit.css
@@ -481,7 +481,7 @@ form#tags-filter {
 
 .misc-pub-curtime {
 	display: grid;
-	grid-template-columns: 27px minmax( 0, 1fr );
+	grid-template-columns: auto minmax( 0, 1fr );
 }
 
 .misc-pub-curtime .timestamp-display {
@@ -501,10 +501,6 @@ form#tags-filter {
 	top: -1px;
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
-}
-
-.misc-pub-curtime #timestamp:before {
-	content: none;
 }
 
 .misc-pub-curtime .edit-timestamp {

--- a/src/wp-admin/css/edit.css
+++ b/src/wp-admin/css/edit.css
@@ -479,6 +479,46 @@ form#tags-filter {
 	height: auto !important;
 }
 
+.misc-pub-curtime {
+	display: grid;
+	grid-template-columns: 27px minmax( 0, 1fr );
+}
+
+.misc-pub-curtime .timestamp-display {
+	grid-column: 2;
+	min-width: 0;
+}
+
+.misc-pub-curtime:before {
+	content: "\f145";
+	content: "\f145" / '';
+	font: normal 20px/1 dashicons;
+	grid-column: 1;
+	grid-row: 1;
+	margin-left: -1px;
+	padding-right: 3px;
+	position: relative;
+	top: -1px;
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+}
+
+.misc-pub-curtime #timestamp:before {
+	content: none;
+}
+
+.misc-pub-curtime .edit-timestamp {
+	margin-left: 0;
+}
+
+.misc-pub-curtime .edit-timestamp-label {
+	white-space: nowrap;
+}
+
+.misc-pub-curtime #timestampdiv {
+	grid-column: 1 / -1;
+}
+
 #post-body .misc-pub-post-status:before,
 #post-body #visibility:before,
 .curtime #timestamp:before,
@@ -525,6 +565,10 @@ form#tags-filter {
 	top: -1px;
 }
 
+.misc-pub-curtime #timestamp:before {
+	content: none;
+}
+
 #post-body .misc-pub-uploadedby:before {
 	content: "\f110";
 	content: "\f110" / '';
@@ -560,6 +604,41 @@ form#tags-filter {
 
 #timestampdiv input {
 	text-align: center;
+}
+
+#timestampdiv.has-native-timestamp-fields {
+	padding-top: 0;
+}
+
+#timestampdiv .timestamp-native-wrap {
+	margin: 3px 0 0;
+}
+
+#timestampdiv.has-native-timestamp-fields .timestamp-native-wrap {
+	display: grid;
+	gap: 8px;
+}
+
+#timestampdiv.has-native-timestamp-fields .timestamp-actions {
+	margin-top: 8px;
+}
+
+#timestampdiv .timestamp-native-wrap input {
+	box-sizing: border-box;
+	text-align: left;
+	width: 100%;
+}
+
+#timestampdiv .timestamp-native-wrap input.form-invalid,
+#timestampdiv .timestamp-native-wrap input.form-invalid:focus {
+	border-color: #d63638 !important;
+	box-shadow: 0 0 2px rgba(214, 54, 56, 0.8);
+}
+
+#timestampdiv .timestamp-site-time {
+	color: #646970;
+	font-size: 12px;
+	margin: -2px 0 0;
 }
 
 .notification-dialog {

--- a/src/wp-admin/includes/meta-boxes.php
+++ b/src/wp-admin/includes/meta-boxes.php
@@ -285,18 +285,20 @@ function post_submit_meta_box( $post, $args = array() ) {
 		if ( $can_publish ) : // Contributors don't get to choose the date of publish.
 			?>
 			<div class="misc-pub-section curtime misc-pub-curtime">
-				<span id="timestamp">
-					<?php printf( $stamp, '<b>' . $date . '</b>' ); ?>
-				</span>
-				<a href="#edit_timestamp" class="edit-timestamp hide-if-no-js" role="button">
-					<span aria-hidden="true"><?php _e( 'Edit' ); ?></span>
-					<span class="screen-reader-text">
-						<?php
-						/* translators: Hidden accessibility text. */
-						_e( 'Edit date and time' );
-						?>
+				<span class="timestamp-display">
+					<span id="timestamp">
+						<?php printf( $stamp, '<b>' . $date . '</b>' ); ?>
 					</span>
-				</a>
+					<a href="#edit_timestamp" class="edit-timestamp hide-if-no-js" role="button">
+						<span aria-hidden="true" class="edit-timestamp-label"><?php _e( 'Edit' ); ?></span>
+						<span class="screen-reader-text">
+							<?php
+							/* translators: Hidden accessibility text. */
+							_e( 'Edit date and time' );
+							?>
+						</span>
+					</a>
+				</span>
 				<fieldset id="timestampdiv" class="hide-if-js">
 					<legend class="screen-reader-text">
 						<?php

--- a/src/wp-admin/includes/meta-boxes.php
+++ b/src/wp-admin/includes/meta-boxes.php
@@ -285,20 +285,18 @@ function post_submit_meta_box( $post, $args = array() ) {
 		if ( $can_publish ) : // Contributors don't get to choose the date of publish.
 			?>
 			<div class="misc-pub-section curtime misc-pub-curtime">
-				<span class="timestamp-display">
-					<span id="timestamp">
-						<?php printf( $stamp, '<b>' . $date . '</b>' ); ?>
-					</span>
-					<a href="#edit_timestamp" class="edit-timestamp hide-if-no-js" role="button">
-						<span aria-hidden="true" class="edit-timestamp-label"><?php _e( 'Edit' ); ?></span>
-						<span class="screen-reader-text">
-							<?php
-							/* translators: Hidden accessibility text. */
-							_e( 'Edit date and time' );
-							?>
-						</span>
-					</a>
+				<span id="timestamp">
+					<?php printf( $stamp, '<b>' . $date . '</b>' ); ?>
 				</span>
+				<a href="#edit_timestamp" class="edit-timestamp hide-if-no-js" role="button">
+					<span aria-hidden="true" class="edit-timestamp-label"><?php _e( 'Edit' ); ?></span>
+					<span class="screen-reader-text">
+						<?php
+						/* translators: Hidden accessibility text. */
+						_e( 'Edit date and time' );
+						?>
+					</span>
+				</a>
 				<fieldset id="timestampdiv" class="hide-if-js">
 					<legend class="screen-reader-text">
 						<?php

--- a/src/wp-admin/includes/template.php
+++ b/src/wp-admin/includes/template.php
@@ -833,8 +833,15 @@ function touch_time( $edit = 1, $for_post = 1, $tab_index = 0, $multi = 0 ) {
 
 	$timezone = wp_timezone_string();
 	if ( preg_match( '/^([+-])(\d{2}):(\d{2})$/', $timezone, $timezone_matches ) ) {
-		$timezone  = 'UTC' . $timezone_matches[1] . (int) $timezone_matches[2];
-		$timezone .= ( '00' === $timezone_matches[3] ) ? '' : ':' . $timezone_matches[3];
+		$offset_hours   = (int) $timezone_matches[2];
+		$offset_minutes = $timezone_matches[3];
+
+		if ( 0 === $offset_hours && '00' === $offset_minutes ) {
+			$timezone = 'UTC';
+		} else {
+			$timezone  = 'UTC' . $timezone_matches[1] . $offset_hours;
+			$timezone .= ( '00' === $offset_minutes ) ? '' : ':' . $offset_minutes;
+		}
 	}
 
 	$month = '<label><span class="screen-reader-text">' .

--- a/src/wp-admin/includes/template.php
+++ b/src/wp-admin/includes/template.php
@@ -831,6 +831,12 @@ function touch_time( $edit = 1, $for_post = 1, $tab_index = 0, $multi = 0 ) {
 	$cur_hh = current_time( 'H' );
 	$cur_mn = current_time( 'i' );
 
+	$timezone = wp_timezone_string();
+	if ( preg_match( '/^([+-])(\d{2}):(\d{2})$/', $timezone, $timezone_matches ) ) {
+		$timezone  = 'UTC' . $timezone_matches[1] . (int) $timezone_matches[2];
+		$timezone .= ( '00' === $timezone_matches[3] ) ? '' : ':' . $timezone_matches[3];
+	}
+
 	$month = '<label><span class="screen-reader-text">' .
 		/* translators: Hidden accessibility text. */
 		__( 'Month' ) .
@@ -865,7 +871,29 @@ function touch_time( $edit = 1, $for_post = 1, $tab_index = 0, $multi = 0 ) {
 	/* translators: 1: Month, 2: Day, 3: Year, 4: Hour, 5: Minute. */
 	printf( __( '%1$s %2$s, %3$s at %4$s:%5$s' ), $month, $day, $year, $hour, $minute );
 
-	echo '</div><input type="hidden" id="ss" name="ss" value="' . $ss . '" />';
+	echo '</div>';
+
+	if ( $for_post && ! $multi ) {
+		?>
+<div class="timestamp-native-wrap hide-if-no-js" hidden>
+	<label for="publish-date-native" class="screen-reader-text"><?php _e( 'Date' ); ?></label>
+	<input type="date" id="publish-date-native" class="form-required" value="<?php echo esc_attr( $aa . '-' . $mm . '-' . $jj ); ?>" />
+	<label for="publish-time-native" class="screen-reader-text"><?php _e( 'Time' ); ?></label>
+	<input type="time" id="publish-time-native" class="form-required" value="<?php echo esc_attr( $hh . ':' . $mn ); ?>" />
+	<p class="timestamp-site-time">
+		<?php
+		printf(
+			/* translators: %s: The site's timezone. */
+			__( 'Site time: %s' ),
+			'<span>' . esc_html( $timezone ) . '</span>'
+		);
+		?>
+	</p>
+</div>
+		<?php
+	}
+
+	echo '<input type="hidden" id="ss" name="ss" value="' . $ss . '" />';
 
 	if ( $multi ) {
 		return;
@@ -890,7 +918,7 @@ function touch_time( $edit = 1, $for_post = 1, $tab_index = 0, $multi = 0 ) {
 	}
 	?>
 
-<p>
+<p class="timestamp-actions">
 <a href="#edit_timestamp" class="save-timestamp hide-if-no-js button"><?php _e( 'OK' ); ?></a>
 <a href="#edit_timestamp" class="cancel-timestamp hide-if-no-js button-cancel"><?php _e( 'Cancel' ); ?></a>
 </p>


### PR DESCRIPTION
## Summary

Continues the work in #12275 (opened by @poligilad-auto, who is currently out) to enhance the classic editor Publish timestamp with server-rendered native `date` and `time` controls, keeping the existing granular `aa`/`mm`/`jj`/`hh`/`mn` fields as the source of truth and fallback.

<img width="960" height="1916" alt="image" src="https://github.com/user-attachments/assets/cd8846eb-c3bc-4446-8772-5186bb317c51" />

<img width="1670" height="7046" alt="image" src="https://github.com/user-attachments/assets/3d346076-74ed-4389-985a-8152eab745fc" />


This branch carries Poli's original commit unchanged and adds a follow-up commit addressing @tyxla's code review:

- **Removed a duplicated CSS rule.** `.misc-pub-curtime #timestamp:before { content: none }` was declared twice; kept the later declaration so it still overrides `.curtime #timestamp:before` (equal specificity, so source order decides which wins).
- **Consistent invalid-state selectors.** The `form-invalid` class is now added and removed on both native inputs via `.timestamp-native-wrap input`, rather than being added to only `#publish-date-native` by ID while being removed from both.
- **`UTC` instead of `UTC+0`.** A zero timezone offset now renders as `UTC` in the site-time note; non-zero offsets are unchanged (`UTC+5:30`, etc.).
- **Aligned the timestamp row with its siblings.** The Publish-box icon column used a fixed `27px`, which pushed the timestamp label ~10px further right than the Status / Visibility / Revisions rows. Sizing the column with `auto` lets it match the sibling dashicon advance, so all rows line up. All new layout CSS remains scoped to `.misc-pub-curtime`, so the other meta boxes are unaffected.

Trac ticket: https://core.trac.wordpress.org/ticket/61652

## Still open from the review

The two higher-level points @tyxla raised on #12275 are not resolved here and still need discussion:

- Confirming this is the design direction the project wants for the classic editor timestamp. @jasmussen - could you take a look?

- Confirming the markup changes don't break plugins that integrate with the existing controls. -- I'll dig into this 

## Testing

- Opened the classic post editor and confirmed the Publish timestamp renders as native `date` and `time` inputs with the site-time note, and that the timestamp row aligns with the other Publish-box rows.
- Confirmed changing the native inputs updates the legacy timestamp fields, and an invalid value keeps the editor open and marks both native inputs invalid.
- `php -l src/wp-admin/includes/template.php` — no syntax errors.
- Measured the Publish-box row alignment before and after the CSS change (sibling rows and the timestamp row now share the same 16.5px label indent).

The follow-up commit was drafted with AI assistance and reviewed by me.

Props poligilad, tyxla.
