### PR TITLE
Coding Standards: Pass $count to the second _list_meta_row() call

### DIFF
--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -1747,7 +1747,7 @@ function wp_ajax_add_meta() {
 						'meta_value' => $value,
 						'meta_id'    => $meta_id,
 					),
-					$c
+					$count
 				),
 				'position'     => 0,
 				'supplemental' => array( 'postid' => $meta->post_id ),


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65934

While reading `wp_ajax_add_meta()` I noticed it passes a variable that doesn't exist.

In [[61224]](https://core.trac.wordpress.org/changeset/61224) the variable `$c` was renamed to `$count`. It's used in three places, but only two of them were changed:

```php
// src/wp-admin/includes/ajax-actions.php

$count = 0;                           // line 1637 - changed
_list_meta_row( $meta, $count )       // line 1703 - changed
_list_meta_row( array( ... ), $c )    // line 1750 - still says $c
```

So the last call passes `$c`, and `$c` isn't defined anywhere in the function.

Normally PHP would warn about that. It doesn't here, because the second argument is taken by reference:

```php
function _list_meta_row( $entry, &$count ) {
```

When you pass an undefined variable by reference, PHP just creates it and sets it to null. No notice, no error. That's also why PHPStan doesn't flag it - `$c` is missing from `tests/phpstan/baselines/variable.undefined.neon`, even though five other variables from this same file are listed there.

This changes that one line to `$count`.

### What breaks

Nothing right now. `$count` is never read after either call, since `$response->send()` runs immediately, so the output is identical before and after.

I'm raising it because the two calls no longer match each other, and if someone uses `$count` after that call later on, it will quietly hold the wrong value.

### Testing

`tests/phpunit/tests/ajax/wpAjaxAddMeta.php` already covers this code path in `test_wp_ajax_add_meta_allows_empty_values_on_updating()`:

```
phpunit --filter test_wp_ajax_add_meta
```

It passes before and after, which is what you'd expect since the behavior doesn't change.

Affects 7.0, 7.1 and trunk. 6.9 and earlier are fine - they still use `$c` in all three places.
