### PR TITLE
Tests: Add unit tests for the Bookmark Administration API

### DIFF
--- a/tests/phpunit/tests/admin/includes/bookmark/AddLink_Test.php
+++ b/tests/phpunit/tests/admin/includes/bookmark/AddLink_Test.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * @group admin
+ * @group bookmark
+ *
+ * @covers ::add_link
+ */
+class Tests_Admin_Includes_Bookmark_AddLink_Test extends WP_UnitTestCase {
+
+	/**
+	 * @ticket 66019
+	 */
+	public function test_should_insert_a_link_from_the_post_data() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+
+		add_filter( 'pre_option_link_manager_enabled', '__return_true' );
+
+		$_POST = array(
+			'link_url'   => 'https://example.com/',
+			'link_name'  => 'Example',
+			'link_image' => '',
+			'link_rss'   => '',
+		);
+
+		$link_id = add_link();
+
+		$this->assertIsInt( $link_id, 'The link ID should be an integer.' );
+		$this->assertSame( 'Example', get_bookmark( $link_id )->link_name, 'The link name was not stored.' );
+	}
+}

--- a/tests/phpunit/tests/admin/includes/bookmark/EditLink_Test.php
+++ b/tests/phpunit/tests/admin/includes/bookmark/EditLink_Test.php
@@ -1,0 +1,156 @@
+<?php
+
+/**
+ * @group admin
+ * @group bookmark
+ *
+ * @covers ::edit_link
+ */
+class Tests_Admin_Includes_Bookmark_EditLink_Test extends WP_UnitTestCase {
+
+	/**
+	 * User ID of an administrator.
+	 *
+	 * @var int
+	 */
+	private static $admin_id;
+
+	/**
+	 * User ID of a subscriber.
+	 *
+	 * @var int
+	 */
+	private static $subscriber_id;
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$admin_id      = $factory->user->create( array( 'role' => 'administrator' ) );
+		self::$subscriber_id = $factory->user->create( array( 'role' => 'subscriber' ) );
+	}
+
+	public function set_up() {
+		parent::set_up();
+
+		// The 'manage_links' capability is only granted while the Link Manager is enabled.
+		add_filter( 'pre_option_link_manager_enabled', '__return_true' );
+	}
+
+	/**
+	 * @ticket 66019
+	 */
+	public function test_should_die_for_users_who_cannot_manage_links() {
+		wp_set_current_user( self::$subscriber_id );
+		$this->set_up_post_data();
+
+		$this->expectException( 'WPDieException' );
+		$this->expectExceptionCode( 403 );
+
+		edit_link();
+	}
+
+	/**
+	 * @ticket 66019
+	 */
+	public function test_should_insert_a_link_from_the_post_data() {
+		wp_set_current_user( self::$admin_id );
+		$this->set_up_post_data();
+
+		$link_id = edit_link();
+
+		$this->assertIsInt( $link_id, 'The link ID should be an integer.' );
+		$this->assertSame( 'Example', get_bookmark( $link_id )->link_name, 'The link name was not stored.' );
+	}
+
+	/**
+	 * @ticket 66019
+	 */
+	public function test_should_update_the_link_when_a_link_id_is_passed() {
+		wp_set_current_user( self::$admin_id );
+		$link_id = self::factory()->bookmark->create( array( 'link_name' => 'Original' ) );
+		$this->set_up_post_data( array( 'link_name' => 'Updated' ) );
+
+		$result = edit_link( $link_id );
+
+		$this->assertSame( $link_id, $result, 'The existing link ID should be returned.' );
+		$this->assertSame( 'Updated', get_bookmark( $link_id )->link_name, 'The link was not updated.' );
+	}
+
+	/**
+	 * @ticket 66019
+	 */
+	public function test_should_escape_the_posted_link_name() {
+		wp_set_current_user( self::$admin_id );
+		$this->set_up_post_data( array( 'link_name' => '<b>Bold</b>' ) );
+
+		$link_id = edit_link();
+
+		$this->assertSame( '&lt;b&gt;Bold&lt;/b&gt;', get_bookmark( $link_id )->link_name );
+	}
+
+	/**
+	 * @ticket 66019
+	 */
+	public function test_should_escape_the_posted_link_url() {
+		wp_set_current_user( self::$admin_id );
+		$this->set_up_post_data( array( 'link_url' => 'https://example.com/?a=1&b=2' ) );
+
+		$link_id = edit_link();
+
+		$this->assertSame( 'https://example.com/?a=1&#038;b=2', get_bookmark( $link_id )->link_url );
+	}
+
+	/**
+	 * @ticket 66019
+	 *
+	 * @dataProvider data_link_visible
+	 *
+	 * @param array  $post_data Values to add to the posted link data.
+	 * @param string $expected  The expected stored visibility.
+	 */
+	public function test_should_normalize_the_posted_visibility( $post_data, $expected ) {
+		wp_set_current_user( self::$admin_id );
+		$this->set_up_post_data( $post_data );
+
+		$link_id = edit_link();
+
+		$this->assertSame( $expected, get_bookmark( $link_id )->link_visible );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array<string, array{post_data: array<string, string>, expected: string}>
+	 */
+	public function data_link_visible() {
+		return array(
+			'no value'       => array(
+				'post_data' => array(),
+				'expected'  => 'Y',
+			),
+			'an uppercase N' => array(
+				'post_data' => array( 'link_visible' => 'N' ),
+				'expected'  => 'N',
+			),
+			'a lowercase n'  => array(
+				'post_data' => array( 'link_visible' => 'n' ),
+				'expected'  => 'Y',
+			),
+		);
+	}
+
+	/**
+	 * Populates $_POST with the fields edit_link() reads unconditionally.
+	 *
+	 * @param array $post_data Optional. Values to add to the posted link data.
+	 */
+	private function set_up_post_data( $post_data = array() ) {
+		$_POST = array_merge(
+			array(
+				'link_url'   => 'https://example.com/',
+				'link_name'  => 'Example',
+				'link_image' => '',
+				'link_rss'   => '',
+			),
+			$post_data
+		);
+	}
+}

--- a/tests/phpunit/tests/admin/includes/bookmark/GetDefaultLinkToEdit_Test.php
+++ b/tests/phpunit/tests/admin/includes/bookmark/GetDefaultLinkToEdit_Test.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * @group admin
+ * @group bookmark
+ *
+ * @covers ::get_default_link_to_edit
+ */
+class Tests_Admin_Includes_Bookmark_GetDefaultLinkToEdit_Test extends WP_UnitTestCase {
+
+	/**
+	 * @ticket 66019
+	 */
+	public function test_should_return_an_empty_visible_link() {
+		$link = get_default_link_to_edit();
+
+		$this->assertSame( '', $link->link_url, 'The link URL should be empty.' );
+		$this->assertSame( '', $link->link_name, 'The link name should be empty.' );
+		$this->assertSame( 'Y', $link->link_visible, 'The link should be visible.' );
+	}
+
+	/**
+	 * @ticket 66019
+	 */
+	public function test_should_use_the_url_and_name_from_the_request() {
+		$_GET['linkurl'] = 'https://example.com/?a=1&b=2';
+		$_GET['name']    = 'O\\\'Brien & Sons';
+
+		$link = get_default_link_to_edit();
+
+		$this->assertSame( 'https://example.com/?a=1&#038;b=2', $link->link_url, 'The link URL was not escaped.' );
+		$this->assertSame( 'O&#039;Brien &amp; Sons', $link->link_name, 'The link name was not unslashed and escaped.' );
+	}
+}

--- a/tests/phpunit/tests/admin/includes/bookmark/GetLinkToEdit_Test.php
+++ b/tests/phpunit/tests/admin/includes/bookmark/GetLinkToEdit_Test.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * @group admin
+ * @group bookmark
+ *
+ * @covers ::get_link_to_edit
+ */
+class Tests_Admin_Includes_Bookmark_GetLinkToEdit_Test extends WP_UnitTestCase {
+
+	/**
+	 * @ticket 66019
+	 */
+	public function test_should_return_the_link_prepared_for_the_edit_context() {
+		$link_id = self::factory()->bookmark->create( array( 'link_name' => 'Tom & "Jerry"' ) );
+
+		$this->assertSame( 'Tom &amp; &quot;Jerry&quot;', get_link_to_edit( $link_id )->link_name );
+	}
+
+	/**
+	 * @ticket 66019
+	 */
+	public function test_should_accept_a_link_object() {
+		$link_id = self::factory()->bookmark->create( array( 'link_name' => 'Tom & "Jerry"' ) );
+
+		$this->assertSame( 'Tom &amp; &quot;Jerry&quot;', get_link_to_edit( get_bookmark( $link_id ) )->link_name );
+	}
+}

--- a/tests/phpunit/tests/admin/includes/bookmark/WpDeleteLink_Test.php
+++ b/tests/phpunit/tests/admin/includes/bookmark/WpDeleteLink_Test.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * @group admin
+ * @group bookmark
+ *
+ * @covers ::wp_delete_link
+ */
+class Tests_Admin_Includes_Bookmark_WpDeleteLink_Test extends WP_UnitTestCase {
+
+	/**
+	 * @ticket 66019
+	 */
+	public function test_should_delete_the_link_and_return_true() {
+		$link_id = self::factory()->bookmark->create();
+
+		$this->assertTrue( wp_delete_link( $link_id ), 'wp_delete_link() should return true.' );
+		$this->assertNull( get_bookmark( $link_id ), 'The link was not deleted.' );
+	}
+
+	/**
+	 * @ticket 66019
+	 */
+	public function test_should_remove_the_link_category_relationships() {
+		$term_id = self::factory()->term->create( array( 'taxonomy' => 'link_category' ) );
+		$link_id = self::factory()->bookmark->create( array( 'link_category' => array( $term_id ) ) );
+
+		wp_delete_link( $link_id );
+
+		$this->assertSame( array(), wp_get_object_terms( $link_id, 'link_category', array( 'fields' => 'ids' ) ) );
+	}
+
+	/**
+	 * @ticket 66019
+	 */
+	public function test_should_clear_the_bookmark_cache() {
+		$link_id = self::factory()->bookmark->create();
+
+		// Prime the cache.
+		get_bookmark( $link_id );
+
+		wp_delete_link( $link_id );
+
+		$this->assertFalse( wp_cache_get( $link_id, 'bookmark' ) );
+	}
+
+	/**
+	 * @ticket 66019
+	 */
+	public function test_should_fire_the_delete_actions_around_the_deletion() {
+		global $wpdb;
+
+		$link_id = self::factory()->bookmark->create();
+
+		$link_exists = static function () use ( $wpdb, $link_id ) {
+			return (bool) $wpdb->get_var( $wpdb->prepare( "SELECT link_id FROM $wpdb->links WHERE link_id = %d", $link_id ) );
+		};
+
+		$fired = array();
+		add_action(
+			'delete_link',
+			static function ( $id ) use ( &$fired, $link_exists ) {
+				$fired[] = array( 'delete_link', $id, $link_exists() );
+			}
+		);
+		add_action(
+			'deleted_link',
+			static function ( $id ) use ( &$fired, $link_exists ) {
+				$fired[] = array( 'deleted_link', $id, $link_exists() );
+			}
+		);
+
+		wp_delete_link( $link_id );
+
+		$this->assertSame(
+			array(
+				array( 'delete_link', $link_id, true ),
+				array( 'deleted_link', $link_id, false ),
+			),
+			$fired
+		);
+	}
+}

--- a/tests/phpunit/tests/admin/includes/bookmark/WpGetLinkCats_Test.php
+++ b/tests/phpunit/tests/admin/includes/bookmark/WpGetLinkCats_Test.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * @group admin
+ * @group bookmark
+ *
+ * @covers ::wp_get_link_cats
+ */
+class Tests_Admin_Includes_Bookmark_WpGetLinkCats_Test extends WP_UnitTestCase {
+
+	/**
+	 * @ticket 66019
+	 */
+	public function test_should_return_the_link_category_ids() {
+		$alpha = self::factory()->term->create(
+			array(
+				'taxonomy' => 'link_category',
+				'name'     => 'Alpha',
+			)
+		);
+		$beta  = self::factory()->term->create(
+			array(
+				'taxonomy' => 'link_category',
+				'name'     => 'Beta',
+			)
+		);
+
+		$link_id = self::factory()->bookmark->create( array( 'link_category' => array( $alpha, $beta ) ) );
+
+		$this->assertSame( array( $alpha, $beta ), wp_get_link_cats( $link_id ) );
+	}
+}

--- a/tests/phpunit/tests/admin/includes/bookmark/WpInsertLink_Test.php
+++ b/tests/phpunit/tests/admin/includes/bookmark/WpInsertLink_Test.php
@@ -1,0 +1,193 @@
+<?php
+
+/**
+ * @group admin
+ * @group bookmark
+ *
+ * @covers ::wp_insert_link
+ */
+class Tests_Admin_Includes_Bookmark_WpInsertLink_Test extends WP_UnitTestCase {
+
+	/**
+	 * @ticket 66019
+	 */
+	public function test_should_insert_a_link_and_return_its_id() {
+		$link_id = wp_insert_link(
+			array(
+				'link_url'  => 'https://example.com/',
+				'link_name' => 'Example',
+			)
+		);
+
+		$this->assertIsInt( $link_id, 'The link ID should be an integer.' );
+
+		$link = get_bookmark( $link_id );
+
+		$this->assertSame( 'https://example.com/', $link->link_url, 'The link URL was not stored.' );
+		$this->assertSame( 'Example', $link->link_name, 'The link name was not stored.' );
+	}
+
+	/**
+	 * @ticket 66019
+	 */
+	public function test_should_return_zero_when_the_url_is_empty() {
+		$this->assertSame( 0, wp_insert_link( array( 'link_name' => 'Example' ) ) );
+	}
+
+	/**
+	 * @ticket 66019
+	 */
+	public function test_should_use_the_url_as_the_name_when_the_name_is_empty() {
+		$link_id = wp_insert_link( array( 'link_url' => 'https://example.com/' ) );
+
+		$this->assertSame( 'https://example.com/', get_bookmark( $link_id )->link_name );
+	}
+
+	/**
+	 * @ticket 66019
+	 */
+	public function test_should_default_link_visible_to_yes() {
+		$link_id = wp_insert_link(
+			array(
+				'link_url'  => 'https://example.com/',
+				'link_name' => 'Example',
+			)
+		);
+
+		$this->assertSame( 'Y', get_bookmark( $link_id )->link_visible );
+	}
+
+	/**
+	 * @ticket 66019
+	 */
+	public function test_should_default_the_owner_to_the_current_user() {
+		$user_id = self::factory()->user->create();
+		wp_set_current_user( $user_id );
+
+		$link_id = wp_insert_link(
+			array(
+				'link_url'  => 'https://example.com/',
+				'link_name' => 'Example',
+			)
+		);
+
+		$this->assertSame( $user_id, (int) get_bookmark( $link_id )->link_owner );
+	}
+
+	/**
+	 * @ticket 66019
+	 */
+	public function test_should_update_the_existing_link_when_a_link_id_is_provided() {
+		$link_id = self::factory()->bookmark->create( array( 'link_name' => 'Original' ) );
+
+		$result = wp_insert_link(
+			array(
+				'link_id'   => $link_id,
+				'link_url'  => 'https://example.com/',
+				'link_name' => 'Updated',
+			)
+		);
+
+		$this->assertSame( $link_id, $result, 'The existing link ID should be returned.' );
+		$this->assertSame( 'Updated', get_bookmark( $link_id )->link_name, 'The link was not updated.' );
+		$this->assertCount( 1, get_bookmarks( array( 'hide_invisible' => false ) ), 'A second link was inserted.' );
+	}
+
+	/**
+	 * @ticket 66019
+	 */
+	public function test_should_return_zero_when_the_database_insert_fails() {
+		$this->assertSame( 0, $this->insert_link_with_a_failing_query( false ) );
+	}
+
+	/**
+	 * @ticket 66019
+	 */
+	public function test_should_return_an_error_when_the_database_insert_fails_and_wp_error_is_true() {
+		$result = $this->insert_link_with_a_failing_query( true );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'db_insert_error', $result->get_error_code() );
+	}
+
+	/**
+	 * @ticket 66019
+	 */
+	public function test_should_fire_the_add_link_action_when_inserting() {
+		$fired = array();
+		add_action(
+			'add_link',
+			static function ( $link_id ) use ( &$fired ) {
+				$fired[] = $link_id;
+			}
+		);
+
+		$link_id = wp_insert_link(
+			array(
+				'link_url'  => 'https://example.com/',
+				'link_name' => 'Example',
+			)
+		);
+
+		$this->assertSame( array( $link_id ), $fired );
+	}
+
+	/**
+	 * @ticket 66019
+	 */
+	public function test_should_fire_the_edit_link_action_when_updating() {
+		$link_id = self::factory()->bookmark->create();
+
+		$fired = array();
+		add_action(
+			'edit_link',
+			static function ( $link_id ) use ( &$fired ) {
+				$fired[] = $link_id;
+			}
+		);
+
+		wp_insert_link(
+			array(
+				'link_id'   => $link_id,
+				'link_url'  => 'https://example.com/',
+				'link_name' => 'Example',
+			)
+		);
+
+		$this->assertSame( array( $link_id ), $fired );
+	}
+
+	/**
+	 * Calls wp_insert_link() with the link insert query rewritten to fail.
+	 *
+	 * @param bool $wp_error Whether to request a WP_Error object on failure.
+	 * @return int|WP_Error The value returned by wp_insert_link().
+	 */
+	private function insert_link_with_a_failing_query( $wp_error ) {
+		global $wpdb;
+
+		$rewrite_query = static function ( $query ) use ( $wpdb ) {
+			if ( str_starts_with( $query, "INSERT INTO `$wpdb->links`" ) ) {
+				return "INSERT INTO `{$wpdb->prefix}links_no_such_table` (`link_id`) VALUES (1)";
+			}
+
+			return $query;
+		};
+
+		$wpdb->suppress_errors( true );
+		add_filter( 'query', $rewrite_query );
+
+		$result = wp_insert_link(
+			array(
+				'link_url'  => 'https://example.com/',
+				'link_name' => 'Example',
+			),
+			$wp_error
+		);
+
+		remove_filter( 'query', $rewrite_query );
+		$wpdb->suppress_errors( false );
+
+		return $result;
+	}
+}

--- a/tests/phpunit/tests/admin/includes/bookmark/WpLinkManagerDisabledMessage_Test.php
+++ b/tests/phpunit/tests/admin/includes/bookmark/WpLinkManagerDisabledMessage_Test.php
@@ -1,0 +1,124 @@
+<?php
+
+/**
+ * @group admin
+ * @group bookmark
+ *
+ * @covers ::wp_link_manager_disabled_message
+ */
+class Tests_Admin_Includes_Bookmark_WpLinkManagerDisabledMessage_Test extends WP_UnitTestCase {
+
+	/**
+	 * User ID of an administrator.
+	 *
+	 * @var int
+	 */
+	private static $admin_id;
+
+	/**
+	 * User ID of a subscriber.
+	 *
+	 * @var int
+	 */
+	private static $subscriber_id;
+
+	/**
+	 * The value of $pagenow before the test ran.
+	 *
+	 * @var string
+	 */
+	private $original_pagenow;
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$admin_id      = $factory->user->create( array( 'role' => 'administrator' ) );
+		self::$subscriber_id = $factory->user->create( array( 'role' => 'subscriber' ) );
+	}
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->original_pagenow = $GLOBALS['pagenow'];
+	}
+
+	public function tear_down() {
+		$GLOBALS['pagenow'] = $this->original_pagenow;
+
+		parent::tear_down();
+	}
+
+	/**
+	 * @ticket 66019
+	 */
+	public function test_should_do_nothing_outside_the_link_manager_screens() {
+		$GLOBALS['pagenow'] = 'index.php';
+		wp_set_current_user( self::$subscriber_id );
+
+		$this->assertNull( wp_link_manager_disabled_message() );
+	}
+
+	/**
+	 * @ticket 66019
+	 *
+	 * @dataProvider data_link_manager_screens
+	 *
+	 * @param string $pagenow The screen to test.
+	 */
+	public function test_should_die_for_users_who_cannot_manage_links( $pagenow ) {
+		$GLOBALS['pagenow'] = $pagenow;
+		wp_set_current_user( self::$subscriber_id );
+
+		$this->expectException( 'WPDieException' );
+		$this->expectExceptionMessage( 'Sorry, you are not allowed to edit the links for this site.' );
+
+		wp_link_manager_disabled_message();
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array<string, array{pagenow: string}>
+	 */
+	public function data_link_manager_screens() {
+		return array(
+			'the link manager' => array( 'pagenow' => 'link-manager.php' ),
+			'adding a link'    => array( 'pagenow' => 'link-add.php' ),
+			'editing a link'   => array( 'pagenow' => 'link.php' ),
+		);
+	}
+
+	/**
+	 * @ticket 66019
+	 *
+	 * @group ms-excluded
+	 */
+	public function test_should_offer_to_install_the_plugin_when_it_is_not_installed() {
+		$GLOBALS['pagenow'] = 'link-manager.php';
+		wp_set_current_user( self::$admin_id );
+		wp_cache_set( 'plugins', array( '' => array() ), 'plugins' );
+
+		$this->expectException( 'WPDieException' );
+		$this->expectExceptionMessage( 'action=install-plugin' );
+
+		wp_link_manager_disabled_message();
+	}
+
+	/**
+	 * @ticket 66019
+	 *
+	 * @group ms-excluded
+	 */
+	public function test_should_offer_to_activate_the_plugin_when_it_is_inactive() {
+		$GLOBALS['pagenow'] = 'link-manager.php';
+		wp_set_current_user( self::$admin_id );
+		wp_cache_set(
+			'plugins',
+			array( '' => array( 'link-manager/link-manager.php' => array( 'Name' => 'Link Manager' ) ) ),
+			'plugins'
+		);
+
+		$this->expectException( 'WPDieException' );
+		$this->expectExceptionMessage( 'action=activate' );
+
+		wp_link_manager_disabled_message();
+	}
+}

--- a/tests/phpunit/tests/admin/includes/bookmark/WpSetLinkCats_Test.php
+++ b/tests/phpunit/tests/admin/includes/bookmark/WpSetLinkCats_Test.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * @group admin
+ * @group bookmark
+ *
+ * @covers ::wp_set_link_cats
+ */
+class Tests_Admin_Includes_Bookmark_WpSetLinkCats_Test extends WP_UnitTestCase {
+
+	/**
+	 * @ticket 66019
+	 */
+	public function test_should_replace_the_existing_categories() {
+		$term_ids = self::factory()->term->create_many( 2, array( 'taxonomy' => 'link_category' ) );
+		$link_id  = self::factory()->bookmark->create( array( 'link_category' => array( $term_ids[0] ) ) );
+
+		wp_set_link_cats( $link_id, array( $term_ids[1] ) );
+
+		$this->assertSame( array( $term_ids[1] ), wp_get_link_cats( $link_id ) );
+	}
+
+	/**
+	 * @ticket 66019
+	 */
+	public function test_should_cast_category_ids_to_integers() {
+		$term_id = self::factory()->term->create( array( 'taxonomy' => 'link_category' ) );
+		$link_id = self::factory()->bookmark->create();
+
+		wp_set_link_cats( $link_id, array( (string) $term_id ) );
+
+		$this->assertSame( array( $term_id ), wp_get_link_cats( $link_id ) );
+	}
+
+	/**
+	 * @ticket 66019
+	 *
+	 * @dataProvider data_categories_that_fall_back_to_the_default
+	 *
+	 * @param mixed $link_categories Value passed as the list of link categories.
+	 */
+	public function test_should_use_the_default_category( $link_categories ) {
+		$assigned_id = self::factory()->term->create( array( 'taxonomy' => 'link_category' ) );
+		$link_id     = self::factory()->bookmark->create( array( 'link_category' => array( $assigned_id ) ) );
+
+		$default_id = self::factory()->term->create( array( 'taxonomy' => 'link_category' ) );
+		update_option( 'default_link_category', $default_id );
+
+		wp_set_link_cats( $link_id, $link_categories );
+
+		$this->assertSame( array( $default_id ), wp_get_link_cats( $link_id ) );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array<string, array{link_categories: mixed}>
+	 */
+	public function data_categories_that_fall_back_to_the_default() {
+		return array(
+			'an empty array' => array( 'link_categories' => array() ),
+			'a string'       => array( 'link_categories' => 'not-an-array' ),
+		);
+	}
+}

--- a/tests/phpunit/tests/admin/includes/bookmark/WpUpdateLink_Test.php
+++ b/tests/phpunit/tests/admin/includes/bookmark/WpUpdateLink_Test.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * @group admin
+ * @group bookmark
+ *
+ * @covers ::wp_update_link
+ */
+class Tests_Admin_Includes_Bookmark_WpUpdateLink_Test extends WP_UnitTestCase {
+
+	/**
+	 * @ticket 66019
+	 */
+	public function test_should_update_the_link_and_return_its_id() {
+		$link_id = self::factory()->bookmark->create( array( 'link_name' => 'Original' ) );
+
+		$result = wp_update_link(
+			array(
+				'link_id'   => $link_id,
+				'link_name' => 'Updated',
+			)
+		);
+
+		$this->assertSame( $link_id, $result, 'The link ID should be returned.' );
+		$this->assertSame( 'Updated', get_bookmark( $link_id )->link_name, 'The link name was not updated.' );
+	}
+
+	/**
+	 * @ticket 66019
+	 */
+	public function test_should_keep_the_fields_that_are_not_passed() {
+		$link_id = self::factory()->bookmark->create(
+			array(
+				'link_url'         => 'https://example.com/',
+				'link_description' => 'A description.',
+			)
+		);
+
+		wp_update_link(
+			array(
+				'link_id'   => $link_id,
+				'link_name' => 'Updated',
+			)
+		);
+
+		$link = get_bookmark( $link_id );
+
+		$this->assertSame( 'https://example.com/', $link->link_url, 'The link URL was not kept.' );
+		$this->assertSame( 'A description.', $link->link_description, 'The link description was not kept.' );
+	}
+
+	/**
+	 * @ticket 66019
+	 */
+	public function test_should_keep_the_existing_categories_when_none_are_passed() {
+		$term_id = self::factory()->term->create( array( 'taxonomy' => 'link_category' ) );
+		$link_id = self::factory()->bookmark->create( array( 'link_category' => array( $term_id ) ) );
+
+		wp_update_link(
+			array(
+				'link_id'   => $link_id,
+				'link_name' => 'Updated',
+			)
+		);
+
+		$this->assertSame( array( $term_id ), wp_get_link_cats( $link_id ) );
+	}
+
+	/**
+	 * @ticket 66019
+	 */
+	public function test_should_replace_the_categories_when_they_are_passed() {
+		$term_ids = self::factory()->term->create_many( 2, array( 'taxonomy' => 'link_category' ) );
+		$link_id  = self::factory()->bookmark->create( array( 'link_category' => array( $term_ids[0] ) ) );
+
+		wp_update_link(
+			array(
+				'link_id'       => $link_id,
+				'link_category' => array( $term_ids[1] ),
+			)
+		);
+
+		$this->assertSame( array( $term_ids[1] ), wp_get_link_cats( $link_id ) );
+	}
+}


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

None of the ten functions in `src/wp-admin/includes/bookmark.php` had direct test coverage; `wp_insert_link()` and `wp_delete_link()` appeared only as fixtures for the `get_bookmark()` tests.

This adds a test file per function under `tests/phpunit/tests/admin/includes/bookmark/`, mirroring the source path and the structure used for `wp-admin/includes/misc.php` in [62369]. The cases pin the documented contracts: the empty-URL and name-fallback returns in `wp_insert_link()`, its `$wp_error` branch, the `manage_links` check and `$_POST` escaping in `edit_link()`, category replacement and integer casting in `wp_set_link_cats()`, the partial-merge behaviour of `wp_update_link()`, and the branches of `wp_link_manager_disabled_message()`.

No production code is changed.

Trac ticket: https://core.trac.wordpress.org/ticket/66019

## Use of AI Tools
AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: writing the test cases and checking that each one fails when the function under test is broken. All changes were reviewed and validated by me.
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
