### PR TITLE
Plugins: Prevent hook callback IDs from being cast to integer array keys

### DIFF
--- a/src/wp-includes/class-wp-hook.php
+++ b/src/wp-includes/class-wp-hook.php
@@ -20,8 +20,8 @@
  *   accepted_args: int,
  * }
  *
- * @phpstan-implements Iterator<int, array<string, Hook_Callback>>
- * @phpstan-implements ArrayAccess<int, array<string, Hook_Callback>>
+ * @phpstan-implements Iterator<int, array<non-decimal-int-string, Hook_Callback>>
+ * @phpstan-implements ArrayAccess<int, array<non-decimal-int-string, Hook_Callback>>
  */
 #[AllowDynamicProperties]
 final class WP_Hook implements Iterator, ArrayAccess {
@@ -31,7 +31,7 @@ final class WP_Hook implements Iterator, ArrayAccess {
 	 *
 	 * @since 4.7.0
 	 * @var array
-	 * @phpstan-var array<int, array<string, Hook_Callback>>
+	 * @phpstan-var array<int, array<non-decimal-int-string, Hook_Callback>>
 	 */
 	public $callbacks = array();
 
@@ -502,7 +502,7 @@ final class WP_Hook implements Iterator, ArrayAccess {
 	 *
 	 * @param int $offset The offset to retrieve.
 	 * @return array|null If set, the value at the specified offset, null otherwise.
-	 * @phpstan-return array<string, Hook_Callback>|null
+	 * @phpstan-return array<non-decimal-int-string, Hook_Callback>|null
 	 */
 	#[ReturnTypeWillChange]
 	public function offsetGet( $offset ) {
@@ -518,7 +518,7 @@ final class WP_Hook implements Iterator, ArrayAccess {
 	 *
 	 * @param int|null $offset The offset to assign the value to.
 	 * @param array    $value The value to set.
-	 * @phpstan-param array<string, Hook_Callback> $value
+	 * @phpstan-param array<non-decimal-int-string, Hook_Callback> $value
 	 */
 	#[ReturnTypeWillChange]
 	public function offsetSet( $offset, $value ) {
@@ -554,7 +554,7 @@ final class WP_Hook implements Iterator, ArrayAccess {
 	 * @link https://www.php.net/manual/en/iterator.current.php
 	 *
 	 * @return array|false Array of callbacks at current priority, false if there are no more elements.
-	 * @phpstan-return array<string, Hook_Callback>|false
+	 * @phpstan-return array<non-decimal-int-string, Hook_Callback>|false
 	 */
 	#[ReturnTypeWillChange]
 	public function current() {
@@ -569,7 +569,7 @@ final class WP_Hook implements Iterator, ArrayAccess {
 	 * @link https://www.php.net/manual/en/iterator.next.php
 	 *
 	 * @return array|false Array of callbacks at next priority, false if there are no more elements.
-	 * @phpstan-return array<string, Hook_Callback>|false
+	 * @phpstan-return array<non-decimal-int-string, Hook_Callback>|false
 	 */
 	#[ReturnTypeWillChange]
 	public function next() {

--- a/src/wp-includes/class-wp-widget-factory.php
+++ b/src/wp-includes/class-wp-widget-factory.php
@@ -34,6 +34,7 @@ class WP_Widget_Factory {
 	 *
 	 * @since 2.8.0
 	 * @var array<string, WP_Widget>
+	 * @phpstan-var array<non-decimal-int-string, WP_Widget>
 	 */
 	public $widgets = array();
 

--- a/src/wp-includes/class-wp-widget-factory.php
+++ b/src/wp-includes/class-wp-widget-factory.php
@@ -22,7 +22,7 @@ class WP_Widget_Factory {
 	 * Without it the key would be the decimal representation of an integer, which PHP casts from
 	 * string to int when it is used as an array key.
 	 *
-	 * @since 7.2.0
+	 * @since 7.1.1
 	 */
 	private const INSTANCE_KEY_PREFIX = 'spl_object_id:';
 
@@ -65,7 +65,7 @@ class WP_Widget_Factory {
 	 * @since 2.8.0
 	 * @since 4.6.0 Updated the `$widget` parameter to also accept a WP_Widget instance object
 	 *              instead of simply a `WP_Widget` subclass name.
-	 * @since 7.2.0 The key for an instance is prefixed so that it is never cast to an integer.
+	 * @since 7.1.1 The key for an instance is prefixed so that it is never cast to an integer.
 	 *
 	 * @param string|WP_Widget $widget Either the name of a `WP_Widget` subclass or an instance of a `WP_Widget` subclass.
 	 */
@@ -83,7 +83,7 @@ class WP_Widget_Factory {
 	 * @since 2.8.0
 	 * @since 4.6.0 Updated the `$widget` parameter to also accept a WP_Widget instance object
 	 *              instead of simply a `WP_Widget` subclass name.
-	 * @since 7.2.0 The key for an instance is prefixed so that it is never cast to an integer.
+	 * @since 7.1.1 The key for an instance is prefixed so that it is never cast to an integer.
 	 *
 	 * @param string|WP_Widget $widget Either the name of a `WP_Widget` subclass or an instance of a `WP_Widget` subclass.
 	 */

--- a/src/wp-includes/class-wp-widget-factory.php
+++ b/src/wp-includes/class-wp-widget-factory.php
@@ -17,10 +17,23 @@
 class WP_Widget_Factory {
 
 	/**
+	 * Prefix for the key under which a widget registered as an instance is stored.
+	 *
+	 * Without it the key would be the decimal representation of an integer, which PHP casts from
+	 * string to int when it is used as an array key.
+	 *
+	 * @since 7.2.0
+	 */
+	private const INSTANCE_KEY_PREFIX = 'spl_object_id:';
+
+	/**
 	 * Widgets array.
 	 *
+	 * Keyed by class name for a widget registered by name, and by a prefixed object ID for a widget
+	 * registered as an instance.
+	 *
 	 * @since 2.8.0
-	 * @var array
+	 * @var array<string, WP_Widget>
 	 */
 	public $widgets = array();
 
@@ -52,12 +65,13 @@ class WP_Widget_Factory {
 	 * @since 2.8.0
 	 * @since 4.6.0 Updated the `$widget` parameter to also accept a WP_Widget instance object
 	 *              instead of simply a `WP_Widget` subclass name.
+	 * @since 7.2.0 The key for an instance is prefixed so that it is never cast to an integer.
 	 *
 	 * @param string|WP_Widget $widget Either the name of a `WP_Widget` subclass or an instance of a `WP_Widget` subclass.
 	 */
 	public function register( $widget ) {
 		if ( $widget instanceof WP_Widget ) {
-			$this->widgets[ spl_object_id( $widget ) ] = $widget;
+			$this->widgets[ self::INSTANCE_KEY_PREFIX . spl_object_id( $widget ) ] = $widget;
 		} else {
 			$this->widgets[ $widget ] = new $widget();
 		}
@@ -69,12 +83,13 @@ class WP_Widget_Factory {
 	 * @since 2.8.0
 	 * @since 4.6.0 Updated the `$widget` parameter to also accept a WP_Widget instance object
 	 *              instead of simply a `WP_Widget` subclass name.
+	 * @since 7.2.0 The key for an instance is prefixed so that it is never cast to an integer.
 	 *
 	 * @param string|WP_Widget $widget Either the name of a `WP_Widget` subclass or an instance of a `WP_Widget` subclass.
 	 */
 	public function unregister( $widget ) {
 		if ( $widget instanceof WP_Widget ) {
-			unset( $this->widgets[ spl_object_id( $widget ) ] );
+			unset( $this->widgets[ self::INSTANCE_KEY_PREFIX . spl_object_id( $widget ) ] );
 		} else {
 			unset( $this->widgets[ $widget ] );
 		}

--- a/src/wp-includes/plugin.php
+++ b/src/wp-includes/plugin.php
@@ -998,6 +998,8 @@ function _wp_call_all_hook( $args ) {
  * @param int      $priority  Unused. The order in which the functions
  *                            associated with a particular action are executed.
  * @return string|null Unique function ID for usage as array key, or null if it couldn't be determined.
+ *
+ * @phpstan-return non-decimal-int-string|null
  */
 function _wp_filter_build_unique_id( $hook_name, $callback, $priority ): ?string {
 	if ( is_string( $callback ) ) {

--- a/src/wp-includes/plugin.php
+++ b/src/wp-includes/plugin.php
@@ -989,7 +989,7 @@ function _wp_call_all_hook( $args ) {
  *              and no longer returns false, but can still return void for invalid callbacks.
  * @since 6.9.0 Returns explicit null if an invalid callback is supplied.
  * @since 7.1.0 Uses spl_object_id() instead of spl_object_hash() for performance.
- * @since 7.2.0 The ID for an object callback is prefixed so that it is never cast to an integer array key.
+ * @since 7.1.1 The ID for an object callback is prefixed so that it is never cast to an integer array key.
  *
  * @access private
  *

--- a/src/wp-includes/plugin.php
+++ b/src/wp-includes/plugin.php
@@ -989,6 +989,7 @@ function _wp_call_all_hook( $args ) {
  *              and no longer returns false, but can still return void for invalid callbacks.
  * @since 6.9.0 Returns explicit null if an invalid callback is supplied.
  * @since 7.1.0 Uses spl_object_id() instead of spl_object_hash() for performance.
+ * @since 7.2.0 The ID for an object callback is prefixed so that it is never cast to an integer array key.
  *
  * @access private
  *
@@ -1007,7 +1008,12 @@ function _wp_filter_build_unique_id( $hook_name, $callback, $priority ): ?string
 	}
 
 	if ( is_object( $callback ) ) {
-		return (string) spl_object_id( $callback );
+		/*
+		 * The prefix keeps the ID from being the decimal representation of an integer. PHP casts such a
+		 * string to int when it is used as an array key, which would change the type of the keys in
+		 * WP_Hook::$callbacks and break consumers that pass them to string functions.
+		 */
+		return 'spl_object_id:' . spl_object_id( $callback );
 	}
 
 	if ( ! isset( $callback[1] ) || ! is_string( $callback[1] ) ) {

--- a/tests/phpstan/baselines/return.type.neon
+++ b/tests/phpstan/baselines/return.type.neon
@@ -109,11 +109,6 @@ parameters:
 			count: 1
 			path: ../../../src/wp-includes/meta.php
 		-
-			message: '#^Function _wp_filter_build_unique_id\(\) should return non\-decimal\-int\-string\|null but returns decimal\-int\-string\.$#'
-			identifier: return.type
-			count: 1
-			path: ../../../src/wp-includes/plugin.php
-		-
 			message: '#^Function wp_post_revision_title\(\) should return string\|false but returns null\.$#'
 			identifier: return.type
 			count: 1

--- a/tests/phpstan/baselines/return.type.neon
+++ b/tests/phpstan/baselines/return.type.neon
@@ -109,6 +109,11 @@ parameters:
 			count: 1
 			path: ../../../src/wp-includes/meta.php
 		-
+			message: '#^Function _wp_filter_build_unique_id\(\) should return non\-decimal\-int\-string\|null but returns decimal\-int\-string\.$#'
+			identifier: return.type
+			count: 1
+			path: ../../../src/wp-includes/plugin.php
+		-
 			message: '#^Function wp_post_revision_title\(\) should return string\|false but returns null\.$#'
 			identifier: return.type
 			count: 1

--- a/tests/phpunit/tests/hooks/buildUniqueId.php
+++ b/tests/phpunit/tests/hooks/buildUniqueId.php
@@ -8,29 +8,63 @@
  */
 class Tests_Hooks_BuildUniqueId extends WP_UnitTestCase {
 
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+
+		require_once __DIR__ . '/../../includes/mock-invokable.php';
+	}
+
+	/**
+	 * @ticket 58291
+	 * @ticket 65919
+	 */
 	public function test_string_callback_returns_string(): void {
 		$result = _wp_filter_build_unique_id( '', '__return_null', 10 );
-		$this->assertIsString( $result );
+		$this->assertIsNonDecimalIntString( $result );
 		$this->assertSame( '__return_null', $result );
 	}
 
+	/**
+	 * @ticket 58291
+	 * @ticket 65919
+	 */
 	public function test_closure_returns_string(): void {
 		$cb     = function (): void {};
 		$result = _wp_filter_build_unique_id( '', $cb, 10 );
-		$this->assertIsString( $result );
+		$this->assertIsNonDecimalIntString( $result );
 	}
 
+	/**
+	 * @ticket 58291
+	 * @ticket 65919
+	 */
+	public function test_invokable_object_returns_string(): void {
+		$result = _wp_filter_build_unique_id( '', new Mock_Invokable(), 10 );
+		$this->assertIsNonDecimalIntString( $result );
+	}
+
+	/**
+	 * @ticket 58291
+	 * @ticket 65919
+	 */
 	public function test_object_callback_returns_string(): void {
 		$a      = new MockAction();
 		$result = _wp_filter_build_unique_id( '', array( $a, 'action' ), 10 );
-		$this->assertIsString( $result );
+		$this->assertIsNonDecimalIntString( $result );
 	}
 
+	/**
+	 * @ticket 58291
+	 * @ticket 65919
+	 */
 	public function test_static_callback_returns_string(): void {
 		$result = _wp_filter_build_unique_id( '', array( 'MockAction', 'action' ), 10 );
-		$this->assertIsString( $result );
+		$this->assertIsNonDecimalIntString( $result );
 	}
 
+	/**
+	 * @ticket 58291
+	 */
 	public function test_two_different_objects_produce_different_ids(): void {
 		$a = new MockAction();
 		$b = new MockAction();
@@ -40,6 +74,9 @@ class Tests_Hooks_BuildUniqueId extends WP_UnitTestCase {
 		);
 	}
 
+	/**
+	 * @ticket 58291
+	 */
 	public function test_same_object_produces_same_id(): void {
 		$a = new MockAction();
 		$this->assertSame(
@@ -48,15 +85,42 @@ class Tests_Hooks_BuildUniqueId extends WP_UnitTestCase {
 		);
 	}
 
+	/**
+	 * @ticket 58291
+	 */
 	public function test_malformed_array_missing_method_returns_null(): void {
 		$a      = new MockAction();
 		$result = _wp_filter_build_unique_id( '', array( $a ), 10 );
 		$this->assertNull( $result );
 	}
 
+	/**
+	 * @ticket 58291
+	 */
 	public function test_malformed_array_non_string_method_returns_null(): void {
 		$a      = new MockAction();
 		$result = _wp_filter_build_unique_id( '', array( $a, 123 ), 10 );
 		$this->assertNull( $result );
+	}
+
+	/**
+	 * Asserts that a value is a string which PHP does not cast to an integer when used as an array key.
+	 *
+	 * The return value of _wp_filter_build_unique_id() is used as the callback key in WP_Hook::$callbacks.
+	 * PHP silently casts an array key from string to int when the string is the canonical decimal
+	 * representation of an integer, which changes the type of the keys that consumers of that public
+	 * property read back. This is the runtime equivalent of PHPStan's `non-decimal-int-string` type.
+	 *
+	 * @param mixed $value Value to check.
+	 */
+	private function assertIsNonDecimalIntString( $value ): void {
+		$this->assertIsString( $value, 'The unique ID is not a string.' );
+
+		$array = array( $value => true );
+
+		$this->assertIsString(
+			array_key_first( $array ),
+			sprintf( 'The unique ID "%s" was cast to an integer when used as an array key.', $value )
+		);
 	}
 }

--- a/tests/phpunit/tests/widgets.php
+++ b/tests/phpunit/tests/widgets.php
@@ -46,6 +46,56 @@ class Tests_Widgets extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that a widget registered as an instance is keyed by a string.
+	 *
+	 * WP_Widget_Factory::$widgets is public, and its keys were strings in every release before the
+	 * object ID was introduced. PHP casts an array key from string to int whenever the string is the
+	 * canonical decimal representation of an integer, so a bare spl_object_id() value would change
+	 * the type of the keys that consumers of that property read back.
+	 *
+	 * @see register_widget()
+	 * @ticket 65919
+	 *
+	 * @global WP_Widget_Factory $wp_widget_factory
+	 */
+	public function test_register_widget_instance_is_keyed_by_string() {
+		global $wp_widget_factory;
+
+		register_widget( new WP_Widget_Search() );
+
+		$this->assertCount( 1, $wp_widget_factory->widgets );
+		$this->assertIsString( array_key_first( $wp_widget_factory->widgets ) );
+	}
+
+	/**
+	 * Tests that the key returned for a widget registered as an instance is a string.
+	 *
+	 * WP_Widget_Factory::get_widget_key() is documented as returning a string, and core passes what
+	 * it returns to the_widget(), which in turn passes it to the 'the_widget' action, both of which
+	 * document the value as a string.
+	 *
+	 * @see WP_Widget_Factory::get_widget_key()
+	 * @ticket 65919
+	 *
+	 * @global WP_Widget_Factory $wp_widget_factory
+	 */
+	public function test_get_widget_key_for_instance_returns_string() {
+		global $wp_widget_factory;
+
+		$widget                              = new WP_Widget_Search();
+		$widget->id_base                     = 'better_search';
+		$widget->name                        = 'Better Search';
+		$widget->option_name                 = 'widget_' . $widget->id_base;
+		$widget->widget_options['classname'] = 'widget_' . $widget->id_base;
+		$widget->control_options['id_base']  = $widget->id_base;
+
+		register_widget( $widget );
+
+		$this->assertIsString( $wp_widget_factory->get_widget_key( 'better_search' ) );
+		$this->assertSame( $widget, $wp_widget_factory->get_widget_object( 'better_search' ) );
+	}
+
+	/**
 	 * Test that registering a widget class and registering a widget instance work together.
 	 *
 	 * @see register_widget()


### PR DESCRIPTION
In r62408, `spl_object_hash()` was replaced with `spl_object_id()` in two places. In both, the resulting array key is no longer a string, and in both the array holding it is a public property that plugins introspect.

Committed in r63334. Core-65919 is reopened for 7.1.1 merge consideration.

## `WP_Hook::$callbacks`

The unique ID that `_wp_filter_build_unique_id()` builds for a callback that is a bare object (e.g. a closure or an instance with `__invoke()`) became the return value of `spl_object_id()` cast to a string, for example `"5292"`.

PHP casts an array key from string to `int` whenever the string is the canonical decimal representation of an integer, so that `(string)` cast is undone one layer down, at the point where the ID becomes a key in `WP_Hook::add_filter()`:

```php
$this->callbacks[ $priority ][ $idx ] = array( ... );
```

The keys therefore became integers for bare-object callbacks, where every release through 7.0.x stored the 32 character hex string returned by `spl_object_hash()`. Any consumer running under `strict_types`, or passing a key to a parameter declared `string`, now fatals:

```php
foreach ( $wp_filter['init']->callbacks[10] as $id => $cb ) {
	$prefix = substr( $id, 0, 3 );
	// TypeError: substr(): Argument #1 ($string) must be of type string, int given
}
```

Prefix the ID with a non-numeric literal so PHP leaves it a string:

```php
return 'spl_object_id:' . spl_object_id( $callback );
```

Only bare-object callbacks are affected. `[ $obj, 'method' ]` already yields `"5292method"`, and function names and `Class::method` are returned unchanged, so no other key format changes.

## `WP_Widget_Factory::$widgets`

The same changeset made the equivalent replacement in `WP_Widget_Factory::register()` and `unregister()`, there without any cast at all:

```diff
-	$this->widgets[ spl_object_hash( $widget ) ] = $widget;
+	$this->widgets[ spl_object_id( $widget ) ] = $widget;
```

So the key for a widget registered as an instance is a genuine `int`, and `WP_Widget_Factory::$widgets` is public as well.

This one also breaks a contract inside core. `get_widget_key()` documents that it returns a `string`, and returns the array key straight out of its loop. Both `render_block_core_legacy_widget()` and `WP_REST_Widget_Types_Controller` pass what it returns to `the_widget()`, whose first parameter is documented `string`, and which forwards it to the `the_widget` action, documented the same way. Nothing fatals inside core, because the lookups agree on the integer — but any `the_widget` listener declaring `function ( string $widget )` under `strict_types` does.

The same prefix applies, held in one place so the two call sites cannot drift:

```php
private const INSTANCE_KEY_PREFIX = 'spl_object_id:';
```

## Guarding against a recurrence

The tests added in r62408 asserted the return type of `_wp_filter_build_unique_id()`, which was correctly `string`. They did not assert the type of the resulting array key, which is where the coercion happens, so the regression passed through them. `WP_Widget_Factory` had no key assertions at all.

The tests now assert what actually matters, by round-tripping the value through an array key, the runtime equivalent of PHPStan's `non-decimal-int-string`:

```php
private function assertIsNonDecimalIntString( $value ): void {
	$this->assertIsString( $value, 'The unique ID is not a string.' );

	$array = array( $value => true );

	$this->assertIsString(
		array_key_first( $array ),
		sprintf( 'The unique ID "%s" was cast to an integer when used as an array key.', $value )
	);
}
```

Coverage for an invokable object callback is added, which had none, as are two tests for the widget factory keys.

Static analysis is tightened in three places:

- `_wp_filter_build_unique_id()` declares `@phpstan-return non-decimal-int-string|null`. PHPStan already infers `(string) spl_object_id( $x )` as `decimal-int-string`, so reintroducing the bare cast is reported as a `return.type` error from rule level 3 upwards, well inside the level 5 this project analyses at.
- The `WP_Hook::$callbacks` key type is narrowed from `string` to `non-decimal-int-string`, along with the `Iterator` and `ArrayAccess` type parameters and the `offsetGet()`, `offsetSet()`, `current()`, and `next()` signatures describing the same array. Analysing the tree at level 8 produces an identical error set before and after, so it costs nothing, and it catches the separate case of the unique ID type widening back to a plain `string`.
- `WP_Widget_Factory::$widgets` declares `@phpstan-var array<non-decimal-int-string, WP_Widget>` beneath a plain `@var array<string, WP_Widget>`, the way `WP_Hook::$callbacks` already carries the same type. A plain `string` key was used at first, on the grounds that PHPStan evaluates both of that class's writes inline — typing a bare `spl_object_id()` as `int` and a cast one as `decimal-int-string`, and modelling the latter as producing an `array<int, …>` — so `array<string, …>` already rejects both regression shapes without the extra report narrowing brings. That weighed the wrong thing: neither key type produces a single report below rule level 7, so at the level this project analyses at the choice is invisible, and two properties disagreeing about the type of a key built the same way costs more than the one report narrowing adds. The value type is a separate gain, retiring several reports of accessing a property or calling a method on `mixed`; analysing that file at level 10 goes from six errors to three.

Two limitations are worth flagging for anyone raising the rule level later, both invisible at level 5:

- PHPStan has no type for a string carrying a known literal prefix, so it infers only `non-falsy-string` for either fixed expression and cannot verify it. That produces one report in each file — on the return in `_wp_filter_build_unique_id()` and on the instance write in `WP_Widget_Factory::register()` — from level 7 upwards.
- The branch of `WP_Widget_Factory::register()` that registers by class name assigns an `object` where a `WP_Widget` is declared, since neither the type system nor `WP_Widget` expresses that a subclass named for registration must have a constructor callable with no arguments. Also level 7 upwards.

## Testing instructions

Before this patch, the two new key assertions fail in each place:

```
✘ Closure returns string
  │ The unique ID "92588" was cast to an integer when used as an array key.
✘ Invokable object returns string
  │ The unique ID "431" was cast to an integer when used as an array key.

✘ Register widget instance is keyed by string
  │ Failed asserting that 92581 is of type "string".
✘ Get widget key for instance returns string
  │ Failed asserting that 432 is of type "string".
```

After it:

- `--filter Tests_Hooks_BuildUniqueId` — 9 tests, 15 assertions
- `--filter Tests_Widgets` — 130 tests, 778 assertions
- `--group hooks` — 168 tests
- PHPStan reports no errors across the analyzed tree

Trac ticket: https://core.trac.wordpress.org/ticket/65919

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Investigating whether PHPStan could be configured to catch this class of bug, drafting the test changes and the fixes, and running the PHPStan and PHPUnit verification. I reviewed and take responsibility for all of it.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**

