### PR TITLE
Script Loader: Prevent fatal error in wp_localize_jquery_ui_datepicker() when $wp_locale is null

### DIFF
--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -1998,6 +1998,10 @@ function wp_localize_jquery_ui_datepicker() {
 		return;
 	}
 
+	if ( ! ( $wp_locale instanceof WP_Locale ) ) {
+		return;
+	}
+
 	// Convert the PHP date format into jQuery UI's format.
 	$datepicker_date_format = str_replace(
 		array(


### PR DESCRIPTION
## Trac Ticket
https://core.trac.wordpress.org/ticket/51947

## Description

Prevents a fatal error when `wp_localize_jquery_ui_datepicker()` is called before the global `$wp_locale` has been initialized in `wp-settings.php`.

### The Problem

In `wp-settings.php`, the bootstrap order is:
1. `do_action('setup_theme')` fires (line 705)
2. Locale is loaded and `$wp_locale = new WP_Locale()` is created (line 728)

`WP_Customize_Manager::setup_theme()` hooks into the `setup_theme` action. When it encounters an error (e.g., non-existent changeset UUID, invalid theme), its `wp_die()` wrapper calls `wp_enqueue_scripts()` when a `messenger_channel` is present. This triggers `wp_localize_jquery_ui_datepicker()`, which attempts to access properties on the null `$wp_locale`:

```
array_values( $wp_locale->month )        // TypeError on PHP 8+
$wp_locale->is_rtl()                     // Fatal: Call to member function on null
```

### Security Surface

As noted by @lambagency in [comment:8](https://core.trac.wordpress.org/ticket/51947#comment:8), this is reachable by **unauthenticated front-end requests**. `_wp_customize_include()` instantiates `WP_Customize_Manager` whenever `$_GET['customize_changeset_uuid']` is set, with no capability check at that point. Any anonymous GET request carrying a non-existent UUID plus `customize_messenger_channel` reaches the fatal error path.

### The Fix

Adds an `instanceof WP_Locale` guard in `wp_localize_jquery_ui_datepicker()` to bail out gracefully when `$wp_locale` has not been initialized yet. This is the approach suggested by @dlh in [comment:5](https://core.trac.wordpress.org/ticket/51947#comment:5).

```diff
 function wp_localize_jquery_ui_datepicker() {
     global $wp_locale;

     if ( ! wp_script_is( 'jquery-ui-datepicker', 'enqueued' ) ) {
         return;
     }

+    if ( ! ( $wp_locale instanceof WP_Locale ) ) {
+        return;
+    }
+
     // Convert the PHP date format into jQuery UI's format.
```

### How to Reproduce

1. Add to any plugin: `add_action('wp_enqueue_scripts', function() { wp_enqueue_script('jquery-ui-datepicker'); });`
2. Visit any front-end URL with query parameters: `?customize_changeset_uuid=nonexistent&customize_messenger_channel=test`
3. Observe the fatal error (with `WP_DEBUG` enabled)

### Why `instanceof` instead of `null` check

Using `instanceof WP_Locale` rather than `! $wp_locale` or `null === $wp_locale` ensures the guard is robust against any non-object value that might end up in the global, not just null.

Props dlh for the suggested approach.
Fixes #51947.