### PR TITLE
Media: Scope the crossorigin bookmark to its media element

### DIFF
--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -6736,24 +6736,37 @@ function wp_add_crossorigin_attributes( string $html ): string {
 		'SOURCE' => array( 'src' ),
 	);
 
-	while ( $processor->next_tag() ) {
+	/*
+	 * Bookmark of the AUDIO or VIDEO element the cursor is inside of. Closing tags
+	 * are visited so it cannot outlive its element and be mistaken for the parent
+	 * of a later SOURCE.
+	 */
+	$media_bookmark = null;
+
+	while ( $processor->next_tag( array( 'tag_closers' => 'visit' ) ) ) {
 		$tag = $processor->get_tag();
 
 		if ( ! isset( $cross_origin_tag_attributes[ $tag ] ) ) {
 			continue;
 		}
+
+		if ( 'AUDIO' === $tag || 'VIDEO' === $tag ) {
+			$media_bookmark = null;
+
+			if ( ! $processor->is_tag_closer() && null === $processor->get_attribute( 'crossorigin' ) ) {
+				$media_bookmark = 'audio-video-parent';
+				$processor->set_bookmark( $media_bookmark );
+			}
+		}
+
+		if ( $processor->is_tag_closer() ) {
+			continue;
+		}
+
 		$crossorigin = $processor->get_attribute( 'crossorigin' );
 		if ( null !== $crossorigin ) {
 			continue;
 		}
-
-		if ( 'AUDIO' === $tag || 'VIDEO' === $tag ) {
-			$processor->set_bookmark( 'audio-video-parent' );
-		}
-
-		$processor->set_bookmark( 'resume' );
-
-		$sought = false;
 
 		$is_cross_origin = false;
 
@@ -6770,18 +6783,17 @@ function wp_add_crossorigin_attributes( string $html ): string {
 
 		if ( $is_cross_origin ) {
 			if ( 'SOURCE' === $tag ) {
-				$sought = $processor->seek( 'audio-video-parent' );
-
-				if ( $sought ) {
+				if ( null !== $media_bookmark ) {
+					$processor->set_bookmark( 'resume' );
+					$processor->seek( $media_bookmark );
 					$processor->set_attribute( 'crossorigin', 'anonymous' );
+					$processor->seek( 'resume' );
+
+					// The element is marked, so further SOURCE children need nothing.
+					$media_bookmark = null;
 				}
 			} else {
 				$processor->set_attribute( 'crossorigin', 'anonymous' );
-			}
-
-			if ( $sought ) {
-				$processor->seek( 'resume' );
-				$processor->release_bookmark( 'audio-video-parent' );
 			}
 		}
 	}

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -6737,9 +6737,10 @@ function wp_add_crossorigin_attributes( string $html ): string {
 	);
 
 	/*
-	 * Bookmark of the AUDIO or VIDEO element the cursor is inside of. Closing tags
-	 * are visited so it cannot outlive its element and be mistaken for the parent
-	 * of a later SOURCE.
+	 * Name of the bookmark on the AUDIO or VIDEO element the cursor is inside of,
+	 * for as long as that element still needs the attribute. Closing tags are
+	 * visited so the bookmark cannot outlive its element and be mistaken for the
+	 * parent of a later SOURCE.
 	 */
 	$media_bookmark = null;
 
@@ -6785,15 +6786,30 @@ function wp_add_crossorigin_attributes( string $html ): string {
 			if ( 'SOURCE' === $tag ) {
 				if ( null !== $media_bookmark ) {
 					$processor->set_bookmark( 'resume' );
-					$processor->seek( $media_bookmark );
-					$processor->set_attribute( 'crossorigin', 'anonymous' );
-					$processor->seek( 'resume' );
 
-					// The element is marked, so further SOURCE children need nothing.
+					/*
+					 * A seek past MAX_SEEK_OPS leaves the cursor where it is, so mark the
+					 * parent only once the cursor has reached it. Marking a SOURCE does
+					 * nothing for CORS and would hide the media element that was missed.
+					 */
+					if ( $processor->seek( $media_bookmark ) ) {
+						$processor->set_attribute( 'crossorigin', 'anonymous' );
+						$processor->seek( 'resume' );
+					}
+
+					/*
+					 * The element is either marked or past the seek budget, which does not
+					 * come back, so its remaining SOURCE children need nothing.
+					 */
 					$media_bookmark = null;
 				}
 			} else {
 				$processor->set_attribute( 'crossorigin', 'anonymous' );
+
+				// A marked AUDIO or VIDEO needs nothing from its SOURCE children.
+				if ( 'AUDIO' === $tag || 'VIDEO' === $tag ) {
+					$media_bookmark = null;
+				}
 			}
 		}
 	}

--- a/tests/phpunit/tests/media/wpCrossOriginIsolation.php
+++ b/tests/phpunit/tests/media/wpCrossOriginIsolation.php
@@ -365,6 +365,7 @@ class Tests_Media_wpCrossOriginIsolation extends WP_UnitTestCase {
 	 * Verifies that cross-origin elements get crossorigin="anonymous" added.
 	 *
 	 * @ticket 64766
+	 * @ticket 65930
 	 *
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
@@ -409,6 +410,9 @@ class Tests_Media_wpCrossOriginIsolation extends WP_UnitTestCase {
 			'cross-origin source inside video' => array(
 				'<video><source src="https://external.example.com/video.mp4" type="video/mp4" /></video>',
 			),
+			'multiple cross-origin sources'    => array(
+				'<video><source src="https://external.example.com/video.mp4" type="video/mp4" /><source src="https://external.example.com/video.webm" type="video/webm" /></video>',
+			),
 		);
 	}
 
@@ -420,6 +424,7 @@ class Tests_Media_wpCrossOriginIsolation extends WP_UnitTestCase {
 	 * in credentialless mode without needing explicit CORS headers.
 	 *
 	 * @ticket 64766
+	 * @ticket 65930
 	 *
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
@@ -460,6 +465,12 @@ class Tests_Media_wpCrossOriginIsolation extends WP_UnitTestCase {
 			),
 			'relative URL script'                     => array(
 				'<script src="/wp-includes/js/wp-embed.min.js"></script>',
+			),
+			'source outside a media element'          => array(
+				'<picture><source src="https://external.example.com/image.avif" /><img src="/local-image.jpg" /></picture>',
+			),
+			'source in a video with crossorigin'      => array(
+				'<audio src="/local-audio.mp3"></audio><video crossorigin="use-credentials"><source src="https://external.example.com/video.mp4" /></video>',
 			),
 		);
 	}

--- a/tests/phpunit/tests/media/wpCrossOriginIsolation.php
+++ b/tests/phpunit/tests/media/wpCrossOriginIsolation.php
@@ -448,6 +448,47 @@ class Tests_Media_wpCrossOriginIsolation extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A failed seek() must not leave the crossorigin attribute on the SOURCE element.
+	 *
+	 * WP_HTML_Tag_Processor::seek() returns false without moving the cursor once
+	 * MAX_SEEK_OPS is exceeded. The cursor is then still on the SOURCE, so marking
+	 * the element without checking the return value adds the attribute where it does
+	 * nothing for CORS and leaves the parent media element unmarked.
+	 *
+	 * @ticket 65930
+	 *
+	 * @covers ::wp_add_crossorigin_attributes
+	 */
+	public function test_source_is_not_marked_when_seeking_the_parent_fails() {
+		$this->setExpectedIncorrectUsage( 'WP_HTML_Tag_Processor::seek' );
+
+		/*
+		 * Marking a media element costs two seeks, one back to the parent and one
+		 * forward to resume, so one more than half the budget outlasts it.
+		 */
+		$media_elements = intdiv( WP_HTML_Tag_Processor::MAX_SEEK_OPS, 2 ) + 1;
+
+		$output = wp_add_crossorigin_attributes(
+			str_repeat(
+				'<video><source src="https://external.example.com/video.mp4" /></video>',
+				$media_elements
+			)
+		);
+
+		$this->assertSame(
+			0,
+			preg_match_all( '/<source\b[^>]*\bcrossorigin\b/i', $output ),
+			'A SOURCE element must never receive the crossorigin attribute.'
+		);
+
+		$this->assertSame(
+			$media_elements - 1,
+			substr_count( $output, 'crossorigin="anonymous"' ),
+			'Every media element reachable within the seek budget should have been marked.'
+		);
+	}
+
+	/**
 	 * Data provider for elements that should not receive crossorigin="anonymous".
 	 *
 	 * @return array[]


### PR DESCRIPTION
A `<source>` element could hand `crossorigin="anonymous"` to the wrong media element, or raise `_doing_it_wrong()` from inside the cross-origin isolation output buffer.

`wp_add_crossorigin_attributes()` tracks the AUDIO or VIDEO parent of a SOURCE with an `audio-video-parent` bookmark that is never scoped to the element it was set on, and releases it after the first cross-origin SOURCE. A second SOURCE then seeks a bookmark that no longer exists, and a SOURCE outside any media element walks back to an unrelated one. This visits closing tags so the bookmark cannot outlive its element, keeps it across sibling sources, and only seeks a bookmark the loop set.

The accepted set only narrows, and the loop now performs fewer `seek()` calls than before.

Trac ticket: https://core.trac.wordpress.org/ticket/65930

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: diagnosing the bookmark scoping fault, implementing the fix, and extending the existing data providers. All changes were reviewed and validated by me.
