### PR TITLE
#40901 - fix: preserve multi-word comments number text

### DIFF
--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -955,6 +955,11 @@ function comments_number( $zero = false, $one = false, $more = false, $post = 0 
  * @param string|false $more Optional. Text for more than one comment. Default false.
  * @param int|WP_Post  $post Optional. Post ID or WP_Post object. Default is the global `$post`.
  * @return string Language string for the number of comments a post has.
+ *
+ * When comment number declension is enabled for the locale, a `$more` string whose visible
+ * text is a single word accompanying the % placeholder (for example '% Comments') is rewritten
+ * using the correct plural form for the count. All other strings have only the % character
+ * replaced with the number.
  */
 function get_comments_number_text( $zero = false, $one = false, $more = false, $post = 0 ) {
 	$comments_number = (int) get_comments_number( $post );
@@ -978,7 +983,7 @@ function get_comments_number_text( $zero = false, $one = false, $more = false, $
 				$text = trim( strip_tags( $text ), '% ' );
 
 				// Replace '% Comments' with a proper plural form.
-				if ( $text && ! preg_match( '/[0-9]+/', $text ) && str_contains( $more, '%' ) ) {
+				if ( $text && ! preg_match( '/[0-9]+/', $text ) && ! preg_match( '/\s/', $text ) && str_contains( $more, '%' ) ) {
 					/* translators: %s: Number of comments. */
 					$new_text = _n( '%s Comment', '%s Comments', $comments_number );
 					$new_text = trim( sprintf( $new_text, '' ) );

--- a/tests/phpunit/tests/comment/template.php
+++ b/tests/phpunit/tests/comment/template.php
@@ -138,7 +138,7 @@ class Tests_Comment_Template extends WP_UnitTestCase {
 			array(
 				2,
 				'Comments (%)',
-				sprintf( _n( '%s Comment', '%s Comments', 2 ), '2' ),
+				'Comments (2)',
 			),
 			array(
 				2,
@@ -183,7 +183,7 @@ class Tests_Comment_Template extends WP_UnitTestCase {
 			array(
 				2,
 				__( 'View all % comments', 'twentythirteen' ),
-				sprintf( _n( '%s Comment', '%s Comments', 2 ), '2' ),
+				'View all 2 comments',
 			),
 			array(
 				2,
@@ -194,6 +194,16 @@ class Tests_Comment_Template extends WP_UnitTestCase {
 				2,
 				__( '% Comments', 'twentyfifteen' ),
 				sprintf( _n( '%s Comment', '%s Comments', 2 ), '2' ),
+			),
+			array(
+				2,
+				' % so far',
+				' 2 so far',
+			),
+			array(
+				2,
+				' and view % comments',
+				' and view 2 comments',
 			),
 		);
 	}


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->
The patch narrows the heuristic to what the feature actually targets: the declined rewrite now only applies when the cleaned remainder is a single word (no internal whitespace). This keeps every existing single-word pattern working exactly as before (% Comments, <b>%</b> Replies, % <span class="reply">comments &rarr;</span>, and translated equivalents like % Komentarzy), while multi-word custom text falls through to the documented behavior: only the % character is substituted with the formatted number.

Trac ticket: https://core.trac.wordpress.org/ticket/40901 <!-- insert a link to the WordPress Trac ticket here -->

## Use of AI Tools
AI assistance: Yes
Tool(s): Claude
Model(s): Sonnet
Used for: test cases, code review
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
