### PR TITLE
Tests: Use assertIsNotArray() for array type assertions

### DIFF
--- a/tests/phpunit/tests/theme.php
+++ b/tests/phpunit/tests/theme.php
@@ -94,7 +94,7 @@ class Tests_Theme extends WP_UnitTestCase {
 
 		foreach ( array_keys( $themes ) as $name ) {
 			$theme = get_theme( $name );
-			// WP_Theme implements ArrayAccess, but is not an array. Not even ArrayObject is.
+			// WP_Theme implements ArrayAccess, but that does not make it an array.
 			$this->assertIsNotArray( $theme );
 			$this->assertInstanceOf( 'WP_Theme', $theme );
 			$this->assertSame( $theme, $themes[ $name ] );

--- a/tests/phpunit/tests/theme.php
+++ b/tests/phpunit/tests/theme.php
@@ -94,8 +94,8 @@ class Tests_Theme extends WP_UnitTestCase {
 
 		foreach ( array_keys( $themes ) as $name ) {
 			$theme = get_theme( $name );
-			// WP_Theme implements ArrayAccess. Even ArrayObject returns false for is_array().
-			$this->assertFalse( is_array( $theme ) );
+			// WP_Theme implements ArrayAccess, but is not an array. Not even ArrayObject is.
+			$this->assertIsNotArray( $theme );
 			$this->assertInstanceOf( 'WP_Theme', $theme );
 			$this->assertSame( $theme, $themes[ $name ] );
 		}


### PR DESCRIPTION
`Tests_Theme::test_get_theme()` wraps a native type check in a boolean assertion. PHPUnit has a dedicated assertion for this, which states the intent directly and reports a more useful message when it fails. The comment above it is reworded in the same change, as it referred to the `is_array()` call that is no longer there.

This is the last remaining convertible occurrence in the test suite.

Follow-up to [[62761]](https://core.trac.wordpress.org/changeset/62761), [[63311]](https://core.trac.wordpress.org/changeset/63311).

Trac ticket: https://core.trac.wordpress.org/ticket/65819

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
