### PR TITLE
Update PHPStan 2.2.13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
 		"squizlabs/php_codesniffer": "3.13.5",
 		"wp-coding-standards/wpcs": "~3.4.1",
 		"phpcompatibility/phpcompatibility-wp": "~2.1.3",
-		"phpstan/phpstan": "2.2.5",
+		"phpstan/phpstan": "2.2.13",
 		"phpstan/phpstan-phpunit": "2.0.18",
 		"yoast/phpunit-polyfills": "^1.1.0"
 	},

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -4848,10 +4848,6 @@ EOF;
 	$safe_text = (string) preg_replace_callback(
 		$regex,
 		static function ( $matches ) {
-			if ( ! isset( $matches[0] ) ) {
-				return '';
-			}
-
 			if ( isset( $matches['non_cdata'] ) ) {
 				// escape HTML entities in the non-CDATA Section.
 				return _wp_specialchars( $matches['non_cdata'], ENT_XML1 );

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -4360,15 +4360,15 @@ function _scalar_wp_die_handler( $message = '', $title = '', $args = array() ) {
  * @since 5.1.0
  * @access private
  *
- * @param string|WP_Error $message Error message or WP_Error object.
- * @param string          $title   Optional. Error title. Default empty string.
- * @param string|array    $args    Optional. Arguments to control behavior. Default empty array.
+ * @param string|WP_Error|int $message Error message, WP_Error object, or integer response.
+ * @param string              $title   Optional. Error title. Default empty string.
+ * @param string|array        $args    Optional. Arguments to control behavior. Default empty array.
  * @return array {
  *     Processed arguments.
  *
- *     @type string $0 Error message.
- *     @type string $1 Error title.
- *     @type array  $2 Arguments to control behavior.
+ *     @type string|int $0 Error message, or integer response.
+ *     @type string     $1 Error title.
+ *     @type array      $2 Arguments to control behavior.
  * }
  */
 function _wp_die_process_input( $message, $title = '', $args = array() ) {

--- a/tests/phpstan/baselines/argument.type.neon
+++ b/tests/phpstan/baselines/argument.type.neon
@@ -774,6 +774,11 @@ parameters:
 			count: 2
 			path: ../../../src/wp-includes/class-wp-embed.php
 		-
+			message: '#^Parameter \#1 \$handle of function curl_getinfo expects resource, \(resource\|false\) given\.$#'
+			identifier: argument.type
+			count: 2
+			path: ../../../src/wp-includes/class-wp-http-curl.php
+		-
 			message: '#^Parameter \#3 \$value of function curl_setopt expects int, string given\.$#'
 			identifier: argument.type
 			count: 1
@@ -928,6 +933,11 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: ../../../src/wp-includes/formatting.php
+		-
+			message: '#^Parameter \#1 \$finfo of function finfo_file expects resource, resource\|false given\.$#'
+			identifier: argument.type
+			count: 2
+			path: ../../../src/wp-includes/functions.php
 		-
 			message: '#^Parameter \#1 \$prefix of function uniqid expects string, int\<0, max\> given\.$#'
 			identifier: argument.type

--- a/tests/phpstan/baselines/empty.variable.neon
+++ b/tests/phpstan/baselines/empty.variable.neon
@@ -24,11 +24,6 @@ parameters:
 			count: 1
 			path: ../../../src/wp-admin/includes/class-wp-posts-list-table.php
 		-
-			message: '#^Variable \$title in empty\(\) always exists and is always falsy\.$#'
-			identifier: empty.variable
-			count: 1
-			path: ../../../src/wp-admin/includes/plugin.php
-		-
 			message: '#^Variable \$parent_file in empty\(\) always exists and is not falsy\.$#'
 			identifier: empty.variable
 			count: 1

--- a/tests/phpstan/baselines/function.alreadyNarrowedType.neon
+++ b/tests/phpstan/baselines/function.alreadyNarrowedType.neon
@@ -24,11 +24,6 @@ parameters:
 			count: 2
 			path: ../../../src/wp-admin/includes/ajax-actions.php
 		-
-			message: '#^Call to function is_wp_error\(\) with WP_Error will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 1
-			path: ../../../src/wp-admin/includes/ajax-actions.php
-		-
 			message: '#^Call to function method_exists\(\) with ''ParagonIE_Sodium…'' and ''runtime_speed_test'' will always evaluate to true\.$#'
 			identifier: function.alreadyNarrowedType
 			count: 1
@@ -52,11 +47,6 @@ parameters:
 			message: '#^Call to function is_string\(\) with string will always evaluate to true\.$#'
 			identifier: function.alreadyNarrowedType
 			count: 1
-			path: ../../../src/wp-includes/block-editor.php
-		-
-			message: '#^Call to function is_string\(\) with string will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 1
 			path: ../../../src/wp-includes/class-wp-block-bindings-registry.php
 		-
 			message: '#^Call to function method_exists\(\) with ''Imagick'' and ''setIteratorIndex'' will always evaluate to true\.$#'
@@ -75,6 +65,16 @@ parameters:
 			path: ../../../src/wp-includes/feed.php
 		-
 			message: '#^Call to function is_callable\(\) with ''exif_imagetype'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: ../../../src/wp-includes/functions.php
+		-
+			message: '#^Call to function is_scalar\(\) with string will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 3
+			path: ../../../src/wp-includes/functions.php
+		-
+			message: '#^Call to function is_string\(\) with string will always evaluate to true\.$#'
 			identifier: function.alreadyNarrowedType
 			count: 1
 			path: ../../../src/wp-includes/functions.php

--- a/tests/phpstan/baselines/function.alreadyNarrowedType.neon
+++ b/tests/phpstan/baselines/function.alreadyNarrowedType.neon
@@ -69,14 +69,9 @@ parameters:
 			count: 1
 			path: ../../../src/wp-includes/functions.php
 		-
-			message: '#^Call to function is_scalar\(\) with string will always evaluate to true\.$#'
+			message: '#^Call to function is_scalar\(\) with int\|string will always evaluate to true\.$#'
 			identifier: function.alreadyNarrowedType
 			count: 3
-			path: ../../../src/wp-includes/functions.php
-		-
-			message: '#^Call to function is_string\(\) with string will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 1
 			path: ../../../src/wp-includes/functions.php
 		-
 			message: '#^Call to function is_array\(\) with array will always evaluate to true\.$#'

--- a/tests/phpstan/baselines/if.alwaysFalse.neon
+++ b/tests/phpstan/baselines/if.alwaysFalse.neon
@@ -32,11 +32,6 @@ parameters:
 			message: '#^If condition is always false\.$#'
 			identifier: if.alwaysFalse
 			count: 1
-			path: ../../../src/wp-includes/load.php
-		-
-			message: '#^If condition is always false\.$#'
-			identifier: if.alwaysFalse
-			count: 1
 			path: ../../../src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
 		-
 			message: '#^If condition is always false\.$#'

--- a/tests/phpstan/baselines/property.notFound.neon
+++ b/tests/phpstan/baselines/property.notFound.neon
@@ -176,7 +176,7 @@ parameters:
 		-
 			message: '#^Access to an undefined property WP_Theme\:\:\$version\.$#'
 			identifier: property.notFound
-			count: 5
+			count: 6
 			path: ../../../src/wp-admin/includes/class-wp-debug-data.php
 		-
 			message: '#^Access to an undefined property WP_Theme\:\:\$auto_update_forced\.$#'


### PR DESCRIPTION
at PHPStan we worked hard to improve performance on recent releases. Updating the tooling makes sure Wordpress can use latest additions and get the best possible PHPStan experience

before this PR (PHPStan 2.2.5)
```
time composer phpstan
197.13s user 10.28s system 667% cpu 31.084 total
```

after this PR (PHPStan 2.2.13)
```
time composer phpstan
112.30s user 5.09s system 981% cpu 11.964 total
```

running on Macbook M4-Pro, PHP 8.5.10 (cli)

=> ~20 seconds faster (wall-time; cold result-cache)

https://core.trac.wordpress.org/ticket/66051