### PR TITLE
Build/Test Tools: Allow the CSS precommit task to be skipped

### DIFF
--- a/.github/workflows/reusable-test-core-build-process.yml
+++ b/.github/workflows/reusable-test-core-build-process.yml
@@ -21,6 +21,11 @@ on:
         required: false
         type: 'boolean'
         default: true
+      test-css:
+        description: 'Whether to run the precommit:css Grunt script.'
+        required: false
+        type: 'boolean'
+        default: true
       test-certificates:
         description: 'Whether to run the certificate related Grunt scripts.'
         required: false
@@ -113,7 +118,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run CSS precommit tasks
-        if: ${{ inputs.directory == 'src' }}
+        if: ${{ inputs.test-css && inputs.directory == 'src' }}
         run: npm run grunt precommit:css
 
       - name: Ensure certificates files are updated


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

The `Test Build Processes` workflow now fails for the 5.2 through 5.7 branches.

The `precommit:css` step added in [63315] runs Autoprefixer against whichever branch is checked out. Those branches have not had the task run since the browser usage database was last updated, so it rewrites tracked CSS files and the `git diff --exit-code` step that follows the build then fails. Since those branches call this reusable workflow at `@trunk`, this adds a `test-css` input mirroring the existing `test-emoji` one, letting each branch opt out.

It defaults to `true`, so no current caller changes behaviour; the affected branches still need `test-css: false` added alongside their existing `test-emoji: false`.

Trac ticket: https://core.trac.wordpress.org/ticket/65993

## Use of AI Tools
AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Tracing the CI failure to the `precommit:css` step and drafting the workflow input. All changes were reviewed and validated by me.
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
