### PR TITLE
Media: Remove a stray closing div from the Site Icon crop preview template

### DIFF
--- a/src/wp-includes/media-template.php
+++ b/src/wp-includes/media-template.php
@@ -1579,10 +1579,9 @@ function wp_print_media_templates() {
 						<img id="preview-favicon" src="{{ data.url }}" class="browser-icon-preview" alt="<?php esc_attr_e( 'Preview as a browser icon' ); ?>" />
 					</div>
 					<div class="site-icon-preview-site-title" aria-hidden="true"><# print( '<?php echo esc_js( get_bloginfo( 'name' ) ); ?>' ) #></div>
-						<svg role="img" aria-hidden="true" fill="none" xmlns="http://www.w3.org/2000/svg" class="close-button">
-							<path d="M12 13.0607L15.7123 16.773L16.773 15.7123L13.0607 12L16.773 8.28772L15.7123 7.22706L12 10.9394L8.28771 7.22705L7.22705 8.28771L10.9394 12L7.22706 15.7123L8.28772 16.773L12 13.0607Z" />
-						</svg>
-					</div>
+					<svg role="img" aria-hidden="true" fill="none" xmlns="http://www.w3.org/2000/svg" class="close-button">
+						<path d="M12 13.0607L15.7123 16.773L16.773 15.7123L13.0607 12L16.773 8.28772L15.7123 7.22706L12 10.9394L8.28771 7.22705L7.22705 8.28771L10.9394 12L7.22706 15.7123L8.28772 16.773L12 13.0607Z" />
+					</svg>
 				</div>
 			</div>
 		</div>

--- a/src/wp-includes/media-template.php
+++ b/src/wp-includes/media-template.php
@@ -1578,7 +1578,9 @@ function wp_print_media_templates() {
 					<div class="image-preview-wrap browser">
 						<img id="preview-favicon" src="{{ data.url }}" class="browser-icon-preview" alt="<?php esc_attr_e( 'Preview as a browser icon' ); ?>" />
 					</div>
-					<div class="site-icon-preview-site-title" aria-hidden="true"><# print( '<?php echo esc_js( get_bloginfo( 'name' ) ); ?>' ) #></div>
+					<div class="site-icon-preview-site-title" aria-hidden="true">
+						<# print( '<?php echo esc_js( get_bloginfo( 'name' ) ); ?>' ) #>
+					</div>
 					<svg role="img" aria-hidden="true" fill="none" xmlns="http://www.w3.org/2000/svg" class="close-button">
 						<path d="M12 13.0607L15.7123 16.773L16.773 15.7123L13.0607 12L16.773 8.28772L15.7123 7.22706L12 10.9394L8.28771 7.22705L7.22705 8.28771L10.9394 12L7.22706 15.7123L8.28772 16.773L12 13.0607Z" />
 					</svg>


### PR DESCRIPTION
## Description

Trac ticket: https://core.trac.wordpress.org/ticket/66024

The `tmpl-site-icon-preview-crop` Backbone template in `media-template.php` opens three `div` elements but closes four, leaving an unmatched `</div>`.

The markup was adapted from the Site Icon preview in `options-general.php`, which has an extra `.direction-wrap` wrapper. The wrapper wasn't carried over, but its closing tag was — along with the extra indentation on the `.close-button` SVG.

This removes the stray tag and dedents the SVG back to a direct child of `.site-icon-preview-tab`, as its `grid-template-columns` rule expects.