### PR TITLE
Media: Correct error message for rejected image uploads

### DIFF
--- a/src/js/_enqueues/vendor/plupload/wp-plupload.js
+++ b/src/js/_enqueues/vendor/plupload/wp-plupload.js
@@ -484,8 +484,14 @@ window.wp = window.wp || {};
 			return pluploadL10n.file_exceeds_size_limit.replace( '%s', file.name );
 		},
 
-		'HTTP_ERROR': function( file ) {
-			if ( file.type && file.type.indexOf( 'image/' ) === 0 ) {
+		'HTTP_ERROR': function( file, error ) {
+			var status = error && error.status;
+
+			if (
+				file.type &&
+				file.type.indexOf( 'image/' ) === 0 &&
+				! ( status >= 400 && status < 500 )
+			) {
 				return pluploadL10n.http_error_image;
 			}
 

--- a/tests/e2e/specs/media-upload.test.js
+++ b/tests/e2e/specs/media-upload.test.js
@@ -6,7 +6,20 @@ import { test, expect } from '@wordpress/e2e-test-utils-playwright';
 /**
  * External dependencies
  */
+import { readFileSync } from 'node:fs';
 import path from 'path';
+
+const testImage = {
+	name: "test'image.jpg",
+	mimeType: 'image/jpeg',
+	buffer: readFileSync(
+		path.join( __dirname, '../../phpunit/data/images/test-image.jpg' )
+	),
+};
+
+test.afterEach( async ( { requestUtils } ) => {
+	await requestUtils.deleteAllMedia();
+} );
 
 test( 'Test dismissing failed upload works correctly', async ({ page, admin, requestUtils }) => {
 	// Log in before visiting admin page.
@@ -32,4 +45,76 @@ test( 'Test dismissing failed upload works correctly', async ({ page, admin, req
 	await expect(
 		page.getByText('“sample.svg” has failed to upload.')
 	).not.toBeVisible();
+} );
+
+test( 'uploads an image with an apostrophe in its filename', async ( {
+	page,
+	admin,
+	requestUtils,
+} ) => {
+	await requestUtils.login();
+	await requestUtils.deleteAllMedia();
+	await admin.visitAdminPage( '/media-new.php' );
+	await page.waitForLoadState( 'load' );
+
+	const input = page.locator( '#plupload-upload-ui input[type="file"]' );
+	await input.setInputFiles( testImage );
+
+	await expect(
+		page.getByText( 'testimage.jpg', { exact: true } )
+	).toBeVisible();
+} );
+
+test( 'uses the generic HTTP error for a rejected image upload', async ( {
+	page,
+	admin,
+	requestUtils,
+} ) => {
+	await requestUtils.login();
+	await page.route( '**/wp-admin/async-upload.php', ( route ) =>
+		route.fulfill( {
+			status: 403,
+			contentType: 'text/plain',
+			body: 'Forbidden',
+		} )
+	);
+	await admin.visitAdminPage( '/media-new.php' );
+	await page.waitForLoadState( 'load' );
+
+	const input = page.locator( '#plupload-upload-ui input[type="file"]' );
+	await input.setInputFiles( testImage );
+
+	await expect(
+		page.getByText( 'Unexpected response from the server.' )
+	).toBeVisible();
+	await expect(
+		page.getByText( 'Suggested maximum size is 2560 pixels.' )
+	).not.toBeVisible();
+} );
+
+test( 'retains the image processing error for a server failure', async ( {
+	page,
+	admin,
+	requestUtils,
+} ) => {
+	await requestUtils.login();
+	await page.route( '**/wp-admin/async-upload.php', ( route ) =>
+		route.fulfill( {
+			status: 500,
+			contentType: 'text/plain',
+			body: 'Internal Server Error',
+		} )
+	);
+	await admin.visitAdminPage( '/media-new.php' );
+	await page.waitForLoadState( 'load' );
+
+	const input = page.locator( '#plupload-upload-ui input[type="file"]' );
+	await input.setInputFiles( testImage );
+
+	await expect(
+		page.getByText( 'The server cannot process the image.' )
+	).toBeVisible();
+	await expect(
+		page.getByText( 'Suggested maximum size is 2560 pixels.' )
+	).toBeVisible();
 } );


### PR DESCRIPTION
## Summary

Plupload currently maps every image `HTTP_ERROR` to the image-processing message, including HTTP 4xx responses from hosting security layers. This makes a ModSecurity rejection look like an image-size or 2560-pixel failure.

This change uses the existing generic HTTP error for image uploads rejected with a 4xx response. Image/server failures outside the 4xx range retain the existing image-processing guidance, and non-image behavior is unchanged.

The patch does not alter filename sanitization or attempt to bypass the hosting firewall. A clean Core environment accepts `test'image.jpg` and stores it as `testimage.jpg`; the original host-specific ModSecurity rejection is not reproducible locally without intercepting the response.

Trac ticket: https://core.trac.wordpress.org/ticket/64617

## Testing

- `npm run test:e2e -- tests/e2e/specs/media-upload.test.js` — 4 passed
- `npm run grunt -- jshint:corejs` — passed
- `npm run typecheck:js` — passed
- `npm run grunt -- qunit:compiled` — build completed, then Grunt's Windows `npx` launcher returned `spawn EINVAL`
- Direct underlying QUnit command, `npx playwright test --config tests/qunit/playwright.config.js` — 2 passed; 566/566 compiled and 566/566 source tests passed

The E2E coverage verifies a clean apostrophe-containing JPEG upload, an intercepted HTTP 403 response using the generic response message without 2560-pixel guidance, and an intercepted HTTP 500 response retaining the image-processing guidance.

### Refresh validation — August 26, 2026

The branch was rebased onto WordPress Core trunk commit `3f5fdc5378`.

- `git diff --check upstream/trunk...HEAD` — passed
- `npm run grunt -- jshint:corejs` — passed
- `npm run typecheck:js` — passed
- `npm run grunt -- qunit:compiled` — build completed, then the known Windows `spawn EINVAL` launcher error recurred
- Direct Playwright QUnit runner — 2 passed; 566/566 compiled and 566/566 source tests passed
- Fresh GitHub CI — all non-skipped checks passed, including both E2E modes and the full PHP/database matrix

The local E2E suite was not rerun during the refresh because Docker Desktop failed to start due to a stale host runtime socket. The fresh GitHub E2E jobs passed with both `SCRIPT_DEBUG` settings.

## Use of AI Tools

AI assistance: Yes
Tool(s): OpenAI Codex
Model(s): GPT-5.6 Sol, GPT-5.6 Luna
Used for: Planning, implementation, test authoring, local validation, and an independent final patch review.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
