### PR TITLE
Site Health: Detect an OPcache file cache as an enabled opcode cache

### DIFF
--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -2802,7 +2802,8 @@ class WP_Site_Health {
 		$opcode_cache_enabled = false;
 		if ( function_exists( 'opcache_get_status' ) ) {
 			$status = @opcache_get_status( false ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- Warning emitted in failure case.
-			if ( $status && true === $status['opcache_enabled'] ) {
+			// OPcache reports `opcache_enabled` as false when only the file cache is in use, though that is still an active opcode cache.
+			if ( $status && ( true === $status['opcache_enabled'] || ! empty( $status['file_cache_only'] ) ) ) {
 				$opcode_cache_enabled = true;
 			}
 		}

--- a/tests/phpunit/tests/admin/wpSiteHealth.php
+++ b/tests/phpunit/tests/admin/wpSiteHealth.php
@@ -684,6 +684,7 @@ class Tests_Admin_wpSiteHealth extends WP_UnitTestCase {
 	 * Covers: opcache enabled, disabled, not available, and opcache_get_status() returns false.
 	 *
 	 * @ticket 63697
+	 * @ticket 65921
 	 *
 	 * @covers ::get_test_opcode_cache()
 	 */
@@ -693,7 +694,7 @@ class Tests_Admin_wpSiteHealth extends WP_UnitTestCase {
 		$opcache_enabled = false;
 		if ( function_exists( 'opcache_get_status' ) ) {
 			$status = @opcache_get_status( false ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- Warning emitted in failure case.
-			if ( $status && true === $status['opcache_enabled'] ) {
+			if ( $status && ( true === $status['opcache_enabled'] || ! empty( $status['file_cache_only'] ) ) ) {
 				$opcache_enabled = true;
 			}
 		}


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

Site Health reports "Opcode cache is not enabled" on servers running OPcache with `opcache.file_cache_only` turned on, even though a file-based opcode cache is active.

`get_test_opcode_cache()` treats `opcache_get_status()['opcache_enabled']` as the only signal, but OPcache sets that flag to `false` in file-cache-only mode and instead exposes a `file_cache_only` key. The patch accepts either signal. That key is present only when the file cache is the active backend, so shared memory configurations are unchanged.

The change only widens what counts as enabled, so no configuration that currently passes can start failing.

Trac ticket: https://core.trac.wordpress.org/ticket/65921

## Use of AI Tools
AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Investigating the OPcache behaviour, drafting the one-line fix, and updating the existing test's environment check. All changes were reviewed and validated by me.

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
