### PR TITLE
Docs: Add missing `@since` changelog lines to the Abilities API

### DIFF
--- a/src/wp-includes/abilities-api.php
+++ b/src/wp-includes/abilities-api.php
@@ -232,6 +232,7 @@ declare( strict_types = 1 );
  *     ),
  *
  * @since 6.9.0
+ * @since 7.1.0 Added the `public` meta argument.
  * @since 7.2.0 The `category` argument is now optional and defaults to `uncategorized`.
  *
  * @see WP_Abilities_Registry::register()

--- a/src/wp-includes/abilities-api/class-wp-abilities-registry.php
+++ b/src/wp-includes/abilities-api/class-wp-abilities-registry.php
@@ -40,6 +40,7 @@ final class WP_Abilities_Registry {
 	 * Do not use this method directly. Instead, use the `wp_register_ability()` function.
 	 *
 	 * @since 6.9.0
+	 * @since 7.1.0 Added the `public` meta argument.
 	 * @since 7.2.0 The `category` argument is now optional and defaults to `uncategorized`.
 	 *
 	 * @see wp_register_ability()
@@ -110,6 +111,7 @@ final class WP_Abilities_Registry {
 		 * Filters the ability arguments before they are validated and used to instantiate the ability.
 		 *
 		 * @since 6.9.0
+		 * @since 7.1.0 Added the `public` meta argument.
 		 * @since 7.2.0 The `category` argument is now optional and defaults to `uncategorized`.
 		 *
 		 * @param array<string, mixed> $args {

--- a/src/wp-includes/abilities-api/class-wp-ability.php
+++ b/src/wp-includes/abilities-api/class-wp-ability.php
@@ -139,6 +139,7 @@ class WP_Ability {
 	 * @access private
 	 *
 	 * @since 6.9.0
+	 * @since 7.1.0 Added the `public` meta argument.
 	 *
 	 * @see wp_register_ability()
 	 *
@@ -209,6 +210,7 @@ class WP_Ability {
 	 * caught and converted to a WP_Error by WP_Abilities_Registry::register().
 	 *
 	 * @since 6.9.0
+	 * @since 7.1.0 Added the `public` meta argument.
 	 *
 	 * @see WP_Abilities_Registry::register()
 	 *
@@ -512,6 +514,7 @@ class WP_Ability {
 	 * Validates input data against the input schema.
 	 *
 	 * @since 6.9.0
+	 * @since 7.1.0 Added the `wp_ability_validate_input` filter.
 	 *
 	 * @param mixed $input Optional. The input data to validate. Default `null`.
 	 * @return true|WP_Error Returns true if valid or the WP_Error object if validation fails.
@@ -577,6 +580,7 @@ class WP_Ability {
 	 * Invokes a callable, ensuring the input is passed through only if the input schema is defined.
 	 *
 	 * @since 6.9.0
+	 * @since 7.1.0 Exceptions thrown by the callback are now caught and returned as a `WP_Error`.
 	 *
 	 * @param callable $callback The callable to invoke.
 	 * @param mixed    $input    Optional. The input data for the ability. Default `null`.
@@ -705,6 +709,7 @@ class WP_Ability {
 	 * Validates output data against the output schema.
 	 *
 	 * @since 6.9.0
+	 * @since 7.1.0 Added the `wp_ability_validate_output` filter.
 	 *
 	 * @param mixed $output The output data to validate.
 	 * @return true|WP_Error Returns true if valid, or a WP_Error object if validation fails.

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-abilities-v1-list-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-abilities-v1-list-controller.php
@@ -244,6 +244,7 @@ class WP_REST_Abilities_V1_List_Controller extends WP_REST_Controller {
 	 * Retrieves the ability's schema, conforming to JSON Schema.
 	 *
 	 * @since 6.9.0
+	 * @since 7.1.0 Added the `meta.public` property.
 	 *
 	 * @return array<string, mixed> Item schema data.
 	 */
@@ -330,6 +331,7 @@ class WP_REST_Abilities_V1_List_Controller extends WP_REST_Controller {
 	 * Retrieves the query params for collections.
 	 *
 	 * @since 6.9.0
+	 * @since 7.1.0 Added the `namespace` and `meta` parameters and the `rest_abilities_collection_params` filter.
 	 *
 	 * @return array<string, mixed> Collection parameters.
 	 */


### PR DESCRIPTION
## What

Adds `@since 7.1.0` changelog lines to Abilities API docblocks that were updated in WordPress 7.1 without a matching changelog entry. Documentation only, no code changes.

## Why

When a change updates an existing docblock (a new `$args` key, a new filter inside an existing method, a new REST schema property), core practice is to add a dated `@since` line next to the original one. For example: `@since 7.2.0 The 'category' argument is now optional…` in the same files, or `@since 7.1.0 Added the 'collection' property.` in `WP_REST_Icons_Controller`. A few 7.1 changes missed this step, so readers cannot tell when the behavior arrived.

## Changes documented

| Docblock | Added line | Introduced in |
| --- | --- | --- |
| `wp_register_ability()`, `WP_Abilities_Registry::register()`, `wp_register_ability_args` filter, `WP_Ability::__construct()`, `WP_Ability::prepare_properties()` | `Added the 'public' meta argument.` | [62729], [62737] |
| `WP_Ability::validate_input()` | `Added the 'wp_ability_validate_input' filter.` | [62398] |
| `WP_Ability::validate_output()` | `Added the 'wp_ability_validate_output' filter.` | [62398] |
| `WP_Ability::invoke_callback()` | `Exceptions thrown by the callback are now caught and returned as a 'WP_Error'.` | [62238] |
| `WP_REST_Abilities_V1_List_Controller::get_item_schema()` | `Added the 'meta.public' property.` | [62729] |
| `WP_REST_Abilities_V1_List_Controller::get_collection_params()` | `Added the 'namespace' and 'meta' parameters and the 'rest_abilities_collection_params' filter.` | [62420], [62548] |

Related tickets: #65568, #64311, #65058, #64990.

Trac ticket: to be added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
