### PR TITLE
Build/Test Tools: Remove npx commands in the 6.8 branch

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1825,15 +1825,15 @@ module.exports = function(grunt) {
 	grunt.registerTask( 'wp-packages:update', 'Update WordPress packages', function() {
 		const distTag = grunt.option('dist-tag') || 'latest';
 		grunt.log.writeln( `Updating WordPress packages (--dist-tag=${distTag})` );
-		spawn( 'npx', [ 'wp-scripts', 'packages-update', `--dist-tag=${distTag}` ], {
+		spawn( 'npm', [ 'exec', '--no', '--', 'wp-scripts', 'packages-update', `--dist-tag=${distTag}` ], {
 			cwd: __dirname,
 			stdio: 'inherit',
 		} );
 	} );
 
 	grunt.registerTask( 'browserslist:update', 'Update the local database of browser supports', function() {
-		grunt.log.writeln( `Updating browsers list` );
-		spawn( 'npx', [ 'browserslist@latest', '--update-db' ], {
+		grunt.log.writeln( 'Updating browsers list' );
+		spawn( 'npm', [ 'exec', '--no', '--', 'update-browserslist-db' ], {
 			cwd: __dirname,
 			stdio: 'inherit',
 		} );

--- a/package-lock.json
+++ b/package-lock.json
@@ -149,6 +149,7 @@
 				"source-map-loader": "5.0.0",
 				"terser-webpack-plugin": "5.3.12",
 				"uglify-js": "^3.19.3",
+				"update-browserslist-db": "1.1.1",
 				"uuid": "11.1.0",
 				"wait-on": "8.0.2",
 				"webpack": "5.98.0",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
 		"source-map-loader": "5.0.0",
 		"terser-webpack-plugin": "5.3.12",
 		"uglify-js": "^3.19.3",
+		"update-browserslist-db": "1.1.1",
 		"uuid": "11.1.0",
 		"wait-on": "8.0.2",
 		"webpack": "5.98.0",


### PR DESCRIPTION
Backport of [r63309](https://core.trac.wordpress.org/changeset/63309), already in trunk via #13021, to the `6.8` branch. It replaces the two remaining `npx` calls in `Gruntfile.js` with `npm exec --no`, which fails on a missing package instead of installing it.

Trac ticket: https://core.trac.wordpress.org/ticket/65864

## Testing instructions

1. Run `npm ci`.
2. Run `npm ls update-browserslist-db`. It is now a direct `devDependency` at `1.1.1`, and the copy under `browserslist` is `deduped`, so the tree gains no package.
3. Run `npm exec --no -- update-browserslist-db --version`. It prints `browserslist-lint 1.1.1` and downloads nothing.
4. Move `node_modules/update-browserslist-db` aside and run `npm exec --no -- update-browserslist-db` again. It fails with `npx canceled due to missing packages and no YES option` instead of fetching the package. Move the directory back.
5. Run `npm exec --no -- wp-scripts --help`. It runs the installed binary and prints `Script name is missing.`

## Use of AI Tools

AI assistance: Yes — Claude Code (Claude Opus 5) applied r63309 to the `6.8` branch and verified the changeset.