### PR TITLE
Tests: Restore locale state after each test

### DIFF
--- a/tests/phpunit/includes/abstract-testcase.php
+++ b/tests/phpunit/includes/abstract-testcase.php
@@ -230,6 +230,9 @@ abstract class WP_UnitTestCase_Base extends PHPUnit_Adapter_TestCase {
 		$this->_restore_hooks();
 		wp_set_current_user( 0 );
 
+		// Synchronize the translation controller with the restored site locale.
+		WP_Translation_Controller::get_instance()->set_locale( determine_locale() );
+
 		$this->reset_lazyload_queue();
 
 		WP_Style_Engine_CSS_Rules_Store::remove_all_stores();

--- a/tests/phpunit/tests/l10n/wpLocaleSwitcher.php
+++ b/tests/phpunit/tests/l10n/wpLocaleSwitcher.php
@@ -26,6 +26,11 @@ class Tests_L10n_wpLocaleSwitcher extends WP_UnitTestCase {
 	 */
 	protected $orig_instance;
 
+	/**
+	 * @var WP_Locale
+	 */
+	protected $orig_wp_locale;
+
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
 		self::$user_id = $factory->user->create(
 			array(
@@ -43,11 +48,12 @@ class Tests_L10n_wpLocaleSwitcher extends WP_UnitTestCase {
 
 		unset( $GLOBALS['l10n'], $GLOBALS['l10n_unloaded'] );
 
-		global $wp_textdomain_registry, $wp_locale_switcher;
+		global $wp_textdomain_registry, $wp_locale_switcher, $wp_locale;
 
 		$wp_textdomain_registry = new WP_Textdomain_Registry();
 
-		$this->orig_instance = $wp_locale_switcher;
+		$this->orig_instance  = $wp_locale_switcher;
+		$this->orig_wp_locale = $wp_locale;
 
 		remove_all_filters( 'locale' );
 		remove_all_filters( 'determine_locale' );
@@ -59,7 +65,7 @@ class Tests_L10n_wpLocaleSwitcher extends WP_UnitTestCase {
 	public function tear_down() {
 		unset( $GLOBALS['l10n'], $GLOBALS['l10n_unloaded'] );
 
-		global $wp_textdomain_registry, $wp_locale_switcher;
+		global $wp_textdomain_registry, $wp_locale_switcher, $wp_locale;
 
 		$wp_textdomain_registry = new WP_Textdomain_Registry();
 
@@ -71,6 +77,7 @@ class Tests_L10n_wpLocaleSwitcher extends WP_UnitTestCase {
 		remove_all_filters( 'determine_locale' );
 
 		$wp_locale_switcher = $this->orig_instance;
+		$wp_locale          = $this->orig_wp_locale;
 
 		unload_textdomain( 'internationalized-plugin' );
 		unload_textdomain( 'custom-internationalized-theme' );


### PR DESCRIPTION
## Summary

- Synchronizes the translation controller with the restored site locale during base teardown and restores the original WP_Locale object after locale-switcher tests.
- Keeps the changes confined to PHPUnit tests and fixtures.

## Verification

- 100 randomized i18n-group runs passed; each completed 267 tests and 809 assertions with one known warning.
- The continuation covered seeds 1789037001 through 1789037050, all within the 30-second hard bound.
- Replayed the original failing seed and focused contaminator/consumer cases during diagnosis.
- PHP syntax checks passed for every changed PHP file.
- `git diff --check` passed.

Trac: https://core.trac.wordpress.org/ticket/65893
