### PR TITLE
Build/Test Tools: Remove npx commands in 7.1

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2279,8 +2279,8 @@ module.exports = function(grunt) {
 	grunt.registerTask( 'qunit', 'Runs QUnit tests.', function() {
 		var done = this.async();
 		grunt.util.spawn( {
-			cmd: 'npx',
-			args: [ 'playwright', 'test', '--config', 'tests/qunit/playwright.config.js' ],
+			cmd: 'npm',
+			args: [ 'exec', '--no', '--', 'playwright', 'test', '--config', 'tests/qunit/playwright.config.js' ],
 			opts: { stdio: 'inherit' }
 		}, function( error, result, code ) {
 			if ( code !== 0 ) {
@@ -2363,15 +2363,15 @@ module.exports = function(grunt) {
 	grunt.registerTask( 'wp-packages:update', 'Update WordPress packages', function() {
 		const distTag = grunt.option('dist-tag') || 'latest';
 		grunt.log.writeln( `Updating WordPress packages (--dist-tag=${distTag})` );
-		spawn( 'npx', [ 'wp-scripts', 'packages-update', `--dist-tag=${distTag}` ], {
+		spawn( 'npm', [ 'exec', '--no', '--', 'wp-scripts', 'packages-update', `--dist-tag=${distTag}` ], {
 			cwd: __dirname,
 			stdio: 'inherit',
 		} );
 	} );
 
 	grunt.registerTask( 'browserslist:update', 'Update the local database of browser supports', function() {
-		grunt.log.writeln( `Updating browsers list` );
-		spawn( 'npx', [ 'update-browserslist-db@latest' ], {
+		grunt.log.writeln( 'Updating browsers list' );
+		spawn( 'npm', [ 'exec', '--no', '--', 'update-browserslist-db' ], {
 			cwd: __dirname,
 			stdio: 'inherit',
 		} );

--- a/package-lock.json
+++ b/package-lock.json
@@ -89,6 +89,7 @@
 				"sinon-test": "~3.1.6",
 				"source-map-loader": "5.0.0",
 				"typescript": "6.0.3",
+				"update-browserslist-db": "1.2.3",
 				"uuid": "14.0.1",
 				"wait-on": "9.0.10",
 				"webpack": "5.108.4"

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
 		"sinon-test": "~3.1.6",
 		"source-map-loader": "5.0.0",
 		"typescript": "6.0.3",
+		"update-browserslist-db": "1.2.3",
 		"uuid": "14.0.1",
 		"wait-on": "9.0.10",
 		"webpack": "5.108.4"

--- a/tests/qunit/playwright.config.js
+++ b/tests/qunit/playwright.config.js
@@ -12,7 +12,7 @@ module.exports = defineConfig( {
 	workers: 1,
 	use: {
 		headless: true,
-		/* This avoids the need to run `npx playwright install` in CI. */
+		/* The system Chrome channel avoids a browser download in CI. */
 		channel: process.env.CI ? 'chrome' : undefined,
 	},
 	reporter: process.env.CI ? 'github' : 'list',


### PR DESCRIPTION
Backport of [r63309](https://core.trac.wordpress.org/changeset/63309), already in trunk via #13021, to the `7.1` branch. It replaces every `npx` call with `npm exec --no`, which runs an installed binary and fails when the package is missing, and declares `update-browserslist-db` as a direct `devDependency`. That dependency is pinned to `1.2.3`, the version this branch already resolves, rather than trunk's `1.3.1`, so nothing is upgraded.

Trac ticket: https://core.trac.wordpress.org/ticket/65864

## Testing instructions

1. Run `npm ci`.
2. Run `npm exec --no -- playwright --version`. It prints the installed version and downloads nothing.
3. Run `npm exec --no -- update-browserslist-db --version`. It prints `browserslist-lint 1.2.3`.
4. Delete `node_modules/update-browserslist-db`, then run `npm exec --no -- update-browserslist-db`. It fails with `npx canceled due to missing packages and no YES option` instead of fetching the package. Restore the tree with `npm ci`.
5. Run `CI=1 npm run grunt qunit`. The QUnit tests pass. `CI=1` selects the system Chrome, as the workflow does. Without it, Playwright looks for a downloaded browser, so run `npm exec --no -- playwright install` first.
6. Run `grep -rn npx Gruntfile.js tests/qunit/ .github/ package.json`. It returns nothing.

## Use of AI Tools

AI assistance: Yes — Claude Code (Claude Opus 5) applied r63309 to the `7.1` branch and verified the changeset.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
