### PR TITLE
Deprecate the Link Manager (Bookmarks) API (see #56362)

### DIFF
--- a/src/wp-admin/edit-link-form.php
+++ b/src/wp-admin/edit-link-form.php
@@ -11,6 +11,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+_deprecated_file( basename( __FILE__ ), '7.2.0', '', __( 'The Link Manager is deprecated. Use the WP Links plugin (https://github.com/georgestephanis/wp-links) instead.' ) );
+
 if ( ! empty( $link_id ) ) {
 	/* translators: %s: URL to Links screen. */
 	$heading      = sprintf( __( '<a href="%s">Links</a> / Edit Link' ), 'link-manager.php' );

--- a/src/wp-admin/includes/bookmark.php
+++ b/src/wp-admin/includes/bookmark.php
@@ -10,10 +10,13 @@
  * Adds a link using values provided in $_POST.
  *
  * @since 2.0.0
+ * @deprecated 7.2.0 Use the WP Links plugin (https://github.com/georgestephanis/wp-links) instead.
  *
  * @return int The link ID on success. The value 0 on failure.
  */
 function add_link() {
+	_deprecated_function( __FUNCTION__, '7.2.0', 'the WP Links plugin (https://github.com/georgestephanis/wp-links)' );
+
 	return edit_link();
 }
 
@@ -21,11 +24,14 @@ function add_link() {
  * Updates or inserts a link using values provided in $_POST.
  *
  * @since 2.0.0
+ * @deprecated 7.2.0 Use the WP Links plugin (https://github.com/georgestephanis/wp-links) instead.
  *
  * @param int $link_id Optional. ID of the link to edit. Default 0.
  * @return int The link ID on success. The value 0 on failure.
  */
 function edit_link( $link_id = 0 ) {
+	_deprecated_function( __FUNCTION__, '7.2.0', 'the WP Links plugin (https://github.com/georgestephanis/wp-links)' );
+
 	if ( ! current_user_can( 'manage_links' ) ) {
 		wp_die(
 			'<h1>' . __( 'You need a higher level of permission.' ) . '</h1>' .
@@ -54,10 +60,13 @@ function edit_link( $link_id = 0 ) {
  * Retrieves the default link for editing.
  *
  * @since 2.0.0
+ * @deprecated 7.2.0 Use the WP Links plugin (https://github.com/georgestephanis/wp-links) instead.
  *
  * @return stdClass Default link object.
  */
 function get_default_link_to_edit() {
+	_deprecated_function( __FUNCTION__, '7.2.0', 'the WP Links plugin (https://github.com/georgestephanis/wp-links)' );
+
 	$link = new stdClass();
 	if ( isset( $_GET['linkurl'] ) ) {
 		$link->link_url = esc_url( wp_unslash( $_GET['linkurl'] ) );
@@ -80,6 +89,7 @@ function get_default_link_to_edit() {
  * Deletes a specified link from the database.
  *
  * @since 2.0.0
+ * @deprecated 7.2.0 Use the WP Links plugin (https://github.com/georgestephanis/wp-links) instead.
  *
  * @global wpdb $wpdb WordPress database abstraction object.
  *
@@ -87,6 +97,8 @@ function get_default_link_to_edit() {
  * @return true Always true.
  */
 function wp_delete_link( $link_id ) {
+	_deprecated_function( __FUNCTION__, '7.2.0', 'the WP Links plugin (https://github.com/georgestephanis/wp-links)' );
+
 	global $wpdb;
 	/**
 	 * Fires before a link is deleted.
@@ -119,11 +131,14 @@ function wp_delete_link( $link_id ) {
  * Retrieves the link category IDs associated with the link specified.
  *
  * @since 2.1.0
+ * @deprecated 7.2.0 Use the WP Links plugin (https://github.com/georgestephanis/wp-links) instead.
  *
  * @param int $link_id Link ID to look up.
  * @return int[] The IDs of the requested link's categories.
  */
 function wp_get_link_cats( $link_id = 0 ) {
+	_deprecated_function( __FUNCTION__, '7.2.0', 'the WP Links plugin (https://github.com/georgestephanis/wp-links)' );
+
 	$cats = wp_get_object_terms( $link_id, 'link_category', array( 'fields' => 'ids' ) );
 	return array_unique( $cats );
 }
@@ -132,11 +147,14 @@ function wp_get_link_cats( $link_id = 0 ) {
  * Retrieves link data based on its ID.
  *
  * @since 2.0.0
+ * @deprecated 7.2.0 Use the WP Links plugin (https://github.com/georgestephanis/wp-links) instead.
  *
  * @param int|stdClass $link Link ID or object to retrieve.
  * @return object Link object for editing.
  */
 function get_link_to_edit( $link ) {
+	_deprecated_function( __FUNCTION__, '7.2.0', 'the WP Links plugin (https://github.com/georgestephanis/wp-links)' );
+
 	return get_bookmark( $link, OBJECT, 'edit' );
 }
 
@@ -147,6 +165,7 @@ function get_link_to_edit( $link ) {
  * and finally saves the link.
  *
  * @since 2.0.0
+ * @deprecated 7.2.0 Use the WP Links plugin (https://github.com/georgestephanis/wp-links) instead.
  *
  * @global wpdb $wpdb WordPress database abstraction object.
  *
@@ -172,6 +191,8 @@ function get_link_to_edit( $link ) {
  * @return int|WP_Error The link ID on success. The value 0 or WP_Error on failure.
  */
 function wp_insert_link( $linkdata, $wp_error = false ) {
+	_deprecated_function( __FUNCTION__, '7.2.0', 'the WP Links plugin (https://github.com/georgestephanis/wp-links)' );
+
 	global $wpdb;
 
 	$defaults = array(
@@ -271,11 +292,14 @@ function wp_insert_link( $linkdata, $wp_error = false ) {
  * Updates link with the specified link categories.
  *
  * @since 2.1.0
+ * @deprecated 7.2.0 Use the WP Links plugin (https://github.com/georgestephanis/wp-links) instead.
  *
  * @param int   $link_id         ID of the link to update.
  * @param int[] $link_categories Array of link category IDs to add the link to.
  */
 function wp_set_link_cats( $link_id = 0, $link_categories = array() ) {
+	_deprecated_function( __FUNCTION__, '7.2.0', 'the WP Links plugin (https://github.com/georgestephanis/wp-links)' );
+
 	// If $link_categories isn't already an array, make it one:
 	if ( ! is_array( $link_categories ) || 0 === count( $link_categories ) ) {
 		$link_categories = array( get_option( 'default_link_category' ) );
@@ -293,11 +317,14 @@ function wp_set_link_cats( $link_id = 0, $link_categories = array() ) {
  * Updates a link in the database.
  *
  * @since 2.0.0
+ * @deprecated 7.2.0 Use the WP Links plugin (https://github.com/georgestephanis/wp-links) instead.
  *
  * @param array $linkdata Link data to update. See wp_insert_link() for accepted arguments.
  * @return int The updated link ID on success. The value 0 on failure.
  */
 function wp_update_link( $linkdata ) {
+	_deprecated_function( __FUNCTION__, '7.2.0', 'the WP Links plugin (https://github.com/georgestephanis/wp-links)' );
+
 	$link_id = (int) $linkdata['link_id'];
 
 	$link = get_bookmark( $link_id, ARRAY_A );

--- a/src/wp-admin/includes/class-wp-links-list-table.php
+++ b/src/wp-admin/includes/class-wp-links-list-table.php
@@ -20,12 +20,15 @@ class WP_Links_List_Table extends WP_List_Table {
 	 * Constructor.
 	 *
 	 * @since 3.1.0
+	 * @deprecated 7.2.0 Use the WP Links plugin (https://github.com/georgestephanis/wp-links) instead.
 	 *
 	 * @see WP_List_Table::__construct() for more information on default arguments.
 	 *
 	 * @param array $args An associative array of arguments.
 	 */
 	public function __construct( $args = array() ) {
+		_deprecated_class( __CLASS__, '7.2.0', 'the WP Links plugin (https://github.com/georgestephanis/wp-links)' );
+
 		parent::__construct(
 			array(
 				'plural' => 'bookmarks',

--- a/src/wp-admin/includes/template.php
+++ b/src/wp-admin/includes/template.php
@@ -261,10 +261,13 @@ function wp_popular_terms_checklist( $taxonomy, $default_term = 0, $number = 10,
  * Outputs a link category checklist element.
  *
  * @since 2.5.1
+ * @deprecated 7.2.0 Use the WP Links plugin (https://github.com/georgestephanis/wp-links) instead.
  *
  * @param int $link_id Optional. The link ID. Default 0.
  */
 function wp_link_category_checklist( $link_id = 0 ) {
+	_deprecated_function( __FUNCTION__, '7.2.0', 'the WP Links plugin (https://github.com/georgestephanis/wp-links)' );
+
 	$default = 1;
 
 	$checked_categories = array();

--- a/src/wp-admin/link-add.php
+++ b/src/wp-admin/link-add.php
@@ -9,6 +9,8 @@
 /** Load WordPress Administration Bootstrap */
 require_once __DIR__ . '/admin.php';
 
+_deprecated_file( basename( __FILE__ ), '7.2.0', '', __( 'The Link Manager is deprecated. Use the WP Links plugin (https://github.com/georgestephanis/wp-links) instead.' ) );
+
 if ( ! current_user_can( 'manage_links' ) ) {
 	wp_die( __( 'Sorry, you are not allowed to add links to this site.' ) );
 }

--- a/src/wp-admin/link-manager.php
+++ b/src/wp-admin/link-manager.php
@@ -8,6 +8,9 @@
 
 /** Load WordPress Administration Bootstrap */
 require_once __DIR__ . '/admin.php';
+
+_deprecated_file( basename( __FILE__ ), '7.2.0', '', __( 'The Link Manager is deprecated. Use the WP Links plugin (https://github.com/georgestephanis/wp-links) instead.' ) );
+
 if ( ! current_user_can( 'manage_links' ) ) {
 	wp_die( __( 'Sorry, you are not allowed to edit the links for this site.' ) );
 }

--- a/src/wp-admin/link-parse-opml.php
+++ b/src/wp-admin/link-parse-opml.php
@@ -11,6 +11,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+_deprecated_file( basename( __FILE__ ), '7.2.0', '', __( 'The Link Manager is deprecated. Use the WP Links plugin (https://github.com/georgestephanis/wp-links) instead.' ) );
+
 /**
  * @global string $opml
  */

--- a/src/wp-admin/link.php
+++ b/src/wp-admin/link.php
@@ -12,6 +12,8 @@
 /** Load WordPress Administration Bootstrap */
 require_once __DIR__ . '/admin.php';
 
+_deprecated_file( basename( __FILE__ ), '7.2.0', '', __( 'The Link Manager is deprecated. Use the WP Links plugin (https://github.com/georgestephanis/wp-links) instead.' ) );
+
 $action  = ! empty( $_REQUEST['action'] ) ? sanitize_text_field( $_REQUEST['action'] ) : '';
 $cat_id  = ! empty( $_REQUEST['cat_id'] ) ? absint( $_REQUEST['cat_id'] ) : 0;
 $link_id = ! empty( $_REQUEST['link_id'] ) ? absint( $_REQUEST['link_id'] ) : 0;

--- a/src/wp-includes/bookmark-template.php
+++ b/src/wp-includes/bookmark-template.php
@@ -165,6 +165,7 @@ function _walk_bookmarks( $bookmarks, $args = '' ) {
  * display for only the 'title_li' string and only if 'title_li' is not empty.
  *
  * @since 2.1.0
+ * @deprecated 7.2.0 Use the WP Links plugin (https://github.com/georgestephanis/wp-links) instead.
  *
  * @see _walk_bookmarks()
  *
@@ -209,6 +210,8 @@ function _walk_bookmarks( $bookmarks, $args = '' ) {
  * @return void|string Void if 'echo' argument is true, HTML list of bookmarks if 'echo' is false.
  */
 function wp_list_bookmarks( $args = '' ) {
+	_deprecated_function( __FUNCTION__, '7.2.0', 'the WP Links plugin (https://github.com/georgestephanis/wp-links)' );
+
 	$defaults = array(
 		'orderby'          => 'name',
 		'order'            => 'ASC',

--- a/src/wp-includes/bookmark.php
+++ b/src/wp-includes/bookmark.php
@@ -10,6 +10,7 @@
  * Retrieves bookmark data.
  *
  * @since 2.1.0
+ * @deprecated 7.2.0 Use the WP Links plugin (https://github.com/georgestephanis/wp-links) instead.
  *
  * @global object $link Current link object.
  * @global wpdb   $wpdb WordPress database abstraction object.
@@ -22,6 +23,8 @@
  * @return array|object|null Type returned depends on $output value.
  */
 function get_bookmark( $bookmark, $output = OBJECT, $filter = 'raw' ) {
+	_deprecated_function( __FUNCTION__, '7.2.0', 'the WP Links plugin (https://github.com/georgestephanis/wp-links)' );
+
 	global $wpdb;
 
 	if ( empty( $bookmark ) ) {
@@ -69,6 +72,7 @@ function get_bookmark( $bookmark, $output = OBJECT, $filter = 'raw' ) {
  * Retrieves single bookmark data item or field.
  *
  * @since 2.3.0
+ * @deprecated 7.2.0 Use the WP Links plugin (https://github.com/georgestephanis/wp-links) instead.
  *
  * @param string $field    The name of the data field to return.
  * @param int    $bookmark The bookmark ID to get field.
@@ -76,6 +80,8 @@ function get_bookmark( $bookmark, $output = OBJECT, $filter = 'raw' ) {
  * @return string|WP_Error
  */
 function get_bookmark_field( $field, $bookmark, $context = 'display' ) {
+	_deprecated_function( __FUNCTION__, '7.2.0', 'the WP Links plugin (https://github.com/georgestephanis/wp-links)' );
+
 	$bookmark = (int) $bookmark;
 	$bookmark = get_bookmark( $bookmark );
 
@@ -102,6 +108,7 @@ function get_bookmark_field( $field, $bookmark, $context = 'display' ) {
  * results will be stored to the cache.
  *
  * @since 2.1.0
+ * @deprecated 7.2.0 Use the WP Links plugin (https://github.com/georgestephanis/wp-links) instead.
  *
  * @global wpdb $wpdb WordPress database abstraction object.
  *
@@ -135,6 +142,8 @@ function get_bookmark_field( $field, $bookmark, $context = 'display' ) {
  * @return object[] List of bookmark row objects.
  */
 function get_bookmarks( $args = '' ) {
+	_deprecated_function( __FUNCTION__, '7.2.0', 'the WP Links plugin (https://github.com/georgestephanis/wp-links)' );
+
 	global $wpdb;
 
 	$defaults = array(
@@ -327,12 +336,15 @@ function get_bookmarks( $args = '' ) {
  * Sanitizes all bookmark fields.
  *
  * @since 2.3.0
+ * @deprecated 7.2.0 Use the WP Links plugin (https://github.com/georgestephanis/wp-links) instead.
  *
  * @param stdClass|array $bookmark Bookmark row.
  * @param string         $context  Optional. How to filter the fields. Default 'display'.
  * @return stdClass|array Same type as $bookmark but with fields sanitized.
  */
 function sanitize_bookmark( $bookmark, $context = 'display' ) {
+	_deprecated_function( __FUNCTION__, '7.2.0', 'the WP Links plugin (https://github.com/georgestephanis/wp-links)' );
+
 	$fields = array(
 		'link_id',
 		'link_url',
@@ -389,6 +401,7 @@ function sanitize_bookmark( $bookmark, $context = 'display' ) {
  * and is passed the `$value`, `$bookmark_id`, and `$context`, respectively.
  *
  * @since 2.3.0
+ * @deprecated 7.2.0 Use the WP Links plugin (https://github.com/georgestephanis/wp-links) instead.
  *
  * @param string $field       The bookmark field.
  * @param mixed  $value       The bookmark field value.
@@ -398,6 +411,8 @@ function sanitize_bookmark( $bookmark, $context = 'display' ) {
  * @return mixed The filtered value.
  */
 function sanitize_bookmark_field( $field, $value, $bookmark_id, $context ) {
+	_deprecated_function( __FUNCTION__, '7.2.0', 'the WP Links plugin (https://github.com/georgestephanis/wp-links)' );
+
 	$int_fields = array( 'link_id', 'link_rating' );
 	if ( in_array( $field, $int_fields, true ) ) {
 		$value = (int) $value;
@@ -462,10 +477,13 @@ function sanitize_bookmark_field( $field, $value, $bookmark_id, $context ) {
  * Deletes the bookmark cache.
  *
  * @since 2.7.0
+ * @deprecated 7.2.0 Use the WP Links plugin (https://github.com/georgestephanis/wp-links) instead.
  *
  * @param int $bookmark_id Bookmark ID.
  */
 function clean_bookmark_cache( $bookmark_id ) {
+	_deprecated_function( __FUNCTION__, '7.2.0', 'the WP Links plugin (https://github.com/georgestephanis/wp-links)' );
+
 	wp_cache_delete( $bookmark_id, 'bookmark' );
 	wp_cache_delete( 'get_bookmarks', 'bookmark' );
 	clean_object_term_cache( $bookmark_id, 'link' );

--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -1673,11 +1673,14 @@ function edit_comment_link( $text = null, $before = '', $after = '' ) {
  * Displays the edit bookmark link.
  *
  * @since 2.7.0
+ * @deprecated 7.2.0 Use the WP Links plugin (https://github.com/georgestephanis/wp-links) instead.
  *
  * @param int|stdClass $link Optional. Bookmark ID. Default is the ID of the current bookmark.
  * @return string|null The edit bookmark link URL.
  */
 function get_edit_bookmark_link( $link = 0 ) {
+	_deprecated_function( __FUNCTION__, '7.2.0', 'the WP Links plugin (https://github.com/georgestephanis/wp-links)' );
+
 	$link = get_bookmark( $link );
 
 	if ( ! current_user_can( 'manage_links' ) ) {
@@ -1701,6 +1704,7 @@ function get_edit_bookmark_link( $link = 0 ) {
  * Displays the edit bookmark link anchor content.
  *
  * @since 2.7.0
+ * @deprecated 7.2.0 Use the WP Links plugin (https://github.com/georgestephanis/wp-links) instead.
  *
  * @param string $link     Optional. Anchor text. If empty, default is 'Edit This'. Default empty.
  * @param string $before   Optional. Display before edit link. Default empty.
@@ -1708,6 +1712,8 @@ function get_edit_bookmark_link( $link = 0 ) {
  * @param int    $bookmark Optional. Bookmark ID. Default is the current bookmark.
  */
 function edit_bookmark_link( $link = '', $before = '', $after = '', $bookmark = null ) {
+	_deprecated_function( __FUNCTION__, '7.2.0', 'the WP Links plugin (https://github.com/georgestephanis/wp-links)' );
+
 	$bookmark = get_bookmark( $bookmark );
 
 	if ( ! current_user_can( 'manage_links' ) ) {

--- a/src/wp-includes/widgets/class-wp-widget-links.php
+++ b/src/wp-includes/widgets/class-wp-widget-links.php
@@ -20,8 +20,11 @@ class WP_Widget_Links extends WP_Widget {
 	 * Sets up a new Links widget instance.
 	 *
 	 * @since 2.8.0
+	 * @deprecated 7.2.0 Use the WP Links plugin (https://github.com/georgestephanis/wp-links) instead.
 	 */
 	public function __construct() {
+		_deprecated_class( __CLASS__, '7.2.0', 'the WP Links plugin (https://github.com/georgestephanis/wp-links)' );
+
 		$widget_ops = array(
 			'description'                 => __( 'Your blogroll' ),
 			'customize_selective_refresh' => true,

--- a/src/wp-links-opml.php
+++ b/src/wp-links-opml.php
@@ -14,6 +14,8 @@
 
 require_once __DIR__ . '/wp-load.php';
 
+_deprecated_file( basename( __FILE__ ), '7.2.0', '', __( 'The Link Manager is deprecated. Use the WP Links plugin (https://github.com/georgestephanis/wp-links) instead.' ) );
+
 header( 'Content-Type: text/xml; charset=' . get_option( 'blog_charset' ), true );
 $link_cat = '';
 if ( ! empty( $_GET['link_cat'] ) ) {


### PR DESCRIPTION
### Related: [#56362](https://core.trac.wordpress.org/ticket/56362)

Step 1 of that ticket's rollout plan — moving the Link Manager functionality into a plugin defensively — is done: https://github.com/georgestephanis/wp-links reproduces this API under the same function/class names, guarded so it activates only once core stops providing them.

This PR is step 2: **flag everything as deprecated, with no behavior change.** `_deprecated_function()`, `_deprecated_class()`, and `_deprecated_file()` only emit a notice when `WP_DEBUG` is on — every function, class, and admin page here keeps working exactly as it does today. This should be safe to merge well ahead of any actual removal, giving plugin/theme authors real advance notice.

## What's deprecated

Matches the companion plugin's coverage:

- `get_bookmark()`, `get_bookmark_field()`, `get_bookmarks()`, `sanitize_bookmark()`, `sanitize_bookmark_field()`, `clean_bookmark_cache()`
- `wp_list_bookmarks()`
- `get_edit_bookmark_link()`, `edit_bookmark_link()` (in the otherwise-generic `wp-includes/link-template.php`, but part of this API surface)
- `add_link()`, `edit_link()`, `get_default_link_to_edit()`, `wp_delete_link()`, `wp_get_link_cats()`, `get_link_to_edit()`, `wp_insert_link()`, `wp_set_link_cats()`, `wp_update_link()`
- `wp_link_category_checklist()`
- `WP_Links_List_Table`, `WP_Widget_Links` (via `_deprecated_class()` in each constructor)
- `wp-admin/link-manager.php`, `link.php`, `link-add.php`, `edit-link-form.php`, `link-parse-opml.php`, `wp-links-opml.php` (via `_deprecated_file()`)

Every deprecation message points at installing the companion plugin — there's no in-core replacement function to name, since the point is this functionality moving out of core entirely.

## Deliberately not touched here

Matches what the companion plugin doesn't cover either — tracked in its [issue #1](https://github.com/georgestephanis/wp-links/issues/1) and [issue #2](https://github.com/georgestephanis/wp-links/issues/2):

- The `link_category` taxonomy registration and `manage_links` capability mapping — no established core convention for deprecating a taxonomy or capability at runtime the way there is for functions/classes/files
- The Links menu entries
- The five `link_*_meta_box()` functions and `xfn_check()` — internal render callbacks for the now-deprecated `edit-link-form.php`; deprecating them individually seemed redundant with deprecating that file
- The two Links-specific AJAX handlers
- The `wp_links` DB table, `link.js`/`xfn.js`
- The already-19-years-deprecated stubs in `wp-includes/deprecated.php`

## How this was verified

Not just PHP lint — tested against a real WordPress environment (WP Playground): link category creation, link insertion, `get_bookmarks()`, `wp_list_bookmarks()` rendering, and widget instantiation all still succeed exactly as before, while each one correctly emits a `PHP_DEPRECATED`-level notice under `WP_DEBUG`.
