### PR TITLE
Plugins: Show "Activate" after updating an inactive plugin from Add Plugins

### DIFF
--- a/src/js/_enqueues/wp/updates.js
+++ b/src/js/_enqueues/wp/updates.js
@@ -611,6 +611,14 @@
 		}
 
 		$document.trigger( 'wp-plugin-update-success', response );
+
+		if ( response.activateUrl ) {
+			setTimeout( function() {
+				wp.updates.checkPluginDependencies( {
+					slug: response.slug
+				} );
+			}, 1000 );
+		}
 	};
 
 	/**
@@ -953,12 +961,12 @@
 	 * @param {string} response.activateUrl URL to activate the just checked plugin.
 	 */
 	wp.updates.checkPluginDependenciesSuccess = function( response ) {
-		var $message = $( '.plugin-card-' + response.slug + ', #plugin-information-footer' ).find( '.install-now' ),
+		var $message = $( '.plugin-card-' + response.slug + ', #plugin-information-footer' ).find( '.install-now, .update-now' ),
 			buttonText, ariaLabel;
 
-		// Transform the 'Install' button into an 'Activate' button.
+		// Transform the 'Install' or 'Update' button into an 'Activate' button.
 		$message
-			.removeClass( 'install-now installed button-disabled updated-message' )
+			.removeClass( 'install-now update-now installed button-disabled updated-message' )
 			.addClass( 'activate-now button-primary' )
 			.attr( 'href', response.activateUrl );
 
@@ -997,7 +1005,7 @@
 				{
 					status: 'dependencies-check-success',
 					slug: response.slug,
-					removeClasses: 'install-now installed button-disabled updated-message',
+					removeClasses: 'install-now update-now installed button-disabled updated-message',
 					addClasses: 'activate-now button-primary',
 					text: buttonText,
 					ariaLabel: ariaLabel,
@@ -1021,7 +1029,7 @@
 	 * @param {string}  response.errorMessage The error that occurred.
 	 */
 	wp.updates.checkPluginDependenciesError = function( response ) {
-		var $message = $( '.plugin-card-' + response.slug + ', #plugin-information-footer' ).find( '.install-now' ),
+		var $message = $( '.plugin-card-' + response.slug + ', #plugin-information-footer' ).find( '.install-now, .update-now' ),
 			buttonText = _x( 'Activate', 'plugin' ),
 			ariaLabel = sprintf(
 				/* translators: 1: Plugin name, 2. The reason the plugin cannot be activated. */
@@ -1045,7 +1053,7 @@
 		$document.trigger( 'wp-check-plugin-dependencies-error', response );
 
 		$message
-			.removeClass( 'install-now installed updated-message' )
+			.removeClass( 'install-now update-now installed updated-message' )
 			.addClass( 'activate-now button-primary' )
 			.attr( 'aria-label', ariaLabel )
 			.text( buttonText );
@@ -1055,7 +1063,7 @@
 				{
 					status: 'dependencies-check-failed',
 					slug: response.slug,
-					removeClasses: 'install-now installed updated-message',
+					removeClasses: 'install-now update-now installed updated-message',
 					addClasses: 'activate-now button-primary',
 					text: buttonText,
 					ariaLabel: ariaLabel

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -4721,6 +4721,26 @@ function wp_ajax_update_plugin() {
 			$status['newVersion'] = sprintf( __( 'Version %s' ), $plugin_data['Version'] );
 		}
 
+		$pagenow = isset( $_POST['pagenow'] ) ? sanitize_key( $_POST['pagenow'] ) : '';
+
+		// If update request is coming from import page, do not return network activation link.
+		$plugins_url = ( 'import' === $pagenow ) ? admin_url( 'plugins.php' ) : network_admin_url( 'plugins.php' );
+
+		if ( current_user_can( 'activate_plugin', $plugin ) && is_plugin_inactive( $plugin ) ) {
+			$status['activateUrl'] = add_query_arg(
+				array(
+					'_wpnonce' => wp_create_nonce( 'activate-plugin_' . $plugin ),
+					'action'   => 'activate',
+					'plugin'   => $plugin,
+				),
+				$plugins_url
+			);
+
+			if ( is_multisite() && current_user_can( 'manage_network_plugins' ) && 'import' !== $pagenow ) {
+				$status['activateUrl'] = add_query_arg( array( 'networkwide' => 1 ), $status['activateUrl'] );
+			}
+		}
+
 		wp_send_json_success( $status );
 	} elseif ( false === $result ) {
 		global $wp_filesystem;


### PR DESCRIPTION
## Trac Ticket
https://core.trac.wordpress.org/ticket/65909

## Description

When updating an inactive plugin from the Add Plugins screen (Plugins > Add New), the button currently remains as a disabled "Updated!" state. Users must navigate to the Installed Plugins screen to activate it.

This PR brings consistency with the plugin installation flow: after successfully updating an inactive plugin, the button changes to "Activate" (or "Network Activate").

### The Changes

1. **`wp_ajax_update_plugin()` (`src/wp-admin/includes/ajax-actions.php`):**
   - Added `activateUrl` generation when the updated plugin is inactive and the current user has the `activate_plugin` capability (matching the logic in `wp_ajax_install_plugin()`).

2. **`wp.updates.updatePluginSuccess` (`src/js/_enqueues/wp/updates.js`):**
   - Added a call to `wp.updates.checkPluginDependencies()` when `response.activateUrl` is present in the response.

3. **`wp.updates.checkPluginDependenciesSuccess` & `wp.updates.checkPluginDependenciesError` (`src/js/_enqueues/wp/updates.js`):**
   - Extended selector matching and class removal to include `.update-now` alongside `.install-now` so update buttons seamlessly transform into `.activate-now` buttons.

### How to Test

1. Ensure an inactive plugin with an available update is installed on the site.
2. Navigate to **Plugins > Add New**.
3. Search for the inactive plugin.
4. Click **Update Now**.
5. After the update completes, observe the button transition from "Updating..." → "Updated!" → **"Activate"**.
6. Click **Activate** to verify one-click activation works directly from the card.

Fixes #65909.