### PR TITLE
Options, Meta APIs: Remove orphaned transient timeout rows on delete and cleanup

### DIFF
--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -1722,6 +1722,7 @@ function delete_expired_transients( $force_db = false ) {
 				"DELETE a FROM {$wpdb->sitemeta} a
 				LEFT JOIN {$wpdb->sitemeta} b
 					ON b.meta_key = CONCAT( '_site_transient_', SUBSTRING( a.meta_key, 25 ) )
+					AND b.site_id = a.site_id
 				WHERE a.meta_key LIKE %s
 				AND a.meta_value < %d
 				AND b.meta_id IS NULL",

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -1397,9 +1397,7 @@ function delete_transient( $transient ) {
 		$option         = '_transient_' . $transient;
 		$result         = delete_option( $option );
 
-		if ( $result ) {
-			delete_option( $option_timeout );
-		}
+		delete_option( $option_timeout );
 	}
 
 	if ( $result ) {
@@ -1629,7 +1627,13 @@ function set_transient( $transient, $value, $expiration = 0 ) {
  * The multi-table delete syntax is used to delete the transient record
  * from table a, and the corresponding transient_timeout record from table b.
  *
+ * Orphaned timeout rows — where a `_transient_timeout_` row exists without a
+ * matching `_transient_` row — are also removed when their timestamp has passed.
+ * These can be created when a request dies between the two writes in
+ * set_transient(), leaving the timeout row committed but the value row absent.
+ *
  * @since 4.9.0
+ * @since 7.2.0 Orphaned timeout rows without a matching value row are also deleted.
  *
  * @global wpdb $wpdb WordPress database abstraction object.
  *
@@ -1655,6 +1659,20 @@ function delete_expired_transients( $force_db = false ) {
 		)
 	);
 
+	// Remove orphaned transient timeout rows (timeout exists, value row is missing).
+	$wpdb->query(
+		$wpdb->prepare(
+			"DELETE a FROM {$wpdb->options} a
+			LEFT JOIN {$wpdb->options} b
+				ON b.option_name = CONCAT( '_transient_', SUBSTRING( a.option_name, 20 ) )
+			WHERE a.option_name LIKE %s
+			AND a.option_value < %d
+			AND b.option_id IS NULL",
+			$wpdb->esc_like( '_transient_timeout_' ) . '%',
+			time()
+		)
+	);
+
 	if ( ! is_multisite() ) {
 		// Single site stores site transients in the options table.
 		$wpdb->query(
@@ -1669,6 +1687,20 @@ function delete_expired_transients( $force_db = false ) {
 				time()
 			)
 		);
+
+		// Remove orphaned site transient timeout rows (timeout exists, value row is missing).
+		$wpdb->query(
+			$wpdb->prepare(
+				"DELETE a FROM {$wpdb->options} a
+				LEFT JOIN {$wpdb->options} b
+					ON b.option_name = CONCAT( '_site_transient_', SUBSTRING( a.option_name, 25 ) )
+				WHERE a.option_name LIKE %s
+				AND a.option_value < %d
+				AND b.option_id IS NULL",
+				$wpdb->esc_like( '_site_transient_timeout_' ) . '%',
+				time()
+			)
+		);
 	} elseif ( is_main_site() && is_main_network() ) {
 		// Multisite stores site transients in the sitemeta table.
 		$wpdb->query(
@@ -1679,6 +1711,20 @@ function delete_expired_transients( $force_db = false ) {
 				AND b.meta_key = CONCAT( '_site_transient_timeout_', SUBSTRING( a.meta_key, 17 ) )
 				AND b.meta_value < %d",
 				$wpdb->esc_like( '_site_transient_' ) . '%',
+				$wpdb->esc_like( '_site_transient_timeout_' ) . '%',
+				time()
+			)
+		);
+
+		// Remove orphaned site transient timeout rows from sitemeta (timeout exists, value row is missing).
+		$wpdb->query(
+			$wpdb->prepare(
+				"DELETE a FROM {$wpdb->sitemeta} a
+				LEFT JOIN {$wpdb->sitemeta} b
+					ON b.meta_key = CONCAT( '_site_transient_', SUBSTRING( a.meta_key, 25 ) )
+				WHERE a.meta_key LIKE %s
+				AND a.meta_value < %d
+				AND b.meta_id IS NULL",
 				$wpdb->esc_like( '_site_transient_timeout_' ) . '%',
 				time()
 			)
@@ -2528,9 +2574,7 @@ function delete_site_transient( $transient ) {
 		$option         = '_site_transient_' . $transient;
 		$result         = delete_site_option( $option );
 
-		if ( $result ) {
-			delete_site_option( $option_timeout );
-		}
+		delete_site_option( $option_timeout );
 	}
 
 	if ( $result ) {

--- a/tests/phpunit/tests/option/transient.php
+++ b/tests/phpunit/tests/option/transient.php
@@ -310,20 +310,34 @@ class Tests_Option_Transient extends WP_UnitTestCase {
 	 * @covers ::delete_expired_transients
 	 */
 	public function test_delete_expired_transients_removes_orphaned_expired_timeout_row() {
-		$transient = 'test_orphan_expired';
+		global $wpdb;
+
+		$transient      = 'test_orphan_expired';
+		$option_timeout = '_transient_timeout_' . $transient;
 
 		// Simulate an orphaned timeout row that has already expired.
-		add_option( '_transient_timeout_' . $transient, time() - 1, '', false );
+		add_option( $option_timeout, time() - 1, '', false );
 
 		// Confirm the value row does not exist and the timeout row does.
 		$this->assertFalse( get_option( '_transient_' . $transient ), 'Value row should not exist.' );
-		$this->assertNotFalse( get_option( '_transient_timeout_' . $transient ), 'Timeout row should exist before cleanup.' );
+		$this->assertNotFalse( get_option( $option_timeout ), 'Timeout row should exist before cleanup.' );
 
 		delete_expired_transients();
 
-		$this->assertFalse(
-			get_option( '_transient_timeout_' . $transient ),
-			'Orphaned expired timeout row should have been removed by delete_expired_transients().'
+		/*
+		 * delete_expired_transients() uses raw SQL and does not clear the option cache.
+		 * Query the database directly to verify the row was physically removed.
+		 */
+		$row = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT option_value FROM {$wpdb->options} WHERE option_name = %s",
+				$option_timeout
+			)
+		);
+
+		$this->assertNull(
+			$row,
+			'Orphaned expired timeout row should have been removed from the database by delete_expired_transients().'
 		);
 	}
 
@@ -335,15 +349,26 @@ class Tests_Option_Transient extends WP_UnitTestCase {
 	 * @covers ::delete_expired_transients
 	 */
 	public function test_delete_expired_transients_keeps_orphaned_future_timeout_row() {
-		$transient = 'test_orphan_future';
+		global $wpdb;
+
+		$transient      = 'test_orphan_future';
+		$option_timeout = '_transient_timeout_' . $transient;
 
 		// Simulate an orphaned timeout row that has not yet expired.
-		add_option( '_transient_timeout_' . $transient, time() + 3600, '', false );
+		add_option( $option_timeout, time() + 3600, '', false );
 
 		delete_expired_transients();
 
-		$this->assertNotFalse(
-			get_option( '_transient_timeout_' . $transient ),
+		// Query the database directly to confirm the row is still present.
+		$row = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT option_value FROM {$wpdb->options} WHERE option_name = %s",
+				$option_timeout
+			)
+		);
+
+		$this->assertNotNull(
+			$row,
 			'Orphaned timeout row with a future expiry should not be removed by delete_expired_transients().'
 		);
 	}

--- a/tests/phpunit/tests/option/transient.php
+++ b/tests/phpunit/tests/option/transient.php
@@ -265,4 +265,86 @@ class Tests_Option_Transient extends WP_UnitTestCase {
 		);
 		$this->assertSame( $expected, $a->get_events() );
 	}
+
+	/**
+	 * Tests that delete_transient() removes an orphaned timeout row when the value row is missing.
+	 *
+	 * set_transient() writes the timeout row before the value row in two separate statements.
+	 * If a request aborts between those two writes, the timeout row is committed but the value
+	 * row never arrives. delete_transient() must still remove the orphaned timeout row.
+	 *
+	 * @ticket 65863
+	 *
+	 * @covers ::delete_transient
+	 */
+	public function test_delete_transient_removes_orphaned_timeout_row() {
+		global $wpdb;
+
+		$transient = 'test_orphan_timeout';
+
+		// Simulate an orphaned timeout row by writing it directly without the value row.
+		add_option( '_transient_timeout_' . $transient, time() + 3600, '', false );
+
+		// Confirm the value row does not exist and the timeout row does.
+		$this->assertFalse( get_option( '_transient_' . $transient ), 'Value row should not exist.' );
+		$this->assertNotFalse( get_option( '_transient_timeout_' . $transient ), 'Timeout row should exist.' );
+
+		// delete_transient() should remove the orphaned timeout row.
+		delete_transient( $transient );
+
+		$this->assertFalse(
+			get_option( '_transient_timeout_' . $transient ),
+			'Orphaned timeout row should have been removed by delete_transient().'
+		);
+	}
+
+	/**
+	 * Tests that delete_expired_transients() removes orphaned timeout rows whose timestamp has passed.
+	 *
+	 * An orphaned timeout row — a `_transient_timeout_` row without a matching `_transient_` row —
+	 * is invisible to the normal multi-table DELETE used by delete_expired_transients() because the
+	 * JOIN requires both rows to exist. A dedicated LEFT JOIN query must remove them.
+	 *
+	 * @ticket 65863
+	 *
+	 * @covers ::delete_expired_transients
+	 */
+	public function test_delete_expired_transients_removes_orphaned_expired_timeout_row() {
+		$transient = 'test_orphan_expired';
+
+		// Simulate an orphaned timeout row that has already expired.
+		add_option( '_transient_timeout_' . $transient, time() - 1, '', false );
+
+		// Confirm the value row does not exist and the timeout row does.
+		$this->assertFalse( get_option( '_transient_' . $transient ), 'Value row should not exist.' );
+		$this->assertNotFalse( get_option( '_transient_timeout_' . $transient ), 'Timeout row should exist before cleanup.' );
+
+		delete_expired_transients();
+
+		$this->assertFalse(
+			get_option( '_transient_timeout_' . $transient ),
+			'Orphaned expired timeout row should have been removed by delete_expired_transients().'
+		);
+	}
+
+	/**
+	 * Tests that delete_expired_transients() does not remove an orphaned timeout row that has not yet expired.
+	 *
+	 * @ticket 65863
+	 *
+	 * @covers ::delete_expired_transients
+	 */
+	public function test_delete_expired_transients_keeps_orphaned_future_timeout_row() {
+		$transient = 'test_orphan_future';
+
+		// Simulate an orphaned timeout row that has not yet expired.
+		add_option( '_transient_timeout_' . $transient, time() + 3600, '', false );
+
+		delete_expired_transients();
+
+		$this->assertNotFalse(
+			get_option( '_transient_timeout_' . $transient ),
+			'Orphaned timeout row with a future expiry should not be removed by delete_expired_transients().'
+		);
+	}
 }

--- a/tests/phpunit/tests/option/transient.php
+++ b/tests/phpunit/tests/option/transient.php
@@ -372,4 +372,72 @@ class Tests_Option_Transient extends WP_UnitTestCase {
 			'Orphaned timeout row with a future expiry should not be removed by delete_expired_transients().'
 		);
 	}
+
+	/**
+	 * Tests that delete_site_transient() removes an orphaned site transient timeout row when the value row is missing.
+	 *
+	 * @ticket 65863
+	 *
+	 * @covers ::delete_site_transient
+	 */
+	public function test_delete_site_transient_removes_orphaned_timeout_row() {
+		$transient = 'test_site_orphan_timeout';
+
+		// Simulate an orphaned site transient timeout row without its matching value row.
+		add_site_option( '_site_transient_timeout_' . $transient, time() + 3600 );
+
+		// Confirm the value row does not exist and the timeout row does.
+		$this->assertFalse( get_site_option( '_site_transient_' . $transient ), 'Value row should not exist.' );
+		$this->assertNotFalse( get_site_option( '_site_transient_timeout_' . $transient ), 'Timeout row should exist.' );
+
+		delete_site_transient( $transient );
+
+		$this->assertFalse(
+			get_site_option( '_site_transient_timeout_' . $transient ),
+			'Orphaned site transient timeout row should have been removed by delete_site_transient().'
+		);
+	}
+
+	/**
+	 * Tests that delete_expired_transients() removes orphaned site transient timeout rows whose timestamp has passed.
+	 *
+	 * On single-site installs, site transients are stored in wp_options.
+	 *
+	 * @ticket 65863
+	 *
+	 * @group site-transient
+	 *
+	 * @covers ::delete_expired_transients
+	 */
+	public function test_delete_expired_transients_removes_orphaned_expired_site_timeout_row() {
+		global $wpdb;
+
+		if ( is_multisite() ) {
+			$this->markTestSkipped( 'Single-site site transient path only.' );
+		}
+
+		$transient      = 'test_site_orphan_expired';
+		$option_timeout = '_site_transient_timeout_' . $transient;
+
+		// Simulate an orphaned site transient timeout row that has already expired.
+		add_option( $option_timeout, time() - 1, '', false );
+
+		// Confirm the value row does not exist and the timeout row does.
+		$this->assertFalse( get_option( '_site_transient_' . $transient ), 'Value row should not exist.' );
+		$this->assertNotFalse( get_option( $option_timeout ), 'Timeout row should exist before cleanup.' );
+
+		delete_expired_transients();
+
+		$row = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT option_value FROM {$wpdb->options} WHERE option_name = %s",
+				$option_timeout
+			)
+		);
+
+		$this->assertNull(
+			$row,
+			'Orphaned expired site transient timeout row should have been removed from the database by delete_expired_transients().'
+		);
+	}
 }


### PR DESCRIPTION
Fixes the two-part bug reported in #65863. This PR addresses **both halves** of the report — unlike the previously submitted PR #13101 which only fixed the first half.

**The problem:**

`set_transient()` writes the timeout row before the value row in two separate, non-transactional statements. If a request dies between those two writes, the timeout row is committed but the value row never arrives.

This creates a permanently stuck orphan row because:

1. `delete_transient()` conditions cleanup of the timeout row on the value row deletion succeeding. With no value row, it returns `false` and leaves the timeout row forever.
2. `delete_expired_transients()` uses a multi-table `DELETE` that joins from the value row side, so an orphaned timeout row has no `a` side to join from and is never seen — regardless of its timestamp.

The same applies to `delete_site_transient()`.

**What this PR does:**

**Fix 1 — `delete_transient()` and `delete_site_transient()`:**
Removes the `if ( $result )` guard so the timeout row is always deleted when requested, whether or not the value row existed.

**Fix 2 — `delete_expired_transients()`:**
Adds a `LEFT JOIN DELETE` statement after each existing cleanup query to remove expired orphaned timeout rows (timeout exists, value row is absent). Covers all three variants: single-site transients, single-site site transients, and multisite sitemeta.

**Tests:**
- `test_delete_transient_removes_orphaned_timeout_row()` — directly simulates the orphan and asserts `delete_transient()` cleans it up.
- `test_delete_expired_transients_removes_orphaned_expired_timeout_row()` — expired orphan is removed by the cleanup job.
- `test_delete_expired_transients_keeps_orphaned_future_timeout_row()` — non-expired orphan is left alone.

**SQL offset note:**
`_transient_timeout_` is 19 characters, so `SUBSTRING(a.option_name, 20)` extracts the transient name. `_site_transient_timeout_` is 24 characters, so `SUBSTRING(a.option_name, 25)` is used for the site transient variants. These match the proposed queries in [ticket comment #3](https://core.trac.wordpress.org/ticket/65863#comment:3) from the reporter.

See https://core.trac.wordpress.org/ticket/65863