### PR TITLE
Expand path filtering for testing old branches

### DIFF
--- a/.github/workflows/test-old-branches.yml
+++ b/.github/workflows/test-old-branches.yml
@@ -7,7 +7,7 @@ on:
       - trunk
     paths:
       - '.github/workflows/test-old-branches.yml'
-      - '.github/workflows/reusable-phpunit-tests-v[1-3].yml'
+      - '.github/workflows/reusable-*.yml'
   # Run twice a month on the 1st and 15th at 00:00 UTC.
   schedule:
     - cron: '0 0 1 * *'


### PR DESCRIPTION
When changes to the reusable PHPUnit test workflows are made, the test old branches workflow runs to confirm that the changes do not break workflows within old branches. However, there are many workflows that make use of reusable workflow files, so the path filtering should be expanded.

Trac ticket: Core-65845.

## Use of AI Tools
None.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
