### PR TITLE
Type wp_parse_args() from the arguments it was called with

### DIFF
--- a/src/wp-admin/includes/template.php
+++ b/src/wp-admin/includes/template.php
@@ -2808,7 +2808,7 @@ function wp_star_rating( $args = array() ) {
 	$parsed_args = wp_parse_args( $args, $defaults );
 
 	// Non-English decimal places when the $rating is coming from a string.
-	$rating = (float) str_replace( ',', '.', $parsed_args['rating'] );
+	$rating = (float) str_replace( ',', '.', (string) $parsed_args['rating'] );
 
 	// Convert percentage to star rating, 0..5 in .5 increments.
 	if ( 'percent' === $parsed_args['type'] ) {

--- a/tests/phpstan/README.md
+++ b/tests/phpstan/README.md
@@ -94,6 +94,24 @@ One kind of hash is outside what the visitor covers today: **a `@var` hash on a 
 
 Hashes are also written on hook docblocks, where core documents `apply_filters()` and `do_action()`. Those are not attached to a function, so they are outside what this visitor sees, and the value a filter passes stays typed by [the hook extensions below](#hook-documentation).
 
+### Parsed arguments
+
+`wp_parse_args()` is documented `@return array`, which discards everything its body works out. The body ends in `array_merge( $defaults, $parsed_args )`, so a call whose defaults are known statically returns an array whose keys are known too — and roughly four in five calls across `src/` pass a defaults array written out at the call site.
+
+`WpParseArgsDynamicFunctionReturnTypeExtension` puts that back:
+
+```php
+wp_parse_args( $query, array( 'orderby' => 'name', 'number' => 10 ) )
+```
+
+is `array{orderby: mixed, number: mixed, ...<string, mixed>}` rather than `array`. The values are `mixed` there because `$query` may hold anything at any key, and an unshaped array genuinely says nothing about what a caller passed.
+
+Where `$args` *is* shaped the value types survive the merge as well, which is where most of the benefit comes from. That happens on its own: [hash notation](#hash-notation) derives a shape from the `@type` list documenting an `$args` parameter, and this extension is what stops the `@return array` from throwing it away again. The two compound — documenting a hash on a function that parses its arguments now types the parsed result too.
+
+Nothing here assumes a caller honors the types of the defaults it overrides. The three branches the body takes for `$args` are modeled as written — an array is used as it is, an object goes through `get_object_vars()`, and anything else through `wp_parse_str()`, whose keys are *not* narrowed to strings since `parse_str()` reads `0=a` as an integer key. The merge itself is handed back to PHPStan's own `array_merge()` support rather than reimplemented, so it stays correct about integer-key renumbering and about how two shapes combine.
+
+A call whose `$args` is `mixed` constrains nothing, and is left with the documented `array`.
+
 ### Hook documentation
 
 The remaining extensions read the docblock documenting a hook where the hook is fired, which is where WordPress documents its hooks. They cover `apply_filters()`, `do_action()` and their `_deprecated` and `_ref_array` variants.

--- a/tests/phpstan/README.md
+++ b/tests/phpstan/README.md
@@ -96,7 +96,7 @@ Hashes are also written on hook docblocks, where core documents `apply_filters()
 
 ### Parsed arguments
 
-`wp_parse_args()` is documented `@return array`, which discards everything its body works out. The body ends in `array_merge( $defaults, $parsed_args )`, so a call whose defaults are known statically returns an array whose keys are known too — and roughly four in five calls across `src/` pass a defaults array written out at the call site.
+`wp_parse_args()` documents what it promises for every call, which is necessarily less than what any particular call returns. The body ends in `array_merge( $defaults, $parsed_args )`, so a call whose defaults are known statically returns an array whose keys are known too — and roughly four in five calls across `src/` pass a defaults array written out at the call site.
 
 `WpParseArgsDynamicFunctionReturnTypeExtension` puts that back:
 
@@ -104,13 +104,15 @@ Hashes are also written on hook docblocks, where core documents `apply_filters()
 wp_parse_args( $query, array( 'orderby' => 'name', 'number' => 10 ) )
 ```
 
-is `array{orderby: mixed, number: mixed, ...<string, mixed>}` rather than `array`. The values are `mixed` there because `$query` may hold anything at any key, and an unshaped array genuinely says nothing about what a caller passed.
+is `array{orderby: mixed, number: mixed, ...<string, mixed>}` rather than the documented `array<array-key, mixed>`. The values are `mixed` there because `$query` may hold anything at any key, and an unshaped array genuinely says nothing about what a caller passed.
 
-Where `$args` *is* shaped the value types survive the merge as well, which is where most of the benefit comes from. That happens on its own: [hash notation](#hash-notation) derives a shape from the `@type` list documenting an `$args` parameter, and this extension is what stops the `@return array` from throwing it away again. The two compound — documenting a hash on a function that parses its arguments now types the parsed result too.
+Where `$args` *is* shaped the value types survive the merge as well, which is where most of the benefit comes from. That happens on its own: [hash notation](#hash-notation) derives a shape from the `@type` list documenting an `$args` parameter, and this extension is what stops the documented return type from throwing it away again. The two compound — documenting a hash on a function that parses its arguments now types the parsed result too.
 
-Nothing here assumes a caller honors the types of the defaults it overrides. The three branches the body takes for `$args` are modeled as written — an array is used as it is, an object goes through `get_object_vars()`, and anything else through `wp_parse_str()`, whose keys are *not* narrowed to strings since `parse_str()` reads `0=a` as an integer key. The merge itself is handed back to PHPStan's own `array_merge()` support rather than reimplemented, so it stays correct about integer-key renumbering and about how two shapes combine.
+Nothing here assumes a caller honors the types of the defaults it overrides. The branches the body takes for `$args` are modeled as written — an array is used as it is, an object goes through `get_object_vars()`, and anything else through `wp_parse_str()`, whose keys are *not* narrowed to strings since `parse_str()` reads `0=a` as an integer key. Both the merge and the object conversion are handed back to PHPStan's own support for `array_merge()` and `get_object_vars()` rather than reimplemented, so they stay correct about integer-key renumbering, about how two shapes combine, and about which properties an object actually has.
 
-A call whose `$args` is `mixed` constrains nothing, and is left with the documented `array`.
+The object conversion is only synthesized outside class scope. `wp_parse_args()` is a global function, so the `get_object_vars()` inside it sees public properties only, while the same call resolved in the caller's scope would see the private and protected ones too. Inside a class the extension therefore declines. This handling is adapted from [szepeviktor/phpstan-wordpress](https://github.com/szepeviktor/phpstan-wordpress/pull/309).
+
+A call whose `$args` could still be an object without being known to be one constrains nothing, and is left with the documented return type. So is a call that unpacks its arguments, since an unpacked argument is not matched up with the parameter it lands on.
 
 ### Hook documentation
 

--- a/tests/phpstan/WpParseArgsDynamicFunctionReturnTypeExtension.php
+++ b/tests/phpstan/WpParseArgsDynamicFunctionReturnTypeExtension.php
@@ -1,0 +1,173 @@
+<?php
+/**
+ * PHPStan dynamic return type extension that types the return value of
+ * `wp_parse_args()` from the arguments it was called with.
+ *
+ * The function's `@return array` discards everything its body computes. The body
+ * ends in `array_merge( $defaults, $parsed_args )`, so a call passing a defaults
+ * array that is known statically returns an array whose keys are known too:
+ *
+ *     wp_parse_args( $query, array( 'orderby' => 'name', 'number' => 10 ) )
+ *
+ * is `array{orderby: mixed, number: mixed, ...<string, mixed>}` rather than
+ * `array`. Where `$args` itself carries a shape — which is common, since
+ * `HashNotationVisitor` derives one from the `@type` hash documenting an `$args`
+ * parameter — the merged value types survive as well.
+ *
+ * Nothing here assumes a caller honors the types of the defaults it overrides.
+ * The three branches the body takes for `$args` are modeled as they are written,
+ * and the merge itself is handed back to PHPStan's own `array_merge()` support
+ * rather than reimplemented.
+ *
+ * @package WordPress
+ */
+
+declare(strict_types=1);
+
+namespace WordPress\PHPStan;
+
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Name;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\Expr\TypeExpr;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\DynamicFunctionReturnTypeExtension;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\StringType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+
+/**
+ * Resolves the return type of wp_parse_args() from its arguments.
+ */
+class WpParseArgsDynamicFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension {
+
+	/**
+	 * Determines whether this extension applies to the given function.
+	 *
+	 * @param FunctionReflection $functionReflection Function being analyzed.
+	 * @return bool
+	 */
+	public function isFunctionSupported( FunctionReflection $functionReflection ): bool {
+		return 'wp_parse_args' === $functionReflection->getName();
+	}
+
+	/**
+	 * Reproduces what the function body does to its two arguments.
+	 *
+	 * Returns null when `$args` says too little to model, which leaves the
+	 * documented `array` in place.
+	 *
+	 * @link https://developer.wordpress.org/reference/functions/wp_parse_args/
+	 *
+	 * @param FunctionReflection $functionReflection Function being analyzed.
+	 * @param FuncCall           $functionCall       The function call node.
+	 * @param Scope              $scope              Analysis scope.
+	 * @return Type|null
+	 */
+	public function getTypeFromFunctionCall( FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope ): ?Type {
+		$args = $functionCall->getArgs();
+
+		if ( array() === $args ) {
+			return null;
+		}
+
+		$args_type   = $scope->getType( $args[0]->value );
+		$parsed_type = $this->getParsedArgsType( $args_type );
+
+		if ( null === $parsed_type ) {
+			return null;
+		}
+
+		/*
+		 * `$defaults` defaults to an empty array, which the body's `&& $defaults`
+		 * rejects, so the parsed arguments are returned unmerged.
+		 */
+		if ( count( $args ) < 2 ) {
+			return $parsed_type;
+		}
+
+		$defaults_type = $scope->getType( $args[1]->value );
+
+		// `if ( is_array( $defaults ) && $defaults )`.
+		$merges = $defaults_type->isArray()->and( $defaults_type->isIterableAtLeastOnce() );
+
+		if ( $merges->no() ) {
+			return $parsed_type;
+		}
+
+		/*
+		 * The merge is PHPStan's to compute: it already knows that array_merge()
+		 * renumbers integer keys, that a key the second array may hold widens the
+		 * first array's value for it, and how two shapes combine. Asking it costs
+		 * a synthetic call node, which is cheaper and more correct than restating
+		 * any of that here.
+		 *
+		 * The call's own argument nodes are passed through wherever they can be,
+		 * and a `TypeExpr` stands in only for an `$args` that is not already an
+		 * array — the case where the type being merged is one this class derived
+		 * rather than one the source wrote. Keeping the real expressions is worth
+		 * the branch: PHPStan reasons about them more precisely than about a bare
+		 * type, which is what keeps the parsed comment data in
+		 * `WP_REST_Comments_Controller::update_item()` from losing a key it sets.
+		 */
+		$parsed_expr = $args_type->isArray()->yes()
+			? $args[0]
+			: new Arg( new TypeExpr( $parsed_type ) );
+
+		$merged_type = $scope->getType(
+			new FuncCall(
+				new Name( 'array_merge' ),
+				array( $args[1], $parsed_expr )
+			)
+		);
+
+		if ( $merges->yes() ) {
+			return $merged_type;
+		}
+
+		// Empty or non-array defaults are possible, so both branches are.
+		return TypeCombinator::union( $merged_type, $parsed_type );
+	}
+
+	/**
+	 * Models the array that the body derives from `$args`.
+	 *
+	 * @param Type $args_type Type of the `$args` argument.
+	 * @return Type|null Parsed arguments, or null when `$args` is unconstrained.
+	 */
+	private function getParsedArgsType( Type $args_type ): ?Type {
+		// A `mixed` argument constrains nothing, so the branches below would all apply.
+		if ( $args_type->isSuperTypeOf( new MixedType() )->yes() ) {
+			return null;
+		}
+
+		$branches = array();
+
+		// `is_array( $args )`: the array is taken as it is, shape and all.
+		foreach ( $args_type->getArrays() as $array_type ) {
+			$branches[] = $array_type;
+		}
+
+		// `is_object( $args )`: get_object_vars() yields the object's properties.
+		if ( ! $args_type->isObject()->no() ) {
+			$branches[] = new ArrayType( new StringType(), new MixedType() );
+		}
+
+		/*
+		 * Anything else goes through wp_parse_str(). Its keys are not narrowed to
+		 * strings: parse_str() reads `0=a` as an integer key, and the `wp_parse_str`
+		 * filter it ends with documents a plain array.
+		 *
+		 * A union of only arrays and objects lands here too, widening the result
+		 * rather than narrowing it, which is the safe direction to be wrong in.
+		 */
+		if ( ! $args_type->isArray()->yes() && ! $args_type->isObject()->yes() ) {
+			$branches[] = new ArrayType( new MixedType(), new MixedType() );
+		}
+
+		return array() === $branches ? null : TypeCombinator::union( ...$branches );
+	}
+}

--- a/tests/phpstan/WpParseArgsDynamicFunctionReturnTypeExtension.php
+++ b/tests/phpstan/WpParseArgsDynamicFunctionReturnTypeExtension.php
@@ -3,21 +3,24 @@
  * PHPStan dynamic return type extension that types the return value of
  * `wp_parse_args()` from the arguments it was called with.
  *
- * The function's `@return array` discards everything its body computes. The body
- * ends in `array_merge( $defaults, $parsed_args )`, so a call passing a defaults
- * array that is known statically returns an array whose keys are known too:
+ * The documented return type describes what the function promises for every call.
+ * The body ends in `array_merge( $defaults, $parsed_args )`, so a particular call
+ * passing a defaults array that is known statically returns an array whose keys
+ * are known too:
  *
  *     wp_parse_args( $query, array( 'orderby' => 'name', 'number' => 10 ) )
  *
  * is `array{orderby: mixed, number: mixed, ...<string, mixed>}` rather than
- * `array`. Where `$args` itself carries a shape — which is common, since
- * `HashNotationVisitor` derives one from the `@type` hash documenting an `$args`
- * parameter — the merged value types survive as well.
+ * `array<array-key, mixed>`. Where `$args` itself carries a shape — which is
+ * common, since `HashNotationVisitor` derives one from the `@type` hash
+ * documenting an `$args` parameter — the merged value types survive as well.
  *
  * Nothing here assumes a caller honors the types of the defaults it overrides.
- * The three branches the body takes for `$args` are modeled as they are written,
- * and the merge itself is handed back to PHPStan's own `array_merge()` support
- * rather than reimplemented.
+ * The branches the body takes for `$args` are modeled as they are written, and
+ * both the merge and the object conversion are handed back to PHPStan's own
+ * support for `array_merge()` and `get_object_vars()` rather than reimplemented.
+ *
+ * @link https://github.com/szepeviktor/phpstan-wordpress/pull/309 The object handling below is adapted from szepeviktor/phpstan-wordpress, MIT license.
  *
  * @package WordPress
  */
@@ -27,6 +30,7 @@ declare(strict_types=1);
 namespace WordPress\PHPStan;
 
 use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Name;
 use PHPStan\Analyser\Scope;
@@ -35,7 +39,6 @@ use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\MixedType;
-use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 
@@ -57,8 +60,8 @@ class WpParseArgsDynamicFunctionReturnTypeExtension implements DynamicFunctionRe
 	/**
 	 * Reproduces what the function body does to its two arguments.
 	 *
-	 * Returns null when `$args` says too little to model, which leaves the
-	 * documented `array` in place.
+	 * Returns null when the arguments say too little to model, which leaves the
+	 * documented return type in place.
 	 *
 	 * @link https://developer.wordpress.org/reference/functions/wp_parse_args/
 	 *
@@ -74,12 +77,20 @@ class WpParseArgsDynamicFunctionReturnTypeExtension implements DynamicFunctionRe
 			return null;
 		}
 
-		$args_type   = $scope->getType( $args[0]->value );
-		$parsed_type = $this->getParsedArgsType( $args_type );
+		// An unpacked argument is not matched up with the parameter it lands on.
+		foreach ( $args as $arg ) {
+			if ( $arg->unpack ) {
+				return null;
+			}
+		}
 
-		if ( null === $parsed_type ) {
+		$parsed_expr = $this->getParsedArgsExpr( $args[0]->value, $scope );
+
+		if ( null === $parsed_expr ) {
 			return null;
 		}
+
+		$parsed_type = $scope->getType( $parsed_expr );
 
 		/*
 		 * `$defaults` defaults to an empty array, which the body's `&& $defaults`
@@ -101,26 +112,12 @@ class WpParseArgsDynamicFunctionReturnTypeExtension implements DynamicFunctionRe
 		/*
 		 * The merge is PHPStan's to compute: it already knows that array_merge()
 		 * renumbers integer keys, that a key the second array may hold widens the
-		 * first array's value for it, and how two shapes combine. Asking it costs
-		 * a synthetic call node, which is cheaper and more correct than restating
-		 * any of that here.
-		 *
-		 * The call's own argument nodes are passed through wherever they can be,
-		 * and a `TypeExpr` stands in only for an `$args` that is not already an
-		 * array — the case where the type being merged is one this class derived
-		 * rather than one the source wrote. Keeping the real expressions is worth
-		 * the branch: PHPStan reasons about them more precisely than about a bare
-		 * type, which is what keeps the parsed comment data in
-		 * `WP_REST_Comments_Controller::update_item()` from losing a key it sets.
+		 * first array's value for it, and how two shapes combine.
 		 */
-		$parsed_expr = $args_type->isArray()->yes()
-			? $args[0]
-			: new Arg( new TypeExpr( $parsed_type ) );
-
 		$merged_type = $scope->getType(
 			new FuncCall(
 				new Name( 'array_merge' ),
-				array( $args[1], $parsed_expr )
+				array( $args[1], new Arg( $parsed_expr ) )
 			)
 		);
 
@@ -133,41 +130,52 @@ class WpParseArgsDynamicFunctionReturnTypeExtension implements DynamicFunctionRe
 	}
 
 	/**
-	 * Models the array that the body derives from `$args`.
+	 * Builds the expression whose type is the array the body derives from `$args`.
 	 *
-	 * @param Type $args_type Type of the `$args` argument.
-	 * @return Type|null Parsed arguments, or null when `$args` is unconstrained.
+	 * @param Expr  $args_expr Expression passed as `$args`.
+	 * @param Scope $scope     Analysis scope.
+	 * @return Expr|null Expression to merge the defaults into, or null when `$args`
+	 *                   is too unconstrained to model.
 	 */
-	private function getParsedArgsType( Type $args_type ): ?Type {
-		// A `mixed` argument constrains nothing, so the branches below would all apply.
-		if ( $args_type->isSuperTypeOf( new MixedType() )->yes() ) {
+	private function getParsedArgsExpr( Expr $args_expr, Scope $scope ): ?Expr {
+		$args_type = $scope->getType( $args_expr );
+
+		// `is_array( $args )`: the array is taken as it is, shape and all.
+		if ( $args_type->isArray()->yes() ) {
+			return $args_expr;
+		}
+
+		if ( $args_type->isObject()->yes() ) {
+			/*
+			 * `is_object( $args )`: get_object_vars() decides both which properties
+			 * come back and what their keys are, so the call is handed to PHPStan
+			 * rather than described here.
+			 *
+			 * It is only safe to synthesize outside class scope. wp_parse_args() is a
+			 * global function, so the get_object_vars() inside it sees public properties
+			 * only, while a call resolved in the caller's scope sees the private and
+			 * protected ones too.
+			 */
+			if ( $scope->isInClass() ) {
+				return null;
+			}
+
+			return new FuncCall( new Name( 'get_object_vars' ), array( new Arg( $args_expr ) ) );
+		}
+
+		// An object remains possible, so neither branch above can be relied on.
+		if ( ! $args_type->isObject()->no() ) {
 			return null;
 		}
 
-		$branches = array();
-
-		// `is_array( $args )`: the array is taken as it is, shape and all.
-		foreach ( $args_type->getArrays() as $array_type ) {
-			$branches[] = $array_type;
-		}
-
-		// `is_object( $args )`: get_object_vars() yields the object's properties.
-		if ( ! $args_type->isObject()->no() ) {
-			$branches[] = new ArrayType( new StringType(), new MixedType() );
-		}
-
 		/*
-		 * Anything else goes through wp_parse_str(). Its keys are not narrowed to
-		 * strings: parse_str() reads `0=a` as an integer key, and the `wp_parse_str`
-		 * filter it ends with documents a plain array.
-		 *
-		 * A union of only arrays and objects lands here too, widening the result
-		 * rather than narrowing it, which is the safe direction to be wrong in.
+		 * What is left is the wp_parse_str() branch, on its own or beside an array.
+		 * Its keys are not narrowed to strings: parse_str() reads `0=a` as an integer
+		 * key, and the `wp_parse_str` filter it ends with documents a plain array.
 		 */
-		if ( ! $args_type->isArray()->yes() && ! $args_type->isObject()->yes() ) {
-			$branches[] = new ArrayType( new MixedType(), new MixedType() );
-		}
+		$branches   = $args_type->getArrays();
+		$branches[] = new ArrayType( new MixedType(), new MixedType() );
 
-		return array() === $branches ? null : TypeCombinator::union( ...$branches );
+		return new TypeExpr( TypeCombinator::union( ...$branches ) );
 	}
 }

--- a/tests/phpstan/base.neon
+++ b/tests/phpstan/base.neon
@@ -40,7 +40,7 @@ services:
 			- phpstan.broker.dynamicFunctionReturnTypeExtension
 
 	# Types the return value of wp_parse_args() from the arguments it was called
-	# with, which its `@return array` otherwise discards.
+	# with, which its documented return type necessarily cannot describe.
 	-
 		class: WordPress\PHPStan\WpParseArgsDynamicFunctionReturnTypeExtension
 		tags:

--- a/tests/phpstan/base.neon
+++ b/tests/phpstan/base.neon
@@ -39,6 +39,13 @@ services:
 		tags:
 			- phpstan.broker.dynamicFunctionReturnTypeExtension
 
+	# Types the return value of wp_parse_args() from the arguments it was called
+	# with, which its `@return array` otherwise discards.
+	-
+		class: WordPress\PHPStan\WpParseArgsDynamicFunctionReturnTypeExtension
+		tags:
+			- phpstan.broker.dynamicFunctionReturnTypeExtension
+
 	# Enforces that every hook invocation is preceded by a documenting docblock or
 	# a valid "This filter is documented in <file>" reference comment.
 	-
@@ -211,6 +218,7 @@ parameters:
 		- HookDocsVisitor.php
 		- HookDocBlock.php
 		- ApplyFiltersDynamicFunctionReturnTypeExtension.php
+		- WpParseArgsDynamicFunctionReturnTypeExtension.php
 		- HookDocumentationRule.php
 		- HookParamCountRule.php
 		- HookDocsResultCacheMetaExtension.php

--- a/tests/phpstan/baselines/argument.type.neon
+++ b/tests/phpstan/baselines/argument.type.neon
@@ -1129,7 +1129,7 @@ parameters:
 			count: 1
 			path: ../../../src/wp-includes/pluggable.php
 		-
-			message: '#^Parameter \#1 \$args of function get_pages expects array\{child_of\?\: int, sort_order\?\: string, sort_column\?\: string, hierarchical\?\: bool, exclude\?\: array\<int\>, include\?\: array\<int\>, meta_key\?\: string, meta_value\?\: string, \.\.\., \.\.\.\}\|string, non\-empty\-array\<mixed\> given\.$#'
+			message: '#^Parameter \#1 \$args of function get_pages expects array\{child_of\?\: int, sort_order\?\: string, sort_column\?\: string, hierarchical\?\: bool, exclude\?\: array\<int\>, include\?\: array\<int\>, meta_key\?\: string, meta_value\?\: string, \.\.\., \.\.\.\}\|string, non\-empty\-array given\.$#'
 			identifier: argument.type
 			count: 1
 			path: ../../../src/wp-includes/post-template.php


### PR DESCRIPTION
Adds a PHPStan dynamic return type extension that types the result of `wp_parse_args()` from the arguments it was called with.

Trac ticket: Core-65817

## Why

In r63522 (41a4f4f0515c9c599064edc4d1ae1ea8fda441b9) the types of `wp_parse_args()` were documented, which says what the function promises. This is the other half: `@return array<string, mixed>` still discards everything the body works out for a *particular* call. The body ends in `array_merge( $defaults, $parsed_args )`, so a call whose defaults are written out at the call site returns an array whose keys are known too — and that is roughly four calls in five across `src/`, 193 of the 240 call sites.

```php
wp_parse_args( $query, array( 'orderby' => 'name', 'number' => 10 ) )
```

resolves to `array{orderby: mixed, number: mixed, ...<string, mixed>}` rather than `array<array-key, mixed>`. The values stay `mixed` there because an unshaped `$args` may hold anything at any key, which is the honest answer rather than a limitation.

**Where `$args` does carry a shape the value types survive the merge, and that is where most of the benefit comes from.** It also arrives for free: `HashNotationVisitor` already derives a shape from the `@type` list documenting an `$args` parameter, and the `@return` was throwing it away again a line later. The two now compound, so documenting a hash on a function that parses its arguments types the parsed result as well.

## How

Nothing here assumes a caller honors the types of the defaults it overrides. The branches the body takes for `$args` are modeled as written — an array is used as it is, an object goes through `get_object_vars()`, and anything else through `wp_parse_str()`, whose keys are **not** narrowed to strings since `parse_str()` reads `0=a` as an integer key and the `wp_parse_str` filter it ends with documents a plain array.

Both the merge and the object conversion are handed back to PHPStan's own support for `array_merge()` and `get_object_vars()` rather than reimplemented, so they stay correct about integer-key renumbering, about how two shapes combine, and about which properties an object actually has. The object conversion is only synthesized outside class scope, because `wp_parse_args()` is a global function whose `get_object_vars()` sees public properties only, while the same call resolved in the caller's scope would see private and protected ones too — inside a class the extension declines. That handling, and the caveat behind it, are adapted from [szepeviktor/phpstan-wordpress#309](https://github.com/szepeviktor/phpstan-wordpress/pull/309), which arrived at the same extension independently.

A call whose `$args` could still be an object without being known to be one keeps the documented type, as does a call that unpacks its arguments, since an unpacked argument is not matched up with the parameter it lands on.

Verified against each branch:

| `$args` | Resolves to |
|---|---|
| `array<string, mixed>` | `array{orderby: mixed, number: mixed, echo: mixed, ...<string, mixed>}` |
| `array<string, mixed>\|string` | `array{orderby: mixed, number: mixed, echo: mixed, ...}` |
| `string` | `array{orderby: mixed, number: mixed, echo: mixed, ...}` |
| `object`, outside class scope | `get_object_vars()`'s own type, merged |
| `object`, inside class scope | declines, keeping the documented type |
| `array{orderby: string, number: int, echo: bool}` | `array{orderby: string, number: int, echo: bool}` |
| no `$defaults`, or empty | `array<string, mixed>` |
| `mixed`, or unpacked arguments | declines, keeping the documented type |

## Measured impact

Measured with PHPStan 2.2.13 against trunk at r63524.

**Against the CI configuration (`phpstan.neon.dist`, level 5 + baselines): no errors.**

At rule level 10 over the whole `src/` tree, trunk reports 27,208 errors and this branch reports 27,062 — a net **−146**, from **164 resolved and 18 introduced**.

| Resolved | | Introduced | |
|---|---:|---|---:|
| `argument.type` | 119 | `class-wp-widget-media-image.php` | 14 |
| `binaryOp.invalid` | 13 | `post-template.php` | 2 |
| `echo.nonString` | 7 | `schema.php` | 1 |
| `offsetAccess.nonOffsetAccessible` | 6 | `script-loader.php` | 1 |
| `encapsedStringPart.nonString` | 5 | | |
| `offsetAccess.notFound` | 5 | | |
| 5 others | 9 | | |

**Fourteen of the eighteen are in one file.** `WP_Widget_Media_Image::render_media()` merges its schema defaults in through `wp_list_pluck()`, whose own `@return array` hides the keys it just added; the result is narrowed to the one key this extension can see, and every other key read is then reported as possibly missing. They are false positives inherited from that rather than from the merge modeled here, and none of the eighteen are reported at the rule level the test suite enforces. Typing `wp_list_pluck()` would clear them, and is worth doing separately.

## The two other commits

**The star rating cast** is a prerequisite. `wp_star_rating()` documents `@type int|float $rating` and hands that value straight to `str_replace()`, whose `$subject` takes a string. The line's own comment says the rating may be "coming from a string", so the value it is written for is not the value the docblock describes, and neither is what `str_replace()` wants. PHP coerces it silently, which is why it has gone unnoticed; the extension makes the documented type visible at that line. Casting makes the conversion the code already relies on explicit, and mirrors the `(float)` cast the result is fed into.

**The baseline regeneration** moves one entry's wording. The `$parsed_args` that `wp_list_pages()` hands to `get_pages()` comes from `wp_parse_args()`, so anything changing how that call is typed changes how the value is described in the message. In r63522 it moved from `non-empty-array` to `non-empty-array<mixed>`; resolving the call to a shape moves it back. The error itself is untouched and still needs fixing — it is a genuine pre-existing problem, and fixing it properly rather than re-baselining it a third time would be a reasonable ask.

## Related

Core-66049 proposes PHPStan extensions for a different gap in the same function — the query-string `$args` form that a conditional return type cannot decide. This does not address that; it types what `wp_parse_args()` returns, not how `X is Y` resolves for a string argument.

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: All three commits, along with the PHPStan measurements reported above and drafting this description. Directed, reviewed and verified by me.
Session transcript: https://claude.ai/code/session_01NtH5qFmG4hJcGWDCx5tMY7

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**

