### PR TITLE
Tests: Use the modern PHPUnit stubbing and matcher shorthands

### DIFF
--- a/tests/phpunit/tests/pomo/pluralForms.php
+++ b/tests/phpunit/tests/pomo/pluralForms.php
@@ -233,7 +233,7 @@ class PluralFormsTest extends WP_UnitTestCase {
 		$mock->expects( $this->once() )
 			->method( 'execute' )
 			->with( $this->identicalTo( 2 ) )
-			->will( $this->returnValue( 1 ) );
+			->willReturn( 1 );
 
 		$first  = $mock->get( 2 );
 		$second = $mock->get( 2 );

--- a/tests/phpunit/tests/rest-api/rest-server.php
+++ b/tests/phpunit/tests/rest-api/rest-server.php
@@ -652,7 +652,7 @@ class Tests_REST_Server extends WP_Test_REST_TestCase {
 
 		$stub->expects( $this->once() )
 			->method( 'set_status' )
-			->with( $this->equalTo( 400 ) );
+			->with( 400 );
 
 		$data     = array(
 			'code'    => 'wp-api-test-error',


### PR DESCRIPTION
Two test cases still used the legacy PHPUnit stub API. This replaces them with the modern shorthands, which are what the rest of the suite already uses.

### Description

`tests/phpunit/tests/pomo/pluralForms.php`

```php
// Before
->will( $this->returnValue( 1 ) );
// After
->willReturn( 1 );
```

`tests/phpunit/tests/rest-api/rest-server.php`

```php
// Before
->with( $this->equalTo( 400 ) );
// After
->with( 400 );
```

### Why this is safe

`willReturn()` is a direct shorthand for `will( $this->returnValue() )` and has been available since PHPUnit 5.4. The test suite enforces a minimum of PHPUnit 5.7.21 in `tests/phpunit/includes/bootstrap.php`, so it is safe on every supported version, and the suite already contains 83 `willReturn()` calls.

`with()` wraps any non-`Constraint` argument in an `equalTo()` constraint itself, so passing `400` directly is identical in behaviour. The suite already has 43 `with()` calls that pass values directly.

Note on the first change: that line was originally written as `willReturn( 1 )` and switched to the long form in [[41725](https://core.trac.wordpress.org/changeset/41725)] because of the PHPUnit versions supported back then. That constraint no longer applies, so this effectively reverts an obsolete workaround.

Trac ticket: https://core.trac.wordpress.org/ticket/65819

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
