### PR TITLE
Build/Test Tools: Remove npx commands in 6.9

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1905,15 +1905,15 @@ module.exports = function(grunt) {
 	grunt.registerTask( 'wp-packages:update', 'Update WordPress packages', function() {
 		const distTag = grunt.option('dist-tag') || 'latest';
 		grunt.log.writeln( `Updating WordPress packages (--dist-tag=${distTag})` );
-		spawn( 'npx', [ 'wp-scripts', 'packages-update', `--dist-tag=${distTag}` ], {
+		spawn( 'npm', [ 'exec', '--no', '--', 'wp-scripts', 'packages-update', `--dist-tag=${distTag}` ], {
 			cwd: __dirname,
 			stdio: 'inherit',
 		} );
 	} );
 
 	grunt.registerTask( 'browserslist:update', 'Update the local database of browser supports', function() {
-		grunt.log.writeln( `Updating browsers list` );
-		spawn( 'npx', [ 'browserslist@latest', '--update-db' ], {
+		grunt.log.writeln( 'Updating browsers list' );
+		spawn( 'npm', [ 'exec', '--no', '--', 'update-browserslist-db' ], {
 			cwd: __dirname,
 			stdio: 'inherit',
 		} );

--- a/package-lock.json
+++ b/package-lock.json
@@ -152,6 +152,7 @@
 				"source-map-loader": "5.0.0",
 				"terser-webpack-plugin": "5.3.14",
 				"uglify-js": "^3.19.3",
+				"update-browserslist-db": "1.1.4",
 				"uuid": "13.0.0",
 				"wait-on": "9.0.3",
 				"webpack": "5.98.0",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
 		"source-map-loader": "5.0.0",
 		"terser-webpack-plugin": "5.3.14",
 		"uglify-js": "^3.19.3",
+		"update-browserslist-db": "1.1.4",
 		"uuid": "13.0.0",
 		"wait-on": "9.0.3",
 		"webpack": "5.98.0",


### PR DESCRIPTION
Replaces the two remaining `npx` calls in `Gruntfile.js` with `npm exec --no`, and adds `update-browserslist-db` as a direct dev dependency. Backport of [r63309](https://core.trac.wordpress.org/changeset/63309), already in trunk via #13021, to the `6.9` branch.

Trac ticket: https://core.trac.wordpress.org/ticket/65864

## Testing instructions

No workflow calls either grunt task, so CI does not exercise this change. Check it locally:

1. Run `npm ci`.
2. Run `npm exec --no -- update-browserslist-db --help`. It prints the CLI help and downloads nothing.
3. Run `npm exec --no -- wp-scripts`. It prints its own `Script name is missing.` usage error, which shows the local binary resolved.
4. Delete `node_modules/update-browserslist-db` and `node_modules/.bin/update-browserslist-db`, then run `npm exec --no -- update-browserslist-db`. It fails with `npx canceled due to missing packages and no YES option` instead of fetching the package. Restore the tree with `npm ci`.
5. Run `npm exec --no -- grunt --help`. Both `wp-packages:update` and `browserslist:update` are still listed.

## Use of AI Tools

AI assistance: Yes — Claude Code (Claude Opus 5) applied r63309 to the `6.9` branch and verified the changeset.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
