### PR TITLE
XML-RPC: enforce key-specific term meta capabilities

### DIFF
--- a/src/wp-includes/class-wp-xmlrpc-server.php
+++ b/src/wp-includes/class-wp-xmlrpc-server.php
@@ -479,7 +479,7 @@ class wp_xmlrpc_server extends IXR_Server {
 
 		foreach ( (array) has_term_meta( $term_id ) as $meta ) {
 
-			if ( ! current_user_can( 'edit_term_meta', $term_id ) ) {
+			if ( ! current_user_can( 'edit_term_meta', $term_id, $meta['meta_key'] ) ) {
 				continue;
 			}
 
@@ -514,13 +514,13 @@ class wp_xmlrpc_server extends IXR_Server {
 						continue;
 					}
 					$meta['value'] = wp_unslash( $meta['value'] );
-					if ( current_user_can( 'edit_term_meta', $term_id ) ) {
+					if ( current_user_can( 'edit_term_meta', $term_id, $meta['key'] ) ) {
 						update_metadata_by_mid( 'term', $meta['id'], $meta['value'] );
 					}
-				} elseif ( current_user_can( 'delete_term_meta', $term_id ) ) {
+				} elseif ( current_user_can( 'delete_term_meta', $term_id, $pmeta->meta_key ) ) {
 					delete_metadata_by_mid( 'term', $meta['id'] );
 				}
-			} elseif ( current_user_can( 'add_term_meta', $term_id ) ) {
+			} elseif ( current_user_can( 'add_term_meta', $term_id, wp_unslash( $meta['key'] ) ) ) {
 				add_term_meta( $term_id, $meta['key'], $meta['value'] );
 			}
 		}

--- a/tests/phpunit/tests/xmlrpc/wp/editTerm.php
+++ b/tests/phpunit/tests/xmlrpc/wp/editTerm.php
@@ -348,4 +348,50 @@ class Tests_XMLRPC_wp_editTerm extends WP_XMLRPC_UnitTestCase {
 		$found = get_term_meta( $t, 'foo' );
 		$this->assertSame( array(), $found );
 	}
+
+	public function test_protected_term_meta_requires_key_specific_capability() {
+		register_taxonomy( 'wptests_tax', 'post' );
+		register_term_meta(
+			'wptests_tax',
+			'_protected',
+			array(
+				'auth_callback' => '__return_false',
+			)
+		);
+
+		$t       = self::factory()->term->create(
+			array(
+				'taxonomy' => 'wptests_tax',
+			)
+		);
+		$meta_id = add_term_meta( $t, '_protected', 'bar' );
+
+		$this->make_user_by_role( 'editor' );
+		$this->assertFalse( current_user_can( 'edit_term_meta', $t, '_protected' ) );
+
+		$result = $this->myxmlrpcserver->wp_editTerm(
+			array(
+				1,
+				'editor',
+				'editor',
+				$t,
+				array(
+					'taxonomy'      => 'wptests_tax',
+					'custom_fields' => array(
+						array(
+							'id'    => $meta_id,
+							'key'   => '_protected',
+							'value' => 'changed',
+						),
+						array(
+							'id' => $meta_id,
+						),
+					),
+				),
+			)
+		);
+
+		$this->assertNotIXRError( $result );
+		$this->assertSame( 'bar', get_term_meta( $t, '_protected', true ) );
+	}
 }


### PR DESCRIPTION
## What changed

Pass the term meta key to the capability checks used by the XML-RPC term custom-fields helpers.

This covers:

- filtering custom fields returned by `wp.getTerm`
- adding new term meta
- updating existing term meta
- deleting existing term meta

A regression test registers a protected term key with a denying authorization callback and verifies that an editor who can edit the term cannot change or delete that key through `wp.editTerm`.

## Why

The post custom-fields helper already checks `edit_post_meta`, `add_post_meta`, and `delete_post_meta` with the key. The term equivalent used the keyless forms of those capabilities. Keyless checks skip the protected-key and registered authorization rules, so XML-RPC could mutate term metadata that the key-specific capability check denied.

## Validation

- PHP lint passed for the changed source and test files.
- `git diff --check` passed.
- The isolated WordPress 7.0.4 harness reproduced the pre-fix mutation with a protected key and an explicit denying authorization callback.
- No external site, transport, credential, or customer data was used.