### PR TITLE
#35805 fix: number comment pages in display order when reversed

### DIFF
--- a/src/wp-includes/class-wp-walker.php
+++ b/src/wp-includes/class-wp-walker.php
@@ -324,9 +324,6 @@ class Walker {
 		if ( -1 === $max_depth ) {
 			if ( ! empty( $args[0]['reverse_top_level'] ) ) {
 				$elements = array_reverse( $elements );
-				$oldstart = $start;
-				$start    = $total_top - $end;
-				$end      = $total_top - $oldstart;
 			}
 
 			$empty_array = array();
@@ -367,9 +364,6 @@ class Walker {
 
 		if ( ! empty( $args[0]['reverse_top_level'] ) ) {
 			$top_level_elements = array_reverse( $top_level_elements );
-			$oldstart           = $start;
-			$start              = $total_top - $end;
-			$end                = $total_top - $oldstart;
 		}
 		if ( ! empty( $args[0]['reverse_children'] ) ) {
 			foreach ( $children_elements as $parent => $children ) {

--- a/tests/phpunit/tests/comment/wpListComments.php
+++ b/tests/phpunit/tests/comment/wpListComments.php
@@ -137,6 +137,101 @@ class Tests_Comment_WpListComments extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 35805
+	 *
+	 * With 'reverse_top_level' => true, page 1 should start with the newest
+	 * comments: page numbering must follow the display order.
+	 */
+	public function test_paged_comments_should_follow_display_order_when_reversed() {
+		$p = self::factory()->post->create();
+
+		$comments = array();
+		$now      = time();
+		for ( $i = 0; $i <= 4; $i++ ) {
+			$comments[] = self::factory()->comment->create(
+				array(
+					'comment_post_ID'  => $p,
+					'comment_date_gmt' => gmdate( 'Y-m-d H:i:s', $now - $i ),
+					'comment_author'   => 'Commenter ' . $i,
+				)
+			);
+		}
+
+		update_option( 'page_comments', true );
+		update_option( 'comments_per_page', 2 );
+
+		$this->go_to( get_permalink( $p ) );
+
+		// comments_template() populates $wp_query->comments.
+		get_echo( 'comments_template' );
+
+		// Page 1 of the reversed list contains the two newest comments.
+		$found1 = wp_list_comments(
+			array(
+				'reverse_top_level' => true,
+				'per_page'          => 2,
+				'page'              => 1,
+				'echo'              => false,
+			)
+		);
+		preg_match_all( '|id="comment\-([0-9]+)"|', $found1, $matches );
+		$this->assertSame( array( $comments[4], $comments[3] ), array_map( 'intval', $matches[1] ) );
+
+		// Page 2 of the reversed list contains the next two older comments.
+		$found2 = wp_list_comments(
+			array(
+				'reverse_top_level' => true,
+				'per_page'          => 2,
+				'page'              => 2,
+				'echo'              => false,
+			)
+		);
+		preg_match_all( '|id="comment\-([0-9]+)"|', $found2, $matches );
+		$this->assertSame( array( $comments[2], $comments[1] ), array_map( 'intval', $matches[1] ) );
+	}
+
+	/**
+	 * @ticket 35805
+	 *
+	 * Without reversal, paging is unchanged: page 1 shows the two oldest
+	 * comments in chronological order.
+	 */
+	public function test_paged_comments_should_be_unchanged_when_not_reversed() {
+		$p = self::factory()->post->create();
+
+		$comments = array();
+		$now      = time();
+		for ( $i = 0; $i <= 4; $i++ ) {
+			$comments[] = self::factory()->comment->create(
+				array(
+					'comment_post_ID'  => $p,
+					'comment_date_gmt' => gmdate( 'Y-m-d H:i:s', $now - $i ),
+					'comment_author'   => 'Commenter ' . $i,
+				)
+			);
+		}
+
+		update_option( 'page_comments', true );
+		update_option( 'comments_per_page', 2 );
+
+		$this->go_to( get_permalink( $p ) );
+
+		// comments_template() populates $wp_query->comments.
+		get_echo( 'comments_template' );
+
+		$found = wp_list_comments(
+			array(
+				'reverse_top_level' => false,
+				'per_page'          => 2,
+				'page'              => 1,
+				'echo'              => false,
+			)
+		);
+		preg_match_all( '|id="comment\-([0-9]+)"|', $found, $matches );
+		$this->assertSame( array( $comments[0], $comments[1] ), array_map( 'intval', $matches[1] ) );
+	}
+
+	/**
 	 * @ticket 35356
 	 * @ticket 35175
 	 */


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->
Removed the $start/$end swap after array_reverse() in both paths of Walker::paged_walk() (flat and threaded). Previously page 1 selected the last window of the reversed array (oldest comments displayed newest-first), which is why pages ran backwards. Now pagination follows display order directly: page 1 of a newest-first list starts with the newest comments.

Trac ticket: https://core.trac.wordpress.org/ticket/35805 <!-- insert a link to the WordPress Trac ticket here -->

## Use of AI Tools
AI assistance: Yes
Tool(s): Claude
Model(s): Sonnet

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
