### PR TITLE
REST API: require promote_users for assigned roles

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
@@ -567,6 +567,14 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 			);
 		}
 
+		if ( ! empty( $request['roles'] ) && ! current_user_can( 'promote_users' ) ) {
+			return new WP_Error(
+				'rest_cannot_edit_roles',
+				__( 'Sorry, you are not allowed to give users that role.' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+
 		return true;
 	}
 

--- a/tests/phpunit/tests/rest-api/rest-users-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-users-controller.php
@@ -1376,6 +1376,43 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->check_add_edit_user_response( $response );
 	}
 
+	public function test_create_item_with_roles_without_promote_users() {
+		$role = 'rest_user_creator';
+		add_role(
+			$role,
+			'REST user creator',
+			array(
+				'read'         => true,
+				'create_users' => true,
+			)
+		);
+
+		$user_id = self::factory()->user->create( array( 'role' => $role ) );
+
+		try {
+			wp_set_current_user( $user_id );
+
+			$params = array(
+				'username' => 'rest-created-user',
+				'password' => 'testpassword',
+				'email'    => 'rest-created-user@example.com',
+				'roles'    => array( 'administrator' ),
+			);
+
+			$request = new WP_REST_Request( 'POST', '/wp/v2/users' );
+			$request->add_header( 'Content-Type', 'application/x-www-form-urlencoded' );
+			$request->set_body_params( $params );
+			$response = rest_get_server()->dispatch( $request );
+
+			$this->assertErrorResponse( 'rest_cannot_edit_roles', $response, 403 );
+			$this->assertFalse( username_exists( 'rest-created-user' ) );
+		} finally {
+			wp_set_current_user( 0 );
+			self::delete_user( $user_id );
+			remove_role( $role );
+		}
+	}
+
 	public function test_create_item_invalid_username() {
 		$this->allow_user_to_manage_multisite();
 


### PR DESCRIPTION
## Summary

The REST API user-creation endpoint checks `create_users` but accepts a caller-supplied `roles` array without requiring `promote_users`. A custom role with `create_users` and no `promote_users` can therefore create a user with an editable privileged role, including `administrator`.

The admin user-creation flow shows the role selector only to users with `promote_users`, and role updates through the REST API already enforce role-promotion permission. This change aligns REST user creation with those existing capability boundaries.

## Changes

- Reject non-empty `roles` on `POST /wp/v2/users` unless the caller has `promote_users`.
- Add a regression test for a custom `create_users`-only role attempting to create an Administrator.
- Preserve the existing behavior for callers who omit `roles`; WordPress will apply the configured default role.

## Testing

- PHP syntax checks pass for the modified controller and test.
- `git diff --check` passes.
- Local WordPress 7.0.4 in-process validation reproduced administrator-role assignment by a `create_users`-only custom role before this fix; the fixture user and role were removed and no credentials were persisted.
- The sparse checkout does not include PHPUnit dependencies, so the full PHPUnit suite was not run locally.