### PR TITLE
Media: Fix GD editor leaking WebP-lossless quality into other output formats

### DIFF
--- a/src/wp-includes/class-wp-image-editor-gd.php
+++ b/src/wp-includes/class-wp-image-editor-gd.php
@@ -612,13 +612,15 @@ class WP_Image_Editor_GD extends WP_Image_Editor {
 			$quality = $this->get_quality();
 		}
 
+		// Use the output mime type if present, matching the fallback parent::set_quality() uses.
+		$mime_type = ! empty( $this->output_mime_type ) ? $this->output_mime_type : $this->mime_type;
+
 		// Handle setting the quality for WebP lossless images, see https://php.watch/versions/8.1/gd-webp-lossless.
 		try {
-			if ( 'image/webp' === $this->mime_type && defined( 'IMG_WEBP_LOSSLESS' ) ) {
+			if ( 'image/webp' === $mime_type && defined( 'IMG_WEBP_LOSSLESS' ) ) {
 				$webp_info = wp_get_webp_info( $this->file );
 				if ( ! empty( $webp_info['type'] ) && 'lossless' === $webp_info['type'] ) {
 					$quality = IMG_WEBP_LOSSLESS;
-					parent::set_quality( $quality, $dims );
 				}
 			}
 		} catch ( Exception $e ) {

--- a/tests/phpunit/tests/image/editorGd.php
+++ b/tests/phpunit/tests/image/editorGd.php
@@ -674,4 +674,26 @@ class Tests_Image_Editor_GD extends WP_Image_UnitTestCase {
 
 		$this->assertTrue( $loaded );
 	}
+
+	/**
+	 * A lossless WebP source's quality should not leak into other output formats.
+	 *
+	 * @ticket 65977
+	 *
+	 * @requires function imagecreatefromwebp
+	 * @requires function imagejpeg
+	 */
+	public function test_set_quality_does_not_leak_webp_lossless_quality_into_other_formats() {
+		$gd_image_editor = new WP_Image_Editor_GD( DIR_TESTDATA . '/images/webp-lossless.webp' );
+		$loaded          = $gd_image_editor->load();
+
+		$this->assertNotWPError( $loaded );
+
+		$saved = $gd_image_editor->save( null, 'image/jpeg' );
+
+		$this->assertNotWPError( $saved );
+		$this->assertSame( 82, $gd_image_editor->get_quality(), 'Quality for a JPEG output should use the JPEG default, not the WebP lossless sentinel value.' );
+
+		unlink( $saved['path'] );
+	}
 }


### PR DESCRIPTION
`WP_Image_Editor_GD::set_quality()` checks `$this->mime_type` (the source image's mime type) instead of the output mime type when deciding whether to apply the WebP-lossless quality sentinel (`IMG_WEBP_LOSSLESS`, 101). Because of that, converting a lossless WebP source to any other format (AVIF, JPEG, etc.) still gets the quality forced to 101 — a value that is intentionally outside the normal `[1,100]` range and only valid for GD's WebP lossless encoder. On PHP 8.4+, passing 101 to `imageavif()`/`imagejpeg()` throws a `ValueError`, producing a fatal error, 0-byte sub-sizes, and broken `wp media regenerate` runs; on older PHP it silently applies the wrong quality to the non-WebP output.

This fixes the mime check to use `$this->output_mime_type` when it's set (falling back to `$this->mime_type`, matching the same fallback the parent class already uses in `WP_Image_Editor::set_quality()`), so the lossless override is only applied when the image is actually being encoded as WebP. It also removes the redundant `parent::set_quality( $quality, $dims )` call for the 101 sentinel, since that value is always rejected by the parent's `[1,100]` validation and its `WP_Error` return was being silently discarded — the direct `$this->quality` assignment right below it was already the only thing doing anything.

Added a PHPUnit test (`Tests_Image_Editor_GD::test_set_quality_does_not_leak_webp_lossless_quality_into_other_formats`) that loads a lossless WebP fixture, saves it as JPEG, and asserts the quality used is the normal JPEG default (82) rather than the leaked WebP-lossless sentinel (101).

Trac ticket: https://core.trac.wordpress.org/ticket/65977

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Sonnet 5
Used for: Root-cause analysis, implementation, tests, and PR description. Reviewed by Igor Rozum.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
