### PR TITLE
REST API: Allow null template origin

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
@@ -1092,9 +1092,9 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'readonly'    => true,
 				),
-				'origin'          => array(
-					'description' => __( 'Source of a customized template' ),
-					'type'        => 'string',
+				'origin' => array(
+                    'description' => __( 'Source of a customized template' ),
+                    'type'        => array( 'string', 'null' ),
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'readonly'    => true,
 				),

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
@@ -1092,9 +1092,9 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'readonly'    => true,
 				),
-				'origin' => array(
-                    'description' => __( 'Source of a customized template' ),
-                    'type'        => array( 'string', 'null' ),
+				'origin'          => array(
+					'description' => __( 'Source of a customized template' ),
+					'type'        => array( 'string', 'null' ),
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'readonly'    => true,
 				),


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

## Description

The REST API schema for the `origin` property of the `wp/v2/template-parts` endpoint currently declares the value as a string.

However, `WP_Block_Template::origin` can also return `null`, so the schema does not accurately describe the actual REST API response.

This change updates the `origin` schema to accept both `string` and `null` values.

Trac ticket: https://core.trac.wordpress.org/ticket/64168

## Testing

- PHPUnit tests for `WP_REST_Templates_Controller` pass.
- Result: 49 tests, 143 assertions.

## Use of AI Tools

AI assistance: Yes
Tool(s): ChatGPT
Model(s): GPT-5.6 Luna
Used for: Reviewing the proposed change, discussing the implementation and test approach, and troubleshooting the Git/GitHub contribution workflow. The final code change was reviewed and tested by me.

---

**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**