### PR TITLE
Build/Test Tools: Run the full PHPUnit matrix by label

### DIFF
--- a/.github/workflows/phpunit-tests-full-matrix.yml
+++ b/.github/workflows/phpunit-tests-full-matrix.yml
@@ -1,0 +1,65 @@
+name: PHPUnit Tests (label)
+run-name: PHPUnit Tests${{ github.event.label.name == 'Full PHPUnit Matrix' && ' (full matrix)' || ' (ignored label)' }}
+
+on:
+  pull_request:
+    types: [ labeled ]
+    branches:
+      - trunk
+      - '3.[7-9]'
+      - '[4-9].[0-9]'
+    # Keep these paths in sync with phpunit-tests.yml.
+    paths:
+      - '**'
+      # Documentation and repository metadata.
+      - '!**.md'
+      - '!.devcontainer/**'
+      - '!.editorconfig'
+      - '!.git-blame-ignore-revs'
+      - '!.gitignore'
+      - '!.mailmap'
+      - '!typings/**'
+      # Configuration for unrelated checks.
+      - '!.eslintrc-jsdoc.js'
+      - '!.prettierrc.js'
+      - '!.version-support-*.json'
+      - '!eslint.config.js'
+      - '!jsdoc.conf.json'
+      - '!phpcompat.xml.dist'
+      - '!phpcs.xml.dist'
+      - '!phpstan.neon.dist'
+      - '!tsconfig.json'
+      # Other test suites, tools, and workflows do not affect these tests.
+      - '!tests/**'
+      - '!tools/**'
+      - '!.github/**'
+      # Re-include documentation, tests, tools, and workflows used here.
+      - 'SECURITY.md'
+      - 'src/license.txt'
+      - 'tests/phpunit/**'
+      - 'tools/gutenberg/**'
+      - 'tools/local-env/**'
+      - 'tools/vendors/**'
+      - 'tools/webpack/**'
+      - 'phpunit.xml.dist'
+      - '.github/workflows/phpunit-tests.yml'
+      - '.github/workflows/phpunit-tests-full-matrix.yml'
+      - '.github/workflows/reusable-phpunit-tests-*.yml'
+      - '.github/workflows/reusable-prepare-gutenberg.yml'
+
+# Disable permissions for all available scopes by default.
+permissions: {}
+
+# The called workflow manages concurrency. Unrelated labels never enter it.
+jobs:
+  full-matrix:
+    if: github.event.label.name == 'Full PHPUnit Matrix'
+    permissions:
+      # Required by the called workflow's recovery job, which is skipped on PR events.
+      actions: write
+      contents: read
+    uses: ./.github/workflows/phpunit-tests.yml
+    secrets:
+      CODEVITALS_PROJECT_TOKEN: ${{ secrets.CODEVITALS_PROJECT_TOKEN }}
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      WPT_REPORT_API_KEY: ${{ secrets.WPT_REPORT_API_KEY }}

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -1,4 +1,5 @@
 name: PHPUnit Tests
+run-name: PHPUnit Tests${{ ( github.event_name == 'schedule' || contains( github.event.pull_request.labels.*.name, 'Full PHPUnit Matrix' ) ) && ' (full matrix)' || '' }}
 
 on:
   push:
@@ -7,6 +8,7 @@ on:
       - '3.[7-9]'
       - '[4-9].[0-9]'
   pull_request:
+    types: [ opened, synchronize, reopened, labeled ]
     branches:
       - trunk
       - '3.[7-9]'
@@ -54,9 +56,8 @@ on:
 
 # Cancels all previous workflow runs for pull requests that have not completed.
 concurrency:
-  # The concurrency group contains the workflow name and the branch name for pull requests
-  # or the commit hash for any other events.
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  # Unrelated label events get their own group so skipped runs cannot cancel active tests.
+  group: ${{ github.workflow }}-${{ github.event.action == 'labeled' && github.event.label.name != 'Full PHPUnit Matrix' && github.run_id || github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 # Disable permissions for all available scopes by default.
@@ -71,11 +72,13 @@ jobs:
     permissions:
       contents: read
     if: |
-      github.repository == 'WordPress/wordpress-develop' || (
-        github.event_name == 'pull_request' && (
-          ! github.event.repository.private ||
-          ! github.event.pull_request.draft ||
-          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+      ( github.event.action != 'labeled' || github.event.label.name == 'Full PHPUnit Matrix' ) && (
+        github.repository == 'WordPress/wordpress-develop' || (
+          github.event_name == 'pull_request' && (
+            ! github.event.repository.private ||
+            ! github.event.pull_request.draft ||
+            contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
+          )
         )
       )
 
@@ -110,11 +113,11 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-24.04 ]
-        # The scheduled run tests every supported PHP version. Other events test the highest and lowest of each major.
-        php: ${{ github.event_name == 'schedule' && fromJSON('["7.4","8.0","8.1","8.2","8.3","8.4","8.5"]') || fromJSON('["7.4","8.0","8.5"]') }}
+        # Scheduled and labeled runs test every supported PHP version. Other runs test the highest and lowest of each major.
+        php: ${{ ( github.event_name == 'schedule' || contains( github.event.pull_request.labels.*.name, 'Full PHPUnit Matrix' ) ) && fromJSON('["7.4","8.0","8.1","8.2","8.3","8.4","8.5"]') || fromJSON('["7.4","8.0","8.5"]') }}
         db-type: [ 'mysql' ]
-        # The scheduled run tests the full database matrix. Other events test the oldest listed version and supported LTS releases.
-        db-version: ${{ github.event_name == 'schedule' && fromJSON('["5.7","8.0","8.4","9.7"]') || fromJSON('["5.7","8.4","9.7"]') }}
+        # Scheduled and labeled runs test the full database matrix. Other runs test the oldest listed version and supported LTS releases.
+        db-version: ${{ ( github.event_name == 'schedule' || contains( github.event.pull_request.labels.*.name, 'Full PHPUnit Matrix' ) ) && fromJSON('["5.7","8.0","8.4","9.7"]') || fromJSON('["5.7","8.4","9.7"]') }}
         tests-domain: [ 'example.org' ]
         multisite: [ false, true ]
         memcached: [ false ]
@@ -174,8 +177,8 @@ jobs:
   #
   # Creates a PHPUnit test job for each PHP/MariaDB combination.
   #
-  # The scheduled run tests all LTS versions of MariaDB supported by WordPress with greater than 1% usage according to
-  # w.org/stats. The exceptions to this rule are the most recent LTS and version 5.5.
+  # Scheduled and labeled runs test all LTS versions of MariaDB supported by WordPress with greater than 1% usage
+  # according to w.org/stats. The exceptions to this rule are the most recent LTS and version 5.5.
   #
   # The 5.5 release was intended as a drop-in replacement for MySQL. Because the MySQL 5.5 Docker containers do not
   # work, this ensures some level of MySQL 5.5 testing.
@@ -203,11 +206,11 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-24.04 ]
-        # The scheduled run tests every supported PHP version. Other events test the highest and lowest of each major.
-        php: ${{ github.event_name == 'schedule' && fromJSON('["7.4","8.0","8.1","8.2","8.3","8.4","8.5"]') || fromJSON('["7.4","8.0","8.5"]') }}
+        # Scheduled and labeled runs test every supported PHP version. Other runs test the highest and lowest of each major.
+        php: ${{ ( github.event_name == 'schedule' || contains( github.event.pull_request.labels.*.name, 'Full PHPUnit Matrix' ) ) && fromJSON('["7.4","8.0","8.1","8.2","8.3","8.4","8.5"]') || fromJSON('["7.4","8.0","8.5"]') }}
         db-type: [ 'mariadb' ]
-        # The scheduled run tests the full database matrix. Other events test the oldest listed version and supported LTS releases.
-        db-version: ${{ github.event_name == 'schedule' && fromJSON('["5.5","10.3","10.5","10.6","10.11","11.4","11.8"]') || fromJSON('["5.5","10.11","11.4","11.8"]') }}
+        # Scheduled and labeled runs test the full database matrix. Other runs test the oldest listed version and supported LTS releases.
+        db-version: ${{ ( github.event_name == 'schedule' || contains( github.event.pull_request.labels.*.name, 'Full PHPUnit Matrix' ) ) && fromJSON('["5.5","10.3","10.5","10.6","10.11","11.4","11.8"]') || fromJSON('["5.5","10.11","11.4","11.8"]') }}
         multisite: [ false, true ]
         memcached: [ false ]
 
@@ -271,8 +274,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-24.04 ]
-        # The scheduled run tests every supported PHP version. Other events test the highest and lowest of each major.
-        php: ${{ github.event_name == 'schedule' && fromJSON('["7.4","8.0","8.1","8.2","8.3","8.4","8.5"]') || fromJSON('["7.4","8.0","8.5"]') }}
+        # Scheduled and labeled runs test every supported PHP version. Other runs test the highest and lowest of each major.
+        php: ${{ ( github.event_name == 'schedule' || contains( github.event.pull_request.labels.*.name, 'Full PHPUnit Matrix' ) ) && fromJSON('["7.4","8.0","8.1","8.2","8.3","8.4","8.5"]') || fromJSON('["7.4","8.0","8.5"]') }}
         db-type: [ 'mysql', 'mariadb' ]
         db-version: [ '12.1' ]
         multisite: [ false, true ]

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -1,5 +1,5 @@
 name: PHPUnit Tests
-run-name: PHPUnit Tests${{ ( github.event_name == 'schedule' || contains( github.event.pull_request.labels.*.name, 'Full PHPUnit Matrix' ) ) && ' (full matrix)' || '' }}
+run-name: PHPUnit Tests${{ ( github.event_name == 'schedule' || ( github.event_name == 'pull_request' && contains( github.event.pull_request.labels.*.name, 'Full PHPUnit Matrix' ) ) ) && ' (full matrix)' || '' }}
 
 on:
   push:
@@ -8,11 +8,11 @@ on:
       - '3.[7-9]'
       - '[4-9].[0-9]'
   pull_request:
-    types: [ opened, synchronize, reopened, labeled ]
     branches:
       - trunk
       - '3.[7-9]'
       - '[4-9].[0-9]'
+    # Keep these paths in sync with phpunit-tests-full-matrix.yml.
     paths:
       - '**'
       # Documentation and repository metadata.
@@ -47,17 +47,35 @@ on:
       - 'tools/webpack/**'
       - 'phpunit.xml.dist'
       - '.github/workflows/phpunit-tests.yml'
+      - '.github/workflows/phpunit-tests-full-matrix.yml'
       - '.github/workflows/reusable-phpunit-tests-*.yml'
       - '.github/workflows/reusable-prepare-gutenberg.yml'
   workflow_dispatch:
+  workflow_call:
+    secrets:
+      CODEVITALS_PROJECT_TOKEN:
+        required: false
+      CODECOV_TOKEN:
+        required: false
+      WPT_REPORT_API_KEY:
+        required: false
+      SLACK_GHA_SUCCESS_WEBHOOK:
+        required: false
+      SLACK_GHA_CANCELLED_WEBHOOK:
+        required: false
+      SLACK_GHA_FIXED_WEBHOOK:
+        required: false
+      SLACK_GHA_FAILURE_WEBHOOK:
+        required: false
   # Once weekly On Sundays at 00:00 UTC.
   schedule:
     - cron: '0 0 * * 0'
 
 # Cancels all previous workflow runs for pull requests that have not completed.
 concurrency:
-  # Unrelated label events get their own group so skipped runs cannot cancel active tests.
-  group: ${{ github.workflow }}-${{ github.event.action == 'labeled' && github.event.label.name != 'Full PHPUnit Matrix' && github.run_id || github.event.pull_request.number || github.sha }}
+  # The concurrency group contains the workflow name and the branch name for pull requests
+  # or the commit hash for any other events.
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
 # Disable permissions for all available scopes by default.
@@ -72,13 +90,11 @@ jobs:
     permissions:
       contents: read
     if: |
-      ( github.event.action != 'labeled' || github.event.label.name == 'Full PHPUnit Matrix' ) && (
-        github.repository == 'WordPress/wordpress-develop' || (
-          github.event_name == 'pull_request' && (
-            ! github.event.repository.private ||
-            ! github.event.pull_request.draft ||
-            contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
-          )
+      github.repository == 'WordPress/wordpress-develop' || (
+        github.event_name == 'pull_request' && (
+          ! github.event.repository.private ||
+          ! github.event.pull_request.draft ||
+          contains( github.event.pull_request.labels.*.name, 'Draft Workflow Runs' )
         )
       )
 
@@ -114,10 +130,10 @@ jobs:
       matrix:
         os: [ ubuntu-24.04 ]
         # Scheduled and labeled runs test every supported PHP version. Other runs test the highest and lowest of each major.
-        php: ${{ ( github.event_name == 'schedule' || contains( github.event.pull_request.labels.*.name, 'Full PHPUnit Matrix' ) ) && fromJSON('["7.4","8.0","8.1","8.2","8.3","8.4","8.5"]') || fromJSON('["7.4","8.0","8.5"]') }}
+        php: ${{ ( github.event_name == 'schedule' || ( github.event_name == 'pull_request' && contains( github.event.pull_request.labels.*.name, 'Full PHPUnit Matrix' ) ) ) && fromJSON('["7.4","8.0","8.1","8.2","8.3","8.4","8.5"]') || fromJSON('["7.4","8.0","8.5"]') }}
         db-type: [ 'mysql' ]
         # Scheduled and labeled runs test the full database matrix. Other runs retain MySQL 5.7 compatibility and the widely used 8.x releases.
-        db-version: ${{ ( github.event_name == 'schedule' || contains( github.event.pull_request.labels.*.name, 'Full PHPUnit Matrix' ) ) && fromJSON('["5.7","8.0","8.4","9.7"]') || fromJSON('["5.7","8.0","8.4"]') }}
+        db-version: ${{ ( github.event_name == 'schedule' || ( github.event_name == 'pull_request' && contains( github.event.pull_request.labels.*.name, 'Full PHPUnit Matrix' ) ) ) && fromJSON('["5.7","8.0","8.4","9.7"]') || fromJSON('["5.7","8.0","8.4"]') }}
         tests-domain: [ 'example.org' ]
         multisite: [ false, true ]
         memcached: [ false ]
@@ -207,10 +223,10 @@ jobs:
       matrix:
         os: [ ubuntu-24.04 ]
         # Scheduled and labeled runs test every supported PHP version. Other runs test the highest and lowest of each major.
-        php: ${{ ( github.event_name == 'schedule' || contains( github.event.pull_request.labels.*.name, 'Full PHPUnit Matrix' ) ) && fromJSON('["7.4","8.0","8.1","8.2","8.3","8.4","8.5"]') || fromJSON('["7.4","8.0","8.5"]') }}
+        php: ${{ ( github.event_name == 'schedule' || ( github.event_name == 'pull_request' && contains( github.event.pull_request.labels.*.name, 'Full PHPUnit Matrix' ) ) ) && fromJSON('["7.4","8.0","8.1","8.2","8.3","8.4","8.5"]') || fromJSON('["7.4","8.0","8.5"]') }}
         db-type: [ 'mariadb' ]
         # Scheduled and labeled runs test the full database matrix. Other runs retain MariaDB 5.5 compatibility, 10.6, and newer LTS releases.
-        db-version: ${{ ( github.event_name == 'schedule' || contains( github.event.pull_request.labels.*.name, 'Full PHPUnit Matrix' ) ) && fromJSON('["5.5","10.3","10.5","10.6","10.11","11.4","11.8"]') || fromJSON('["5.5","10.6","10.11","11.4","11.8"]') }}
+        db-version: ${{ ( github.event_name == 'schedule' || ( github.event_name == 'pull_request' && contains( github.event.pull_request.labels.*.name, 'Full PHPUnit Matrix' ) ) ) && fromJSON('["5.5","10.3","10.5","10.6","10.11","11.4","11.8"]') || fromJSON('["5.5","10.6","10.11","11.4","11.8"]') }}
         multisite: [ false, true ]
         memcached: [ false ]
 
@@ -275,7 +291,7 @@ jobs:
       matrix:
         os: [ ubuntu-24.04 ]
         # Scheduled and labeled runs test every supported PHP version. Other runs test the highest and lowest of each major.
-        php: ${{ ( github.event_name == 'schedule' || contains( github.event.pull_request.labels.*.name, 'Full PHPUnit Matrix' ) ) && fromJSON('["7.4","8.0","8.1","8.2","8.3","8.4","8.5"]') || fromJSON('["7.4","8.0","8.5"]') }}
+        php: ${{ ( github.event_name == 'schedule' || ( github.event_name == 'pull_request' && contains( github.event.pull_request.labels.*.name, 'Full PHPUnit Matrix' ) ) ) && fromJSON('["7.4","8.0","8.1","8.2","8.3","8.4","8.5"]') || fromJSON('["7.4","8.0","8.5"]') }}
         db-type: [ 'mysql', 'mariadb' ]
         db-version: [ '12.1' ]
         multisite: [ false, true ]

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -116,8 +116,8 @@ jobs:
         # Scheduled and labeled runs test every supported PHP version. Other runs test the highest and lowest of each major.
         php: ${{ ( github.event_name == 'schedule' || contains( github.event.pull_request.labels.*.name, 'Full PHPUnit Matrix' ) ) && fromJSON('["7.4","8.0","8.1","8.2","8.3","8.4","8.5"]') || fromJSON('["7.4","8.0","8.5"]') }}
         db-type: [ 'mysql' ]
-        # Scheduled and labeled runs test the full database matrix. Other runs test the oldest listed version and supported LTS releases.
-        db-version: ${{ ( github.event_name == 'schedule' || contains( github.event.pull_request.labels.*.name, 'Full PHPUnit Matrix' ) ) && fromJSON('["5.7","8.0","8.4","9.7"]') || fromJSON('["5.7","8.4","9.7"]') }}
+        # Scheduled and labeled runs test the full database matrix. Other runs retain MySQL 5.7 compatibility and the widely used 8.x releases.
+        db-version: ${{ ( github.event_name == 'schedule' || contains( github.event.pull_request.labels.*.name, 'Full PHPUnit Matrix' ) ) && fromJSON('["5.7","8.0","8.4","9.7"]') || fromJSON('["5.7","8.0","8.4"]') }}
         tests-domain: [ 'example.org' ]
         multisite: [ false, true ]
         memcached: [ false ]
@@ -209,8 +209,8 @@ jobs:
         # Scheduled and labeled runs test every supported PHP version. Other runs test the highest and lowest of each major.
         php: ${{ ( github.event_name == 'schedule' || contains( github.event.pull_request.labels.*.name, 'Full PHPUnit Matrix' ) ) && fromJSON('["7.4","8.0","8.1","8.2","8.3","8.4","8.5"]') || fromJSON('["7.4","8.0","8.5"]') }}
         db-type: [ 'mariadb' ]
-        # Scheduled and labeled runs test the full database matrix. Other runs test the oldest listed version and supported LTS releases.
-        db-version: ${{ ( github.event_name == 'schedule' || contains( github.event.pull_request.labels.*.name, 'Full PHPUnit Matrix' ) ) && fromJSON('["5.5","10.3","10.5","10.6","10.11","11.4","11.8"]') || fromJSON('["5.5","10.11","11.4","11.8"]') }}
+        # Scheduled and labeled runs test the full database matrix. Other runs retain MariaDB 5.5 compatibility, 10.6, and newer LTS releases.
+        db-version: ${{ ( github.event_name == 'schedule' || contains( github.event.pull_request.labels.*.name, 'Full PHPUnit Matrix' ) ) && fromJSON('["5.5","10.3","10.5","10.6","10.11","11.4","11.8"]') || fromJSON('["5.5","10.6","10.11","11.4","11.8"]') }}
         multisite: [ false, true ]
         memcached: [ false ]
 

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -113,7 +113,8 @@ jobs:
         # The scheduled run tests every supported PHP version. Other events test the highest and lowest of each major.
         php: ${{ github.event_name == 'schedule' && fromJSON('["7.4","8.0","8.1","8.2","8.3","8.4","8.5"]') || fromJSON('["7.4","8.0","8.5"]') }}
         db-type: [ 'mysql' ]
-        db-version: [ '5.7', '8.0', '8.4', '9.7' ]
+        # The scheduled run tests the full database matrix. Other events test the oldest listed version and supported LTS releases.
+        db-version: ${{ github.event_name == 'schedule' && fromJSON('["5.7","8.0","8.4","9.7"]') || fromJSON('["5.7","8.4","9.7"]') }}
         tests-domain: [ 'example.org' ]
         multisite: [ false, true ]
         memcached: [ false ]
@@ -173,8 +174,8 @@ jobs:
   #
   # Creates a PHPUnit test job for each PHP/MariaDB combination.
   #
-  # All LTS versions of MariaDB supported by WordPress with greater than 1% usage according to w.org/stats should be
-  # tested. The exceptions to this rule are the most recent LTS and version 5.5.
+  # The scheduled run tests all LTS versions of MariaDB supported by WordPress with greater than 1% usage according to
+  # w.org/stats. The exceptions to this rule are the most recent LTS and version 5.5.
   #
   # The 5.5 release was intended as a drop-in replacement for MySQL. Because the MySQL 5.5 Docker containers do not
   # work, this ensures some level of MySQL 5.5 testing.
@@ -205,7 +206,8 @@ jobs:
         # The scheduled run tests every supported PHP version. Other events test the highest and lowest of each major.
         php: ${{ github.event_name == 'schedule' && fromJSON('["7.4","8.0","8.1","8.2","8.3","8.4","8.5"]') || fromJSON('["7.4","8.0","8.5"]') }}
         db-type: [ 'mariadb' ]
-        db-version: [ '5.5', '10.3', '10.5', '10.6', '10.11', '11.4', '11.8' ]
+        # The scheduled run tests the full database matrix. Other events test the oldest listed version and supported LTS releases.
+        db-version: ${{ github.event_name == 'schedule' && fromJSON('["5.5","10.3","10.5","10.6","10.11","11.4","11.8"]') || fromJSON('["5.5","10.11","11.4","11.8"]') }}
         multisite: [ false, true ]
         memcached: [ false ]
 

--- a/tests/phpunit/README.md
+++ b/tests/phpunit/README.md
@@ -8,10 +8,12 @@ For more information, please review the relevant Core Handbook pages:
 
 ## Run the full matrix on a pull request
 
-Add the `Full PHPUnit Matrix` label to a pull request in `WordPress/wordpress-develop` to run the same PHP and database combinations as the weekly scheduled run. The existing PHPUnit path filters still apply; documentation-only changes do not trigger tests.
+Add the `Full PHPUnit Matrix` label to a pull request in `WordPress/wordpress-develop` to run the same PHP and database combinations as the weekly scheduled run. The label-triggered workflow uses the same path filters as normal PHPUnit runs.
 
 If you cannot apply labels, leave a PR comment asking a reviewer with triage access to add it. Fork PRs follow GitHub's usual workflow approval requirements.
 
-Adding the label starts a run without another code push. New commits run the full matrix while the label remains. Remove and reapply it to request another run for the current revision, or remove it to return subsequent runs to the reduced matrix.
+Adding the label starts a separate run without another code push. An existing reduced-matrix run continues alongside it; its checks and results are preserved. New commits run the full matrix while the label remains. Remove and reapply it to request another run for the current revision, or remove it to return subsequent runs to the reduced matrix.
+
+Unrelated labels skip only the label-triggered workflow's `full-matrix` job and do not replace or cancel PHPUnit checks.
 
 Look for `PHPUnit Tests (full matrix)` in GitHub Actions and the PHPUnit checks on the PR. Each run tests the PR's merge commit and retains its own logs and results, so check the revision before relying on an older run.

--- a/tests/phpunit/README.md
+++ b/tests/phpunit/README.md
@@ -5,3 +5,13 @@ PHPUnit is the official testing framework chosen by the core team to test PHP co
 For more information, please review the relevant Core Handbook pages:
 - [PHP: PHPUnit](https://make.wordpress.org/core/handbook/testing/automated-testing/phpunit/)
 - [Writing PHP Tests](https://make.wordpress.org/core/handbook/testing/automated-testing/writing-phpunit-tests/)
+
+## Run the full matrix on a pull request
+
+Add the `Full PHPUnit Matrix` label to a pull request in `WordPress/wordpress-develop` to run the same PHP and database combinations as the weekly scheduled run. The existing PHPUnit path filters still apply; documentation-only changes do not trigger tests.
+
+If you cannot apply labels, leave a PR comment asking a reviewer with triage access to add it. Fork PRs follow GitHub's usual workflow approval requirements.
+
+Adding the label starts a run without another code push. New commits run the full matrix while the label remains. Remove and reapply it to request another run for the current revision, or remove it to return subsequent runs to the reduced matrix.
+
+Look for `PHPUnit Tests (full matrix)` in GitHub Actions and the PHPUnit checks on the PR. Each run tests the PR's merge commit and retains its own logs and results, so check the revision before relying on an older run.


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/66071

Adding the `Full PHPUnit Matrix` label starts the weekly PHP and database matrix on an eligible PR without another code push. New commits keep using the full matrix while the label remains. Runs appear as `PHPUnit Tests (full matrix)`, with checks and logs on the PR.

A separate label-trigger workflow calls the existing PHPUnit workflow. Unrelated labels skip only its uniquely named `full-matrix` job, preserving existing PHPUnit results. The called workflow manages concurrency; an existing reduced-matrix run continues alongside a label-triggered run.

Both workflows use the same branch and path filters. Contributors without label access can ask a reviewer in a PR comment. Fork approval requirements and individual test-job permissions remain unchanged.

The caller forwards the three reporting secrets explicitly. Its declared `actions: write` permission accommodates the existing recovery job in the called workflow; that job remains disabled for PR events, and test jobs use `contents: read`.

Depends on #13447 (https://core.trac.wordpress.org/ticket/66069), which must land first. This branch includes its revised database selection.

## Validation

- actionlint, zizmor, and `git diff --check` passed.
- Matrix expansion confirms 68 ordinary jobs and 182 full jobs, including Gutenberg preparation. Scheduled, label-triggered, and subsequent labeled-push rows match exactly.
- Verified matching path/branch filters, PR event guards, skipped unrelated-label behavior, and secret/permission declarations.
- Live validation on d75e75ad774428fe067f0850183852bcd83d6614: the [68-job reduced run](https://github.com/WordPress/wordpress-develop/actions/runs/34367736150) continued alongside the [182-job full run](https://github.com/WordPress/wordpress-develop/actions/runs/34367774999). Adding an unrelated label produced [exactly one skipped wrapper job](https://github.com/WordPress/wordpress-develop/actions/runs/34367933234), without replacing or cancelling either test run. Those runs finished with two reduced-matrix and eight full-matrix jobs reaching the 30-minute limit during Build WordPress, before PHPUnit started. The remaining workload jobs passed. Failed-job retries are running; local matrix validation, actionlint, and zizmor passed again before SVN preparation.

## Use of AI tools

AI assistance: Yes  
Tool(s): Codex  
Model(s): GPT-6, GPT-5.6  
Used for: Workflow implementation, review, validation, and PR description/replies. I take responsibility for the submitted change.
