### PR TITLE
Interactivity API: Make class WP_Interactivity_API minimally extensible

### DIFF
--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -12,7 +12,7 @@
  *
  * @since 6.5.0
  */
-final class WP_Interactivity_API {
+class WP_Interactivity_API {
 	/**
 	 * Holds the mapping of directive attribute names to their processor methods.
 	 *


### PR DESCRIPTION
<!-- Insert a description of your changes here -->

Trac ticket: 65757

Remove final from WP_Interactivity_API to allow for minimal extensibility of the server-side iAPI processor

## Use of AI Tools

No

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**