### PR TITLE
Networks and Sites: Add search engine visibility option when creating a site

### DIFF
--- a/src/wp-admin/network/site-new.php
+++ b/src/wp-admin/network/site-new.php
@@ -65,8 +65,13 @@ if ( isset( $_REQUEST['action'] ) && 'add-site' === $_REQUEST['action'] ) {
 
 	$title = $blog['title'];
 
+	$public = 1;
+	if ( isset( $_POST['blog']['options']['blog_public'] ) && '0' === $_POST['blog']['options']['blog_public'] ) {
+		$public = 0;
+	}
+
 	$meta = array(
-		'public' => 1,
+		'public' => $public,
 	);
 
 	// Handle translation installation for the new site.
@@ -286,6 +291,24 @@ if ( ! empty( $messages ) ) {
 		</tr>
 		<tr class="form-field">
 			<td colspan="2" class="td-full"><p id="site-admin-email"><?php _e( 'A new user will be created if the above email address is not in the database.' ); ?><br /><?php _e( 'The username and a link to set the password will be mailed to this email address.' ); ?></p></td>
+		</tr>
+		<tr class="form-field">
+			<th scope="row"><?php esc_html_e( 'Search engine visibility' ); ?></th>
+			<td>
+				<fieldset>
+					<legend class="screen-reader-text">
+						<?php
+						/* translators: Hidden accessibility text. */
+						esc_html_e( 'Search engine visibility' );
+						?>
+					</legend>
+					<label for="blog_public">
+						<input name="blog[options][blog_public]" type="checkbox" id="blog_public" value="0" <?php checked( isset( $_POST['blog']['options']['blog_public'] ) && '0' === $_POST['blog']['options']['blog_public'] ); ?> />
+						<?php esc_html_e( 'Discourage search engines from indexing this site' ); ?>
+					</label>
+					<p class="description"><?php esc_html_e( 'It is up to search engines to honor this request.' ); ?></p>
+				</fieldset>
+			</td>
 		</tr>
 	</table>
 


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/56886

This PR provides a refreshed implementation for #56886 and references the existing PR #3882, whose current implementation predates the later requested changes.

The implementation:

- scopes handling specifically to `blog_public`;
- preserves the default `public = 1` behavior when no visibility option is submitted;
- uses the Network Admin Add Site form with a "Search engine visibility" checkbox;
- uses `blog[options][blog_public]` rather than generic `blog[meta]` processing;
- avoids `intval()` and unnecessary `wp_unslash()` in the new handling;
- preserves the existing `network_site_new_form` extension point;
- uses the current "Discourage search engines from indexing this site" wording.

Validation performed against current trunk for the exact submitted source change:

- `git diff --check`: PASS
- PHP syntax: PASS
- PHPCS for `src/wp-admin/network/site-new.php`: PASS
- Multisite regression tests: 220 tests, 596 assertions, PASS
- `tests/phpunit/tests/option/sanitizeOption.php`: 65 tests, 80 assertions, PASS
- Total selected tests: 285
- Total selected assertions: 676
- Network Admin Add Site form rendering: PASS
- Omitted visibility input creates the site with `blog_public = 1`: PASS
- Explicit `blog[options][blog_public] = 0` creates the site with `blog_public = 0`: PASS
- Temporary behavior-test sites were removed successfully.

Existing PR context: #3882.

This PR does not assert that any attached Trac patch supersedes another attachment.