### PR TITLE
reject traversal in wp_delete_file_from_directory stream paths

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -7905,6 +7905,16 @@ function wp_delete_file_from_directory( $file, $directory ) {
 
 	if ( false !== $real_file ) {
 		$real_file = wp_normalize_path( $real_file );
+
+		/*
+		 * realpath() resolves `..` segments for real filesystem paths, but it does
+		 * not support stream wrappers, so the stream branch above leaves them in
+		 * place. A surviving `..` segment lets the prefix check below pass while the
+		 * wrapper walks back out of $directory on delete, so reject it here.
+		 */
+		if ( preg_match( '#(?:^|/)\.\.(?:/|$)#', $real_file ) ) {
+			return false;
+		}
 	}
 
 	if ( false !== $real_directory ) {

--- a/tests/phpunit/tests/functions/wpDeleteFileFromDirectory.php
+++ b/tests/phpunit/tests/functions/wpDeleteFileFromDirectory.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * Tests for wp_delete_file_from_directory().
+ *
+ * @group functions
+ *
+ * @covers ::wp_delete_file_from_directory
+ */
+class Tests_Functions_WpDeleteFileFromDirectory extends WP_UnitTestCase {
+
+	/**
+	 * Paths passed to the test stream wrapper's unlink() handler.
+	 *
+	 * @var string[]
+	 */
+	public static $unlinked = array();
+
+	public function set_up() {
+		parent::set_up();
+		self::$unlinked = array();
+		stream_wrapper_register( 'wpdeletetest', WpDeleteFileFromDirectory_Stream::class );
+	}
+
+	public function tear_down() {
+		stream_wrapper_unregister( 'wpdeletetest' );
+		parent::tear_down();
+	}
+
+	/**
+	 * A stream-wrapped path inside the directory is deleted.
+	 */
+	public function test_deletes_contained_stream_path() {
+		$directory = 'wpdeletetest://bucket/uploads';
+		$file      = 'wpdeletetest://bucket/uploads/2024/image.jpg';
+
+		$this->assertTrue( wp_delete_file_from_directory( $file, $directory ) );
+		$this->assertSame( array( $file ), self::$unlinked );
+	}
+
+	/**
+	 * A `..` segment must not let a stream-wrapped path escape the directory.
+	 *
+	 * realpath() resolves `..` for real filesystem paths, but is skipped for
+	 * stream wrappers, so the containment check has to reject the traversal
+	 * itself rather than delete a file outside the directory.
+	 */
+	public function test_rejects_stream_path_traversal() {
+		$directory = 'wpdeletetest://bucket/uploads';
+		$file      = 'wpdeletetest://bucket/uploads/../../secret/keys.json';
+
+		$this->assertFalse( wp_delete_file_from_directory( $file, $directory ) );
+		$this->assertSame( array(), self::$unlinked );
+	}
+
+	/**
+	 * A trailing `..` segment is also rejected.
+	 */
+	public function test_rejects_trailing_stream_path_traversal() {
+		$directory = 'wpdeletetest://bucket/uploads';
+		$file      = 'wpdeletetest://bucket/uploads/subdir/..';
+
+		$this->assertFalse( wp_delete_file_from_directory( $file, $directory ) );
+		$this->assertSame( array(), self::$unlinked );
+	}
+
+	/**
+	 * Dots inside a filename are not treated as a traversal.
+	 */
+	public function test_allows_dots_within_stream_filename() {
+		$directory = 'wpdeletetest://bucket/uploads';
+		$file      = 'wpdeletetest://bucket/uploads/my..archive.zip';
+
+		$this->assertTrue( wp_delete_file_from_directory( $file, $directory ) );
+		$this->assertSame( array( $file ), self::$unlinked );
+	}
+}
+
+/**
+ * Minimal stream wrapper that records the paths passed to unlink().
+ */
+class WpDeleteFileFromDirectory_Stream {
+
+	public $context;
+
+	public function unlink( $path ) {
+		Tests_Functions_WpDeleteFileFromDirectory::$unlinked[] = $path;
+		return true;
+	}
+
+	public function url_stat( $path, $flags ) {
+		return array();
+	}
+
+	public function stream_open( $path, $mode, $options, &$opened_path ) {
+		return true;
+	}
+}


### PR DESCRIPTION
`wp_delete_file_from_directory()` resolves paths with `realpath()` before the containment check, but `realpath()` does not support stream wrappers, so the stream branch keeps the path as-is and `wp_normalize_path()` only collapses slashes without resolving `..`. A stream path such as `s3://bucket/uploads/../../secret/keys.json` therefore still passes `str_starts_with()` against the uploads base, and the wrapper walks back out of the directory when the delete runs. On stream-backed uploads (for example an S3 offload plugin where `$uploadpath['basedir']` is `s3://bucket/uploads`), the attachment-meta delete path in `wp_delete_attachment()` reaches this with an attacker-controlled `_wp_attached_file` value.

Reject any `..` path segment on the normalized path before the prefix check. `realpath()` already strips those segments for real files, so this only tightens the stream branch and leaves valid paths unchanged, including filenames that merely contain dots. Keeping the guard in the callee means the several `wp_delete_attachment()` call sites don't each need their own check.

Trac ticket: 

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
