### PR TITLE
Themes: Fix disabled button semantics and focus visibility in theme installer

### DIFF
--- a/src/wp-admin/css/themes.css
+++ b/src/wp-admin/css/themes.css
@@ -291,7 +291,9 @@ body.js .theme-browser.search-loading {
 
 .theme-browser .theme.active .theme-actions .button:not(.button-primary):focus {
 	background: #fff;
-	box-shadow: 0 0 0 var(--wp-admin-border-width-focus, 1.5px) #fff;
+	box-shadow:
+		0 0 0 var(--wp-admin-border-width-focus, 1.5px) #fff,
+		inset 0 0 0 1px var(--wp-admin-theme-color, #3858e9);
 	outline: 1px solid transparent;
 }
 

--- a/src/wp-admin/css/themes.css
+++ b/src/wp-admin/css/themes.css
@@ -291,6 +291,8 @@ body.js .theme-browser.search-loading {
 
 .theme-browser .theme.active .theme-actions .button:not(.button-primary):focus {
 	background: #fff;
+	box-shadow: 0 0 0 var(--wp-admin-border-width-focus, 1.5px) #fff;
+	outline: 1px solid transparent;
 }
 
 .theme-browser .theme .theme-author {

--- a/src/wp-admin/theme-install.php
+++ b/src/wp-admin/theme-install.php
@@ -412,7 +412,7 @@ if ( $tab ) {
 						<# if ( ! data.active ) { #>
 							<a class="button button-primary button-compact activate" href="{{ data.activate_url }}" aria-label="<?php echo esc_attr( $aria_label ); ?>"><?php _e( 'Activate' ); ?></a>
 						<# } else { #>
-							<button class="button button-primary button-compact disabled"><?php _ex( 'Activated', 'theme' ); ?></button>
+							<button class="button button-primary button-compact disabled" disabled><?php _ex( 'Activated', 'theme' ); ?></button>
 						<# } #>
 					<# } #>
 					<# if ( data.customize_url ) { #>
@@ -432,12 +432,12 @@ if ( $tab ) {
 					$aria_label = sprintf( _x( 'Cannot Activate %s', 'theme' ), '{{ data.name }}' );
 					?>
 					<# if ( data.activate_url ) { #>
-						<a class="button button-primary button-compact disabled" aria-label="<?php echo esc_attr( $aria_label ); ?>"><?php _ex( 'Cannot Activate', 'theme' ); ?></a>
+						<a class="button button-primary button-compact disabled" aria-label="<?php echo esc_attr( $aria_label ); ?>" aria-disabled="true" tabindex="-1"><?php _ex( 'Cannot Activate', 'theme' ); ?></a>
 					<# } #>
 					<# if ( data.customize_url ) { #>
-						<a class="button button-compact disabled"><?php _e( 'Live Preview' ); ?></a>
+						<a class="button button-compact disabled" aria-disabled="true" tabindex="-1"><?php _e( 'Live Preview' ); ?></a>
 					<# } else { #>
-						<button class="button button-compact disabled"><?php echo esc_html_x( 'Preview', 'verb' ); ?></button>
+						<button class="button button-compact disabled" disabled><?php echo esc_html_x( 'Preview', 'verb' ); ?></button>
 					<# } #>
 				<# } #>
 			<# } else { #>
@@ -453,8 +453,8 @@ if ( $tab ) {
 					/* translators: %s: Theme name. */
 					$aria_label = sprintf( _x( 'Cannot Install %s', 'theme' ), '{{ data.name }}' );
 					?>
-					<a class="button button-primary button-compact disabled" data-name="{{ data.name }}" aria-label="<?php echo esc_attr( $aria_label ); ?>"><?php _ex( 'Cannot Install', 'theme' ); ?></a>
-					<button class="button button-compact disabled"><?php echo esc_html_x( 'Preview', 'verb' ); ?></button>
+					<a class="button button-primary button-compact disabled" data-name="{{ data.name }}" aria-label="<?php echo esc_attr( $aria_label ); ?>" aria-disabled="true" tabindex="-1"><?php _ex( 'Cannot Install', 'theme' ); ?></a>
+					<button class="button button-compact disabled" disabled><?php echo esc_html_x( 'Preview', 'verb' ); ?></button>
 				<# } #>
 			<# } #>
 		</div>
@@ -491,16 +491,16 @@ if ( $tab ) {
 					<# if ( ! data.active ) { #>
 						<a class="button button-primary activate" href="{{ data.activate_url }}" aria-label="<?php echo esc_attr( $aria_label ); ?>"><?php _e( 'Activate' ); ?></a>
 					<# } else { #>
-						<button class="button button-primary disabled"><?php _ex( 'Activated', 'theme' ); ?></button>
+						<button class="button button-primary disabled" disabled><?php _ex( 'Activated', 'theme' ); ?></button>
 					<# } #>
 				<# } else { #>
-					<a class="button button-primary disabled" ><?php _ex( 'Cannot Activate', 'theme' ); ?></a>
+					<a class="button button-primary disabled" aria-disabled="true" tabindex="-1"><?php _ex( 'Cannot Activate', 'theme' ); ?></a>
 				<# } #>
 			<# } else { #>
 				<# if ( data.compatible_wp && data.compatible_php ) { #>
 					<a href="{{ data.install_url }}" class="button button-primary theme-install" data-name="{{ data.name }}" data-slug="{{ data.id }}"><?php _e( 'Install' ); ?></a>
 				<# } else { #>
-					<a class="button button-primary disabled" ><?php _ex( 'Cannot Install', 'theme' ); ?></a>
+					<a class="button button-primary disabled" aria-disabled="true" tabindex="-1"><?php _ex( 'Cannot Install', 'theme' ); ?></a>
 				<# } #>
 			<# } #>
 		</div>


### PR DESCRIPTION


This PR fixes two accessibility issues in the Theme Installer related to disabled buttons and focus visibility:

1. **Disabled semantics**: Replaces the visual-only `.disabled` CSS class with proper semantic attributes (`disabled` for `<button>` elements, and `aria-disabled="true" tabindex="-1"` for `<a>` elements). This removes them from the tab order.
2. **Invisible focus ring**: Updates the focus ring color to `#fff` for secondary buttons on the active theme card. Previously, the default focus ring color blended exactly with the theme name background, making it invisible when reached via keyboard.

Trac ticket: https://core.trac.wordpress.org/ticket/66038

## Use of AI Tools

AI assistance: Yes
Tool(s): Github Copilot
Model(s): Claude Sonnet 4.6
Used for: Edge-case checks, and assistance with the PR description; implementation and testing were reviewed and verified by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
