### PR TITLE
Docs: Align `@param` tag columns in REST API docblocks

### DIFF
--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -1885,7 +1885,7 @@ function rest_find_matching_pattern_property_schema( $property, $args ) {
  * @since 5.6.0
  *
  * @param string $param The parameter name.
- * @param array $error  The error details.
+ * @param array  $error The error details.
  * @return WP_Error
  */
 function rest_format_combining_operation_error( $param, $error ) {

--- a/src/wp-includes/rest-api/class-wp-rest-server.php
+++ b/src/wp-includes/rest-api/class-wp-rest-server.php
@@ -259,7 +259,7 @@ class WP_REST_Server {
 		 *
 		 * @since 6.1.0
 		 *
-		 * @param int $options             JSON encoding options {@see json_encode()}.
+		 * @param int             $options JSON encoding options {@see json_encode()}.
 		 * @param WP_REST_Request $request Current request object.
 		 */
 		return apply_filters( 'rest_json_encode_options', $options, $request );
@@ -1914,7 +1914,7 @@ class WP_REST_Server {
 	 *
 	 * @since 4.4.0
 	 *
-	 * @param string $key Header key.
+	 * @param string $key   Header key.
 	 * @param string $value Header value.
 	 */
 	public function send_header( $key, $value ) {

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-abilities-v1-categories-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-abilities-v1-categories-controller.php
@@ -185,7 +185,7 @@ class WP_REST_Abilities_V1_Categories_Controller extends WP_REST_Controller {
 	 * @since 6.9.0
 	 *
 	 * @param WP_Ability_Category $category The ability category object.
-	 * @param WP_REST_Request     $request Request object.
+	 * @param WP_REST_Request     $request  Request object.
 	 * @return WP_REST_Response Response object.
 	 */
 	public function prepare_item_for_response( $category, $request ) {

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
@@ -523,10 +523,10 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 			 *
 			 * @since 4.7.0
 			 *
-			 * @param bool $allow_anonymous Whether to allow anonymous comments to
-			 *                              be created. Default `false`.
-			 * @param WP_REST_Request $request Request used to generate the
-			 *                                 response.
+			 * @param bool            $allow_anonymous Whether to allow anonymous comments to
+			 *                                         be created. Default `false`.
+			 * @param WP_REST_Request $request         Request used to generate the
+			 *                                         response.
 			 */
 			$allow_anonymous = apply_filters( 'rest_allow_anonymous_comments', false, $request );
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-menu-items-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-menu-items-controller.php
@@ -322,9 +322,9 @@ class WP_REST_Menu_Items_Controller extends WP_REST_Posts_Controller {
 		 *
 		 * @since 5.9.0
 		 *
-		 * @param object          $nav_menu_item Inserted or updated menu item object.
-		 * @param WP_REST_Response $response The response data.
-		 * @param WP_REST_Request $request       Request object.
+		 * @param object           $nav_menu_item Inserted or updated menu item object.
+		 * @param WP_REST_Response $response      The response data.
+		 * @param WP_REST_Request  $request       Request object.
 		 */
 		do_action( 'rest_delete_nav_menu_item', $menu_item, $response, $request );
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-revisions-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-revisions-controller.php
@@ -527,10 +527,10 @@ class WP_REST_Revisions_Controller extends WP_REST_Controller {
 		 *
 		 * @since 4.7.0
 		 *
-		 * @param WP_Post|false|null $result The revision object (if it was deleted or moved to the Trash successfully)
-		 *                                   or false or null (failure). If the revision was moved to the Trash, $result represents
-		 *                                   its new state; if it was deleted, $result represents its state before deletion.
-		 * @param WP_REST_Request $request The request sent to the API.
+		 * @param WP_Post|false|null $result  The revision object (if it was deleted or moved to the Trash successfully)
+		 *                                    or false or null (failure). If the revision was moved to the Trash, $result represents
+		 *                                    its new state; if it was deleted, $result represents its state before deletion.
+		 * @param WP_REST_Request    $request The request sent to the API.
 		 */
 		do_action( 'rest_delete_revision', $result, $request );
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-widget-types-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-widget-types-controller.php
@@ -572,7 +572,7 @@ class WP_REST_Widget_Types_Controller extends WP_REST_Controller {
 	 * @since 5.8.0
 	 *
 	 * @param WP_Widget $widget_object Widget object to call widget() on.
-	 * @param array     $instance Widget instance settings.
+	 * @param array     $instance      Widget instance settings.
 	 * @return string
 	 */
 	private function get_widget_form( $widget_object, $instance ) {
@@ -620,7 +620,7 @@ class WP_REST_Widget_Types_Controller extends WP_REST_Controller {
 	 *
 	 * @since 5.9.0
 	 *
-	 * @param string $id_base The id base of the requested widget.
+	 * @param string $id_base  The id base of the requested widget.
 	 * @param array  $instance The widget instance attributes.
 	 * @return string Rendered Legacy Widget block preview.
 	 */


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65818

The [PHP inline documentation standards](https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/) call for `@param` tags in a docblock to line up in columns — types, variable names, and descriptions each starting at the same offset — with wrapped descriptions indented to the description column:

```php
/**
 * Summary.
 *
 * @since x.x.x
 *
 * @param string $var       Description.
 * @param bool   $other_var Description that wraps
 *                          onto a second line.
 */
```

This corrects **17 `@param` lines across 7 files** in the REST API.

### Example

`src/wp-includes/rest-api/class-wp-rest-server.php` — before:

```php
 * @param int $options             JSON encoding options {@see json_encode()}.
 * @param WP_REST_Request $request Current request object.
```

after:

```php
 * @param int             $options JSON encoding options {@see json_encode()}.
 * @param WP_REST_Request $request Current request object.
```

<details>
<summary>Files changed (7)</summary>

- `src/wp-includes/rest-api.php`
- `src/wp-includes/rest-api/class-wp-rest-server.php`
- `src/wp-includes/rest-api/endpoints/class-wp-rest-abilities-v1-categories-controller.php`
- `src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php`
- `src/wp-includes/rest-api/endpoints/class-wp-rest-menu-items-controller.php`
- `src/wp-includes/rest-api/endpoints/class-wp-rest-revisions-controller.php`
- `src/wp-includes/rest-api/endpoints/class-wp-rest-widget-types-controller.php`

</details>


### Part of a series

The original work was a single branch touching 80 files. It is split by component so each can be reviewed and committed independently:

- #13311 — block editor
- **#13312 — REST API (this PR)**
- #13313 — upgrade, plugins, and themes
- #13314 — users and multisite
- #13315 — posts, comments, taxonomy, and media
- #13316 — administration
- #13317 — general core APIs

This is a **whitespace-only** change: `git diff -w` against `trunk` is empty, so there is no functional change and no change to any generated documentation output beyond the alignment itself.

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Grouping a single large docblock alignment branch into per-component pull requests, verifying that the split is whitespace-only and that the seven branches together reproduce the original diff line for line, and drafting this description. I reviewed the alignment changes before submitting.
