### PR TITLE
Manually exclude the `sync.js` files.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -80,6 +80,18 @@ module.exports = function(grunt) {
 			SOURCE_DIR + 'wp-includes/assets/script-modules-packages.php',
 		],
 
+		/*
+		 * Files included in the `/gutenberg` directory that should be excluded.
+		 *
+		 * `tools/gutenberg/copy.js` copies every package under `gutenberg/build/scripts/`
+		 * indiscriminately. These files are not properly excluded from the built zip file
+		 * built for WordPress Core, so they need to be ecluded manually instead.
+		 */
+		gutenbergExcludedCoreFiles = [
+			'wp-includes/js/dist/sync.js',
+			'wp-includes/js/dist/sync.min.js',
+		],
+
 		// All files built by Webpack, in /src or /build.
 		// Webpack only builds Core-specific media files and development scripts.
 		// Blocks, packages, script modules, and vendors come from the Gutenberg build.
@@ -1727,6 +1739,20 @@ module.exports = function(grunt) {
 		} );
 	} );
 
+	/*
+	 * Remove files that are in the `gutenberg` directory that should be included in Core.
+	 */
+	grunt.registerTask( 'gutenberg:remove-excluded-files', 'Removes Gutenberg-sourced files that should not ship in WordPress Core.', function() {
+		gutenbergExcludedCoreFiles.forEach( function( file ) {
+			var filePath = WORKING_DIR + file;
+
+			if ( fs.existsSync( filePath ) ) {
+				fs.unlinkSync( filePath );
+				grunt.log.writeln( 'Removed ' + filePath );
+			}
+		} );
+	} );
+
 	grunt.renameTask( 'watch', '_watch' );
 
 	grunt.registerTask( 'watch', function() {
@@ -2238,7 +2264,8 @@ module.exports = function(grunt) {
 				'build:js',
 				'build:css',
 				'build:codemirror',
-				'build:certificates'
+				'build:certificates',
+				'gutenberg:remove-excluded-files'
 			] );
 		} else {
 			grunt.task.run( [
@@ -2250,7 +2277,8 @@ module.exports = function(grunt) {
 				'build:css',
 				'build:codemirror',
 				'replace:source-maps',
-				'verify:build'
+				'verify:build',
+				'gutenberg:remove-excluded-files'
 			] );
 		}
 	} );

--- a/src/wp-admin/includes/update-core.php
+++ b/src/wp-admin/includes/update-core.php
@@ -905,12 +905,8 @@ $_old_files = array(
 	// 7.0.2
 	'wp-includes/collaboration',
 	'wp-includes/collaboration.php',
-	/*
-	 * Restored in WordPress 7.1.
-	 *
-	 * 'wp-includes/js/dist/sync.js',
-	 * 'wp-includes/js/dist/sync.min.js',
-	 */
+	'wp-includes/js/dist/sync.js',
+	'wp-includes/js/dist/sync.min.js',
 	// 7.1
 	'wp-includes/images/icon-library/accordion-heading.svg',
 	'wp-includes/images/icon-library/accordion-item.svg',


### PR DESCRIPTION
This adds a temporary Grunt task to delete the remaining RTC-related files after building.

This is a temporary alternative approach to #13061/https://github.com/WordPress/gutenberg/pull/81683.

Trac ticket: Core-65813

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
