### PR TITLE
Taxonomy: Prevent overlong term slugs in wp_unique_term_slug()

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -2401,6 +2401,34 @@ function sanitize_title_with_dashes( $title, $raw_title = '', $context = 'displa
 }
 
 /**
+ * Truncates a slug to a given length.
+ *
+ * Non-ASCII slugs are stored percent-encoded, so the slug is truncated on a
+ * character boundary to avoid cutting a percent-encoded sequence in half.
+ *
+ * @since 7.2.0
+ * @access private
+ *
+ * @see utf8_uri_encode()
+ *
+ * @param string $slug   The slug to truncate.
+ * @param int    $length Optional. Max length of the slug. Default 200 (characters).
+ * @return string The truncated slug.
+ */
+function _truncate_slug( $slug, $length = 200 ) {
+	if ( strlen( $slug ) > $length ) {
+		$decoded_slug = urldecode( $slug );
+		if ( $decoded_slug === $slug ) {
+			$slug = substr( $slug, 0, $length );
+		} else {
+			$slug = utf8_uri_encode( $decoded_slug, $length, true );
+		}
+	}
+
+	return rtrim( $slug, '-' );
+}
+
+/**
  * Ensures a string is a valid SQL 'order by' clause.
  *
  * Accepts one or more columns, with or without a sort order (ASC / DESC).

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -5614,7 +5614,7 @@ function wp_unique_post_slug( $slug, $post_id, $post_status, $post_type, $post_p
 		) {
 			$suffix = 2;
 			do {
-				$alt_post_name   = _truncate_post_slug( $slug, 200 - ( strlen( $suffix ) + 1 ) ) . "-$suffix";
+				$alt_post_name   = _truncate_slug( $slug, 200 - ( strlen( $suffix ) + 1 ) ) . "-$suffix";
 				$post_name_check = $wpdb->get_var( $wpdb->prepare( $check_sql, $alt_post_name, $post_id ) );
 				++$suffix;
 			} while ( $post_name_check );
@@ -5651,7 +5651,7 @@ function wp_unique_post_slug( $slug, $post_id, $post_status, $post_type, $post_p
 		) {
 			$suffix = 2;
 			do {
-				$alt_post_name   = _truncate_post_slug( $slug, 200 - ( strlen( $suffix ) + 1 ) ) . "-$suffix";
+				$alt_post_name   = _truncate_slug( $slug, 200 - ( strlen( $suffix ) + 1 ) ) . "-$suffix";
 				$post_name_check = $wpdb->get_var( $wpdb->prepare( $check_sql, $alt_post_name, $post_type, $post_id, $post_parent ) );
 				++$suffix;
 			} while ( $post_name_check );
@@ -5707,7 +5707,7 @@ function wp_unique_post_slug( $slug, $post_id, $post_status, $post_type, $post_p
 		) {
 			$suffix = 2;
 			do {
-				$alt_post_name   = _truncate_post_slug( $slug, 200 - ( strlen( $suffix ) + 1 ) ) . "-$suffix";
+				$alt_post_name   = _truncate_slug( $slug, 200 - ( strlen( $suffix ) + 1 ) ) . "-$suffix";
 				$post_name_check = $wpdb->get_var( $wpdb->prepare( $check_sql, $alt_post_name, $post_type, $post_id ) );
 				++$suffix;
 			} while ( $post_name_check );
@@ -5734,25 +5734,17 @@ function wp_unique_post_slug( $slug, $post_id, $post_status, $post_type, $post_p
  * Truncates a post slug.
  *
  * @since 3.6.0
+ * @since 7.2.0 Now an alias of _truncate_slug(), which is not post specific.
  * @access private
  *
- * @see utf8_uri_encode()
+ * @see _truncate_slug()
  *
  * @param string $slug   The slug to truncate.
  * @param int    $length Optional. Max length of the slug. Default 200 (characters).
  * @return string The truncated slug.
  */
 function _truncate_post_slug( $slug, $length = 200 ) {
-	if ( strlen( $slug ) > $length ) {
-		$decoded_slug = urldecode( $slug );
-		if ( $decoded_slug === $slug ) {
-			$slug = substr( $slug, 0, $length );
-		} else {
-			$slug = utf8_uri_encode( $decoded_slug, $length, true );
-		}
-	}
-
-	return rtrim( $slug, '-' );
+	return _truncate_slug( $slug, $length );
 }
 
 /**
@@ -8619,7 +8611,7 @@ function wp_add_trashed_suffix_to_post_name_for_post( $post ) {
 		return $post->post_name;
 	}
 	add_post_meta( $post->ID, '_wp_desired_post_slug', $post->post_name );
-	$post_name = _truncate_post_slug( $post->post_name, 191 ) . '__trashed';
+	$post_name = _truncate_slug( $post->post_name, 191 ) . '__trashed';
 	$wpdb->update( $wpdb->posts, array( 'post_name' => $post_name ), array( 'ID' => $post->ID ) );
 	clean_post_cache( $post->ID );
 	return $post_name;

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -3123,9 +3123,15 @@ function wp_remove_object_terms( $object_id, $terms, $taxonomy ) {
  * If that still doesn't return a unique slug, then it tries to append a number
  * until it finds a number that is truly unique.
  *
+ * Appending a parent slug or a number can push the result past the 200 character
+ * limit of the `slug` column in the terms table, so the slug is truncated to make
+ * room for whatever is appended to it.
+ *
  * The only purpose for `$term` is for appending a parent, if one exists.
  *
  * @since 2.3.0
+ * @since 7.2.0 The returned slug is truncated to 200 characters when a parent slug
+ *              or a numeric suffix is appended to it.
  *
  * @global wpdb $wpdb WordPress database abstraction object.
  *
@@ -3181,7 +3187,7 @@ function wp_unique_term_slug( $slug, $term ) {
 	 */
 	if ( apply_filters( 'wp_unique_term_slug_is_bad_slug', $needs_suffix, $slug, $term ) ) {
 		if ( $parent_suffix ) {
-			$slug .= $parent_suffix;
+			$slug = _truncate_slug( $slug . $parent_suffix, 200 );
 		}
 
 		if ( ! empty( $term->term_id ) ) {
@@ -3193,7 +3199,9 @@ function wp_unique_term_slug( $slug, $term ) {
 		if ( $wpdb->get_var( $query ) ) { // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 			$num = 2;
 			do {
-				$alt_slug = $slug . "-$num";
+				// Reserve room for the suffix so the result still fits the 200 character column.
+				$numeric_suffix = "-$num";
+				$alt_slug       = _truncate_slug( $slug, 200 - strlen( $numeric_suffix ) ) . $numeric_suffix;
 				++$num;
 				$slug_check = $wpdb->get_var( $wpdb->prepare( "SELECT slug FROM $wpdb->terms WHERE slug = %s", $alt_slug ) );
 			} while ( $slug_check );

--- a/src/wp-includes/theme-templates.php
+++ b/src/wp-includes/theme-templates.php
@@ -87,7 +87,7 @@ function wp_filter_wp_template_unique_post_slug( $override_slug, $slug, $post_id
 		$suffix = 2;
 		do {
 			$query_args                  = $check_query_args;
-			$alt_post_name               = _truncate_post_slug( $override_slug, 200 - ( strlen( $suffix ) + 1 ) ) . "-$suffix";
+			$alt_post_name               = _truncate_slug( $override_slug, 200 - ( strlen( $suffix ) + 1 ) ) . "-$suffix";
 			$query_args['post_name__in'] = array( $alt_post_name );
 			$query                       = new WP_Query( $query_args );
 			++$suffix;

--- a/tests/phpunit/tests/formatting/truncateSlug.php
+++ b/tests/phpunit/tests/formatting/truncateSlug.php
@@ -1,0 +1,105 @@
+<?php
+
+/**
+ * @group formatting
+ *
+ * @covers ::_truncate_slug
+ */
+class Tests_Formatting_TruncateSlug extends WP_UnitTestCase {
+
+	/**
+	 * Tests that _truncate_slug() correctly truncates slugs.
+	 *
+	 * @ticket 56868
+	 *
+	 * @dataProvider data_truncate_slug_should_truncate
+	 *
+	 * @param string $slug     The slug to truncate.
+	 * @param int    $length   Max length of the slug.
+	 * @param string $expected The expected truncated slug.
+	 * @param string $message  Test feedback message.
+	 */
+	public function test_truncate_slug_should_truncate( $slug, $length, $expected, $message ) {
+		$this->assertSame( $expected, _truncate_slug( $slug, $length ), $message );
+	}
+
+	/**
+	 * Data provider for test_truncate_slug_should_truncate().
+	 *
+	 * @return array[]
+	 */
+	public function data_truncate_slug_should_truncate() {
+		return array(
+			'a slug that is too long'                      => array(
+				'slug'     => 'truncated slug',
+				'length'   => 9,
+				'expected' => 'truncated',
+				'message'  => '"truncated slug" should have been truncated to "truncated".',
+			),
+			'a slug that is too long and ends with a dash' => array(
+				'slug'     => 'truncated-slug',
+				'length'   => 10,
+				'expected' => 'truncated',
+				'message'  => '"truncated-slug" should have been truncated to "truncated".',
+			),
+
+			// URL-encoded characters.
+			'URL-encoded characters and "length" includes the first URL-encoded character' => array(
+				'slug'     => 'myslug%2F',
+				'length'   => 7,
+				'expected' => 'myslug',
+				'message'  => '"myslug%2F" should have been truncated to "myslug".',
+			),
+			'URL-encoded characters and "length" includes the second URL-encoded character' => array(
+				'slug'     => 'myslug%2F',
+				'length'   => 8,
+				'expected' => 'myslug',
+				'message'  => '"myslug%2F" should have been truncated to "myslug".',
+			),
+			'URL-encoded characters and "length" includes the third URL-encoded character' => array(
+				'slug'     => 'myslug%2F',
+				'length'   => 9,
+				'expected' => 'myslug%2F',
+				'message'  => '"myslug%2F" should have been truncated to "myslug%2F".',
+			),
+
+			// URL-encoded accent characters.
+			'URL-encoded accent characters and "length" includes the first URL-encoded character' => array(
+				'slug'     => 'myslug%C4%85',
+				'length'   => 7,
+				'expected' => 'myslug',
+				'message'  => '"myslug%C4%85" should have been truncated to "myslug".',
+			),
+			'URL-encoded accent characters and "length" includes the second URL-encoded character' => array(
+				'slug'     => 'myslug%C4%85',
+				'length'   => 8,
+				'expected' => 'myslug',
+				'message'  => '"myslug%C4%85" should have been truncated to "myslug".',
+			),
+			'URL-encoded accent characters and "length" includes the third URL-encoded character' => array(
+				'slug'     => 'myslug%C4%85',
+				'length'   => 9,
+				'expected' => 'myslug',
+				'message'  => '"myslug%C4%85" should have been truncated to "myslug".',
+			),
+			'URL-encoded accent characters and "length" includes the fourth URL-encoded character' => array(
+				'slug'     => 'myslug%C4%85',
+				'length'   => 10,
+				'expected' => 'myslug',
+				'message'  => '"myslug%C4%85" should have been truncated to "myslug".',
+			),
+			'URL-encoded accent characters and "length" includes the fifth URL-encoded character' => array(
+				'slug'     => 'myslug%C4%85',
+				'length'   => 11,
+				'expected' => 'myslug',
+				'message'  => '"myslug%C4%85" should have been truncated to "myslug".',
+			),
+			'URL-encoded accent characters and "length" includes the sixth URL-encoded character' => array(
+				'slug'     => 'myslug%C4%85',
+				'length'   => 12,
+				'expected' => 'myslug%C4%85',
+				'message'  => '"myslug%C4%85" should have been truncated to "myslug%C4%85".',
+			),
+		);
+	}
+}

--- a/tests/phpunit/tests/post/truncatePostSlug.php
+++ b/tests/phpunit/tests/post/truncatePostSlug.php
@@ -8,98 +8,14 @@
 class Tests_Post_TruncatePostSlug extends WP_UnitTestCase {
 
 	/**
-	 * Tests that _truncate_post_slug() correctly truncates slugs.
+	 * _truncate_post_slug() is retained as an alias of _truncate_slug().
 	 *
-	 * @ticket 56868
-	 *
-	 * @dataProvider data_truncate_post_slug_should_truncate
-	 *
-	 * @param string $slug     The slug to truncate.
-	 * @param int    $length   Max length of the slug.
-	 * @param string $expected The expected truncated slug.
-	 * @param string $message  Test feedback message.
+	 * @ticket 46010
 	 */
-	public function test_truncate_post_slug_should_truncate( $slug, $length, $expected, $message ) {
-		$this->assertSame( $expected, _truncate_post_slug( $slug, $length ), $message );
-	}
+	public function test_truncate_post_slug_should_be_an_alias_of_truncate_slug() {
+		$slug = 'myslug%C4%85';
 
-	/**
-	 * Data provider for test_truncate_post_slug_should_truncate().
-	 *
-	 * @return array[]
-	 */
-	public function data_truncate_post_slug_should_truncate() {
-		return array(
-			'a slug that is too long'                      => array(
-				'slug'     => 'truncated slug',
-				'length'   => 9,
-				'expected' => 'truncated',
-				'message'  => '"truncated slug" should have been truncated to "truncated".',
-			),
-			'a slug that is too long and ends with a dash' => array(
-				'slug'     => 'truncated-slug',
-				'length'   => 10,
-				'expected' => 'truncated',
-				'message'  => '"truncated-slug" should have been truncated to "truncated".',
-			),
-
-			// URL-encoded characters.
-			'URL-encoded characters and "length" includes the first URL-encoded character' => array(
-				'slug'     => 'myslug%2F',
-				'length'   => 7,
-				'expected' => 'myslug',
-				'message'  => '"myslug%2F" should have been truncated to "myslug".',
-			),
-			'URL-encoded characters and "length" includes the second URL-encoded character' => array(
-				'slug'     => 'myslug%2F',
-				'length'   => 8,
-				'expected' => 'myslug',
-				'message'  => '"myslug%2F" should have been truncated to "myslug".',
-			),
-			'URL-encoded characters and "length" includes the third URL-encoded character' => array(
-				'slug'     => 'myslug%2F',
-				'length'   => 9,
-				'expected' => 'myslug%2F',
-				'message'  => '"myslug%2F" should have been truncated to "myslug%2F".',
-			),
-
-			// URL-encoded accent characters.
-			'URL-encoded accent characters and "length" includes the first URL-encoded character' => array(
-				'slug'     => 'myslug%C4%85',
-				'length'   => 7,
-				'expected' => 'myslug',
-				'message'  => '"myslug%C4%85" should have been truncated to "myslug".',
-			),
-			'URL-encoded accent characters and "length" includes the second URL-encoded character' => array(
-				'slug'     => 'myslug%C4%85',
-				'length'   => 8,
-				'expected' => 'myslug',
-				'message'  => '"myslug%C4%85" should have been truncated to "myslug".',
-			),
-			'URL-encoded accent characters and "length" includes the third URL-encoded character' => array(
-				'slug'     => 'myslug%C4%85',
-				'length'   => 9,
-				'expected' => 'myslug',
-				'message'  => '"myslug%C4%85" should have been truncated to "myslug".',
-			),
-			'URL-encoded accent characters and "length" includes the fourth URL-encoded character' => array(
-				'slug'     => 'myslug%C4%85',
-				'length'   => 10,
-				'expected' => 'myslug',
-				'message'  => '"myslug%C4%85" should have been truncated to "myslug".',
-			),
-			'URL-encoded accent characters and "length" includes the fifth URL-encoded character' => array(
-				'slug'     => 'myslug%C4%85',
-				'length'   => 11,
-				'expected' => 'myslug',
-				'message'  => '"myslug%C4%85" should have been truncated to "myslug".',
-			),
-			'URL-encoded accent characters and "length" includes the sixth URL-encoded character' => array(
-				'slug'     => 'myslug%C4%85',
-				'length'   => 12,
-				'expected' => 'myslug%C4%85',
-				'message'  => '"myslug%C4%85" should have been truncated to "myslug%C4%85".',
-			),
-		);
+		$this->assertSame( _truncate_slug( $slug, 9 ), _truncate_post_slug( $slug, 9 ) );
+		$this->assertSame( _truncate_slug( $slug ), _truncate_post_slug( $slug ) );
 	}
 }

--- a/tests/phpunit/tests/term/wpInsertTerm.php
+++ b/tests/phpunit/tests/term/wpInsertTerm.php
@@ -907,6 +907,52 @@ class Tests_Term_WpInsertTerm extends WP_UnitTestCase {
 		$this->assertSame( 'invalid_term_name', $term->get_error_code() );
 	}
 
+	/**
+	 * Non-ASCII slugs are stored percent-encoded, so a short term name can still
+	 * overflow the 200 character `slug` column once a parent slug is appended.
+	 *
+	 * @ticket 46010
+	 */
+	public function test_child_term_with_long_encoded_slug_should_be_inserted() {
+		$taxonomy = 'wptests_tax';
+		register_taxonomy( $taxonomy, 'post', array( 'hierarchical' => true ) );
+
+		$name = 'Категория на продукта';
+
+		$parent = wp_insert_term( $name, $taxonomy );
+		$this->assertNotWPError( $parent );
+
+		$child = wp_insert_term( $name, $taxonomy, array( 'parent' => $parent['term_id'] ) );
+
+		$this->assertNotWPError( $child, 'The child term could not be inserted.' );
+		$this->assertLessThanOrEqual( 200, strlen( get_term( $child['term_id'] )->slug ) );
+	}
+
+	/**
+	 * @ticket 46010
+	 */
+	public function test_terms_with_long_colliding_slugs_should_remain_unique() {
+		$taxonomy = 'wptests_tax';
+		register_taxonomy( $taxonomy, 'post' );
+
+		// 22 characters percent-encode to exactly 198 bytes, so every name below shares a slug.
+		$prefix = str_repeat( 'あ', 22 );
+
+		$slugs = array();
+		for ( $i = 1; $i <= 12; $i++ ) {
+			$term = wp_insert_term( $prefix . ' ' . str_repeat( 'か', $i ), $taxonomy );
+
+			$this->assertNotWPError( $term, "Term $i could not be inserted." );
+
+			$slug = get_term( $term['term_id'] )->slug;
+			$this->assertLessThanOrEqual( 200, strlen( $slug ), "Term $i has an overlong slug." );
+
+			$slugs[] = $slug;
+		}
+
+		$this->assertSame( $slugs, array_unique( $slugs ), 'Duplicate slugs were created.' );
+	}
+
 	/** Helpers */
 
 	public function deleted_term_cb( $term, $tt_id, $taxonomy, $deleted_term, $object_ids ) {

--- a/tests/phpunit/tests/term/wpUniqueTermSlug.php
+++ b/tests/phpunit/tests/term/wpUniqueTermSlug.php
@@ -172,4 +172,111 @@ class Tests_Term_WpUniqueTermSlug extends WP_UnitTestCase {
 
 		$this->assertSame( 'dog-animal-2', $slug );
 	}
+
+	/**
+	 * The `slug` column in the terms table holds 200 characters.
+	 *
+	 * @ticket 46010
+	 */
+	public function test_parent_suffixed_slug_should_be_truncated_to_the_column_length() {
+		// This name percent-encodes to a 116 character slug, so appending it to itself overflows.
+		$name = 'Категория на продукта';
+		$slug = sanitize_title( $name );
+
+		$parent = self::factory()->term->create(
+			array(
+				'taxonomy' => 'wptests_tax2',
+				'name'     => $name,
+				'slug'     => $slug,
+			)
+		);
+
+		$child = self::factory()->term->create_and_get(
+			array(
+				'taxonomy' => 'wptests_tax2',
+				'name'     => 'Child',
+				'slug'     => 'child',
+				'parent'   => $parent,
+			)
+		);
+
+		$actual = wp_unique_term_slug( $slug, $child );
+
+		$this->assertLessThanOrEqual( 200, strlen( $actual ), 'The slug does not fit the column.' );
+		$this->assertSame(
+			0,
+			preg_match( '/%(?![0-9a-fA-F]{2})/', $actual ),
+			'The slug contains a truncated percent-encoded sequence.'
+		);
+		$this->assertTrue(
+			wp_is_valid_utf8( urldecode( $actual ) ),
+			'The slug does not decode to valid UTF-8.'
+		);
+	}
+
+	/**
+	 * @ticket 46010
+	 */
+	public function test_numeric_suffixed_slug_should_be_truncated_to_the_column_length() {
+		$slug = str_repeat( 'a', 200 );
+
+		self::factory()->term->create(
+			array(
+				'taxonomy' => 'wptests_tax1',
+				'name'     => 'Existing',
+				'slug'     => $slug,
+			)
+		);
+
+		$term = self::factory()->term->create_and_get(
+			array(
+				'taxonomy' => 'wptests_tax1',
+				'name'     => 'New',
+				'slug'     => 'new',
+			)
+		);
+
+		$this->assertSame( str_repeat( 'a', 198 ) . '-2', wp_unique_term_slug( $slug, $term ) );
+	}
+
+	/**
+	 * A two digit suffix needs one more character of headroom than a one digit suffix.
+	 *
+	 * @ticket 46010
+	 */
+	public function test_multi_digit_numeric_suffix_should_be_truncated_to_the_column_length() {
+		$slug = str_repeat( 'a', 198 );
+
+		self::factory()->term->create(
+			array(
+				'taxonomy' => 'wptests_tax1',
+				'name'     => 'Existing',
+				'slug'     => $slug,
+			)
+		);
+
+		// Occupy every one digit suffix, forcing the loop on to "-10".
+		for ( $num = 2; $num <= 9; $num++ ) {
+			self::factory()->term->create(
+				array(
+					'taxonomy' => 'wptests_tax1',
+					'name'     => "Existing $num",
+					'slug'     => $slug . "-$num",
+				)
+			);
+		}
+
+		$term = self::factory()->term->create_and_get(
+			array(
+				'taxonomy' => 'wptests_tax1',
+				'name'     => 'New',
+				'slug'     => 'new',
+			)
+		);
+
+		$actual = wp_unique_term_slug( $slug, $term );
+
+		$this->assertSame( str_repeat( 'a', 197 ) . '-10', $actual );
+		$this->assertNull( term_exists( $actual ), 'The returned slug is already in use.' );
+	}
 }

--- a/tests/phpunit/tests/term/wpUpdateTerm.php
+++ b/tests/phpunit/tests/term/wpUpdateTerm.php
@@ -802,4 +802,54 @@ class Tests_Term_WpUpdateTerm extends WP_UnitTestCase {
 		$this->assertWPError( $found );
 		$this->assertSame( 'invalid_term', $found->get_error_code() );
 	}
+
+	/**
+	 * wp_update_term() shares the uniquifier with wp_insert_term().
+	 *
+	 * @ticket 46010
+	 */
+	public function test_wp_update_term_child_with_long_encoded_slug_should_be_updated() {
+		$taxonomy = 'wptests_tax';
+		register_taxonomy( $taxonomy, 'post', array( 'hierarchical' => true ) );
+
+		$name = 'Категория на продукта';
+
+		$parent = wp_insert_term( $name, $taxonomy );
+		$this->assertNotWPError( $parent );
+
+		$child = self::factory()->term->create(
+			array(
+				'taxonomy' => $taxonomy,
+				'name'     => 'Child',
+				'slug'     => 'child',
+				'parent'   => $parent['term_id'],
+			)
+		);
+
+		/*
+		 * Clearing the slug field on the Edit Category screen regenerates the slug
+		 * from the name, which then collides with the parent and gets suffixed.
+		 */
+		$found = wp_update_term(
+			$child,
+			$taxonomy,
+			array(
+				'name'   => $name,
+				'slug'   => '',
+				'parent' => $parent['term_id'],
+			)
+		);
+
+		$this->assertNotWPError( $found, 'The term could not be updated.' );
+
+		$updated = get_term( $child );
+
+		// wp_update_term() ignores the return value of $wpdb->update(), so an
+		// overlong slug leaves the whole row unwritten without reporting an error.
+		$this->assertSame( $name, $updated->name, 'The term name was not updated.' );
+		$this->assertNotSame( 'child', $updated->slug, 'The term slug was not updated.' );
+		$this->assertLessThanOrEqual( 200, strlen( $updated->slug ) );
+
+		_unregister_taxonomy( $taxonomy );
+	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

`wp_unique_term_slug()` appends a parent slug or numeric suffix without
reserving room in the 200 character `slug` column. `wp_insert_term()` then
fails with a generic "Could not insert term into the database.";
`wp_update_term()` discards the write without reporting an error.

Non-ASCII slugs are stored percent-encoded, so this is reachable from the
Categories screen with short names in any non-Latin script — the ticket uses a
21 character Cyrillic name.

The slug is now truncated before appending, reserving room for the suffix, as
`wp_unique_post_slug()` already does. The helper is renamed `_truncate_slug()`
and moved to formatting.php since it is not post specific, with
`_truncate_post_slug()` kept as a silent alias. Fixing this inside
`wp_unique_term_slug()` covers `wp_update_term()` too, as suggested on the
ticket.

Trac ticket: https://core.trac.wordpress.org/ticket/46010

## Use of AI Tools
AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Root-cause investigation against trunk, the patch, the unit tests, and running the PHPUnit/PHPCS/PHPStan validation. All changes were reviewed and validated by me.
and final review are mine.
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
