### PR TITLE
REST API: Fix object/array schema validation and sanitization for JSON-serialized strings

### DIFF
--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -2280,9 +2280,32 @@ function rest_validate_value_from_schema( $value, $args, $param = '' ) {
 			$is_valid = rest_validate_boolean_value_from_schema( $value, $param );
 			break;
 		case 'object':
+			/*
+			 * A JSON-encoded string (e.g. from a GET query parameter) should be
+			 * decoded before validation, mirroring what parse_json_params() does
+			 * for application/json request bodies.
+			 */
+			if ( is_string( $value ) ) {
+				$decoded = json_decode( $value, true );
+				if ( null !== $decoded && JSON_ERROR_NONE === json_last_error() ) {
+					$value = $decoded;
+				}
+			}
 			$is_valid = rest_validate_object_value_from_schema( $value, $args, $param );
 			break;
 		case 'array':
+			/*
+			 * A JSON-encoded string (e.g. ?ids=[1,2,3]) should be decoded before
+			 * validation. This takes priority over the comma-separated-value
+			 * fallback in rest_is_array() / wp_parse_list(), which cannot
+			 * preserve value types.
+			 */
+			if ( is_string( $value ) && str_starts_with( ltrim( $value ), '[' ) ) {
+				$decoded = json_decode( $value, true );
+				if ( is_array( $decoded ) && JSON_ERROR_NONE === json_last_error() ) {
+					$value = $decoded;
+				}
+			}
 			$is_valid = rest_validate_array_value_from_schema( $value, $args, $param );
 			break;
 		case 'number':
@@ -2870,6 +2893,19 @@ function rest_sanitize_value_from_schema( $value, $args, $param = '' ) {
 	}
 
 	if ( 'array' === $args['type'] ) {
+		/*
+		 * A JSON-encoded string (e.g. ?ids=[1,2,3]) should be decoded before
+		 * sanitization. This takes priority over the comma-separated-value
+		 * fallback in rest_sanitize_array() / wp_parse_list(), which cannot
+		 * preserve value types.
+		 */
+		if ( is_string( $value ) && str_starts_with( ltrim( $value ), '[' ) ) {
+			$decoded = json_decode( $value, true );
+			if ( is_array( $decoded ) && JSON_ERROR_NONE === json_last_error() ) {
+				$value = $decoded;
+			}
+		}
+
 		$value = rest_sanitize_array( $value );
 
 		if ( ! empty( $args['items'] ) ) {
@@ -2887,6 +2923,18 @@ function rest_sanitize_value_from_schema( $value, $args, $param = '' ) {
 	}
 
 	if ( 'object' === $args['type'] ) {
+		/*
+		 * A JSON-encoded string (e.g. from a GET query parameter) should be
+		 * decoded before sanitization, mirroring what parse_json_params() does
+		 * for application/json request bodies.
+		 */
+		if ( is_string( $value ) ) {
+			$decoded = json_decode( $value, true );
+			if ( null !== $decoded && JSON_ERROR_NONE === json_last_error() ) {
+				$value = $decoded;
+			}
+		}
+
 		$value = rest_sanitize_object( $value );
 
 		foreach ( $value as $property => $v ) {

--- a/tests/phpunit/tests/rest-api.php
+++ b/tests/phpunit/tests/rest-api.php
@@ -2785,4 +2785,86 @@ class Tests_REST_API extends WP_UnitTestCase {
 			throw $e; // Re-throw to satisfy expectException
 		}
 	}
+
+	/**
+	 * @ticket 64926
+	 */
+	public function test_validate_json_string_array() {
+		$schema = array(
+			'type'  => 'array',
+			'items' => array( 'type' => 'integer' ),
+		);
+
+		$value    = '[1, 2, 3]';
+		$is_valid = rest_validate_value_from_schema( $value, $schema, 'test_param' );
+
+		$this->assertTrue( $is_valid, 'The JSON array string should be correctly decoded and validated.' );
+	}
+
+	/**
+	 * @ticket 64926
+	 */
+	public function test_validate_json_string_object() {
+		$schema = array(
+			'type'       => 'object',
+			'properties' => array(
+				'id'   => array( 'type' => 'integer' ),
+				'name' => array( 'type' => 'string' ),
+			),
+		);
+
+		$value    = '{"id": 123, "name": "Gemini"}';
+		$is_valid = rest_validate_value_from_schema( $value, $schema, 'test_param' );
+
+		$this->assertTrue( $is_valid, 'The JSON object string should be correctly decoded and validated.' );
+	}
+
+	/**
+	 * @ticket 64926
+	 */
+	public function test_sanitize_json_string_array() {
+		$schema = array(
+			'type'  => 'array',
+			'items' => array( 'type' => 'integer' ),
+		);
+
+		$value     = '[10, "20", 30]';
+		$sanitized = rest_sanitize_value_from_schema( $value, $schema, 'test_param' );
+
+		$this->assertIsArray( $sanitized );
+		$this->assertSame( array( 10, 20, 30 ), $sanitized );
+	}
+
+	/**
+	 * @ticket 64926
+	 */
+	public function test_sanitize_json_string_object() {
+		$schema = array(
+			'type'       => 'object',
+			'properties' => array(
+				'active' => array( 'type' => 'boolean' ),
+			),
+		);
+
+		$value     = '{"active": "true"}';
+		$sanitized = rest_sanitize_value_from_schema( $value, $schema, 'test_param' );
+
+		$this->assertIsArray( $sanitized );
+		$this->assertTrue( $sanitized['active'] );
+	}
+
+	/**
+	 * @ticket 64926
+	 */
+	public function test_validate_invalid_json_falls_back() {
+		$schema = array(
+			'type' => 'array',
+		);
+
+		$value = '1,2,3';
+
+		$is_valid = rest_validate_value_from_schema( $value, $schema, 'test_param' );
+
+		$this->assertNotWPError( $is_valid );
+	}
 }


### PR DESCRIPTION
## Trac Ticket
https://core.trac.wordpress.org/ticket/64926

## Description

This PR fixes an issue where REST API `GET` requests (or any query-string based requests) fail schema validation when parameters defined as `object` or `array` are passed as JSON-encoded strings (e.g. `?filter={"post_id":123}` or `?ids=[1,2,3]`).

### The Problem

When a query string is used, PHP populates `$_GET` parameters as raw strings. 
`rest_validate_value_from_schema()` checks whether the string matches type `object` or `array`, which fails with a `400 Bad Request` (`rest_invalid_type`) before `rest_sanitize_value_from_schema()` has the opportunity to decode it.

While `POST` requests with `Content-Type: application/json` decode parameters early in `WP_REST_Request::parse_json_params()`, query parameters did not have equivalent decoding prior to validation.

### The Fix

1. In `rest_validate_value_from_schema()`:
   - For `case 'object'`: If `$value` is a string, attempt `json_decode()`. If valid JSON, validate the decoded object/array.
   - For `case 'array'`: If `$value` is a string starting with `[`, attempt `json_decode()`. If valid JSON array, validate the decoded array.

2. In `rest_sanitize_value_from_schema()`:
   - Mirror the same JSON decoding step for `array` and `object` types prior to running `rest_sanitize_array()` and `rest_sanitize_object()`.

3. Added unit tests in `tests/phpunit/tests/rest-api.php` covering:
   - JSON array string validation & sanitization
   - JSON object string validation & sanitization
   - Fallback to non-JSON string handling (e.g. comma-separated lists for array schemas)

Fixes #64926.