### PR TITLE
Taxonomy: Guard against non-object values in the terms cache.

### DIFF
--- a/src/wp-includes/class-wp-term.php
+++ b/src/wp-includes/class-wp-term.php
@@ -124,7 +124,7 @@ final class WP_Term {
 		$_term = wp_cache_get( $term_id, 'terms' );
 
 		// If there isn't a cached version, hit the database.
-		if ( ! $_term || ( $taxonomy && $taxonomy !== $_term->taxonomy ) ) {
+		if ( ! is_object( $_term ) || ( $taxonomy && $taxonomy !== $_term->taxonomy ) ) {
 			// Any term found in the cache is not a match, so don't use it.
 			$_term = false;
 

--- a/src/wp-includes/class-wp-term.php
+++ b/src/wp-includes/class-wp-term.php
@@ -124,7 +124,7 @@ final class WP_Term {
 		$_term = wp_cache_get( $term_id, 'terms' );
 
 		// If there isn't a cached version, hit the database.
-		if ( ! is_object( $_term ) || ( $taxonomy && $taxonomy !== $_term->taxonomy ) ) {
+		if ( ! is_object( $_term ) || ! isset( $_term->taxonomy ) || ( $taxonomy && $taxonomy !== $_term->taxonomy ) ) {
 			// Any term found in the cache is not a match, so don't use it.
 			$_term = false;
 

--- a/tests/phpunit/tests/term/wpTerm.php
+++ b/tests/phpunit/tests/term/wpTerm.php
@@ -102,16 +102,16 @@ class Tests_Term_WpTerm extends WP_UnitTestCase {
 
 		$found = WP_Term::get_instance( self::$term_id );
 
-		$this->assertInstanceOf( 'WP_Term', $found );
+		$this->assertInstanceOf( WP_Term::class, $found );
 		$this->assertSame( self::$term_id, $found->term_id );
 	}
 
 	/**
 	 * Data provider.
 	 *
-	 * @return array[]
+	 * @return array<non-falsy-string, array{ 0: mixed }>
 	 */
-	public function data_get_instance_should_ignore_non_object_cached_values() {
+	public function data_get_instance_should_ignore_non_object_cached_values(): array {
 		return array(
 			'an array'   => array( array( 'term_id' => 12345 ) ),
 			'an integer' => array( 12345 ),

--- a/tests/phpunit/tests/term/wpTerm.php
+++ b/tests/phpunit/tests/term/wpTerm.php
@@ -89,4 +89,33 @@ class Tests_Term_WpTerm extends WP_UnitTestCase {
 		$found = WP_Term::get_instance( self::$term_id, 'wptests_tax2' );
 		$this->assertFalse( $found );
 	}
+
+	/**
+	 * @ticket 65915
+	 *
+	 * @dataProvider data_get_instance_should_ignore_non_object_cached_values
+	 *
+	 * @param mixed $cached_value A non-object value stored in the 'terms' cache group.
+	 */
+	public function test_get_instance_should_ignore_non_object_cached_values( $cached_value ) {
+		wp_cache_set( self::$term_id, $cached_value, 'terms' );
+
+		$found = WP_Term::get_instance( self::$term_id );
+
+		$this->assertInstanceOf( 'WP_Term', $found );
+		$this->assertSame( self::$term_id, $found->term_id );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_get_instance_should_ignore_non_object_cached_values() {
+		return array(
+			'an array'   => array( array( 'term_id' => 12345 ) ),
+			'an integer' => array( 12345 ),
+			'a string'   => array( 'a term' ),
+		);
+	}
 }

--- a/tests/phpunit/tests/term/wpTerm.php
+++ b/tests/phpunit/tests/term/wpTerm.php
@@ -93,17 +93,18 @@ class Tests_Term_WpTerm extends WP_UnitTestCase {
 	/**
 	 * @ticket 65915
 	 *
-	 * @dataProvider data_get_instance_should_ignore_non_object_cached_values
+	 * @dataProvider data_get_instance_should_ignore_unusable_cached_values
 	 *
-	 * @param mixed $cached_value A non-object value stored in the 'terms' cache group.
+	 * @param mixed $cached_value A cached value that is not a usable term object.
 	 */
-	public function test_get_instance_should_ignore_non_object_cached_values( $cached_value ) {
+	public function test_get_instance_should_ignore_unusable_cached_values( $cached_value ) {
 		wp_cache_set( self::$term_id, $cached_value, 'terms' );
 
 		$found = WP_Term::get_instance( self::$term_id );
 
 		$this->assertInstanceOf( WP_Term::class, $found );
 		$this->assertSame( self::$term_id, $found->term_id );
+		$this->assertSame( 'wptests_tax', $found->taxonomy );
 	}
 
 	/**
@@ -111,11 +112,13 @@ class Tests_Term_WpTerm extends WP_UnitTestCase {
 	 *
 	 * @return array<non-falsy-string, array{ 0: mixed }>
 	 */
-	public function data_get_instance_should_ignore_non_object_cached_values(): array {
+	public function data_get_instance_should_ignore_unusable_cached_values(): array {
 		return array(
-			'an array'   => array( array( 'term_id' => 12345 ) ),
-			'an integer' => array( 12345 ),
-			'a string'   => array( 'a term' ),
+			'an array'                       => array( array( 'term_id' => 12345 ) ),
+			'an integer'                     => array( 12345 ),
+			'a string'                       => array( 'a term' ),
+			'an object with no taxonomy'     => array( (object) array( 'term_id' => 12345 ) ),
+			'an object with a null taxonomy' => array( (object) array( 'taxonomy' => null ) ),
 		);
 	}
 }


### PR DESCRIPTION
A truthy non-object in the `terms` cache group skipped the database lookup and fataled in `get_object_vars()`, taking down any `get_terms()` call that reached it.

This happens when the site uses a persistent cache (like redis) that fails to unserialize the object. In which case, it returns a string.

In this case, Core should check if the value returned from the cache can be properly used. If not, it should pull the term directly from the database.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/65915#ticket

## Use of AI Tools
AI assistance: Yes
Tool(s): Claude Code
Model(s): Opus 4.8
Used for: Writing the test
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
