### PR TITLE
Icons: Allow registering icons that are hidden from the REST API with `public` property

### DIFF
--- a/src/wp-includes/class-wp-icons-registry.php
+++ b/src/wp-includes/class-wp-icons-registry.php
@@ -46,6 +46,7 @@ class WP_Icons_Registry {
 	 *
 	 * @since 7.0.0
 	 * @since 7.1.0 The icon name must be namespaced in the form "collection/icon-name".
+	 * @since 7.2.0 Added the `public` property.
 	 *
 	 * @param string $icon_name       Namespaced icon name in the form "collection/icon-name"
 	 *                                (e.g. "core/arrow-left").
@@ -57,6 +58,10 @@ class WP_Icons_Registry {
 	 *                             If not provided, the content will be retrieved from the `file_path` if set.
 	 *                             If both `content` and `file_path` are not set, the icon will not be registered.
 	 *     @type string $file_path Optional. The full path to the file containing the icon content.
+	 *     @type bool   $public    Optional. Whether the icon is exposed through the REST API, and
+	 *                             therefore selectable in the editor's icon picker. Non-public icons
+	 *                             stay available to server-side code via {@see wp_get_icon()}.
+	 *                             Default true.
 	 * }
 	 * @return bool True if the icon was registered with success and false otherwise.
 	 */
@@ -101,7 +106,7 @@ class WP_Icons_Registry {
 			return false;
 		}
 
-		$allowed_keys = array_fill_keys( array( 'label', 'content', 'file_path' ), 1 );
+		$allowed_keys = array_fill_keys( array( 'label', 'content', 'file_path', 'public' ), 1 );
 		foreach ( array_keys( $icon_properties ) as $key ) {
 			if ( ! array_key_exists( $key, $allowed_keys ) ) {
 				_doing_it_wrong(
@@ -135,6 +140,15 @@ class WP_Icons_Registry {
 				__METHOD__,
 				__( 'Icon label must be a string.' ),
 				'7.0.0'
+			);
+			return false;
+		}
+
+		if ( isset( $icon_properties['public'] ) && ! is_bool( $icon_properties['public'] ) ) {
+			_doing_it_wrong(
+				__METHOD__,
+				__( 'Icon public property must be a boolean.' ),
+				'7.2.0'
 			);
 			return false;
 		}

--- a/src/wp-includes/icons.php
+++ b/src/wp-includes/icons.php
@@ -41,6 +41,7 @@ function wp_unregister_icon_collection( $slug ) {
  * Registers a new icon.
  *
  * @since 7.1.0
+ * @since 7.2.0 Added the `public` property.
  *
  * @param string $icon_name Namespaced icon name in the form "collection/icon-name"
  *                          (e.g. "my-plugin/arrow-left"). The "core" collection is
@@ -55,6 +56,10 @@ function wp_unregister_icon_collection( $slug ) {
  *                             If not provided, the content will be retrieved from the `file_path` if set.
  *                             If both `content` and `file_path` are not set, the icon will not be registered.
  *     @type string $file_path Optional. The full path to the file containing the icon content.
+ *     @type bool   $public    Optional. Whether the icon is exposed through the REST API, and
+ *                             therefore selectable in the editor's icon picker. Non-public icons
+ *                             stay available to server-side code via {@see wp_get_icon()}.
+ *                             Default true.
  * }
  * @return bool True if the icon was registered successfully, else false.
  */
@@ -132,13 +137,16 @@ function _wp_register_default_icons() {
 			return;
 		}
 
-		wp_register_icon(
-			'core/' . $icon_name,
-			array(
-				'label'     => $icon_data['label'],
-				'file_path' => $icons_directory . $icon_data['filePath'],
-			)
+		$icon_args = array(
+			'label'     => $icon_data['label'],
+			'file_path' => $icons_directory . $icon_data['filePath'],
 		);
+
+		if ( isset( $icon_data['public'] ) ) {
+			$icon_args['public'] = $icon_data['public'];
+		}
+
+		wp_register_icon( 'core/' . $icon_name, $icon_args );
 	}
 }
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-icons-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-icons-controller.php
@@ -143,6 +143,7 @@ class WP_REST_Icons_Controller extends WP_REST_Controller {
 	 *
 	 * @since 7.0.0
 	 * @since 7.1.0 Supports filtering by collection.
+	 * @since 7.2.0 Icons registered as non-public are omitted.
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
@@ -167,6 +168,9 @@ class WP_REST_Icons_Controller extends WP_REST_Controller {
 		$icons    = WP_Icons_Registry::get_instance()->get_registered_icons( $search );
 
 		foreach ( $icons as $icon ) {
+			if ( false === ( $icon['public'] ?? true ) ) {
+				continue;
+			}
 			if ( null !== $collection && ( ! isset( $icon['collection'] ) || $icon['collection'] !== $collection ) ) {
 				continue;
 			}
@@ -198,6 +202,7 @@ class WP_REST_Icons_Controller extends WP_REST_Controller {
 	 * Retrieves a specific icon from the registry.
 	 *
 	 * @since 7.0.0
+	 * @since 7.2.0 Icons registered as non-public are reported as not found.
 	 *
 	 * @param string $name Icon name.
 	 * @return array|WP_Error Icon data on success, or WP_Error object on failure.
@@ -206,7 +211,7 @@ class WP_REST_Icons_Controller extends WP_REST_Controller {
 		$registry = WP_Icons_Registry::get_instance();
 		$icon     = $registry->get_registered_icon( $name );
 
-		if ( null === $icon ) {
+		if ( null === $icon || false === ( $icon['public'] ?? true ) ) {
 			return new WP_Error(
 				'rest_icon_not_found',
 				sprintf(

--- a/tests/phpunit/tests/icons/wpIconsRegistry.php
+++ b/tests/phpunit/tests/icons/wpIconsRegistry.php
@@ -453,4 +453,27 @@ class Tests_Icons_WpIconsRegistry extends WP_UnitTestCase {
 
 		$this->assertNull( $icon['content'] );
 	}
+
+	/**
+	 * Should reject a `public` property that is not a boolean.
+	 *
+	 * @ticket 66087
+	 *
+	 * @covers ::register
+	 *
+	 * @expectedIncorrectUsage WP_Icons_Registry::register
+	 */
+	public function test_register_rejects_non_boolean_public_property() {
+		$result = $this->registry->register(
+			'test-collection/invalid-visibility',
+			array(
+				'label'   => 'Icon',
+				'content' => '<svg></svg>',
+				'public'  => 'yes',
+			)
+		);
+
+		$this->assertFalse( $result );
+		$this->assertFalse( $this->registry->is_registered( 'test-collection/invalid-visibility' ) );
+	}
 }

--- a/tests/phpunit/tests/icons/wpRestIconsController.php
+++ b/tests/phpunit/tests/icons/wpRestIconsController.php
@@ -537,4 +537,76 @@ class Tests_REST_WpRestIconsController extends WP_Test_REST_Controller_Testcase 
 
 		$this->assertErrorResponse( 'rest_cannot_view', $response, 401 );
 	}
+
+	/**
+	 * Test that icons registered as non-public are omitted from the collection.
+	 *
+	 * @ticket 66087
+	 *
+	 * @covers ::get_items
+	 */
+	public function test_get_items_omits_non_public_icons() {
+		wp_register_icon_collection( 'rest-visibility-list', array( 'label' => 'REST Visibility' ) );
+		wp_register_icon(
+			'rest-visibility-list/visible',
+			array(
+				'label'   => 'Visible',
+				'content' => '<svg><path d="M0 0"/></svg>',
+			)
+		);
+		wp_register_icon(
+			'rest-visibility-list/hidden',
+			array(
+				'label'   => 'Hidden',
+				'content' => '<svg><path d="M1 1"/></svg>',
+				'public'  => false,
+			)
+		);
+
+		wp_set_current_user( self::$editor_id );
+
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/icons' );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$names = wp_list_pluck( $response->get_data(), 'name' );
+		$this->assertContains( 'rest-visibility-list/visible', $names );
+		$this->assertNotContains( 'rest-visibility-list/hidden', $names );
+
+		wp_unregister_icon_collection( 'rest-visibility-list' );
+	}
+
+	/**
+	 * Test that a non-public icon is reported as not found by name, while
+	 * remaining available to server-side code.
+	 *
+	 * @ticket 66087
+	 *
+	 * @covers ::get_item
+	 * @covers ::get_icon
+	 */
+	public function test_get_item_returns_404_for_non_public_icon() {
+		wp_register_icon_collection( 'rest-visibility-single', array( 'label' => 'REST Visibility' ) );
+		wp_register_icon(
+			'rest-visibility-single/hidden',
+			array(
+				'label'   => 'Hidden',
+				'content' => '<svg><path d="M1 1"/></svg>',
+				'public'  => false,
+			)
+		);
+
+		wp_set_current_user( self::$editor_id );
+
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/icons/rest-visibility-single/hidden' );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertErrorResponse( 'rest_icon_not_found', $response, 404 );
+
+		// The icon is hidden from the REST API, not unregistered.
+		$this->assertStringContainsString( '<svg', wp_get_icon( 'rest-visibility-single/hidden' ) );
+
+		wp_unregister_icon_collection( 'rest-visibility-single' );
+	}
 }


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/66087.
Backport from https://github.com/WordPress/gutenberg/pull/82634.

## What

This PR allows an optional boolean `public` property to icon registration via `wp_register_icon()`.

Icons registered with `public: false` will still be available through `wp_get_icon()`, but the REST API will not return them, so they aren't exposed in the Icon block.

As a back-compatibility, if we don't provide a `public` property, the default is `true` and the behavior will be the same as the existing behavior.

Here's a summary of the behavior:

| Registered with | Registry /`wp_get_icon()` | REST API / Icon block |
| --- | --- | --- |
| `public` omitted or `true` | yes | yes |
| `public: false` | yes | no |

## Use of AI Tools

Used Claude Opus to generate the backported changes from the linked Gutenberg PR, then checked the changes myself.

