### PR TITLE
Administration: Add a reusable .delete-link CSS class

### DIFF
--- a/src/wp-admin/css/colors/_admin.scss
+++ b/src/wp-admin/css/colors/_admin.scss
@@ -66,7 +66,8 @@ span.wp-media-buttons-icon:before {
 .media-modal .trash-attachment,
 .media-modal .untrash-attachment,
 /* Needs higher specificity to override the default button-link. */
-.wp-core-ui .button-link.button-link-delete {
+.wp-core-ui .button-link.button-link-delete,
+.wp-core-ui .delete-link {
 	color: tokens.$alert-red;
 }
 
@@ -78,7 +79,9 @@ span.wp-media-buttons-icon:before {
 .media-modal .untrash-attachment:focus,
 /* Needs higher specificity to override the default button-link. */
 .wp-core-ui .button-link.button-link-delete:hover,
-.wp-core-ui .button-link.button-link-delete:focus {
+.wp-core-ui .button-link.button-link-delete:focus,
+.wp-core-ui .delete-link:hover,
+.wp-core-ui .delete-link:focus {
 	color: color.adjust(tokens.$alert-red, $lightness: -10%);
 }
 


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/36882

## Summary
- Adds a reusable `.delete-link` admin CSS class for destructive action links.
- Mirrors the existing `.button-link-delete` color rules (base + hover/focus) in the admin color schemes.
- Gives plugin and theme authors a standard class instead of reusing unrelated core selectors or copying red link styles by hand.

## Test plan
- [ ] Confirm `.wp-core-ui .delete-link` uses the alert-red color in an admin screen
- [ ] Confirm hover/focus lightens/darkens consistently with `.button-link-delete`
- [ ] Confirm existing `.button-link-delete` buttons are unchanged
- [ ] Spot-check at least one admin color scheme (e.g. Default / Modern)