### PR TITLE
Build/Test Tools: Flag slow PHPUnit tests with annotations

### DIFF
--- a/.github/workflows/reusable-phpunit-tests-v3.yml
+++ b/.github/workflows/reusable-phpunit-tests-v3.yml
@@ -126,8 +126,8 @@ jobs:
   # - Logs debug information about what's installed within the WordPress Docker containers.
   # - Install WordPress within the Docker container.
   # - Run the PHPUnit tests.
-  # - Publish PHPUnit timing metrics to CodeVitals.
   # - Flags slow PHPUnit tests with GitHub Actions annotations and a run summary.
+  # - Publish PHPUnit timing metrics to CodeVitals.
   # - Upload the code coverage report to Codecov.io.
   # - Ensures version-controlled files are not modified or deleted.
   # - Checks out the WordPress Test reporter repository.
@@ -274,6 +274,28 @@ jobs:
           TEST_GROUPS: ${{ inputs.phpunit-test-groups }}
           MULTISITE_FLAG: ${{ inputs.multisite && 'multisite' || 'single' }}
 
+      - name: Flag slow PHPUnit tests
+        # Runs when the test step succeeds or fails, but skips cancelled jobs.
+        # This step never fails the job itself (continue-on-error), because the
+        # slow-test signal is advisory only.
+        if: >-
+          ${{
+            ! cancelled() && inputs.report && inputs.php == '8.5' &&
+            ( github.event_name == 'pull_request' ||
+              ( github.event_name == 'push' && github.ref == 'refs/heads/trunk' ) )
+          }}
+        continue-on-error: true
+        run: |
+          if [ -f tests/phpunit/build/logs/junit.xml ]; then
+            php tests/phpunit/prepare-slow-test-annotations.php \
+              tests/phpunit/build/logs/junit.xml \
+              1.0 \
+              20 \
+              "$RUNNER_TEMP/phpunit-timing-metrics.json"
+          else
+            echo 'PHPUnit JUnit report not found; skipping slow-test annotations.'
+          fi
+
       - name: Publish PHPUnit timing metrics
         continue-on-error: true
         if: |
@@ -296,6 +318,7 @@ jobs:
               trunk \
               "$GITHUB_SHA" \
               "$COMMITTED_AT" \
+              "$RUNNER_TEMP/phpunit-timing-metrics.json" \
               | curl --fail-with-body --silent --show-error \
                 --request POST \
                 --header 'Content-Type: application/json' \
@@ -307,24 +330,6 @@ jobs:
             exit 1
           fi
           echo 'Published six PHPUnit timing metrics to CodeVitals.'
-
-      - name: Flag slow PHPUnit tests
-        # Runs when the test step succeeds or fails, but skips cancelled jobs.
-        # This step never fails the job itself (continue-on-error), because the
-        # slow-test signal is advisory only.
-        if: >-
-          ${{
-            ! cancelled() && inputs.report && inputs.php == '8.5' &&
-            ( github.event_name == 'pull_request' ||
-              ( github.event_name == 'push' && github.ref == 'refs/heads/trunk' ) )
-          }}
-        continue-on-error: true
-        run: |
-          if [ -f tests/phpunit/build/logs/junit.xml ]; then
-            php tests/phpunit/prepare-slow-test-annotations.php tests/phpunit/build/logs/junit.xml
-           else
-             echo 'PHPUnit JUnit report not found; skipping slow-test annotations.'
-           fi
 
       - name: Run AJAX tests
         if: ${{ ! inputs.phpunit-test-groups && ! inputs.coverage-report }}

--- a/.github/workflows/reusable-phpunit-tests-v3.yml
+++ b/.github/workflows/reusable-phpunit-tests-v3.yml
@@ -127,6 +127,7 @@ jobs:
   # - Install WordPress within the Docker container.
   # - Run the PHPUnit tests.
   # - Publish PHPUnit timing metrics to CodeVitals.
+  # - Flags slow PHPUnit tests with GitHub Actions annotations and a run summary.
   # - Upload the code coverage report to Codecov.io.
   # - Ensures version-controlled files are not modified or deleted.
   # - Checks out the WordPress Test reporter repository.
@@ -308,13 +309,15 @@ jobs:
           echo 'Published six PHPUnit timing metrics to CodeVitals.'
 
       - name: Flag slow PHPUnit tests
-        # Runs even when the test step failed (always()), so the signal still
-        # surfaces on red runs, and never fails the job itself (continue-on-error),
-        # because this is advisory only.
+        # Runs when the test step succeeds or fails, but skips cancelled jobs.
+        # This step never fails the job itself (continue-on-error), because the
+        # slow-test signal is advisory only.
         if: >-
-          always() && inputs.report && inputs.php == '8.5' &&
-          ( github.event_name == 'pull_request' ||
-            ( github.event_name == 'push' && github.ref == 'refs/heads/trunk' ) )
+          ${{
+            ! cancelled() && inputs.report && inputs.php == '8.5' &&
+            ( github.event_name == 'pull_request' ||
+              ( github.event_name == 'push' && github.ref == 'refs/heads/trunk' ) )
+          }}
         continue-on-error: true
         run: |
           if [ -f tests/phpunit/build/logs/junit.xml ]; then

--- a/.github/workflows/reusable-phpunit-tests-v3.yml
+++ b/.github/workflows/reusable-phpunit-tests-v3.yml
@@ -307,6 +307,22 @@ jobs:
           fi
           echo 'Published six PHPUnit timing metrics to CodeVitals.'
 
+      - name: Flag slow PHPUnit tests
+        # Runs even when the test step failed (always()), so the signal still
+        # surfaces on red runs, and never fails the job itself (continue-on-error),
+        # because this is advisory only.
+        if: >-
+          always() && inputs.report && inputs.php == '8.5' &&
+          ( github.event_name == 'pull_request' ||
+            ( github.event_name == 'push' && github.ref == 'refs/heads/trunk' ) )
+        continue-on-error: true
+        run: |
+          if [ -f tests/phpunit/build/logs/junit.xml ]; then
+            php tests/phpunit/prepare-slow-test-annotations.php tests/phpunit/build/logs/junit.xml
+           else
+             echo 'PHPUnit JUnit report not found; skipping slow-test annotations.'
+           fi
+
       - name: Run AJAX tests
         if: ${{ ! inputs.phpunit-test-groups && ! inputs.coverage-report }}
         continue-on-error: ${{ inputs.allow-errors }}

--- a/tests/phpunit/includes/class-wp-phpunit-timing-metrics.php
+++ b/tests/phpunit/includes/class-wp-phpunit-timing-metrics.php
@@ -8,50 +8,93 @@ final class WP_PHPUnit_Timing_Metrics {
 	/**
 	 * Extracts timing metrics from a JUnit XML file.
 	 *
-	 * @param string $file Path to the JUnit XML file.
+	 * @param string        $file              Path to the JUnit XML file.
+	 * @param callable|null $testcase_callback Optional callback invoked for each timed testcase.
 	 * @return array<string, float|int> Timing metrics keyed for CodeVitals.
-	 * @throws RuntimeException If the file cannot be read or contains invalid timing data.
+	 * @throws RuntimeException If the file cannot be read or contains invalid XML.
 	 */
-	public static function from_file( $file ) {
+	public static function from_file( $file, $testcase_callback = null ) {
 		if ( ! is_readable( $file ) ) {
 			throw new RuntimeException( 'The JUnit timing report could not be read.' );
 		}
 
-		$reader = new XMLReader();
-		if ( ! $reader->open( $file, null, LIBXML_NONET | LIBXML_COMPACT ) ) {
-			throw new RuntimeException( 'The JUnit timing report could not be opened.' );
+		if ( null !== $testcase_callback && ! is_callable( $testcase_callback ) ) {
+			throw new InvalidArgumentException( 'The testcase callback must be callable.' );
 		}
 
-		$suite_time = null;
-		$test_times = array();
+		$reader                = new XMLReader();
+		$previous_libxml_state = libxml_use_internal_errors( true );
+		$reader_is_open        = false;
+		$suite_time            = null;
+		$test_times            = array();
+		$xml_errors            = array();
 
-		while ( $reader->read() ) {
-			if ( XMLReader::ELEMENT !== $reader->nodeType ) {
-				continue;
+		libxml_clear_errors();
+
+		try {
+			if ( ! $reader->open( $file, null, LIBXML_NONET | LIBXML_COMPACT ) ) {
+				throw new RuntimeException( 'The JUnit timing report could not be opened.' );
 			}
 
-			if ( null === $suite_time && 'testsuite' === $reader->name ) {
-				$time = $reader->getAttribute( 'time' );
-				if ( is_numeric( $time ) ) {
-					$suite_time = (float) $time;
+			$reader_is_open = true;
+
+			while ( $reader->read() ) {
+				if ( XMLReader::ELEMENT !== $reader->nodeType ) {
+					continue;
 				}
-				continue;
+
+				if ( null === $suite_time && 'testsuite' === $reader->name ) {
+					$time = $reader->getAttribute( 'time' );
+					if ( is_numeric( $time ) ) {
+						$suite_time = (float) $time;
+					}
+					continue;
+				}
+
+				if ( 'testcase' !== $reader->name ) {
+					continue;
+				}
+
+				$time = $reader->getAttribute( 'time' );
+
+				// A testcase without numeric timing, such as a skipped test, carries
+				// no timing signal and is excluded from the aggregate metrics.
+				if ( ! is_numeric( $time ) ) {
+					continue;
+				}
+
+				$test_time    = (float) $time;
+				$test_times[] = $test_time;
+
+				if ( null !== $testcase_callback ) {
+					$testcase_callback(
+						array(
+							'name'         => (string) $reader->getAttribute( 'name' ),
+							'class'        => (string) $reader->getAttribute( 'class' ),
+							'file'         => (string) $reader->getAttribute( 'file' ),
+							'line'         => (string) $reader->getAttribute( 'line' ),
+							'time'         => $test_time,
+							'time_display' => (string) $time,
+						)
+					);
+				}
 			}
 
-			if ( 'testcase' !== $reader->name ) {
-				continue;
-			}
-
-			$time = $reader->getAttribute( 'time' );
-			if ( ! is_numeric( $time ) ) {
+			$xml_errors = libxml_get_errors();
+		} finally {
+			if ( $reader_is_open ) {
 				$reader->close();
-				throw new RuntimeException( 'A JUnit testcase is missing numeric timing data.' );
 			}
 
-			$test_times[] = (float) $time;
+			libxml_clear_errors();
+			libxml_use_internal_errors( $previous_libxml_state );
 		}
 
-		$reader->close();
+		foreach ( $xml_errors as $xml_error ) {
+			if ( LIBXML_ERR_WARNING < $xml_error->level ) {
+				throw new RuntimeException( 'The JUnit timing report contains invalid XML.' );
+			}
+		}
 
 		if ( ! $test_times ) {
 			throw new RuntimeException( 'The JUnit timing report contains no testcases.' );

--- a/tests/phpunit/prepare-slow-test-annotations.php
+++ b/tests/phpunit/prepare-slow-test-annotations.php
@@ -7,11 +7,13 @@
  * Usage:
  *
  *     php tests/phpunit/prepare-slow-test-annotations.php <junit-file> \
- *         [threshold-seconds] [max-summary-tests]
+ *         [threshold-seconds] [max-summary-tests] [timing-metrics-file]
  *
  * @package WordPress
  * @subpackage UnitTests
  */
+
+require_once __DIR__ . '/includes/class-wp-phpunit-timing-metrics.php';
 
 /**
  * Escapes a GitHub Actions workflow command message.
@@ -106,11 +108,11 @@ function wp_phpunit_write_summary( $summary ) {
 	}
 }
 
-if ( $argc < 2 || $argc > 4 ) {
+if ( $argc < 2 || $argc > 5 ) {
 	fwrite(
 		STDERR,
 		'Usage: php tests/phpunit/prepare-slow-test-annotations.php <junit-file> '
-		. "[threshold-seconds] [max-summary-tests]\n"
+		. "[threshold-seconds] [max-summary-tests] [timing-metrics-file]\n"
 	);
 	exit( 1 );
 }
@@ -119,6 +121,7 @@ try {
 	$file                    = $argv[1];
 	$threshold_value         = $argv[2] ?? '1.0';
 	$max_summary_tests_value = $argv[3] ?? '20';
+	$timing_metrics_file     = $argv[4] ?? null;
 
 	if ( ! is_numeric( $threshold_value ) || (float) $threshold_value < 0 ) {
 		throw new RuntimeException( 'The slow-test threshold must be a non-negative number.' );
@@ -128,66 +131,26 @@ try {
 		throw new RuntimeException( 'The maximum summary test count must be a positive integer.' );
 	}
 
-	if ( ! is_readable( $file ) ) {
-		throw new RuntimeException( 'The JUnit report could not be read.' );
-	}
-
-	$threshold             = (float) $threshold_value;
-	$max_summary_tests     = (int) $max_summary_tests_value;
-	$reader                = new XMLReader();
-	$previous_libxml_state = libxml_use_internal_errors( true );
-	$reader_is_open        = false;
-
-	libxml_clear_errors();
-
-	try {
-		if ( ! $reader->open( $file, null, LIBXML_NONET | LIBXML_COMPACT ) ) {
-			throw new RuntimeException( 'The JUnit report could not be opened.' );
-		}
-
-		$reader_is_open = true;
-		$slow_tests     = array();
-
-		while ( $reader->read() ) {
-			if ( XMLReader::ELEMENT !== $reader->nodeType || 'testcase' !== $reader->name ) {
-				continue;
+	$threshold         = (float) $threshold_value;
+	$max_summary_tests = (int) $max_summary_tests_value;
+	$slow_tests        = array();
+	$timing_metrics    = WP_PHPUnit_Timing_Metrics::from_file(
+		$file,
+		static function ( $testcase ) use ( &$slow_tests, $threshold ) {
+			if ( $testcase['time'] <= $threshold ) {
+				return;
 			}
 
-			$time = $reader->getAttribute( 'time' );
-
-			// A testcase without numeric timing (for example a skipped test) carries
-			// no slow-test signal, so it is ignored rather than treated as an error.
-			if ( ! is_numeric( $time ) ) {
-				continue;
-			}
-
-			if ( (float) $time <= $threshold ) {
-				continue;
-			}
-
-			$slow_tests[] = array(
-				'name'         => (string) $reader->getAttribute( 'name' ),
-				'class'        => (string) $reader->getAttribute( 'class' ),
-				'file'         => wp_phpunit_relative_path( (string) $reader->getAttribute( 'file' ) ),
-				'line'         => (string) $reader->getAttribute( 'line' ),
-				'time'         => (float) $time,
-				'time_display' => $time,
-			);
+			$testcase['file'] = wp_phpunit_relative_path( $testcase['file'] );
+			$slow_tests[]     = $testcase;
 		}
+	);
 
-		$xml_errors = libxml_get_errors();
-	} finally {
-		if ( $reader_is_open ) {
-			$reader->close();
-		}
+	if ( null !== $timing_metrics_file ) {
+		$timing_metrics_json = json_encode( $timing_metrics, JSON_THROW_ON_ERROR );
 
-		libxml_clear_errors();
-		libxml_use_internal_errors( $previous_libxml_state );
-	}
-
-	foreach ( $xml_errors as $xml_error ) {
-		if ( LIBXML_ERR_WARNING < $xml_error->level ) {
-			throw new RuntimeException( 'The JUnit report contains invalid XML.' );
+		if ( false === file_put_contents( $timing_metrics_file, $timing_metrics_json . "\n" ) ) {
+			throw new RuntimeException( 'The PHPUnit timing metrics file could not be written.' );
 		}
 	}
 

--- a/tests/phpunit/prepare-slow-test-annotations.php
+++ b/tests/phpunit/prepare-slow-test-annotations.php
@@ -1,0 +1,268 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Flags slow PHPUnit tests with GitHub Actions annotations and a run summary.
+ *
+ * Usage:
+ *
+ *     php tests/phpunit/prepare-slow-test-annotations.php <junit-file> \
+ *         [threshold-seconds] [max-annotations]
+ *
+ * @package WordPress
+ * @subpackage UnitTests
+ */
+
+/**
+ * Escapes a GitHub Actions workflow command message.
+ *
+ * @param string $value Message to escape.
+ * @return string Escaped message.
+ */
+function wp_phpunit_escape_command_message( $value ) {
+	return str_replace(
+		array( '%', "\r", "\n" ),
+		array( '%25', '%0D', '%0A' ),
+		$value
+	);
+}
+
+/**
+ * Escapes a GitHub Actions workflow command property.
+ *
+ * @param string $value Property value to escape.
+ * @return string Escaped property value.
+ */
+function wp_phpunit_escape_command_property( $value ) {
+	return str_replace(
+		array( ',', ':' ),
+		array( '%2C', '%3A' ),
+		wp_phpunit_escape_command_message( $value )
+	);
+}
+
+/**
+ * Escapes text for a Markdown table cell.
+ *
+ * @param string $value Cell value to escape.
+ * @return string Escaped cell value.
+ */
+function wp_phpunit_escape_markdown_cell( $value ) {
+	return str_replace(
+		array( '|', "\r", "\n" ),
+		array( '\\|', ' ', ' ' ),
+		$value
+	);
+}
+
+/**
+ * Converts a container-absolute test path to a repository-relative one.
+ *
+ * PHPUnit records absolute paths (the repository is mounted at /var/www in the
+ * Docker environment). GitHub annotations need repository-relative paths to
+ * resolve to a line, so a known workspace prefix is stripped when present.
+ *
+ * @param string $file Path recorded in the JUnit report.
+ * @return string Repository-relative path, or the input unchanged.
+ */
+function wp_phpunit_relative_path( $file ) {
+	if ( '' === $file ) {
+		return '';
+	}
+
+	$prefixes  = array( '/var/www/' );
+	$workspace = getenv( 'GITHUB_WORKSPACE' );
+
+	if ( is_string( $workspace ) && '' !== $workspace ) {
+		$prefixes[] = rtrim( $workspace, '/' ) . '/';
+	}
+
+	foreach ( $prefixes as $prefix ) {
+		if ( 0 === strncmp( $file, $prefix, strlen( $prefix ) ) ) {
+			return substr( $file, strlen( $prefix ) );
+		}
+	}
+
+	return $file;
+}
+
+/**
+ * Appends a summary to GitHub Actions or writes it to standard output.
+ *
+ * @param string $summary Markdown summary.
+ * @return void
+ * @throws RuntimeException If the GitHub Actions summary cannot be written.
+ */
+function wp_phpunit_write_summary( $summary ) {
+	$summary_file = getenv( 'GITHUB_STEP_SUMMARY' );
+
+	if ( false === $summary_file || '' === $summary_file ) {
+		echo $summary;
+		return;
+	}
+
+	if ( false === file_put_contents( $summary_file, $summary, FILE_APPEND ) ) {
+		throw new RuntimeException( 'The GitHub Actions step summary could not be written.' );
+	}
+}
+
+if ( $argc < 2 || $argc > 4 ) {
+	fwrite(
+		STDERR,
+		"Usage: php tests/phpunit/prepare-slow-test-annotations.php <junit-file> "
+		. "[threshold-seconds] [max-annotations]\n"
+	);
+	exit( 1 );
+}
+
+try {
+	$file              = $argv[1];
+	$threshold_value   = $argv[2] ?? '1.0';
+	$max_annotations   = $argv[3] ?? '20';
+
+	if ( ! is_numeric( $threshold_value ) || (float) $threshold_value < 0 ) {
+		throw new RuntimeException( 'The slow-test threshold must be a non-negative number.' );
+	}
+
+	if ( ! ctype_digit( $max_annotations ) || (int) $max_annotations < 1 ) {
+		throw new RuntimeException( 'The maximum annotation count must be a positive integer.' );
+	}
+
+	if ( ! is_readable( $file ) ) {
+		throw new RuntimeException( 'The JUnit report could not be read.' );
+	}
+
+	$threshold             = (float) $threshold_value;
+	$max_annotations       = (int) $max_annotations;
+	$reader                = new XMLReader();
+	$previous_libxml_state = libxml_use_internal_errors( true );
+	$reader_is_open        = false;
+
+	libxml_clear_errors();
+
+	try {
+		if ( ! $reader->open( $file, null, LIBXML_NONET | LIBXML_COMPACT ) ) {
+			throw new RuntimeException( 'The JUnit report could not be opened.' );
+		}
+
+		$reader_is_open = true;
+		$slow_tests     = array();
+
+		while ( $reader->read() ) {
+			if ( XMLReader::ELEMENT !== $reader->nodeType || 'testcase' !== $reader->name ) {
+				continue;
+			}
+
+			$time = $reader->getAttribute( 'time' );
+
+			// A testcase without numeric timing (for example a skipped test) carries
+			// no slow-test signal, so it is ignored rather than treated as an error.
+			if ( ! is_numeric( $time ) ) {
+				continue;
+			}
+
+			if ( (float) $time <= $threshold ) {
+				continue;
+			}
+
+			$slow_tests[] = array(
+				'name'         => (string) $reader->getAttribute( 'name' ),
+				'class'        => (string) $reader->getAttribute( 'class' ),
+				'file'         => wp_phpunit_relative_path( (string) $reader->getAttribute( 'file' ) ),
+				'line'         => (string) $reader->getAttribute( 'line' ),
+				'time'         => (float) $time,
+				'time_display' => $time,
+			);
+		}
+
+		$xml_errors = libxml_get_errors();
+	} finally {
+		if ( $reader_is_open ) {
+			$reader->close();
+		}
+
+		libxml_clear_errors();
+		libxml_use_internal_errors( $previous_libxml_state );
+	}
+
+	foreach ( $xml_errors as $xml_error ) {
+		if ( LIBXML_ERR_WARNING < $xml_error->level ) {
+			throw new RuntimeException( 'The JUnit report contains invalid XML.' );
+		}
+	}
+
+	usort(
+		$slow_tests,
+		static function ( $left, $right ) {
+			if ( $left['time'] === $right['time'] ) {
+				return strcmp( $left['class'] . '::' . $left['name'], $right['class'] . '::' . $right['name'] );
+			}
+
+			return $right['time'] <=> $left['time'];
+		}
+	);
+
+	$slow_tests = array_slice( $slow_tests, 0, $max_annotations );
+
+	if ( ! $slow_tests ) {
+		wp_phpunit_write_summary( "No PHPUnit tests exceeded {$threshold_value}s.\n" );
+		exit( 0 );
+	}
+
+	// GitHub Actions renders at most 10 warning annotations per step, so the inline
+	// annotations are capped there while the summary table below can list more.
+	foreach ( array_slice( $slow_tests, 0, 10 ) as $test ) {
+		$properties = array();
+
+		if ( '' !== $test['file'] ) {
+			$properties[] = 'file=' . wp_phpunit_escape_command_property( $test['file'] );
+		}
+
+		if ( '' !== $test['line'] ) {
+			$properties[] = 'line=' . wp_phpunit_escape_command_property( $test['line'] );
+		}
+
+		$properties[] = 'title=' . wp_phpunit_escape_command_property( 'Slow PHPUnit test' );
+		$message      = sprintf(
+			'%s::%s took %ss',
+			$test['class'],
+			$test['name'],
+			$test['time_display']
+		);
+
+		printf(
+			"::warning %s::%s\n",
+			implode( ',', $properties ),
+			wp_phpunit_escape_command_message( $message )
+		);
+	}
+
+	$summary = "### Slowest PHPUnit tests (main suite, over {$threshold_value}s)\n\n";
+	$summary .= "| Test | Time (s) | File:line |\n";
+	$summary .= "| --- | ---: | --- |\n";
+
+	foreach ( $slow_tests as $test ) {
+		$location = $test['file'];
+
+		if ( '' !== $test['line'] ) {
+			$location .= ( '' !== $location ? ':' : 'Line ' ) . $test['line'];
+		}
+
+		if ( '' === $location ) {
+			$location = '&mdash;';
+		}
+
+		$summary .= sprintf(
+			"| %s::%s | %s | %s |\n",
+			wp_phpunit_escape_markdown_cell( $test['class'] ),
+			wp_phpunit_escape_markdown_cell( $test['name'] ),
+			$test['time_display'],
+			wp_phpunit_escape_markdown_cell( $location )
+		);
+	}
+
+	wp_phpunit_write_summary( $summary );
+} catch ( Throwable $error ) {
+	fwrite( STDERR, $error->getMessage() . "\n" );
+	exit( 1 );
+}

--- a/tests/phpunit/prepare-slow-test-annotations.php
+++ b/tests/phpunit/prepare-slow-test-annotations.php
@@ -7,7 +7,7 @@
  * Usage:
  *
  *     php tests/phpunit/prepare-slow-test-annotations.php <junit-file> \
- *         [threshold-seconds] [max-annotations]
+ *         [threshold-seconds] [max-summary-tests]
  *
  * @package WordPress
  * @subpackage UnitTests
@@ -109,23 +109,23 @@ function wp_phpunit_write_summary( $summary ) {
 if ( $argc < 2 || $argc > 4 ) {
 	fwrite(
 		STDERR,
-		"Usage: php tests/phpunit/prepare-slow-test-annotations.php <junit-file> "
-		. "[threshold-seconds] [max-annotations]\n"
+		'Usage: php tests/phpunit/prepare-slow-test-annotations.php <junit-file> '
+		. "[threshold-seconds] [max-summary-tests]\n"
 	);
 	exit( 1 );
 }
 
 try {
-	$file              = $argv[1];
-	$threshold_value   = $argv[2] ?? '1.0';
-	$max_annotations   = $argv[3] ?? '20';
+	$file                    = $argv[1];
+	$threshold_value         = $argv[2] ?? '1.0';
+	$max_summary_tests_value = $argv[3] ?? '20';
 
 	if ( ! is_numeric( $threshold_value ) || (float) $threshold_value < 0 ) {
 		throw new RuntimeException( 'The slow-test threshold must be a non-negative number.' );
 	}
 
-	if ( ! ctype_digit( $max_annotations ) || (int) $max_annotations < 1 ) {
-		throw new RuntimeException( 'The maximum annotation count must be a positive integer.' );
+	if ( ! ctype_digit( $max_summary_tests_value ) || (int) $max_summary_tests_value < 1 ) {
+		throw new RuntimeException( 'The maximum summary test count must be a positive integer.' );
 	}
 
 	if ( ! is_readable( $file ) ) {
@@ -133,7 +133,7 @@ try {
 	}
 
 	$threshold             = (float) $threshold_value;
-	$max_annotations       = (int) $max_annotations;
+	$max_summary_tests     = (int) $max_summary_tests_value;
 	$reader                = new XMLReader();
 	$previous_libxml_state = libxml_use_internal_errors( true );
 	$reader_is_open        = false;
@@ -202,12 +202,13 @@ try {
 		}
 	);
 
-	$slow_tests = array_slice( $slow_tests, 0, $max_annotations );
-
 	if ( ! $slow_tests ) {
 		wp_phpunit_write_summary( "No PHPUnit tests exceeded {$threshold_value}s.\n" );
 		exit( 0 );
 	}
+
+	$total_slow_tests = count( $slow_tests );
+	$summary_tests    = array_slice( $slow_tests, 0, $max_summary_tests );
 
 	// GitHub Actions renders at most 10 warning annotations per step, so the inline
 	// annotations are capped there while the summary table below can list more.
@@ -216,10 +217,10 @@ try {
 
 		if ( '' !== $test['file'] ) {
 			$properties[] = 'file=' . wp_phpunit_escape_command_property( $test['file'] );
-		}
 
-		if ( '' !== $test['line'] ) {
-			$properties[] = 'line=' . wp_phpunit_escape_command_property( $test['line'] );
+			if ( '' !== $test['line'] ) {
+				$properties[] = 'line=' . wp_phpunit_escape_command_property( $test['line'] );
+			}
 		}
 
 		$properties[] = 'title=' . wp_phpunit_escape_command_property( 'Slow PHPUnit test' );
@@ -238,10 +239,19 @@ try {
 	}
 
 	$summary = "### Slowest PHPUnit tests (main suite, over {$threshold_value}s)\n\n";
+
+	if ( $total_slow_tests > count( $summary_tests ) ) {
+		$summary .= sprintf(
+			"Showing the %d slowest of %d tests above the threshold.\n\n",
+			count( $summary_tests ),
+			$total_slow_tests
+		);
+	}
+
 	$summary .= "| Test | Time (s) | File:line |\n";
 	$summary .= "| --- | ---: | --- |\n";
 
-	foreach ( $slow_tests as $test ) {
+	foreach ( $summary_tests as $test ) {
 		$location = $test['file'];
 
 		if ( '' !== $test['line'] ) {

--- a/tests/phpunit/prepare-timing-results.php
+++ b/tests/phpunit/prepare-timing-results.php
@@ -10,12 +10,44 @@
 
 require_once __DIR__ . '/includes/class-wp-phpunit-timing-metrics.php';
 
-if ( 5 !== $argc ) {
-	fwrite( STDERR, "Usage: prepare-timing-results.php <junit-file> <branch> <hash> <timestamp>\n" );
+if ( 5 !== $argc && 6 !== $argc ) {
+	fwrite( STDERR, "Usage: prepare-timing-results.php <junit-file> <branch> <hash> <timestamp> [timing-metrics-file]\n" );
 	exit( 1 );
 }
 
 try {
+	if ( 6 === $argc ) {
+		if ( ! is_readable( $argv[5] ) ) {
+			throw new RuntimeException( 'The prepared PHPUnit timing metrics could not be read.' );
+		}
+
+		$timing_metrics_json = file_get_contents( $argv[5] );
+
+		if ( false === $timing_metrics_json ) {
+			throw new RuntimeException( 'The prepared PHPUnit timing metrics could not be read.' );
+		}
+
+		$timing_metrics = json_decode( $timing_metrics_json, true, 512, JSON_THROW_ON_ERROR );
+		$metric_keys    = array(
+			'phpunit-suite-time',
+			'phpunit-p95-test-time',
+			'phpunit-p99-test-time',
+			'phpunit-max-test-time',
+			'phpunit-tests-over-500ms',
+			'phpunit-tests-over-1s',
+		);
+
+		if (
+			! is_array( $timing_metrics )
+			|| array_keys( $timing_metrics ) !== $metric_keys
+			|| count( $timing_metrics ) !== count( array_filter( $timing_metrics, 'is_numeric' ) )
+		) {
+			throw new RuntimeException( 'The prepared PHPUnit timing metrics are invalid.' );
+		}
+	} else {
+		$timing_metrics = WP_PHPUnit_Timing_Metrics::from_file( $argv[1] );
+	}
+
 	$timestamp = new DateTimeImmutable( $argv[4] );
 	$payload   = array(
 		'branch'      => $argv[2],
@@ -23,7 +55,7 @@ try {
 		'baseHash'    => $argv[3],
 		'baseMetrics' => new stdClass(),
 		'timestamp'   => $timestamp->format( DATE_ATOM ),
-		'metrics'     => WP_PHPUnit_Timing_Metrics::from_file( $argv[1] ),
+		'metrics'     => $timing_metrics,
 	);
 
 	echo json_encode( $payload, JSON_THROW_ON_ERROR ) . "\n";

--- a/tests/phpunit/tests/includes/junitTimingMetrics.php
+++ b/tests/phpunit/tests/includes/junitTimingMetrics.php
@@ -61,6 +61,55 @@ class Tests_Includes_JUnit_Timing_Metrics extends WP_UnitTestCase {
 		$this->assertSame( 0.6, $metrics['phpunit-suite-time'] );
 	}
 
+	public function test_passes_timed_testcase_details_to_callback() {
+		$file      = $this->create_junit_file( array( 0.25, 1.5 ), 1.75 );
+		$testcases = array();
+
+		WP_PHPUnit_Timing_Metrics::from_file(
+			$file,
+			static function ( $testcase ) use ( &$testcases ) {
+				$testcases[] = $testcase;
+			}
+		);
+
+		$this->assertSame(
+			array(
+				array(
+					'name'         => 'test_0',
+					'class'        => 'Tests_Example',
+					'file'         => '/var/www/tests/phpunit/tests/example.php',
+					'line'         => '100',
+					'time'         => 0.25,
+					'time_display' => '0.25',
+				),
+				array(
+					'name'         => 'test_1',
+					'class'        => 'Tests_Example',
+					'file'         => '/var/www/tests/phpunit/tests/example.php',
+					'line'         => '101',
+					'time'         => 1.5,
+					'time_display' => '1.5',
+				),
+			),
+			$testcases
+		);
+	}
+
+	public function test_ignores_testcase_without_numeric_timing() {
+		$file      = $this->create_junit_file( array( 0.5, null, 1.5 ), 2.0 );
+		$testcases = array();
+
+		$metrics = WP_PHPUnit_Timing_Metrics::from_file(
+			$file,
+			static function ( $testcase ) use ( &$testcases ) {
+				$testcases[] = $testcase;
+			}
+		);
+
+		$this->assertCount( 2, $testcases );
+		$this->assertSame( 1500.0, $metrics['phpunit-max-test-time'] );
+	}
+
 	public function test_rejects_report_without_testcases() {
 		$file = $this->create_junit_file( array(), 0.0 );
 
@@ -70,14 +119,48 @@ class Tests_Includes_JUnit_Timing_Metrics extends WP_UnitTestCase {
 		WP_PHPUnit_Timing_Metrics::from_file( $file );
 	}
 
+	public function test_rejects_invalid_xml() {
+		$file = $this->create_temporary_file( '<?xml version="1.0"?><testsuites><testsuite><testcase time="1">' );
+
+		$this->expectException( RuntimeException::class );
+		$this->expectExceptionMessage( 'The JUnit timing report contains invalid XML.' );
+
+		WP_PHPUnit_Timing_Metrics::from_file( $file );
+	}
+
 	/**
 	 * Creates a JUnit XML file for a test.
 	 *
-	 * @param float[]   $times      Testcase times in seconds.
-	 * @param float|int $suite_time Optional testsuite time in seconds.
+	 * @param array<float|null> $times      Testcase times in seconds. Null omits the timing attribute.
+	 * @param float|int|null    $suite_time Optional testsuite time in seconds.
 	 * @return string Path to the temporary file.
 	 */
 	private function create_junit_file( $times, $suite_time = null ) {
+		$suite_time_attribute = null === $suite_time ? '' : sprintf( ' time="%s"', $suite_time );
+		$testcases            = '';
+
+		foreach ( $times as $index => $time ) {
+			$time_attribute = null === $time ? '' : sprintf( ' time="%s"', $time );
+			$testcases     .= sprintf(
+				'<testcase name="test_%1$d" class="Tests_Example" file="/var/www/tests/phpunit/tests/example.php" line="%2$d"%3$s/>',
+				$index,
+				100 + $index,
+				$time_attribute
+			);
+		}
+
+		return $this->create_temporary_file(
+			sprintf( '<?xml version="1.0"?><testsuites><testsuite tests="%1$d"%2$s>%3$s</testsuite></testsuites>', count( $times ), $suite_time_attribute, $testcases )
+		);
+	}
+
+	/**
+	 * Creates a temporary file containing the provided data.
+	 *
+	 * @param string $data File contents.
+	 * @return string Path to the temporary file.
+	 */
+	private function create_temporary_file( $data ) {
 		$file = tempnam( sys_get_temp_dir(), 'junit-timing-' );
 
 		if ( false === $file ) {
@@ -85,17 +168,7 @@ class Tests_Includes_JUnit_Timing_Metrics extends WP_UnitTestCase {
 		}
 
 		$this->temporary_files[] = $file;
-		$suite_time_attribute    = null === $suite_time ? '' : sprintf( ' time="%s"', $suite_time );
-		$testcases               = '';
-
-		foreach ( $times as $index => $time ) {
-			$testcases .= sprintf( '<testcase name="test_%1$d" time="%2$s"/>', $index, $time );
-		}
-
-		file_put_contents(
-			$file,
-			sprintf( '<?xml version="1.0"?><testsuites><testsuite tests="%1$d"%2$s>%3$s</testsuite></testsuites>', count( $times ), $suite_time_attribute, $testcases )
-		);
+		file_put_contents( $file, $data );
 
 		return $file;
 	}


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65887

## What this changes
Adds a `Flag slow PHPUnit tests` step to the canonical PHP 8.5 report job. It parses the JUnit report and, for tests over a threshold (default 1s), emits GitHub Actions warning annotations and a run-summary table naming the slowest tests. Runs on pull requests and pushes to trunk.

This complements #13083: those six CodeVitals aggregates store the trend but cannot name a test. This one names the slow ones, so a PR author can spot a slow test they added.

The annotation pass reuses #13083's streaming parser and passes its six aggregate metrics to the CodeVitals publisher through the runner's temporary directory. On trunk, both features now traverse the JUnit report once.

## Behavior
- Advisory only: runs after successful or failed test runs, skips cancelled jobs (`!cancelled()`), and never fails the job (`continue-on-error`).
- Inline annotations capped at 10 (GitHub's per-step limit); the summary table lists more.
- Container-absolute paths normalized to repository-relative so annotations resolve.
- A testcase without timing data (e.g. a skipped test) is ignored, not an error.

## Use of AI Tools
AI assistance: Yes
Tool(s): Codex (via Claude Code), hardened with an adversarial multi-lens review
Used for: drafting the workflow step and PHP script, and reviewing it before submission.
