### PR TITLE
Twenty Twenty: Replace the abandoned `stylelint-a11y` dependency

### DIFF
--- a/src/wp-content/themes/twentytwenty/.stylelintrc.json
+++ b/src/wp-content/themes/twentytwenty/.stylelintrc.json
@@ -1,6 +1,6 @@
 {
 	"extends": [
-		"stylelint-config-wordpress"
+		"@wordpress/stylelint-config"
 	],
 	"plugins": ["@double-great/stylelint-a11y"],
 	"rules": {

--- a/src/wp-content/themes/twentytwenty/.stylelintrc.json
+++ b/src/wp-content/themes/twentytwenty/.stylelintrc.json
@@ -2,7 +2,7 @@
 	"extends": [
 		"stylelint-config-wordpress"
 	],
-	"plugins": ["stylelint-a11y"],
+	"plugins": ["@double-great/stylelint-a11y"],
 	"rules": {
 		"font-family-no-missing-generic-family-keyword": null,
 		"no-descending-specificity": null,

--- a/src/wp-content/themes/twentytwenty/package-lock.json
+++ b/src/wp-content/themes/twentytwenty/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "3.2.0",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
-				"@double-great/stylelint-a11y": "^3.5.2",
+				"@double-great/stylelint-a11y": "~3.4.15",
 				"@wordpress/browserslist-config": "^6.34.0",
 				"@wordpress/scripts": "^30.27.0",
 				"autoprefixer": "^10.4.22",
@@ -2050,16 +2050,16 @@
 			}
 		},
 		"node_modules/@double-great/stylelint-a11y": {
-			"version": "3.5.2",
-			"resolved": "https://registry.npmjs.org/@double-great/stylelint-a11y/-/stylelint-a11y-3.5.2.tgz",
-			"integrity": "sha512-tzCK6ItlIiUJwGnATxO54ELtSaQwiMtghhIy6G5umOsp6wTPyMfTUKXt9g/TIGO2+APG1NM4V/V3aiG5W6R8Rw==",
+			"version": "3.4.15",
+			"resolved": "https://registry.npmjs.org/@double-great/stylelint-a11y/-/stylelint-a11y-3.4.15.tgz",
+			"integrity": "sha512-yMpE5UpdXt4ezKv7fxf69k61ycOrJ7xa+Wt6p1XuV8r1y2PKWyVGp1qxFcc4BMEpptOA0XhWPhKHrpbP3+tmuw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"postcss": "^8.5.26"
+				"postcss": "^8.5.15"
 			},
 			"engines": {
-				"node": ">=22.0.0"
+				"node": ">=18.12.0"
 			},
 			"peerDependencies": {
 				"stylelint": ">=16.0.0"
@@ -21577,12 +21577,12 @@
 			"dev": true
 		},
 		"@double-great/stylelint-a11y": {
-			"version": "3.5.2",
-			"resolved": "https://registry.npmjs.org/@double-great/stylelint-a11y/-/stylelint-a11y-3.5.2.tgz",
-			"integrity": "sha512-tzCK6ItlIiUJwGnATxO54ELtSaQwiMtghhIy6G5umOsp6wTPyMfTUKXt9g/TIGO2+APG1NM4V/V3aiG5W6R8Rw==",
+			"version": "3.4.15",
+			"resolved": "https://registry.npmjs.org/@double-great/stylelint-a11y/-/stylelint-a11y-3.4.15.tgz",
+			"integrity": "sha512-yMpE5UpdXt4ezKv7fxf69k61ycOrJ7xa+Wt6p1XuV8r1y2PKWyVGp1qxFcc4BMEpptOA0XhWPhKHrpbP3+tmuw==",
 			"dev": true,
 			"requires": {
-				"postcss": "^8.5.26"
+				"postcss": "^8.5.15"
 			}
 		},
 		"@dual-bundle/import-meta-resolve": {

--- a/src/wp-content/themes/twentytwenty/package-lock.json
+++ b/src/wp-content/themes/twentytwenty/package-lock.json
@@ -9,14 +9,14 @@
 			"version": "3.2.0",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
+				"@double-great/stylelint-a11y": "^3.5.2",
 				"@wordpress/browserslist-config": "^6.34.0",
 				"@wordpress/scripts": "^30.27.0",
 				"autoprefixer": "^10.4.22",
 				"concurrently": "^9.2.1",
 				"postcss": "^8.5.6",
 				"postcss-cli": "^11.0.1",
-				"rtlcss": "^4.3.0",
-				"stylelint-a11y": "^1.2.3"
+				"rtlcss": "^4.3.0"
 			},
 			"engines": {
 				"node": ">=16",
@@ -2047,6 +2047,22 @@
 			"dev": true,
 			"engines": {
 				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/@double-great/stylelint-a11y": {
+			"version": "3.5.2",
+			"resolved": "https://registry.npmjs.org/@double-great/stylelint-a11y/-/stylelint-a11y-3.5.2.tgz",
+			"integrity": "sha512-tzCK6ItlIiUJwGnATxO54ELtSaQwiMtghhIy6G5umOsp6wTPyMfTUKXt9g/TIGO2+APG1NM4V/V3aiG5W6R8Rw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"postcss": "^8.5.26"
+			},
+			"engines": {
+				"node": ">=22.0.0"
+			},
+			"peerDependencies": {
+				"stylelint": ">=16.0.0"
 			}
 		},
 		"node_modules/@dual-bundle/import-meta-resolve": {
@@ -14044,9 +14060,9 @@
 			}
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.11",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-			"integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+			"version": "3.3.18",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+			"integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
 			"dev": true,
 			"funding": [
 				{
@@ -15040,9 +15056,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.6",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-			"integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+			"version": "8.5.26",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+			"integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -15060,7 +15076,7 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"nanoid": "^3.3.11",
+				"nanoid": "^3.3.17",
 				"picocolors": "^1.1.1",
 				"source-map-js": "^1.2.1"
 			},
@@ -18043,18 +18059,6 @@
 			},
 			"engines": {
 				"node": ">=18.12.0"
-			}
-		},
-		"node_modules/stylelint-a11y": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/stylelint-a11y/-/stylelint-a11y-1.2.3.tgz",
-			"integrity": "sha512-S/iiKFUsYBfa4suxP0pYQqoPB9R1+SnvxVuzHHlz9al0IWxLZzXlnZEqEez0zNOhVh5iO3rATUmDnbZE5wm/pQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=8.7.0"
-			},
-			"peerDependencies": {
-				"stylelint": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0"
 			}
 		},
 		"node_modules/stylelint-config-recommended": {
@@ -21571,6 +21575,15 @@
 			"resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
 			"integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
 			"dev": true
+		},
+		"@double-great/stylelint-a11y": {
+			"version": "3.5.2",
+			"resolved": "https://registry.npmjs.org/@double-great/stylelint-a11y/-/stylelint-a11y-3.5.2.tgz",
+			"integrity": "sha512-tzCK6ItlIiUJwGnATxO54ELtSaQwiMtghhIy6G5umOsp6wTPyMfTUKXt9g/TIGO2+APG1NM4V/V3aiG5W6R8Rw==",
+			"dev": true,
+			"requires": {
+				"postcss": "^8.5.26"
+			}
 		},
 		"@dual-bundle/import-meta-resolve": {
 			"version": "4.1.0",
@@ -30013,9 +30026,9 @@
 			}
 		},
 		"nanoid": {
-			"version": "3.3.11",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-			"integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+			"version": "3.3.18",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+			"integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
 			"dev": true
 		},
 		"natural-compare": {
@@ -30730,12 +30743,12 @@
 			"dev": true
 		},
 		"postcss": {
-			"version": "8.5.6",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-			"integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+			"version": "8.5.26",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+			"integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
 			"dev": true,
 			"requires": {
-				"nanoid": "^3.3.11",
+				"nanoid": "^3.3.17",
 				"picocolors": "^1.1.1",
 				"source-map-js": "^1.2.1"
 			}
@@ -32934,12 +32947,6 @@
 					}
 				}
 			}
-		},
-		"stylelint-a11y": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/stylelint-a11y/-/stylelint-a11y-1.2.3.tgz",
-			"integrity": "sha512-S/iiKFUsYBfa4suxP0pYQqoPB9R1+SnvxVuzHHlz9al0IWxLZzXlnZEqEez0zNOhVh5iO3rATUmDnbZE5wm/pQ==",
-			"dev": true
 		},
 		"stylelint-config-recommended": {
 			"version": "14.0.1",

--- a/src/wp-content/themes/twentytwenty/package.json
+++ b/src/wp-content/themes/twentytwenty/package.json
@@ -22,14 +22,14 @@
 		"npm": ">=9.8.1"
 	},
 	"devDependencies": {
+		"@double-great/stylelint-a11y": "^3.5.2",
 		"@wordpress/browserslist-config": "^6.34.0",
 		"@wordpress/scripts": "^30.27.0",
 		"autoprefixer": "^10.4.22",
 		"concurrently": "^9.2.1",
 		"postcss": "^8.5.6",
 		"postcss-cli": "^11.0.1",
-		"rtlcss": "^4.3.0",
-		"stylelint-a11y": "^1.2.3"
+		"rtlcss": "^4.3.0"
 	},
 	"browserslist": [
 		"extends @wordpress/browserslist-config"

--- a/src/wp-content/themes/twentytwenty/package.json
+++ b/src/wp-content/themes/twentytwenty/package.json
@@ -22,7 +22,7 @@
 		"npm": ">=9.8.1"
 	},
 	"devDependencies": {
-		"@double-great/stylelint-a11y": "^3.5.2",
+		"@double-great/stylelint-a11y": "~3.4.15",
 		"@wordpress/browserslist-config": "^6.34.0",
 		"@wordpress/scripts": "^30.27.0",
 		"autoprefixer": "^10.4.22",


### PR DESCRIPTION
The [`@double-great/stylelint-a11y` package](https://www.npmjs.com/package/@double-great/stylelint-a11y) is a seemingly well maintained fork of the original `stylelint-a11y` which has not been updated for over 7 years.

This replaces `stylelint-a11y` with `@double-great/stylelint-a11y`.

Note: the latest version of the package is not used intentionally. Version `3.5.0` dropped support for Node.js 20.x. After Core is updated to use 24.x, the latest version of `@double-great/stylelint-a11y` can be used.

Trac ticket: Core-66004.

## Use of AI Tools

Cursor with Composer 2.5 was used to analyze the situation for possible ways to fix this issue.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
