### PR TITLE
#30631 Prevent duplicate content with nopaging queries

### DIFF
--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -2821,6 +2821,18 @@ class WP_Query {
 				$pgstrt = absint( ( $page - 1 ) * $query_vars['posts_per_page'] ) . ', ';
 			}
 			$limits = 'LIMIT ' . $pgstrt . $query_vars['posts_per_page'];
+		} elseif ( ! empty( $query_vars['nopaging'] ) && ! $this->is_singular && absint( $query_vars['paged'] ) > 1 ) {
+			/*
+			 * The query retrieves all posts ('nopaging' true, e.g. via
+			 * 'posts_per_page' => -1) yet a page greater than 1 was requested.
+			 *
+			 * Without a LIMIT clause every paginated URL would return the full
+			 * result set, producing unlimited identical pages of duplicate
+			 * content (e.g. when 'posts_per_page' => -1 is applied to an archive
+			 * via 'pre_get_posts'). Return no posts instead, mirroring how an
+			 * out-of-bounds page behaves in normal pagination.
+			 */
+			$limits = 'LIMIT 0';
 		}
 
 		// Comments feeds.
@@ -3735,7 +3747,16 @@ class WP_Query {
 		$this->found_posts = (int) apply_filters_ref_array( 'found_posts', array( $this->found_posts, &$this ) );
 
 		if ( ! empty( $limits ) ) {
-			$this->max_num_pages = (int) ceil( $this->found_posts / $query_vars['posts_per_page'] );
+			if ( ! empty( $query_vars['nopaging'] ) ) {
+				/*
+				 * All posts are retrieved ('posts_per_page' => -1), so there is
+				 * only one page. 'posts_per_page' is -1 here and cannot be used
+				 * to divide the total.
+				 */
+				$this->max_num_pages = 1;
+			} else {
+				$this->max_num_pages = (int) ceil( $this->found_posts / $query_vars['posts_per_page'] );
+			}
 		}
 	}
 

--- a/tests/phpunit/tests/query/noFoundRows.php
+++ b/tests/phpunit/tests/query/noFoundRows.php
@@ -102,4 +102,82 @@ class Tests_Query_NoFoundRows extends WP_UnitTestCase {
 		$this->assertStringNotContainsString( 'SQL_CALC_FOUND_ROWS', $q->request );
 		$this->assertSame( 1, $q->found_posts );
 	}
+
+	/**
+	 * @ticket 30631
+	 */
+	public function test_nopaging_with_paged_returns_no_posts() {
+		$cat_id = self::factory()->category->create();
+		self::factory()->post->create_many( 5, array( 'category' => $cat_id ) );
+
+		$q = new WP_Query(
+			array(
+				'cat'            => $cat_id,
+				'posts_per_page' => -1,
+				'paged'          => 2,
+			)
+		);
+
+		$this->assertSame( 0, $q->post_count );
+		$this->assertSame( 5, $q->found_posts );
+		$this->assertSame( 1, $q->max_num_pages );
+	}
+
+	/**
+	 * @ticket 30631
+	 */
+	public function test_nopaging_without_paged_returns_all_posts() {
+		$cat_id = self::factory()->category->create();
+		self::factory()->post->create_many( 5, array( 'category' => $cat_id ) );
+
+		$q = new WP_Query(
+			array(
+				'cat'            => $cat_id,
+				'posts_per_page' => -1,
+				'paged'          => 1,
+			)
+		);
+
+		$this->assertSame( 5, $q->post_count );
+		$this->assertSame( 5, $q->found_posts );
+		$this->assertSame( 1, $q->max_num_pages );
+	}
+
+	/**
+	 * @ticket 30631
+	 */
+	public function test_out_of_bounds_page_returns_no_posts() {
+		$cat_id = self::factory()->category->create();
+		self::factory()->post->create_many( 5, array( 'category' => $cat_id ) );
+
+		$q = new WP_Query(
+			array(
+				'cat'            => $cat_id,
+				'posts_per_page' => 2,
+				'paged'          => 3,
+			)
+		);
+
+		$this->assertSame( 0, $q->post_count );
+		$this->assertSame( 5, $q->found_posts );
+		$this->assertSame( 3, $q->max_num_pages );
+	}
+
+	/**
+	 * @ticket 30631
+	 */
+	public function test_nopaging_singular_unaffected() {
+		$post_id = self::factory()->post->create();
+
+		$q = new WP_Query(
+			array(
+				'p'              => $post_id,
+				'posts_per_page' => -1,
+				'paged'          => 2,
+			)
+		);
+
+		$this->assertSame( 1, $q->post_count );
+		$this->assertSame( $post_id, $q->posts[0]->ID );
+	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->
1. Paging block: new elseif - when nopaging is truthy, not singular, and paged > 1, set $limits = 'LIMIT 0'. The query returns zero rows instead of the full result set on every paginated URL.
2. set_found_posts(): when $limits is non-empty and nopaging is truthy, max_num_pages = 1 (posts_per_page is -1 there and can't divide the total).

Trac ticket: https://core.trac.wordpress.org/ticket/30631 <!-- insert a link to the WordPress Trac ticket here -->

## Use of AI Tools
AI assistance: Yes
Tool(s): Claude
Model(s): Sonnet
Used for: review and test cases
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
