### PR TITLE
View Config: Add the form of the root/site entity

### DIFF
--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -834,5 +834,6 @@ foreach ( array( 'page', 'wp_block', 'wp_template_part', 'wp_template' ) as $pos
 		5
 	);
 }
+add_filter( 'get_entity_view_config_root_site', '_wp_get_entity_view_config_root_site', 5 );
 
 unset( $filter, $action, $post_type );

--- a/src/wp-includes/view-config.php
+++ b/src/wp-includes/view-config.php
@@ -769,3 +769,36 @@ function _wp_get_entity_view_config_posttype_wp_template( $data ) {
 
 	return $data;
 }
+
+/**
+ * Provides the view configuration for the `root`/`site` entity.
+ *
+ * The site settings are a singleton record edited through a form (the site
+ * editor's Identity screen) rather than listed in a view, so only the `form`
+ * is defined here. The generic `default_view`, `default_layouts`, and
+ * `view_list` built by wp_get_entity_view_config() are left untouched.
+ *
+ * @since 7.2.0
+ *
+ * @param WP_View_Config_Data $data The view configuration container for the entity.
+ * @return WP_View_Config_Data The updated view configuration container.
+ */
+function _wp_get_entity_view_config_root_site( $data ) {
+	return $data->set(
+		array(
+			'form' => array(
+				'layout' => array(
+					'type'          => 'regular',
+					'labelPosition' => 'top',
+				),
+				'fields' => array(
+					'title',
+					'description',
+					'site_logo',
+					'site_icon',
+				),
+			),
+		),
+		1
+	);
+}

--- a/tests/phpunit/tests/rest-api/rest-view-config-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-view-config-controller.php
@@ -303,6 +303,35 @@ class WP_REST_View_Config_Controller_Test extends WP_Test_REST_TestCase {
 	}
 
 	/**
+	 * The `root`/`site` entity provides the form of the site identity screen.
+	 *
+	 * @ticket 65981
+	 *
+	 * @covers ::get_items
+	 */
+	public function test_get_items_root_site_form() {
+		// Admin: reading root config requires `manage_options`.
+		wp_set_current_user( self::$admin_id );
+
+		$response = $this->dispatch_request( 'root', 'site' );
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = json_decode( wp_json_encode( $response->get_data() ), true );
+
+		$this->assertSame(
+			array(
+				'type'          => 'regular',
+				'labelPosition' => 'top',
+			),
+			$data['form']['layout']
+		);
+		$this->assertSame(
+			array( 'title', 'description', 'site_logo', 'site_icon' ),
+			$data['form']['fields']
+		);
+	}
+
+	/**
 	 * Empty object-typed config values serialize as JSON objects ({}), not arrays ([]).
 	 *
 	 * @covers ::get_items


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65981

Adds a base view configuration for the `root`/`site` entity, served by `GET /wp/v2/view-config?kind=root&name=site`. It provides the form the site editor's Identity screen renders over the site settings: a regular layout with labels on top, and the site title, tagline, logo, and icon fields. Only the `form` is defined, since the site settings are a singleton record that is never listed in a view. The Identity screen of the site editor reads this form from the endpoint once the `@wordpress/edit-site` package is updated, so plugins can adjust it through the `get_entity_view_config_root_site` filter.

This affects a stable screen of the site editor, so it is separate from the view configuration changes that wait on the site editor v2 experiment.

# Backports

Gutenberg PRs:

- https://github.com/WordPress/gutenberg/pull/82692

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Fable
Used for: Porting the server-side change from the Gutenberg PR. Reviewed and edited by me.

This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.
