### PR TITLE
Coding Standards: Replace remaining `join()` aliases with `implode()`.

### DIFF
--- a/src/wp-includes/canonical.php
+++ b/src/wp-includes/canonical.php
@@ -986,7 +986,7 @@ function redirect_guess_404_permalink() {
 				if ( empty( $post_types ) ) {
 					return false;
 				}
-				$where .= " AND post_type IN ('" . join( "', '", esc_sql( $post_types ) ) . "')";
+				$where .= " AND post_type IN ('" . implode( "', '", esc_sql( $post_types ) ) . "')";
 			} else {
 				if ( ! in_array( get_query_var( 'post_type' ), $publicly_viewable_post_types, true ) ) {
 					return false;

--- a/tests/phpunit/tests/functions/wpGetArchives.php
+++ b/tests/phpunit/tests/functions/wpGetArchives.php
@@ -220,7 +220,7 @@ EOF;
 
 		$ids = array_slice( array_reverse( self::$post_ids ), 0, 3 );
 
-		$expected = join(
+		$expected = implode(
 			'',
 			array_map(
 				static function ( $id ) {

--- a/tests/phpunit/tests/script-modules/wpScriptModules.php
+++ b/tests/phpunit/tests/script-modules/wpScriptModules.php
@@ -486,7 +486,7 @@ class Tests_Script_Modules_WpScriptModules extends WP_UnitTestCase {
 				foreach ( $test_case as $param_name => $param_value ) {
 					$key_parts[] = sprintf( '%s_%s', $param_name, json_encode( $param_value ) );
 				}
-				$data[ join( '_', $key_parts ) ] = $test_case;
+				$data[ implode( '_', $key_parts ) ] = $test_case;
 			}
 		}
 


### PR DESCRIPTION
`join()` is an alias of `implode()`. Using the canonical function name is strongly recommended, as aliases may be deprecated or removed without (much) warning. This replaces the last three uses of the alias in actively maintained PHP code.

The three instances were introduced in [49200](https://core.trac.wordpress.org/changeset/49200), [60704](https://core.trac.wordpress.org/changeset/60704) and [61326](https://core.trac.wordpress.org/changeset/61326), after the previous alias cleanups in [49193](https://core.trac.wordpress.org/changeset/49193), [56616](https://core.trac.wordpress.org/changeset/56616) and [57567](https://core.trac.wordpress.org/changeset/57567).

## Scope

This brings the number of `join()` calls in actively maintained PHP code to zero. The following occurrences are deliberately left untouched:

- `src/wp-includes/atomlib.php` — bundled third-party library (AtomLib by Elias Torres)
- `src/wp-includes/rss.php` — bundled third-party library (MagpieRSS), deprecated since 3.0.0
- `src/wp-includes/class-json.php` — bundled third-party library (Services_JSON), deprecated since 5.3.0
- `src/wp-admin/includes/deprecated.php` — deprecated functions, kept as-is for historical accuracy
- `src/wp-includes/media-template.php` — this is `Array.prototype.join()` in a JavaScript template, not PHP

Trac ticket: https://core.trac.wordpress.org/ticket/65818

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
