### PR TITLE
Build/Test Tools: Remove npx commands in 6.5

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1705,15 +1705,15 @@ module.exports = function(grunt) {
 	grunt.registerTask( 'wp-packages:update', 'Update WordPress packages', function() {
 		const distTag = grunt.option('dist-tag') || 'latest';
 		grunt.log.writeln( `Updating WordPress packages (--dist-tag=${distTag})` );
-		spawn( 'npx', [ 'wp-scripts', 'packages-update', `--dist-tag=${distTag}` ], {
+		spawn( 'npm', [ 'exec', '--no', '--', 'wp-scripts', 'packages-update', `--dist-tag=${distTag}` ], {
 			cwd: __dirname,
 			stdio: 'inherit',
 		} );
 	} );
 
 	grunt.registerTask( 'browserslist:update', 'Update the local database of browser supports', function() {
-		grunt.log.writeln( `Updating browsers list` );
-		spawn( 'npx', [ 'browserslist@latest', '--update-db' ], {
+		grunt.log.writeln( 'Updating browsers list' );
+		spawn( 'npm', [ 'exec', '--no', '--', 'update-browserslist-db' ], {
 			cwd: __dirname,
 			stdio: 'inherit',
 		} );

--- a/package-lock.json
+++ b/package-lock.json
@@ -150,6 +150,7 @@
 				"source-map-loader": "5.0.0",
 				"terser-webpack-plugin": "5.3.10",
 				"uglify-js": "^3.17.4",
+				"update-browserslist-db": "1.0.13",
 				"uuid": "9.0.1",
 				"wait-on": "7.2.0",
 				"webpack": "5.90.2",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
 		"source-map-loader": "5.0.0",
 		"terser-webpack-plugin": "5.3.10",
 		"uglify-js": "^3.17.4",
+		"update-browserslist-db": "1.0.13",
 		"uuid": "9.0.1",
 		"wait-on": "7.2.0",
 		"webpack": "5.90.2",


### PR DESCRIPTION
Backport of [r63309](https://core.trac.wordpress.org/changeset/63309) to the `6.5` branch, already in trunk via #13021. It replaces the two remaining `npx` calls in `Gruntfile.js` with `npm exec --no`, which fails on a missing package instead of installing it, and declares `update-browserslist-db` as a direct `devDependency`.

Trac ticket: https://core.trac.wordpress.org/ticket/65864

## Testing instructions

1. Run `npm ci`.
2. Run `npm exec --no -- update-browserslist-db --version`. It prints `browserslist-lint 1.0.13` and downloads nothing.
3. Run `npm exec --no -- wp-scripts`. It prints `Script name is missing.`, which confirms the local binary ran.
4. Move `node_modules/update-browserslist-db` out of the tree, then run `npm exec --no -- update-browserslist-db` again. It fails with `npx canceled due to missing packages and no YES option` instead of fetching the package. Restore the tree with `npm ci`.
5. Run `npm run grunt -- --help`. Confirm that `wp-packages:update` and `browserslist:update` still appear in the task list.

## Use of AI Tools

AI assistance: Yes — Claude Code (Claude Opus 5) applied r63309 to the `6.5` branch and verified the changeset.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
