### PR TITLE
test: add unit tests for get_the_terms() object cache handling

### DIFF
--- a/tests/phpunit/tests/term/getTheTerms.php
+++ b/tests/phpunit/tests/term/getTheTerms.php
@@ -284,4 +284,91 @@ class Tests_Term_GetTheTerms extends WP_UnitTestCase {
 		$this->assertIsArray( $terms );
 		$this->assertSame( array( $term_ids[1] ), wp_list_pluck( $terms, 'term_id' ) );
 	}
+
+	/**
+	 * Tests that get_the_terms() returns the correct terms when the object term cache
+	 * was primed with an empty array before terms were assigned.
+	 *
+	 * @ticket 49799
+	 */
+	public function test_get_the_terms_returns_terms_when_cache_was_primed_empty_before_assignment() {
+		register_taxonomy( 'wptests_tax', 'post' );
+
+		$post_id = self::factory()->post->create();
+		$term_id = self::factory()->term->create( array( 'taxonomy' => 'wptests_tax' ) );
+
+		// Prime cache with an empty array.
+		update_object_term_cache( array( $post_id ), array( 'post' ) );
+
+		$cached = wp_cache_get( $post_id, 'wptests_tax_relationships' );
+		$this->assertIsArray( $cached );
+		$this->assertEmpty( $cached );
+
+		// Assign a term, clearing the cache.
+		wp_set_object_terms( $post_id, $term_id, 'wptests_tax' );
+
+		$cached_after_set = wp_cache_get( $post_id, 'wptests_tax_relationships' );
+		$this->assertFalse( $cached_after_set );
+
+		$terms = get_the_terms( $post_id, 'wptests_tax' );
+
+		$this->assertIsArray( $terms );
+		$this->assertCount( 1, $terms );
+		$this->assertSame( $term_id, (int) $terms[0]->term_id );
+	}
+
+	/**
+	 * Tests that get_the_terms() returns false for a post with no terms even when
+	 * update_object_term_cache() has primed the cache with an empty array.
+	 *
+	 * @ticket 49799
+	 */
+	public function test_get_the_terms_returns_false_for_post_with_no_terms_when_cache_primed() {
+		register_taxonomy( 'wptests_tax', 'post' );
+
+		$post_id = self::factory()->post->create();
+
+		// Prime cache with an empty array.
+		update_object_term_cache( array( $post_id ), array( 'post' ) );
+
+		$cached = wp_cache_get( $post_id, 'wptests_tax_relationships' );
+		$this->assertIsArray( $cached );
+		$this->assertEmpty( $cached );
+
+		$num_queries_before = get_num_queries();
+		$terms              = get_the_terms( $post_id, 'wptests_tax' );
+
+		$this->assertSame( 0, get_num_queries() - $num_queries_before );
+		$this->assertFalse( $terms );
+	}
+
+	/**
+	 * Tests that get_the_terms() returns correct terms after update_object_term_cache()
+	 * is called following term assignment.
+	 *
+	 * @ticket 49799
+	 */
+	public function test_get_the_terms_returns_correct_terms_when_cache_primed_after_assignment() {
+		register_taxonomy( 'wptests_tax', 'post' );
+
+		$post_id = self::factory()->post->create();
+		$term_id = self::factory()->term->create( array( 'taxonomy' => 'wptests_tax' ) );
+
+		wp_set_object_terms( $post_id, $term_id, 'wptests_tax' );
+
+		// Prime cache after assignment.
+		update_object_term_cache( array( $post_id ), array( 'post' ) );
+
+		$cached = wp_cache_get( $post_id, 'wptests_tax_relationships' );
+		$this->assertIsArray( $cached );
+		$this->assertNotEmpty( $cached );
+
+		$num_queries_before = get_num_queries();
+		$terms              = get_the_terms( $post_id, 'wptests_tax' );
+
+		$this->assertSame( 0, get_num_queries() - $num_queries_before );
+		$this->assertIsArray( $terms );
+		$this->assertCount( 1, $terms );
+		$this->assertSame( $term_id, (int) $terms[0]->term_id );
+	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

The ticket reports that `get_the_terms()` returns `false` instead of the correct terms when `get_object_term_cache()` returns an empty array.

Investigation shows the `false === $terms` check is correct. It distinguishes a cache miss from a valid "no terms" state (`[]`). When terms are assigned, `wp_set_object_terms()` properly clears the cache so `get_the_terms()` will query the database on the next call. The reported bug is likely a test environment configuration issue.

As requested, this PR adds unit tests to verify the expected cache behavior:

1. Cache primed with `[]` before terms assigned → terms assigned → returns correct terms.
2. Cache primed with `[]` for a post with no terms → returns `false` without a DB query.
3. Cache primed after term assignment → returns correct terms from cache.

All tests pass on current trunk with no source change needed.

Trac ticket: https://core.trac.wordpress.org/ticket/49799

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): Claude Sonnet 4.6
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->
AI assistance: Yes
Tool(s): Github Copilot
Used for: Investigating the cache flow and generating initial unit tests. Implementation and testing were reviewed and edited by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
