### PR TITLE
Toolbar: remove white background from transparent site icon

### DIFF
--- a/src/wp-admin/css/site-icon.css
+++ b/src/wp-admin/css/site-icon.css
@@ -97,7 +97,7 @@
 .site-icon-preview .app-icon-preview {
 	aspect-ratio: 1/1;
 	border-radius: 10px;
-	box-shadow: 0 1px 5px 0 var(--site-icon-shadow-3);
+	filter: drop-shadow(0 1px 5px var(--site-icon-shadow-3));
 	flex-shrink: 0;
 	width: 100%;
 	z-index: 1;

--- a/src/wp-includes/css/admin-bar.css
+++ b/src/wp-includes/css/admin-bar.css
@@ -601,7 +601,6 @@ html:lang(he-il) .rtl #wpadminbar * {
 #wpadminbar #wp-admin-bar-site-name > .ab-item .site-icon {
 	width: 20px;
 	height: 20px;
-	background: #f0f0f1; /* matching my-account (user avatar) node's background */
 	border-radius: 2px;
 }
 


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65974

This PR removes white background from transparent site icons. This is done so that site icons maintain their original shape.

I actually implemented the initial background color so that the site icons are consistently square, but now that the feature is live and I've seen some client sites, I think it's a mistake. In some brands, the shape of a transparent site icon gets weird with the added white rounded square.

With this change, these 4 places are now consistent:

- toolbar
- browser tabs (at least Chrome and Firefox show transparent favicons as-is)
- Settings -> General site icon preview
- Site Editor -> Identity -> Site Icon form input

---

### Solid site icon (no change)

Toolbar

<img width="196" height="32" alt="image" src="https://github.com/user-attachments/assets/13ca45d4-3a0a-48dc-af60-3147230d9cce" />

Settings -> General

<img width="400" alt="image" src="https://github.com/user-attachments/assets/1ca2f485-8ce8-4d87-8ddd-ee8fe9181bf9" />

Site Editor -> Identity

<img width="354" height="82" alt="image" src="https://github.com/user-attachments/assets/e9267d22-fea0-490f-a5cd-302f873a5196" />


Actual browser Chrome tab

<img width="240" height="40" alt="image" src="https://github.com/user-attachments/assets/e683f558-0d0e-4b0a-ad71-0b198fe189c1" />

---

### Transparent site icon

Toolbar - BEFORE vs AFTER

<img width="196" height="32" alt="image" src="https://github.com/user-attachments/assets/60d95647-b125-42d2-a86e-cc3db5634579" />
<br>
<img width="196" height="32" alt="image" src="https://github.com/user-attachments/assets/e9b4f59b-6dd0-4d2e-93a8-264a55586294" />

Settings -> General - BEFORE vs AFTER

<img width="400" alt="image" src="https://github.com/user-attachments/assets/5b540c80-daca-4bc5-a2c1-d694769910a6" />
<br>
<img width="400" alt="image" src="https://github.com/user-attachments/assets/570651df-0f7c-4e43-9d4a-c0f46a09c4dc" />

Site Editor -> Identity

<img width="346" height="77" alt="image" src="https://github.com/user-attachments/assets/054d1c89-102d-4ef4-9b39-b6e2d0a0a7d9" />

Actual browser (Chrome) tab

<img width="246" height="42" alt="image" src="https://github.com/user-attachments/assets/1c345b10-4053-4500-8fea-a214fcf56fa6" />



## Use of AI Tools

Used Claude Code, Opus 5 to help generate the CSS changes.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
