### PR TITLE
Core Needs a Validating Cache Get Function: wp_cache_get_valid()

### DIFF
--- a/src/wp-includes/cache-compat.php
+++ b/src/wp-includes/cache-compat.php
@@ -313,6 +313,206 @@ if ( ! function_exists( 'wp_cache_set_multiple_salted' ) ) :
 	}
 endif;
 
+if ( ! function_exists( 'wp_cache_get_valid' ) ) :
+	/**
+	 * Retrieves the cache contents by key and group, only if they are valid.
+	 *
+	 * A validating wrapper around wp_cache_get(). The cache contents are returned
+	 * only when they match an expected `$type` and, if a `$callback` is provided,
+	 * the callback returns `true` for them. Otherwise `false` is returned, which
+	 * callers should treat as a cache miss: regenerate the value and store it
+	 * with wp_cache_set().
+	 *
+	 * The `$valid` parameter, passed by reference, is `true` only when the
+	 * contents were found and passed validation. Unlike the `$found` parameter
+	 * of wp_cache_get(), it is `false` for contents that were found but failed
+	 * validation. When the cached value itself can be `false` (the 'bool' type),
+	 * the return value is ambiguous, so check `$valid` instead. When a
+	 * not-found sentinel such as `false` or `-1` is cached alongside regular
+	 * contents, include the sentinel's type in `$type`.
+	 *
+	 * The callback receives one argument, the cache contents, and must return a
+	 * boolean. It may assume the contents matched an expected type, and must
+	 * tolerate any contents of those types without throwing. It must not access
+	 * the object cache or have side effects.
+	 *
+	 * Invalid contents are left in the cache by default, to be overwritten when
+	 * the caller regenerates the value. Passing `true` for `$delete_invalid`
+	 * deletes them instead, for callers that do not regenerate immediately.
+	 * Nothing is deleted on a plain cache miss or on incorrect usage of this
+	 * function.
+	 *
+	 * This is not a security boundary. A persistent cache backend unserializes
+	 * contents before this check runs, and passing validation does not make the
+	 * contents trustworthy.
+	 *
+	 * @link https://core.trac.wordpress.org/ticket/66005
+	 *
+	 * @since 7.2.0
+	 *
+	 * @param int|string      $key            The key under which the cache contents are stored.
+	 * @param string          $group          Where the cache contents are grouped.
+	 * @param string|string[] $type           The expected type of the cache contents, or a list of
+	 *                                        types of which the contents must match at least one.
+	 *                                        Accepts 'array', 'object', 'string', 'int', 'integer',
+	 *                                        'float', 'double', 'bool', 'boolean', or 'numeric'.
+	 * @param callable|string $callback       Optional. Callback to further validate the cache contents
+	 *                                        beyond the type check. Default empty string (no callback).
+	 * @param bool            $force          Optional. Whether to force an update of the local cache
+	 *                                        from the persistent cache. Default false.
+	 * @param bool            $delete_invalid Optional. Whether to delete the cache contents when they
+	 *                                        are found but fail validation. Default false.
+	 * @param bool|null       $valid          Optional. Whether the contents were found and passed
+	 *                                        validation (passed by reference). Disambiguates a return
+	 *                                        of false, a storable value. Default null.
+	 * @param-out bool $valid
+	 * @return mixed|false The cache contents on success, false if the contents are missing or invalid.
+	 */
+	function wp_cache_get_valid( $key, $group, $type, $callback = '', bool $force = false, bool $delete_invalid = false, ?bool &$valid = null ) {
+		$valid = false;
+
+		$type_checks = array(
+			'array'   => 'is_array',
+			'object'  => 'is_object',
+			'string'  => 'is_string',
+			'int'     => 'is_int',
+			'integer' => 'is_int',
+			'float'   => 'is_float',
+			'double'  => 'is_float',
+			'bool'    => 'is_bool',
+			'boolean' => 'is_bool',
+			'numeric' => 'is_numeric',
+		);
+
+		if ( ! is_array( $type ) ) {
+			$type = array( $type );
+		}
+
+		if ( array() === $type ) {
+			if ( ! function_exists( '__' ) ) {
+				wp_load_translations_early();
+			}
+
+			_doing_it_wrong(
+				__FUNCTION__,
+				__( 'At least one expected type must be provided.' ),
+				'7.2.0'
+			);
+
+			return false;
+		}
+
+		foreach ( $type as $expected_type ) {
+			if ( ! is_string( $expected_type ) || ! isset( $type_checks[ $expected_type ] ) ) {
+				if ( ! function_exists( '__' ) ) {
+					wp_load_translations_early();
+				}
+
+				_doing_it_wrong(
+					__FUNCTION__,
+					sprintf(
+						/* translators: %s: List of valid cache content types. */
+						__( 'Each expected type must be one of: %s.' ),
+						"'" . implode( "', '", array_keys( $type_checks ) ) . "'"
+					),
+					'7.2.0'
+				);
+
+				return false;
+			}
+		}
+
+		if ( '' !== $callback && ! is_callable( $callback ) ) {
+			if ( ! function_exists( '__' ) ) {
+				wp_load_translations_early();
+			}
+
+			_doing_it_wrong(
+				__FUNCTION__,
+				__( 'The validation callback is not callable.' ),
+				'7.2.0'
+			);
+
+			return false;
+		}
+
+		$found = false;
+		$value = wp_cache_get( $key, $group, $force, $found );
+
+		if ( ! $found ) {
+			return false;
+		}
+
+		$type_matched = false;
+
+		foreach ( $type as $expected_type ) {
+			if ( call_user_func( $type_checks[ $expected_type ], $value ) ) {
+				$type_matched = true;
+				break;
+			}
+		}
+
+		if ( ! $type_matched ) {
+			/**
+			 * Fires when cache contents were found but failed validation.
+			 *
+			 * Unless deletion was requested via the `$delete_invalid` parameter
+			 * of wp_cache_get_valid(), the invalid contents remain in the cache
+			 * until the caller overwrites them with wp_cache_set().
+			 *
+			 * @since 7.2.0
+			 *
+			 * @param int|string $key    The key under which the cache contents are stored.
+			 * @param string     $group  Where the cache contents are grouped.
+			 * @param mixed      $value  The invalid cache contents.
+			 * @param string     $reason Why validation failed: 'type' if the contents were not
+			 *                           of an expected type, 'callback' if the validation
+			 *                           callback did not return true.
+			 */
+			do_action( 'wp_cache_get_valid_failed', $key, $group, $value, 'type' );
+
+			if ( $delete_invalid ) {
+				wp_cache_delete( $key, $group );
+			}
+
+			return false;
+		}
+
+		if ( '' !== $callback ) {
+			$callback_result = call_user_func( $callback, $value );
+
+			if ( ! is_bool( $callback_result ) ) {
+				if ( ! function_exists( '__' ) ) {
+					wp_load_translations_early();
+				}
+
+				_doing_it_wrong(
+					__FUNCTION__,
+					__( 'The validation callback must return a boolean.' ),
+					'7.2.0'
+				);
+
+				return false;
+			}
+
+			if ( true !== $callback_result ) {
+				/** This action is documented in wp-includes/cache-compat.php */
+				do_action( 'wp_cache_get_valid_failed', $key, $group, $value, 'callback' );
+
+				if ( $delete_invalid ) {
+					wp_cache_delete( $key, $group );
+				}
+
+				return false;
+			}
+		}
+
+		$valid = true;
+
+		return $value;
+	}
+endif;
+
 if ( ! function_exists( 'wp_cache_switch_to_blog' ) ) :
 	/**
 	 * Used when switch_to_blog() and restore_current_blog() are called, but

--- a/tests/phpunit/tests/functions/wpCacheGetValid.php
+++ b/tests/phpunit/tests/functions/wpCacheGetValid.php
@@ -1,0 +1,528 @@
+<?php
+
+/**
+ * Tests for the behavior of `wp_cache_get_valid()`
+ *
+ * @group functions
+ * @group cache
+ *
+ * @covers ::wp_cache_get_valid
+ */
+class Tests_Functions_wpCacheGetValid extends WP_UnitTestCase {
+
+	/**
+	 * Test that contents of an expected type are returned.
+	 *
+	 * @dataProvider data_valid_type_returns_contents
+	 *
+	 * @param mixed           $value The value to store in the cache.
+	 * @param string|string[] $type  The expected type(s) to pass to wp_cache_get_valid().
+	 *
+	 * @ticket 66005
+	 */
+	public function test_valid_type_returns_contents( $value, $type ): void {
+		wp_cache_set( 'cache_key', $value, 'cache_group' );
+
+		$this->assertSame( $value, wp_cache_get_valid( 'cache_key', 'cache_group', $type ) );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[] Data provider.
+	 */
+	public function data_valid_type_returns_contents(): array {
+		return array(
+			'array'                    => array( array( 1, 2, 3 ), 'array' ),
+			'empty array'              => array( array(), 'array' ),
+			'string'                   => array( 'a string', 'string' ),
+			'empty string'             => array( '', 'string' ),
+			'int'                      => array( 123, 'int' ),
+			'integer'                  => array( 123, 'integer' ),
+			'zero'                     => array( 0, 'int' ),
+			'float'                    => array( 1.5, 'float' ),
+			'double'                   => array( 1.5, 'double' ),
+			'numeric string'           => array( '123', 'numeric' ),
+			'bool true'                => array( true, 'bool' ),
+			'boolean true'             => array( true, 'boolean' ),
+			'array in type list'       => array( array( 1, 2, 3 ), array( 'object', 'array' ) ),
+			'single type in list form' => array( 'a string', array( 'string' ) ),
+		);
+	}
+
+	/**
+	 * Test that objects of the expected type are returned.
+	 *
+	 * @ticket 66005
+	 */
+	public function test_valid_object_returns_contents(): void {
+		$value      = new stdClass();
+		$value->foo = 'bar';
+
+		wp_cache_set( 'cache_key', $value, 'cache_group' );
+
+		$result = wp_cache_get_valid( 'cache_key', 'cache_group', 'object' );
+
+		$this->assertInstanceOf( stdClass::class, $result );
+		$this->assertSame( 'bar', $result->foo );
+	}
+
+	/**
+	 * Test that a cached boolean false is returned with $valid set to true.
+	 *
+	 * A false return is ambiguous for the 'bool' type, so callers rely on
+	 * the $valid reference parameter instead.
+	 *
+	 * @ticket 66005
+	 */
+	public function test_cached_false_sets_valid_true(): void {
+		wp_cache_set( 'cache_key', false, 'cache_group' );
+
+		$valid  = null;
+		$result = wp_cache_get_valid( 'cache_key', 'cache_group', 'bool', '', false, false, $valid );
+
+		$this->assertFalse( $result );
+		$this->assertTrue( $valid );
+	}
+
+	/**
+	 * Test that $valid is set to true when the contents pass validation.
+	 *
+	 * @ticket 66005
+	 */
+	public function test_valid_is_true_on_success(): void {
+		wp_cache_set( 'cache_key', array( 1, 2, 3 ), 'cache_group' );
+
+		$valid = null;
+		wp_cache_get_valid( 'cache_key', 'cache_group', 'array', '__return_true', false, false, $valid );
+
+		$this->assertTrue( $valid );
+	}
+
+	/**
+	 * Test that $valid is reset to false in every failure case.
+	 *
+	 * @dataProvider data_valid_is_false_on_failure
+	 *
+	 * @param callable $scenario Callback that performs the failing call, receiving $valid by reference.
+	 *
+	 * @ticket 66005
+	 */
+	public function test_valid_is_false_on_failure( callable $scenario ): void {
+		// Pre-set to true to confirm the function resets the reference.
+		$valid = true;
+
+		$scenario( $valid );
+
+		$this->assertFalse( $valid );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[] Data provider.
+	 */
+	public function data_valid_is_false_on_failure(): array {
+		return array(
+			'cache miss'         => array(
+				static function ( &$valid ): void {
+					wp_cache_get_valid( 'missing_key', 'cache_group', 'array', '', false, false, $valid );
+				},
+			),
+			'type mismatch'      => array(
+				static function ( &$valid ): void {
+					wp_cache_set( 'cache_key', 'a string', 'cache_group' );
+					wp_cache_get_valid( 'cache_key', 'cache_group', 'array', '', false, false, $valid );
+				},
+			),
+			'callback rejection' => array(
+				static function ( &$valid ): void {
+					wp_cache_set( 'cache_key', array( 1, 2, 3 ), 'cache_group' );
+					wp_cache_get_valid( 'cache_key', 'cache_group', 'array', '__return_false', false, false, $valid );
+				},
+			),
+		);
+	}
+
+	/**
+	 * Test that a cache miss returns false.
+	 *
+	 * @ticket 66005
+	 */
+	public function test_cache_miss_returns_false(): void {
+		$this->assertFalse( wp_cache_get_valid( 'missing_key', 'cache_group', 'array' ) );
+	}
+
+	/**
+	 * Test that contents of an unexpected type return false.
+	 *
+	 * @dataProvider data_type_mismatch_returns_false
+	 *
+	 * @param mixed           $value The value to store in the cache.
+	 * @param string|string[] $type  The expected type(s) to pass to wp_cache_get_valid().
+	 *
+	 * @ticket 66005
+	 */
+	public function test_type_mismatch_returns_false( $value, $type ): void {
+		wp_cache_set( 'cache_key', $value, 'cache_group' );
+
+		$this->assertFalse( wp_cache_get_valid( 'cache_key', 'cache_group', $type ) );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[] Data provider.
+	 */
+	public function data_type_mismatch_returns_false(): array {
+		return array(
+			'string, array expected'        => array( 'a string', 'array' ),
+			'array, object expected'        => array( array( 1, 2, 3 ), 'object' ),
+			'numeric string, int expected'  => array( '123', 'int' ),
+			'float, int expected'           => array( 1.5, 'int' ),
+			'non-numeric string'            => array( 'abc', 'numeric' ),
+			'null, array expected'          => array( null, 'array' ),
+			'true, array expected'          => array( true, 'array' ),
+			'string, none in list expected' => array( 'a string', array( 'object', 'numeric' ) ),
+		);
+	}
+
+	/**
+	 * Test that the contents are returned when the callback returns true.
+	 *
+	 * @ticket 66005
+	 */
+	public function test_callback_returning_true_returns_contents(): void {
+		$value = array( 'id' => 5 );
+
+		wp_cache_set( 'cache_key', $value, 'cache_group' );
+
+		$result = wp_cache_get_valid(
+			'cache_key',
+			'cache_group',
+			'array',
+			static function ( array $contents ): bool {
+				return isset( $contents['id'] ) && is_int( $contents['id'] );
+			}
+		);
+
+		$this->assertSame( $value, $result );
+	}
+
+	/**
+	 * Test that false is returned when the callback returns false.
+	 *
+	 * @ticket 66005
+	 */
+	public function test_callback_returning_false_returns_false(): void {
+		wp_cache_set( 'cache_key', array( 'id' => 'not an int' ), 'cache_group' );
+
+		$result = wp_cache_get_valid(
+			'cache_key',
+			'cache_group',
+			'array',
+			static function ( array $contents ): bool {
+				return isset( $contents['id'] ) && is_int( $contents['id'] );
+			}
+		);
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test that the callback is not invoked when the type check fails.
+	 *
+	 * @ticket 66005
+	 */
+	public function test_callback_not_invoked_on_type_mismatch(): void {
+		$invoked = false;
+
+		wp_cache_set( 'cache_key', 'a string', 'cache_group' );
+
+		$result = wp_cache_get_valid(
+			'cache_key',
+			'cache_group',
+			'array',
+			static function () use ( &$invoked ): bool {
+				$invoked = true;
+				return true;
+			}
+		);
+
+		$this->assertFalse( $result );
+		$this->assertFalse( $invoked );
+	}
+
+	/**
+	 * Test that an unsupported type is incorrect usage and returns false.
+	 *
+	 * @dataProvider data_unsupported_type_is_doing_it_wrong
+	 *
+	 * @expectedIncorrectUsage wp_cache_get_valid
+	 *
+	 * @param string|array $type The unsupported type value.
+	 *
+	 * @ticket 66005
+	 */
+	public function test_unsupported_type_is_doing_it_wrong( $type ): void {
+		wp_cache_set( 'cache_key', array( 1, 2, 3 ), 'cache_group' );
+
+		$this->assertFalse( wp_cache_get_valid( 'cache_key', 'cache_group', $type ) );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[] Data provider.
+	 */
+	public function data_unsupported_type_is_doing_it_wrong(): array {
+		return array(
+			'null'                     => array( 'null' ),
+			'class name'               => array( 'WP_Post' ),
+			'mixed case'               => array( 'Array' ),
+			'empty type list'          => array( array() ),
+			'unsupported type in list' => array( array( 'array', 'null' ) ),
+			'non-string type in list'  => array( array( 'array', 123 ) ),
+		);
+	}
+
+	/**
+	 * Test that a non-callable callback is incorrect usage and returns false.
+	 *
+	 * @expectedIncorrectUsage wp_cache_get_valid
+	 *
+	 * @ticket 66005
+	 */
+	public function test_non_callable_callback_is_doing_it_wrong(): void {
+		wp_cache_set( 'cache_key', array( 1, 2, 3 ), 'cache_group' );
+
+		$this->assertFalse( wp_cache_get_valid( 'cache_key', 'cache_group', 'array', 'not_a_real_function_name' ) );
+	}
+
+	/**
+	 * Test that a callback returning a non-boolean is incorrect usage and returns false.
+	 *
+	 * @dataProvider data_non_boolean_callback_return_is_doing_it_wrong
+	 *
+	 * @expectedIncorrectUsage wp_cache_get_valid
+	 *
+	 * @param mixed $callback_return The non-boolean value for the callback to return.
+	 *
+	 * @ticket 66005
+	 */
+	public function test_non_boolean_callback_return_is_doing_it_wrong( $callback_return ): void {
+		wp_cache_set( 'cache_key', array( 1, 2, 3 ), 'cache_group' );
+
+		$result = wp_cache_get_valid(
+			'cache_key',
+			'cache_group',
+			'array',
+			static function () use ( $callback_return ) {
+				return $callback_return;
+			}
+		);
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[] Data provider.
+	 */
+	public function data_non_boolean_callback_return_is_doing_it_wrong(): array {
+		return array(
+			'truthy int'     => array( 1 ),
+			'the value back' => array( array( 1, 2, 3 ) ),
+		);
+	}
+
+	/**
+	 * Test that the failure action fires on a type mismatch.
+	 *
+	 * @ticket 66005
+	 */
+	public function test_failed_action_fires_on_type_mismatch(): void {
+		$captured = array();
+
+		add_action(
+			'wp_cache_get_valid_failed',
+			static function ( $key, $group, $value, $reason ) use ( &$captured ): void {
+				$captured = array( $key, $group, $value, $reason );
+			},
+			10,
+			4
+		);
+
+		wp_cache_set( 'cache_key', 'a string', 'cache_group' );
+		wp_cache_get_valid( 'cache_key', 'cache_group', 'array' );
+
+		$this->assertSame( array( 'cache_key', 'cache_group', 'a string', 'type' ), $captured );
+	}
+
+	/**
+	 * Test that the failure action fires when the callback rejects the contents.
+	 *
+	 * @ticket 66005
+	 */
+	public function test_failed_action_fires_on_callback_rejection(): void {
+		$captured = array();
+
+		add_action(
+			'wp_cache_get_valid_failed',
+			static function ( $key, $group, $value, $reason ) use ( &$captured ): void {
+				$captured = array( $key, $group, $value, $reason );
+			},
+			10,
+			4
+		);
+
+		wp_cache_set( 'cache_key', array( 1, 2, 3 ), 'cache_group' );
+		wp_cache_get_valid( 'cache_key', 'cache_group', 'array', '__return_false' );
+
+		$this->assertSame( array( 'cache_key', 'cache_group', array( 1, 2, 3 ), 'callback' ), $captured );
+	}
+
+	/**
+	 * Test that the failure action does not fire on a plain cache miss.
+	 *
+	 * @ticket 66005
+	 */
+	public function test_failed_action_does_not_fire_on_cache_miss(): void {
+		$fired = false;
+
+		add_action(
+			'wp_cache_get_valid_failed',
+			static function () use ( &$fired ): void {
+				$fired = true;
+			}
+		);
+
+		wp_cache_get_valid( 'missing_key', 'cache_group', 'array' );
+
+		$this->assertFalse( $fired );
+	}
+
+	/**
+	 * Test that invalid contents are left in the cache by default.
+	 *
+	 * @ticket 66005
+	 */
+	public function test_invalid_contents_are_not_deleted_by_default(): void {
+		wp_cache_set( 'cache_key', 'a string', 'cache_group' );
+
+		$this->assertFalse( wp_cache_get_valid( 'cache_key', 'cache_group', 'array' ) );
+
+		$found = false;
+		$this->assertSame( 'a string', wp_cache_get( 'cache_key', 'cache_group', false, $found ) );
+		$this->assertTrue( $found );
+	}
+
+	/**
+	 * Test that invalid contents are deleted when requested.
+	 *
+	 * @dataProvider data_invalid_contents_are_deleted_when_requested
+	 *
+	 * @param mixed           $value    The invalid value to store in the cache.
+	 * @param callable|string $callback The validation callback to pass, if any.
+	 *
+	 * @ticket 66005
+	 */
+	public function test_invalid_contents_are_deleted_when_requested( $value, $callback ): void {
+		wp_cache_set( 'cache_key', $value, 'cache_group' );
+
+		$this->assertFalse( wp_cache_get_valid( 'cache_key', 'cache_group', 'array', $callback, false, true ) );
+
+		$found = false;
+		wp_cache_get( 'cache_key', 'cache_group', false, $found );
+		$this->assertFalse( $found );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[] Data provider.
+	 */
+	public function data_invalid_contents_are_deleted_when_requested(): array {
+		return array(
+			'type mismatch'      => array( 'a string', '' ),
+			'callback rejection' => array( array( 1, 2, 3 ), '__return_false' ),
+		);
+	}
+
+	/**
+	 * Test that valid contents are not deleted when deletion is requested.
+	 *
+	 * @ticket 66005
+	 */
+	public function test_valid_contents_are_not_deleted(): void {
+		$value = array( 1, 2, 3 );
+
+		wp_cache_set( 'cache_key', $value, 'cache_group' );
+
+		$this->assertSame( $value, wp_cache_get_valid( 'cache_key', 'cache_group', 'array', '', false, true ) );
+		$this->assertSame( $value, wp_cache_get( 'cache_key', 'cache_group' ) );
+	}
+
+	/**
+	 * Test that contents are not deleted when the function was called incorrectly.
+	 *
+	 * Deletion only applies to contents that were found and failed validation,
+	 * never to cases where validation itself could not run.
+	 *
+	 * @dataProvider data_contents_are_not_deleted_on_incorrect_usage
+	 *
+	 * @expectedIncorrectUsage wp_cache_get_valid
+	 *
+	 * @param string|array    $type     The type value to pass.
+	 * @param callable|string $callback The callback to pass.
+	 *
+	 * @ticket 66005
+	 */
+	public function test_contents_are_not_deleted_on_incorrect_usage( $type, $callback ): void {
+		$value = array( 1, 2, 3 );
+
+		wp_cache_set( 'cache_key', $value, 'cache_group' );
+
+		$this->assertFalse( wp_cache_get_valid( 'cache_key', 'cache_group', $type, $callback, false, true ) );
+		$this->assertSame( $value, wp_cache_get( 'cache_key', 'cache_group' ) );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[] Data provider.
+	 */
+	public function data_contents_are_not_deleted_on_incorrect_usage(): array {
+		return array(
+			'unsupported type'     => array( 'not_a_type', '' ),
+			'non-callable'         => array( 'array', 'not_a_real_function_name' ),
+			'non-boolean callback' => array( 'array', '__return_null' ),
+		);
+	}
+
+	/**
+	 * Test the sentinel-union pattern: an object or a numeric not-found marker.
+	 *
+	 * Mirrors the `sites` cache in WP_Site::get_instance(), where a cached `-1`
+	 * records a previous lookup that found nothing.
+	 *
+	 * @ticket 66005
+	 */
+	public function test_type_list_supports_sentinel_union(): void {
+		wp_cache_set( 'cache_key', -1, 'cache_group' );
+
+		$this->assertSame( -1, wp_cache_get_valid( 'cache_key', 'cache_group', array( 'object', 'numeric' ) ) );
+
+		$site      = new stdClass();
+		$site->foo = 'bar';
+		wp_cache_set( 'cache_key', $site, 'cache_group' );
+
+		$result = wp_cache_get_valid( 'cache_key', 'cache_group', array( 'object', 'numeric' ) );
+		$this->assertInstanceOf( stdClass::class, $result );
+
+		wp_cache_set( 'cache_key', 'poisoned', 'cache_group' );
+
+		$this->assertFalse( wp_cache_get_valid( 'cache_key', 'cache_group', array( 'object', 'numeric' ) ) );
+	}
+}


### PR DESCRIPTION
https://core.trac.wordpress.org/ticket/66005

The aim is to keep simple improvements simple, while providing enough flexibility to also address more complex situations.

At the core this is a wrapper around `wp_cache_get()` - with type checking.

```php
function wp_cache_get_valid( $key, $group, $type, $callback = '', bool $force = false, bool $delete_invalid = false, ?bool &$valid = null ) {}
```

- Returns the cache contents only when they match an expected `$type`; a string, or an array meaning "any of these". Otherwise returns `false`, which callers treat as a miss: regenerate and `wp_cache_set()`.
- An optional `$callback` runs after the type check for structural validation (for example, "object with a non-empty `ID`").
- `$valid` (by reference) reports whether contents were found and passed validation, so cached booleans stay usable.
- Invalid contents are left in place by default for the caller to overwrite; `$delete_invalid` opts into deleting them.
- A `wp_cache_get_valid_failed` action fires when found contents fail validation, giving monitoring tools a signal that they did not have before.
- Implemented in `cache-compat.php` purely on top of `wp_cache_get()` (the `wp_cache_get_salted()` pattern), so behavior is identical over every drop-in and nothing new is required from cache backends.

There are several cases in WordPress core where this could be appllied to make sure that the return type of cached values is correct.

AI assistance: Yes
Tool(s): Claude Code
Model(s): Fable 5
Used for: I did a lot of rubber ducking with Claude on the `wp_cache_get_valid()` itself, to narrow down what the implementation should look like.  Claude wrote the tests.


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
