### PR TITLE
Narrow the documented types of wp_array_slice_assoc()

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -5137,7 +5137,7 @@ function wp_parse_slug_list( $input_list ): array {
  * @phpstan-param array<TKey> $keys
  * @phpstan-return array<TKey, TValue>
  */
-function wp_array_slice_assoc( $input_array, $keys ) {
+function wp_array_slice_assoc( $input_array, $keys ): array {
 	$slice = array();
 
 	foreach ( $keys as $key ) {

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -5130,6 +5130,12 @@ function wp_parse_slug_list( $input_list ): array {
  * @param array<string, mixed> $input_array The original array.
  * @param string[]             $keys        The list of keys.
  * @return array<string, mixed> The array slice.
+ *
+ * @phpstan-template TKey of string
+ * @phpstan-template TValue
+ * @phpstan-param array<string, TValue> $input_array
+ * @phpstan-param array<TKey> $keys
+ * @phpstan-return array<TKey, TValue>
  */
 function wp_array_slice_assoc( $input_array, $keys ) {
 	$slice = array();

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -5127,9 +5127,9 @@ function wp_parse_slug_list( $input_list ): array {
  *
  * @since 3.1.0
  *
- * @param array $input_array The original array.
- * @param array $keys        The list of keys.
- * @return array The array slice.
+ * @param array<string, mixed> $input_array The original array.
+ * @param string[]             $keys        The list of keys.
+ * @return array<string, mixed> The array slice.
  */
 function wp_array_slice_assoc( $input_array, $keys ) {
 	$slice = array();


### PR DESCRIPTION
✅ Committed in r63511 (906d99c1eb4e9d8306e0d221f789659dc503223f).

----
Narrows the documented types of `wp_array_slice_assoc()`, and adds PHPStan generics so that the keys of the returned slice are inferred from the `$keys` argument rather than being lost.

Trac ticket: Core-65817

## Background

`wp_array_slice_assoc()` was introduced in r15574 (September 2010, See Core-14572) to back `wp_dropdown_users()`, and shipped in 3.1.0. Its docblock has carried a bare `array` for both parameters and the return value ever since. The touches it has had since — r18448 for typo fixes, r54929 for the reserved-keyword parameter rename — adjusted prose and names but never the types, so the function still describes itself no more precisely than it did in 2010.

That matters more than it looks, because the function is a pure key filter: everything about what it returns is determined by what it was passed. Documented as `array`, all of that is discarded at every one of its ~40 call sites.

## What this changes

Three commits, each self-contained.

**1. Narrow the plain docblock types.** `@param array<string, mixed> $input_array`, `@param string[] $keys`, `@return array<string, mixed>`.

**2. Add generics so the returned key set follows `$keys`.** Bound with `@phpstan-`-prefixed tags below the plain ones, so the human-readable types in the developer reference are untouched:

```php
 * @phpstan-template TKey of string
 * @phpstan-template TValue
 * @phpstan-param array<string, TValue> $input_array
 * @phpstan-param array<TKey> $keys
 * @phpstan-return array<TKey, TValue>
```

A call with a literal list of keys now resolves to `array<'age'|'name', ...>` rather than `array<string, ...>`, and the input's value types carry through to the slice. A call whose keys are not known statically falls back to `array<string, ...>` as before.

**3. Add a native `: array` return type hint** to the signature, matching what the docblock now documents.

## Measured impact

Measured with PHPStan 2.2.13, comparing each commit against trunk.

**Against the CI configuration (`phpstan.neon.dist`, level 5 + baselines): no errors, and no baseline count changes.** Nothing here reaches CI.

At the stricter level 10 the picture is mixed, and worth stating plainly. Over the whole `src/` tree, trunk reports 27,106 errors; this branch reports 27,119, a net **+13**.

| | Δ | Resolved | Introduced |
|---|---:|---:|---:|
| Commit 1 (narrow types) | +9 | 6 | 15 |
| Commit 2 (generics) | +4 | 1 | 5 |
| Commit 3 (native return type) | 0 | 0 | 0 |

**Resolved by commit 1** — all inside the function itself: three `missingType.iterableValue` for its own untyped signature, and three `offsetAccess.invalidOffset` ("Possibly invalid array key type mixed") now that `$key` is known to be a string.

**Introduced by commit 1** — fifteen `argument.type` errors, every one a caller passing an untyped `array` into the newly narrowed `array<string, mixed>`. These are pre-existing gaps in the callers' own documentation that the narrowing surfaces; they are not defects created here, and each is fixed by typing the caller rather than by widening this function back:

- `wp-includes/author-template.php:484`
- `wp-includes/class-wp-comment-query.php:455`, `:853`, `:1051`
- `wp-includes/class-wp-customize-panel.php:227`
- `wp-includes/class-wp-customize-section.php:238`
- `wp-includes/class-wp-site-query.php:352`
- `wp-includes/class-wp-term-query.php:1183`
- `wp-includes/comment.php:2981`
- `wp-includes/theme.php:2572`, `:3557`, `:3558`
- `wp-includes/user.php:938`, `:1773`
- `wp-includes/widgets/class-wp-widget-media.php:341`

**Commit 3** produces an identical error set to commit 2 at level 10 — nothing resolved, nothing introduced.

**Resolved by commit 2** — one `return.type` in `wp-includes/class-wp-script-modules.php:738`, where `get_marked_for_enqueue()` no longer returns something broader than the shape it documents.

**Introduced by commit 2** — five `argument.templateType`, "Unable to resolve the template type TValue". All five are call sites that pass `mixed` as `$input_array`, so there is nothing for `TValue` to bind to:

- `wp-includes/class-wp-customize-manager.php:1395`
- `wp-includes/widgets/class-wp-widget-media-audio.php:157`
- `wp-includes/widgets/class-wp-widget-media-gallery.php:145`
- `wp-includes/widgets/class-wp-widget-media-image.php:320`
- `wp-includes/widgets/class-wp-widget-media-video.php:196`

These are the same five lines that already report `expects array<string, mixed>, mixed given`, so each of those call sites now reports twice for one underlying defect. Typing those five callers clears both errors at each. If reviewers would rather not take that cost, commit 2 can be dropped independently of commit 1, at the price of the `class-wp-script-modules.php` fix.

## Follow-up

The twenty call sites listed above are the natural next step, and are deliberately left out of this PR to keep it reviewable and scoped to the function itself.

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: The generics commit ("Infer the returned key set of wp_array_slice_assoc() from $keys", the `@phpstan-` template tags) only; the PHPStan measurements reported above and the per-commit comparisons behind them; and drafting this description. The other commits are my own work. Directed, reviewed and verified by me.
Session transcript: https://claude.ai/code/session_01NtH5qFmG4hJcGWDCx5tMY7

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**




