### PR TITLE
Text Changes: Clarify the Site Icon description wording

### DIFF
--- a/src/wp-admin/options-general.php
+++ b/src/wp-admin/options-general.php
@@ -212,7 +212,7 @@ $tagline_description = sprintf(
 		<?php
 			printf(
 				/* translators: 1: pixel value for icon size. 2: pixel value for icon size. */
-				__( 'The Site Icon is what you see in browser tabs, bookmark bars, and within the WordPress mobile apps. It should be square and at least <strong>%1$s by %2$s</strong> pixels.' ),
+				__( 'The Site Icon appears in browser tabs, bookmark bars, and within the WordPress mobile apps. It must have a square aspect ratio (1:1) and be at least <strong>%1$s &times; %2$s</strong> pixels in size.' ),
 				512,
 				512
 			);

--- a/src/wp-includes/class-wp-customize-manager.php
+++ b/src/wp-includes/class-wp-customize-manager.php
@@ -5208,7 +5208,7 @@ final class WP_Customize_Manager {
 					'label'       => __( 'Site Icon' ),
 					'description' => sprintf(
 						/* translators: 1: pixel value for icon size. 2: pixel value for icon size. */
-						'<p>' . __( 'The Site Icon is what you see in browser tabs, bookmark bars, and within the WordPress mobile apps. It should be square and at least <strong>%1$s by %2$s</strong> pixels.' ) . '</p>',
+						'<p>' . __( 'The Site Icon appears in browser tabs, bookmark bars, and within the WordPress mobile apps. It must have a square aspect ratio (1:1) and be at least <strong>%1$s &times; %2$s</strong> pixels in size.' ) . '</p>',
 						512,
 						512
 					),


### PR DESCRIPTION
Clarifies the Site Icon help text in Settings → General and the matching Customizer control. The wording now makes it clear that "square" refers to the aspect ratio, so rounded or circular icons are also valid.

Updated the same translatable string in both `options-general.php` and `class-wp-customize-manager.php` to keep them in sync. Placeholders are unchanged, and `&times;` is used to match Core's existing dimension format.

Trac ticket: https://core.trac.wordpress.org/ticket/65975

## Use of AI Tools

AI assistance: No

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**