### PR TITLE
use esc_url() for the term link href in get_the_taxonomies()

### DIFF
--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -4903,7 +4903,7 @@ function get_the_taxonomies( $post = 0, $args = array() ) {
 		$links = array();
 
 		foreach ( $terms as $term ) {
-			$links[] = wp_sprintf( $t['term_template'], esc_attr( get_term_link( $term ) ), $term->name );
+			$links[] = wp_sprintf( $t['term_template'], esc_url( get_term_link( $term ) ), $term->name );
 		}
 		if ( $links ) {
 			$taxonomies[ $taxonomy ] = wp_sprintf( $t['template'], $t['label'], $links, $terms );

--- a/tests/phpunit/tests/taxonomy.php
+++ b/tests/phpunit/tests/taxonomy.php
@@ -83,6 +83,25 @@ class Tests_Taxonomy extends WP_UnitTestCase {
 		$this->assertSame( 'Categories: <span class="foo"><a href="' . $link . '">Uncategorized</a></span>.', $taxes['category'] );
 	}
 
+	/**
+	 * The term URL fills an `href`, so it must be escaped with esc_url() to
+	 * enforce the protocol allowlist, matching get_the_term_list(). A term_link
+	 * filter returning a javascript: URL must not survive into the markup.
+	 */
+	public function test_get_the_taxonomies_escapes_term_url() {
+		$post_id = self::factory()->post->create();
+
+		add_filter( 'term_link', array( $this, 'filter_term_link_to_js' ) );
+		$taxes = get_the_taxonomies( $post_id );
+		remove_filter( 'term_link', array( $this, 'filter_term_link_to_js' ) );
+
+		$this->assertStringNotContainsString( 'javascript:', $taxes['category'] );
+	}
+
+	public function filter_term_link_to_js() {
+		return 'javascript:alert(1)';
+	}
+
 	public function test_the_taxonomies() {
 		$post_id = self::factory()->post->create();
 


### PR DESCRIPTION
Failing assertion when a `term_link` filter returns a `javascript:` URL:

    Failed asserting that 'Categories: <a href="javascript:alert(1)">Uncategorized</a>.'
    does not contain "javascript:".

`get_the_taxonomies()` builds the term `href` with `esc_attr( get_term_link( $term ) )`. `esc_attr()` does not apply the protocol allowlist, so a scheme injected through the public `term_link` filter reaches the anchor unchanged. The sibling renderers `get_the_term_list()` and `get_the_category_list()` already run the same value through `esc_url()`; this brings `get_the_taxonomies()` in line with them. Included a regression test that fails on the current code and passes with the change.

Trac ticket: 