### PR TITLE
Build/Test Tools: Match raw PR body when closing PRs for fixed Trac tickets

### DIFF
--- a/.github/workflows/reusable-cleanup-pull-requests.yml
+++ b/.github/workflows/reusable-cleanup-pull-requests.yml
@@ -66,23 +66,31 @@ jobs:
                     nodes {
                       ... on PullRequest {
                         number
-                        bodyText
+                        body
                       }
                     }
                   }
                 }
               `;
 
-              const searchQuery = `repo:${context.repo.owner}/${context.repo.repo} is:pr is:open ( "${tracTicketUrl}" OR "${corePrefix}" )`;
+              // The PR template only asks for "a link to the WordPress Trac ticket", so some
+              // PRs reference it as a Markdown link with just the ticket number as the link
+              // text (e.g. "Trac ticket: [65864](https://core.trac.wordpress.org/ticket/65864)").
+              // GitHub's search index doesn't cover Markdown link targets, only the rendered
+              // text, so the bare ticket number is searched for too to surface those PRs.
+              const searchQuery = `repo:${context.repo.owner}/${context.repo.repo} is:pr is:open ( "${tracTicketUrl}" OR "${corePrefix}" OR "${ticket}" )`;
 
               const result = await github.graphql(query, {
                 searchQuery,
               });
 
-              // Since search queries will match anywhere for any activity on a pull request, the body specifically needs to be manually checked.
+              // Since search queries will match anywhere for any activity on a pull request, the body
+              // specifically needs to be manually checked. The raw `body` (rather than `bodyText`) is used
+              // here because `bodyText` strips Markdown links down to just their visible text, which would
+              // drop the Trac ticket URL entirely for PRs that link the ticket via its number.
               const matchingPRs = result.search.nodes
                 .filter(pr => {
-                  const bodyLower = pr.bodyText.toLowerCase();
+                  const bodyLower = pr.body.toLowerCase();
 
                   return bodyLower.includes(tracTicketUrl.toLowerCase()) || bodyLower.includes(corePrefix.toLowerCase());
               }).map(pr => pr.number);


### PR DESCRIPTION
The `reusable-cleanup-pull-requests.yml` workflow closes open PRs that reference a Trac ticket noted as fixed in a commit message. It does this by searching GitHub for PRs whose body contains either the full Trac ticket URL or a `core-<id>` string, then double-checks the match against the PR's body text before closing it.

Both the search and the double-check miss PRs that reference the ticket as a Markdown link with just the ticket number as the link text (e.g. `Trac ticket: [65864](https://core.trac.wordpress.org/ticket/65864)`), which the PR template's own wording ("a link to the WordPress Trac ticket") doesn't rule out. GitHub's search index only covers a PR's rendered/visible text, not Markdown link targets, so the URL search term never matches this style. The double-check filter had the same problem in a second way: it read the `bodyText` field, which strips Markdown links down to their visible text and drops the URL entirely, so even a PR that *did* surface via search would fail the manual re-check.

This fixes both:
- Adds the bare ticket number as a third alternative search term, since GitHub's index does cover the plain ticket number when it's the visible text of a link.
- Switches the manual re-check from `bodyText` to the raw `body` field, which retains the literal URL even inside a Markdown link, so the widened search doesn't introduce false positives from unrelated PRs that merely mention the same number.

Verified against the real GitHub GraphQL API using ticket #65864 (the ticket cited in the bug report) — the current search misses PR #13021 (Markdown-link style), and the widened query surfaces it. Also unit-verified the body-matching logic in isolation against a plain-URL body, a Markdown-link body, a `core-<id>` body, and a deliberately unrelated body that just happens to mention the same number — the fix matches the first three and correctly rejects the last. `actionlint` and `zizmor` both pass clean on the modified file.

Trac ticket: https://core.trac.wordpress.org/ticket/65892

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Sonnet 5
Used for: Root-cause investigation (via GitHub's GraphQL API), implementation, and PR description. Reviewed by Igor Rozum.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
