### PR TITLE
HTML API: Refactor `wp_get_admin_notice()`

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -9233,23 +9233,26 @@ function wp_get_admin_notice( $message, $args = array() ) {
 	 * @param array  $args    The arguments for the admin notice.
 	 * @param string $message The message for the admin notice.
 	 */
-	$args       = apply_filters( 'wp_admin_notice_args', $args, $message );
-	$id         = '';
-	$classes    = 'notice';
-	$attributes = '';
+	$args = apply_filters( 'wp_admin_notice_args', $args, $message );
+
+	$wrap_with_p  = false !== $args['paragraph_wrap'];
+	$wrap_opener  = $wrap_with_p ? '<p>' : '';
+	$wrap_closer  = $wrap_with_p ? '</p>' : '';
+	$html_builder = new WP_HTML_Tag_Processor( "<div class=\"notice\">{$wrap_opener}" );
+	$html_builder->next_token();
 
 	if ( is_string( $args['id'] ) ) {
 		$trimmed_id = trim( $args['id'] );
 
 		if ( '' !== $trimmed_id ) {
-			$id = 'id="' . $trimmed_id . '" ';
+			$html_builder->set_attribute( 'id', $trimmed_id );
 		}
 	}
 
 	if ( is_string( $args['type'] ) ) {
 		$type = trim( $args['type'] );
 
-		if ( str_contains( $type, ' ' ) ) {
+		if ( strlen( $type ) !== strcspn( $type, " \f\t\r\n" ) ) {
 			_doing_it_wrong(
 				__FUNCTION__,
 				sprintf(
@@ -9262,36 +9265,40 @@ function wp_get_admin_notice( $message, $args = array() ) {
 		}
 
 		if ( '' !== $type ) {
-			$classes .= ' notice-' . $type;
+			$html_builder->add_class( "notice-{$type}" );
 		}
 	}
 
 	if ( true === $args['dismissible'] ) {
-		$classes .= ' is-dismissible';
+		$html_builder->add_class( 'is-dismissible' );
 	}
 
 	if ( is_array( $args['additional_classes'] ) && ! empty( $args['additional_classes'] ) ) {
-		$classes .= ' ' . implode( ' ', $args['additional_classes'] );
+		foreach ( $args['additional_classes'] as $class_name ) {
+			$html_builder->add_class( $class_name );
+		}
 	}
 
 	if ( is_array( $args['attributes'] ) && ! empty( $args['attributes'] ) ) {
-		$attributes = '';
-		foreach ( $args['attributes'] as $attr => $val ) {
-			if ( is_bool( $val ) ) {
-				$attributes .= $val ? ' ' . $attr : '';
-			} elseif ( is_int( $attr ) ) {
-				$attributes .= ' ' . esc_attr( trim( $val ) );
-			} elseif ( $val ) {
-				$attributes .= ' ' . $attr . '="' . esc_attr( trim( $val ) ) . '"';
+		foreach ( $args['attributes'] as $name => $value ) {
+			if ( is_int( $name ) ) {
+				/*
+				 * Boolean attributes may have been appended as numeric list items,
+				 * for example, with `$args['attributes'][] = 'disabled'`. They should
+				 * be recorded with the value serving as their name.
+				 */
+				$html_builder->set_attribute( $value, true );
+			} elseif ( true === $value ) {
+				$html_builder->set_attribute( $name, true );
+			} elseif ( false !== $value ) {
+				$html_builder->set_attribute( $name, trim( (string) $value ) );
 			}
 		}
 	}
 
-	if ( false !== $args['paragraph_wrap'] ) {
-		$message = "<p>$message</p>";
-	}
-
-	$markup = sprintf( '<div %1$sclass="%2$s"%3$s>%4$s</div>', $id, $classes, $attributes, $message );
+	$markup  = $html_builder->get_updated_html();
+	$markup .= $message;
+	$markup .= "{$wrap_closer}</div>";
 
 	/**
 	 * Filters the markup for an admin notice.

--- a/tests/phpunit/tests/functions/wpAdminNotice.php
+++ b/tests/phpunit/tests/functions/wpAdminNotice.php
@@ -25,7 +25,7 @@ class Tests_Functions_WpAdminNotice extends WP_UnitTestCase {
 		wp_admin_notice( $message, $args );
 		$actual = ob_get_clean();
 
-		$this->assertSame( $expected, $actual );
+		$this->assertEqualHTML( $expected, $actual );
 	}
 
 	/**

--- a/tests/phpunit/tests/functions/wpAdminNotice.php
+++ b/tests/phpunit/tests/functions/wpAdminNotice.php
@@ -154,21 +154,21 @@ class Tests_Functions_WpAdminNotice extends WP_UnitTestCase {
 				'args'     => array(
 					'type' => '"><script>alert("Howdy,admin!");</script>',
 				),
-				'expected' => '<div class="notice notice-">alert("Howdy,admin!");"&gt;<p>A notice with an unsafe type.</p></div>',
+				'expected' => '<div class="notice notice-&quot;><script>alert(&quot;Howdy,admin!&quot;);</script>"><p>A notice with an unsafe type.</p></div>',
 			),
 			'an unsafe ID'                              => array(
 				'message'  => 'A notice with an unsafe ID.',
 				'args'     => array(
 					'id' => '"><script>alert( "Howdy, admin!" );</script> <div class="notice',
 				),
-				'expected' => '<div id="">alert( "Howdy, admin!" ); <div class="notice"><p>A notice with an unsafe ID.</p></div>',
+				'expected' => '<div id="&quot;><script>alert( &quot;Howdy, admin!&quot; );</script> <div class=&quot;notice" class="notice"><p>A notice with an unsafe ID.</p></div>',
 			),
 			'unsafe additional classes'                 => array(
 				'message'  => 'A notice with unsafe additional classes.',
 				'args'     => array(
 					'additional_classes' => array( '"><script>alert( "Howdy, admin!" );</script> <div class="notice' ),
 				),
-				'expected' => '<div class="notice ">alert( "Howdy, admin!" ); <div class="notice"><p>A notice with unsafe additional classes.</p></div>',
+				'expected' => '<div class="notice &quot;><script>alert( &quot;Howdy, admin!&quot; );</script> <div class=&quot;notice"><p>A notice with unsafe additional classes.</p></div>',
 			),
 			'a type that is not a string'               => array(
 				'message'  => 'A notice with a type that is not a string.',

--- a/tests/phpunit/tests/functions/wpGetAdminNotice.php
+++ b/tests/phpunit/tests/functions/wpGetAdminNotice.php
@@ -21,7 +21,7 @@ class Tests_Functions_WpGetAdminNotice extends WP_UnitTestCase {
 	 * @param string $expected The expected admin notice markup.
 	 */
 	public function test_should_return_admin_notice( $message, $args, $expected ) {
-		$this->assertSame( $expected, wp_get_admin_notice( $message, $args ) );
+		$this->assertEqualHTML( $expected, wp_get_admin_notice( $message, $args ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/functions/wpGetAdminNotice.php
+++ b/tests/phpunit/tests/functions/wpGetAdminNotice.php
@@ -150,21 +150,21 @@ class Tests_Functions_WpGetAdminNotice extends WP_UnitTestCase {
 				'args'     => array(
 					'type' => '"><script>alert("Howdy,admin!");</script>',
 				),
-				'expected' => '<div class="notice notice-"><script>alert("Howdy,admin!");</script>"><p>A notice with an unsafe type.</p></div>',
+				'expected' => '<div class="notice notice-&quot;><script>alert(&quot;Howdy,admin!&quot;);</script>"><p>A notice with an unsafe type.</p></div>',
 			),
 			'an unsafe ID'                              => array(
 				'message'  => 'A notice with an unsafe ID.',
 				'args'     => array(
 					'id' => '"><script>alert( "Howdy, admin!" );</script> <div class="notice',
 				),
-				'expected' => '<div id=""><script>alert( "Howdy, admin!" );</script> <div class="notice" class="notice"><p>A notice with an unsafe ID.</p></div>',
+				'expected' => '<div id="&quot;><script>alert( &quot;Howdy, admin!&quot; );</script> <div class=&quot;notice" class="notice"><p>A notice with an unsafe ID.</p></div>',
 			),
 			'unsafe additional classes'                 => array(
 				'message'  => 'A notice with unsafe additional classes.',
 				'args'     => array(
 					'additional_classes' => array( '"><script>alert( "Howdy, admin!" );</script> <div class="notice' ),
 				),
-				'expected' => '<div class="notice "><script>alert( "Howdy, admin!" );</script> <div class="notice"><p>A notice with unsafe additional classes.</p></div>',
+				'expected' => '<div class="notice &quot;><script>alert( &quot;Howdy, admin!&quot; );</script> <div class=&quot;notice"><p>A notice with unsafe additional classes.</p></div>',
 			),
 			'a type that is not a string'               => array(
 				'message'  => 'A notice with a type that is not a string.',


### PR DESCRIPTION
Trac ticket: Core-65984

Refactors `wp_get_admin_notice()` to rely on the HTML API for HTML generation. This provides more reliable parsing and hardening for and against the provided arguments, but introduces behavioral changes that should only affect already-broken cases.

Namely, the function previously generated its output and then mandated that calling code run it through `wp_kses()`. This meant that certain kinds of corruption were possible which would break boundaries within the generated HTML and result in mangled output through `wp_kses()`. _Now_, the function preserves all boundaries when generating the output, meaning that `wp_kses()` will receive already-normalized content. As part of this change, the `$message` parameter runs through `wp_kses()` in advance. This may lead to some existing static message values changing from what they previously generated.