### PR TITLE
Site Icon: Update outdated Chrome documentation links

### DIFF
--- a/src/wp-admin/includes/class-wp-site-icon.php
+++ b/src/wp-admin/includes/class-wp-site-icon.php
@@ -48,8 +48,8 @@ class WP_Site_Icon {
 		/*
 		 * App icon for Android/Chrome.
 		 *
-		 * @link https://developers.google.com/web/updates/2014/11/Support-for-theme-color-in-Chrome-39-for-Android
-		 * @link https://developer.chrome.com/multidevice/android/installtohomescreen
+		 * @link https://developer.chrome.com/blog/support-for-theme-color-in-chrome-39-for-android
+		 * @link https://web.dev/articles/add-manifest
 		 */
 		192,
 


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65940

## Summary
- Updates outdated/broken Chrome documentation `@link` URLs in `WP_Site_Icon`.
- Replaces the redirected `developers.google.com/web/updates/...` link with the current Chrome blog URL.
- Replaces the broken (`404`) `installtohomescreen` link with the current web.dev manifest documentation.

## Test plan
- [ ] Confirm the old theme-color URL redirects to `https://developer.chrome.com/blog/support-for-theme-color-in-chrome-39-for-android`
- [ ] Confirm the old `installtohomescreen` URL returns `404`
- [ ] Confirm both new URLs return `200`
- [ ] Confirm this is docs-only (no runtime/functional change)