### PR TITLE
Customize: Fix visual/DOM order mismatch of Widgets panel buttons

### DIFF
--- a/src/wp-admin/css/customize-controls.css
+++ b/src/wp-admin/css/customize-controls.css
@@ -2493,12 +2493,18 @@ body.cheatin p {
  * Widgets and Menus common styles
  */
 
+.customize-control-widgets-buttons {
+	display: flex;
+	justify-content: flex-end;
+	align-items: center;
+	gap: 8px;
+}
+
 /* higher specificity than .wp-core-ui .button */
 #customize-theme-controls .add-new-widget,
 #customize-theme-controls .add-new-menu-item {
 	cursor: pointer;
-	float: right;
-	margin: 0 0 0 10px;
+	margin: 0;
 	transition: all 0.2s;
 	-webkit-user-select: none;
 	user-select: none;
@@ -2530,7 +2536,6 @@ body.cheatin p {
 
 /* Reordering */
 .reorder-toggle {
-	float: right;
 	padding: 5px 8px;
 	text-decoration: none;
 	cursor: pointer;

--- a/src/wp-includes/customize/class-wp-widget-area-customize-control.php
+++ b/src/wp-includes/customize/class-wp-widget-area-customize-control.php
@@ -53,13 +53,15 @@ class WP_Widget_Area_Customize_Control extends WP_Customize_Control {
 	public function render_content() {
 		$id = 'reorder-widgets-desc-' . str_replace( array( '[', ']' ), array( '-', '' ), $this->id );
 		?>
-		<button type="button" class="button add-new-widget" aria-expanded="false" aria-controls="available-widgets">
-			<?php _e( 'Add a Widget' ); ?>
-		</button>
-		<button type="button" class="button-link reorder-toggle" aria-label="<?php esc_attr_e( 'Reorder widgets' ); ?>" aria-describedby="<?php echo esc_attr( $id ); ?>">
-			<span class="reorder"><?php _e( 'Reorder' ); ?></span>
-			<span class="reorder-done"><?php _e( 'Done' ); ?></span>
-		</button>
+		<div class="customize-control-widgets-buttons">
+			<button type="button" class="button-link reorder-toggle" aria-label="<?php esc_attr_e( 'Reorder widgets' ); ?>" aria-describedby="<?php echo esc_attr( $id ); ?>">
+				<span class="reorder"><?php _e( 'Reorder' ); ?></span>
+				<span class="reorder-done"><?php _e( 'Done' ); ?></span>
+			</button>
+			<button type="button" class="button add-new-widget" aria-expanded="false" aria-controls="available-widgets">
+				<?php _e( 'Add a Widget' ); ?>
+			</button>
+		</div>
 		<p class="screen-reader-text" id="<?php echo esc_attr( $id ); ?>">
 			<?php
 			/* translators: Hidden accessibility text. */


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

In the Customizer's Widgets panel, the "Add a Widget" and "Reorder" buttons are laid out with CSS floats, so their DOM order (Add, then Reorder) doesn't match their visual order (Reorder, then Add); this breaks keyboard tab order, and the buttons also sit slightly out of vertical alignment.

`WP_Widget_Area_Customize_Control::render_content()` now wraps both buttons in a `.customize-control-widgets-buttons` container and outputs `Reorder` before `Add a Widget`, matching the visual order; a new flex rule in `customize-controls.css` replaces the floats, right-aligning and vertically centering the pair the same way the Menus panel does.

The equivalent Menus buttons have the same float-based mismatch, but that's already covered by a separate ticket and PR, so this change is limited to the Widgets panel.

Trac ticket: https://core.trac.wordpress.org/ticket/65902

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: implementing the CSS/markup fix and verifying the DOM/visual order and button alignment against the running Customizer. All changes were reviewed and validated by me.
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
