### PR TITLE
Fix rich-text block attribute validation (alternative)

### DIFF
--- a/src/wp-includes/class-wp-block-type.php
+++ b/src/wp-includes/class-wp-block-type.php
@@ -494,20 +494,22 @@ class WP_Block_Type {
 	 * @return array Prepared block attributes.
 	 */
 	public function prepare_attributes_for_render( $attributes ) {
+		$attribute_schemas = $this->get_attributes_for_rest_validation();
+
 		// If there are no attribute definitions for the block type, skip
 		// processing and return verbatim.
-		if ( ! isset( $this->attributes ) ) {
+		if ( empty( $attribute_schemas ) ) {
 			return $attributes;
 		}
 
 		foreach ( $attributes as $attribute_name => $value ) {
 			// If the attribute is not defined by the block type, it cannot be
 			// validated.
-			if ( ! isset( $this->attributes[ $attribute_name ] ) ) {
+			if ( ! isset( $attribute_schemas[ $attribute_name ] ) ) {
 				continue;
 			}
 
-			$schema = $this->attributes[ $attribute_name ];
+			$schema = $attribute_schemas[ $attribute_name ];
 
 			// Validate value by JSON schema. An invalid value should revert to
 			// its default, if one exists. This occurs by virtue of the missing
@@ -521,7 +523,7 @@ class WP_Block_Type {
 
 		// Populate values of any missing attributes for which the block type
 		// defines a default.
-		$missing_schema_attributes = array_diff_key( $this->attributes, $attributes );
+		$missing_schema_attributes = array_diff_key( $attribute_schemas, $attributes );
 		foreach ( $missing_schema_attributes as $attribute_name => $schema ) {
 			if ( isset( $schema['default'] ) ) {
 				$attributes[ $attribute_name ] = $schema['default'];

--- a/src/wp-includes/class-wp-block-type.php
+++ b/src/wp-includes/class-wp-block-type.php
@@ -488,6 +488,7 @@ class WP_Block_Type {
 	 * defaulted and missing values.
 	 *
 	 * @since 5.0.0
+	 * @since 7.2.0 Avoids rich-text and other type invalidations by calling `$this->get_attributes_for_rest_validation()`.
 	 *
 	 * @param array $attributes Original block attributes.
 	 * @return array Prepared block attributes.
@@ -586,6 +587,38 @@ class WP_Block_Type {
 		return is_array( $this->attributes ) ?
 			$this->attributes :
 			array();
+	}
+
+	/**
+	 * Get all available block attributes, removing any quirks of the Blocks
+	 * API incompatible with JSON Schema.
+	 *
+	 * @see rest_validate_value_from_schema
+	 *
+	 * @since 7.2.0
+	 *
+	 * @return array Array of attributes.
+	 */
+	public function get_attributes_for_rest_validation() {
+		$attributes = $this->get_attributes();
+
+		// In the block editor, rich-text attributes are kept as instances of
+		// RichTextData, which is why the Blocks API has a dedicated
+		// "rich-text" type, distinct from "string".
+		//
+		// This is not a valid JSON Schema type, but we can replace it with
+		// "string", since any rich-text attribute handled by the server will
+		// appear in its serialised form, i.e. a string.
+		//
+		// TODO: Next, consider what to do with subtypes.
+		foreach ( $attributes as &$attr ) {
+			if ( isset( $attr['type'] ) && 'rich-text' === $attr['type'] ) {
+				$attr['type'] = 'string';
+			}
+		}
+		unset( $attr ); // Avoid dangerous dangling refs
+
+		return $attributes;
 	}
 
 	/**

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-block-renderer-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-block-renderer-controller.php
@@ -64,7 +64,7 @@ class WP_REST_Block_Renderer_Controller extends WP_REST_Controller {
 
 								$schema = array(
 									'type'                 => 'object',
-									'properties'           => $block->get_attributes(),
+									'properties'           => $block->get_attributes_for_rest_validation(),
 									'additionalProperties' => false,
 								);
 
@@ -80,7 +80,7 @@ class WP_REST_Block_Renderer_Controller extends WP_REST_Controller {
 
 								$schema = array(
 									'type'                 => 'object',
-									'properties'           => $block->get_attributes(),
+									'properties'           => $block->get_attributes_for_rest_validation(),
 									'additionalProperties' => false,
 								);
 

--- a/tests/phpunit/tests/blocks/wpBlockType.php
+++ b/tests/phpunit/tests/blocks/wpBlockType.php
@@ -202,6 +202,7 @@ class Tests_Blocks_wpBlockType extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 45097
+	 * @ticket 61406
 	 */
 	public function test_prepare_attributes() {
 		$attributes = array(
@@ -211,6 +212,8 @@ class Tests_Blocks_wpBlockType extends WP_UnitTestCase {
 			/* missingDefaulted */
 			'undefined'          => 'include',
 			'intendedNull'       => null,
+			'richTextCorrect'    => 'actually just a string',
+			'richTextWrong'      => 5,
 		);
 
 		$block_type = new WP_Block_Type(
@@ -235,6 +238,12 @@ class Tests_Blocks_wpBlockType extends WP_UnitTestCase {
 						'type'    => array( 'string', 'null' ),
 						'default' => 'wrong',
 					),
+					'richTextCorrect'    => array(
+						'type' => 'rich-text',
+					),
+					'richTextWrong'      => array(
+						'type' => 'rich-text',
+					),
 				),
 			)
 		);
@@ -249,6 +258,8 @@ class Tests_Blocks_wpBlockType extends WP_UnitTestCase {
 				'missingDefaulted'   => 'define',
 				'undefined'          => 'include',
 				'intendedNull'       => null,
+				'richTextCorrect'    => 'actually just a string',
+				/* richTextWrong */
 			),
 			$prepared_attributes
 		);

--- a/tests/phpunit/tests/rest-api/rest-block-renderer-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-block-renderer-controller.php
@@ -158,18 +158,22 @@ class REST_Block_Renderer_Controller_Test extends WP_Test_REST_Controller_Testca
 			self::$block_name,
 			array(
 				'attributes'      => array(
-					'some_string' => array(
+					'some_string'    => array(
 						'type'    => 'string',
 						'default' => 'some_default',
 					),
-					'some_int'    => array(
+					'some_int'       => array(
 						'type' => 'integer',
 					),
-					'some_array'  => array(
+					'some_array'     => array(
 						'type'  => 'array',
 						'items' => array(
 							'type' => 'integer',
 						),
+					),
+					'some_rich_text' => array(
+						'type'    => 'rich-text',
+						'default' => 'some_default',
 					),
 				),
 				'render_callback' => array( $this, 'render_test_block' ),
@@ -390,6 +394,7 @@ class REST_Block_Renderer_Controller_Test extends WP_Test_REST_Controller_Testca
 	 * Check getting item with attributes provided.
 	 *
 	 * @ticket 45098
+	 * @ticket 61406
 	 *
 	 * @covers WP_REST_Block_Renderer_Controller::get_item
 	 */
@@ -398,9 +403,12 @@ class REST_Block_Renderer_Controller_Test extends WP_Test_REST_Controller_Testca
 
 		$block_type = WP_Block_Type_Registry::get_instance()->get_registered( self::$block_name );
 		$attributes = array(
-			'some_int'    => '123',
-			'some_string' => 'foo',
-			'some_array'  => array( 1, '2', 3 ),
+			'some_int'       => '123',
+			'some_string'    => 'foo',
+			'some_array'     => array( 1, '2', 3 ),
+			// A rich-text attribute must pass validation (disguising as a
+			// string) and must be preserved through sanitization.
+			'some_rich_text' => 'Hello, <em>world</em>',
 		);
 
 		$expected_attributes               = $attributes;


### PR DESCRIPTION
Alternative to https://github.com/WordPress/wordpress-develop/pull/12333
Original report at https://github.com/WordPress/gutenberg/issues/72180

Trac ticket: https://core.trac.wordpress.org/ticket/61406

It currently differs from 12333 by introducing `WP_Block_Type::get_attributes_for_rest_validation`, a variation of the existing `::get_attributes`. Adding this new public method:

- gives visibility to the heretofore hidden schema discrepancy between block attribute schemas and JSON schema;
- allows other subsystems to rely on it, like the block-rendering REST endpoint.

## To do / questions

- [ ] Handle attribute subtypes, e.g. values of type `rich-text` in an array or object
- [ ] Should we be more prescriptive and treat sourced rich-text attributes and non-sourced rich-text attributes differently?
    - [ ] Pending: [get more info from issue reporters and decide](https://github.com/WordPress/gutenberg/issues/72180#issuecomment-5443012300)

## Testing instructions

Ensure that `rest_validate_value_from_schema` no longer calls `_doing_it_wrong` when validating a block containing rich-text attributes. **Note that the server cannot see [sourced attributes](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#value-source)**, which is why most Core blocks were never affected by this bug. So the bug can be created in two ways:
- use a dummy block type with a non-sourced rich-text attribute;
- save a core block type while artificially treating its rich-text attribute as non-sourced.

Here, we'll do the latter:
1. Make sure your `WP_DEBUG` is true
1. Start a new post
1. Switch to the code editor
1. Paste in the following source `<!-- wp:heading {"content":"foo"} /-->`
1. Save and preview the draft — **ensure no errors are displayed/logged**

Before | After
-|-
<img width="1172" height="908" alt="rest-rich-text-invalidation-before" src="https://github.com/user-attachments/assets/1321650e-0b4f-42de-9cbc-39fd4e347a97" /> | <img width="1172" height="908" alt="rest-rich-text-invalidation-after" src="https://github.com/user-attachments/assets/03f2586b-2d4e-447d-9e8a-991f58dbbaaa" />
