### PR TITLE
KSES: Support autofocus for dialog children

### DIFF
--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -965,7 +965,57 @@ function wp_kses( $content, $allowed_html, $allowed_protocols = array() ) {
 
 	$content = wp_kses_no_null( $content, array( 'slash_zero' => 'keep' ) );
 	$content = wp_kses_normalize_entities( $content );
-	$content = wp_kses_hook( $content, $allowed_html, $allowed_protocols );
+
+	/*
+	 * Preserve the existing pre_kses hook contract before establishing
+	 * contextual ancestry.
+	 */
+	$hook_input = $content;
+	$content    = wp_kses_hook( $hook_input, $allowed_html, $allowed_protocols );
+
+	/*
+	 * If pre_kses changed the normalized input, structural identity is no
+	 * longer established. Preserve the hook mutation but do not broaden
+	 * contextual autofocus for this invocation.
+	 */
+	if ( 'post' === $allowed_html && $content !== $hook_input ) {
+		return wp_kses_split( $content, $allowed_html, $allowed_protocols );
+	}
+
+	if ( 'post' === $allowed_html && false !== stripos( $content, 'autofocus' ) ) {
+		$dialog_autofocus_content = _wp_kses_sanitize_dialog_autofocus( $content );
+
+		if ( null === $dialog_autofocus_content ) {
+			return wp_kses_split( $content, $allowed_html, $allowed_protocols );
+		}
+
+		if ( false === stripos( $dialog_autofocus_content, 'autofocus' ) ) {
+			return wp_kses_split( $dialog_autofocus_content, $allowed_html, $allowed_protocols );
+		}
+
+		/*
+		 * Resolve the broadened post policy before entering the regex KSES
+		 * tokenizer. Recursive comment sanitization therefore receives the
+		 * same resolved policy instead of mutating contextual state.
+		 */
+		$dialog_autofocus_allowed_html = wp_kses_allowed_html( '_wp_kses_post_with_dialog_autofocus' );
+		$filtered_content              = wp_kses_split(
+			$dialog_autofocus_content,
+			$dialog_autofocus_allowed_html,
+			$allowed_protocols
+		);
+		$dialog_autofocus_content      = _wp_kses_sanitize_dialog_autofocus( $filtered_content );
+
+		if ( null !== $dialog_autofocus_content ) {
+			return $dialog_autofocus_content;
+		}
+
+		/*
+		 * Fail closed using already-hooked content so pre_kses is not
+		 * executed a second time.
+		 */
+		return wp_kses_split( $content, $allowed_html, $allowed_protocols );
+	}
 
 	return wp_kses_split( $content, $allowed_html, $allowed_protocols );
 }
@@ -1063,6 +1113,11 @@ function wp_kses_one_attr( $attr, $element ) {
 function wp_kses_allowed_html( $context = '' ) {
 	global $allowedposttags, $allowedtags, $allowedentitynames;
 
+	$allow_dialog_autofocus = '_wp_kses_post_with_dialog_autofocus' === $context;
+	if ( $allow_dialog_autofocus ) {
+		$context = 'post';
+	}
+
 	if ( is_array( $context ) ) {
 		// When `$context` is an array it's actually an array of allowed HTML elements and attributes.
 		$html    = $context;
@@ -1086,7 +1141,11 @@ function wp_kses_allowed_html( $context = '' ) {
 	switch ( $context ) {
 		case 'post':
 			/** This filter is documented in wp-includes/kses.php */
-			$tags = apply_filters( 'wp_kses_allowed_html', $allowedposttags, $context );
+			$tags = $allowedposttags;
+			if ( $allow_dialog_autofocus ) {
+				$tags = _wp_kses_add_dialog_autofocus_to_allowed_html( $tags );
+			}
+			$tags = apply_filters( 'wp_kses_allowed_html', $tags, $context );
 
 			// 5.0.1 removed the `<form>` tag, allow it if a filter is allowing it's sub-elements `<input>` or `<select>`.
 			if ( ! CUSTOM_TAGS && ! isset( $tags['form'] ) && ( isset( $tags['input'] ) || isset( $tags['select'] ) ) ) {
@@ -1101,6 +1160,10 @@ function wp_kses_allowed_html( $context = '' ) {
 					'name'           => true,
 					'target'         => true,
 				);
+
+				if ( $allow_dialog_autofocus ) {
+					$tags = _wp_kses_add_dialog_autofocus_to_allowed_html( $tags );
+				}
 
 				/** This filter is documented in wp-includes/kses.php */
 				$tags = apply_filters( 'wp_kses_allowed_html', $tags, $context );
@@ -1130,6 +1193,79 @@ function wp_kses_allowed_html( $context = '' ) {
 			/** This filter is documented in wp-includes/kses.php */
 			return apply_filters( 'wp_kses_allowed_html', $allowedtags, $context );
 	}
+}
+
+/**
+ * Reduces the post-context autofocus allowance to actual dialog scope.
+ *
+ * This parser-backed pass runs on unchanged pre_kses output before KSES and
+ * again after KSES. It does not replace KSES or allow any other tag or
+ * attribute. Returning null causes the caller to use the legacy post allowlist
+ * and therefore fail closed.
+ *
+ * @since 7.2.0
+ * @access private
+ *
+ * @param string $content Content to inspect and update.
+ * @return string|null Updated content, or null when structural processing cannot complete.
+ */
+function _wp_kses_sanitize_dialog_autofocus( $content ): ?string {
+	if ( false === stripos( $content, 'autofocus' ) ) {
+		return $content;
+	}
+
+	$processor = WP_HTML_Processor::create_fragment( $content );
+
+	if ( false === $processor ) {
+		return null;
+	}
+
+	while ( $processor->next_tag() ) {
+		if ( null === $processor->get_attribute( 'autofocus' ) ) {
+			continue;
+		}
+
+		if ( in_array( 'DIALOG', $processor->get_breadcrumbs(), true ) ) {
+			continue;
+		}
+
+		$processor->remove_attribute( 'autofocus' );
+	}
+
+	if ( null !== $processor->get_last_error() ) {
+		return null;
+	}
+
+	return $processor->get_updated_html();
+}
+
+/**
+ * Adds autofocus to Core's post-context attributes before structural reduction.
+ *
+ * The public {@see 'wp_kses_allowed_html'} filter runs after this helper, so
+ * developers can still narrow or remove the permission. Explicit allowlist
+ * arrays do not use this internal post context and are never broadened.
+ *
+ * @since 7.2.0
+ * @access private
+ *
+ * @param array<string, array<string, mixed>> $allowed Allowed post HTML.
+ * @return array<string, array<string, mixed>> Updated allowed post HTML.
+ */
+function _wp_kses_add_dialog_autofocus_to_allowed_html( $allowed ): array {
+	if ( ! is_array( $allowed ) ) {
+		$allowed = array();
+	}
+
+	foreach ( $allowed as $element => $attributes ) {
+		if ( ! is_array( $attributes ) ) {
+			continue;
+		}
+
+		$allowed[ $element ]['autofocus'] = true;
+	}
+
+	return $allowed;
 }
 
 /**

--- a/tests/phpunit/tests/kses.php
+++ b/tests/phpunit/tests/kses.php
@@ -2312,6 +2312,315 @@ EOF;
 	}
 
 	/**
+	 * Tests parser-backed autofocus handling for dialog descendants.
+	 *
+	 * @ticket 65717
+	 *
+	 * @dataProvider data_wp_kses_dialog_descendant_autofocus
+	 *
+	 * @param string $html     Input HTML.
+	 * @param string $expected Expected filtered HTML.
+	 */
+	public function test_wp_kses_dialog_descendant_autofocus( $html, $expected ) {
+		$this->assertEqualHTML( $expected, wp_kses_post( $html ) );
+	}
+
+	/**
+	 * Data provider for test_wp_kses_dialog_descendant_autofocus().
+	 *
+	 * @return array<string, array{0: string, 1: string}>
+	 */
+	public static function data_wp_kses_dialog_descendant_autofocus() {
+		return array(
+			'direct descendant'          => array(
+				'<dialog><button type="button" autofocus>Save</button></dialog>',
+				'<dialog><button type="button" autofocus>Save</button></dialog>',
+			),
+			'nested descendant'          => array(
+				'<dialog><div><button type="button" autofocus>Save</button></div></dialog>',
+				'<dialog><div><button type="button" autofocus>Save</button></div></dialog>',
+			),
+			'tabindex descendant'        => array(
+				'<dialog><div tabindex="0" autofocus>Focusable</div></dialog>',
+				'<dialog><div tabindex="0" autofocus>Focusable</div></dialog>',
+			),
+			'allowed dialog descendant'  => array(
+				'<dialog><span autofocus>Content</span></dialog>',
+				'<dialog><span autofocus>Content</span></dialog>',
+			),
+			'dialog itself'              => array(
+				'<dialog open autofocus>Content</dialog>',
+				'<dialog open autofocus>Content</dialog>',
+			),
+			'outside dialog'             => array(
+				'<button type="button" autofocus>Outside</button>',
+				'<button type="button">Outside</button>',
+			),
+			'mixed inside and outside'   => array(
+				'<button type="button" autofocus>Outside</button>'
+					. '<dialog><button type="button" autofocus>Inside</button></dialog>',
+				'<button type="button">Outside</button>'
+					. '<dialog><button type="button" autofocus>Inside</button></dialog>',
+			),
+			'nested dialogs'             => array(
+				'<dialog><dialog><button type="button" autofocus>Nested</button></dialog></dialog>',
+				'<dialog><dialog><button type="button" autofocus>Nested</button></dialog></dialog>',
+			),
+			'unrelated unsafe attribute' => array(
+				'<dialog><button type="button" autofocus onclick="alert(1)">Save</button></dialog>',
+				'<dialog><button type="button" autofocus>Save</button></dialog>',
+			),
+		);
+	}
+
+	/**
+	 * Tests that a dialog token in an HTML comment cannot leak autofocus.
+	 *
+	 * @ticket 65717
+	 */
+	public function test_wp_kses_dialog_autofocus_is_not_leaked_by_commented_dialog() {
+		$html = '<!-- <dialog> --><button type="button" autofocus>Fake</button>';
+
+		$this->assertStringNotContainsString( 'autofocus', wp_kses_post( $html ) );
+	}
+
+	/**
+	 * Tests that a dialog token in RCDATA cannot leak autofocus.
+	 *
+	 * @ticket 65717
+	 */
+	public function test_wp_kses_dialog_autofocus_is_not_leaked_by_rcdata_dialog() {
+		$html = '<textarea><dialog></textarea><button type="button" autofocus>Fake</button>';
+
+		$this->assertStringNotContainsString( 'autofocus', wp_kses_post( $html ) );
+	}
+
+	/**
+	 * Tests that an HTML comment inside a dialog does not break valid context.
+	 *
+	 * @ticket 65717
+	 */
+	public function test_wp_kses_dialog_autofocus_is_retained_after_comment_inside_dialog() {
+		$html     = '<dialog open><!-- note --><button type="button" autofocus>Real</button></dialog>';
+		$filtered = wp_kses_post( $html );
+
+		$this->assertStringContainsString( '<button type="button" autofocus>', $filtered );
+	}
+
+	/**
+	 * Tests that an unmatched closing dialog cannot create autofocus context.
+	 *
+	 * @ticket 65717
+	 */
+	public function test_wp_kses_dialog_autofocus_is_not_leaked_by_unmatched_closer() {
+		$html = '</dialog><button type="button" autofocus>Outside</button>';
+
+		$this->assertStringNotContainsString( 'autofocus', wp_kses_post( $html ) );
+	}
+
+	/**
+	 * Tests that dialog autofocus state is isolated across KSES calls.
+	 *
+	 * @ticket 65717
+	 */
+	public function test_wp_kses_dialog_autofocus_is_isolated_across_calls() {
+		$inside  = wp_kses_post(
+			'<dialog><!-- note --><button type="button" autofocus>Inside</button></dialog>'
+		);
+		$outside = wp_kses_post( '<button type="button" autofocus>Outside</button>' );
+
+		$this->assertStringContainsString( 'autofocus', $inside );
+		$this->assertStringNotContainsString( 'autofocus', $outside );
+	}
+
+	/**
+	 * Tests that an explicit allowlist is not broadened by dialog context.
+	 *
+	 * @ticket 65717
+	 */
+	public function test_wp_kses_dialog_autofocus_does_not_broaden_explicit_allowlist() {
+		$allowed_html = array(
+			'dialog' => array(
+				'open'      => true,
+				'autofocus' => true,
+			),
+			'button' => array(
+				'type' => true,
+			),
+		);
+		$html         = '<dialog><button type="button" autofocus>Save</button></dialog>';
+		$expected     = '<dialog><button type="button">Save</button></dialog>';
+
+		$this->assertEqualHTML( $expected, wp_kses( $html, $allowed_html ) );
+	}
+
+	/**
+	 * Tests that the post allowlist filter can remove contextual autofocus.
+	 *
+	 * @ticket 65717
+	 */
+	public function test_wp_kses_dialog_autofocus_can_be_narrowed_by_filter() {
+		$filter = static function ( $allowed, $context ) {
+			if (
+				'post' === $context
+				&& isset( $allowed['button'] )
+				&& is_array( $allowed['button'] )
+			) {
+				unset( $allowed['button']['autofocus'] );
+			}
+
+			return $allowed;
+		};
+
+		add_filter( 'wp_kses_allowed_html', $filter, 20, 2 );
+
+		try {
+			$html     = '<dialog><button type="button" autofocus>Save</button></dialog>';
+			$expected = '<dialog><button type="button">Save</button></dialog>';
+
+			$this->assertEqualHTML( $expected, wp_kses_post( $html ) );
+		} finally {
+			remove_filter( 'wp_kses_allowed_html', $filter, 20 );
+		}
+	}
+
+	/**
+	 * Tests that final dialog ancestry is checked after KSES removes a dialog.
+	 *
+	 * @ticket 65717
+	 */
+	public function test_wp_kses_dialog_autofocus_is_removed_when_dialog_is_filtered() {
+		$filter = static function ( $allowed, $context ) {
+			if ( 'post' === $context ) {
+				unset( $allowed['dialog'] );
+			}
+
+			return $allowed;
+		};
+
+		add_filter( 'wp_kses_allowed_html', $filter, 20, 2 );
+
+		try {
+			$html     = '<dialog><button type="button" autofocus>Save</button></dialog>';
+			$expected = '<button type="button">Save</button>';
+
+			$this->assertEqualHTML( $expected, wp_kses_post( $html ) );
+		} finally {
+			remove_filter( 'wp_kses_allowed_html', $filter, 20 );
+		}
+	}
+
+	/**
+	 * Tests that wp_kses_one_attr() does not gain structural context.
+	 *
+	 * @ticket 65717
+	 */
+	public function test_wp_kses_one_attr_dialog_autofocus_behavior_is_unchanged() {
+		$this->assertSame( '', wp_kses_one_attr( 'autofocus', 'button' ) );
+		$this->assertSame( 'autofocus', wp_kses_one_attr( 'autofocus', 'dialog' ) );
+	}
+
+	/**
+	 * Tests that pre_kses observes autofocus before ordinary KSES removes it.
+	 *
+	 * @ticket 65717
+	 */
+	public function test_wp_kses_dialog_autofocus_preserves_pre_kses_observability() {
+		$observed = array();
+
+		$filter = static function ( $content, $allowed_html ) use ( &$observed ) {
+			$observed[] = array(
+				'content' => $content,
+				'context' => is_array( $allowed_html ) ? 'ARRAY' : $allowed_html,
+			);
+
+			return $content;
+		};
+
+		add_filter( 'pre_kses', $filter, -999, 2 );
+
+		try {
+			$html     = '<button type="button" autofocus>Outside</button>';
+			$expected = '<button type="button">Outside</button>';
+			$filtered = wp_kses_post( $html );
+		} finally {
+			remove_filter( 'pre_kses', $filter, -999 );
+		}
+
+		$this->assertCount( 1, $observed );
+		$this->assertSame( $html, $observed[0]['content'] );
+		$this->assertSame( 'post', $observed[0]['context'] );
+		$this->assertEqualHTML( $expected, $filtered );
+	}
+
+	/**
+	 * Tests that a pre_kses content mutation is preserved while contextual autofocus fails closed.
+	 *
+	 * @ticket 65717
+	 */
+	public function test_wp_kses_dialog_autofocus_fails_closed_after_pre_kses_mutation() {
+		$filter = static function ( $content, $allowed_html ) {
+			if ( 'post' === $allowed_html ) {
+				return str_replace( 'Save', 'Changed', $content );
+			}
+
+			return $content;
+		};
+
+		add_filter( 'pre_kses', $filter, 20, 2 );
+
+		try {
+			$html     = '<dialog><button type="button" autofocus>Save</button></dialog>';
+			$expected = '<dialog><button type="button">Changed</button></dialog>';
+
+			$this->assertEqualHTML( $expected, wp_kses_post( $html ) );
+		} finally {
+			remove_filter( 'pre_kses', $filter, 20 );
+		}
+	}
+
+	/**
+	 * Tests that a structural pre_kses mutation cannot manufacture contextual autofocus permission.
+	 *
+	 * @ticket 65717
+	 */
+	public function test_wp_kses_dialog_autofocus_fails_closed_after_pre_kses_structural_mutation() {
+		$filter = static function ( $content, $allowed_html ) {
+			if ( 'post' === $allowed_html ) {
+				return '<dialog>' . $content . '</dialog>';
+			}
+
+			return $content;
+		};
+
+		add_filter( 'pre_kses', $filter, 20, 2 );
+
+		try {
+			$html     = '<button type="button" autofocus>Outside</button>';
+			$expected = '<dialog><button type="button">Outside</button></dialog>';
+
+			$this->assertEqualHTML( $expected, wp_kses_post( $html ) );
+		} finally {
+			remove_filter( 'pre_kses', $filter, 20 );
+		}
+	}
+
+	/**
+	 * Tests dialog descendant autofocus with block-editor-style HTML comments.
+	 *
+	 * @ticket 65717
+	 */
+	public function test_wp_kses_dialog_autofocus_survives_block_comment_markup() {
+		$html     = '<!-- wp:html --><dialog><button type="button" autofocus>Save</button></dialog><!-- /wp:html -->';
+		$filtered = wp_kses_post( $html );
+
+		$this->assertStringContainsString(
+			'<dialog><button type="button" autofocus>Save</button></dialog>',
+			$filtered
+		);
+	}
+
+	/**
 	 * Test that Invoker Commands API attributes are preserved on buttons in post content.
 	 *
 	 * @ticket 64576


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65717

## Summary

Adds context-aware KSES support for the utofocus attribute on descendants of dialog elements while preserving existing behavior outside the intended dialog context.

## Testing

- PHP lint passes for src/wp-includes/kses.php
- PHP lint passes for 	ests/phpunit/tests/kses.php
- Targeted PHPUnit: 23 tests, 28 assertions, passing
- Full KSES PHPUnit: 417 tests, 1472 assertions, passing
- WordPress Coding Standards: passing
- git diff --check: passing
- Candidate validated against current trunk with no material intervening overlap found

## Use of AI Tools

AI assistance: Yes.

Used for implementation analysis, candidate refinement, validation planning, and test/review assistance. The final implementation and publication candidate were independently validated against the WordPress test and coding-standard toolchain.