### PR TITLE
Tests: Prevent state leaks in functions tests

### DIFF
--- a/tests/phpunit/tests/functions/forceSslAdmin.php
+++ b/tests/phpunit/tests/functions/forceSslAdmin.php
@@ -16,6 +16,12 @@ class Tests_Functions_ForceSslAdmin extends WP_UnitTestCase {
 		force_ssl_admin( false );
 	}
 
+	public function tear_down() {
+		force_ssl_admin( false );
+
+		parent::tear_down();
+	}
+
 	/**
 	 * Tests that force_ssl_admin() returns expected values based on various inputs.
 	 *

--- a/tests/phpunit/tests/functions/forceSslAdmin.php
+++ b/tests/phpunit/tests/functions/forceSslAdmin.php
@@ -10,14 +10,24 @@
  */
 class Tests_Functions_ForceSslAdmin extends WP_UnitTestCase {
 
+	/**
+	 * The `force_ssl_admin()` value in effect before the test ran.
+	 *
+	 * @var bool
+	 */
+	private $forced_ssl_admin;
+
 	public function set_up() {
 		parent::set_up();
-		// Reset the `$forced` static variable before each test.
-		force_ssl_admin( false );
+		/*
+		 * Reset the `$forced` static variable before each test, keeping the value it held
+		 * so tear_down() can put it back. force_ssl_admin() returns the previous value.
+		 */
+		$this->forced_ssl_admin = force_ssl_admin( false );
 	}
 
 	public function tear_down() {
-		force_ssl_admin( false );
+		force_ssl_admin( $this->forced_ssl_admin );
 
 		parent::tear_down();
 	}

--- a/tests/phpunit/tests/functions/wpTimezoneChoice.php
+++ b/tests/phpunit/tests/functions/wpTimezoneChoice.php
@@ -112,7 +112,7 @@ class Tests_Functions_WpTimezoneChoice extends WP_UnitTestCase {
 	 */
 	public function test_wp_timezone_choice_es( string $expected ): void {
 		$this->restore_timezone_translations = true;
-		$timezone_list = wp_timezone_choice( '', 'es_ES' );
+		$timezone_list                       = wp_timezone_choice( '', 'es_ES' );
 		$this->assertStringContainsString( $expected, $timezone_list );
 	}
 

--- a/tests/phpunit/tests/functions/wpTimezoneChoice.php
+++ b/tests/phpunit/tests/functions/wpTimezoneChoice.php
@@ -10,10 +10,23 @@
 class Tests_Functions_WpTimezoneChoice extends WP_UnitTestCase {
 
 	/**
-	 * Restores the current locale after each test runs.
+	 * Whether timezone translations need to be restored after the test.
+	 *
+	 * @var bool
+	 */
+	private $restore_timezone_translations = false;
+
+	/**
+	 * Restores the current locale and timezone translations after each test runs.
 	 */
 	public function tear_down(): void {
 		restore_current_locale();
+
+		if ( $this->restore_timezone_translations ) {
+			// Synchronize the function's static locale tracking with the restored translations.
+			wp_timezone_choice( '', get_locale() );
+		}
+
 		parent::tear_down();
 	}
 
@@ -98,6 +111,7 @@ class Tests_Functions_WpTimezoneChoice extends WP_UnitTestCase {
 	 * @param string $expected Expected string HTML fragment.
 	 */
 	public function test_wp_timezone_choice_es( string $expected ): void {
+		$this->restore_timezone_translations = true;
 		$timezone_list = wp_timezone_choice( '', 'es_ES' );
 		$this->assertStringContainsString( $expected, $timezone_list );
 	}
@@ -125,6 +139,7 @@ class Tests_Functions_WpTimezoneChoice extends WP_UnitTestCase {
 	 * @param string $expected Expected string HTML fragment.
 	 */
 	public function test_wp_timezone_choice_es_set( string $expected ): void {
+		$this->restore_timezone_translations = true;
 		switch_to_locale( 'es_ES' );
 		$timezone_list = wp_timezone_choice( '' );
 		$this->assertStringContainsString( $expected, $timezone_list );

--- a/tests/phpunit/tests/functions/wpTimezoneChoice.php
+++ b/tests/phpunit/tests/functions/wpTimezoneChoice.php
@@ -25,6 +25,7 @@ class Tests_Functions_WpTimezoneChoice extends WP_UnitTestCase {
 		if ( $this->restore_timezone_translations ) {
 			// Synchronize the function's static locale tracking with the restored translations.
 			wp_timezone_choice( '', get_locale() );
+			$this->restore_timezone_translations = false;
 		}
 
 		parent::tear_down();

--- a/tests/phpunit/tests/functions/wpTimezoneChoice.php
+++ b/tests/phpunit/tests/functions/wpTimezoneChoice.php
@@ -10,23 +10,23 @@
 class Tests_Functions_WpTimezoneChoice extends WP_UnitTestCase {
 
 	/**
-	 * Whether timezone translations need to be restored after the test.
-	 *
-	 * @var bool
-	 */
-	private $restore_timezone_translations = false;
-
-	/**
-	 * Restores the current locale and timezone translations after each test runs.
+	 * Restores the current locale and the timezone translations after each test runs.
 	 */
 	public function tear_down(): void {
 		restore_current_locale();
 
-		if ( $this->restore_timezone_translations ) {
-			// Synchronize the function's static locale tracking with the restored translations.
-			wp_timezone_choice( '', get_locale() );
-			$this->restore_timezone_translations = false;
-		}
+		/*
+		 * wp_timezone_choice() records the locale of the `continents-cities` translations
+		 * it loaded in a function static that nothing outside the function can reset, and
+		 * restoring the locale above reloads those translations without updating it. Call
+		 * the function with the restored locale so the static matches the loaded
+		 * translations again. This runs after every test because the class cannot tell
+		 * which of them left the static set.
+		 *
+		 * It must run before parent::tear_down(): the call fires the load_textdomain and
+		 * gettext hooks, and the parent restores the hook snapshot taken in set_up().
+		 */
+		wp_timezone_choice( '', get_locale() );
 
 		parent::tear_down();
 	}
@@ -112,8 +112,7 @@ class Tests_Functions_WpTimezoneChoice extends WP_UnitTestCase {
 	 * @param string $expected Expected string HTML fragment.
 	 */
 	public function test_wp_timezone_choice_es( string $expected ): void {
-		$this->restore_timezone_translations = true;
-		$timezone_list                       = wp_timezone_choice( '', 'es_ES' );
+		$timezone_list = wp_timezone_choice( '', 'es_ES' );
 		$this->assertStringContainsString( $expected, $timezone_list );
 	}
 
@@ -140,7 +139,6 @@ class Tests_Functions_WpTimezoneChoice extends WP_UnitTestCase {
 	 * @param string $expected Expected string HTML fragment.
 	 */
 	public function test_wp_timezone_choice_es_set( string $expected ): void {
-		$this->restore_timezone_translations = true;
 		switch_to_locale( 'es_ES' );
 		$timezone_list = wp_timezone_choice( '' );
 		$this->assertStringContainsString( $expected, $timezone_list );


### PR DESCRIPTION
## Summary

- Resets the forced-SSL function-static fixture and resynchronizes timezone-choice translation state after locale-changing data sets.
- Keeps the changes confined to PHPUnit tests and fixtures.

## Verification

- 100 randomized functions-group runs passed; each completed 1,212 tests and 2,499 assertions with 27 known warnings and one skip.
- The continuation covered seeds 1789042001 through 1789042050; authoritative PHPUnit times remained below 50 seconds.
- Replayed the original failing seed and focused contaminator/consumer cases during diagnosis.
- PHP syntax checks passed for every changed PHP file.
- `git diff --check` passed.

Trac: https://core.trac.wordpress.org/ticket/65893
