### PR TITLE
Administration: Document the 6.9 bottom-tablenav skip when a list table has no items

### DIFF
--- a/src/wp-admin/includes/class-wp-list-table.php
+++ b/src/wp-admin/includes/class-wp-list-table.php
@@ -1674,6 +1674,7 @@ class WP_List_Table {
 	 * Generates the table navigation above or below the table.
 	 *
 	 * @since 3.1.0
+	 * @since 6.9.0 The bottom navigation is no longer generated when the list table has no items.
 	 *
 	 * @param string $which The location of the navigation: Either 'top' or 'bottom'.
 	 */

--- a/src/wp-admin/includes/class-wp-posts-list-table.php
+++ b/src/wp-admin/includes/class-wp-posts-list-table.php
@@ -613,6 +613,7 @@ class WP_Posts_List_Table extends WP_List_Table {
 		 * list table.
 		 *
 		 * @since 4.4.0
+		 * @since 6.9.0 No longer fires for `$which === 'bottom'` when the list table has no items.
 		 *
 		 * @param string $which The location of the extra table nav markup: 'top' or 'bottom'.
 		 */


### PR DESCRIPTION
**What changed**: Adds an `@since 6.9.0` docblock note to two places affected by [7dae010b65] (Fixes #63369), which made `WP_List_Table::display_tablenav()` skip rendering the bottom tablenav container entirely when the list table has no items:
- `WP_List_Table::display_tablenav()` in `class-wp-list-table.php`
- The `manage_posts_extra_tablenav` action docblock in `class-wp-posts-list-table.php`

**Why**: As reported on the ticket, plugins hooking into `manage_posts_extra_tablenav` with `$which === 'bottom'` (e.g. to render a custom empty-state notice) will find that code silently stops firing when the list is empty, since the entire bottom container — including this action — is now skipped. That's existing, intentional behavior from 6.9, but it wasn't documented on the hook or the method that causes it, so this only adds the missing `@since` notes; no behavior changes.

Trac ticket: https://core.trac.wordpress.org/ticket/64602

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Sonnet 5
Used for: Ticket triage, locating the relevant hook/method and confirming the behavior change via git history, and drafting the docblock updates. All changes were reviewed by me before submitting.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**