### PR TITLE
Editor: Surface community-contributed patterns from the Pattern Directory (opt-in)

### DIFF
--- a/src/wp-includes/block-patterns.php
+++ b/src/wp-includes/block-patterns.php
@@ -136,6 +136,13 @@ function _register_core_block_patterns_and_categories() {
 		)
 	);
 	register_block_pattern_category(
+		'community',
+		array(
+			'label'       => _x( 'Community', 'Block pattern category' ),
+			'description' => __( 'Patterns contributed by the WordPress community.' ),
+		)
+	);
+	register_block_pattern_category(
 		'call-to-action',
 		array(
 			'label'       => _x( 'Call to action', 'Block pattern category' ),
@@ -351,6 +358,63 @@ function _load_remote_featured_patterns() {
 		// Some patterns might be already registered as core patterns with the `core` prefix.
 		$is_registered = $registry->is_registered( $pattern_name ) || $registry->is_registered( "core/$pattern_name" );
 		if ( ! $is_registered ) {
+			register_block_pattern( $pattern_name, $normalized_pattern );
+		}
+	}
+}
+
+/**
+ * Register `Community` (category) patterns from wordpress.org/patterns.
+ *
+ * Unlike the curated `core` keyword and `featured` category sets, this loads
+ * community-contributed patterns from the Pattern Directory. Because that
+ * collection is large and not curated, loading is opt-in via the
+ * `load_remote_community_block_patterns` filter (disabled by default), so
+ * existing sites are unaffected until a theme, plugin, or site owner opts in.
+ *
+ * @since 7.2.0
+ */
+function _load_remote_community_patterns() {
+	$supports_core_patterns = get_theme_support( 'core-block-patterns' );
+
+	/** This filter is documented in wp-includes/block-patterns.php */
+	$should_load_remote = apply_filters( 'should_load_remote_block_patterns', true );
+
+	/**
+	 * Filters whether community-contributed patterns are loaded from the Pattern Directory.
+	 *
+	 * The community collection is large and not curated, so it is not loaded by
+	 * default. Return true to surface it in the inserter under the `Community`
+	 * category.
+	 *
+	 * @since 7.2.0
+	 *
+	 * @param bool $load_community Whether to load community patterns. Default false.
+	 */
+	$load_community = apply_filters( 'load_remote_community_block_patterns', false );
+
+	if ( ! $should_load_remote || ! $supports_core_patterns || ! $load_community ) {
+		return;
+	}
+
+	$request = new WP_REST_Request( 'GET', '/wp/v2/pattern-directory/patterns' );
+	// Omitting `keyword`/`category` requests the general (community) collection.
+	$request->set_param( 'per_page', 100 );
+	$response = rest_do_request( $request );
+	if ( $response->is_error() ) {
+		return;
+	}
+	$patterns = $response->get_data();
+	$registry = WP_Block_Patterns_Registry::get_instance();
+	foreach ( $patterns as $pattern ) {
+		$pattern['source']  = 'pattern-directory/community';
+		$normalized_pattern = wp_normalize_remote_block_pattern( $pattern );
+
+		// Group everything from this loader under the `Community` category.
+		$normalized_pattern['categories'] = array( 'community' );
+
+		$pattern_name = 'community/' . sanitize_title( $normalized_pattern['title'] );
+		if ( ! $registry->is_registered( $pattern_name ) ) {
 			register_block_pattern( $pattern_name, $normalized_pattern );
 		}
 	}

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-block-patterns-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-block-patterns-controller.php
@@ -106,6 +106,7 @@ class WP_REST_Block_Patterns_Controller extends WP_REST_Controller {
 			// Load block patterns from w.org.
 			_load_remote_block_patterns(); // Patterns with the `core` keyword.
 			_load_remote_featured_patterns(); // Patterns in the `featured` category.
+			_load_remote_community_patterns(); // Community-contributed patterns (opt-in).
 			_register_remote_theme_patterns(); // Patterns requested by current theme.
 
 			$this->remote_patterns_loaded = true;

--- a/tests/phpunit/tests/blocks/loadRemoteCommunityPatterns.php
+++ b/tests/phpunit/tests/blocks/loadRemoteCommunityPatterns.php
@@ -1,0 +1,204 @@
+<?php
+/**
+ * Unit tests for _load_remote_community_patterns().
+ *
+ * @package WordPress
+ * @subpackage Blocks
+ *
+ * @since 7.2.0
+ *
+ * @ticket 65897
+ *
+ * @group blocks
+ * @group patterns
+ *
+ * @covers ::_load_remote_community_patterns
+ */
+class Tests_Blocks_LoadRemoteCommunityPatterns extends WP_UnitTestCase {
+
+	const PATTERN_NAME = 'community/community-hero';
+
+	/**
+	 * Admin user ID. The Pattern Directory endpoint requires `edit_posts`.
+	 *
+	 * @var int
+	 */
+	protected static $admin_id;
+
+	/**
+	 * Original WP_Block_Patterns_Registry instance, restored after the class.
+	 *
+	 * @var WP_Block_Patterns_Registry
+	 */
+	protected static $orig_registry;
+
+	/**
+	 * Reflected `instance` property of WP_Block_Patterns_Registry.
+	 *
+	 * @var ReflectionProperty
+	 */
+	private static $registry_instance_property;
+
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$admin_id = $factory->user->create( array( 'role' => 'administrator' ) );
+
+		self::$orig_registry              = WP_Block_Patterns_Registry::get_instance();
+		self::$registry_instance_property = new ReflectionProperty( 'WP_Block_Patterns_Registry', 'instance' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			self::$registry_instance_property->setAccessible( true );
+		}
+	}
+
+	public static function wpTearDownAfterClass() {
+		self::delete_user( self::$admin_id );
+
+		self::$registry_instance_property->setValue( null, self::$orig_registry );
+		if ( PHP_VERSION_ID < 80100 ) {
+			self::$registry_instance_property->setAccessible( false );
+		}
+		self::$registry_instance_property = null;
+		self::$orig_registry              = null;
+	}
+
+	public function set_up() {
+		parent::set_up();
+
+		// Isolate registrations in a fresh registry per test.
+		self::$registry_instance_property->setValue( null, new WP_Block_Patterns_Registry() );
+
+		// The loader is gated on this theme support.
+		add_theme_support( 'core-block-patterns' );
+
+		wp_set_current_user( self::$admin_id );
+	}
+
+	public function tear_down() {
+		// Restore the shared registry between tests.
+		self::$registry_instance_property->setValue( null, self::$orig_registry );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Intercepts requests to the Pattern Directory API and returns one
+	 * community pattern, so tests never hit the network.
+	 */
+	private function mock_directory_response() {
+		add_filter(
+			'pre_http_request',
+			static function ( $preempt, $args, $url ) {
+				if ( 'api.wordpress.org' !== wp_parse_url( $url, PHP_URL_HOST ) ) {
+					return $preempt;
+				}
+
+				$pattern = array(
+					'id'              => 5001,
+					'title'           => array( 'rendered' => 'Community Hero' ),
+					'pattern_content' => '<!-- wp:paragraph --><p>Community</p><!-- /wp:paragraph -->',
+					'category_slugs'  => array( 'header' ),
+					'meta'            => array(
+						'wpop_keywords'       => 'hero',
+						'wpop_description'    => 'A community hero.',
+						'wpop_viewport_width' => 1200,
+						'wpop_block_types'    => array( 'core/paragraph' ),
+					),
+				);
+
+				return array(
+					'headers'  => array(),
+					'response' => array(
+						'code'    => 200,
+						'message' => 'OK',
+					),
+					'body'     => wp_json_encode( array( $pattern ) ),
+					'cookies'  => array(),
+					'filename' => null,
+				);
+			},
+			10,
+			3
+		);
+	}
+
+	/**
+	 * By default (no opt-in filter) community patterns are not loaded, and no
+	 * request to the directory is made.
+	 *
+	 * @ticket 65897
+	 */
+	public function test_not_loaded_by_default() {
+		$http_requested = false;
+		add_filter(
+			'pre_http_request',
+			function ( $preempt, $args, $url ) use ( &$http_requested ) {
+				if ( 'api.wordpress.org' === wp_parse_url( $url, PHP_URL_HOST ) ) {
+					$http_requested = true;
+				}
+				return $preempt;
+			},
+			10,
+			3
+		);
+
+		_load_remote_community_patterns();
+
+		$this->assertFalse(
+			WP_Block_Patterns_Registry::get_instance()->is_registered( self::PATTERN_NAME ),
+			'Community patterns should not be registered unless explicitly enabled.'
+		);
+		$this->assertFalse(
+			$http_requested,
+			'No request to the Pattern Directory should be made while the feature is disabled.'
+		);
+	}
+
+	/**
+	 * With the opt-in filter, community patterns are registered under the
+	 * `community` category and tagged with the community source.
+	 *
+	 * @ticket 65897
+	 */
+	public function test_loaded_when_opted_in() {
+		$this->mock_directory_response();
+		add_filter( 'load_remote_community_block_patterns', '__return_true' );
+
+		_load_remote_community_patterns();
+
+		$registry = WP_Block_Patterns_Registry::get_instance();
+		$this->assertTrue(
+			$registry->is_registered( self::PATTERN_NAME ),
+			'Community patterns should be registered when the opt-in filter returns true.'
+		);
+
+		$pattern = $registry->get_registered( self::PATTERN_NAME );
+		$this->assertSame(
+			'pattern-directory/community',
+			$pattern['source'],
+			'The pattern should be tagged with the community source.'
+		);
+		$this->assertSame(
+			array( 'community' ),
+			$pattern['categories'],
+			'The pattern should be grouped under the community category.'
+		);
+	}
+
+	/**
+	 * The master `should_load_remote_block_patterns` gate still wins even when
+	 * community loading is opted in.
+	 *
+	 * @ticket 65897
+	 */
+	public function test_respects_should_load_remote_gate() {
+		$this->mock_directory_response();
+		add_filter( 'load_remote_community_block_patterns', '__return_true' );
+		add_filter( 'should_load_remote_block_patterns', '__return_false' );
+
+		_load_remote_community_patterns();
+
+		$this->assertFalse(
+			WP_Block_Patterns_Registry::get_instance()->is_registered( self::PATTERN_NAME ),
+			'The should_load_remote_block_patterns filter should prevent loading.'
+		);
+	}
+}


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65897

## What

Adds a third remote pattern loader, `_load_remote_community_patterns()`, alongside the existing `_load_remote_block_patterns()` (core keyword) and `_load_remote_featured_patterns()` (featured category), registering results under a new `community` block-pattern category.

Loading the uncurated community collection is **opt-in and disabled by default**, behind a new `load_remote_community_block_patterns` filter. With the filter off, behavior is unchanged and no extra directory request is made.

Enable it with:

```php
add_filter( 'load_remote_community_block_patterns', '__return_true' );
```

## Why

The inserter only exposes the curated `core`/`featured` slices; the larger pool of community-contributed patterns is not reachable from the editor. This provides a supported, first-class opt-in without regressing the default out-of-the-box experience.

## Testing

- New: `tests/phpunit/tests/blocks/loadRemoteCommunityPatterns.php` (`OK (3 tests, 6 assertions)`), covering: no request when disabled, registration under `community` when enabled, and the `should_load_remote_block_patterns` gate still winning.
- Manual: with the filter enabled, a "Community" category appears in the inserter, populated from the Pattern Directory; inserting yields editable blocks.

---

This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request.