### PR TITLE
Media: escape the track label before inserting it into the captions menu

### DIFF
--- a/src/js/_enqueues/vendor/mediaelement/mediaelement-and-player.js
+++ b/src/js/_enqueues/vendor/mediaelement/mediaelement-and-player.js
@@ -2625,7 +2625,12 @@ Object.assign(_player2.default.prototype, {
 			label = _i18n2.default.t(_mejs2.default.language.codes[lang]) || lang;
 		}
 
-		t.captionsButton.querySelector('ul').innerHTML += '<li class="' + t.options.classPrefix + 'captions-selector-list-item">' + ('<input type="radio" class="' + t.options.classPrefix + 'captions-selector-input" ') + ('name="' + t.id + '_captions" id="' + trackId + '" value="' + trackId + '" disabled>') + ('<label class="' + t.options.classPrefix + 'captions-selector-label"') + ('for="' + trackId + '">' + label + ' (loading)</label>') + '</li>';
+		// The label comes from the track element's `label` attribute and is inserted
+		// as HTML below. Escape it so a label is always rendered as text rather than
+		// parsed as markup.
+		var labelText = ('' + label).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#039;');
+
+		t.captionsButton.querySelector('ul').innerHTML += '<li class="' + t.options.classPrefix + 'captions-selector-list-item">' + ('<input type="radio" class="' + t.options.classPrefix + 'captions-selector-input" ') + ('name="' + t.id + '_captions" id="' + trackId + '" value="' + trackId + '" disabled>') + ('<label class="' + t.options.classPrefix + 'captions-selector-label"') + ('for="' + trackId + '">' + labelText + ' (loading)</label>') + '</li>';
 	},
 	checkForTracks: function checkForTracks() {
 		var t = this;


### PR DESCRIPTION
### Summary

`MediaElementPlayer.addTrackButton()` in the bundled MediaElement builds the captions/subtitles selector by concatenating a `<track>` element's `label` into `innerHTML`, so markup in a track label is parsed as HTML rather than shown as text. This escapes the label before it is inserted.

Change is on the vendored source (`src/js/_enqueues/vendor/mediaelement/mediaelement-and-player.js`); the `wp-includes/js/mediaelement/` copy and the `.min.js` are build-generated and not committed here.

### Why

UI strings should be treated as text. Escaping the label (or, longer term, building the list item with `document.createElement`/`textContent`) keeps a track label from being interpreted as markup.

### Testing instructions

- Add a `<track>` with a `label` attribute containing markup to a video/audio player.
- Open the captions/subtitles menu; the label now appears as literal text rather than being parsed as HTML.

### Trac ticket

To follow.
