### PR TITLE
Tests: Restore locale without post-rollback queries

### DIFF
--- a/tests/phpunit/includes/abstract-testcase.php
+++ b/tests/phpunit/includes/abstract-testcase.php
@@ -24,6 +24,12 @@ abstract class WP_UnitTestCase_Base extends PHPUnit_Adapter_TestCase {
 
 	protected static $hooks_saved = array();
 	protected static $ignore_files;
+
+	/**
+	 * Site locale before each test.
+	 *
+	 * @var string
+	 */
 	protected $original_locale = 'en_US';
 
 	/**

--- a/tests/phpunit/includes/abstract-testcase.php
+++ b/tests/phpunit/includes/abstract-testcase.php
@@ -24,6 +24,7 @@ abstract class WP_UnitTestCase_Base extends PHPUnit_Adapter_TestCase {
 
 	protected static $hooks_saved = array();
 	protected static $ignore_files;
+	protected $original_locale = 'en_US';
 
 	/**
 	 * Fixture factory.
@@ -121,6 +122,14 @@ abstract class WP_UnitTestCase_Base extends PHPUnit_Adapter_TestCase {
 		}
 
 		$this->clean_up_global_scope();
+
+		/*
+		 * Capture the site locale after resetting the runtime cache so it can be
+		 * restored without querying the database after the test transaction rolls back.
+		 */
+		unset( $GLOBALS['locale'] );
+		$this->original_locale = determine_locale();
+		WP_Translation_Controller::get_instance()->set_locale( $this->original_locale );
 
 		/*
 		 * When running core tests, ensure that post types and taxonomies
@@ -229,7 +238,9 @@ abstract class WP_UnitTestCase_Base extends PHPUnit_Adapter_TestCase {
 		remove_filter( 'wp_die_handler', array( $this, 'get_wp_die_handler' ) );
 		$this->_restore_hooks();
 		wp_set_current_user( 0 );
-
+		// Synchronize the locale globals with the site locale captured before the test.
+		$GLOBALS['locale'] = $this->original_locale;
+		WP_Translation_Controller::get_instance()->set_locale( $this->original_locale );
 		$this->reset_lazyload_queue();
 
 		WP_Style_Engine_CSS_Rules_Store::remove_all_stores();

--- a/tests/phpunit/tests/l10n/loadScriptTextdomain.php
+++ b/tests/phpunit/tests/l10n/loadScriptTextdomain.php
@@ -19,6 +19,8 @@ class Tests_L10n_LoadScriptTextdomain extends WP_UnitTestCase {
 	 * @dataProvider data_resolve_relative_path
 	 */
 	public function test_resolve_relative_path( $translation_path, $handle, $src, $textdomain, $filter = array() ) {
+		wp_scripts();
+
 		if ( ! empty( $filter ) ) {
 			add_filter( $filter[0], $filter[1], 10, $filter[2] ?? 1 );
 		}

--- a/tests/phpunit/tests/privacy/wpPrivacySendErasureFulfillmentNotification.php
+++ b/tests/phpunit/tests/privacy/wpPrivacySendErasureFulfillmentNotification.php
@@ -84,6 +84,10 @@ class Tests_Privacy_wpPrivacySendErasureFulfillmentNotification extends WP_UnitT
 	 */
 	public function set_up() {
 		parent::set_up();
+
+		unset( $GLOBALS['locale'] );
+		get_locale();
+
 		reset_phpmailer_instance();
 	}
 
@@ -96,6 +100,8 @@ class Tests_Privacy_wpPrivacySendErasureFulfillmentNotification extends WP_UnitT
 		reset_phpmailer_instance();
 		restore_previous_locale();
 		parent::tear_down();
+
+		unset( $GLOBALS['locale'] );
 	}
 
 	/**

--- a/tests/phpunit/tests/privacy/wpPrivacySendPersonalDataExportEmail.php
+++ b/tests/phpunit/tests/privacy/wpPrivacySendPersonalDataExportEmail.php
@@ -80,6 +80,10 @@ class Tests_Privacy_wpPrivacySendPersonalDataExportEmail extends WP_UnitTestCase
 	 */
 	public function set_up() {
 		parent::set_up();
+
+		unset( $GLOBALS['locale'] );
+		get_locale();
+
 		reset_phpmailer_instance();
 	}
 
@@ -92,6 +96,8 @@ class Tests_Privacy_wpPrivacySendPersonalDataExportEmail extends WP_UnitTestCase
 		reset_phpmailer_instance();
 		restore_previous_locale();
 		parent::tear_down();
+
+		unset( $GLOBALS['locale'] );
 	}
 
 	/**

--- a/tests/phpunit/tests/user/wpSendUserRequest.php
+++ b/tests/phpunit/tests/user/wpSendUserRequest.php
@@ -60,6 +60,9 @@ class Tests_User_wpSendUserRequest extends WP_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 
+		unset( $GLOBALS['locale'] );
+		get_locale();
+
 		set_current_screen( 'dashboard' );
 		reset_phpmailer_instance();
 	}
@@ -72,10 +75,10 @@ class Tests_User_wpSendUserRequest extends WP_UnitTestCase {
 	public function tear_down() {
 		reset_phpmailer_instance();
 
-		unset( $GLOBALS['locale'] );
-
 		restore_previous_locale();
 		parent::tear_down();
+
+		unset( $GLOBALS['locale'] );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Initializes WP_Scripts before case-specific URL filters and restores locale state around privacy and user-request email fixtures.
- Captures a clean site locale during setup and restores the locale global and translation controller after transaction rollback without querying options.
- Avoids opening a new parent transaction that can metadata-lock separate-process test installation.
- Keeps the source changes confined to PHPUnit tests and fixtures.

## Verification

- Replayed the original l10n failure and the Ajax and formatting seeds that previously hung at separate-process tests.
- 100 consecutive fresh randomized l10n-group runs passed on the combined campaign head with the same locale implementation; each completed 266 tests and 804 assertions with the known warning. That gate head also contained an unrelated permalink teardown reset omitted from this isolated PR.
- 100 consecutive fresh randomized Ajax-group runs also passed; each completed 190 tests and 1,212 assertions with one skip.
- Seeds 1789060001 through 1789060100 covered the final l10n proof; Ajax seeds 1789050001 through 1789050100 covered the metadata-lock regression.
- PHP syntax checks and `git diff --check` passed.

Trac: https://core.trac.wordpress.org/ticket/65893
