### PR TITLE
Posts, Post Types: Improve checks for deprecation notice from get_the_excerpt

### DIFF
--- a/src/wp-includes/post-template.php
+++ b/src/wp-includes/post-template.php
@@ -407,12 +407,12 @@ function the_excerpt() {
  * @since 0.71
  * @since 4.5.0 Introduced the `$post` parameter.
  *
- * @param int|WP_Post|null $post Optional. Post ID or WP_Post object. Default is global $post.
+ * @param int|WP_Post $post Optional. Post ID or WP_Post object. Default is global $post.
  * @return string Post excerpt.
  */
 function get_the_excerpt( $post = null ) {
-	if ( is_bool( $post ) ) {
-		_deprecated_argument( __FUNCTION__, '2.3.0' );
+	if ( ! is_null( $post ) && ! is_numeric( $post ) && ! ( $post instanceof WP_Post ) ) {
+		_deprecated_argument( __FUNCTION__, '2.3.0', __( 'The bool $fakeit argument has been replaced with an int|WP_Post $post argument.' ) );
 	}
 
 	$post = get_post( $post );

--- a/tests/phpunit/tests/post/getTheExcerpt.php
+++ b/tests/phpunit/tests/post/getTheExcerpt.php
@@ -24,6 +24,42 @@ class Tests_Post_GetTheExcerpt extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 55523
+	 * @expectedDeprecated get_the_excerpt
+	 *
+	 * @dataProvider data_the_excerpt_deprecated_arguments
+	 */
+	public function test_the_excerpt_deprecated_for_invalid_arguments( $post ) {
+		$this->assertSame( '', get_the_excerpt( $post ) );
+	}
+
+	/**
+	 * Data provider for test_the_excerpt_deprecated_for_invalid_arguments().
+	 *
+	 * @return array[]
+	 */
+	public function data_the_excerpt_deprecated_arguments() {
+		return array(
+			array( 'invalid' ),
+			array( array() ),
+			array( new stdClass() ),
+		);
+	}
+
+	/**
+	 * @ticket 55523
+	 */
+	public function test_the_excerpt_should_not_be_deprecated_for_valid_arguments() {
+		$post            = self::factory()->post->create_and_get( array( 'post_excerpt' => 'Post excerpt' ) );
+		$GLOBALS['post'] = $post;
+
+		$this->assertSame( 'Post excerpt', get_the_excerpt() );
+		$this->assertSame( 'Post excerpt', get_the_excerpt( 0 ) );
+		$this->assertSame( 'Post excerpt', get_the_excerpt( (string) $post->ID ) );
+		$this->assertSame( 'Post excerpt', get_the_excerpt( $post ) );
+	}
+
+	/**
 	 * @ticket 27246
 	 */
 	public function test_the_excerpt() {


### PR DESCRIPTION
Improve the `get_the_excerpt()` deprecation check so it only warns for arguments that are neither `null`, numeric post IDs, nor `WP_Post` instances. The deprecation message now explains the replacement argument types, and focused PHPUnit coverage verifies both deprecated and accepted argument cases.

Trac ticket: https://core.trac.wordpress.org/ticket/55523

## Use of AI Tools

AI assistance: Yes
Tool(s): OpenAI Codex
Model(s): GPT-5
Used for: Ticket investigation, implementation, test design, and local validation; the final patch was reviewed and tested locally.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**