### PR TITLE
General: Correct wp_list_pages() include param docblock and add coverage

### DIFF
--- a/src/wp-includes/post-template.php
+++ b/src/wp-includes/post-template.php
@@ -1288,7 +1288,7 @@ function wp_dropdown_pages( $args = '' ) {
  *                                           the given n depth). Default 0.
  *     @type bool              $echo         Whether or not to echo the list of pages. Default true.
  *     @type string            $exclude      Comma-separated list of page IDs to exclude. Default empty.
- *     @type array             $include      Comma-separated list of page IDs to include. Default empty.
+ *     @type int[]|string      $include      Array or comma-separated list of page IDs to include. Default empty array.
  *     @type string            $link_after   Text or HTML to follow the page link label. Default null.
  *     @type string            $link_before  Text or HTML to precede the page link label. Default null.
  *     @type string            $post_type    Post type to query for. Default 'page'.

--- a/tests/phpunit/tests/post/wpListPages.php
+++ b/tests/phpunit/tests/post/wpListPages.php
@@ -437,6 +437,22 @@ class Tests_Post_wpListPages extends WP_UnitTestCase {
 		$this->assertSameIgnoreEOL( $expected, wp_list_pages( $args ) );
 	}
 
+	/**
+	 * @ticket 66052
+	 */
+	public function test_wp_list_pages_include_accepts_array_of_ids() {
+		$args = array(
+			'echo'    => false,
+			'include' => array( self::$parent_1, self::$parent_3 ),
+		);
+
+		$expected = '<li class="pagenav">Pages<ul><li class="page_item page-item-' . self::$parent_1 . '"><a href="' . get_permalink( self::$parent_1 ) . '">Parent 1</a></li>
+<li class="page_item page-item-' . self::$parent_3 . '"><a href="' . get_permalink( self::$parent_3 ) . '">Parent 3</a></li>
+</ul></li>';
+
+		$this->assertSameIgnoreEOL( $expected, wp_list_pages( $args ) );
+	}
+
 	public function test_wp_list_pages_exclude_tree() {
 		$args = array(
 			'echo'         => false,


### PR DESCRIPTION
The `include` entry in `wp_list_pages()`'s `$args` docblock was documented as `@type array $include Comma-separated list of page IDs to include. Default empty`, which mismatches both its documented type (`array`) and its actual behavior — `$args['include']` is passed straight through to `get_pages()`, which expects an `int[]` of page IDs defaulting to an empty array, not a comma-separated string. This corrects the docblock to `@type int[]|string $include Array or comma-separated list of page IDs to include. Default empty array.`, matching how `get_pages()` documents the same argument, and adds a unit test asserting that `wp_list_pages()` correctly accepts an array of page IDs for `include`.

Trac ticket: https://core.trac.wordpress.org/ticket/66052

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Sonnet 5
Used for: Implementation, tests, and PR description. Reviewed by Igor Rozum.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**