### PR TITLE
General: Bump the pinned hash for Gutenberg to `dd294ab` (7.1.1 package update)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"url": "https://develop.svn.wordpress.org/trunk"
 	},
 	"gutenberg": {
-		"sha": "8ae0957cfa0b3e5c270e75656a55591debc6def0",
+		"sha": "3f82d42667908afa5a04db1c7d646fbca0156a10",
 		"ghcrRepo": "WordPress/gutenberg/gutenberg-wp-develop-build"
 	},
 	"engines": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"url": "https://develop.svn.wordpress.org/trunk"
 	},
 	"gutenberg": {
-		"sha": "943e0d825bb66ba582e9a10d32743cbb136de460",
+		"sha": "8ae0957cfa0b3e5c270e75656a55591debc6def0",
 		"ghcrRepo": "WordPress/gutenberg/gutenberg-wp-develop-build"
 	},
 	"engines": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"url": "https://develop.svn.wordpress.org/trunk"
 	},
 	"gutenberg": {
-		"sha": "3f82d42667908afa5a04db1c7d646fbca0156a10",
+		"sha": "dd294ab86ceaf9f3d7d42a09b78f399238ce8826",
 		"ghcrRepo": "WordPress/gutenberg/gutenberg-wp-develop-build"
 	},
 	"engines": {

--- a/src/wp-includes/assets/script-loader-packages.php
+++ b/src/wp-includes/assets/script-loader-packages.php
@@ -104,7 +104,7 @@
 			'wp-url',
 			'wp-warning'
 		),
-		'version' => 'd3cbb2c45b145b27a5cf'
+		'version' => '37e58da384b2558bd479'
 	),
 	'block-library.js' => array(
 		'dependencies' => array(
@@ -150,7 +150,7 @@
 				'import' => 'dynamic'
 			)
 		),
-		'version' => '2e80403676c10cc0a473'
+		'version' => '00e6e2a44788af201f35'
 	),
 	'block-serialization-default-parser.js' => array(
 		'dependencies' => array(
@@ -402,7 +402,7 @@
 				'import' => 'static'
 			)
 		),
-		'version' => 'a7750dea8d5c880ddf33'
+		'version' => 'a6cb1641d13f718c01bd'
 	),
 	'edit-site.js' => array(
 		'dependencies' => array(
@@ -452,7 +452,7 @@
 				'import' => 'static'
 			)
 		),
-		'version' => '638e98d0061f4b9f1efb'
+		'version' => '008f89f2cb2ad17a5947'
 	),
 	'edit-widgets.js' => array(
 		'dependencies' => array(
@@ -543,7 +543,7 @@
 				'import' => 'static'
 			)
 		),
-		'version' => '2cd3b932f41a420d5904'
+		'version' => '1beaeebde7484b6bf3e3'
 	),
 	'element.js' => array(
 		'dependencies' => array(
@@ -663,7 +663,7 @@
 			'wp-url',
 			'wp-warning'
 		),
-		'version' => 'b8bf604c1cc119e63ee6'
+		'version' => '07c1c94f9b21baa97a96'
 	),
 	'notices.js' => array(
 		'dependencies' => array(
@@ -881,7 +881,7 @@
 				'import' => 'dynamic'
 			)
 		),
-		'version' => 'f7174b0617bcd68e57c3'
+		'version' => '996352700f53b76866a5'
 	),
 	'url.js' => array(
 		'dependencies' => array(

--- a/src/wp-includes/assets/script-loader-packages.php
+++ b/src/wp-includes/assets/script-loader-packages.php
@@ -543,7 +543,7 @@
 				'import' => 'static'
 			)
 		),
-		'version' => '1beaeebde7484b6bf3e3'
+		'version' => 'af070cfff88093363220'
 	),
 	'element.js' => array(
 		'dependencies' => array(
@@ -881,7 +881,7 @@
 				'import' => 'dynamic'
 			)
 		),
-		'version' => '996352700f53b76866a5'
+		'version' => 'a2c026d433c295fd5145'
 	),
 	'url.js' => array(
 		'dependencies' => array(

--- a/src/wp-includes/assets/script-modules-packages.php
+++ b/src/wp-includes/assets/script-modules-packages.php
@@ -360,7 +360,7 @@
 		'dependencies' => array(
 			
 		),
-		'version' => '685442d334b2d3e70832'
+		'version' => '7e33cd8c4128731126e8'
 	),
 	'workflow/index.js' => array(
 		'dependencies' => array(

--- a/src/wp-includes/build/pages/font-library/page.php
+++ b/src/wp-includes/build/pages/font-library/page.php
@@ -310,6 +310,22 @@ function wp_font_library_render_page() {
 function wp_font_library_intercept_render() {
 	// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 	if ( isset( $_GET['page'] ) && 'font-library' === $_GET['page'] ) {
+		// The page renders outside the menu page callback flow, so it must
+		// enforce authentication and capability checks itself. Without this,
+		// any admin entry point firing `admin_init` (such as admin-post.php,
+		// which serves logged-out requests) would render the page for
+		// unauthenticated visitors.
+		if ( ! is_user_logged_in() ) {
+			auth_redirect();
+		}
+
+		if ( ! current_user_can( 'edit_theme_options' ) ) {
+			wp_die(
+				__( 'Sorry, you are not allowed to access this page.' ),
+				403
+			);
+		}
+
 		wp_font_library_render_page();
 		exit;
 	}

--- a/src/wp-includes/build/pages/options-connectors/page.php
+++ b/src/wp-includes/build/pages/options-connectors/page.php
@@ -310,6 +310,22 @@ function wp_options_connectors_render_page() {
 function wp_options_connectors_intercept_render() {
 	// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 	if ( isset( $_GET['page'] ) && 'options-connectors' === $_GET['page'] ) {
+		// The page renders outside the menu page callback flow, so it must
+		// enforce authentication and capability checks itself. Without this,
+		// any admin entry point firing `admin_init` (such as admin-post.php,
+		// which serves logged-out requests) would render the page for
+		// unauthenticated visitors.
+		if ( ! is_user_logged_in() ) {
+			auth_redirect();
+		}
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die(
+				__( 'Sorry, you are not allowed to access this page.' ),
+				403
+			);
+		}
+
 		wp_options_connectors_render_page();
 		exit;
 	}


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/66037

## What

Gutenberg package update for **WordPress 7.1.1**: bumps the pinned Gutenberg hash from `943e0d8` to `dd294ab86ceaf9f3d7d42a09b78f399238ce8826` and regenerates the script loader manifests.

> [!NOTE]
> The earlier dry-run pin (`3f82d42`, head of the cherry-pick PR WordPress/gutenberg#82383) has been replaced: #82383 landed on `wp/7.1` via rebase and merge on 2026-09-10, and this PR is now re-pinned to the resulting `wp/7.1` tip (`dd294ab`). As predicted, the build content is identical — the re-pin only changes `package.json`, and the regenerated manifests are unchanged (`grunt gutenberg:verify` passes against the GHCR artifact).

Full diff of the Gutenberg changes: https://github.com/WordPress/gutenberg/compare/943e0d825bb66ba582e9a10d32743cbb136de460...dd294ab86ceaf9f3d7d42a09b78f399238ce8826

## Gutenberg PRs included

- WordPress/gutenberg#82183 - useViewConfig: don't request the view config twice (already on `wp/7.1` since the last pin)
- WordPress/gutenberg#81770 - Block Editor: Add translator context to pseudo-state labels
- WordPress/gutenberg#81813 - Post Editor: Fix 403 on /wp/v2/settings at boot for users without manage_options cap
- WordPress/gutenberg#82046 - Media: Refuse a multi-file drop on a placeholder that takes one file
- WordPress/gutenberg#82011 - List: outdent an empty middle item without adding an item
- WordPress/gutenberg#81782 - Accordion Panel: Reset padding-block when panel is hidden
- WordPress/gutenberg#81964 - List View: Don't focus the last Table cell on keyboard activation
- WordPress/gutenberg#81397 - Media: Stop claiming "Upload complete" when upload failed
- WordPress/gutenberg#81884 - Media: keep indexed PNG sub-sizes indexed
- WordPress/gutenberg#82316 - Image block cropping: Sync image size and link destination settings
- WordPress/gutenberg#82318 - Gallery block: Fix 'Crop images to fit' broken in editor
- WordPress/gutenberg#82254 - Pages: require authentication and a capability to render generated standalone pages
- WordPress/gutenberg#82353 - Media Utils: Preserve arrays in multipart form data
- WordPress/gutenberg#82478 - wp-env: Fix Docker build errors with Debian Bullseye repositories (CI-only)
- WordPress/gutenberg#82465 - Query Loop: Fall back to `post` when the query has no `postType`
- WordPress/gutenberg#81908 - Block Supports: Bail early in state styles when a block has no style attribute
- WordPress/gutenberg#82335 - Fix: Restore layout styles for block style variations
- WordPress/gutenberg#81947 - Editor: Store the finalize response as the attachment record
- WordPress/gutenberg#82265 - Media: Only blame the browser's codecs when HEIC really cannot be decoded
- WordPress/gutenberg#82249 - CI: Unify the automation comments into a single PR comment (CI-only)
- WordPress/gutenberg#82635 - Framework: Update Node.js to v24 LTS and npm to v11 (CI-only, came in from `wp/7.1`)

Since the previous pin (`8ae0957`), only the `editor` and `upload-media` package hashes changed in the regenerated manifest.

## Related core patches

Three of the included PRs carry PHP changes that do not travel through the package build. All three are already on the `7.1` branch:

- WordPress/gutenberg#81908 -> [changeset 63474](https://core.trac.wordpress.org/changeset/63474).
- WordPress/gutenberg#82335 -> [changeset 63523](https://core.trac.wordpress.org/changeset/63523), tracked on [Trac #66044](https://core.trac.wordpress.org/ticket/66044).
- WordPress/gutenberg#81947 -> [changeset 63564](https://core.trac.wordpress.org/changeset/63564) on trunk, merged to `7.1` in [changeset 63572](https://core.trac.wordpress.org/changeset/63572), tracked on [Trac #66056](https://core.trac.wordpress.org/ticket/66056).

## AI Use

Description written with 🤖 Claude Code, the re-pin and manifest regeneration ran through `npm run gutenberg:download`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GXuW8W41AXnGkpT3hfEhzE
