### PR TITLE
Administration: Underline the in-text links in the Activity widget

### DIFF
--- a/src/wp-admin/css/dashboard.css
+++ b/src/wp-admin/css/dashboard.css
@@ -1123,6 +1123,10 @@ body #dashboard-widgets .postbox form .submit {
 	color: #646970;
 }
 
+#latest-comments #the-comment-list .comment-meta a {
+	text-decoration: underline;
+}
+
 #latest-comments #the-comment-list .comment-meta cite {
 	font-style: normal;
 	font-weight: 400;

--- a/src/wp-admin/css/dashboard.css
+++ b/src/wp-admin/css/dashboard.css
@@ -1066,7 +1066,7 @@ body #dashboard-widgets .postbox form .submit {
 	min-width: 0;
 }
 
-#dashboard-widgets li a,
+#dashboard-widgets li:not(.activity-block li):not(.comment) a,
 #dashboard-widgets .button-link,
 .community-events-footer a {
 	text-decoration: none;
@@ -1121,10 +1121,6 @@ body #dashboard-widgets .postbox form .submit {
 	line-height: 1.5;
 	margin: 0;
 	color: #646970;
-}
-
-#latest-comments #the-comment-list .comment-meta a {
-	text-decoration: underline;
 }
 
 #latest-comments #the-comment-list .comment-meta cite {


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

In the Activity dashboard widget, the comment author and post links sit inside a sentence and are distinguished from the surrounding text by color alone, which axe-core reports as a `link-in-text-block` violation.

`#dashboard-widgets li a` removes the underline from every link inside a dashboard widget list item, including the two links in the `.comment-meta` sentence. This patch restores `text-decoration: underline` for links within `.comment-meta`.

The row action and footer links, which context already distinguishes as links, are unchanged.

Trac ticket: https://core.trac.wordpress.org/ticket/66017

## Use of AI Tools
AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Writing PR details. All changes were reviewed and validated by me.
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
