### PR TITLE
Templates for posts with the same title never get the slug suffix appended

### DIFF
--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -729,7 +729,8 @@ function _wp_build_title_and_description_for_single_post_type_block_template( $p
 	);
 
 	$args = array(
-		'title' => $post_title,
+		'title'          => $post_title,
+		'posts_per_page' => 2,
 	);
 	$args = wp_parse_args( $args, $default_args );
 

--- a/tests/phpunit/tests/block-templates/buildBlockTemplateResultFromPost.php
+++ b/tests/phpunit/tests/block-templates/buildBlockTemplateResultFromPost.php
@@ -177,6 +177,78 @@ class Tests_Block_Templates_BuildBlockTemplateResultFromPost extends WP_Block_Te
 	}
 
 	/**
+	 * @ticket 65966
+	 */
+	public function test_should_append_post_slug_to_title_when_posts_share_the_same_title() {
+		self::factory()->post->create(
+			array(
+				'post_title' => 'Same Title',
+				'post_name'  => 'first-post',
+			)
+		);
+		self::factory()->post->create(
+			array(
+				'post_title' => 'Same Title',
+				'post_name'  => 'second-post',
+			)
+		);
+
+		$template_post = self::factory()->post->create_and_get(
+			array(
+				'post_type'    => 'wp_template',
+				'post_name'    => 'single-post-first-post',
+				'post_title'   => 'single-post-first-post',
+				'post_content' => 'Content',
+				'post_excerpt' => '',
+				'tax_input'    => array(
+					'wp_theme' => array(
+						self::TEST_THEME,
+					),
+				),
+			)
+		);
+		wp_set_post_terms( $template_post->ID, self::TEST_THEME, 'wp_theme' );
+
+		$template = _build_block_template_result_from_post( $template_post );
+
+		$this->assertNotWPError( $template );
+		$this->assertSame( 'Post: Same Title (first-post)', $template->title );
+	}
+
+	/**
+	 * @ticket 65966
+	 */
+	public function test_should_not_append_post_slug_to_title_when_post_title_is_unique() {
+		self::factory()->post->create(
+			array(
+				'post_title' => 'Unique Title',
+				'post_name'  => 'unique-post',
+			)
+		);
+
+		$template_post = self::factory()->post->create_and_get(
+			array(
+				'post_type'    => 'wp_template',
+				'post_name'    => 'single-post-unique-post',
+				'post_title'   => 'single-post-unique-post',
+				'post_content' => 'Content',
+				'post_excerpt' => '',
+				'tax_input'    => array(
+					'wp_theme' => array(
+						self::TEST_THEME,
+					),
+				),
+			)
+		);
+		wp_set_post_terms( $template_post->ID, self::TEST_THEME, 'wp_theme' );
+
+		$template = _build_block_template_result_from_post( $template_post );
+
+		$this->assertNotWPError( $template );
+		$this->assertSame( 'Post: Unique Title', $template->title );
+	}
+
+	/**
 	 * @ticket 59646
 	 * @ticket 60506
 	 */

--- a/tests/phpunit/tests/block-templates/buildBlockTemplateResultFromPost.php
+++ b/tests/phpunit/tests/block-templates/buildBlockTemplateResultFromPost.php
@@ -228,10 +228,10 @@ class Tests_Block_Templates_BuildBlockTemplateResultFromPost extends WP_Block_Te
 		$first_template  = _build_block_template_result_from_post( $first_template_post );
 		$second_template = _build_block_template_result_from_post( $second_template_post );
 
-		$this->assertNotWPError( $first_template );
-		$this->assertSame( 'Post: Same Title (first-post)', $first_template->title );
-		$this->assertNotWPError( $second_template );
-		$this->assertSame( 'Post: Same Title (second-post)', $second_template->title );
+		$this->assertNotWPError( $first_template, 'Building the template for the first post should not return an error.' );
+		$this->assertSame( 'Post: Same Title (first-post)', $first_template->title, 'The title of the first post template should be suffixed with the post slug.' );
+		$this->assertNotWPError( $second_template, 'Building the template for the second post should not return an error.' );
+		$this->assertSame( 'Post: Same Title (second-post)', $second_template->title, 'The title of the second post template should be suffixed with the post slug.' );
 	}
 
 	/**
@@ -263,8 +263,8 @@ class Tests_Block_Templates_BuildBlockTemplateResultFromPost extends WP_Block_Te
 
 		$template = _build_block_template_result_from_post( $template_post );
 
-		$this->assertNotWPError( $template );
-		$this->assertSame( 'Post: Unique Title', $template->title );
+		$this->assertNotWPError( $template, 'Building the template should not return an error.' );
+		$this->assertSame( 'Post: Unique Title', $template->title, 'The template title should not be suffixed with the post slug when the post title is unique.' );
 	}
 
 	/**
@@ -321,10 +321,10 @@ class Tests_Block_Templates_BuildBlockTemplateResultFromPost extends WP_Block_Te
 		$first_template  = _build_block_template_result_from_post( $first_template_post );
 		$second_template = _build_block_template_result_from_post( $second_template_post );
 
-		$this->assertNotWPError( $first_template );
-		$this->assertSame( 'Tag: Same Name (first-tag)', $first_template->title );
-		$this->assertNotWPError( $second_template );
-		$this->assertSame( 'Tag: Same Name (second-tag)', $second_template->title );
+		$this->assertNotWPError( $first_template, 'Building the template for the first term should not return an error.' );
+		$this->assertSame( 'Tag: Same Name (first-tag)', $first_template->title, 'The title of the first term template should be suffixed with the term slug.' );
+		$this->assertNotWPError( $second_template, 'Building the template for the second term should not return an error.' );
+		$this->assertSame( 'Tag: Same Name (second-tag)', $second_template->title, 'The title of the second term template should be suffixed with the term slug.' );
 	}
 
 	/**
@@ -357,8 +357,8 @@ class Tests_Block_Templates_BuildBlockTemplateResultFromPost extends WP_Block_Te
 
 		$template = _build_block_template_result_from_post( $template_post );
 
-		$this->assertNotWPError( $template );
-		$this->assertSame( 'Category: Unique Category', $template->title );
+		$this->assertNotWPError( $template, 'Building the template should not return an error.' );
+		$this->assertSame( 'Category: Unique Category', $template->title, 'The template title should not be suffixed with the term slug when the term name is unique.' );
 	}
 
 	/**

--- a/tests/phpunit/tests/block-templates/buildBlockTemplateResultFromPost.php
+++ b/tests/phpunit/tests/block-templates/buildBlockTemplateResultFromPost.php
@@ -193,7 +193,7 @@ class Tests_Block_Templates_BuildBlockTemplateResultFromPost extends WP_Block_Te
 			)
 		);
 
-		$template_post = self::factory()->post->create_and_get(
+		$first_template_post = self::factory()->post->create_and_get(
 			array(
 				'post_type'    => 'wp_template',
 				'post_name'    => 'single-post-first-post',
@@ -207,12 +207,31 @@ class Tests_Block_Templates_BuildBlockTemplateResultFromPost extends WP_Block_Te
 				),
 			)
 		);
-		wp_set_post_terms( $template_post->ID, self::TEST_THEME, 'wp_theme' );
+		wp_set_post_terms( $first_template_post->ID, self::TEST_THEME, 'wp_theme' );
 
-		$template = _build_block_template_result_from_post( $template_post );
+		$second_template_post = self::factory()->post->create_and_get(
+			array(
+				'post_type'    => 'wp_template',
+				'post_name'    => 'single-post-second-post',
+				'post_title'   => 'single-post-second-post',
+				'post_content' => 'Content',
+				'post_excerpt' => '',
+				'tax_input'    => array(
+					'wp_theme' => array(
+						self::TEST_THEME,
+					),
+				),
+			)
+		);
+		wp_set_post_terms( $second_template_post->ID, self::TEST_THEME, 'wp_theme' );
 
-		$this->assertNotWPError( $template );
-		$this->assertSame( 'Post: Same Title (first-post)', $template->title );
+		$first_template  = _build_block_template_result_from_post( $first_template_post );
+		$second_template = _build_block_template_result_from_post( $second_template_post );
+
+		$this->assertNotWPError( $first_template );
+		$this->assertSame( 'Post: Same Title (first-post)', $first_template->title );
+		$this->assertNotWPError( $second_template );
+		$this->assertSame( 'Post: Same Title (second-post)', $second_template->title );
 	}
 
 	/**
@@ -246,6 +265,100 @@ class Tests_Block_Templates_BuildBlockTemplateResultFromPost extends WP_Block_Te
 
 		$this->assertNotWPError( $template );
 		$this->assertSame( 'Post: Unique Title', $template->title );
+	}
+
+	/**
+	 * @ticket 65966
+	 */
+	public function test_should_append_term_slug_to_title_when_terms_share_the_same_name() {
+		self::factory()->term->create(
+			array(
+				'taxonomy' => 'post_tag',
+				'name'     => 'Same Name',
+				'slug'     => 'first-tag',
+			)
+		);
+		self::factory()->term->create(
+			array(
+				'taxonomy' => 'post_tag',
+				'name'     => 'Same Name',
+				'slug'     => 'second-tag',
+			)
+		);
+
+		$first_template_post = self::factory()->post->create_and_get(
+			array(
+				'post_type'    => 'wp_template',
+				'post_name'    => 'tag-first-tag',
+				'post_title'   => 'tag-first-tag',
+				'post_content' => 'Content',
+				'post_excerpt' => '',
+				'tax_input'    => array(
+					'wp_theme' => array(
+						self::TEST_THEME,
+					),
+				),
+			)
+		);
+		wp_set_post_terms( $first_template_post->ID, self::TEST_THEME, 'wp_theme' );
+
+		$second_template_post = self::factory()->post->create_and_get(
+			array(
+				'post_type'    => 'wp_template',
+				'post_name'    => 'tag-second-tag',
+				'post_title'   => 'tag-second-tag',
+				'post_content' => 'Content',
+				'post_excerpt' => '',
+				'tax_input'    => array(
+					'wp_theme' => array(
+						self::TEST_THEME,
+					),
+				),
+			)
+		);
+		wp_set_post_terms( $second_template_post->ID, self::TEST_THEME, 'wp_theme' );
+
+		$first_template  = _build_block_template_result_from_post( $first_template_post );
+		$second_template = _build_block_template_result_from_post( $second_template_post );
+
+		$this->assertNotWPError( $first_template );
+		$this->assertSame( 'Tag: Same Name (first-tag)', $first_template->title );
+		$this->assertNotWPError( $second_template );
+		$this->assertSame( 'Tag: Same Name (second-tag)', $second_template->title );
+	}
+
+	/**
+	 * @ticket 65966
+	 */
+	public function test_should_not_append_term_slug_to_title_when_term_name_is_unique() {
+		self::factory()->term->create(
+			array(
+				'taxonomy' => 'category',
+				'name'     => 'Unique Category',
+				'slug'     => 'unique-category',
+			)
+		);
+
+		$template_post = self::factory()->post->create_and_get(
+			array(
+				'post_type'    => 'wp_template',
+				'post_name'    => 'category-unique-category',
+				'post_title'   => 'category-unique-category',
+				'post_content' => 'Content',
+				'post_excerpt' => '',
+				'tax_input'    => array(
+					'wp_theme' => array(
+						self::TEST_THEME,
+					),
+				),
+			)
+		);
+		wp_set_post_terms( $template_post->ID, self::TEST_THEME, 'wp_theme' );
+
+		$template = _build_block_template_result_from_post( $template_post );
+
+		$this->assertNotWPError( $template );
+		$this->assertSame( 'Category: Unique Category', $template->title );
 	}
 
 	/**


### PR DESCRIPTION



<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/65966


When a template is created for a specific post or page, _wp_build_title_and_description_for_single_post_type_block_template() is supposed to append the post slug to the computed template title when more posts share the same title, so they can be distinguished in the templates list.

That check can never match though. The second query only sets title and is merged into $default_args, which contains posts_per_page => 1, so count( $posts_with_same_title_query->posts ) > 1 is always false. This has been the case since the function was introduced in 6.1(https://github.com/WordPress/gutenberg/pull/43862).

### Steps to reproduce:

Create two published posts with the same title.
In the Site Editor, create a template for each of them (Templates > Add template > Single item: Post).
Both templates show the same title (Post: {title}), without the (slug) suffix.
The fix is to let the second query fetch up to two posts, same as the taxonomy variant already does with number => 2 in _wp_build_title_and_description_for_taxonomy_block_template():

```PHP
$args = array(
      'title'          => $post_title,
      'posts_per_page' => 2,
);
```
The taxonomy and author variants are not affected.

## Screenshots

<img width="630" height="528" alt="Screenshot 2026-08-26 at 1 26 34 PM" src="https://github.com/user-attachments/assets/3e6f12e2-53b8-4143-99d1-af5584cf4f77" />


## Use of AI Tools
Generated with Fable 5 and adjusted/reviewed manually.


<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
