### PR TITLE
Make sure the uploads directory content is preserved when running the tests

### DIFF
--- a/tests/phpunit/tests/fonts/font-library/fontLibraryHooks.php
+++ b/tests/phpunit/tests/fonts/font-library/fontLibraryHooks.php
@@ -10,6 +10,15 @@
  */
 class Tests_Fonts_FontLibraryHooks extends WP_UnitTestCase {
 
+	/**
+	 * Tear down the test fixture.
+	 */
+	public function tear_down() {
+		// Remove all fonts uploaded during the tests.
+		$this->remove_added_uploads();
+		parent::tear_down();
+	}
+
 	public function test_deleting_font_family_deletes_child_font_faces() {
 		$font_family_id       = self::factory()->post->create(
 			array(

--- a/tests/phpunit/tests/fonts/font-library/wpRestFontFacesController.php
+++ b/tests/phpunit/tests/fonts/font-library/wpRestFontFacesController.php
@@ -461,6 +461,9 @@ class Tests_REST_WpRestFontFacesController extends WP_Test_REST_Controller_Testc
 		// Delete the post.
 		wp_delete_post( $data['id'], true );
 		$this->assertFileDoesNotExist( $expected_file_path, 'The font file should have been deleted when the post was deleted.' );
+
+		// Clean up: Delete the subdir test directory.
+		rmdir( WP_CONTENT_DIR . '/uploads/fonts/subdir' );
 	}
 
 	/**

--- a/tests/phpunit/tests/user/getActiveBlogForUser.php
+++ b/tests/phpunit/tests/user/getActiveBlogForUser.php
@@ -69,7 +69,14 @@ class Tests_User_GetActiveBlogForUser extends WP_UnitTestCase {
 
 		$result = get_active_blog_for_user( self::$user_id );
 
-		wp_delete_site( $primary_site_id );
+		/*
+		 * Avoid using wp_delete_site() here because it will delete the uploads
+		 * directory without checking if the site is the main one. Otherwise,
+		 * when this test runs in a single site environment (e.g. when running
+		 * grunt precommit), it will delete the entire contents of the uploads
+		 * directory, which we want to avoid.
+		 */
+		wpmu_delete_blog( $primary_site_id, true );
 
 		$this->assertSame( $primary_site_id, $result->id );
 	}


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65621

Currently, running the PHPUnit tests entirely wipes out the uploads directory. This behavior can be osserved, for example, when running `grunt precommit` after changes to some PHP files. This should never happen.
This PR is a work in progress to make sure the uploads directory content is preserved.

## Use of AI Tools

None

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
