### PR TITLE
Build/Test Tools: Remove npx commands in 7.0

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2346,15 +2346,15 @@ module.exports = function(grunt) {
 	grunt.registerTask( 'wp-packages:update', 'Update WordPress packages', function() {
 		const distTag = grunt.option('dist-tag') || 'latest';
 		grunt.log.writeln( `Updating WordPress packages (--dist-tag=${distTag})` );
-		spawn( 'npx', [ 'wp-scripts', 'packages-update', `--dist-tag=${distTag}` ], {
+		spawn( 'npm', [ 'exec', '--no', '--', 'wp-scripts', 'packages-update', `--dist-tag=${distTag}` ], {
 			cwd: __dirname,
 			stdio: 'inherit',
 		} );
 	} );
 
 	grunt.registerTask( 'browserslist:update', 'Update the local database of browser supports', function() {
-		grunt.log.writeln( `Updating browsers list` );
-		spawn( 'npx', [ 'update-browserslist-db@latest' ], {
+		grunt.log.writeln( 'Updating browsers list' );
+		spawn( 'npm', [ 'exec', '--no', '--', 'update-browserslist-db' ], {
 			cwd: __dirname,
 			stdio: 'inherit',
 		} );

--- a/package-lock.json
+++ b/package-lock.json
@@ -90,6 +90,7 @@
 				"source-map-loader": "5.0.0",
 				"terser-webpack-plugin": "5.4.0",
 				"typescript": "5.9.3",
+				"update-browserslist-db": "1.2.3",
 				"uuid": "13.0.0",
 				"wait-on": "9.0.4",
 				"webpack": "5.105.4"

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
 		"source-map-loader": "5.0.0",
 		"terser-webpack-plugin": "5.4.0",
 		"typescript": "5.9.3",
+		"update-browserslist-db": "1.2.3",
 		"uuid": "13.0.0",
 		"wait-on": "9.0.4",
 		"webpack": "5.105.4"


### PR DESCRIPTION
Backport of [r63309](https://core.trac.wordpress.org/changeset/63309), already in `trunk` via #13021, to the `7.0` branch. It replaces the last two `npx` calls in `Gruntfile.js` with `npm exec --no`, which runs an installed binary instead of downloading and installing one, and declares `update-browserslist-db` as a direct `devDependency`.

Trac ticket: https://core.trac.wordpress.org/ticket/65864

## Testing instructions

1. Run `npm ci`. It completes, and `git status` stays clean. This confirms `package.json` and `package-lock.json` agree.
2. Run `npm ls update-browserslist-db`. It reports `update-browserslist-db@1.2.3` as a direct dependency.
3. Run `npm exec --no -- update-browserslist-db --help` and `npm exec --no -- wp-scripts`. Each runs the local binary and downloads nothing.
4. Delete `node_modules/update-browserslist-db` and run `npm exec --no -- update-browserslist-db`. It fails with `npx canceled due to missing packages and no YES option` instead of fetching the package. Restore the tree with `npm ci`.

## Use of AI Tools

AI assistance: Yes — Claude Code (Claude Opus 5) applied r63309 to the `7.0` branch and verified the changeset.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
