### PR TITLE
Interactivity API: Make class WP_Interactivity_API minimally extensible

### DIFF
--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -12,7 +12,7 @@
  *
  * @since 6.5.0
  */
-final class WP_Interactivity_API {
+class WP_Interactivity_API {
 	/**
 	 * Holds the mapping of directive attribute names to their processor methods.
 	 *
@@ -1422,7 +1422,7 @@ final class WP_Interactivity_API {
 	 * @return string The CSS styles for the router's top loading bar animation.
 	 */
 	private function get_router_animation_styles(): string {
-		return <<<CSS
+		return <<<'CSS'
 			.wp-interactivity-router-loading-bar {
 				position: fixed;
 				top: 0;
@@ -1475,7 +1475,7 @@ CSS;
 	 * @since 6.7.0
 	 */
 	public function print_router_markup() {
-		echo <<<HTML
+		echo <<<'HTML'
 			<div
 				class="wp-interactivity-router-loading-bar"
 				data-wp-interactive="core/router/private"

--- a/src/wp-includes/interactivity-api/interactivity-api.php
+++ b/src/wp-includes/interactivity-api/interactivity-api.php
@@ -20,11 +20,27 @@
  * @return WP_Interactivity_API The main WP_Interactivity_API instance.
  */
 function wp_interactivity(): WP_Interactivity_API {
-	global $wp_interactivity;
+		global $wp_interactivity;
+
 	if ( ! ( $wp_interactivity instanceof WP_Interactivity_API ) ) {
-		$wp_interactivity = new WP_Interactivity_API();
+			$wp_interactivity = new WP_Interactivity_API();
+
+		if (
+					defined( 'WP_INTERACTIVITY_ALLOW_PRIVATE_API' )
+					&& WP_INTERACTIVITY_ALLOW_PRIVATE_API
+			) {
+				$instance = apply_filters(
+					'wp_interactivity_instance',
+					$wp_interactivity
+				);
+
+			if ( $instance instanceof WP_Interactivity_API ) {
+				$wp_interactivity = $instance;
+			}
+		}
 	}
-	return $wp_interactivity;
+
+		return $wp_interactivity;
 }
 
 /**

--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -458,7 +458,12 @@ require ABSPATH . WPINC . '/speculative-loading.php';
 require ABSPATH . WPINC . '/view-transitions.php';
 
 add_action( 'after_setup_theme', array( wp_script_modules(), 'add_hooks' ) );
-add_action( 'after_setup_theme', array( wp_interactivity(), 'add_hooks' ) );
+add_action(
+	'after_setup_theme',
+	function () {
+		wp_interactivity()->add_hooks();
+	}
+);
 
 /**
  * @since 3.3.0


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65757#comment:19

As per the discussion in the trac ticet, this PR aims to make the Interactivity API's `WP_Interactivity_API` class - used for server side processing of directives - minimally extensible. 

Removing `final` from the class is the most minimal change that needs to be made to achieve this goal, without changing the private and protected status of the various properties and methods. But the concern still remains that even if someone wrote their entirely own class rather than override the methods/properties, it would still lock the API into a public contract. 

So, this PR implements a pattern that is used in Gutenberg, and in the `interactivity` package in particular: an explicit developer opt-in when they are using an unstable/internal/private API. This would be achieved by defining a `WP_INTERACTIVITY_ALLOW_PRIVATE_API` const and also using the `wp_interactivity_instance` filter to replace the class instance with one that extends it. 

Feedback on the possibility of this approach would be quite welcomed. 

## Use of AI Tools

AI assistance: No

**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
