### PR TITLE
Build/Test Tools: Regenerate the CSS for the 5.5 branch

### DIFF
--- a/src/wp-admin/css/admin-menu.css
+++ b/src/wp-admin/css/admin-menu.css
@@ -155,7 +155,6 @@
 /* side admin menu */
 #adminmenu * {
 	-webkit-user-select: none;
-	-moz-user-select: none;
 	-ms-user-select: none;
 	user-select: none;
 }

--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -2104,7 +2104,6 @@ html.wp-toolbar {
 .postbox .hndle,
 .stuffbox .hndle {
 	-webkit-user-select: none;
-	-moz-user-select: none;
 	-ms-user-select: none;
 	user-select: none;
 }
@@ -3497,7 +3496,6 @@ img {
 	border-left: 1px solid #ddd;
 	border-right: 1px solid #ddd;
 	-webkit-user-select: none;
-	-moz-user-select: none;
 	-ms-user-select: none;
 	user-select: none;
 }

--- a/src/wp-admin/css/customize-controls.css
+++ b/src/wp-admin/css/customize-controls.css
@@ -1265,7 +1265,6 @@ p.customize-section-description {
 	padding: 4px 5px;
 	border: 2px solid #eee;
 	-webkit-user-select: none;
-	-moz-user-select: none;
 	-ms-user-select: none;
 	user-select: none;
 }
@@ -2391,7 +2390,6 @@ body.cheatin p {
 	margin-left: 10px;
 	transition: all 0.2s;
 	-webkit-user-select: none;
-	-moz-user-select: none;
 	-ms-user-select: none;
 	user-select: none;
 	outline: none;

--- a/src/wp-admin/css/customize-nav-menus.css
+++ b/src/wp-admin/css/customize-nav-menus.css
@@ -511,7 +511,6 @@
 	transition: background-color 0.15s;
 	/* Reset the value inherited from the base .accordion-section-title style. Ticket #37589. */
 	-webkit-user-select: auto;
-	-moz-user-select: auto;
 	-ms-user-select: auto;
 	user-select: auto;
 }

--- a/src/wp-admin/css/customize-widgets.css
+++ b/src/wp-admin/css/customize-widgets.css
@@ -53,7 +53,6 @@
 .customize-control-widget_form.widget-form-disabled .widget-content {
 	opacity: 0.7;
 	pointer-events: none;
-	-moz-user-select: none;
 	-webkit-user-select: none;
 	-ms-user-select: none;
 	user-select: none;
@@ -167,7 +166,6 @@
 	border-top: 1px solid #eee;
 	cursor: pointer;
 	-webkit-user-select: none;
-	-moz-user-select: none;
 	-ms-user-select: none;
 	user-select: none;
 }

--- a/src/wp-admin/css/site-health.css
+++ b/src/wp-admin/css/site-health.css
@@ -299,7 +299,6 @@
 	align-items: center;
 	justify-content: space-between;
 	-webkit-user-select: auto;
-	-moz-user-select: auto;
 	-ms-user-select: auto;
 	user-select: auto;
 }

--- a/src/wp-admin/css/themes.css
+++ b/src/wp-admin/css/themes.css
@@ -646,7 +646,6 @@ body.folded .theme-browser ~ .theme-overlay .theme-wrap {
 	border-radius: 2px;
 	margin: 0 0 -10px;
 	-webkit-user-select: none;
-	-moz-user-select: none;
 	-ms-user-select: none;
 	user-select: none;
 }

--- a/src/wp-admin/css/widgets.css
+++ b/src/wp-admin/css/widgets.css
@@ -37,7 +37,6 @@
 	white-space: nowrap;
 	text-overflow: ellipsis;
 	-webkit-user-select: none;
-	-moz-user-select: none;
 	-ms-user-select: none;
 	user-select: none;
 }
@@ -567,7 +566,6 @@ div#widgets-right .closed .widgets-sortables {
 .widgets-holder-wrap .sidebar-name,
 .widgets-holder-wrap .sidebar-description {
 	-webkit-user-select: none;
-	-moz-user-select: none;
 	-ms-user-select: none;
 	user-select: none;
 }

--- a/src/wp-includes/css/admin-bar.css
+++ b/src/wp-includes/css/admin-bar.css
@@ -969,6 +969,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 		to 100% viewport width at responsive sizes. */
 	#wpadminbar .ab-top-menu > .menupop > .ab-sub-wrapper {
 		min-width: -webkit-fit-content;
+		min-width: -moz-fit-content;
 		min-width: fit-content;
 	}
 

--- a/src/wp-includes/css/editor.css
+++ b/src/wp-includes/css/editor.css
@@ -257,7 +257,6 @@ div.mce-inline-toolbar-grp {
 	box-sizing: border-box;
 	margin-bottom: 8px;
 	position: absolute;
-	-moz-user-select: none;
 	-webkit-user-select: none;
 	-ms-user-select: none;
 	user-select: none;

--- a/src/wp-includes/css/media-views.css
+++ b/src/wp-includes/css/media-views.css
@@ -607,7 +607,6 @@
 	border-right-style: solid;
 	border-right-color: #ccc;
 	-webkit-user-select: none;
-	-moz-user-select: none;
 	-ms-user-select: none;
 	user-select: none;
 }
@@ -947,7 +946,6 @@
 	list-style: none;
 	text-align: center;
 	-webkit-user-select: none;
-	-moz-user-select: none;
 	-ms-user-select: none;
 	user-select: none;
 	width: 25%;


### PR DESCRIPTION
The `Test Build Processes` workflow fails on the 5.5 branch. The `precommit:css` step added in [63315] runs Autoprefixer over `src` and rewrites tracked CSS, so the clean-tree check that follows it fails.

The task has not been run since the browser usage database pinned in `package-lock.json` was last updated. This commits its output and nothing else; every changed line is an Autoprefixer vendor prefix.

Following the discussion in PR 13318, this fixes the flagged CSS rather than skipping the check. The `src` jobs fail on Linux, Windows and macOS today, and all three produce an identical diff.

Trac ticket: https://core.trac.wordpress.org/ticket/65993

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Reproducing the CI failure locally and running `npm run grunt precommit:css` to regenerate the CSS. All changes were reviewed and validated by me.
