### PR TITLE
XML-RPC: Fatal TypeError when the fields argument is not an array

### DIFF
--- a/src/wp-includes/class-wp-xmlrpc-server.php
+++ b/src/wp-includes/class-wp-xmlrpc-server.php
@@ -815,6 +815,8 @@ class wp_xmlrpc_server extends IXR_Server {
 	 *
 	 * @param mixed $fields The `$fields` argument to check.
 	 * @return bool True if `$fields` is an array, false otherwise.
+	 *
+	 * @phpstan-assert-if-true array $fields
 	 */
 	protected function _is_fields_array( $fields ): bool {
 		if ( ! is_array( $fields ) ) {

--- a/src/wp-includes/class-wp-xmlrpc-server.php
+++ b/src/wp-includes/class-wp-xmlrpc-server.php
@@ -809,6 +809,23 @@ class wp_xmlrpc_server extends IXR_Server {
 	}
 
 	/**
+	 * Checks that the `$fields` argument received from a client is an array.
+	 *
+	 * @since 7.2.0
+	 *
+	 * @param mixed $fields The `$fields` argument to check.
+	 * @return bool True if `$fields` is an array, false otherwise.
+	 */
+	protected function _is_fields_array( $fields ) {
+		if ( ! is_array( $fields ) ) {
+			$this->error = new IXR_Error( 400, __( 'The fields argument must be an array.' ) );
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
 	 * Prepares taxonomy data for return in an XML-RPC object.
 	 *
 	 * @param WP_Taxonomy $taxonomy The unprepared taxonomy data.
@@ -1871,6 +1888,7 @@ class wp_xmlrpc_server extends IXR_Server {
 	 * Retrieves a post.
 	 *
 	 * @since 3.4.0
+	 * @since 7.2.0 Returns an error if the `$fields` argument is not an array.
 	 *
 	 * The optional $fields parameter specifies what fields will be included
 	 * in the response array. This should be a list of field names. 'post_id' will
@@ -1928,6 +1946,10 @@ class wp_xmlrpc_server extends IXR_Server {
 		$post_id  = (int) $args[3];
 
 		if ( isset( $args[4] ) ) {
+			if ( ! $this->_is_fields_array( $args[4] ) ) {
+				return $this->error;
+			}
+
 			$fields = $args[4];
 		} else {
 			/**
@@ -1967,6 +1989,7 @@ class wp_xmlrpc_server extends IXR_Server {
 	 * Retrieves posts.
 	 *
 	 * @since 3.4.0
+	 * @since 7.2.0 Returns an error if the `$fields` argument is not an array.
 	 *
 	 * @see wp_get_recent_posts()
 	 * @see wp_getPost() for more on `$fields`
@@ -1997,6 +2020,10 @@ class wp_xmlrpc_server extends IXR_Server {
 		$filter   = $args[3] ?? array();
 
 		if ( isset( $args[4] ) ) {
+			if ( ! $this->_is_fields_array( $args[4] ) ) {
+				return $this->error;
+			}
+
 			$fields = $args[4];
 		} else {
 			/** This action is documented in wp-includes/class-wp-xmlrpc-server.php */
@@ -2534,6 +2561,7 @@ class wp_xmlrpc_server extends IXR_Server {
 	 * Retrieves a taxonomy.
 	 *
 	 * @since 3.4.0
+	 * @since 7.2.0 Returns an error if the `$fields` argument is not an array.
 	 *
 	 * @see get_taxonomy()
 	 *
@@ -2562,6 +2590,10 @@ class wp_xmlrpc_server extends IXR_Server {
 		$taxonomy = $args[3];
 
 		if ( isset( $args[4] ) ) {
+			if ( ! $this->_is_fields_array( $args[4] ) ) {
+				return $this->error;
+			}
+
 			$fields = $args[4];
 		} else {
 			/**
@@ -2601,6 +2633,7 @@ class wp_xmlrpc_server extends IXR_Server {
 	 * Retrieves all taxonomies.
 	 *
 	 * @since 3.4.0
+	 * @since 7.2.0 Returns an error if the `$fields` argument is not an array.
 	 *
 	 * @see get_taxonomies()
 	 *
@@ -2628,6 +2661,10 @@ class wp_xmlrpc_server extends IXR_Server {
 		$filter   = $args[3] ?? array( 'public' => true );
 
 		if ( isset( $args[4] ) ) {
+			if ( ! $this->_is_fields_array( $args[4] ) ) {
+				return $this->error;
+			}
+
 			$fields = $args[4];
 		} else {
 			/** This action is documented in wp-includes/class-wp-xmlrpc-server.php */
@@ -2670,6 +2707,9 @@ class wp_xmlrpc_server extends IXR_Server {
 	 * names can be used to specify multiple fields. The available conceptual
 	 * groups are 'basic' and 'all'.
 	 *
+	 * @since 3.5.0
+	 * @since 7.2.0 Returns an error if the `$fields` argument is not an array.
+	 *
 	 * @uses get_userdata()
 	 *
 	 * @param array $args {
@@ -2707,6 +2747,10 @@ class wp_xmlrpc_server extends IXR_Server {
 		$user_id  = (int) $args[3];
 
 		if ( isset( $args[4] ) ) {
+			if ( ! $this->_is_fields_array( $args[4] ) ) {
+				return $this->error;
+			}
+
 			$fields = $args[4];
 		} else {
 			/**
@@ -2751,6 +2795,9 @@ class wp_xmlrpc_server extends IXR_Server {
 	 * The optional $fields parameter specifies what fields will be included
 	 * in the response array.
 	 *
+	 * @since 3.5.0
+	 * @since 7.2.0 Returns an error if the `$fields` argument is not an array.
+	 *
 	 * @uses get_users()
 	 * @see wp_getUser() for more on $fields and return values
 	 *
@@ -2777,6 +2824,10 @@ class wp_xmlrpc_server extends IXR_Server {
 		$filter   = $args[3] ?? array();
 
 		if ( isset( $args[4] ) ) {
+			if ( ! $this->_is_fields_array( $args[4] ) ) {
+				return $this->error;
+			}
+
 			$fields = $args[4];
 		} else {
 			/** This action is documented in wp-includes/class-wp-xmlrpc-server.php */
@@ -2834,6 +2885,9 @@ class wp_xmlrpc_server extends IXR_Server {
 	/**
 	 * Retrieves information about the requesting user.
 	 *
+	 * @since 3.5.0
+	 * @since 7.2.0 Returns an error if the `$fields` argument is not an array.
+	 *
 	 * @uses get_userdata()
 	 *
 	 * @param array $args {
@@ -2857,6 +2911,10 @@ class wp_xmlrpc_server extends IXR_Server {
 		$password = $args[2];
 
 		if ( isset( $args[3] ) ) {
+			if ( ! $this->_is_fields_array( $args[3] ) ) {
+				return $this->error;
+			}
+
 			$fields = $args[3];
 		} else {
 			/** This action is documented in wp-includes/class-wp-xmlrpc-server.php */
@@ -4533,6 +4591,7 @@ class wp_xmlrpc_server extends IXR_Server {
 	 * Retrieves a post type.
 	 *
 	 * @since 3.4.0
+	 * @since 7.2.0 Returns an error if the `$fields` argument is not an array.
 	 *
 	 * @see get_post_type_object()
 	 *
@@ -4568,6 +4627,10 @@ class wp_xmlrpc_server extends IXR_Server {
 		$post_type_name = $args[3];
 
 		if ( isset( $args[4] ) ) {
+			if ( ! $this->_is_fields_array( $args[4] ) ) {
+				return $this->error;
+			}
+
 			$fields = $args[4];
 		} else {
 			/**
@@ -4607,6 +4670,7 @@ class wp_xmlrpc_server extends IXR_Server {
 	 * Retrieves post types.
 	 *
 	 * @since 3.4.0
+	 * @since 7.2.0 Returns an error if the `$fields` argument is not an array.
 	 *
 	 * @see get_post_types()
 	 *
@@ -4633,6 +4697,10 @@ class wp_xmlrpc_server extends IXR_Server {
 		$filter   = $args[3] ?? array( 'public' => true );
 
 		if ( isset( $args[4] ) ) {
+			if ( ! $this->_is_fields_array( $args[4] ) ) {
+				return $this->error;
+			}
+
 			$fields = $args[4];
 		} else {
 			/** This action is documented in wp-includes/class-wp-xmlrpc-server.php */
@@ -4666,6 +4734,7 @@ class wp_xmlrpc_server extends IXR_Server {
 	 * Retrieves revisions for a specific post.
 	 *
 	 * @since 3.5.0
+	 * @since 7.2.0 Returns an error if the `$fields` argument is not an array.
 	 *
 	 * The optional $fields parameter specifies what fields will be included
 	 * in the response array.
@@ -4696,6 +4765,10 @@ class wp_xmlrpc_server extends IXR_Server {
 		$post_id  = (int) $args[3];
 
 		if ( isset( $args[4] ) ) {
+			if ( ! $this->_is_fields_array( $args[4] ) ) {
+				return $this->error;
+			}
+
 			$fields = $args[4];
 		} else {
 			/**

--- a/src/wp-includes/class-wp-xmlrpc-server.php
+++ b/src/wp-includes/class-wp-xmlrpc-server.php
@@ -816,7 +816,7 @@ class wp_xmlrpc_server extends IXR_Server {
 	 * @param mixed $fields The `$fields` argument to check.
 	 * @return bool True if `$fields` is an array, false otherwise.
 	 */
-	protected function _is_fields_array( $fields ) {
+	protected function _is_fields_array( $fields ): bool {
 		if ( ! is_array( $fields ) ) {
 			$this->error = new IXR_Error( 400, __( 'The fields argument must be an array.' ) );
 			return false;

--- a/tests/phpunit/tests/xmlrpc/wp/getPost.php
+++ b/tests/phpunit/tests/xmlrpc/wp/getPost.php
@@ -147,4 +147,16 @@ class Tests_XMLRPC_wp_getPost extends WP_XMLRPC_UnitTestCase {
 		$this->assertEquals( $parent_page_id, $result['post_parent'] );
 		$this->assertSame( 2, $result['menu_order'] );
 	}
+
+	/**
+	 * Ensure a non-array `$fields` argument is rejected instead of causing a fatal error.
+	 *
+	 * @ticket 65983
+	 */
+	public function test_non_array_fields_returns_error(): void {
+		$result = $this->myxmlrpcserver->wp_getPost( array( 1, 'author', 'author', $this->post_id, 'post' ) );
+
+		$this->assertIXRError( $result );
+		$this->assertSame( 400, $result->code );
+	}
 }

--- a/tests/phpunit/tests/xmlrpc/wp/getPostType.php
+++ b/tests/phpunit/tests/xmlrpc/wp/getPostType.php
@@ -123,4 +123,18 @@ class Tests_XMLRPC_wp_getPostType extends WP_XMLRPC_UnitTestCase {
 			$this->assertSame( $value, $result[ $key ] );
 		}
 	}
+
+	/**
+	 * Ensure a non-array `$fields` argument is rejected instead of causing a fatal error.
+	 *
+	 * @ticket 65983
+	 */
+	public function test_non_array_fields_returns_error(): void {
+		$this->make_user_by_role( 'editor' );
+
+		$result = $this->myxmlrpcserver->wp_getPostType( array( 1, 'editor', 'editor', 'post', 'labels' ) );
+
+		$this->assertIXRError( $result );
+		$this->assertSame( 400, $result->code );
+	}
 }

--- a/tests/phpunit/tests/xmlrpc/wp/getPostTypes.php
+++ b/tests/phpunit/tests/xmlrpc/wp/getPostTypes.php
@@ -40,4 +40,18 @@ class Tests_XMLRPC_wp_getPostTypes extends WP_XMLRPC_UnitTestCase {
 		$this->assertContains( 'page', $result_names );
 		$this->assertNotContains( 'post', $result_names );
 	}
+
+	/**
+	 * Ensure a non-array `$fields` argument is rejected instead of causing a fatal error.
+	 *
+	 * @ticket 65983
+	 */
+	public function test_non_array_fields_returns_error(): void {
+		$this->make_user_by_role( 'editor' );
+
+		$result = $this->myxmlrpcserver->wp_getPostTypes( array( 1, 'editor', 'editor', array(), 'labels' ) );
+
+		$this->assertIXRError( $result );
+		$this->assertSame( 400, $result->code );
+	}
 }

--- a/tests/phpunit/tests/xmlrpc/wp/getPosts.php
+++ b/tests/phpunit/tests/xmlrpc/wp/getPosts.php
@@ -169,4 +169,18 @@ class Tests_XMLRPC_wp_getPosts extends WP_XMLRPC_UnitTestCase {
 		$this->assertNotIXRError( $results );
 		$this->assertCount( 1, $results );
 	}
+
+	/**
+	 * Ensure a non-array `$fields` argument is rejected instead of causing a fatal error.
+	 *
+	 * @ticket 65983
+	 */
+	public function test_non_array_fields_returns_error(): void {
+		$this->make_user_by_role( 'editor' );
+
+		$result = $this->myxmlrpcserver->wp_getPosts( array( 1, 'editor', 'editor', array(), 'post' ) );
+
+		$this->assertIXRError( $result );
+		$this->assertSame( 400, $result->code );
+	}
 }

--- a/tests/phpunit/tests/xmlrpc/wp/getProfile.php
+++ b/tests/phpunit/tests/xmlrpc/wp/getProfile.php
@@ -45,4 +45,18 @@ class Tests_XMLRPC_wp_getProfile extends WP_XMLRPC_UnitTestCase {
 		sort( $keys );
 		$this->assertSameSets( $expected_fields, $keys );
 	}
+
+	/**
+	 * Ensure a non-array `$fields` argument is rejected instead of causing a fatal error.
+	 *
+	 * @ticket 65983
+	 */
+	public function test_non_array_fields_returns_error(): void {
+		$this->make_user_by_role( 'editor' );
+
+		$result = $this->myxmlrpcserver->wp_getProfile( array( 1, 'editor', 'editor', 'all' ) );
+
+		$this->assertIXRError( $result );
+		$this->assertSame( 400, $result->code );
+	}
 }

--- a/tests/phpunit/tests/xmlrpc/wp/getRevisions.php
+++ b/tests/phpunit/tests/xmlrpc/wp/getRevisions.php
@@ -77,4 +77,19 @@ class Tests_XMLRPC_wp_getRevisions extends WP_XMLRPC_UnitTestCase {
 		$result = $this->myxmlrpcserver->wp_getRevisions( array( 1, 'editor', 'editor', $post_id ) );
 		$this->assertCount( 1, $result );
 	}
+
+	/**
+	 * Ensure a non-array `$fields` argument is rejected instead of causing a fatal error.
+	 *
+	 * @ticket 65983
+	 */
+	public function test_non_array_fields_returns_error(): void {
+		$this->make_user_by_role( 'editor' );
+		$post_id = self::factory()->post->create();
+
+		$result = $this->myxmlrpcserver->wp_getRevisions( array( 1, 'editor', 'editor', $post_id, 'post_date' ) );
+
+		$this->assertIXRError( $result );
+		$this->assertSame( 400, $result->code );
+	}
 }

--- a/tests/phpunit/tests/xmlrpc/wp/getTaxonomies.php
+++ b/tests/phpunit/tests/xmlrpc/wp/getTaxonomies.php
@@ -17,4 +17,18 @@ class Tests_XMLRPC_wp_getTaxonomies extends WP_XMLRPC_UnitTestCase {
 		$result = $this->myxmlrpcserver->wp_getTaxonomies( array( 1, 'editor', 'editor' ) );
 		$this->assertNotIXRError( $result );
 	}
+
+	/**
+	 * Ensure a non-array `$fields` argument is rejected instead of causing a fatal error.
+	 *
+	 * @ticket 65983
+	 */
+	public function test_non_array_fields_returns_error(): void {
+		$this->make_user_by_role( 'editor' );
+
+		$result = $this->myxmlrpcserver->wp_getTaxonomies( array( 1, 'editor', 'editor', array(), 'labels' ) );
+
+		$this->assertIXRError( $result );
+		$this->assertSame( 400, $result->code );
+	}
 }

--- a/tests/phpunit/tests/xmlrpc/wp/getTaxonomy.php
+++ b/tests/phpunit/tests/xmlrpc/wp/getTaxonomy.php
@@ -75,4 +75,18 @@ class Tests_XMLRPC_wp_getTaxonomy extends WP_XMLRPC_UnitTestCase {
 		$this->assertNotIXRError( $result );
 		$this->assertTrue( $result['show_in_menu'] );
 	}
+
+	/**
+	 * Ensure a non-array `$fields` argument is rejected instead of causing a fatal error.
+	 *
+	 * @ticket 65983
+	 */
+	public function test_non_array_fields_returns_error(): void {
+		$this->make_user_by_role( 'editor' );
+
+		$result = $this->myxmlrpcserver->wp_getTaxonomy( array( 1, 'editor', 'editor', 'category', 'labels' ) );
+
+		$this->assertIXRError( $result );
+		$this->assertSame( 400, $result->code );
+	}
 }

--- a/tests/phpunit/tests/xmlrpc/wp/getUser.php
+++ b/tests/phpunit/tests/xmlrpc/wp/getUser.php
@@ -140,4 +140,16 @@ class Tests_XMLRPC_wp_getUser extends WP_XMLRPC_UnitTestCase {
 		sort( $keys );
 		$this->assertSameSets( $expected_fields, $keys );
 	}
+
+	/**
+	 * Ensure a non-array `$fields` argument is rejected instead of causing a fatal error.
+	 *
+	 * @ticket 65983
+	 */
+	public function test_non_array_fields_returns_error(): void {
+		$result = $this->myxmlrpcserver->wp_getUser( array( 1, 'administrator', 'administrator', $this->administrator_id, 'all' ) );
+
+		$this->assertIXRError( $result );
+		$this->assertSame( 400, $result->code );
+	}
 }

--- a/tests/phpunit/tests/xmlrpc/wp/getUsers.php
+++ b/tests/phpunit/tests/xmlrpc/wp/getUsers.php
@@ -125,4 +125,18 @@ class Tests_XMLRPC_wp_getUsers extends WP_XMLRPC_UnitTestCase {
 			$last_email = $user['email'];
 		}
 	}
+
+	/**
+	 * Ensure a non-array `$fields` argument is rejected instead of causing a fatal error.
+	 *
+	 * @ticket 65983
+	 */
+	public function test_non_array_fields_returns_error(): void {
+		$this->make_user_by_role( 'administrator' );
+
+		$result = $this->myxmlrpcserver->wp_getUsers( array( 1, 'administrator', 'administrator', array(), 'all' ) );
+
+		$this->assertIXRError( $result );
+		$this->assertSame( 400, $result->code );
+	}
 }


### PR DESCRIPTION
https://core.trac.wordpress.org/ticket/65983



AI assistance: Yes
Tool(s): Claude
Model(s): Fable 5
Used for: It wrote the tests.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
