### PR TITLE
Docs: Correct the `$operator` default for `wp_filter_object_list()`

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -5410,7 +5410,7 @@ function wp_is_numeric_array( $data ): bool {
  * @param string      $operator   Optional. The logical operation to perform. 'AND' means
  *                                all elements from the array must match. 'OR' means only
  *                                one element needs to match. 'NOT' means no elements may
- *                                match. Default 'AND'.
+ *                                match. The value is case-insensitive. Default 'and'.
  * @param bool|string $field      Optional. A field from the object to place instead
  *                                of the entire object. Default false.
  * @return array A list of objects or object fields.


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

`wp_filter_object_list()` documents its `$operator` default as `'AND'`, but the function signature declares `$operator = 'and'`.

The mismatch dates to the function's introduction in 3.0.0. Neither casing is wrong at runtime, since `WP_List_Util::filter()` uppercases the operator before validating it, so the patch corrects the documented default to `'and'` and notes that the value is case-insensitive — the sentence that reconciles the uppercase operator names above it with the lowercase default.

`wp_list_filter()` and `WP_List_Util::filter()` already document `'AND'` as both their default and their declared value, so they are left alone.

Trac ticket: https://core.trac.wordpress.org/ticket/65933

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
