### PR TITLE
Taxonomy: Return a descriptive WP_Error when a term name exceeds the DB column length

### DIFF
--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -2402,6 +2402,41 @@ function wp_get_object_terms( $object_ids, $taxonomies, $args = array() ) {
 }
 
 /**
+ * Checks a term name against the maximum length allowed by the `wp_terms` table's `name` column.
+ *
+ * @since 7.2.0
+ * @access private
+ *
+ * @global wpdb $wpdb WordPress database abstraction object.
+ *
+ * @param string $name Term name to check.
+ * @return true|WP_Error True if the name fits the column, WP_Error otherwise.
+ */
+function _wp_check_term_name_length( $name ) {
+	global $wpdb;
+
+	$max_length = 200;
+	$col_length = $wpdb->get_col_length( $wpdb->terms, 'name' );
+
+	if ( is_array( $col_length ) && ! empty( $col_length['length'] ) ) {
+		$max_length = (int) $col_length['length'];
+	}
+
+	if ( mb_strlen( $name ) > $max_length ) {
+		return new WP_Error(
+			'term_name_too_long',
+			sprintf(
+				/* translators: %d: Maximum number of characters. */
+				__( 'Term name may not be longer than %d characters.' ),
+				$max_length
+			)
+		);
+	}
+
+	return true;
+}
+
+/**
  * Adds a new term to the database.
  *
  * A non-existent term is inserted in the following sequence:
@@ -2518,6 +2553,11 @@ function wp_insert_term( $term, $taxonomy, $args = array() ) {
 	// Sanitization could clean the name to an empty string that must be checked again.
 	if ( '' === $name ) {
 		return new WP_Error( 'invalid_term_name', __( 'Invalid term name.' ) );
+	}
+
+	$name_length_error = _wp_check_term_name_length( $name );
+	if ( is_wp_error( $name_length_error ) ) {
+		return $name_length_error;
 	}
 
 	$slug_provided = ! empty( $args['slug'] );
@@ -3310,6 +3350,11 @@ function wp_update_term( $term_id, $taxonomy, $args = array() ) {
 
 	if ( '' === trim( $name ) ) {
 		return new WP_Error( 'empty_term_name', __( 'A name is required for this term.' ) );
+	}
+
+	$name_length_error = _wp_check_term_name_length( $name );
+	if ( is_wp_error( $name_length_error ) ) {
+		return $name_length_error;
 	}
 
 	if ( (int) $parsed_args['parent'] > 0 && ! term_exists( (int) $parsed_args['parent'] ) ) {

--- a/tests/phpunit/tests/term/wpInsertTerm.php
+++ b/tests/phpunit/tests/term/wpInsertTerm.php
@@ -907,6 +907,39 @@ class Tests_Term_WpInsertTerm extends WP_UnitTestCase {
 		$this->assertSame( 'invalid_term_name', $term->get_error_code() );
 	}
 
+	/**
+	 * @ticket 36610
+	 */
+	public function test_wp_insert_term_name_too_long_should_return_wp_error() {
+		register_taxonomy( 'wptests_tax', 'post' );
+		$found = wp_insert_term( str_repeat( 'a', 201 ), 'wptests_tax' );
+
+		$this->assertWPError( $found );
+		$this->assertSame( 'term_name_too_long', $found->get_error_code() );
+	}
+
+	/**
+	 * @ticket 36610
+	 */
+	public function test_wp_insert_term_name_at_max_length_should_succeed() {
+		register_taxonomy( 'wptests_tax', 'post' );
+		$found = wp_insert_term( str_repeat( 'a', 200 ), 'wptests_tax' );
+
+		$this->assertNotWPError( $found );
+	}
+
+	/**
+	 * @ticket 36610
+	 */
+	public function test_wp_insert_term_name_length_should_be_counted_in_characters_not_bytes() {
+		register_taxonomy( 'wptests_tax', 'post' );
+
+		// 200 multibyte characters fit the column, even though their byte length is far greater than 200.
+		$found = wp_insert_term( str_repeat( 'é', 200 ), 'wptests_tax' );
+
+		$this->assertNotWPError( $found );
+	}
+
 	/** Helpers */
 
 	public function deleted_term_cb( $term, $tt_id, $taxonomy, $deleted_term, $object_ids ) {

--- a/tests/phpunit/tests/term/wpUpdateTerm.php
+++ b/tests/phpunit/tests/term/wpUpdateTerm.php
@@ -802,4 +802,45 @@ class Tests_Term_WpUpdateTerm extends WP_UnitTestCase {
 		$this->assertWPError( $found );
 		$this->assertSame( 'invalid_term', $found->get_error_code() );
 	}
+
+	/**
+	 * @ticket 36610
+	 */
+	public function test_wp_update_term_name_too_long_should_return_wp_error() {
+		register_taxonomy( 'wptests_tax', 'post' );
+		$t = self::factory()->term->create( array( 'taxonomy' => 'wptests_tax' ) );
+
+		$found = wp_update_term(
+			$t,
+			'wptests_tax',
+			array(
+				'name' => str_repeat( 'a', 201 ),
+			)
+		);
+
+		_unregister_taxonomy( 'wptests_tax' );
+
+		$this->assertWPError( $found );
+		$this->assertSame( 'term_name_too_long', $found->get_error_code() );
+	}
+
+	/**
+	 * @ticket 36610
+	 */
+	public function test_wp_update_term_name_at_max_length_should_succeed() {
+		register_taxonomy( 'wptests_tax', 'post' );
+		$t = self::factory()->term->create( array( 'taxonomy' => 'wptests_tax' ) );
+
+		$found = wp_update_term(
+			$t,
+			'wptests_tax',
+			array(
+				'name' => str_repeat( 'a', 200 ),
+			)
+		);
+
+		_unregister_taxonomy( 'wptests_tax' );
+
+		$this->assertNotWPError( $found );
+	}
 }


### PR DESCRIPTION
`wp_insert_term()` and `wp_update_term()` never validate the length of the term name before writing it, unlike the equivalent checks already in place for `wp_insert_user()`, `wp_check_comment_data_max_lengths()`, `register_post_type()`, and `register_taxonomy()`. When a sanitized name exceeds the `wp_terms.name` column's length, the create path fails with a generic `db_insert_error` ("Could not insert term into the database.") instead of a descriptive error, and the update path is worse: `$wpdb->update()`'s return value is never checked, so `wp_update_term()` reports success while silently discarding the change.

This adds a small private helper, `_wp_check_term_name_length()`, that reads the actual column length via `$wpdb->get_col_length( $wpdb->terms, 'name' )` (falling back to the schema default of 200) and compares it against the name's character count with `mb_strlen()` — matching the DB column's `char`-typed length semantics rather than counting bytes. Both `wp_insert_term()` and `wp_update_term()` now call this right after their existing empty-name checks and return a new `term_name_too_long` `WP_Error` before attempting any database write.

The original ticket's reported symptom (multibyte category/tag names getting silently truncated to invalid UTF-8 and losing all their bytes) no longer reproduces on current trunk — `strip_invalid_text()` now truncates on character boundaries via `mb_substr()` for `char`-typed columns, so `wp_check_invalid_utf8()` never sees a split sequence. What remains, and what this PR fixes, is the missing length validation itself: crossing the limit no longer causes silent data loss, but it still surfaced as an unhelpful low-level DB error (or, on update, as a false "success").

The separate bug where `wp_update_term()` reports success without saving *any* change (unrelated to name length) is filed as its own ticket, #66007, and is intentionally out of scope here.

Trac ticket: https://core.trac.wordpress.org/ticket/36610

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Implementation, tests, and PR description. Reviewed by irozum.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
