### PR TITLE
Build/Test Tools: Make the WordPress installation E2E test repeatable

### DIFF
--- a/tests/e2e/specs/install.test.js
+++ b/tests/e2e/specs/install.test.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { writeFileSync, readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
 import { join } from 'node:path';
 
 /**
@@ -29,15 +30,42 @@ test.describe( 'WordPress installation process', () => {
 
 	test.afterEach( async () => {
 		writeFileSync( wpConfig, wpConfigOriginal );
+
+		// The test completes a full install under the `wp_e2e_` prefix. Drop those
+		// tables, otherwise the next run finds a pre-existing install and never
+		// reaches the installation screen it's meant to be testing.
+		const tables = [
+			'commentmeta', 'comments', 'links', 'options', 'postmeta', 'posts',
+			'term_relationships', 'term_taxonomy', 'termmeta', 'terms', 'usermeta', 'users',
+		];
+		const dropTablesPhp = tables
+			.map( ( table ) => `global $wpdb; $wpdb->query( "DROP TABLE IF EXISTS wp_e2e_${ table }" );` )
+			.join( ' ' );
+
+		execFileSync(
+			process.execPath,
+			[
+				join( process.cwd(), 'tools/local-env/scripts/docker.js' ),
+				'exec',
+				'--user',
+				'wp_php',
+				'cli',
+				'wp',
+				'eval',
+				dropTablesPhp,
+			],
+			{ stdio: 'inherit' }
+		);
 	} );
 
 	test( 'should install WordPress with pre-existing database credentials', async ( { page } ) => {
-		await page.goto( '/' );
-
-		await expect(
-			page,
-			'should redirect to the installation page'
-		).toHaveURL( /wp-admin\/install\.php$/ );
+		// The config file was just rewritten on the host; retry the navigation
+		// (not just the URL check) since the container's view of the file can
+		// lag behind the write by a request or two.
+		await expect( async () => {
+			await page.goto( '/' );
+			expect( page.url() ).toMatch( /wp-admin\/install\.php$/ );
+		}, 'should redirect to the installation page' ).toPass( { timeout: 10_000 } );
 
 		await expect(
 			page.getByText( /WordPress database error/ ),

--- a/tests/e2e/specs/install.test.js
+++ b/tests/e2e/specs/install.test.js
@@ -12,6 +12,11 @@ import { test, expect } from '@wordpress/e2e-test-utils-playwright';
 
 let wpConfigOriginal;
 
+// The prefix used to trick WP into "not installed" mode. Kept as a single
+// constant since it has to stay in sync between the config rewrite and the
+// cleanup query below.
+const TEST_TABLE_PREFIX = 'wp_e2e_';
+
 test.describe( 'WordPress installation process', () => {
 	const wpConfig = join(
 		process.cwd(),
@@ -24,22 +29,22 @@ test.describe( 'WordPress installation process', () => {
 		// Changing the table prefix tricks WP into new install mode.
 		writeFileSync(
 			wpConfig,
-			wpConfigOriginal.replace( `$table_prefix = 'wp_';`, `$table_prefix = 'wp_e2e_';` )
+			wpConfigOriginal.replace( `$table_prefix = 'wp_';`, `$table_prefix = '${ TEST_TABLE_PREFIX }';` )
 		);
 	} );
 
 	test.afterEach( async () => {
 		writeFileSync( wpConfig, wpConfigOriginal );
 
-		// The test completes a full install under the `wp_e2e_` prefix. Drop those
-		// tables, otherwise the next run finds a pre-existing install and never
-		// reaches the installation screen it's meant to be testing.
+		// The test completes a full install under the `TEST_TABLE_PREFIX`. Drop
+		// those tables, otherwise the next run finds a pre-existing install and
+		// never reaches the installation screen it's meant to be testing.
 		const tables = [
 			'commentmeta', 'comments', 'links', 'options', 'postmeta', 'posts',
 			'term_relationships', 'term_taxonomy', 'termmeta', 'terms', 'usermeta', 'users',
 		];
 		const dropTablesPhp = tables
-			.map( ( table ) => `global $wpdb; $wpdb->query( "DROP TABLE IF EXISTS wp_e2e_${ table }" );` )
+			.map( ( table ) => `global $wpdb; $wpdb->query( "DROP TABLE IF EXISTS ${ TEST_TABLE_PREFIX }${ table }" );` )
 			.join( ' ' );
 
 		execFileSync(

--- a/tests/e2e/specs/install.test.js
+++ b/tests/e2e/specs/install.test.js
@@ -68,9 +68,14 @@ test.describe( 'WordPress installation process', () => {
 
 
 	test.beforeEach( async () => {
+		// Read this before the cleanup call below, which can throw. Otherwise,
+		// if it does, `afterEach` runs anyway (Playwright always runs it) and
+		// crashes trying to restore `wp-config.php` from an unset variable,
+		// masking the real cleanup error behind a confusing second one.
+		wpConfigOriginal = readFileSync( wpConfig, 'utf-8' );
+
 		dropE2eTables();
 
-		wpConfigOriginal = readFileSync( wpConfig, 'utf-8' );
 		// Changing the table prefix tricks WP into new install mode.
 		writeFileSync(
 			wpConfig,

--- a/tests/e2e/specs/install.test.js
+++ b/tests/e2e/specs/install.test.js
@@ -17,11 +17,6 @@ let wpConfigOriginal;
 // cleanup query below.
 const TEST_TABLE_PREFIX = 'wp_e2e_';
 
-const TEST_TABLES = [
-	'commentmeta', 'comments', 'links', 'options', 'postmeta', 'posts',
-	'term_relationships', 'term_taxonomy', 'termmeta', 'terms', 'usermeta', 'users',
-];
-
 /**
  * Drops any tables left over under TEST_TABLE_PREFIX.
  *
@@ -29,20 +24,29 @@ const TEST_TABLES = [
  * left stale tables behind — otherwise this run fails once and only
  * "self-heals" on the next run) and after it (so the next run starts clean).
  *
+ * Queries the database for whatever `TEST_TABLE_PREFIX`-prefixed tables
+ * actually exist rather than maintaining a hardcoded list, so it can't miss
+ * a table WordPress core adds in the future.
+ *
  * `wp eval` exits 0 even when a `$wpdb->query()` call inside it returns
  * false, so each DROP's result is checked explicitly and reported via
  * `WP_CLI::error()`, which does set a non-zero exit code — otherwise a
  * failed cleanup would silently report as a passing test.
  */
 function dropE2eTables() {
-	const dropTablesPhp = TEST_TABLES
-		.map( ( table ) => `
-			$result = $wpdb->query( "DROP TABLE IF EXISTS ${ TEST_TABLE_PREFIX }${ table }" );
+	// `_` is a single-character wildcard in SQL LIKE, so it must be escaped
+	// to match the prefix's underscores literally.
+	const likePattern = `${ TEST_TABLE_PREFIX.replace( /_/g, '\\_' ) }%`;
+
+	const dropTablesPhp = `
+		global $wpdb;
+		foreach ( $wpdb->get_col( "SHOW TABLES LIKE '${ likePattern }'" ) as $table ) {
+			$result = $wpdb->query( "DROP TABLE IF EXISTS {$table}" );
 			if ( false === $result ) {
-				WP_CLI::error( "Failed to drop ${ TEST_TABLE_PREFIX }${ table }: {$wpdb->last_error}" );
+				WP_CLI::error( "Failed to drop {$table}: {$wpdb->last_error}" );
 			}
-		` )
-		.join( '' );
+		}
+	`;
 
 	execFileSync(
 		process.execPath,
@@ -54,7 +58,7 @@ function dropE2eTables() {
 			'cli',
 			'wp',
 			'eval',
-			`global $wpdb; ${ dropTablesPhp }`,
+			dropTablesPhp,
 		],
 		{ stdio: 'inherit' }
 	);

--- a/tests/e2e/specs/install.test.js
+++ b/tests/e2e/specs/install.test.js
@@ -77,10 +77,24 @@ test.describe( 'WordPress installation process', () => {
 		dropE2eTables();
 
 		// Changing the table prefix tricks WP into new install mode.
-		writeFileSync(
-			wpConfig,
-			wpConfigOriginal.replace( `$table_prefix = 'wp_';`, `$table_prefix = '${ TEST_TABLE_PREFIX }';` )
+		const wpConfigPatched = wpConfigOriginal.replace(
+			`$table_prefix = 'wp_';`,
+			`$table_prefix = '${ TEST_TABLE_PREFIX }';`
 		);
+
+		// A prior run killed after this rewrite but before `afterEach` restores
+		// it leaves wp-config.php stranded on TEST_TABLE_PREFIX. `.replace()`
+		// then silently no-ops instead of throwing, and since the tables were
+		// just cleared above, the site looks freshly uninstalled under the
+		// already-stranded prefix — the test would pass while leaving the
+		// checkout stuck. Fail loudly here instead.
+		if ( wpConfigPatched === wpConfigOriginal ) {
+			throw new Error(
+				`wp-config.php does not contain the default table prefix. An interrupted run may have left it on '${ TEST_TABLE_PREFIX }'.`
+			);
+		}
+
+		writeFileSync( wpConfig, wpConfigPatched );
 	} );
 
 	test.afterEach( async () => {

--- a/tests/e2e/specs/install.test.js
+++ b/tests/e2e/specs/install.test.js
@@ -17,6 +17,49 @@ let wpConfigOriginal;
 // cleanup query below.
 const TEST_TABLE_PREFIX = 'wp_e2e_';
 
+const TEST_TABLES = [
+	'commentmeta', 'comments', 'links', 'options', 'postmeta', 'posts',
+	'term_relationships', 'term_taxonomy', 'termmeta', 'terms', 'usermeta', 'users',
+];
+
+/**
+ * Drops any tables left over under TEST_TABLE_PREFIX.
+ *
+ * Called both before the prefix swap (in case a previous run crashed and
+ * left stale tables behind — otherwise this run fails once and only
+ * "self-heals" on the next run) and after it (so the next run starts clean).
+ *
+ * `wp eval` exits 0 even when a `$wpdb->query()` call inside it returns
+ * false, so each DROP's result is checked explicitly and reported via
+ * `WP_CLI::error()`, which does set a non-zero exit code — otherwise a
+ * failed cleanup would silently report as a passing test.
+ */
+function dropE2eTables() {
+	const dropTablesPhp = TEST_TABLES
+		.map( ( table ) => `
+			$result = $wpdb->query( "DROP TABLE IF EXISTS ${ TEST_TABLE_PREFIX }${ table }" );
+			if ( false === $result ) {
+				WP_CLI::error( "Failed to drop ${ TEST_TABLE_PREFIX }${ table }: {$wpdb->last_error}" );
+			}
+		` )
+		.join( '' );
+
+	execFileSync(
+		process.execPath,
+		[
+			join( process.cwd(), 'tools/local-env/scripts/docker.js' ),
+			'exec',
+			'--user',
+			'wp_php',
+			'cli',
+			'wp',
+			'eval',
+			`global $wpdb; ${ dropTablesPhp }`,
+		],
+		{ stdio: 'inherit' }
+	);
+}
+
 test.describe( 'WordPress installation process', () => {
 	const wpConfig = join(
 		process.cwd(),
@@ -25,6 +68,8 @@ test.describe( 'WordPress installation process', () => {
 
 
 	test.beforeEach( async () => {
+		dropE2eTables();
+
 		wpConfigOriginal = readFileSync( wpConfig, 'utf-8' );
 		// Changing the table prefix tricks WP into new install mode.
 		writeFileSync(
@@ -36,31 +81,10 @@ test.describe( 'WordPress installation process', () => {
 	test.afterEach( async () => {
 		writeFileSync( wpConfig, wpConfigOriginal );
 
-		// The test completes a full install under the `TEST_TABLE_PREFIX`. Drop
-		// those tables, otherwise the next run finds a pre-existing install and
-		// never reaches the installation screen it's meant to be testing.
-		const tables = [
-			'commentmeta', 'comments', 'links', 'options', 'postmeta', 'posts',
-			'term_relationships', 'term_taxonomy', 'termmeta', 'terms', 'usermeta', 'users',
-		];
-		const dropTablesPhp = tables
-			.map( ( table ) => `global $wpdb; $wpdb->query( "DROP TABLE IF EXISTS ${ TEST_TABLE_PREFIX }${ table }" );` )
-			.join( ' ' );
-
-		execFileSync(
-			process.execPath,
-			[
-				join( process.cwd(), 'tools/local-env/scripts/docker.js' ),
-				'exec',
-				'--user',
-				'wp_php',
-				'cli',
-				'wp',
-				'eval',
-				dropTablesPhp,
-			],
-			{ stdio: 'inherit' }
-		);
+		// The test completes a full install under TEST_TABLE_PREFIX. Drop
+		// those tables, otherwise the next run finds a pre-existing install
+		// and never reaches the installation screen it's meant to be testing.
+		dropE2eTables();
 	} );
 
 	test( 'should install WordPress with pre-existing database credentials', async ( { page } ) => {


### PR DESCRIPTION
afterEach in tests/e2e/specs/install.test.js reverted wp-config.php's table prefix but never dropped the wp_e2e_* tables the test's own install wizard creates. As a result:

- The first run against a clean database passes, but leaves a fully-installed wp_e2e_options, wp_e2e_users, etc. behind.
- Every run after that flips the prefix to wp_e2e_ again, WordPress finds those tables already present, and the test never reaches /wp-admin/install.php — it fails deterministically on every subsequent run until someone manually drops the tables.

### **This PR:**

- Drops the wp_e2e_* tables in afterEach via wp eval, routed through WP's own $wpdb/mysqli connection rather than wp-cli's db query, which shells out to the mysql binary and can hit unrelated SSL/client issues on some hosts.
- Wraps the initial navigation + redirect assertion in expect(...).toPass() so the navigation itself retries, not just the URL check. A single page.goto('/') right after the config swap can occasionally observe a not-yet-updated wp-config.php on some hosts (consistent with Docker bind-mount write propagation lag).

### **Testing**

Isolation data — three consecutive runs of each variant, with wp_e2e_* tables dropped before each:
```

trunk (unpatched)          1 passed / 2 failed
retry navigation only      0 passed / 3 failed
table drop only            2 passed / 1 failed
both changes                3 passed / 0 failed

```

Both changes are independently necessary — neither one alone is sufficient to make the test reliably repeatable.

Trac ticket: https://core.trac.wordpress.org/ticket/65982

### **Use of AI Tools**

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Sonnet 5
Used for: Diagnosing the root cause (including tracing a Playwright network trace and DB state to rule out a false lead), drafting the fix, and building the A/B isolation harness used to produce the testing data above. I reviewed the diagnosis, ran and verified the fix and the isolation tests myself, and take responsibility for the change.


