### PR TITLE
Administration: Hide the cb column in list table body rows when it is hidden

### DIFF
--- a/src/wp-admin/includes/class-wp-list-table.php
+++ b/src/wp-admin/includes/class-wp-list-table.php
@@ -1822,7 +1822,13 @@ class WP_List_Table {
 			$attributes = "class='$classes' $data";
 
 			if ( 'cb' === $column_name ) {
-				echo '<td class="check-column">';
+				$cb_classes = 'check-column';
+
+				if ( in_array( $column_name, $hidden, true ) ) {
+					$cb_classes .= ' hidden';
+				}
+
+				echo '<td class="' . $cb_classes . '">';
 				echo $this->column_cb( $item );
 				echo '</td>';
 			} elseif ( method_exists( $this, '_column_' . $column_name ) ) {

--- a/tests/phpunit/tests/admin/wpListTable.php
+++ b/tests/phpunit/tests/admin/wpListTable.php
@@ -592,4 +592,75 @@ class Tests_Admin_WpListTable extends WP_UnitTestCase {
 
 		$this->assertStringContainsString( $expected_html, $actual );
 	}
+
+	/**
+	 * Tests that `WP_List_Table::single_row_columns()` hides the checkbox column
+	 * when it is included in the hidden columns.
+	 *
+	 * @ticket 65968
+	 *
+	 * @covers WP_List_Table::single_row_columns
+	 */
+	public function test_single_row_columns_should_hide_the_checkbox_column_when_hidden() {
+		$list_table = $this->get_list_table_with_checkbox_column( array( 'cb' ) );
+
+		$actual = get_echo( array( $list_table, 'single_row_columns' ), array( array( 'name' => 'Alpha' ) ) );
+
+		$this->assertStringContainsString(
+			'<td class="check-column hidden">',
+			$actual,
+			'The checkbox column should be given the "hidden" class.'
+		);
+	}
+
+	/**
+	 * Tests that `WP_List_Table::single_row_columns()` does not hide the checkbox
+	 * column when it is not included in the hidden columns.
+	 *
+	 * @ticket 65968
+	 *
+	 * @covers WP_List_Table::single_row_columns
+	 */
+	public function test_single_row_columns_should_not_hide_the_checkbox_column_when_not_hidden() {
+		$list_table = $this->get_list_table_with_checkbox_column( array() );
+
+		$actual = get_echo( array( $list_table, 'single_row_columns' ), array( array( 'name' => 'Alpha' ) ) );
+
+		$this->assertStringContainsString(
+			'<td class="check-column">',
+			$actual,
+			'The checkbox column should not be given the "hidden" class.'
+		);
+	}
+
+	/**
+	 * Returns a list table with a checkbox column and the given hidden columns.
+	 *
+	 * @param string[] $hidden Array of IDs of hidden columns.
+	 * @return WP_List_Table List table instance.
+	 */
+	private function get_list_table_with_checkbox_column( $hidden ) {
+		return new class( $hidden ) extends WP_List_Table {
+			public function __construct( $hidden ) {
+				parent::__construct( array( 'screen' => '_wp_tests_checkbox_column' ) );
+
+				$this->_column_headers = array( $this->get_columns(), $hidden, array() );
+			}
+
+			public function get_columns() {
+				return array(
+					'cb'   => '<input type="checkbox" />',
+					'name' => 'Name',
+				);
+			}
+
+			protected function column_cb( $item ) {
+				return '<input type="checkbox" />';
+			}
+
+			protected function column_default( $item, $column_name ) {
+				return $item[ $column_name ] ?? '';
+			}
+		};
+	}
 }


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65968

## What

When `cb` is included in a list table's hidden columns, `<thead>` and `<tfoot>` hide it but `<tbody>` does not, so every row still renders a checkbox cell.

`WP_List_Table::print_column_headers()` honours `$hidden` for every column including `cb`, but `single_row_columns()` short-circuits the `cb` case before `$classes` is used and always emits `<td class="check-column">`.

On a wide screen the still-visible body cell also absorbs the width freed by the hidden header, so it renders ~330px wide instead of ~35px and pushes the remaining columns out of alignment.

## How

Apply the `hidden` class to the checkbox cell when `cb` is in `$hidden`. `$hidden` is already available from the `get_column_info()` call at the top of the method.

## Test

1. Create a list table with a `cb` column that sets `$this->_column_headers = array( $this->get_columns(), array( 'cb' ), array() );` and render it on an admin page.
2. Before: the header and footer hide the checkbox column, but every body row shows an empty checkbox cell and the columns are misaligned.
3. After: the checkbox column is hidden in the body too, at both desktop and sub-782px widths, and the columns line up.
4. Confirm Posts, Plugins and Users are unchanged, since `cb` is not hidden there.

## Screenshots

**Before -**

<img width="998" height="148" alt="t65968-before" src="https://github.com/user-attachments/assets/0367159a-535f-42b5-8161-8f023303e93a" />

**After -** 

<img width="998" height="148" alt="t65968-after" src="https://github.com/user-attachments/assets/d975180c-f481-4b9a-a522-442394ea90cd" />

**No regression -** 

<img width="998" height="225" alt="t65968-posts-no-regression" src="https://github.com/user-attachments/assets/8f148e47-e3e9-48d2-b649-6f0d3390f631" />

## AI Usage

AI assistance: Yes
Tool(s): Claude Code
Model(s): Opus 5
Used for: drafting the fix and unit tests