### PR TITLE
Upgrade/Install: Align update details toggle line height

### DIFF
--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -576,6 +576,10 @@ code {
 	margin-left: 0;
 }
 
+.js-update-details-toggle {
+	line-height: inherit;
+}
+
 .js-update-details-toggle .dashicons {
 	text-decoration: none;
 }


### PR DESCRIPTION
## Summary

Sets the update-details toggle button to inherit the notice paragraph line height. This keeps the disclosure icon aligned with the message text and removes the one-pixel vertical discrepancy described in the ticket.

Trac ticket: https://core.trac.wordpress.org/ticket/64588

## Testing

- `git diff --check`
- Verified the patch applies cleanly in reverse against the current checkout.

This pull request is for code review. Core changes are committed through the WordPress SVN workflow.