### PR TITLE
Build/Test Tools: Remove npx commands in 6.7

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1707,15 +1707,15 @@ module.exports = function(grunt) {
 	grunt.registerTask( 'wp-packages:update', 'Update WordPress packages', function() {
 		const distTag = grunt.option('dist-tag') || 'latest';
 		grunt.log.writeln( `Updating WordPress packages (--dist-tag=${distTag})` );
-		spawn( 'npx', [ 'wp-scripts', 'packages-update', `--dist-tag=${distTag}` ], {
+		spawn( 'npm', [ 'exec', '--no', '--', 'wp-scripts', 'packages-update', `--dist-tag=${distTag}` ], {
 			cwd: __dirname,
 			stdio: 'inherit',
 		} );
 	} );
 
 	grunt.registerTask( 'browserslist:update', 'Update the local database of browser supports', function() {
-		grunt.log.writeln( `Updating browsers list` );
-		spawn( 'npx', [ 'browserslist@latest', '--update-db' ], {
+		grunt.log.writeln( 'Updating browsers list' );
+		spawn( 'npm', [ 'exec', '--no', '--', 'update-browserslist-db' ], {
 			cwd: __dirname,
 			stdio: 'inherit',
 		} );

--- a/package-lock.json
+++ b/package-lock.json
@@ -150,6 +150,7 @@
 				"source-map-loader": "5.0.0",
 				"terser-webpack-plugin": "5.3.10",
 				"uglify-js": "^3.17.4",
+				"update-browserslist-db": "1.1.1",
 				"uuid": "9.0.1",
 				"wait-on": "8.0.1",
 				"webpack": "5.90.2",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
 		"source-map-loader": "5.0.0",
 		"terser-webpack-plugin": "5.3.10",
 		"uglify-js": "^3.17.4",
+		"update-browserslist-db": "1.1.1",
 		"uuid": "9.0.1",
 		"wait-on": "8.0.1",
 		"webpack": "5.90.2",


### PR DESCRIPTION
Backport of [r63309](https://core.trac.wordpress.org/changeset/63309), already in trunk via #13021, to the `6.7` branch. It replaces the two remaining `npx` calls with `npm exec --no`, which runs an installed binary and fails when the package is missing, and declares `update-browserslist-db` as a direct `devDependency`. That dependency is pinned to `1.1.1`, the version this branch already resolves, rather than trunk's `1.3.1`, so nothing is upgraded.

Trac ticket: https://core.trac.wordpress.org/ticket/65864

## Testing instructions

1. Run `npm ci`.
2. Run `npm exec --no -- wp-scripts`. It prints `Script name is missing.`, the local binary's own output, and downloads nothing.
3. Run `npm exec --no -- update-browserslist-db --version`. It prints `browserslist-lint 1.1.1`.
4. Delete `node_modules/update-browserslist-db`, then run `npm exec --no -- update-browserslist-db`. It fails with `npx canceled due to missing packages and no YES option` instead of fetching the package. Restore the tree with `npm ci`.
5. Run `npm exec --no -- grunt --help`. Both `wp-packages:update` and `browserslist:update` are listed.
6. Run `grep -rn npx Gruntfile.js .github/ package.json`. It returns nothing.

## Use of AI Tools

AI assistance: Yes — Claude Code (Claude Opus 5) applied r63309 to the `6.7` branch and verified the changeset.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
