### PR TITLE
Upgrade/Install: Do not reuse an unconnected filesystem in WP_Upgrader::maintenance_mode().

### DIFF
--- a/src/wp-admin/includes/class-wp-upgrader.php
+++ b/src/wp-admin/includes/class-wp-upgrader.php
@@ -1000,7 +1000,7 @@ class WP_Upgrader {
 	 *
 	 * @since 2.8.0
 	 *
-	 * @global WP_Filesystem_Base $wp_filesystem WordPress filesystem subclass.
+	 * @global WP_Filesystem_Base|null $wp_filesystem WordPress filesystem subclass.
 	 *
 	 * @param bool $enable True to enable maintenance mode, false to disable.
 	 */
@@ -1010,10 +1010,10 @@ class WP_Upgrader {
 		/*
 		 * WP_Filesystem() assigns the global before connecting and returns false on a
 		 * constructor error without calling connect(), so a failed call earlier in the
-		 * request leaves an object here that has never been connected. Checking for
-		 * recorded errors as well, the way fs_connect() does, catches that case.
+		 * request leaves an object here that has never been connected. Checking the
+		 * recorded errors too, as fs_connect() does, catches that case.
 		 */
-		if ( ! is_object( $wp_filesystem )
+		if ( ! ( $wp_filesystem instanceof WP_Filesystem_Base )
 			|| ( is_wp_error( $wp_filesystem->errors ) && $wp_filesystem->errors->has_errors() )
 		) {
 			if ( ! function_exists( 'WP_Filesystem' ) ) {

--- a/src/wp-admin/includes/class-wp-upgrader.php
+++ b/src/wp-admin/includes/class-wp-upgrader.php
@@ -1007,7 +1007,15 @@ class WP_Upgrader {
 	public function maintenance_mode( $enable = false ) {
 		global $wp_filesystem;
 
-		if ( ! $wp_filesystem ) {
+		/*
+		 * WP_Filesystem() assigns the global before connecting and returns false on a
+		 * constructor error without calling connect(), so a failed call earlier in the
+		 * request leaves an object here that has never been connected. Checking for
+		 * recorded errors as well, the way fs_connect() does, catches that case.
+		 */
+		if ( ! is_object( $wp_filesystem )
+			|| ( is_wp_error( $wp_filesystem->errors ) && $wp_filesystem->errors->has_errors() )
+		) {
 			if ( ! function_exists( 'WP_Filesystem' ) ) {
 				require_once ABSPATH . 'wp-admin/includes/file.php';
 			}

--- a/tests/phpunit/tests/admin/wpUpgrader.php
+++ b/tests/phpunit/tests/admin/wpUpgrader.php
@@ -1764,4 +1764,28 @@ class Tests_Admin_WpUpgrader extends WP_UnitTestCase {
 			'Unexpected WP_Error code'
 		);
 	}
+
+	/**
+	 * Tests that `WP_Upgrader::maintenance_mode()` does not reuse a filesystem
+	 * object that was left in the global by a failed `WP_Filesystem()` call.
+	 *
+	 * `WP_Filesystem()` assigns the global before it connects, and returns false
+	 * on a constructor error without ever calling connect(), so a failed call
+	 * leaves an unusable object behind for the next caller to find.
+	 *
+	 * @ticket 65942
+	 *
+	 * @covers WP_Upgrader::maintenance_mode
+	 */
+	public function test_maintenance_mode_should_not_reuse_a_filesystem_global_that_reported_errors() {
+		self::$wp_filesystem_mock->errors = new WP_Error( 'empty_password', 'FTP password is required' );
+
+		self::$instance->maintenance_mode( false );
+
+		$this->assertNotSame(
+			self::$wp_filesystem_mock,
+			$GLOBALS['wp_filesystem'],
+			'maintenance_mode() reused the filesystem object that WP_Filesystem() had failed on'
+		);
+	}
 }


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65942

`maintenance_mode()` guards initialization with `! $wp_filesystem`, which treats any object in the global as usable. `WP_Filesystem()` assigns that global at `file.php:2213` before connecting and returns false at `:2226` on a constructor error, so a failed call earlier in the request leaves an unconnected object behind. `maintenance_mode()` then calls `abspath()` on it, and under PHP 8 the transport fatals on a null link. It is called once per `WP_Automatic_Updater::update()`, so the whole update run aborts rather than the one item.

This is the branch [60107] did not cover on the same function, and the check mirrors `fs_connect()` in this class.

Design decision worth flagging: the guard treats any recorded error as unusable. `WP_Filesystem_Base::$errors` is set in the constructor and never cleared, and `WP_Filesystem_FTPext::connect()` deliberately tolerates `connect` and `auth` codes so a failed attempt can be retried on the same instance. An instance that failed once and then connected successfully still carries those codes, so this guard will discard it and reinitialize. That costs a reconnect in a rare case, and I preferred it to inspecting transport-specific link properties from the caller. `fs_connect()` is stricter still and hard-fails on the same condition.

## Testing

Set `FS_METHOD` to `ftpext`, call `WP_Filesystem()` once with incomplete credentials, then run `maintenance_mode( true )`. Before the change that fatals in the transport; after it, the existing "Could not access filesystem." notice path from [60107] handles it.


## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Investigation, the reproduction, drafting the change, the test, this description and my comments on this pull request. The verification is mine: the failure reproduces on a running site before the change and not after, the test fails without the patch, the guard was mutation checked against pre-patch trunk, and `--group upgrade`, `phpcs` and `phpstan` were run. I reviewed everything before it was posted and I take responsibility for the change.
