### PR TITLE
#30023 Chrome autofill password keeps showing in password field

### DIFF
--- a/src/wp-login.php
+++ b/src/wp-login.php
@@ -1626,13 +1626,9 @@ switch ( $action ) {
 		$login_script .= 'try {';
 
 		if ( $user_login ) {
-			$login_script .= 'd = document.getElementById( "user_pass" ); d.value = "";';
+			$login_script .= 'd = document.getElementById( "user_pass" );';
 		} else {
 			$login_script .= 'd = document.getElementById( "user_login" );';
-
-			if ( $errors->get_error_code() === 'invalid_username' ) {
-				$login_script .= 'd.value = "";';
-			}
 		}
 
 		$login_script .= 'd.focus(); d.select();';


### PR DESCRIPTION


<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->
On the login screen, wp_attempt_focus() clears form fields after a failed login attempt. In Chrome this backfires: after a failed login, the browser autofills the password field, wp_attempt_focus() empties it via JavaScript, but Chrome keeps displaying the field as filled with dots even though it is actually empty. Submitting then fails with "ERROR: The password field is empty."

This removes the field-clearing behavior from wp_attempt_focus(). After a failed attempt, the function now only focuses and selects the relevant field:
- When the username was preserved ($user_login set), it focuses user_pass.
- Otherwise it focuses user_login.

Trac ticket: https://core.trac.wordpress.org/ticket/30023 <!-- insert a link to the WordPress Trac ticket here -->

## Use of AI Tools
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
