### PR TITLE
Tests: Reduce execution cost of Tests_Blocks_registerCoreBlockStyleHandles

### DIFF
--- a/tests/phpunit/tests/blocks/registerCoreBlockStyleHandles.php
+++ b/tests/phpunit/tests/blocks/registerCoreBlockStyleHandles.php
@@ -54,26 +54,24 @@ class Tests_Blocks_registerCoreBlockStyleHandles extends WP_UnitTestCase {
 	/**
 	 * @ticket 58528
 	 *
-	 * @dataProvider data_block_data
-	 *
 	 * @covers ::register_core_block_style_handles
 	 * @covers ::wp_should_load_separate_core_block_assets
-	 *
-	 * @param string $name   The block name.
-	 * @param array  $schema The block's schema.
 	 */
-	public function test_wp_should_load_separate_core_block_assets_false( $name, $schema ) {
+	public function test_wp_should_load_separate_core_block_assets_false() {
 		add_filter( 'should_load_separate_core_block_assets', '__return_false' );
-		$this->assertFalse( wp_should_load_separate_core_block_assets(), 'Core blocks are not expected to load separate assets' );
 		register_core_block_style_handles();
 
-		foreach ( self::STYLE_FIELDS as $style_field => $filename ) {
-			$style_handle = $schema[ $style_field ];
-			if ( is_array( $style_handle ) ) {
-				continue;
-			}
+		foreach ( $this->get_block_data() as $name => $schema ) {
+			$this->assertFalse( wp_should_load_separate_core_block_assets(), "Block {$name}: Core blocks are not expected to load separate assets" );
 
-			$this->assertArrayNotHasKey( $style_handle, $GLOBALS['wp_styles']->registered, 'The key should not exist, as this style should not be registered' );
+			foreach ( self::STYLE_FIELDS as $style_field => $filename ) {
+				$style_handle = $schema[ $style_field ];
+				if ( is_array( $style_handle ) ) {
+					continue;
+				}
+
+				$this->assertArrayNotHasKey( $style_handle, $GLOBALS['wp_styles']->registered, "Block {$name}: The key should not exist, as this style should not be registered" );
+			}
 		}
 	}
 
@@ -81,74 +79,66 @@ class Tests_Blocks_registerCoreBlockStyleHandles extends WP_UnitTestCase {
 	/**
 	 * @ticket 58528
 	 *
-	 * @dataProvider data_block_data
-	 *
 	 * @covers ::register_core_block_style_handles
 	 * @covers ::wp_should_load_separate_core_block_assets
-	 *
-	 * @param string $name   The block name.
-	 * @param array  $schema The block's schema.
 	 */
-	public function test_wp_should_load_separate_core_block_assets_true( $name, $schema ) {
+	public function test_wp_should_load_separate_core_block_assets_true() {
 		add_filter( 'should_load_separate_core_block_assets', '__return_true' );
-		$this->assertTrue( wp_should_load_separate_core_block_assets(), 'Core assets are expected to load separately' );
 		register_core_block_style_handles();
 
 		$wp_styles = $GLOBALS['wp_styles'];
 
-		foreach ( self::STYLE_FIELDS as $style_field => $filename ) {
-			$style_handle = $schema[ $style_field ];
-			if ( is_array( $style_handle ) ) {
-				continue;
-			}
+		foreach ( $this->get_block_data() as $name => $schema ) {
+			$this->assertTrue( wp_should_load_separate_core_block_assets(), "Block {$name}: Core assets are expected to load separately" );
 
-			$this->assertArrayHasKey( $style_handle, $wp_styles->registered, 'The key should exist, as this style should be registered' );
-			if ( false === $wp_styles->registered[ $style_handle ]->src ) {
-				$this->assertEmpty( $wp_styles->registered[ $style_handle ]->extra, 'If source is false, style path should not be set' );
-			} else {
-				$this->assertStringContainsString( $this->includes_url, $wp_styles->registered[ $style_handle ]->src, 'Source of style should contain the includes url' );
-				$this->assertNotEmpty( $wp_styles->registered[ $style_handle ]->extra, 'The path of the style should exist' );
-				$this->assertArrayHasKey( 'path', $wp_styles->registered[ $style_handle ]->extra, 'The path key of the style should exist in extra array' );
-				$this->assertNotEmpty( $wp_styles->registered[ $style_handle ]->extra['path'], 'The path key of the style should not be empty' );
+			foreach ( self::STYLE_FIELDS as $style_field => $filename ) {
+				$style_handle = $schema[ $style_field ];
+				if ( is_array( $style_handle ) ) {
+					continue;
+				}
+
+				$this->assertArrayHasKey( $style_handle, $wp_styles->registered, "Block {$name}: The key should exist, as this style should be registered" );
+				if ( false === $wp_styles->registered[ $style_handle ]->src ) {
+					$this->assertEmpty( $wp_styles->registered[ $style_handle ]->extra, "Block {$name}: If source is false, style path should not be set" );
+				} else {
+					$this->assertStringContainsString( $this->includes_url, $wp_styles->registered[ $style_handle ]->src, "Block {$name}: Source of style should contain the includes url" );
+					$this->assertNotEmpty( $wp_styles->registered[ $style_handle ]->extra, "Block {$name}: The path of the style should exist" );
+					$this->assertArrayHasKey( 'path', $wp_styles->registered[ $style_handle ]->extra, "Block {$name}: The path key of the style should exist in extra array" );
+					$this->assertNotEmpty( $wp_styles->registered[ $style_handle ]->extra['path'], "Block {$name}: The path key of the style should not be empty" );
+				}
 			}
 		}
 	}
 
 	/**
 	 * @ticket 58560
-	 *
-	 * @dataProvider data_block_data
-	 *
-	 * @param string $name The block name.
 	 */
-	public function test_wp_should_load_separate_core_block_assets_current_theme_supports( $name ) {
+	public function test_wp_should_load_separate_core_block_assets_current_theme_supports() {
 		add_filter( 'should_load_separate_core_block_assets', '__return_true' );
 		add_theme_support( 'wp-block-styles' );
 		register_core_block_style_handles();
 
 		$wp_styles = $GLOBALS['wp_styles'];
 
-		$style_handle = "wp-block-{$name}-theme";
+		foreach ( array_keys( $this->get_block_data() ) as $name ) {
+			$style_handle = "wp-block-{$name}-theme";
 
-		$this->assertArrayHasKey( $style_handle, $wp_styles->registered, 'The key should exist, as this style should be registered' );
-		if ( false === $wp_styles->registered[ $style_handle ]->src ) {
-			$this->assertEmpty( $wp_styles->registered[ $style_handle ]->extra, 'If source is false, style path should not be set' );
-		} else {
-			$this->assertStringContainsString( $this->includes_url, $wp_styles->registered[ $style_handle ]->src, 'Source of style should contain the includes url' );
-			$this->assertNotEmpty( $wp_styles->registered[ $style_handle ]->extra, 'The path of the style should exist' );
-			$this->assertArrayHasKey( 'path', $wp_styles->registered[ $style_handle ]->extra, 'The path key of the style should exist in extra array' );
-			$this->assertNotEmpty( $wp_styles->registered[ $style_handle ]->extra['path'], 'The path key of the style should not be empty' );
+			$this->assertArrayHasKey( $style_handle, $wp_styles->registered, "Block {$name}: The key should exist, as this style should be registered" );
+			if ( false === $wp_styles->registered[ $style_handle ]->src ) {
+				$this->assertEmpty( $wp_styles->registered[ $style_handle ]->extra, "Block {$name}: If source is false, style path should not be set" );
+			} else {
+				$this->assertStringContainsString( $this->includes_url, $wp_styles->registered[ $style_handle ]->src, "Block {$name}: Source of style should contain the includes url" );
+				$this->assertNotEmpty( $wp_styles->registered[ $style_handle ]->extra, "Block {$name}: The path of the style should exist" );
+				$this->assertArrayHasKey( 'path', $wp_styles->registered[ $style_handle ]->extra, "Block {$name}: The path key of the style should exist in extra array" );
+				$this->assertNotEmpty( $wp_styles->registered[ $style_handle ]->extra['path'], "Block {$name}: The path key of the style should not be empty" );
+			}
 		}
 	}
 
 	/**
 	 * @ticket 59715
-	 *
-	 * @dataProvider data_block_data
-	 *
-	 * @param string $name The block name.
 	 */
-	public function test_register_core_block_style_handles_should_load_rtl_stylesheets_for_rtl_text_direction( $name ) {
+	public function test_register_core_block_style_handles_should_load_rtl_stylesheets_for_rtl_text_direction() {
 		global $wp_locale;
 
 		$orig_text_dir             = $wp_locale->text_direction;
@@ -159,23 +149,30 @@ class Tests_Blocks_registerCoreBlockStyleHandles extends WP_UnitTestCase {
 
 		$wp_styles = $GLOBALS['wp_styles'];
 
-		$style_handle = "wp-block-{$name}-theme";
-
 		$wp_locale->text_direction = $orig_text_dir;
 
-		$this->assertArrayHasKey( $style_handle, $wp_styles->registered, 'The key should exist, as this style should be registered' );
-		if ( false === $wp_styles->registered[ $style_handle ]->src ) {
-			$this->assertEmpty( $wp_styles->registered[ $style_handle ]->extra, 'If source is false, style path should not be set' );
-		} else {
-			$this->assertStringContainsString( $this->includes_url, $wp_styles->registered[ $style_handle ]->src, 'Source of style should contain the includes url' );
-			$this->assertNotEmpty( $wp_styles->registered[ $style_handle ]->extra, 'The path of the style should exist' );
-			$this->assertArrayHasKey( 'path', $wp_styles->registered[ $style_handle ]->extra, 'The path key of the style should exist in extra array' );
-			$this->assertNotEmpty( $wp_styles->registered[ $style_handle ]->extra['path'], 'The path key of the style should not be empty' );
-			$this->assertArrayHasKey( 'rtl', $wp_styles->registered[ $style_handle ]->extra, 'The rtl key of the style should exist in extra array' );
+		foreach ( array_keys( $this->get_block_data() ) as $name ) {
+			$style_handle = "wp-block-{$name}-theme";
+
+			$this->assertArrayHasKey( $style_handle, $wp_styles->registered, "Block {$name}: The key should exist, as this style should be registered" );
+			if ( false === $wp_styles->registered[ $style_handle ]->src ) {
+				$this->assertEmpty( $wp_styles->registered[ $style_handle ]->extra, "Block {$name}: If source is false, style path should not be set" );
+			} else {
+				$this->assertStringContainsString( $this->includes_url, $wp_styles->registered[ $style_handle ]->src, "Block {$name}: Source of style should contain the includes url" );
+				$this->assertNotEmpty( $wp_styles->registered[ $style_handle ]->extra, "Block {$name}: The path of the style should exist" );
+				$this->assertArrayHasKey( 'path', $wp_styles->registered[ $style_handle ]->extra, "Block {$name}: The path key of the style should exist in extra array" );
+				$this->assertNotEmpty( $wp_styles->registered[ $style_handle ]->extra['path'], "Block {$name}: The path key of the style should not be empty" );
+				$this->assertArrayHasKey( 'rtl', $wp_styles->registered[ $style_handle ]->extra, "Block {$name}: The rtl key of the style should exist in extra array" );
+			}
 		}
 	}
 
-	public function data_block_data() {
+	/**
+	 * Gets the blocks to check after registering styles once per scenario.
+	 *
+	 * @return array[] Block schemas keyed by block name.
+	 */
+	private function get_block_data() {
 		$core_blocks_meta = require ABSPATH . WPINC . '/blocks/blocks-json.php';
 
 		// Remove this blocks for now, as they are registered elsewhere.
@@ -191,7 +188,7 @@ class Tests_Blocks_registerCoreBlockStyleHandles extends WP_UnitTestCase {
 				$schema['editorStyle'] = "wp-block-{$name}-editor";
 			}
 
-			$data[ $name ] = array( $name, $schema );
+			$data[ $name ] = $schema;
 		}
 
 		return $data;


### PR DESCRIPTION
Updates `Tests_Blocks_registerCoreBlockStyleHandles` to avoid repeating the same setup for each block.

Previously, four test methods each ran separately for 113 blocks, giving 452 test cases. Each case called `register_core_block_style_handles()`, which registers styles for all blocks when separate block assets are enabled, but checked only one block.

Each method now calls the function once and loops through all blocks to check the results. This reduces the test cases from 452 to 4 while preserving all 1,873 assertions and their expected values. Failure messages include the block name to help identify problems.


### Performance
Tested locally across three consecutive runs on `trunk` versus the fix branch:
| Run | Trunk Test Time (`junit.xml`) | Trunk Wall Time | Fix Test Time (`junit.xml`) | Fix Wall Time |
|---|---|---|---|---|
| Run 1 | 4.474s | 4.798s | 0.062s | 0.342s |
| Run 2 | 4.062s | 4.377s | 0.057s | 0.295s |
| Run 3 | 3.709s | 4.029s | 0.094s | 0.352s |
| **Average** | **4.082s** | **4.401s** | **0.071s** | **0.330s** |


Trac ticket: https://core.trac.wordpress.org/ticket/66074

## Use of AI Tools

AI assistance: Yes
Tool(s): Github Copilot
Model(s): Claude Sonnet 4.6
Used for: Edge-case checks, and assistance with the PR description, implementation and testing were reviewed and verified by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**