### PR TITLE
Tests: Remove implicit dependencies on some leaky state

### DIFF
--- a/tests/phpunit/tests/fonts/font-face/base.php
+++ b/tests/phpunit/tests/fonts/font-face/base.php
@@ -69,6 +69,7 @@ abstract class WP_Font_Face_UnitTestCase extends WP_UnitTestCase {
 	public static function tear_down_after_class() {
 		// Reset static flags.
 		self::$requires_switch_theme_fixtures = false;
+		self::$theme_root                     = null;
 
 		parent::tear_down_after_class();
 	}

--- a/tests/phpunit/tests/fonts/font-face/wpPrintFontFacesFromStyleVariations.php
+++ b/tests/phpunit/tests/fonts/font-face/wpPrintFontFacesFromStyleVariations.php
@@ -16,8 +16,9 @@ class Tests_Fonts_WpPrintFontFacesFromStyleVariations extends WP_Font_Face_UnitT
 	const FONTS_THEME = 'fonts-block-theme';
 
 	public static function set_up_before_class() {
-		parent::set_up_before_class();
 		self::$requires_switch_theme_fixtures = true;
+
+		parent::set_up_before_class();
 	}
 
 	/**

--- a/tests/phpunit/tests/rest-api/rest-block-type-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-block-type-controller.php
@@ -32,6 +32,20 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	protected static $subscriber_id;
 
 	/**
+	 * Pre-existing block types registered before the current test.
+	 *
+	 * @var string[] $registered_block_types
+	 */
+	private $registered_block_types = array();
+
+	/**
+	 * Pre-existing block styles registered before the current test, grouped by block type name.
+	 *
+	 * @var array[] $registered_block_styles
+	 */
+	private $registered_block_styles = array();
+
+	/**
 	 * Create fake data before our tests run.
 	 *
 	 * @since 5.5.0
@@ -49,19 +63,55 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 				'role' => 'subscriber',
 			)
 		);
-
-		$name     = 'fake/test';
-		$settings = array(
-			'icon' => 'text',
-		);
-
-		register_block_type( $name, $settings );
 	}
 
 	public static function wpTearDownAfterClass() {
 		self::delete_user( self::$admin_id );
 		self::delete_user( self::$subscriber_id );
-		unregister_block_type( 'fake/test' );
+	}
+
+	/**
+	 * Sets up each test method.
+	 *
+	 * Records the registered block types and block styles so that anything
+	 * registered by a test can be unregistered again in tear_down(), and
+	 * registers a block type used by many tests in this class.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->registered_block_types  = array_keys( WP_Block_Type_Registry::get_instance()->get_all_registered() );
+		$this->registered_block_styles = WP_Block_Styles_Registry::get_instance()->get_all_registered();
+
+		register_block_type(
+			'fake/test',
+			array(
+				'icon' => 'text',
+			)
+		);
+	}
+
+	/**
+	 * Tears down each test method.
+	 *
+	 * Unregisters any block types and block styles registered while the test ran.
+	 */
+	public function tear_down() {
+		foreach ( WP_Block_Styles_Registry::get_instance()->get_all_registered() as $block_name => $block_styles ) {
+			foreach ( array_keys( $block_styles ) as $block_style_name ) {
+				if ( ! isset( $this->registered_block_styles[ $block_name ][ $block_style_name ] ) ) {
+					unregister_block_style( $block_name, $block_style_name );
+				}
+			}
+		}
+
+		foreach ( array_keys( WP_Block_Type_Registry::get_instance()->get_all_registered() ) as $block_name ) {
+			if ( ! in_array( $block_name, $this->registered_block_types, true ) ) {
+				unregister_block_type( $block_name );
+			}
+		}
+
+		parent::tear_down();
 	}
 
 	/**
@@ -136,8 +186,7 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		wp_set_current_user( self::$admin_id );
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/block-types/' . $block_name );
 		$response = rest_get_server()->dispatch( $request );
-		unregister_block_type( $block_name );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 		$this->assertSameSets( array( $block_styles ), $data['styles'] );
 	}
 
@@ -165,7 +214,6 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		wp_set_current_user( self::$admin_id );
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/block-types/' . $block_name );
 		$response = rest_get_server()->dispatch( $request );
-		unregister_block_type( $block_name );
 		$data     = $response->get_data();
 		$expected = array(
 			array(
@@ -232,8 +280,7 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		wp_set_current_user( self::$admin_id );
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/block-types/' . $block_type );
 		$response = rest_get_server()->dispatch( $request );
-		unregister_block_type( $block_type );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 		$this->assertSame( $block_type, $data['name'] );
 		$this->assertSame( '1', $data['title'] );
 		$this->assertNull( $data['category'] );
@@ -312,8 +359,7 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		wp_set_current_user( self::$admin_id );
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/block-types/' . $block_type );
 		$response = rest_get_server()->dispatch( $request );
-		unregister_block_type( $block_type );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 		$this->assertSame( $block_type, $data['name'] );
 		$this->assertSame( '', $data['title'] );
 		$this->assertNull( $data['category'] );
@@ -370,8 +416,7 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		wp_set_current_user( self::$admin_id );
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/block-types/' . $block_type );
 		$response = rest_get_server()->dispatch( $request );
-		unregister_block_type( $block_type );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 		$this->assertSameSets(
 			array( 'hello_world' ),
 			$data['editor_script_handles'],
@@ -441,8 +486,7 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		wp_set_current_user( self::$admin_id );
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/block-types/' . $block_type );
 		$response = rest_get_server()->dispatch( $request );
-		unregister_block_type( $block_type );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 		$this->assertSameSets(
 			$settings['editor_script'],
 			$data['editor_script_handles'],
@@ -529,8 +573,7 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		wp_set_current_user( self::$admin_id );
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/block-types/' . $block_type );
 		$response = rest_get_server()->dispatch( $request );
-		unregister_block_type( $block_type );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 		$this->assertSame( $block_type, $data['name'] );
 		$this->assertArrayHasKey( 'variations', $data );
 		$this->assertCount( 1, $data['variations'] );
@@ -873,8 +916,7 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		wp_set_current_user( self::$admin_id );
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/block-types/' . $block_type );
 		$response = rest_get_server()->dispatch( $request );
-		unregister_block_type( $block_type );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 		$this->assertSameSets( $this->mock_variation_callback(), $data['variations'] );
 	}
 

--- a/tests/phpunit/tests/rest-api/rest-block-type-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-block-type-controller.php
@@ -62,8 +62,6 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		self::delete_user( self::$admin_id );
 		self::delete_user( self::$subscriber_id );
 		unregister_block_type( 'fake/test' );
-		unregister_block_type( 'fake/invalid' );
-		unregister_block_type( 'fake/false' );
 	}
 
 	/**
@@ -138,6 +136,7 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		wp_set_current_user( self::$admin_id );
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/block-types/' . $block_name );
 		$response = rest_get_server()->dispatch( $request );
+		unregister_block_type( $block_name );
 		$data     = $response->get_data();
 		$this->assertSameSets( array( $block_styles ), $data['styles'] );
 	}
@@ -166,6 +165,7 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		wp_set_current_user( self::$admin_id );
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/block-types/' . $block_name );
 		$response = rest_get_server()->dispatch( $request );
+		unregister_block_type( $block_name );
 		$data     = $response->get_data();
 		$expected = array(
 			array(
@@ -232,6 +232,7 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		wp_set_current_user( self::$admin_id );
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/block-types/' . $block_type );
 		$response = rest_get_server()->dispatch( $request );
+		unregister_block_type( $block_type );
 		$data     = $response->get_data();
 		$this->assertSame( $block_type, $data['name'] );
 		$this->assertSame( '1', $data['title'] );
@@ -311,6 +312,7 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		wp_set_current_user( self::$admin_id );
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/block-types/' . $block_type );
 		$response = rest_get_server()->dispatch( $request );
+		unregister_block_type( $block_type );
 		$data     = $response->get_data();
 		$this->assertSame( $block_type, $data['name'] );
 		$this->assertSame( '', $data['title'] );
@@ -368,6 +370,7 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		wp_set_current_user( self::$admin_id );
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/block-types/' . $block_type );
 		$response = rest_get_server()->dispatch( $request );
+		unregister_block_type( $block_type );
 		$data     = $response->get_data();
 		$this->assertSameSets(
 			array( 'hello_world' ),
@@ -438,6 +441,7 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		wp_set_current_user( self::$admin_id );
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/block-types/' . $block_type );
 		$response = rest_get_server()->dispatch( $request );
+		unregister_block_type( $block_type );
 		$data     = $response->get_data();
 		$this->assertSameSets(
 			$settings['editor_script'],
@@ -525,6 +529,7 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		wp_set_current_user( self::$admin_id );
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/block-types/' . $block_type );
 		$response = rest_get_server()->dispatch( $request );
+		unregister_block_type( $block_type );
 		$data     = $response->get_data();
 		$this->assertSame( $block_type, $data['name'] );
 		$this->assertArrayHasKey( 'variations', $data );
@@ -868,6 +873,7 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		wp_set_current_user( self::$admin_id );
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/block-types/' . $block_type );
 		$response = rest_get_server()->dispatch( $request );
+		unregister_block_type( $block_type );
 		$data     = $response->get_data();
 		$this->assertSameSets( $this->mock_variation_callback(), $data['variations'] );
 	}

--- a/tests/phpunit/tests/rest-api/rest-block-type-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-block-type-controller.php
@@ -137,7 +137,7 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/block-types/' . $block_name );
 		$response = rest_get_server()->dispatch( $request );
 		unregister_block_type( $block_name );
-		$data     = $response->get_data();
+		$data = $response->get_data();
 		$this->assertSameSets( array( $block_styles ), $data['styles'] );
 	}
 
@@ -233,7 +233,7 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/block-types/' . $block_type );
 		$response = rest_get_server()->dispatch( $request );
 		unregister_block_type( $block_type );
-		$data     = $response->get_data();
+		$data = $response->get_data();
 		$this->assertSame( $block_type, $data['name'] );
 		$this->assertSame( '1', $data['title'] );
 		$this->assertNull( $data['category'] );
@@ -313,7 +313,7 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/block-types/' . $block_type );
 		$response = rest_get_server()->dispatch( $request );
 		unregister_block_type( $block_type );
-		$data     = $response->get_data();
+		$data = $response->get_data();
 		$this->assertSame( $block_type, $data['name'] );
 		$this->assertSame( '', $data['title'] );
 		$this->assertNull( $data['category'] );
@@ -371,7 +371,7 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/block-types/' . $block_type );
 		$response = rest_get_server()->dispatch( $request );
 		unregister_block_type( $block_type );
-		$data     = $response->get_data();
+		$data = $response->get_data();
 		$this->assertSameSets(
 			array( 'hello_world' ),
 			$data['editor_script_handles'],
@@ -442,7 +442,7 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/block-types/' . $block_type );
 		$response = rest_get_server()->dispatch( $request );
 		unregister_block_type( $block_type );
-		$data     = $response->get_data();
+		$data = $response->get_data();
 		$this->assertSameSets(
 			$settings['editor_script'],
 			$data['editor_script_handles'],
@@ -530,7 +530,7 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/block-types/' . $block_type );
 		$response = rest_get_server()->dispatch( $request );
 		unregister_block_type( $block_type );
-		$data     = $response->get_data();
+		$data = $response->get_data();
 		$this->assertSame( $block_type, $data['name'] );
 		$this->assertArrayHasKey( 'variations', $data );
 		$this->assertCount( 1, $data['variations'] );
@@ -874,7 +874,7 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/block-types/' . $block_type );
 		$response = rest_get_server()->dispatch( $request );
 		unregister_block_type( $block_type );
-		$data     = $response->get_data();
+		$data = $response->get_data();
 		$this->assertSameSets( $this->mock_variation_callback(), $data['variations'] );
 	}
 

--- a/tests/phpunit/tests/sitemaps/sitemaps.php
+++ b/tests/phpunit/tests/sitemaps/sitemaps.php
@@ -464,15 +464,17 @@ class Tests_Sitemaps_Sitemaps extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 50643
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
 	 */
 	public function test_disable_sitemap_should_return_404() {
 		add_filter( 'wp_sitemaps_enabled', '__return_false' );
 
+		// Instantiate the server before navigating: registering the sitemap
+		// rewrite tags is what adds `sitemap` to `$wp->public_query_vars`.
+		$sitemaps = wp_sitemaps_get_server();
+
 		$this->go_to( home_url( '/?sitemap=index' ) );
 
-		wp_sitemaps_get_server()->render_sitemaps();
+		$sitemaps->render_sitemaps();
 
 		remove_filter( 'wp_sitemaps_enabled', '__return_false' );
 
@@ -481,8 +483,6 @@ class Tests_Sitemaps_Sitemaps extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 50643
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
 	 */
 	public function test_empty_url_list_should_return_404() {
 		wp_register_sitemap_provider( 'foo', new WP_Sitemaps_Empty_Test_Provider( 'foo' ) );

--- a/tests/phpunit/tests/widgets/wpWidgetMediaAudio.php
+++ b/tests/phpunit/tests/widgets/wpWidgetMediaAudio.php
@@ -316,6 +316,9 @@ class Tests_Widgets_wpWidgetMediaAudio extends WP_UnitTestCase {
 	 * @covers WP_Widget_Media_Audio::render_control_template_scripts
 	 */
 	public function test_render_control_template_scripts() {
+		// Provides wp_underscore_audio_template(), normally loaded by wp_enqueue_media().
+		require_once ABSPATH . WPINC . '/media-template.php';
+
 		$widget = new WP_Widget_Media_Audio();
 
 		ob_start();

--- a/tests/phpunit/tests/widgets/wpWidgetMediaVideo.php
+++ b/tests/phpunit/tests/widgets/wpWidgetMediaVideo.php
@@ -344,6 +344,9 @@ class Tests_Widgets_wpWidgetMediaVideo extends WP_UnitTestCase {
 	 * @covers WP_Widget_Media_Video::render_control_template_scripts
 	 */
 	public function test_render_control_template_scripts() {
+		// Provides wp_underscore_video_template(), normally loaded by wp_enqueue_media().
+		require_once ABSPATH . WPINC . '/media-template.php';
+
 		$widget = new WP_Widget_Media_Video();
 
 		ob_start();


### PR DESCRIPTION
There are a bunch of PHPUnit tests that implicitly depend on state leaked from other tests. This leaky state isn't observed in "normal" test runs, but can be easily seen by running:

```
npm run test:php -- --order-by=random
```

Leaky state can cause several problems:
* A test may fail when run by itself (if it depends on state leaked by a previously run test)
* A test class may fail when run by itself
* A test may pass only because of some leaked state, not because the test is testing what it's supposed to test.
* etc.

This is not a comprehensive fix across all tests. It's a random grab bag of issues discovered during WCUS.

Trac ticket: https://core.trac.wordpress.org/ticket/65893

## Use of AI Tools

AI assistance: Yes
Tool: Claude Code
Model: Opus 5
Used for: Analysis for failing tests, initial implementation; final implementation reviewed/edited by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
