### PR TITLE
REST API: Guard against a non-array return from the `rest_endpoints` filter

### DIFF
--- a/src/wp-includes/rest-api/class-wp-rest-server.php
+++ b/src/wp-includes/rest-api/class-wp-rest-server.php
@@ -972,6 +972,20 @@ class WP_REST_Server {
 		 */
 		$endpoints = apply_filters( 'rest_endpoints', $endpoints );
 
+		if ( ! is_array( $endpoints ) ) {
+			_doing_it_wrong(
+				__METHOD__,
+				sprintf(
+					/* translators: %s: The name of the filter. */
+					__( 'The %s filter must return an array of endpoints.' ),
+					'<code>rest_endpoints</code>'
+				),
+				'7.2.0'
+			);
+
+			$endpoints = array();
+		}
+
 		// Normalize the endpoints.
 		$defaults = array(
 			'methods'       => '',

--- a/tests/phpunit/tests/rest-api/rest-server.php
+++ b/tests/phpunit/tests/rest-api/rest-server.php
@@ -2083,6 +2083,44 @@ class Tests_REST_Server extends WP_Test_REST_TestCase {
 	}
 
 	/**
+	 * @ticket 65953
+	 */
+	public function test_get_routes_returns_array_when_rest_endpoints_filter_returns_null() {
+		$this->setExpectedIncorrectUsage( 'WP_REST_Server::get_routes' );
+
+		add_filter( 'rest_endpoints', '__return_null' );
+
+		$this->assertSame( array(), rest_get_server()->get_routes() );
+	}
+
+	/**
+	 * @ticket 65953
+	 */
+	public function test_dispatch_does_not_error_when_rest_endpoints_filter_returns_null() {
+		$this->setExpectedIncorrectUsage( 'WP_REST_Server::get_routes' );
+
+		register_rest_route(
+			'test-ns/v1',
+			'/test',
+			array(
+				'methods'             => array( 'GET' ),
+				'callback'            => static function () {
+					return new WP_REST_Response( 'data', 204 );
+				},
+				'permission_callback' => '__return_true',
+			)
+		);
+
+		add_filter( 'rest_endpoints', '__return_null' );
+
+		$request  = new WP_REST_Request( 'GET', '/test-ns/v1/test' );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 404, $response->get_status() );
+		$this->assertSame( 'rest_no_route', $response->as_error()->get_error_code() );
+	}
+
+	/**
 	 * @ticket 50244
 	 */
 	public function test_no_route() {


### PR DESCRIPTION
### Ticket

Trac ticket: https://core.trac.wordpress.org/ticket/65953

### Description

`WP_REST_Server::get_routes()` documents an `array` return, but does not validate what the `rest_endpoints` filter gives back. A callback that forgets to `return $endpoints` makes it return `null`, which reaches `array_merge( ...$with_namespace )` in `match_request_to_handler()` and throws a fatal `TypeError` on PHP 8. On PHP 7.4 it only warned, so it looks like an upgrade regression.

The fix validates the filtered value in `get_routes()`, where the bad value originates, so every caller is covered. A non-array falls back to an empty array and calls `_doing_it_wrong()` to surface the offending callback. Dispatch then returns a normal `rest_no_route` 404.

Unit tests are included.

### Testing instructions

1. Add a broken filter, e.g. `add_filter( 'rest_endpoints', function ( $endpoints ) { unset( $endpoints['/wp/v2/users'] ); } );`
2. Request any REST route on `trunk` and observe the fatal `TypeError`.
3. With the patch, the request returns a `rest_no_route` 404 plus a `_doing_it_wrong()` notice for `WP_REST_Server::get_routes`.

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: drafting the fix and unit tests