### PR TITLE
Code Quality: Annotate three impure functions for PHPStan

### DIFF
--- a/src/wp-admin/includes/class-wp-filesystem-base.php
+++ b/src/wp-admin/includes/class-wp-filesystem-base.php
@@ -606,6 +606,8 @@ class WP_Filesystem_Base {
 	 * @param bool      $recursive Optional. If set to true, changes file permissions recursively.
 	 *                             Default false.
 	 * @return bool True on success, false on failure.
+	 *
+	 * @phpstan-impure
 	 */
 	public function chmod( $file, $mode = false, $recursive = false ) {
 		return false;

--- a/src/wp-includes/capabilities.php
+++ b/src/wp-includes/capabilities.php
@@ -909,6 +909,8 @@ function map_meta_cap( $cap, $user_id, ...$args ) {
  * @param mixed  ...$args    Optional further parameters, typically starting with an object ID.
  * @return bool Whether the current user has the given capability. If `$capability` is a meta cap and `$object_id` is
  *              passed, whether the current user has the given meta capability for the given object.
+ *
+ * @phpstan-impure
  */
 function current_user_can( $capability, ...$args ) {
 	return user_can( wp_get_current_user(), $capability, ...$args );

--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -778,6 +778,8 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 * @since 6.7.2 Refactored so subclasses may extend.
 	 *
 	 * @return bool Whether a token was parsed.
+	 *
+	 * @phpstan-impure
 	 */
 	public function next_token(): bool {
 		return $this->next_visitable_token();

--- a/tests/phpstan/baselines/booleanAnd.leftAlwaysTrue.neon
+++ b/tests/phpstan/baselines/booleanAnd.leftAlwaysTrue.neon
@@ -22,11 +22,6 @@ parameters:
 			message: '#^Left side of && is always true\.$#'
 			identifier: booleanAnd.leftAlwaysTrue
 			count: 1
-			path: ../../../src/wp-admin/network/users.php
-		-
-			message: '#^Left side of && is always true\.$#'
-			identifier: booleanAnd.leftAlwaysTrue
-			count: 1
 			path: ../../../src/wp-admin/themes.php
 		-
 			message: '#^Left side of && is always true\.$#'

--- a/tests/phpstan/baselines/booleanNot.alwaysFalse.neon
+++ b/tests/phpstan/baselines/booleanNot.alwaysFalse.neon
@@ -22,26 +22,6 @@ parameters:
 			message: '#^Negated boolean expression is always false\.$#'
 			identifier: booleanNot.alwaysFalse
 			count: 1
-			path: ../../../src/wp-admin/includes/theme.php
-		-
-			message: '#^Negated boolean expression is always false\.$#'
-			identifier: booleanNot.alwaysFalse
-			count: 1
-			path: ../../../src/wp-admin/link-manager.php
-		-
-			message: '#^Negated boolean expression is always false\.$#'
-			identifier: booleanNot.alwaysFalse
-			count: 2
-			path: ../../../src/wp-admin/network/users.php
-		-
-			message: '#^Negated boolean expression is always false\.$#'
-			identifier: booleanNot.alwaysFalse
-			count: 1
-			path: ../../../src/wp-admin/plugins.php
-		-
-			message: '#^Negated boolean expression is always false\.$#'
-			identifier: booleanNot.alwaysFalse
-			count: 1
 			path: ../../../src/wp-includes/class-wp-comment-query.php
 		-
 			message: '#^Negated boolean expression is always false\.$#'

--- a/tests/phpstan/baselines/booleanNot.alwaysTrue.neon
+++ b/tests/phpstan/baselines/booleanNot.alwaysTrue.neon
@@ -27,27 +27,7 @@ parameters:
 			message: '#^Negated boolean expression is always true\.$#'
 			identifier: booleanNot.alwaysTrue
 			count: 1
-			path: ../../../src/wp-admin/includes/class-language-pack-upgrader.php
-		-
-			message: '#^Negated boolean expression is always true\.$#'
-			identifier: booleanNot.alwaysTrue
-			count: 1
-			path: ../../../src/wp-admin/includes/class-wp-upgrader.php
-		-
-			message: '#^Negated boolean expression is always true\.$#'
-			identifier: booleanNot.alwaysTrue
-			count: 1
-			path: ../../../src/wp-admin/includes/file.php
-		-
-			message: '#^Negated boolean expression is always true\.$#'
-			identifier: booleanNot.alwaysTrue
-			count: 1
 			path: ../../../src/wp-includes/class-wp-block-templates-registry.php
-		-
-			message: '#^Negated boolean expression is always true\.$#'
-			identifier: booleanNot.alwaysTrue
-			count: 1
-			path: ../../../src/wp-includes/class-wp-block.php
 		-
 			message: '#^Negated boolean expression is always true\.$#'
 			identifier: booleanNot.alwaysTrue

--- a/tests/phpstan/baselines/booleanOr.alwaysTrue.neon
+++ b/tests/phpstan/baselines/booleanOr.alwaysTrue.neon
@@ -23,8 +23,3 @@ parameters:
 			identifier: booleanOr.alwaysTrue
 			count: 1
 			path: ../../../src/wp-includes/block-supports/position.php
-		-
-			message: '#^Result of \|\| is always true\.$#'
-			identifier: booleanOr.alwaysTrue
-			count: 1
-			path: ../../../src/wp-includes/class-wp-block.php

--- a/tests/phpstan/baselines/deadCode.unreachable.neon
+++ b/tests/phpstan/baselines/deadCode.unreachable.neon
@@ -281,11 +281,6 @@ parameters:
 		-
 			message: '#^Unreachable statement \- code above always terminates\.$#'
 			identifier: deadCode.unreachable
-			count: 1
-			path: ../../../src/wp-includes/class-wp-block.php
-		-
-			message: '#^Unreachable statement \- code above always terminates\.$#'
-			identifier: deadCode.unreachable
 			count: 31
 			path: ../../../src/wp-includes/html-api/class-wp-html-processor.php
 		-

--- a/tests/phpstan/baselines/if.alwaysTrue.neon
+++ b/tests/phpstan/baselines/if.alwaysTrue.neon
@@ -22,16 +22,6 @@ parameters:
 			message: '#^If condition is always true\.$#'
 			identifier: if.alwaysTrue
 			count: 1
-			path: ../../../src/wp-admin/my-sites.php
-		-
-			message: '#^If condition is always true\.$#'
-			identifier: if.alwaysTrue
-			count: 2
-			path: ../../../src/wp-admin/upload.php
-		-
-			message: '#^If condition is always true\.$#'
-			identifier: if.alwaysTrue
-			count: 1
 			path: ../../../src/wp-content/themes/twentynineteen/comments.php
 		-
 			message: '#^If condition is always true\.$#'

--- a/tests/phpstan/baselines/ternary.alwaysTrue.neon
+++ b/tests/phpstan/baselines/ternary.alwaysTrue.neon
@@ -23,8 +23,3 @@ parameters:
 			identifier: ternary.alwaysTrue
 			count: 1
 			path: ../../../src/wp-admin/menu-header.php
-		-
-			message: '#^Ternary operator condition is always true\.$#'
-			identifier: ternary.alwaysTrue
-			count: 1
-			path: ../../../src/wp-admin/theme-install.php


### PR DESCRIPTION
PHPStan infers `current_user_can()`, `WP_Filesystem_Base::chmod()` and `WP_HTML_Processor::next_token()` as pure, so it remembers what each returned and reuses that value at a later call in the same scope. All three can legitimately answer differently the second time:

| Function | Why a second call can differ |
| --- | --- |
| `current_user_can()` | Reads the current user and applies the `user_has_cap` filter, so a plugin hooked in between can change the answer |
| `WP_Filesystem_Base::chmod()` | Changes the permissions that a following `is_writable()` reports |
| `WP_HTML_Processor::next_token()` | Advances the parser, so the token accessors then describe a different token |

The clearest case is `wp-admin/link-manager.php`. Line 11 bails out unless the user has `manage_links`, and line 91 checks the same capability again after `admin-header.php` has been required and its hooks have fired. PHPStan carried the line 11 answer forward and reported the line 91 guard as dead.

### Annotating the mutation, not the accessor

PHPStan's tips name `is_writable()`, `is_tag_closer()`, `expects_closer()`, `get_current_depth()` and `set_bookmark()` as candidates. Those are read-only accessors and annotating them would be inaccurate. What actually invalidates a remembered value is the mutating call sitting between the two reads, so the annotation belongs there: in `WP_Upgrader::install_package()` it is the `chmod()` between two `is_writable()` calls, and in `WP_Block` it is the `next_token()` loop between two `is_tag_closer()` calls.

`WP_Filesystem_Base::copy()` was annotated at first and then removed after re-running the analysis with and without it produced identical results; `chmod()` alone covers the `copy_dir()` case. `WP_User::has_cap()`, where the `user_has_cap` filter is actually applied, was also tried and cleared nothing, so the annotation sits on `current_user_can()` itself.

### Impact

16 errors resolved across seven identifiers, with no new error of any identifier anywhere in the codebase. Eleven are in the boolean baselines this targets:

| Baseline | Before | After |
| --- | --- | --- |
| `booleanNot.alwaysFalse` | 7 | 2 |
| `booleanNot.alwaysTrue` | 8 | 4 |
| `booleanAnd.leftAlwaysTrue` | 5 | 4 |
| `booleanOr.alwaysTrue` | 2 | 1 |

The other five fall outside those baselines and come along for free: `wp-admin/my-sites.php` and `wp-admin/upload.php` (×2) in `if.alwaysTrue`, `wp-admin/theme-install.php` in `ternary.alwaysTrue`, and a `deadCode.unreachable` in `class-wp-block.php` that was only unreachable because of the boolean error above it.

The baselines are generated, not hand-edited. No baseline reaches zero here, so none is deleted and `phpstan.neon.dist` is unchanged.

### Testing instructions

1. `npm run typecheck:php` on `trunk` reports `[OK] No errors`, because the occurrences are baselined.
2. With this branch applied, `npm run typecheck:php` reports `[OK] No errors` across 1289 files with the seven baselines regenerated.
3. To confirm the change is surgical, run the analysis with all baselines suppressed before and after and diff the results, comparing on file plus message rather than on line number: adding two lines to `class-wp-html-processor.php` shifts every line below it, which makes a naive line-keyed diff report roughly 40 spurious changes. Compared correctly, exactly 16 errors disappear and none appears.
4. `npm run test:php` — 30871 tests, 4558975 assertions, 86 warnings, 44 skipped, and one failure: `Tests_Script_Modules_WpScriptModules::test_default_script_module_files_exist`, looking for `src/wp-includes/js/dist/script-modules/a11y/index.js`. That path is gitignored build output that is unbuilt in my checkout, and the test fails identically on unmodified `trunk`, so it is unrelated to this change.

Documentation-only change; no runtime behaviour is affected.

Related: https://github.com/WordPress/wordpress-develop/pull/13057 annotates `WP_HTML_Tag_Processor::parse_next_tag()` for the same reason, and https://github.com/WordPress/wordpress-develop/pull/13071 clears a different cluster of the same boolean baselines. All three are independent and touch disjoint files.

Trac ticket: https://core.trac.wordpress.org/ticket/65817

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: grouping the remaining boolean PHPStan baselines by root cause, identifying this cluster, testing which annotation placements were load-bearing, measuring the before/after error diff across the whole codebase, regenerating the baselines, and drafting this description. The change itself and the verification runs were reviewed and confirmed by me in a local development environment.

`Count of removed errors: 7`