### PR TITLE
Add checksum verification to upgrade & installation test workflows

### DIFF
--- a/.github/workflows/install-testing.yml
+++ b/.github/workflows/install-testing.yml
@@ -58,6 +58,7 @@ jobs:
   # Performs the following steps:
   # - Sets up PHP.
   # - Downloads the specified version of WordPress.
+  # - Verifies files against WordPress.org’s checksums.
   # - Creates a `wp-config.php` file.
   # - Installs WordPress.
   install-tests-mysql:
@@ -128,6 +129,9 @@ jobs:
         run: wp core download --version="${WP_VERSION}"
         env:
           WP_VERSION: ${{ inputs.wp-version || 'nightly' }}
+
+      - name: Verify checksums
+        run: wp core verify-checksums
 
       - name: Create wp-config.php file
         run: wp config create --dbname=test_db --dbuser=root --dbpass=root --dbhost="127.0.0.1:${DB_PORT}"

--- a/.github/workflows/reusable-upgrade-testing.yml
+++ b/.github/workflows/reusable-upgrade-testing.yml
@@ -47,6 +47,7 @@ jobs:
   # Performs the following steps:
   # - Sets up PHP.
   # - Downloads the specified version of WordPress.
+  # - Verifies files against WordPress.org’s checksums.
   # - Creates a `wp-config.php` file.
   # - Installs WordPress.
   # - Checks the version of WordPress before the upgrade.
@@ -88,6 +89,9 @@ jobs:
         run: wp core download --version="${WP_VERSION}"
         env:
           WP_VERSION: ${{ inputs.wp }}
+
+      - name: Verify checksums
+        run: wp core verify-checksums
 
       - name: Create wp-config.php file
         run: wp config create --dbname=test_db --dbuser=root --dbpass=root --dbhost="127.0.0.1:${DB_PORT}"


### PR DESCRIPTION
This adds a step to both the upgrade & installation test workflows to perform a checksum verification after downloading WordPress.

Trac ticket: Core-65845

## Use of AI Tools

None

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
