### PR TITLE
Build/Test Tools: Use createMock() in WP_Upgrader tests

### DIFF
--- a/tests/phpunit/tests/admin/wpUpgrader.php
+++ b/tests/phpunit/tests/admin/wpUpgrader.php
@@ -49,11 +49,11 @@ class Tests_Admin_WpUpgrader extends WP_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 
-		self::$upgrader_skin_mock = $this->getMockBuilder( 'WP_Upgrader_Skin' )->getMock();
+		self::$upgrader_skin_mock = $this->createMock( 'WP_Upgrader_Skin' );
 
 		self::$instance = new WP_Upgrader( self::$upgrader_skin_mock );
 
-		self::$wp_filesystem_mock = $this->getMockBuilder( 'WP_Filesystem_Base' )->getMock();
+		self::$wp_filesystem_mock = $this->createMock( 'WP_Filesystem_Base' );
 
 		if ( array_key_exists( 'wp_filesystem', $GLOBALS ) ) {
 			self::$wp_filesystem_backup = $GLOBALS['wp_filesystem'];


### PR DESCRIPTION
Replace `getMockBuilder( $class )->getMock()` with the shorter `createMock( $class )` in the `WP_Upgrader` test setup. Neither mock configures constructor arguments or a method list, so the builder adds nothing here, and `createMock()` is the form already used across the rest of the test suite.

The remaining `getMockBuilder()` calls in the test suite are left untouched, as they all configure constructor arguments or mocked methods and therefore genuinely need the builder.

Trac ticket: https://core.trac.wordpress.org/ticket/65819

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
