### PR TITLE
View Config: Remove stale fields from the wp_template default view

### DIFF
--- a/src/wp-includes/view-config.php
+++ b/src/wp-includes/view-config.php
@@ -566,7 +566,7 @@ function _wp_get_entity_view_config_posttype_wp_template( $data ) {
 		'titleField'       => 'title',
 		'descriptionField' => 'description',
 		'mediaField'       => 'preview',
-		'fields'           => array( 'author', 'active', 'slug', 'theme' ),
+		'fields'           => array( 'author' ),
 		'filters'          => array(),
 		'showMedia'        => true,
 	);


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65981

Removes the `active`, `slug`, and `theme` fields from the default view of the `wp_template` entity in `view-config.php`. Those fields were rendered by the template activation experiment, which has been removed from the editor (https://github.com/WordPress/gutenberg/pull/82241). No field with those ids is registered for templates anymore, so the entries do nothing. DataViews drops unknown ids from `view.fields`, so there is no change in what the Templates page shows: title, description, and author.

# Backports

Gutenberg PRs:

- https://github.com/WordPress/gutenberg/pull/82602

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Fable
Used for: Tracing the history of the fields and porting the change from the Gutenberg PR. Reviewed and edited by me.

This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.
