### PR TITLE
Replace usages of the gray #787c82 with darker gray colors.

### DIFF
--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -2553,7 +2553,7 @@ h1.nav-tab-wrapper, /* Back-compat for pre-4.4 */
 	position: absolute;
 	right: 10px;
 	left: auto;
-	color: #787c82;
+	color: #50575e;
 	border-radius: 50px;
 	top: 50%;
 	transform: translateY(-50%);
@@ -3372,7 +3372,7 @@ img {
 .bulk-action-notice .toggle-indicator::before {
 	line-height: 16px;
 	vertical-align: top;
-	color: #787c82;
+	color: #50575e;
 }
 
 .postbox .handle-order-higher:focus,

--- a/src/wp-admin/css/customize-nav-menus.css
+++ b/src/wp-admin/css/customize-nav-menus.css
@@ -329,7 +329,7 @@
 	display: block;
 	padding: 1px 2px 1px 0;
 	border-radius: 50%;
-	color: #787c82;
+	color: #50575e;
 	font: normal 20px/1 dashicons;
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
@@ -770,7 +770,7 @@ body.adding-menu-items #customize-preview iframe {
 	cursor: default;
 	opacity: .5;
 	background: #fff;
-	color: #787c82;
+	color: #50575e;
 }
 
 .added-menu-item .menu-item-handle {

--- a/src/wp-admin/css/customize-widgets.css
+++ b/src/wp-admin/css/customize-widgets.css
@@ -25,7 +25,7 @@
 }
 
 .customize-control .widget-action {
-	color: #787c82;
+	color: #50575e;
 }
 
 .customize-control .widget-top:hover .widget-action,

--- a/src/wp-admin/css/edit.css
+++ b/src/wp-admin/css/edit.css
@@ -876,7 +876,7 @@ form#tags-filter {
 .privacy-settings-tab:focus,
 .health-check-tab:focus {
 	color: #1d2327;
-	outline: 1px solid #787c82;
+	outline: 1px solid #50575e;
 	box-shadow: none;
 }
 
@@ -1087,7 +1087,7 @@ form#tags-filter {
 .privacy-settings-accordion-panel div > *:not(h1):not(h2):not(h3):not(h4):not(h5):not(h6):not(div):not(.privacy-policy-tutorial):not(.wp-policy-help):not(.privacy-text-copy):not(span.success):not(.notice p) {
 	margin: 0;
 	padding: 1em;
-	border-left: 2px solid #787c82;
+	border-left: 2px solid #50575e;
 }
 
 /* Media queries */

--- a/src/wp-admin/css/forms.css
+++ b/src/wp-admin/css/forms.css
@@ -1188,7 +1188,7 @@ table.form-table td .updated p {
 }
 
 .pressthis-bookmarklet span:before {
-	color: #787c82;
+	color: #50575e;
 	font: normal 20px/1 dashicons;
 	content: "\f157";
 	content: "\f157" / '';

--- a/src/wp-admin/css/list-tables.css
+++ b/src/wp-admin/css/list-tables.css
@@ -793,7 +793,7 @@ th.sorted a span {
 
 .view-switch a:hover:before,
 .view-switch a:focus:before {
-	color: #787c82;
+	color: #1e1e1e;
 }
 
 .view-switch a.current:before {

--- a/src/wp-admin/css/media.css
+++ b/src/wp-admin/css/media.css
@@ -675,7 +675,7 @@ border color while dragging a file over the uploader drop area */
 .edit-attachment-frame .edit-media-header .left,
 .edit-attachment-frame .edit-media-header .right {
 	cursor: pointer;
-	color: #787c82;
+	color: #50575e;
 	background-color: transparent;
 	height: 50px;
 	width: 50px;

--- a/src/wp-admin/css/themes.css
+++ b/src/wp-admin/css/themes.css
@@ -453,7 +453,7 @@ body.js .theme-browser.search-loading {
 
 .theme-overlay .theme-header .close:before {
 	font: normal 22px/50px dashicons !important;
-	color: #787c82;
+	color: #50575e;
 	display: inline-block;
 	content: "\f335";
 	content: "\f335" / '';
@@ -464,7 +464,7 @@ body.js .theme-browser.search-loading {
 .theme-overlay .theme-header .right,
 .theme-overlay .theme-header .left {
 	cursor: pointer;
-	color: #787c82;
+	color: #50575e;
 	background-color: transparent;
 	height: 48px;
 	width: 54px;

--- a/src/wp-admin/css/widgets.css
+++ b/src/wp-admin/css/widgets.css
@@ -516,7 +516,7 @@ div#widgets-right .closed .widgets-sortables {
 
 /* Dragging a widget over a closed sidebar */
 #widgets-right .widgets-holder-wrap.widget-hover {
-	border-color: #787c82;
+	border-color: #50575e;
 	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
 }
 

--- a/src/wp-includes/css/wp-auth-check.css
+++ b/src/wp-includes/css/wp-auth-check.css
@@ -86,7 +86,7 @@
 	right: 5px;
 	height: 22px;
 	width: 22px;
-	color: #787c82;
+	color: #50575e;
 	text-decoration: none;
 	text-align: center;
 }

--- a/src/wp-includes/css/wp-pointer.css
+++ b/src/wp-includes/css/wp-pointer.css
@@ -64,7 +64,7 @@
 
 .wp-pointer-buttons a.close::before {
 	background: none;
-	color: #787c82;
+	color: #50575e;
 	content: "\f153";
 	content: "\f153" / "";
 	display: block !important;


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65995

The color `#787c82` doesn't meet minimum color contrast ratio when used for text of icon-only controls (where the icon is equivalent to text that must meet the contrast threshold).

This PRs removes all usages of `#787c82` in favor of darker gray shades.

## Use of AI Tools

None.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
