### PR TITLE
Fix duplicate meta and closed comment status when adding a custom field to an auto-draft

### DIFF
--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -1649,21 +1649,25 @@ function wp_ajax_add_meta() {
 
 		// If the post is an autodraft, save the post as a draft and then attempt to save the meta.
 		if ( 'auto-draft' === $post->post_status ) {
-			$post_data                = array();
-			$post_data['action']      = 'draft'; // Warning fix.
-			$post_data['post_ID']     = $post_id;
-			$post_data['post_type']   = $post->post_type;
-			$post_data['post_status'] = 'draft';
-			$now                      = time();
+			$now = time();
 
-			$post_data['post_title'] = sprintf(
-				/* translators: 1: Post creation date, 2: Post creation time. */
-				__( 'Draft created on %1$s at %2$s' ),
-				gmdate( __( 'F j, Y' ), $now ),
-				gmdate( __( 'g:i a' ), $now )
+			/*
+			 * Update the post directly instead of via edit_post(), which would
+			 * add the meta a second time from the $_POST data and reset the
+			 * comment and ping status of the post to 'closed'. See #66016.
+			 */
+			$post_data = array(
+				'ID'          => $post_id,
+				'post_status' => 'draft',
+				'post_title'  => sprintf(
+					/* translators: 1: Post creation date, 2: Post creation time. */
+					__( 'Draft created on %1$s at %2$s' ),
+					gmdate( __( 'F j, Y' ), $now ),
+					gmdate( __( 'g:i a' ), $now )
+				),
 			);
 
-			$post_id = edit_post( $post_data );
+			$post_id = wp_update_post( $post_data, true );
 
 			if ( $post_id ) {
 				if ( is_wp_error( $post_id ) ) {
@@ -1675,6 +1679,8 @@ function wp_ajax_add_meta() {
 					);
 					$response->send();
 				}
+
+				update_post_meta( $post_id, '_edit_last', get_current_user_id() );
 
 				$meta_id = add_meta( $post_id );
 

--- a/tests/phpunit/tests/ajax/wpAjaxAddMeta.php
+++ b/tests/phpunit/tests/ajax/wpAjaxAddMeta.php
@@ -75,4 +75,75 @@ class Tests_Ajax_wpAjaxAddMeta extends WP_Ajax_UnitTestCase {
 
 		$this->assertSame( '', get_post_meta( $post, 'testkey', true ) );
 	}
+
+	/**
+	 * Adding meta to an auto-draft should only create the meta once.
+	 *
+	 * @ticket 66016
+	 */
+	public function test_adding_meta_to_an_auto_draft_should_not_duplicate_the_meta() {
+		$post = self::factory()->post->create(
+			array(
+				'post_status' => 'auto-draft',
+			)
+		);
+
+		// Become an administrator.
+		$this->_setRole( 'administrator' );
+
+		$_POST = array(
+			'post_id'              => $post,
+			'metakeyinput'         => 'testkey',
+			'metavalue'            => 'testvalue',
+			'_ajax_nonce-add-meta' => wp_create_nonce( 'add-meta' ),
+		);
+
+		// Make the request.
+		try {
+			$this->_handleAjax( 'add-meta' );
+		} catch ( WPAjaxDieContinueException $e ) {
+			unset( $e );
+		}
+
+		$this->assertSame( array( 'testvalue' ), get_post_meta( $post, 'testkey' ) );
+	}
+
+	/**
+	 * Adding meta to an auto-draft should save the post as a draft
+	 * without changing its comment or ping status.
+	 *
+	 * @ticket 66016
+	 */
+	public function test_adding_meta_to_an_auto_draft_should_not_change_the_comment_and_ping_status() {
+		$post = self::factory()->post->create(
+			array(
+				'post_status'    => 'auto-draft',
+				'comment_status' => 'open',
+				'ping_status'    => 'open',
+			)
+		);
+
+		// Become an administrator.
+		$this->_setRole( 'administrator' );
+
+		$_POST = array(
+			'post_id'              => $post,
+			'metakeyinput'         => 'testkey',
+			'metavalue'            => 'testvalue',
+			'_ajax_nonce-add-meta' => wp_create_nonce( 'add-meta' ),
+		);
+
+		// Make the request.
+		try {
+			$this->_handleAjax( 'add-meta' );
+		} catch ( WPAjaxDieContinueException $e ) {
+			unset( $e );
+		}
+
+		$post = get_post( $post );
+
+		$this->assertSame( 'draft', $post->post_status, 'The auto-draft should have been saved as a draft.' );
+		$this->assertSame( 'open', $post->comment_status, 'The comment status of the post should not have changed.' );
+		$this->assertSame( 'open', $post->ping_status, 'The ping status of the post should not have changed.' );
+	}
 }


### PR DESCRIPTION
Adding a custom field to a new post (auto-draft) through the legacy Custom Fields meta box inserts the meta twice and switches the post's comment and ping status to closed.

`wp_ajax_add_meta()` promotes the auto-draft to a draft through `edit_post()`. That function reads `metakeyinput` and `metavalue` from `$_POST`, which the AJAX request body contains, so the meta is added there first. Control then returns to `wp_ajax_add_meta()`, which calls `add_meta()` again. The same `edit_post()` call passes no `comment_status` or `ping_status`, so `_wp_translate_postdata()` defaults both to `closed`. The block editor only sends `comment_status` over the REST API when the Discussion panel was changed, so the closed status sticks after publishing.

This change promotes the auto-draft with `wp_update_post()` instead. The meta is inserted exactly once, the post keeps its comment and ping status, and the `_edit_last` meta is still set as before.

Includes unit tests covering both symptoms. They fail against the current code and pass with this change:

```
1) test_adding_meta_to_an_auto_draft_should_not_duplicate_the_meta
Failed asserting that two arrays are identical.
 Array &0 (
     0 => 'testvalue'
+    1 => 'testvalue'
 )

2) test_adding_meta_to_an_auto_draft_should_not_change_the_comment_and_ping_status
The comment status of the post should not have changed.
-'open'
+'closed'
```

To reproduce manually: on a clean install with the Custom Fields panel enabled, open Posts > Add New, add a custom field before saving, then check `wp_postmeta` and the post's `comment_status`.

Trac ticket: https://core.trac.wordpress.org/ticket/66016

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Used for: diagnosis, draft patch, and test suggestions. I reviewed, tested, and edited the final change.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
