### PR TITLE
Build/Test Tools: Make the WordPress installation E2E test repeatable

### DIFF
--- a/tests/e2e/specs/install.test.js
+++ b/tests/e2e/specs/install.test.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { writeFileSync, readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
 import { join } from 'node:path';
 
 /**
@@ -11,33 +12,115 @@ import { test, expect } from '@wordpress/e2e-test-utils-playwright';
 
 let wpConfigOriginal;
 
-test.describe( 'WordPress installation process', () => {
-	const wpConfig = join(
-		process.cwd(),
-		'wp-config.php',
-	);
+/**
+ * Prefix used to put WordPress into "not installed" mode for this suite.
+ * Must stay in sync between the wp-config rewrite and table cleanup.
+ */
+const TEST_TABLE_PREFIX = 'wp_e2e_';
 
+/**
+ * Core tables created by a standard single-site install.
+ *
+ * Kept as an explicit list (rather than SHOW TABLES LIKE) so cleanup cannot
+ * accidentally touch unrelated tables if the prefix ever changes.
+ */
+const TEST_INSTALL_TABLES = [
+	'commentmeta',
+	'comments',
+	'links',
+	'options',
+	'postmeta',
+	'posts',
+	'term_relationships',
+	'term_taxonomy',
+	'termmeta',
+	'terms',
+	'usermeta',
+	'users',
+];
+
+/**
+ * Drops leftover `wp_e2e_*` install tables via WP's own `$wpdb` connection.
+ *
+ * Must run before the prefix swap (so a stale install cannot short-circuit the
+ * wizard) and again in teardown after the test creates a fresh install.
+ * Throws when any DROP returns false so a failed cleanup cannot leave the
+ * suite green while tables remain.
+ */
+function dropTestInstallTables() {
+	const tablesPhp = TEST_INSTALL_TABLES.map(
+		( table ) => `'${ table }'`
+	).join( ', ' );
+
+	const dropTablesPhp = [
+		'global $wpdb;',
+		`$prefix = '${ TEST_TABLE_PREFIX }';`,
+		`$tables = array( ${ tablesPhp } );`,
+		'foreach ( $tables as $table ) {',
+		'	$result = $wpdb->query( "DROP TABLE IF EXISTS `{$prefix}{$table}`" );',
+		'	if ( false === $result ) {',
+		'		fwrite( STDERR, "Failed to drop {$prefix}{$table}: " . $wpdb->last_error . "\\n" );',
+		'		exit( 1 );',
+		'	}',
+		'}',
+	].join( ' ' );
+
+	execFileSync(
+		process.execPath,
+		[
+			join( process.cwd(), 'tools/local-env/scripts/docker.js' ),
+			'exec',
+			'--user',
+			'wp_php',
+			'cli',
+			'wp',
+			'eval',
+			dropTablesPhp,
+		],
+		{ stdio: 'inherit' }
+	);
+}
+
+test.describe( 'WordPress installation process', () => {
+	const wpConfig = join( process.cwd(), 'wp-config.php' );
 
 	test.beforeEach( async () => {
 		wpConfigOriginal = readFileSync( wpConfig, 'utf-8' );
+
+		// Clear any leftover tables from a previous run before flipping the
+		// prefix, otherwise WordPress treats the site as already installed.
+		dropTestInstallTables();
+
 		// Changing the table prefix tricks WP into new install mode.
 		writeFileSync(
 			wpConfig,
-			wpConfigOriginal.replace( `$table_prefix = 'wp_';`, `$table_prefix = 'wp_e2e_';` )
+			wpConfigOriginal.replace(
+				`$table_prefix = 'wp_';`,
+				`$table_prefix = '${ TEST_TABLE_PREFIX }';`
+			)
 		);
 	} );
 
 	test.afterEach( async () => {
 		writeFileSync( wpConfig, wpConfigOriginal );
+
+		// The test completes a full install under TEST_TABLE_PREFIX. Drop those
+		// tables so the next run reaches the installation screen again.
+		dropTestInstallTables();
 	} );
 
-	test( 'should install WordPress with pre-existing database credentials', async ( { page } ) => {
-		await page.goto( '/' );
-
-		await expect(
-			page,
-			'should redirect to the installation page'
-		).toHaveURL( /wp-admin\/install\.php$/ );
+	test( 'should install WordPress with pre-existing database credentials', async ( {
+		page,
+	} ) => {
+		// The config file was just rewritten on the host; retry the navigation
+		// (not just the URL check) since the container's view of the file can
+		// lag behind the write by a request or two.
+		await expect( async () => {
+			await page.goto( '/' );
+			expect( page.url() ).toMatch( /wp-admin\/install\.php$/ );
+		}, 'should redirect to the installation page' ).toPass( {
+			timeout: 10_000,
+		} );
 
 		await expect(
 			page.getByText( /WordPress database error/ ),
@@ -49,7 +132,9 @@ test.describe( 'WordPress installation process', () => {
 
 		// Second page: enter site name, username & password.
 
-		await expect( page.getByRole( 'heading', { name: 'Welcome' } ) ).toBeVisible();
+		await expect(
+			page.getByRole( 'heading', { name: 'Welcome' } )
+		).toBeVisible();
 
 		// This information matches tools/local-env/scripts/install.js.
 
@@ -57,21 +142,22 @@ test.describe( 'WordPress installation process', () => {
 		await page.getByLabel( 'Username' ).fill( 'admin' );
 		await page.getByLabel( 'Password', { exact: true } ).fill( '' );
 		await page.getByLabel( 'Password', { exact: true } ).fill( 'password' );
-		await page.getByLabel( /Confirm use of weak password/ ).check()
+		await page.getByLabel( /Confirm use of weak password/ ).check();
 		await page.getByLabel( 'Your Email' ).fill( 'test@example.com' );
 
 		await page.getByRole( 'button', { name: 'Install WordPress' } ).click();
 
 		// Installation finished, can now log in.
 
-		await expect( page.getByRole( 'heading', { name: 'Success!' } ) ).toBeVisible();
+		await expect(
+			page.getByRole( 'heading', { name: 'Success!' } )
+		).toBeVisible();
 
 		await page.getByRole( 'link', { name: 'Log In' } ).click();
 
-		await expect(
-			page,
-			'should redirect to the login page'
-		).toHaveURL( /wp-login\.php$/ );
+		await expect( page, 'should redirect to the login page' ).toHaveURL(
+			/wp-login\.php$/
+		);
 
 		await page.getByLabel( 'Username or Email Address' ).fill( 'admin' );
 		await page.getByLabel( 'Password', { exact: true } ).fill( 'password' );
@@ -79,7 +165,10 @@ test.describe( 'WordPress installation process', () => {
 		await page.getByRole( 'button', { name: 'Log In' } ).click();
 
 		await expect(
-			page.getByRole( 'heading', { name: 'Welcome to WordPress', level: 2 })
+			page.getByRole( 'heading', {
+				name: 'Welcome to WordPress',
+				level: 2,
+			} )
 		).toBeVisible();
 	} );
 } );


### PR DESCRIPTION
## Description

`tests/e2e/specs/install.test.js` rewrites `$table_prefix` to `wp_e2e_` so WordPress enters the install wizard, but it never dropped the tables that install creates. After the first green run, leftover `wp_e2e_*` tables make every later run treat the site as already installed, so the test never reaches `/wp-admin/install.php`.

This change:

- Extracts table cleanup into a `dropTestInstallTables()` helper that drops the standard single-site tables under `TEST_TABLE_PREFIX` via `wp eval` / `$wpdb` (avoids shelling out to the `mysql` client).
- Runs that helper **before** the prefix swap in `beforeEach` and again in `afterEach` teardown, so stale tables cannot short-circuit the wizard on the first attempt.
- Exits non-zero when any `$wpdb->query()` returns `false`, so failed cleanup cannot leave the suite green.
- Retries `page.goto('/')` with `expect(...).toPass()` so navigation itself retries after the host-side `wp-config.php` rewrite (Docker bind-mount lag).
- Also fixes the missing semicolon after `.check()` in the install form fill.

This builds on the approach discussed in https://github.com/WordPress/wordpress-develop/pull/13302 and incorporates the review feedback there (helper extraction, cleanup before the prefix change, and failing on false query results).

## Testing Instructions

1. Ensure the local env is running (`npm run env:start`).
2. Optionally leave stale tables behind once:
   ```
   npm run test:e2e -- tests/e2e/specs/install.test.js
   ```
3. Run the same file again (and a third time). All runs should pass and land on `install.php` without manual `DROP TABLE` cleanup.
4. To confirm cleanup failure handling, temporarily break a table name in `TEST_INSTALL_TABLES` and confirm the helper exits non-zero.

Trac ticket: https://core.trac.wordpress.org/ticket/65982

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**