### PR TITLE
Code Quality: Annotate three more impure functions for PHPStan

### DIFF
--- a/src/wp-includes/load.php
+++ b/src/wp-includes/load.php
@@ -1629,6 +1629,8 @@ function wp_load_translations_early() {
  *                            Omit this parameter if you only want to fetch the current status.
  * @return bool True if WP is installing, otherwise false. When a `$is_installing` is passed, the function will
  *              report whether WP was in installing mode prior to the change to `$is_installing`.
+ *
+ * @phpstan-impure
  */
 function wp_installing( $is_installing = null ) {
 	static $installing = null;

--- a/src/wp-includes/query.php
+++ b/src/wp-includes/query.php
@@ -462,6 +462,8 @@ function is_comment_feed() {
  * @global WP_Query $wp_query WordPress Query object.
  *
  * @return bool Whether the query is for the front page of the site.
+ *
+ * @phpstan-impure
  */
 function is_front_page() {
 	global $wp_query;

--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -3155,6 +3155,8 @@ function _remove_theme_support( $feature ) {
  *                        of possible values.
  * @param mixed  ...$args Optional extra arguments to be checked against certain features.
  * @return bool True if the active theme supports the feature, false otherwise.
+ *
+ * @phpstan-impure
  */
 function current_theme_supports( $feature, ...$args ) {
 	global $_wp_theme_features;

--- a/tests/phpstan/baselines/booleanAnd.leftAlwaysTrue.neon
+++ b/tests/phpstan/baselines/booleanAnd.leftAlwaysTrue.neon
@@ -37,9 +37,4 @@ parameters:
 			message: '#^Left side of && is always true\.$#'
 			identifier: booleanAnd.leftAlwaysTrue
 			count: 1
-			path: ../../../src/wp-includes/canonical.php
-		-
-			message: '#^Left side of && is always true\.$#'
-			identifier: booleanAnd.leftAlwaysTrue
-			count: 1
 			path: ../../../src/wp-includes/html-api/class-wp-html-processor.php

--- a/tests/phpstan/baselines/booleanNot.alwaysTrue.neon
+++ b/tests/phpstan/baselines/booleanNot.alwaysTrue.neon
@@ -22,11 +22,6 @@ parameters:
 			message: '#^Negated boolean expression is always true\.$#'
 			identifier: booleanNot.alwaysTrue
 			count: 1
-			path: ../../../src/wp-admin/includes/class-custom-image-header.php
-		-
-			message: '#^Negated boolean expression is always true\.$#'
-			identifier: booleanNot.alwaysTrue
-			count: 1
 			path: ../../../src/wp-admin/includes/class-language-pack-upgrader.php
 		-
 			message: '#^Negated boolean expression is always true\.$#'
@@ -53,8 +48,3 @@ parameters:
 			identifier: booleanNot.alwaysTrue
 			count: 1
 			path: ../../../src/wp-includes/general-template.php
-		-
-			message: '#^Negated boolean expression is always true\.$#'
-			identifier: booleanNot.alwaysTrue
-			count: 1
-			path: ../../../src/wp-includes/option.php


### PR DESCRIPTION
PHPStan infers `current_theme_supports()`, `wp_installing()` and `is_front_page()` as pure, so it remembers what each returned and reuses that value at a later call in the same scope. All three read state that can change between calls:

| Function | Mutable state it reads |
| --- | --- |
| `current_theme_supports()` | The `$_wp_theme_features` global, and applies the `current_theme_supports-{$feature}` filter before returning |
| `wp_installing()` | A `static $installing`, which the same function sets when passed an argument |
| `is_front_page()` | The `$wp_query` global |

This resolves three baselined errors:

| Site | Error |
| --- | --- |
| `Custom_Image_Header::step_1()`, `class-custom-image-header.php:619` | `booleanNot.alwaysTrue` |
| `get_transient()`, `option.php:1459` | `booleanNot.alwaysTrue` |
| `redirect_canonical()`, `canonical.php:688` | `booleanAnd.leftAlwaysTrue` |

In the first, the enclosing `elseif` chain has already tested `current_theme_supports( 'custom-header', 'flex-height' )`, so PHPStan carried that answer into the inner check. In the second, `get_transient()` reaches the `else` branch only when `wp_using_ext_object_cache() || wp_installing()` was false, so the later `! wp_installing()` looked settled.

`booleanNot.alwaysTrue` goes from 8 to 6 and `booleanAnd.leftAlwaysTrue` from 5 to 4. The baselines are generated, not hand-edited; neither reaches zero, so no baseline is deleted and `phpstan.neon.dist` is unchanged.

### A note on `redirect_canonical()`

The condition reads `( ! is_front_page() || is_front_page() && get_query_var( 'paged' ) > 1 )`. Both calls sit inside one expression with nothing in between, so `! A || A && B` could equally be simplified to `! A || B` rather than annotated. I chose the annotation because it is independently true — `is_front_page()` really does read mutable global state, and PHPStan should not assume otherwise anywhere else either — and because rewriting a condition in the canonical redirect path carries behaviour risk for no analytical gain. Happy to switch to the simplification if reviewers prefer it.

### Testing instructions

1. `npm run typecheck:php` on `trunk` reports `[OK] No errors`, because the occurrences are baselined.
2. With this branch applied, `npm run typecheck:php` reports `[OK] No errors` across 1289 files with both baselines regenerated.
3. To confirm the change is surgical, run the analysis with all baselines suppressed before and after and diff the results on file plus message rather than line number: exactly three errors disappear and none appears, anywhere in the codebase, for any identifier.
4. `composer lint` reports no errors for the three modified files. `src/wp-includes/query.php` carries four pre-existing `WordPress.DB.PreparedSQL.NotPrepared` warnings at lines 1228 and 1231; the same four are present in the file on `trunk` and are untouched by a docblock change at line 462.

Documentation-only change; no runtime behaviour is affected.

Related: https://github.com/WordPress/wordpress-develop/pull/13074 annotates `current_user_can()`, `WP_Filesystem_Base::chmod()` and `WP_HTML_Processor::next_token()` for the same reason, and https://github.com/WordPress/wordpress-develop/pull/13057 annotates `WP_HTML_Tag_Processor::parse_next_tag()`. This PR is independent of both and touches disjoint files.

Trac ticket: https://core.trac.wordpress.org/ticket/65817

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: grouping the remaining boolean PHPStan baselines by root cause, identifying this cluster, measuring the before/after error diff across the whole codebase, regenerating the baselines, and drafting this description. The change itself and the verification runs were reviewed and confirmed by me in a local development environment.

`Count of removed errors: 2`