### PR TITLE
Query: Do not replace the posts page with the front page when previewing.

### DIFF
--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -2049,7 +2049,10 @@ class WP_Query {
 			$query_vars['comments_per_page'] = get_option( 'comments_per_page' );
 		}
 
-		if ( $this->is_home && ( empty( $this->query ) || 'true' === $query_vars['preview'] ) && ( 'page' === get_option( 'show_on_front' ) ) && get_option( 'page_on_front' ) ) {
+		if ( $this->is_home && ! $this->is_posts_page
+			&& ( empty( $this->query ) || 'true' === $query_vars['preview'] )
+			&& ( 'page' === get_option( 'show_on_front' ) ) && get_option( 'page_on_front' )
+		) {
 			$this->is_page         = true;
 			$this->is_home         = false;
 			$query_vars['page_id'] = get_option( 'page_on_front' );


### PR DESCRIPTION
When a static front page and a separate posts page are configured, previewing the posts page incorrectly displays the front page.

`WP_Query::parse_query()` correctly identifies the request as both `is_home` and `is_posts_page`. However, in `WP_Query::get_posts()`, the front page preview logic only checks `is_home`, which is also true for the posts page. As a result, it replaces the requested `page_id` with `page_on_front`.

That behavior is needed when previewing the static front page, since its preview URL is a bare `/?preview=true`. This change avoids the substitution when the request explicitly targets the posts page.

### Steps to reproduce

1. Create two pages, "My home" and "My posts".
2. Under Settings → Reading, set the homepage to "My home" and the posts page to
   "My posts".
3. Edit "My posts" in the block editor.
4. Click **View** → **Preview in new tab**.

Before this change the preview shows "My home". After it, "My posts".

Trac ticket: https://core.trac.wordpress.org/ticket/49969

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Code Review

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**