### PR TITLE
Blocks: Process shortcodes in pattern blocks

### DIFF
--- a/src/wp-includes/blocks/pattern.php
+++ b/src/wp-includes/blocks/pattern.php
@@ -23,6 +23,7 @@ function register_block_core_pattern() {
  * Renders the `core/pattern` block on the server.
  *
  * @since 6.3.0 Backwards compatibility: blocks with no `syncStatus` attribute do not receive block wrapper.
+ * @since 7.2.0 Processes shortcodes in pattern content.
  *
  * @global WP_Embed $wp_embed Used to process embedded content within patterns
  *
@@ -60,6 +61,8 @@ function render_block_core_pattern( $attributes ) {
 
 	$seen_refs[ $attributes['slug'] ] = true;
 
+	$content = shortcode_unautop( $content );
+	$content = do_shortcode( $content );
 	$content = do_blocks( $content );
 
 	global $wp_embed;

--- a/tests/phpunit/tests/blocks/renderBlockCorePattern.php
+++ b/tests/phpunit/tests/blocks/renderBlockCorePattern.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Tests for the core/pattern block renderer.
+ *
+ * @package WordPress
+ * @subpackage Blocks
+ *
+ * @group blocks
+ *
+ * @covers ::render_block_core_pattern
+ */
+class Tests_Blocks_RenderBlockCorePattern extends WP_UnitTestCase {
+	/**
+	 * Pattern used by the tests.
+	 *
+	 * @var string
+	 */
+	const PATTERN_NAME = 'tests/pattern-with-shortcode';
+
+	/**
+	 * Shortcode used by the tests.
+	 *
+	 * @var string
+	 */
+	const SHORTCODE_NAME = 'pattern_shortcode';
+
+	/**
+	 * Cleans up registered test data.
+	 */
+	public function tear_down() {
+		if ( WP_Block_Patterns_Registry::get_instance()->is_registered( self::PATTERN_NAME ) ) {
+			unregister_block_pattern( self::PATTERN_NAME );
+		}
+		remove_shortcode( self::SHORTCODE_NAME );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Tests that shortcodes in patterns are processed when rendered in templates.
+	 *
+	 * @ticket 58397
+	 */
+	public function test_renders_shortcode_in_pattern() {
+		add_shortcode(
+			self::SHORTCODE_NAME,
+			static function () {
+				return 'Shortcode output';
+			}
+		);
+
+		register_block_pattern(
+			self::PATTERN_NAME,
+			array(
+				'title'   => 'Pattern containing a shortcode',
+				'content' => '<!-- wp:shortcode -->[pattern_shortcode]<!-- /wp:shortcode -->',
+			)
+		);
+
+		$template = '<!-- wp:pattern {"slug":"tests/pattern-with-shortcode"} /-->';
+		$content  = do_shortcode( $template );
+		$content  = do_blocks( $content );
+
+		$this->assertSame( "<p>Shortcode output</p>\n", $content );
+	}
+}


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/58397

## What?

When a `core/pattern` block is used in a block template, template-level shortcode processing runs before the pattern is expanded. Shortcodes introduced by the pattern therefore remain unprocessed and are rendered literally.

This change applies `shortcode_unautop()` and `do_shortcode()` to registered pattern content before `do_blocks()` renders its blocks.

## Why?

Processing shortcodes before blocks matches the existing block-template ordering and also allows block markup returned by a shortcode to be rendered.

## Testing

A PHPUnit regression test registers a shortcode and a pattern containing a `core/shortcode` block, renders the pattern through the same shortcode-then-block ordering used by block templates, and verifies the shortcode output.

Focused command:

```
npm run test:php -- --filter Tests_Blocks_RenderBlockCorePattern
```

The focused test was not run locally because the available environment does not include PHP or Docker. This is submitted as a draft so CI and contributor testing can validate it before review.

## Use of AI Tools

AI assistance: Yes  
Tool(s): OpenAI Codex in ChatGPT Work  
Model(s): GPT-5  
Used for: Investigating the rendering order, drafting the implementation and regression test, reviewing the diff for scope and consistency, and preparing this pull request description. PHPUnit was not available in the working environment, as disclosed above.

---

**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**