### PR TITLE
General: Bump the pinned hash for Gutenberg to 943e0d

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"url": "https://develop.svn.wordpress.org/trunk"
 	},
 	"gutenberg": {
-		"sha": "1984a8058ff0c1465615ef88fe52e14cb207f6c0",
+		"sha": "943e0d825bb66ba582e9a10d32743cbb136de460",
 		"ghcrRepo": "WordPress/gutenberg/gutenberg-wp-develop-build"
 	},
 	"engines": {

--- a/src/wp-includes/assets/script-loader-packages.php
+++ b/src/wp-includes/assets/script-loader-packages.php
@@ -312,7 +312,7 @@
 				'import' => 'static'
 			)
 		),
-		'version' => 'a73c35651dc8614d5fb3'
+		'version' => '3bebbde9a9f5d2d35fb3'
 	),
 	'data.js' => array(
 		'dependencies' => array(
@@ -402,7 +402,7 @@
 				'import' => 'static'
 			)
 		),
-		'version' => 'e566fa04fc489a642398'
+		'version' => 'a7750dea8d5c880ddf33'
 	),
 	'edit-site.js' => array(
 		'dependencies' => array(
@@ -452,7 +452,7 @@
 				'import' => 'static'
 			)
 		),
-		'version' => '789f35fae26c8d01c548'
+		'version' => '638e98d0061f4b9f1efb'
 	),
 	'edit-widgets.js' => array(
 		'dependencies' => array(
@@ -493,7 +493,7 @@
 				'import' => 'static'
 			)
 		),
-		'version' => 'a84bb1dba0b91cf80efa'
+		'version' => 'e3dea93676b5aabfef8f'
 	),
 	'editor.js' => array(
 		'dependencies' => array(
@@ -543,7 +543,7 @@
 				'import' => 'static'
 			)
 		),
-		'version' => '4849df258387a9077371'
+		'version' => '2cd3b932f41a420d5904'
 	),
 	'element.js' => array(
 		'dependencies' => array(

--- a/src/wp-includes/assets/script-modules-packages.php
+++ b/src/wp-includes/assets/script-modules-packages.php
@@ -164,7 +164,7 @@
 				'import' => 'static'
 			)
 		),
-		'version' => 'e6158521d3acdf579ed2'
+		'version' => '97d6c844a12f1615212a'
 	),
 	'connectors/index.js' => array(
 		'dependencies' => array(


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65529

This ticket is for syncing the changes between `1984a8058ff0c1465615ef88fe52e14cb207f6c0` into `wordpress-develop` (`943e0d825bb66ba582e9a10d32743cbb136de460`).

Diff: https://github.com/WordPress/gutenberg/compare/1984a8058ff0c1465615ef88fe52e14cb207f6c0...943e0d825bb66ba582e9a10d32743cbb136de460