### PR TITLE
Tests: Remove unused variables in the sitemaps taxonomies tests

### DIFF
--- a/tests/phpunit/tests/sitemaps/wpSitemapsTaxonomies.php
+++ b/tests/phpunit/tests/sitemaps/wpSitemapsTaxonomies.php
@@ -45,8 +45,8 @@ class Tests_Sitemaps_wpSitemapsTaxonomies extends WP_UnitTestCase {
 		// Add the default category to the list of categories we're testing.
 		$categories = array_merge( array( 1 ), self::$cats );
 
-		// Create a test post to calculate update times.
-		$post = self::factory()->post->create_and_get(
+		// Create a test post so the test terms are assigned and counted.
+		self::factory()->post->create(
 			array(
 				'tags_input'    => self::$post_tags,
 				'post_category' => $categories,
@@ -58,7 +58,7 @@ class Tests_Sitemaps_wpSitemapsTaxonomies extends WP_UnitTestCase {
 		$cat_list = $tax_provider->get_url_list( 1, 'category' );
 
 		$expected_cats = array_map(
-			static function ( $id ) use ( $post ) {
+			static function ( $id ) {
 				return array(
 					'loc' => get_term_link( $id, 'category' ),
 				);
@@ -71,7 +71,7 @@ class Tests_Sitemaps_wpSitemapsTaxonomies extends WP_UnitTestCase {
 		$tag_list = $tax_provider->get_url_list( 1, 'post_tag' );
 
 		$expected_tags = array_map(
-			static function ( $id ) use ( $post ) {
+			static function ( $id ) {
 				return array(
 					'loc' => get_term_link( $id, 'post_tag' ),
 				);
@@ -97,10 +97,10 @@ class Tests_Sitemaps_wpSitemapsTaxonomies extends WP_UnitTestCase {
 		$terms = self::factory()->term->create_many( 10, array( 'taxonomy' => $taxonomy ) );
 
 		// Create a test post applied to all test terms.
-		$post = self::factory()->post->create_and_get( array( 'tax_input' => array( $taxonomy => $terms ) ) );
+		self::factory()->post->create( array( 'tax_input' => array( $taxonomy => $terms ) ) );
 
 		$expected = array_map(
-			static function ( $id ) use ( $taxonomy, $post ) {
+			static function ( $id ) use ( $taxonomy ) {
 				return array(
 					'loc' => get_term_link( $id, $taxonomy ),
 				);


### PR DESCRIPTION
The three closures building the expected URL lists in `Tests_Sitemaps_wpSitemapsTaxonomies` import `$post` via `use` but never reference it: they only call `get_term_link()` on the term ID passed in. That leaves `$post` assigned but never read, so the factory calls switch from `create_and_get()` to `create()`. Only the side effect matters here, attaching the test terms to a published post so `WP_Sitemaps_Taxonomies::get_url_list()` returns them, and the post is still created with identical arguments, so the terms still have a non-zero count and still appear in the provider's output.

The comment above the factory call is corrected as well. It claimed the post exists "to calculate update times", but the assertions have only ever compared `loc` values.

No test behaviour changes.

Follow-up to [r48072](https://core.trac.wordpress.org/changeset/48072).

Trac ticket: https://core.trac.wordpress.org/ticket/65819

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**