### PR TITLE
Database: Handle the utf8mb3 charset reported by newer MySQL and MariaDB versions

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -324,6 +324,7 @@
 	</rule>
 	<rule ref="WordPress.DB.PreparedSQL.NotPrepared">
 		<exclude-pattern>/tests/phpunit/tests/admin/includesSchema\.php</exclude-pattern>
+		<exclude-pattern>/tests/phpunit/tests/admin/includesUpgrade\.php</exclude-pattern>
 		<exclude-pattern>/tests/phpunit/tests/multisite/site\.php</exclude-pattern>
 	</rule>
 

--- a/src/wp-admin/includes/upgrade.php
+++ b/src/wp-admin/includes/upgrade.php
@@ -2795,7 +2795,7 @@ function maybe_convert_table_to_utf8mb4( $table ) {
 		if ( $column->Collation ) {
 			list( $charset ) = explode( '_', $column->Collation );
 			$charset         = strtolower( $charset );
-			if ( 'utf8' !== $charset && 'utf8mb4' !== $charset ) {
+			if ( 'utf8' !== $charset && 'utf8mb3' !== $charset && 'utf8mb4' !== $charset ) {
 				// Don't upgrade tables that have non-utf8 columns.
 				return false;
 			}

--- a/src/wp-includes/class-wpdb.php
+++ b/src/wp-includes/class-wpdb.php
@@ -883,16 +883,16 @@ class wpdb {
 			return compact( 'charset', 'collate' );
 		}
 
-		if ( 'utf8' === $charset ) {
+		if ( 'utf8' === $charset || 'utf8mb3' === $charset ) {
 			$charset = 'utf8mb4';
 		}
 
 		if ( 'utf8mb4' === $charset ) {
 			// _general_ is outdated, so we can upgrade it to _unicode_, instead.
-			if ( ! $collate || 'utf8_general_ci' === $collate ) {
+			if ( ! $collate || 'utf8_general_ci' === $collate || 'utf8mb3_general_ci' === $collate ) {
 				$collate = 'utf8mb4_unicode_ci';
 			} else {
-				$collate = str_replace( 'utf8_', 'utf8mb4_', $collate );
+				$collate = str_replace( array( 'utf8mb3_', 'utf8_' ), 'utf8mb4_', $collate );
 			}
 		}
 

--- a/tests/phpunit/tests/admin/includesUpgrade.php
+++ b/tests/phpunit/tests/admin/includesUpgrade.php
@@ -1,0 +1,132 @@
+<?php
+
+/**
+ * Test the admin includes upgrade functions.
+ *
+ * @group admin
+ * @group upgrade
+ */
+class Tests_Admin_IncludesUpgrade extends WP_UnitTestCase {
+
+	/**
+	 * The name of the table used by the tests.
+	 *
+	 * @var string
+	 */
+	private static $table;
+
+	/**
+	 * Whether the server reports utf8 as utf8mb3 (MariaDB 10.6.1+ or MySQL 8.0.30+).
+	 *
+	 * @var bool
+	 */
+	private static $utf8_is_utf8mb3 = false;
+
+	/**
+	 * Load the upgrade code and determine how the server reports utf8.
+	 */
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+
+		global $wpdb;
+
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+
+		self::$table = $wpdb->prefix . 'utf8mb3_test';
+
+		$db_server_info = $wpdb->db_server_info();
+		$db_version     = $wpdb->db_version();
+
+		// Account for MariaDB version being prefixed with '5.5.5-' on older PHP versions.
+		if ( '5.5.5' === $db_version && str_contains( $db_server_info, 'MariaDB' ) && PHP_VERSION_ID < 80016 ) {
+			$db_server_info = preg_replace( '/^5\.5\.5-(.*)/', '$1', $db_server_info );
+			$db_version     = preg_replace( '/[^0-9.].*/', '', $db_server_info );
+		}
+
+		/*
+		 * MariaDB 10.6.1 or later and MySQL 8.0.30 or later
+		 * use utf8mb3 instead of utf8 in various commands output.
+		 */
+		if ( ( str_contains( $db_server_info, 'MariaDB' ) && version_compare( $db_version, '10.6.1', '>=' ) )
+			|| ( ! str_contains( $db_server_info, 'MariaDB' ) && version_compare( $db_version, '8.0.30', '>=' ) )
+		) {
+			self::$utf8_is_utf8mb3 = true;
+		}
+	}
+
+	/**
+	 * Drop the table used by the tests.
+	 */
+	public static function tear_down_after_class() {
+		global $wpdb;
+
+		$wpdb->query( $wpdb->prepare( 'DROP TABLE IF EXISTS %i', self::$table ) );
+
+		parent::tear_down_after_class();
+	}
+
+	/**
+	 * @ticket 60002
+	 *
+	 * @covers ::maybe_convert_table_to_utf8mb4
+	 */
+	public function test_maybe_convert_table_to_utf8mb4_converts_utf8_table() {
+		global $wpdb;
+
+		$table = self::$table;
+
+		$charset = self::$utf8_is_utf8mb3 ? 'utf8mb3' : 'utf8';
+		$collate = self::$utf8_is_utf8mb3 ? 'utf8mb3_general_ci' : 'utf8_general_ci';
+
+		// Remove the temporary table filters as `SHOW TABLE STATUS` cannot see temporary tables.
+		remove_filter( 'query', array( $this, '_create_temporary_tables' ) );
+		remove_filter( 'query', array( $this, '_drop_temporary_tables' ) );
+
+		$wpdb->query( $wpdb->prepare( 'DROP TABLE IF EXISTS %i', $table ) );
+
+		$create = "CREATE TABLE `$table` (
+			id bigint(20) NOT NULL AUTO_INCREMENT,
+			name varchar(50),
+			PRIMARY KEY (id)
+		) DEFAULT CHARACTER SET {$charset} COLLATE {$collate}"; // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		$this->assertNotFalse( $wpdb->query( $create ) );
+
+		$this->assertTrue( maybe_convert_table_to_utf8mb4( $table ) );
+
+		$table_details = $wpdb->get_row( $wpdb->prepare( 'SHOW TABLE STATUS LIKE %s', $table ) );
+
+		$this->assertSame( 'utf8mb4_unicode_ci', $table_details->Collation );
+
+		$wpdb->query( $wpdb->prepare( 'DROP TABLE IF EXISTS %i', $table ) );
+	}
+
+	/**
+	 * @ticket 60002
+	 *
+	 * @covers ::maybe_convert_table_to_utf8mb4
+	 */
+	public function test_maybe_convert_table_to_utf8mb4_skips_non_utf8_columns() {
+		global $wpdb;
+
+		$table = self::$table;
+
+		// Remove the temporary table filters as `SHOW TABLE STATUS` cannot see temporary tables.
+		remove_filter( 'query', array( $this, '_create_temporary_tables' ) );
+		remove_filter( 'query', array( $this, '_drop_temporary_tables' ) );
+
+		$wpdb->query( $wpdb->prepare( 'DROP TABLE IF EXISTS %i', $table ) );
+
+		$create = "CREATE TABLE `$table` (
+			id bigint(20) NOT NULL AUTO_INCREMENT,
+			name varchar(50) CHARACTER SET latin1 COLLATE latin1_swedish_ci,
+			PRIMARY KEY (id)
+		) DEFAULT CHARACTER SET latin1 COLLATE latin1_swedish_ci"; // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		$this->assertNotFalse( $wpdb->query( $create ) );
+
+		$this->assertFalse( maybe_convert_table_to_utf8mb4( $table ) );
+
+		$wpdb->query( $wpdb->prepare( 'DROP TABLE IF EXISTS %i', $table ) );
+	}
+}

--- a/tests/phpunit/tests/db.php
+++ b/tests/phpunit/tests/db.php
@@ -1464,6 +1464,32 @@ class Tests_DB extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 60002
+	 */
+	public function test_utf8mb3_charset_switched_to_utf8mb4() {
+		global $wpdb;
+
+		$result = $wpdb->determine_charset( 'utf8mb3', 'utf8mb3_general_ci' );
+
+		$this->assertSame( 'utf8mb4', $result['charset'] );
+
+		$expected_collate = $wpdb->has_cap( 'utf8mb4_520' ) ? 'utf8mb4_unicode_520_ci' : 'utf8mb4_unicode_ci';
+		$this->assertSame( $expected_collate, $result['collate'] );
+	}
+
+	/**
+	 * @ticket 60002
+	 */
+	public function test_utf8mb3_non_unicode_collation_switched_to_utf8mb4() {
+		global $wpdb;
+
+		$result = $wpdb->determine_charset( 'utf8mb3', 'utf8mb3_swedish_ci' );
+
+		$this->assertSame( 'utf8mb4', $result['charset'] );
+		$this->assertSame( 'utf8mb4_swedish_ci', $result['collate'] );
+	}
+
+	/**
 	 * @ticket 32105
 	 * @ticket 36917
 	 */


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

MySQL 8.0.30+ and MariaDB 10.6.1+ report the `utf8` charset as `utf8mb3` in `SHOW` statements and Information Schema output. Some code that inspects that output still only checks for `utf8` and `utf8mb4`, so tables can end up unconverted or collations invalid on those servers. [5d78ecbe25](https://github.com/WordPress/wordpress-develop/commit/5d78ecbe25b7b6b41a851ec52d4a41f68beee1f3) already fixed this inside `wpdb` for table charset lookups and text checks. This PR fixes the remaining two gaps:

### `maybe_convert_table_to_utf8mb4()`

**Before:** `src/wp-admin/includes/upgrade.php` listed each column charset with `if ( 'utf8' !== $charset && 'utf8mb4' !== $charset )`. On MySQL 8.0.30+ or MariaDB 10.6.1+, every column of a `utf8` table is reported as `utf8mb3`, so the check failed and the function returned `false`. Tables were left unconverted during upgrades.

**After:** `utf8mb3` is accepted in the allowlist, matching the `utf8` and `utf8mb4` entries already handled by `get_table_charset()`.

### `wpdb::determine_charset()`

**Before:** `src/wp-includes/class-wpdb.php` only matched an exact `'utf8'` charset, and rewrote collations with `str_replace( 'utf8_', 'utf8mb4_', ... )`. On newer servers, `'utf8mb3'` fell through untouched, and a reported collation like `utf8mb3_general_ci` would pair with the upgraded charset to produce the invalid combination `utf8mb4` + `utf8mb3_general_ci`, causing "illegal mix of collations" errors.

**After:** `utf8mb3` is treated like `utf8` and normalized to `utf8mb4`, `utf8mb3_general_ci` is treated like `utf8_general_ci`, and `utf8mb3_` collation prefixes are rewritten alongside `utf8_`. This matches the existing handling in `get_table_charset()` and `check_safe_collation()`.

### Testing

New tests:
- `Tests_DB::test_utf8mb3_charset_switched_to_utf8mb4()` and `Tests_DB::test_utf8mb3_non_unicode_collation_switched_to_utf8mb4()` for `determine_charset()`.
- `Tests_Admin_IncludesUpgrade::test_maybe_convert_table_to_utf8mb4_converts_utf8_table()` and `::test_maybe_convert_table_to_utf8mb4_skips_non_utf8_columns()` for `maybe_convert_table_to_utf8mb4()`. The tests use a real table and remove the `query` filters that rewrite `CREATE TABLE` to `CREATE TEMPORARY TABLE`, because `SHOW TABLE STATUS` cannot see temporary tables. On servers that still report `utf8`, the create uses `utf8`, so the tests pass on older setups too.

Verified that the new tests fail against unpatched trunk and pass with the fix. Focused suites pass on MySQL 9.7 (`Tests_Admin_IncludesUpgrade`, `Tests_DB`, `Tests_DB_Charset`, `Tests_DB_dbDelta`, `IncludesSchema`): 105 tests, 212 assertions. PHPCS clean on the touched files.

Trac ticket: https://core.trac.wordpress.org/ticket/60002

## Use of AI Tools

AI assistance: Yes
Tool(s): ZCode
Model(s): GLM 5.3 flash
Used for: Ticket research, implementing the charset checks, writing the regression tests, and running the local test suite. The changes and this description were reviewed and submitted by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**