### PR TITLE
Media: Prevent a partial third line in the grid label overlay.

### DIFF
--- a/src/wp-includes/css/media-views.css
+++ b/src/wp-includes/css/media-views.css
@@ -1019,10 +1019,12 @@ select#media-attachment-filters ~ select#media-attachment-date-filters {
 	font-size: 12px;
 	background-color: rgba(255, 255, 255, 0.8);
 	color: #1d2327;
-	max-height: 3rem;
+	line-height: 1.75;
+	/* Overflow clips at the padding box, so vertical padding would expose part of a third line. */
+	max-height: calc( 2 * 1.75em );
 	overflow: hidden;
 	text-align: start;
-	padding: 5px 10px;
+	padding: 0 10px;
 	word-wrap: break-word;
 	box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.15);
 	box-sizing: border-box;


### PR DESCRIPTION
In the Media Library grid, a long image label shows two full lines plus the clipped top of a third.

The overlay is a `::after` on the grid item, clamped with `max-height: 3rem` while keeping `5px` of vertical padding. Overflow is clipped at the padding box rather than the content box, so that padding is exactly where the third line shows through. The patch sets a line height on the overlay, drops the vertical padding, and clamps to two line boxes, so the clip edge always falls between lines.

The leading now supplies the spacing, and the overlay is 6px shorter.

Trac ticket: https://core.trac.wordpress.org/ticket/65896

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Locating the rule, measuring the clipping behaviour in the browser, and comparing candidate clamps. All changes were reviewed and validated by me.
