### PR TITLE
Networks and Sites: Remove network list view modes

### DIFF
--- a/src/wp-admin/includes/class-wp-ms-sites-list-table.php
+++ b/src/wp-admin/includes/class-wp-ms-sites-list-table.php
@@ -65,19 +65,11 @@ class WP_MS_Sites_List_Table extends WP_List_Table {
 	 *
 	 * @since 3.1.0
 	 *
-	 * @global string $mode List table view mode.
 	 * @global string $s    Search string.
 	 * @global wpdb   $wpdb WordPress database abstraction object.
 	 */
 	public function prepare_items() {
-		global $mode, $s, $wpdb;
-
-		if ( ! empty( $_REQUEST['mode'] ) ) {
-			$mode = 'excerpt' === $_REQUEST['mode'] ? 'excerpt' : 'list';
-			set_user_setting( 'sites_list_mode', $mode );
-		} else {
-			$mode = get_user_setting( 'sites_list_mode', 'list' );
-		}
+		global $s, $wpdb;
 
 		$per_page = $this->get_items_per_page( 'sites_network_per_page' );
 
@@ -311,25 +303,6 @@ class WP_MS_Sites_List_Table extends WP_List_Table {
 	}
 
 	/**
-	 * Displays the pagination.
-	 *
-	 * @since 3.1.0
-	 *
-	 * @global string $mode List table view mode.
-	 *
-	 * @param string $which The location of the pagination nav markup: Either 'top' or 'bottom'.
-	 */
-	protected function pagination( $which ) {
-		global $mode;
-
-		parent::pagination( $which );
-
-		if ( 'top' === $which ) {
-			$this->view_switcher( $mode );
-		}
-	}
-
-	/**
 	 * Displays extra controls between bulk actions and pagination.
 	 *
 	 * @since 5.3.0
@@ -472,13 +445,9 @@ class WP_MS_Sites_List_Table extends WP_List_Table {
 	 *
 	 * @since 4.3.0
 	 *
-	 * @global string $mode List table view mode.
-	 *
 	 * @param array $blog Current site.
 	 */
 	public function column_blogname( $blog ) {
-		global $mode;
-
 		$blogname = untrailingslashit( $blog['domain'] . $blog['path'] );
 
 		?>
@@ -494,18 +463,6 @@ class WP_MS_Sites_List_Table extends WP_List_Table {
 			?>
 		</strong>
 		<?php
-		if ( 'list' !== $mode ) {
-			switch_to_blog( $blog['blog_id'] );
-			echo '<p>';
-			printf(
-				/* translators: 1: Site title, 2: Site tagline. */
-				__( '%1$s &#8211; %2$s' ),
-				get_option( 'blogname' ),
-				'<em>' . get_option( 'blogdescription' ) . '</em>'
-			);
-			echo '</p>';
-			restore_current_blog();
-		}
 	}
 
 	/**
@@ -513,18 +470,10 @@ class WP_MS_Sites_List_Table extends WP_List_Table {
 	 *
 	 * @since 4.3.0
 	 *
-	 * @global string $mode List table view mode.
-	 *
 	 * @param array $blog Current site.
 	 */
 	public function column_lastupdated( $blog ) {
-		global $mode;
-
-		if ( 'list' === $mode ) {
-			$date = __( 'Y/m/d' );
-		} else {
-			$date = __( 'Y/m/d g:i:s a' );
-		}
+		$date = __( 'Y/m/d g:i:s a' );
 
 		if ( '0000-00-00 00:00:00' === $blog['last_updated'] ) {
 			_e( 'Never' );
@@ -538,18 +487,10 @@ class WP_MS_Sites_List_Table extends WP_List_Table {
 	 *
 	 * @since 4.3.0
 	 *
-	 * @global string $mode List table view mode.
-	 *
 	 * @param array $blog Current site.
 	 */
 	public function column_registered( $blog ) {
-		global $mode;
-
-		if ( 'list' === $mode ) {
-			$date = __( 'Y/m/d' );
-		} else {
-			$date = __( 'Y/m/d g:i:s a' );
-		}
+		$date = __( 'Y/m/d g:i:s a' );
 
 		if ( '0000-00-00 00:00:00' === $blog['registered'] ) {
 			echo '&#x2014;';

--- a/src/wp-admin/includes/class-wp-ms-users-list-table.php
+++ b/src/wp-admin/includes/class-wp-ms-users-list-table.php
@@ -23,19 +23,11 @@ class WP_MS_Users_List_Table extends WP_List_Table {
 	}
 
 	/**
-	 * @global string $mode       List table view mode.
 	 * @global string $usersearch
 	 * @global string $role
 	 */
 	public function prepare_items() {
-		global $mode, $usersearch, $role;
-
-		if ( ! empty( $_REQUEST['mode'] ) ) {
-			$mode = 'excerpt' === $_REQUEST['mode'] ? 'excerpt' : 'list';
-			set_user_setting( 'network_users_list_mode', $mode );
-		} else {
-			$mode = get_user_setting( 'network_users_list_mode', 'list' );
-		}
+		global $usersearch, $role;
 
 		$usersearch = isset( $_REQUEST['s'] ) ? wp_unslash( trim( $_REQUEST['s'] ) ) : '';
 
@@ -167,21 +159,6 @@ class WP_MS_Users_List_Table extends WP_List_Table {
 		);
 
 		return $this->get_views_links( $role_links );
-	}
-
-	/**
-	 * @global string $mode List table view mode.
-	 *
-	 * @param string $which
-	 */
-	protected function pagination( $which ) {
-		global $mode;
-
-		parent::pagination( $which );
-
-		if ( 'top' === $which ) {
-			$this->view_switcher( $mode );
-		}
 	}
 
 	/**
@@ -334,18 +311,10 @@ class WP_MS_Users_List_Table extends WP_List_Table {
 	 *
 	 * @since 4.3.0
 	 *
-	 * @global string $mode List table view mode.
-	 *
 	 * @param WP_User $user The current WP_User object.
 	 */
 	public function column_registered( $user ) {
-		global $mode;
-		if ( 'list' === $mode ) {
-			$date = __( 'Y/m/d' );
-		} else {
-			$date = __( 'Y/m/d g:i:s a' );
-		}
-		echo mysql2date( $date, $user->user_registered );
+		echo mysql2date( __( 'Y/m/d g:i:s a' ), $user->user_registered );
 	}
 
 	/**

--- a/src/wp-admin/network/sites.php
+++ b/src/wp-admin/network/sites.php
@@ -29,7 +29,7 @@ get_current_screen()->add_help_tab(
 		'title'   => __( 'Overview' ),
 		'content' =>
 		'<p>' . __( 'Add Site takes you to the screen for adding a new site to the network. You can search for a site by Name, ID number, or IP address. Screen Options allows you to choose how many sites to display on one page.' ) . '</p>' .
-		'<p>' . __( 'This is the main table of all sites on this network. Switch between list and excerpt views by using the icons above the right side of the table.' ) . '</p>' .
+		'<p>' . __( 'This is the main table of all sites on this network.' ) . '</p>' .
 			'<p>' . __( 'Hovering over each site reveals seven options (three for the primary site):' ) . '</p>' .
 			'<ul><li>' . __( 'An Edit link to a separate Edit Site screen.' ) . '</li>' .
 			'<li>' . __( 'Dashboard leads to the Dashboard for that site.' ) . '</li>' .

--- a/src/wp-admin/network/users.php
+++ b/src/wp-admin/network/users.php
@@ -286,7 +286,7 @@ get_current_screen()->add_help_tab(
 			'<p>' . __( 'This table shows all users across the network and the sites to which they are assigned.' ) . '</p>' .
 			'<p>' . __( 'Hover over any user on the list to make the edit links appear. The Edit link on the left will take you to their Edit User profile page; the Edit link on the right by any site name goes to an Edit Site screen for that site.' ) . '</p>' .
 			'<p>' . __( 'You can also go to the user&#8217;s profile page by clicking on the individual username.' ) . '</p>' .
-			'<p>' . __( 'You can sort the table by clicking on any of the table headings and switch between list and excerpt views by using the icons above the users list.' ) . '</p>' .
+			'<p>' . __( 'You can sort the table by clicking on any of the table headings.' ) . '</p>' .
 			'<p>' . __( 'The bulk action will permanently delete selected users, or mark/unmark those selected as spam. Spam users will have posts removed and will be unable to sign up again with the same email addresses.' ) . '</p>' .
 			'<p>' . __( 'You can make an existing user an additional super admin by going to the Edit User profile page and checking the box to grant that privilege.' ) . '</p>',
 	)

--- a/tests/phpunit/tests/multisite/wpMsSitesListTable.php
+++ b/tests/phpunit/tests/multisite/wpMsSitesListTable.php
@@ -242,4 +242,75 @@ class Tests_Multisite_wpMsSitesListTable extends WP_UnitTestCase {
 
 		$this->assertSame( $expected, $this->table->get_views() );
 	}
+
+	/**
+	 * @ticket 43899
+	 */
+	public function test_view_switcher_is_not_displayed() {
+		$pagination = new ReflectionMethod( $this->table, 'pagination' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$pagination->setAccessible( true );
+		}
+
+		ob_start();
+		$pagination->invoke( $this->table, 'top' );
+		$output = ob_get_clean();
+
+		$this->assertStringNotContainsString( 'view-switch', $output );
+	}
+
+	/**
+	 * @ticket 43899
+	 */
+	public function test_site_details_are_not_displayed_without_switching_blog() {
+		$site_id = self::$site_ids['wordpress.org/foo/'];
+		update_blog_option( $site_id, 'blogname', 'Test site title' );
+		update_blog_option( $site_id, 'blogdescription', 'Test site tagline' );
+
+		$switch_blog = new MockAction();
+		add_action( 'switch_blog', array( $switch_blog, 'action' ) );
+
+		ob_start();
+		$this->table->column_blogname(
+			array(
+				'blog_id' => $site_id,
+				'domain'  => 'wordpress.org',
+				'path'    => '/foo/',
+			)
+		);
+		$output = ob_get_clean();
+
+		remove_action( 'switch_blog', array( $switch_blog, 'action' ) );
+
+		$this->assertStringNotContainsString( 'Test site title', $output );
+		$this->assertStringNotContainsString( 'Test site tagline', $output );
+		$this->assertSame( 0, $switch_blog->get_call_count() );
+	}
+
+	/**
+	 * @ticket 43899
+	 */
+	public function test_excerpt_mode_request_does_not_change_site_date_format() {
+		$_REQUEST['mode'] = 'excerpt';
+		$this->table->prepare_items();
+		unset( $_REQUEST['mode'] );
+
+		$date = '2025-01-02 03:04:05';
+		$blog = array(
+			'last_updated' => $date,
+			'registered'   => $date,
+		);
+
+		ob_start();
+		$this->table->column_lastupdated( $blog );
+		$last_updated = ob_get_clean();
+
+		ob_start();
+		$this->table->column_registered( $blog );
+		$registered = ob_get_clean();
+
+		$expected = mysql2date( __( 'Y/m/d g:i:s a' ), $date );
+		$this->assertSame( $expected, $last_updated );
+		$this->assertSame( $expected, $registered );
+	}
 }

--- a/tests/phpunit/tests/multisite/wpMsUsersListTable.php
+++ b/tests/phpunit/tests/multisite/wpMsUsersListTable.php
@@ -104,4 +104,38 @@ class Tests_Multisite_wpMsUsersListTable extends WP_UnitTestCase {
 
 		$this->assertSame( $expected, $this->table->get_views() );
 	}
+
+	/**
+	 * @ticket 43899
+	 */
+	public function test_view_switcher_is_not_displayed() {
+		$pagination = new ReflectionMethod( $this->table, 'pagination' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$pagination->setAccessible( true );
+		}
+
+		ob_start();
+		$pagination->invoke( $this->table, 'top' );
+		$output = ob_get_clean();
+
+		$this->assertStringNotContainsString( 'view-switch', $output );
+	}
+
+	/**
+	 * @ticket 43899
+	 */
+	public function test_excerpt_mode_request_does_not_change_registered_date_format() {
+		$_REQUEST['mode'] = 'excerpt';
+		$this->table->prepare_items();
+		unset( $_REQUEST['mode'] );
+
+		$user                  = new WP_User();
+		$user->user_registered = '2025-01-02 03:04:05';
+
+		ob_start();
+		$this->table->column_registered( $user );
+		$output = ob_get_clean();
+
+		$this->assertSame( mysql2date( __( 'Y/m/d g:i:s a' ), $user->user_registered ), $output );
+	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/43899

## What this PR does

Removes the list/excerpt view modes from the Network Admin Sites and Users list tables.

The differences between the modes were minimal:
  - Sites excerpt mode added the site title, tagline, and full timestamps.
  - Users excerpt mode only added the full registration timestamp.

This PR:
  - Removes both view mode switchers.
  - Removes `mode` request handling and the associated user settings.
  - Retains full timestamps as the canonical date format.
  - Removes site title/tagline output to avoid `switch_to_blog()` and option reads for every displayed site.
  - Updates the Network Sites and Users help text.
  
## Screenshots

### Network Sites
   
<img width="2880" height="1052" alt="comparison-sites" src="https://github.com/user-attachments/assets/ddfff6bf-0ba0-4cef-9308-4188e6bc6c2a" />


### Network Users

<img width="2880" height="1052" alt="comparison-users" src="https://github.com/user-attachments/assets/87a81860-d685-46d9-a2db-4c9040d1db2e" />

## Manual testing

 1. Set up a multisite installation containing several sites and users.
 2. Visit Network Admin → Sites.
 3. Confirm the view switcher is absent.
 4. Confirm Last Updated and Registered display full timestamps.
 5. Visit Network Admin → Users.
 6. Confirm the view switcher is absent.
 7. Confirm Registered displays a full timestamp.
 8. Load both screens with ?mode=list and ?mode=excerpt.
 9. Confirm the query parameter does not change the output.
 10. Open each screen’s Help panel and confirm it no longer mentions switching views.


## Use of AI Tools

AI assistance: Yes
Tool(s): Pi coding agent
Model(s): GPT-5.6
Used for: Initial code skeleton, test suggestions and code review; final implementation and tests were reviewed and edited by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
