### PR TITLE
Lint the colors _tokens.scss file

### DIFF
--- a/src/wp-admin/css/colors/_tokens.scss
+++ b/src/wp-admin/css/colors/_tokens.scss
@@ -51,14 +51,14 @@ $radius-full: 9999px; // radius-full - Pills, avatars, circles
 
 $gray-100: #f0f0f0;   // Scales/Grays/gray-100 - Page background, disabled inputs
 $gray-200: #e0e0e0;   // Scales/Grays/gray-200
-$gray-300: #ddd;   // Scales/Grays/gray-300
-$gray-400: #ccc;   // Scales/Grays/gray-400 - Disabled borders
+$gray-300: #ddd;      // Scales/Grays/gray-300
+$gray-400: #ccc;      // Scales/Grays/gray-400 - Disabled borders
 $gray-600: #949494;   // Scales/Grays/gray-600 - Input borders, disabled text
 $gray-700: #757575;   // Scales/Grays/gray-700
 $gray-800: #2f2f2f;   // Scales/Grays/gray-800
 $gray-900: #1e1e1e;   // Scales/Grays/gray-900 - Primary text
 
-$white: #fff;      // Scales/Black & White/white
+$white: #fff;         // Scales/Black & White/white
 
 /**
  * Theme Colors (Static reference values)
@@ -100,7 +100,7 @@ $synced-color: #7a00df;    // Scales/Purple/--wp-block-synced-color
 
 $text-primary: $gray-900;     // Primary text color
 $text-secondary: $gray-700;   // Secondary text
-$text-tertiary: #5d5d5d;      // Alias/text/text-tertiary - Placeholder, hints
+$text-tertiary: #5d5d5d;    // Alias/text/text-tertiary - Placeholder, hints
 $text-disabled: $gray-600;    // Disabled text
 
 /**

--- a/src/wp-admin/css/colors/_tokens.scss
+++ b/src/wp-admin/css/colors/_tokens.scss
@@ -16,11 +16,11 @@
 //
 // ==========================================================================
 
-
-// --------------------------------------------------------------------------
-// Grid Units (Spacing)
-// --------------------------------------------------------------------------
-// Based on 4px base unit. Use for padding, margin, and gap values.
+/**
+ * Grid Units (Spacing)
+ *
+ * Based on 4px base unit. Use for padding, margin, and gap values.
+ */
 
 $grid-unit-05: 4px;   // Scales/grid unit 05
 $grid-unit-10: 8px;   // Scales/grid unit 10
@@ -32,10 +32,9 @@ $grid-unit-50: 40px;  // Scales/grid unit 50
 $grid-unit-60: 48px;  // Scales/grid unit 60
 $grid-unit-70: 56px;  // Scales/grid unit 70
 
-
-// --------------------------------------------------------------------------
-// Border Radius
-// --------------------------------------------------------------------------
+/**
+ * Border Radius
+ */
 
 $radius-xs: 1px;      // radius-xs
 $radius-s: 2px;       // radius-s - Buttons, inputs
@@ -44,29 +43,29 @@ $radius-l: 8px;       // radius-l - Cards, dashboard widgets
 $radius-30: 12px;     // Radius 30
 $radius-full: 9999px; // radius-full - Pills, avatars, circles
 
-
-// --------------------------------------------------------------------------
-// Gray Scale
-// --------------------------------------------------------------------------
-// Neutral colors for backgrounds, borders, and text.
+/**
+ * Gray Scale
+ *
+ * Neutral colors for backgrounds, borders, and text.
+ */
 
 $gray-100: #f0f0f0;   // Scales/Grays/gray-100 - Page background, disabled inputs
 $gray-200: #e0e0e0;   // Scales/Grays/gray-200
-$gray-300: #dddddd;   // Scales/Grays/gray-300
-$gray-400: #cccccc;   // Scales/Grays/gray-400 - Disabled borders
+$gray-300: #ddd;   // Scales/Grays/gray-300
+$gray-400: #ccc;   // Scales/Grays/gray-400 - Disabled borders
 $gray-600: #949494;   // Scales/Grays/gray-600 - Input borders, disabled text
 $gray-700: #757575;   // Scales/Grays/gray-700
 $gray-800: #2f2f2f;   // Scales/Grays/gray-800
 $gray-900: #1e1e1e;   // Scales/Grays/gray-900 - Primary text
 
-$white: #ffffff;      // Scales/Black & White/white
+$white: #fff;      // Scales/Black & White/white
 
-
-// --------------------------------------------------------------------------
-// Theme Colors (Static reference values)
-// --------------------------------------------------------------------------
-// For actual theme color usage, use var(--wp-admin-theme-color) instead.
-// These are provided for reference and for contexts where CSS vars aren't available.
+/**
+ * Theme Colors (Static reference values)
+ *
+ * For actual theme color usage, use var(--wp-admin-theme-color) instead.
+ * These are provided for reference and for contexts where CSS vars aren't available.
+ */
 
 $theme-reference: #3858e9;           // Scales/Theme/theme (modern scheme)
 $theme-darker-10-reference: #2145e6; // Scales/Theme/theme-darker-10
@@ -76,12 +75,12 @@ $theme-alpha-08: rgba(56, 88, 233, 0.08); // Scales/Theme/theme-alpha-08 (8% opa
 
 $brand-9: #4465db;    // Scales/brand-9 - Focus ring color (static, not theme-dependent)
 
-
-// --------------------------------------------------------------------------
-// Semantic Colors
-// --------------------------------------------------------------------------
-// Use these for notices, alerts, and status indicators.
-// These are intentionally NOT theme-dependent for consistency.
+/**
+ * Semantic Colors
+ *
+ * Use these for notices, alerts, and status indicators.
+ * These are intentionally NOT theme-dependent for consistency.
+ */
 
 $alert-yellow: #f0b849;    // Scales/Yellow/alert-yellow - Warnings
 $alert-green: #4ab866;     // Scales/Green/alert-green - Success
@@ -95,20 +94,18 @@ $alert-red-bg: #fcf0f0;    // Error notice background
 
 $synced-color: #7a00df;    // Scales/Purple/--wp-block-synced-color
 
-
-// --------------------------------------------------------------------------
-// Text Colors
-// --------------------------------------------------------------------------
+/**
+ * Text Colors
+ */
 
 $text-primary: $gray-900;     // Primary text color
 $text-secondary: $gray-700;   // Secondary text
 $text-tertiary: #5d5d5d;      // Alias/text/text-tertiary - Placeholder, hints
 $text-disabled: $gray-600;    // Disabled text
 
-
-// --------------------------------------------------------------------------
-// Component Tokens
-// --------------------------------------------------------------------------
+/**
+ * Component Tokens
+ */
 
 // Inputs
 $input-bg: $white;                    // Alias/bg/bg-input
@@ -154,10 +151,9 @@ $card-padding-lg-v: $grid-unit-30;        // 24px - Large cards vertical
 $page-padding-large: 48px;            // Alias/page-large
 $page-padding-small: 24px;            // Alias/page-small
 
-
-// --------------------------------------------------------------------------
-// Typography Scale
-// --------------------------------------------------------------------------
+/**
+ * Typography Scale
+ */
 
 // Font Sizes
 $font-size-xs: 11px;    // xs - Small labels, button small
@@ -171,37 +167,35 @@ $line-height-xs: 16px;  // xs
 $line-height-s: 20px;   // s - Most UI elements
 $line-height-m: 24px;   // m - Body large
 
-// --------------------------------------------------------------------------
-// Elevation (Box Shadows)
-// --------------------------------------------------------------------------
+/**
+ * Elevation (Box Shadows)
+ */
 
 $elevation-xs:
-  0 4px 4px rgba(0, 0, 0, 0.01),
-  0 3px 3px rgba(0, 0, 0, 0.02),
-  0 1px 2px rgba(0, 0, 0, 0.02),
-  0 1px 1px rgba(0, 0, 0, 0.03);
+	0 4px 4px rgba(0, 0, 0, 0.01),
+	0 3px 3px rgba(0, 0, 0, 0.02),
+	0 1px 2px rgba(0, 0, 0, 0.02),
+	0 1px 1px rgba(0, 0, 0, 0.03);
 
 $elevation-s:
-  0 8px 8px rgba(0, 0, 0, 0.02),
-  0 1px 2px rgba(0, 0, 0, 0.05);
+	0 8px 8px rgba(0, 0, 0, 0.02),
+	0 1px 2px rgba(0, 0, 0, 0.05);
 
 $elevation-m:
-  0 16px 16px rgba(0, 0, 0, 0.02),
-  0 4px 5px rgba(0, 0, 0, 0.03),
-  0 2px 3px rgba(0, 0, 0, 0.05);
+	0 16px 16px rgba(0, 0, 0, 0.02),
+	0 4px 5px rgba(0, 0, 0, 0.03),
+	0 2px 3px rgba(0, 0, 0, 0.05);
 
 $elevation-l:
-  0 50px 43px rgba(0, 0, 0, 0.02),
-  0 30px 36px rgba(0, 0, 0, 0.04),
-  0 15px 27px rgba(0, 0, 0, 0.07),
-  0 5px 15px rgba(0, 0, 0, 0.08);
+	0 50px 43px rgba(0, 0, 0, 0.02),
+	0 30px 36px rgba(0, 0, 0, 0.04),
+	0 15px 27px rgba(0, 0, 0, 0.07),
+	0 5px 15px rgba(0, 0, 0, 0.08);
 
-
-// --------------------------------------------------------------------------
-// Layout
-// --------------------------------------------------------------------------
+/**
+ * Layout
+ */
 
 $modal-width-small: 384px;    // Layout/Modal small
 $modal-width-medium: 512px;   // Layout/Modal medium
 $modal-width-large: 840px;    // Layout/Modal large
-


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65898

Part of the ongoing CSS linting work for https://core.trac.wordpress.org/ticket/65898

Important:
This file uses a few scss variables to define line-heights values in pixels. In Core, line-height values must be unitless according to the CSS Coding Standards. This needs a decision:

```
$line-height-xs: 16px;  // xs
$line-height-s: 20px;   // s - Most UI elements
$line-height-m: 24px;   // m - Body large
```

## Use of AI Tools

None

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
