### PR TITLE
Build/Test Tools: Give PHPStan baseline generation its own cache directory

### DIFF
--- a/tests/phpstan/README.md
+++ b/tests/phpstan/README.md
@@ -213,4 +213,6 @@ The results cache alone is not the problem. PHPStan invalidates that itself when
 
 The same cache is worth clearing after analysing a subset of the tree. A file named on the command line is analysed, but a file merely *read* on its behalf is parsed without these extensions, and the reflection stored for it carries no derived shape. A later full run reads that back and reports against a type that is no longer what the docblock says, which is the same silence as above arriving from the other direction.
 
+Baseline generation is exempt from that last hazard. [`generate-baselines.php`](generate-baselines.php) points its analysis at `.cache/baselines` instead, a directory only it writes to and only ever from a full run, so a baseline can never record a message derived from reflection some earlier narrowed run left behind. Clearing the cache after editing anything in this directory still applies to it, and the `rm -rf .cache` above covers both.
+
 Sometimes, due to the lack of type information in legacy code, PHPStan may still struggle to analyze certain parts of the codebase. In such cases, you can use the `--debug` flag to disable caching and see which files are causing issues.

--- a/tests/phpstan/generate-baselines.php
+++ b/tests/phpstan/generate-baselines.php
@@ -182,7 +182,12 @@ $analysis_tmp_dir = $repo_root . '/.cache/baselines';
 file_put_contents(
 	$temp_config,
 	sprintf(
-		"includes:\n\t- %s\n\nparameters:\n\ttmpDir: %s\n",
+		<<<'NEON'
+		includes:
+			- %s
+		parameters:
+			tmpDir: %s
+		NEON,
 		basename( $temp_stripped ),
 		quote_neon_value( $analysis_tmp_dir )
 	)

--- a/tests/phpstan/generate-baselines.php
+++ b/tests/phpstan/generate-baselines.php
@@ -119,15 +119,12 @@ if ( ! is_file( $config_path ) ) {
 }
 
 /*
- * The temporary configuration has to sit beside the original, because a neon
- * file's `includes` entries resolve relative to its own directory.
- */
-/*
- * Both temporary files sit beside the configuration, and so inside the
+ * All three temporary files sit beside the configuration, and so inside the
  * repository, for two separate reasons.
  *
  * A neon file's `includes` resolve relative to its own directory, so the copy of
- * the configuration has to live where the original did.
+ * the configuration, and the wrapper including it, have to live where the
+ * original did.
  *
  * PHPStan writes a PHP baseline's paths as __DIR__ followed by a relative chain,
  * which it can only produce when the baseline shares an ancestry with the files
@@ -135,12 +132,14 @@ if ( ! is_file( $config_path ) ) {
  * it emits `__DIR__ . '//absolute/path'` instead, and every path in it then
  * resolves to somewhere under that directory rather than to the source file.
  */
-$temp_config   = dirname( $config_path ) . '/.phpstan-baselines-' . getmypid() . '.neon';
-$temp_baseline = dirname( $config_path ) . '/.phpstan-baselines-' . getmypid() . '.php';
+$temp_prefix   = dirname( $config_path ) . '/.phpstan-baselines-' . getmypid();
+$temp_config   = $temp_prefix . '.neon';
+$temp_stripped = $temp_prefix . '-stripped.neon';
+$temp_baseline = $temp_prefix . '.php';
 
 register_shutdown_function(
-	static function () use ( $temp_config, $temp_baseline ): void {
-		foreach ( array( $temp_config, $temp_baseline ) as $file ) {
+	static function () use ( $temp_config, $temp_stripped, $temp_baseline ): void {
+		foreach ( array( $temp_config, $temp_stripped, $temp_baseline ) as $file ) {
 			if ( is_file( $file ) ) {
 				unlink( $file );
 			}
@@ -148,7 +147,46 @@ register_shutdown_function(
 	}
 );
 
-file_put_contents( $temp_config, strip_baseline_includes( $config_path, $output_dir ) );
+file_put_contents( $temp_stripped, strip_baseline_includes( $config_path, $output_dir ) );
+
+/*
+ * The analysis gets a scratch directory of its own, rather than the `tmpDir` that
+ * `tests/phpstan/base.neon` configures for everything else.
+ *
+ * That directory holds more than the analysis results. PHPStan also stores what
+ * it read out of each source file there, the docblocks and signatures it found,
+ * keyed by that file's contents and nothing else. The extensions in this
+ * directory change what reading a file yields without changing the file:
+ * HashNotationVisitor rewrites a docblock in the syntax tree, and the bytes on
+ * disk stay as they were.
+ *
+ * That rewriting only reaches the files PHPStan routes to its rich parser, which
+ * is the set of files being analyzed. A run narrowed to a few paths — an editor
+ * analyzing the file being typed in, or one scoped to a diff — therefore caches
+ * the unrewritten reading of every file outside those paths, and a later full run
+ * sharing the directory restores it. The baseline generated from that run records
+ * messages derived from types the extensions would have replaced.
+ *
+ * A directory only ever written by this script cannot be poisoned that way,
+ * because this script only ever analyzes the full set of configured paths.
+ */
+$analysis_tmp_dir = $repo_root . '/.cache/baselines';
+
+/*
+ * `tmpDir` is set in a wrapper including the stripped copy, rather than in the
+ * copy itself, because neon rejects a duplicated key and the copy already carries
+ * the `parameters` section it was made from. A file's own parameters win over
+ * those of the files it includes, so the wrapper's `tmpDir` is the one that takes
+ * effect.
+ */
+file_put_contents(
+	$temp_config,
+	sprintf(
+		"includes:\n\t- %s\n\nparameters:\n\ttmpDir: %s\n",
+		basename( $temp_stripped ),
+		quote_neon_value( $analysis_tmp_dir )
+	)
+);
 
 /*
  * PHPStan reports on stdout, which --combined reserves for the baseline itself,

--- a/tests/phpstan/generate-baselines.php
+++ b/tests/phpstan/generate-baselines.php
@@ -48,6 +48,13 @@ const BASELINES_START_MARKER = '# phpstan:baselines start';
  */
 const BASELINES_END_MARKER = '# phpstan:baselines end';
 
+/**
+ * The configuration analyzed when `--config` does not name one.
+ *
+ * Relative to the repository root.
+ */
+const DEFAULT_CONFIG = 'phpstan.neon.dist';
+
 if ( 'cli' !== PHP_SAPI ) {
 	fwrite( STDERR, "This script must be run from the command line.\n" );
 	exit( 1 );
@@ -64,7 +71,7 @@ foreach ( (array) ( $_SERVER['argv'] ?? array() ) as $arg ) {
 }
 array_shift( $args );
 
-$config_option    = 'phpstan.neon.dist';
+$config_option    = DEFAULT_CONFIG;
 $output_option    = 'tests/phpstan/baselines';
 $memory_limit     = '2G';
 $only_identifiers = array();
@@ -171,6 +178,22 @@ file_put_contents( $temp_stripped, strip_baseline_includes( $config_path, $outpu
  * because this script only ever analyzes the full set of configured paths.
  */
 $analysis_tmp_dir = $repo_root . '/.cache/baselines';
+
+/*
+ * A configuration other than the default gets a directory to itself.
+ *
+ * "The full set of configured paths" is only as wide as the configuration saying
+ * what they are, and `--config` can name one covering less than the default does.
+ * A run of that configuration is a full run of it, but measured against the
+ * default it is a narrowed one, and it would leave behind the same unrewritten
+ * readings of everything it does not cover. Keying the directory on the
+ * configuration keeps each one's reflection to itself.
+ */
+$config_relative = trim( normalize_path( $config_option ), '/' );
+
+if ( DEFAULT_CONFIG !== $config_relative ) {
+	$analysis_tmp_dir .= '-' . (string) preg_replace( '/[^A-Za-z0-9._]+/', '-', $config_relative );
+}
 
 /*
  * `tmpDir` is set in a wrapper including the stripped copy, rather than in the


### PR DESCRIPTION
✅ Committed in r63460 (c6d26fef18c6b8322b2c388f52dd7f7a0862ac04).

----
PHPStan's cache holds more than analysis results. It also stores what PHPStan read out of each source file — the docblocks and signatures it found — keyed by that file's contents and nothing else. The extensions in `tests/phpstan` change what reading a file yields without changing the file: `HashNotationVisitor` rewrites a docblock in the syntax tree, and the bytes on disk stay as they were.

That rewriting only reaches the files PHPStan routes to its rich parser, which is the set of files being analyzed. `PathRoutingParser` sends everything else to the simple parser, where the visitors never run. So a run narrowed to a few paths — an editor analyzing the file being typed in, or one scoped to a diff — caches the unrewritten reading of every file outside those paths.

Because `generate-baselines.php` shared the `tmpDir` that those runs write to, a later regeneration restored that reading and recorded messages derived from types the extensions would have replaced.

## How it showed up

While an unrelated docblock was being edited, regenerating the baselines produced a one-line change to `assign.propertyType.neon` that had nothing to do with the edit:

```diff
-message: '#^Static property WP_Widget_Media\:\:\$l10n_defaults \(array\<string\>\) does not accept array\<string, array\<int\|string, string\|null\>\|string\>\.$#'
+message: '#^Static property WP_Widget_Media\:\:\$l10n_defaults \(array\<string\>\) does not accept array\<string, array\|string\>\.$#'
```

`WP_Widget_Media::get_l10n_defaults()` assigns the return of `_n_noop()`, whose `@return` is written in hash notation. With `HashNotationVisitor` applied, that resolves to the array shape the notation describes, which generalizes to `array<int|string, string|null>`. Without it, `_n_noop()` returns a bare `array` — the second line above.

Reverting the docblock edit did not clear it, because the entry was never caused by the edit. It came from a cached reading of `l10n.php` left behind by an earlier narrowed run.

## The fix

Point the analysis at `.cache/baselines`, a directory only this script writes to and only ever from a full run, so no narrowed run can leave anything in it.

`tmpDir` is set in a wrapper that includes the stripped copy of the configuration rather than in the copy itself, because NEON rejects a duplicated key (`Duplicated key 'parameters'`) and the copy already carries the `parameters` section it was made from. A file's own parameters win over those of the files it includes, so the wrapper's `tmpDir` is what takes effect.

The directory is then keyed on the configuration analyzed, because "the full set of configured paths" is only as wide as the configuration saying what those paths are. `--config` can name one covering less than the default does, and a run of that is a full run of it while still being a narrowed one measured against the default. So a non-default configuration gets `.cache/baselines-<its path>` and the default keeps the unsuffixed `.cache/baselines`.

## Why pinning `phpstan.neon.dist` is not already enough

The script analyzes `phpstan.neon.dist` rather than whatever `phpstan.neon` sits beside it, so a reasonable question is why the cache needs pinning too. The answer is that configuration is not the axis along which the cache leaks. Measured, each against a cold level-5 full run of the same tree, all in one shared `tmpDir`:

| First run in the directory | Then a full level-5 run | Result |
| --- | --- | --- |
| local `phpstan.neon` — level 10, `bleedingEdge`, full tree | ✔ | identical, 1544 errors |
| a configuration whose own `paths` cover one directory | ✔ | identical |
| **the same configuration, narrowed by a path argument** | ✔ | **one entry differs** |
| as above, then `resultCache.php` deleted | ✔ | one entry differs |

Reflection entries are keyed per configuration, so a local override genuinely cannot reach the ones a baseline run reads. What it shares with is every **other run of the pinned configuration** — which, on a checkout carrying no local override, is what an editor, a diff-scoped run and `composer phpstan -- <path>` all resolve to.

The last row also locates the carrier: that narrowed run wrote no `resultCache.php` at all, only `cache/`, so what survives into the next run is the per-file reflection, not the recorded errors.

## Verification

- Poisoning a shared `.cache` with a narrowed run reproduces the degraded message, and a regeneration immediately afterwards now leaves the baselines unchanged. Before this change, that same sequence produced the diff above.
- A full `composer phpstan:baselines` regenerating every identifier leaves `tests/phpstan/baselines` and `phpstan.neon.dist` byte-identical.
- A generator run no longer touches `.cache/resultCache.php` or `.cache/cache`.
- A run passing `--config` for another configuration writes to a directory of its own and leaves `.cache/baselines` untouched, down to its mtime. The spellings that resolve to the default — a leading `./` or `/` — resolve to the unsuffixed directory.

`tests/phpstan/README.md` already documented this hazard in both directions; it now notes that baseline generation is exempt from the narrowed-run half of it.

Also here: the wrapper's NEON document is written as a nowdoc rather than a single-line format string carrying four escapes, so the structure it produces reads as the shape it is; and `generate-baselines.php` gains the trailing newline it was missing, which every sibling in the directory has.

## Not addressed here

This makes baseline generation immune to the cache being poisoned. It does not make narrowed runs themselves correct — a run scoped to a subset still reports against a bare `array` wherever a hash-notation type crosses a file boundary, whether or not it shares a cache with anything. That is a separate problem and worth its own ticket.

Trac ticket: Core-65817

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Diagnosing the cache interaction, and drafting the change and its comments. The diagnosis was confirmed by reproducing the degraded baseline entry from a poisoned cache and confirming a wiped cache regenerates it identically to trunk; the implementation and verification were reviewed by me.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EdFn9fuiUhJMXzacuhmdGJ

