### PR TITLE
Fixing a bug in sprintf would cause metabox to completely fail.

### DIFF
--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -537,18 +537,17 @@ function wp_get_tooltip_helper( $content, $args = array() ) {
 		// Tooltips are only used to visually display labels.
 		$label  = wp_strip_all_tags( $content, true );
 		$markup = sprintf(
-			'<span class="%1$s">
-				' . $button . '
-				<span popover="hint" id="%2$s" class="wp-tooltip__bubble" role="tooltip">' .
-					'<span id="%2$s-text" class="wp-tooltip__text">%5$s</span>' .
-				'</span>' .
-			'</span>',
-			esc_attr( $classes ),
-			esc_attr( $id ),
-			esc_attr( $label ),
-			esc_attr( $icon ),
-			esc_html( $content ),
-		);
+            '<span class="%1$s"> %6$s <span popover="hint" id="%2$s" class="wp-tooltip__bubble" role="tooltip">' .
+            '<span id="%2$s-text" class="wp-tooltip__text">%5$s</span>' .
+            '</span>' .
+            '</span>',
+            esc_attr( $classes ),
+            esc_attr( $id ),
+            esc_attr( $label ),
+            esc_attr( $icon ),
+            esc_html( $content ),
+            $button
+        );
 	} else {
 		/*
 		 * A `span` with `role="dialog"` is used instead of a `dialog` element to keep the

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -543,7 +543,7 @@ function wp_get_tooltip_helper( $content, $args = array() ) {
 				$button
 			);
 		}
-    	$markup = sprintf(
+		$markup = sprintf(
 			'<span class="%1$s">%4$s<span popover="hint" id="%2$s" class="wp-tooltip__bubble" role="tooltip">' .
 			'<span id="%2$s-text" class="wp-tooltip__text">%3$s</span>' .
 			'</span>' .
@@ -559,22 +559,27 @@ function wp_get_tooltip_helper( $content, $args = array() ) {
 		 * markup as phrasing content. The `aria-label`, `tabindex`, and `autofocus`
 		 * attributes reproduce the accessible name and focus handling of the native element.
 		 */
+		if ( is_string( $button ) ) {
+			$button = str_replace(
+				array( '%1$s', '%2$s', '%3$s', '%4$s' ),
+				array( esc_attr( $classes ), esc_attr( $id ), esc_attr( $args['label'] ), esc_attr( $icon ) ),
+				$button
+			);
+		}
 		$markup = sprintf(
-			'<span class="%1$s">
-				' . $button . '
-				<span popover="auto" id="%2$s" class="wp-tooltip__bubble" role="dialog" aria-label="%3$s" tabindex="-1" autofocus>' .
-					'<span id="%2$s-text" class="wp-tooltip__text">%5$s</span>' .
-					'<button type="button" class="wp-tooltip__close" popovertarget="%2$s" popovertargetaction="hide" aria-label="%6$s">' .
-						'<span class="dashicons dashicons-no-alt" aria-hidden="true"></span>' .
-					'</button>' .
-				'</span>' .
+			'<span class="%1$s">%6$s<span popover="auto" id="%2$s" class="wp-tooltip__bubble" role="dialog" aria-label="%3$s" tabindex="-1" autofocus>' .
+			'<span id="%2$s-text" class="wp-tooltip__text">%4$s</span>' .
+			'<button type="button" class="wp-tooltip__close" popovertarget="%2$s" popovertargetaction="hide" aria-label="%5$s">' .
+			'<span class="dashicons dashicons-no-alt" aria-hidden="true"></span>' .
+			'</button>' .
+			'</span>' .
 			'</span>',
 			esc_attr( $classes ),
 			esc_attr( $id ),
 			esc_attr( $args['label'] ),
-			esc_attr( $icon ),
 			esc_html( $content ),
 			esc_attr( $args['close_label'] ),
+			$button
 		);
 	}
 

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -536,15 +536,20 @@ function wp_get_tooltip_helper( $content, $args = array() ) {
 	if ( 'tooltip' === $args['type'] ) {
 		// Tooltips are only used to visually display labels.
 		$label  = wp_strip_all_tags( $content, true );
-		$markup = sprintf(
-			'<span class="%1$s">%6$s<span popover="hint" id="%2$s" class="wp-tooltip__bubble" role="tooltip">' .
-			'<span id="%2$s-text" class="wp-tooltip__text">%5$s</span>' .
+		if ( is_string( $button ) ) {
+			$button = str_replace(
+				array( '%1$s', '%2$s', '%3$s', '%4$s' ),
+				array( esc_attr( $classes ), esc_attr( $id ), esc_attr( $label ), esc_attr( $icon ) ),
+				$button
+			);
+		}
+    	$markup = sprintf(
+			'<span class="%1$s">%4$s<span popover="hint" id="%2$s" class="wp-tooltip__bubble" role="tooltip">' .
+			'<span id="%2$s-text" class="wp-tooltip__text">%3$s</span>' .
 			'</span>' .
 			'</span>',
 			esc_attr( $classes ),
 			esc_attr( $id ),
-			esc_attr( $label ),
-			esc_attr( $icon ),
 			esc_html( $content ),
 			$button
 		);

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -537,17 +537,17 @@ function wp_get_tooltip_helper( $content, $args = array() ) {
 		// Tooltips are only used to visually display labels.
 		$label  = wp_strip_all_tags( $content, true );
 		$markup = sprintf(
-            '<span class="%1$s"> %6$s <span popover="hint" id="%2$s" class="wp-tooltip__bubble" role="tooltip">' .
-            '<span id="%2$s-text" class="wp-tooltip__text">%5$s</span>' .
-            '</span>' .
-            '</span>',
-            esc_attr( $classes ),
-            esc_attr( $id ),
-            esc_attr( $label ),
-            esc_attr( $icon ),
-            esc_html( $content ),
-            $button
-        );
+			'<span class="%1$s">%6$s<span popover="hint" id="%2$s" class="wp-tooltip__bubble" role="tooltip">' .
+			'<span id="%2$s-text" class="wp-tooltip__text">%5$s</span>' .
+			'</span>' .
+			'</span>',
+			esc_attr( $classes ),
+			esc_attr( $id ),
+			esc_attr( $label ),
+			esc_attr( $icon ),
+			esc_html( $content ),
+			$button
+		);
 	} else {
 		/*
 		 * A `span` with `role="dialog"` is used instead of a `dialog` element to keep the


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65914

When `$button` has a structure like `%a`, a PHP parser error can cause Pods or other similar custom metadata blocks to fail to display, resulting in a serious problem. This often disrupts the normal management and use of WordPress. This patch corrects this issue in a way that has been verified to be effective!

It's worth noting that, whether we like it or not, this solution is generated by AI combined with internet data retrieval. This solution is very simple and therefore involves no human creativity; I must admit, it was generated by AI.

Hopefully, it can be merged quickly to resolve the issue as much as possible. It aims to fix the following bugs:

```
  thrown in /var/www/wordpress/wp-includes/general-template.php on line
533" while reading response header from upstream, client: 10.20.245.1,
server: www.qhjack.top, request: "GET
/wp-admin/post.php?post=582&action=edit HTTP/1.0", upstream:
"fastcgi://unix:///run/php/php8.5-fpm.sock:", host: "www.qhjack.top",
referrer: "https://www.qhjack.top/wp-admin/edit.php?post_type=services"
2026/08/30 16:25:15 [error] 289643#289643: *106436 FastCGI sent in
stderr: "PHP message: PHP Fatal error:  Uncaught ValueError: Unknown
format specifier "a" in
/var/www/wordpress/wp-includes/general-template.php:533
Stack trace:
#0 /var/www/wordpress/wp-includes/general-template.php(533): sprintf()
#1 /var/www/wordpress/wp-includes/general-template.php(400):
wp_get_tooltip_helper()
#2 /var/www/wordpress/wp-admin/includes/template.php(1410):
wp_get_tooltip()
#3 /var/www/wordpress/wp-admin/includes/post.php(2392): do_meta_boxes()
#4 /var/www/wordpress/wp-admin/edit-form-blocks.php(401):
the_block_editor_meta_boxes()
#5 /var/www/wordpress/wp-admin/post.php(199): require('...')
#6 {main}
```

## Use of AI Tools

AI assistance: Yes
Tool(s): chrome/openwebui
Model(s): Gemini/Doubao AI
Used for:  Apart from the former which uses AI entirely, it is mainly used for fault investigation and internet information retrieval.
