### PR TITLE
Upgrade/Install: Update Sodium Compat to 1.24.1

### DIFF
--- a/src/wp-includes/sodium_compat/src/Core/Curve25519.php
+++ b/src/wp-includes/sodium_compat/src/Core/Curve25519.php
@@ -2899,6 +2899,7 @@ abstract class ParagonIE_Sodium_Core_Curve25519 extends ParagonIE_Sodium_Core_Cu
                 # ge_sub(&t, &u, &Ai[(-aslide[i]) / 2]);
                 $t = self::ge_sub($u, $Ai[(int)(-$aslide[$i] / 2)]);
             }
+            $r = self::ge_p1p1_to_p3($t);
         }
 
         # ge_p1p1_to_p3(r, &t);

--- a/src/wp-includes/sodium_compat/src/Core/Ed25519.php
+++ b/src/wp-includes/sodium_compat/src/Core/Ed25519.php
@@ -119,7 +119,7 @@ abstract class ParagonIE_Sodium_Core_Ed25519 extends ParagonIE_Sodium_Core_Curve
     {
         $p1 = self::ge_mul_l($A);
         $t = self::fe_sub($p1->Y, $p1->Z);
-        return self::fe_isnonzero($p1->X) && self::fe_isnonzero($t);
+        return !self::fe_isnonzero($p1->X) && !self::fe_isnonzero($t);
     }
 
     /**

--- a/src/wp-includes/sodium_compat/src/Core32/Curve25519.php
+++ b/src/wp-includes/sodium_compat/src/Core32/Curve25519.php
@@ -3154,6 +3154,7 @@ abstract class ParagonIE_Sodium_Core32_Curve25519 extends ParagonIE_Sodium_Core3
                 # ge_sub(&t, &u, &Ai[(-aslide[i]) / 2]);
                 $t = self::ge_sub($u, $Ai[(int)(-$aslide[$i] / 2)]);
             }
+            $r = self::ge_p1p1_to_p3($t);
         }
         # ge_p1p1_to_p3(r, &t);
         return self::ge_p1p1_to_p3($t);

--- a/src/wp-includes/sodium_compat/src/Core32/Ed25519.php
+++ b/src/wp-includes/sodium_compat/src/Core32/Ed25519.php
@@ -107,6 +107,22 @@ abstract class ParagonIE_Sodium_Core32_Ed25519 extends ParagonIE_Sodium_Core32_C
     }
 
     /**
+     * Returns TRUE if $A represents a point on the order of the Edwards25519 prime order subgroup.
+     * Returns FALSE if $A is on a different subgroup.
+     *
+     * @param ParagonIE_Sodium_Core32_Curve25519_Ge_P3 $A
+     * @return bool
+     *
+     * @throws SodiumException
+     */
+    public static function is_on_main_subgroup(ParagonIE_Sodium_Core32_Curve25519_Ge_P3 $A)
+    {
+        $p1 = self::ge_mul_l($A);
+        $t = self::fe_sub($p1->Y, $p1->Z);
+        return !self::fe_isnonzero($p1->X) && !self::fe_isnonzero($t);
+    }
+
+    /**
      * @param string $pk
      * @return string
      * @throws SodiumException
@@ -118,9 +134,8 @@ abstract class ParagonIE_Sodium_Core32_Ed25519 extends ParagonIE_Sodium_Core32_C
             throw new SodiumException('Public key is on a small order');
         }
         $A = self::ge_frombytes_negate_vartime($pk);
-        $p1 = self::ge_mul_l($A);
-        if (!self::fe_isnonzero($p1->X)) {
-            throw new SodiumException('Unexpected zero result');
+        if (!self::is_on_main_subgroup($A)) {
+            throw new SodiumException('Public key is not on a member of the main subgroup');
         }
 
         # fe_1(one_minus_y);
@@ -307,6 +322,9 @@ abstract class ParagonIE_Sodium_Core32_Ed25519 extends ParagonIE_Sodium_Core32_C
 
         /** @var ParagonIE_Sodium_Core32_Curve25519_Ge_P3 $A */
         $A = self::ge_frombytes_negate_vartime($pk);
+        if (!self::is_on_main_subgroup($A)) {
+            throw new SodiumException('Public key is not on a member of the main subgroup');
+        }
 
         /** @var string $hDigest */
         $hDigest = hash(

--- a/src/wp-includes/sodium_compat/src/File.php
+++ b/src/wp-includes/sodium_compat/src/File.php
@@ -1329,8 +1329,14 @@ class ParagonIE_Sodium_File extends ParagonIE_Sodium_Core_Util
         // Set ParagonIE_Sodium_Compat::$fastMult to true to speed up verification.
         ParagonIE_Sodium_Compat::$fastMult = true;
 
+        if (ParagonIE_Sodium_Core32_Ed25519::small_order($publicKey)) {
+            throw new SodiumException('Public key has small order');
+        }
         /** @var ParagonIE_Sodium_Core32_Curve25519_Ge_P3 $A */
         $A = ParagonIE_Sodium_Core32_Ed25519::ge_frombytes_negate_vartime($publicKey);
+        if (!ParagonIE_Sodium_Core32_Ed25519::is_on_main_subgroup($A)) {
+            throw new SodiumException('Public key is not on a member of the main subgroup');
+        }
 
         $hs = hash_init('sha512');
         self::hash_update($hs, self::substr($sig, 0, 32));


### PR DESCRIPTION
### Ticket

Trac ticket: https://core.trac.wordpress.org/ticket/65903

### Description

Updates `sodium_compat` from v1.24.0 to v1.24.1.

This release fixes Ed25519 main subgroup validation and ensures public key validation correctly rejects points not on the main prime order subgroup across 64-bit and 32-bit implementations.

References:
- Upstream PR: https://github.com/paragonie/sodium_compat/pull/207
- Full diff: https://github.com/paragonie/sodium_compat/compare/v1.24.0...v1.24.1

### Testing Instructions

Verify that `sodium_compat` loads and functions as expected without errors.