### PR TITLE
Build/Test Tools: Remove npx commands in 6.4

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1684,15 +1684,15 @@ module.exports = function(grunt) {
 	grunt.registerTask( 'wp-packages:update', 'Update WordPress packages', function() {
 		const distTag = grunt.option('dist-tag') || 'latest';
 		grunt.log.writeln( `Updating WordPress packages (--dist-tag=${distTag})` );
-		spawn( 'npx', [ 'wp-scripts', 'packages-update', `--dist-tag=${distTag}` ], {
+		spawn( 'npm', [ 'exec', '--no', '--', 'wp-scripts', 'packages-update', `--dist-tag=${distTag}` ], {
 			cwd: __dirname,
 			stdio: 'inherit',
 		} );
 	} );
 
 	grunt.registerTask( 'browserslist:update', 'Update the local database of browser supports', function() {
-		grunt.log.writeln( `Updating browsers list` );
-		spawn( 'npx', [ 'browserslist@latest', '--update-db' ], {
+		grunt.log.writeln( 'Updating browsers list' );
+		spawn( 'npm', [ 'exec', '--no', '--', 'update-browserslist-db' ], {
 			cwd: __dirname,
 			stdio: 'inherit',
 		} );

--- a/package-lock.json
+++ b/package-lock.json
@@ -153,6 +153,7 @@
 				"source-map-loader": "4.0.1",
 				"terser-webpack-plugin": "5.3.9",
 				"uglify-js": "^3.17.4",
+				"update-browserslist-db": "1.0.11",
 				"uuid": "9.0.1",
 				"wait-on": "7.0.1",
 				"webpack": "5.89.0",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
 		"source-map-loader": "4.0.1",
 		"terser-webpack-plugin": "5.3.9",
 		"uglify-js": "^3.17.4",
+		"update-browserslist-db": "1.0.11",
 		"uuid": "9.0.1",
 		"wait-on": "7.0.1",
 		"webpack": "5.89.0",


### PR DESCRIPTION
Backport of [r63309](https://core.trac.wordpress.org/changeset/63309) to the `6.4` branch, already in trunk via #13021. It replaces the two remaining `npx` calls with `npm exec --no`, which runs an installed binary only instead of first downloading and installing a missing package and its dependencies.

Trac ticket: https://core.trac.wordpress.org/ticket/65864

## Testing Instructions

Both Grunt tasks are manual release-lead tools. No workflow runs them, so check them locally.

1. Run `npm ci`. It completes without errors.
2. Run `npm exec --offline --no -- update-browserslist-db --help`. It prints the tool's usage text. `--offline` proves the binary comes from `node_modules`, not the registry.
3. Run `npm exec --offline --no -- wp-scripts --help`. The local `wp-scripts` binary prints `Script name is missing.`
4. Run `npm ls update-browserslist-db`. It lists the package as a direct dependency, and again under `browserslist` as deduped.
5. Run `npm exec --no -- a-package-that-is-not-installed`. The command fails and installs nothing.

## Use of AI Tools

AI assistance: Yes — Claude Code (Claude Opus 5) applied r63309 to `6.4` and verified the changeset.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
