### PR TITLE
Posts, Post Types: Preserve updated slugs when resurrecting or updating trashed posts

### DIFF
--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -4869,14 +4869,17 @@ function wp_insert_post( $postarr, $wp_error = false, $fire_after_hooks = true )
 
 	/*
 	 * If the post is being untrashed and it has a desired slug stored in post meta,
-	 * reassign it.
+	 * reassign it, unless a new slug was provided during the update.
 	 */
 	if ( 'trash' === $previous_status && 'trash' !== $post_status ) {
 		$desired_post_slug = get_post_meta( $post_id, '_wp_desired_post_slug', true );
 
 		if ( $desired_post_slug ) {
 			delete_post_meta( $post_id, '_wp_desired_post_slug' );
-			$post_name = $desired_post_slug;
+
+			if ( ! $post_before || $post_name === $post_before->post_name ) {
+				$post_name = $desired_post_slug;
+			}
 		}
 	}
 
@@ -4901,6 +4904,9 @@ function wp_insert_post( $postarr, $wp_error = false, $fire_after_hooks = true )
 	// When trashing an existing post, change its slug to allow non-trashed posts to use it.
 	if ( 'trash' === $post_status && 'trash' !== $previous_status && 'new' !== $previous_status ) {
 		$post_name = wp_add_trashed_suffix_to_post_name_for_post( $post_id );
+		// When changing the slug of a trashed post, keep the desired slug in post meta.
+	} elseif ( 'trash' === $post_status && 'trash' === $previous_status && isset( $postarr['post_name'] ) ) {
+		$post_name = wp_add_trashed_suffix_to_post_name_for_post( $post_id, $post_name );
 	}
 
 	$post_name = wp_unique_post_slug( $post_name, $post_id, $post_status, $post_type, $post_parent );
@@ -8607,19 +8613,26 @@ function wp_add_trashed_suffix_to_post_name_for_trashed_posts( $post_name, $post
  *
  * @global wpdb $wpdb WordPress database abstraction object.
  *
- * @param WP_Post $post The post.
+ * @param WP_Post $post      The post.
+ * @param string  $post_name Optional. The desired post slug to preserve while the post remains
+ *                           trashed. Default empty string.
  * @return string New slug for the post.
  */
-function wp_add_trashed_suffix_to_post_name_for_post( $post ) {
+function wp_add_trashed_suffix_to_post_name_for_post( $post, $post_name = '' ) {
 	global $wpdb;
 
 	$post = get_post( $post );
 
-	if ( str_ends_with( $post->post_name, '__trashed' ) ) {
-		return $post->post_name;
+	if ( empty( $post_name ) ) {
+		$post_name = $post->post_name;
 	}
-	add_post_meta( $post->ID, '_wp_desired_post_slug', $post->post_name );
-	$post_name = _truncate_post_slug( $post->post_name, 191 ) . '__trashed';
+
+	if ( str_ends_with( $post_name, '__trashed' ) ) {
+		return $post_name;
+	}
+
+	update_post_meta( $post->ID, '_wp_desired_post_slug', $post_name );
+	$post_name = _truncate_post_slug( $post_name, 191 ) . '__trashed';
 	$wpdb->update( $wpdb->posts, array( 'post_name' => $post_name ), array( 'ID' => $post->ID ) );
 	clean_post_cache( $post->ID );
 	return $post_name;

--- a/tests/phpunit/tests/post/wpInsertPost.php
+++ b/tests/phpunit/tests/post/wpInsertPost.php
@@ -1316,6 +1316,83 @@ class Tests_Post_wpInsertPost extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 44805
+	 */
+	public function test_updating_a_trashed_posts_slug_should_update_the_stored_desired_post_name() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_status' => 'publish',
+				'post_name'   => 'a',
+				'post_title'  => 'A',
+			)
+		);
+
+		wp_trash_post( $post_id );
+		wp_update_post(
+			array(
+				'ID'        => $post_id,
+				'post_name' => 'foo',
+			)
+		);
+
+		$this->assertSame( 'foo__trashed', get_post( $post_id )->post_name );
+		$this->assertSame( 'foo', get_post_meta( $post_id, '_wp_desired_post_slug', true ) );
+	}
+
+	/**
+	 * @ticket 44805
+	 */
+	public function test_publishing_a_trashed_post_should_keep_an_updated_slug() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_status' => 'publish',
+				'post_name'   => 'a',
+				'post_title'  => 'A',
+			)
+		);
+
+		wp_trash_post( $post_id );
+		wp_update_post(
+			array(
+				'ID'        => $post_id,
+				'post_name' => 'foo',
+			)
+		);
+		wp_update_post(
+			array(
+				'ID'          => $post_id,
+				'post_status' => 'publish',
+			)
+		);
+
+		$this->assertSame( 'foo', get_post( $post_id )->post_name );
+	}
+
+	/**
+	 * @ticket 44805
+	 */
+	public function test_publishing_a_trashed_post_with_a_new_slug_in_the_same_update_should_keep_the_new_slug() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_status' => 'publish',
+				'post_name'   => 'a',
+				'post_title'  => 'A',
+			)
+		);
+
+		wp_trash_post( $post_id );
+		wp_update_post(
+			array(
+				'ID'          => $post_id,
+				'post_name'   => 'foo',
+				'post_status' => 'publish',
+			)
+		);
+
+		$this->assertSame( 'foo', get_post( $post_id )->post_name );
+	}
+
+	/**
 	 * @ticket 23022
 	 * @dataProvider data_various_post_statuses
 	 */


### PR DESCRIPTION
## Trac Ticket
https://core.trac.wordpress.org/ticket/44805

## Description

This PR ensures that updating the slug of a trashed post or publishing a trashed post with an updated slug preserves the new slug instead of reverting to the original slug stored when the post was first trashed.

### The Problem

When a post is trashed, `wp_add_trashed_suffix_to_post_name_for_post()` stores the original slug in `_wp_desired_post_slug` post meta and appends `__trashed` to the post name in the database.

However:
1. If a post's slug is updated while it remains in trash, `_wp_desired_post_slug` was not updated to reflect the new desired slug.
2. When the post is untrashed/published, `wp_insert_post()` unconditionally restored `_wp_desired_post_slug`, overwriting any new slug that was provided during the update or while the post was in trash.

### The Fix

1. **In `wp_insert_post()`:** When untrashing a post, only reassign `_wp_desired_post_slug` if no new slug was passed during the update (i.e. `! $post_before || $post_name === $post_before->post_name`).
2. **In `wp_insert_post()`:** When updating a trashed post that remains trashed, update the desired slug meta using `wp_add_trashed_suffix_to_post_name_for_post( $post_id, $post_name )`.
3. **In `wp_add_trashed_suffix_to_post_name_for_post()`:** Added an optional `$post_name` parameter to allow passing the new desired slug and updating `_wp_desired_post_slug` meta via `update_post_meta()`.
4. **Unit Tests:** Added tests in `tests/phpunit/tests/post/wpInsertPost.php` covering:
   - Updating a trashed post's slug updates the stored desired post name.
   - Publishing a trashed post after updating its slug keeps the updated slug.
   - Publishing a trashed post with a new slug in the same update keeps the new slug.

Fixes #44805.