### PR TITLE
Administration: Rename the Site Editor menu item to "Edit Site"

### DIFF
--- a/src/wp-admin/menu.php
+++ b/src/wp-admin/menu.php
@@ -225,7 +225,7 @@ if ( ! is_multisite() && current_user_can( 'update_themes' ) ) {
 	$submenu['themes.php'][5] = array( sprintf( __( 'Themes %s' ), $count ), $appearance_capability, 'themes.php' );
 
 if ( wp_is_block_theme() ) {
-	$submenu['themes.php'][6] = array( _x( 'Editor', 'site editor menu item' ), 'edit_theme_options', 'site-editor.php' );
+	$submenu['themes.php'][6] = array( _x( 'Edit Site', 'site editor menu item' ), 'edit_theme_options', 'site-editor.php' );
 } else {
 	$supports_stylebook = ( current_theme_supports( 'editor-styles' ) || wp_theme_has_theme_json() );
 


### PR DESCRIPTION
Renames the Appearance submenu item for the Site Editor from "Editor" to "Edit Site", so it matches the "Edit Site" node in the admin bar and the wording used elsewhere for the same action. Only the block theme branch is affected; the classic theme labels ("Design" and "Patterns") are unchanged. Note this modifies an existing translatable string, so it will need re-translation.

Trac ticket: https://core.trac.wordpress.org/ticket/66046

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Locating the menu registration and making the one-line string change; reviewed by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
