### PR TITLE
REST API: Fix status-only comment update route never running

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
@@ -913,6 +913,21 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 			return $prepared_args;
 		}
 
+		/*
+		 * `prepare_item_for_database()` always sets `comment_author_IP` (to the
+		 * request's remote address or the '127.0.0.1' fallback) and may set
+		 * `comment_agent` from the User-Agent header, even when neither field was
+		 * included in the update request.  Remove them here so that a status-only
+		 * update produces an empty `$prepared_args` array and is routed through the
+		 * lightweight `handle_status_param()` path rather than a full wp_update_comment().
+		 */
+		if ( ! isset( $request['author_ip'] ) ) {
+			unset( $prepared_args['comment_author_IP'] );
+		}
+		if ( ! isset( $request['author_user_agent'] ) ) {
+			unset( $prepared_args['comment_agent'] );
+		}
+
 		if ( ! empty( $prepared_args['comment_post_ID'] ) ) {
 			$post = get_post( $prepared_args['comment_post_ID'] );
 

--- a/tests/phpstan/baselines/if.alwaysFalse.neon
+++ b/tests/phpstan/baselines/if.alwaysFalse.neon
@@ -37,11 +37,6 @@ parameters:
 			message: '#^If condition is always false\.$#'
 			identifier: if.alwaysFalse
 			count: 1
-			path: ../../../src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
-		-
-			message: '#^If condition is always false\.$#'
-			identifier: if.alwaysFalse
-			count: 1
 			path: ../../../src/wp-includes/template.php
 		-
 			message: '#^If condition is always false\.$#'

--- a/tests/phpunit/tests/rest-api/rest-comments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-comments-controller.php
@@ -3044,11 +3044,11 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 
 		$comment_id = self::factory()->comment->create(
 			array(
-				'comment_approved'    => 0,
-				'comment_post_ID'     => self::$post_id,
-				'comment_content'     => $original_content,
-				'comment_author_IP'   => $original_ip,
-				'comment_agent'       => $original_agent,
+				'comment_approved'  => 0,
+				'comment_post_ID'   => self::$post_id,
+				'comment_content'   => $original_content,
+				'comment_author_IP' => $original_ip,
+				'comment_agent'     => $original_agent,
 			)
 		);
 

--- a/tests/phpunit/tests/rest-api/rest-comments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-comments-controller.php
@@ -3030,6 +3030,83 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 	}
 
 	/**
+	 * Tests that a status-only update routes through handle_status_param() and does not
+	 * overwrite comment fields that were not included in the request.
+	 *
+	 * @ticket 64248
+	 */
+	public function test_update_comment_status_only_does_not_overwrite_existing_fields() {
+		wp_set_current_user( self::$admin_id );
+
+		$original_ip      = '203.0.113.42';
+		$original_agent   = 'TestBrowser/1.0';
+		$original_content = 'Original comment content.';
+
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_approved'    => 0,
+				'comment_post_ID'     => self::$post_id,
+				'comment_content'     => $original_content,
+				'comment_author_IP'   => $original_ip,
+				'comment_agent'       => $original_agent,
+			)
+		);
+
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/comments/%d', $comment_id ) );
+		$request->add_header( 'Content-Type', 'application/json' );
+		$request->add_header( 'User-Agent', 'DifferentAgent/2.0' );
+		$request->set_body( wp_json_encode( array( 'status' => 'approve' ) ) );
+
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertSame( 200, $response->get_status() );
+
+		$updated = get_comment( $comment_id );
+		$this->assertSame( '1', $updated->comment_approved, 'Comment status should be updated to approved.' );
+		$this->assertSame( $original_content, $updated->comment_content, 'Comment content should not be overwritten.' );
+		$this->assertSame( $original_ip, $updated->comment_author_IP, 'Comment author IP should not be overwritten by a status-only update.' );
+		$this->assertSame( $original_agent, $updated->comment_agent, 'Comment agent should not be overwritten by a status-only update.' );
+	}
+
+	/**
+	 * Tests that a status-only update does not trigger wp_update_comment().
+	 *
+	 * When only status is being changed the lightweight handle_status_param() path
+	 * should be taken instead of a full wp_update_comment() call.
+	 *
+	 * @ticket 64248
+	 */
+	public function test_update_comment_status_only_uses_handle_status_param_path() {
+		wp_set_current_user( self::$admin_id );
+
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_approved' => 0,
+				'comment_post_ID'  => self::$post_id,
+			)
+		);
+
+		$wp_update_comment_called = false;
+		add_filter(
+			'wp_update_comment_data',
+			static function ( $data ) use ( &$wp_update_comment_called ) {
+				$wp_update_comment_called = true;
+				return $data;
+			}
+		);
+
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/comments/%d', $comment_id ) );
+		$request->add_header( 'Content-Type', 'application/json' );
+		$request->set_body( wp_json_encode( array( 'status' => 'approve' ) ) );
+
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertFalse( $wp_update_comment_called, 'wp_update_comment() should not be called for a status-only update.' );
+
+		$updated = get_comment( $comment_id );
+		$this->assertSame( '1', $updated->comment_approved, 'Comment status should be updated to approved.' );
+	}
+
+	/**
 	 * Blocks comments from being updated by returning WP_Error.
 	 */
 	public function _wp_update_comment_data_filter( $data, $comment, $commentarr ) {


### PR DESCRIPTION
<!-- wp:heading -->
Trac ticket: https://core.trac.wordpress.org/ticket/64248

## Description

When only `status` is changed via the REST API (`PUT /wp/v2/comments/{id}`), `update_item()` is supposed to take a lightweight path through `handle_status_param()` rather than a full `wp_update_comment()` call:

```php
if ( empty( $prepared_args ) && isset( $request['status'] ) ) {
    // Only the comment status is being changed.
    $change = $this->handle_status_param( $request['status'], $id );
    ...
}
```

This path **never runs** because `prepare_item_for_database()` unconditionally sets `comment_author_IP` — falling back to `$_SERVER['REMOTE_ADDR']` or `'127.0.0.1'` — so `$prepared_args` is always non-empty.

The bug was introduced in [#38819](https://core.trac.wordpress.org/ticket/38819) and has existed since 4.7.

## Fix

In `update_item()`, after calling `prepare_item_for_database()`, unset `comment_author_IP` and `comment_agent` from `$prepared_args` unless the caller explicitly included `author_ip` or `author_user_agent` in the request body. This restores the intended routing without changing create behaviour.

## Testing

Two new PHPUnit tests added to `WP_Test_REST_Comments_Controller`:

- `test_update_comment_status_only_does_not_overwrite_existing_fields()` — verifies that a status-only `PUT` does not overwrite the stored IP, agent, or content.
- `test_update_comment_status_only_uses_handle_status_param_path()` — verifies that `wp_update_comment_data` filter is **not** triggered (i.e. `wp_update_comment()` is not called) on a status-only update.

## Use of AI Tools

Generated with Claude Sonnet and adjusted/reviewed manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)