### PR TITLE
REST API: Describe the table column styles in the view config schema

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-view-config-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-view-config-controller.php
@@ -508,17 +508,21 @@ class WP_REST_View_Config_Controller extends WP_REST_Controller {
 			'type'       => 'object',
 			'properties' => array(
 				'width'    => array(
-					'type' => array( 'string', 'number' ),
+					'description' => __( 'The width of the column.' ),
+					'type'        => array( 'string', 'number' ),
 				),
 				'maxWidth' => array(
-					'type' => array( 'string', 'number' ),
+					'description' => __( 'The maximum width of the column.' ),
+					'type'        => array( 'string', 'number' ),
 				),
 				'minWidth' => array(
-					'type' => array( 'string', 'number' ),
+					'description' => __( 'The minimum width of the column.' ),
+					'type'        => array( 'string', 'number' ),
 				),
 				'align'    => array(
-					'type' => 'string',
-					'enum' => array( 'start', 'center', 'end' ),
+					'description' => __( 'The horizontal alignment of the column content.' ),
+					'type'        => 'string',
+					'enum'        => array( 'start', 'center', 'end' ),
 				),
 			),
 		);
@@ -536,6 +540,7 @@ class WP_REST_View_Config_Controller extends WP_REST_Controller {
 			'type'       => 'object',
 			'properties' => array(
 				'styles'       => array(
+					'description'          => __( 'Column styles keyed by field id, for the columns listed in the view fields. The primary column (title, media, and description fields) ignores these styles; in the table layout it takes the width left over by the other columns, or the last column does when there is no primary column.' ),
 					'type'                 => 'object',
 					'additionalProperties' => $this->get_column_style_schema(),
 				),


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65981

Adds `description`s to the `styles` property of the table layout schema in the view config REST controller and to the `ColumnStyle` properties (`width`, `maxWidth`, `minWidth`, `align`). The `styles` description notes that the styles apply to the columns listed in the view `fields` and not to the primary column (title, media, and description fields), which takes the width the other columns leave over. No behavior changes.

# Backports

Gutenberg PRs:

- https://github.com/WordPress/gutenberg/pull/82238

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Fable
Used for: Porting the server-side change from the Gutenberg PR. Reviewed and edited by me.

This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.
