### PR TITLE
Media: Refresh attachment tile aria-label when model data loads

### DIFF
--- a/src/js/media/views/attachment.js
+++ b/src/js/media/views/attachment.js
@@ -17,7 +17,15 @@ Attachment = View.extend(/** @lends wp.media.view.Attachment.prototype */{
 	className: 'attachment',
 	template:  wp.template('attachment'),
 
-	attributes: function() {
+	/**
+	 * Compute the accessible name for an attachment tile.
+	 *
+	 * Factored out of attributes() so render() can refresh the label when a
+	 * model finishes loading after the view was created. See #65852.
+	 *
+	 * @return {string} Accessible name for the attachment.
+	 */
+	getAriaLabel: function() {
 		var ariaLabel = this.model.get( 'title' );
 
 		if ( ! ariaLabel ) {
@@ -28,10 +36,14 @@ Attachment = View.extend(/** @lends wp.media.view.Attachment.prototype */{
 			}
 		}
 
+		return ariaLabel;
+	},
+
+	attributes: function() {
 		return {
 			'tabIndex':     0,
 			'role':         'checkbox',
-			'aria-label':   ariaLabel,
+			'aria-label':   this.getAriaLabel(),
 			'aria-checked': false,
 			'data-id':      this.model.get( 'id' )
 		};
@@ -156,6 +168,17 @@ Attachment = View.extend(/** @lends wp.media.view.Attachment.prototype */{
 		this.updateSave();
 
 		this.views.render();
+
+		/*
+		 * Backbone only evaluates attributes() when the element is created.
+		 * When a tile is built for an id-only model that is still fetching,
+		 * the aria-label is computed from empty data and never refreshes.
+		 * Re-apply it here once the model has data. Skip subclasses that
+		 * reset attributes (e.g. Attachment.Details). See #65852, #47458.
+		 */
+		if ( undefined !== _.result( this, 'attributes' )['aria-label'] ) {
+			this.$el.attr( 'aria-label', this.getAriaLabel() );
+		}
 
 		return this;
 	},


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**
-->

Media Library grid tiles can keep a stale `aria-label` (`uploading…` / `(no title)`) when the view is created for an id-only attachment model that is still fetching. The visible CSS label overlay (added in 7.0) makes that staleness obvious to everyone, not only screen reader users.

## Problem

`wp.media.view.Attachment` computes `aria-label` only in `attributes()`, and Backbone evaluates that once during `_ensureElement()`. Core (and Gutenberg) often create tiles via `Attachment.get( id )` + `fetch()`, so the label is computed from empty model data and never updates when the model later receives a title — even though `render()` re-runs on model `change`.

This is distinct from #65438 / [62892], which only changes which fallback string is used for a titleless model.

## Fix

- Factor the label computation into `getAriaLabel()`.
- Re-apply `aria-label` at the end of `render()` once the model has data.
- Skip subclasses that reset `attributes` (e.g. `Attachment.Details`, see #47458) so we do not add inappropriate attributes there.
- Leave `aria-checked` alone so selection state from `updateSelect()` is not clobbered.

## Testing instructions

1. Use the Playground blueprint from the Trac ticket, or locally:
   - Create a post with a titled featured image.
   - Reload the post edit screen and open the Featured image modal.
2. Confirm the selected tile label updates to the attachment title (not stuck on `uploading…` / `(no title)`).
3. Confirm untitled tiles still show `(no title)`, and in-progress uploads still show `uploading…`.
4. Confirm Attachment Details (sidebar) is unchanged (no checkbox/`aria-label` attributes added).

Trac ticket: https://core.trac.wordpress.org/ticket/65852

## Use of AI Tools

AI assistance: Yes
Tool(s): Cursor
Model(s): Cursor Grok 4.5
Used for: Implementation assistance following the approach suggested on the Trac ticket. Changes were reviewed against the codebase and existing Attachment.Details attribute reset pattern.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**