### PR TITLE
Menus: Stop a nested loop clobbering the slug it is matching against.

### DIFF
--- a/src/wp-includes/nav-menu.php
+++ b/src/wp-includes/nav-menu.php
@@ -1288,13 +1288,17 @@ function wp_map_nav_menu_locations( $new_nav_menu_locations, $old_nav_menu_locat
 				// Then see if any of the old locations...
 				foreach ( $old_nav_menu_locations as $location => $menu_id ) {
 
-					// ...and any slug in the same group...
-					foreach ( $slug_group as $slug ) {
+					/*
+					 * ...and any slug in the same group. This uses its own variable
+					 * because the outer loop's $slug is still needed for the
+					 * remaining new locations once this one is done.
+					 */
+					foreach ( $slug_group as $old_slug ) {
 
 						// ... have a match as well.
-						if ( is_string( $location ) && false === stripos( $location, $slug ) && false === stripos( $slug, $location ) ) {
+						if ( is_string( $location ) && false === stripos( $location, $old_slug ) && false === stripos( $old_slug, $location ) ) {
 							continue;
-						} elseif ( is_numeric( $location ) && $location !== $slug ) {
+						} elseif ( is_numeric( $location ) && $location !== $old_slug ) {
 							continue;
 						}
 
@@ -1310,7 +1314,7 @@ function wp_map_nav_menu_locations( $new_nav_menu_locations, $old_nav_menu_locat
 							// Go back and check the next new menu location.
 							continue 3;
 						}
-					} // End foreach ( $slug_group as $slug ).
+					} // End foreach ( $slug_group as $old_slug ).
 				} // End foreach ( $old_nav_menu_locations as $location => $menu_id ).
 			} // End foreach foreach ( $registered_nav_menus as $new_location => $name ).
 		} // End foreach ( $slug_group as $slug ).

--- a/tests/phpunit/tests/menu/nav-menu.php
+++ b/tests/phpunit/tests/menu/nav-menu.php
@@ -180,6 +180,35 @@ class Tests_Nav_Menu_Theme_Change extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A new location that matches only one slug in its group should still be mapped
+	 * after an earlier location in the same group has been mapped.
+	 *
+	 * 'primary-menu' matches 'primary' and nothing else in that group, so unlike
+	 * 'main' in the test above it has no later slug to be picked up by.
+	 *
+	 * @ticket 65884
+	 *
+	 * @covers ::wp_map_nav_menu_locations
+	 */
+	public function test_location_guessing_after_an_earlier_location_in_the_group_matched() {
+		$this->register_nav_menu_locations( array( 'primary', 'primary-menu' ) );
+
+		$prev_theme_nav_menu_locations = array(
+			'header'   => 1,
+			'mainmenu' => 2,
+		);
+
+		$old_next_theme_nav_menu_locations = array();
+		$new_next_theme_nav_menu_locations = wp_map_nav_menu_locations( $old_next_theme_nav_menu_locations, $prev_theme_nav_menu_locations );
+
+		$expected_nav_menu_locations = array(
+			'primary'      => 1,
+			'primary-menu' => 2,
+		);
+		$this->assertSame( $expected_nav_menu_locations, $new_next_theme_nav_menu_locations );
+	}
+
+	/**
 	 * Technically possible to register menu locations numerically.
 	 *
 	 * @expectedIncorrectUsage register_nav_menus


### PR DESCRIPTION
`wp_map_nav_menu_locations()` uses `$slug` for two nested loops: the one over the slug group
at `nav-menu.php:1276`, and the one at `:1292` nested three levels inside it. PHP leaves a
`foreach` variable at its last assigned value, so once any new location descends into the
old-location loops, the comparison at `:1282` runs against whatever the inner loop left
behind rather than the outer loop's slug.

A skipped location is only recovered if it happens to match a later slug in the same group.
When it matches exactly one, nothing picks it up and the assignment is lost.

Measured on trunk. New theme locations on the left, previous theme's assignments on the right:

| New locations | Previous assignments | Before | After |
| --- | --- | --- | --- |
| `primary`, `primary-menu` | `header`, `mainmenu` | 1 of 2 mapped | 2 of 2 |
| `primary`, `primary-nav` | `header`, `mainmenu` | 1 of 2 mapped | 2 of 2 |
| `footer`, `footer-menu` | `secondary`, `bottom` | 1 of 2 mapped | 2 of 2 |
| `primary`, `main` | `navigation-menu`, `top-menu` | 2 of 2 | 2 of 2 |
| `header`, `header-top` | `primary`, `top-menu` | 2 of 2 | 2 of 2 |

The last two rows are why this has gone unnoticed. `primary` + `main` is exactly
`test_location_guessing_one_menu_per_location()`, and it passes today because `main` is
itself a slug in the group, so the skipped location is picked up on a later pass.
`header-top` recovers the same way via `top`. Only a location matching a single slug is
actually lost.

Reached on every theme switch via `_wp_menus_changed()` on `after_switch_theme`
(`default-filters.php:376`) and from `class-wp-customize-nav-menus.php:734`.

Present since [41237] (#39692) in 4.9 — the inner loop has carried the outer loop's variable
name since the first version.

## Approach

Renamed the inner loop variable to `$old_slug`. That is the whole change; the matching
logic is untouched. I confirmed the rename is what fixes it by applying it in isolation to
an extracted copy of the function and re-running the table above.

## Testing

The new test fails without the `nav-menu.php` change and is the only failure of the 106 in
the `menu` group, so it fails on its own assertion rather than a precondition. With the
change, `menu` is 106/106 and `customize` is 243/243. `phpcs` passes on both files.

Trac ticket: https://core.trac.wordpress.org/ticket/65884

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Drafting this description and a first pass at the test. I confirmed the mechanism
myself against the source, produced the before/after table by running the real function,
verified the rename alone is what changes the outcome, checked the test fails without the
patch, ran the `menu` and `customize` suites and `phpcs`, and I take responsibility for the
change.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
