### PR TITLE
Cache API: Do not cache a miss while cache addition is suspended.

### DIFF
--- a/src/wp-includes/class-wp-comment.php
+++ b/src/wp-includes/class-wp-comment.php
@@ -273,8 +273,14 @@ final class WP_Comment {
 				return false;
 			}
 
-			// Not wp_cache_add(), since an unusable cached value may still be present and must be replaced.
-			wp_cache_set( $_comment->comment_ID, $_comment, 'comment' );
+			/*
+			 * Not wp_cache_add(), since an unusable cached value may still be present and must be
+			 * replaced. add() checks wp_suspend_cache_addition() and set() does not, so the check
+			 * moves to the call site.
+			 */
+			if ( ! wp_suspend_cache_addition() ) {
+				wp_cache_set( $_comment->comment_ID, $_comment, 'comment' );
+			}
 		}
 
 		return new WP_Comment( $_comment );

--- a/src/wp-includes/class-wp-network.php
+++ b/src/wp-includes/class-wp-network.php
@@ -119,8 +119,14 @@ class WP_Network {
 				$_network = -1;
 			}
 
-			// Not wp_cache_add(), since an unusable cached value may still be present and must be replaced.
-			wp_cache_set( $network_id, $_network, 'networks' );
+			/*
+			 * Not wp_cache_add(), since an unusable cached value may still be present and must be
+			 * replaced. add() checks wp_suspend_cache_addition() and set() does not, so the check
+			 * moves to the call site.
+			 */
+			if ( ! wp_suspend_cache_addition() ) {
+				wp_cache_set( $network_id, $_network, 'networks' );
+			}
 		}
 
 		if ( is_numeric( $_network ) ) {

--- a/src/wp-includes/class-wp-post.php
+++ b/src/wp-includes/class-wp-post.php
@@ -296,8 +296,14 @@ final class WP_Post {
 
 			$_post = sanitize_post( $_post, 'raw' );
 
-			// Not wp_cache_add(), since an unusable cached value may still be present and must be replaced.
-			wp_cache_set( (int) $_post->ID, $_post, 'posts' );
+			/*
+			 * Not wp_cache_add(), since an unusable cached value may still be present and must be
+			 * replaced. add() checks wp_suspend_cache_addition() and set() does not, so the check
+			 * moves to the call site.
+			 */
+			if ( ! wp_suspend_cache_addition() ) {
+				wp_cache_set( (int) $_post->ID, $_post, 'posts' );
+			}
 		} elseif ( empty( $_post->filter ) || 'raw' !== $_post->filter ) {
 			$_post = sanitize_post( $_post, 'raw' );
 		}

--- a/src/wp-includes/class-wp-site.php
+++ b/src/wp-includes/class-wp-site.php
@@ -188,8 +188,14 @@ final class WP_Site {
 				$_site = -1;
 			}
 
-			// Not wp_cache_add(), since an unusable cached value may still be present and must be replaced.
-			wp_cache_set( $site_id, $_site, 'sites' );
+			/*
+			 * Not wp_cache_add(), since an unusable cached value may still be present and must be
+			 * replaced. add() checks wp_suspend_cache_addition() and set() does not, so the check
+			 * moves to the call site.
+			 */
+			if ( ! wp_suspend_cache_addition() ) {
+				wp_cache_set( $site_id, $_site, 'sites' );
+			}
 		}
 
 		if ( is_numeric( $_site ) ) {

--- a/src/wp-includes/class-wp-term.php
+++ b/src/wp-includes/class-wp-term.php
@@ -185,8 +185,14 @@ final class WP_Term {
 
 			// Don't cache terms that are shared between taxonomies.
 			if ( 1 === count( $terms ) ) {
-				// Not wp_cache_add(), since an unusable cached value may still be present and must be replaced.
-				wp_cache_set( $term_id, $_term, 'terms' );
+				/*
+				 * Not wp_cache_add(), since an unusable cached value may still be present and must be
+				 * replaced. add() checks wp_suspend_cache_addition() and set() does not, so the check
+				 * moves to the call site.
+				 */
+				if ( ! wp_suspend_cache_addition() ) {
+					wp_cache_set( $term_id, $_term, 'terms' );
+				}
 			}
 		}
 

--- a/tests/phpunit/tests/comment/wpComment.php
+++ b/tests/phpunit/tests/comment/wpComment.php
@@ -247,4 +247,25 @@ class Tests_Comment_WpComment extends WP_UnitTestCase {
 		$this->assertFalse( $is_set, 'Expected __isset() to return false for an unattached comment.' );
 		$this->assertNull( $title, 'Expected __get() not to read the field from the global post.' );
 	}
+
+	/**
+	 * Tests that a cache miss is not stored while cache addition is suspended.
+	 *
+	 * @ticket 66006
+	 */
+	public function test_get_instance_does_not_cache_a_miss_while_cache_addition_is_suspended(): void {
+		clean_comment_cache( self::$comment_id );
+		$this->assertFalse( wp_cache_get( self::$comment_id, 'comment' ), 'The comment was cached before the test began.' );
+
+		$suspend = wp_suspend_cache_addition();
+		wp_suspend_cache_addition( true );
+
+		$comment = WP_Comment::get_instance( self::$comment_id );
+
+		wp_suspend_cache_addition( $suspend );
+
+		$this->assertInstanceOf( WP_Comment::class, $comment, 'A comment object was not returned.' );
+		$this->assertSame( self::$comment_id, (int) $comment->comment_ID, 'The wrong comment was returned.' );
+		$this->assertFalse( wp_cache_get( self::$comment_id, 'comment' ), 'The comment was added to the cache.' );
+	}
 }

--- a/tests/phpunit/tests/multisite/network.php
+++ b/tests/phpunit/tests/multisite/network.php
@@ -760,4 +760,27 @@ class Tests_Multisite_Network extends WP_UnitTestCase {
 		static::factory()->network->create();
 		return (int) $wpdb->get_var( 'SELECT id FROM ' . $wpdb->site . ' ORDER BY id DESC LIMIT 1' ) + 1;
 	}
+
+	/**
+	 * Tests that a cache miss is not stored while cache addition is suspended.
+	 *
+	 * @ticket 66006
+	 *
+	 * @covers WP_Network::get_instance
+	 */
+	public function test_get_instance_does_not_cache_a_miss_while_cache_addition_is_suspended(): void {
+		clean_network_cache( self::$different_network_id );
+		$this->assertFalse( wp_cache_get( self::$different_network_id, 'networks' ), 'The network was cached before the test began.' );
+
+		$suspend = wp_suspend_cache_addition();
+		wp_suspend_cache_addition( true );
+
+		$network = WP_Network::get_instance( self::$different_network_id );
+
+		wp_suspend_cache_addition( $suspend );
+
+		$this->assertInstanceOf( WP_Network::class, $network, 'A network object was not returned.' );
+		$this->assertSame( self::$different_network_id, (int) $network->id, 'The wrong network was returned.' );
+		$this->assertFalse( wp_cache_get( self::$different_network_id, 'networks' ), 'The network was added to the cache.' );
+	}
 }

--- a/tests/phpunit/tests/multisite/wpSite.php
+++ b/tests/phpunit/tests/multisite/wpSite.php
@@ -307,4 +307,25 @@ class Tests_Multisite_wpSite extends WP_UnitTestCase {
 			'a float as a string'  => array( '3.5' ),
 		);
 	}
+
+	/**
+	 * Tests that a cache miss is not stored while cache addition is suspended.
+	 *
+	 * @ticket 66006
+	 */
+	public function test_get_instance_does_not_cache_a_miss_while_cache_addition_is_suspended(): void {
+		clean_blog_cache( self::$site_id );
+		$this->assertFalse( wp_cache_get( self::$site_id, 'sites' ), 'The site was cached before the test began.' );
+
+		$suspend = wp_suspend_cache_addition();
+		wp_suspend_cache_addition( true );
+
+		$site = WP_Site::get_instance( self::$site_id );
+
+		wp_suspend_cache_addition( $suspend );
+
+		$this->assertInstanceOf( WP_Site::class, $site, 'A site object was not returned.' );
+		$this->assertSame( self::$site_id, (int) $site->blog_id, 'The wrong site was returned.' );
+		$this->assertFalse( wp_cache_get( self::$site_id, 'sites' ), 'The site was added to the cache.' );
+	}
 }

--- a/tests/phpunit/tests/post/wpPost.php
+++ b/tests/phpunit/tests/post/wpPost.php
@@ -140,4 +140,27 @@ class Tests_Post_wpPost extends WP_UnitTestCase {
 			'a WP_Post without ID'  => array( new WP_Post( new stdClass() ) ),
 		);
 	}
+
+	/**
+	 * Tests that a cache miss is not stored while cache addition is suspended.
+	 *
+	 * @ticket 66006
+	 *
+	 * @covers WP_Post::get_instance
+	 */
+	public function test_get_instance_does_not_cache_a_miss_while_cache_addition_is_suspended(): void {
+		clean_post_cache( self::$post_id );
+		$this->assertFalse( wp_cache_get( self::$post_id, 'posts' ), 'The post was cached before the test began.' );
+
+		$suspend = wp_suspend_cache_addition();
+		wp_suspend_cache_addition( true );
+
+		$post = WP_Post::get_instance( self::$post_id );
+
+		wp_suspend_cache_addition( $suspend );
+
+		$this->assertInstanceOf( WP_Post::class, $post, 'A post object was not returned.' );
+		$this->assertSame( self::$post_id, $post->ID, 'The wrong post was returned.' );
+		$this->assertFalse( wp_cache_get( self::$post_id, 'posts' ), 'The post was added to the cache.' );
+	}
 }

--- a/tests/phpunit/tests/term/wpTerm.php
+++ b/tests/phpunit/tests/term/wpTerm.php
@@ -187,4 +187,27 @@ class Tests_Term_WpTerm extends WP_UnitTestCase {
 			'a WP_Term without term_id'  => array( new WP_Term( new stdClass() ) ),
 		);
 	}
+
+	/**
+	 * Tests that a cache miss is not stored while cache addition is suspended.
+	 *
+	 * @ticket 66006
+	 *
+	 * @covers WP_Term::get_instance
+	 */
+	public function test_get_instance_does_not_cache_a_miss_while_cache_addition_is_suspended(): void {
+		clean_term_cache( self::$term_id, 'wptests_tax' );
+		$this->assertFalse( wp_cache_get( self::$term_id, 'terms' ), 'The term was cached before the test began.' );
+
+		$suspend = wp_suspend_cache_addition();
+		wp_suspend_cache_addition( true );
+
+		$term = WP_Term::get_instance( self::$term_id, 'wptests_tax' );
+
+		wp_suspend_cache_addition( $suspend );
+
+		$this->assertInstanceOf( WP_Term::class, $term, 'A term object was not returned.' );
+		$this->assertSame( self::$term_id, $term->term_id, 'The wrong term was returned.' );
+		$this->assertFalse( wp_cache_get( self::$term_id, 'terms' ), 'The term was added to the cache.' );
+	}
 }


### PR DESCRIPTION
`wp_cache_add()` returns early when `wp_suspend_cache_addition()` is on and `wp_cache_set()` does not, so the swap in r63354 left `WP_Post`, `WP_Term`, `WP_Comment`, `WP_Site` and `WP_Network::get_instance()` writing to the object cache while additions are suspended.

r63354 reached for `set()` because an unusable cached value has to be replaced and `add()` will not overwrite. That still works: only the suspension check moves to the call site, so a poisoned entry is replaced as before on a normal request, and nothing is written while the flag is on. Simplified per review; the first version also replaced while suspended.

Measured on a running site with the cache cleared and the flag on: post, term and comment are PRESENT on trunk and MISS on this branch, with a plain `wp_cache_add()` control MISS throughout. Each of the five guards is mutation checked, reverting one file fails exactly one test. Groups post, comment, taxonomy, cache, ms-site and ms-network are green, and the single taxonomy warning is present on clean trunk too. PHPCS and PHPStan clean.

Trac ticket: https://core.trac.wordpress.org/ticket/66006

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Drafting the fix and the regression tests, and running the reproduction, mutation and lint checks. Reviewed and verified by me before opening.
