### PR TITLE
Editor: Preserve empty object block attributes through parse and serialize

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -2560,6 +2560,42 @@ function parse_blocks( $content ) {
 }
 
 /**
+ * Parses blocks while preserving nested empty JSON object attributes.
+ *
+ * An attribute written as `{}` decodes to an empty PHP array like any other JSON object,
+ * and is therefore re-serialized as `[]`. This is only a problem for code that parses
+ * stored markup and writes it back, so preservation is limited to the two workflows that
+ * do: the Block Hooks algorithm and block content filtering through KSES.
+ *
+ * Nested empty objects are returned as empty stdClass instances. Every other value keeps
+ * the shape the default parse path produces.
+ *
+ * Custom block parsers that do not implement `parse_with_options()` fall back to their
+ * existing parse behavior.
+ *
+ * @since 7.2.0
+ * @access private
+ *
+ * @param string $content Post content.
+ * @return array[] Array of parsed block objects.
+ */
+function _wp_parse_blocks_preserving_empty_object_attributes( $content ) {
+	/** This filter is documented in wp-includes/blocks.php */
+	$parser_class = apply_filters( 'block_parser_class', 'WP_Block_Parser' );
+
+	$parser = new $parser_class();
+
+	if ( method_exists( $parser, 'parse_with_options' ) ) {
+		return $parser->parse_with_options(
+			$content,
+			array( 'preserve_empty_object_attributes' => true )
+		);
+	}
+
+	return $parser->parse( $content );
+}
+
+/**
  * Parses dynamic blocks out of `post_content` and re-renders them.
  *
  * @since 5.0.0

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1025,6 +1025,30 @@ function insert_hooked_blocks( &$parsed_anchor_block, $relative_position, $hooke
 	$hooked_block_types = apply_filters( 'hooked_block_types', $hooked_block_types, $relative_position, $anchor_block_type, $context );
 
 	$markup = '';
+
+	/*
+	 * Nothing below reads or writes anything but the anchor block, so an empty list
+	 * leaves no work to do. Returning here avoids copying the anchor block's attributes
+	 * for the many blocks that have no hooked blocks.
+	 *
+	 * This must run after the `hooked_block_types` filter, which can add a hooked block
+	 * type to an anchor that has none registered.
+	 */
+	if ( empty( $hooked_block_types ) ) {
+		return $markup;
+	}
+
+	// Filters have always received array-shaped attributes.
+	$filtered_anchor_block = _wp_get_block_hooks_filter_anchor_block( $parsed_anchor_block );
+
+	/*
+	 * Read `metadata` through an array cast. On the preserving parse path `"metadata":{}`
+	 * arrives as an empty stdClass, and in PHP an array offset on an object is a fatal
+	 * error, including inside isset() and ??.
+	 */
+	$anchor_metadata       = (array) ( $parsed_anchor_block['attrs']['metadata'] ?? array() );
+	$ignored_hooked_blocks = (array) ( $anchor_metadata['ignoredHookedBlocks'] ?? array() );
+
 	foreach ( $hooked_block_types as $hooked_block_type ) {
 		$parsed_hooked_block = array(
 			'blockName'    => $hooked_block_type,
@@ -1046,7 +1070,7 @@ function insert_hooked_blocks( &$parsed_anchor_block, $relative_position, $hooke
 		 * @param WP_Block_Template|WP_Post|array $context             The block template, template part, post object,
 		 *                                                             or pattern that the anchor block belongs to.
 		 */
-		$parsed_hooked_block = apply_filters( 'hooked_block', $parsed_hooked_block, $hooked_block_type, $relative_position, $parsed_anchor_block, $context );
+		$parsed_hooked_block = apply_filters( 'hooked_block', $parsed_hooked_block, $hooked_block_type, $relative_position, $filtered_anchor_block, $context );
 
 		/**
 		 * Filters the parsed block array for a given hooked block.
@@ -1062,7 +1086,7 @@ function insert_hooked_blocks( &$parsed_anchor_block, $relative_position, $hooke
 		 * @param WP_Block_Template|WP_Post|array $context             The block template, template part, post object,
 		 *                                                             or pattern that the anchor block belongs to.
 		 */
-		$parsed_hooked_block = apply_filters( "hooked_block_{$hooked_block_type}", $parsed_hooked_block, $hooked_block_type, $relative_position, $parsed_anchor_block, $context );
+		$parsed_hooked_block = apply_filters( "hooked_block_{$hooked_block_type}", $parsed_hooked_block, $hooked_block_type, $relative_position, $filtered_anchor_block, $context );
 
 		if ( null === $parsed_hooked_block ) {
 			continue;
@@ -1070,10 +1094,7 @@ function insert_hooked_blocks( &$parsed_anchor_block, $relative_position, $hooke
 
 		// It's possible that the filter returned a block of a different type, so we explicitly
 		// look for the original `$hooked_block_type` in the `ignoredHookedBlocks` metadata.
-		if (
-			! isset( $parsed_anchor_block['attrs']['metadata']['ignoredHookedBlocks'] ) ||
-			! in_array( $hooked_block_type, $parsed_anchor_block['attrs']['metadata']['ignoredHookedBlocks'], true )
-		) {
+		if ( ! in_array( $hooked_block_type, $ignored_hooked_blocks, true ) ) {
 			$markup .= serialize_block( $parsed_hooked_block );
 		}
 	}
@@ -1108,6 +1129,9 @@ function set_ignored_hooked_blocks_metadata( &$parsed_anchor_block, $relative_po
 		return '';
 	}
 
+	// Filters have always received array-shaped attributes.
+	$filtered_anchor_block = _wp_get_block_hooks_filter_anchor_block( $parsed_anchor_block );
+
 	foreach ( $hooked_block_types as $index => $hooked_block_type ) {
 		$parsed_hooked_block = array(
 			'blockName'    => $hooked_block_type,
@@ -1117,24 +1141,32 @@ function set_ignored_hooked_blocks_metadata( &$parsed_anchor_block, $relative_po
 		);
 
 		/** This filter is documented in wp-includes/blocks.php */
-		$parsed_hooked_block = apply_filters( 'hooked_block', $parsed_hooked_block, $hooked_block_type, $relative_position, $parsed_anchor_block, $context );
+		$parsed_hooked_block = apply_filters( 'hooked_block', $parsed_hooked_block, $hooked_block_type, $relative_position, $filtered_anchor_block, $context );
 
 		/** This filter is documented in wp-includes/blocks.php */
-		$parsed_hooked_block = apply_filters( "hooked_block_{$hooked_block_type}", $parsed_hooked_block, $hooked_block_type, $relative_position, $parsed_anchor_block, $context );
+		$parsed_hooked_block = apply_filters( "hooked_block_{$hooked_block_type}", $parsed_hooked_block, $hooked_block_type, $relative_position, $filtered_anchor_block, $context );
 
 		if ( null === $parsed_hooked_block ) {
 			unset( $hooked_block_types[ $index ] );
 		}
 	}
 
-	$previously_ignored_hooked_blocks = $parsed_anchor_block['attrs']['metadata']['ignoredHookedBlocks'] ?? array();
+	/*
+	 * Rebuild `metadata` through an array cast rather than writing into it in place. On
+	 * the preserving parse path `"metadata":{}` arrives as an empty stdClass, and in PHP
+	 * an array offset on an object is a fatal error, assignment included.
+	 */
+	$anchor_metadata                  = (array) ( $parsed_anchor_block['attrs']['metadata'] ?? array() );
+	$previously_ignored_hooked_blocks = (array) ( $anchor_metadata['ignoredHookedBlocks'] ?? array() );
 
-	$parsed_anchor_block['attrs']['metadata']['ignoredHookedBlocks'] = array_unique(
+	$anchor_metadata['ignoredHookedBlocks'] = array_unique(
 		array_merge(
 			$previously_ignored_hooked_blocks,
 			$hooked_block_types
 		)
 	);
+
+	$parsed_anchor_block['attrs']['metadata'] = $anchor_metadata;
 
 	// Markup for the hooked blocks has already been created (in `insert_hooked_blocks`).
 	return '';
@@ -1237,7 +1269,7 @@ function apply_block_hooks_to_content( $content, $context = null, $callback = 'i
 	};
 	add_filter( 'hooked_block_types', $suppress_single_instance_blocks, PHP_INT_MAX );
 	$content = traverse_and_serialize_blocks(
-		parse_blocks( $content ),
+		_wp_parse_blocks_preserving_empty_object_attributes( $content ),
 		$before_block_visitor,
 		$after_block_visitor
 	);
@@ -2123,7 +2155,7 @@ function filter_block_content( $text, $allowed_html = 'post', $allowed_protocols
 		$text = preg_replace_callback( '%<!--(.*?)--->%', '_filter_block_content_callback', $text );
 	}
 
-	$blocks = parse_blocks( $text );
+	$blocks = _wp_parse_blocks_preserving_empty_object_attributes( $text );
 	foreach ( $blocks as $block ) {
 		$block   = filter_block_kses( $block, $allowed_html, $allowed_protocols );
 		$result .= serialize_block( $block );
@@ -2593,6 +2625,59 @@ function _wp_parse_blocks_preserving_empty_object_attributes( $content ) {
 	}
 
 	return $parser->parse( $content );
+}
+
+/**
+ * Converts preserved empty object attributes back to empty arrays.
+ *
+ * Used when exposing an internally preserved parsed block to extension points that
+ * historically received arrays throughout.
+ *
+ * @since 7.2.0
+ * @access private
+ *
+ * @param mixed $value Attribute value.
+ * @return mixed The value with empty objects converted to empty arrays.
+ */
+function _wp_block_attribute_empty_objects_to_arrays( $value ) {
+	if ( $value instanceof stdClass ) {
+		return array();
+	}
+
+	if ( ! is_array( $value ) ) {
+		return $value;
+	}
+
+	foreach ( $value as $key => $child_value ) {
+		if ( is_array( $child_value ) || $child_value instanceof stdClass ) {
+			$value[ $key ] = _wp_block_attribute_empty_objects_to_arrays( $child_value );
+		}
+	}
+
+	return $value;
+}
+
+/**
+ * Returns a parsed block using the historical all-array attribute shape.
+ *
+ * The Block Hooks algorithm parses with empty-object preservation enabled, so an anchor
+ * block handed to a third-party filter would otherwise expose an empty stdClass where
+ * that filter has always seen an empty array.
+ *
+ * @since 7.2.0
+ * @access private
+ *
+ * @param array $parsed_block A block, in parsed block array format.
+ * @return array A copy of the block with all-array attributes.
+ */
+function _wp_get_block_hooks_filter_anchor_block( $parsed_block ) {
+	if ( empty( $parsed_block['attrs'] ) || ! is_array( $parsed_block['attrs'] ) ) {
+		return $parsed_block;
+	}
+
+	$parsed_block['attrs'] = _wp_block_attribute_empty_objects_to_arrays( $parsed_block['attrs'] );
+
+	return $parsed_block;
 }
 
 /**

--- a/src/wp-includes/class-wp-block-parser.php
+++ b/src/wp-includes/class-wp-block-parser.php
@@ -49,6 +49,14 @@ class WP_Block_Parser {
 	public $stack;
 
 	/**
+	 * Parse options for the current parse
+	 *
+	 * @since 7.2.0
+	 * @var array
+	 */
+	protected $options = array();
+
+	/**
 	 * Parses a document and returns a list of block structures
 	 *
 	 * When encountering an invalid parse will return a best-effort
@@ -71,6 +79,35 @@ class WP_Block_Parser {
 		}
 
 		return $this->output;
+	}
+
+	/**
+	 * Parses a document with parse options and returns a list of block structures.
+	 *
+	 * Separate from {@see WP_Block_Parser::parse()} to leave that method's signature
+	 * unchanged, since a parser supplied through the `block_parser_class` filter may
+	 * subclass this class and override it. Delegating to `parse()` rather than
+	 * reimplementing it keeps any such override in effect.
+	 *
+	 * @since 7.2.0
+	 *
+	 * @param string $document Input document being parsed.
+	 * @param array  $options  Optional. Parse options. Supports the
+	 *                         `preserve_empty_object_attributes` key, which keeps a
+	 *                         nested empty JSON object attribute as an empty object
+	 *                         rather than collapsing it to an empty array. Anything
+	 *                         that is not an array is ignored. Default empty array.
+	 * @return array[]
+	 */
+	public function parse_with_options( $document, $options = array() ) {
+		$this->options = is_array( $options ) ? $options : array();
+
+		try {
+			return $this->parse( $document );
+		} finally {
+			// Options apply to a single parse only.
+			$this->options = array();
+		}
 	}
 
 	/**
@@ -277,7 +314,7 @@ class WP_Block_Parser {
 		 * are associative arrays. If we use `array()` we get a JSON `[]`
 		 */
 		$attrs = $has_attrs
-			? json_decode( $matches['attrs'][0], /* as-associative */ true )
+			? $this->parse_block_attributes( $matches['attrs'][0] )
 			: array();
 
 		/*
@@ -386,6 +423,85 @@ class WP_Block_Parser {
 		}
 
 		$this->output[] = (array) $stack_top->block;
+	}
+
+	/**
+	 * Decodes a block's attribute JSON.
+	 *
+	 * @since 7.2.0
+	 *
+	 * @param string $json Raw attribute JSON from the block delimiter.
+	 * @return array|null Decoded attributes, or null on invalid JSON.
+	 */
+	private function parse_block_attributes( $json ) {
+		if (
+			empty( $this->options['preserve_empty_object_attributes'] )
+			/*
+			 * An attribute string with no `{}` token cannot contain an empty object, so
+			 * there is nothing to preserve and the historical decode is used. Most
+			 * attributes fall in that group, which keeps their cost unchanged. The
+			 * character class covers the whitespace JSON permits between the braces.
+			 *
+			 * A `{}` inside a string value, as in `{"tpl":"{}"}`, only leads to a walk
+			 * that finds nothing to change, so this is an optimization, not a fork.
+			 */
+			|| ! preg_match( '/\{[ \t\r\n]*\}/', $json )
+		) {
+			// Default (historical) behavior: objects and arrays both decode to arrays.
+			return json_decode( $json, /* associative */ true );
+		}
+
+		$decoded = json_decode( $json, /* associative */ false );
+		if ( JSON_ERROR_NONE !== json_last_error() ) {
+			return null;
+		}
+
+		return self::normalize_block_attributes( $decoded, /* is_attribute_root */ true );
+	}
+
+	/**
+	 * Converts a json_decode(..., false) result into the parsed attribute shape,
+	 * keeping only nested empty objects as objects.
+	 *
+	 * Every other JSON object becomes a PHP array, matching the default parse path. An
+	 * empty object holds no keys and no strings, so nothing downstream needs to read
+	 * into it or sanitize it; a populated object would hide its contents from code that
+	 * walks arrays.
+	 *
+	 * wp_json_encode() emits `{}` for an empty object and `[]` for an empty array, so
+	 * the distinction survives serialization without a marker or a restore step.
+	 *
+	 * @since 7.2.0
+	 *
+	 * @param mixed $value             Decoded value (stdClass, array, or scalar).
+	 * @param bool  $is_attribute_root Whether $value is the top-level attribute container,
+	 *                                 which always becomes an array so that empty
+	 *                                 attributes keep being dropped on serialization.
+	 * @return mixed The normalized value.
+	 */
+	private static function normalize_block_attributes( $value, $is_attribute_root = false ) {
+		if ( $value instanceof stdClass ) {
+			$properties = get_object_vars( $value );
+
+			if ( ! $is_attribute_root && empty( $properties ) ) {
+				return $value;
+			}
+
+			$normalized = array();
+			foreach ( $properties as $key => $child_value ) {
+				$normalized[ $key ] = self::normalize_block_attributes( $child_value );
+			}
+
+			return $normalized;
+		}
+
+		if ( is_array( $value ) ) {
+			foreach ( $value as $key => $child_value ) {
+				$value[ $key ] = self::normalize_block_attributes( $child_value );
+			}
+		}
+
+		return $value; // Scalars and null pass through unchanged.
 	}
 }
 

--- a/tests/phpunit/tests/blocks/applyBlockHooksToContent.php
+++ b/tests/phpunit/tests/blocks/applyBlockHooksToContent.php
@@ -191,4 +191,171 @@ class Tests_Blocks_ApplyBlockHooksToContent extends WP_UnitTestCase {
 			$actual
 		);
 	}
+
+	/**
+	 * An empty object attribute on the anchor block must survive hooked block insertion.
+	 *
+	 * The Block Hooks algorithm parses stored markup and writes it back, which is what
+	 * turned `{}` into `[]` before empty-object preservation existed.
+	 *
+	 * @ticket 63325
+	 */
+	public function test_empty_object_attribute_survives_hooked_block_insertion() {
+		$context          = new WP_Block_Template();
+		$context->content = '<!-- wp:post-content {"layout":{"columns":{}}} /-->';
+
+		$actual = apply_block_hooks_to_content( $context->content, $context, 'insert_hooked_blocks' );
+
+		$this->assertSame(
+			'<!-- wp:post-content {"layout":{"columns":{}}} /--><!-- wp:tests/hooked-block /-->',
+			$actual
+		);
+	}
+
+	/**
+	 * An empty `metadata` object must not break the algorithm that writes to it.
+	 *
+	 * `set_ignored_hooked_blocks_metadata()` and `insert_hooked_blocks()` index into
+	 * `attrs.metadata.ignoredHookedBlocks`. In PHP every array offset against an object
+	 * is fatal -- including inside isset() and ?? -- so an anchor block carrying
+	 * `"metadata":{}` would take down the whole request without the array casts there.
+	 *
+	 * @ticket 63325
+	 *
+	 * @dataProvider data_object_shaped_metadata
+	 *
+	 * @param string $attributes Anchor block attribute JSON.
+	 */
+	public function test_object_shaped_metadata_does_not_fatal( $attributes ) {
+		$context          = new WP_Block_Template();
+		$context->content = "<!-- wp:post-content $attributes /-->";
+
+		$actual = apply_block_hooks_to_content( $context->content, $context, 'insert_hooked_blocks' );
+
+		$this->assertStringContainsString( '<!-- wp:tests/hooked-block /-->', $actual );
+	}
+
+	/**
+	 * Same shapes, through the visitor that records ignored hooked blocks.
+	 *
+	 * @ticket 63325
+	 *
+	 * @dataProvider data_object_shaped_metadata
+	 *
+	 * @param string $attributes Anchor block attribute JSON.
+	 */
+	public function test_object_shaped_metadata_does_not_fatal_when_setting_metadata( $attributes ) {
+		$context          = new WP_Block_Template();
+		$context->content = "<!-- wp:post-content $attributes /-->";
+
+		$actual = apply_block_hooks_to_content( $context->content, $context, 'set_ignored_hooked_blocks_metadata' );
+
+		$this->assertStringContainsString( '"ignoredHookedBlocks":["tests/hooked-block"]', $actual );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_object_shaped_metadata() {
+		return array(
+			'empty metadata object'             => array( '{"metadata":{}}' ),
+			'empty ignoredHookedBlocks object'  => array( '{"metadata":{"ignoredHookedBlocks":{}}}' ),
+			'empty object beside real metadata' => array( '{"metadata":{"name":"Test","extra":{}}}' ),
+		);
+	}
+
+	/**
+	 * Filters must keep receiving the historical all-array attribute shape.
+	 *
+	 * The preserved empty object stays in the block that gets serialized, but the copy
+	 * handed to `hooked_block` is converted, so existing callbacks that walk attributes
+	 * with array access are unaffected.
+	 *
+	 * @ticket 63325
+	 */
+	public function test_hooked_block_filter_receives_array_shaped_attributes() {
+		$anchor_attrs = null;
+
+		$filter = static function ( $parsed_hooked_block, $hooked_block_type, $relative_position, $anchor_block ) use ( &$anchor_attrs ) {
+			$anchor_attrs = $anchor_block['attrs'];
+
+			return $parsed_hooked_block;
+		};
+
+		$context          = new WP_Block_Template();
+		$context->content = '<!-- wp:post-content {"layout":{"columns":{}}} /-->';
+
+		add_filter( 'hooked_block', $filter, 10, 4 );
+		$actual = apply_block_hooks_to_content( $context->content, $context, 'insert_hooked_blocks' );
+		remove_filter( 'hooked_block', $filter, 10 );
+
+		$this->assertIsArray( $anchor_attrs['layout']['columns'], 'The filter should not see a preserved object.' );
+		$this->assertSame( array(), $anchor_attrs['layout']['columns'] );
+
+		// The serialized markup still carries the empty object.
+		$this->assertStringContainsString( '"columns":{}', $actual );
+	}
+
+	/**
+	 * A hooked block added purely by filter must still be inserted.
+	 *
+	 * `insert_hooked_blocks()` returns early when no hooked block types remain, which is what
+	 * lets it skip normalizing the anchor block's attributes for the majority of blocks. That
+	 * check has to run after the `hooked_block_types` filter: an anchor with nothing registered
+	 * statically starts with an empty list, and a plugin is entitled to fill it.
+	 *
+	 * @ticket 63325
+	 */
+	public function test_filter_can_add_hooked_block_to_anchor_with_no_registered_hooks() {
+		$anchor_block_type = 'tests/anchor-block-without-registered-hooks';
+
+		// Nothing is hooked to this anchor, so the list is empty until the filter runs.
+		$this->assertSame(
+			array(),
+			get_hooked_blocks()[ $anchor_block_type ] ?? array(),
+			'The anchor block should have no statically registered hooked blocks.'
+		);
+
+		$filter = static function ( $hooked_block_types, $relative_position, $anchor ) use ( $anchor_block_type ) {
+			if ( $anchor_block_type === $anchor && 'after' === $relative_position ) {
+				$hooked_block_types[] = 'tests/hooked-block';
+			}
+
+			return $hooked_block_types;
+		};
+
+		$context          = new WP_Block_Template();
+		$context->content = "<!-- wp:$anchor_block_type /-->";
+
+		add_filter( 'hooked_block_types', $filter, 10, 3 );
+		$actual = apply_block_hooks_to_content( $context->content, $context, 'insert_hooked_blocks' );
+		remove_filter( 'hooked_block_types', $filter, 10 );
+
+		$this->assertSame(
+			"<!-- wp:$anchor_block_type /--><!-- wp:tests/hooked-block /-->",
+			$actual
+		);
+	}
+
+	/**
+	 * An anchor block with no hooked blocks must serialize back unchanged.
+	 *
+	 * Companion to the test above: this is the path that now returns before normalizing the
+	 * anchor block, and a preserved empty object still has to survive it.
+	 *
+	 * @ticket 63325
+	 */
+	public function test_anchor_block_without_hooked_blocks_round_trips() {
+		$content = '<!-- wp:tests/anchor-block-without-registered-hooks {"layout":{"columns":{}}} /-->';
+
+		$context          = new WP_Block_Template();
+		$context->content = $content;
+
+		$this->assertSame(
+			$content,
+			apply_block_hooks_to_content( $content, $context, 'insert_hooked_blocks' )
+		);
+	}
 }

--- a/tests/phpunit/tests/blocks/filterBlockContent.php
+++ b/tests/phpunit/tests/blocks/filterBlockContent.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Tests for filter_block_content().
+ *
+ * @package WordPress
+ * @subpackage Blocks
+ *
+ * @since 7.2.0
+ *
+ * @group blocks
+ * @group kses
+ *
+ * @covers ::filter_block_content
+ */
+class Tests_Blocks_FilterBlockContent extends WP_UnitTestCase {
+
+	/**
+	 * Block content filtering re-serializes what it parses, so an empty object
+	 * attribute must survive it. This is the save-time path the bug was reported
+	 * against, and it runs for every user without the `unfiltered_html` capability.
+	 *
+	 * @ticket 63325
+	 *
+	 * @dataProvider data_empty_object_markup
+	 *
+	 * @param string $markup Block markup that must survive unchanged.
+	 */
+	public function test_empty_objects_survive_kses_filtering( $markup ) {
+		$this->assertSame( $markup, filter_block_content( $markup ) );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_empty_object_markup() {
+		return array(
+			'empty object and empty array' => array( '<!-- wp:test {"nested":{"object":{},"array":[]}} /-->' ),
+			'inside an array'              => array( '<!-- wp:test {"items":[{},[]]} /-->' ),
+			'inner blocks'                 => array( '<!-- wp:outer {"a":{}} --><!-- wp:inner {"b":{}} /--><!-- /wp:outer -->' ),
+		);
+	}
+
+	/**
+	 * Strings inside a populated object must still be sanitized.
+	 *
+	 * filter_block_kses_value() recurses through arrays only, so a populated object
+	 * left as an object would carry its strings past wp_kses().
+	 *
+	 * @ticket 63325
+	 */
+	public function test_kses_still_sanitizes_strings_beside_a_preserved_empty_object() {
+		$markup = '<!-- wp:test {"config":{"label":"<script>alert(1)</script><strong>Safe</strong>","options":{}}} /-->';
+
+		$actual = filter_block_content( $markup );
+
+		$this->assertStringNotContainsString( 'script', $actual, 'The disallowed tag should have been stripped.' );
+		$this->assertStringContainsString( 'strong', $actual, 'The allowed tag should have survived.' );
+		$this->assertStringContainsString( '"options":{}', $actual, 'The empty object should have survived.' );
+	}
+
+	/**
+	 * The empty object must not reach saved content as anything but `{}`.
+	 *
+	 * Preservation uses no marker key or sentinel value. This guards against one
+	 * being introduced later.
+	 *
+	 * @ticket 63325
+	 */
+	public function test_no_implementation_data_reaches_filtered_content() {
+		$actual = filter_block_content( '<!-- wp:test {"nested":{"object":{}}} /-->' );
+
+		$this->assertStringNotContainsString( '__wp', $actual );
+		$this->assertStringNotContainsString( 'stdClass', $actual );
+	}
+}

--- a/tests/phpunit/tests/blocks/serialize.php
+++ b/tests/phpunit/tests/blocks/serialize.php
@@ -358,4 +358,85 @@ class Tests_Blocks_Serialize extends WP_UnitTestCase {
 
 		$this->assertSame( $markup, $actual );
 	}
+
+	/**
+	 * A nested empty object survives the round trip, and an empty array stays an array.
+	 *
+	 * No serializer change is involved: wp_json_encode() emits `{}` for an empty object
+	 * and `[]` for an empty array, so the parsed representation carries the distinction
+	 * on its own.
+	 *
+	 * @ticket 63325
+	 *
+	 * @dataProvider data_empty_object_round_trip
+	 *
+	 * @covers ::serialize_blocks
+	 *
+	 * @param string $markup Block markup that must survive unchanged.
+	 */
+	public function test_empty_objects_survive_the_round_trip( $markup ) {
+		$actual = serialize_blocks( _wp_parse_blocks_preserving_empty_object_attributes( $markup ) );
+
+		$this->assertSame( $markup, $actual );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_empty_object_round_trip() {
+		return array(
+			'empty object beside empty array' => array( '<!-- wp:test {"object":{},"array":[]} /-->' ),
+			'deeply nested'                   => array( '<!-- wp:test {"one":{"two":{"empty":{}}}} /-->' ),
+			'inside an array'                 => array( '<!-- wp:test {"items":[{},[],{"nested":{}}]} /-->' ),
+			'populated sibling'               => array( '<!-- wp:test {"config":{"enabled":true,"options":{}}} /-->' ),
+			'inner blocks'                    => array( '<!-- wp:outer {"a":{}} --><!-- wp:inner {"b":{}} /--><!-- /wp:outer -->' ),
+		);
+	}
+
+	/**
+	 * The default parse path is unchanged, so it still collapses `{}` to `[]`.
+	 *
+	 * @ticket 63325
+	 *
+	 * @covers ::serialize_blocks
+	 */
+	public function test_default_parse_path_still_collapses_empty_objects() {
+		$actual = serialize_blocks( parse_blocks( '<!-- wp:test {"object":{},"array":[]} /-->' ) );
+
+		$this->assertSame( '<!-- wp:test {"object":[],"array":[]} /-->', $actual );
+	}
+
+	/**
+	 * Empty top-level attributes keep being dropped, as they always have been.
+	 *
+	 * @ticket 63325
+	 *
+	 * @covers ::serialize_blocks
+	 */
+	public function test_empty_top_level_attributes_are_still_dropped() {
+		$actual = serialize_blocks( _wp_parse_blocks_preserving_empty_object_attributes( '<!-- wp:test {} /-->' ) );
+
+		$this->assertSame( '<!-- wp:test /-->', $actual );
+	}
+
+	/**
+	 * Preservation is deliberately limited to empty objects.
+	 *
+	 * An object whose keys are the sequential strings "0", "1", ... also encodes as a
+	 * JSON array, but restoring that would mean tracking the type of every value rather
+	 * than the one shape this ticket is about. It stays out of scope.
+	 *
+	 * @ticket 63325
+	 *
+	 * @covers ::serialize_blocks
+	 */
+	public function test_numeric_keyed_objects_are_not_preserved() {
+		$actual = serialize_blocks(
+			_wp_parse_blocks_preserving_empty_object_attributes( '<!-- wp:test {"numeric":{"0":"first","1":"second"}} /-->' )
+		);
+
+		$this->assertSame( '<!-- wp:test {"numeric":["first","second"]} /-->', $actual );
+	}
 }

--- a/tests/phpunit/tests/blocks/wpBlockParser.php
+++ b/tests/phpunit/tests/blocks/wpBlockParser.php
@@ -114,4 +114,328 @@ class Tests_Blocks_wpBlockParser extends WP_UnitTestCase {
 	protected function strip_r( $input ) {
 		return str_replace( "\r", '', $input );
 	}
+
+	/**
+	 * Parses markup with empty-object preservation and returns the first block's attributes.
+	 *
+	 * @param string $markup Block markup with a single top-level block.
+	 * @return array|null The parsed attributes.
+	 */
+	private function parse_attrs_preserving( $markup ) {
+		$blocks = _wp_parse_blocks_preserving_empty_object_attributes( $markup );
+
+		return $blocks[0]['attrs'];
+	}
+
+	/**
+	 * The default parse path must be untouched: an empty object and an empty array
+	 * both decode to an empty PHP array, as they always have.
+	 *
+	 * @ticket 63325
+	 *
+	 * @covers ::parse_blocks
+	 */
+	public function test_default_parse_collapses_empty_objects_to_arrays() {
+		$blocks = parse_blocks( '<!-- wp:test {"object":{},"array":[]} /-->' );
+		$attrs  = $blocks[0]['attrs'];
+
+		$this->assertSame( array(), $attrs['object'] );
+		$this->assertSame( array(), $attrs['array'] );
+	}
+
+	/**
+	 * With preservation on, only the empty object becomes an object.
+	 *
+	 * @ticket 63325
+	 *
+	 * @covers ::_wp_parse_blocks_preserving_empty_object_attributes
+	 */
+	public function test_preserving_parse_keeps_only_empty_objects_as_objects() {
+		$attrs = $this->parse_attrs_preserving( '<!-- wp:test {"object":{},"array":[]} /-->' );
+
+		$this->assertInstanceOf( 'stdClass', $attrs['object'] );
+		$this->assertSame( array(), get_object_vars( $attrs['object'] ) );
+		$this->assertSame( array(), $attrs['array'] );
+	}
+
+	/**
+	 * An empty object written with whitespace between the braces is still an empty object.
+	 *
+	 * The preserving path is gated on finding a `{}` token, so the gate has to accept every
+	 * whitespace form JSON permits there rather than only the two-character sequence that
+	 * `JSON.stringify()` happens to emit.
+	 *
+	 * @ticket 63325
+	 *
+	 * @covers ::_wp_parse_blocks_preserving_empty_object_attributes
+	 *
+	 * @dataProvider data_empty_object_whitespace
+	 *
+	 * @param string $empty_object An empty JSON object, possibly containing whitespace.
+	 */
+	public function test_preserving_parse_accepts_json_whitespace_in_empty_objects( $empty_object ) {
+		$attrs = $this->parse_attrs_preserving( '<!-- wp:test {"object":' . $empty_object . '} /-->' );
+
+		$this->assertInstanceOf( 'stdClass', $attrs['object'] );
+		$this->assertSame( array(), get_object_vars( $attrs['object'] ) );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_empty_object_whitespace() {
+		return array(
+			'no whitespace'   => array( '{}' ),
+			'space'           => array( '{ }' ),
+			'tab'             => array( "{\t}" ),
+			'line feed'       => array( "{\n}" ),
+			'carriage return' => array( "{\r}" ),
+			'all of them'     => array( "{ \t\r\n }" ),
+		);
+	}
+
+	/**
+	 * A `{}` sequence inside a string value must not change the parsed result.
+	 *
+	 * The gate on the preserving path is lexical, so markup like `{"tpl":"{}"}` takes the
+	 * slower path even though it holds no empty object. That is allowed to cost a wasted
+	 * walk; it is not allowed to change the value, which must stay a string.
+	 *
+	 * @ticket 63325
+	 *
+	 * @covers ::_wp_parse_blocks_preserving_empty_object_attributes
+	 *
+	 * @dataProvider data_empty_object_inside_a_string
+	 *
+	 * @param string $value The string value, as written in the attribute JSON.
+	 */
+	public function test_empty_object_inside_a_string_stays_a_string( $value ) {
+		$markup = '<!-- wp:test {"tpl":"' . $value . '"} /-->';
+		$attrs  = $this->parse_attrs_preserving( $markup );
+
+		$this->assertIsString( $attrs['tpl'] );
+		$this->assertSame( $value, $attrs['tpl'] );
+
+		// And the markup is reproduced byte for byte.
+		$this->assertSame( $markup, serialize_blocks( _wp_parse_blocks_preserving_empty_object_attributes( $markup ) ) );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_empty_object_inside_a_string() {
+		return array(
+			'no whitespace'     => array( '{}' ),
+			'space'             => array( '{ }' ),
+			'beside other text' => array( 'before {} after' ),
+		);
+	}
+
+	/**
+	 * A real empty object and a string that merely looks like one, in the same attributes.
+	 *
+	 * Proves the two are told apart by the parse itself rather than by the lexical gate,
+	 * which only decides whether to look.
+	 *
+	 * @ticket 63325
+	 *
+	 * @covers ::_wp_parse_blocks_preserving_empty_object_attributes
+	 */
+	public function test_empty_object_and_lookalike_string_are_told_apart() {
+		$attrs = $this->parse_attrs_preserving( '<!-- wp:test {"tpl":"{}","object":{}} /-->' );
+
+		$this->assertSame( '{}', $attrs['tpl'] );
+		$this->assertInstanceOf( 'stdClass', $attrs['object'] );
+	}
+
+	/**
+	 * A populated object still becomes an array, so code that walks attributes with
+	 * array access and array functions keeps working.
+	 *
+	 * @ticket 63325
+	 *
+	 * @covers ::_wp_parse_blocks_preserving_empty_object_attributes
+	 */
+	public function test_preserving_parse_converts_non_empty_objects_to_arrays() {
+		$attrs = $this->parse_attrs_preserving( '<!-- wp:test {"object":{"enabled":true}} /-->' );
+
+		$this->assertSame( array( 'enabled' => true ), $attrs['object'] );
+	}
+
+	/**
+	 * Only the innermost empty object is an object; its ancestors stay arrays.
+	 *
+	 * @ticket 63325
+	 *
+	 * @covers ::_wp_parse_blocks_preserving_empty_object_attributes
+	 */
+	public function test_preserving_parse_handles_deep_nesting() {
+		$attrs = $this->parse_attrs_preserving( '<!-- wp:test {"one":{"two":{"empty":{}}}} /-->' );
+
+		$this->assertIsArray( $attrs['one'] );
+		$this->assertIsArray( $attrs['one']['two'] );
+		$this->assertInstanceOf( 'stdClass', $attrs['one']['two']['empty'] );
+	}
+
+	/**
+	 * Empty objects are preserved inside JSON arrays too.
+	 *
+	 * @ticket 63325
+	 *
+	 * @covers ::_wp_parse_blocks_preserving_empty_object_attributes
+	 */
+	public function test_preserving_parse_handles_empty_objects_inside_arrays() {
+		$attrs = $this->parse_attrs_preserving( '<!-- wp:test {"items":[{},[],{"nested":{}}]} /-->' );
+
+		$this->assertInstanceOf( 'stdClass', $attrs['items'][0] );
+		$this->assertSame( array(), $attrs['items'][1] );
+		$this->assertInstanceOf( 'stdClass', $attrs['items'][2]['nested'] );
+	}
+
+	/**
+	 * The top-level attribute container always becomes an array, so that empty
+	 * attributes keep being dropped on serialization.
+	 *
+	 * @ticket 63325
+	 *
+	 * @covers ::_wp_parse_blocks_preserving_empty_object_attributes
+	 */
+	public function test_preserving_parse_converts_the_attribute_root_to_an_array() {
+		$this->assertSame( array(), $this->parse_attrs_preserving( '<!-- wp:test {} /-->' ) );
+	}
+
+	/**
+	 * Malformed attribute JSON behaves identically on both paths.
+	 *
+	 * @ticket 63325
+	 *
+	 * @dataProvider data_invalid_attribute_json
+	 *
+	 * @covers ::_wp_parse_blocks_preserving_empty_object_attributes
+	 *
+	 * @param string $json Malformed attribute JSON.
+	 */
+	public function test_invalid_json_yields_null_attributes_on_both_paths( $json ) {
+		$markup = "<!-- wp:test $json /-->";
+
+		$this->assertNull( parse_blocks( $markup )[0]['attrs'] );
+		$this->assertNull( $this->parse_attrs_preserving( $markup ) );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_invalid_attribute_json() {
+		return array(
+			'missing value'  => array( '{"broken":}' ),
+			'unquoted keys'  => array( '{not json}' ),
+			'trailing comma' => array( '{"a":1,}' ),
+		);
+	}
+
+	/**
+	 * A replacement parser that only implements parse() must keep working.
+	 *
+	 * This is the reason preservation is requested through parse_with_options()
+	 * rather than by adding a parameter to parse(): PHP rejects a subclass that
+	 * declares fewer parameters than its parent, so widening parse() itself would
+	 * fatal for every plugin that overrides it.
+	 *
+	 * @ticket 63325
+	 *
+	 * @covers ::_wp_parse_blocks_preserving_empty_object_attributes
+	 */
+	public function test_replacement_parser_without_parse_with_options_falls_back() {
+		$filter = static function () {
+			return 'Tests_Blocks_Legacy_Parser';
+		};
+		add_filter( 'block_parser_class', $filter );
+
+		try {
+			$attrs = $this->parse_attrs_preserving( '<!-- wp:test {"object":{}} /-->' );
+		} finally {
+			remove_filter( 'block_parser_class', $filter );
+		}
+
+		// The legacy parser knows nothing about preservation, so the historical shape comes back.
+		$this->assertSame( array(), $attrs['object'] );
+	}
+
+	/**
+	 * A subclass may still override parse() with the one-argument signature.
+	 *
+	 * Widening parse() itself would make every such subclass a fatal error, and
+	 * delegating parse_with_options() to parse() keeps the override in effect even
+	 * when core requests options.
+	 *
+	 * @ticket 63325
+	 *
+	 * @covers ::_wp_parse_blocks_preserving_empty_object_attributes
+	 */
+	public function test_subclass_overriding_parse_is_still_used() {
+		$filter = static function () {
+			return 'Tests_Blocks_Subclassed_Parser';
+		};
+		add_filter( 'block_parser_class', $filter );
+
+		try {
+			$blocks = _wp_parse_blocks_preserving_empty_object_attributes( '<!-- wp:test {"object":{}} /-->' );
+		} finally {
+			remove_filter( 'block_parser_class', $filter );
+		}
+
+		$this->assertTrue(
+			Tests_Blocks_Subclassed_Parser::$parse_was_called,
+			'The subclass override of parse() should still run.'
+		);
+		// Preservation still applies, because the option is read during the inherited parse.
+		$this->assertInstanceOf( 'stdClass', $blocks[0]['attrs']['object'] );
+	}
+}
+
+/**
+ * A replacement parser predating parse_with_options(), implementing only parse().
+ */
+class Tests_Blocks_Legacy_Parser {
+	/**
+	 * Parses a document into blocks.
+	 *
+	 * @param string $document Input document being parsed.
+	 * @return array[]
+	 */
+	public function parse( $document ) {
+		$parser = new WP_Block_Parser();
+
+		return $parser->parse( $document );
+	}
+}
+
+/**
+ * A parser subclass that overrides parse() with the historical signature.
+ */
+class Tests_Blocks_Subclassed_Parser extends WP_Block_Parser {
+	/**
+	 * Whether the override ran.
+	 *
+	 * @var bool
+	 */
+	public static $parse_was_called = false;
+
+	/**
+	 * Parses a document into blocks.
+	 *
+	 * @param string $document Input document being parsed.
+	 * @return array[]
+	 */
+	public function parse( $document ) {
+		self::$parse_was_called = true;
+
+		return parent::parse( $document );
+	}
 }


### PR DESCRIPTION
A block attribute written as `{}` is decoded with `json_decode( $json, true )`, which produces an empty PHP array. Serializing that array writes `[]` back out. Any workflow that parses stored block markup and saves it again therefore rewrites the attribute, and the editor then reports the block as invalid.

This replaces #8735, which approached the same ticket by changing the serializer. The block delimiter format is co-owned by JavaScript — `@wordpress/blocks` writes it with `JSON.stringify()` and `@wordpress/block-serialization-default-parser` reads it with `JSON.parse()` — so the fix belongs on the PHP decode side instead.

## Approach

`WP_Block_Parser::parse_with_options()` accepts a `preserve_empty_object_attributes` option. With it enabled, attribute JSON is decoded to objects and every value except a nested empty object is converted back to the array shape the default parse path produces. The empty object stays an empty `stdClass`, which `wp_json_encode()` writes as `{}`.

There is no marker key, no sentinel value, and no restore step. `wp_json_encode()` already distinguishes an empty object from an empty array, so the parsed representation carries the difference on its own. `serialize_block_attributes()` is untouched.

Two workflows opt in, because they are the ones that parse stored markup and write it back:

- the Block Hooks algorithm, through `apply_block_hooks_to_content()`
- block content filtering through KSES, in `filter_block_content()` — the save-time path the bug was reported against, which runs for every user without the `unfiltered_html` capability

`parse()`, `parse_blocks()`, and rendering through `do_blocks()` are unchanged. `do_blocks()` does not write parsed content back, so it keeps the default parse and its existing cost.

`parse_with_options()` is a separate method rather than a second parameter on `parse()` because a parser registered through `block_parser_class` may subclass `WP_Block_Parser` and override `parse()`; PHP rejects an override declaring fewer parameters than its parent. Delegating to `parse()` also keeps any such override in effect. A replacement parser that predates the new method falls back to `parse()`.

## Compatibility

Preservation puts an empty `stdClass` where extension points have always received an array. Two things follow:

- `insert_hooked_blocks()` and `set_ignored_hooked_blocks_metadata()` hand the `hooked_block` filters an anchor block converted back to all-array attributes.
- Both read `metadata` through an array cast. In PHP an array offset on an object is a fatal error, including inside `isset()` and `??`, and including assignment.

## Out of scope

Populated objects are still decoded as arrays, so `{"0":"a","1":"b"}` still serializes as `["a","b"]`. Distinguishing those would change what KSES traverses and what shape plugins receive from attributes they already read as arrays. That is a wider compatibility question than this ticket needs.

## Performance

Preservation costs a second decode plus a conversion walk, so both consumers pay for it. Two things limit that: attribute strings containing no `{}` token cannot hold an empty object and skip the walk entirely, and `insert_hooked_blocks()` returns before converting the anchor block when no hooked block types remain after the `hooked_block_types` filter.

Measured on PHP 8.3.31 against this branch's merge base. Timing method: 8 runs per template, take each template's minimum, report the median across templates.

`apply_block_hooks_to_content()` over 478 templates in which 81.3% of attribute strings contain an empty object, with a hooked block registered:

| | median |
|---|---|
| trunk | 214.5 µs |
| this branch | 282.5 µs (+32%) |

Attribute decoding across the 394 attribute strings in the bundled themes, none of which contain an empty object:

| | total |
|---|---|
| trunk | 0.187 ms |
| this branch | 0.216 ms (+15%) |
| without the lexical skip | 0.352 ms (+88%) |

The early return in `insert_hooked_blocks()` is what keeps the first table from roughly doubling; the lexical skip is what keeps the second from it. Content rendered through `do_blocks()` is unaffected.

## Testing

New tests cover the parser option, the boundaries of the lexical skip, and both consumers:

- whitespace between the braces (`{ }`, `{\t}`, `{\n}`, `{\r}`) still counts as an empty object
- a `{}` inside a string value stays a string and round-trips byte-identically
- a real empty object and a lookalike string in the same attributes are told apart
- the top-level attribute container still becomes an array, so `<!-- wp:test {} /-->` still serializes without attributes
- malformed attribute JSON behaves identically on both paths
- a replacement parser implementing only `parse()`, and a subclass overriding `parse()` with the historical signature, both keep working
- KSES still sanitizes strings in a populated object sitting beside a preserved empty object
- a `hooked_block_types` filter can still inject a hooked block into an anchor with none registered, which is what pins the early return after the filter rather than before it

Commands run:

```
npm run test:php -- --group blocks,kses,block-hooks
```

1594 tests, 4444 assertions, all passing. Each of the two commits passes this group on its own.

```
node ./tools/local-env/scripts/docker.js run --rm php ./vendor/bin/phpcs src/wp-includes/blocks.php src/wp-includes/class-wp-block-parser.php
node ./tools/local-env/scripts/docker.js run --rm php ./vendor/bin/phpstan analyse --memory-limit=2G src/wp-includes/blocks.php src/wp-includes/class-wp-block-parser.php
```

Both clean.

Separately, against a corpus of 478 real block templates containing 41,569 empty object attributes: trunk destroys 41,406 of them (99.6%) and corrupts 476 of the 478 templates. With this branch all 41,569 are preserved, all 478 templates round-trip byte-identically, and no internal representation reaches the serialized output.

Trac ticket: https://core.trac.wordpress.org/ticket/63325
Related: https://github.com/WordPress/gutenberg/issues/69959
Replaces: #8735

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Investigating the regression, drafting the implementation and the tests, and building and running the benchmarks. The approach and scope were mine, and I reviewed the changes before submitting.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
