### PR TITLE
Grunt jshint:plugins: Ignore node_modules and common paths for built files.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1069,6 +1069,17 @@ module.exports = function(grunt) {
 					'**/*.js',
 					'!**/*.min.js'
 				],
+				// Prevent traversal into these directories during glob expansion.
+				// This is much faster than using negation patterns alone.
+				ignore: [
+					'**/build/**',
+					'**/dist/**',
+					'**/gutenberg/**',
+					'**/node_modules/**',
+					'**/packages/**',
+					'**/test/**',
+					'**/vendor/**'
+				],
 				/*
 				 * Limit JSHint's run to a single specified plugin directory:
 				 *


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65923

Adds an `ignore` property to the Grunt `jshint:plugins` to exclude any directory where the name matches:
- build
- dist
- gutenberg
- node_modules
- packages
- test
- vendor

## Use of AI Tools

None

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
