### PR TITLE
Fix the order of the buttons in the Customizer Menus panel.

### DIFF
--- a/src/wp-admin/css/customize-controls.css
+++ b/src/wp-admin/css/customize-controls.css
@@ -2493,6 +2493,7 @@ body.cheatin p {
  * Widgets and Menus common styles
  */
 
+ .customize-control-nav_menu-buttons,
 .customize-control-widgets-buttons {
 	display: flex;
 	flex-wrap: wrap;

--- a/src/wp-admin/css/customize-nav-menus.css
+++ b/src/wp-admin/css/customize-nav-menus.css
@@ -860,10 +860,6 @@ li.assigned-to-menu-location .add-new-menu-item {
 }
 
 .customize-control-nav_menu .customize-control-nav_menu-buttons {
-	display: flex;
-	flex-direction: row-reverse;
-	align-items: center;
-	gap: 8px;
 	margin-top: 12px;
 }
 

--- a/src/wp-includes/customize/class-wp-customize-nav-menu-control.php
+++ b/src/wp-includes/customize/class-wp-customize-nav-menu-control.php
@@ -49,12 +49,12 @@ class WP_Customize_Nav_Menu_Control extends WP_Customize_Control {
 			?>
 		</p>
 		<div class="customize-control-nav_menu-buttons">
-			<button type="button" class="button add-new-menu-item" aria-label="<?php esc_attr_e( 'Add or remove menu items' ); ?>" aria-expanded="false" aria-controls="available-menu-items">
-				<?php echo $add_items; ?>
-			</button>
 			<button type="button" class="button-link reorder-toggle" aria-label="<?php esc_attr_e( 'Reorder menu items' ); ?>" aria-describedby="reorder-items-desc-{{ data.menu_id }}">
 				<span class="reorder"><?php _e( 'Reorder' ); ?></span>
 				<span class="reorder-done"><?php _e( 'Done' ); ?></span>
+			</button>
+			<button type="button" class="button add-new-menu-item" aria-label="<?php esc_attr_e( 'Add or remove menu items' ); ?>" aria-expanded="false" aria-controls="available-menu-items">
+				<?php echo $add_items; ?>
 			</button>
 		</div>
 		<p class="screen-reader-text" id="reorder-items-desc-{{ data.menu_id }}">

--- a/tests/qunit/index.html
+++ b/tests/qunit/index.html
@@ -254,12 +254,14 @@
 
 		<!-- Templates for Customizer Menus -->
 		<script type="text/html" id="tmpl-customize-control-nav_menu-content">
-					<button type="button" class="button add-new-menu-item" aria-label="Add or remove menu items" aria-expanded="false" aria-controls="available-menu-items">
-			Add Items		</button>
-		<button type="button" class="not-a-button reorder-toggle" aria-label="Reorder menu items" aria-describedby="reorder-items-desc-{{ data.menu_id }}">
-			<span class="reorder">Reorder</span>
-			<span class="reorder-done">Done</span>
-		</button>
+		<div class="customize-control-nav_menu-buttons">
+			<button type="button" class="button-link reorder-toggle" aria-label="Reorder menu items" aria-describedby="reorder-items-desc-242">
+				<span class="reorder">Reorder</span>
+				<span class="reorder-done">Done</span>
+			</button>
+			<button type="button" class="button add-new-menu-item" aria-label="Add or remove menu items" aria-expanded="false" aria-controls="available-menu-items">
+				Add Items			</button>
+		</div>
 		<p class="screen-reader-text" id="reorder-items-desc-{{ data.menu_id }}">When in reorder mode, additional controls to reorder menu items will be available in the items list above.</p>
 		<span class="add-menu-item-loading spinner"></span>
 		<span class="menu-delete-item">


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65935#ticket

Fixes the order of the Reorder' and 'Add Items' in the Customizer > Menus panel.

## Use of AI Tools

None

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
