### PR TITLE
Docs: Align `@param` tag columns in administration docblocks

### DIFF
--- a/src/wp-admin/includes/class-wp-community-events.php
+++ b/src/wp-admin/includes/class-wp-community-events.php
@@ -39,7 +39,7 @@ class WP_Community_Events {
 	 *
 	 * @since 4.8.0
 	 *
-	 * @param int        $user_id       WP user ID.
+	 * @param int         $user_id       WP user ID.
 	 * @param false|array $user_location {
 	 *     Stored location data for the user. false to pass no location.
 	 *

--- a/src/wp-admin/includes/class-wp-internal-pointers.php
+++ b/src/wp-admin/includes/class-wp-internal-pointers.php
@@ -109,8 +109,8 @@ final class WP_Internal_Pointers {
 	 * @since 3.3.0
 	 *
 	 * @param string $pointer_id The pointer ID.
-	 * @param string $selector The HTML elements, on which the pointer should be attached.
-	 * @param array  $args Arguments to be passed to the pointer JS (see wp-pointer.js).
+	 * @param string $selector   The HTML elements, on which the pointer should be attached.
+	 * @param array  $args       Arguments to be passed to the pointer JS (see wp-pointer.js).
 	 */
 	private static function print_js( $pointer_id, $selector, $args ) {
 		if ( empty( $pointer_id ) || empty( $selector ) || empty( $args ) || empty( $args['content'] ) ) {

--- a/src/wp-admin/includes/class-wp-list-table.php
+++ b/src/wp-admin/includes/class-wp-list-table.php
@@ -729,7 +729,7 @@ class WP_List_Table {
 		 *
 		 * @since 5.7.0
 		 *
-		 * @param object[]|false $months   'Months' drop-down results. Default false.
+		 * @param object[]|false $months    'Months' drop-down results. Default false.
 		 * @param string         $post_type The post type.
 		 */
 		$months = apply_filters( 'pre_months_dropdown_query', false, $post_type );

--- a/src/wp-admin/includes/class-wp-posts-list-table.php
+++ b/src/wp-admin/includes/class-wp-posts-list-table.php
@@ -1854,7 +1854,7 @@ class WP_Posts_List_Table extends WP_List_Table {
 							 * @see wp_dropdown_users()
 							 *
 							 * @param array $users_opt An array of arguments passed to wp_dropdown_users().
-							 * @param bool $bulk A flag to denote if it's a bulk action.
+							 * @param bool  $bulk      A flag to denote if it's a bulk action.
 							 */
 							$users_opt = apply_filters( 'quick_edit_dropdown_authors_args', $users_opt, $bulk );
 

--- a/src/wp-admin/includes/class-wp-terms-list-table.php
+++ b/src/wp-admin/includes/class-wp-terms-list-table.php
@@ -395,8 +395,8 @@ class WP_Terms_List_Table extends WP_List_Table {
 		 *
 		 * @see WP_Terms_List_Table::column_name()
 		 *
-		 * @param string $pad_tag_name The term name, padded if not top-level.
-		 * @param WP_Term $tag         Term object.
+		 * @param string  $pad_tag_name The term name, padded if not top-level.
+		 * @param WP_Term $tag          Term object.
 		 */
 		$name = apply_filters( 'term_name', $pad . ' ' . $tag->name, $tag );
 

--- a/src/wp-admin/includes/list-table.php
+++ b/src/wp-admin/includes/list-table.php
@@ -84,7 +84,7 @@ function _get_list_table( $class_name, $args = array() ) {
  *
  * @since 2.7.0
  *
- * @param string    $screen The handle for the screen to register column headers for. This is
+ * @param string   $screen  The handle for the screen to register column headers for. This is
  *                          usually the hook name returned by the `add_*_page()` functions.
  * @param string[] $columns An array of columns with column IDs as the keys and translated
  *                          column names as the values.

--- a/src/wp-admin/includes/template.php
+++ b/src/wp-admin/includes/template.php
@@ -1808,7 +1808,7 @@ function do_settings_sections( $page ) {
  *
  * @global array $wp_settings_fields Storage array of settings fields and their pages/sections.
  *
- * @param string $page Slug title of the admin page whose settings fields you want to show.
+ * @param string $page    Slug title of the admin page whose settings fields you want to show.
  * @param string $section Slug title of the settings section whose fields you want to show.
  */
 function do_settings_fields( $page, $section ) {

--- a/src/wp-includes/class-walker-nav-menu.php
+++ b/src/wp-includes/class-walker-nav-menu.php
@@ -99,13 +99,13 @@ class Walker_Nav_Menu extends Walker {
 		 *
 		 * @since 6.3.0
 		 *
-		 * @param array $atts {
+		 * @param array    $atts {
 		 *     The HTML attributes applied to the `<ul>` element, empty strings are ignored.
 		 *
 		 *     @type string $class    HTML CSS class attribute.
 		 * }
-		 * @param stdClass $args      An object of `wp_nav_menu()` arguments.
-		 * @param int      $depth     Depth of menu item. Used for padding.
+		 * @param stdClass $args  An object of `wp_nav_menu()` arguments.
+		 * @param int      $depth Depth of menu item. Used for padding.
 		 */
 		$atts       = apply_filters( 'nav_menu_submenu_attributes', $atts, $args, $depth );
 		$attributes = $this->build_atts( $atts );
@@ -215,7 +215,7 @@ class Walker_Nav_Menu extends Walker {
 		 *
 		 * @since 6.3.0
 		 *
-		 * @param array $li_atts {
+		 * @param array    $li_atts {
 		 *     The HTML attributes applied to the menu item's `<li>` element, empty strings are ignored.
 		 *
 		 *     @type string $class        HTML CSS class attribute.
@@ -281,7 +281,7 @@ class Walker_Nav_Menu extends Walker {
 		 * @since 3.6.0
 		 * @since 4.1.0 The `$depth` parameter was added.
 		 *
-		 * @param array $atts {
+		 * @param array    $atts {
 		 *     The HTML attributes applied to the menu item's `<a>` element, empty strings are ignored.
 		 *
 		 *     @type string $title        Title attribute.

--- a/src/wp-includes/class-walker-page.php
+++ b/src/wp-includes/class-walker-page.php
@@ -176,7 +176,7 @@ class Walker_Page extends Walker {
 		 *
 		 * @since 4.8.0
 		 *
-		 * @param array $atts {
+		 * @param array   $atts {
 		 *     The HTML attributes applied to the menu item's `<a>` element, empty strings are ignored.
 		 *
 		 *     @type string $href         The href attribute.

--- a/src/wp-includes/class-wp-admin-bar.php
+++ b/src/wp-includes/class-wp-admin-bar.php
@@ -504,7 +504,7 @@ class WP_Admin_Bar {
 	 * @since 3.3.0
 	 * @since 6.5.0 Added `$menu_title` parameter to allow an ARIA menu name.
 	 *
-	 * @param object $node
+	 * @param object      $node
 	 * @param string|bool $menu_title The accessible name of this ARIA menu or false if not provided.
 	 */
 	final protected function _render_group( $node, $menu_title = false ) {

--- a/src/wp-includes/class-wp-customize-manager.php
+++ b/src/wp-includes/class-wp-customize-manager.php
@@ -3250,7 +3250,7 @@ final class WP_Customize_Manager {
 	 * @since 4.9.0
 	 *
 	 * @param int  $changeset_post_id Changeset post ID.
-	 * @param bool $take_over Whether to take over the changeset. Default false.
+	 * @param bool $take_over         Whether to take over the changeset. Default false.
 	 */
 	public function set_changeset_lock( $changeset_post_id, $take_over = false ) {
 		if ( $changeset_post_id ) {

--- a/src/wp-includes/customize/class-wp-customize-selective-refresh.php
+++ b/src/wp-includes/customize/class-wp-customize-selective-refresh.php
@@ -417,7 +417,7 @@ final class WP_Customize_Selective_Refresh {
 		 *
 		 * @since 4.5.0
 		 *
-		 * @param array $response {
+		 * @param array                          $response {
 		 *     Response.
 		 *
 		 *     @type array $contents Associative array mapping a partial ID its corresponding array of contents

--- a/src/wp-includes/widgets.php
+++ b/src/wp-includes/widgets.php
@@ -1999,7 +1999,7 @@ function wp_assign_widget_to_sidebar( $widget_id, $sidebar_id ) {
  * @global array $wp_registered_widgets  The registered widgets.
  * @global array $wp_registered_sidebars The registered sidebars.
  *
- * @param string $widget_id Widget ID.
+ * @param string $widget_id  Widget ID.
  * @param string $sidebar_id Sidebar ID.
  * @return string
  */


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65818

The [PHP inline documentation standards](https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/) call for `@param` tags in a docblock to line up in columns — types, variable names, and descriptions each starting at the same offset — with wrapped descriptions indented to the description column:

```php
/**
 * Summary.
 *
 * @since x.x.x
 *
 * @param string $var       Description.
 * @param bool   $other_var Description that wraps
 *                          onto a second line.
 */
```

This corrects **19 `@param` lines across 13 files** in the administration screens.

### Example

`src/wp-admin/includes/class-wp-community-events.php` — before:

```php
 * @param int        $user_id       WP user ID.
 * @param false|array $user_location {
```

after:

```php
 * @param int         $user_id       WP user ID.
 * @param false|array $user_location {
```

<details>
<summary>Files changed (13)</summary>

- `src/wp-admin/includes/class-wp-list-table.php`
- `src/wp-admin/includes/class-wp-posts-list-table.php`
- `src/wp-admin/includes/class-wp-terms-list-table.php`
- `src/wp-admin/includes/list-table.php`
- `src/wp-admin/includes/template.php`
- `src/wp-admin/includes/class-wp-internal-pointers.php`
- `src/wp-admin/includes/class-wp-community-events.php`
- `src/wp-includes/class-wp-admin-bar.php`
- `src/wp-includes/class-walker-nav-menu.php`
- `src/wp-includes/class-walker-page.php`
- `src/wp-includes/class-wp-customize-manager.php`
- `src/wp-includes/customize/class-wp-customize-selective-refresh.php`
- `src/wp-includes/widgets.php`

</details>


### Part of a series

The original work was a single branch touching 80 files. It is split by component so each can be reviewed and committed independently:

- #13311 — block editor
- #13312 — REST API
- #13313 — upgrade, plugins, and themes
- #13314 — users and multisite
- #13315 — posts, comments, taxonomy, and media
- **#13316 — administration (this PR)**
- #13317 — general core APIs

This is a **whitespace-only** change: `git diff -w` against `trunk` is empty, so there is no functional change and no change to any generated documentation output beyond the alignment itself.

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Grouping a single large docblock alignment branch into per-component pull requests, verifying that the split is whitespace-only and that the seven branches together reproduce the original diff line for line, and drafting this description. I reviewed the alignment changes before submitting.
