### PR TITLE
Media/Admin: migrate raw inline scripts to wp_print_inline_script_tag()

### DIFF
--- a/src/wp-admin/admin-header.php
+++ b/src/wp-admin/admin-header.php
@@ -135,7 +135,7 @@ wp_print_inline_script_tag(
 				'decimalPoint'       => $wp_locale->number_format['decimal_point'],
 				'isRtl'              => (int) is_rtl(),
 			),
-			0 | JSON_HEX_TAG | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_LINE_TERMINATORS
+			JSON_HEX_TAG | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_LINE_TERMINATORS
 		)
 	)
 );

--- a/src/wp-admin/admin-header.php
+++ b/src/wp-admin/admin-header.php
@@ -105,19 +105,19 @@ $admin_body_class = preg_replace( '/[^a-z0-9_-]+/i', '-', $hook_suffix );
 // `wp_inline_script_attributes` filter (e.g. a CSP nonce) applies.
 wp_print_inline_script_tag(
 	<<<'JS'
-	function addLoadEvent(func) {
-		if (typeof jQuery !== 'undefined') {
-			jQuery(function () {
+	function addLoadEvent( func ) {
+		if ( typeof jQuery !== 'undefined' ) {
+			jQuery( function () {
 				func();
-			});
-		} else if (typeof wpOnload !== 'function') {
+			} );
+		} else if ( typeof wpOnload !== 'function' ) {
 			window.wpOnload = func;
 		} else {
-			const oldonload = wpOnload;
+			const oldOnload = window.wpOnload;
 			window.wpOnload = function () {
-				oldonload();
+				oldOnload();
 				func();
-			}
+			};
 		}
 	}
 	JS

--- a/src/wp-admin/admin-header.php
+++ b/src/wp-admin/admin-header.php
@@ -134,7 +134,8 @@ wp_print_inline_script_tag(
 				'thousandsSeparator' => $wp_locale->number_format['thousands_sep'],
 				'decimalPoint'       => $wp_locale->number_format['decimal_point'],
 				'isRtl'              => (int) is_rtl(),
-			)
+			),
+			0 | JSON_HEX_TAG | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_LINE_TERMINATORS
 		)
 	)
 );

--- a/src/wp-admin/admin-header.php
+++ b/src/wp-admin/admin-header.php
@@ -100,8 +100,7 @@ wp_enqueue_script( 'utils' );
 wp_enqueue_script( 'svg-painter' );
 
 $admin_body_class = preg_replace( '/[^a-z0-9_-]+/i', '-', $hook_suffix );
-?>
-<?php
+
 // Print the global admin inline scripts through the script tag API so the
 // `wp_inline_script_attributes` filter (e.g. a CSP nonce) applies.
 wp_print_inline_script_tag(
@@ -134,13 +133,11 @@ wp_print_inline_script_tag(
 				'adminpage'          => $admin_body_class,
 				'thousandsSeparator' => $wp_locale->number_format['thousands_sep'],
 				'decimalPoint'       => $wp_locale->number_format['decimal_point'],
-				'isRtl'              => (bool) is_rtl(),
+				'isRtl'              => (int) is_rtl(),
 			)
 		)
 	)
 );
-?>
-<?php
 
 /**
  * Fires when enqueuing scripts for all admin pages.
@@ -284,11 +281,11 @@ $admin_body_classes = ltrim( $admin_body_classes . ' ' . $admin_body_class );
 <body class="wp-admin wp-core-ui no-js <?php echo esc_attr( $admin_body_classes ); ?>">
 <?php
 wp_print_inline_script_tag(
-	"document.body.className = document.body.className.replace('no-js','js');"
+	<<<'JS'
+	document.body.className = document.body.className.replace( 'no-js', 'js' );
+	JS
 );
-?>
 
-<?php
 // Make sure the customize body classes are correct as early as possible.
 if ( current_user_can( 'customize' ) ) {
 	wp_customize_support_script();

--- a/src/wp-admin/admin-header.php
+++ b/src/wp-admin/admin-header.php
@@ -101,16 +101,20 @@ wp_enqueue_script( 'svg-painter' );
 
 $admin_body_class = preg_replace( '/[^a-z0-9_-]+/i', '-', $hook_suffix );
 ?>
-<script>
-addLoadEvent = function(func){if(typeof jQuery!=='undefined')jQuery(function(){func();});else if(typeof wpOnload!=='function'){wpOnload=func;}else{var oldonload=wpOnload;wpOnload=function(){oldonload();func();}}};
-var ajaxurl = '<?php echo esc_js( admin_url( 'admin-ajax.php', 'relative' ) ); ?>',
-	pagenow = '<?php echo esc_js( $current_screen->id ); ?>',
-	typenow = '<?php echo esc_js( $current_screen->post_type ); ?>',
-	adminpage = '<?php echo esc_js( $admin_body_class ); ?>',
-	thousandsSeparator = '<?php echo esc_js( $wp_locale->number_format['thousands_sep'] ); ?>',
-	decimalPoint = '<?php echo esc_js( $wp_locale->number_format['decimal_point'] ); ?>',
-	isRtl = <?php echo (int) is_rtl(); ?>;
-</script>
+<?php
+// Print the global admin inline scripts through the script tag API so the
+// `wp_inline_script_attributes` filter (e.g. a CSP nonce) applies.
+$admin_inline_js  = "addLoadEvent = function(func){if(typeof jQuery!=='undefined')jQuery(function(){func();});else if(typeof wpOnload!=='function'){wpOnload=func;}else{var oldonload=wpOnload;wpOnload=function(){oldonload();func();}}};\n";
+$admin_inline_js .= "var ajaxurl = '" . esc_js( admin_url( 'admin-ajax.php', 'relative' ) ) . "',\n";
+$admin_inline_js .= "\tpagenow = '" . esc_js( $current_screen->id ) . "',\n";
+$admin_inline_js .= "\ttypenow = '" . esc_js( $current_screen->post_type ) . "',\n";
+$admin_inline_js .= "\tadminpage = '" . esc_js( $admin_body_class ) . "',\n";
+$admin_inline_js .= "\tthousandsSeparator = '" . esc_js( $wp_locale->number_format['thousands_sep'] ) . "',\n";
+$admin_inline_js .= "\tdecimalPoint = '" . esc_js( $wp_locale->number_format['decimal_point'] ) . "',\n";
+$admin_inline_js .= "\tisRtl = " . (int) is_rtl() . ";\n";
+
+wp_print_inline_script_tag( $admin_inline_js );
+?>
 <?php
 
 /**
@@ -253,9 +257,11 @@ $admin_body_classes = apply_filters( 'admin_body_class', '' );
 $admin_body_classes = ltrim( $admin_body_classes . ' ' . $admin_body_class );
 ?>
 <body class="wp-admin wp-core-ui no-js <?php echo esc_attr( $admin_body_classes ); ?>">
-<script>
-	document.body.className = document.body.className.replace('no-js','js');
-</script>
+<?php
+wp_print_inline_script_tag(
+	"document.body.className = document.body.className.replace('no-js','js');"
+);
+?>
 
 <?php
 // Make sure the customize body classes are correct as early as possible.

--- a/src/wp-admin/admin-header.php
+++ b/src/wp-admin/admin-header.php
@@ -135,7 +135,7 @@ wp_print_inline_script_tag(
 				'decimalPoint'       => $wp_locale->number_format['decimal_point'],
 				'isRtl'              => (int) is_rtl(),
 			),
-			JSON_HEX_TAG | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_LINE_TERMINATORS
+			JSON_HEX_TAG | JSON_UNESCAPED_SLASHES
 		)
 	)
 );

--- a/src/wp-admin/admin-header.php
+++ b/src/wp-admin/admin-header.php
@@ -104,16 +104,41 @@ $admin_body_class = preg_replace( '/[^a-z0-9_-]+/i', '-', $hook_suffix );
 <?php
 // Print the global admin inline scripts through the script tag API so the
 // `wp_inline_script_attributes` filter (e.g. a CSP nonce) applies.
-$admin_inline_js  = "addLoadEvent = function(func){if(typeof jQuery!=='undefined')jQuery(function(){func();});else if(typeof wpOnload!=='function'){wpOnload=func;}else{var oldonload=wpOnload;wpOnload=function(){oldonload();func();}}};\n";
-$admin_inline_js .= "var ajaxurl = '" . esc_js( admin_url( 'admin-ajax.php', 'relative' ) ) . "',\n";
-$admin_inline_js .= "\tpagenow = '" . esc_js( $current_screen->id ) . "',\n";
-$admin_inline_js .= "\ttypenow = '" . esc_js( $current_screen->post_type ) . "',\n";
-$admin_inline_js .= "\tadminpage = '" . esc_js( $admin_body_class ) . "',\n";
-$admin_inline_js .= "\tthousandsSeparator = '" . esc_js( $wp_locale->number_format['thousands_sep'] ) . "',\n";
-$admin_inline_js .= "\tdecimalPoint = '" . esc_js( $wp_locale->number_format['decimal_point'] ) . "',\n";
-$admin_inline_js .= "\tisRtl = " . (int) is_rtl() . ";\n";
-
-wp_print_inline_script_tag( $admin_inline_js );
+wp_print_inline_script_tag(
+	<<<'JS'
+	function addLoadEvent(func) {
+		if (typeof jQuery !== 'undefined') {
+			jQuery(function () {
+				func();
+			});
+		} else if (typeof wpOnload !== 'function') {
+			window.wpOnload = func;
+		} else {
+			const oldonload = wpOnload;
+			window.wpOnload = function () {
+				oldonload();
+				func();
+			}
+		}
+	}
+	JS
+);
+wp_print_inline_script_tag(
+	sprintf(
+		'Object.assign( window, %s );',
+		wp_json_encode(
+			array(
+				'ajaxurl'            => admin_url( 'admin-ajax.php', 'relative' ),
+				'pagenow'            => $current_screen->id,
+				'typenow'            => $current_screen->post_type,
+				'adminpage'          => $admin_body_class,
+				'thousandsSeparator' => $wp_locale->number_format['thousands_sep'],
+				'decimalPoint'       => $wp_locale->number_format['decimal_point'],
+				'isRtl'              => (bool) is_rtl(),
+			)
+		)
+	)
+);
 ?>
 <?php
 

--- a/src/wp-admin/includes/media.php
+++ b/src/wp-admin/includes/media.php
@@ -668,11 +668,9 @@ function wp_iframe( $content_func, ...$args ) {
 	/** This action is documented in wp-admin/admin-footer.php */
 	do_action( 'admin_print_footer_scripts' );
 
-	?>
-	<?php
 	wp_print_inline_script_tag(
 		<<<'JS'
-		if( typeof wpOnload === 'function' ) {
+		if ( typeof wpOnload === 'function' ) {
 			wpOnload();
 		}
 		JS

--- a/src/wp-admin/includes/media.php
+++ b/src/wp-admin/includes/media.php
@@ -2282,8 +2282,6 @@ function media_upload_form( $errors = null ) {
 	 */
 	$plupload_init = apply_filters( 'plupload_init', $plupload_init );
 
-	?>
-	<?php
 	// Verify size is an int. If not return default value.
 	$large_size_h = absint( get_option( 'large_size_h' ) );
 

--- a/src/wp-admin/includes/media.php
+++ b/src/wp-admin/includes/media.php
@@ -273,10 +273,12 @@ function _cleanup_image_add_caption( $matches ) {
  */
 function media_send_to_editor( $html ) {
 	?>
-	<script>
-	var win = window.dialogArguments || opener || parent || top;
-	win.send_to_editor( <?php echo wp_json_encode( $html, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ); ?> );
-	</script>
+	<?php
+	wp_print_inline_script_tag(
+		"var win = window.dialogArguments || opener || parent || top;\n"
+		. "\twin.send_to_editor( " . wp_json_encode( $html, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ) . ' );'
+	);
+	?>
 	<?php
 	exit;
 }
@@ -568,11 +570,13 @@ function wp_iframe( $content_func, ...$args ) {
 	}
 
 	?>
-	<script>
-	addLoadEvent = function(func){if(typeof jQuery!=='undefined')jQuery(function(){func();});else if(typeof wpOnload!=='function'){wpOnload=func;}else{var oldonload=wpOnload;wpOnload=function(){oldonload();func();}}};
-	var ajaxurl = '<?php echo esc_js( admin_url( 'admin-ajax.php', 'relative' ) ); ?>', pagenow = 'media-upload-popup', adminpage = 'media-upload-popup',
-	isRtl = <?php echo (int) is_rtl(); ?>;
-	</script>
+	<?php
+	wp_print_inline_script_tag(
+		"addLoadEvent = function(func){if(typeof jQuery!=='undefined')jQuery(function(){func();});else if(typeof wpOnload!=='function'){wpOnload=func;}else{var oldonload=wpOnload;wpOnload=function(){oldonload();func();}}};\n"
+		. "var ajaxurl = '" . esc_js( admin_url( 'admin-ajax.php', 'relative' ) ) . "', pagenow = 'media-upload-popup', adminpage = 'media-upload-popup',\n"
+		. 'isRtl = ' . (int) is_rtl() . ';'
+	);
+	?>
 	<?php
 	/** This action is documented in wp-admin/admin-header.php */
 	do_action( 'admin_enqueue_scripts', 'media-upload-popup' );
@@ -630,9 +634,11 @@ function wp_iframe( $content_func, ...$args ) {
 	?>
 	</head>
 	<body<?php echo $body_id_attr; ?> class="wp-core-ui no-js <?php echo 'admin-color-' . sanitize_html_class( get_user_option( 'admin_color' ), 'modern' ); ?>">
-	<script>
-	document.body.className = document.body.className.replace('no-js', 'js');
-	</script>
+	<?php
+	wp_print_inline_script_tag(
+		"document.body.className = document.body.className.replace('no-js', 'js');"
+	);
+	?>
 	<?php
 
 	call_user_func_array( $content_func, $args );
@@ -641,7 +647,7 @@ function wp_iframe( $content_func, ...$args ) {
 	do_action( 'admin_print_footer_scripts' );
 
 	?>
-	<script>if(typeof wpOnload==='function')wpOnload();</script>
+	<?php wp_print_inline_script_tag( "if(typeof wpOnload==='function')wpOnload();" ); ?>
 	</body>
 	</html>
 	<?php
@@ -839,10 +845,11 @@ function media_upload_form_handler() {
 
 	if ( isset( $_POST['insert-gallery'] ) || isset( $_POST['update-gallery'] ) ) {
 		?>
-		<script>
-		var win = window.dialogArguments || opener || parent || top;
-		win.tb_remove();
-		</script>
+		<?php
+		wp_print_inline_script_tag(
+			"var win = window.dialogArguments || opener || parent || top;\n\t\twin.tb_remove();"
+		);
+		?>
 		<?php
 
 		exit;
@@ -2099,7 +2106,7 @@ function get_compat_media_markup( $attachment_id, $args = null ) {
 function media_upload_header() {
 	$post_id = isset( $_REQUEST['post_id'] ) ? (int) $_REQUEST['post_id'] : 0;
 
-	echo '<script>post_id = ' . $post_id . ';</script>';
+	wp_print_inline_script_tag( 'post_id = ' . $post_id . ';' );
 
 	if ( empty( $_GET['chromeless'] ) ) {
 		echo '<div id="media-upload-header">';
@@ -2248,7 +2255,6 @@ function media_upload_form( $errors = null ) {
 	$plupload_init = apply_filters( 'plupload_init', $plupload_init );
 
 	?>
-	<script>
 	<?php
 	// Verify size is an int. If not return default value.
 	$large_size_h = absint( get_option( 'large_size_h' ) );
@@ -2263,10 +2269,11 @@ function media_upload_form( $errors = null ) {
 		$large_size_w = 1024;
 	}
 
+	wp_print_inline_script_tag(
+		"var resize_height = {$large_size_h}, resize_width = {$large_size_w},\n"
+		. 'wpUploaderInit = ' . wp_json_encode( $plupload_init, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ) . ';'
+	);
 	?>
-	var resize_height = <?php echo $large_size_h; ?>, resize_width = <?php echo $large_size_w; ?>,
-	wpUploaderInit = <?php echo wp_json_encode( $plupload_init, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ); ?>;
-	</script>
 
 	<div id="plupload-upload-ui" class="hide-if-no-js">
 	<?php
@@ -2390,15 +2397,17 @@ function media_upload_type_form( $type = 'file', $errors = null, $id = null ) {
 
 	<?php media_upload_form( $errors ); ?>
 
-	<script>
-	jQuery(function($){
-		var preloaded = $(".media-item.preloaded");
-		if ( preloaded.length > 0 ) {
-			preloaded.each(function(){prepareMediaItem({id:this.id.replace(/[^0-9]/g, '')},'');});
-		}
-		updateMediaForm();
-	});
-	</script>
+	<?php
+	wp_print_inline_script_tag(
+		"jQuery(function($){\n"
+		. "\t\tvar preloaded = $(\".media-item.preloaded\");\n"
+		. "\t\tif ( preloaded.length > 0 ) {\n"
+		. "\t\t\tpreloaded.each(function(){prepareMediaItem({id:this.id.replace(/[^0-9]/g, '')},'');});\n"
+		. "\t\t}\n"
+		. "\t\tupdateMediaForm();\n"
+		. '});'
+	);
+	?>
 	<div id="media-items">
 	<?php
 
@@ -2597,15 +2606,17 @@ function media_upload_gallery_form( $errors ) {
 	}
 
 	?>
-	<script>
-	jQuery(function($){
-		var preloaded = $(".media-item.preloaded");
-		if ( preloaded.length > 0 ) {
-			preloaded.each(function(){prepareMediaItem({id:this.id.replace(/[^0-9]/g, '')},'');});
-			updateMediaForm();
-		}
-	});
-	</script>
+	<?php
+	wp_print_inline_script_tag(
+		"jQuery(function($){\n"
+		. "\t\tvar preloaded = $(\".media-item.preloaded\");\n"
+		. "\t\tif ( preloaded.length > 0 ) {\n"
+		. "\t\t\tpreloaded.each(function(){prepareMediaItem({id:this.id.replace(/[^0-9]/g, '')},'');});\n"
+		. "\t\t\tupdateMediaForm();\n"
+		. "\t\t}\n"
+		. '});'
+	);
+	?>
 	<div id="sort-buttons" class="hide-if-no-js">
 	<span>
 		<?php _e( 'All Tabs:' ); ?>
@@ -2925,15 +2936,17 @@ function media_upload_library_form( $errors ) {
 	<form enctype="multipart/form-data" method="post" action="<?php echo esc_url( $form_action_url ); ?>" class="<?php echo $form_class; ?>" id="library-form">
 	<?php wp_nonce_field( 'media-form' ); ?>
 
-	<script>
-	jQuery(function($){
-		var preloaded = $(".media-item.preloaded");
-		if ( preloaded.length > 0 ) {
-			preloaded.each(function(){prepareMediaItem({id:this.id.replace(/[^0-9]/g, '')},'');});
-			updateMediaForm();
-		}
-	});
-	</script>
+	<?php
+	wp_print_inline_script_tag(
+		"jQuery(function($){\n"
+		. "\t\tvar preloaded = $(\".media-item.preloaded\");\n"
+		. "\t\tif ( preloaded.length > 0 ) {\n"
+		. "\t\t\tpreloaded.each(function(){prepareMediaItem({id:this.id.replace(/[^0-9]/g, '')},'');});\n"
+		. "\t\t\tupdateMediaForm();\n"
+		. "\t\t}\n"
+		. '});'
+	);
+	?>
 
 	<div id="media-items">
 		<?php add_filter( 'attachment_fields_to_edit', 'media_post_single_attachment_fields_to_edit', 10, 2 ); ?>

--- a/src/wp-admin/includes/media.php
+++ b/src/wp-admin/includes/media.php
@@ -2133,7 +2133,7 @@ function media_upload_header() {
 	$post_id = isset( $_REQUEST['post_id'] ) ? (int) $_REQUEST['post_id'] : 0;
 
 	wp_print_inline_script_tag(
-		sprintf( 'var post_id = %s;', wp_json_encode( $post_id ) )
+		sprintf( 'var post_id = %s;', wp_json_encode( $post_id, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ) )
 	);
 
 	if ( empty( $_GET['chromeless'] ) ) {

--- a/src/wp-admin/includes/media.php
+++ b/src/wp-admin/includes/media.php
@@ -596,7 +596,7 @@ function wp_iframe( $content_func, ...$args ) {
 					'adminpage' => 'media-upload-popup',
 					'isRtl'     => (int) is_rtl(),
 				),
-				0 | JSON_HEX_TAG | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_LINE_TERMINATORS
+				JSON_HEX_TAG | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_LINE_TERMINATORS
 			)
 		)
 	);
@@ -2306,7 +2306,7 @@ function media_upload_form( $errors = null ) {
 					'resize_width'   => $large_size_w,
 					'wpUploaderInit' => $plupload_init,
 				),
-				0 | JSON_HEX_TAG | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_LINE_TERMINATORS
+				JSON_HEX_TAG | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_LINE_TERMINATORS
 			)
 		)
 	);

--- a/src/wp-admin/includes/media.php
+++ b/src/wp-admin/includes/media.php
@@ -596,7 +596,7 @@ function wp_iframe( $content_func, ...$args ) {
 					'adminpage' => 'media-upload-popup',
 					'isRtl'     => (int) is_rtl(),
 				),
-				JSON_HEX_TAG | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_LINE_TERMINATORS
+				JSON_HEX_TAG | JSON_UNESCAPED_SLASHES
 			)
 		)
 	);
@@ -2306,7 +2306,7 @@ function media_upload_form( $errors = null ) {
 					'resize_width'   => $large_size_w,
 					'wpUploaderInit' => $plupload_init,
 				),
-				JSON_HEX_TAG | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_LINE_TERMINATORS
+				JSON_HEX_TAG | JSON_UNESCAPED_SLASHES
 			)
 		)
 	);

--- a/src/wp-admin/includes/media.php
+++ b/src/wp-admin/includes/media.php
@@ -272,14 +272,12 @@ function _cleanup_image_add_caption( $matches ) {
  * @return never
  */
 function media_send_to_editor( $html ) {
-	?>
-	<?php
 	wp_print_inline_script_tag(
-		"var win = window.dialogArguments || opener || parent || top;\n"
-		. "\twin.send_to_editor( " . wp_json_encode( $html, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ) . ' );'
+		sprintf(
+			'( window.dialogArguments || opener || parent || top ).send_to_editor( %s );',
+			wp_json_encode( $html, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES )
+		)
 	);
-	?>
-	<?php
 	exit;
 }
 
@@ -569,15 +567,39 @@ function wp_iframe( $content_func, ...$args ) {
 		wp_enqueue_style( 'deprecated-media' );
 	}
 
-	?>
-	<?php
 	wp_print_inline_script_tag(
-		"addLoadEvent = function(func){if(typeof jQuery!=='undefined')jQuery(function(){func();});else if(typeof wpOnload!=='function'){wpOnload=func;}else{var oldonload=wpOnload;wpOnload=function(){oldonload();func();}}};\n"
-		. "var ajaxurl = '" . esc_js( admin_url( 'admin-ajax.php', 'relative' ) ) . "', pagenow = 'media-upload-popup', adminpage = 'media-upload-popup',\n"
-		. 'isRtl = ' . (int) is_rtl() . ';'
+		<<<'JS'
+		function addLoadEvent(func) {
+			if (typeof jQuery !== 'undefined') {
+				jQuery(function () {
+					func();
+				});
+			} else if (typeof wpOnload !== 'function') {
+				window.wpOnload = func;
+			} else {
+				const oldonload = wpOnload;
+				window.wpOnload = function () {
+					oldonload();
+					func();
+				}
+			}
+		}
+		JS
 	);
-	?>
-	<?php
+	wp_print_inline_script_tag(
+		sprintf(
+			'Object.assign( window, %s );',
+			wp_json_encode(
+				array(
+					'ajaxurl'   => admin_url( 'admin-ajax.php', 'relative' ),
+					'pagenow'   => 'media-upload-popup',
+					'adminpage' => 'media-upload-popup',
+					'isRtl'     => (int) is_rtl(),
+				),
+				0 | JSON_HEX_TAG | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_LINE_TERMINATORS
+			)
+		)
+	);
 	/** This action is documented in wp-admin/admin-header.php */
 	do_action( 'admin_enqueue_scripts', 'media-upload-popup' );
 
@@ -638,8 +660,6 @@ function wp_iframe( $content_func, ...$args ) {
 	wp_print_inline_script_tag(
 		"document.body.className = document.body.className.replace('no-js', 'js');"
 	);
-	?>
-	<?php
 
 	call_user_func_array( $content_func, $args );
 
@@ -844,13 +864,9 @@ function media_upload_form_handler() {
 	}
 
 	if ( isset( $_POST['insert-gallery'] ) || isset( $_POST['update-gallery'] ) ) {
-		?>
-		<?php
 		wp_print_inline_script_tag(
 			"var win = window.dialogArguments || opener || parent || top;\n\t\twin.tb_remove();"
 		);
-		?>
-		<?php
 
 		exit;
 	}
@@ -2399,13 +2415,15 @@ function media_upload_type_form( $type = 'file', $errors = null, $id = null ) {
 
 	<?php
 	wp_print_inline_script_tag(
-		"jQuery(function($){\n"
-		. "\t\tvar preloaded = $(\".media-item.preloaded\");\n"
-		. "\t\tif ( preloaded.length > 0 ) {\n"
-		. "\t\t\tpreloaded.each(function(){prepareMediaItem({id:this.id.replace(/[^0-9]/g, '')},'');});\n"
-		. "\t\t}\n"
-		. "\t\tupdateMediaForm();\n"
-		. '});'
+		<<<'JS'
+		jQuery(function($){
+			var preloaded = $(".media-item.preloaded");
+			if ( preloaded.length > 0 ) {
+				preloaded.each(function(){prepareMediaItem({id:this.id.replace(/[^0-9]/g, '')},'');});
+			}
+			updateMediaForm();
+		});
+		JS
 	);
 	?>
 	<div id="media-items">
@@ -2605,16 +2623,16 @@ function media_upload_gallery_form( $errors ) {
 		$form_class .= ' html-uploader';
 	}
 
-	?>
-	<?php
 	wp_print_inline_script_tag(
-		"jQuery(function($){\n"
-		. "\t\tvar preloaded = $(\".media-item.preloaded\");\n"
-		. "\t\tif ( preloaded.length > 0 ) {\n"
-		. "\t\t\tpreloaded.each(function(){prepareMediaItem({id:this.id.replace(/[^0-9]/g, '')},'');});\n"
-		. "\t\t\tupdateMediaForm();\n"
-		. "\t\t}\n"
-		. '});'
+		<<<'JS'
+		jQuery(function($){
+			var preloaded = $(".media-item.preloaded");
+			if ( preloaded.length > 0 ) {
+				preloaded.each(function(){prepareMediaItem({id:this.id.replace(/[^0-9]/g, '')},'');});
+				updateMediaForm();
+			}
+		});
+		JS
 	);
 	?>
 	<div id="sort-buttons" class="hide-if-no-js">
@@ -2938,13 +2956,15 @@ function media_upload_library_form( $errors ) {
 
 	<?php
 	wp_print_inline_script_tag(
-		"jQuery(function($){\n"
-		. "\t\tvar preloaded = $(\".media-item.preloaded\");\n"
-		. "\t\tif ( preloaded.length > 0 ) {\n"
-		. "\t\t\tpreloaded.each(function(){prepareMediaItem({id:this.id.replace(/[^0-9]/g, '')},'');});\n"
-		. "\t\t\tupdateMediaForm();\n"
-		. "\t\t}\n"
-		. '});'
+		<<<'JS'
+		jQuery(function($){
+			var preloaded = $(".media-item.preloaded");
+			if ( preloaded.length > 0 ) {
+				preloaded.each(function(){prepareMediaItem({id:this.id.replace(/[^0-9]/g, '')},'');});
+				updateMediaForm();
+			}
+		});
+		JS
 	);
 	?>
 

--- a/src/wp-admin/includes/media.php
+++ b/src/wp-admin/includes/media.php
@@ -2437,13 +2437,15 @@ function media_upload_type_form( $type = 'file', $errors = null, $id = null ) {
 	<?php
 	wp_print_inline_script_tag(
 		<<<'JS'
-		jQuery(function($){
-			var preloaded = $(".media-item.preloaded");
+		jQuery( function ( $ ) {
+			var preloaded = $( '.media-item.preloaded' );
 			if ( preloaded.length > 0 ) {
-				preloaded.each(function(){prepareMediaItem({id:this.id.replace(/[^0-9]/g, '')},'');});
+				preloaded.each( function () {
+					prepareMediaItem( { id: this.id.replace( /[^0-9]/g, '' ) }, '' );
+				} );
 			}
 			updateMediaForm();
-		});
+		} );
 		JS
 	);
 	?>
@@ -2646,13 +2648,15 @@ function media_upload_gallery_form( $errors ) {
 
 	wp_print_inline_script_tag(
 		<<<'JS'
-		jQuery(function($){
-			var preloaded = $(".media-item.preloaded");
+		jQuery( function ( $ ) {
+			var preloaded = $( '.media-item.preloaded' );
 			if ( preloaded.length > 0 ) {
-				preloaded.each(function(){prepareMediaItem({id:this.id.replace(/[^0-9]/g, '')},'');});
+				preloaded.each( function () {
+					prepareMediaItem( { id: this.id.replace( /[^0-9]/g, '' ) }, '' );
+				} );
 				updateMediaForm();
 			}
-		});
+		} );
 		JS
 	);
 	?>
@@ -2978,13 +2982,15 @@ function media_upload_library_form( $errors ) {
 	<?php
 	wp_print_inline_script_tag(
 		<<<'JS'
-		jQuery(function($){
-			var preloaded = $(".media-item.preloaded");
+		jQuery( function ( $ ) {
+			var preloaded = $( '.media-item.preloaded' );
 			if ( preloaded.length > 0 ) {
-				preloaded.each(function(){prepareMediaItem({id:this.id.replace(/[^0-9]/g, '')},'');});
+				preloaded.each( function () {
+					prepareMediaItem( { id: this.id.replace( /[^0-9]/g, '' ) }, '' );
+				} );
 				updateMediaForm();
 			}
-		});
+		} );
 		JS
 	);
 	?>

--- a/src/wp-admin/includes/media.php
+++ b/src/wp-admin/includes/media.php
@@ -2506,6 +2506,7 @@ function media_upload_type_url_form( $type = null, $errors = null, $id = null ) 
 
 	<h3 class="media-title"><?php _e( 'Insert media from another website' ); ?></h3>
 
+	<?php ob_start(); ?>
 	<script>
 	var addExtImage = {
 
@@ -2599,6 +2600,7 @@ function media_upload_type_url_form( $type = null, $errors = null, $id = null ) 
 		});
 	} );
 	</script>
+	<?php wp_print_inline_script_tag( wp_remove_surrounding_empty_script_tags( (string) ob_get_clean() ) ); ?>
 
 	<div id="media-items">
 	<div class="media-item media-blank">

--- a/src/wp-admin/includes/media.php
+++ b/src/wp-admin/includes/media.php
@@ -658,7 +658,9 @@ function wp_iframe( $content_func, ...$args ) {
 	<body<?php echo $body_id_attr; ?> class="wp-core-ui no-js <?php echo 'admin-color-' . sanitize_html_class( get_user_option( 'admin_color' ), 'modern' ); ?>">
 	<?php
 	wp_print_inline_script_tag(
-		"document.body.className = document.body.className.replace('no-js', 'js');"
+		<<<'JS'
+		document.body.className = document.body.className.replace( 'no-js', 'js' );
+		JS
 	);
 
 	call_user_func_array( $content_func, $args );
@@ -667,7 +669,15 @@ function wp_iframe( $content_func, ...$args ) {
 	do_action( 'admin_print_footer_scripts' );
 
 	?>
-	<?php wp_print_inline_script_tag( "if(typeof wpOnload==='function')wpOnload();" ); ?>
+	<?php
+	wp_print_inline_script_tag(
+		<<<'JS'
+		if( typeof wpOnload === 'function' ) {
+			wpOnload();
+		}
+		JS
+	);
+	?>
 	</body>
 	</html>
 	<?php
@@ -865,7 +875,9 @@ function media_upload_form_handler() {
 
 	if ( isset( $_POST['insert-gallery'] ) || isset( $_POST['update-gallery'] ) ) {
 		wp_print_inline_script_tag(
-			"var win = window.dialogArguments || opener || parent || top;\n\t\twin.tb_remove();"
+			<<<'JS'
+			( window.dialogArguments || opener || parent || top ).tb_remove();
+			JS
 		);
 
 		exit;
@@ -2122,7 +2134,9 @@ function get_compat_media_markup( $attachment_id, $args = null ) {
 function media_upload_header() {
 	$post_id = isset( $_REQUEST['post_id'] ) ? (int) $_REQUEST['post_id'] : 0;
 
-	wp_print_inline_script_tag( 'post_id = ' . $post_id . ';' );
+	wp_print_inline_script_tag(
+		sprintf( 'var post_id = %s;', wp_json_encode( $post_id ) )
+	);
 
 	if ( empty( $_GET['chromeless'] ) ) {
 		echo '<div id="media-upload-header">';
@@ -2286,8 +2300,17 @@ function media_upload_form( $errors = null ) {
 	}
 
 	wp_print_inline_script_tag(
-		"var resize_height = {$large_size_h}, resize_width = {$large_size_w},\n"
-		. 'wpUploaderInit = ' . wp_json_encode( $plupload_init, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ) . ';'
+		sprintf(
+			'Object.assign( window, %s );',
+			wp_json_encode(
+				array(
+					'resize_height'  => $large_size_h,
+					'resize_width'   => $large_size_w,
+					'wpUploaderInit' => $plupload_init,
+				),
+				0 | JSON_HEX_TAG | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_LINE_TERMINATORS
+			)
+		)
 	);
 	?>
 

--- a/src/wp-admin/includes/media.php
+++ b/src/wp-admin/includes/media.php
@@ -569,19 +569,19 @@ function wp_iframe( $content_func, ...$args ) {
 
 	wp_print_inline_script_tag(
 		<<<'JS'
-		function addLoadEvent(func) {
-			if (typeof jQuery !== 'undefined') {
-				jQuery(function () {
+		function addLoadEvent( func ) {
+			if ( typeof jQuery !== 'undefined' ) {
+				jQuery( function () {
 					func();
-				});
-			} else if (typeof wpOnload !== 'function') {
+				} );
+			} else if ( typeof wpOnload !== 'function' ) {
 				window.wpOnload = func;
 			} else {
-				const oldonload = wpOnload;
+				const oldOnload = window.wpOnload;
 				window.wpOnload = function () {
-					oldonload();
+					oldOnload();
 					func();
-				}
+				};
 			}
 		}
 		JS

--- a/src/wp-admin/includes/template.php
+++ b/src/wp-admin/includes/template.php
@@ -2259,7 +2259,15 @@ function iframe_footer() {
 	do_action( 'admin_print_footer_scripts' );
 	?>
 	</div>
-<script>if(typeof wpOnload==='function')wpOnload();</script>
+	<?php
+	wp_print_inline_script_tag(
+		<<<'JS'
+		if ( typeof wpOnload === 'function' ) {
+			wpOnload();
+		}
+		JS
+	);
+	?>
 </body>
 </html>
 	<?php

--- a/src/wp-admin/includes/template.php
+++ b/src/wp-admin/includes/template.php
@@ -2140,19 +2140,50 @@ function iframe_header( $title = '', $deprecated = false ) {
 <title><?php bloginfo( 'name' ); ?> &rsaquo; <?php echo $title; ?> &#8212; <?php _e( 'WordPress' ); ?></title>
 	<?php
 	wp_enqueue_style( 'colors' );
-	?>
-<script>
-addLoadEvent = function(func){if(typeof jQuery!=='undefined')jQuery(function(){func();});else if(typeof wpOnload!=='function'){wpOnload=func;}else{var oldonload=wpOnload;wpOnload=function(){oldonload();func();}}};
-function tb_close(){var win=window.dialogArguments||opener||parent||top;win.tb_remove();}
-var ajaxurl = '<?php echo esc_js( admin_url( 'admin-ajax.php', 'relative' ) ); ?>',
-	pagenow = '<?php echo esc_js( $current_screen->id ); ?>',
-	typenow = '<?php echo esc_js( $current_screen->post_type ); ?>',
-	adminpage = '<?php echo esc_js( $admin_body_class ); ?>',
-	thousandsSeparator = '<?php echo esc_js( $wp_locale->number_format['thousands_sep'] ); ?>',
-	decimalPoint = '<?php echo esc_js( $wp_locale->number_format['decimal_point'] ); ?>',
-	isRtl = <?php echo (int) is_rtl(); ?>;
-</script>
-	<?php
+
+	// Print the global admin inline scripts through the script tag API so the
+	// `wp_inline_script_attributes` filter (e.g. a CSP nonce) applies.
+	wp_print_inline_script_tag(
+		<<<'JS'
+		function addLoadEvent( func ) {
+			if ( typeof jQuery !== 'undefined' ) {
+				jQuery( function () {
+					func();
+				} );
+			} else if ( typeof wpOnload !== 'function' ) {
+				window.wpOnload = func;
+			} else {
+				const oldOnload = window.wpOnload;
+				window.wpOnload = function () {
+					oldOnload();
+					func();
+				};
+			}
+		}
+
+		function tb_close() {
+			( window.dialogArguments || opener || parent || top ).tb_remove();
+		}
+		JS
+	);
+	wp_print_inline_script_tag(
+		sprintf(
+			'Object.assign( window, %s );',
+			wp_json_encode(
+				array(
+					'ajaxurl'            => admin_url( 'admin-ajax.php', 'relative' ),
+					'pagenow'            => $current_screen->id ?? '',
+					'typenow'            => $current_screen->post_type ?? '',
+					'adminpage'          => $admin_body_class,
+					'thousandsSeparator' => $wp_locale->number_format['thousands_sep'],
+					'decimalPoint'       => $wp_locale->number_format['decimal_point'],
+					'isRtl'              => (int) is_rtl(),
+				),
+				JSON_HEX_TAG | JSON_UNESCAPED_SLASHES
+			)
+		)
+	);
+
 	/** This action is documented in wp-admin/admin-header.php */
 	do_action( 'admin_enqueue_scripts', $hook_suffix );
 
@@ -2191,14 +2222,12 @@ var ajaxurl = '<?php echo esc_js( admin_url( 'admin-ajax.php', 'relative' ) ); ?
 	$admin_body_classes = ltrim( $admin_body_classes . ' ' . $admin_body_class );
 	?>
 <body <?php echo $admin_body_id; ?>class="wp-admin wp-core-ui no-js iframe <?php echo esc_attr( $admin_body_classes ); ?>">
-<script>
-(function(){
-var c = document.body.className;
-c = c.replace(/no-js/, 'js');
-document.body.className = c;
-})();
-</script>
 	<?php
+	wp_print_inline_script_tag(
+		<<<'JS'
+		document.body.className = document.body.className.replace( 'no-js', 'js' );
+		JS
+	);
 }
 
 /**


### PR DESCRIPTION
✅ Committed in r63481 (474555a85c052de90ddd22d4abdf163e678b88ac).

----
## Description

Follows up on the Trac ticket discussion (comment 19): migrates the raw inline
`<script>` blocks in `wp-admin/admin-header.php`, `wp-admin/includes/media.php` and
`wp-admin/includes/template.php` to `wp_print_inline_script_tag()`, matching the patterns
established in r60909 / r60913.

This is a prerequisite slice for the Content Security Policy rollout discussed in Trac Core-59446: once all admin inline scripts route through the script tag API, the
`wp_inline_script_attributes` filter becomes the single point where a per-request nonce can be attached.

## Changes

### `wp-admin/admin-header.php`

- The global admin JS (`addLoadEvent`, `ajaxurl`, `pagenow`, `typenow`, `adminpage`, locale separators, `isRtl`) and the `no-js` → `js` body-class replacement now print via `wp_print_inline_script_tag()`.
- `addLoadEvent` is now a function declaration (previously a minified one-liner assigned to an implicit global). It assigns to `window.wpOnload` instead of relying on implicit global creation, and is strict-mode compatible.
- The globals block uses `Object.assign( window, wp_json_encode( ... ) )` with `JSON_HEX_TAG | JSON_UNESCAPED_SLASHES` instead of `esc_js()` string building. `isRtl` remains `(int)` to preserve the previous JS value type.
- Static JS blocks use nowdoc heredocs (`<<<'JS'`) so IDEs syntax-check the JavaScript.

### `wp-admin/includes/media.php`

- 12 inline script blocks migrated to `wp_print_inline_script_tag()`:
  - `media_send_to_editor()`: prints via `sprintf()` + `wp_json_encode()` (per review suggestion).
  - `wp_iframe()`: `addLoadEvent` (same function-declaration refactor as admin-header), globals via `Object.assign()`, `no-js` replacement, and the `wpOnload()` trigger.
  - `media_upload_form_handler()`: `tb_remove()` call.
  - `media_upload_header()`: `post_id` is now scoped with `var` (previously an implicit global) and printed via `sprintf( 'var post_id = %s;', wp_json_encode( $post_id, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ) )`.
  - `media_upload_form()`: `resize_height`, `resize_width`, and `wpUploaderInit` now set via `Object.assign( window, ... )` instead of raw `var` declarations.
  - `media_upload_type_form()`, `media_upload_gallery_form()`, `media_upload_library_form()`: preloaded-item handlers use nowdoc heredocs.
  - `media_upload_type_url_form()`: the `addExtImage` block. This one interleaves PHP throughout, so a heredoc is not workable; the existing markup is buffered and handed to `wp_print_inline_script_tag()` with the wrapping tags removed, matching how `wp-login.php`, `WP_Customize_Manager` and the archives and categories widgets already do this. The one remaining `<script` occurrence in the file is the literal opening tag inside that buffer, which is consumed rather than emitted.
- PHP close/reopen pairs introduced by the migration were removed in `media_send_to_editor()`, `wp_iframe()`, `media_upload_form_handler()`, `media_upload_gallery_form()`, `media_upload_form()`, and `admin-header.php`.

### `wp-admin/includes/template.php`

The same block of global admin JavaScript existed in a third place. Covering only the first two would have left Thickbox iframes on the old `esc_js()` behavior while every other admin screen used the new one, so a `thousands_sep` containing an ampersand would have arrived as `&amp;` in an iframe and as `&` elsewhere.

- `iframe_header()`: `addLoadEvent`, `tb_close()`, the globals block, and the `no-js` → `js` replacement.
- `iframe_footer()`: the `wpOnload()` trigger. This is the most consequential of the three, since it is the script that actually invokes `wpOnload` — leaving it raw would have caused every callback registered through `addLoadEvent()` on a Thickbox iframe to be silently dropped under a CSP while the surrounding page continued to work. The tag stays positioned after the closing div that wraps the footer hooks.
- `pagenow` and `typenow` pick up a null coalesce here because `iframe_header()` reads the screen through `get_current_screen()`, which is nullable, where `admin-header.php` uses the global that is guaranteed to be set. Falling back to an empty string matches what `esc_js()` produced for a null screen, minus the PHP notice.
- `compression_test()` still emits a raw `<script>` and is deliberately untouched, as its removal is intended separately.

## Behavioral notes

The emitted JavaScript is **not** byte-identical to the previous output. Most of this is intentional and per review feedback, but three differences are not apparent from the diff and are called out here for review.

### Replacing `esc_js()` with `wp_json_encode()` changes the emitted values

This is not a pure refactor. `esc_js()` runs the value through `_wp_specialchars( $text, ENT_COMPAT )` and applies `stripslashes()`, so the JavaScript string previously contained HTML entities rather than the literal characters:

| Input | Before (`esc_js` inside `'…'`) | After (`wp_json_encode`) |
|---|---|---|
| `Tom & Jerry` | `'Tom &amp; Jerry'` | `"Tom & Jerry"` |
| `a "quoted" value` | `'a &quot;quoted&quot; value'` | `"a \"quoted\" value"` |
| `back\slash` | `'back\slash'` (backslash lost) | `"back\\slash"` |
| `&nbsp;` | `'&amp;nbsp;'` | `"&nbsp;"` |

Every case above is a correction rather than a regression, since the old output was mangled. The affected values are `ajaxurl`, `pagenow`, `typenow`, `adminpage`, `thousandsSeparator` and `decimalPoint`. The two locale-supplied separators are the ones most likely to contain an affected character in practice, as they come from translations.

### The `js_escape` filter no longer runs for these values

`esc_js()` ends with `apply_filters( 'js_escape', $safe_text, $text )`. A plugin hooking that filter was previously able to alter the six values above. That extension point is gone for them — a removal rather than a change.

### Global property descriptors differ

Because `var ajaxurl = …` became `Object.assign( window, … )`, and `addLoadEvent = function …` became a function declaration, the resulting globals carry different property descriptors. Measured in a browser rather than inferred:

| Global | Before | After |
|---|---|---|
| `ajaxurl`, `pagenow`, `typenow`, `adminpage` | `configurable: false` | `configurable: true` |
| `addLoadEvent` | `configurable: true` | `configurable: false` |

The flags move in opposite directions because the old globals were created by `var` (non-configurable) while `addLoadEvent` was an implicit global assignment (configurable). Values, writability and enumerability are unchanged, and `isRtl` remains a number. The practical effect is that `delete window.ajaxurl` now succeeds where it previously could not. No core or bundled code depends on either behavior, and the three copies are now uniform where previously they were not.

### Other intentional changes

- `addLoadEvent`: unminified function declaration; behavior preserved (jQuery-present, no-`wpOnload`, and existing-`wpOnload` chaining all verified). It is now hoisted, which is strictly a widening.
- `post_id`: explicit `var` binding; remains a window-global as before.
- `media_send_to_editor()`: single `sprintf()` call replaces the PHP open/close dance. The `var win` global it used to leave behind is gone; the same applies to `media_upload_form_handler()`. Both `exit` immediately afterwards, so nothing reads it. `tb_close()` in `iframe_header()` kept its behavior exactly, as its inner `win` was function-scoped rather than global.

### JSON flags

`JSON_HEX_TAG | JSON_UNESCAPED_SLASHES` is used throughout. `JSON_HEX_TAG` is what makes the JSON safe inside a SCRIPT element — with `<` escaped, the parser can never enter the script data double escaped state — and `/` can then be left unescaped because a SCRIPT element cannot be closed without a `<`.

`JSON_UNESCAPED_UNICODE` and `JSON_UNESCAPED_LINE_TERMINATORS` were considered and dropped. They are only safe when the page is served as UTF-8, which is not guaranteed in the admin, as `admin-header.php` sends the charset straight from the `blog_charset` option. `WP_Script_Modules::print_script_module_data()` gates the same pair behind `is_utf8_charset()` for this reason. Rather than repeat that gate at several call sites for a marginal saving on very small payloads, the narrower pair is used everywhere, matching the rest of core.

`wp_json_encode()` returning `false` is deliberately left unguarded. A filter that renders the data non-encodable is a bug, and a loud `SyntaxError` surfaces it better than a silent fallback would. The realistic path to `false` is narrow in any case, since `wp_json_encode()` retries through `_wp_json_sanity_check()`, which strips invalid UTF-8.

## Verification

Static checks:

- `php -l` on all three files: clean.
- PHPCS: clean on all changed lines.
- PHPStan at level 10 via `phpstan-diff`: no errors on changed lines.
- `git diff --check`: no whitespace errors.
- Nowdoc blocks all parse as JavaScript (Node `vm` sandbox). `addLoadEvent` verified in 3 scenarios: jQuery present → callback runs immediately; no existing `wpOnload` → callback stored as `wpOnload`; existing `wpOnload` → chaining preserves order `[existing, callback]`.
- Raw `<script>` tags remaining: 0 in `admin-header.php`; 1 in `media.php` (the buffered opening tag, consumed not emitted); 1 in `template.php` (`compression_test()`, intentionally deferred). `wp_print_inline_script_tag()` call counts: 3, 12 and 4 respectively.

Checked in a browser against the running admin:

- All globals carry their expected values and types on the Dashboard, on `media-upload.php` in both the `type` and `type_url` tabs, and on a Thickbox iframe page.
- `wpOnload()` is invoked exactly once from `iframe_footer()`, and the tag remains positioned after the closing div that wraps the footer hooks.
- The `addExtImage` block survives `WP_HTML_Tag_Processor` byte-for-byte, including `'</a>'`, `replace(/</g, '&lt;')` and `'<br />'`, with none of the Unicode escaping that `escape_javascript_script_contents()` would apply to a `<script` or `</script` sequence. It was then driven through its real inline handlers: the `onblur` populated width and height from an actual image, the align radio's `onclick` set `addExtImage.align`, and `insert()` produced the expected caption shortcode.
- `plupload` initializes and `window.uploader` is instantiated.
- `tb_close()` resolves the same target and preserves `this`.
- No console errors on any page. The only console output anywhere was a pre-existing `JQMIGRATE` deprecation notice and a pre-existing `<label for>` issue, neither touched here.

## Known gap

The "Insert media from another website" tab is still not usable under a strict CSP even with its script tag now able to carry a nonce, because `wp_media_insert_url_form()` drives `addExtImage` entirely through inline `onclick` and `onblur` attributes, which a nonce cannot cover. That needs a separate change and is not addressed here.

## Next steps

With this in place, the script-loader can attach a per-request nonce via the
`wp_inline_script_attributes` filter, enabling the report-only CSP discussed in Trac Core-59446.

Trac ticket: https://core.trac.wordpress.org/ticket/59446 (see [comment 19](https://core.trac.wordpress.org/ticket/59446#comment:19)).

