### PR TITLE
Menus: Add bulk moving to selected menu items

### DIFF
--- a/src/js/_enqueues/lib/nav-menu.js
+++ b/src/js/_enqueues/lib/nav-menu.js
@@ -47,6 +47,7 @@
 
 			this.attachBulkSelectButtonListeners();
 			this.attachMenuCheckBoxListeners();
+			this.attachMenuItemMoveButton();
 			this.attachMenuItemDeleteButton();
 			this.attachPendingMenuItemsListForDeletion();
 
@@ -518,6 +519,7 @@
 			api.refreshAdvancedAccessibility();
 			thisItem.updateParentDropdown();
 			thisItem.updateOrderDropdown();
+			api.updateBulkMoveControls();
 
 			if ( a11ySpeech ) {
 				wp.a11y.speak( a11ySpeech );
@@ -616,6 +618,7 @@
 
 			menuItem.insertAfter( menuItems.eq( menuItemNewPosition ) ).updateParentMenuItemDBId().updateParentDropdown().updateOrderDropdown();
 
+			api.updateBulkMoveControls();
 			api.registerChange();
 			api.refreshKeyboardAccessibility();
 			api.refreshAdvancedAccessibility();
@@ -661,6 +664,7 @@
 				menuItem.detach().insertAfter( menuItems.eq( menuItemNewPosition ) ).updateOrderDropdown();
 			}
 
+			api.updateBulkMoveControls();
 			api.registerChange();
 			api.refreshKeyboardAccessibility();
 			api.refreshAdvancedAccessibility();
@@ -975,6 +979,7 @@
 					ui.item.updateParentDropdown();
 					ui.item.updateOrderDropdown();
 					api.refreshAdvancedAccessibilityOfItem( ui.item.find( 'a.item-edit' ) );
+					api.updateBulkMoveControls();
 				},
 				change: function(e, ui) {
 					// Make sure the placeholder is inside the menu.
@@ -1213,6 +1218,7 @@
 
 			$( '.menu-items-delete' ).addClass( 'disabled' );
 			$( '#pending-menu-items-to-delete ul' ).empty();
+			this.updateBulkMoveControls();
 		},
 
 		/**
@@ -1225,7 +1231,244 @@
 
 			$( '#menu-to-edit' ).on( 'change', '.menu-item-checkbox', function() {
 				that.setRemoveSelectedButtonStatus();
+				that.updateBulkMoveControls();
 			});
+		},
+
+		/**
+		 * Get the topmost selected menu items.
+		 *
+		 * A selected child is omitted when its parent is also selected, because
+		 * moving the parent already moves the entire subtree.
+		 *
+		 * @since 7.2.0
+		 *
+		 * @return {jQuery} Selected menu items without selected ancestors.
+		 */
+		getSelectedMenuItems : function() {
+			var selectedMenuItems = $(),
+				selectedDepth = -1;
+
+			api.menuList.children( '.menu-item' ).each( function() {
+				var menuItem = $( this ),
+					depth = menuItem.menuItemDepth();
+
+				if ( depth <= selectedDepth ) {
+					selectedDepth = -1;
+				}
+
+				if ( -1 === selectedDepth && menuItem.find( '.menu-item-checkbox' ).prop( 'checked' ) ) {
+					selectedMenuItems = selectedMenuItems.add( menuItem );
+					selectedDepth = depth;
+				}
+			});
+
+			return selectedMenuItems;
+		},
+
+		/**
+		 * Get the greatest depth below any selected root.
+		 *
+		 * @since 7.2.0
+		 *
+		 * @param {jQuery} selectedMenuItems Selected root menu items.
+		 * @return {number} Greatest relative child depth.
+		 */
+		getSelectedMenuItemsMaxChildDepth : function( selectedMenuItems ) {
+			var maxChildDepth = 0;
+
+			selectedMenuItems.each( function() {
+				var menuItem = $( this ),
+					depth = menuItem.menuItemDepth();
+
+				menuItem.childMenuItems().each( function() {
+					maxChildDepth = Math.max( maxChildDepth, $( this ).menuItemDepth() - depth );
+				});
+			});
+
+			return maxChildDepth;
+		},
+
+		/**
+		 * Populate and set the state of the bulk move controls.
+		 *
+		 * @since 7.2.0
+		 */
+		updateBulkMoveControls : function() {
+			var menuItems = api.menuList.children( '.menu-item' ),
+				selectedMenuItems = api.getSelectedMenuItems(),
+				excludedMenuItems = selectedMenuItems.add( selectedMenuItems.childMenuItems() ),
+				maxChildDepth = api.getSelectedMenuItemsMaxChildDepth( selectedMenuItems ),
+				fieldset = $( '#bulk-menu-items-move' ),
+				parentDropdown = $( '#bulk-menu-item-parent' ),
+				positionDropdown = $( '#bulk-menu-item-position' ),
+				selectOption = parentDropdown.find( 'option' ).first().clone();
+
+			fieldset.prop( 'disabled', ! selectedMenuItems.length );
+			parentDropdown.empty().append( selectOption );
+			positionDropdown.val( '' ).prop( 'disabled', true );
+			$( '.menu-items-move' ).prop( 'disabled', true );
+
+			if ( ! selectedMenuItems.length ) {
+				return;
+			}
+
+			parentDropdown.append(
+				$( '<option>', {
+					value: '0',
+					text: wp.i18n._x( 'No Parent', 'menu item without a parent in navigation menu' ),
+				} )
+			);
+
+			menuItems.each( function() {
+				var menuItem = $( this );
+
+				if (
+					! excludedMenuItems.is( menuItem ) &&
+					menuItem.menuItemDepth() + maxChildDepth < api.options.globalMaxDepth
+				) {
+					parentDropdown.append(
+						$( '<option>', {
+							value: menuItem.find( '.menu-item-data-db-id' ).val(),
+							text: menuItem.find( '.edit-menu-item-title' ).val(),
+						} )
+					);
+				}
+			});
+		},
+
+		/**
+		 * Populate the starting position dropdown for the selected parent.
+		 *
+		 * @since 7.2.0
+		 */
+		updateBulkMovePositionDropdown : function() {
+			var i,
+				parentID = $( '#bulk-menu-item-parent' ).val(),
+				selectedMenuItems = api.getSelectedMenuItems(),
+				positionDropdown = $( '#bulk-menu-item-position' ),
+				selectOption = positionDropdown.find( 'option' ).first().clone(),
+				siblings;
+
+			positionDropdown.empty().append( selectOption ).prop( 'disabled', true );
+			$( '.menu-items-move' ).prop( 'disabled', true );
+
+			if ( '' === parentID ) {
+				return;
+			}
+
+			siblings = api.menuList.children( '.menu-item' ).filter( function() {
+				return parentID === String( $( this ).find( '.menu-item-data-parent-id' ).val() );
+			}).not( selectedMenuItems );
+
+			for ( i = 1; i <= siblings.length + 1; i++ ) {
+				positionDropdown.append(
+					$( '<option>', {
+						value: i,
+						text: wp.i18n.sprintf(
+							/* translators: 1: The first selected menu item position, 2: The total number of menu items. */
+							wp.i18n._x( '%1$s of %2$s', 'part of a total number of menu items' ),
+							i,
+							siblings.length + selectedMenuItems.length
+						),
+					} )
+				);
+			}
+
+			positionDropdown.prop( 'disabled', false );
+		},
+
+		/**
+		 * Set up the bulk move controls.
+		 *
+		 * @since 7.2.0
+		 */
+		attachMenuItemMoveButton : function() {
+			$( '#bulk-menu-item-parent' ).on( 'change', function() {
+				api.updateBulkMovePositionDropdown();
+			});
+
+			$( '#bulk-menu-item-position' ).on( 'change', function() {
+				$( '.menu-items-move' ).prop( 'disabled', ! this.value );
+			});
+
+			$( '.menu-items-move' ).on( 'click', function() {
+				if ( ! this.disabled ) {
+					api.moveSelectedMenuItems();
+				}
+			});
+		},
+
+		/**
+		 * Move selected menu item subtrees as a contiguous group.
+		 *
+		 * @since 7.2.0
+		 */
+		moveSelectedMenuItems : function() {
+			var menuItem,
+				itemsToMove = $(),
+				selectedMenuItems = api.getSelectedMenuItems(),
+				selectedSubtrees = selectedMenuItems.add( selectedMenuItems.childMenuItems() ),
+				selectedItemsCount = api.menuList.find( '.menu-item-checkbox:checked' ).length,
+				maxChildDepth = api.getSelectedMenuItemsMaxChildDepth( selectedMenuItems ),
+				parentID = $( '#bulk-menu-item-parent' ).val(),
+				position = parseInt( $( '#bulk-menu-item-position' ).val(), 10 ),
+				parentItem = api.menuList.children( '#menu-item-' + parentID ),
+				newDepth = parentItem.length ? parseInt( parentItem.menuItemDepth(), 10 ) + 1 : 0,
+				siblings;
+
+			if ( ! selectedMenuItems.length || '' === parentID || isNaN( position ) ) {
+				return;
+			}
+
+			if (
+				( '0' !== parentID && ! parentItem.length ) ||
+				parentItem.length && (
+					selectedSubtrees.is( parentItem ) ||
+					newDepth + maxChildDepth > api.options.globalMaxDepth
+				)
+			) {
+				api.updateBulkMoveControls();
+				$( '#bulk-menu-item-parent' ).trigger( 'focus' );
+				wp.a11y.speak(
+					wp.i18n.__( 'The selected menu items could not be moved. Please choose a new parent and position.' ),
+					'assertive'
+				);
+				return;
+			}
+
+			selectedMenuItems.each( function() {
+				menuItem = $( this );
+				itemsToMove = itemsToMove.add( menuItem ).add( menuItem.childMenuItems() );
+				menuItem.moveHorizontally( newDepth, menuItem.menuItemDepth() );
+			});
+
+			itemsToMove.detach();
+			siblings = api.menuList.children( '.menu-item' ).filter( function() {
+				return parentID === String( $( this ).find( '.menu-item-data-parent-id' ).val() );
+			});
+
+			if ( position <= siblings.length ) {
+				itemsToMove.insertBefore( siblings.eq( position - 1 ) );
+			} else if ( parentItem.length ) {
+				menuItem = parentItem.childMenuItems().last();
+				itemsToMove.insertAfter( menuItem.length ? menuItem : parentItem );
+			} else {
+				itemsToMove.appendTo( api.menuList );
+			}
+
+			itemsToMove.updateParentMenuItemDBId();
+			api.menuList.updateParentDropdown().updateOrderDropdown();
+			api.registerChange();
+			api.refreshKeyboardAccessibility();
+			api.refreshAdvancedAccessibility();
+			wp.a11y.speak(
+				wp.i18n.sprintf(
+					wp.i18n._n( '%d menu item moved.', '%d menu items moved.', selectedItemsCount ),
+					selectedItemsCount
+				),
+				'polite'
+			);
 		},
 
 		/**
@@ -1335,6 +1578,7 @@
 			});
 
 			that.setRemoveSelectedButtonStatus();
+			that.updateBulkMoveControls();
 		},
 
 		/**
@@ -1850,6 +2094,7 @@
 					wp.a11y.speak( menus.itemRemoved );
 					$( '#menu-to-edit' ).updateParentDropdown();
 					$( '#menu-to-edit' ).updateOrderDropdown();
+					api.updateBulkMoveControls();
 				});
 		},
 
@@ -1887,9 +2132,16 @@
 	});
 
 	// Show bulk action.
-	$( document ).on( 'menu-item-added', function() {
+	$( document ).on( 'menu-item-added', function( event, menuItem ) {
 		if ( ! $( '.bulk-actions' ).is( ':visible' ) ) {
 			$( '.bulk-actions' ).show();
+		}
+
+		if ( api.menuList ) {
+			if ( api.menuList.hasClass( 'bulk-selection' ) ) {
+				$( menuItem ).find( '.menu-item-checkbox' ).prop( 'disabled', false );
+			}
+			api.updateBulkMoveControls();
 		}
 	} );
 

--- a/src/wp-admin/css/nav-menus.css
+++ b/src/wp-admin/css/nav-menus.css
@@ -194,6 +194,25 @@ input.bulk-select-switcher:focus + .bulk-select-button-label {
 	color: #0a4b78;
 }
 
+#bulk-menu-items-move {
+	display: none;
+	align-items: flex-end;
+	flex-wrap: wrap;
+	gap: 8px;
+	margin: 1em 0;
+	padding: 0;
+	border: 0;
+}
+
+.bulk-selection #bulk-menu-items-move {
+	display: flex;
+}
+
+#bulk-menu-items-move label,
+#bulk-menu-items-move select {
+	display: block;
+}
+
 .bulk-actions input.menu-items-delete {
 	appearance: none;
 	font-size: inherit;

--- a/src/wp-admin/nav-menus.php
+++ b/src/wp-admin/nav-menus.php
@@ -1163,9 +1163,25 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 										<input type="checkbox" id="bulk-select-switcher-bottom" name="bulk-select-switcher-top" class="bulk-select-switcher">
 										<span class="bulk-select-button-label"><?php _e( 'Bulk Select' ); ?></span>
 									</label>
+									<fieldset id="bulk-menu-items-move" disabled="disabled">
+										<legend class="screen-reader-text"><?php _e( 'Move selected menu items' ); ?></legend>
+										<label for="bulk-menu-item-parent">
+											<?php _e( 'Menu Parent' ); ?>
+											<select id="bulk-menu-item-parent">
+												<option value=""><?php _e( '&mdash; Select &mdash;' ); ?></option>
+											</select>
+										</label>
+										<label for="bulk-menu-item-position">
+											<?php _e( 'Starting Position' ); ?>
+											<select id="bulk-menu-item-position" disabled="disabled">
+												<option value=""><?php _e( '&mdash; Select &mdash;' ); ?></option>
+											</select>
+										</label>
+										<button type="button" class="button menu-items-move" disabled="disabled"><?php _e( 'Move Selected Items' ); ?></button>
+									</fieldset>
 									<input type="button" class="deletion menu-items-delete disabled" value="<?php esc_attr_e( 'Remove Selected Items' ); ?>">
 									<div id="pending-menu-items-to-delete">
-										<p><?php _e( 'List of menu items selected for deletion:' ); ?></p>
+										<p><?php _e( 'List of selected menu items:' ); ?></p>
 										<ul></ul>
 									</div>
 								</div>

--- a/tests/qunit/wp-admin/js/nav-menu.js
+++ b/tests/qunit/wp-admin/js/nav-menu.js
@@ -5,6 +5,75 @@
 		eventsExpected = 3,
 		eventsFired = 0;
 
+	function menuItem( id, depth, parentID, checked ) {
+		return $( '<li>', {
+			id: 'menu-item-' + id,
+			'class': 'menu-item menu-item-depth-' + depth,
+		} ).append(
+			$( '<input>', {
+				type: 'checkbox',
+				'class': 'menu-item-checkbox',
+				checked: checked,
+			} ),
+			$( '<input>', {
+				'class': 'menu-item-data-db-id',
+				value: id,
+			} ),
+			$( '<input>', {
+				'class': 'menu-item-data-parent-id',
+				value: parentID,
+			} ),
+			$( '<input>', {
+				'class': 'edit-menu-item-title',
+				value: 'Item ' + id,
+			} )
+		);
+	}
+
+	function setupBulkMoveTest( menuItems, parentID, position ) {
+		var originalMenuList = wpNavMenu.menuList,
+			originalMenusChanged = wpNavMenu.menusChanged,
+			menu = $( '<ul>', { id: 'menu-to-edit' } ).append( menuItems ),
+			parentDropdown = $( '<select>', { id: 'bulk-menu-item-parent' } ).append(
+				$( '<option>', { value: '' } ),
+				$( '<option>', { value: parentID, selected: true } )
+			),
+			positionDropdown = $( '<select>', { id: 'bulk-menu-item-position' } ).append(
+				$( '<option>', { value: '' } ),
+				$( '<option>', { value: position, selected: true } )
+			),
+			fieldset = $( '<fieldset>', { id: 'bulk-menu-items-move' } ).append(
+				parentDropdown,
+				positionDropdown,
+				$( '<button>', { 'class': 'menu-items-move' } )
+			);
+
+		$( '#qunit-fixture' ).append( fieldset, menu );
+		wpNavMenu.jQueryExtensions();
+		$.fn.menuItemDepth = function() {
+			return parseInt( this.attr( 'class' ).match( /menu-item-depth-(\d+)/ )[1], 10 );
+		};
+		wpNavMenu.menuList = menu;
+		wpNavMenu.menusChanged = false;
+
+		return {
+			menu: menu,
+			parentDropdown: parentDropdown,
+			positionDropdown: positionDropdown,
+			restore: function() {
+				wpNavMenu.jQueryExtensions();
+				wpNavMenu.menuList = originalMenuList;
+				wpNavMenu.menusChanged = originalMenusChanged;
+			}
+		};
+	}
+
+	function menuItemIDs( menu ) {
+		return menu.children().map( function() {
+			return parseInt( this.id.replace( 'menu-item-', '' ), 10 );
+		} ).get();
+	}
+
 	// Fail if we don't see the expected number of events triggered in 3 seconds.
 	setTimeout( function( assert ) {
 		// QUnit may load this file without running it, in which case `assert`
@@ -90,6 +159,125 @@
 			$( document ).off( theEvent.shouldTrigger );
 		} );
 
+	} );
+
+	QUnit.test( 'Bulk moving preserves selected subtrees and order.', function( assert ) {
+		var test = setupBulkMoveTest(
+			[
+				menuItem( 1, 0, 0, false ),
+				menuItem( 2, 0, 0, true ),
+				menuItem( 3, 1, 2, true ),
+				menuItem( 4, 0, 0, false ),
+				menuItem( 5, 0, 0, true ),
+				menuItem( 6, 0, 0, false )
+			],
+			1,
+			1
+		);
+
+		assert.equal( wpNavMenu.getSelectedMenuItems().length, 2, 'Selected descendants are part of their selected ancestor subtree.' );
+
+		wpNavMenu.moveSelectedMenuItems();
+
+		assert.deepEqual( menuItemIDs( test.menu ), [ 1, 2, 3, 5, 4, 6 ], 'Selected subtrees are moved as a contiguous group in their existing order.' );
+		assert.equal( $( '#menu-item-2' ).menuItemDepth(), 1, 'The first selected root has the new depth.' );
+		assert.equal( $( '#menu-item-3' ).menuItemDepth(), 2, 'Its descendant keeps its relative depth.' );
+		assert.equal( $( '#menu-item-5' ).menuItemDepth(), 1, 'The second selected root has the new depth.' );
+		assert.equal( $( '#menu-item-2 .menu-item-data-parent-id' ).val(), '1', 'The first selected root has the new parent.' );
+		assert.equal( $( '#menu-item-3 .menu-item-data-parent-id' ).val(), '2', 'The descendant keeps its parent.' );
+		assert.equal( $( '#menu-item-5 .menu-item-data-parent-id' ).val(), '1', 'The second selected root has the new parent.' );
+
+		test.restore();
+	} );
+
+	QUnit.test( 'Bulk moving rejects stale parents and cycles.', function( assert ) {
+		var test = setupBulkMoveTest(
+			[
+				menuItem( 1, 0, 0, true ),
+				menuItem( 2, 1, 1, false ),
+				menuItem( 3, 0, 0, false )
+			],
+			2,
+			1
+		);
+
+		wpNavMenu.moveSelectedMenuItems();
+
+		assert.deepEqual( menuItemIDs( test.menu ), [ 1, 2, 3 ], 'A selected subtree cannot move below its descendant.' );
+		assert.equal( $( '#menu-item-1 .menu-item-data-parent-id' ).val(), '0', 'The rejected move preserves the parent.' );
+		assert.notOk( wpNavMenu.menusChanged, 'The rejected move does not dirty the menu.' );
+		test.restore();
+
+		$( '#qunit-fixture' ).empty();
+		test = setupBulkMoveTest(
+			[
+				menuItem( 1, 0, 0, true ),
+				menuItem( 2, 0, 0, false )
+			],
+			99,
+			1
+		);
+
+		wpNavMenu.moveSelectedMenuItems();
+
+		assert.deepEqual( menuItemIDs( test.menu ), [ 1, 2 ], 'A missing parent does not become a top-level move.' );
+		assert.notOk( wpNavMenu.menusChanged, 'The missing-parent move does not dirty the menu.' );
+		test.restore();
+	} );
+
+	QUnit.test( 'Bulk moving enforces the maximum subtree depth.', function( assert ) {
+		var test = setupBulkMoveTest(
+			[
+				menuItem( 1, 10, 0, false ),
+				menuItem( 2, 9, 0, false ),
+				menuItem( 3, 0, 0, true ),
+				menuItem( 4, 1, 3, false )
+			],
+			1,
+			1
+		);
+
+		wpNavMenu.updateBulkMoveControls();
+
+		assert.notOk( test.parentDropdown.find( 'option[value="1"]' ).length, 'A parent that would exceed the maximum depth is excluded.' );
+		assert.ok( test.parentDropdown.find( 'option[value="2"]' ).length, 'A parent at the maximum valid boundary remains available.' );
+
+		test.parentDropdown.append( $( '<option>', { value: 1, selected: true } ) );
+		test.positionDropdown.append( $( '<option>', { value: 1, selected: true } ) );
+		wpNavMenu.moveSelectedMenuItems();
+
+		assert.equal( $( '#menu-item-3' ).menuItemDepth(), 0, 'The action guard preserves the selected root depth.' );
+		assert.equal( $( '#menu-item-4' ).menuItemDepth(), 1, 'The action guard preserves the child depth.' );
+		assert.notOk( wpNavMenu.menusChanged, 'The rejected deep move does not dirty the menu.' );
+		test.restore();
+	} );
+
+	QUnit.test( 'Bulk moving supports the final starting position.', function( assert ) {
+		var test = setupBulkMoveTest(
+			[
+				menuItem( 4, 0, 0, true ),
+				menuItem( 5, 0, 0, true ),
+				menuItem( 1, 0, 0, false ),
+				menuItem( 2, 1, 1, false ),
+				menuItem( 3, 1, 1, false ),
+				menuItem( 6, 0, 0, false )
+			],
+			1,
+			3
+		);
+
+		wpNavMenu.updateBulkMovePositionDropdown();
+		assert.deepEqual( test.positionDropdown.find( 'option' ).map( function() {
+			return this.value;
+		} ).get(), [ '', '1', '2', '3' ], 'Every valid starting position is available.' );
+
+		test.positionDropdown.val( '3' );
+		wpNavMenu.moveSelectedMenuItems();
+
+		assert.deepEqual( menuItemIDs( test.menu ), [ 1, 2, 3, 4, 5, 6 ], 'Selected items append after the final existing sibling.' );
+		assert.equal( $( '#menu-item-4 .menu-item-data-parent-id' ).val(), '1', 'The appended group gets the selected parent.' );
+		assert.equal( $( '#menu-item-5 .menu-item-data-parent-id' ).val(), '1', 'Every appended root gets the selected parent.' );
+		test.restore();
 	} );
 
 


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/51964

The classic **Appearance → Menus** screen currently allows administrators to bulk-remove menu items, but not bulk-move them. Moving several items through the existing individual parent and position controls is inefficient, especially for larger menus.

This PR adds bulk controls for choosing:
- A destination parent.
- A starting position under that parent.
- An action to move the selected items.

## Manual testing steps

### Setup

1. Activate a classic theme that supports **Appearance → Menus**.
2. Open **Appearance → Menus**.
3. Create or select a menu containing several root items and nested descendants.
4. Use a structure similar to:

   ```text
   Home
   Products
     Product A
       Documentation
   About
     Team
   Contact
   Sample Page
   ```
   
### Basic bulk movement

1. Enable **Bulk Select**.
2. Select two non-adjacent root items, such as `Products` and `Contact`.
3. Confirm that the **Menu Parent** control becomes enabled.
4. Select `About` as the parent.
5. Confirm that **Starting Position** becomes enabled.
6. Select a starting position.
7. Activate **Move Selected Items**.
8. Confirm that:
   - The selected roots appear under `About`.
   - They are placed contiguously.
   - Their relative order is unchanged.
   - `Products` retains its complete descendant subtree.
   - Existing children of `About` remain in the expected order.
   
### Selected parent and descendant

1. Reload or restore the original menu structure.
2. Enable **Bulk Select**.
3. Select `Products`, `Product A`, and another root such as `Contact`.
4. Move the selection under `About`.
5. Confirm that `Product A` is not moved twice.
6. Confirm that the complete `Products` subtree remains intact.

### Keyboard and accessibility

1. Navigate to **Bulk Select** using only the keyboard.
2. Select menu items using the keyboard.
3. Tab through **Menu Parent**, **Starting Position**, and **Move Selected Items**.
4. Confirm that controls are disabled until their required preceding choices are complete.
5. Activate the move using the keyboard.
6. With a screen reader, confirm that the number of moved menu items is announced.
7. Confirm that a rejected destination produces an assertive failure announcement and returns focus to **Menu Parent**.

## Screenshots

### Parent choices exclude selected subtrees

<img width="2000" height="1020" alt="51964-parent-cycle-prevention" src="https://github.com/user-attachments/assets/50447635-fb23-4b15-9f8a-8922f1c73276" />


### Selected subtrees moved under About

<img width="2000" height="1020" alt="51964-after-bulk-move" src="https://github.com/user-attachments/assets/ee4fa593-fe17-419d-9241-32c0dc9e8227" />


## Use of AI Tools

AI assistance: Yes
Tool(s): Pi coding agent
Model(s): GPT-5.6
Used for: Initial code skeleton,  test suggestions, code review, PR description drafting; final implementation and tests were reviewed and edited by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
