### PR TITLE
Tests: Simplify font-face test fixtures

### DIFF
--- a/tests/phpunit/tests/fonts/font-face/base.php
+++ b/tests/phpunit/tests/fonts/font-face/base.php
@@ -28,16 +28,6 @@ abstract class WP_Font_Face_UnitTestCase extends WP_UnitTestCase {
 	protected $property = array();
 
 	/**
-	 * Indicates the test class uses `switch_theme()` and requires
-	 * set_up and tear_down fixtures to set and reset hooks and memory.
-	 *
-	 * If a test class switches themes, set this property to `true`.
-	 *
-	 * @var bool
-	 */
-	protected static $requires_switch_theme_fixtures = false;
-
-	/**
 	 * Theme root directory.
 	 *
 	 * @var string
@@ -61,15 +51,11 @@ abstract class WP_Font_Face_UnitTestCase extends WP_UnitTestCase {
 	public static function set_up_before_class() {
 		parent::set_up_before_class();
 
-		if ( self::$requires_switch_theme_fixtures ) {
-			self::$theme_root = realpath( DIR_TESTDATA . '/themedir1' );
-		}
+		self::$theme_root = realpath( DIR_TESTDATA . '/themedir1' );
 	}
 
 	public static function tear_down_after_class() {
-		// Reset static flags.
-		self::$requires_switch_theme_fixtures = false;
-		self::$theme_root                     = null;
+		self::$theme_root = null;
 
 		parent::tear_down_after_class();
 	}
@@ -77,21 +63,19 @@ abstract class WP_Font_Face_UnitTestCase extends WP_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 
-		if ( self::$requires_switch_theme_fixtures ) {
-			$this->orig_theme_dir = $GLOBALS['wp_theme_directories'];
+		$this->orig_theme_dir = $GLOBALS['wp_theme_directories'];
 
-			// /themes is necessary as theme.php functions assume /themes is the root if there is only one root.
-			$GLOBALS['wp_theme_directories'] = array( WP_CONTENT_DIR . '/themes', self::$theme_root );
+		// /themes is necessary as theme.php functions assume /themes is the root if there is only one root.
+		$GLOBALS['wp_theme_directories'] = array( WP_CONTENT_DIR . '/themes', self::$theme_root );
 
-			// Set up the new root.
-			add_filter( 'theme_root', array( $this, 'filter_set_theme_root' ) );
-			add_filter( 'stylesheet_root', array( $this, 'filter_set_theme_root' ) );
-			add_filter( 'template_root', array( $this, 'filter_set_theme_root' ) );
+		// Set up the new root.
+		add_filter( 'theme_root', array( $this, 'filter_set_theme_root' ) );
+		add_filter( 'stylesheet_root', array( $this, 'filter_set_theme_root' ) );
+		add_filter( 'template_root', array( $this, 'filter_set_theme_root' ) );
 
-			// Clear caches.
-			wp_clean_themes_cache();
-			unset( $GLOBALS['wp_themes'] );
-		}
+		// Clear caches.
+		wp_clean_themes_cache();
+		unset( $GLOBALS['wp_themes'] );
 	}
 
 	public function tear_down() {
@@ -104,15 +88,13 @@ abstract class WP_Font_Face_UnitTestCase extends WP_UnitTestCase {
 		}
 
 		// Restore themes.
-		if ( self::$requires_switch_theme_fixtures ) {
-			$GLOBALS['wp_theme_directories'] = $this->orig_theme_dir;
-			remove_filter( 'theme_root', array( $this, 'filter_set_theme_root' ) );
-			remove_filter( 'stylesheet_root', array( $this, 'filter_set_theme_root' ) );
-			remove_filter( 'template_root', array( $this, 'filter_set_theme_root' ) );
-			wp_clean_themes_cache();
-			wp_clean_theme_json_cache();
-			unset( $GLOBALS['wp_themes'] );
-		}
+		$GLOBALS['wp_theme_directories'] = $this->orig_theme_dir;
+		remove_filter( 'theme_root', array( $this, 'filter_set_theme_root' ) );
+		remove_filter( 'stylesheet_root', array( $this, 'filter_set_theme_root' ) );
+		remove_filter( 'template_root', array( $this, 'filter_set_theme_root' ) );
+		wp_clean_themes_cache();
+		wp_clean_theme_json_cache();
+		unset( $GLOBALS['wp_themes'] );
 
 		parent::tear_down();
 	}

--- a/tests/phpunit/tests/fonts/font-face/wpFontFaceResolver/getFontsFromStyleVariations.php
+++ b/tests/phpunit/tests/fonts/font-face/wpFontFaceResolver/getFontsFromStyleVariations.php
@@ -15,12 +15,6 @@
 class Tests_Fonts_WPFontFaceResolver_GetFontsFromStyleVariations extends WP_Font_Face_UnitTestCase {
 	const FONTS_THEME = 'fonts-block-theme';
 
-	public static function set_up_before_class() {
-		self::$requires_switch_theme_fixtures = true;
-
-		parent::set_up_before_class();
-	}
-
 	/**
 	 * Ensure that an empty array is returned when the theme has no style variations.
 	 *

--- a/tests/phpunit/tests/fonts/font-face/wpFontFaceResolver/getFontsFromThemeJson.php
+++ b/tests/phpunit/tests/fonts/font-face/wpFontFaceResolver/getFontsFromThemeJson.php
@@ -15,12 +15,6 @@
 class Tests_Fonts_WPFontFaceResolver_GetFontsFromThemeJson extends WP_Font_Face_UnitTestCase {
 	const FONTS_THEME = 'fonts-block-theme';
 
-	public static function set_up_before_class() {
-		self::$requires_switch_theme_fixtures = true;
-
-		parent::set_up_before_class();
-	}
-
 	public function test_should_return_empty_array_when_no_fonts_defined_in_theme() {
 		switch_theme( 'block-theme' );
 

--- a/tests/phpunit/tests/fonts/font-face/wpPrintFontFaces.php
+++ b/tests/phpunit/tests/fonts/font-face/wpPrintFontFaces.php
@@ -15,12 +15,6 @@
 class Tests_Fonts_WpPrintFontFaces extends WP_Font_Face_UnitTestCase {
 	const FONTS_THEME = 'fonts-block-theme';
 
-	public static function set_up_before_class() {
-		self::$requires_switch_theme_fixtures = true;
-
-		parent::set_up_before_class();
-	}
-
 	public function test_should_not_print_when_no_fonts() {
 		switch_theme( 'block-theme' );
 

--- a/tests/phpunit/tests/fonts/font-face/wpPrintFontFacesFromStyleVariations.php
+++ b/tests/phpunit/tests/fonts/font-face/wpPrintFontFacesFromStyleVariations.php
@@ -15,12 +15,6 @@
 class Tests_Fonts_WpPrintFontFacesFromStyleVariations extends WP_Font_Face_UnitTestCase {
 	const FONTS_THEME = 'fonts-block-theme';
 
-	public static function set_up_before_class() {
-		self::$requires_switch_theme_fixtures = true;
-
-		parent::set_up_before_class();
-	}
-
 	/**
 	 * Ensure that no fonts are printed when the theme has no fonts.
 	 *


### PR DESCRIPTION
## Summary

- Prepares font-face test theme fixtures in their shared base class.
- Removes redundant `set_up_before_class()` overrides from the four font-face test classes.

## Testing

- `./vendor/bin/phpunit --group fontface` (29 tests, 42 assertions)
- PHPCS for the five changed files

Trac: https://core.trac.wordpress.org/ticket/65893

Follow-up to the [review discussion in #13091](https://github.com/WordPress/wordpress-develop/pull/13091#discussion_r3842297553).

## AI use

Codex GPT 5.6 Sol