### PR TITLE
Code Modernization: Use the null coalescing operator for isset() return checks in WP_Customize_Manager

### DIFF
--- a/src/wp-includes/class-wp-customize-manager.php
+++ b/src/wp-includes/class-wp-customize-manager.php
@@ -3872,11 +3872,7 @@ final class WP_Customize_Manager {
 	 * @return WP_Customize_Setting|null The setting, if set.
 	 */
 	public function get_setting( $id ) {
-		if ( isset( $this->settings[ $id ] ) ) {
-			return $this->settings[ $id ];
-		}
-
-		return null;
+		return $this->settings[ $id ] ?? null;
 	}
 
 	/**
@@ -3926,11 +3922,7 @@ final class WP_Customize_Manager {
 	 * @return WP_Customize_Panel|null Requested panel instance, if set.
 	 */
 	public function get_panel( $id ) {
-		if ( isset( $this->panels[ $id ] ) ) {
-			return $this->panels[ $id ];
-		}
-
-		return null;
+		return $this->panels[ $id ] ?? null;
 	}
 
 	/**
@@ -4024,11 +4016,7 @@ final class WP_Customize_Manager {
 	 * @return WP_Customize_Section|null The section, if set.
 	 */
 	public function get_section( $id ) {
-		if ( isset( $this->sections[ $id ] ) ) {
-			return $this->sections[ $id ];
-		}
-
-		return null;
+		return $this->sections[ $id ] ?? null;
 	}
 
 	/**
@@ -4105,11 +4093,7 @@ final class WP_Customize_Manager {
 	 * @return WP_Customize_Control|null The control object, if set.
 	 */
 	public function get_control( $id ) {
-		if ( isset( $this->controls[ $id ] ) ) {
-			return $this->controls[ $id ];
-		}
-
-		return null;
+		return $this->controls[ $id ] ?? null;
 	}
 
 	/**


### PR DESCRIPTION
The four object getters on `WP_Customize_Manager`: `get_setting()`, `get_panel()`, `get_section()` and `get_control()`, each spell out an `isset()` guard followed by `return null`. The null coalescing operator says the same thing in one line.

`??` applies the same `isset()` semantics as the guard it replaces, and since the fallback here is `null` itself, both forms return the identical value in every case. This covers the complete set of same-shaped getters in the class.

Follow-up to [[63378]](https://core.trac.wordpress.org/changeset/63378)

Trac ticket: https://core.trac.wordpress.org/ticket/65818

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
