### PR TITLE
Toolbar: Show the item indicator only on keyboard focus.

### DIFF
--- a/src/wp-includes/css/admin-bar.css
+++ b/src/wp-includes/css/admin-bar.css
@@ -84,18 +84,14 @@ html:lang(he-il) .rtl #wpadminbar * {
 	outline: 2px solid transparent;
 }
 
-#wpadminbar a:hover,
-#wpadminbar a:focus,
-#wpadminbar .ab-item[tabindex="0"]:hover,
-#wpadminbar .ab-item[tabindex="0"]:focus {
+#wpadminbar a:focus-visible,
+#wpadminbar .ab-item[tabindex="0"]:focus-visible {
 	box-shadow: inset 0 -4px 0 0 currentColor;
 	transition: box-shadow 0.1s linear;
 }
 
-#wpadminbar .ab-submenu a:hover,
-#wpadminbar .ab-submenu a:focus,
-#wpadminbar .ab-submenu .ab-item[tabindex="0"]:hover,
-#wpadminbar .ab-submenu .ab-item[tabindex="0"]:focus {
+#wpadminbar .ab-submenu a:focus-visible,
+#wpadminbar .ab-submenu .ab-item[tabindex="0"]:focus-visible {
 	box-shadow: inset 4px 0 0 0 currentColor;
 }
 


### PR DESCRIPTION
To address the awkwardness of the indicator appearing only while a Toolbar item is being clicked, [r63201](https://core.trac.wordpress.org/changeset/63201) made the indicator show on hover as well as on focus. However, that is a significant change from a design perspective and is open to debate, as noted in the ticket.

The problem to solve was the focus style, not the hover style. So for now, this PR reverts the hover styles and uses `:focus-visible` instead, so the indicator is shown only on keyboard focus. The transparent `outline` for Windows High Contrast mode stays on `:focus`.

The shape of the focus indicator itself is left to a separate design pass.

Trac ticket: https://core.trac.wordpress.org/ticket/65849

## Testing Instructions

1. Hover over an item in the Toolbar, including submenu items. The indicator should not appear.
2. Click an item in the Toolbar. The indicator should not appear while clicking.
3. Move focus through the Toolbar with the keyboard. The indicator should appear only on the item that has keyboard focus.

https://github.com/user-attachments/assets/15a47636-25e8-488a-a229-f28601edebe2

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Applying the selector change and drafting this pull request description. The approach was decided by me, and the result was reviewed and edited by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
