### PR TITLE
#56312: Ignore an empty name query variable on static front pages

### DIFF
--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -1062,6 +1062,11 @@ class WP_Query {
 				unset( $_query['pagename'] );
 			}
 
+			// Ignore an empty post name query variable.
+			if ( isset( $_query['name'] ) && '' === $_query['name'] ) {
+				unset( $_query['name'] );
+			}
+
 			unset( $_query['embed'] );
 
 			if ( empty( $_query ) || ! array_diff( array_keys( $_query ), array( 'preview', 'page', 'paged', 'cpage' ) ) ) {

--- a/tests/phpunit/tests/query/conditionals.php
+++ b/tests/phpunit/tests/query/conditionals.php
@@ -72,6 +72,37 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 		delete_option( 'page_for_posts' );
 	}
 
+	/**
+	 * Tests that an empty name query variable does not override the static front page.
+	 *
+	 * @ticket 56312
+	 */
+	public function test_page_on_front_with_empty_name_query_var() {
+		$page_on_front = self::factory()->post->create(
+			array(
+				'post_type' => 'page',
+			)
+		);
+
+		$page_for_posts = self::factory()->post->create(
+			array(
+				'post_type' => 'page',
+			)
+		);
+
+		update_option( 'show_on_front', 'page' );
+		update_option( 'page_on_front', $page_on_front );
+		update_option( 'page_for_posts', $page_for_posts );
+
+		$this->go_to( '/?name' );
+
+		$this->assertQueryTrue( 'is_front_page', 'is_page', 'is_singular' );
+
+		update_option( 'show_on_front', 'posts' );
+		delete_option( 'page_on_front' );
+		delete_option( 'page_for_posts' );
+	}
+
 	public function test_404() {
 		$this->go_to( '/notapage' );
 		$this->assertQueryTrue( 'is_404' );


### PR DESCRIPTION
An empty `name` query variable prevents `WP_Query` from converting the
main query into the configured static front-page query. As a result,
`/?name` displays the posts page instead of the static front page.

This change ignores `name` when its value is an empty string, matching
the existing handling for an empty `pagename` query variable. Non-empty
post-name queries remain unchanged.

A regression test has been added for the empty `name` query variable.

Trac ticket: https://core.trac.wordpress.org/ticket/56312

## Testing

- `npm run test:php -- --filter test_page_on_front_with_empty_name_query_var`
- `npm run test:php -- --group query`
  - 1,894 tests and 4,426 assertions passed
- `git diff --check`

## Use of AI Tools

AI assistance: Yes  
Tool(s): ChatGPT  
Model(s): GPT-5 (Codex)  
Used for: Local environment troubleshooting, tracing the relevant query
handling, proposing the regression test, and reviewing the resulting
changes. I manually applied and reviewed the changes and ran the relevant
test suite.