### PR TITLE
XML-RPC: enforce post type publication capabilities

### DIFF
--- a/src/wp-includes/class-wp-xmlrpc-server.php
+++ b/src/wp-includes/class-wp-xmlrpc-server.php
@@ -5240,7 +5240,7 @@ class wp_xmlrpc_server extends IXR_Server {
 		if ( ! current_user_can( 'edit_post', $post_id ) ) {
 			return new IXR_Error( 401, __( 'Sorry, you are not allowed to edit this post.' ) );
 		}
-		if ( 'publish' === $actual_post['post_status'] && ! current_user_can( 'publish_posts' ) ) {
+		if ( ( $publish || 'publish' === $actual_post['post_status'] ) && ! current_user_can( 'publish_posts' ) ) {
 			return new IXR_Error( 401, __( 'Sorry, you are not allowed to publish this post.' ) );
 		}
 
@@ -6911,7 +6911,9 @@ class wp_xmlrpc_server extends IXR_Server {
 			return new IXR_Error( 404, __( 'Invalid post ID.' ) );
 		}
 
-		if ( ! current_user_can( 'publish_posts' ) || ! current_user_can( 'edit_post', $post_id ) ) {
+		$post_type = get_post_type_object( $postdata['post_type'] );
+
+		if ( ! $post_type || ! current_user_can( $post_type->cap->publish_posts ) || ! current_user_can( 'edit_post', $post_id ) ) {
 			return new IXR_Error( 401, __( 'Sorry, you are not allowed to publish this post.' ) );
 		}
 

--- a/tests/phpunit/tests/xmlrpc/blogger/editPost.php
+++ b/tests/phpunit/tests/xmlrpc/blogger/editPost.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * @group xmlrpc
+ */
+class Tests_XMLRPC_blogger_editPost extends WP_XMLRPC_UnitTestCase {
+
+	public function test_cannot_publish_draft_without_publish_posts() {
+		$contributor_id = $this->make_user_by_role( 'contributor' );
+		$post_id        = self::factory()->post->create(
+			array(
+				'post_author' => $contributor_id,
+				'post_status' => 'draft',
+			)
+		);
+
+		$result = $this->myxmlrpcserver->blogger_editPost(
+			array(
+				1,
+				$post_id,
+				'contributor',
+				'contributor',
+				'<title>Updated through Blogger</title>Updated content',
+				1,
+			)
+		);
+
+		$this->assertIXRError( $result );
+		$this->assertSame( 401, $result->code );
+		$this->assertSame( 'draft', get_post_status( $post_id ) );
+	}
+}

--- a/tests/phpunit/tests/xmlrpc/mt/publishPost.php
+++ b/tests/phpunit/tests/xmlrpc/mt/publishPost.php
@@ -11,8 +11,8 @@ class Tests_XMLRPC_mt_publishPost extends WP_XMLRPC_UnitTestCase {
 			$role,
 			'XML-RPC page publisher',
 			array(
-				'read'                => true,
-				'edit_pages'          => true,
+				'read'                 => true,
+				'edit_pages'           => true,
 				'edit_published_pages' => true,
 				'publish_posts'        => true,
 			)

--- a/tests/phpunit/tests/xmlrpc/mt/publishPost.php
+++ b/tests/phpunit/tests/xmlrpc/mt/publishPost.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * @group xmlrpc
+ */
+class Tests_XMLRPC_mt_publishPost extends WP_XMLRPC_UnitTestCase {
+
+	public function test_cannot_publish_page_with_post_capability() {
+		$role = 'xmlrpc_page_publisher';
+		add_role(
+			$role,
+			'XML-RPC page publisher',
+			array(
+				'read'                => true,
+				'edit_pages'          => true,
+				'edit_published_pages' => true,
+				'publish_posts'        => true,
+			)
+		);
+
+		try {
+			$user_id = $this->make_user_by_role( $role );
+			$page_id = self::factory()->post->create(
+				array(
+					'post_author' => $user_id,
+					'post_type'   => 'page',
+					'post_status' => 'draft',
+				)
+			);
+
+			$result = $this->myxmlrpcserver->mt_publishPost( array( $page_id, $role, $role ) );
+
+			$this->assertIXRError( $result );
+			$this->assertSame( 401, $result->code );
+			$this->assertSame( 'draft', get_post_status( $page_id ) );
+		} finally {
+			remove_role( $role );
+		}
+	}
+}


### PR DESCRIPTION
## Summary

This change closes two authorization gaps in legacy XML-RPC publication methods:

- `blogger.editPost` accepted a publish flag and changed a draft to `publish` without checking `publish_posts`.
- `mt.publishPost` used the generic `publish_posts` capability even when the target was a page, instead of the target post type's publication capability.

Both paths now reject the unauthorized transition and retain the draft status.

## Changes

- Apply the Blogger publication check whenever the request publishes or the existing post is already published.
- Resolve the target post type in `mt.publishPost` and require its `publish_posts` capability.
- Add regression tests for a Contributor publishing through Blogger and a role with `publish_posts` but not `publish_pages` publishing a page through Movable Type.

## Testing

- PHP syntax checks pass for the modified source and both new tests.
- `git diff --check` passes.
- Local WordPress 7.0.4 in-process XML-RPC validation reproduced both unauthorized transitions twice before the change; the modern `wp.editPost` path retained its existing post-type capability check.
- The sparse checkout does not include PHPUnit dependencies, so the full PHPUnit suite was not run in this checkout.