### PR TITLE
Editor: Cache merged global styles in the theme_json group

### DIFF
--- a/src/wp-includes/block-supports/layout.php
+++ b/src/wp-includes/block-supports/layout.php
@@ -953,8 +953,6 @@ function wp_get_layout_style( $selector, $layout, $has_block_gap_support = false
  * @return string Filtered block content.
  */
 function wp_render_layout_support_flag( $block_content, $block ) {
-	static $global_styles = null;
-
 	$block_type            = WP_Block_Type_Registry::get_instance()->get_registered( $block['blockName'] );
 	$block_supports_layout = block_has_support( $block_type, 'layout', false ) || block_has_support( $block_type, '__experimentalLayout', false );
 	$style_attr            = $block['attrs']['style'] ?? array();
@@ -1167,10 +1165,8 @@ function wp_render_layout_support_flag( $block_content, $block ) {
 
 		// Get default blockGap value from global styles for use in layouts like grid.
 		// Check style variation first, then block-specific styles, then fall back to root styles.
-		$block_name = $block['blockName'] ?? '';
-		if ( null === $global_styles ) {
-			$global_styles = wp_get_global_styles();
-		}
+		$block_name    = $block['blockName'] ?? '';
+		$global_styles = wp_get_global_styles();
 
 		// Check if the block has an active style variation with a blockGap value.
 		// Only check the registry if the className contains a variation class to avoid unnecessary lookups.

--- a/src/wp-includes/global-styles-and-settings.php
+++ b/src/wp-includes/global-styles-and-settings.php
@@ -91,6 +91,8 @@ function wp_get_global_settings( $path = array(), $context = array() ) {
  *              to "var(--wp--preset--font-size--small)" so consumers don't have to.
  * @since 6.3.0 `transforms` is now usable in the `context` parameter. In case [`transforms`]['resolve_variables']
  *              is defined, variables are resolved to their value in the styles.
+ * @since 7.2.0 The merged styles are cached in the non-persistent `theme_json` group,
+ *              matching wp_get_global_settings().
  *
  * @param array $path    Path to the specific style to retrieve. Optional.
  *                       If empty, will return all styles.
@@ -122,11 +124,43 @@ function wp_get_global_styles( $path = array(), $context = array() ) {
 	&& is_array( $context['transforms'] )
 	&& in_array( 'resolve-variables', $context['transforms'], true );
 
-	$merged_data = WP_Theme_JSON_Resolver::get_merged_data( $origin );
-	if ( $resolve_variables ) {
-		$merged_data = WP_Theme_JSON::resolve_variables( $merged_data );
+	/*
+	 * By using the 'theme_json' group, this data is marked to be non-persistent across requests.
+	 * See `wp_cache_add_non_persistent_groups` in src/wp-includes/load.php and other places.
+	 *
+	 * The rationale is the same as for wp_get_global_settings(): derived theme.json data is
+	 * always rebuilt for each request so that hooks using dynamic data are honored.
+	 *
+	 * The $origin and the resolve-variables transform are part of the cache key. Changes here
+	 * need to account for clearing the cache appropriately in wp_clean_theme_json_cache().
+	 */
+	$cache_group = 'theme_json';
+	$cache_key   = $resolve_variables
+		? 'wp_get_global_styles_' . $origin . '_resolved'
+		: 'wp_get_global_styles_' . $origin;
+
+	/*
+	 * Ignore cache when the development mode is set to 'theme', so it doesn't interfere with the theme
+	 * developer's workflow.
+	 */
+	$can_use_cached = ! wp_is_development_mode( 'theme' );
+
+	$styles = false;
+	if ( $can_use_cached ) {
+		$styles = wp_cache_get( $cache_key, $cache_group );
 	}
-	$styles = $merged_data->get_raw_data()['styles'];
+
+	if ( false === $styles ) {
+		$merged_data = WP_Theme_JSON_Resolver::get_merged_data( $origin );
+		if ( $resolve_variables ) {
+			$merged_data = WP_Theme_JSON::resolve_variables( $merged_data );
+		}
+		$styles = $merged_data->get_raw_data()['styles'] ?? array();
+		if ( $can_use_cached ) {
+			wp_cache_set( $cache_key, $styles, $cache_group );
+		}
+	}
+
 	return _wp_array_get( $styles, $path, $styles );
 }
 
@@ -432,6 +466,10 @@ function wp_clean_theme_json_cache() {
 	wp_cache_delete( 'wp_get_global_styles_svg_filters', 'theme_json' );
 	wp_cache_delete( 'wp_get_global_settings_custom', 'theme_json' );
 	wp_cache_delete( 'wp_get_global_settings_theme', 'theme_json' );
+	wp_cache_delete( 'wp_get_global_styles_custom', 'theme_json' );
+	wp_cache_delete( 'wp_get_global_styles_theme', 'theme_json' );
+	wp_cache_delete( 'wp_get_global_styles_custom_resolved', 'theme_json' );
+	wp_cache_delete( 'wp_get_global_styles_theme_resolved', 'theme_json' );
 	wp_cache_delete( 'wp_get_global_styles_custom_css', 'theme_json' );
 	wp_cache_delete( 'wp_get_theme_data_template_parts', 'theme_json' );
 	WP_Theme_JSON_Resolver::clean_cached_data();

--- a/tests/phpunit/tests/block-supports/layout.php
+++ b/tests/phpunit/tests/block-supports/layout.php
@@ -978,6 +978,8 @@ class Tests_Block_Supports_Layout extends WP_UnitTestCase {
 	 *
 	 * @ticket 64624
 	 * @covers ::wp_render_layout_support_flag
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
 	 */
 	public function test_layout_support_flag_uses_variation_block_gap_value() {
 		switch_theme( 'block-theme' );

--- a/tests/phpunit/tests/block-supports/layout.php
+++ b/tests/phpunit/tests/block-supports/layout.php
@@ -978,8 +978,6 @@ class Tests_Block_Supports_Layout extends WP_UnitTestCase {
 	 *
 	 * @ticket 64624
 	 * @covers ::wp_render_layout_support_flag
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
 	 */
 	public function test_layout_support_flag_uses_variation_block_gap_value() {
 		switch_theme( 'block-theme' );


### PR DESCRIPTION
## Summary

- Removes the unresettable function-static global-styles snapshot from layout rendering.
- Caches merged global styles in the invalidatable, non-persistent `theme_json` cache group, including origin and variable-resolution mode in each key.
- Clears the new keys through `wp_clean_theme_json_cache()` and bypasses them in theme development mode.

## Verification

- Replayed the original failing seed and focused contaminator/consumer sequence during diagnosis.
- 100 consecutive fresh randomized block-supports-group runs passed on the final implementation; each completed 400 tests and 532 assertions.
- Seeds 1789070001 through 1789070100 all completed within the 30-second hard bound.
- PHP syntax checks and `git diff --check` passed.

Trac: https://core.trac.wordpress.org/ticket/65893
