### PR TITLE
Taxonomy: Report a rejected database write from wp_update_term()

### DIFF
--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -2429,6 +2429,7 @@ function wp_get_object_terms( $object_ids, $taxonomies, $args = array() ) {
  * @global wpdb $wpdb WordPress database abstraction object.
  *
  * @since 2.3.0
+ * @since 7.2.0 Returns a `WP_Error` object when a database write is rejected.
  *
  * @param string       $term     The term name to add.
  * @param string       $taxonomy The taxonomy to which to add the term.
@@ -2637,7 +2638,10 @@ function wp_insert_term( $term, $taxonomy, $args = array() ) {
 
 		/** This action is documented in wp-includes/taxonomy.php */
 		do_action( 'edit_terms', $term_id, $taxonomy, $args );
-		$wpdb->update( $wpdb->terms, compact( 'slug' ), compact( 'term_id' ) );
+
+		if ( false === $wpdb->update( $wpdb->terms, compact( 'slug' ), compact( 'term_id' ) ) ) {
+			return new WP_Error( 'db_update_error', __( 'Could not update term in the database.' ), $wpdb->last_error );
+		}
 
 		/** This action is documented in wp-includes/taxonomy.php */
 		do_action( 'edited_terms', $term_id, $taxonomy, $args );
@@ -3235,6 +3239,7 @@ function wp_unique_term_slug( $slug, $term ) {
  * If you don't pass any slug, then a unique one will be created.
  *
  * @since 2.3.0
+ * @since 7.2.0 Returns a `WP_Error` object when a database write is rejected.
  *
  * @global wpdb $wpdb WordPress database abstraction object.
  *
@@ -3415,11 +3420,16 @@ function wp_update_term( $term_id, $taxonomy, $args = array() ) {
 	 */
 	$data = apply_filters( 'wp_update_term_data', $data, $term_id, $taxonomy, $args );
 
-	$wpdb->update( $wpdb->terms, $data, compact( 'term_id' ) );
+	if ( false === $wpdb->update( $wpdb->terms, $data, compact( 'term_id' ) ) ) {
+		return new WP_Error( 'db_update_error', __( 'Could not update term in the database.' ), $wpdb->last_error );
+	}
 
 	if ( empty( $slug ) ) {
 		$slug = sanitize_title( $name, $term_id );
-		$wpdb->update( $wpdb->terms, compact( 'slug' ), compact( 'term_id' ) );
+
+		if ( false === $wpdb->update( $wpdb->terms, compact( 'slug' ), compact( 'term_id' ) ) ) {
+			return new WP_Error( 'db_update_error', __( 'Could not update term in the database.' ), $wpdb->last_error );
+		}
 	}
 
 	/**
@@ -3447,7 +3457,9 @@ function wp_update_term( $term_id, $taxonomy, $args = array() ) {
 	 */
 	do_action( 'edit_term_taxonomy', $tt_id, $taxonomy, $args );
 
-	$wpdb->update( $wpdb->term_taxonomy, compact( 'term_id', 'taxonomy', 'description', 'parent' ), array( 'term_taxonomy_id' => $tt_id ) );
+	if ( false === $wpdb->update( $wpdb->term_taxonomy, compact( 'term_id', 'taxonomy', 'description', 'parent' ), array( 'term_taxonomy_id' => $tt_id ) ) ) {
+		return new WP_Error( 'db_update_error', __( 'Could not update term taxonomy in the database.' ), $wpdb->last_error );
+	}
 
 	/**
 	 * Fires immediately after a term-taxonomy relationship is updated.

--- a/tests/phpunit/tests/term/wpUpdateTerm.php
+++ b/tests/phpunit/tests/term/wpUpdateTerm.php
@@ -802,4 +802,149 @@ class Tests_Term_WpUpdateTerm extends WP_UnitTestCase {
 		$this->assertWPError( $found );
 		$this->assertSame( 'invalid_term', $found->get_error_code() );
 	}
+
+	/**
+	 * A rejected write must not be reported as a successful update.
+	 *
+	 * `wpdb::process_fields()` refuses a value that does not fit its column, so
+	 * `$wpdb->update()` returns false without sending a query.
+	 *
+	 * @ticket 66007
+	 */
+	public function test_wp_update_term_should_return_wp_error_when_the_term_write_is_rejected() {
+		register_taxonomy( 'wptests_tax', 'post' );
+		$t = self::factory()->term->create(
+			array(
+				'taxonomy' => 'wptests_tax',
+				'name'     => 'Original name',
+			)
+		);
+
+		$found = wp_update_term(
+			$t,
+			'wptests_tax',
+			array(
+				'name' => str_repeat( 'a', 201 ),
+			)
+		);
+
+		$this->assertWPError( $found );
+		$this->assertSame( 'db_update_error', $found->get_error_code() );
+		$this->assertSame( 'Original name', get_term( $t, 'wptests_tax' )->name, 'The term should be left untouched.' );
+	}
+
+	/**
+	 * @ticket 66007
+	 */
+	public function test_wp_update_term_should_not_fire_update_hooks_when_the_term_write_is_rejected() {
+		register_taxonomy( 'wptests_tax', 'post' );
+		$t = self::factory()->term->create(
+			array(
+				'taxonomy' => 'wptests_tax',
+			)
+		);
+
+		$edited_terms = new MockAction();
+		$edit_term    = new MockAction();
+		$edited_term  = new MockAction();
+
+		add_action( 'edited_terms', array( $edited_terms, 'action' ) );
+		add_action( 'edit_term', array( $edit_term, 'action' ) );
+		add_action( 'edited_term', array( $edited_term, 'action' ) );
+
+		wp_update_term(
+			$t,
+			'wptests_tax',
+			array(
+				'name' => str_repeat( 'a', 201 ),
+			)
+		);
+
+		$this->assertSame( 0, $edited_terms->get_call_count(), '"edited_terms" should not fire.' );
+		$this->assertSame( 0, $edit_term->get_call_count(), '"edit_term" should not fire.' );
+		$this->assertSame( 0, $edited_term->get_call_count(), '"edited_term" should not fire.' );
+	}
+
+	/**
+	 * The length of the name is only the easiest trigger. Any value the database
+	 * layer rejects must be reported the same way.
+	 *
+	 * @ticket 66007
+	 */
+	public function test_wp_update_term_should_return_wp_error_when_filtered_term_data_is_rejected() {
+		register_taxonomy( 'wptests_tax', 'post' );
+		$t = self::factory()->term->create(
+			array(
+				'taxonomy' => 'wptests_tax',
+			)
+		);
+
+		add_filter(
+			'wp_update_term_data',
+			static function ( $data ) {
+				// A short name carrying an unpaired UTF-16 surrogate.
+				$data['name'] = "Bad\xED\xA0\x80name";
+				return $data;
+			}
+		);
+
+		$found = wp_update_term( $t, 'wptests_tax', array( 'name' => 'Anything' ) );
+
+		$this->assertWPError( $found );
+		$this->assertSame( 'db_update_error', $found->get_error_code() );
+	}
+
+	/**
+	 * @ticket 66007
+	 */
+	public function test_wp_update_term_should_return_wp_error_when_the_term_taxonomy_write_is_rejected() {
+		register_taxonomy( 'wptests_tax', 'post' );
+		$t = self::factory()->term->create(
+			array(
+				'taxonomy' => 'wptests_tax',
+			)
+		);
+
+		add_filter(
+			'pre_term_description',
+			static function () {
+				return "Bad\xED\xA0\x80description";
+			},
+			99
+		);
+
+		$found = wp_update_term( $t, 'wptests_tax', array( 'description' => 'Anything' ) );
+
+		$this->assertWPError( $found );
+		$this->assertSame( 'db_update_error', $found->get_error_code() );
+	}
+
+	/**
+	 * `$wpdb->update()` returns 0 when the row matches but no value changes.
+	 * That is a successful update and must not be mistaken for a failure.
+	 *
+	 * @ticket 66007
+	 */
+	public function test_wp_update_term_should_succeed_when_no_column_values_change() {
+		register_taxonomy( 'wptests_tax', 'post' );
+		$t = self::factory()->term->create(
+			array(
+				'taxonomy' => 'wptests_tax',
+				'name'     => 'Unchanged',
+				'slug'     => 'unchanged',
+			)
+		);
+
+		$found = wp_update_term(
+			$t,
+			'wptests_tax',
+			array(
+				'name' => 'Unchanged',
+				'slug' => 'unchanged',
+			)
+		);
+
+		$this->assertNotWPError( $found );
+		$this->assertSame( $t, $found['term_id'] );
+	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

`wp_update_term()` discards the return of all three of its `$wpdb->update()` calls. When `wpdb::process_fields()` refuses a value the write never reaches MySQL, yet the function still fires `edited_terms` and `edited_term`, clears the cache, and returns the success array — REST answers 200 with stale data. `wp_insert_term()` has the same gap on its empty-slug write.

Each write is now checked and returns `WP_Error( 'db_update_error', …, $wpdb->last_error )` before the hooks fire. The comparison is strictly `false ===`, since `$wpdb->update()` returns `0` when the row matches but nothing changes, which is a success.

Five tests cover the rejected `terms` and `term_taxonomy` writes, a value rejected through `wp_update_term_data`, the hooks not firing, and a no-op update still succeeding.

Trac ticket: https://core.trac.wordpress.org/ticket/66007

## Use of AI Tools
AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Investigating the defect against trunk, drafting the patch, and writing the five unit tests. All changes were reviewed and validated by me.
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
