### PR TITLE
Abilities API: Make the ability category optional

### DIFF
--- a/src/wp-includes/abilities-api.php
+++ b/src/wp-includes/abilities-api.php
@@ -128,6 +128,9 @@ declare( strict_types = 1 );
  *     }
  *     add_action( 'wp_abilities_api_init', 'my_plugin_register_abilities' );
  *
+ * On failure, this function returns `null` and calls `_doing_it_wrong()` with the reason.
+ * By default, the resulting notice is displayed when `WP_DEBUG` is enabled.
+ *
  * ### Naming Conventions
  *
  * Ability names must follow these rules:
@@ -138,8 +141,9 @@ declare( strict_types = 1 );
  *
  * ### Categories
  *
- * Abilities must be organized into categories. Ability categories provide better
- * discoverability and must be registered before the abilities that reference them:
+ * Abilities can be organized into categories. If no category is provided, the ability is
+ * assigned to the built-in `uncategorized` category. Custom categories must be registered
+ * before the abilities that reference them:
  *
  *     function my_plugin_register_categories(): void {
  *         wp_register_ability_category(
@@ -228,6 +232,7 @@ declare( strict_types = 1 );
  *     ),
  *
  * @since 6.9.0
+ * @since 7.2.0 The `category` argument is now optional and defaults to `uncategorized`.
  *
  * @see WP_Abilities_Registry::register()
  * @see wp_register_ability_category()
@@ -242,9 +247,9 @@ declare( strict_types = 1 );
  *     @type string               $label               Required. The human-readable label for the ability.
  *     @type string               $description         Required. A detailed description of what the ability does
  *                                                     and when it should be used.
- *     @type string               $category            Required. The ability category slug this ability belongs to.
- *                                                     The ability category must be registered via `wp_register_ability_category()`
- *                                                     before registering the ability.
+ *     @type string               $category            Optional. The ability category slug this ability belongs to.
+ *                                                     Defaults to `uncategorized`. Custom categories must be registered
+ *                                                     via `wp_register_ability_category()` before registering the ability.
  *     @type callable             $execute_callback    Required. A callback function to execute when the ability is invoked.
  *                                                     Receives optional mixed input data and must return either a result
  *                                                     value (any type) or a `WP_Error` object on failure.
@@ -607,8 +612,10 @@ function _wp_get_abilities_match_meta( array $meta, array $conditions ): bool {
  * Registers a new ability category.
  *
  * Ability categories provide a way to organize and group related abilities for better
- * discoverability and management. Ability categories must be registered before abilities
- * that reference them.
+ * discoverability and management. Custom categories must be registered before abilities
+ * that reference them. Abilities that omit a category are assigned to the built-in
+ * `uncategorized` category, which is intended as an escape hatch for simple or transitional
+ * registrations.
  *
  * Ability categories must be registered on the `wp_abilities_api_categories_init` action hook.
  *
@@ -624,6 +631,9 @@ function _wp_get_abilities_match_meta( array $meta, array $conditions ): bool {
  *         );
  *     }
  *     add_action( 'wp_abilities_api_categories_init', 'my_plugin_register_categories' );
+ *
+ * On failure, this function returns `null` and calls `_doing_it_wrong()` with the reason.
+ * By default, the resulting notice is displayed when `WP_DEBUG` is enabled.
  *
  * @since 6.9.0
  *

--- a/src/wp-includes/abilities-api/class-wp-abilities-registry.php
+++ b/src/wp-includes/abilities-api/class-wp-abilities-registry.php
@@ -146,6 +146,15 @@ final class WP_Abilities_Registry {
 			$args['category'] = 'uncategorized';
 		}
 
+		if ( ! is_string( $args['category'] ) ) {
+			_doing_it_wrong(
+				__METHOD__,
+				__( 'Ability category must be a string.' ),
+				'6.9.0'
+			);
+			return null;
+		}
+
 		if ( ! wp_has_ability_category( $args['category'] ) ) {
 			_doing_it_wrong(
 				__METHOD__,

--- a/src/wp-includes/abilities-api/class-wp-abilities-registry.php
+++ b/src/wp-includes/abilities-api/class-wp-abilities-registry.php
@@ -40,6 +40,7 @@ final class WP_Abilities_Registry {
 	 * Do not use this method directly. Instead, use the `wp_register_ability()` function.
 	 *
 	 * @since 6.9.0
+	 * @since 7.2.0 The `category` argument is now optional and defaults to `uncategorized`.
 	 *
 	 * @see wp_register_ability()
 	 *
@@ -51,7 +52,8 @@ final class WP_Abilities_Registry {
 	 *
 	 *     @type string               $label                 The human-readable label for the ability.
 	 *     @type string               $description           A detailed description of what the ability does.
-	 *     @type string               $category              The ability category slug this ability belongs to.
+	 *     @type string               $category              Optional. The ability category slug this ability belongs to.
+	 *                                                       Defaults to `uncategorized`.
 	 *     @type callable             $execute_callback      A callback function to execute when the ability is invoked.
 	 *                                                       Receives optional mixed input and returns mixed result or WP_Error.
 	 *     @type callable             $permission_callback   A callback function to check permissions before execution.
@@ -108,13 +110,15 @@ final class WP_Abilities_Registry {
 		 * Filters the ability arguments before they are validated and used to instantiate the ability.
 		 *
 		 * @since 6.9.0
+		 * @since 7.2.0 The `category` argument is now optional and defaults to `uncategorized`.
 		 *
 		 * @param array<string, mixed> $args {
 		 *     An associative array of arguments for the ability.
 		 *
 		 *     @type string               $label                 The human-readable label for the ability.
 		 *     @type string               $description           A detailed description of what the ability does.
-		 *     @type string               $category              The ability category slug this ability belongs to.
+		 *     @type string               $category              Optional. The ability category slug this ability belongs to.
+		 *                                                       Defaults to `uncategorized`.
 		 *     @type callable             $execute_callback      A callback function to execute when the ability is invoked.
 		 *                                                       Receives optional mixed input and returns mixed result or WP_Error.
 		 *     @type callable             $permission_callback   A callback function to check permissions before execution.
@@ -138,8 +142,12 @@ final class WP_Abilities_Registry {
 		 */
 		$args = apply_filters( 'wp_register_ability_args', $args, $name );
 
-		// Validate ability category exists if provided (will be validated as required in WP_Ability).
-		if ( isset( $args['category'] ) ) {
+		if ( ! isset( $args['category'] ) || '' === $args['category'] ) {
+			$args['category'] = 'uncategorized';
+		}
+
+		// Validate ability category exists after applying the default.
+		if ( is_string( $args['category'] ) ) {
 			if ( ! wp_has_ability_category( $args['category'] ) ) {
 				_doing_it_wrong(
 					__METHOD__,

--- a/src/wp-includes/abilities-api/class-wp-abilities-registry.php
+++ b/src/wp-includes/abilities-api/class-wp-abilities-registry.php
@@ -146,15 +146,6 @@ final class WP_Abilities_Registry {
 			$args['category'] = 'uncategorized';
 		}
 
-		if ( ! is_string( $args['category'] ) ) {
-			_doing_it_wrong(
-				__METHOD__,
-				__( 'Ability category must be a string.' ),
-				'6.9.0'
-			);
-			return null;
-		}
-
 		if ( ! wp_has_ability_category( $args['category'] ) ) {
 			_doing_it_wrong(
 				__METHOD__,

--- a/src/wp-includes/abilities-api/class-wp-abilities-registry.php
+++ b/src/wp-includes/abilities-api/class-wp-abilities-registry.php
@@ -142,25 +142,31 @@ final class WP_Abilities_Registry {
 		 */
 		$args = apply_filters( 'wp_register_ability_args', $args, $name );
 
-		if ( ! isset( $args['category'] ) || '' === $args['category'] ) {
+		if ( ! array_key_exists( 'category', $args ) ) {
 			$args['category'] = 'uncategorized';
 		}
 
-		// Validate ability category exists after applying the default.
-		if ( is_string( $args['category'] ) ) {
-			if ( ! wp_has_ability_category( $args['category'] ) ) {
-				_doing_it_wrong(
-					__METHOD__,
-					sprintf(
-						/* translators: %1$s: ability category slug, %2$s: ability name */
-						__( 'Ability category "%1$s" is not registered. Please register the ability category before assigning it to ability "%2$s".' ),
-						esc_html( $args['category'] ),
-						esc_html( $name )
-					),
-					'6.9.0'
-				);
-				return null;
-			}
+		if ( ! is_string( $args['category'] ) ) {
+			_doing_it_wrong(
+				__METHOD__,
+				__( 'Ability category must be a string.' ),
+				'6.9.0'
+			);
+			return null;
+		}
+
+		if ( ! wp_has_ability_category( $args['category'] ) ) {
+			_doing_it_wrong(
+				__METHOD__,
+				sprintf(
+					/* translators: %1$s: ability category slug, %2$s: ability name */
+					__( 'Ability category "%1$s" is not registered. Please register the ability category before assigning it to ability "%2$s".' ),
+					esc_html( $args['category'] ),
+					esc_html( $name )
+				),
+				'6.9.0'
+			);
+			return null;
 		}
 
 		// The class is only used to instantiate the ability, and is not a property of the ability itself.

--- a/src/wp-includes/abilities.php
+++ b/src/wp-includes/abilities.php
@@ -13,6 +13,7 @@ declare( strict_types = 1 );
  * Registers the core ability categories.
  *
  * @since 6.9.0
+ * @since 7.2.0 Added the `uncategorized` category.
  */
 function wp_register_core_ability_categories(): void {
 	wp_register_ability_category(
@@ -28,6 +29,14 @@ function wp_register_core_ability_categories(): void {
 		array(
 			'label'       => __( 'User' ),
 			'description' => __( 'Abilities that retrieve or modify user information and settings.' ),
+		)
+	);
+
+	wp_register_ability_category(
+		'uncategorized',
+		array(
+			'label'       => __( 'Uncategorized' ),
+			'description' => __( 'Abilities that have not been assigned to a specific category.' ),
 		)
 	);
 }

--- a/tests/phpunit/tests/abilities-api/wpAbilitiesRegistry.php
+++ b/tests/phpunit/tests/abilities-api/wpAbilitiesRegistry.php
@@ -225,6 +225,22 @@ class Tests_Abilities_API_WpAbilitiesRegistry extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that an invalid category type is not replaced by the default.
+	 *
+	 * @ticket 65569
+	 *
+	 * @expectedIncorrectUsage WP_Abilities_Registry::register
+	 */
+	public function test_register_ability_rejects_invalid_category_type(): void {
+		$args             = self::$test_ability_args;
+		$args['category'] = false;
+
+		$result = $this->registry->register( self::$test_ability_name, $args );
+
+		$this->assertNull( $result );
+	}
+
+	/**
 	 * Should reject ability registration without an execute callback.
 	 *
 	 * @ticket 64098

--- a/tests/phpunit/tests/abilities-api/wpAbilitiesRegistry.php
+++ b/tests/phpunit/tests/abilities-api/wpAbilitiesRegistry.php
@@ -225,19 +225,61 @@ class Tests_Abilities_API_WpAbilitiesRegistry extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that an invalid category type is not replaced by the default.
+	 * Tests that an invalid category type is rejected before the category lookup.
+	 *
+	 * @ticket 65569
+	 *
+	 * @dataProvider data_invalid_category_types
+	 *
+	 * @expectedIncorrectUsage WP_Abilities_Registry::register
+	 *
+	 * @param mixed $category Invalid category value.
+	 */
+	public function test_register_ability_rejects_invalid_category_type( $category ): void {
+		$args             = self::$test_ability_args;
+		$args['category'] = $category;
+
+		$result = $this->registry->register( self::$test_ability_name, $args );
+
+		$this->assertNull( $result );
+		$this->assertStringContainsString(
+			'Ability category must be a string.',
+			$this->caught_doing_it_wrong['WP_Abilities_Registry::register']
+		);
+	}
+
+	/**
+	 * Data provider for invalid category types.
+	 *
+	 * @return array<string, array<mixed>> Test cases.
+	 */
+	public static function data_invalid_category_types(): array {
+		return array(
+			'null'    => array( null ),
+			'boolean' => array( false ),
+			'integer' => array( 1 ),
+			'array'   => array( array() ),
+		);
+	}
+
+	/**
+	 * Tests that an empty category is rejected rather than replaced by the default.
 	 *
 	 * @ticket 65569
 	 *
 	 * @expectedIncorrectUsage WP_Abilities_Registry::register
 	 */
-	public function test_register_ability_rejects_invalid_category_type(): void {
+	public function test_register_ability_rejects_empty_category(): void {
 		$args             = self::$test_ability_args;
-		$args['category'] = false;
+		$args['category'] = '';
 
 		$result = $this->registry->register( self::$test_ability_name, $args );
 
 		$this->assertNull( $result );
+		$this->assertStringContainsString(
+			'Ability category "" is not registered.',
+			$this->caught_doing_it_wrong['WP_Abilities_Registry::register']
+		);
 	}
 
 	/**

--- a/tests/phpunit/tests/abilities-api/wpAbilitiesRegistry.php
+++ b/tests/phpunit/tests/abilities-api/wpAbilitiesRegistry.php
@@ -225,11 +225,15 @@ class Tests_Abilities_API_WpAbilitiesRegistry extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that an invalid category type is rejected by the category lookup.
+	 * Tests that an invalid category type is rejected before the category lookup.
 	 *
 	 * @ticket 65569
 	 *
 	 * @dataProvider data_invalid_category_types
+	 *
+	 * @covers WP_Abilities_Registry::register
+	 *
+	 * @expectedIncorrectUsage WP_Abilities_Registry::register
 	 *
 	 * @param mixed $category Invalid category value.
 	 */
@@ -237,9 +241,13 @@ class Tests_Abilities_API_WpAbilitiesRegistry extends WP_UnitTestCase {
 		$args             = self::$test_ability_args;
 		$args['category'] = $category;
 
-		$this->expectException( TypeError::class );
+		$result = $this->registry->register( self::$test_ability_name, $args );
 
-		$this->registry->register( self::$test_ability_name, $args );
+		$this->assertNull( $result );
+		$this->assertStringContainsString(
+			'Ability category must be a string.',
+			$this->caught_doing_it_wrong['WP_Abilities_Registry::register']
+		);
 	}
 
 	/**
@@ -260,6 +268,8 @@ class Tests_Abilities_API_WpAbilitiesRegistry extends WP_UnitTestCase {
 	 * Tests that an empty category is rejected rather than replaced by the default.
 	 *
 	 * @ticket 65569
+	 *
+	 * @covers WP_Abilities_Registry::register
 	 *
 	 * @expectedIncorrectUsage WP_Abilities_Registry::register
 	 */

--- a/tests/phpunit/tests/abilities-api/wpAbilitiesRegistry.php
+++ b/tests/phpunit/tests/abilities-api/wpAbilitiesRegistry.php
@@ -225,13 +225,11 @@ class Tests_Abilities_API_WpAbilitiesRegistry extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that an invalid category type is rejected before the category lookup.
+	 * Tests that an invalid category type is rejected by the category lookup.
 	 *
 	 * @ticket 65569
 	 *
 	 * @dataProvider data_invalid_category_types
-	 *
-	 * @expectedIncorrectUsage WP_Abilities_Registry::register
 	 *
 	 * @param mixed $category Invalid category value.
 	 */
@@ -239,13 +237,9 @@ class Tests_Abilities_API_WpAbilitiesRegistry extends WP_UnitTestCase {
 		$args             = self::$test_ability_args;
 		$args['category'] = $category;
 
-		$result = $this->registry->register( self::$test_ability_name, $args );
+		$this->expectException( TypeError::class );
 
-		$this->assertNull( $result );
-		$this->assertStringContainsString(
-			'Ability category must be a string.',
-			$this->caught_doing_it_wrong['WP_Abilities_Registry::register']
-		);
+		$this->registry->register( self::$test_ability_name, $args );
 	}
 
 	/**

--- a/tests/phpunit/tests/abilities-api/wpRegisterAbility.php
+++ b/tests/phpunit/tests/abilities-api/wpRegisterAbility.php
@@ -100,6 +100,9 @@ class Test_Abilities_API_WpRegisterAbility extends WP_UnitTestCase {
 
 		// Clean up registered test ability category.
 		wp_unregister_ability_category( 'math' );
+		if ( wp_has_ability_category( 'uncategorized' ) ) {
+			wp_unregister_ability_category( 'uncategorized' );
+		}
 
 		parent::tear_down();
 	}
@@ -220,6 +223,42 @@ class Test_Abilities_API_WpRegisterAbility extends WP_UnitTestCase {
 				)
 			)
 		);
+	}
+
+	/**
+	 * @ticket 65569
+	 */
+	public function test_register_ability_without_category_uses_uncategorized_category(): void {
+		global $wp_current_filter;
+
+		$this->simulate_doing_wp_abilities_init_action();
+
+		$wp_current_filter[] = 'wp_abilities_api_categories_init';
+		wp_register_ability_category(
+			'uncategorized',
+			array(
+				'label'       => 'Uncategorized',
+				'description' => 'Abilities that have not been assigned to a specific category.',
+			)
+		);
+		array_pop( $wp_current_filter );
+
+		$ability = wp_register_ability(
+			'test/without-category',
+			array(
+				'label'               => 'Test ability without category',
+				'description'         => 'Test ability description.',
+				'input_schema'        => array(),
+				'output_schema'       => array(),
+				'permission_callback' => '__return_true',
+				'execute_callback'    => static function (): array {
+					return array( 'success' => true );
+				},
+			)
+		);
+
+		$this->assertInstanceOf( WP_Ability::class, $ability );
+		$this->assertSame( 'uncategorized', $ability->get_category() );
 	}
 
 	/**

--- a/tests/phpunit/tests/abilities-api/wpRegisterCoreAbilities.php
+++ b/tests/phpunit/tests/abilities-api/wpRegisterCoreAbilities.php
@@ -54,6 +54,19 @@ class Tests_Abilities_API_WpRegisterCoreAbilities extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that the uncategorized fallback category is registered by core.
+	 *
+	 * @ticket 65569
+	 */
+	public function test_uncategorized_category_is_registered(): void {
+		$category = wp_get_ability_category( 'uncategorized' );
+
+		$this->assertInstanceOf( WP_Ability_Category::class, $category );
+		$this->assertSame( 'Uncategorized', $category->get_label() );
+		$this->assertSame( 'Abilities that have not been assigned to a specific category.', $category->get_description() );
+	}
+
+	/**
 	 * Tests that the `core/get-site-info` ability is registered with the expected schema.
 	 * @ticket 64146
 	 */


### PR DESCRIPTION
This makes the `category` argument optional when registering an ability. When it is omitted, the registry assigns the built-in `uncategorized` category.

Previously, the registry only validated a category when one was provided, but `WP_Ability` still required the argument during instantiation. This left registrations without a category unable to succeed. Applying the fallback before validation keeps explicit invalid category values rejected while allowing simple or transitional registrations to omit a category.

The change:

- registers the `uncategorized` category with the other core ability categories;
- defaults an omitted category to `uncategorized`;
- relies on the category lookup's `string` type declaration to reject invalid types;
- requires provided category strings, including an empty string, to name a registered category;
- updates the public API documentation; and
- adds regression coverage for the fallback and invalid category values.

Props @Sachin7907 for the patch and @itzmekhokan for feedback.

Trac ticket: https://core.trac.wordpress.org/ticket/65569

## Testing

- `git diff --check` passes.
- PHPCS passes for all changed PHP files.
- `wpAbilitiesRegistry.php`: 37 tests, 71 assertions.
- `wpRegisterAbility.php`: 20 tests, 50 assertions.
- `wpRegisterCoreAbilities.php`: 14 tests, 131 assertions.

## Use of AI Tools

AI assistance: Yes  
Tool(s): OpenAI Codex  
Model(s): GPT-5  
Used for: Reviewing the existing local diff, running validation, and preparing the commits and pull request description. The implementation was reviewed by the submitter.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
