### PR TITLE
Adds missing descriptions to several JS docblocks in the media directory

### DIFF
--- a/src/js/media/controllers/collection-add.js
+++ b/src/js/media/controllers/collection-add.js
@@ -51,6 +51,8 @@ CollectionAdd = Library.extend(/** @lends wp.media.controller.CollectionAdd.prot
 	}, Library.prototype.defaults ),
 
 	/**
+	 * Initializes the CollectionAdd controller.
+	 *
 	 * @since 3.9.0
 	 */
 	initialize: function() {
@@ -72,6 +74,8 @@ CollectionAdd = Library.extend(/** @lends wp.media.controller.CollectionAdd.prot
 	},
 
 	/**
+	 * Activates the CollectionAdd controller.
+	 *
 	 * @since 3.9.0
 	 */
 	activate: function() {

--- a/src/js/media/controllers/collection-edit.js
+++ b/src/js/media/controllers/collection-edit.js
@@ -57,6 +57,8 @@ CollectionEdit = Library.extend(/** @lends wp.media.controller.CollectionEdit.pr
 	},
 
 	/**
+	 * Initializes the CollectionEdit controller.
+	 *
 	 * @since 3.9.0
 	 */
 	initialize: function() {
@@ -81,6 +83,8 @@ CollectionEdit = Library.extend(/** @lends wp.media.controller.CollectionEdit.pr
 	},
 
 	/**
+	 * Activates the CollectionEdit controller.
+	 *
 	 * @since 3.9.0
 	 */
 	activate: function() {
@@ -98,6 +102,8 @@ CollectionEdit = Library.extend(/** @lends wp.media.controller.CollectionEdit.pr
 	},
 
 	/**
+	 * Deactivates the CollectionEdit controller.
+	 *
 	 * @since 3.9.0
 	 */
 	deactivate: function() {

--- a/src/js/media/controllers/featured-image.js
+++ b/src/js/media/controllers/featured-image.js
@@ -48,6 +48,8 @@ FeaturedImage = Library.extend(/** @lends wp.media.controller.FeaturedImage.prot
 	}, Library.prototype.defaults ),
 
 	/**
+	 * Initializes the FeaturedImage controller.
+	 *
 	 * @since 3.5.0
 	 */
 	initialize: function() {
@@ -84,6 +86,8 @@ FeaturedImage = Library.extend(/** @lends wp.media.controller.FeaturedImage.prot
 	},
 
 	/**
+	 * Activates the FeaturedImage controller.
+	 *
 	 * @since 3.5.0
 	 */
 	activate: function() {
@@ -93,6 +97,8 @@ FeaturedImage = Library.extend(/** @lends wp.media.controller.FeaturedImage.prot
 	},
 
 	/**
+	 * Deactivates the FeaturedImage controller.
+	 *
 	 * @since 3.5.0
 	 */
 	deactivate: function() {
@@ -102,6 +108,8 @@ FeaturedImage = Library.extend(/** @lends wp.media.controller.FeaturedImage.prot
 	},
 
 	/**
+	 * Updates the selection to match the current featured image.
+	 *
 	 * @since 3.5.0
 	 */
 	updateSelection: function() {

--- a/src/js/media/controllers/image-details.js
+++ b/src/js/media/controllers/image-details.js
@@ -42,6 +42,8 @@ ImageDetails = State.extend(/** @lends wp.media.controller.ImageDetails.prototyp
 	}, Library.prototype.defaults ),
 
 	/**
+	 * Initializes the ImageDetails controller.
+	 *
 	 * @since 3.9.0
 	 *
 	 * @param {Object} options Attributes.
@@ -52,6 +54,8 @@ ImageDetails = State.extend(/** @lends wp.media.controller.ImageDetails.prototyp
 	},
 
 	/**
+	 * Activates the ImageDetails controller.
+	 *
 	 * @since 3.9.0
 	 */
 	activate: function() {

--- a/src/js/media/controllers/library.js
+++ b/src/js/media/controllers/library.js
@@ -192,7 +192,7 @@ Library = wp.media.controller.State.extend(/** @lends wp.media.controller.Librar
 	},
 
 	/**
-	 * Determines whether an attachment is image.
+	 * Determines whether an attachment is an image.
 	 *
 	 * @since 4.4.1
 	 *

--- a/src/js/media/controllers/library.js
+++ b/src/js/media/controllers/library.js
@@ -58,6 +58,8 @@ Library = wp.media.controller.State.extend(/** @lends wp.media.controller.Librar
 	},
 
 	/**
+	 * Initializes the Library controller.
+	 *
 	 * If a library isn't provided, query all media items.
 	 * If a selection instance isn't provided, create one.
 	 *
@@ -89,6 +91,8 @@ Library = wp.media.controller.State.extend(/** @lends wp.media.controller.Librar
 	},
 
 	/**
+	 * Activates the Library controller.
+	 *
 	 * @since 3.5.0
 	 */
 	activate: function() {
@@ -105,6 +109,8 @@ Library = wp.media.controller.State.extend(/** @lends wp.media.controller.Librar
 	},
 
 	/**
+	 * Deactivates the Library controller.
+	 *
 	 * @since 3.5.0
 	 */
 	deactivate: function() {
@@ -120,7 +126,7 @@ Library = wp.media.controller.State.extend(/** @lends wp.media.controller.Librar
 	},
 
 	/**
-	 * Reset the library to its initial state.
+	 * Resets the library to its initial state.
 	 *
 	 * @since 3.5.0
 	 */
@@ -131,7 +137,7 @@ Library = wp.media.controller.State.extend(/** @lends wp.media.controller.Librar
 	},
 
 	/**
-	 * Reset the attachment display settings defaults to the site options.
+	 * Resets the attachment display settings defaults to the site options.
 	 *
 	 * If site options don't define them, fall back to a persistent user setting.
 	 *
@@ -148,7 +154,7 @@ Library = wp.media.controller.State.extend(/** @lends wp.media.controller.Librar
 	},
 
 	/**
-	 * Create a model to represent display settings (alignment, etc.) for an attachment.
+	 * Creates a model to represent display settings (alignment, etc.) for an attachment.
 	 *
 	 * @since 3.5.0
 	 *
@@ -165,7 +171,7 @@ Library = wp.media.controller.State.extend(/** @lends wp.media.controller.Librar
 	},
 
 	/**
-	 * Given an attachment, create attachment display settings properties.
+	 * Given an attachment, creates attachment display settings properties.
 	 *
 	 * @since 3.6.0
 	 *
@@ -186,7 +192,7 @@ Library = wp.media.controller.State.extend(/** @lends wp.media.controller.Librar
 	},
 
 	/**
-	 * Whether an attachment is image.
+	 * Determines whether an attachment is image.
 	 *
 	 * @since 4.4.1
 	 *
@@ -203,7 +209,7 @@ Library = wp.media.controller.State.extend(/** @lends wp.media.controller.Librar
 	},
 
 	/**
-	 * Whether an attachment can be embedded (audio or video).
+	 * Determines whether an attachment can be embedded (audio or video).
 	 *
 	 * @since 3.6.0
 	 *
@@ -224,6 +230,8 @@ Library = wp.media.controller.State.extend(/** @lends wp.media.controller.Librar
 
 
 	/**
+	 * Resets the content mode to the default.
+	 *
 	 * If the state is active, no items are selected, and the current
 	 * content mode is not an option in the state's router (provided
 	 * the state has a router), reset the content mode to the default.
@@ -270,7 +278,7 @@ Library = wp.media.controller.State.extend(/** @lends wp.media.controller.Librar
 	},
 
 	/**
-	 * Persist the mode of the content region as a user setting.
+	 * Persists the mode of the content region as a user setting.
 	 *
 	 * @since 3.5.0
 	 */

--- a/src/js/media/controllers/media-library.js
+++ b/src/js/media/controllers/media-library.js
@@ -22,6 +22,8 @@ MediaLibrary = Library.extend(/** @lends wp.media.controller.MediaLibrary.protot
 	}, Library.prototype.defaults ),
 
 	/**
+	 * Initializes the MediaLibrary controller.
+	 *
 	 * @since 3.9.0
 	 *
 	 * @param {Object} options Attributes.
@@ -35,6 +37,8 @@ MediaLibrary = Library.extend(/** @lends wp.media.controller.MediaLibrary.protot
 	},
 
 	/**
+	 * Activates the MediaLibrary controller.
+	 *
 	 * @since 3.9.0
 	 */
 	activate: function() {

--- a/src/js/media/controllers/replace-image.js
+++ b/src/js/media/controllers/replace-image.js
@@ -48,6 +48,8 @@ ReplaceImage = Library.extend(/** @lends wp.media.controller.ReplaceImage.protot
 	}, Library.prototype.defaults ),
 
 	/**
+	 * Initializes the ReplaceImage controller.
+	 *
 	 * @since 3.9.0
 	 *
 	 * @param {Object} options Attributes.
@@ -87,6 +89,8 @@ ReplaceImage = Library.extend(/** @lends wp.media.controller.ReplaceImage.protot
 	},
 
 	/**
+	 * Activates the ReplaceImage controller.
+	 *
 	 * @since 3.9.0
 	 */
 	activate: function() {
@@ -96,6 +100,8 @@ ReplaceImage = Library.extend(/** @lends wp.media.controller.ReplaceImage.protot
 	},
 
 	/**
+	 * Deactivates the ReplaceImage controller.
+	 *
 	 * @since 5.9.0
 	 */
 	deactivate: function() {
@@ -105,6 +111,8 @@ ReplaceImage = Library.extend(/** @lends wp.media.controller.ReplaceImage.protot
 	},
 
 	/**
+	 * Updates the selection to match the current image.
+	 *
 	 * @since 3.9.0
 	 */
 	updateSelection: function() {

--- a/src/js/media/controllers/state-machine.js
+++ b/src/js/media/controllers/state-machine.js
@@ -106,18 +106,24 @@ _.extend( StateMachine.prototype, Backbone.Events,/** @lends wp.media.controller
 // Map all event binding and triggering on a StateMachine to its `states` collection.
 _.each([ 'on', 'off', 'trigger' ], function( method ) {
 	/**
+	 * Binds an event listener to events in the StateMachine's states collection.
+	 *
 	 * @function on
 	 * @memberOf wp.media.controller.StateMachine
 	 * @instance
 	 * @return {wp.media.controller.StateMachine} Returns itself to allow chaining.
 	 */
 	/**
+	 * Unbinds an event listener from the StateMachine's states collection.
+	 *
 	 * @function off
 	 * @memberOf wp.media.controller.StateMachine
 	 * @instance
 	 * @return {wp.media.controller.StateMachine} Returns itself to allow chaining.
 	 */
 	/**
+	 * Triggers an event on the StateMachine's states collection.
+	 *
 	 * @function trigger
 	 * @memberOf wp.media.controller.StateMachine
 	 * @instance

--- a/src/js/media/controllers/state.js
+++ b/src/js/media/controllers/state.js
@@ -71,6 +71,8 @@ var State = Backbone.Model.extend(/** @lends wp.media.controller.State.prototype
 	reset: function() {},
 
 	/**
+	 * Ready event callback.
+	 *
 	 * @since 3.5.0
 	 * @access private
 	 */
@@ -79,6 +81,8 @@ var State = Backbone.Model.extend(/** @lends wp.media.controller.State.prototype
 	},
 
 	/**
+	 * Pre-activate event callback.
+	 *
 	 * @since 3.5.0
 	 * @access private
 	*/
@@ -87,6 +91,8 @@ var State = Backbone.Model.extend(/** @lends wp.media.controller.State.prototype
 	},
 
 	/**
+	 * Post-activate event callback.
+	 *
 	 * @since 3.5.0
 	 * @access private
 	 */
@@ -106,6 +112,8 @@ var State = Backbone.Model.extend(/** @lends wp.media.controller.State.prototype
 	},
 
 	/**
+	 * Deactivate event callback.
+	 *
 	 * @since 3.5.0
 	 * @access private
 	 */
@@ -121,6 +129,9 @@ var State = Backbone.Model.extend(/** @lends wp.media.controller.State.prototype
 	},
 
 	/**
+	 * Renders the frame's title using the titleMode property.
+	 *
+	 *
 	 * @since 3.5.0
 	 * @access private
 	 */
@@ -129,6 +140,8 @@ var State = Backbone.Model.extend(/** @lends wp.media.controller.State.prototype
 	},
 
 	/**
+	 * Renders the title in the media frame.
+	 *
 	 * @param {media.view.Title} view The title view.
 	 * @since 3.5.0
 	 * @access private
@@ -138,6 +151,8 @@ var State = Backbone.Model.extend(/** @lends wp.media.controller.State.prototype
 	},
 
 	/**
+	 * Renders and manages the router region.
+	 *
 	 * @since 3.5.0
 	 * @access private
 	 */
@@ -160,6 +175,8 @@ var State = Backbone.Model.extend(/** @lends wp.media.controller.State.prototype
 	},
 
 	/**
+	 * Renders and manages the menu region.
+	 *
 	 * @since 3.5.0
 	 * @access private
 	 */
@@ -189,6 +206,8 @@ var State = Backbone.Model.extend(/** @lends wp.media.controller.State.prototype
 	},
 
 	/**
+	 * Updates the menu.
+	 *
 	 * @since 3.5.0
 	 * @access private
 	 */
@@ -206,7 +225,7 @@ var State = Backbone.Model.extend(/** @lends wp.media.controller.State.prototype
 	},
 
 	/**
-	 * Create a view in the media menu for the state.
+	 * Creates a view in the media menu for the state.
 	 *
 	 * @since 3.5.0
 	 * @access private
@@ -234,8 +253,13 @@ var State = Backbone.Model.extend(/** @lends wp.media.controller.State.prototype
 	}
 });
 
+/**
+ * Creates render methods for frame regions.
+ */
 _.each(['toolbar','content'], function( region ) {
 	/**
+	 * Renders the region in the media frame.
+	 *
 	 * @access private
 	 */
 	State.prototype[ '_' + region ] = function() {

--- a/src/js/media/models/attachment.js
+++ b/src/js/media/models/attachment.js
@@ -113,6 +113,8 @@ Attachment = Backbone.Model.extend(/** @lends wp.media.model.Attachment.prototyp
 		return resp;
 	},
 	/**
+	 * Save attachment details using the `save-attachment-compat` action.
+	 *
 	 * @param {Object} data The properties to be saved.
 	 * @param {Object} options Sync options. e.g. patch, wait, success, error.
 	 *

--- a/src/js/media/models/attachments.js
+++ b/src/js/media/models/attachments.js
@@ -28,6 +28,8 @@ var Attachments = Backbone.Collection.extend(/** @lends wp.media.model.Attachmen
 	 */
 	model: wp.media.model.Attachment,
 	/**
+	 * Initializes the Attachments collection.
+	 *
 	 * @param {Array} [models=[]] Array of models used to populate the collection.
 	 * @param {Object} [options={}]
 	 */
@@ -65,7 +67,7 @@ var Attachments = Backbone.Collection.extend(/** @lends wp.media.model.Attachmen
 		}
 	},
 	/**
-	 * Sort the collection when the order attribute changes.
+	 * Sorts the collection when the order attribute changes.
 	 *
 	 * @access private
 	 */
@@ -75,7 +77,7 @@ var Attachments = Backbone.Collection.extend(/** @lends wp.media.model.Attachmen
 		}
 	},
 	/**
-	 * Set the default comparator only when the `orderby` property is set.
+	 * Sets the default comparator only when the `orderby` property is set.
 	 *
 	 * @access private
 	 *
@@ -95,8 +97,7 @@ var Attachments = Backbone.Collection.extend(/** @lends wp.media.model.Attachmen
 		}
 	},
 	/**
-	 * If the `query` property is set to true, query the server using
-	 * the `props` values, and sync the results to this collection.
+	 * Queries the server using the `props` values and syncs the results to this collection if the `query` property is set to true.
 	 *
 	 * @access private
 	 *
@@ -112,6 +113,8 @@ var Attachments = Backbone.Collection.extend(/** @lends wp.media.model.Attachmen
 		}
 	},
 	/**
+	 * Updates the collection when a property that has a filter is changed.
+	 *
 	 * @access private
 	 *
 	 * @param {Backbone.Model} model
@@ -173,7 +176,7 @@ var Attachments = Backbone.Collection.extend(/** @lends wp.media.model.Attachmen
 		}, this );
 	},
 	/**
-	 * Add or remove an attachment to the collection depending on its validity.
+	 * Adds or removes an attachment to the collection depending on its validity.
 	 *
 	 * @param {wp.media.model.Attachment} attachment
 	 * @param {Object} options
@@ -193,7 +196,7 @@ var Attachments = Backbone.Collection.extend(/** @lends wp.media.model.Attachmen
 	},
 
 	/**
-	 * Add or remove all attachments from another collection depending on each one's validity.
+	 * Adds or removes all attachments from another collection depending on each one's validity.
 	 *
 	 * @param {wp.media.model.Attachments} attachments
 	 * @param {Object} [options={}]
@@ -215,8 +218,7 @@ var Attachments = Backbone.Collection.extend(/** @lends wp.media.model.Attachmen
 		return this;
 	},
 	/**
-	 * Start observing another attachments collection change events
-	 * and replicate them on this collection.
+	 * Starts observing another attachments collection change events and replicates them on this collection.
 	 *
 	 * @param {wp.media.model.Attachments} attachments The attachments collection to observe.
 	 * @return {wp.media.model.Attachments} Returns itself to allow chaining.
@@ -231,7 +233,7 @@ var Attachments = Backbone.Collection.extend(/** @lends wp.media.model.Attachmen
 		return this;
 	},
 	/**
-	 * Stop replicating collection change events from another attachments collection.
+	 * Stops replicating collection change events from another attachments collection.
 	 *
 	 * @param {wp.media.model.Attachments} attachments The attachments collection to stop observing.
 	 * @return {wp.media.model.Attachments} Returns itself to allow chaining.
@@ -251,7 +253,7 @@ var Attachments = Backbone.Collection.extend(/** @lends wp.media.model.Attachmen
 		return this;
 	},
 	/**
-	 * Update total attachment count when items are added to a collection.
+	 * Updates total attachment count when items are added to a collection.
 	 *
 	 * @access private
 	 *
@@ -263,7 +265,7 @@ var Attachments = Backbone.Collection.extend(/** @lends wp.media.model.Attachmen
 		}
 	},
 	/**
-	 * Update total attachment count when items are added to a collection.
+	 * Updates total attachment count when items are added to a collection.
 	 *
 	 * @access private
 	 *
@@ -275,6 +277,8 @@ var Attachments = Backbone.Collection.extend(/** @lends wp.media.model.Attachmen
 		}
 	},
 	/**
+	 * Validates an attachment against the collection's rules.
+	 *
 	 * @access private
 	 *
 	 * @param {wp.media.model.Attachments} attachment
@@ -293,6 +297,8 @@ var Attachments = Backbone.Collection.extend(/** @lends wp.media.model.Attachmen
 		return this.validate( attachment, options );
 	},
 	/**
+	 * Validates all attachments in a collection against the collection's rules.
+	 *
 	 * @access private
 	 *
 	 * @param {wp.media.model.Attachments} attachments
@@ -303,8 +309,7 @@ var Attachments = Backbone.Collection.extend(/** @lends wp.media.model.Attachmen
 		return this.validateAll( attachments, options );
 	},
 	/**
-	 * Start mirroring another attachments collection, clearing out any models already
-	 * in the collection.
+	 * Starts mirroring another attachments collection, clearing out any models already in the collection.
 	 *
 	 * @param {wp.media.model.Attachments} attachments The attachments collection to mirror.
 	 * @return {wp.media.model.Attachments} Returns itself to allow chaining.
@@ -333,7 +338,7 @@ var Attachments = Backbone.Collection.extend(/** @lends wp.media.model.Attachmen
 		return this;
 	},
 	/**
-	 * Stop mirroring another attachments collection.
+	 * Stops mirroring another attachments collection.
 	 */
 	unmirror: function() {
 		if ( ! this.mirroring ) {
@@ -344,7 +349,7 @@ var Attachments = Backbone.Collection.extend(/** @lends wp.media.model.Attachmen
 		delete this.mirroring;
 	},
 	/**
-	 * Retrieve more attachments from the server for the collection.
+	 * Retrieves more attachments from the server for the collection.
 	 *
 	 * Only works if the collection is mirroring a Query Attachments collection,
 	 * and forwards to its `more` method. This collection class doesn't have
@@ -379,8 +384,7 @@ var Attachments = Backbone.Collection.extend(/** @lends wp.media.model.Attachmen
 		return deferred.promise();
 	},
 	/**
-	 * Whether there are more attachments that haven't been sync'd from the server
-	 * that match the collection's query.
+	 * Checks whether there are more attachments that haven't been sync'd from the server that match the collection's query.
 	 *
 	 * Only works if the collection is mirroring a Query Attachments collection,
 	 * and forwards to its `hasMore` method. This collection class doesn't have
@@ -449,7 +453,7 @@ var Attachments = Backbone.Collection.extend(/** @lends wp.media.model.Attachmen
 	},
 
 	/**
-	 * If the collection is a query, create and mirror an Attachments Query collection.
+	 * Creates and mirrors an Attachments Query collection if the collection is a query.
 	 *
 	 * @access private
 	 */
@@ -461,8 +465,7 @@ var Attachments = Backbone.Collection.extend(/** @lends wp.media.model.Attachmen
 		}
 	},
 	/**
-	 * If this collection is sorted by `menuOrder`, recalculates and saves
-	 * the menu order to the database.
+	 * If this collection is sorted by `menuOrder`, recalculates and saves the menu order to the database.
 	 *
 	 * @return {undefined|Promise} Returns a promise if the menu order is saved, otherwise undefined.
 	 */
@@ -533,6 +536,8 @@ var Attachments = Backbone.Collection.extend(/** @lends wp.media.model.Attachmen
 	/** @namespace wp.media.model.Attachments.filters */
 	filters: {
 		/**
+		 * Filters attachments based on a search query.
+		 *
 		 * @static
 		 * Note that this client-side searching is *not* equivalent
 		 * to our server-side searching.
@@ -554,6 +559,8 @@ var Attachments = Backbone.Collection.extend(/** @lends wp.media.model.Attachmen
 			}, this );
 		},
 		/**
+		 * Filters attachments based on their type.
+		 *
 		 * @static
 		 * @param {wp.media.model.Attachment} attachment
 		 *
@@ -581,6 +588,8 @@ var Attachments = Backbone.Collection.extend(/** @lends wp.media.model.Attachmen
 			return found;
 		},
 		/**
+		 * Filters attachments based on their uploadedTo property.
+		 *
 		 * @static
 		 * @param {wp.media.model.Attachment} attachment
 		 *
@@ -597,6 +606,8 @@ var Attachments = Backbone.Collection.extend(/** @lends wp.media.model.Attachmen
 			return uploadedTo === attachment.get('uploadedTo');
 		},
 		/**
+		 * Filters attachments based on their status property.
+		 *
 		 * @static
 		 * @param {wp.media.model.Attachment} attachment
 		 *

--- a/src/js/media/models/query.js
+++ b/src/js/media/models/query.js
@@ -22,6 +22,8 @@ var Attachments = wp.media.model.Attachments,
  */
 Query = Attachments.extend(/** @lends wp.media.model.Query.prototype */{
 	/**
+	 * Initializes the Query collection.
+	 *
 	 * @param {Array}  [models=[]]  Array of initial models to populate the collection.
 	 * @param {Object} [options={}]
 	 */
@@ -236,6 +238,8 @@ Query = Attachments.extend(/** @lends wp.media.model.Query.prototype */{
 		var queries = [];
 
 		/**
+		 * Creates and returns an Attachments Query collection given the properties.
+		 *
 		 * @param {Object} [props]
 		 * @param {Object} [options]
 		 * @return {Query} A new Attachments Query collection.

--- a/src/js/media/utils/selection-sync.js
+++ b/src/js/media/utils/selection-sync.js
@@ -12,6 +12,8 @@
  */
 var selectionSync = {
 	/**
+	 * Syncs the selection in this state with the master selection.
+	 *
 	 * @since 3.5.0
 	 */
 	syncSelection: function() {

--- a/src/js/media/views/attachment-compat.js
+++ b/src/js/media/views/attachment-compat.js
@@ -30,6 +30,8 @@ AttachmentCompat = View.extend(/** @lends wp.media.view.AttachmentCompat.prototy
 	},
 
 	/**
+	 * Disposes of the view and its children.
+	 *
 	 * @return {wp.media.view.AttachmentCompat} Returns itself to allow chaining.
 	 */
 	dispose: function() {
@@ -42,6 +44,8 @@ AttachmentCompat = View.extend(/** @lends wp.media.view.AttachmentCompat.prototy
 		return View.prototype.dispose.apply( this, arguments );
 	},
 	/**
+	 * Renders the view.
+	 *
 	 * @return {void|wp.media.view.AttachmentCompat} Returns itself to allow chaining.
 	 */
 	render: function() {
@@ -56,12 +60,16 @@ AttachmentCompat = View.extend(/** @lends wp.media.view.AttachmentCompat.prototy
 		return this;
 	},
 	/**
+	 * Prevents the default action of the event.
+	 *
 	 * @param {Object} event
 	 */
 	preventDefault: function( event ) {
 		event.preventDefault();
 	},
 	/**
+	 * Saves the attachment compat data.
+	 *
 	 * @param {Object} event
 	 */
 	save: function( event ) {
@@ -79,6 +87,9 @@ AttachmentCompat = View.extend(/** @lends wp.media.view.AttachmentCompat.prototy
 		this.model.saveCompat( data ).always( _.bind( this.postSave, this ) );
 	},
 
+	/**
+	 * Triggers the `attachment:compat:ready` event on the controller after saving the compat data.
+	 */
 	postSave: function() {
 		this.controller.trigger( 'attachment:compat:ready', ['ready'] );
 	}

--- a/src/js/media/views/attachment-filters.js
+++ b/src/js/media/views/attachment-filters.js
@@ -39,6 +39,8 @@ AttachmentFilters = wp.media.View.extend(/** @lends wp.media.view.AttachmentFilt
 	},
 
 	/**
+	 * Creates the filters for the view.
+	 *
 	 * @abstract
 	 */
 	createFilters: function() {
@@ -46,7 +48,7 @@ AttachmentFilters = wp.media.View.extend(/** @lends wp.media.view.AttachmentFilt
 	},
 
 	/**
-	 * When the selected filter changes, update the Attachment Query properties to match.
+	 * Updates the Attachment Query properties to match when the selected filter changes.
 	 */
 	change: function() {
 		var filter = this.filters[ this.el.value ];
@@ -55,6 +57,9 @@ AttachmentFilters = wp.media.View.extend(/** @lends wp.media.view.AttachmentFilt
 		}
 	},
 
+	/**
+	 * Selects the filter based on the Attachment Query properties.
+	 */
 	select: function() {
 		var model = this.model,
 			value = 'all',

--- a/src/js/media/views/attachment.js
+++ b/src/js/media/views/attachment.js
@@ -570,6 +570,8 @@ _.each({
 	album:   '_syncAlbum'
 }, function( method, setting ) {
 	/**
+	 * Updates the DOM when the model's caption changes.
+	 *
 	 * @function _syncCaption
 	 * @memberOf wp.media.view.Attachment
 	 * @instance
@@ -579,6 +581,8 @@ _.each({
 	 * @return {wp.media.view.Attachment} Returns itself to allow chaining.
 	 */
 	/**
+	 * Updates the DOM when the model's title changes.
+	 *
 	 * @function _syncTitle
 	 * @memberOf wp.media.view.Attachment
 	 * @instance
@@ -588,6 +592,8 @@ _.each({
 	 * @return {wp.media.view.Attachment} Returns itself to allow chaining.
 	 */
 	/**
+	 * Updates the DOM when the model's artist changes.
+	 *
 	 * @function _syncArtist
 	 * @memberOf wp.media.view.Attachment
 	 * @instance
@@ -597,6 +603,8 @@ _.each({
 	 * @return {wp.media.view.Attachment} Returns itself to allow chaining.
 	 */
 	/**
+	 * Updates the DOM when the model's album changes.
+	 *
 	 * @function _syncAlbum
 	 * @memberOf wp.media.view.Attachment
 	 * @instance

--- a/src/js/media/views/attachments/browser.js
+++ b/src/js/media/views/attachments/browser.js
@@ -33,6 +33,9 @@ AttachmentsBrowser = View.extend(/** @lends wp.media.view.AttachmentsBrowser.pro
 	tagName:   'div',
 	className: 'attachments-browser',
 
+	/**
+	 * Initializes the AttachmentsBrowser view.
+	 */
 	initialize: function() {
 		_.defaults( this.options, {
 			filters: false,
@@ -147,12 +150,19 @@ AttachmentsBrowser = View.extend(/** @lends wp.media.view.AttachmentsBrowser.pro
 		}
 	}, 200 ),
 
+	/**
+	 * Edits the selection in the modal. This is used when the user clicks the "Edit" button in the modal.
+	 *
+	 * @param {wp.media.view.Modal} modal The modal view.
+	 */
 	editSelection: function( modal ) {
 		// When editing a selection, move focus to the "Go to library" button.
 		modal.$( '.media-button-backToLibrary' ).focus();
 	},
 
 	/**
+	 * Disposes of the view and its children.
+	 *
 	 * @return {wp.media.view.AttachmentsBrowser} Returns itself to allow chaining.
 	 */
 	dispose: function() {
@@ -161,6 +171,9 @@ AttachmentsBrowser = View.extend(/** @lends wp.media.view.AttachmentsBrowser.pro
 		return this;
 	},
 
+	/**
+	 * Creates the toolbar view.
+	 */
 	createToolbar: function() {
 		var LibraryViewSwitcher, Filters, toolbarOptions,
 			showFilterByType = -1 !== $.inArray( this.options.filters, [ 'uploaded', 'all' ] );
@@ -410,6 +423,9 @@ AttachmentsBrowser = View.extend(/** @lends wp.media.view.AttachmentsBrowser.pro
 		}
 	},
 
+	/**
+	 * Updates the content of the attachments browser.
+	 */
 	updateContent: function() {
 		var view = this,
 			noItemsView;
@@ -441,6 +457,9 @@ AttachmentsBrowser = View.extend(/** @lends wp.media.view.AttachmentsBrowser.pro
 		}
 	},
 
+	/**
+	 * Creates the uploader view.
+	 */
 	createUploader: function() {
 		this.uploader = new wp.media.view.UploaderInline({
 			controller: this.controller,
@@ -453,6 +472,9 @@ AttachmentsBrowser = View.extend(/** @lends wp.media.view.AttachmentsBrowser.pro
 		this.views.add( this.uploader );
 	},
 
+	/**
+	 * Toggles the uploader view.
+	 */
 	toggleUploader: function() {
 		if ( this.uploader.$el.hasClass( 'hidden' ) ) {
 			this.uploader.show();
@@ -478,6 +500,9 @@ AttachmentsBrowser = View.extend(/** @lends wp.media.view.AttachmentsBrowser.pro
 		this.createAttachments();
 	},
 
+	/**
+	 * Creates the attachments view.
+	 */
 	createAttachments: function() {
 		this.attachments = new wp.media.view.Attachments({
 			controller:           this.controller,
@@ -661,6 +686,9 @@ AttachmentsBrowser = View.extend(/** @lends wp.media.view.AttachmentsBrowser.pro
 		this.firstAddedMediaItem.focus();
 	},
 
+	/**
+	 * Creates the attachments heading view.
+	 */
 	createAttachmentsHeading: function() {
 		this.attachmentsHeading = new wp.media.view.Heading( {
 			text: l10n.attachmentsList,
@@ -670,6 +698,9 @@ AttachmentsBrowser = View.extend(/** @lends wp.media.view.AttachmentsBrowser.pro
 		this.views.add( this.attachmentsHeading );
 	},
 
+	/**
+	 * Creates the sidebar view.
+	 */
 	createSidebar: function() {
 		var options = this.options,
 			selection = options.selection,
@@ -694,6 +725,9 @@ AttachmentsBrowser = View.extend(/** @lends wp.media.view.AttachmentsBrowser.pro
 		}
 	},
 
+	/**
+	 * Creates the single attachment view.
+	 */
 	createSingle: function() {
 		var sidebar = this.sidebar,
 			single = this.options.selection.single();
@@ -726,6 +760,9 @@ AttachmentsBrowser = View.extend(/** @lends wp.media.view.AttachmentsBrowser.pro
 		}
 	},
 
+	/**
+	 * Disposes of the single attachment view.
+	 */
 	disposeSingle: function() {
 		var sidebar = this.sidebar;
 		sidebar.unset('details');

--- a/src/js/media/views/button.js
+++ b/src/js/media/views/button.js
@@ -47,6 +47,8 @@ var Button = wp.media.View.extend(/** @lends wp.media.view.Button.prototype */{
 		this.listenTo( this.model, 'change', this.render );
 	},
 	/**
+	 * Renders the button.
+	 *
 	 * @return {wp.media.view.Button} Returns itself to allow chaining.
 	 */
 	render: function() {
@@ -70,6 +72,8 @@ var Button = wp.media.View.extend(/** @lends wp.media.view.Button.prototype */{
 		return this;
 	},
 	/**
+	 * Handles the click event.
+	 *
 	 * @param {Object} event
 	 */
 	click: function( event ) {

--- a/src/js/media/views/embed.js
+++ b/src/js/media/views/embed.js
@@ -8,9 +8,12 @@
  * @augments wp.Backbone.View
  * @augments Backbone.View
  */
-var Embed = wp.media.View.extend(/** @lends wp.media.view.Ember.prototype */{
+var Embed = wp.media.View.extend(/** @lends wp.media.view.Embed.prototype */{
 	className: 'media-embed',
 
+	/**
+	 * Initializes the embed view.
+	 */
 	initialize: function() {
 		/**
 		 * @member {wp.media.view.EmbedUrl}
@@ -27,6 +30,8 @@ var Embed = wp.media.View.extend(/** @lends wp.media.view.Ember.prototype */{
 	},
 
 	/**
+	 * Sets the settings for the embed view.
+	 *
 	 * @param {Object} view
 	 */
 	settings: function( view ) {
@@ -37,6 +42,9 @@ var Embed = wp.media.View.extend(/** @lends wp.media.view.Ember.prototype */{
 		this.views.add( view );
 	},
 
+	/**
+	 * Refreshes the embed view based on the type of embed.
+	 */
 	refresh: function() {
 		var type = this.model.get('type'),
 			constructor;
@@ -56,6 +64,9 @@ var Embed = wp.media.View.extend(/** @lends wp.media.view.Ember.prototype */{
 		}) );
 	},
 
+	/**
+	 * Toggles the loading state of the embed view.
+	 */
 	loading: function() {
 		this.$el.toggleClass( 'embed-loading', this.model.get('loading') );
 	}

--- a/src/js/media/views/frame/manage.js
+++ b/src/js/media/views/frame/manage.js
@@ -23,7 +23,7 @@ var MediaFrame = wp.media.view.MediaFrame,
  */
 Manage = MediaFrame.extend(/** @lends wp.media.view.MediaFrame.Manage.prototype */{
 	/**
-	 * @constructs
+	 * Initializes the manage frame.
 	 */
 	initialize: function() {
 		_.defaults( this.options, {
@@ -87,6 +87,9 @@ Manage = MediaFrame.extend(/** @lends wp.media.view.MediaFrame.Manage.prototype 
 		wp.media.frames.browse = this;
 	},
 
+	/**
+	 * Binds the search input to the grid router.
+	 */
 	bindSearchHandler: function() {
 		var search = this.$( '#media-search-input' ),
 			searchView = this.browserView.toolbar.get( 'search' ).$el,
@@ -123,7 +126,7 @@ Manage = MediaFrame.extend(/** @lends wp.media.view.MediaFrame.Manage.prototype 
 	},
 
 	/**
-	 * Create the default states for the frame.
+	 * Creates the default states for the frame.
 	 */
 	createStates: function() {
 		var options = this.options;
@@ -148,7 +151,7 @@ Manage = MediaFrame.extend(/** @lends wp.media.view.MediaFrame.Manage.prototype 
 	},
 
 	/**
-	 * Bind region mode activation events to proper handlers.
+	 * Binds region mode activation events to proper handlers.
 	 */
 	bindRegionModeHandlers: function() {
 		this.on( 'content:create:browse', this.browseContent, this );
@@ -160,6 +163,11 @@ Manage = MediaFrame.extend(/** @lends wp.media.view.MediaFrame.Manage.prototype 
 		this.on( 'select:deactivate', this.unbindKeydown, this );
 	},
 
+	/**
+	 * Handles keydown events for the frame.
+	 *
+	 * @param {JQuery.Event} e The keydown event.
+	 */
 	handleKeydown: function( e ) {
 		if ( 27 === e.which ) {
 			e.preventDefault();
@@ -167,14 +175,23 @@ Manage = MediaFrame.extend(/** @lends wp.media.view.MediaFrame.Manage.prototype 
 		}
 	},
 
+	/**
+	 * Binds the keydown event for the frame.
+	 */
 	bindKeydown: function() {
 		this.$body.on( 'keydown.select', _.bind( this.handleKeydown, this ) );
 	},
 
+	/**
+	 * Unbinds the keydown event for the frame.
+	 */
 	unbindKeydown: function() {
 		this.$body.off( 'keydown.select' );
 	},
 
+	/**
+	 * Fixes the position of the attachments browser when scrolling the page.
+	 */
 	fixPosition: function() {
 		var $browser, $toolbar;
 		if ( ! this.isModeActive( 'select' ) ) {
@@ -209,7 +226,7 @@ Manage = MediaFrame.extend(/** @lends wp.media.view.MediaFrame.Manage.prototype 
 	},
 
 	/**
-	 * Open the Edit Attachment modal.
+	 * Opens the Edit Attachment modal.
 	 *
 	 * @param {wp.media.model.Attachment} model The attachment model to edit.
 	 */
@@ -228,7 +245,7 @@ Manage = MediaFrame.extend(/** @lends wp.media.view.MediaFrame.Manage.prototype 
 	},
 
 	/**
-	 * Create an attachments browser view within the content region.
+	 * Creates an attachments browser view within the content region.
 	 *
 	 * @param {Object} contentRegion Basic object with a `view` property, which
 	 *                               should be set with the proper region view.
@@ -264,10 +281,16 @@ Manage = MediaFrame.extend(/** @lends wp.media.view.MediaFrame.Manage.prototype 
 		this.errors.on( 'add remove reset', this.sidebarVisibility, this );
 	},
 
+	/**
+	 * Hadles the visibility of the sidebar
+	 */
 	sidebarVisibility: function() {
 		this.browserView.$( '.media-sidebar' ).toggle( !! this.errors.length );
 	},
 
+	/**
+	 * Binds the deferred object of the browser view to the startHistory method.
+	 */
 	bindDeferred: function() {
 		if ( ! this.browserView.dfd ) {
 			return;
@@ -275,6 +298,9 @@ Manage = MediaFrame.extend(/** @lends wp.media.view.MediaFrame.Manage.prototype 
 		this.browserView.dfd.done( _.bind( this.startHistory, this ) );
 	},
 
+	/**
+	 * Starts the history for the frame, if supported.
+	 */
 	startHistory: function() {
 		// Verify pushState support and activate.
 		if ( window.history && window.history.pushState ) {

--- a/src/js/media/views/frame/manage.js
+++ b/src/js/media/views/frame/manage.js
@@ -24,6 +24,8 @@ var MediaFrame = wp.media.view.MediaFrame,
 Manage = MediaFrame.extend(/** @lends wp.media.view.MediaFrame.Manage.prototype */{
 	/**
 	 * Initializes the manage frame.
+	 *
+	 * @constructs
 	 */
 	initialize: function() {
 		_.defaults( this.options, {
@@ -282,7 +284,7 @@ Manage = MediaFrame.extend(/** @lends wp.media.view.MediaFrame.Manage.prototype 
 	},
 
 	/**
-	 * Hadles the visibility of the sidebar
+	 * Handles the visibility of the sidebar
 	 */
 	sidebarVisibility: function() {
 		this.browserView.$( '.media-sidebar' ).toggle( !! this.errors.length );

--- a/src/js/media/views/frame/post.js
+++ b/src/js/media/views/frame/post.js
@@ -234,6 +234,9 @@ Post = Select.extend(/** @lends wp.media.view.MediaFrame.Post.prototype */{
 		}, this );
 	},
 
+	/**
+	 * Activates the frame.
+	 */
 	activate: function() {
 		// Hide menu items for states tied to particular media types if there are no items.
 		_.each( this.counts, function( type ) {
@@ -243,6 +246,12 @@ Post = Select.extend(/** @lends wp.media.view.MediaFrame.Post.prototype */{
 		}, this );
 	},
 
+	/**
+	 * Handles the counts of media types.
+	 *
+	 * @param {wp.media.model.Attachments} model The attachment model that changed.
+	 * @param {string}                     attr  The attribute that changed on the model.
+	 */
 	mediaTypeCounts: function( model, attr ) {
 		if ( typeof this.counts[ attr ] !== 'undefined' && this.counts[ attr ].count < 1 ) {
 			this.counts[ attr ].count++;
@@ -252,6 +261,8 @@ Post = Select.extend(/** @lends wp.media.view.MediaFrame.Post.prototype */{
 
 	// Menus.
 	/**
+	 * Handles the main menu for the frame.
+	 *
 	 * @param {wp.Backbone.View} view
 	 */
 	mainMenu: function( view ) {
@@ -266,6 +277,12 @@ Post = Select.extend(/** @lends wp.media.view.MediaFrame.Post.prototype */{
 		});
 	},
 
+	/**
+	 * Handles the visibility of menu items for the frame.
+	 *
+	 * @param {string} state      The state to show or hide.
+	 * @param {string} visibility The visibility of the menu item, either 'show' or 'hide'.
+	 */
 	menuItemVisibility: function( state, visibility ) {
 		var menu = this.menu.get();
 		if ( visibility === 'hide' ) {
@@ -275,6 +292,8 @@ Post = Select.extend(/** @lends wp.media.view.MediaFrame.Post.prototype */{
 		}
 	},
 	/**
+	 * Handles the gallery menu for the frame.
+	 *
 	 * @param {wp.Backbone.View} view
 	 */
 	galleryMenu: function( view ) {
@@ -304,6 +323,11 @@ Post = Select.extend(/** @lends wp.media.view.MediaFrame.Post.prototype */{
 		});
 	},
 
+	/**
+	 * Handles the playlist menu for the frame.
+	 *
+	 * @param {wp.Backbone.View} view The menu view.
+	 */
 	playlistMenu: function( view ) {
 		var lastState = this.lastState(),
 			previous = lastState && lastState.id,
@@ -331,6 +355,11 @@ Post = Select.extend(/** @lends wp.media.view.MediaFrame.Post.prototype */{
 		});
 	},
 
+	/**
+	 * Handles the video playlist menu for the frame.
+	 *
+	 * @param {wp.Backbone.View} view The menu view.
+	 */
 	videoPlaylistMenu: function( view ) {
 		var lastState = this.lastState(),
 			previous = lastState && lastState.id,
@@ -359,7 +388,12 @@ Post = Select.extend(/** @lends wp.media.view.MediaFrame.Post.prototype */{
 	},
 
 	// Content.
-	embedContent: function() {
+	/**
+	 * Handles the embed content for the frame.
+	 *
+	 * @param {wp.Backbone.View} view The content view.
+	 */
+	embedContent: function( view ) {
 		var view = new wp.media.view.Embed({
 			controller: this,
 			model:      this.state()
@@ -368,6 +402,9 @@ Post = Select.extend(/** @lends wp.media.view.MediaFrame.Post.prototype */{
 		this.content.set( view );
 	},
 
+	/**
+	 * Handles the edit selection content for the frame.
+	 */
 	editSelectionContent: function() {
 		var state = this.state(),
 			selection = state.get('selection'),
@@ -404,6 +441,9 @@ Post = Select.extend(/** @lends wp.media.view.MediaFrame.Post.prototype */{
 		this.trigger( 'edit:selection', this );
 	},
 
+	/**
+	 * Handles the edit image content for the frame.
+	 */
 	editImageContent: function() {
 		var image = this.state().get('image'),
 			view = new wp.media.view.EditImage( { model: image, controller: this } ).render();
@@ -418,7 +458,9 @@ Post = Select.extend(/** @lends wp.media.view.MediaFrame.Post.prototype */{
 	// Toolbars.
 
 	/**
-	 * @param {wp.Backbone.View} view
+	 * Handles the selection status toolbar for the frame
+	 *
+	 * @param {wp.Backbone.View} view The toolbar view.
 	 */
 	selectionStatusToolbar: function( view ) {
 		var editable = this.state().get('editable');
@@ -437,7 +479,9 @@ Post = Select.extend(/** @lends wp.media.view.MediaFrame.Post.prototype */{
 	},
 
 	/**
-	 * @param {wp.Backbone.View} view
+	 * Handles the main insert toolbar for the frame.
+	 *
+	 * @param {wp.Backbone.View} view The toolbar view.
 	 */
 	mainInsertToolbar: function( view ) {
 		var controller = this;
@@ -466,7 +510,9 @@ Post = Select.extend(/** @lends wp.media.view.MediaFrame.Post.prototype */{
 	},
 
 	/**
-	 * @param {wp.Backbone.View} view
+	 * Handles the main gallery toolbar for the frame.
+	 *
+	 * @param {wp.Backbone.View} view The toolbar view.
 	 */
 	mainGalleryToolbar: function( view ) {
 		var controller = this;
@@ -498,6 +544,11 @@ Post = Select.extend(/** @lends wp.media.view.MediaFrame.Post.prototype */{
 		});
 	},
 
+	/**
+	 * Handles the main playlist toolbar for the frame.
+	 *
+	 * @param {wp.Backbone.View} view The toolbar view.
+	 */
 	mainPlaylistToolbar: function( view ) {
 		var controller = this;
 
@@ -528,6 +579,11 @@ Post = Select.extend(/** @lends wp.media.view.MediaFrame.Post.prototype */{
 		});
 	},
 
+	/**
+	 * Handles the main video playlist toolbar for the frame.
+	 *
+	 * @param {wp.Backbone.View} view The toolbar view.
+	 */
 	mainVideoPlaylistToolbar: function( view ) {
 		var controller = this;
 
@@ -558,6 +614,11 @@ Post = Select.extend(/** @lends wp.media.view.MediaFrame.Post.prototype */{
 		});
 	},
 
+	/**
+	 * Handles the featured image toolbar for the frame.
+	 *
+	 * @param {wp.media.view.Toolbar} toolbar The toolbar view.
+	 */
 	featuredImageToolbar: function( toolbar ) {
 		this.createSelectToolbar( toolbar, {
 			text:  l10n.setFeaturedImage,
@@ -565,12 +626,20 @@ Post = Select.extend(/** @lends wp.media.view.MediaFrame.Post.prototype */{
 		});
 	},
 
+	/**
+	 * Handles the main embed toolbar for the frame.
+	 *
+	 * @param {wp.media.view.Toolbar} toolbar The toolbar view.
+	 */
 	mainEmbedToolbar: function( toolbar ) {
 		toolbar.view = new wp.media.view.Toolbar.Embed({
 			controller: this
 		});
 	},
 
+	/**
+	 * Handles the edit image toolbar for the frame.
+	 */
 	galleryEditToolbar: function() {
 		var editing = this.state().get('editing');
 		this.toolbar.set( new wp.media.view.Toolbar({
@@ -583,6 +652,8 @@ Post = Select.extend(/** @lends wp.media.view.MediaFrame.Post.prototype */{
 					requires: { library: true, uploadingComplete: true },
 
 					/**
+					 * Handles the click event for the insert button.
+					 *
 					 * @fires wp.media.controller.State#update
 					 */
 					click: function() {
@@ -601,6 +672,9 @@ Post = Select.extend(/** @lends wp.media.view.MediaFrame.Post.prototype */{
 		}) );
 	},
 
+	/**
+	 * Handles the add to gallery toolbar for the frame.
+	 */
 	galleryAddToolbar: function() {
 		this.toolbar.set( new wp.media.view.Toolbar({
 			controller: this,
@@ -612,6 +686,8 @@ Post = Select.extend(/** @lends wp.media.view.MediaFrame.Post.prototype */{
 					requires: { selection: true },
 
 					/**
+					 * Handles the click event for the insert button.
+					 *
 					 * @fires wp.media.controller.State#reset
 					 */
 					click: function() {
@@ -630,6 +706,9 @@ Post = Select.extend(/** @lends wp.media.view.MediaFrame.Post.prototype */{
 		}) );
 	},
 
+	/**
+	 * Handles the edit playlist toolbar for the frame.
+	 */
 	playlistEditToolbar: function() {
 		var editing = this.state().get('editing');
 		this.toolbar.set( new wp.media.view.Toolbar({
@@ -642,6 +721,8 @@ Post = Select.extend(/** @lends wp.media.view.MediaFrame.Post.prototype */{
 					requires: { library: true },
 
 					/**
+					 * Handles the click event for the insert button.
+					 *
 					 * @fires wp.media.controller.State#update
 					 */
 					click: function() {
@@ -660,6 +741,9 @@ Post = Select.extend(/** @lends wp.media.view.MediaFrame.Post.prototype */{
 		}) );
 	},
 
+	/**
+	 * Handles the add to playlist toolbar for the frame.
+	 */
 	playlistAddToolbar: function() {
 		this.toolbar.set( new wp.media.view.Toolbar({
 			controller: this,
@@ -671,6 +755,8 @@ Post = Select.extend(/** @lends wp.media.view.MediaFrame.Post.prototype */{
 					requires: { selection: true },
 
 					/**
+					 * Handles the click event for the insert button.
+					 *
 					 * @fires wp.media.controller.State#reset
 					 */
 					click: function() {
@@ -689,6 +775,9 @@ Post = Select.extend(/** @lends wp.media.view.MediaFrame.Post.prototype */{
 		}) );
 	},
 
+	/**
+	 * Handles the edit video playlist toolbar for the frame.
+	 */
 	videoPlaylistEditToolbar: function() {
 		var editing = this.state().get('editing');
 		this.toolbar.set( new wp.media.view.Toolbar({
@@ -719,6 +808,9 @@ Post = Select.extend(/** @lends wp.media.view.MediaFrame.Post.prototype */{
 		}) );
 	},
 
+	/**
+	 * Handles the add to video playlist toolbar for the frame.
+	 */
 	videoPlaylistAddToolbar: function() {
 		this.toolbar.set( new wp.media.view.Toolbar({
 			controller: this,

--- a/src/js/media/views/frame/post.js
+++ b/src/js/media/views/frame/post.js
@@ -390,10 +390,8 @@ Post = Select.extend(/** @lends wp.media.view.MediaFrame.Post.prototype */{
 	// Content.
 	/**
 	 * Handles the embed content for the frame.
-	 *
-	 * @param {wp.Backbone.View} view The content view.
 	 */
-	embedContent: function( view ) {
+	embedContent: function() {
 		var view = new wp.media.view.Embed({
 			controller: this,
 			model:      this.state()

--- a/src/js/media/views/iframe.js
+++ b/src/js/media/views/iframe.js
@@ -11,6 +11,8 @@
 var Iframe = wp.media.View.extend(/** @lends wp.media.view.Iframe.prototype */{
 	className: 'media-iframe',
 	/**
+	 * Renders the iframe view.
+	 *
 	 * @return {wp.media.view.Iframe} Returns itself to allow chaining.
 	 */
 	render: function() {

--- a/src/js/media/views/media-details.js
+++ b/src/js/media/views/media-details.js
@@ -17,8 +17,8 @@ var AttachmentDisplay = wp.media.view.Settings.AttachmentDisplay,
  */
 MediaDetails = AttachmentDisplay.extend(/** @lends wp.media.view.MediaDetails.prototype */{
 	/**
-	 * Initialize the media details view.
-	*/
+	 * Initializes the media details view.
+	 */
 	initialize: function() {
 		_.bindAll(this, 'success');
 		this.players = [];
@@ -157,7 +157,7 @@ MediaDetails = AttachmentDisplay.extend(/** @lends wp.media.view.MediaDetails.pr
 	/**
 	 * Renders the media details view.
 	 *
-	 * @return {media.view.MediaDetails} Returns itself to allow chaining.
+	 * @return {wp.media.view.MediaDetails} Returns itself to allow chaining.
 	 */
 	render: function() {
 		AttachmentDisplay.prototype.render.apply( this, arguments );

--- a/src/js/media/views/media-details.js
+++ b/src/js/media/views/media-details.js
@@ -16,6 +16,9 @@ var AttachmentDisplay = wp.media.view.Settings.AttachmentDisplay,
  * @augments Backbone.View
  */
 MediaDetails = AttachmentDisplay.extend(/** @lends wp.media.view.MediaDetails.prototype */{
+	/**
+	 * Initialize the media details view.
+	*/
 	initialize: function() {
 		_.bindAll(this, 'success');
 		this.players = [];
@@ -28,6 +31,11 @@ MediaDetails = AttachmentDisplay.extend(/** @lends wp.media.view.MediaDetails.pr
 		AttachmentDisplay.prototype.initialize.apply( this, arguments );
 	},
 
+	/**
+	 * Handle events for the media details view.
+	 *
+	 * @return {Object} The events object.
+	 */
 	events: function(){
 		return _.extend( {
 			'click .remove-setting' : 'removeSetting',
@@ -37,6 +45,11 @@ MediaDetails = AttachmentDisplay.extend(/** @lends wp.media.view.MediaDetails.pr
 		}, AttachmentDisplay.prototype.events );
 	},
 
+	/**
+	 * Prepares the data for the media details view.
+	 *
+	 * @return {Object} The prepared data.
+	 */
 	prepare: function() {
 		return _.defaults({
 			model: this.model.toJSON()
@@ -44,7 +57,7 @@ MediaDetails = AttachmentDisplay.extend(/** @lends wp.media.view.MediaDetails.pr
 	},
 
 	/**
-	 * Remove a setting's UI when the model unsets it
+	 * Removes a setting's UI when the model unsets it
 	 *
 	 * @fires wp.media.view.MediaDetails#media:setting:remove
 	 *
@@ -63,6 +76,7 @@ MediaDetails = AttachmentDisplay.extend(/** @lends wp.media.view.MediaDetails.pr
 	},
 
 	/**
+	 * Sets the tracks for the media details view.
 	 *
 	 * @fires wp.media.view.MediaDetails#media:setting:remove
 	 */
@@ -77,16 +91,27 @@ MediaDetails = AttachmentDisplay.extend(/** @lends wp.media.view.MediaDetails.pr
 		this.trigger( 'media:setting:remove', this );
 	},
 
+	/**
+	 * Adds a source to the media details view.
+	 *
+	 * @param {JQuery.Event} e The event object.
+	 */
 	addSource : function( e ) {
 		this.controller.lastMime = $( e.currentTarget ).data( 'mime' );
 		this.controller.setState( 'add-' + this.controller.defaults.id + '-source' );
 	},
 
+	/**
+	 * Loads the media player for the media details view.
+	 */
 	loadPlayer: function () {
 		this.players.push( new MediaElementPlayer( this.media, this.settings ) );
 		this.scriptXhr = false;
 	},
 
+	/**
+	 * Sets the media player for the media details view.
+	 */
 	setPlayer : function() {
 		var src;
 
@@ -104,12 +129,19 @@ MediaDetails = AttachmentDisplay.extend(/** @lends wp.media.view.MediaDetails.pr
 	},
 
 	/**
+	 * Sets the media for the media details view.
+	 *
 	 * @abstract
 	 */
 	setMedia : function() {
 		return this;
 	},
 
+	/**
+	 * Handles the success event for the media details view.
+	 *
+	 * @param {MediaElementPlayer} mejs The media element player instance.
+	 */
 	success : function(mejs) {
 		var autoplay = mejs.attributes.autoplay && 'false' !== mejs.attributes.autoplay;
 
@@ -123,6 +155,8 @@ MediaDetails = AttachmentDisplay.extend(/** @lends wp.media.view.MediaDetails.pr
 	},
 
 	/**
+	 * Renders the media details view.
+	 *
 	 * @return {media.view.MediaDetails} Returns itself to allow chaining.
 	 */
 	render: function() {
@@ -139,6 +173,9 @@ MediaDetails = AttachmentDisplay.extend(/** @lends wp.media.view.MediaDetails.pr
 		return this.setMedia();
 	},
 
+	/**
+	 * Scrolls the media details view to the top.
+	 */
 	scrollToTop: function() {
 		this.$( '.embed-media-settings' ).scrollTop( 0 );
 	}

--- a/src/js/media/views/media-frame.js
+++ b/src/js/media/views/media-frame.js
@@ -27,6 +27,8 @@ MediaFrame = Frame.extend(/** @lends wp.media.view.MediaFrame.prototype */{
 	},
 
 	/**
+	 * Initializes the media frame.
+	 *
 	 * @constructs
 	 */
 	initialize: function() {
@@ -141,6 +143,8 @@ MediaFrame = Frame.extend(/** @lends wp.media.view.MediaFrame.prototype */{
 	},
 
 	/**
+	 * Renders the media frame.
+	 *
 	 * @return {wp.media.view.MediaFrame} Returns itself to allow chaining.
 	 */
 	render: function() {
@@ -154,6 +158,8 @@ MediaFrame = Frame.extend(/** @lends wp.media.view.MediaFrame.prototype */{
 		return Frame.prototype.render.apply( this, arguments );
 	},
 	/**
+	 * Creates the title view.
+	 *
 	 * @param {Object} title
 	 * @this wp.media.controller.Region
 	 */
@@ -164,6 +170,8 @@ MediaFrame = Frame.extend(/** @lends wp.media.view.MediaFrame.prototype */{
 		});
 	},
 	/**
+	 * Creates the menu view.
+	 *
 	 * @param {Object} menu
 	 * @this wp.media.controller.Region
 	 */
@@ -180,6 +188,11 @@ MediaFrame = Frame.extend(/** @lends wp.media.view.MediaFrame.prototype */{
 		this.menuView = menu.view;
 	},
 
+	/**
+	 * Toggles the menu visibility.
+	 *
+	 * @param {JQuery.Event} event The click event.
+	 */
 	toggleMenu: function( event ) {
 		var menu = this.$el.find( '.media-menu' );
 
@@ -188,6 +201,8 @@ MediaFrame = Frame.extend(/** @lends wp.media.view.MediaFrame.prototype */{
 	},
 
 	/**
+	 * Creates the toolbar view.
+	 *
 	 * @param {Object} toolbar
 	 * @this wp.media.controller.Region
 	 */
@@ -197,6 +212,8 @@ MediaFrame = Frame.extend(/** @lends wp.media.view.MediaFrame.prototype */{
 		});
 	},
 	/**
+	 * Creates the router view.
+	 *
 	 * @param {Object} router
 	 * @this wp.media.controller.Region
 	 */
@@ -213,6 +230,8 @@ MediaFrame = Frame.extend(/** @lends wp.media.view.MediaFrame.prototype */{
 		this.routerView = router.view;
 	},
 	/**
+	 * Creates the iframe states.
+	 *
 	 * @param {Object} options
 	 */
 	createIframeStates: function( options ) {
@@ -250,6 +269,8 @@ MediaFrame = Frame.extend(/** @lends wp.media.view.MediaFrame.prototype */{
 	},
 
 	/**
+	 * Creates the iframe content view.
+	 *
 	 * @param {Object} content
 	 * @this wp.media.controller.Region
 	 */
@@ -260,10 +281,18 @@ MediaFrame = Frame.extend(/** @lends wp.media.view.MediaFrame.prototype */{
 		});
 	},
 
+	/**
+	 * Cleans up the iframe content view.
+	 */
 	iframeContentCleanup: function() {
 		this.$el.removeClass('hide-toolbar');
 	},
 
+	/**
+	 * Creates the iframe menu.
+	 *
+	 * @param {wp.media.view.Menu} view The menu view.
+	 */
 	iframeMenu: function( view ) {
 		var views = {};
 
@@ -281,6 +310,9 @@ MediaFrame = Frame.extend(/** @lends wp.media.view.MediaFrame.prototype */{
 		view.set( views );
 	},
 
+	/**
+	 * Hijacks the Thickbox close function to close the media modal.
+	 */
 	hijackThickbox: function() {
 		var frame = this;
 
@@ -297,6 +329,9 @@ MediaFrame = Frame.extend(/** @lends wp.media.view.MediaFrame.prototype */{
 		};
 	},
 
+	/**
+	 * Restores the Thickbox close function.
+	 */
 	restoreThickbox: function() {
 		if ( ! this._tb_remove ) {
 			return;
@@ -310,6 +345,8 @@ MediaFrame = Frame.extend(/** @lends wp.media.view.MediaFrame.prototype */{
 // Map some of the modal's methods to the frame.
 _.each(['open','close','attach','detach','escape'], function( method ) {
 	/**
+	 * Opens the media frame modal.
+	 *
 	 * @function open
 	 * @memberOf wp.media.view.MediaFrame
 	 * @instance
@@ -317,6 +354,8 @@ _.each(['open','close','attach','detach','escape'], function( method ) {
 	 * @return {wp.media.view.MediaFrame} Returns itself to allow chaining.
 	 */
 	/**
+	 * Closes the media frame modal.
+	 *
 	 * @function close
 	 * @memberOf wp.media.view.MediaFrame
 	 * @instance
@@ -324,6 +363,8 @@ _.each(['open','close','attach','detach','escape'], function( method ) {
 	 * @return {wp.media.view.MediaFrame} Returns itself to allow chaining.
 	 */
 	/**
+	 * Attaches the media frame to the DOM.
+	 *
 	 * @function attach
 	 * @memberOf wp.media.view.MediaFrame
 	 * @instance
@@ -331,6 +372,8 @@ _.each(['open','close','attach','detach','escape'], function( method ) {
 	 * @return {wp.media.view.MediaFrame} Returns itself to allow chaining.
 	 */
 	/**
+	 * Detaches the media frame from the DOM.
+	 *
 	 * @function detach
 	 * @memberOf wp.media.view.MediaFrame
 	 * @instance
@@ -338,6 +381,8 @@ _.each(['open','close','attach','detach','escape'], function( method ) {
 	 * @return {wp.media.view.MediaFrame} Returns itself to allow chaining.
 	 */
 	/**
+	 * Triggers the escape action on the media frame modal.
+	 *
 	 * @function escape
 	 * @memberOf wp.media.view.MediaFrame
 	 * @instance

--- a/src/js/media/views/menu-item.js
+++ b/src/js/media/views/menu-item.js
@@ -36,6 +36,9 @@ MenuItem = wp.media.View.extend(/** @lends wp.media.view.MenuItem.prototype */{
 		}
 	},
 
+	/**
+	 * Handles the click event.
+	 */
 	click: function() {
 		var state = this.options.state;
 
@@ -47,6 +50,8 @@ MenuItem = wp.media.View.extend(/** @lends wp.media.view.MenuItem.prototype */{
 	},
 
 	/**
+	 * Renders the menu item.
+	 *
 	 * @return {wp.media.view.MenuItem} returns itself to allow chaining.
 	 */
 	render: function() {

--- a/src/js/media/views/menu.js
+++ b/src/js/media/views/menu.js
@@ -25,6 +25,9 @@ Menu = PriorityList.extend(/** @lends wp.media.view.Menu.prototype */{
 		'aria-orientation': 'horizontal'
 	},
 
+	/**
+	 * Initializes the menu view.
+	 */
 	initialize: function() {
 		this._views = {};
 
@@ -46,6 +49,8 @@ Menu = PriorityList.extend(/** @lends wp.media.view.Menu.prototype */{
 	},
 
 	/**
+	 * Creates a view for the given options and id.
+	 *
 	 * @param {Object} options
 	 * @param {string} id
 	 * @return {wp.media.View} The view instance.
@@ -56,6 +61,9 @@ Menu = PriorityList.extend(/** @lends wp.media.view.Menu.prototype */{
 		return new this.ItemView( options ).render();
 	},
 
+	/**
+	 * Updates the menu when the state changes.
+	 */
 	ready: function() {
 		/**
 		 * call 'ready' directly on the parent class
@@ -67,6 +75,9 @@ Menu = PriorityList.extend(/** @lends wp.media.view.Menu.prototype */{
 		this.focusManager.setupAriaTabs();
 	},
 
+	/**
+	 * Sets the menu items.
+	 */
 	set: function() {
 		/**
 		 * call 'set' directly on the parent class
@@ -75,6 +86,9 @@ Menu = PriorityList.extend(/** @lends wp.media.view.Menu.prototype */{
 		this.visibility();
 	},
 
+	/**
+	 * Unsets the menu items.
+	 */
 	unset: function() {
 		/**
 		 * call 'unset' directly on the parent class
@@ -83,6 +97,9 @@ Menu = PriorityList.extend(/** @lends wp.media.view.Menu.prototype */{
 		this.visibility();
 	},
 
+	/**
+	 * Updates the menu visibility.
+	 */
 	visibility: function() {
 		var region = this.region,
 			view = this.controller[ region ].get(),
@@ -97,7 +114,9 @@ Menu = PriorityList.extend(/** @lends wp.media.view.Menu.prototype */{
 		}
 	},
 	/**
-	 * @param {string} id
+	 * Selects the menu item with the given id.
+	 *
+	 * @param {string} id The menu item id.
 	 */
 	select: function( id ) {
 		var view = this.get( id );
@@ -113,10 +132,18 @@ Menu = PriorityList.extend(/** @lends wp.media.view.Menu.prototype */{
 		this.focusManager.setupAriaTabs();
 	},
 
+	/**
+	 * Deselects the menu items.
+	 */
 	deselect: function() {
 		this.$el.children().removeClass('active');
 	},
 
+	/**
+	 * Hides the menu item with the given id.
+	 *
+	 * @param {string} id The menu item id.
+	 */
 	hide: function( id ) {
 		var view = this.get( id );
 
@@ -127,6 +154,11 @@ Menu = PriorityList.extend(/** @lends wp.media.view.Menu.prototype */{
 		view.$el.addClass('hidden');
 	},
 
+	/**
+	 * Shows the menu item with the given id.
+	 *
+	 * @param {string} id The menu item id.
+	 */
 	show: function( id ) {
 		var view = this.get( id );
 

--- a/src/js/media/views/search.js
+++ b/src/js/media/views/search.js
@@ -24,6 +24,8 @@ Search = wp.media.View.extend(/** @lends wp.media.view.Search.prototype */{
 	},
 
 	/**
+	 * Renders the search input.
+	 *
 	 * @return {wp.media.view.Search} Returns itself to allow chaining.
 	 */
 	render: function() {
@@ -31,6 +33,11 @@ Search = wp.media.View.extend(/** @lends wp.media.view.Search.prototype */{
 		return this;
 	},
 
+	/**
+	 * Searches the media library.
+	 *
+	 * @param {JQuery.Event} event The input event.
+	 */
 	search: _.debounce( function( event ) {
 		var searchTerm = event.target.value.trim();
 

--- a/src/js/media/views/settings.js
+++ b/src/js/media/views/settings.js
@@ -20,17 +20,27 @@ Settings = View.extend(/** @lends wp.media.view.Settings.prototype */{
 		'change textarea': 'updateHandler'
 	},
 
+	/**
+	 * Initializes the settings view.
+	 */
 	initialize: function() {
 		this.model = this.model || new Backbone.Model();
 		this.listenTo( this.model, 'change', this.updateChanges );
 	},
 
+	/**
+	 * Prepares the data for rendering.
+	 *
+	 * @return {Object} The data to be used in the template.
+	 */
 	prepare: function() {
 		return _.defaults({
 			model: this.model.toJSON()
 		}, this.options );
 	},
 	/**
+	 * Renders the settings view.
+	 *
 	 * @return {wp.media.view.Settings} Returns itself to allow chaining.
 	 */
 	render: function() {
@@ -40,6 +50,8 @@ Settings = View.extend(/** @lends wp.media.view.Settings.prototype */{
 		return this;
 	},
 	/**
+	 * Updates the selected value for a setting.
+	 *
 	 * @param {string} key
 	 */
 	update: function( key ) {
@@ -87,6 +99,8 @@ Settings = View.extend(/** @lends wp.media.view.Settings.prototype */{
 		}
 	},
 	/**
+	 * Updates the model when a setting is changed.
+	 *
 	 * @param {Object} event
 	 */
 	updateHandler: function( event ) {
@@ -116,6 +130,11 @@ Settings = View.extend(/** @lends wp.media.view.Settings.prototype */{
 		}
 	},
 
+	/**
+	 * Updates the view when the model changes.
+	 *
+	 * @param {Backbone.Model} model The model that changed.
+	 */
 	updateChanges: function( model ) {
 		if ( model.hasChanged() ) {
 			_( model.changed ).chain().keys().each( this.update, this );

--- a/src/js/media/views/settings/attachment-display.js
+++ b/src/js/media/views/settings/attachment-display.js
@@ -16,6 +16,9 @@ AttachmentDisplay = Settings.extend(/** @lends wp.media.view.Settings.Attachment
 	className: 'attachment-display-settings',
 	template:  wp.template('attachment-display-settings'),
 
+	/**
+	 * Initializes the attachment display settings view.
+	 */
 	initialize: function() {
 		var attachment = this.options.attachment;
 
@@ -31,6 +34,9 @@ AttachmentDisplay = Settings.extend(/** @lends wp.media.view.Settings.Attachment
 		}
 	},
 
+	/**
+	 * Disposes of the attachment display settings view.
+	 */
 	dispose: function() {
 		var attachment = this.options.attachment;
 		if ( attachment ) {
@@ -42,6 +48,8 @@ AttachmentDisplay = Settings.extend(/** @lends wp.media.view.Settings.Attachment
 		Settings.prototype.dispose.apply( this, arguments );
 	},
 	/**
+	 * Renders the attachment display settings view.
+	 *
 	 * @return {wp.media.view.AttachmentDisplay} Returns itself to allow chaining.
 	 */
 	render: function() {
@@ -60,6 +68,9 @@ AttachmentDisplay = Settings.extend(/** @lends wp.media.view.Settings.Attachment
 		return this;
 	},
 
+	/**
+	 * Updates the linkTo setting.
+	 */
 	updateLinkTo: function() {
 		var linkTo = this.model.get('link'),
 			$input = this.$('.link-to-custom'),

--- a/src/js/media/views/toolbar.js
+++ b/src/js/media/views/toolbar.js
@@ -18,6 +18,9 @@ Toolbar = View.extend(/** @lends wp.media.view.Toolbar.prototype */{
 	tagName:   'div',
 	className: 'media-toolbar',
 
+	/**
+	 * Initializes the toolbar view.
+	 */
 	initialize: function() {
 		var state = this.controller.state(),
 			selection = this.selection = state.get('selection'),
@@ -52,6 +55,8 @@ Toolbar = View.extend(/** @lends wp.media.view.Toolbar.prototype */{
 		}
 	},
 	/**
+	 * Disposes of the toolbar view.
+	 *
 	 * @return {wp.media.view.Toolbar} Returns itself to allow chaining
 	 */
 	dispose: function() {
@@ -68,11 +73,16 @@ Toolbar = View.extend(/** @lends wp.media.view.Toolbar.prototype */{
 		return View.prototype.dispose.apply( this, arguments );
 	},
 
+	/**
+	 * Prepares the data for rendering.
+	 */
 	ready: function() {
 		this.refresh();
 	},
 
 	/**
+	 * Sets a view by its ID.
+	 *
 	 * @param {string} id
 	 * @param {Backbone.View|Object} view
 	 * @param {Object} [options={}]
@@ -118,6 +128,8 @@ Toolbar = View.extend(/** @lends wp.media.view.Toolbar.prototype */{
 		return this._views[ id ];
 	},
 	/**
+	 * Unsets a view by its ID.
+	 *
 	 * @param {string} id
 	 * @param {Object} options
 	 * @return {wp.media.view.Toolbar} Returns itself to allow chaining.
@@ -134,6 +146,9 @@ Toolbar = View.extend(/** @lends wp.media.view.Toolbar.prototype */{
 		return this;
 	},
 
+	/**
+	 * Refreshes the toolbar view.
+	 */
 	refresh: function() {
 		var state = this.controller.state(),
 			library = state.get('library'),

--- a/src/js/media/views/view.js
+++ b/src/js/media/views/view.js
@@ -17,6 +17,11 @@
  * @augments Backbone.View
  */
 var View = wp.Backbone.View.extend(/** @lends wp.media.View.prototype */{
+	/**
+	 * Constructor for the media view.
+	 *
+	 * @param {Object} [options] Options for the view.
+	 */
 	constructor: function( options ) {
 		if ( options && options.controller ) {
 			this.controller = options.controller;
@@ -24,6 +29,8 @@ var View = wp.Backbone.View.extend(/** @lends wp.media.View.prototype */{
 		wp.Backbone.View.apply( this, arguments );
 	},
 	/**
+	 * Disposes of the media view.
+	 *
 	 * @todo The internal comment mentions this might have been a stop-gap
 	 *       before Backbone 0.9.8 came out. Figure out if Backbone core takes
 	 *       care of this in Backbone.View now.
@@ -54,6 +61,8 @@ var View = wp.Backbone.View.extend(/** @lends wp.media.View.prototype */{
 		return this;
 	},
 	/**
+	 * Removes the media view.
+	 *
 	 * @return {wp.media.View} Returns itself to allow chaining.
 	 */
 	remove: function() {


### PR DESCRIPTION
See https://core.trac.wordpress.org/ticket/66033

In preparation of the introduction of the rule `jsdoc/require-description` for JSDoc, this PR adds several missing descriptions to JS functions in the media directory. 

## Use of AI Tools

AI assistance: Yes
Tool(s): GitHub Copilot
Model(s): Claude Haiku 4.5
Used for: Quickly drafting some descriptions.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
