### PR TITLE
Options, Meta APIs: Pass $delete_all to the delete_{$meta_type}_meta and deleted_{$meta_type}_meta actions.

### DIFF
--- a/src/wp-includes/meta.php
+++ b/src/wp-includes/meta.php
@@ -491,13 +491,16 @@ function delete_metadata( $meta_type, $object_id, $meta_key, $meta_value = '', $
 	 *  - `delete_user_meta`
 	 *
 	 * @since 3.1.0
+	 * @since 7.2.0 The `$delete_all` parameter was added.
 	 *
 	 * @param string[] $meta_ids    An array of metadata entry IDs to delete.
 	 * @param int      $object_id   ID of the object metadata is for.
 	 * @param string   $meta_key    Metadata key.
 	 * @param mixed    $_meta_value Metadata value.
+	 * @param bool     $delete_all  Whether the matching metadata entries are deleted
+	 *                              for all objects, ignoring the specified $object_id.
 	 */
-	do_action( "delete_{$meta_type}_meta", $meta_ids, $object_id, $meta_key, $_meta_value );
+	do_action( "delete_{$meta_type}_meta", $meta_ids, $object_id, $meta_key, $_meta_value, $delete_all );
 
 	// Old-style action.
 	if ( 'post' === $meta_type ) {
@@ -541,13 +544,16 @@ function delete_metadata( $meta_type, $object_id, $meta_key, $meta_value = '', $
 	 *  - `deleted_user_meta`
 	 *
 	 * @since 2.9.0
+	 * @since 7.2.0 The `$delete_all` parameter was added.
 	 *
 	 * @param string[] $meta_ids    An array of metadata entry IDs to delete.
 	 * @param int      $object_id   ID of the object metadata is for.
 	 * @param string   $meta_key    Metadata key.
 	 * @param mixed    $_meta_value Metadata value.
+	 * @param bool     $delete_all  Whether the matching metadata entries are deleted
+	 *                              for all objects, ignoring the specified $object_id.
 	 */
-	do_action( "deleted_{$meta_type}_meta", $meta_ids, $object_id, $meta_key, $_meta_value );
+	do_action( "deleted_{$meta_type}_meta", $meta_ids, $object_id, $meta_key, $_meta_value, $delete_all );
 
 	// Old-style action.
 	if ( 'post' === $meta_type ) {
@@ -1063,7 +1069,7 @@ function delete_metadata_by_mid( $meta_type, $meta_id ) {
 		$object_id = (int) $meta->{$column};
 
 		/** This action is documented in wp-includes/meta.php */
-		do_action( "delete_{$meta_type}_meta", (array) $meta_id, $object_id, $meta->meta_key, $meta->meta_value );
+		do_action( "delete_{$meta_type}_meta", (array) $meta_id, $object_id, $meta->meta_key, $meta->meta_value, false );
 
 		// Old-style action.
 		if ( 'post' === $meta_type || 'comment' === $meta_type ) {
@@ -1092,7 +1098,7 @@ function delete_metadata_by_mid( $meta_type, $meta_id ) {
 		wp_cache_delete( $object_id, $meta_type . '_meta' );
 
 		/** This action is documented in wp-includes/meta.php */
-		do_action( "deleted_{$meta_type}_meta", (array) $meta_id, $object_id, $meta->meta_key, $meta->meta_value );
+		do_action( "deleted_{$meta_type}_meta", (array) $meta_id, $object_id, $meta->meta_key, $meta->meta_value, false );
 
 		// Old-style action.
 		if ( 'post' === $meta_type || 'comment' === $meta_type ) {

--- a/tests/phpunit/tests/meta/deleteMetadata.php
+++ b/tests/phpunit/tests/meta/deleteMetadata.php
@@ -161,4 +161,62 @@ class Tests_Meta_DeleteMetadata extends WP_UnitTestCase {
 			gettype( $object_id )
 		);
 	}
+
+	/**
+	 * @ticket 65976
+	 *
+	 * @dataProvider data_actions_should_receive_delete_all
+	 *
+	 * @param bool $delete_all Whether to delete the matching metadata entries for all objects.
+	 */
+	public function test_actions_should_receive_delete_all( $delete_all ) {
+		add_metadata( 'post', 123, 'test_key', 'value' );
+
+		$delete_action  = new MockAction();
+		$deleted_action = new MockAction();
+
+		add_action( 'delete_post_meta', array( $delete_action, 'action' ), 10, 5 );
+		add_action( 'deleted_post_meta', array( $deleted_action, 'action' ), 10, 5 );
+
+		delete_metadata( 'post', 123, 'test_key', '', $delete_all );
+
+		$delete_args  = $delete_action->get_args();
+		$deleted_args = $deleted_action->get_args();
+
+		$this->assertSame( $delete_all, $delete_args[0][4], 'The delete_post_meta action should receive the value of $delete_all.' );
+		$this->assertSame( $delete_all, $deleted_args[0][4], 'The deleted_post_meta action should receive the value of $delete_all.' );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_actions_should_receive_delete_all() {
+		return array(
+			'deleting for a single object' => array( false ),
+			'deleting for all objects'     => array( true ),
+		);
+	}
+
+	/**
+	 * @ticket 65976
+	 */
+	public function test_actions_should_receive_delete_all_false_when_deleting_by_mid() {
+		$meta_id = add_metadata( 'post', 123, 'test_key', 'value' );
+
+		$delete_action  = new MockAction();
+		$deleted_action = new MockAction();
+
+		add_action( 'delete_post_meta', array( $delete_action, 'action' ), 10, 5 );
+		add_action( 'deleted_post_meta', array( $deleted_action, 'action' ), 10, 5 );
+
+		delete_metadata_by_mid( 'post', $meta_id );
+
+		$delete_args  = $delete_action->get_args();
+		$deleted_args = $deleted_action->get_args();
+
+		$this->assertFalse( $delete_args[0][4], 'The delete_post_meta action should receive false for $delete_all when deleting by meta ID.' );
+		$this->assertFalse( $deleted_args[0][4], 'The deleted_post_meta action should receive false for $delete_all when deleting by meta ID.' );
+	}
 }


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65976

## What

Passes the `$delete_all` flag given to `delete_metadata()` through to the `delete_{$meta_type}_meta` and `deleted_{$meta_type}_meta` action hooks as an additional (5th) argument. `delete_metadata_by_mid()`, which fires the same actions, passes an explicit `false`.

## Why

When `$delete_all` is true, matching metadata is deleted for **all** objects and the `$object_id` passed to these hooks is ignored — but callbacks currently have no way to know that. The `delete_{$meta_type}_metadata` short-circuit filter already receives `$delete_all`; this brings the actions in line with it, following the same approach as #39706 / PR #12768 did for `$unique` on the add actions.

Passing an explicit `false` in `delete_metadata_by_mid()` ensures callbacks that opt into the additional argument work on both code paths that fire these hooks.

The change is backward compatible: existing callbacks declared their accepted argument count against the old signature and continue to receive exactly the arguments they did before.

## Testing

New unit tests in `tests/phpunit/tests/meta/deleteMetadata.php` assert that both actions receive `$delete_all` for both `true` and `false`, and that they receive `false` when deleting via `delete_metadata_by_mid()`.

- New tests: 3 tests, 6 assertions, passing
- Full meta group: 461 tests, 1224 assertions, passing
- PHPCS: no new issues on changed files
- PHPStan: no new errors (only pre-existing baseline drift in unrelated files)

## Notes

`@since 7.2.0` matches the version used in PR #12768; happy to adjust.

https://claude.ai/code/session_01Bjv7bM9MF844TKLMqueyF7
