### PR TITLE
Code Quality: Explicitly support passing an int to the wp_parse_*_list() functions

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -5028,7 +5028,7 @@ function wp_parse_args( $args, $defaults = array() ) {
  * Converts a comma- or space-separated list of scalar values to an array.
  *
  * @since 5.1.0
- * @since 7.2.0 Added explicit support for an integer to be passed.
+ * @since 7.2.0 Added explicit support for passing an integer.
  *
  * @param mixed[]|string|int $input_list List of values.
  * @return array Array of scalar values. A string is split into a list, while an array
@@ -5058,7 +5058,7 @@ function wp_parse_list( $input_list ): array {
  *
  * @since 3.0.0
  * @since 5.1.0 Refactored to use {@see wp_parse_list()}.
- * @since 7.2.0 Passing an integer is now explicitly supported.
+ * @since 7.2.0 Added explicit support for passing an integer.
  *
  * @param mixed[]|string|int $input_list List of IDs.
  * @return int[] Sanitized array of IDs. May include zero. Keys are preserved
@@ -5077,7 +5077,7 @@ function wp_parse_id_list( $input_list ): array {
  *
  * @since 4.7.0
  * @since 5.1.0 Refactored to use {@see wp_parse_list()}.
- * @since 7.2.0 Passing an integer is now explicitly supported.
+ * @since 7.2.0 Added explicit support for passing an integer.
  *
  * @param mixed[]|string|int $input_list List of slugs.
  * @return string[] Sanitized array of slugs. May include an empty string. Keys

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -5028,18 +5028,21 @@ function wp_parse_args( $args, $defaults = array() ) {
  * Converts a comma- or space-separated list of scalar values to an array.
  *
  * @since 5.1.0
+ * @since 7.2.0 Added explicit support for an integer to be passed.
  *
- * @param mixed[]|string $input_list List of values.
+ * @param mixed[]|string|int $input_list List of values.
  * @return array Array of scalar values. A string is split into a list, while an array
  *               keeps its keys, so the result is not necessarily a list.
  * @phpstan-return (
- *     $input_list is string ? list<string> : (
+ *     $input_list is string|int ? list<string> : (
  *         $input_list is array<string> ? array<string> : array<scalar>
  *     )
  * )
  */
 function wp_parse_list( $input_list ): array {
-	if ( ! is_array( $input_list ) ) {
+	if ( is_int( $input_list ) ) {
+		$input_list = array( (string) $input_list );
+	} elseif ( ! is_array( $input_list ) ) {
 		$parsed_list = preg_split( '/[\s,]+/', $input_list, -1, PREG_SPLIT_NO_EMPTY );
 		return is_array( $parsed_list ) ? $parsed_list : array();
 	}
@@ -5054,9 +5057,10 @@ function wp_parse_list( $input_list ): array {
  * Cleans up an array, comma- or space-separated list of IDs.
  *
  * @since 3.0.0
- * @since 5.1.0 Refactored to use wp_parse_list().
+ * @since 5.1.0 Refactored to use {@see wp_parse_list()}.
+ * @since 7.2.0 Passing an integer is now explicitly supported.
  *
- * @param mixed[]|string $input_list List of IDs.
+ * @param mixed[]|string|int $input_list List of IDs.
  * @return int[] Sanitized array of IDs. May include zero. Keys are preserved
  *               from the input and `array_unique()` may leave gaps, so the
  *               result is not necessarily a list.
@@ -5072,9 +5076,10 @@ function wp_parse_id_list( $input_list ): array {
  * Cleans up an array, comma- or space-separated list of slugs.
  *
  * @since 4.7.0
- * @since 5.1.0 Refactored to use wp_parse_list().
+ * @since 5.1.0 Refactored to use {@see wp_parse_list()}.
+ * @since 7.2.0 Passing an integer is now explicitly supported.
  *
- * @param mixed[]|string $input_list List of slugs.
+ * @param mixed[]|string|int $input_list List of slugs.
  * @return string[] Sanitized array of slugs. May include an empty string. Keys
  *                  are preserved from the input and `array_unique()` may leave
  *                  gaps, so the result is not necessarily a list.

--- a/tests/phpunit/tests/functions/wpParseIdList.php
+++ b/tests/phpunit/tests/functions/wpParseIdList.php
@@ -16,7 +16,7 @@ class Tests_Functions_wpParseIdList extends WP_UnitTestCase {
 	 * @dataProvider data_wp_parse_id_list
 	 * @dataProvider data_unexpected_input
 	 *
-	 * @param mixed[]|string $input_list
+	 * @param mixed[]|string|int $input_list
 	 * @param array<non-negative-int> $expected
 	 */
 	public function test_wp_parse_id_list( $input_list, array $expected ): void {
@@ -37,7 +37,7 @@ class Tests_Functions_wpParseIdList extends WP_UnitTestCase {
 	/**
 	 * Data provider.
 	 *
-	 * @return array<string, array{ input_list: mixed[]|string, expected: array<non-negative-int> }>
+	 * @return array<string, array{ input_list: mixed[]|string|int, expected: array<non-negative-int> }>
 	 */
 	public function data_wp_parse_id_list(): array {
 		return array(
@@ -74,13 +74,25 @@ class Tests_Functions_wpParseIdList extends WP_UnitTestCase {
 				'input_list' => array( -1, 2, '-3', '4' ),
 				'expected'   => array( 1, 2, 3, 4 ),
 			),
+			'positive int'             => array(
+				'input_list' => 5,
+				'expected'   => array( 5 ),
+			),
+			'negative int'             => array(
+				'input_list' => -5,
+				'expected'   => array( 5 ),
+			),
+			'zero'                     => array(
+				'input_list' => 0,
+				'expected'   => array( 0 ),
+			),
 		);
 	}
 
 	/**
 	 * Data provider.
 	 *
-	 * @return array<string, array{ input_list: mixed[]|string, expected: array<non-negative-int> }>
+	 * @return array<string, array{ input_list: mixed[]|string|int, expected: array<non-negative-int> }>
 	 */
 	public function data_unexpected_input(): array {
 		return array(
@@ -98,6 +110,10 @@ class Tests_Functions_wpParseIdList extends WP_UnitTestCase {
 			),
 			'array with spaces'  => array(
 				'input_list' => array( '1 2 string with spaces' ),
+				'expected'   => array( 1 ),
+			),
+			'comma in array'     => array(
+				'input_list' => array( '1,2' ),
 				'expected'   => array( 1 ),
 			),
 			'string with html'   => array(

--- a/tests/phpunit/tests/functions/wpParseList.php
+++ b/tests/phpunit/tests/functions/wpParseList.php
@@ -14,7 +14,7 @@ class Tests_Functions_wpParseList extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_wp_parse_list
 	 *
-	 * @param mixed[]|string $input_list
+	 * @param mixed[]|string|int $input_list
 	 * @param array<scalar> $expected
 	 */
 	public function test_wp_parse_list( $input_list, array $expected ): void {
@@ -35,7 +35,7 @@ class Tests_Functions_wpParseList extends WP_UnitTestCase {
 	/**
 	 * Data provider.
 	 *
-	 * @return array<string, array{ input_list: mixed[]|string, expected: array<scalar> }>
+	 * @return array<string, array{ input_list: mixed[]|string|int, expected: array<scalar> }>
 	 */
 	public function data_wp_parse_list(): array {
 		return array(
@@ -82,6 +82,22 @@ class Tests_Functions_wpParseList extends WP_UnitTestCase {
 			'double comma only'   => array(
 				'input_list' => ',,',
 				'expected'   => array(),
+			),
+			'positive int'        => array(
+				'input_list' => 5,
+				'expected'   => array( '5' ),
+			),
+			'negative int'        => array(
+				'input_list' => -5,
+				'expected'   => array( '-5' ),
+			),
+			'zero'                => array(
+				'input_list' => 0,
+				'expected'   => array( '0' ),
+			),
+			'comma in array item' => array(
+				'input_list' => array( '1,2' ),
+				'expected'   => array( '1,2' ),
 			),
 			'passed scalar array' => array(
 				'input_list' => array( 'foo', true, false, 1, 3.14 ),

--- a/tests/phpunit/tests/functions/wpParseSlugList.php
+++ b/tests/phpunit/tests/functions/wpParseSlugList.php
@@ -16,7 +16,7 @@ class Tests_Functions_WpParseSlugList extends WP_UnitTestCase {
 	 * @dataProvider data_wp_parse_slug_list
 	 * @dataProvider data_unexpected_input
 	 *
-	 * @param mixed[]|string $input_list
+	 * @param mixed[]|string|int $input_list
 	 * @param array<string> $expected
 	 */
 	public function test_wp_parse_slug_list( $input_list, array $expected ): void {
@@ -37,7 +37,7 @@ class Tests_Functions_WpParseSlugList extends WP_UnitTestCase {
 	/**
 	 * Data provider.
 	 *
-	 * @return array<string, array{ input_list: mixed[]|string, expected: array<string> }>
+	 * @return array<string, array{ input_list: mixed[]|string|int, expected: array<string> }>
 	 */
 	public function data_wp_parse_slug_list(): array {
 		return array(
@@ -75,6 +75,18 @@ class Tests_Functions_WpParseSlugList extends WP_UnitTestCase {
 				'input_list' => array( 'apple ', 'banana carrot', 'd o g' ),
 				'expected'   => array( 'apple', 'banana-carrot', 'd-o-g' ),
 			),
+			'positive int'               => array(
+				'input_list' => 5,
+				'expected'   => array( '5' ),
+			),
+			'negative int'               => array(
+				'input_list' => -5,
+				'expected'   => array( '5' ),
+			),
+			'zero'                       => array(
+				'input_list' => 0,
+				'expected'   => array( '0' ),
+			),
 			'passed assoc array'         => array(
 				'input_list' => array(
 					'one'   => 'foo',
@@ -93,7 +105,7 @@ class Tests_Functions_WpParseSlugList extends WP_UnitTestCase {
 	/**
 	 * Data provider.
 	 *
-	 * @return array<string, array{ input_list: mixed[]|string, expected: array<string> }>
+	 * @return array<string, array{ input_list: mixed[]|string|int, expected: array<string> }>
 	 */
 	public function data_unexpected_input(): array {
 		return array(


### PR DESCRIPTION
✅ Committed in r63366 (c72064d3c24c8b2e948f5caa8e259543488b06c7).

----
Formalizes `int` as an accepted input type for `wp_parse_list()`, `wp_parse_id_list()`, and `wp_parse_slug_list()`, which previously documented `mixed[]|string`.

## Background

Passing an integer has always worked, but only by accident of type coercion. `wp_parse_id_list()` has called `preg_split()` on non-array input since it was introduced in 3.0.0, and `wp_parse_list()` inherited that when the three functions were consolidated in 5.1.0. Because `preg_split()`'s `$subject` parameter is a `string`, PHP coerces an `int` on the way in — `wp_parse_id_list( 5 )` returns `array( 5 )` and always has.

Core relies on this in several places:

- `WP_Tax_Query` documents `@type string|int|array $terms` and passes that value straight to `wp_parse_id_list()` in `WP_Tax_Query::transform_query()`.
- `get_bookmarks()` reassigns `$parsed_args['category']` to a `WP_Term::$term_id` (an `int`) when resolving `category_name`, then passes it to `wp_parse_id_list()`.
- `wp_list_bookmarks()` calls `get_bookmarks()` with `'category' => $cat->term_id`.

So the documented type was narrower than both the implementation and the callers. At PHPStan rule level 10 this surfaces as an `argument.type` error at each of those call sites, for input the functions handle correctly.

## Changes

The `@param` types become `mixed[]|string|int`, and `wp_parse_list()` handles the `int` case explicitly rather than leaning on implicit coercion of a non-string into `preg_split()`:

```php
if ( is_int( $input_list ) ) {
	$input_list = array( (string) $input_list );
} elseif ( ! is_array( $input_list ) ) {
	// ...
}
```

The `@phpstan-return` conditional is updated so `int` resolves to `list<string>` alongside `string`, rather than falling through to the array branch.

There is no behavior change: the new branch produces exactly what `preg_split()` produced for every `int`, including `0`, negative values, `PHP_INT_MAX`, and `PHP_INT_MIN`.

## Why not `float` and `bool`

Both are also silently coerced today, and both are deliberately left out of the documented contract.

`float` produces nonsense for anything ID-shaped: `1.0e25` stringifies to `"1.0E+25"` and `absint()` saturates it to `PHP_INT_MAX`, while `0.5` becomes `0`. `bool` is worse — `wp_parse_id_list( true )` returns `array( 1 )`, silently converting a flag into a query for object ID 1.

Runtime behavior for both is untouched; they are simply not promised. Since the previously declared `mixed[]|string` is *narrower* than the new `mixed[]|string|int`, this is a strict widening and no existing caller can newly fail static analysis.

## Testing

The data providers for these three functions had no non-string scalar input at all. Added coverage for a positive int, a negative int, and zero in each, plus a case pinning the contrast between a comma inside an array item and the same value passed as a string — array items are never split, so `wp_parse_id_list( array( '1,2' ) )` yields `array( 1 )` while `wp_parse_id_list( '1,2' )` yields `array( 1, 2 )`.

`Tests_Functions_wpParse*` goes from 46 to 57 tests, all passing.

Trac ticket: Core-65817

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Reviewing the initial change, verifying the inferred PHPStan types and the runtime equivalence of the `is_int()` branch, and drafting the added test cases and docblock wording. The implementation was authored by me, and I have reviewed and take responsibility for all of it.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**

