### PR TITLE
Build/Test Tools: Ensure strict assertion

### DIFF
--- a/tests/phpunit/tests/customize/nav-menu-item-setting.php
+++ b/tests/phpunit/tests/customize/nav-menu-item-setting.php
@@ -632,14 +632,14 @@ class Test_WP_Customize_Nav_Menu_Item_Setting extends WP_UnitTestCase {
 		$post          = get_post( $nav_menu_item_id );
 		$nav_menu_item = wp_setup_nav_menu_item( clone $post );
 
-		/**
+		/*
 		 * Keep assertEquals() because sanitize() returns object_id as an integer
 		 * while wp_setup_nav_menu_item() retrieves it as a string from post meta.
 		 */
 		$this->assertEquals( $expected_sanitized['object_id'], $nav_menu_item->object_id );
 		$this->assertSame( $expected_sanitized['object'], $nav_menu_item->object );
 
-		/**
+		/*
 		 * Keep assertEquals() because sanitize() returns menu_item_parent as an integer,
 		 * while wp_setup_nav_menu_item() retrieves it as a string from post meta.
 		 */
@@ -707,7 +707,7 @@ class Test_WP_Customize_Nav_Menu_Item_Setting extends WP_UnitTestCase {
 		$post_value['post_status'] = $post_value['status'];
 		unset( $post_value['status'] );
 
-		/**
+		/*
 		 * Keep assertEquals() because object_id is an integer in $post_value
 		 * but is returned as a string from post meta by wp_setup_nav_menu_item().
 		 */
@@ -785,7 +785,7 @@ class Test_WP_Customize_Nav_Menu_Item_Setting extends WP_UnitTestCase {
 		$post_value['menu_order'] = $post_value['position'];
 		unset( $post_value['position'] );
 
-		/**
+		/*
 		 * Keep assertEquals() because object_id is an integer in $post_value
 		 * but is returned as a string from post meta by wp_setup_nav_menu_item().
 		 */

--- a/tests/phpunit/tests/customize/nav-menu-item-setting.php
+++ b/tests/phpunit/tests/customize/nav-menu-item-setting.php
@@ -190,7 +190,7 @@ class Test_WP_Customize_Nav_Menu_Item_Setting extends WP_UnitTestCase {
 		$value = $setting->value();
 		$this->assertSame( $menu_item->title, $value['title'] );
 		$this->assertSame( $menu_item->type, $value['type'] );
-		$this->assertEquals( $menu_item->object_id, $value['object_id'] );
+		$this->assertSame( (int) $menu_item->object_id, $value['object_id'] );
 		$this->assertSame( $menu_id, $value['nav_menu_term_id'] );
 		$this->assertSame( 'Hello World', $value['original_title'] );
 
@@ -273,7 +273,7 @@ class Test_WP_Customize_Nav_Menu_Item_Setting extends WP_UnitTestCase {
 		$value = $setting->value();
 		$this->assertSame( $menu_item->title, $value['title'] );
 		$this->assertSame( $menu_item->type, $value['type'] );
-		$this->assertEquals( $menu_item->object_id, $value['object_id'] );
+		$this->assertSame( (int) $menu_item->object_id, $value['object_id'] );
 		$this->assertSame( $menu_id, $value['nav_menu_term_id'] );
 		$this->assertSame( 'Salutations', $value['original_title'] );
 	}
@@ -632,8 +632,17 @@ class Test_WP_Customize_Nav_Menu_Item_Setting extends WP_UnitTestCase {
 		$post          = get_post( $nav_menu_item_id );
 		$nav_menu_item = wp_setup_nav_menu_item( clone $post );
 
+		/**
+		 * Keep assertEquals() because sanitize() returns object_id as an integer
+		 * while wp_setup_nav_menu_item() retrieves it as a string from post meta.
+		 */
 		$this->assertEquals( $expected_sanitized['object_id'], $nav_menu_item->object_id );
 		$this->assertSame( $expected_sanitized['object'], $nav_menu_item->object );
+
+		/**
+		 * Keep assertEquals() because sanitize() returns menu_item_parent as an integer,
+		 * while wp_setup_nav_menu_item() retrieves it as a string from post meta.
+		 */
 		$this->assertEquals( $expected_sanitized['menu_item_parent'], $nav_menu_item->menu_item_parent );
 		$this->assertSame( $expected_sanitized['position'], $post->menu_order );
 		$this->assertSame( $expected_sanitized['type'], $nav_menu_item->type );
@@ -697,6 +706,11 @@ class Test_WP_Customize_Nav_Menu_Item_Setting extends WP_UnitTestCase {
 		$updated_item              = $menu_items[ $i ];
 		$post_value['post_status'] = $post_value['status'];
 		unset( $post_value['status'] );
+
+		/**
+		 * Keep assertEquals() because object_id is an integer in $post_value
+		 * but is returned as a string from post meta by wp_setup_nav_menu_item().
+		 */
 		foreach ( $post_value as $key => $value ) {
 			$this->assertEquals( $value, $updated_item->$key, "Key $key mismatch" );
 		}
@@ -770,6 +784,11 @@ class Test_WP_Customize_Nav_Menu_Item_Setting extends WP_UnitTestCase {
 		unset( $post_value['status'] );
 		$post_value['menu_order'] = $post_value['position'];
 		unset( $post_value['position'] );
+
+		/**
+		 * Keep assertEquals() because object_id is an integer in $post_value
+		 * but is returned as a string from post meta by wp_setup_nav_menu_item().
+		 */
 		foreach ( $post_value as $key => $value ) {
 			$this->assertEquals( $value, $last_item->$key, "Mismatch for $key property." );
 		}

--- a/tests/phpunit/tests/customize/nav-menu-setting.php
+++ b/tests/phpunit/tests/customize/nav-menu-setting.php
@@ -232,6 +232,8 @@ class Test_WP_Customize_Nav_Menu_Setting extends WP_UnitTestCase {
 		$this->assertSameSets( $value, wp_array_slice_assoc( $term, array_keys( $value ) ) );
 
 		$menu_object = wp_get_nav_menu_object( $menu_id );
+
+		// Keep assertEquals() because the objects are intentionally compared by value.
 		$this->assertEquals( (object) $term, $menu_object );
 		$this->assertSame( $post_value['name'], $menu_object->name );
 
@@ -277,6 +279,8 @@ class Test_WP_Customize_Nav_Menu_Setting extends WP_UnitTestCase {
 		$this->assertSame( $menu_id, $term['term_taxonomy_id'] );
 
 		$menu_object = wp_get_nav_menu_object( $menu_id );
+
+		// Keep assertEquals() because the objects are intentionally compared by value.
 		$this->assertEquals( (object) $term, $menu_object );
 		$this->assertSame( $post_value['name'], $menu_object->name );
 

--- a/tests/phpunit/tests/customize/widgets.php
+++ b/tests/phpunit/tests/customize/widgets.php
@@ -515,7 +515,7 @@ class Tests_WP_Customize_Widgets extends WP_UnitTestCase {
 		$this->assertSame( '', $sanitized_for_js['title'] );
 		$this->assertTrue( $sanitized_for_js['is_widget_customizer_js_value'] );
 		$this->assertArrayHasKey( 'instance_hash_key', $sanitized_for_js );
-		$this->assertEquals( (object) $block_instance, $sanitized_for_js['raw_instance'] );
+		$this->assertSame( (object) $block_instance, $sanitized_for_js['raw_instance'] );
 
 		$unsanitized_from_js = $this->manager->widgets->sanitize_widget_instance( $sanitized_for_js );
 		$this->assertSame( $unsanitized_from_js, $block_instance );

--- a/tests/phpunit/tests/customize/widgets.php
+++ b/tests/phpunit/tests/customize/widgets.php
@@ -515,7 +515,9 @@ class Tests_WP_Customize_Widgets extends WP_UnitTestCase {
 		$this->assertSame( '', $sanitized_for_js['title'] );
 		$this->assertTrue( $sanitized_for_js['is_widget_customizer_js_value'] );
 		$this->assertArrayHasKey( 'instance_hash_key', $sanitized_for_js );
-		$this->assertSame( (object) $block_instance, $sanitized_for_js['raw_instance'] );
+
+		// Keep assertEquals() because the objects are intentionally compared by value.
+		$this->assertEquals( (object) $block_instance, $sanitized_for_js['raw_instance'] );
 
 		$unsanitized_from_js = $this->manager->widgets->sanitize_widget_instance( $sanitized_for_js );
 		$this->assertSame( $unsanitized_from_js, $block_instance );


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->
Replace `assertEquals` with `assertSame` in `Test_WP_Customize_Nav_Menu_Item_Setting::test_value_type_post_type` and ` Test_WP_Customize_Nav_Menu_Item_Setting::test_value_type_taxanomy`.

Converted the `$expected` value to an integer to account for the integer normalization performed by `populate_value()` when it is called in `WP_Customize_Nav_Menu_Item_Setting::value()`.

For the rest of the `assertEquals`, I kept them as is for the reasons below:
1. In
```
$this->assertEquals( $expected_sanitized['object_id'], $nav_menu_item->object_id );
```
The `$expected_sanitized['object_id']` is an integer while `$nav_menu_item->object_id` is a string returned from post meta by `wp_setup_nav_menu_item()`, so this assertion cannot be converted to `assertSame` without resolving the type mismatch.

2. In
 ```
$this->assertEquals( $expected_sanitized['menu_item_parent'], $nav_menu_item->menu_item_parent );
```
The `$expected_sanitized['menu_item_parent']` is an integer while `$nav_menu_item->menu_item_parent` is a string returned from post meta by `wp_setup_nav_menu_item()`, so this assertion cannot be converted to `assertSame` without resolving the type mismatch.

3. In
```
foreach ( $post_value as $key => $value ) {
	$this->assertEquals( $value, $updated_item->$key, "Key $key mismatch" );
}
```
The `$post_value[object_id']` is an integer while `$updated_item->object_id` is a string returned from post meta by `wp_setup_nav_menu_item()`, so this assertion cannot be converted to `assertSame` without resolving the type mismatch.


4. In
```
foreach ( $post_value as $key => $value ) {
	$this->assertEquals( $value, $last_item->$key, "Mismatch for $key property." );
}
```
The `$post_value[object_id']` is an integer while `$last_item->object_id` is a string returned from post meta by `wp_setup_nav_menu_item()`, so this assertion cannot be converted to `assertSame` without resolving the type mismatch.

5. In
```
$this->assertEquals( (object) $term, $menu_object );
```
The `(object) $term` and `$menu_object` are objects being compared by value, so this assertion should remain `assertEquals()` rather than requiring identical object instances with `assertSame()`.

6. In
```
$this->assertEquals( (object) $block_instance, $sanitized_for_js['raw_instance'] );
```
Kept `assertEquals` because `raw_instance` is a newly created cast from the input array, so the test intentionally compares the objects by value rather than requiring the same object instance.

Trac ticket: <!-- insert a link to the WordPress Trac ticket here --> [#64895](https://core.trac.wordpress.org/ticket/64895)

## Use of AI Tools
AI assistance: Yes
Tool(s): ChatGPT
Model(s): GPT-5.6
Used for: To track down how values are transformed through `sanitize`,` wp_set_up_nav_menu_item` and `populate_value` to determine which assertions should be converted or retained. The final code changes and decisions were reviewed and made by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
