### PR TITLE
#66062: Preserve wpautop priority after nested content filtering

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -2621,6 +2621,17 @@ function do_blocks( $content ) {
 function _restore_wpautop_hook( $content ) {
 	$current_priority = has_filter( 'the_content', '_restore_wpautop_hook' );
 
+	/*
+	 * A nested `the_content` run started by a later callback at the same priority
+	 * may already have restored wpautop() and removed this hook. The outer
+	 * WP_Hook loop still calls its copy of the callback; without this check
+	 * `$current_priority - 1` would add wpautop() at priority -1 for the rest
+	 * of the request.
+	 */
+	if ( false === $current_priority ) {
+		return $content;
+	}
+
 	add_filter( 'the_content', 'wpautop', $current_priority - 1 );
 	remove_filter( 'the_content', '_restore_wpautop_hook', $current_priority );
 

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -2622,11 +2622,11 @@ function _restore_wpautop_hook( $content ) {
 	$current_priority = has_filter( 'the_content', '_restore_wpautop_hook' );
 
 	/*
-	 * A nested `the_content` run started by a later callback at the same priority
-	 * may already have restored wpautop() and removed this hook. The outer
-	 * WP_Hook loop still calls its copy of the callback; without this check
-	 * `$current_priority - 1` would add wpautop() at priority -1 for the rest
-	 * of the request.
+	 * Another callback at the same priority, such as do_shortcode(), may run
+	 * before this one and apply `the_content` recursively. That nested run
+	 * restores wpautop() and removes this hook, but the outer WP_Hook loop
+	 * still invokes this callback. Without this check, `$current_priority - 1`
+	 * would add wpautop() at priority -1 for the rest of the request.
 	 */
 	if ( false === $current_priority ) {
 		return $content;

--- a/tests/phpunit/tests/blocks/render.php
+++ b/tests/phpunit/tests/blocks/render.php
@@ -113,6 +113,71 @@ class Tests_Blocks_Render extends WP_UnitTestCase {
 		return $content;
 	}
 
+	/**
+	 * A nested `the_content` run started by a shortcode before the restore
+	 * callback at priority 11 must preserve the wpautop() registration.
+	 *
+	 * @ticket 66062
+	 * @dataProvider data_nested_the_content_from_later_callback
+	 *
+	 * @param string $nested_content Content filtered by the shortcode callback.
+	 */
+	public function test_nested_the_content_from_later_callback_keeps_wpautop_priority( $nested_content ) {
+		global $wp_filter;
+
+		add_shortcode(
+			'nested_the_content',
+			static function () use ( $nested_content ) {
+				return apply_filters( 'the_content', $nested_content );
+			}
+		);
+
+		$wpautop_priority = has_filter( 'the_content', 'wpautop' );
+
+		try {
+			apply_filters( 'the_content', '<!-- wp:paragraph --><p>[nested_the_content]</p><!-- /wp:paragraph -->' );
+		} finally {
+			remove_shortcode( 'nested_the_content' );
+		}
+
+		// Check every registration: has_filter() only returns the first priority.
+		$wpautop_priorities = array();
+		foreach ( $wp_filter['the_content']->callbacks as $priority => $callbacks ) {
+			if ( isset( $callbacks['wpautop'] ) ) {
+				$wpautop_priorities[] = $priority;
+			}
+		}
+
+		$this->assertSame( array( $wpautop_priority ), $wpautop_priorities );
+		$this->assertFalse( has_filter( 'the_content', '_restore_wpautop_hook' ) );
+
+		// Block content filtered later in the same request must not be autop'ed.
+		$this->assertSame(
+			'test',
+			trim( apply_filters( 'the_content', "<!-- wp:fake/block -->\ntest\n<!-- /wp:fake/block -->" ) )
+		);
+
+		// Classic content filtered afterward must still receive paragraph formatting.
+		$this->assertSame(
+			"<p>First paragraph.</p>\n<p>Second paragraph.</p>\n",
+			apply_filters( 'the_content', "First paragraph.\n\nSecond paragraph." )
+		);
+		$this->assertSame( $wpautop_priority, has_filter( 'the_content', 'wpautop' ) );
+		$this->assertFalse( has_filter( 'the_content', '_restore_wpautop_hook' ) );
+	}
+
+	/**
+	 * Data provider for test_nested_the_content_from_later_callback_keeps_wpautop_priority().
+	 *
+	 * @return array[]
+	 */
+	public static function data_nested_the_content_from_later_callback() {
+		return array(
+			'plain text'    => array( 'nested' ),
+			'block content' => array( '<!-- wp:paragraph --><p>nested</p><!-- /wp:paragraph -->' ),
+		);
+	}
+
 	public function test_can_nest_at_least_so_deep() {
 		$minimum_depth = 99;
 

--- a/tests/phpunit/tests/blocks/render.php
+++ b/tests/phpunit/tests/blocks/render.php
@@ -118,11 +118,11 @@ class Tests_Blocks_Render extends WP_UnitTestCase {
 	 * callback at priority 11 must preserve the wpautop() registration.
 	 *
 	 * @ticket 66062
-	 * @dataProvider data_nested_the_content_from_later_callback
+	 * @dataProvider data_nested_the_content_from_earlier_callback
 	 *
 	 * @param string $nested_content Content filtered by the shortcode callback.
 	 */
-	public function test_nested_the_content_from_later_callback_keeps_wpautop_priority( $nested_content ) {
+	public function test_nested_the_content_from_earlier_callback_keeps_wpautop_priority( $nested_content ) {
 		global $wp_filter;
 
 		add_shortcode(
@@ -167,11 +167,11 @@ class Tests_Blocks_Render extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Data provider for test_nested_the_content_from_later_callback_keeps_wpautop_priority().
+	 * Data provider for test_nested_the_content_from_earlier_callback_keeps_wpautop_priority().
 	 *
 	 * @return array[]
 	 */
-	public static function data_nested_the_content_from_later_callback() {
+	public static function data_nested_the_content_from_earlier_callback() {
 		return array(
 			'plain text'    => array( 'nested' ),
 			'block content' => array( '<!-- wp:paragraph --><p>nested</p><!-- /wp:paragraph -->' ),


### PR DESCRIPTION
Fixes https://core.trac.wordpress.org/ticket/66062

When a shortcode recursively applies `the_content` at priority 11, before
the pending `_restore_wpautop_hook` callback, the inner run restores
`wpautop` and removes the restore hook. The outer hook iteration still
invokes its stale callback. `has_filter()` then returns `false`, and
subtracting one registers `wpautop` at priority -1, causing unwanted
paragraph formatting in content rendered later in the same request.

This change makes `_restore_wpautop_hook()` return the content unchanged
when it is no longer registered.

The regression test covers nested plain-text and block content. It checks
that `wpautop` is registered only at its original priority, that the
temporary restore hook is removed, and that subsequent block and classic
content receive the appropriate formatting.

Validation:

- `Tests_Blocks_Render`: 108 tests, 147 assertions, all passing.
- Both regression cases fail against the original core code, showing
  `wpautop` registered at both -1 and 10.
- PHPCS passes for both changed files.

AI assistance: Yes
Tool(s): Claude Code; Codex
Model(s): Claude Fable 5.1; GPT-6 Astra
Used for:

- Claude Code: Investigation of the hook-state sequence, the reproduction
  script, a first draft of the guard and unit test, and the Trac ticket text.
- Codex: Independent review of the ticket and fix, expanded regression
  coverage, test and coding-standard verification, and revisions to the
  commit message and PR description.

I reviewed the final change and validation results and take responsibility
for this contribution.
