### PR TITLE
View Config for the site editor v2

### DIFF
--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -823,7 +823,7 @@ add_filter( 'rest_pre_insert_wp_template', 'inject_ignored_hooked_blocks_metadat
 add_filter( 'rest_pre_insert_wp_template_part', 'inject_ignored_hooked_blocks_metadata_attributes' );
 
 // View Config API.
-foreach ( array( 'page', 'wp_block', 'wp_template_part', 'wp_template' ) as $post_type ) {
+foreach ( array( 'page', 'wp_block', 'wp_template_part', 'wp_template', 'wp_navigation' ) as $post_type ) {
 	// Base definitions run before the default priority, so third-party
 	// callbacks registered at the default compose on top of them
 	// regardless of registration order.

--- a/src/wp-includes/view-config.php
+++ b/src/wp-includes/view-config.php
@@ -761,3 +761,41 @@ function _wp_get_entity_view_config_posttype_wp_template( $data ) {
 
 	return $data;
 }
+
+/**
+ * Provides the view configuration for the `wp_navigation` post type.
+ *
+ * @since 7.2.0
+ *
+ * @param WP_View_Config_Data $data The view configuration container for the entity.
+ * @return WP_View_Config_Data The updated view configuration container.
+ */
+function _wp_get_entity_view_config_posttype_wp_navigation( $data ) {
+	$default_layouts = array(
+		'list' => array(),
+	);
+
+	$default_view = array(
+		'type'       => 'list',
+		'filters'    => array(),
+		'perPage'    => 20,
+		'sort'       => array(
+			'field'     => 'date',
+			'direction' => 'desc',
+		),
+		'titleField' => 'title',
+		'fields'     => array(),
+	);
+
+	// The base config already provides the "All" view titled with the post
+	// type's `all_items` label, so only the default view and layouts change.
+	$data->set(
+		array(
+			'default_view'    => $default_view,
+			'default_layouts' => $default_layouts,
+		),
+		1
+	);
+
+	return $data;
+}

--- a/tests/phpunit/tests/rest-api/rest-view-config-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-view-config-controller.php
@@ -303,6 +303,36 @@ class WP_REST_View_Config_Controller_Test extends WP_Test_REST_TestCase {
 	}
 
 	/**
+	 * The `wp_navigation` post type provides its own list-based default view.
+	 *
+	 * @ticket TODO
+	 *
+	 * @covers ::get_items
+	 */
+	public function test_get_items_wp_navigation_default_view() {
+		// Admin: reading wp_navigation config requires `edit_theme_options`.
+		wp_set_current_user( self::$admin_id );
+
+		$response = $this->dispatch_request( 'postType', 'wp_navigation' );
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = json_decode( wp_json_encode( $response->get_data() ), true );
+
+		$this->assertSame( 'list', $data['default_view']['type'] );
+		$this->assertSame(
+			array(
+				'field'     => 'date',
+				'direction' => 'desc',
+			),
+			$data['default_view']['sort']
+		);
+		$this->assertSame( 'title', $data['default_view']['titleField'] );
+		$this->assertSame( array( 'list' ), array_keys( $data['default_layouts'] ) );
+		$this->assertCount( 1, $data['view_list'] );
+		$this->assertSame( 'all', $data['view_list'][0]['slug'] );
+	}
+
+	/**
 	 * Empty object-typed config values serialize as JSON objects ({}), not arrays ([]).
 	 *
 	 * @covers ::get_items


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65981

Not to land until the site editor v2 experiment is confirmed to land. cc @youknowriad 

# Backports

Gutenberg PRs:

- https://github.com/WordPress/gutenberg/pull/82138


## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Fable
Used for: Porting the server-side change from the Gutenberg PR. Reviewed and edited by me.

This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.