### PR TITLE
Comments: Add a filter to allow comments on draft posts

### DIFF
--- a/src/wp-includes/comment.php
+++ b/src/wp-includes/comment.php
@@ -4024,31 +4024,52 @@ function wp_handle_comment_submission( $comment_data ) {
 	} elseif ( 'trash' === $status ) {
 
 		/**
-		 * Fires when a comment is attempted on a trashed post.
+		 * Filters whether to allow comments on trashed posts.
 		 *
-		 * @since 2.9.0
+		 * @since 7.2.0
 		 *
-		 * @param int $comment_post_id Post ID.
+		 * @param bool $allow           Whether to allow comments on trashed posts. Default false.
+		 * @param int  $comment_post_id Post ID.
 		 */
-		do_action( 'comment_on_trash', $comment_post_id );
+		if ( ! apply_filters( 'allow_comment_on_trash', false, $comment_post_id ) ) {
 
-		return new WP_Error( 'comment_on_trash' );
+			/**
+			 * Fires when a comment is attempted on a trashed post.
+			 *
+			 * @since 2.9.0
+			 *
+			 * @param int $comment_post_id Post ID.
+			 */
+			do_action( 'comment_on_trash', $comment_post_id );
 
+			return new WP_Error( 'comment_on_trash' );
+		}
 	} elseif ( ! $status_obj->public && ! $status_obj->private ) {
 
 		/**
-		 * Fires when a comment is attempted on a post in draft mode.
+		 * Filters whether to allow comments on draft posts.
 		 *
-		 * @since 1.5.1
+		 * @since 7.2.0
 		 *
-		 * @param int $comment_post_id Post ID.
+		 * @param bool $allow           Whether to allow comments on draft posts. Default false.
+		 * @param int  $comment_post_id Post ID.
 		 */
-		do_action( 'comment_on_draft', $comment_post_id );
+		if ( ! apply_filters( 'allow_comment_on_draft', false, $comment_post_id ) ) {
 
-		if ( current_user_can( 'read_post', $comment_post_id ) ) {
-			return new WP_Error( 'comment_on_draft', __( 'Sorry, comments are not allowed for this item.' ), 403 );
-		} else {
-			return new WP_Error( 'comment_on_draft' );
+			/**
+			 * Fires when a comment is attempted on a post in draft mode.
+			 *
+			 * @since 1.5.1
+			 *
+			 * @param int $comment_post_id Post ID.
+			 */
+			do_action( 'comment_on_draft', $comment_post_id );
+
+			if ( current_user_can( 'read_post', $comment_post_id ) ) {
+				return new WP_Error( 'comment_on_draft', __( 'Sorry, comments are not allowed for this item.' ), 403 );
+			} else {
+				return new WP_Error( 'comment_on_draft' );
+			}
 		}
 	} elseif ( post_password_required( $comment_post_id ) ) {
 
@@ -4063,16 +4084,16 @@ function wp_handle_comment_submission( $comment_data ) {
 
 		return new WP_Error( 'comment_on_password_protected' );
 
-	} else {
-		/**
-		 * Fires before a comment is posted.
-		 *
-		 * @since 2.8.0
-		 *
-		 * @param int $comment_post_id Post ID.
-		 */
-		do_action( 'pre_comment_on_post', $comment_post_id );
 	}
+
+	/**
+	 * Fires before a comment is posted.
+	 *
+	 * @since 2.8.0
+	 *
+	 * @param int $comment_post_id Post ID.
+	 */
+	do_action( 'pre_comment_on_post', $comment_post_id );
 
 	// If the user is logged in.
 	$user = wp_get_current_user();

--- a/src/wp-includes/comment.php
+++ b/src/wp-includes/comment.php
@@ -4024,26 +4024,15 @@ function wp_handle_comment_submission( $comment_data ) {
 	} elseif ( 'trash' === $status ) {
 
 		/**
-		 * Filters whether to allow comments on trashed posts.
+		 * Fires when a comment is attempted on a trashed post.
 		 *
-		 * @since 7.2.0
+		 * @since 2.9.0
 		 *
-		 * @param bool $allow           Whether to allow comments on trashed posts. Default false.
-		 * @param int  $comment_post_id Post ID.
+		 * @param int $comment_post_id Post ID.
 		 */
-		if ( ! apply_filters( 'allow_comment_on_trash', false, $comment_post_id ) ) {
+		do_action( 'comment_on_trash', $comment_post_id );
 
-			/**
-			 * Fires when a comment is attempted on a trashed post.
-			 *
-			 * @since 2.9.0
-			 *
-			 * @param int $comment_post_id Post ID.
-			 */
-			do_action( 'comment_on_trash', $comment_post_id );
-
-			return new WP_Error( 'comment_on_trash' );
-		}
+		return new WP_Error( 'comment_on_trash' );
 	} elseif ( ! $status_obj->public && ! $status_obj->private ) {
 
 		/**

--- a/tests/phpunit/tests/comment/wpHandleCommentSubmission.php
+++ b/tests/phpunit/tests/comment/wpHandleCommentSubmission.php
@@ -181,6 +181,58 @@ class Tests_Comment_wpHandleCommentSubmission extends WP_UnitTestCase {
 		$this->assertSame( $error, $comment->get_error_code() );
 	}
 
+
+	/**
+	 * @ticket 19739
+	 */
+	public function test_allow_comment_on_draft_filter_default_blocks_comment() {
+		$error = 'comment_on_draft';
+
+		$post = self::factory()->post->create_and_get(
+			array(
+				'post_status' => 'draft',
+			)
+		);
+
+		$this->assertSame( 0, did_action( $error ) );
+
+		$data    = array(
+			'comment_post_ID' => $post->ID,
+		);
+		$comment = wp_handle_comment_submission( $data );
+
+		$this->assertSame( 1, did_action( $error ) );
+		$this->assertWPError( $comment );
+		$this->assertSame( $error, $comment->get_error_code() );
+	}
+
+	/**
+	 * @ticket 19739
+	 */
+	public function test_allow_comment_on_draft_filter_allows_comment() {
+		add_filter( 'allow_comment_on_draft', '__return_true' );
+
+		$post = self::factory()->post->create_and_get(
+			array(
+				'post_status' => 'draft',
+			)
+		);
+
+		$user = get_user_by( 'id', self::$author_id2 );
+		wp_set_current_user( $user->ID );
+
+		$data    = array(
+			'comment_post_ID' => $post->ID,
+			'comment'         => 'Test comment on draft post.',
+		);
+		$comment = wp_handle_comment_submission( $data );
+
+		remove_filter( 'allow_comment_on_draft', '__return_true' );
+
+		$this->assertNotWPError( $comment );
+		$this->assertInstanceOf( 'WP_Comment', $comment );
+	}
+
 	public function test_submitting_comment_to_password_required_post_returns_error() {
 
 		$error = 'comment_on_password_protected';


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

This PR introduces an `allow_comment_on_draft` filter to `wp_handle_comment_submission()`. 

Currently, comments on draft posts are hard-blocked. This filter allows developers to override this behavior by returning `true`, enabling use cases like internal editorial workflows and pre-publication discussions. The existing `comment_on_draft` action is preserved inside the conditional logic so it continues to fire when comments are blocked.

Additionally, the `pre_comment_on_post` action has been moved outside the final `else` block so that it fires unconditionally when no error is returned, aligning with the intent of the original patch.

**Note:** Based on recent Slack discussions, the `allow_comment_on_trash` filter originally proposed in this ticket has been omitted due to unresolved architectural questions around how comments on trashed posts should interact with `wp_trash_post()` and `wp_untrash_post()`.

https://github.com/user-attachments/assets/a5fddcfc-8f05-4948-8ac5-ecafc9a02b04




Trac ticket: https://core.trac.wordpress.org/ticket/19739

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

AI assistance: Yes
Tool(s): GitHub Copilot
Model(s): Claude 4.6 Sonnet
Used for: Edge-case checks, and assistance with the PR description; implementation and testing were reviewed and verified by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
