### PR TITLE
Add input to the test Gutenberg build workflow

### DIFF
--- a/.github/workflows/reusable-test-gutenberg-build-process.yml
+++ b/.github/workflows/reusable-test-gutenberg-build-process.yml
@@ -20,7 +20,7 @@ on:
         description: 'The branch in the Gutenberg repository that should be tested against.'
         required: false
         type: 'string'
-        default: ''
+        default: 'trunk'
 
 env:
   GUTENBERG_DIRECTORY: ${{ inputs.directory == 'build' && 'build' || 'src' }}/wp-content/plugins/gutenberg
@@ -63,7 +63,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: 'WordPress/gutenberg'
-          ref: ${{ inputs.gutenberg-branch && inputs.gutenberg-branch || 'trunk' }}
+          ref: ${{ inputs.gutenberg-branch }}
           path: ${{ env.GUTENBERG_DIRECTORY }}
           show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
           persist-credentials: false

--- a/.github/workflows/reusable-test-gutenberg-build-process.yml
+++ b/.github/workflows/reusable-test-gutenberg-build-process.yml
@@ -16,6 +16,11 @@ on:
         required: false
         type: 'string'
         default: 'src'
+      gutenberg-branch:
+        description: 'The branch in the Gutenberg repository that should be tested against.'
+        required: false
+        type: 'string'
+        default: ''
 
 env:
   GUTENBERG_DIRECTORY: ${{ inputs.directory == 'build' && 'build' || 'src' }}/wp-content/plugins/gutenberg
@@ -58,6 +63,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: 'WordPress/gutenberg'
+          ref: ${{ inputs.gutenberg-branch && inputs.gutenberg-branch || 'trunk' }}
           path: ${{ env.GUTENBERG_DIRECTORY }}
           show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
           persist-credentials: false


### PR DESCRIPTION
This adds a new input for the reusable workflow responsible for testing the Gutenberg build script to allow branches to use  a specific branch in the `gutenberg` repository.

This allows for a similar pattern to that used in the end to end testing workflow where a specific version of the Gutenberg plugin is pinned once support for the branch of WordPress running the workflow is dropped.

The motive for this change came about from [this failed workflow run](https://github.com/WordPress/wordpress-develop/actions/runs/33666786230/job/100373024791), which started failing after https://github.com/wordpress/gutenberg was updated to use Node.js version 24.x instead of 20.x, which is what the 6.8 branch uses.

Trac ticket: Core-66040.

## Use of AI Tools
 
 None