### PR TITLE
Gate popover handling

### DIFF
--- a/src/js/_enqueues/wp/wp-tooltip.js
+++ b/src/js/_enqueues/wp/wp-tooltip.js
@@ -8,6 +8,12 @@
  */
 (() => {
 
+	const supportsPopover = Object.prototype.hasOwnProperty.call( HTMLElement.prototype, 'popover' );
+	let hidePopover = false;
+	if ( ! supportsPopover ) {
+		hidePopover = true;
+	}
+
 	const popovers = /** @type {NodeListOf<HTMLSpanElement>} */ ( document.querySelectorAll( '.wp-is-tooltip' ) );
 
 	/** @type {ReturnType<typeof setTimeout>} */
@@ -16,7 +22,11 @@
 	popovers.forEach( function( popover ) {
 		const trigger = /** @type {HTMLButtonElement|HTMLAnchorElement|null} */ ( popover.querySelector( '.wp-tooltip__toggle' ) );
 		const panel   = /** @type {HTMLSpanElement|null} */ ( popover.querySelector( 'span.wp-tooltip__bubble' ) );
+		if ( hidePopover && panel ) {
+			panel.classList.add( 'hidden' );
 
+			return;
+		}
 		if ( ! trigger || ! panel ) {
 			return;
 		}

--- a/src/js/_enqueues/wp/wp-tooltip.js
+++ b/src/js/_enqueues/wp/wp-tooltip.js
@@ -8,7 +8,7 @@
  */
 (() => {
 
-	const supportsPopover = Object.prototype.hasOwnProperty.call( HTMLElement.prototype, 'popover' );
+	const supportsPopover = /** @type {boolean} */ ( Object.prototype.hasOwnProperty.call( HTMLElement.prototype, 'popover' ) );
 	let hidePopover = false;
 	if ( ! supportsPopover ) {
 		hidePopover = true;


### PR DESCRIPTION
Implement a check for popover, and if not available, hide popover panel.

Prevents errors from the potentially invalid selector `:popover-open` and prevents uncloseable panels.

Not yet tested in a browser that doesn't support popovers, so this is currently hypothetical. 

Trac ticket: https://core.trac.wordpress.org/ticket/65943

## Use of AI Tools
None
---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
