### PR TITLE
Administration: Restore the full-width upload folder row on Settings > Media

### DIFF
--- a/src/wp-admin/options-media.php
+++ b/src/wp-admin/options-media.php
@@ -140,12 +140,9 @@ if ( isset( $GLOBALS['wp_settings']['media']['embeds'] ) ) :
 <p class="description"><?php _e( 'Configuring this is optional. By default, it should be blank.' ); ?></p>
 </td>
 </tr>
+<?php endif; ?>
 <tr>
 <td colspan="2" class="td-full">
-<?php else : ?>
-<tr>
-<td class="td-full">
-<?php endif; ?>
 <label for="uploads_use_yearmonth_folders">
 <input name="uploads_use_yearmonth_folders" type="checkbox" id="uploads_use_yearmonth_folders" value="1"<?php checked( '1', get_option( 'uploads_use_yearmonth_folders' ) ); ?> />
 	<?php _e( 'Organize my uploads into month- and year-based folders' ); ?>


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/51190

## Problem

On Settings > Media, "Organize my uploads into month- and year-based folders" wraps onto three lines as soon as any plugin registers a field in the `uploads` settings section.

## Cause

The row spanned both columns unconditionally until [40823] (#37004, HTML validation fixes) moved it inside the upload-path conditional in order to change its `th` to a `td`. That carried `colspan="2"` onto the editable-paths branch only:

```php
<tr>
<td colspan="2" class="td-full">
<?php else : ?>
<tr>
<td class="td-full">
<?php endif; ?>
```

The `else` branch is what a site with default upload paths gets. With no fields registered the table has one column and the cell fills it, so nothing looks wrong. The `do_settings_fields( 'media', 'uploads' )` call on the next line invites a second column, and once anything takes it, `.form-table th { width: 200px }` claims the first and the core label wraps.

`forms.css` dates the change from the other side: `.form-table th.th-full, /* Not used by core. Back-compat for pre-4.8 */`.

## Fix

Close the conditional above the row and restore the single unconditional cell, keeping the `td`/`td-full` markup [40823] introduced.

Measured at a 1238px content width:

| | cell width | label height |
|---|---|---|
| no plugin fields, no colspan (trunk) | 1238px | 17px |
| no plugin fields, `colspan="2"` | 1238px | 17px |
| one plugin field, no colspan (trunk) | 210px | 55px |
| one plugin field, `colspan="2"` | 1238px | 17px |

The first two rows are identical because `colspan="2"` on a lone cell in a one-column table spans what it already spanned, so no check for registered fields is needed and rendering is unchanged for sites without them.

## Testing instructions

1. Make sure `upload_path` and `upload_url_path` are at their defaults, so the paths are locked (the common case).
2. Visit Settings > Media and confirm the checkbox is on one line.
3. Drop this in `wp-content/mu-plugins/`:

```php
<?php
add_action( 'admin_init', function () {
	add_settings_field(
		'demo_field',
		'Demo Field',
		function () {
			echo '<input type="text" class="regular-text">';
		},
		'media',
		'uploads'
	);
} );
```

4. Reload Settings > Media. On trunk the checkbox label wraps onto three lines in a 200px column; with this change it stays on one line and the new field renders below it.

Props imath for the report and diagnosis.
