### PR TITLE
Merge block style variations with array_merge() and type the registry's block style properties

### DIFF
--- a/src/wp-includes/class-wp-block-styles-registry.php
+++ b/src/wp-includes/class-wp-block-styles-registry.php
@@ -19,7 +19,8 @@ final class WP_Block_Styles_Registry {
 	 *
 	 * @since 5.3.0
 	 *
-	 * @var array[]
+	 * @var array<string, array<string, array<string, mixed>>>
+	 * @phpstan-var array<string, array<string, Block_Style_Properties>>
 	 */
 	private $registered_block_styles = array();
 
@@ -50,14 +51,14 @@ final class WP_Block_Styles_Registry {
 	 * @param array           $style_properties {
 	 *     Array containing the properties of the style.
 	 *
-	 *     @type string $name         The identifier of the style used to compute a CSS class.
-	 *     @type string $label        A human-readable label for the style.
-	 *     @type string $inline_style Inline CSS code that registers the CSS class required
-	 *                                for the style.
-	 *     @type string $style_handle The handle to an already registered style that should be
-	 *                                enqueued in places where block styles are needed.
-	 *     @type bool   $is_default   Whether this is the default style for the block type.
-	 *     @type array  $style_data   Theme.json-like object to generate CSS from.
+	 *     @type string               $name         The identifier of the style used to compute a CSS class.
+	 *     @type string               $label        A human-readable label for the style.
+	 *     @type string               $inline_style Inline CSS code that registers the CSS class required
+	 *                                              for the style.
+	 *     @type string               $style_handle The handle to an already registered style that should be
+	 *                                              enqueued in places where block styles are needed.
+	 *     @type bool                 $is_default   Whether this is the default style for the block type.
+	 *     @type array<string, mixed> $style_data   Theme.json-like object to generate CSS from.
 	 * }
 	 * @return bool True if the block style was registered with success and false otherwise.
 	 */
@@ -140,7 +141,8 @@ final class WP_Block_Styles_Registry {
 	 *
 	 * @param string $block_name       Block type name including namespace.
 	 * @param string $block_style_name Block style name.
-	 * @return array|null Registered block style properties or `null` if the block style is not registered.
+	 * @return array<string, mixed>|null Registered block style properties or `null` if the block style is not registered.
+	 * @phpstan-return Block_Style_Properties|null
 	 */
 	public function get_registered( $block_name, $block_style_name ) {
 		if ( ! $this->is_registered( $block_name, $block_style_name ) ) {
@@ -155,7 +157,9 @@ final class WP_Block_Styles_Registry {
 	 *
 	 * @since 5.3.0
 	 *
-	 * @return array[] Array of arrays containing the registered block styles properties grouped by block type.
+	 * @return array<string, array<string, array<string, mixed>>> Array of arrays containing the registered block styles
+	 *                                                            properties grouped by block type.
+	 * @phpstan-return array<string, array<string, Block_Style_Properties>>
 	 */
 	public function get_all_registered() {
 		return $this->registered_block_styles;
@@ -167,7 +171,9 @@ final class WP_Block_Styles_Registry {
 	 * @since 5.3.0
 	 *
 	 * @param string $block_name Block type name including namespace.
-	 * @return array[] Array whose keys are block style names and whose values are block style properties.
+	 * @return array<string, array<string, mixed>> Array whose keys are block style names and whose values are
+	 *                                             block style properties.
+	 * @phpstan-return array<string, Block_Style_Properties>
 	 */
 	public function get_registered_styles_for_block( $block_name ) {
 		return $this->registered_block_styles[ $block_name ] ?? array();

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-block-types-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-block-types-controller.php
@@ -13,13 +13,6 @@
  * @since 5.5.0
  *
  * @see WP_REST_Controller
- *
- * @phpstan-type Block_Style array{
- *     name: string,
- *     label?: string,
- *     inline_style?: string,
- *     style_handle?: string,
- * }
  */
 class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 
@@ -342,10 +335,13 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 
 			/*
 			 * The loop above assigns this key from rest_sanitize_value_from_schema(), whose
-			 * return is documented as `mixed|WP_Error`, so what the schema guarantees has to
-			 * be restated here. A WP_Error is why the value is checked rather than cast.
+			 * return is documented as `mixed|WP_Error`, so what the styles came back as has
+			 * to be restated here. A WP_Error is why the value is checked rather than cast.
 			 */
-			/** @phpstan-var list<Block_Style> $block_styles */
+			/**
+			 * @var array<string, mixed>[] $block_styles
+			 * @phpstan-var list<Block_Style_Properties> $block_styles
+			 */
 			$block_styles = isset( $data['styles'] ) && is_array( $data['styles'] ) ? $data['styles'] : array();
 
 			$data['styles'] = array_merge( $block_styles, $styles );

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-block-types-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-block-types-controller.php
@@ -13,6 +13,13 @@
  * @since 5.5.0
  *
  * @see WP_REST_Controller
+ *
+ * @phpstan-type Block_Style array{
+ *     name: string,
+ *     label?: string,
+ *     inline_style?: string,
+ *     style_handle?: string,
+ * }
  */
 class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 
@@ -330,9 +337,18 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 		}
 
 		if ( rest_is_field_included( 'styles', $fields ) ) {
-			$styles         = $this->style_registry->get_registered_styles_for_block( $block_type->name );
-			$styles         = array_values( $styles );
-			$data['styles'] = wp_parse_args( $styles, $data['styles'] );
+			$styles = $this->style_registry->get_registered_styles_for_block( $block_type->name );
+			$styles = array_values( $styles );
+
+			/*
+			 * The loop above assigns this key from rest_sanitize_value_from_schema(), whose
+			 * return is documented as `mixed|WP_Error`, so what the schema guarantees has to
+			 * be restated here. A WP_Error is why the value is checked rather than cast.
+			 */
+			/** @phpstan-var list<Block_Style> $block_styles */
+			$block_styles = isset( $data['styles'] ) && is_array( $data['styles'] ) ? $data['styles'] : array();
+
+			$data['styles'] = array_merge( $block_styles, $styles );
 			$data['styles'] = array_filter( $data['styles'] );
 		}
 

--- a/tests/phpstan/base.neon
+++ b/tests/phpstan/base.neon
@@ -276,3 +276,22 @@ parameters:
 				1: string,
 			}
 		'''
+
+		# The properties of a block style as WP_Block_Styles_Registry stores them, which is
+		# more than its register() hash accepts: `name` is required for a style to be
+		# registered at all, and `label` is filled in from the name when the caller omits
+		# it, so both are always present on the way back out. The shape stays open because
+		# the array is stored verbatim, so a caller's own keys survive — including into the
+		# REST response, which does not set `additionalProperties` to false. Read from
+		# procedural files as well as classes, which is why it is declared here.
+		Block_Style_Properties: '''
+			array{
+				name: string,
+				label: string,
+				inline_style?: string,
+				style_handle?: string,
+				is_default?: bool,
+				style_data?: array<string, mixed>,
+				...
+			}
+		'''

--- a/tests/phpstan/baselines/argument.type.neon
+++ b/tests/phpstan/baselines/argument.type.neon
@@ -1249,11 +1249,6 @@ parameters:
 			count: 1
 			path: ../../../src/wp-includes/rest-api/endpoints/class-wp-rest-application-passwords-controller.php
 		-
-			message: '#^Parameter \#1 \$args of function wp_parse_args expects array\<string, mixed\>\|object\|string, list\<array\> given\.$#'
-			identifier: argument.type
-			count: 1
-			path: ../../../src/wp-includes/rest-api/endpoints/class-wp-rest-block-types-controller.php
-		-
 			message: '#^Parameter \#2 \$value of method WP_HTTP_Response\:\:header\(\) expects string, int given\.$#'
 			identifier: argument.type
 			count: 1


### PR DESCRIPTION
✅ Committed in r63524 (94b9c2349b9e214a666359a06f20b866ff8eabbe).

----
Merges the registered block styles with `array_merge()` instead of `wp_parse_args()`, and documents the shape of a registered block style so that the values coming out of `WP_Block_Styles_Registry` are no longer `mixed`. 

This is a follow-up to a static analysis issue that was exposed by improved typing to `wp_parse_args()` added in r63522 (41a4f4f0515c9c599064edc4d1ae1ea8fda441b9) via https://github.com/WordPress/wordpress-develop/pull/13430.

The code in question was introduced in r48173 (5b90ea41b518b9713b0e4c005745be7d73de281e) for Core-47620.

Trac ticket: Core-65817, Core-65860

## The call

`WP_REST_Block_Types_Controller::prepare_item_for_response()` has combined the registered block styles with the ones already prepared for the response by calling `wp_parse_args()` since the endpoint was introduced in r48173:

```php
$styles         = $this->style_registry->get_registered_styles_for_block( $block_type->name );
$styles         = array_values( $styles );
$data['styles'] = wp_parse_args( $styles, $data['styles'] );
```

Both operands are lists — `$styles` is run through `array_values()` on the line above, and the `styles` schema is an array of objects — so the call reaches `array_merge()` inside `wp_parse_args()` and concatenates them. Nothing `wp_parse_args()` adds over `array_merge()` applies to two lists: there are no string keys to merge on, and nothing is being defaulted.

Calling `array_merge()` directly means saying what the existing value is, which `wp_parse_args()` was absorbing. The key is assigned in the loop above from `rest_sanitize_value_from_schema()`, documented as returning `mixed|WP_Error`, so neither its presence nor its type is established where it is read. The `WP_Error` is why the value is checked rather than cast, and the previous behavior — returning the registered styles unchanged when the value is absent or not an array — is preserved exactly.

## The shape

`WP_Block_Styles_Registry` hands out block style properties from three getters, all documented as a bare `array` or `array[]`, so every consumer reads the properties off a `mixed`. This documents them in two registers: the plain tags gain the array generics, which is as much as the developer reference and an editor can use, and a `Block_Style_Properties` alias carries the shape itself for static analysis.

The alias says more than the `register()` hash it derives from, because it describes what is **stored** rather than what is **accepted**: `name` is required for a style to be registered at all, and `label` is filled in from the name when the caller omits it, so both are always present on the way back out even though a caller may pass neither. It is left open, since the array is stored verbatim and a caller's own keys survive — including into the REST response, which never sets `additionalProperties` to false.

It goes in `base.neon` beside `Maybe_Callable` rather than on the registry class, because the styles are read from `script-loader.php` and `block-supports/layout.php` as well as from classes, and a type alias declared on a class can only be imported into another class docblock. Only `WP_REST_Block_Types_Controller` needs to name the alias; everything else picks the shape up through the return types.

`$style_data` is documented as `array<string, mixed>` to match, which realigns the hash. Theme.json-like data is string-keyed, and a bare `array` inside the alias makes the whole alias invalid — it is reported as having no value type specified, and every tag referring to it is then silently ignored.

## The baseline entry

Narrowing `wp_parse_args()` in r63522 surfaced one error that no caller documentation could fix, precisely because the argument is a list rather than a keyed array. It was baselined there so the typing could land on its own, with the note that a follow-up would rewrite the call. This is that follow-up, so the entry now matches nothing and is removed.

## Measured impact

Measured with PHPStan 2.2.13 against trunk at r63522.

**Against the CI configuration (`phpstan.neon.dist`, level 5 + baselines): no errors.**

At rule level 10 over the whole `src/` tree, trunk reports 27,233 errors and this branch reports 27,206 — **27 resolved and none introduced**:

| File | Resolved |
|---|---:|
| `script-loader.php` | 8 |
| `class-wp-block-styles-registry.php` | 7 |
| `class-wp-theme-json.php` | 6 |
| `class-wp-theme-json-resolver.php` | 3 |
| `class-wp-rest-block-types-controller.php` | 2 |
| `block-supports/layout.php` | 1 |

The spread across four subsystems is the point of declaring the alias globally: nothing outside the registry names it, and every one of those files picks the shape up through a return type.

## Note on test coverage

No test changes accompany this, deliberately. The `array_merge()` replacement is behavior-preserving in every case — `wp_parse_args()` reduces to `array_merge( $defaults, $args )` when the defaults are a non-empty array and returns the args otherwise, which is what the explicit check reproduces. That was verified by writing a test for the one uncovered path (a block type registered with `'styles' => false` alongside a `register_block_style()` call) and running it against the code as it stands on trunk, where it also passes. There is no input that distinguishes the two implementations, so there is no assertion that could fail before this change and pass after it.

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: All three commits, along with the PHPStan measurements reported above and drafting this description. Directed, reviewed and verified by me.
Session transcript: https://claude.ai/code/session_01NtH5qFmG4hJcGWDCx5tMY7

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**

