### PR TITLE
Administration: Correct the message shown when build files are unavailable

### DIFF
--- a/src/wp-admin/font-library.php
+++ b/src/wp-admin/font-library.php
@@ -18,11 +18,15 @@ if ( ! current_user_can( 'edit_theme_options' ) ) {
 	);
 }
 
-// Check if Gutenberg build files are available
+// Check if the build files are available.
 if ( ! function_exists( 'wp_font_library_wp_admin_render_page' ) ) {
 	wp_die(
 		'<h1>' . __( 'Font Library is not available.' ) . '</h1>' .
-		'<p>' . __( 'The Font Library requires Gutenberg build files. Please run <code>npm install</code> to build the necessary files.' ) . '</p>',
+		'<p>' . sprintf(
+			/* translators: %s: npm run build */
+			__( 'The Font Library requires build files. Please run %s to build the necessary files.' ),
+			'<code>npm run build</code>'
+		) . '</p>',
 		503
 	);
 }

--- a/src/wp-admin/font-library.php
+++ b/src/wp-admin/font-library.php
@@ -21,12 +21,8 @@ if ( ! current_user_can( 'edit_theme_options' ) ) {
 // Check if the build files are available.
 if ( ! function_exists( 'wp_font_library_wp_admin_render_page' ) ) {
 	wp_die(
-		'<h1>' . __( 'Font Library is not available.' ) . '</h1>' .
-		'<p>' . sprintf(
-			/* translators: %s: npm run build */
-			__( 'The Font Library requires build files. Please run %s to build the necessary files.' ),
-			'<code>npm run build</code>'
-		) . '</p>',
+		'<h1>' . __( 'The Font Library is not available.' ) . '</h1>' .
+		'<p>' . __( 'The Font Library requires build files. Please build WordPress and try again.' ) . '</p>',
 		503
 	);
 }

--- a/src/wp-admin/options-connectors.php
+++ b/src/wp-admin/options-connectors.php
@@ -21,7 +21,11 @@ if ( ! current_user_can( 'manage_options' ) ) {
 if ( ! class_exists( '\WordPress\AiClient\AiClient' ) || ! function_exists( 'wp_options_connectors_wp_admin_render_page' ) ) {
 	wp_die(
 		'<h1>' . __( 'Connectors are not available.' ) . '</h1>' .
-		'<p>' . __( 'The Connectors page requires build files. Please run <code>npm install</code> to build the necessary files.' ) . '</p>',
+		'<p>' . sprintf(
+			/* translators: %s: npm run build */
+			__( 'The Connectors page requires build files. Please run %s to build the necessary files.' ),
+			'<code>npm run build</code>'
+		) . '</p>',
 		503
 	);
 }

--- a/src/wp-admin/options-connectors.php
+++ b/src/wp-admin/options-connectors.php
@@ -20,12 +20,8 @@ if ( ! current_user_can( 'manage_options' ) ) {
 
 if ( ! class_exists( '\WordPress\AiClient\AiClient' ) || ! function_exists( 'wp_options_connectors_wp_admin_render_page' ) ) {
 	wp_die(
-		'<h1>' . __( 'Connectors are not available.' ) . '</h1>' .
-		'<p>' . sprintf(
-			/* translators: %s: npm run build */
-			__( 'The Connectors page requires build files. Please run %s to build the necessary files.' ),
-			'<code>npm run build</code>'
-		) . '</p>',
+		'<h1>' . __( 'The Connectors are not available.' ) . '</h1>' .
+		'<p>' . __( 'The Connectors page requires build files. Please build WordPress and try again.' ) . '</p>',
 		503
 	);
 }


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/66022

The Font Library and Connectors screens tell the user to run `npm install` when build files are missing. That was correct when [61492](https://core.trac.wordpress.org/changeset/61492) added a `postinstall` hook that built the assets; [62321](https://core.trac.wordpress.org/changeset/62321) removed it and the messages were never updated. The two strings are also inconsistent — one says "Gutenberg build files", the other "build files".

## Changes

* `npm install` → `npm run build` in both messages.
* Dropped the "Gutenberg" reference so both strings read consistently.
* Moved the command into a `sprintf()` placeholder with a translators comment, per `src/index.php`.

## Screenshots

### Font Library

| Before | After |
| ------ | ----- |
| <img width="2000" height="520" alt="font-library-before" src="https://github.com/user-attachments/assets/6d86e3a0-ee0f-4382-bd73-e79e7bd630ee" /> | <img width="2000" height="520" alt="font-library-after" src="https://github.com/user-attachments/assets/af463218-66aa-4101-80c0-c4788baf8f43" /> |

### Connectors

| Before | After |
| ------ | ----- |
| <img width="2000" height="520" alt="options-connectors-before" src="https://github.com/user-attachments/assets/dbaff9fe-62bc-4675-bec7-a6787928cb0f" /> | <img width="2000" height="520" alt="options-connectors-after" src="https://github.com/user-attachments/assets/72692349-566f-4051-84fa-65ca314454ef" /> |


## Use of AI

AI assistance: Yes
Tool(s): Claude Code
Model(s): Sonnet 5
Used for: Go through changesets