### PR TITLE
REST API: Split comma-separated methods given in array form.

### DIFF
--- a/src/wp-includes/rest-api/class-wp-rest-server.php
+++ b/src/wp-includes/rest-api/class-wp-rest-server.php
@@ -1008,7 +1008,15 @@ class WP_REST_Server {
 				if ( is_string( $handler['methods'] ) ) {
 					$methods = explode( ',', $handler['methods'] );
 				} elseif ( is_array( $handler['methods'] ) ) {
-					$methods = $handler['methods'];
+					$methods = array();
+
+					/*
+					 * Array values may themselves be comma-separated, either written that way or
+					 * because they are a multi-method constant such as WP_REST_Server::EDITABLE.
+					 */
+					foreach ( $handler['methods'] as $method ) {
+						$methods = array_merge( $methods, explode( ',', $method ) );
+					}
 				} else {
 					$methods = array();
 				}

--- a/tests/phpunit/tests/rest-api.php
+++ b/tests/phpunit/tests/rest-api.php
@@ -362,6 +362,116 @@ class Tests_REST_API extends WP_UnitTestCase {
 		);
 	}
 
+	/**
+	 * The 'methods' arg should split comma-separated values given inside an array,
+	 * matching how the string form is handled.
+	 *
+	 * @ticket 65905
+	 */
+	public function test_route_method_array_with_comma_separated_values() {
+		register_rest_route(
+			'test-ns',
+			'/test',
+			array(
+				'methods'             => array( 'GET,POST', 'DELETE' ),
+				'callback'            => '__return_null',
+				'permission_callback' => '__return_true',
+			)
+		);
+
+		$routes = $GLOBALS['wp_rest_server']->get_routes();
+
+		$this->assertSame(
+			array(
+				'GET'    => true,
+				'POST'   => true,
+				'DELETE' => true,
+			),
+			$routes['/test-ns/test'][0]['methods']
+		);
+	}
+
+	/**
+	 * A multi-method constant inside an array should register each of its methods.
+	 *
+	 * WP_REST_Server::EDITABLE is 'POST, PUT, PATCH'. Before #65905 the array form did not
+	 * split it, registering the single unmatchable key 'POST, PUT, PATCH'.
+	 *
+	 * @ticket 65905
+	 */
+	public function test_route_method_array_with_multi_method_constant() {
+		register_rest_route(
+			'test-ns',
+			'/test',
+			array(
+				'methods'             => array( WP_REST_Server::READABLE, WP_REST_Server::EDITABLE ),
+				'callback'            => '__return_null',
+				'permission_callback' => '__return_true',
+			)
+		);
+
+		$routes = $GLOBALS['wp_rest_server']->get_routes();
+
+		$this->assertSame(
+			array(
+				'GET'   => true,
+				'POST'  => true,
+				'PUT'   => true,
+				'PATCH' => true,
+			),
+			$routes['/test-ns/test'][0]['methods']
+		);
+	}
+
+	/**
+	 * Each method of a multi-method constant given in an array should route.
+	 *
+	 * The registered keys are asserted above; this covers the behavior a plugin author
+	 * actually observes, which was a 404.
+	 *
+	 * @ticket 65905
+	 */
+	public function test_route_method_array_with_multi_method_constant_dispatches() {
+		register_rest_route(
+			'test-ns',
+			'/test',
+			array(
+				'methods'             => array( WP_REST_Server::READABLE, WP_REST_Server::EDITABLE ),
+				'callback'            => static function () {
+					return new WP_REST_Response( 'ok', 200 );
+				},
+				'permission_callback' => '__return_true',
+			)
+		);
+
+		foreach ( array( 'GET', 'POST', 'PUT', 'PATCH' ) as $method ) {
+			$response = rest_get_server()->dispatch( new WP_REST_Request( $method, '/test-ns/test' ) );
+
+			$this->assertSame( 200, $response->get_status(), "$method should route to the handler." );
+		}
+	}
+
+	/**
+	 * An empty 'methods' array should register no methods rather than an empty one.
+	 *
+	 * @ticket 65905
+	 */
+	public function test_route_method_empty_array() {
+		register_rest_route(
+			'test-ns',
+			'/test',
+			array(
+				'methods'             => array(),
+				'callback'            => '__return_null',
+				'permission_callback' => '__return_true',
+			)
+		);
+
+		$routes = $GLOBALS['wp_rest_server']->get_routes();
+
+		$this->assertSame( array(), $routes['/test-ns/test'][0]['methods'] );
+	}
+
 	public function test_options_request() {
 		register_rest_route(
 			'test-ns',


### PR DESCRIPTION
✅ Committed in r63756 (cef8ae398dec880f84571c5b660c443b88d75d92).

----
Trac ticket: https://core.trac.wordpress.org/ticket/65905

## Problem

`WP_REST_Server::register_route()` accepts `methods` as a string or an array, but only the string form is split on commas. Any array element containing a comma becomes a single unmatchable method key.

```php
register_rest_route( 'ns/v1', '/thing', array(
	'methods'             => array( WP_REST_Server::READABLE, WP_REST_Server::EDITABLE ),
	'callback'            => '__return_true',
	'permission_callback' => '__return_true',
) );
```

registers the keys `'GET'` and `'POST, PUT, PATCH'`. `GET` works; `POST`, `PUT` and `PATCH` all 404. The same route written as the string `'GET, POST, PUT, PATCH'` works. Nothing warns at registration time.

Dates to the array support added in 4.4.

## Fix

Split the array branch as well, merging each element's comma-separated parts.

A comma is a delimiter in the RFC 9110 `token` grammar, so no valid HTTP method name can contain one. Splitting can therefore only turn a permanently-dead method key into working ones — there is no case where the current behavior is the desired one.

The loop is deliberate rather than `explode( ',', implode( ',', $handler['methods'] ) )`: imploding an empty array yields `''`, which would register an empty-string method key. `test_route_method_empty_array()` guards that.

## Tests

Four tests added to the existing `test_route_method_*` group, which covered an array of methods and a comma-separated string but not their intersection:

| Test | On trunk |
|---|---|
| `test_route_method_array_with_comma_separated_values` | fails |
| `test_route_method_array_with_multi_method_constant` | fails |
| `test_route_method_array_with_multi_method_constant_dispatches` | fails (404 instead of 200) |
| `test_route_method_empty_array` | passes — regression guard |

`--group restapi`: 3554 tests / 16246 assertions, no new failures against a 3550 / 16239 baseline (identical pre-existing error and warning profile).

## Impact

A plugin-directory regex sweep found 4 occurrences across 3 plugins — all `array( CREATABLE, EDITABLE )` or the reverse, where `POST` works and the intended `PUT`/`PATCH` silently 404:

| Plugin | Occurrences | Active installs | Downloads |
|---|---|---|---|
| [WPChat](https://wordpress.org/plugins/smashballoon-wpchat-livechat-customer-support/) | 2 | 5,000 | 24,446 |
| [LinkGreen Product Import](https://wordpress.org/plugins/linkgreen-product-import/) | 1 | — | 1,018 |
| [Hero AI Blogger](https://wordpress.org/plugins/solvex-ai-blogger/) | 1 | — | 215 |

The latter two report no active-install count on WordPress.org. The array form itself is common (921 plugins), but only 87 of 7,024 array-form `methods` lines name a `WP_REST_Server::` constant at all, which is why the bug has stayed quiet.

The larger reason to fix it is forward-looking. This was found while measuring what would happen if a method constant gained a second method — as it would if `QUERY` ([RFC 10008](https://www.rfc-editor.org/rfc/rfc10008.html)) were added to `READABLE` or `ALLMETHODS`. Every array-form registration naming that constant would break at once, with no error. Landing this removes that constraint before the question comes up.

## Back-compat considerations

Routes affected by this bug currently 404 for the methods that were not split out, so in the common case this change only revives requests that were already failing.

One client-visible difference: the `methods` array such a route advertises in the REST index changes from e.g. `["POST, PUT, PATCH", "POST"]` to `["POST", "PUT", "PATCH"]`, since `WP_REST_Server::get_data_for_route()` reports `array_keys()` of the same map.

There is one further effect in principle. `WP_REST_Server::match_request_to_handler()` dispatches to the *first* handler on a route whose `methods` map contains the request method. Because this change makes handlers match that previously could not, a route registered with multiple handlers — where an earlier one used the array form with a multi-method constant, and a later one covers a method that earlier handler now claims — would dispatch to the earlier handler instead, changing which `callback` *and* `permission_callback` run.

That combination does not occur in the directories. Each of the three plugins above registers the affected form as the only handler covering those methods. The sweep also found no theme using the array form with a multi-method constant, and no registration anywhere using a literal comma inside an array element, e.g. `array( 'GET,POST' )`. The case is noted for completeness, and because the sweep covers the WordPress.org directories only — premium and custom plugins are out of scope, as is any `'methods' => $var` assembled dynamically.

## Static analysis typing

When analyzing PHPUnit tests, PHPStan found static typing issues with the `WP_REST_Server::get_routes()` method. It was documented as returning a bare `array`, so every caller saw `mixed` from the first offset onward — including the tests added here, which assert on `$routes['/test-ns/test'][0]['methods']`. The route map is now described to PHPStan:

- Two `@phpstan-type` aliases on the class, `Route_Handler` and `Endpoint_Arg`, describing a handler as `get_routes()` returns it, once the defaults are filled in and the methods normalized. Both shapes are left open (`...`), since the `rest_endpoints` filter and `register_route()` callers may add their own keys. `methods` is `array<uppercase-string, true>`, matching the `strtoupper( trim( … ) )` the loop applies.
- An endpoint argument is a JSON Schema fragment, so `Endpoint_Arg` names only the five keys WordPress reads itself — `required`, `default`, `type`, `validate_callback` and `sanitize_callback` — and leaves the rest of the vocabulary from `rest_get_allowed_schema_keywords()` to the open end of the shape.
- The three properties the map is built from — `$endpoints`, `$route_options` and `$namespaces` — are typed, along with `@phpstan-param non-empty-string $route` on `register_route()`, which the route keys require.
- A `@phpstan-param` on the `rest_endpoints` docblock, which this repository's `ApplyFiltersDynamicFunctionReturnTypeExtension` reads to type the filter's return value.

The long description and `@return` of `get_routes()` are corrected at the same time. They described the value as `array( $callback, $bitmask )`, which has never been accurate — there is no bitmask, the value is a list of handler arrays, and the route options are moved out to `get_route_options()`. The `rest_endpoints` docblock repeated the same wrong format, and now states that the endpoints it passes are the ones as registered, before normalization.

PHPStan level 10 errors in `class-wp-rest-server.php` drop from 166 to 141, with none introduced. `phpstan.neon.dist` (level 5) reports no errors project-wide.

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: See the per-commit breakdown below. Each commit records its own authorship; those written with AI assistance carry a `Co-Authored-By: Claude Opus 5` trailer.

| Commit | Author | AI assistance |
|---|---|---|
| e6a44f7242 — the fix and its four tests | @moonmeister | Yes |
| 95776564ac — guard against exploding non-strings | @westonruter | No |
| 18043d350b — use explicit globals for static analysis | @westonruter | No |
| 9a43a91b3c — document the route map shape | @westonruter | Yes |
| dec9b6478c — docblock placement and `callback` key | @westonruter | Yes |

The changes in dec9b6478c were prompted by an AI code review of the branch, and the plugin and theme directory sweep reported under Impact and Back-compat considerations was carried out with AI tooling. The Impact, Back-compat considerations and Static analysis typing sections of this description were drafted with AI assistance.

All AI output has been reviewed by the committing authors, who take responsibility for it.


