### PR TITLE
Administration: Prevent PHP 8.1+ deprecation notice in get_admin_page_title()

### DIFF
--- a/src/wp-admin/includes/plugin.php
+++ b/src/wp-admin/includes/plugin.php
@@ -2041,6 +2041,10 @@ function get_admin_page_title() {
 		return $title;
 	}
 
+	if ( ! is_string( $plugin_page ) ) {
+		$plugin_page = '';
+	}
+
 	$hook = get_plugin_page_hook( $plugin_page, $pagenow );
 
 	$parent  = get_admin_page_parent();


### PR DESCRIPTION
## Trac Ticket
https://core.trac.wordpress.org/ticket/59365

## Description

Prevents a PHP 8.1+ deprecation notice when calling `get_admin_page_title()` on admin pages where the global `$plugin_page` is `null` (e.g., Tools, Plugins pages).

### The Problem

When `get_admin_page_title()` is called on admin pages that don't have a `?page` query parameter, the global `$plugin_page` is `null`. This null value flows through the call chain:

```
get_admin_page_title()
  → get_plugin_page_hook($plugin_page, $pagenow)
    → get_plugin_page_hookname($plugin_page, $parent_page)
      → preg_replace('!\\.php!', '', $plugin_page)  // null passed here
```

Since PHP 8.1, `preg_replace()` no longer accepts `null` for its `$subject` parameter, triggering:

> Deprecated: preg_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated

### The Fix

Adds an early type guard in `get_admin_page_title()` to ensure `$plugin_page` is a string before passing it to `get_plugin_page_hook()`. If `$plugin_page` is not a string (e.g., `null`), it is coerced to an empty string `''`.

This preserves existing behavior — the function already handles the case where `$plugin_page` doesn't match any registered menu by falling through to matching by `$pagenow`.

### How to Reproduce

Add the following to any plugin:
```php
add_action( 'admin_init', 'get_admin_page_title' );
```

Then visit any core admin page (e.g., Tools, Plugins) with PHP 8.1+ and `WP_DEBUG` enabled.

### Changes

- Adds a `! is_string( $plugin_page )` type guard in `get_admin_page_title()` before calling `get_plugin_page_hook()`

Props hellofromTonya for the suggested approach.
Fixes #59365.