### PR TITLE
Add missing typing for wp_parse_args()

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -5024,9 +5024,9 @@ function smilies_init() {
  * @since 2.2.0
  * @since 2.3.0 `$args` can now also be an object.
  *
- * @param string|array|object $args     Value to merge with $defaults.
- * @param array               $defaults Optional. Array that serves as the defaults.
- *                                      Default empty array.
+ * @param string|array<string, mixed>|object $args     Value to merge with $defaults.
+ * @param array<string, mixed>               $defaults Optional. Array that serves as the defaults.
+ *                                                     Default empty array.
  * @return array Merged user defined values with defaults.
  */
 function wp_parse_args( $args, $defaults = array() ) {

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -5029,7 +5029,7 @@ function smilies_init() {
  *                                                     Default empty array.
  * @return array Merged user defined values with defaults.
  */
-function wp_parse_args( $args, $defaults = array() ) {
+function wp_parse_args( $args, $defaults = array() ): array {
 	if ( is_object( $args ) ) {
 		$parsed_args = get_object_vars( $args );
 	} elseif ( is_array( $args ) ) {

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -5021,13 +5021,20 @@ function smilies_init() {
  * This function is used throughout WordPress to allow for both string or array
  * to be merged into another array.
  *
+ * The keys of the returned array are documented as strings, since that is what
+ * callers mean by them, but they are not promised as such to static analysis.
+ * Integer keys remain reachable through arguments that are perfectly valid:
+ * `json_decode( '{"0":"a"}' )` is an object whose properties `get_object_vars()`
+ * reports under an integer key, and `parse_str()` reads `0=a` as one as well.
+ *
  * @since 2.2.0
  * @since 2.3.0 `$args` can now also be an object.
  *
  * @param string|array<string, mixed>|object $args     Value to merge with $defaults.
  * @param array<string, mixed>               $defaults Optional. Array that serves as the defaults.
  *                                                     Default empty array.
- * @return array Merged user defined values with defaults.
+ * @return array<string, mixed> Merged user defined values with defaults.
+ * @phpstan-return array<array-key, mixed>
  */
 function wp_parse_args( $args, $defaults = array() ): array {
 	if ( is_object( $args ) ) {

--- a/tests/phpstan/baselines/argument.type.neon
+++ b/tests/phpstan/baselines/argument.type.neon
@@ -1129,7 +1129,7 @@ parameters:
 			count: 1
 			path: ../../../src/wp-includes/pluggable.php
 		-
-			message: '#^Parameter \#1 \$args of function get_pages expects array\{child_of\?\: int, sort_order\?\: string, sort_column\?\: string, hierarchical\?\: bool, exclude\?\: array\<int\>, include\?\: array\<int\>, meta_key\?\: string, meta_value\?\: string, \.\.\., \.\.\.\}\|string, non\-empty\-array given\.$#'
+			message: '#^Parameter \#1 \$args of function get_pages expects array\{child_of\?\: int, sort_order\?\: string, sort_column\?\: string, hierarchical\?\: bool, exclude\?\: array\<int\>, include\?\: array\<int\>, meta_key\?\: string, meta_value\?\: string, \.\.\., \.\.\.\}\|string, non\-empty\-array\<mixed\> given\.$#'
 			identifier: argument.type
 			count: 1
 			path: ../../../src/wp-includes/post-template.php

--- a/tests/phpstan/baselines/argument.type.neon
+++ b/tests/phpstan/baselines/argument.type.neon
@@ -1249,6 +1249,11 @@ parameters:
 			count: 1
 			path: ../../../src/wp-includes/rest-api/endpoints/class-wp-rest-application-passwords-controller.php
 		-
+			message: '#^Parameter \#1 \$args of function wp_parse_args expects array\<string, mixed\>\|object\|string, list\<array\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: ../../../src/wp-includes/rest-api/endpoints/class-wp-rest-block-types-controller.php
+		-
 			message: '#^Parameter \#2 \$value of method WP_HTTP_Response\:\:header\(\) expects string, int given\.$#'
 			identifier: argument.type
 			count: 1


### PR DESCRIPTION
✅ Committed in r63522 (41a4f4f0515c9c599064edc4d1ae1ea8fda441b9).

----
Documents the types of `wp_parse_args()`, which has described its two parameters and its return value as a bare `array` since it was introduced.

Trac ticket: Core-65817, Core-65860

## Background

`wp_parse_args()` entered trunk in r5234, as part of the tag cloud work, and its docblock has carried untyped arrays ever since. (It was rolled out of 2.2 and resurrected in r5397, but that pair lives on the 2.2 branch, not on trunk.) The touches it has had since — r38670 improving a parameter description, r47429 correcting the documented default of `$defaults` — adjusted prose and defaults but never the types.

That matters because the function is used throughout core to normalize arguments, so every one of its ~240 call sites in `src/` reads its result as an untyped array, and everything downstream of those reads is `mixed`.

## What this changes

- `@param string|array<string, mixed>|object $args`
- `@param array<string, mixed> $defaults`
- `@return array<string, mixed>`, plus a native `: array` return type on the signature.

**The documented return and the analysis return deliberately differ**, which is worth explaining rather than leaving to be rediscovered:

```php
 * @return array<string, mixed> Merged user defined values with defaults.
 * @phpstan-return array<array-key, mixed>
```

String keys are what every caller means, but they are not something the function can promise, and integer keys stay reachable through arguments that satisfy the documented parameter types exactly:

```php
wp_parse_args( json_decode( '{"0":"a","name":"b"}' ), array( 'name' => '' ) );
// array( 'name' => 'b', 0 => 'a' )

wp_parse_args( '0=a&name=b', array( 'name' => '' ) );
// array( 'name' => 'b', 0 => 'a' )
```

`get_object_vars()` reports a numeric-string property under an integer key, and `parse_str()` reads `0=a` as one. Both of those are in-contract inputs, so narrowing callers further cannot close the gap — only changing the body could. Documenting `array<string, mixed>` alone leaves two `return.type` errors on the function's own `return` statements, which no docblock elsewhere can pay off; the prefixed tag records what can actually come back so the documented type can still describe the intent.

## Measured impact

Measured with PHPStan 2.2.13 against trunk.

**Against the CI configuration (`phpstan.neon.dist`, level 5 + baselines): no errors.**

At the stricter level 10, over the whole `src/` tree, trunk reports 27,115 errors and this branch reports 27,233 — a net **+118**, from **3 resolved and 121 surfaced**.

The three resolved are the `missingType.iterableValue` errors on the function's own two parameters and return value.

The 121 surfaced are all `argument.type`, spread across 65 files, and every one is a caller handing `wp_parse_args()` an array it has not documented the contents of:

```
Parameter #1 $args of function wp_parse_args expects array<string, mixed>|object|string, array given.
```

These are pre-existing gaps in the callers' own documentation that the narrowing makes visible; they are not defects introduced here, and each is fixed by typing the caller rather than by widening this function back. They are deliberately left for follow-up so that this change stays reviewable — per the guidance on Core-65817, they are best worked through by component rather than all at once.

## One baselined error

One of the surfaced errors is not caller documentation and cannot be fixed by adding types:

```
src/wp-includes/rest-api/endpoints/class-wp-rest-block-types-controller.php:335
Parameter #1 $args of function wp_parse_args expects array<string, mixed>|object|string, list<array> given.
```

`WP_REST_Block_Types_Controller::prepare_item_for_response()` runs the registered block styles through `array_values()` and then merges them with `wp_parse_args()`. Both operands are lists, so the call reaches `array_merge()` and simply concatenates them — none of what `wp_parse_args()` adds over `array_merge()` applies, and a list can never satisfy `array<string, mixed>`.

It is baselined here rather than fixed, to keep this change to the docblock. A follow-up replaces the call with `array_merge()` and removes the baseline entry.

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Two of the five commits — "Add missing typing for the wp_parse_args() return value" and "Update the argument.type baseline after typing wp_parse_args()" — along with the PHPStan measurements reported above and drafting this description. The other commits are my own work. Directed, reviewed and verified by me.
Session transcript: https://claude.ai/code/session_01NtH5qFmG4hJcGWDCx5tMY7

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**


