### PR TITLE
View Config: Add the `showPlaceholderIfEmpty` option of the panel form layout to the view config schema

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-view-config-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-view-config-controller.php
@@ -631,6 +631,7 @@ class WP_REST_View_Config_Controller extends WP_REST_Controller {
 	 * matching the TypeScript Layout union in dataviews/src/types/dataform.ts.
 	 *
 	 * @since 7.1.0
+	 * @since 7.2.0 Added the `showPlaceholderIfEmpty` property to the panel layout.
 	 *
 	 * @return array Schema for a form layout object.
 	 */
@@ -655,15 +656,15 @@ class WP_REST_View_Config_Controller extends WP_REST_Controller {
 				array(
 					'type'       => 'object',
 					'properties' => array(
-						'type'           => array(
+						'type'                   => array(
 							'type' => 'string',
 							'enum' => array( 'panel' ),
 						),
-						'labelPosition'  => array(
+						'labelPosition'          => array(
 							'type' => 'string',
 							'enum' => array( 'top', 'side', 'none' ),
 						),
-						'openAs'         => array(
+						'openAs'                 => array(
 							'oneOf' => array(
 								array(
 									'type' => 'string',
@@ -686,7 +687,7 @@ class WP_REST_View_Config_Controller extends WP_REST_Controller {
 								),
 							),
 						),
-						'summary'        => array(
+						'summary'                => array(
 							'oneOf' => array(
 								array( 'type' => 'string' ),
 								array(
@@ -697,9 +698,12 @@ class WP_REST_View_Config_Controller extends WP_REST_Controller {
 								),
 							),
 						),
-						'editVisibility' => array(
+						'editVisibility'         => array(
 							'type' => 'string',
 							'enum' => array( 'always', 'on-hover' ),
+						),
+						'showPlaceholderIfEmpty' => array(
+							'type' => 'boolean',
 						),
 					),
 				),


### PR DESCRIPTION

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/65981

Adds a boolean `showPlaceholderIfEmpty` property to the panel form layout in the view config REST schema. When true, the panel summary shows the field's `placeholder` instead of its `render` output when the value is `undefined`, `null`, or an empty string. It is `false` by default, so existing forms are unchanged. Schema only, no behavior changes on the server.

  # Backports

  Gutenberg PRs:

  - https://github.com/WordPress/gutenberg/pull/82527

  ## Use of AI Tools

  AI assistance: Yes
  Tool(s): Claude Code
  Model(s): Claude Fable
  Used for: Porting the server-side change from the Gutenberg PR.
  Reviewed and edited by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
