### PR TITLE
Editor: Reinitialize TinyMCE after meta box move

### DIFF
--- a/src/js/_enqueues/admin/postbox.js
+++ b/src/js/_enqueues/admin/postbox.js
@@ -127,6 +127,7 @@
 				}
 
 				postbox.prevAll( '.postbox:visible' ).eq( 0 ).before( postbox );
+				$document.trigger( 'postbox-moved', postbox );
 				button.trigger( 'focus' );
 				postboxes.updateOrderButtonsProperties();
 				postboxes.save_order( postboxes.page );
@@ -141,6 +142,7 @@
 				}
 
 				postbox.nextAll( '.postbox:visible' ).eq( 0 ).after( postbox );
+				$document.trigger( 'postbox-moved', postbox );
 				button.trigger( 'focus' );
 				postboxes.updateOrderButtonsProperties();
 				postboxes.save_order( postboxes.page );
@@ -189,6 +191,7 @@
 				$( detachedPostbox ).prependTo( '#' + sortablesIds[ sortablesIndex + 1 ] );
 			}
 
+			$document.trigger( 'postbox-moved', postbox );
 			postboxes._mark_area();
 			button.focus();
 			postboxes.updateOrderButtonsProperties();

--- a/src/js/_enqueues/wp/editor/base.js
+++ b/src/js/_enqueues/wp/editor/base.js
@@ -1401,4 +1401,55 @@ window.wp = window.wp || {};
 		return $( '#' + id ).val();
 	};
 
+	/**
+	 * Re-initializes TinyMCE editors inside a meta box that was just moved.
+	 *
+	 * Moving a meta box re-inserts its DOM subtree. When the box contains a
+	 * TinyMCE editor, re-inserting its iframe resets the iframe document and
+	 * leaves TinyMCE holding a stale reference, so the editor renders blank and
+	 * a later Visual/Code switch throws. Recreating the affected editors after
+	 * the move restores their content and mode.
+	 *
+	 * @since 7.2.0
+	 *
+	 * @param {Event}  event   The postbox-moved event.
+	 * @param {Object} postbox The jQuery object for the meta box that was moved.
+	 */
+	function reinitializeMovedEditors( event, postbox ) {
+		if ( ! window.tinymce || ! window.tinyMCEPreInit ) {
+			return;
+		}
+
+		$( postbox ).find( 'textarea.wp-editor-area' ).each( function() {
+			var id = this.id,
+				editor = id && window.tinymce.get( id ),
+				wasVisible;
+
+			// Nothing to do when no TinyMCE instance is attached to this textarea.
+			if ( ! editor ) {
+				return;
+			}
+
+			wasVisible = ! editor.isHidden();
+
+			// Persist the current Visual content to the textarea before removing.
+			if ( wasVisible ) {
+				editor.save();
+			}
+
+			// Drop the stale instance so its reset iframe is discarded.
+			editor.remove();
+
+			/*
+			 * Recreate the editor only when it was in Visual mode. In Code mode the
+			 * textarea is used directly, and switching back to Visual re-initializes it.
+			 */
+			if ( wasVisible && window.tinyMCEPreInit.mceInit[ id ] ) {
+				window.tinymce.init( window.tinyMCEPreInit.mceInit[ id ] );
+			}
+		} );
+	}
+
+	$( document ).on( 'postbox-moved', reinitializeMovedEditors );
+
 }( window.jQuery, window.wp ));


### PR DESCRIPTION
## Trac ticket

https://core.trac.wordpress.org/ticket/65958

## What

Moving a meta box re-inserts its DOM subtree; when the box holds a `wp_editor()` TinyMCE editor, the re-inserted iframe is reset and TinyMCE keeps a stale reference, so the editor goes blank and the next Visual/Code switch throws.

`postbox.js` now fires the existing `postbox-moved` event on the Move up/down paths (it already fires on cross-area drag). A listener in `editor.js` re-initialises each editor in the moved box — save content, remove the stale instance, re-init in the same mode — keeping `postbox.js` editor-agnostic.

## Test

- [x] `grunt jshint:core` — 98 files lint free
- [x] Register a `wp_editor()` meta box, type in Visual, Move up/down: editor keeps its content, `getDoc() === iframe.contentDocument` stays true, no console error
- [x] After the move, switch Code then Visual: no `setBaseAndExtent` TypeError
- [ ] Same, in Firefox

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 4.8
Used for: root-cause analysis, implementation, and local verification
