### PR TITLE
Posts: Unstick a post given a password through Quick Edit.

### DIFF
--- a/src/wp-admin/includes/post.php
+++ b/src/wp-admin/includes/post.php
@@ -301,6 +301,11 @@ function edit_post( $post_data = null ) {
 		}
 	}
 
+	// Password visibility.
+	if ( ! empty( $post_data['post_password'] ) ) {
+		$post_data['visibility'] = 'password';
+	}
+
 	if ( isset( $post_data['visibility'] ) ) {
 		switch ( $post_data['visibility'] ) {
 			case 'public':

--- a/tests/phpunit/tests/admin/includesPost.php
+++ b/tests/phpunit/tests/admin/includesPost.php
@@ -1371,4 +1371,52 @@ class Tests_Admin_IncludesPost extends WP_UnitTestCase {
 		$this->assertNotEmpty( $response['wp-refresh-metabox-loader-nonces']['replace']['_wpnonce'] );
 		$this->assertNotEmpty( $response['wp-refresh-metabox-loader-nonces']['replace']['metabox_loader_nonce'] );
 	}
+
+	/**
+	 * Ensures that giving a sticky post a password through edit_post() unsticks it,
+	 * even when the caller never sends an explicit `visibility` value.
+	 *
+	 * The block editor sends `visibility`, so `edit_post()` reaches the
+	 * `case 'password'` branch and drops the `sticky` flag. Quick Edit never sends
+	 * it, so a post could end up both sticky and password protected, a combination
+	 * the editor itself forbids.
+	 *
+	 * @ticket 64810
+	 *
+	 * @covers ::edit_post
+	 */
+	public function test_edit_post_unsticks_a_post_when_a_password_is_set_without_visibility() {
+		wp_set_current_user( self::$admin_id );
+
+		$post_id = self::factory()->post->create(
+			array(
+				'post_status' => 'publish',
+				'post_author' => self::$admin_id,
+			)
+		);
+
+		stick_post( $post_id );
+		$this->assertTrue( is_sticky( $post_id ), 'The post was not sticky to begin with: check test setup.' );
+
+		// Mirrors Quick Edit, which posts `sticky` but no `visibility`.
+		edit_post(
+			array(
+				'post_ID'       => $post_id,
+				'post_title'    => 'Protected and sticky',
+				'post_status'   => 'publish',
+				'post_password' => 'secret',
+				'sticky'        => 'sticky',
+			)
+		);
+
+		$this->assertSame(
+			'secret',
+			get_post( $post_id )->post_password,
+			'The password was not saved: check test setup.'
+		);
+		$this->assertFalse(
+			is_sticky( $post_id ),
+			'A password protected post was left sticky when no explicit visibility was sent.'
+		);
+	}
 }

--- a/tests/phpunit/tests/admin/includesPost.php
+++ b/tests/phpunit/tests/admin/includesPost.php
@@ -1419,4 +1419,145 @@ class Tests_Admin_IncludesPost extends WP_UnitTestCase {
 			'A password protected post was left sticky when no explicit visibility was sent.'
 		);
 	}
+
+	/**
+	 * Ensures that an explicit `public` visibility clears any existing post password.
+	 *
+	 * @ticket 64810
+	 *
+	 * @covers ::edit_post
+	 */
+	public function test_edit_post_clears_the_password_when_visibility_is_public() {
+		wp_set_current_user( self::$admin_id );
+
+		$post_id = self::factory()->post->create(
+			array(
+				'post_status'   => 'publish',
+				'post_author'   => self::$admin_id,
+				'post_password' => 'secret',
+			)
+		);
+
+		edit_post(
+			array(
+				'post_ID'       => $post_id,
+				'post_title'    => 'Now public',
+				'post_status'   => 'publish',
+				'post_password' => '',
+				'visibility'    => 'public',
+			)
+		);
+
+		$this->assertSame( '', get_post( $post_id )->post_password );
+	}
+
+	/**
+	 * Ensures that an explicit `password` visibility unsticks the post.
+	 *
+	 * The companion test above covers the same branch reached through an
+	 * inferred visibility; this one covers a caller that sends it outright.
+	 *
+	 * @ticket 64810
+	 *
+	 * @covers ::edit_post
+	 */
+	public function test_edit_post_unsticks_the_post_when_visibility_is_password() {
+		wp_set_current_user( self::$admin_id );
+
+		$post_id = self::factory()->post->create(
+			array(
+				'post_status' => 'publish',
+				'post_author' => self::$admin_id,
+			)
+		);
+
+		stick_post( $post_id );
+
+		edit_post(
+			array(
+				'post_ID'       => $post_id,
+				'post_title'    => 'Protected',
+				'post_status'   => 'publish',
+				'post_password' => 'secret',
+				'sticky'        => 'sticky',
+				'visibility'    => 'password',
+			)
+		);
+
+		$this->assertSame( 'secret', get_post( $post_id )->post_password, 'The password was not saved: check test setup.' );
+		$this->assertFalse( is_sticky( $post_id ), 'A password protected post was left sticky.' );
+	}
+
+	/**
+	 * Ensures that an explicit `private` visibility privatises the post, drops any
+	 * password and unsticks it.
+	 *
+	 * @ticket 64810
+	 *
+	 * @covers ::edit_post
+	 */
+	public function test_edit_post_privatises_and_unsticks_the_post_when_visibility_is_private() {
+		wp_set_current_user( self::$admin_id );
+
+		$post_id = self::factory()->post->create(
+			array(
+				'post_status' => 'publish',
+				'post_author' => self::$admin_id,
+			)
+		);
+
+		stick_post( $post_id );
+
+		edit_post(
+			array(
+				'post_ID'       => $post_id,
+				'post_title'    => 'Private',
+				'post_status'   => 'publish',
+				'post_password' => '',
+				'sticky'        => 'sticky',
+				'visibility'    => 'private',
+			)
+		);
+
+		$post = get_post( $post_id );
+
+		$this->assertSame( 'private', $post->post_status, 'The post was not made private.' );
+		$this->assertSame( '', $post->post_password, 'A private post kept a password.' );
+		$this->assertFalse( is_sticky( $post_id ), 'A private post was left sticky.' );
+	}
+
+	/**
+	 * Documents that a non-empty password wins over a `public` visibility sent alongside it.
+	 *
+	 * Inferring the visibility from the password means the two can now contradict each
+	 * other, and the inferred value is applied last. The editors never send that
+	 * combination, since selecting "Public" clears the password field, but `edit_post()`
+	 * is reachable from bulk edit and Quick Edit too, so the precedence is worth pinning.
+	 *
+	 * @ticket 64810
+	 *
+	 * @covers ::edit_post
+	 */
+	public function test_edit_post_prefers_the_password_over_a_contradicting_public_visibility() {
+		wp_set_current_user( self::$admin_id );
+
+		$post_id = self::factory()->post->create(
+			array(
+				'post_status' => 'publish',
+				'post_author' => self::$admin_id,
+			)
+		);
+
+		edit_post(
+			array(
+				'post_ID'       => $post_id,
+				'post_title'    => 'Contradictory',
+				'post_status'   => 'publish',
+				'post_password' => 'secret',
+				'visibility'    => 'public',
+			)
+		);
+
+		$this->assertSame( 'secret', get_post( $post_id )->post_password );
+	}
 }


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/64810

Opened at @audrasjb's request in [comment:15](https://core.trac.wordpress.org/ticket/64810#comment:15): the change from #11180 plus the unit test that was only sitting in a comment there, so the ticket can lose `needs-unit-tests` and be committed as one changeset.

## The change

`@Hug0-Drelon`'s patch from #11180, committed under their authorship, plus one guard added in review (see below).

Quick Edit posts `sticky` but never posts `visibility`. `edit_post()` only unsets `sticky` inside `case 'password'` of the `visibility` switch, so that branch was never reached and a post could end up both sticky and password protected, a combination the block editor itself forbids.

Inferring `visibility => 'password'` from a non-empty post password makes the existing branch run for a caller that sends no visibility of its own:

```php
// Infer the password visibility when the caller did not send one of its own.
if ( ! isset( $post_data['visibility'] ) && ! empty( $post_data['post_password'] ) ) {
	$post_data['visibility'] = 'password';
}
```

### Why the `! isset()` guard

Inferring unconditionally would have outranked the caller. Two inputs changed behaviour beyond the reported one:

- `visibility => 'public'` sent with a non-empty password kept the password, where trunk drops it.
- `visibility => 'private'` sent with a password left the post public and password protected instead of private. This one is reachable from the screen the ticket is about: `wp_ajax_inline_save()` sets `visibility` to `private` whenever "Private" is ticked ([`ajax-actions.php:2146`](https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-admin/includes/ajax-actions.php#L2146)).

With the guard, the only behaviour this PR changes is the reported one.

## The tests

Five tests in `tests/phpunit/tests/admin/includesPost.php`, which had no coverage of the visibility / sticky / password interaction at all.

- `test_edit_post_unsticks_a_post_when_a_password_is_set_without_visibility()` reproduces the Quick Edit payload: `sticky` is posted, `visibility` is not. This is the ticket's bug.
- Three characterisation tests for the `public`, `password` and `private` branches reached by an explicit value. The `private` one sends a password alongside, which makes it the regression test for the Quick Edit Private case above.
- `test_edit_post_keeps_an_explicit_visibility_over_an_inferred_one()` pins that the inference never overrides the caller.

Verified in three directions locally, PHP 8.3 against a single site:

| `src/wp-admin/includes/post.php` | Result |
| --- | --- |
| this branch | `OK (5 tests, 10 assertions)` |
| trunk, tests kept | 1 failure, only the ticket's bug |
| unguarded inference, tests kept | 2 failures, the `private` case and the explicit-`public` case |

Whole file: 56 tests, 125 assertions, 0 failures. The 6 warnings are the pre-existing `E_DEPRECATED` expectation notices PHPUnit 9.6 emits across that file.

`phpcs` on both touched files: 0 errors. The single warning in `src/wp-admin/includes/post.php` is at line 901 and predates this branch.

## Testing

Independently confirmed in Playground by @arkaprabhachowdhury in [comment:20](https://core.trac.wordpress.org/ticket/64810#comment:20) against `7.2-alpha`, PHP 8.3.

## Credit

The fix is `@Hug0-Drelon`'s work and the props on #11180 already list hugod, wildworks, abcd95, motylanogha. If this lands instead of #11180, that props line should carry over, plus arkaprabhachowdhury for the test report.

## The open question this PR does not settle

`2nd-opinion` was removed from the ticket on 2026-08-24, but the disagreement behind it stands on its own: in [comment:13](https://core.trac.wordpress.org/ticket/64810#comment:13) @wildworks argued that password protected and sticky should be allowed together in all cases, and that #11180 removes something Quick Edit could previously do.

That is a disagreement about intended behaviour, not about the code. This PR exists because @audrasjb asked for the change and the test in one place; if the ticket resolves the other way, the same test file is where the inverse expectation would go.
