### PR TITLE
Fix Snoopy stream timeout handling

### DIFF
--- a/src/wp-includes/class-snoopy.php
+++ b/src/wp-includes/class-snoopy.php
@@ -278,7 +278,6 @@ class Snoopy
 
 	function submit($URI, $formvars="", $formfiles="")
 	{
-		unset($postdata);
 
 		$postdata = $this->_prepare_post_body($formvars, $formfiles);
 
@@ -844,7 +843,7 @@ class Snoopy
 
 		// set the read timeout if needed
 		if ($this->read_timeout > 0)
-			socket_set_timeout($fp, $this->read_timeout);
+			stream_set_timeout($fp, $this->read_timeout);
 		$this->timed_out = false;
 
 		fwrite($fp,$headers.$body,strlen($headers.$body));


### PR DESCRIPTION
## Description

Replaces the deprecated `socket_set_timeout()` function with `stream_set_timeout()` in `class-snoopy.php`.

Also removes the unnecessary `unset( $postdata )` before `$postdata` is assigned.

### Changes

* Replace `socket_set_timeout()` with `stream_set_timeout()` for setting the read timeout.
* Remove the unnecessary `unset( $postdata )` statement.

Trac ticket: [https://core.trac.wordpress.org/ticket/65965](https://core.trac.wordpress.org/ticket/65965)

## Use of AI Tools

AI assistance: Yes
Tool(s): ChatGPT
Model(s): GPT-5.6 Luna
Used for: Improving the English in the ticket and pull request description.