### PR TITLE
Adds missing descriptions to several JS docblocks in the enqueues directory

### DIFF
--- a/src/js/_enqueues/admin/application-passwords.js
+++ b/src/js/_enqueues/admin/application-passwords.js
@@ -3,6 +3,8 @@
  */
 
 /**
+ * Handles the Application Passwords functionality in the user profile screen.
+ *
  * @param {JQueryStatic} $ The jQuery object.
  */
 ( function( $ ) {

--- a/src/js/_enqueues/admin/edit-comments.js
+++ b/src/js/_enqueues/admin/edit-comments.js
@@ -2,11 +2,12 @@
 /* global commentReply, theExtraList, theList, setCommentsList */
 
 /**
- * Handles updating and editing comments.
  * @output wp-admin/js/edit-comments.js
  */
 
 /**
+ * Handles updating and editing comments.
+ *
  * @param {JQueryStatic} $ The jQuery object.
  */
 (function($) {

--- a/src/js/_enqueues/admin/post.js
+++ b/src/js/_enqueues/admin/post.js
@@ -15,6 +15,8 @@ window.makeSlugeditClickable = window.editPermalink = function(){};
 window.wp = window.wp || {};
 
 /**
+ * Handles the dynamic functionality needed on post and term pages.
+ *
  * @param {JQueryStatic} $ The jQuery object.
  */
 ( function( $ ) {
@@ -256,7 +258,7 @@ window.wp = window.wp || {};
 }(jQuery));
 
 /**
- * Heartbeat refresh nonces.
+ * Handles the Heartbeat refresh nonces.
  *
  * @param {JQueryStatic} $ The jQuery object.
  */
@@ -304,7 +306,7 @@ window.wp = window.wp || {};
 }(jQuery));
 
 /**
- * All post and postbox controls and functionality.
+ * Handles all post and postbox controls and functionality.
  *
  * @param {JQueryStatic} $ The jQuery object.
  */
@@ -1328,7 +1330,7 @@ jQuery( function($) {
 } );
 
 /**
- * TinyMCE word count display
+ * Handles the TinyMCE word count display.
  *
  * @param {JQueryStatic}         $       The jQuery object.
  * @param {wp.utils.WordCounter} counter The WordCounter object.

--- a/src/js/_enqueues/admin/user-profile.js
+++ b/src/js/_enqueues/admin/user-profile.js
@@ -5,6 +5,8 @@
  */
 
 /**
+ * Handles the user profile functionality.
+ *
  * @param {JQueryStatic} $ The jQuery object.
  */
 (function($) {

--- a/src/js/_enqueues/lib/accordion.js
+++ b/src/js/_enqueues/lib/accordion.js
@@ -30,6 +30,8 @@
  */
 
 /**
+ * Handles the accordion functionality.
+ *
  * @param {JQueryStatic} $ The jQuery object.
  */
 ( function( $ ){

--- a/src/js/_enqueues/lib/auth-check.js
+++ b/src/js/_enqueues/lib/auth-check.js
@@ -1,10 +1,10 @@
 /**
- * Interim login dialog.
- *
  * @output wp-includes/js/wp-auth-check.js
  */
 
 /**
+ * Handles the interim login dialog.
+ *
  * @param {JQueryStatic} $ The jQuery object.
  */
 ( function( $ ) {

--- a/src/js/_enqueues/lib/color-picker.js
+++ b/src/js/_enqueues/lib/color-picker.js
@@ -5,6 +5,8 @@
  */
 
 /**
+ * Handles the color picker functionality.
+ *
  * @param {JQueryStatic} $     The jQuery object.
  * @param {undefined}    undef The undefined value.
  */

--- a/src/js/_enqueues/lib/list-revisions.js
+++ b/src/js/_enqueues/lib/list-revisions.js
@@ -1,10 +1,16 @@
 /**
- * @param {Window} w The global window object.
  * @output wp-includes/js/wp-list-revisions.js
+ */
+
+/**
+ * Hides the revisions radio buttons to stop selecting reverse comparisons
+ *
+ * @param {Window} w The global window object.
  */
 
 (function(w) {
 	var init = function() {
+		console.log('init');
 		var pr = document.getElementById('post-revisions'),
 		inputs = pr ? pr.getElementsByTagName('input') : [];
 		pr.onclick = function() {

--- a/src/js/_enqueues/lib/list-revisions.js
+++ b/src/js/_enqueues/lib/list-revisions.js
@@ -10,7 +10,6 @@
 
 (function(w) {
 	var init = function() {
-		console.log('init');
 		var pr = document.getElementById('post-revisions'),
 		inputs = pr ? pr.getElementsByTagName('input') : [];
 		pr.onclick = function() {

--- a/src/js/_enqueues/lib/lists.js
+++ b/src/js/_enqueues/lib/lists.js
@@ -5,6 +5,8 @@
 /* global ajaxurl, wpAjax */
 
 /**
+ * Handles the dynamic functionality needed for lists.
+ *
  * @param {JQueryStatic} $ The jQuery object.
  */
 ( function( $ ) {

--- a/src/js/_enqueues/lib/nav-menu.js
+++ b/src/js/_enqueues/lib/nav-menu.js
@@ -1,16 +1,15 @@
 /**
- * WordPress Administration Navigation Menu
- * Interface JS functions
- *
- * @version 2.0.0
- *
- * @package WordPress
  * @output wp-admin/js/nav-menu.js
  */
 
 /* global menus, postboxes, columns, isRtl, ajaxurl, wpNavMenu */
 
 /**
+ * Handles the WordPress Administration Navigation Menu Interface functionality.
+ *
+ * @version 2.0.0
+ * @package WordPress
+ *
  * @param {JQueryStatic} $ The jQuery object.
  */
 (function($) {

--- a/src/js/_enqueues/wp/api-request.js
+++ b/src/js/_enqueues/wp/api-request.js
@@ -1,4 +1,8 @@
 /**
+ * @output wp-includes/js/api-request.js
+ */
+
+/**
  * Thin jQuery.ajax wrapper for WP REST API requests.
  *
  * Currently only applies to requests that do not use the `wp-api.js` Backbone
@@ -11,10 +15,7 @@
  * @since 4.9.0
  * @since 5.6.0 Added overriding of the "PUT" and "DELETE" methods with "POST".
  *              Added an "application/json" Accept header to all requests.
- * @output wp-includes/js/api-request.js
- */
-
-/**
+ *
  * @param {JQueryStatic} $ The jQuery object.
  */
 ( function( $ ) {

--- a/src/js/_enqueues/wp/api.js
+++ b/src/js/_enqueues/wp/api.js
@@ -1,9 +1,13 @@
 /**
- * @param {Window}    window    The global window object.
- * @param {undefined} undefined The undefined value.
  * @output wp-includes/js/wp-api.js
  */
 
+/**
+ * Initialize the WordPress REST API client.
+ *
+ * @param {Window}    window    The global window object.
+ * @param {undefined} undefined The undefined value.
+ */
 (function( window, undefined ) {
 
 	'use strict';
@@ -33,6 +37,12 @@
 
 })( window );
 
+/**
+ * Sets up the WordPress REST API client with utilities and Backbone model mixins for managing API resources.
+ *
+ * @param {Window}    window    The global window object.
+ * @param {undefined} undefined The undefined value.
+ */
 (function( window, undefined ) {
 
 	'use strict';
@@ -826,6 +836,10 @@
 
 // Suppress warning about parse function's unused "options" argument:
 /* jshint unused:false */
+
+/**
+ * Creates the base Backbone model for WordPress REST API.
+ */
 (function() {
 
 	'use strict';
@@ -978,6 +992,9 @@
 	);
 })();
 
+/**
+ * Creates the base Backbone collection for WordPress REST API.
+ */
 ( function() {
 
 	'use strict';
@@ -1135,6 +1152,9 @@
 
 } )();
 
+/**
+ * Constructs Backbone models and collections from the WordPress REST API schema.
+ */
 ( function() {
 
 	'use strict';

--- a/src/js/_enqueues/wp/code-editor.js
+++ b/src/js/_enqueues/wp/code-editor.js
@@ -138,11 +138,10 @@ if ( 'undefined' === typeof window.wp.codeEditor ) {
  */
 
 /**
- * @param {JQueryStatic} $ The jQuery object.
- * @param {Object & {
- *   codeEditor: WpCodeEditor,
- *   CodeMirror: typeof import('codemirror'),
- * }} wp - WordPress namespace.
+ * Handles the Code Editor (CodeMirror) functionality.
+ *
+ * @param {JQueryStatic} $  The jQuery object.
+ * @param {wp}           wp The WordPress global object.
  */
 ( function( $, wp ) {
 	'use strict';
@@ -165,7 +164,7 @@ if ( 'undefined' === typeof window.wp.codeEditor ) {
 	};
 
 	/**
-	 * Configure linting.
+	 * Configures linting.
 	 *
 	 * @param {CodeEditorSettings} settings - Code editor settings.
 	 *
@@ -192,7 +191,7 @@ if ( 'undefined' === typeof window.wp.codeEditor ) {
 		}
 
 		/**
-		 * Get lint options.
+		 * Gets the lint options.
 		 *
 		 * @return {CombinedLintOptions|false} Lint options.
 		 */
@@ -236,6 +235,8 @@ if ( 'undefined' === typeof window.wp.codeEditor ) {
 			// Wrap the onUpdateLinting CodeMirror event to route to onChangeLintingErrors and onUpdateErrorNotice.
 			linterOptions.onUpdateLinting = (function( onUpdateLintingOverridden ) {
 				/**
+				 * Wraps the onUpdateLinting event to filter errors, detect state changes, and manage error notice visibility.
+				 *
 				 * @param {LintAnnotation[]} annotations - Annotations.
 				 * @param {LintAnnotation[]} annotationsSorted - Sorted annotations.
 				 * @param {CodeMirrorEditor} cm - Editor.
@@ -278,6 +279,8 @@ if ( 'undefined' === typeof window.wp.codeEditor ) {
 		return {
 			getLintOptions,
 			/**
+			 * Initializes the CodeMirror editor.
+			 *
 			 * @param {CodeMirrorEditor} editor - Editor instance.
 			 * @return {void}
 			 */

--- a/src/js/_enqueues/wp/customize/base.js
+++ b/src/js/_enqueues/wp/customize/base.js
@@ -227,6 +227,8 @@ window.wp = window.wp || {};
 	 */
 	api.Value = api.Class.extend(/** @lends wp.customize.Value.prototype */{
 		/**
+		 * Initializes the Value instance and configures callbacks and options.
+		 *
 		 * @param {*}      initial   The initial value.
 		 * @param {Object} [options] Options to extend the instance with.
 		 */

--- a/src/js/_enqueues/wp/editor/dfw.js
+++ b/src/js/_enqueues/wp/editor/dfw.js
@@ -3,6 +3,8 @@
  */
 
 /**
+ * Handles the editor Distraction-Free Writing (DFW) functionality.
+ *
  * @param {Window}       window    The global window object.
  * @param {JQueryStatic} $         The jQuery object.
  * @param {undefined}    undefined The undefined value.

--- a/src/js/_enqueues/wp/heartbeat.js
+++ b/src/js/_enqueues/wp/heartbeat.js
@@ -1,5 +1,9 @@
 /**
- * Heartbeat API
+ * @output wp-includes/js/heartbeat.js
+ */
+
+/**
+ * Handles the Heartbeat API.
  *
  * Heartbeat is a simple server polling API that sends XHR requests to
  * the server every 15 - 60 seconds and triggers events (or callbacks) upon
@@ -24,10 +28,6 @@
  * - heartbeat-nonces-expired
  *
  * @since 3.6.0
- * @output wp-includes/js/heartbeat.js
- */
-
-/**
  * @param {JQueryStatic} $         The jQuery object.
  * @param {Window}       window    The global window object.
  * @param {undefined}    undefined The undefined value.

--- a/src/js/_enqueues/wp/media/editor.js
+++ b/src/js/_enqueues/wp/media/editor.js
@@ -4,8 +4,12 @@
 
 /* global getUserSetting, tinymce, QTags */
 
-// WordPress, TinyMCE, and Media
-// -----------------------------
+/**
+ * Handles the initialization, refreshing and rendering of media editor components.
+ *
+ * @param {JQueryStatic}       $ The jQuery object.
+ * @param {_.UnderscoreStatic} _ The Underscore.js object.
+ */
 (function($, _){
 	/**
 	 * Stores the editors' `wp.media.controller.Frame` instances.
@@ -333,6 +337,8 @@
 	};
 
 	/**
+	 * Factory function that creates a media collection controller for managing gallery, playlist, and other media shortcodes.
+	 *
 	 * @class wp.media.collection
 	 *
 	 * @param {Object} attributes

--- a/src/js/_enqueues/wp/sanitize.js
+++ b/src/js/_enqueues/wp/sanitize.js
@@ -2,6 +2,9 @@
  * @output wp-includes/js/wp-sanitize.js
  */
 
+/**
+ * Provides helper functions to sanitize strings.
+ */
 ( function () {
 
 	window.wp = window.wp || {};

--- a/src/js/_enqueues/wp/updates.js
+++ b/src/js/_enqueues/wp/updates.js
@@ -1,15 +1,16 @@
 /**
- * Functions for ajaxified updates, deletions and installs inside the WordPress admin.
- *
- * @version 4.2.0
  * @output wp-admin/js/updates.js
  */
 
 /* global pagenow, _wpThemeSettings */
 
 /**
+ * Provides functions for ajaxified updates, deletions and installs inside the WordPress admin.
+ *
+ * @version 4.2.0
+ *
  * @param {JQueryStatic} $                                        The jQuery object.
- * @param {Object}       wp                                       WP object.
+ * @param {Object}       wp                                       The WordPress global object.
  * @param {Object}       settings                                 WP Updates settings.
  * @param {string}       settings.ajax_nonce                      Ajax nonce.
  * @param {Object}       settings.plugins                         Base names of plugins in their different states.


### PR DESCRIPTION
See https://core.trac.wordpress.org/ticket/66033

In preparation of the introduction of the rule `jsdoc/require-description` for JSDoc, this PR adds several missing descriptions to JS functions in the enqueues directory. Leaves out:
- All the Customize related files.
- All the Media related files.

## Use of AI Tools


AI assistance: Yes
Tool(s): GitHub Copilot
Model(s): Claude Haiku 4.5
Used for: Quickly drafting some descriptions.


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
