### PR TITLE
Code Modernization: Use the null coalescing assignment operator for registration argument defaults

### DIFF
--- a/src/wp-includes/class-wp-post-type.php
+++ b/src/wp-includes/class-wp-post-type.php
@@ -570,19 +570,13 @@ final class WP_Post_Type {
 		$args['name'] = $this->name;
 
 		// If not set, default to the setting for 'public'.
-		if ( null === $args['publicly_queryable'] ) {
-			$args['publicly_queryable'] = $args['public'];
-		}
+		$args['publicly_queryable'] ??= $args['public'];
 
 		// If not set, default to the setting for 'public'.
-		if ( null === $args['show_ui'] ) {
-			$args['show_ui'] = $args['public'];
-		}
+		$args['show_ui'] ??= $args['public'];
 
 		// If not set, default to the setting for 'public'.
-		if ( null === $args['embeddable'] ) {
-			$args['embeddable'] = $args['public'];
-		}
+		$args['embeddable'] ??= $args['public'];
 
 		// If not set, default rest_namespace to wp/v2 if show_in_rest is true.
 		if ( false === $args['rest_namespace'] && ! empty( $args['show_in_rest'] ) ) {
@@ -595,19 +589,13 @@ final class WP_Post_Type {
 		}
 
 		// If not set, default to the setting for 'show_in_menu'.
-		if ( null === $args['show_in_admin_bar'] ) {
-			$args['show_in_admin_bar'] = (bool) $args['show_in_menu'];
-		}
+		$args['show_in_admin_bar'] ??= (bool) $args['show_in_menu'];
 
 		// If not set, default to the setting for 'public'.
-		if ( null === $args['show_in_nav_menus'] ) {
-			$args['show_in_nav_menus'] = $args['public'];
-		}
+		$args['show_in_nav_menus'] ??= $args['public'];
 
 		// If not set, default to true if not public, false if public.
-		if ( null === $args['exclude_from_search'] ) {
-			$args['exclude_from_search'] = ! $args['public'];
-		}
+		$args['exclude_from_search'] ??= ! $args['public'];
 
 		// Back compat with quirky handling in version 3.0. #14122.
 		if ( empty( $args['capabilities'] )
@@ -617,9 +605,7 @@ final class WP_Post_Type {
 		}
 
 		// If not set, default to false.
-		if ( null === $args['map_meta_cap'] ) {
-			$args['map_meta_cap'] = false;
-		}
+		$args['map_meta_cap'] ??= false;
 
 		// If there's no specified edit link and no UI, remove the edit link.
 		if ( ! $args['show_ui'] && ! $has_edit_link ) {
@@ -648,18 +634,12 @@ final class WP_Post_Type {
 			if ( empty( $args['rewrite']['slug'] ) ) {
 				$args['rewrite']['slug'] = $this->name;
 			}
-			if ( ! isset( $args['rewrite']['with_front'] ) ) {
-				$args['rewrite']['with_front'] = true;
-			}
-			if ( ! isset( $args['rewrite']['pages'] ) ) {
-				$args['rewrite']['pages'] = true;
-			}
+			$args['rewrite']['with_front'] ??= true;
+			$args['rewrite']['pages']      ??= true;
 			if ( ! isset( $args['rewrite']['feeds'] ) || ! $args['has_archive'] ) {
 				$args['rewrite']['feeds'] = (bool) $args['has_archive'];
 			}
-			if ( ! isset( $args['rewrite']['ep_mask'] ) ) {
-				$args['rewrite']['ep_mask'] = $args['permalink_epmask'] ?? EP_PERMALINK;
-			}
+			$args['rewrite']['ep_mask'] ??= $args['permalink_epmask'] ?? EP_PERMALINK;
 		}
 
 		foreach ( $args as $property_name => $property_value ) {

--- a/src/wp-includes/class-wp-taxonomy.php
+++ b/src/wp-includes/class-wp-taxonomy.php
@@ -376,9 +376,7 @@ final class WP_Taxonomy {
 		$args = array_merge( $defaults, $args );
 
 		// If not set, default to the setting for 'public'.
-		if ( null === $args['publicly_queryable'] ) {
-			$args['publicly_queryable'] = $args['public'];
-		}
+		$args['publicly_queryable'] ??= $args['public'];
 
 		if ( false !== $args['query_var'] && ( is_admin() || false !== $args['publicly_queryable'] ) ) {
 			if ( true === $args['query_var'] ) {
@@ -407,9 +405,7 @@ final class WP_Taxonomy {
 		}
 
 		// If not set, default to the setting for 'public'.
-		if ( null === $args['show_ui'] ) {
-			$args['show_ui'] = $args['public'];
-		}
+		$args['show_ui'] ??= $args['public'];
 
 		// If not set, default to the setting for 'show_ui'.
 		if ( null === $args['show_in_menu'] || ! $args['show_ui'] ) {
@@ -417,19 +413,13 @@ final class WP_Taxonomy {
 		}
 
 		// If not set, default to the setting for 'public'.
-		if ( null === $args['show_in_nav_menus'] ) {
-			$args['show_in_nav_menus'] = $args['public'];
-		}
+		$args['show_in_nav_menus'] ??= $args['public'];
 
 		// If not set, default to the setting for 'show_ui'.
-		if ( null === $args['show_tagcloud'] ) {
-			$args['show_tagcloud'] = $args['show_ui'];
-		}
+		$args['show_tagcloud'] ??= $args['show_ui'];
 
 		// If not set, default to the setting for 'show_ui'.
-		if ( null === $args['show_in_quick_edit'] ) {
-			$args['show_in_quick_edit'] = $args['show_ui'];
-		}
+		$args['show_in_quick_edit'] ??= $args['show_ui'];
 
 		// If not set, default rest_namespace to wp/v2 if show_in_rest is true.
 		if ( false === $args['rest_namespace'] && ! empty( $args['show_in_rest'] ) ) {


### PR DESCRIPTION
Replaces the "assign a default only if not already set" guard blocks in `WP_Post_Type::set_props()` and `WP_Taxonomy::set_props()` with the null coalescing assignment operator (`??=`).

Both classes normalize their registration arguments with the same idiom, so the two methods now read identically. 15 guard blocks in total, 45 lines removed for 15 added.

## Scope

This covers `WP_Post_Type::set_props()` and `WP_Taxonomy::set_props()` completely: every guard in those two methods that `??=` can express is converted, so the two methods are internally consistent rather than half-modernized. The same pattern exists elsewhere in core; that is left for separate follow-ups on the same ticket so each one stays reviewable.

Trac ticket: https://core.trac.wordpress.org/ticket/65823

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**