### PR TITLE
Add lint:jsdoc grunt task to precommit:js task.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1761,6 +1761,7 @@ module.exports = function(grunt) {
 	grunt.registerTask( 'precommit:js', [
 		'webpack:prod',
 		'jshint:corejs',
+		'lint:jsdoc',
 		'typecheck:js',
 		'uglify:imgareaselect',
 		'uglify:jqueryform',
@@ -2312,6 +2313,18 @@ module.exports = function(grunt) {
 		grunt.util.spawn( {
 			cmd: 'npm',
 			args: [ 'run', 'typecheck:js' ],
+			opts: { stdio: 'inherit' }
+		}, function( error ) {
+			done( ! error );
+		} );
+	} );
+
+	grunt.registerTask( 'lint:jsdoc', 'Runs JSDoc linting on JavaScript files.', function() {
+		var done = this.async();
+
+		grunt.util.spawn( {
+			cmd: 'npm',
+			args: [ 'run', 'lint:jsdoc' ],
 			opts: { stdio: 'inherit' }
 		}, function( error ) {
 			done( ! error );


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65950


> [!IMPORTANT]
> Do not merge before https://github.com/WordPress/wordpress-develop/pull/10743 otherwise the tests on CI will fail for any pull request.

Adds a Grunt task to run the `lint:jsdoc` as part of the precommit task.

Needs https://github.com/WordPress/wordpress-develop/pull/10743 to be merged first.

Test instructions:

- Make a temporary change to any admin JS file.
- From the terminal, run `grunt precommit`.
- The task should detect that only JS files have been modified and only run the JS tests and sub-tasks, see `precommit:js`.
- Observe `lint:jsdoc` runs as part of `precommit:js`..
- Note that until https://github.com/WordPress/wordpress-develop/pull/10743 isn't merged yet, `lint:jsdoc` will report several violations.


## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
