### PR TITLE
Rewrite Rules: Require a path-segment boundary when stripping the home path in WP::parse_request()

### DIFF
--- a/src/wp-includes/class-wp.php
+++ b/src/wp-includes/class-wp.php
@@ -178,7 +178,7 @@ class WP {
 			$home_path_regex = '';
 			if ( is_string( $home_path ) && '' !== $home_path ) {
 				$home_path       = trim( $home_path, '/' );
-				$home_path_regex = sprintf( '|^%s|i', preg_quote( $home_path, '|' ) );
+				$home_path_regex = sprintf( '!^%s(?:/|$)!i', preg_quote( $home_path, '!' ) );
 			}
 
 			/*

--- a/tests/phpunit/tests/wp/parseRequest.php
+++ b/tests/phpunit/tests/wp/parseRequest.php
@@ -56,4 +56,27 @@ class Tests_WP_ParseRequest extends WP_UnitTestCase {
 		$this->wp->parse_request();
 		$this->assertSame( '', $this->wp->request );
 	}
+
+	/**
+	 * Tests that a requested path starting with the same characters as the home
+	 * path, but not actually inside it, is not stripped as if it were a match.
+	 *
+	 * @ticket 40339
+	 */
+	public function test_pathinfo_prefix_matching_home_path_is_not_stripped() {
+		$this->set_permalink_structure( '/%year%/%monthnum%/%postname%/' );
+
+		add_filter(
+			'home_url',
+			static function () {
+				return 'http://' . WP_TESTS_DOMAIN . '/wp';
+			}
+		);
+
+		$_SERVER['PATH_INFO'] = '/wp-json/wc/v1/products';
+
+		$this->wp->parse_request();
+
+		$this->assertSame( 'wp-json/wc/v1/products', $this->wp->request );
+	}
 }


### PR DESCRIPTION
`WP::parse_request()` strips the site's home path off the front of `PATH_INFO`/`REQUEST_URI`/`PHP_SELF` using a regex built with `sprintf( '|^%s|i', preg_quote( $home_path, '|' ) )`. Because this only anchors on the start of the string and never checks what comes right after the home path, it matches any path that merely begins with the same characters as the home path, not just paths that are actually nested under it.

For a site installed in a subdirectory named `wp`, a request for `wp-json/wc/v1/products` (a REST API route) gets the literal substring `wp` stripped off the front, leaving the mangled path `-json/wc/v1/products` — breaking REST API routing on such installs. The same root cause affects any endpoint whose name happens to share a prefix with the install's subdirectory (e.g. a `sitemap.xml` request on a site installed under `/site`).

This changes the regex to require a `/` or end-of-string right after the home path (`!^%s(?:/|$)!i`) before stripping it, so a bare prefix match like `wp-json` is left alone, while a real subdirectory match like `wp/wp-json/...` still has `wp/` stripped correctly.

Adds a regression test, `Tests_WP_ParseRequest::test_pathinfo_prefix_matching_home_path_is_not_stripped`, which fails on trunk and passes with this fix.

Trac ticket: https://core.trac.wordpress.org/ticket/40339

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Sonnet 5
Used for: Implementation, tests, and PR description. Reviewed by Igor Rozum.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**