### PR TITLE
REST API: Prevent fatal error when a null template reaches prepare_item_for_response()

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
@@ -670,12 +670,24 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 	 * @since 7.1.0 Added `date` property to the response.
 	 * @since 7.1.0 The `modified` property is `null` for templates that have no
 	 *              modification date.
+	 * @since 7.2.0 Returns a `WP_Error` instead of causing a fatal error
+	 *              when the template is `null`.
 	 *
-	 * @param WP_Block_Template $item    Template instance.
-	 * @param WP_REST_Request   $request Request object.
-	 * @return WP_REST_Response Response object.
+	 * @param WP_Block_Template|null $item    Template instance.
+	 * @param WP_REST_Request        $request Request object.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error when the template is `null`.
 	 */
 	public function prepare_item_for_response( $item, $request ) {
+		/*
+		 * `update_item()` passes its `get_block_template()` refetches here
+		 * unchecked, both after writing an update and after deleting the
+		 * template's post on its revert-to-theme path. Reading `$item->content`
+		 * on `null` is a fatal error, so answer with an error response instead.
+		 */
+		if ( ! $item ) {
+			return new WP_Error( 'rest_template_not_found', __( 'No templates exist with that id.' ), array( 'status' => 404 ) );
+		}
+
 		// Don't prepare the response body for HEAD requests.
 		if ( $request->is_method( 'HEAD' ) ) {
 			return new WP_REST_Response( array() );

--- a/tests/phpunit/tests/rest-api/wpRestTemplatesController.php
+++ b/tests/phpunit/tests/rest-api/wpRestTemplatesController.php
@@ -972,6 +972,23 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 		// Controller does not implement prepare_item().
 	}
 
+	/**
+	 * A `null` template must produce an error response, not a fatal error from
+	 * reading properties on `null`.
+	 *
+	 * @ticket 66032
+	 * @covers WP_REST_Templates_Controller::prepare_item_for_response
+	 */
+	public function test_prepare_item_for_response_with_null_template() {
+		$controller = new WP_REST_Templates_Controller( 'wp_template' );
+		$request    = new WP_REST_Request( 'PUT', '/wp/v2/templates/default//does-not-exist' );
+
+		$response = $controller->prepare_item_for_response( null, $request );
+
+		$this->assertWPError( $response, 'A null template should produce a WP_Error, not a fatal error.' );
+		$this->assertSame( 'rest_template_not_found', $response->get_error_code() );
+	}
+
 	public function test_prepare_item_limit_fields() {
 		wp_set_current_user( self::$admin_id );
 


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/66032

Backports the guard from https://github.com/WordPress/gutenberg/pull/82374.

## What

Prevents an uncaught fatal error (`Attempt to assign property "content" on null`) in `WP_REST_Templates_Controller::prepare_item_for_response()` when it receives a `null` template.

## Why

`WP_REST_Templates_Controller::update_item()` passes its `get_block_template()` refetches to `prepare_item_for_response()` without checking them, both after writing an update and on its revert-to-theme path, which force-deletes the template's post before checking that a theme or plugin version of the template exists. When a refetch returns `null`, the method fatals reading `$item->content`.

## What changed

- `prepare_item_for_response()` returns a `rest_template_not_found` `WP_Error` (404) when the template is `null`, instead of crashing.
- Adds a unit test that calls `prepare_item_for_response( null, ... )` directly, the exact condition that fatals on trunk. Without the guard the call fatals and the run aborts, so the test can only pass through the guard.

## Manual testing

The revert path is the easiest way to reach the fatal:

1. Create a template that exists only in the database: `POST /wp/v2/templates` with `{ "slug": "db-only", "title": "T", "content": "" }`.
2. Send `PUT /wp/v2/templates/<theme>//db-only` with `{ "source": "theme" }`.
3. On trunk this fatals with the error above; with this branch it returns 404 `rest_template_not_found`.
