### PR TITLE
Block supports: Add the has-fit-text class when rendering fit text on the server

### DIFF
--- a/src/wp-includes/block-supports/typography.php
+++ b/src/wp-includes/block-supports/typography.php
@@ -311,11 +311,6 @@ function wp_render_typography_support( $block_content, $block ) {
 		if ( ! empty( $block_content ) ) {
 			$processor = new WP_HTML_Tag_Processor( $block_content );
 			if ( $processor->next_tag() ) {
-				/*
-				 * Static blocks serialize this class into their saved markup, but
-				 * dynamically rendered blocks have no save step, so it is added here.
-				 * `add_class()` is a no-op when the class is already present.
-				 */
 				$processor->add_class( 'has-fit-text' );
 				if ( ! $processor->get_attribute( 'data-wp-interactive' ) ) {
 					$processor->set_attribute( 'data-wp-interactive', true );

--- a/src/wp-includes/block-supports/typography.php
+++ b/src/wp-includes/block-supports/typography.php
@@ -311,6 +311,12 @@ function wp_render_typography_support( $block_content, $block ) {
 		if ( ! empty( $block_content ) ) {
 			$processor = new WP_HTML_Tag_Processor( $block_content );
 			if ( $processor->next_tag() ) {
+				/*
+				 * Static blocks serialize this class into their saved markup, but
+				 * dynamically rendered blocks have no save step, so it is added here.
+				 * `add_class()` is a no-op when the class is already present.
+				 */
+				$processor->add_class( 'has-fit-text' );
 				if ( ! $processor->get_attribute( 'data-wp-interactive' ) ) {
 					$processor->set_attribute( 'data-wp-interactive', true );
 				}

--- a/tests/phpunit/tests/block-supports/typography.php
+++ b/tests/phpunit/tests/block-supports/typography.php
@@ -1136,6 +1136,80 @@ class Tests_Block_Supports_Typography extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that the `has-fit-text` class name is added to the block wrapper when the
+	 * `fitText` attribute is set.
+	 *
+	 * @ticket 65973
+	 *
+	 * @covers ::wp_render_typography_support
+	 *
+	 * @dataProvider data_should_add_fit_text_class_name
+	 *
+	 * @param string $block_content  HTML block content.
+	 * @param string $expected_class Expected value of the class attribute on the block wrapper.
+	 */
+	public function test_should_add_fit_text_class_name( $block_content, $expected_class ) {
+		$block = array(
+			'blockName' => 'core/site-title',
+			'attrs'     => array(
+				'fitText' => true,
+			),
+		);
+
+		$actual = wp_render_typography_support( $block_content, $block );
+
+		$processor = new WP_HTML_Tag_Processor( $actual );
+		$processor->next_tag();
+
+		$this->assertSame( $expected_class, $processor->get_attribute( 'class' ), 'The block wrapper does not have the expected class names.' );
+		$this->assertSame( 1, substr_count( $actual, 'has-fit-text' ), 'The class name should be added exactly once, to the outermost tag only.' );
+	}
+
+	/**
+	 * Data provider for test_should_add_fit_text_class_name().
+	 *
+	 * @return array
+	 */
+	public function data_should_add_fit_text_class_name() {
+		return array(
+			'wrapper without a class attribute' => array(
+				'block_content'  => '<h1>Site Title</h1>',
+				'expected_class' => 'has-fit-text',
+			),
+			'wrapper with existing class names' => array(
+				'block_content'  => '<h1 class="wp-block-site-title"><a href="https://example.com">Site Title</a></h1>',
+				'expected_class' => 'wp-block-site-title has-fit-text',
+			),
+			'wrapper with an already serialized class name' => array(
+				'block_content'  => '<p class="has-fit-text">A paragraph</p>',
+				'expected_class' => 'has-fit-text',
+			),
+			'wrapper with inner blocks'         => array(
+				'block_content'  => '<div class="wp-block-group"><p>A paragraph inside a group</p></div>',
+				'expected_class' => 'wp-block-group has-fit-text',
+			),
+		);
+	}
+
+	/**
+	 * Tests that the `has-fit-text` class name is not added when the block does not
+	 * opt in to the fit text support.
+	 *
+	 * @ticket 65973
+	 *
+	 * @covers ::wp_render_typography_support
+	 */
+	public function test_should_not_add_fit_text_class_name_without_fit_text_attribute() {
+		$block_content = '<h1 class="wp-block-site-title">Site Title</h1>';
+		$block         = array(
+			'blockName' => 'core/site-title',
+			'attrs'     => array(),
+		);
+
+		$this->assertSame( $block_content, wp_render_typography_support( $block_content, $block ) );
+	}
+
+	/**
 	 * Tests that valid font size values are parsed.
 	 *
 	 * @ticket 56467

--- a/tests/phpunit/tests/block-supports/typography.php
+++ b/tests/phpunit/tests/block-supports/typography.php
@@ -1148,8 +1148,8 @@ class Tests_Block_Supports_Typography extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_should_add_fit_text_class_name
 	 *
-	 * @param string $block_content  HTML block content.
-	 * @param string $expected_class Expected value of the class attribute on the block wrapper.
+	 * @param non-falsy-string $block_content  HTML block content.
+	 * @param non-falsy-string $expected_class Expected value of the class attribute on the block wrapper.
 	 */
 	public function test_should_add_fit_text_class_name( string $block_content, string $expected_class ) {
 		$block = array(

--- a/tests/phpunit/tests/block-supports/typography.php
+++ b/tests/phpunit/tests/block-supports/typography.php
@@ -1151,7 +1151,7 @@ class Tests_Block_Supports_Typography extends WP_UnitTestCase {
 	 * @param string $block_content  HTML block content.
 	 * @param string $expected_class Expected value of the class attribute on the block wrapper.
 	 */
-	public function test_should_add_fit_text_class_name( $block_content, $expected_class ) {
+	public function test_should_add_fit_text_class_name( string $block_content, string $expected_class ) {
 		$block = array(
 			'blockName' => 'core/site-title',
 			'attrs'     => array(

--- a/tests/phpunit/tests/block-supports/typography.php
+++ b/tests/phpunit/tests/block-supports/typography.php
@@ -1171,9 +1171,9 @@ class Tests_Block_Supports_Typography extends WP_UnitTestCase {
 	/**
 	 * Data provider for test_should_add_fit_text_class_name().
 	 *
-	 * @return array
+	 * @return array<non-falsy-string, array{ block_content: non-falsy-string, expected_class: non-falsy-string }>
 	 */
-	public function data_should_add_fit_text_class_name() {
+	public function data_should_add_fit_text_class_name(): array {
 		return array(
 			'wrapper without a class attribute' => array(
 				'block_content'  => '<h1>Site Title</h1>',

--- a/tests/phpunit/tests/block-supports/typography.php
+++ b/tests/phpunit/tests/block-supports/typography.php
@@ -58,6 +58,9 @@ class Tests_Block_Supports_Typography extends WP_UnitTestCase {
 		unregister_block_type( $this->test_block_name );
 		$this->test_block_name = null;
 
+		// Resets script modules enqueued while rendering fit text.
+		$GLOBALS['wp_script_modules'] = null;
+
 		parent::tear_down();
 	}
 


### PR DESCRIPTION
Applies the PHP portion of https://github.com/WordPress/gutenberg/pull/82074 to Core.

Trac ticket: https://core.trac.wordpress.org/ticket/65973

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Porting the change from the linked Gutenberg PR and drafting the unit tests; reviewed and edited by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
