### PR TITLE
Build/Test Tools: Regenerate the CSS for the 5.7 branch

### DIFF
--- a/src/wp-admin/css/about.css
+++ b/src/wp-admin/css/about.css
@@ -573,6 +573,8 @@
 }
 
 .about__container .about__image-comparison img {
+	-webkit-user-select: none;
+	-ms-user-select: none;
 	user-select: none;
 	width: auto;
 	max-width: none;


### PR DESCRIPTION
The `Test Build Processes` workflow fails on the 5.7 branch. The `precommit:css` step added in [63315] runs Autoprefixer over `src` and rewrites tracked CSS, so the clean-tree check that follows it fails.

The task has not been run since the browser usage database pinned in `package-lock.json` was last updated. This commits its output and nothing else; every changed line is an Autoprefixer vendor prefix.

Following the discussion in PR 13318, this fixes the flagged CSS rather than skipping the check. The `src` jobs fail on Linux, Windows and macOS today, and all three produce an identical diff.

Trac ticket: https://core.trac.wordpress.org/ticket/65993

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Reproducing the CI failure locally and running `npm run grunt precommit:css` to regenerate the CSS. All changes were reviewed and validated by me.
