### PR TITLE
Posts, Post Types: Sort page templates by their translated name

### DIFF
--- a/src/wp-admin/includes/template.php
+++ b/src/wp-admin/includes/template.php
@@ -904,14 +904,14 @@ function touch_time( $edit = 1, $for_post = 1, $tab_index = 0, $multi = 0 ) {
  *
  * @since 1.5.0
  * @since 4.7.0 Added the `$post_type` parameter.
+ * @since 7.2.0 Templates are no longer re-sorted here; the order from
+ *              WP_Theme::get_post_templates() (by translated name) is preserved.
  *
  * @param string $default_template Optional. The template file name. Default empty.
  * @param string $post_type        Optional. Post type to get templates for. Default 'page'.
  */
 function page_template_dropdown( $default_template = '', $post_type = 'page' ) {
 	$templates = get_page_templates( null, $post_type );
-
-	ksort( $templates );
 
 	foreach ( array_keys( $templates ) as $template ) {
 		$selected = selected( $default_template, $templates[ $template ], false );

--- a/src/wp-includes/class-wp-theme.php
+++ b/src/wp-includes/class-wp-theme.php
@@ -1320,6 +1320,7 @@ final class WP_Theme implements ArrayAccess {
 	 *
 	 * @since 4.7.0
 	 * @since 5.8.0 Include block templates.
+	 * @since 7.2.0 Templates are sorted by their translated name.
 	 *
 	 * @return array[] Array of page template arrays, keyed by post type and filename,
 	 *                 with the value of the translated header name.
@@ -1392,7 +1393,14 @@ final class WP_Theme implements ArrayAccess {
 					$post_template = $this->translate_header( 'Template Name', $post_template );
 				}
 			}
+			unset( $post_type, $post_template );
 		}
+
+		// Sort each post type's templates by their translated name, keeping the file names as keys.
+		foreach ( $post_templates as &$post_type ) {
+			uasort( $post_type, 'strnatcasecmp' );
+		}
+		unset( $post_type );
 
 		return $post_templates;
 	}

--- a/tests/phpunit/data/themedir1/page-templates-sort/a-template.php
+++ b/tests/phpunit/data/themedir1/page-templates-sort/a-template.php
@@ -1,0 +1,5 @@
+<?php
+/*
+ * Template Name: Zebra Template
+ */
+?>

--- a/tests/phpunit/data/themedir1/page-templates-sort/b-template.php
+++ b/tests/phpunit/data/themedir1/page-templates-sort/b-template.php
@@ -1,0 +1,5 @@
+<?php
+/*
+ * Template Name: mango template
+ */
+?>

--- a/tests/phpunit/data/themedir1/page-templates-sort/c-template.php
+++ b/tests/phpunit/data/themedir1/page-templates-sort/c-template.php
@@ -1,0 +1,5 @@
+<?php
+/*
+ * Template Name: Apple Template
+ */
+?>

--- a/tests/phpunit/data/themedir1/page-templates-sort/index.php
+++ b/tests/phpunit/data/themedir1/page-templates-sort/index.php
@@ -1,0 +1,3 @@
+<?php
+// Intentionally left blank.
+?>

--- a/tests/phpunit/data/themedir1/page-templates-sort/section-10.php
+++ b/tests/phpunit/data/themedir1/page-templates-sort/section-10.php
@@ -1,0 +1,5 @@
+<?php
+/*
+ * Template Name: Section 10
+ */
+?>

--- a/tests/phpunit/data/themedir1/page-templates-sort/section-2.php
+++ b/tests/phpunit/data/themedir1/page-templates-sort/section-2.php
@@ -1,0 +1,5 @@
+<?php
+/*
+ * Template Name: Section 2
+ */
+?>

--- a/tests/phpunit/data/themedir1/page-templates-sort/style.css
+++ b/tests/phpunit/data/themedir1/page-templates-sort/style.css
@@ -1,0 +1,11 @@
+/*
+Theme Name: Page Template Sorting Theme
+Theme URI: http://example.org/
+Description: An example theme for testing that page templates are sorted by name.
+Version: 0.1
+Author: Mr. WordPress
+Author URI: http://wordpress.org/
+
+This is just a stub to test that get_post_templates() sorts by the template name.
+
+*/

--- a/tests/phpunit/tests/admin/includesTemplate.php
+++ b/tests/phpunit/tests/admin/includesTemplate.php
@@ -547,4 +547,32 @@ class Tests_Admin_IncludesTemplate extends WP_UnitTestCase {
 			'raw button-compact unchanged' => array( 'button-compact', 'button button-compact' ),
 		);
 	}
+
+	/**
+	 * The template drop-down should list options in the order provided by
+	 * WP_Theme::get_post_templates() (by translated name), not re-sort them.
+	 *
+	 * @ticket 49194
+	 *
+	 * @covers ::page_template_dropdown
+	 */
+	public function test_page_template_dropdown_preserves_name_order() {
+		$current_theme = wp_get_theme();
+		switch_theme( 'page-templates-sort' );
+
+		ob_start();
+		page_template_dropdown( '', 'page' );
+		$output = ob_get_clean();
+
+		switch_theme( $current_theme->get_stylesheet() );
+
+		// Options follow the translated name order from WP_Theme::get_post_templates().
+		$expected  = "\n\t<option value='c-template.php' >Apple Template</option>";
+		$expected .= "\n\t<option value='b-template.php' >mango template</option>";
+		$expected .= "\n\t<option value='section-2.php' >Section 2</option>";
+		$expected .= "\n\t<option value='section-10.php' >Section 10</option>";
+		$expected .= "\n\t<option value='a-template.php' >Zebra Template</option>";
+
+		$this->assertSameIgnoreEOL( $expected, $output );
+	}
 }

--- a/tests/phpunit/tests/theme/themeDir.php
+++ b/tests/phpunit/tests/theme/themeDir.php
@@ -169,6 +169,7 @@ class Tests_Theme_ThemeDir extends WP_UnitTestCase {
 			'My Subdir Theme',                    // Theme in a subdirectory should work.
 			'Page Template Child Theme',          // Theme which inherits page templates.
 			'Page Template Theme',                // Theme with page templates for other test code.
+			'Page Template Sorting Theme',        // Theme for testing page templates are sorted by name.
 			'Theme with Spaces in the Directory',
 			'Internationalized Theme',
 			'Custom Internationalized Theme',

--- a/tests/phpunit/tests/theme/wpThemeGetPostTemplates.php
+++ b/tests/phpunit/tests/theme/wpThemeGetPostTemplates.php
@@ -117,4 +117,29 @@ class Tests_Theme_wpThemeGetPostTemplates extends WP_UnitTestCase {
 		// Verify the `extra_theme_headers` filter is called.
 		$this->assertGreaterThan( 0, $filter->get_call_count(), 'The `extra_theme_headers` filter should be called at least once.' );
 	}
+
+	/**
+	 * Templates should be ordered by their human-readable name, not by the file name.
+	 *
+	 * @ticket 49194
+	 */
+	public function test_get_post_templates_are_sorted_by_name() {
+		$theme = wp_get_theme( 'page-templates-sort' );
+		$this->assertNotEmpty( $theme );
+
+		$post_templates = $theme->get_post_templates();
+		$this->assertArrayHasKey( 'page', $post_templates );
+
+		// Templates are sorted by name (case-insensitive, natural order), keeping the file names as keys.
+		$this->assertSame(
+			array(
+				'c-template.php' => 'Apple Template',
+				'b-template.php' => 'mango template',
+				'section-2.php'  => 'Section 2',
+				'section-10.php' => 'Section 10',
+				'a-template.php' => 'Zebra Template',
+			),
+			$post_templates['page']
+		);
+	}
 }


### PR DESCRIPTION
The Page Template dropdown lists templates in filename order instead of by their human-readable "Template Name". This sorts `WP_Theme::get_post_templates()` by the translated name, so the dropdown (and every other consumer) is ordered by what the user actually sees.

Uses `uasort()` with `strnatcasecmp` — case-insensitive, natural order ("Section 2" before "Section 10"), file name keys preserved. Sorting happens after translation so it respects the active locale.

Trac ticket: https://core.trac.wordpress.org/ticket/49194

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 4.8
Used for: Code Review

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
