### PR TITLE
Block Supports: Output flex-direction row when a viewport override switches a vertical flex layout to horizontal.

### DIFF
--- a/src/wp-includes/block-supports/layout.php
+++ b/src/wp-includes/block-supports/layout.php
@@ -793,6 +793,17 @@ function wp_get_layout_style( $selector, $layout, $has_block_gap_support = false
 
 		if ( 'horizontal' === $layout_orientation ) {
 			/*
+			 * `row` is the flex default, so the base layout never declares it. A viewport
+			 * override that switches a vertical base layout to horizontal has to declare
+			 * it explicitly, otherwise the base `flex-direction: column` keeps applying.
+			 */
+			if ( null !== $viewport_overrides && $has_viewport_property_override( 'orientation' ) ) {
+				$layout_styles[] = array(
+					'selector'     => $selector,
+					'declarations' => array( 'flex-direction' => 'row' ),
+				);
+			}
+			/*
 			 * Add this style only if is not empty for backwards compatibility,
 			 * since we intend to convert blocks that had flex layout implemented
 			 * by custom css.

--- a/tests/phpunit/tests/block-supports/layout.php
+++ b/tests/phpunit/tests/block-supports/layout.php
@@ -1234,6 +1234,67 @@ class Tests_Block_Supports_Layout extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that a viewport override switching a vertical flex layout to horizontal
+	 * outputs an explicit `flex-direction: row`, so the base `flex-direction: column`
+	 * no longer applies on that viewport.
+	 *
+	 * @covers ::wp_get_layout_style
+	 */
+	public function test_wp_get_layout_style_outputs_flex_direction_row_for_horizontal_viewport_override() {
+		$layout_styles = wp_get_layout_style(
+			'.wp-layout',
+			array(
+				'type'           => 'flex',
+				'orientation'    => 'vertical',
+				'flexWrap'       => 'nowrap',
+				'justifyContent' => 'center',
+			),
+			false,
+			null,
+			false,
+			'0.5em',
+			null,
+			array(
+				'viewport_overrides' => array(
+					'orientation'    => 'horizontal',
+					'justifyContent' => 'left',
+				),
+			)
+		);
+
+		$this->assertSame( '.wp-layout{flex-direction:row;justify-content:flex-start;}', $layout_styles );
+	}
+
+	/**
+	 * Tests that a viewport override which does not change a horizontal orientation
+	 * keeps relying on the flex default and does not output `flex-direction`.
+	 *
+	 * @covers ::wp_get_layout_style
+	 */
+	public function test_wp_get_layout_style_keeps_flex_direction_implicit_without_orientation_override() {
+		$layout_styles = wp_get_layout_style(
+			'.wp-layout',
+			array(
+				'type'           => 'flex',
+				'orientation'    => 'horizontal',
+				'justifyContent' => 'left',
+			),
+			false,
+			null,
+			false,
+			'0.5em',
+			null,
+			array(
+				'viewport_overrides' => array(
+					'justifyContent' => 'right',
+				),
+			)
+		);
+
+		$this->assertSame( '.wp-layout{justify-content:flex-end;}', $layout_styles );
+	}
+
+	/**
 	 * Tests that a responsive grid child with a non-string parent minimumColumnWidth
 	 * does not cause a fatal error in the explode() call.
 	 *


### PR DESCRIPTION
Backport of https://github.com/WordPress/gutenberg/pull/82364.

Currently, when a vertical (Stack) flex layout is set to horizontal on the tablet or mobile viewports, the block stays vertical. The viewport rule only outputs the justification and the base `flex-direction: column` keeps applying. This PR fixes the issue by outputting `flex-direction: row` when a viewport override switches the orientation to horizontal.

Trac ticket: https://core.trac.wordpress.org/ticket/66096

## Use of AI Tools

AI assistance: Yes
Used for: fix and tests drafted with AI assistance; reviewed and edited by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
