### PR TITLE
Build/Test Tools: Preserve PHPUnit timing results for use in metrics

### DIFF
--- a/.github/workflows/reusable-phpunit-tests-v3.yml
+++ b/.github/workflows/reusable-phpunit-tests-v3.yml
@@ -274,8 +274,7 @@ jobs:
       - name: Upload PHPUnit timing results
         if: |
           always() &&
-          ( github.event_name == 'schedule' ||
-            ( github.event_name == 'pull_request' && github.event.pull_request.number == 13070 ) ) &&
+          github.event_name == 'schedule' &&
           inputs.php == '8.5' &&
           inputs.report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/reusable-phpunit-tests-v3.yml
+++ b/.github/workflows/reusable-phpunit-tests-v3.yml
@@ -123,7 +123,7 @@ jobs:
   # - Logs debug information about what's installed within the WordPress Docker containers.
   # - Install WordPress within the Docker container.
   # - Run the PHPUnit tests.
-  # - Upload JUnit timing results for scheduled runs.
+  # - Upload JUnit timing results as an artifact.
   # - Upload the code coverage report to Codecov.io.
   # - Ensures version-controlled files are not modified or deleted.
   # - Checks out the WordPress Test reporter repository.
@@ -270,11 +270,11 @@ jobs:
           TEST_GROUPS: ${{ inputs.phpunit-test-groups }}
           MULTISITE_FLAG: ${{ inputs.multisite && 'multisite' || 'single' }}
 
-      # Use the existing host test reporting job as the canonical timing environment.
-      - name: Upload PHPUnit timing results
+      - name: Upload PHPUnit timing results as an artifact
         if: |
           always() &&
-          github.event_name == 'schedule' &&
+          github.event_name == 'push' &&
+          github.ref == 'refs/heads/trunk' &&
           inputs.php == '8.5' &&
           inputs.report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/reusable-phpunit-tests-v3.yml
+++ b/.github/workflows/reusable-phpunit-tests-v3.yml
@@ -274,7 +274,8 @@ jobs:
       - name: Upload PHPUnit timing results
         if: |
           always() &&
-          github.event_name == 'schedule' &&
+          ( github.event_name == 'schedule' ||
+            ( github.event_name == 'pull_request' && github.event.pull_request.number == 13070 ) ) &&
           inputs.php == '8.5' &&
           inputs.report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/reusable-phpunit-tests-v3.yml
+++ b/.github/workflows/reusable-phpunit-tests-v3.yml
@@ -123,6 +123,7 @@ jobs:
   # - Logs debug information about what's installed within the WordPress Docker containers.
   # - Install WordPress within the Docker container.
   # - Run the PHPUnit tests.
+  # - Upload JUnit test results for scheduled runs.
   # - Upload the code coverage report to Codecov.io.
   # - Ensures version-controlled files are not modified or deleted.
   # - Checks out the WordPress Test reporter repository.
@@ -254,7 +255,7 @@ jobs:
       - name: Run external HTTP tests
         if: ${{ ! inputs.multisite && ! inputs.phpunit-test-groups && ! inputs.coverage-report }}
         continue-on-error: ${{ inputs.allow-errors }}
-        run: node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose -c "${PHPUNIT_CONFIG}" --group external-http
+        run: node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose -c "${PHPUNIT_CONFIG}" --group external-http ${{ github.event_name == 'schedule' && '--log-junit tests/phpunit/build/logs/junit-external-http.xml' || '' }}
 
       - name: Run PHPUnit tests${{ inputs.phpunit-test-groups && format( ' ({0} groups)', inputs.phpunit-test-groups ) || '' }}${{ inputs.coverage-report && ' with coverage report' || '' }}
         continue-on-error: ${{ inputs.allow-errors }}
@@ -264,6 +265,7 @@ jobs:
             --verbose \
             -c "${PHPUNIT_CONFIG}" \
             ${{ inputs.phpunit-test-groups && '--group "${TEST_GROUPS}"' || '' }} \
+            ${{ github.event_name == 'schedule' && '--log-junit tests/phpunit/build/logs/junit-main.xml' || '' }} \
             ${{ inputs.coverage-report && '--coverage-clover "wp-code-coverage-${MULTISITE_FLAG}-${GITHUB_SHA}.xml"' || '' }}
         env:
           TEST_GROUPS: ${{ inputs.phpunit-test-groups }}
@@ -272,18 +274,27 @@ jobs:
       - name: Run AJAX tests
         if: ${{ ! inputs.phpunit-test-groups && ! inputs.coverage-report }}
         continue-on-error: ${{ inputs.allow-errors }}
-        run: node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose -c "${PHPUNIT_CONFIG}" --group ajax
+        run: node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose -c "${PHPUNIT_CONFIG}" --group ajax ${{ github.event_name == 'schedule' && '--log-junit tests/phpunit/build/logs/junit-ajax.xml' || '' }}
 
       - name: Run ms-files tests as a multisite install
         if: ${{ inputs.multisite && ! inputs.phpunit-test-groups && ! inputs.coverage-report }}
         continue-on-error: ${{ inputs.allow-errors }}
-        run: node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose -c "${PHPUNIT_CONFIG}" --group ms-files
+        run: node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose -c "${PHPUNIT_CONFIG}" --group ms-files ${{ github.event_name == 'schedule' && '--log-junit tests/phpunit/build/logs/junit-ms-files.xml' || '' }}
 
       # __fakegroup__ is excluded to force PHPUnit to ignore the <exclude> settings in phpunit.xml.dist.
       - name: Run (Xdebug) tests
         if: ${{ ! inputs.phpunit-test-groups && ! inputs.coverage-report }}
         continue-on-error: ${{ inputs.allow-errors }}
-        run: LOCAL_PHP_XDEBUG=true node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit -v --group xdebug --exclude-group __fakegroup__
+        run: LOCAL_PHP_XDEBUG=true node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit -v --group xdebug --exclude-group __fakegroup__ ${{ github.event_name == 'schedule' && '--log-junit tests/phpunit/build/logs/junit-xdebug.xml' || '' }}
+
+      - name: Upload PHPUnit test results
+        if: ${{ always() && github.event_name == 'schedule' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: phpunit-results-php-${{ inputs.php }}-${{ inputs.db-type }}-${{ inputs.db-version }}-${{ inputs.multisite && 'multisite' || 'single-site' }}-${{ inputs.memcached && 'memcached' || 'default' }}${{ inputs.phpunit-test-groups && format('-{0}', inputs.phpunit-test-groups) || '' }}${{ 'example.org' != inputs.tests-domain && '-custom-domain' || '' }}
+          path: tests/phpunit/build/logs/*.xml
+          if-no-files-found: error
+          retention-days: 14
 
       - name: Upload test coverage report to Codecov
         if: ${{ inputs.coverage-report }}

--- a/.github/workflows/reusable-phpunit-tests-v3.yml
+++ b/.github/workflows/reusable-phpunit-tests-v3.yml
@@ -123,7 +123,7 @@ jobs:
   # - Logs debug information about what's installed within the WordPress Docker containers.
   # - Install WordPress within the Docker container.
   # - Run the PHPUnit tests.
-  # - Upload JUnit test results for scheduled runs.
+  # - Upload JUnit timing results for scheduled runs.
   # - Upload the code coverage report to Codecov.io.
   # - Ensures version-controlled files are not modified or deleted.
   # - Checks out the WordPress Test reporter repository.
@@ -255,7 +255,7 @@ jobs:
       - name: Run external HTTP tests
         if: ${{ ! inputs.multisite && ! inputs.phpunit-test-groups && ! inputs.coverage-report }}
         continue-on-error: ${{ inputs.allow-errors }}
-        run: node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose -c "${PHPUNIT_CONFIG}" --group external-http ${{ github.event_name == 'schedule' && '--log-junit tests/phpunit/build/logs/junit-external-http.xml' || '' }}
+        run: node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose -c "${PHPUNIT_CONFIG}" --group external-http
 
       - name: Run PHPUnit tests${{ inputs.phpunit-test-groups && format( ' ({0} groups)', inputs.phpunit-test-groups ) || '' }}${{ inputs.coverage-report && ' with coverage report' || '' }}
         continue-on-error: ${{ inputs.allow-errors }}
@@ -265,36 +265,39 @@ jobs:
             --verbose \
             -c "${PHPUNIT_CONFIG}" \
             ${{ inputs.phpunit-test-groups && '--group "${TEST_GROUPS}"' || '' }} \
-            ${{ github.event_name == 'schedule' && '--log-junit tests/phpunit/build/logs/junit-main.xml' || '' }} \
             ${{ inputs.coverage-report && '--coverage-clover "wp-code-coverage-${MULTISITE_FLAG}-${GITHUB_SHA}.xml"' || '' }}
         env:
           TEST_GROUPS: ${{ inputs.phpunit-test-groups }}
           MULTISITE_FLAG: ${{ inputs.multisite && 'multisite' || 'single' }}
 
+      # Use the existing host test reporting job as the canonical timing environment.
+      - name: Upload PHPUnit timing results
+        if: |
+          always() &&
+          github.event_name == 'schedule' &&
+          inputs.php == '8.5' &&
+          inputs.report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: phpunit-timing-results
+          path: tests/phpunit/build/logs/junit.xml
+          if-no-files-found: error
+
       - name: Run AJAX tests
         if: ${{ ! inputs.phpunit-test-groups && ! inputs.coverage-report }}
         continue-on-error: ${{ inputs.allow-errors }}
-        run: node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose -c "${PHPUNIT_CONFIG}" --group ajax ${{ github.event_name == 'schedule' && '--log-junit tests/phpunit/build/logs/junit-ajax.xml' || '' }}
+        run: node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose -c "${PHPUNIT_CONFIG}" --group ajax
 
       - name: Run ms-files tests as a multisite install
         if: ${{ inputs.multisite && ! inputs.phpunit-test-groups && ! inputs.coverage-report }}
         continue-on-error: ${{ inputs.allow-errors }}
-        run: node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose -c "${PHPUNIT_CONFIG}" --group ms-files ${{ github.event_name == 'schedule' && '--log-junit tests/phpunit/build/logs/junit-ms-files.xml' || '' }}
+        run: node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose -c "${PHPUNIT_CONFIG}" --group ms-files
 
       # __fakegroup__ is excluded to force PHPUnit to ignore the <exclude> settings in phpunit.xml.dist.
       - name: Run (Xdebug) tests
         if: ${{ ! inputs.phpunit-test-groups && ! inputs.coverage-report }}
         continue-on-error: ${{ inputs.allow-errors }}
-        run: LOCAL_PHP_XDEBUG=true node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit -v --group xdebug --exclude-group __fakegroup__ ${{ github.event_name == 'schedule' && '--log-junit tests/phpunit/build/logs/junit-xdebug.xml' || '' }}
-
-      - name: Upload PHPUnit test results
-        if: ${{ always() && github.event_name == 'schedule' }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: phpunit-results-php-${{ inputs.php }}-${{ inputs.db-type }}-${{ inputs.db-version }}-${{ inputs.multisite && 'multisite' || 'single-site' }}-${{ inputs.memcached && 'memcached' || 'default' }}${{ inputs.phpunit-test-groups && format('-{0}', inputs.phpunit-test-groups) || '' }}${{ 'example.org' != inputs.tests-domain && '-custom-domain' || '' }}
-          path: tests/phpunit/build/logs/*.xml
-          if-no-files-found: error
-          retention-days: 14
+        run: LOCAL_PHP_XDEBUG=true node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit -v --group xdebug --exclude-group __fakegroup__
 
       - name: Upload test coverage report to Codecov
         if: ${{ inputs.coverage-report }}


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65887

## What this changes

The PHPUnit workflow uploads the existing JUnit report after every push to `trunk` from one canonical job:

- PHP 8.5;
- MySQL 8.4;
- single site;
- default domain and cache configuration.

The upload happens immediately after the main test suite, before later test-group runs replace the configured JUnit file.

Each `trunk` push produces one artifact named `phpunit-timing-results`. The artifact contains `junit.xml` with per-test timing data. Other events and matrix jobs do not upload timing artifacts.

## Why one artifact

One stable environment provides comparable results and the raw data needed to find slow tests. Collecting every test segment from every matrix job adds storage, naming, and analysis work without helping the first use case.

GitHub uses the repository default retention period. CodeVitals and aggregate trend reporting are handled separately in #13083.

## How to validate

An end-to-end test temporarily allowed PR #13070 to run the upload step from the canonical job:

- [workflow run 31969896671](https://github.com/WordPress/wordpress-develop/actions/runs/31969896671);
- [PHP 8.5/MySQL 8.4 test-reporting job](https://github.com/WordPress/wordpress-develop/actions/runs/31969896671/job/95220656319);
- [phpunit-timing-results artifact](https://github.com/WordPress/wordpress-develop/actions/runs/31969896671/artifacts/9269644091).

The downloaded artifact contained an 8,909,462-byte, well-formed `junit.xml` file with timing for 30,871 test cases. The final condition limits uploads to pushes on `trunk`.

After merge, open the latest `trunk` push:

https://github.com/WordPress/wordpress-develop/actions/workflows/phpunit-tests.yml?query=event%3Apush+branch%3Atrunk

The **Artifacts** section should contain `phpunit-timing-results`. Download it with GitHub CLI:

    gh run download <run-id> --repo WordPress/wordpress-develop --name phpunit-timing-results

Reviewers can confirm that the existing configuration creates the uploaded file:

    npm run test:php -- --filter Tests_Functions::test_wp_parse_args_object
    test -s tests/phpunit/build/logs/junit.xml

## Testing

- `actionlint` passed.
- The targeted PHPUnit command above passed with one test and two assertions and wrote its timing to `junit.xml`.
- The end-to-end test uploaded, downloaded, and parsed `phpunit-timing-results` successfully.
