### PR TITLE
I18N: Add missing PHPDoc comments and type declarations to Translation_Entry

### DIFF
--- a/src/wp-includes/pomo/entry.php
+++ b/src/wp-includes/pomo/entry.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Contains Translation_Entry class
+ * Contains Translation_Entry class.
  *
  * @version $Id: entry.php 1157 2015-11-20 04:30:11Z dd32 $
  * @package pomo
@@ -23,32 +23,85 @@ if ( ! class_exists( 'Translation_Entry', false ) ) :
 		 */
 		public $is_plural = false;
 
-		public $context             = null;
-		public $singular            = null;
-		public $plural              = null;
-		public $translations        = array();
-		public $translator_comments = '';
-		public $extracted_comments  = '';
-		public $references          = array();
-		public $flags               = array();
+		/**
+		 * The string to translate.
+		 *
+		 * @var string|null
+		 */
+		public $singular = null;
 
 		/**
-		 * @param array $args {
-		 *     Arguments array, supports the following keys:
+		 * The plural form of the string.
 		 *
-		 *     @type string $singular            The string to translate, if omitted an
-		 *                                       empty entry will be created.
-		 *     @type string $plural              The plural form of the string, setting
-		 *                                       this will set `$is_plural` to true.
-		 *     @type array  $translations        Translations of the string and possibly
-		 *                                       its plural forms.
-		 *     @type string $context             A string differentiating two equal strings
-		 *                                       used in different contexts.
-		 *     @type string $translator_comments Comments left by translators.
-		 *     @type string $extracted_comments  Comments left by developers.
-		 *     @type array  $references          Places in the code this string is used, in
-		 *                                       relative_to_root_path/file.php:linenum form.
-		 *     @type array  $flags               Flags like php-format.
+		 * @var string|null
+		 */
+		public $plural = null;
+
+		/**
+		 * Translations of the string and possibly its plural forms.
+		 *
+		 * Plural forms which have not been filled in are null.
+		 *
+		 * @var (string|null)[]
+		 */
+		public $translations = array();
+
+		/**
+		 * Context of the string, used to differentiate two equal strings used in different contexts.
+		 *
+		 * @var string|null
+		 */
+		public $context = null;
+
+		/**
+		 * Comments left by translators.
+		 *
+		 * @var string
+		 */
+		public $translator_comments = '';
+
+		/**
+		 * Comments left by developers.
+		 *
+		 * @var string
+		 */
+		public $extracted_comments = '';
+
+		/**
+		 * Places in the code this string is used, in relative_to_root_path/file.php:linenum form.
+		 *
+		 * @var string[]
+		 */
+		public $references = array();
+
+		/**
+		 * Flags like php-format.
+		 *
+		 * @var string[]
+		 */
+		public $flags = array();
+
+		/**
+		 * Constructor.
+		 *
+		 * @since 2.8.0
+		 *
+		 * @param array $args {
+		 *     Optional. Array of arguments. Default empty array.
+		 *
+		 *     @type string          $singular            The string to translate, if omitted an
+		 *                                                empty entry will be created.
+		 *     @type string          $plural              The plural form of the string, setting
+		 *                                                this will set `$is_plural` to true.
+		 *     @type (string|null)[] $translations        Translations of the string and possibly
+		 *                                                its plural forms.
+		 *     @type string          $context             A string differentiating two equal strings
+		 *                                                used in different contexts.
+		 *     @type string          $translator_comments Comments left by translators.
+		 *     @type string          $extracted_comments  Comments left by developers.
+		 *     @type string[]        $references          Places in the code this string is used, in
+		 *                                                relative_to_root_path/file.php:linenum form.
+		 *     @type string[]        $flags               Flags like php-format.
 		 * }
 		 */
 		public function __construct( $args = array() ) {
@@ -81,6 +134,8 @@ if ( ! class_exists( 'Translation_Entry', false ) ) :
 		 * @deprecated 5.4.0 Use __construct() instead.
 		 *
 		 * @see Translation_Entry::__construct()
+		 *
+		 * @param array $args Optional. Array of arguments. Default empty array.
 		 */
 		public function Translation_Entry( $args = array() ) {
 			_deprecated_constructor( self::class, '5.4.0', static::class );
@@ -113,6 +168,7 @@ if ( ! class_exists( 'Translation_Entry', false ) ) :
 		 * @since 2.8.0
 		 *
 		 * @param Translation_Entry $other Other translation entry.
+		 * @return void
 		 */
 		public function merge_with( &$other ) {
 			$this->flags      = array_unique( array_merge( $this->flags, $other->flags ) );


### PR DESCRIPTION
## Trac Ticket
https://core.trac.wordpress.org/ticket/65901

## Description

Adds missing PHPDoc blocks and type declarations to the `Translation_Entry` class in `src/wp-includes/pomo/entry.php`.

### Changes

**Property docblocks added** for all previously undocumented properties:
- `$singular` — `string|null`
- `$plural` — `string|null`
- `$translations` — `(string|null)[]`
- `$context` — `string|null`
- `$translator_comments` — `string`
- `$extracted_comments` — `string`
- `$references` — `string[]`
- `$flags` — `string[]`

**Constructor docblock improved:**
- Added `@since 2.8.0` tag
- Added summary line (`Constructor.`)
- Updated parameter description to `Optional. Array of arguments. Default empty array.`
- Updated `@type` annotations with precise types (`string[]` instead of `array`, `(string|null)[]` for translations)

**Other improvements:**
- Added missing `@param` tag to the deprecated PHP4 constructor `Translation_Entry()`
- Added `@return void` to `merge_with()`
- Fixed period at end of file-level docblock description

Fixes #65901.