### PR TITLE
Upgrade/Install: Load the `.maintenance` file non-fatally

### DIFF
--- a/src/wp-admin/includes/class-wp-automatic-updater.php
+++ b/src/wp-admin/includes/class-wp-automatic-updater.php
@@ -1766,8 +1766,11 @@ Thanks! -- The WordPress Team"
 			return false;
 		}
 
-		require $maintenance_file;
-		if ( ! is_int( $upgrading ) ) {
+		// The file may be removed between the check above and the load below.
+		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- Warning emitted in expected failure case.
+		$maintenance_file_loaded = @include $maintenance_file;
+
+		if ( false === $maintenance_file_loaded || ! is_int( $upgrading ) ) {
 			return false;
 		}
 

--- a/src/wp-includes/load.php
+++ b/src/wp-includes/load.php
@@ -441,7 +441,13 @@ function wp_is_maintenance_mode() {
 		return false;
 	}
 
-	require ABSPATH . '.maintenance';
+	// The file may be removed between the check above and the load below.
+	// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- Warning emitted in expected failure case.
+	$maintenance_file_loaded = @include ABSPATH . '.maintenance';
+
+	if ( false === $maintenance_file_loaded ) {
+		return false;
+	}
 
 	// If the $upgrading timestamp is older than 10 minutes, consider maintenance over.
 	if ( ( time() - $upgrading ) >= 10 * MINUTE_IN_SECONDS ) {

--- a/tests/phpunit/tests/load/wpIsMaintenanceMode.php
+++ b/tests/phpunit/tests/load/wpIsMaintenanceMode.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Unit tests for `wp_is_maintenance_mode()`.
+ *
+ * @package WordPress
+ * @subpackage UnitTests
+ *
+ * @group load
+ *
+ * @covers ::wp_is_maintenance_mode
+ */
+class Test_WP_Is_Maintenance_Mode extends WP_UnitTestCase {
+
+	public function tear_down() {
+		if ( is_dir( ABSPATH . '.maintenance' ) ) {
+			rmdir( ABSPATH . '.maintenance' );
+		}
+
+		parent::tear_down();
+	}
+
+	/**
+	 * @ticket 65911
+	 */
+	public function test_should_return_false_when_the_maintenance_file_cannot_be_loaded() {
+		if ( file_exists( ABSPATH . '.maintenance' ) ) {
+			$this->markTestSkipped( 'A .maintenance file already exists in ABSPATH.' );
+		}
+
+		mkdir( ABSPATH . '.maintenance' );
+
+		$this->assertFalse( wp_is_maintenance_mode() );
+	}
+}


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

After a successful update, WordPress can end the request with `Uncaught Error: Failed opening required '.maintenance'` from `wp-includes/load.php`.

`wp_is_maintenance_mode()` and `WP_Automatic_Updater::has_fatal_error()` both check for the file with `file_exists()` and then load it with `require`. A concurrent request can delete it in between, and with `opcache.enable_file_override=1` the cached script entry keeps `file_exists()` returning true after the deletion, so `require` fails fatally. Both now load the file with `include` and bail when it returns false.

The `file_exists()` fast path is kept deliberately: suppressed warnings are still dispatched to custom error handlers, so loading unconditionally would add two per request on every site.

Trac ticket: https://core.trac.wordpress.org/ticket/65911

## Use of AI Tools
AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Reproducing the failure shape, drafting the patch, and adding a regression test. All changes were reviewed and validated by me.
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
