### PR TITLE
REST API: Record the source attachment of an uploaded image edit.

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
@@ -340,6 +340,29 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 			},
 		);
 
+		$args['parent_image'] = array(
+			'type'              => 'integer',
+			'minimum'           => 1,
+			'description'       => __( 'ID of the attachment the uploaded image was edited from. Recorded in the new attachment\'s metadata, as the edit endpoint does.' ),
+			'validate_callback' => static function ( $value, $request, $param ) {
+				// Re-apply the schema checks a custom validate_callback replaces.
+				$valid = rest_validate_request_arg( $value, $request, $param );
+				if ( is_wp_error( $valid ) ) {
+					return $valid;
+				}
+
+				if ( ! wp_attachment_is_image( (int) $value ) ) {
+					return new WP_Error(
+						'rest_invalid_param',
+						__( 'Invalid parent image.' ),
+						array( 'status' => 400 )
+					);
+				}
+
+				return true;
+			},
+		);
+
 		return $args;
 	}
 
@@ -424,6 +447,15 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 				array( 'status' => rest_authorization_required_code() )
 			);
 		}
+
+		// Recording an edit relation requires being allowed to edit the source, as the edit endpoint requires.
+		if ( ! empty( $request['parent_image'] ) && ! current_user_can( 'edit_post', (int) $request['parent_image'] ) ) {
+			return new WP_Error(
+				'rest_cannot_edit_image',
+				__( 'Sorry, you are not allowed to edit this image.' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
 		$files = $request->get_file_params();
 
 		/**
@@ -503,6 +535,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 	 *
 	 * @since 4.7.0
 	 * @since 7.1.0 Added the `generate_sub_sizes`, `convert_format`, and `url` parameters.
+	 * @since 7.2.0 Added the `parent_image` parameter.
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_REST_Response|WP_Error Response object on success, WP_Error object on failure.
@@ -629,6 +662,10 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 		 */
 		wp_update_attachment_metadata( $attachment_id, wp_generate_attachment_metadata( $attachment_id, $file ) );
 
+		if ( ! empty( $request['parent_image'] ) ) {
+			$this->record_parent_image( $attachment_id, (int) $request['parent_image'] );
+		}
+
 		$this->remove_client_side_media_processing_filters();
 
 		$response = $this->prepare_item_for_response( $attachment, $request );
@@ -637,6 +674,53 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 		$response->header( 'Location', rest_url( sprintf( '%s/%s/%d', $this->namespace, $this->rest_base, $attachment_id ) ) );
 
 		return $response;
+	}
+
+	/**
+	 * Records the attachment an uploaded image was edited from.
+	 *
+	 * Mirrors what the edit endpoint stores for the attachment it creates, so an
+	 * image edited in the browser relates to its source the same way: the
+	 * `parent_image` entry, the source's EXIF data for any field the new file
+	 * lacks, and an upright orientation, since the edited pixels are upright.
+	 *
+	 * @since 7.2.0
+	 *
+	 * @param int $attachment_id ID of the new attachment.
+	 * @param int $parent_id     ID of the attachment it was edited from.
+	 */
+	private function record_parent_image( int $attachment_id, int $parent_id ): void {
+		$metadata = wp_get_attachment_metadata( $attachment_id );
+		if ( ! is_array( $metadata ) ) {
+			$metadata = array();
+		}
+
+		$parent_metadata = wp_get_attachment_metadata( $parent_id );
+		if ( isset( $parent_metadata['image_meta'] ) && is_array( $parent_metadata['image_meta'] ) ) {
+			if ( ! isset( $metadata['image_meta'] ) || ! is_array( $metadata['image_meta'] ) ) {
+				$metadata['image_meta'] = array();
+			}
+			// Merge but skip empty values, as the edit endpoint does.
+			foreach ( $parent_metadata['image_meta'] as $key => $value ) {
+				if ( empty( $metadata['image_meta'][ $key ] ) && ! empty( $value ) ) {
+					$metadata['image_meta'][ $key ] = $value;
+				}
+			}
+		}
+
+		if ( ! empty( $metadata['image_meta']['orientation'] ) ) {
+			$metadata['image_meta']['orientation'] = 1;
+		}
+
+		$parent_file = wp_get_original_image_path( $parent_id );
+
+		$metadata['parent_image'] = array(
+			'attachment_id' => $parent_id,
+			// Path to the originally uploaded image file relative to the uploads directory.
+			'file'          => $parent_file ? _wp_relative_upload_path( $parent_file ) : '',
+		);
+
+		wp_update_attachment_metadata( $attachment_id, $metadata );
 	}
 
 	/**

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
@@ -720,6 +720,9 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 			'file'          => $parent_file ? _wp_relative_upload_path( $parent_file ) : '',
 		);
 
+		/** This filter is documented in wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php */
+		$metadata = apply_filters( 'wp_edited_image_metadata', $metadata, $attachment_id, $parent_id );
+
 		wp_update_attachment_metadata( $attachment_id, $metadata );
 	}
 

--- a/tests/phpunit/tests/rest-api/rest-attachments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-attachments-controller.php
@@ -2333,6 +2333,39 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 	/**
 	 * @ticket 66027
 	 *
+	 * @covers WP_REST_Attachments_Controller::record_parent_image
+	 */
+	public function test_create_item_filters_the_edited_image_metadata(): void {
+		wp_set_current_user( self::$superadmin_id );
+
+		$parent_id = self::factory()->attachment->create_upload_object( DIR_TESTDATA . '/images/canola.jpg' );
+		$received  = array();
+
+		add_filter(
+			'wp_edited_image_metadata',
+			static function ( $new_image_meta, $new_attachment_id, $attachment_id ) use ( &$received ) {
+				$received                        = compact( 'new_image_meta', 'new_attachment_id', 'attachment_id' );
+				$new_image_meta['original_root'] = $attachment_id;
+				return $new_image_meta;
+			},
+			10,
+			3
+		);
+
+		$response = $this->create_edited_image_response( $parent_id );
+		$this->assertSame( 201, $response->get_status() );
+
+		$new_id = $response->get_data()['id'];
+
+		$this->assertSame( $new_id, $received['new_attachment_id'], 'The filter receives the new attachment.' );
+		$this->assertSame( $parent_id, $received['attachment_id'], 'The filter receives the source attachment.' );
+		$this->assertSame( $parent_id, $received['new_image_meta']['parent_image']['attachment_id'], 'The filter sees the recorded source.' );
+		$this->assertSame( $parent_id, wp_get_attachment_metadata( $new_id )['original_root'], 'The filtered metadata is what gets saved.' );
+	}
+
+	/**
+	 * @ticket 66027
+	 *
 	 * @covers WP_REST_Attachments_Controller::create_item
 	 */
 	public function test_create_item_without_parent_image_records_nothing(): void {

--- a/tests/phpunit/tests/rest-api/rest-attachments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-attachments-controller.php
@@ -2279,6 +2279,104 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 	}
 
 	/**
+	 * Uploads an image through the REST API, optionally as an edit of another attachment.
+	 *
+	 * @param int|null $parent_image Attachment the upload was edited from.
+	 * @return WP_REST_Response Response.
+	 */
+	private function create_edited_image_response( ?int $parent_image = null ): WP_REST_Response {
+		$request = new WP_REST_Request( 'POST', '/wp/v2/media' );
+		$request->set_header( 'Content-Type', 'image/jpeg' );
+		$request->set_header( 'Content-Disposition', 'attachment; filename=canola-edited.jpg' );
+		$request->set_param( 'generate_sub_sizes', false );
+		if ( null !== $parent_image ) {
+			$request->set_param( 'parent_image', $parent_image );
+		}
+		$request->set_body( file_get_contents( DIR_TESTDATA . '/images/canola.jpg' ) );
+
+		return rest_get_server()->dispatch( $request );
+	}
+
+	/**
+	 * A client-side edit records its source attachment like the edit endpoint does.
+	 *
+	 * @ticket 66027
+	 *
+	 * @covers WP_REST_Attachments_Controller::create_item
+	 */
+	public function test_create_item_records_parent_image(): void {
+		wp_set_current_user( self::$superadmin_id );
+
+		$parent_id = self::factory()->attachment->create_upload_object( DIR_TESTDATA . '/images/canola.jpg' );
+
+		$parent_metadata                              = wp_get_attachment_metadata( $parent_id );
+		$parent_metadata['image_meta']['credit']      = 'Photographer';
+		$parent_metadata['image_meta']['orientation'] = 6;
+		wp_update_attachment_metadata( $parent_id, $parent_metadata );
+
+		$response = $this->create_edited_image_response( $parent_id );
+		$this->assertSame( 201, $response->get_status() );
+
+		$data     = $response->get_data();
+		$metadata = wp_get_attachment_metadata( $data['id'] );
+		$expected = array(
+			'attachment_id' => $parent_id,
+			'file'          => _wp_relative_upload_path( wp_get_original_image_path( $parent_id ) ),
+		);
+
+		$this->assertSame( $expected, $metadata['parent_image'], 'The metadata records the source attachment.' );
+		$this->assertSame( $expected, $data['media_details']['parent_image'], 'The response reflects the source attachment.' );
+		$this->assertSame( 'Photographer', $metadata['image_meta']['credit'], 'EXIF fields the new file lacks are copied from the source.' );
+		$this->assertSame( 1, $metadata['image_meta']['orientation'], 'The edited pixels are upright.' );
+	}
+
+	/**
+	 * @ticket 66027
+	 *
+	 * @covers WP_REST_Attachments_Controller::create_item
+	 */
+	public function test_create_item_without_parent_image_records_nothing(): void {
+		wp_set_current_user( self::$superadmin_id );
+
+		$response = $this->create_edited_image_response();
+		$this->assertSame( 201, $response->get_status() );
+
+		$metadata = wp_get_attachment_metadata( $response->get_data()['id'] );
+		$this->assertArrayNotHasKey( 'parent_image', $metadata );
+	}
+
+	/**
+	 * @ticket 66027
+	 *
+	 * @covers WP_REST_Attachments_Controller::get_endpoint_args_for_item_schema
+	 */
+	public function test_create_item_rejects_a_parent_image_that_is_not_an_image(): void {
+		wp_set_current_user( self::$superadmin_id );
+
+		$post_id  = self::factory()->post->create();
+		$response = $this->create_edited_image_response( $post_id );
+
+		$this->assertErrorResponse( 'rest_invalid_param', $response, 400 );
+	}
+
+	/**
+	 * @ticket 66027
+	 *
+	 * @covers WP_REST_Attachments_Controller::create_item_permissions_check
+	 */
+	public function test_create_item_requires_permission_to_edit_the_parent_image(): void {
+		wp_set_current_user( self::$superadmin_id );
+		$parent_id = self::factory()->attachment->create_upload_object( DIR_TESTDATA . '/images/canola.jpg' );
+
+		// Authors can upload, but cannot edit another user's attachment.
+		wp_set_current_user( self::$author_id );
+
+		$response = $this->create_edited_image_response( $parent_id );
+
+		$this->assertErrorResponse( 'rest_cannot_edit_image', $response, 403 );
+	}
+
+	/**
 	 * Verifies image_output_format reflects an image_editor_output_format filter
 	 * that remaps JPEG to WebP, and that the filter sees the real attached
 	 * filename and MIME type.

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -3166,6 +3166,12 @@ mockedApiResponse.Schema = {
                             "format": "uri",
                             "description": "URL of an external image to sideload into the media library, instead of uploading a file.",
                             "required": false
+                        },
+                        "parent_image": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "description": "ID of the attachment the uploaded image was edited from. Recorded in the new attachment's metadata, as the edit endpoint does.",
+                            "required": false
                         }
                     }
                 }


### PR DESCRIPTION
Companion to https://github.com/WordPress/gutenberg/pull/82362.

_Claude Code wrote this up from the Gutenberg change:_

> With client-side media processing, image edits (crop, rotate, flip) made in the editor are moving from the server `media/<id>/edit` endpoint into the browser: the edit is applied with libvips and the result is uploaded through `POST /wp/v2/media` as a new attachment. The one thing `/edit` records that the upload endpoint could not is where the new image came from.
>
> This adds an optional `parent_image` integer parameter to the media create endpoint. When set it must reference an existing image attachment the current user can edit (the same check the `/edit` endpoint applies), and after the upload the new attachment's metadata gets what `edit_media_item()` writes for its new attachment: the `parent_image` entry (`attachment_id` and the source's relative `file`), the source's EXIF `image_meta` for any field the new file lacks, and an orientation reset to 1. Without the parameter nothing changes.
>
> Tests cover the recorded metadata and response, the no-parameter case, a `parent_image` that is not an image (400), and an author who cannot edit the source attachment (403).

Trac ticket: https://core.trac.wordpress.org/ticket/66027

## AI Use

Code and description both written with 🤖 Claude Code. I will review and test.
