### PR TITLE
Add missing descriptions to the Customize JavaScript docs 

### DIFF
--- a/.eslintrc-jsdoc.js
+++ b/.eslintrc-jsdoc.js
@@ -55,6 +55,7 @@ module.exports = [
 			'jsdoc/require-returns': 'error',
 			'jsdoc/require-returns-type': 'error',
 			'jsdoc/check-syntax': 'error',
+			'jsdoc/require-description': 'error',
 		},
 	},
 ];

--- a/src/js/_enqueues/wp/customize/base.js
+++ b/src/js/_enqueues/wp/customize/base.js
@@ -6,6 +6,8 @@
 window.wp = window.wp || {};
 
 /**
+ * The WordPress Customizer API.
+ *
  * @param {Object}       wp The WordPress global object.
  * @param {JQueryStatic} $  The jQuery object.
  */

--- a/src/js/_enqueues/wp/customize/controls.js
+++ b/src/js/_enqueues/wp/customize/controls.js
@@ -5,6 +5,8 @@
 /* global _wpCustomizeHeader, _wpCustomizeBackground, _wpMediaViewsL10n, MediaElementPlayer, console, confirm */
 
 /**
+ * The WordPress Customizer controls API.
+ *
  * @param {Object}       wp The WordPress global object.
  * @param {JQueryStatic} $  The jQuery object.
  */
@@ -1067,6 +1069,8 @@
 		},
 
 		/**
+		 * Ready state handler.
+		 *
 		 * @since 4.1.0
 		 *
 		 * @abstract
@@ -1175,6 +1179,8 @@
 		},
 
 		/**
+		 * Handles the toggle logic to transition the active state.
+		 *
 		 * @since 4.1.0
 		 *
 		 * @param {boolean} active   The active state to transition to.
@@ -1438,6 +1444,8 @@
 		},
 
 		/**
+		 * Initializes a section.
+		 *
 		 * @constructs wp.customize.Section
 		 * @augments   wp.customize~Container
 		 *
@@ -2804,6 +2812,8 @@
 		containerType: 'panel',
 
 		/**
+		 * Initializes a panel.
+		 *
 		 * @constructs wp.customize.Panel
 		 * @augments   wp.customize~Container
 		 *
@@ -2864,6 +2874,8 @@
 		},
 
 		/**
+		 * Attaches events to the panel.
+		 *
 		 * @since 4.1.0
 		 */
 		attachEvents: function () {
@@ -5196,6 +5208,8 @@
 		screenshotRendered: false,
 
 		/**
+		 * Handles the control's ready state.
+		 *
 		 * @since 4.2.0
 		 */
 		ready: function() {
@@ -6558,6 +6572,8 @@
 		refreshBuffer: null, // Will get set to api.settings.timeouts.windowRefresh.
 
 		/**
+		 * Initializes the previewer.
+		 *
 		 * @constructs wp.customize.Previewer
 		 * @augments   wp.customize.Messenger
 		 *

--- a/src/js/_enqueues/wp/customize/controls.js
+++ b/src/js/_enqueues/wp/customize/controls.js
@@ -1069,7 +1069,7 @@
 		},
 
 		/**
-		 * Ready state handler.
+		 * Handles the ready state (when overridden).
 		 *
 		 * @since 4.1.0
 		 *

--- a/src/js/_enqueues/wp/customize/loader.js
+++ b/src/js/_enqueues/wp/customize/loader.js
@@ -13,6 +13,8 @@
 window.wp = window.wp || {};
 
 /**
+ * The WordPress Customizer loader API.
+ *
  * @param {Object}       wp The WordPress global object.
  * @param {JQueryStatic} $  The jQuery object.
  */

--- a/src/js/_enqueues/wp/customize/models.js
+++ b/src/js/_enqueues/wp/customize/models.js
@@ -5,6 +5,8 @@
 /* global _wpCustomizeHeader */
 
 /**
+ * The WordPress Customizer models API.
+ *
  * @param {JQueryStatic} $  The jQuery object.
  * @param {Object}       wp The WordPress global object.
  */

--- a/src/js/_enqueues/wp/customize/nav-menus.js
+++ b/src/js/_enqueues/wp/customize/nav-menus.js
@@ -5,6 +5,8 @@
 /* global menus, _wpCustomizeNavMenusSettings, wpNavMenu, console */
 
 /**
+ * The WordPress Customizer nav menus API.
+ *
  * @param {Object}       api The Customizer API.
  * @param {Object}       wp  The WordPress global object.
  * @param {JQueryStatic} $   The jQuery object.
@@ -910,11 +912,13 @@
 		}, 2000 ),
 
 		/**
+		 * eslint-disable-next-line eslint-plugin-jsdoc
 		 * @deprecated Since 4.7.0 now that the nav_menu sections are responsible for toggling the classes on their own containers.
 		 */
 		checked: function() {},
 
 		/**
+		 * eslint-disable-next-line eslint-plugin-jsdoc
 		 * @deprecated Since 4.7.0 now that the nav_menu sections are responsible for toggling the classes on their own containers.
 		 */
 		unchecked: function() {},
@@ -1132,7 +1136,7 @@
 		},
 
 		/**
-		 *
+		 * Refreshes the list of theme locations.
 		 */
 		refreshAssignedLocations: function() {
 			var section = this,
@@ -1147,6 +1151,8 @@
 		},
 
 		/**
+		 * Updates the section title to reflect the theme locations assigned to this menu.
+		 *
 		 * @param {string[]} themeLocationSlugs Theme location slugs.
 		 */
 		updateAssignedLocationsInSectionTitle: function( themeLocationSlugs ) {
@@ -3542,6 +3548,8 @@
 	};
 
 	/**
+	 * Gets the setting ID for a given menu item ID.
+	 *
 	 * @alias wp.customize.Menus~menuItemIdToSettingId
 	 *
 	 * @param {string} menuItemId The ID of the menu item.

--- a/src/js/_enqueues/wp/customize/nav-menus.js
+++ b/src/js/_enqueues/wp/customize/nav-menus.js
@@ -912,13 +912,15 @@
 		}, 2000 ),
 
 		/**
-		 * eslint-disable-next-line eslint-plugin-jsdoc
+		 * Adds the active field class for the section container.
+		 *
 		 * @deprecated Since 4.7.0 now that the nav_menu sections are responsible for toggling the classes on their own containers.
 		 */
 		checked: function() {},
 
 		/**
-		 * eslint-disable-next-line eslint-plugin-jsdoc
+		 * Removes the active field class for the section container.
+		 *
 		 * @deprecated Since 4.7.0 now that the nav_menu sections are responsible for toggling the classes on their own containers.
 		 */
 		unchecked: function() {},

--- a/src/js/_enqueues/wp/customize/preview.js
+++ b/src/js/_enqueues/wp/customize/preview.js
@@ -110,6 +110,8 @@
 	 */
 	api.Preview = api.Messenger.extend(/** @lends wp.customize.Preview.prototype */{
 		/**
+		 * Initializes the previewer.
+		 *
 		 * @param {Object} params  Parameters to configure the messenger.
 		 * @param {Object} options Extend any instance parameter or method with this object.
 		 */

--- a/src/js/_enqueues/wp/customize/views.js
+++ b/src/js/_enqueues/wp/customize/views.js
@@ -3,6 +3,8 @@
  */
 
 /**
+ * The WordPress Customizer views API.
+ *
  * @param {JQueryStatic}       $  The jQuery object.
  * @param {Object}             wp The WordPress global object.
  * @param {_.UnderscoreStatic} _  The Underscore.js object.

--- a/src/js/_enqueues/wp/customize/widgets.js
+++ b/src/js/_enqueues/wp/customize/widgets.js
@@ -5,6 +5,8 @@
 /* global _wpCustomizeWidgetsSettings */
 
 /**
+ * The WordPress Customizer widgets API.
+ *
  * @param {Object}       wp The WordPress global object.
  * @param {JQueryStatic} $  The jQuery object.
  */
@@ -476,6 +478,8 @@
 	api.Widgets.formSyncHandlers = {
 
 		/**
+		 * Handles the widget-synced event for RSS widgets.
+		 *
 		 * @param {JQuery.Event} e       The widget-synced event.
 		 * @param {JQuery}       widget  The widget root element.
 		 * @param {string}       newForm The HTML for the updated widget form.
@@ -1554,6 +1558,8 @@
 		},
 
 		/**
+		 * Moves the widget up or down one position in the sidebar.
+		 *
 		 * @private
 		 *
 		 * @param {number} offset The number of positions to move the widget, either 1 or -1.
@@ -2362,6 +2368,8 @@
 	}
 
 	/**
+	 * Parses a widget ID into its id_base and number components.
+	 *
 	 * @param {string} widgetId The widget ID to parse.
 	 * @return {Object} Parsed widget ID with id_base and number properties.
 	 */
@@ -2384,6 +2392,8 @@
 	}
 
 	/**
+	 * Returns the setting ID for a given widget ID.
+	 *
 	 * @param {string} widgetId The widget ID.
 	 * @return {string} The setting ID for the widget.
 	 */


### PR DESCRIPTION
See https://core.trac.wordpress.org/ticket/66033

In preparation of the introduction of the rule jsdoc/require-description for JSDoc, this PR adds several missing descriptions to the Customize JS functions.

Also, enables the `jsdoc/require-description` JSDoc rule.

- Run `npm run lint:jsdoc` and observe there are no reported errors.
- Check the added descriptions are meaningful.

## Use of AI Tools


AI assistance: Yes
Tool(s): GitHub Copilot
Model(s): Claude Haiku 4.5
Used for: Quickly drafting some descriptions.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
