### PR TITLE
Build/Test Tools: Trim the routine PHPUnit database matrix

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -113,8 +113,8 @@ jobs:
         # The scheduled run tests every supported PHP version. Other events test the highest and lowest of each major.
         php: ${{ github.event_name == 'schedule' && fromJSON('["7.4","8.0","8.1","8.2","8.3","8.4","8.5"]') || fromJSON('["7.4","8.0","8.5"]') }}
         db-type: [ 'mysql' ]
-        # The scheduled run tests the full database matrix. Other events test the oldest listed version and supported LTS releases.
-        db-version: ${{ github.event_name == 'schedule' && fromJSON('["5.7","8.0","8.4","9.7"]') || fromJSON('["5.7","8.4","9.7"]') }}
+        # The scheduled run tests the full database matrix. Other events retain MySQL 5.7 compatibility and the widely used 8.x releases.
+        db-version: ${{ github.event_name == 'schedule' && fromJSON('["5.7","8.0","8.4","9.7"]') || fromJSON('["5.7","8.0","8.4"]') }}
         tests-domain: [ 'example.org' ]
         multisite: [ false, true ]
         memcached: [ false ]
@@ -206,8 +206,8 @@ jobs:
         # The scheduled run tests every supported PHP version. Other events test the highest and lowest of each major.
         php: ${{ github.event_name == 'schedule' && fromJSON('["7.4","8.0","8.1","8.2","8.3","8.4","8.5"]') || fromJSON('["7.4","8.0","8.5"]') }}
         db-type: [ 'mariadb' ]
-        # The scheduled run tests the full database matrix. Other events test the oldest listed version and supported LTS releases.
-        db-version: ${{ github.event_name == 'schedule' && fromJSON('["5.5","10.3","10.5","10.6","10.11","11.4","11.8"]') || fromJSON('["5.5","10.11","11.4","11.8"]') }}
+        # The scheduled run tests the full database matrix. Other events retain MariaDB 5.5 compatibility, 10.6, and newer LTS releases.
+        db-version: ${{ github.event_name == 'schedule' && fromJSON('["5.5","10.3","10.5","10.6","10.11","11.4","11.8"]') || fromJSON('["5.5","10.6","10.11","11.4","11.8"]') }}
         multisite: [ false, true ]
         memcached: [ false ]
 

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -113,7 +113,8 @@ jobs:
         # The scheduled run tests every supported PHP version. Other events test the highest and lowest of each major.
         php: ${{ github.event_name == 'schedule' && fromJSON('["7.4","8.0","8.1","8.2","8.3","8.4","8.5"]') || fromJSON('["7.4","8.0","8.5"]') }}
         db-type: [ 'mysql' ]
-        db-version: [ '5.7', '8.0', '8.4', '9.7' ]
+        # The scheduled run tests the full database matrix. Other events test the oldest listed version and supported LTS releases.
+        db-version: ${{ github.event_name == 'schedule' && fromJSON('["5.7","8.0","8.4","9.7"]') || fromJSON('["5.7","8.4","9.7"]') }}
         tests-domain: [ 'example.org' ]
         multisite: [ false, true ]
         memcached: [ false ]
@@ -173,8 +174,8 @@ jobs:
   #
   # Creates a PHPUnit test job for each PHP/MariaDB combination.
   #
-  # All LTS versions of MariaDB supported by WordPress with greater than 1% usage according to w.org/stats should be
-  # tested. The exceptions to this rule are the most recent LTS and version 5.5.
+  # The scheduled run tests all LTS versions of MariaDB supported by WordPress with greater than 1% usage according to
+  # w.org/stats. The exceptions to this rule are the most recent LTS and version 5.5.
   #
   # The 5.5 release was intended as a drop-in replacement for MySQL. Because the MySQL 5.5 Docker containers do not
   # work, this ensures some level of MySQL 5.5 testing.
@@ -205,7 +206,8 @@ jobs:
         # The scheduled run tests every supported PHP version. Other events test the highest and lowest of each major.
         php: ${{ github.event_name == 'schedule' && fromJSON('["7.4","8.0","8.1","8.2","8.3","8.4","8.5"]') || fromJSON('["7.4","8.0","8.5"]') }}
         db-type: [ 'mariadb' ]
-        db-version: [ '5.5', '10.3', '10.5', '10.6', '10.11', '11.4', '11.8' ]
+        # The scheduled run tests the full database matrix. Other events test the oldest listed version and supported LTS releases.
+        db-version: ${{ github.event_name == 'schedule' && fromJSON('["5.5","10.3","10.5","10.6","10.11","11.4","11.8"]') || fromJSON('["5.5","10.11","11.4","11.8"]') }}
         multisite: [ false, true ]
         memcached: [ false ]
 


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/66069

Reduce the database versions tested on pushes, pull requests, and manual runs. Keep the complete database lists on the weekly schedule, following the existing PHP matrix pattern.

- MySQL: retain 5.7, 8.0, and 8.4 on routine runs; test 9.7 weekly.
- MariaDB: retain 5.5, 10.6, 10.11, 11.4, and 11.8 on routine runs; test 10.3 and 10.5 weekly.

Routine runs drop from 86 to 68 jobs (21% fewer); weekly runs remain at 182. These totals include shared Gutenberg preparation and exclude notification and failure-handling jobs. Memcached, alternate-domain, reporting, HTML API, innovation-release, and PHP prerelease configurations are preserved.

Label-triggered full-matrix runs on PRs are tracked separately in https://core.trac.wordpress.org/ticket/66071.

## Validation

- `actionlint .github/workflows/phpunit-tests.yml`
- `uvx --offline zizmor@1.24.1 --persona=regular --offline .github/workflows/phpunit-tests.yml`
- Expanded the before/after matrices for push, pull request, manual, and scheduled events. Confirmed 86 → 68 for each routine event and 182 → 182 weekly; every retained job configuration matches exactly, including reporting and other additional configurations.

- CI on the reviewed head completed with six jobs reaching the 30-minute limit: five during Build WordPress and one during PHPUnit, with no recorded assertion failures. The [failed-job retry is running](https://github.com/WordPress/wordpress-develop/actions/runs/34366978921). Local matrix validation, actionlint, and zizmor passed again before SVN preparation.

## Use of AI tools

AI assistance: Yes  
Tool(s): Codex  
Model(s): GPT-6, GPT-5.6  
Used for: Workflow edits, matrix validation, code review, and drafting this description. I take responsibility for the submitted change.

---
**This pull request is for code review only. Please keep other discussion in the Trac ticket. Do not merge this pull request.**
