### PR TITLE
Refactor AJAX URL construction for compression test to handle existing query string

### DIFF
--- a/src/wp-admin/includes/template.php
+++ b/src/wp-admin/includes/template.php
@@ -2519,7 +2519,12 @@ function compression_test() {
 					}
 				};
 
-				x.open('GET', ajaxurl + '?action=wp-compression-test&test='+test+'&_ajax_nonce='+compressionNonce+'&'+(new Date()).getTime(), true);
+				var url = new URL(ajaxurl, window.location);
+				url.searchParams.set('action', 'wp-compression-test')
+				url.searchParams.set('test', test)
+				url.searchParams.set('_ajax_nonce', compressionNonce)
+				url.searchParams.set(new Date().getTime(), '');
+				x.open('GET', url.toString(), true);
 				x.send('');
 			}
 		},


### PR DESCRIPTION
The admin_url function is a function that is filtered, as such other plugins can add query string to it like `?lang=en` when this is the case the request for the compression test is an invalid request that triggers error 400 because it contains multiple '?' in the url

This pull request changes the handling to handle this case

Trac ticket: https://core.trac.wordpress.org/ticket/65980#ticket
