### PR TITLE
Administration: Preserve non-default ports in list table URLs

### DIFF
--- a/src/wp-admin/includes/class-wp-list-table.php
+++ b/src/wp-admin/includes/class-wp-list-table.php
@@ -1054,7 +1054,7 @@ class WP_List_Table {
 		$current              = $this->get_pagenum();
 		$removable_query_args = wp_removable_query_args();
 
-		$current_url = set_url_scheme( 'http://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'] );
+		$current_url = $this->get_current_url();
 
 		$current_url = remove_query_arg( $removable_query_args, $current_url );
 
@@ -1182,6 +1182,36 @@ class WP_List_Table {
 		$this->_pagination = "<div class='tablenav-pages{$page_class}'>$output</div>";
 
 		echo $this->_pagination;
+	}
+
+	/**
+	 * Builds the current request URL for list table links.
+	 *
+	 * When `HTTP_HOST` omits the port, non-default ports from `SERVER_PORT`
+	 * are preserved so search, sorting, and pagination keep working.
+	 *
+	 * @since 7.2.0
+	 *
+	 * @return string Current URL including scheme, host, port, and request URI.
+	 */
+	protected function get_current_url() {
+		$host = isset( $_SERVER['HTTP_HOST'] ) ? $_SERVER['HTTP_HOST'] : '';
+		$uri  = isset( $_SERVER['REQUEST_URI'] ) ? $_SERVER['REQUEST_URI'] : '';
+
+		if ( isset( $_SERVER['SERVER_PORT'] ) ) {
+			$port   = (int) $_SERVER['SERVER_PORT'];
+			$parsed = wp_parse_url( 'http://' . $host );
+
+			if ( $port && empty( $parsed['port'] ) ) {
+				$default_port = is_ssl() ? 443 : 80;
+
+				if ( $default_port !== $port ) {
+					$host .= ':' . $port;
+				}
+			}
+		}
+
+		return set_url_scheme( 'http://' . $host . $uri );
 	}
 
 	/**
@@ -1408,7 +1438,7 @@ class WP_List_Table {
 	public function print_column_headers( $with_id = true ) {
 		list( $columns, $hidden, $sortable, $primary ) = $this->get_column_info();
 
-		$current_url = set_url_scheme( 'http://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'] );
+		$current_url = $this->get_current_url();
 		$current_url = remove_query_arg( 'paged', $current_url );
 
 		// When users click on a column header to sort by other columns.

--- a/tests/phpunit/tests/admin/wpListTable.php
+++ b/tests/phpunit/tests/admin/wpListTable.php
@@ -592,4 +592,103 @@ class Tests_Admin_WpListTable extends WP_UnitTestCase {
 
 		$this->assertStringContainsString( $expected_html, $actual );
 	}
+
+	/**
+	 * Tests that list table pagination links preserve a non-default port
+	 * when HTTP_HOST does not include it.
+	 *
+	 * @ticket 59272
+	 *
+	 * @covers WP_List_Table::get_current_url
+	 * @covers WP_List_Table::pagination
+	 */
+	public function test_pagination_links_preserve_non_default_port() {
+		$list_table = new WP_List_Table_Current_Url_Test_Double();
+
+		$_SERVER['HTTP_HOST']   = 'localhost';
+		$_SERVER['REQUEST_URI'] = '/wp-admin/edit.php';
+		$_SERVER['SERVER_PORT'] = '8182';
+		unset( $_SERVER['HTTPS'] );
+
+		$output = $list_table->get_pagination_html();
+
+		$this->assertStringContainsString( 'localhost:8182/wp-admin/edit.php', $output );
+		$this->assertStringNotContainsString( 'http://localhost/wp-admin/edit.php', $output );
+	}
+
+	/**
+	 * Tests that list table pagination links do not duplicate a port already
+	 * present in HTTP_HOST.
+	 *
+	 * @ticket 59272
+	 *
+	 * @covers WP_List_Table::get_current_url
+	 * @covers WP_List_Table::pagination
+	 */
+	public function test_pagination_links_do_not_duplicate_port_in_host() {
+		$list_table = new WP_List_Table_Current_Url_Test_Double();
+
+		$_SERVER['HTTP_HOST']   = 'localhost:8182';
+		$_SERVER['REQUEST_URI'] = '/wp-admin/edit.php';
+		$_SERVER['SERVER_PORT'] = '8182';
+		unset( $_SERVER['HTTPS'] );
+
+		$output = $list_table->get_pagination_html();
+
+		$this->assertStringContainsString( 'localhost:8182/wp-admin/edit.php', $output );
+		$this->assertStringNotContainsString( 'localhost:8182:8182', $output );
+	}
+
+	/**
+	 * Tests that default ports are not appended when HTTP_HOST has no port.
+	 *
+	 * @ticket 59272
+	 *
+	 * @covers WP_List_Table::get_current_url
+	 * @covers WP_List_Table::pagination
+	 */
+	public function test_pagination_links_do_not_append_default_http_port() {
+		$list_table = new WP_List_Table_Current_Url_Test_Double();
+
+		$_SERVER['HTTP_HOST']   = 'example.org';
+		$_SERVER['REQUEST_URI'] = '/wp-admin/edit.php';
+		$_SERVER['SERVER_PORT'] = '80';
+		unset( $_SERVER['HTTPS'] );
+
+		$output = $list_table->get_pagination_html();
+
+		$this->assertStringContainsString( 'example.org/wp-admin/edit.php', $output );
+		$this->assertStringNotContainsString( 'example.org:80/', $output );
+	}
+}
+
+/**
+ * Test double that exposes pagination HTML for URL assertions.
+ */
+class WP_List_Table_Current_Url_Test_Double extends WP_List_Table {
+	public function get_columns() {
+		return array(
+			'title' => 'Title',
+		);
+	}
+
+	/**
+	 * Returns pagination markup for the current request URL.
+	 *
+	 * @return string Pagination HTML.
+	 */
+	public function get_pagination_html() {
+		$this->_pagination = null;
+		$this->set_pagination_args(
+			array(
+				'total_items' => 40,
+				'total_pages' => 4,
+				'per_page'    => 10,
+			)
+		);
+
+		ob_start();
+		$this->pagination( 'bottom' );
+		return ob_get_clean();
+	}
 }


### PR DESCRIPTION
See https://core.trac.wordpress.org/ticket/59272

WordPress.org username: hell0bunny

WP_List_Table built search, sort, and pagination links from HTTP_HOST alone, which drops custom ports such as :8182 and breaks those admin actions.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
