### PR TITLE
Tests: Isolate user fixtures from randomized execution

### DIFF
--- a/tests/phpunit/tests/user/capabilities.php
+++ b/tests/phpunit/tests/user/capabilities.php
@@ -1406,6 +1406,7 @@ class Tests_User_Capabilities extends WP_UnitTestCase {
 		// Add 'edit_foobars' primitive cap to a user.
 		$admin->add_cap( 'edit_foobars', true );
 		$admin = new WP_User( $admin->ID );
+		self::$users['administrator'] = $admin;
 		$this->assertTrue( $admin->has_cap( $cap->create_posts ) );
 		$this->assertFalse( $author->has_cap( $cap->create_posts ) );
 		$this->assertFalse( $editor->has_cap( $cap->create_posts ) );

--- a/tests/phpunit/tests/user/capabilities.php
+++ b/tests/phpunit/tests/user/capabilities.php
@@ -1405,7 +1405,7 @@ class Tests_User_Capabilities extends WP_UnitTestCase {
 
 		// Add 'edit_foobars' primitive cap to a user.
 		$admin->add_cap( 'edit_foobars', true );
-		$admin = new WP_User( $admin->ID );
+		$admin                        = new WP_User( $admin->ID );
 		self::$users['administrator'] = $admin;
 		$this->assertTrue( $admin->has_cap( $cap->create_posts ) );
 		$this->assertFalse( $author->has_cap( $cap->create_posts ) );

--- a/tests/phpunit/tests/user/countUserPosts.php
+++ b/tests/phpunit/tests/user/countUserPosts.php
@@ -156,7 +156,12 @@ class Tests_User_CountUserPosts extends WP_UnitTestCase {
 	 */
 	public function test_count_user_posts_for_user_created_after_being_assigned_posts() {
 		global $wpdb;
-		$next_user_id = (int) $wpdb->get_var( "SELECT `auto_increment` FROM INFORMATION_SCHEMA.TABLES WHERE table_name = '$wpdb->users'" );
+		$next_user_id = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				'SELECT AUTO_INCREMENT FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = %s',
+				$wpdb->users
+			)
+		);
 
 		// Assign post to next user.
 		self::factory()->post->create(

--- a/tests/phpunit/tests/user/mapMetaCap.php
+++ b/tests/phpunit/tests/user/mapMetaCap.php
@@ -337,22 +337,6 @@ class Tests_User_MapMetaCap extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @ticket 20488
-	 */
-	public function test_file_edit_caps_not_reliant_on_unfiltered_html_constant() {
-		$this->assertFalse( defined( 'DISALLOW_FILE_MODS' ) );
-		$this->assertFalse( defined( 'DISALLOW_FILE_EDIT' ) );
-
-		if ( ! defined( 'DISALLOW_UNFILTERED_HTML' ) ) {
-			define( 'DISALLOW_UNFILTERED_HTML', true );
-		}
-
-		$this->assertTrue( DISALLOW_UNFILTERED_HTML );
-		$this->assertSame( array( 'update_core' ), map_meta_cap( 'update_core', self::$user_id ) );
-		$this->assertSame( array( 'edit_plugins' ), map_meta_cap( 'edit_plugins', self::$user_id ) );
-	}
-
-	/**
 	 * Test a post without an author.
 	 *
 	 * @ticket 27020
@@ -456,5 +440,32 @@ class Tests_User_MapMetaCap extends WP_UnitTestCase {
 			array( 'delete_term' ),
 			array( 'assign_term' ),
 		);
+	}
+}
+
+/**
+ * @group user
+ * @group capabilities
+ * @covers ::map_meta_cap
+ */
+class Tests_User_MapMetaCap_Constants extends WP_UnitTestCase {
+
+	/**
+	 * @ticket 20488
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_file_edit_caps_not_reliant_on_unfiltered_html_constant() {
+		$this->assertFalse( defined( 'DISALLOW_FILE_MODS' ) );
+		$this->assertFalse( defined( 'DISALLOW_FILE_EDIT' ) );
+
+		if ( ! defined( 'DISALLOW_UNFILTERED_HTML' ) ) {
+			define( 'DISALLOW_UNFILTERED_HTML', true );
+		}
+
+		$this->assertTrue( DISALLOW_UNFILTERED_HTML );
+		$this->assertSame( array( 'update_core' ), map_meta_cap( 'update_core', 0 ) );
+		$this->assertSame( array( 'edit_plugins' ), map_meta_cap( 'edit_plugins', 0 ) );
 	}
 }

--- a/tests/phpunit/tests/user/mapMetaCap.php
+++ b/tests/phpunit/tests/user/mapMetaCap.php
@@ -457,15 +457,27 @@ class Tests_User_MapMetaCap_Constants extends WP_UnitTestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test_file_edit_caps_not_reliant_on_unfiltered_html_constant() {
-		$this->assertFalse( defined( 'DISALLOW_FILE_MODS' ) );
-		$this->assertFalse( defined( 'DISALLOW_FILE_EDIT' ) );
+		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
 
-		if ( ! defined( 'DISALLOW_UNFILTERED_HTML' ) ) {
-			define( 'DISALLOW_UNFILTERED_HTML', true );
+		if ( is_multisite() ) {
+			grant_super_admin( $user_id );
 		}
 
-		$this->assertTrue( DISALLOW_UNFILTERED_HTML );
-		$this->assertSame( array( 'update_core' ), map_meta_cap( 'update_core', 0 ) );
-		$this->assertSame( array( 'edit_plugins' ), map_meta_cap( 'edit_plugins', 0 ) );
+		try {
+			$this->assertFalse( defined( 'DISALLOW_FILE_MODS' ) );
+			$this->assertFalse( defined( 'DISALLOW_FILE_EDIT' ) );
+
+			if ( ! defined( 'DISALLOW_UNFILTERED_HTML' ) ) {
+				define( 'DISALLOW_UNFILTERED_HTML', true );
+			}
+
+			$this->assertTrue( DISALLOW_UNFILTERED_HTML );
+			$this->assertSame( array( 'update_core' ), map_meta_cap( 'update_core', $user_id ) );
+			$this->assertSame( array( 'edit_plugins' ), map_meta_cap( 'edit_plugins', $user_id ) );
+		} finally {
+			if ( is_multisite() ) {
+				revoke_super_admin( $user_id );
+			}
+		}
 	}
 }

--- a/tests/phpunit/tests/user/query.php
+++ b/tests/phpunit/tests/user/query.php
@@ -1656,20 +1656,20 @@ class Tests_User_Query extends WP_UnitTestCase {
 	 */
 	public function test_search_by_display_name_only() {
 
-		$new_user1          = self::factory()->user->create(
+		$new_user1 = self::factory()->user->create(
 			array(
 				'user_login'   => 'name1',
 				'display_name' => 'Sophia Andresen',
 			)
 		);
-		self::$author_ids[] = $new_user1;
+		$author_ids = array_merge( self::$author_ids, array( $new_user1 ) );
 
 		$q = new WP_User_Query(
 			array(
 				'search'         => '*Sophia*',
 				'fields'         => '',
 				'search_columns' => array( 'display_name' ),
-				'include'        => self::$author_ids,
+				'include'        => $author_ids,
 			)
 		);
 
@@ -1684,20 +1684,20 @@ class Tests_User_Query extends WP_UnitTestCase {
 	 */
 	public function test_search_by_display_name_only_ignore_others() {
 
-		$new_user1          = self::factory()->user->create(
+		$new_user1 = self::factory()->user->create(
 			array(
 				'user_login'   => 'Sophia Andresen',
 				'display_name' => 'name1',
 			)
 		);
-		self::$author_ids[] = $new_user1;
+		$author_ids = array_merge( self::$author_ids, array( $new_user1 ) );
 
 		$q = new WP_User_Query(
 			array(
 				'search'         => '*Sophia*',
 				'fields'         => '',
 				'search_columns' => array( 'display_name' ),
-				'include'        => self::$author_ids,
+				'include'        => $author_ids,
 			)
 		);
 

--- a/tests/phpunit/tests/user/query.php
+++ b/tests/phpunit/tests/user/query.php
@@ -1656,7 +1656,7 @@ class Tests_User_Query extends WP_UnitTestCase {
 	 */
 	public function test_search_by_display_name_only() {
 
-		$new_user1 = self::factory()->user->create(
+		$new_user1  = self::factory()->user->create(
 			array(
 				'user_login'   => 'name1',
 				'display_name' => 'Sophia Andresen',
@@ -1684,7 +1684,7 @@ class Tests_User_Query extends WP_UnitTestCase {
 	 */
 	public function test_search_by_display_name_only_ignore_others() {
 
-		$new_user1 = self::factory()->user->create(
+		$new_user1  = self::factory()->user->create(
 			array(
 				'user_login'   => 'Sophia Andresen',
 				'display_name' => 'name1',


### PR DESCRIPTION
Avoid mutating shared user IDs, refresh the shared capability fixture, and isolate the capability test that defines `DISALLOW_UNFILTERED_HTML`. Also restrict the `INFORMATION_SCHEMA` lookup to the active database so it cannot read another test database's auto-increment value.

The constant test has its own file and class, `Tests_User_MapMetaCapDisallowUnfilteredHtml`, so PHPUnit discovers it when invoked by file. A separate process prevents the constant from affecting later tests. A separate class prevents the child process's class teardown from deleting fixtures still needed by `Tests_User_MapMetaCap` in the parent process. The isolated test creates its own administrator and grants super-admin privileges on multisite; test teardown rolls back that grant.

Verified locally on 2026-09-14 with PHP 8.5.10 and PHPUnit 9.6.36:

- Both capability files pass when invoked individually on single site and multisite: the isolated file runs 1 test with 5 assertions; the original runs 35 tests with 95 assertions on single site and 96 on multisite.
- Randomized `user` group with seed `1789039001`: 1,344 tests / 4,534 assertions on single site and 1,403 / 5,000 on multisite. Both exit 0 with five existing PHPUnit deprecation warnings; single site also has one skip.
- PHPCS passes on both files changed by the split. `git diff --check` passes.

Trac: https://core.trac.wordpress.org/ticket/65893
