### PR TITLE
Script Loader: Add an API for filtering inline style attributes

### DIFF
--- a/src/wp-includes/class-wp-styles.php
+++ b/src/wp-includes/class-wp-styles.php
@@ -157,16 +157,6 @@ class WP_Styles extends WP_Dependencies {
 		$src          = $obj->src;
 		$inline_style = $this->print_inline_style( $handle, false );
 
-		if ( $inline_style ) {
-			$processor = new WP_HTML_Tag_Processor( '<style></style>' );
-			$processor->next_tag();
-			$processor->set_attribute( 'id', "{$handle}-inline-css" );
-			$processor->set_modifiable_text( "\n{$inline_style}\n" );
-			$inline_style_tag = "{$processor->get_updated_html()}\n";
-		} else {
-			$inline_style_tag = '';
-		}
-
 		if ( $this->do_concat ) {
 			if ( is_string( $src ) && $this->in_default_dir( $src ) && ! isset( $obj->extra['alt'] ) ) {
 				$this->concat         .= "$handle,";
@@ -182,7 +172,12 @@ class WP_Styles extends WP_Dependencies {
 
 		// A single item may alias a set of items, by having dependencies, but no source.
 		if ( ! $src ) {
-			if ( $inline_style_tag ) {
+			if ( $inline_style ) {
+				$inline_style_tag = wp_get_inline_style_tag(
+					$inline_style,
+					array( 'id' => "{$handle}-inline-css" )
+				);
+
 				if ( $this->do_concat ) {
 					$this->print_html .= $inline_style_tag;
 				} else {
@@ -253,8 +248,11 @@ class WP_Styles extends WP_Dependencies {
 
 		if ( $this->do_concat ) {
 			$this->print_html .= $tag;
-			if ( $inline_style_tag ) {
-				$this->print_html .= $inline_style_tag;
+			if ( $inline_style ) {
+				$this->print_html .= wp_get_inline_style_tag(
+					$inline_style,
+					array( 'id' => "{$handle}-inline-css" )
+				);
 			}
 		} else {
 			echo $tag;
@@ -332,11 +330,10 @@ class WP_Styles extends WP_Dependencies {
 			return $output;
 		}
 
-		$processor = new WP_HTML_Tag_Processor( '<style></style>' );
-		$processor->next_tag();
-		$processor->set_attribute( 'id', "{$handle}-inline-css" );
-		$processor->set_modifiable_text( "\n{$output}\n" );
-		echo "{$processor->get_updated_html()}\n";
+		wp_print_inline_style_tag(
+			$output,
+			array( 'id' => "{$handle}-inline-css" )
+		);
 
 		return true;
 	}

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2445,12 +2445,9 @@ function _print_styles() {
 		echo "<link rel='stylesheet' href='" . esc_attr( $href ) . "' media='all' />\n";
 
 		if ( ! empty( $wp_styles->print_code ) ) {
-			$processor = new WP_HTML_Tag_Processor( '<style></style>' );
-			$processor->next_tag();
-			$style_tag_contents = "\n{$wp_styles->print_code}\n"
-				. sprintf( "/*# sourceURL=%s */\n", rawurlencode( $concat_source_url ) );
-			$processor->set_modifiable_text( $style_tag_contents );
-			echo "{$processor->get_updated_html()}\n";
+			$style_tag_contents = $wp_styles->print_code . "\n"
+				. sprintf( '/*# sourceURL=%s */', rawurlencode( $concat_source_url ) );
+			wp_print_inline_style_tag( $style_tag_contents );
 		}
 	}
 
@@ -3078,6 +3075,76 @@ function wp_get_inline_script_tag( $data, $attributes = array() ) {
  */
 function wp_print_inline_script_tag( $data, $attributes = array() ) {
 	echo wp_get_inline_script_tag( $data, $attributes );
+}
+
+/**
+ * Constructs an inline style tag.
+ *
+ * It is possible to inject attributes in the `<style>` tag via the {@see 'wp_inline_style_attributes'} filter.
+ *
+ * @since 7.2.0
+ *
+ * @param string                     $data       CSS for the style tag.
+ * @param array<string, string|bool> $attributes Optional. Key-value pairs representing `<style>` tag attributes.
+ * @return string HTML style tag containing the provided CSS.
+ */
+function wp_get_inline_style_tag( $data, $attributes = array() ) {
+	$data = "\n" . trim( $data, "\n\r " ) . "\n";
+
+	/**
+	 * Filters attributes to be added to an inline style tag.
+	 *
+	 * @since 7.2.0
+	 *
+	 * @param array<string, string|bool> $attributes Key-value pairs representing `<style>` tag attributes.
+	 *                                               Only the attribute name is added to the `<style>` tag for
+	 *                                               entries with a boolean value, and that are true.
+	 * @param string                     $data       Inline CSS.
+	 */
+	$attributes = apply_filters( 'wp_inline_style_attributes', $attributes, $data );
+
+	$processor = new WP_HTML_Tag_Processor( '<style></style>' );
+	$processor->next_tag();
+	foreach ( $attributes as $name => $value ) {
+		/*
+		 * Lexical variations of an attribute name may represent the
+		 * same attribute in HTML, therefore it is possible that the
+		 * input array might contain duplicate attributes even though
+		 * it is keyed on their name. Calling code should rewrite an
+		 * attribute's value rather than sending a duplicate attribute.
+		 *
+		 * Example:
+		 *
+		 *     array( 'id' => 'main', 'ID' => 'nav' )
+		 *
+		 * In this example, there are two keys both describing the `id`
+		 * attribute. PHP array iteration is in key-insertion order so
+		 * the 'id' value will be set in the STYLE tag.
+		 */
+		if ( null !== $processor->get_attribute( $name ) ) {
+			continue;
+		}
+
+		$processor->set_attribute( $name, $value ?? true );
+	}
+
+	$processor->set_modifiable_text( $data );
+
+	return "{$processor->get_updated_html()}\n";
+}
+
+/**
+ * Prints an inline style tag.
+ *
+ * It is possible to inject attributes in the `<style>` tag via the {@see 'wp_inline_style_attributes'} filter.
+ *
+ * @since 7.2.0
+ *
+ * @param string                     $data       CSS for the style tag.
+ * @param array<string, string|bool> $attributes Optional. Key-value pairs representing `<style>` tag attributes.
+ */
+function wp_print_inline_style_tag( $data, $attributes = array() ) {
+	echo wp_get_inline_style_tag( $data, $attributes );
 }
 
 /**

--- a/tests/phpunit/tests/dependencies/styles.php
+++ b/tests/phpunit/tests/dependencies/styles.php
@@ -226,6 +226,136 @@ class Tests_Dependencies_Styles extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that inline style attributes are filtered during normal style output.
+	 *
+	 * @ticket 51325
+	 */
+	public function test_inline_style_attributes_filter() {
+		$filter_calls = 0;
+		add_filter(
+			'wp_inline_style_attributes',
+			static function ( $attributes ) use ( &$filter_calls ) {
+				++$filter_calls;
+				$attributes['nonce'] = 'test-nonce';
+				return $attributes;
+			}
+		);
+
+		wp_enqueue_style( 'handle', 'http://example.com', array(), 1 );
+		wp_add_inline_style( 'handle', 'body { color: #123456; }' );
+
+		$printed = get_echo( 'wp_print_styles' );
+
+		$this->assertStringContainsString( '<style id="handle-inline-css" nonce="test-nonce">', $printed );
+		$this->assertSame( 1, $filter_calls );
+	}
+
+	/**
+	 * Tests that inline style attributes are filtered when print_inline_style() is called directly.
+	 *
+	 * @ticket 51325
+	 */
+	public function test_inline_style_attributes_filter_with_direct_call() {
+		global $wp_styles;
+
+		add_filter(
+			'wp_inline_style_attributes',
+			static function ( $attributes ) {
+				$attributes['nonce'] = 'test-nonce';
+				return $attributes;
+			}
+		);
+
+		wp_register_style( 'handle', 'http://example.com' );
+		wp_add_inline_style( 'handle', 'body { color: #123456; }' );
+
+		$printed = get_echo( array( $wp_styles, 'print_inline_style' ), array( 'handle' ) );
+
+		$this->assertStringContainsString( '<style id="handle-inline-css" nonce="test-nonce">', $printed );
+	}
+
+	/**
+	 * Tests that inline style attributes are filtered for a concatenated non-core stylesheet.
+	 *
+	 * @ticket 51325
+	 */
+	public function test_inline_style_attributes_filter_with_non_core_concat() {
+		global $wp_styles;
+
+		$wp_styles->do_concat    = true;
+		$wp_styles->default_dirs = array( '/wp-admin/', '/wp-includes/css/' );
+
+		add_filter(
+			'wp_inline_style_attributes',
+			static function ( $attributes ) {
+				$attributes['nonce'] = 'test-nonce';
+				return $attributes;
+			}
+		);
+
+		wp_enqueue_style( 'handle', 'http://example.com', array(), 1 );
+		wp_add_inline_style( 'handle', 'body { color: #123456; }' );
+		wp_print_styles();
+
+		$this->assertStringContainsString(
+			'<style id="handle-inline-css" nonce="test-nonce">',
+			$wp_styles->print_html
+		);
+	}
+
+	/**
+	 * Tests that inline style attributes are filtered for concatenated core styles.
+	 *
+	 * @ticket 51325
+	 */
+	public function test_inline_style_attributes_filter_with_core_concat() {
+		global $wp_styles;
+
+		$wp_styles->do_concat    = true;
+		$wp_styles->default_dirs = array( '/wp-admin/' );
+
+		add_filter(
+			'wp_inline_style_attributes',
+			static function ( $attributes ) {
+				$attributes['nonce'] = 'test-nonce';
+				return $attributes;
+			}
+		);
+
+		wp_enqueue_style( 'handle', '/wp-admin/example.css' );
+		wp_add_inline_style( 'handle', 'body { color: #123456; }' );
+		wp_print_styles();
+
+		$printed = get_echo( '_print_styles' );
+
+		$this->assertStringContainsString( '<style nonce="test-nonce">', $printed );
+	}
+
+	/**
+	 * Tests that inline style attributes are not filtered when style output is suppressed.
+	 *
+	 * @ticket 51325
+	 */
+	public function test_inline_style_attributes_filter_not_called_when_output_is_suppressed() {
+		$filter_calls = 0;
+
+		add_filter( 'style_loader_src', '__return_false' );
+		add_filter(
+			'wp_inline_style_attributes',
+			static function ( $attributes ) use ( &$filter_calls ) {
+				++$filter_calls;
+				return $attributes;
+			}
+		);
+
+		wp_enqueue_style( 'handle', 'http://example.com', array(), 1 );
+		wp_add_inline_style( 'handle', 'body { color: #123456; }' );
+
+		$this->assertSame( '', get_echo( 'wp_print_styles' ) );
+		$this->assertSame( 0, $filter_calls );
+	}
+
+	/**
 	 * Test normalizing relative links in CSS.
 	 *
 	 * @dataProvider data_normalize_relative_css_links

--- a/tests/phpunit/tests/dependencies/wpInlineStyleTag.php
+++ b/tests/phpunit/tests/dependencies/wpInlineStyleTag.php
@@ -1,0 +1,149 @@
+<?php
+
+/**
+ * Test wp_get_inline_style_tag() and wp_print_inline_style_tag().
+ *
+ * @group dependencies
+ * @group styles
+ * @covers ::wp_get_inline_style_tag
+ * @covers ::wp_print_inline_style_tag
+ */
+class Tests_Dependencies_wpInlineStyleTag extends WP_UnitTestCase {
+
+	private $css = 'body { color: #123456; }';
+
+	/**
+	 * @ticket 51325
+	 */
+	public function test_get_inline_style_tag_with_attributes() {
+		$this->assertSame(
+			"<style id=\"test-inline-css\" nonce=\"test-nonce\">\n{$this->css}\n</style>\n",
+			wp_get_inline_style_tag(
+				$this->css,
+				array(
+					'id'    => 'test-inline-css',
+					'nonce' => 'test-nonce',
+				)
+			)
+		);
+	}
+
+	/**
+	 * @ticket 51325
+	 */
+	public function test_print_inline_style_tag_prints_get_inline_style_tag() {
+		$attributes = array( 'id' => 'test-inline-css' );
+
+		$this->assertSame(
+			wp_get_inline_style_tag( $this->css, $attributes ),
+			get_echo(
+				'wp_print_inline_style_tag',
+				array( $this->css, $attributes )
+			)
+		);
+	}
+
+	/**
+	 * @ticket 51325
+	 */
+	public function test_inline_style_attributes_filter() {
+		$filtered_data = null;
+
+		add_filter(
+			'wp_inline_style_attributes',
+			static function ( $attributes, $data ) use ( &$filtered_data ) {
+				$attributes['nonce'] = 'test-nonce';
+				$filtered_data       = $data;
+				return $attributes;
+			},
+			10,
+			2
+		);
+
+		$this->assertSame(
+			"<style nonce=\"test-nonce\">\n{$this->css}\n</style>\n",
+			wp_get_inline_style_tag( $this->css )
+		);
+		$this->assertSame( "\n{$this->css}\n", $filtered_data );
+	}
+
+	/**
+	 * Test the behavior of generated style tag attributes passed different values and types of values.
+	 *
+	 * @ticket 51325
+	 */
+	public function test_inline_style_tag_attribute_value_types() {
+		$expected = <<<'HTML'
+<style
+	true
+	null
+	empty-string=""
+	0-string="0"
+	1-string="1"
+	0-numeric="0"
+	1-numeric="1"
+>
+body { color: #123456; }
+</style>
+
+HTML;
+
+		$this->assertEqualHTML(
+			$expected,
+			wp_get_inline_style_tag(
+				$this->css,
+				array(
+					'true'         => true,
+					'false'        => false,
+					'null'         => null,
+					'empty-string' => '',
+					'0-string'     => '0',
+					'1-string'     => '1',
+					'0-numeric'    => 0,
+					'1-numeric'    => 1,
+				)
+			)
+		);
+	}
+
+	/**
+	 * Test the behavior of generated style tag repeated attributes.
+	 *
+	 * HTML will ignore case-insensitive repeated attributes. Ensure that the handling of input
+	 * attributes aligns with expectations.
+	 *
+	 * @ticket 51325
+	 */
+	public function test_inline_style_tag_repeat_attributes() {
+		$expected = <<<'HTML'
+<style test="test-a">
+body { color: #123456; }
+</style>
+
+HTML;
+
+		$this->assertEqualHTML(
+			$expected,
+			wp_get_inline_style_tag(
+				$this->css,
+				array(
+					'test' => 'test-a',
+					'tesT' => 'tesT-b',
+					'teST' => 'teST-c',
+					'tEST' => 'tEST-d',
+					'TEST' => 'TEST-e',
+				)
+			)
+		);
+	}
+
+	/**
+	 * @ticket 51325
+	 */
+	public function test_inline_style_tag_escapes_closing_style_tag() {
+		$this->assertSame(
+			"<style>\nbody::after { content: \"\\3c\\2fstyle>\"; }\n</style>\n",
+			wp_get_inline_style_tag( 'body::after { content: "</style>"; }' )
+		);
+	}
+}


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

## What this PR does

Adds a structured API for generating and filtering inline `<style>` tags:

- Adds `wp_get_inline_style_tag()`.
- Adds `wp_print_inline_style_tag()`.
- Adds the `wp_inline_style_attributes` filter.
- Routes `WP_Styles` output through the new API.
- Covers normal, direct, no-source, and concatenated style output.
- Uses `WP_HTML_Tag_Processor` for safe attribute and CSS handling.

This allows plugins to add attributes such as CSP nonces without modifying complete HTML strings.

The script portion of the original ticket is already covered by `wp_inline_script_attributes`, so this PR focuses on the remaining inline-style functionality.

Trac ticket: https://core.trac.wordpress.org/ticket/51325

## Use of AI Tools

AI assistance: Yes
Tool(s): OpenAI Codex
Model(s): GPT-5.6
Used for: Initial code skeleton, test suggestions and code review; final implementation and tests were reviewed and edited by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
