### PR TITLE
Restore `void` on the dual-mode `$display` functions with conditional return types

### DIFF
--- a/src/wp-content/themes/twentytwenty/inc/template-tags.php
+++ b/src/wp-content/themes/twentytwenty/inc/template-tags.php
@@ -107,13 +107,15 @@ function twentytwenty_site_logo( $args = array(), $display = true ) {
  * @since Twenty Twenty 1.0
  *
  * @param bool $display Display or return the HTML.
- * @return string|void The HTML to display.
+ * @return string|void The HTML when `$display` is false, null when the site has no
+ *                     description. Nothing otherwise.
+ * @phpstan-return ( $display is true ? void : string|null )
  */
 function twentytwenty_site_description( $display = true ) {
 	$description = get_bloginfo( 'description' );
 
 	if ( ! $description ) {
-		return;
+		return null;
 	}
 
 	$wrapper = '<div class="site-description">%s</div><!-- .site-description -->';

--- a/src/wp-includes/author-template.php
+++ b/src/wp-includes/author-template.php
@@ -449,7 +449,12 @@ function get_author_posts_url( $author_id, $author_nicename = '' ) {
  *     @type int[]|string $exclude       Array or comma/space-separated list of author IDs to exclude. Default empty.
  *     @type int[]|string $include       Array or comma/space-separated list of author IDs to include. Default empty.
  * }
- * @return void|string Void if 'echo' argument is true, list of authors if 'echo' is false.
+ * @return string|void List of authors if 'echo' is false, nothing otherwise.
+ * @phpstan-return (
+ *     $args is array{ echo: false|0|''|'0', ... }
+ *         ? string
+ *         : ( $args is ''|array ? void : string|null )
+ * )
  */
 function wp_list_authors( $args = '' ) {
 	global $wpdb;

--- a/src/wp-includes/bookmark-template.php
+++ b/src/wp-includes/bookmark-template.php
@@ -206,7 +206,12 @@ function _walk_bookmarks( $bookmarks, $args = '' ) {
  *                                          $categorize is true. Accepts 'ASC' (ascending) or 'DESC' (descending).
  *                                          Default 'ASC'.
  * }
- * @return void|string Void if 'echo' argument is true, HTML list of bookmarks if 'echo' is false.
+ * @return string|void HTML list of bookmarks if 'echo' is false, nothing otherwise.
+ * @phpstan-return (
+ *     $args is array{ echo: false|0|''|'0', ... }
+ *         ? string
+ *         : ( $args is ''|array ? void : string|null )
+ * )
  */
 function wp_list_bookmarks( $args = '' ) {
 	$defaults = array(

--- a/src/wp-includes/category-template.php
+++ b/src/wp-includes/category-template.php
@@ -710,8 +710,16 @@ function wp_list_categories( $args = '' ) {
  *                             associated with the taxonomy.
  *     @type bool   $echo      Whether or not to echo the return value. Default true.
  * }
- * @return void|string|string[] Void if 'echo' argument is true, or on failure. Otherwise, tag cloud
- *                              as a string or an array, depending on 'format' argument.
+ * @return string|string[]|void Tag cloud as a string, or as an array when the 'format' argument
+ *                              is 'array'. Nothing when 'echo' is true and 'format' is not
+ *                              'array', or on failure.
+ * @phpstan-return (
+ *     $args is array{ format: 'array', ... }
+ *         ? string[]|void
+ *         : ( $args is array{ echo: false|0|''|'0', ... }
+ *             ? string|void
+ *             : ( $args is ''|array ? void : string|string[]|void ) )
+ * )
  */
 function wp_tag_cloud( $args = '' ) {
 	$defaults = array(

--- a/src/wp-includes/category-template.php
+++ b/src/wp-includes/category-template.php
@@ -711,14 +711,14 @@ function wp_list_categories( $args = '' ) {
  *     @type bool   $echo      Whether or not to echo the return value. Default true.
  * }
  * @return string|string[]|void Tag cloud as a string, or as an array when the 'format' argument
- *                              is 'array'. Nothing when 'echo' is true and 'format' is not
- *                              'array', or on failure.
+ *                              is 'array'. Null on failure. Nothing when 'echo' is true and
+ *                              'format' is not 'array'.
  * @phpstan-return (
  *     $args is array{ format: 'array', ... }
- *         ? string[]|void
+ *         ? string[]|null
  *         : ( $args is array{ echo: false|0|''|'0', ... }
- *             ? string|void
- *             : ( $args is ''|array ? void : string|string[]|void ) )
+ *             ? string|null
+ *             : ( $args is ''|array ? void : string|string[]|null ) )
  * )
  */
 function wp_tag_cloud( $args = '' ) {
@@ -753,7 +753,7 @@ function wp_tag_cloud( $args = '' ) {
 	); // Always query top tags.
 
 	if ( empty( $tags ) || is_wp_error( $tags ) ) {
-		return;
+		return null;
 	}
 
 	foreach ( $tags as $key => $tag ) {
@@ -764,7 +764,7 @@ function wp_tag_cloud( $args = '' ) {
 		}
 
 		if ( is_wp_error( $link ) ) {
-			return;
+			return null;
 		}
 
 		$tags[ $key ]->link = $link;

--- a/src/wp-includes/class-wp-scripts.php
+++ b/src/wp-includes/class-wp-scripts.php
@@ -201,8 +201,9 @@ class WP_Scripts extends WP_Dependencies {
 	 * @param string $handle  The script's registered handle.
 	 * @param bool   $display Optional. Whether to print the extra script
 	 *                        instead of just returning it. Default true.
-	 * @return bool|string|null Null if no data exists, extra scripts if `$display` is true,
+	 * @return bool|string|null Null if no data exists, extra scripts if `$display` is false,
 	 *                          true otherwise.
+	 * @phpstan-return ( $display is true ? true|null : string|null )
 	 */
 	public function print_scripts_l10n( $handle, $display = true ) {
 		_deprecated_function( __FUNCTION__, '3.3.0', 'WP_Scripts::print_extra_script()' );
@@ -217,8 +218,9 @@ class WP_Scripts extends WP_Dependencies {
 	 * @param string $handle  The script's registered handle.
 	 * @param bool   $display Optional. Whether to print the extra script
 	 *                        instead of just returning it. Default true.
-	 * @return bool|string|null Null if no data exists, extra scripts if `$display` is true,
+	 * @return bool|string|null Null if no data exists, extra scripts if `$display` is false,
 	 *                          true otherwise.
+	 * @phpstan-return ( $display is true ? true|null : string|null )
 	 */
 	public function print_extra_script( $handle, $display = true ) {
 		$output = $this->get_data( $handle, 'data' );

--- a/src/wp-includes/class-wp-styles.php
+++ b/src/wp-includes/class-wp-styles.php
@@ -296,8 +296,9 @@ class WP_Styles extends WP_Dependencies {
 	 * @param string $handle  The style's registered handle.
 	 * @param bool   $display Optional. Whether to print the inline style
 	 *                        instead of just returning it. Default true.
-	 * @return string|bool False if no data exists, inline styles if `$display` is true,
+	 * @return string|bool False if no data exists, inline styles if `$display` is false,
 	 *                     true otherwise.
+	 * @phpstan-return ( $display is true ? bool : string|false )
 	 */
 	public function print_inline_style( $handle, $display = true ) {
 		$output = $this->get_data( $handle, 'after' );

--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -1240,10 +1240,14 @@ function get_trackback_url() {
  * Displays the current post's trackback URL.
  *
  * @since 0.71
+ * @since 2.5.0 Deprecated the `$deprecated_echo` argument.
  *
- * @param bool $deprecated_echo Not used.
- * @return void|string Should only be used to echo the trackback URL, use get_trackback_url()
- *                     for the result instead.
+ * @see get_trackback_url()
+ *
+ * @param bool $deprecated_echo Deprecated. Use {@see get_trackback_url()}. Echo the URL or
+ *                              return it. Default true.
+ * @return string|void The trackback URL when `$deprecated_echo` is false, nothing otherwise.
+ * @phpstan-return ( $deprecated_echo is true ? void : string )
  */
 function trackback_url( $deprecated_echo = true ) {
 	if ( true !== $deprecated_echo ) {

--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -2229,12 +2229,12 @@ function _get_comment_reply_id( $post = null ) {
  *     @type bool     $echo              Whether to echo the output or return it. Default true.
  * }
  * @param WP_Comment[] $comments Optional. Array of WP_Comment objects. Default null.
- * @return string|void HTML list of comments if 'echo' is false, nothing otherwise
- *                     or when there are no comments to list.
+ * @return string|void HTML list of comments when 'echo' is false, null when there are no
+ *                     comments to list. Nothing otherwise.
  * @phpstan-return (
  *     $args is array{ echo: false|0|''|'0', ... }
- *         ? string|void
- *         : ( $args is ''|array ? void : string|void )
+ *         ? string|null
+ *         : ( $args is ''|array ? void : string|null )
  * )
  */
 function wp_list_comments( $args = array(), $comments = null ) {
@@ -2280,12 +2280,12 @@ function wp_list_comments( $args = array(), $comments = null ) {
 	if ( null !== $comments ) {
 		$comments = (array) $comments;
 		if ( empty( $comments ) ) {
-			return;
+			return null;
 		}
 		if ( 'all' !== $parsed_args['type'] ) {
 			$comments_by_type = separate_comments( $comments );
 			if ( empty( $comments_by_type[ $parsed_args['type'] ] ) ) {
-				return;
+				return null;
 			}
 			$_comments = $comments_by_type[ $parsed_args['type'] ];
 		} else {
@@ -2326,7 +2326,7 @@ function wp_list_comments( $args = array(), $comments = null ) {
 				if ( 'all' !== $parsed_args['type'] ) {
 					$comments_by_type = separate_comments( $comments );
 					if ( empty( $comments_by_type[ $parsed_args['type'] ] ) ) {
-						return;
+						return null;
 					}
 
 					$_comments = $comments_by_type[ $parsed_args['type'] ];
@@ -2338,14 +2338,14 @@ function wp_list_comments( $args = array(), $comments = null ) {
 			// Otherwise, fall back on the comments from `$wp_query->comments`.
 		} else {
 			if ( empty( $wp_query->comments ) ) {
-				return;
+				return null;
 			}
 			if ( 'all' !== $parsed_args['type'] ) {
 				if ( empty( $wp_query->comments_by_type ) ) {
 					$wp_query->comments_by_type = separate_comments( $wp_query->comments );
 				}
 				if ( empty( $wp_query->comments_by_type[ $parsed_args['type'] ] ) ) {
-					return;
+					return null;
 				}
 				$_comments = $wp_query->comments_by_type[ $parsed_args['type'] ];
 			} else {

--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -488,7 +488,8 @@ function comment_author_url_link( $link_text = '', $before = '', $after = '', $c
  * @param int|WP_Post     $post      Optional. Post ID or WP_Post object. Default current post.
  * @param bool            $display   Optional. Whether to print or return the output.
  *                                   Default true.
- * @return void|string Void if `$display` argument is true, comment classes if `$display` is false.
+ * @return string|void Comment classes if `$display` is false, nothing otherwise.
+ * @phpstan-return ( $display is true ? void : string )
  */
 function comment_class( $css_class = '', $comment = null, $post = null, $display = true ) {
 	// Separates classes with a single space, collates classes for comment DIV.

--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -2229,8 +2229,13 @@ function _get_comment_reply_id( $post = null ) {
  *     @type bool     $echo              Whether to echo the output or return it. Default true.
  * }
  * @param WP_Comment[] $comments Optional. Array of WP_Comment objects. Default null.
- * @return void|string Void if 'echo' argument is true, or no comments to list.
- *                     Otherwise, HTML list of comments.
+ * @return string|void HTML list of comments if 'echo' is false, nothing otherwise
+ *                     or when there are no comments to list.
+ * @phpstan-return (
+ *     $args is array{ echo: false|0|''|'0', ... }
+ *         ? string|void
+ *         : ( $args is ''|array ? void : string|void )
+ * )
  */
 function wp_list_comments( $args = array(), $comments = null ) {
 	global $wp_query, $comment_alt, $comment_depth, $comment_thread_alt, $overridden_cpage, $in_comment_loop;

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -8737,15 +8737,15 @@ function wp_get_default_update_php_url() {
  * @param string $before  Markup to output before the annotation. Default `<p class="description">`.
  * @param string $after   Markup to output after the annotation. Default `</p>`.
  * @param bool   $display Whether to echo or return the markup. Default `true` for echo.
- * @return string|void Update PHP page annotation if available and `$display` is false,
- *                     nothing otherwise.
- * @phpstan-return ( $display is true ? void : string|void )
+ * @return string|void Update PHP page annotation when `$display` is false, null when no
+ *                     annotation is available. Nothing otherwise.
+ * @phpstan-return ( $display is true ? void : string|null )
  */
 function wp_update_php_annotation( $before = '<p class="description">', $after = '</p>', $display = true ) {
 	$annotation = wp_get_update_php_annotation();
 
 	if ( ! $annotation ) {
-		return;
+		return null;
 	}
 
 	if ( ! $display ) {

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -8739,7 +8739,7 @@ function wp_get_default_update_php_url() {
  * @param bool   $display Whether to echo or return the markup. Default `true` for echo.
  * @return string|void Update PHP page annotation if available and `$display` is false,
  *                     nothing otherwise.
- * @phpstan-return ( $display is true ? void : string|null )
+ * @phpstan-return ( $display is true ? void : string|void )
  */
 function wp_update_php_annotation( $before = '<p class="description">', $after = '</p>', $display = true ) {
 	$annotation = wp_get_update_php_annotation();

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -8737,19 +8737,22 @@ function wp_get_default_update_php_url() {
  * @param string $before  Markup to output before the annotation. Default `<p class="description">`.
  * @param string $after   Markup to output after the annotation. Default `</p>`.
  * @param bool   $display Whether to echo or return the markup. Default `true` for echo.
- * @return string|null Update PHP page annotation if available and $display is false, null otherwise.
+ * @return string|void Update PHP page annotation if available and `$display` is false,
+ *                     nothing otherwise.
+ * @phpstan-return ( $display is true ? void : string|null )
  */
 function wp_update_php_annotation( $before = '<p class="description">', $after = '</p>', $display = true ) {
 	$annotation = wp_get_update_php_annotation();
 
-	if ( $annotation ) {
-		if ( $display ) {
-			echo $before . $annotation . $after;
-		} else {
-			return $before . $annotation . $after;
-		}
+	if ( ! $annotation ) {
+		return;
 	}
-	return null;
+
+	if ( ! $display ) {
+		return $before . $annotation . $after;
+	}
+
+	echo $before . $annotation . $after;
 }
 
 /**

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -1780,7 +1780,7 @@ function post_type_archive_title( $prefix = '', $display = true ) {
  * @param string $prefix  Optional. What to display before the title.
  * @param bool   $display Optional. Whether to display or retrieve title. Default true.
  * @return string|void Title when retrieving, nothing when displaying or on failure.
- * @phpstan-return ( $display is true ? void : string|void )
+ * @phpstan-return ( $display is true ? void : string|null )
  */
 function single_cat_title( $prefix = '', $display = true ) {
 	if ( ! $display ) {
@@ -1802,7 +1802,7 @@ function single_cat_title( $prefix = '', $display = true ) {
  * @param string $prefix  Optional. What to display before the title.
  * @param bool   $display Optional. Whether to display or retrieve title. Default true.
  * @return string|void Title when retrieving, nothing when displaying or on failure.
- * @phpstan-return ( $display is true ? void : string|void )
+ * @phpstan-return ( $display is true ? void : string|null )
  */
 function single_tag_title( $prefix = '', $display = true ) {
 	if ( ! $display ) {

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -236,7 +236,8 @@ function get_template_part( $slug, $name = null, $args = array() ) {
  *                              multiple search forms on the same page and improve
  *                              accessibility. Default empty.
  * }
- * @return void|string Void if 'echo' argument is true, search form HTML if 'echo' is false.
+ * @return string|void Search form HTML if 'echo' is false, nothing otherwise.
+ * @phpstan-return ( $args is array{ echo: false|0|''|'0', ... } ? string : void )
  */
 function get_search_form( $args = array() ) {
 	/**
@@ -722,7 +723,8 @@ function wp_registration_url() {
  *                                     Default false.
  *
  * }
- * @return void|string Void if 'echo' argument is true, login form HTML if 'echo' is false.
+ * @return string|void Login form HTML if 'echo' is false, nothing otherwise.
+ * @phpstan-return ( $args is array{ echo: false|0|''|'0', ... } ? string : void )
  */
 function wp_login_form( $args = array() ) {
 	$defaults = array(
@@ -2222,7 +2224,12 @@ function get_archives_link( $url, $text, $format = 'html', $before = '', $after 
  *     @type string     $day             Day. Default current day.
  *     @type string     $w               Week. Default current week.
  * }
- * @return void|string Void if 'echo' argument is true, archive links if 'echo' is false.
+ * @return string|void Archive links if 'echo' is false, nothing otherwise.
+ * @phpstan-return (
+ *     $args is array{ echo: false|0|''|'0', ... }
+ *         ? string|void
+ *         : ( $args is ''|array ? void : string|void )
+ * )
  */
 function wp_get_archives( $args = '' ) {
 	global $wpdb, $wp_locale;
@@ -2492,7 +2499,8 @@ function calendar_week_mod( $num ) {
  *     @type bool   $display   Whether to display the calendar output. Default true.
  *     @type string $post_type Optional. Post type. Default 'post'.
  * }
- * @return void|string Void if `$display` argument is true, calendar HTML if `$display` is false.
+ * @return string|void Calendar HTML if `$display` is false, nothing otherwise.
+ * @phpstan-return ( $args is array{ display: false|0|''|'0', ... } ? string|void : void )
  */
 function get_calendar( $args = array() ) {
 	global $wpdb, $m, $monthnum, $year, $wp_locale, $posts;

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -1699,14 +1699,15 @@ function wp_title( $sep = '&raquo;', $display = true, $seplocation = '' ) {
  *
  * @param string $prefix  Optional. What to display before the title.
  * @param bool   $display Optional. Whether to display or retrieve title. Default true.
- * @return string|void Title when retrieving, nothing when displaying or on failure.
- * @phpstan-return ( $display is true ? void : string|void )
+ * @return string|void Title when retrieving, null on failure.
+ *                     Nothing when displaying.
+ * @phpstan-return ( $display is true ? void : string|null )
  */
 function single_post_title( $prefix = '', $display = true ) {
 	$_post = get_queried_object();
 
 	if ( ! isset( $_post->post_title ) ) {
-		return;
+		return null;
 	}
 
 	/**
@@ -1736,12 +1737,13 @@ function single_post_title( $prefix = '', $display = true ) {
  *
  * @param string $prefix  Optional. What to display before the title.
  * @param bool   $display Optional. Whether to display or retrieve title. Default true.
- * @return string|void Title when retrieving, nothing when displaying or on failure.
- * @phpstan-return ( $display is true ? void : string|void )
+ * @return string|void Title when retrieving, null on failure.
+ *                     Nothing when displaying.
+ * @phpstan-return ( $display is true ? void : string|null )
  */
 function post_type_archive_title( $prefix = '', $display = true ) {
 	if ( ! is_post_type_archive() ) {
-		return;
+		return null;
 	}
 
 	$post_type = get_query_var( 'post_type' );
@@ -1779,7 +1781,8 @@ function post_type_archive_title( $prefix = '', $display = true ) {
  *
  * @param string $prefix  Optional. What to display before the title.
  * @param bool   $display Optional. Whether to display or retrieve title. Default true.
- * @return string|void Title when retrieving, nothing when displaying or on failure.
+ * @return string|void Title when retrieving, null on failure.
+ *                     Nothing when displaying.
  * @phpstan-return ( $display is true ? void : string|null )
  */
 function single_cat_title( $prefix = '', $display = true ) {
@@ -1801,7 +1804,8 @@ function single_cat_title( $prefix = '', $display = true ) {
  *
  * @param string $prefix  Optional. What to display before the title.
  * @param bool   $display Optional. Whether to display or retrieve title. Default true.
- * @return string|void Title when retrieving, nothing when displaying or on failure.
+ * @return string|void Title when retrieving, null on failure.
+ *                     Nothing when displaying.
  * @phpstan-return ( $display is true ? void : string|null )
  */
 function single_tag_title( $prefix = '', $display = true ) {
@@ -1823,14 +1827,15 @@ function single_tag_title( $prefix = '', $display = true ) {
  *
  * @param string $prefix  Optional. What to display before the title.
  * @param bool   $display Optional. Whether to display or retrieve title. Default true.
- * @return string|void Title when retrieving, nothing when displaying or on failure.
- * @phpstan-return ( $display is true ? void : string|void )
+ * @return string|void Title when retrieving, null on failure.
+ *                     Nothing when displaying.
+ * @phpstan-return ( $display is true ? void : string|null )
  */
 function single_term_title( $prefix = '', $display = true ) {
 	$term = get_queried_object();
 
 	if ( ! $term ) {
-		return;
+		return null;
 	}
 
 	if ( is_category() ) {
@@ -1861,11 +1866,11 @@ function single_term_title( $prefix = '', $display = true ) {
 		 */
 		$term_name = apply_filters( 'single_term_title', $term->name );
 	} else {
-		return;
+		return null;
 	}
 
 	if ( empty( $term_name ) ) {
-		return;
+		return null;
 	}
 
 	if ( ! $display ) {
@@ -2224,11 +2229,12 @@ function get_archives_link( $url, $text, $format = 'html', $before = '', $after 
  *     @type string     $day             Day. Default current day.
  *     @type string     $w               Week. Default current week.
  * }
- * @return string|void Archive links if 'echo' is false, nothing otherwise.
+ * @return string|void Archive links when 'echo' is false, null when the post type is
+ *                     not viewable. Nothing otherwise.
  * @phpstan-return (
  *     $args is array{ echo: false|0|''|'0', ... }
- *         ? string|void
- *         : ( $args is ''|array ? void : string|void )
+ *         ? string|null
+ *         : ( $args is ''|array ? void : string|null )
  * )
  */
 function wp_get_archives( $args = '' ) {
@@ -2265,7 +2271,7 @@ function wp_get_archives( $args = '' ) {
 
 	$post_type_object = get_post_type_object( $parsed_args['post_type'] );
 	if ( ! is_post_type_viewable( $post_type_object ) ) {
-		return;
+		return null;
 	}
 
 	$parsed_args['post_type'] = $post_type_object->name;
@@ -2499,8 +2505,9 @@ function calendar_week_mod( $num ) {
  *     @type bool   $display   Whether to display the calendar output. Default true.
  *     @type string $post_type Optional. Post type. Default 'post'.
  * }
- * @return string|void Calendar HTML if `$display` is false, nothing otherwise.
- * @phpstan-return ( $args is array{ display: false|0|''|'0', ... } ? string|void : void )
+ * @return string|void Calendar HTML when `$display` is false, null when the site has
+ *                     no posts. Nothing otherwise.
+ * @phpstan-return ( $args is array{ display: false|0|''|'0', ... } ? string|null : void )
  */
 function get_calendar( $args = array() ) {
 	global $wpdb, $m, $monthnum, $year, $wp_locale, $posts;
@@ -2611,7 +2618,7 @@ function get_calendar( $args = array() ) {
 		if ( ! $gotsome ) {
 			$cache[ $key ] = '';
 			wp_cache_set( 'get_calendar', $cache, 'calendar' );
-			return;
+			return null;
 		}
 	}
 

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -237,7 +237,12 @@ function get_template_part( $slug, $name = null, $args = array() ) {
  *                              accessibility. Default empty.
  * }
  * @return string|void Search form HTML if 'echo' is false, nothing otherwise.
- * @phpstan-return ( $args is array{ echo: false|0|''|'0', ... } ? string : void )
+ * @phpstan-param array<string, mixed>|bool $args
+ * @phpstan-return (
+ *     $args is array{ echo: false|0|''|'0', ... }
+ *         ? string
+ *         : ( $args is false|0|''|'0' ? string : void )
+ * )
  */
 function get_search_form( $args = array() ) {
 	/**

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -909,8 +909,9 @@ function wp_lostpassword_url( $redirect = '' ) {
  * @param string $before  Text to output before the link. Default `<li>`.
  * @param string $after   Text to output after the link. Default `</li>`.
  * @param bool   $display Default to echo and not return the link.
- * @return string|void Registration or admin link if `$display` is false,
- *                     nothing otherwise.
+ * @return string|void The registration or admin link when `$display` is false, or an empty
+ *                     string when registration is disabled or the logged-in user cannot
+ *                     access the dashboard. Nothing otherwise.
  * @phpstan-return ( $display is true ? void : string )
  */
 function wp_register( $before = '<li>', $after = '</li>', $display = true ) {

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -1543,7 +1543,8 @@ function _wp_render_title_tag() {
  *                            Default '&raquo;'.
  * @param bool   $display     Optional. Whether to display or retrieve title. Default true.
  * @param string $seplocation Optional. Location of the separator (either 'left' or 'right').
- * @return string|null String when `$display` is false, null otherwise.
+ * @return string|void String when `$display` is false, nothing otherwise.
+ * @phpstan-return ( $display is true ? void : string )
  */
 function wp_title( $sep = '&raquo;', $display = true, $seplocation = '' ) {
 	global $wp_locale;
@@ -1678,8 +1679,6 @@ function wp_title( $sep = '&raquo;', $display = true, $seplocation = '' ) {
 	}
 
 	echo $title;
-
-	return null;
 }
 
 /**
@@ -1696,13 +1695,14 @@ function wp_title( $sep = '&raquo;', $display = true, $seplocation = '' ) {
  *
  * @param string $prefix  Optional. What to display before the title.
  * @param bool   $display Optional. Whether to display or retrieve title. Default true.
- * @return string|null Title when retrieving.
+ * @return string|void Title when retrieving.
+ * @phpstan-return ( $display is true ? void : string|null )
  */
 function single_post_title( $prefix = '', $display = true ) {
 	$_post = get_queried_object();
 
 	if ( ! isset( $_post->post_title ) ) {
-		return null;
+		return;
 	}
 
 	/**
@@ -1720,8 +1720,6 @@ function single_post_title( $prefix = '', $display = true ) {
 	}
 
 	echo $prefix . $title;
-
-	return null;
 }
 
 /**
@@ -1734,11 +1732,12 @@ function single_post_title( $prefix = '', $display = true ) {
  *
  * @param string $prefix  Optional. What to display before the title.
  * @param bool   $display Optional. Whether to display or retrieve title. Default true.
- * @return string|null Title when retrieving, null when displaying or on failure.
+ * @return string|void Title when retrieving, nothing when displaying or on failure.
+ * @phpstan-return ( $display is true ? void : string|null )
  */
 function post_type_archive_title( $prefix = '', $display = true ) {
 	if ( ! is_post_type_archive() ) {
-		return null;
+		return;
 	}
 
 	$post_type = get_query_var( 'post_type' );
@@ -1763,8 +1762,6 @@ function post_type_archive_title( $prefix = '', $display = true ) {
 	}
 
 	echo $prefix . $title;
-
-	return null;
 }
 
 /**
@@ -1778,10 +1775,15 @@ function post_type_archive_title( $prefix = '', $display = true ) {
  *
  * @param string $prefix  Optional. What to display before the title.
  * @param bool   $display Optional. Whether to display or retrieve title. Default true.
- * @return string|null Title when retrieving.
+ * @return string|void Title when retrieving.
+ * @phpstan-return ( $display is true ? void : string|null )
  */
 function single_cat_title( $prefix = '', $display = true ) {
-	return single_term_title( $prefix, $display );
+	if ( ! $display ) {
+		return single_term_title( $prefix, false );
+	}
+
+	single_term_title( $prefix, true );
 }
 
 /**
@@ -1795,10 +1797,15 @@ function single_cat_title( $prefix = '', $display = true ) {
  *
  * @param string $prefix  Optional. What to display before the title.
  * @param bool   $display Optional. Whether to display or retrieve title. Default true.
- * @return string|null Title when retrieving.
+ * @return string|void Title when retrieving.
+ * @phpstan-return ( $display is true ? void : string|null )
  */
 function single_tag_title( $prefix = '', $display = true ) {
-	return single_term_title( $prefix, $display );
+	if ( ! $display ) {
+		return single_term_title( $prefix, false );
+	}
+
+	single_term_title( $prefix, true );
 }
 
 /**
@@ -1812,13 +1819,14 @@ function single_tag_title( $prefix = '', $display = true ) {
  *
  * @param string $prefix  Optional. What to display before the title.
  * @param bool   $display Optional. Whether to display or retrieve title. Default true.
- * @return string|null Title when retrieving.
+ * @return string|void Title when retrieving.
+ * @phpstan-return ( $display is true ? void : string|null )
  */
 function single_term_title( $prefix = '', $display = true ) {
 	$term = get_queried_object();
 
 	if ( ! $term ) {
-		return null;
+		return;
 	}
 
 	if ( is_category() ) {
@@ -1849,11 +1857,11 @@ function single_term_title( $prefix = '', $display = true ) {
 		 */
 		$term_name = apply_filters( 'single_term_title', $term->name );
 	} else {
-		return null;
+		return;
 	}
 
 	if ( empty( $term_name ) ) {
-		return null;
+		return;
 	}
 
 	if ( ! $display ) {
@@ -1861,8 +1869,6 @@ function single_term_title( $prefix = '', $display = true ) {
 	}
 
 	echo $prefix . $term_name;
-
-	return null;
 }
 
 /**
@@ -2898,7 +2904,8 @@ function the_date_xml() {
  * @param string $before  Optional. Output before the date. Default empty.
  * @param string $after   Optional. Output after the date. Default empty.
  * @param bool   $display Optional. Whether to echo the date or return it. Default true.
- * @return string|null String if retrieving.
+ * @return string|void String if retrieving.
+ * @phpstan-return ( $display is true ? void : string )
  */
 function the_date( $format = '', $before = '', $after = '', $display = true ) {
 	global $currentday, $previousday;
@@ -2927,8 +2934,6 @@ function the_date( $format = '', $before = '', $after = '', $display = true ) {
 	}
 
 	echo $the_date;
-
-	return null;
 }
 
 /**
@@ -2975,7 +2980,8 @@ function get_the_date( $format = '', $post = null ) {
  * @param string $before  Optional. Output before the date. Default empty.
  * @param string $after   Optional. Output after the date. Default empty.
  * @param bool   $display Optional. Whether to echo the date or return it. Default true.
- * @return string|null String if retrieving.
+ * @return string|void String if retrieving.
+ * @phpstan-return ( $display is true ? void : string )
  */
 function the_modified_date( $format = '', $before = '', $after = '', $display = true ) {
 	$the_modified_date = $before . get_the_modified_date( $format ) . $after;
@@ -2997,8 +3003,6 @@ function the_modified_date( $format = '', $before = '', $after = '', $display = 
 	}
 
 	echo $the_modified_date;
-
-	return null;
 }
 
 /**

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -1699,8 +1699,8 @@ function wp_title( $sep = '&raquo;', $display = true, $seplocation = '' ) {
  *
  * @param string $prefix  Optional. What to display before the title.
  * @param bool   $display Optional. Whether to display or retrieve title. Default true.
- * @return string|void Title when retrieving.
- * @phpstan-return ( $display is true ? void : string|null )
+ * @return string|void Title when retrieving, nothing when displaying or on failure.
+ * @phpstan-return ( $display is true ? void : string|void )
  */
 function single_post_title( $prefix = '', $display = true ) {
 	$_post = get_queried_object();
@@ -1737,7 +1737,7 @@ function single_post_title( $prefix = '', $display = true ) {
  * @param string $prefix  Optional. What to display before the title.
  * @param bool   $display Optional. Whether to display or retrieve title. Default true.
  * @return string|void Title when retrieving, nothing when displaying or on failure.
- * @phpstan-return ( $display is true ? void : string|null )
+ * @phpstan-return ( $display is true ? void : string|void )
  */
 function post_type_archive_title( $prefix = '', $display = true ) {
 	if ( ! is_post_type_archive() ) {
@@ -1779,8 +1779,8 @@ function post_type_archive_title( $prefix = '', $display = true ) {
  *
  * @param string $prefix  Optional. What to display before the title.
  * @param bool   $display Optional. Whether to display or retrieve title. Default true.
- * @return string|void Title when retrieving.
- * @phpstan-return ( $display is true ? void : string|null )
+ * @return string|void Title when retrieving, nothing when displaying or on failure.
+ * @phpstan-return ( $display is true ? void : string|void )
  */
 function single_cat_title( $prefix = '', $display = true ) {
 	if ( ! $display ) {
@@ -1801,8 +1801,8 @@ function single_cat_title( $prefix = '', $display = true ) {
  *
  * @param string $prefix  Optional. What to display before the title.
  * @param bool   $display Optional. Whether to display or retrieve title. Default true.
- * @return string|void Title when retrieving.
- * @phpstan-return ( $display is true ? void : string|null )
+ * @return string|void Title when retrieving, nothing when displaying or on failure.
+ * @phpstan-return ( $display is true ? void : string|void )
  */
 function single_tag_title( $prefix = '', $display = true ) {
 	if ( ! $display ) {
@@ -1823,8 +1823,8 @@ function single_tag_title( $prefix = '', $display = true ) {
  *
  * @param string $prefix  Optional. What to display before the title.
  * @param bool   $display Optional. Whether to display or retrieve title. Default true.
- * @return string|void Title when retrieving.
- * @phpstan-return ( $display is true ? void : string|null )
+ * @return string|void Title when retrieving, nothing when displaying or on failure.
+ * @phpstan-return ( $display is true ? void : string|void )
  */
 function single_term_title( $prefix = '', $display = true ) {
 	$term = get_queried_object();

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -581,7 +581,8 @@ function wp_get_tooltip_helper( $content, $args = array() ) {
  *
  * @param string $redirect Optional path to redirect to on login/logout.
  * @param bool   $display  Default to echo and not return the link.
- * @return void|string Void if `$display` argument is true, log in/out link if `$display` is false.
+ * @return string|void Log in/out link if `$display` is false, nothing otherwise.
+ * @phpstan-return ( $display is true ? void : string )
  */
 function wp_loginout( $redirect = '', $display = true ) {
 	if ( ! is_user_logged_in() ) {
@@ -901,8 +902,9 @@ function wp_lostpassword_url( $redirect = '' ) {
  * @param string $before  Text to output before the link. Default `<li>`.
  * @param string $after   Text to output after the link. Default `</li>`.
  * @param bool   $display Default to echo and not return the link.
- * @return void|string Void if `$display` argument is true, registration or admin link
- *                     if `$display` is false.
+ * @return string|void Registration or admin link if `$display` is false,
+ *                     nothing otherwise.
+ * @phpstan-return ( $display is true ? void : string )
  */
 function wp_register( $before = '<li>', $after = '</li>', $display = true ) {
 	if ( ! is_user_logged_in() ) {

--- a/src/wp-includes/l10n.php
+++ b/src/wp-includes/l10n.php
@@ -1735,7 +1735,9 @@ function wp_get_l10n_php_file_data( $php_file ) {
  *     @type bool     $explicit_option_en_us        Whether the English (United States) option uses an explicit value of en_US
  *                                                  instead of an empty value. Default false.
  * }
- * @return string|void HTML dropdown list of languages.
+ * @return string|void HTML dropdown list of languages. Always returned, whether or not
+ *                     'echo' is true; nothing is returned when the required `id` or `name`
+ *                     argument is missing.
  */
 function wp_dropdown_languages( $args = array() ) {
 

--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -1131,9 +1131,9 @@ function get_edit_term_link( $term, $taxonomy = '', $object_type = '' ) {
  * @param string           $after   Optional. Display after edit link. Default empty.
  * @param int|WP_Term|null $term    Optional. Term ID or object. If null, the queried object will be inspected. Default null.
  * @param bool             $display Optional. Whether or not to echo the return. Default true.
- * @return string|void HTML content when retrieving, nothing when displaying,
- *                     on failure, or without the capability to edit the term.
- * @phpstan-return ( $display is true ? void : string|void )
+ * @return string|void HTML content when retrieving, null on failure or without the
+ *                     capability to edit the term. Nothing when displaying.
+ * @phpstan-return ( $display is true ? void : string|null )
  */
 function edit_term_link( $link = '', $before = '', $after = '', $term = null, $display = true ) {
 	if ( is_null( $term ) ) {
@@ -1143,11 +1143,11 @@ function edit_term_link( $link = '', $before = '', $after = '', $term = null, $d
 	}
 
 	if ( ! $term ) {
-		return;
+		return null;
 	}
 
 	if ( ! current_user_can( 'edit_term', $term->term_id ) ) {
-		return;
+		return null;
 	}
 
 	if ( empty( $link ) ) {
@@ -3267,22 +3267,22 @@ function previous_comments_link( $label = '' ) {
  *
  * @param string|array $args Optional args. See paginate_links(). Default empty array.
  * @return string|string[]|void Markup for comment page links, or an array of them when the 'type'
- *                              argument is 'array'. Nothing when 'echo' is true and 'type' is not
- *                              'array', or if the query is not for an existing single post of any
- *                              post type.
+ *                              argument is 'array'. Null if the query is not for an existing single
+ *                              post of any post type. Nothing when 'echo' is true and 'type' is not
+ *                              'array'.
  * @phpstan-return (
  *     $args is array{ type: 'array', ... }
- *         ? string[]|void
+ *         ? string[]|null
  *         : ( $args is array{ echo: false|0|''|'0', ... }
- *             ? string|void
- *             : ( $args is ''|array ? void : string|string[]|void ) )
+ *             ? string|null
+ *             : ( $args is ''|array ? void : string|string[]|null ) )
  * )
  */
 function paginate_comments_links( $args = array() ) {
 	global $wp_rewrite;
 
 	if ( ! is_singular() ) {
-		return;
+		return null;
 	}
 
 	$page = get_query_var( 'cpage' );

--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -1131,7 +1131,8 @@ function get_edit_term_link( $term, $taxonomy = '', $object_type = '' ) {
  * @param string           $after   Optional. Display after edit link. Default empty.
  * @param int|WP_Term|null $term    Optional. Term ID or object. If null, the queried object will be inspected. Default null.
  * @param bool             $display Optional. Whether or not to echo the return. Default true.
- * @return string|null HTML content.
+ * @return string|void HTML content.
+ * @phpstan-return ( $display is true ? void : string|null )
  */
 function edit_term_link( $link = '', $before = '', $after = '', $term = null, $display = true ) {
 	if ( is_null( $term ) ) {
@@ -1141,11 +1142,11 @@ function edit_term_link( $link = '', $before = '', $after = '', $term = null, $d
 	}
 
 	if ( ! $term ) {
-		return null;
+		return;
 	}
 
 	if ( ! current_user_can( 'edit_term', $term->term_id ) ) {
-		return null;
+		return;
 	}
 
 	if ( empty( $link ) ) {
@@ -1169,8 +1170,6 @@ function edit_term_link( $link = '', $before = '', $after = '', $term = null, $d
 	}
 
 	echo $link;
-
-	return null;
 }
 
 /**
@@ -2543,7 +2542,8 @@ function get_next_posts_page_link( $max_page = 0 ) {
  *
  * @param int  $max_page Optional. Max pages. Default 0.
  * @param bool $display  Optional. Whether to echo the link. Default true.
- * @return string|null The link URL for next posts page if `$display = false`.
+ * @return string|void The link URL for next posts page if `$display = false`.
+ * @phpstan-return ( $display is true ? void : string )
  */
 function next_posts( $max_page = 0, $display = true ) {
 	$link   = get_next_posts_page_link( $max_page );
@@ -2554,8 +2554,6 @@ function next_posts( $max_page = 0, $display = true ) {
 	}
 
 	echo $output;
-
-	return null;
 }
 
 /**
@@ -2655,7 +2653,8 @@ function get_previous_posts_page_link() {
  * @since 0.71
  *
  * @param bool $display Optional. Whether to echo the link. Default true.
- * @return string|null The previous posts page link if `$display = false`.
+ * @return string|void The previous posts page link if `$display = false`.
+ * @phpstan-return ( $display is true ? void : string )
  */
 function previous_posts( $display = true ) {
 	$link   = get_previous_posts_page_link();
@@ -2666,8 +2665,6 @@ function previous_posts( $display = true ) {
 	}
 
 	echo $output;
-
-	return null;
 }
 
 /**

--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -3265,10 +3265,17 @@ function previous_comments_link( $label = '' ) {
  * @global WP_Rewrite $wp_rewrite WordPress rewrite component.
  *
  * @param string|array $args Optional args. See paginate_links(). Default empty array.
- * @return void|string|array Void if 'echo' argument is true and 'type' is not an array,
- *                           or if the query is not for an existing single post of any post type.
- *                           Otherwise, markup for comment page links or array of comment page links,
- *                           depending on 'type' argument.
+ * @return string|string[]|void Markup for comment page links, or an array of them when the 'type'
+ *                              argument is 'array'. Nothing when 'echo' is true and 'type' is not
+ *                              'array', or if the query is not for an existing single post of any
+ *                              post type.
+ * @phpstan-return (
+ *     $args is array{ type: 'array', ... }
+ *         ? string[]|void
+ *         : ( $args is array{ echo: false|0|''|'0', ... }
+ *             ? string|void
+ *             : ( $args is ''|array ? void : string|string[]|void ) )
+ * )
  */
 function paginate_comments_links( $args = array() ) {
 	global $wp_rewrite;

--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -2543,7 +2543,8 @@ function get_next_posts_page_link( $max_page = 0 ) {
  *
  * @param int  $max_page Optional. Max pages. Default 0.
  * @param bool $display  Optional. Whether to echo the link. Default true.
- * @return string|void The link URL for next posts page if `$display = false`.
+ * @return string|void The next posts page link when `$display` is false, or an empty
+ *                     string when there is no next page. Nothing otherwise.
  * @phpstan-return ( $display is true ? void : string )
  */
 function next_posts( $max_page = 0, $display = true ) {
@@ -2654,7 +2655,8 @@ function get_previous_posts_page_link() {
  * @since 0.71
  *
  * @param bool $display Optional. Whether to echo the link. Default true.
- * @return string|void The previous posts page link if `$display = false`.
+ * @return string|void The previous posts page link when `$display` is false, or an empty
+ *                     string when there is no previous page. Nothing otherwise.
  * @phpstan-return ( $display is true ? void : string )
  */
 function previous_posts( $display = true ) {

--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -1131,8 +1131,9 @@ function get_edit_term_link( $term, $taxonomy = '', $object_type = '' ) {
  * @param string           $after   Optional. Display after edit link. Default empty.
  * @param int|WP_Term|null $term    Optional. Term ID or object. If null, the queried object will be inspected. Default null.
  * @param bool             $display Optional. Whether or not to echo the return. Default true.
- * @return string|void HTML content.
- * @phpstan-return ( $display is true ? void : string|null )
+ * @return string|void HTML content when retrieving, nothing when displaying,
+ *                     on failure, or without the capability to edit the term.
+ * @phpstan-return ( $display is true ? void : string|void )
  */
 function edit_term_link( $link = '', $before = '', $after = '', $term = null, $display = true ) {
 	if ( is_null( $term ) ) {

--- a/src/wp-includes/post-template.php
+++ b/src/wp-includes/post-template.php
@@ -37,15 +37,15 @@ function get_the_ID() { // phpcs:ignore WordPress.NamingConventions.ValidFunctio
  * @param string $before  Optional. Markup to prepend to the title. Default empty.
  * @param string $after   Optional. Markup to append to the title. Default empty.
  * @param bool   $display Optional. Whether to echo or return the title. Default true for echo.
- * @return string|void Current post title if `$display` is false, nothing otherwise
- *                     or when the title is empty.
- * @phpstan-return ( $display is true ? void : string|void )
+ * @return string|void Current post title when `$display` is false, null when the title
+ *                     is empty. Nothing otherwise.
+ * @phpstan-return ( $display is true ? void : string|null )
  */
 function the_title( $before = '', $after = '', $display = true ) {
 	$title = get_the_title();
 
 	if ( strlen( $title ) === 0 ) {
-		return;
+		return null;
 	}
 
 	$title = $before . $title . $after;
@@ -77,12 +77,12 @@ function the_title( $before = '', $after = '', $display = true ) {
  *     @type bool    $echo   Whether to echo or return the title. Default true for echo.
  *     @type WP_Post $post   Current post object to retrieve the title for.
  * }
- * @return string|void The title attribute if 'echo' is false, nothing otherwise
- *                     or when the title is empty.
+ * @return string|void The title attribute when 'echo' is false, null when the title is
+ *                     empty. Nothing otherwise.
  * @phpstan-return (
  *     $args is array{ echo: false|0|''|'0', ... }
- *         ? string|void
- *         : ( $args is ''|array ? void : string|void )
+ *         ? string|null
+ *         : ( $args is ''|array ? void : string|null )
  * )
  */
 function the_title_attribute( $args = '' ) {
@@ -97,7 +97,7 @@ function the_title_attribute( $args = '' ) {
 	$title = get_the_title( $parsed_args['post'] );
 
 	if ( strlen( $title ) === 0 ) {
-		return;
+		return null;
 	}
 
 	$title = $parsed_args['before'] . $title . $parsed_args['after'];

--- a/src/wp-includes/post-template.php
+++ b/src/wp-includes/post-template.php
@@ -37,8 +37,9 @@ function get_the_ID() { // phpcs:ignore WordPress.NamingConventions.ValidFunctio
  * @param string $before  Optional. Markup to prepend to the title. Default empty.
  * @param string $after   Optional. Markup to append to the title. Default empty.
  * @param bool   $display Optional. Whether to echo or return the title. Default true for echo.
- * @return void|string Void if `$display` argument is true or the title is empty,
- *                     current post title if `$display` is false.
+ * @return string|void Current post title if `$display` is false, nothing otherwise
+ *                     or when the title is empty.
+ * @phpstan-return ( $display is true ? void : string|null )
  */
 function the_title( $before = '', $after = '', $display = true ) {
 	$title = get_the_title();

--- a/src/wp-includes/post-template.php
+++ b/src/wp-includes/post-template.php
@@ -77,7 +77,13 @@ function the_title( $before = '', $after = '', $display = true ) {
  *     @type bool    $echo   Whether to echo or return the title. Default true for echo.
  *     @type WP_Post $post   Current post object to retrieve the title for.
  * }
- * @return void|string Void if 'echo' argument is true, the title attribute if 'echo' is false.
+ * @return string|void The title attribute if 'echo' is false, nothing otherwise
+ *                     or when the title is empty.
+ * @phpstan-return (
+ *     $args is array{ echo: false|0|''|'0', ... }
+ *         ? string|void
+ *         : ( $args is ''|array ? void : string|void )
+ * )
  */
 function the_title_attribute( $args = '' ) {
 	$defaults    = array(
@@ -1299,7 +1305,12 @@ function wp_dropdown_pages( $args = '' ) {
  *     @type Walker            $walker       Walker instance to use for listing pages. Default empty which results in a
  *                                           Walker_Page instance being used.
  * }
- * @return void|string Void if 'echo' argument is true, HTML list of pages if 'echo' is false.
+ * @return string|void HTML list of pages if 'echo' is false, nothing otherwise.
+ * @phpstan-return (
+ *     $args is array{ echo: false|0|''|'0', ... }
+ *         ? string
+ *         : ( $args is ''|array ? void : string|null )
+ * )
  */
 function wp_list_pages( $args = '' ) {
 	$defaults = array(
@@ -1422,7 +1433,12 @@ function wp_list_pages( $args = '' ) {
  *     @type Walker          $walker       Walker instance to use for listing pages. Default empty which results in a
  *                                         Walker_Page instance being used.
  * }
- * @return void|string Void if 'echo' argument is true, HTML menu if 'echo' is false.
+ * @return string|void HTML menu if 'echo' is false, nothing otherwise.
+ * @phpstan-return (
+ *     $args is array{ echo: false|0|''|'0', ... }
+ *         ? string
+ *         : ( $args is ''|array ? void : string|null )
+ * )
  */
 function wp_page_menu( $args = array() ) {
 	$defaults = array(

--- a/src/wp-includes/post-template.php
+++ b/src/wp-includes/post-template.php
@@ -39,7 +39,7 @@ function get_the_ID() { // phpcs:ignore WordPress.NamingConventions.ValidFunctio
  * @param bool   $display Optional. Whether to echo or return the title. Default true for echo.
  * @return string|void Current post title if `$display` is false, nothing otherwise
  *                     or when the title is empty.
- * @phpstan-return ( $display is true ? void : string|null )
+ * @phpstan-return ( $display is true ? void : string|void )
  */
 function the_title( $before = '', $after = '', $display = true ) {
 	$title = get_the_title();

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -907,7 +907,12 @@ function get_users( $args = array() ) {
  *     @type string $exclude       An array, comma-, or space-separated list of user IDs to exclude. Default empty.
  *     @type string $include       An array, comma-, or space-separated list of user IDs to include. Default empty.
  * }
- * @return string|null The output if echo is false. Otherwise null.
+ * @return string|void The output if 'echo' is false, nothing otherwise.
+ * @phpstan-return (
+ *     $args is array{ echo: false|0|''|'0', ... }
+ *         ? string
+ *         : ( $args is ''|array ? void : string|null )
+ * )
  */
 function wp_list_users( $args = array() ) {
 	$defaults = array(
@@ -1015,8 +1020,6 @@ function wp_list_users( $args = array() ) {
 	}
 
 	echo $return;
-
-	return null;
 }
 
 /**


### PR DESCRIPTION
✅ Committed in:

* r63441 (308c95d)
* r63440 (5186490)

----
Follow-up to r63379, addressing [review feedback](https://github.com/WordPress/wordpress-develop/pull/13082#issuecomment-5484098475) from @IanDelMar on #13082.

The point raised there was that the `void` unions on the functions taking a `$display` parameter were less a type-system problem than a consequence of those functions having two responsibilities: depending on the argument they either print a result or return one. Replacing `void` with `null` removed the union, but it also removed information: Under `string|null` PHPStan treats the display-mode result as a legitimate value, so consuming a meaningless one is no longer reported.

That is correct, and it turns out to understate the problem.

## `void` in a plain union conveys nothing

PHPStan raises `Result of function … (void) is used.` only when the resolved return type is *exactly* `void`. A plain union never resolves to that, so `@return string|void` and `@return void|string` carry no more information than `string|null` does. Verified with two otherwise identical functions:

```php
/** @return void|string */
function plain_union( string $prefix = '', bool $display = true ) { … }

/**
 * @return void|string
 *
 * @phpstan-return ( $display is true ? void : string )
 */
function with_conditional( string $prefix = '', bool $display = true ) { … }

var_dump( plain_union( 'x' ) );       // no error
var_dump( with_conditional( 'x' ) );  // Result of function with_conditional (void) is used. [function.void]
```

Only the conditional annotation does any work. So this is not a matter of putting back what r61768 and r63379 took away — the functions that still carry `void` today were never getting anything from it either.

## The shape used throughout

Every conditional added here has one branch that is exactly `void`, meaning the call has no value to give, and one branch that is the retrieval type, unioned with `null` where the function can bail. Bails reachable in retrieval mode say `return null;`, because in that mode the null is a value the caller observes; a bare `return;` is kept only where it can never be reached by a caller expecting a value.

The two `void`s are not redundant. The `void` branch is what makes the display-mode call resolve to exactly `void` and so be reported. The `null` in the other branch is what keeps `strlen( post_type_archive_title( '', false ) )` reported as passing a possible null. Narrowing that branch to plain `string` would trade a real bug class for nothing.

## Changes

Eleven commits, each independently reviewable.

**1. The nine functions from r63379.** `wp_title()`, `single_post_title()`, `post_type_archive_title()`, `single_term_title()`, `the_date()`, `the_modified_date()`, `edit_term_link()`, `next_posts()` and `previous_posts()` go back to `string|void` and gain a conditional `@phpstan-return`. The trailing `return null;` statements added by r63379 are removed, since `void` in the union licenses falling off the end.

`single_cat_title()` and `single_tag_title()` delegate to `single_term_title()` and take the same annotation, which requires expanding their one-line body into an early return — returning the delegate's value unconditionally never returns void, and PHPStan reports the `void` as unused.

**2. Five more with the same shape**, found by sweeping core for the pattern: `comment_class()`, `the_title()`, `wp_loginout()`, `wp_register()` and `wp_update_php_annotation()`. The first four already documented `void|string` and so, per the above, were getting nothing for it. `wp_update_php_annotation()` needs a small body change: its trailing `return null;` is reached in both modes, so the missing-annotation path becomes an early bail instead. No behavior change.

**3. An unrelated docs bug found by the same sweep.** `WP_Styles::print_inline_style()`, `WP_Scripts::print_extra_script()` and the deprecated `WP_Scripts::print_scripts_l10n()` document their return inverted: each says the markup comes back when `$display` is true, but the string is returned on the `! $display` branch and the printing branch returns `true`. Corrected, and given conditional annotations as well — not for void detection, but for narrowing:

| Call | Before | After |
| --- | --- | --- |
| `print_inline_style( $h )` | `string\|bool` | `bool` |
| `print_inline_style( $h, false )` | `string\|bool` | `string\|false` |
| `print_extra_script( $h )` | `bool\|string\|null` | `true\|null` |
| `print_extra_script( $h, false )` | `bool\|string\|null` | `string\|null` |

This matters at the two internal call sites that pass `false` and then use the result as a string, where `true` was previously considered possible. Happy to split this commit off into its own ticket if preferred.

**4. The tags taking the flag inside an `$args` array.** `the_title_attribute()`, `get_search_form()`, `get_calendar()` (whose flag is `display`), `wp_login_form()`, `wp_get_archives()`, `wp_list_pages()`, `wp_page_menu()`, `wp_list_comments()`, `wp_list_bookmarks()`, `wp_list_authors()`, `wp_list_users()`, `wp_tag_cloud()` and `paginate_comments_links()`.

These were nearly left out, on the grounds that `$args` accepts a query string as well as an array, so an `array{echo: false}` condition would resolve to the `void` branch for `wp_list_categories( 'echo=0&title_li=' )` and report correct code as an error. Testing rather than reasoning about it showed two of the assumptions behind that to be wrong:

- **Array shapes in a condition are not sealed.** `array( 'echo' => false, 'aria_label' => 'a' )` matches `array{ echo: false, ... }`, so extra keys are not a problem.
- **The query-string case is avoidable** with a third branch. When `$args` is neither the falsy-flag shape nor an array, the type stays a union and nothing is reported. All that gives up is the undecidable call styles — the bare `the_title_attribute()`, the empty array and an explicit truthy flag all still resolve to `void`.

The flag also has to be matched as `false|0|''|'0'` rather than `false`, since these tags variously default it to `true` or to `1`. Matching only `false` reports `array( 'echo' => 0 )` as void while it actually returns the markup.

`wp_tag_cloud()` and `paginate_comments_links()` answer to `format` and `type` as well, either of which returns an array even while printing, so their conditions nest that dimension first. `wp_list_users()` also loses the trailing `return null;` r63378 gave it. Where `$args` is documented as an array the third branch is always true and PHPStan says so, so those take the plain two-branch form.

Narrowing `paginate_comments_links()` to `string[]` resolves three existing errors as a side effect, two of them in Twenty Twenty, where the result of a call passing `echo => false` and no `type` was still typed as possibly an array.

`wp_dropdown_languages()` turns out not to belong to this group at all — it prints and then returns the markup regardless of the flag, so its `void` is correct for the bail on a missing `id` or `name`, and only the description needed saying.

**5–7. Settling on one shape.** Addressing @Copilot's review, which spotted that some conditionals gave the retrieval branch as `string|null` while the `@return` above said `string|void`, so the two tags disagreed about the third outcome. Resolved in the direction described under *The shape used throughout*, rather than by adding `null` to the public tag, which would have produced `string|null|void` — not an idiom used elsewhere in core, and one that blurs the distinction this pull request restores. `single_cat_title()` and `single_tag_title()` keep `null`, correctly: neither bails, and their retrieval path hands back the delegate's value.

**8. `trackback_url()`**, the last function in core with this shape. No bail, so the condition is the simple one. Its `@param` also said the argument was "Not used.", which is wrong — it is read twice, once to raise the 2.5.0 deprecation notice and again to choose between echoing and returning.

**9. `twentytwenty_site_description()`**, the same shape in a bundled theme. Also separable onto its own ticket if preferred.

**10. A regression this pull request introduced, caught by @Copilot.** `get_search_form()` still honors the boolean `$echo` flag that r44956 replaced with `$args`, casting a non-array argument to bool and using it as the flag. The condition described only the array form, so `get_search_form( false )` resolved to `void` while at runtime it returns the markup.

The guard that would have covered this was present earlier on the branch and was removed because PHPStan reported `$args is array` as `Condition … is always true`. That report was the symptom rather than the problem: `@param array $args` is what makes the non-array branch look unreachable, while a call passing `false` is still resolved against the argument's own type — so the branch that mattered went and the wrong one stayed. Declaring the legacy form in `@phpstan-param array<string, mixed>|bool $args` makes the two agree, and the condition then nests the boolean case:

| Call | Resolves to | Reported |
| --- | --- | --- |
| `get_search_form( false )` | `string` | no |
| `get_search_form( true )` | `void` | yes |
| `get_search_form()` | `void` | yes |
| `get_search_form( array( 'echo' => false ) )` | `string` | no |
| `get_search_form( $someBool )` | `string\|null` | no |

The last row is why the boolean case is nested rather than folded into the first branch: where the flag cannot be determined the type stays a union and nothing is reported.

The neighbors were checked for the same trap. `get_calendar()` also accepts legacy positional arguments, but its first one sets `initial` rather than `display`, so `get_calendar( false )` prints and resolving it to `void` is already correct. `wp_login_form()` has no back-compat branch.

**11. Three descriptions that promise more than the function delivers**, from a further @Copilot pass. `next_posts()` says it returns "the link URL for next posts page" when retrieving, but maps a missing link to an empty string, which is what a caller gets on the last page. `previous_posts()` has the identical shape, and `wp_register()` promises a registration or admin link while setting the value to an empty string when registration is disabled and the visitor is logged out, or when a logged-in user cannot reach the dashboard. The types were already right — an empty string is a string — so only the descriptions changed.

## Deliberately not changed

Sweeping all of `src` for `void` in a return union turns up 35 further symbols in core and the bundled themes. None of them can drop the `void`, and none of them can be given a conditional that resolves to it. Grouped by why:

**Dual-mode, but the printing branch cannot be `void`.** Each returns a meaningful value on a path shared by both modes, so that branch is `X|void` and never resolves to plain `void`. Changing what those paths return would alter what callers receive, which is not worth doing for an annotation:

| Function | Returns on the shared path |
| --- | --- |
| `single_month_title()` | `false` when there is no valid title for the month |
| `wp_list_categories()` | `false` when the taxonomy does not exist |
| `wp_nav_menu()` | `false` when no menu is found, plus the `fallback_cb` result |
| `twentytwenty_site_logo()` | `''` when the site has no title |

**Not dual-mode at all** — the `void` covers only a bail, and there is no argument for a condition to switch on: `wp_dropdown_languages()`, `twentytwenty_get_post_meta()` and `twentytwentyfive_format_binding()`. `WP_Widget::form()` belongs here too: whether it returns anything depends on the subclass, not on an argument, which is what r59336 recorded when it added the `void`.

**Void on success, error on failure** — 26 functions whose failure value is not predictable from the arguments and is legitimately consumed, as in `if ( false === get_header() )`. The `void` in the union is correct and no report is wanted:

- `void|false` — `get_header()`, `get_footer()`, `get_sidebar()`, `get_template_part()`, `add_theme_support()`, `do_enclose()`, `do_trackbacks()`, `the_terms()`, `update_object_term_cache()`, `update_user_caches()`, `WP_Customize_Setting::save()`, `site_admin_notice()`, `parent_dropdown()`, `maintenance_nag()`, `update_nag()`, `wp_plugin_update_row()`, `wp_theme_update_row()`, `make_site_theme_from_default()`, `wp_dropdown_cats()`
- `void|WP_Error` and friends — `register_importer()`, `_fix_attachment_links()`, `WP_Image_Editor_Imagick::thumbnail_image()`, `WP_Metadata_Lazyloader::queue_objects()`, `WP_Metadata_Lazyloader::reset_queue()`, `WP_XMLRPC_Server::_toggle_sticky()`, `WP_REST_Edit_Site_Export_Controller::export()`

Also unchanged are the functions that print **and then** return the value unconditionally, where the result is always meaningful and no `void` is involved: `wp_nonce_field()`, `wp_referer_field()`, `wp_original_referer_field()`, `checked()` / `selected()` / `disabled()` / `wp_readonly()` / `readonly()` and `__checked_selected_helper()`, `menu_page_url()`, `_post_states()`, `_media_states()`, `timer_stop()`, `wp_popular_terms_checklist()`, `wp_nav_menu_disabled_check()`, `WP_Scripts::print_inline_script()` and `WP_Scripts::print_translations()`. Deprecated functions of this shape are left alone as well: `the_category_ID()`, `get_author_link()`, `get_category_rss_link()`, `get_author_rss_link()`, `get_most_active_blogs()` and `wp_get_links()`.

## Verification

- A temporary probe file confirms that every function touched here resolves to plain `void` in printing mode and is reported when consumed, and that none of them are reported in retrieval mode — including `echo => 0` as well as `echo => false`, flags accompanied by other keys, and `format`/`type` of `'array'`. Query-string and dynamic `$args` are reported in neither mode, nor is `get_search_form()`'s legacy boolean argument where its value cannot be determined. Retrieval-mode calls type exactly as they did before.
- Full PHPStan runs at level 10 before and after report the same error set, less the three resolved by the `paginate_comments_links()` narrowing. Two reports restate a narrower expected type without changing meaning: the pre-existing `return.type` on `print_extra_script()` and on `wp_list_comments()`, both of which stem from a `mixed` reaching the return.
- Worth noting for anyone reproducing that: the analysis is not deterministic. Two runs of identical, unmodified code with the result cache cleared differ by three to five errors, all of them array-shape inferences resolving to `mixed` in one run and to a shape in another. The comparisons above were repeated until stable, and `phpstan-diff --changed --staged` is clean on every commit.
- `tests/phpstan/baselines/return.missing.neon` stays deleted — `void` in the union is precisely what licenses falling off the end.
- PHPCS reports no new issues.
- PHPUnit: `Tests_General_`, `Tests_Link_`, `Tests_Date_`, `Tests_Post_`, `Tests_Comment_`, `Tests_Term_`, `Tests_Category_`, `Tests_User_`, `Tests_Functions_` and `Tests_Dependencies_` all pass.

Trac ticket: https://core.trac.wordpress.org/ticket/65817

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Opus 5
Used for: Evaluating the review feedback, sweeping core for other instances of the pattern, and drafting the annotations and this description. The PHPStan and PHPUnit verification was run against the working tree, and the result has been reviewed and is owned by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**




