### PR TITLE
Embeds: Remove Someecards from the oEmbed provider allow list

### DIFF
--- a/src/wp-includes/class-wp-oembed.php
+++ b/src/wp-includes/class-wp-oembed.php
@@ -102,9 +102,6 @@ class WP_oEmbed {
 			'#https?://(www\.)?amzn\.in/.*#i'              => array( 'https://read.amazon.in/kp/api/oembed', true ),
 			'#https?://(www\.)?amzn\.asia/.*#i'            => array( 'https://read.amazon.com.au/kp/api/oembed', true ),
 			'#https?://(www\.)?z\.cn/.*#i'                 => array( 'https://read.amazon.cn/kp/api/oembed', true ),
-			'#https?://www\.someecards\.com/.+-cards/.+#i' => array( 'https://www.someecards.com/v2/oembed/', true ),
-			'#https?://www\.someecards\.com/usercards/viewcard/.+#i' => array( 'https://www.someecards.com/v2/oembed/', true ),
-			'#https?://some\.ly\/.+#i'                     => array( 'https://www.someecards.com/v2/oembed/', true ),
 			'#https?://(www\.)?tiktok\.com/.*/video/.*#i'  => array( 'https://www.tiktok.com/oembed', true ),
 			'#https?://(www\.)?tiktok\.com/@.*#i'          => array( 'https://www.tiktok.com/oembed', true ),
 			'#https?://([a-z]{2}|www)\.pinterest\.com(\.(au|mx))?/.*#i' => array( 'https://www.pinterest.com/oembed.json', true ),
@@ -183,8 +180,6 @@ class WP_oEmbed {
 		 * | Amazon       | a.co                                      | 4.9.0   |
 		 * | Amazon       | amzn.to (eu, in, asia)                    | 4.9.0   |
 		 * | Amazon       | z.cn                                      | 4.9.0   |
-		 * | Someecards   | someecards.com                            | 4.9.0   |
-		 * | Someecards   | some.ly                                   | 4.9.0   |
 		 * | Crowdsignal  | survey.fm                                 | 5.1.0   |
 		 * | TikTok       | tiktok.com                                | 5.4.0   |
 		 * | Pinterest    | pinterest.com                             | 5.9.0   |
@@ -219,6 +214,8 @@ class WP_oEmbed {
 		 * | Meetup.com   | meetu.ps             | 3.9.0     | 6.0.1     |
 		 * | SlideShare   | slideshare.net       | 3.5.0     | 6.6.0     |
 		 * | Screencast   | screencast.com       | 4.8.0     | 6.8.2     |
+		 * | Someecards   | someecards.com       | 4.9.0     | 7.1.2     |
+		 * | Someecards   | some.ly              | 4.9.0     | 7.1.2     |
 		 *
 		 * @see wp_oembed_add_provider()
 		 *


### PR DESCRIPTION
The Someecards oEmbed endpoint now returns a 404 response, and card pages no longer advertise an oEmbed discovery link.

This removes the provider patterns for `someecards.com` and `some.ly` from the oEmbed allow list and documents Someecards as no longer supported as of WordPress 7.1.1.

Trac ticket: https://core.trac.wordpress.org/ticket/66078

### Use of AI Tools

AI assistance: Yes
Tool(s): OpenAI Codex
Model(s): GPT-5.6 Sol light
Used for: Identifying the relevant code path, final implementation were reviewed and edited by me.