### PR TITLE
Added Layout and Blockgap Support in List Block

### DIFF
--- a/src/wp-includes/blocks/list/block.json
+++ b/src/wp-includes/blocks/list/block.json
@@ -37,10 +37,6 @@
 	},
 	"supports": {
 		"anchor": true,
-		"align": [ "wide", "full" ],
-		"layout": {
-			"allowJustification": false
-		},
 		"html": false,
 		"__experimentalBorder": {
 			"color": true,
@@ -72,7 +68,6 @@
 		"spacing": {
 			"margin": true,
 			"padding": true,
-			"blockGap": true,
 			"__experimentalDefaultControls": {
 				"margin": false,
 				"padding": false

--- a/src/wp-includes/blocks/list/block.json
+++ b/src/wp-includes/blocks/list/block.json
@@ -37,6 +37,10 @@
 	},
 	"supports": {
 		"anchor": true,
+		"align": [ "wide", "full" ],
+		"layout": {
+			"allowJustification": false
+		},
 		"html": false,
 		"__experimentalBorder": {
 			"color": true,
@@ -68,6 +72,7 @@
 		"spacing": {
 			"margin": true,
 			"padding": true,
+			"blockGap": true,
 			"__experimentalDefaultControls": {
 				"margin": false,
 				"padding": false

--- a/tests/phpunit/tests/block-bindings/render.php
+++ b/tests/phpunit/tests/block-bindings/render.php
@@ -480,9 +480,9 @@ HTML;
 				),
 				'bound_value'             => 'Bound list item',
 				'expected_rendered_block' => <<<HTML
-<ul class="wp-block-list">
+<ul class="wp-block-list is-layout-flow wp-block-list-is-layout-flow">
 <li>Bound list item
-<ul class="wp-block-list">
+<ul class="wp-block-list is-layout-flow wp-block-list-is-layout-flow">
 <li>Nested child</li>
 </ul>
 </li>
@@ -500,9 +500,9 @@ HTML
 				),
 				'bound_value'             => 'Bound list item',
 				'expected_rendered_block' => <<<HTML
-<ul class="wp-block-list">
+<ul class="wp-block-list is-layout-flow wp-block-list-is-layout-flow">
 <li>Bound list item
-<ul class="wp-block-list">
+<ul class="wp-block-list is-layout-flow wp-block-list-is-layout-flow">
 <li>Nested child</li>
 </ul>
 </li>
@@ -520,9 +520,9 @@ HTML
 				),
 				'bound_value'             => 'Bound list item',
 				'expected_rendered_block' => <<<HTML
-<ul class="wp-block-list">
+<ul class="wp-block-list is-layout-flow wp-block-list-is-layout-flow">
 <li>Bound list item
-<ul class="wp-block-list">
+<ul class="wp-block-list is-layout-flow wp-block-list-is-layout-flow">
 <li>Nested child</li>
 </ul>
 </li>
@@ -540,9 +540,9 @@ HTML
 				),
 				'bound_value'             => 'Bound <em>línea</em>',
 				'expected_rendered_block' => <<<HTML
-<ul class="wp-block-list">
+<ul class="wp-block-list is-layout-flow wp-block-list-is-layout-flow">
 <li>Bound <em>línea</em>
-<ul class="wp-block-list">
+<ul class="wp-block-list is-layout-flow wp-block-list-is-layout-flow">
 <li>Nested child</li>
 </ul>
 </li>
@@ -561,11 +561,11 @@ HTML
 				),
 				'bound_value'             => 'Bound parent',
 				'expected_rendered_block' => <<<HTML
-<ul class="wp-block-list">
+<ul class="wp-block-list is-layout-flow wp-block-list-is-layout-flow">
 <li>Bound parent
-<ul class="wp-block-list">
+<ul class="wp-block-list is-layout-flow wp-block-list-is-layout-flow">
 <li>Nested parent
-<ul class="wp-block-list">
+<ul class="wp-block-list is-layout-flow wp-block-list-is-layout-flow">
 <li>Nested grandchild</li>
 </ul>
 </li>
@@ -587,9 +587,9 @@ HTML
 				),
 				'bound_value'             => 'Bound ordered parent',
 				'expected_rendered_block' => <<<HTML
-<ul class="wp-block-list">
+<ul class="wp-block-list is-layout-flow wp-block-list-is-layout-flow">
 <li>Bound ordered parent
-<ol class="wp-block-list" start="3">
+<ol class="wp-block-list is-layout-flow wp-block-list-is-layout-flow" start="3">
 <li>Ordered child</li>
 
 <li>Second ordered child</li>
@@ -776,9 +776,9 @@ HTML;
 		$result        = $block->render();
 
 		$expected_rendered_block = <<<HTML
-<ul class="wp-block-list">
+<ul class="wp-block-list is-layout-flow wp-block-list-is-layout-flow">
 <li>Pattern <em>override</em>
-<ul class="wp-block-list">
+<ul class="wp-block-list is-layout-flow wp-block-list-is-layout-flow">
 <li>Nested child</li>
 </ul>
 </li>
@@ -841,9 +841,9 @@ HTML;
 		$result        = $block->render();
 
 		$expected_rendered_block = <<<HTML
-<ul class="wp-block-list">
+<ul class="wp-block-list is-layout-flow wp-block-list-is-layout-flow">
 <li>Bound value
-<ul class="wp-block-list">
+<ul class="wp-block-list is-layout-flow wp-block-list-is-layout-flow">
 <li>Nested child</li>
 </ul>
 trailing text</li>


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->

## What

Backport PR of: https://github.com/WordPress/gutenberg/pull/68002/

Added Layout support and also added Align Wide and full width support and also `BlockGap` to the List block.

**Trac ticket:**  TBD

## Use of AI Tools
- No
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
