### PR TITLE
Networks and Sites: Display Network Settings errors

### DIFF
--- a/src/wp-admin/includes/template.php
+++ b/src/wp-admin/includes/template.php
@@ -1877,13 +1877,23 @@ function add_settings_error( $setting, $code, $message, $type = 'error' ) {
 }
 
 /**
+ * Stores settings errors for retrieval on the next Network Admin page load.
+ *
+ * @since x.x.x
+ */
+function set_network_settings_errors() {
+	set_site_transient( 'settings_errors', get_settings_errors(), 30 );
+}
+
+/**
  * Fetches settings errors registered by add_settings_error().
  *
  * Checks the $wp_settings_errors array for any errors declared during the current
  * pageload and returns them.
  *
  * If changes were just submitted ($_GET['settings-updated']) and settings errors were saved
- * to the 'settings_errors' transient then those errors will be returned instead. This
+ * to the 'settings_errors' transient then those errors will be returned instead. In Network
+ * Admin, the same applies to $_GET['updated'] and the 'settings_errors' site transient. This
  * is used to pass errors back across pageloads.
  *
  * Use the $sanitize argument to manually re-sanitize the option before returning errors.
@@ -1892,6 +1902,7 @@ function add_settings_error( $setting, $code, $message, $type = 'error' ) {
  * action hook).
  *
  * @since 3.0.0
+ * @since x.x.x Added support for network settings errors stored in a site transient.
  *
  * @global array[] $wp_settings_errors Storage array of errors registered during this pageload
  *
@@ -1924,10 +1935,13 @@ function get_settings_errors( $setting = '', $sanitize = false ) {
 		sanitize_option( $setting, get_option( $setting ) );
 	}
 
-	// If settings were passed back from options.php then use them.
+	// If settings were passed back from options.php or network/settings.php then use them.
 	if ( isset( $_GET['settings-updated'] ) && $_GET['settings-updated'] && get_transient( 'settings_errors' ) ) {
 		$wp_settings_errors = array_merge( (array) $wp_settings_errors, get_transient( 'settings_errors' ) );
 		delete_transient( 'settings_errors' );
+	} elseif ( is_network_admin() && isset( $_GET['updated'] ) && 'true' === $_GET['updated'] && get_site_transient( 'settings_errors' ) ) {
+		$wp_settings_errors = array_merge( (array) $wp_settings_errors, get_site_transient( 'settings_errors' ) );
+		delete_site_transient( 'settings_errors' );
 	}
 
 	// Check global in case errors have been added on this pageload.

--- a/src/wp-admin/network/settings.php
+++ b/src/wp-admin/network/settings.php
@@ -131,6 +131,8 @@ if ( $_POST ) {
 	 */
 	do_action( 'update_wpmu_options' );
 
+	set_network_settings_errors();
+
 	wp_redirect( add_query_arg( 'updated', 'true', network_admin_url( 'settings.php' ) ) );
 	exit;
 }
@@ -138,14 +140,20 @@ if ( $_POST ) {
 require_once ABSPATH . 'wp-admin/admin-header.php';
 
 if ( isset( $_GET['updated'] ) ) {
-	wp_admin_notice(
-		__( 'Settings saved.' ),
-		array(
-			'type'        => 'success',
-			'dismissible' => true,
-			'id'          => 'message',
-		)
-	);
+	$settings_errors = get_settings_errors();
+
+	if ( $settings_errors ) {
+		settings_errors();
+	} elseif ( 'true' === $_GET['updated'] ) {
+		wp_admin_notice(
+			__( 'Settings saved.' ),
+			array(
+				'type'        => 'success',
+				'dismissible' => true,
+				'id'          => 'message',
+			)
+		);
+	}
 }
 ?>
 

--- a/tests/phpunit/tests/admin/includesTemplate.php
+++ b/tests/phpunit/tests/admin/includesTemplate.php
@@ -426,6 +426,46 @@ class Tests_Admin_IncludesTemplate extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 18088
+	 * @covers ::get_settings_errors
+	 * @covers ::set_network_settings_errors
+	 * @global array $wp_settings_errors
+	 */
+	public function test_get_settings_errors_from_network_transient() {
+		global $current_screen, $wp_settings_errors;
+
+		$previous_screen = $current_screen;
+		$error           = array(
+			'setting' => 'new_admin_email',
+			'code'    => 'invalid_new_admin_email',
+			'message' => 'Invalid email address.',
+			'type'    => 'error',
+		);
+
+		set_current_screen( 'dashboard-network' );
+		$wp_settings_errors = null;
+		add_settings_error( $error['setting'], $error['code'], $error['message'], $error['type'] );
+		set_network_settings_errors();
+
+		$_GET['updated']    = 'false';
+		$wp_settings_errors = null;
+		$errors_when_false  = get_settings_errors();
+
+		$_GET['updated']    = 'true';
+		$wp_settings_errors = null;
+		$errors_when_true   = get_settings_errors();
+		$transient          = get_site_transient( 'settings_errors' );
+
+		unset( $_GET['updated'] );
+		$current_screen     = $previous_screen;
+		$wp_settings_errors = null;
+
+		$this->assertSame( array(), $errors_when_false );
+		$this->assertSame( array( $error ), $errors_when_true );
+		$this->assertFalse( $transient );
+	}
+
+	/**
 	 * @ticket 44941
 	 * @covers ::settings_errors
 	 * @global array $wp_settings_errors


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/18088

Network Settings validation errors were lost during the redirect after form submission. Consequently, invalid values such as an invalid Network Admin Email displayed a “Settings saved” success notice even though the value was rejected.

This PR:
   - Stores Network Settings errors in a site transient before redirecting.
   - Restores and deletes those errors on the redirected Network Admin request.
   - Displays validation errors instead of the success notice.
   - Shows the success notice only for `updated=true` when no errors exist.

The network-option fallback behavior tracked in #35379 remains outside this PR’s scope.

## Use of AI Tools

AI assistance: Yes
Tool(s): pi
Model(s): GPT-5.6
Used for: Code review and PR description drafting; final implementation and tests were reviewed and edited by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
