### PR TITLE
Docs: Align `@param` tag columns in general core API docblocks

### DIFF
--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -1312,7 +1312,7 @@ function download_url( $url, $timeout = 300, $signature_verification = false ) {
 			 * @since 5.2.0
 			 *
 			 * @param false|string $signature_url The URL where signatures can be found for a file, or false if none are known.
-			 * @param string $url                 The URL being verified.
+			 * @param string       $url           The URL being verified.
 			 */
 			$signature_url = apply_filters( 'wp_signature_url', $signature_url, $url );
 

--- a/src/wp-includes/class-wp-fatal-error-handler.php
+++ b/src/wp-includes/class-wp-fatal-error-handler.php
@@ -228,8 +228,8 @@ class WP_Fatal_Error_Handler {
 		 *
 		 * @since 5.2.0
 		 *
-		 * @param array $args Associative array of arguments passed to `wp_die()`. By default these contain a
-		 *                    'response' key, and optionally 'link_url' and 'link_text' keys.
+		 * @param array $args  Associative array of arguments passed to `wp_die()`. By default these contain a
+		 *                     'response' key, and optionally 'link_url' and 'link_text' keys.
 		 * @param array $error Error information retrieved from `error_get_last()`.
 		 */
 		$args = apply_filters( 'wp_php_error_args', $args, $error );

--- a/src/wp-includes/class-wp-hook.php
+++ b/src/wp-includes/class-wp-hook.php
@@ -517,7 +517,7 @@ final class WP_Hook implements Iterator, ArrayAccess {
 	 * @link https://www.php.net/manual/en/arrayaccess.offsetset.php
 	 *
 	 * @param int|null $offset The offset to assign the value to.
-	 * @param array    $value The value to set.
+	 * @param array    $value  The value to set.
 	 * @phpstan-param array<non-decimal-int-string, Hook_Callback> $value
 	 */
 	#[ReturnTypeWillChange]

--- a/src/wp-includes/class-wp-http-requests-hooks.php
+++ b/src/wp-includes/class-wp-http-requests-hooks.php
@@ -68,9 +68,9 @@ class WP_HTTP_Requests_Hooks extends WpOrg\Requests\Hooks {
 		 *
 		 * @since 4.7.0
 		 *
-		 * @param array $parameters Parameters from Requests internal hook.
-		 * @param array $request Request data in WP_Http format.
-		 * @param string $url URL to request.
+		 * @param array  $parameters Parameters from Requests internal hook.
+		 * @param array  $request    Request data in WP_Http format.
+		 * @param string $url        URL to request.
 		 */
 		do_action_ref_array( "requests-{$hook}", $parameters, $this->request, $this->url ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
 

--- a/src/wp-includes/class-wp-oembed.php
+++ b/src/wp-includes/class-wp-oembed.php
@@ -807,7 +807,7 @@ class WP_oEmbed {
 	 *
 	 * @param string|false $html Existing HTML.
 	 * @param object       $data Data object from WP_oEmbed::data2html()
-	 * @param string       $url The original URL passed to oEmbed.
+	 * @param string       $url  The original URL passed to oEmbed.
 	 * @return string|false Possibly modified $html.
 	 */
 	public function _strip_newlines( $html, $data, $url ) {

--- a/src/wp-includes/cron.php
+++ b/src/wp-includes/cron.php
@@ -787,12 +787,12 @@ function wp_get_scheduled_event( $hook, $args = array(), $timestamp = null ) {
 	 *
 	 * @since 5.1.0
 	 *
-	 * @param null|false|object $pre  Value to return instead. Default null to continue retrieving the event.
-	 * @param string            $hook Action hook of the event.
-	 * @param array             $args Array containing each separate argument to pass to the hook's callback function.
-	 *                                Although not passed to a callback, these arguments are used to uniquely identify
-	 *                                the event.
-	 * @param int|null  $timestamp Unix timestamp (UTC) of the event. Null to retrieve next scheduled event.
+	 * @param null|false|object $pre       Value to return instead. Default null to continue retrieving the event.
+	 * @param string            $hook      Action hook of the event.
+	 * @param array             $args      Array containing each separate argument to pass to the hook's callback function.
+	 *                                     Although not passed to a callback, these arguments are used to uniquely identify
+	 *                                     the event.
+	 * @param int|null          $timestamp Unix timestamp (UTC) of the event. Null to retrieve next scheduled event.
 	 */
 	$pre = apply_filters( 'pre_get_scheduled_event', null, $hook, $args, $timestamp );
 
@@ -966,7 +966,7 @@ function spawn_cron( $gmt_time = 0 ) {
 	 * @since 3.5.0
 	 * @since 4.5.0 The `$doing_wp_cron` parameter was added.
 	 *
-	 * @param array $cron_request_array {
+	 * @param array  $cron_request_array {
 	 *     An array of cron request URL arguments.
 	 *
 	 *     @type string $url  The cron request URL.
@@ -979,7 +979,7 @@ function spawn_cron( $gmt_time = 0 ) {
 	 *         @type bool $sslverify Whether SSL should be verified for the request. Default false.
 	 *     }
 	 * }
-	 * @param string $doing_wp_cron The Unix timestamp (UTC) of the cron lock with microseconds.
+	 * @param string $doing_wp_cron      The Unix timestamp (UTC) of the cron lock with microseconds.
 	 */
 	$cron_request = apply_filters(
 		'cron_request',

--- a/src/wp-includes/embed.php
+++ b/src/wp-includes/embed.php
@@ -98,7 +98,7 @@ function wp_embed_defaults( $url = '' ) {
  *
  * @see WP_oEmbed
  *
- * @param string $url  The URL that should be embedded.
+ * @param string       $url  The URL that should be embedded.
  * @param array|string $args {
  *     Optional. Additional arguments for retrieving embed HTML. Default empty.
  *
@@ -264,8 +264,8 @@ function wp_embed_handler_youtube( $matches, $attr, $url, $rawattr ) {
  * @since 3.6.0
  *
  * @param array  $matches The RegEx matches from the provided regex when calling wp_embed_register_handler().
- * @param array  $attr Embed attributes.
- * @param string $url The original URL that was matched by the regex.
+ * @param array  $attr    Embed attributes.
+ * @param string $url     The original URL that was matched by the regex.
  * @param array  $rawattr The original unmodified attributes.
  * @return string The embed HTML.
  */

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -3840,9 +3840,9 @@ function sanitize_email( $email ) {
 		 *
 		 * @since 2.8.0
 		 *
-		 * @param string $sanitized_email The sanitized email address.
-		 * @param string $email           The email address, as provided to sanitize_email().
-		 * @param string|null $message    A message to pass to the user. null if email is sanitized.
+		 * @param string      $sanitized_email The sanitized email address.
+		 * @param string      $email           The email address, as provided to sanitize_email().
+		 * @param string|null $message         A message to pass to the user. null if email is sanitized.
 		 */
 		return apply_filters( 'sanitize_email', '', $email, 'email_too_short' );
 	}

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -3794,7 +3794,7 @@ function wp_nonce_ays( $action ) {
  *                                     error data with the key 'title' may be used to specify the title.
  *                                     If `$title` is an integer, then it is treated as the response code.
  *                                     Default empty string.
- * @param string|array|int $args {
+ * @param string|array|int    $args {
  *     Optional. Arguments to control behavior. If `$args` is an integer, then it is treated
  *     as the response code. Default empty array.
  *
@@ -8361,7 +8361,7 @@ All at ###SITENAME###
 	 *
 	 * @since 4.9.0
 	 *
-	 * @param array $email_change_email {
+	 * @param array  $email_change_email {
 	 *     Used to build wp_mail().
 	 *
 	 *     @type string $to      The intended recipient.
@@ -8374,8 +8374,8 @@ All at ###SITENAME###
 	 *          - `###SITEURL###`   The URL to the site.
 	 *     @type string $headers Headers.
 	 * }
-	 * @param string $old_email The old site admin email address.
-	 * @param string $new_email The new site admin email address.
+	 * @param string $old_email          The old site admin email address.
+	 * @param string $new_email          The new site admin email address.
 	 */
 	$email_change_email = apply_filters( 'site_admin_email_change_email', $email_change_email, $old_email, $new_email );
 
@@ -8917,7 +8917,7 @@ function wp_get_direct_update_https_url() {
  * @since MU (3.0.0)
  * @since 5.2.0 $max_execution_time parameter added.
  *
- * @param string $directory Full path of a directory.
+ * @param string $directory          Full path of a directory.
  * @param int    $max_execution_time Maximum time to run before giving up. In seconds.
  *                                   The timeout is global and is measured from the moment WordPress started to load.
  * @return int|false|null Size in bytes if a valid directory. False if not. Null if timeout.

--- a/src/wp-includes/functions.wp-scripts.php
+++ b/src/wp-includes/functions.wp-scripts.php
@@ -445,7 +445,7 @@ function wp_deregister_script( $handle ) {
  *                                 as a query string for cache busting purposes. If version is set to false, a version
  *                                 number is automatically added equal to current installed WordPress version.
  *                                 If set to null, no version is added.
- * @param array|bool $args {
+ * @param array|bool       $args {
  *     Optional. An array of extra args for the script. Default empty array.
  *     Otherwise, it may be a boolean in which case it determines whether the script is printed in the footer. Default false.
  *

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -4786,7 +4786,7 @@ function get_language_attributes( $doctype = 'html' ) {
 	 * @since 2.5.0
 	 * @since 4.3.0 Added the `$doctype` parameter.
 	 *
-	 * @param string $output A space-separated list of language attributes.
+	 * @param string $output  A space-separated list of language attributes.
 	 * @param string $doctype The type of HTML document (xhtml|html).
 	 */
 	return apply_filters( 'language_attributes', $output, $doctype );

--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -2007,9 +2007,9 @@ function get_adjacent_post( $in_same_term = false, $excluded_terms = '', $previo
 	 * @since 4.9.0 Added the `$order` parameter.
 	 * @since 6.9.0 Adds ID sort to ensure deterministic ordering for posts with identical dates.
 	 *
-	 * @param string $order_by The `ORDER BY` clause in the SQL.
-	 * @param WP_Post $post    WP_Post object.
-	 * @param string  $order   Sort order. 'DESC' for previous post, 'ASC' for next.
+	 * @param string  $order_by The `ORDER BY` clause in the SQL.
+	 * @param WP_Post $post     WP_Post object.
+	 * @param string  $order    Sort order. 'DESC' for previous post, 'ASC' for next.
 	 */
 	$sort = apply_filters( "get_{$adjacent}_post_sort", "ORDER BY p.post_date $order, p.ID $order LIMIT 1", $post, $order );
 

--- a/src/wp-includes/load.php
+++ b/src/wp-includes/load.php
@@ -2042,8 +2042,8 @@ function wp_is_site_protected_by_basic_auth( $context = '' ) {
 	 *
 	 * @since 5.6.1
 	 *
-	 * @param bool $is_protected Whether the site is protected by Basic Auth.
-	 * @param string $context    The context to check for protection. One of 'login', 'admin', or 'front'.
+	 * @param bool   $is_protected Whether the site is protected by Basic Auth.
+	 * @param string $context      The context to check for protection. One of 'login', 'admin', or 'front'.
 	 */
 	return apply_filters( 'wp_is_site_protected_by_basic_auth', $is_protected, $context );
 }

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -2978,7 +2978,7 @@ function register_initial_settings() {
  * @param string $option_group A settings group name. Should correspond to an allowed option key name.
  *                             Default allowed option key names include 'general', 'discussion', 'media',
  *                             'reading', 'writing', and 'options'.
- * @param string $option_name The name of an option to sanitize and save.
+ * @param string $option_name  The name of an option to sanitize and save.
  * @param array  $args {
  *     Data used to describe the setting when registered.
  *

--- a/src/wp-includes/pomo/mo.php
+++ b/src/wp-includes/pomo/mo.php
@@ -310,8 +310,8 @@ if ( ! class_exists( 'MO', false ) ) :
 		 * found in a MO file
 		 *
 		 * @static
-		 * @param string $original original string to translate from MO file. Might contain
-		 *  0x04 as context separator or 0x00 as singular/plural separator
+		 * @param string $original    original string to translate from MO file. Might contain
+		 *     0x04 as context separator or 0x00 as singular/plural separator
 		 * @param string $translation translation string from MO file. Might contain
 		 *  0x00 as a plural translations separator
 		 * @return Translation_Entry Entry instance.

--- a/src/wp-includes/pomo/mo.php
+++ b/src/wp-includes/pomo/mo.php
@@ -311,9 +311,9 @@ if ( ! class_exists( 'MO', false ) ) :
 		 *
 		 * @static
 		 * @param string $original    original string to translate from MO file. Might contain
-		 *     0x04 as context separator or 0x00 as singular/plural separator
+		 *                            0x04 as context separator or 0x00 as singular/plural separator
 		 * @param string $translation translation string from MO file. Might contain
-		 *  0x00 as a plural translations separator
+		 *                            0x00 as a plural translations separator
 		 * @return Translation_Entry Entry instance.
 		 */
 		public function &make_entry( $original, $translation ) {

--- a/src/wp-includes/pomo/translations.php
+++ b/src/wp-includes/pomo/translations.php
@@ -91,7 +91,7 @@ if ( ! class_exists( 'Translations', false ) ) :
 		 * @since 2.8.0
 		 *
 		 * @param string $header header name, without trailing :
-		 * @param string $value header value, without trailing \n
+		 * @param string $value  header value, without trailing \n
 		 */
 		public function set_header( $header, $value ) {
 			$this->headers[ $header ] = $value;


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65818

The [PHP inline documentation standards](https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/) call for `@param` tags in a docblock to line up in columns — types, variable names, and descriptions each starting at the same offset — with wrapped descriptions indented to the description column:

```php
/**
 * Summary.
 *
 * @since x.x.x
 *
 * @param string $var       Description.
 * @param bool   $other_var Description that wraps
 *                          onto a second line.
 */
```

This corrects **38 `@param` lines across 16 files** in the general core APIs.

### Example

`src/wp-includes/class-wp-fatal-error-handler.php` — before:

```php
 * @param array $args Associative array of arguments passed to `wp_die()`. By default these contain a
 *                    'response' key, and optionally 'link_url' and 'link_text' keys.
 * @param array $error Error information retrieved from `error_get_last()`.
```

after:

```php
 * @param array $args  Associative array of arguments passed to `wp_die()`. By default these contain a
 *                     'response' key, and optionally 'link_url' and 'link_text' keys.
 * @param array $error Error information retrieved from `error_get_last()`.
```

<details>
<summary>Files changed (16)</summary>

- `src/wp-includes/functions.php`
- `src/wp-includes/load.php`
- `src/wp-includes/class-wp-fatal-error-handler.php`
- `src/wp-includes/class-wp-hook.php`
- `src/wp-includes/cron.php`
- `src/wp-includes/formatting.php`
- `src/wp-includes/general-template.php`
- `src/wp-includes/link-template.php`
- `src/wp-includes/option.php`
- `src/wp-includes/embed.php`
- `src/wp-includes/class-wp-oembed.php`
- `src/wp-includes/class-wp-http-requests-hooks.php`
- `src/wp-includes/pomo/mo.php`
- `src/wp-includes/pomo/translations.php`
- `src/wp-includes/functions.wp-scripts.php`
- `src/wp-admin/includes/file.php`

</details>


### Part of a series

The original work was a single branch touching 80 files. It is split by component so each can be reviewed and committed independently:

- #13311 — block editor
- #13312 — REST API
- #13313 — upgrade, plugins, and themes
- #13314 — users and multisite
- #13315 — posts, comments, taxonomy, and media
- #13316 — administration
- **#13317 — general core APIs (this PR)**

This is a **whitespace-only** change: `git diff -w` against `trunk` is empty, so there is no functional change and no change to any generated documentation output beyond the alignment itself.

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Grouping a single large docblock alignment branch into per-component pull requests, verifying that the split is whitespace-only and that the seven branches together reproduce the original diff line for line, and drafting this description. I reviewed the alignment changes before submitting.
