### PR TITLE
Build/Test Tools: Discard stale roles before reinstalling the test tables

### DIFF
--- a/tests/phpunit/includes/install.php
+++ b/tests/phpunit/includes/install.php
@@ -79,6 +79,15 @@ foreach ( $wpdb->tables( 'ms_global' ) as $table => $prefixed_table ) {
 }
 $wpdb->query( 'SET foreign_key_checks = 1' );
 
+/*
+ * Discard the roles object created while bootstrapping WordPress above, as it
+ * holds role data loaded from the tables that were just dropped. If it were
+ * kept, populate_roles() would see the default roles as already existing and
+ * write the stale capabilities back to the database. The next call to
+ * wp_roles() recreates the object after the fresh tables are in place.
+ */
+unset( $GLOBALS['wp_roles'] );
+
 // Prefill a permalink structure so that WP doesn't try to determine one itself.
 add_action( 'populate_options', '_set_default_permalink_structure_for_tests' );
 


### PR DESCRIPTION
The test installer loads `wp-settings.php` before it drops and recreates the test tables, so the global `WP_Roles` object is created from the previous run's data. `populate_roles()` then sees the default roles as already existing on that object and writes the stale capabilities back into the fresh tables. Role data from a previous run therefore survives reinstallation until the database is dropped by hand. This affects the Core test installer only, not production WordPress installs.

This change discards the roles object right after the tables are dropped. `wp_roles()` recreates it lazily inside `populate_roles()`, which runs after `wp_install()` has created the fresh tables, so every run starts from the default roles.

Reproduction steps, the full verification list and the same patch as a diff are on the ticket. Verified on single site and multisite install paths, on repeated runs, and end to end on a fresh clone with a new database. `WP_TESTS_SKIP_INSTALL=1` behaviour is unchanged.

Trac ticket: https://core.trac.wordpress.org/ticket/65972

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code, Codex (testing and review)
The investigation, verification and final decisions are mine, and I take responsibility for the change.