### PR TITLE
Code Quality: Resolve the block processor's variable.undefined PHPStan errors

### DIFF
--- a/src/wp-includes/class-wp-block-processor.php
+++ b/src/wp-includes/class-wp-block-processor.php
@@ -786,7 +786,119 @@ class WP_Block_Processor {
 
 		$this->state          = self::READY;
 		$after_prev_delimiter = $this->matched_delimiter_at + $this->matched_delimiter_length;
-		$at                   = $after_prev_delimiter;
+
+		$delimiter = $this->scan_next_delimiter( $text, $end, $after_prev_delimiter );
+		if ( null === $delimiter ) {
+			/*
+			 * The scan set the terminating state; only a trailing HTML span
+			 * leaves a token still to be visited.
+			 */
+			return self::HTML_SPAN === $this->state;
+		}
+
+		$this->state = self::MATCHED;
+
+		/*
+		 * From this point forward, a delimiter has been matched. There
+		 * might also be an HTML span that appears before the delimiter.
+		 */
+
+		$this->after_previous_delimiter = $after_prev_delimiter;
+
+		$this->matched_delimiter_at     = $delimiter['comment_opening_at'];
+		$this->matched_delimiter_length = $delimiter['comment_closing_at'] + 3 - $delimiter['comment_opening_at'];
+
+		$this->namespace_at = $delimiter['namespace_at'];
+		$this->name_at      = $delimiter['name_at'];
+		$this->name_length  = $delimiter['name_length'];
+
+		$this->json_at     = $delimiter['json_at'];
+		$this->json_length = $delimiter['json_length'];
+
+		/*
+		 * When delimiters contain both the void flag and the closing flag
+		 * they shall be interpreted as void blocks, per the spec parser.
+		 */
+		if ( $delimiter['has_void_flag'] ) {
+			$this->type          = self::VOID;
+			$this->next_stack_op = 'void';
+		} elseif ( $delimiter['has_closer'] ) {
+			$this->type          = self::CLOSER;
+			$this->next_stack_op = 'pop';
+
+			/*
+			 * @todo Check if the name matches and bail according to the spec parser.
+			 *       The default parser doesn’t examine the names.
+			 */
+		} else {
+			$this->type          = self::OPENER;
+			$this->next_stack_op = 'push';
+		}
+
+		$this->has_closing_flag = $delimiter['has_closer'];
+
+		// HTML spans are visited before the delimiter that follows them.
+		if ( $delimiter['comment_opening_at'] > $after_prev_delimiter ) {
+			$this->state                = self::HTML_SPAN;
+			$this->open_blocks_at[]     = $after_prev_delimiter;
+			$this->open_blocks_length[] = 0;
+			$this->was_void             = true;
+
+			return true;
+		}
+
+		// If there were no HTML spans then flush the enqueued stack operations immediately.
+		switch ( $this->next_stack_op ) {
+			case 'void':
+				$this->was_void             = true;
+				$this->open_blocks_at[]     = $this->namespace_at;
+				$this->open_blocks_length[] = $this->name_at + $this->name_length - $this->namespace_at;
+				break;
+
+			case 'push':
+				$this->open_blocks_at[]     = $this->namespace_at;
+				$this->open_blocks_length[] = $this->name_at + $this->name_length - $this->namespace_at;
+				break;
+
+			case 'pop':
+				array_pop( $this->open_blocks_at );
+				array_pop( $this->open_blocks_length );
+				break;
+		}
+
+		$this->next_stack_op = null;
+
+		return true;
+	}
+
+	/**
+	 * Scans for the next block delimiter, starting after the previously-matched delimiter.
+	 *
+	 * When no delimiter is matched, the parser state records why: `HTML_SPAN` when a final
+	 * run of HTML remains to be visited, `COMPLETE` when the document is exhausted, and
+	 * `INCOMPLETE_INPUT` when the document ends part-way through a delimiter.
+	 *
+	 * @since 7.2.0
+	 *
+	 * @param string $text                 Document being parsed.
+	 * @param int    $end                  Length of the document.
+	 * @param int    $after_prev_delimiter Byte offset just after the previously-matched delimiter.
+	 * @return array{
+	 *     comment_opening_at: int,
+	 *     comment_closing_at: int,
+	 *     namespace_at: int,
+	 *     name_at: int,
+	 *     name_length: int,
+	 *     json_at: int,
+	 *     json_length: int,
+	 *     has_void_flag: bool,
+	 *     has_closer: bool,
+	 * }|null Spans and flags of the matched delimiter, or `null` if none was matched.
+	 *
+	 * @phpstan-impure
+	 */
+	private function scan_next_delimiter( string $text, int $end, int $after_prev_delimiter ): ?array {
+		$at = $after_prev_delimiter;
 
 		while ( $at < $end ) {
 			/*
@@ -831,7 +943,7 @@ class WP_Block_Processor {
 					$this->open_blocks_at[]         = $after_prev_delimiter;
 					$this->open_blocks_length[]     = 0;
 					$this->was_void                 = true;
-					return true;
+					return null;
 				}
 
 				/*
@@ -844,7 +956,7 @@ class WP_Block_Processor {
 
 				// Otherwise this is the end.
 				$this->state = self::COMPLETE;
-				return false;
+				return null;
 			}
 
 			// <!-- ⃨/wp:core/paragraph {"dropCap":true} /-->
@@ -997,8 +1109,17 @@ class WP_Block_Processor {
 			if ( ! $has_json ) {
 				if ( $after_name_whitespace_at + $after_name_whitespace_length === $comment_closing_at - $void_flag_length ) {
 					// This must be a block delimiter!
-					$this->state = self::MATCHED;
-					break;
+					return array(
+						'comment_opening_at' => $comment_opening_at,
+						'comment_closing_at' => $comment_closing_at,
+						'namespace_at'       => $namespace_at,
+						'name_at'            => $name_at,
+						'name_length'        => $name_length,
+						'json_at'            => $json_at,
+						'json_length'        => $json_length,
+						'has_void_flag'      => $has_void_flag,
+						'has_closer'         => $has_closer,
+					);
 				}
 
 				$at = $this->find_html_comment_end( $comment_opening_at, $end );
@@ -1045,92 +1166,27 @@ class WP_Block_Processor {
 			}
 
 			// This must be a block delimiter!
-			$this->state = self::MATCHED;
-			break;
+			return array(
+				'comment_opening_at' => $comment_opening_at,
+				'comment_closing_at' => $comment_closing_at,
+				'namespace_at'       => $namespace_at,
+				'name_at'            => $name_at,
+				'name_length'        => $name_length,
+				'json_at'            => $json_at,
+				'json_length'        => $json_length,
+				'has_void_flag'      => $has_void_flag,
+				'has_closer'         => $has_closer,
+			);
 		}
 
 		// The end of the document was reached without a match.
-		if ( self::MATCHED !== $this->state ) {
-			$this->state = self::COMPLETE;
-			return false;
-		}
-
-		/*
-		 * From this point forward, a delimiter has been matched. There
-		 * might also be an HTML span that appears before the delimiter.
-		 */
-
-		$this->after_previous_delimiter = $after_prev_delimiter;
-
-		$this->matched_delimiter_at     = $comment_opening_at;
-		$this->matched_delimiter_length = $comment_closing_at + 3 - $comment_opening_at;
-
-		$this->namespace_at = $namespace_at;
-		$this->name_at      = $name_at;
-		$this->name_length  = $name_length;
-
-		$this->json_at     = $json_at;
-		$this->json_length = $json_length;
-
-		/*
-		 * When delimiters contain both the void flag and the closing flag
-		 * they shall be interpreted as void blocks, per the spec parser.
-		 */
-		if ( $has_void_flag ) {
-			$this->type          = self::VOID;
-			$this->next_stack_op = 'void';
-		} elseif ( $has_closer ) {
-			$this->type          = self::CLOSER;
-			$this->next_stack_op = 'pop';
-
-			/*
-			 * @todo Check if the name matches and bail according to the spec parser.
-			 *       The default parser doesn’t examine the names.
-			 */
-		} else {
-			$this->type          = self::OPENER;
-			$this->next_stack_op = 'push';
-		}
-
-		$this->has_closing_flag = $has_closer;
-
-		// HTML spans are visited before the delimiter that follows them.
-		if ( $comment_opening_at > $after_prev_delimiter ) {
-			$this->state                = self::HTML_SPAN;
-			$this->open_blocks_at[]     = $after_prev_delimiter;
-			$this->open_blocks_length[] = 0;
-			$this->was_void             = true;
-
-			return true;
-		}
-
-		// If there were no HTML spans then flush the enqueued stack operations immediately.
-		switch ( $this->next_stack_op ) {
-			case 'void':
-				$this->was_void             = true;
-				$this->open_blocks_at[]     = $namespace_at;
-				$this->open_blocks_length[] = $name_at + $name_length - $namespace_at;
-				break;
-
-			case 'push':
-				$this->open_blocks_at[]     = $namespace_at;
-				$this->open_blocks_length[] = $name_at + $name_length - $namespace_at;
-				break;
-
-			case 'pop':
-				array_pop( $this->open_blocks_at );
-				array_pop( $this->open_blocks_length );
-				break;
-		}
-
-		$this->next_stack_op = null;
-
-		return true;
+		$this->state = self::COMPLETE;
+		return null;
 
 		incomplete:
 		$this->state      = self::COMPLETE;
 		$this->last_error = self::INCOMPLETE_INPUT;
-		return false;
+		return null;
 	}
 
 	/**

--- a/tests/phpstan/baselines/variable.undefined.neon
+++ b/tests/phpstan/baselines/variable.undefined.neon
@@ -719,51 +719,6 @@ parameters:
 			count: 1
 			path: ../../../src/wp-includes/class-walker-category.php
 		-
-			message: '#^Variable \$comment_closing_at might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: ../../../src/wp-includes/class-wp-block-processor.php
-		-
-			message: '#^Variable \$comment_opening_at might not be defined\.$#'
-			identifier: variable.undefined
-			count: 3
-			path: ../../../src/wp-includes/class-wp-block-processor.php
-		-
-			message: '#^Variable \$has_closer might not be defined\.$#'
-			identifier: variable.undefined
-			count: 2
-			path: ../../../src/wp-includes/class-wp-block-processor.php
-		-
-			message: '#^Variable \$has_void_flag might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: ../../../src/wp-includes/class-wp-block-processor.php
-		-
-			message: '#^Variable \$json_at might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: ../../../src/wp-includes/class-wp-block-processor.php
-		-
-			message: '#^Variable \$json_length might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: ../../../src/wp-includes/class-wp-block-processor.php
-		-
-			message: '#^Variable \$name_at might not be defined\.$#'
-			identifier: variable.undefined
-			count: 3
-			path: ../../../src/wp-includes/class-wp-block-processor.php
-		-
-			message: '#^Variable \$name_length might not be defined\.$#'
-			identifier: variable.undefined
-			count: 3
-			path: ../../../src/wp-includes/class-wp-block-processor.php
-		-
-			message: '#^Variable \$namespace_at might not be defined\.$#'
-			identifier: variable.undefined
-			count: 5
-			path: ../../../src/wp-includes/class-wp-block-processor.php
-		-
 			message: '#^Variable \$section_id might not be defined\.$#'
 			identifier: variable.undefined
 			count: 1


### PR DESCRIPTION
Resolves the twenty `variable.undefined` errors in `src/wp-includes/class-wp-block-processor.php`, the densest single file in that baseline. `variable.undefined` is a **rule level 1** error — the lowest level, which the ticket asks contributors to prioritize.

## Background

`WP_Block_Processor` was introduced in r60939 (Core-61401, WP 6.9), and `next_token()` has had its present shape since that changeset. It scans for the next block delimiter in a `while` loop that assigns nine locals, `continue`s past every rejection, and `break`s only once a delimiter is confirmed:

```php
while ( $at < $end ) {
    // …
    // This must be a block delimiter!
    $this->state = self::MATCHED;
    break;
}

// The end of the document was reached without a match.
if ( self::MATCHED !== $this->state ) {
    $this->state = self::COMPLETE;
    return false;
}

$this->matched_delimiter_at = $comment_opening_at;
// …and nineteen more reads of the loop's locals.
```

The code is correct: the `break` is the only path that sets `MATCHED`, so reaching the block below guarantees every local was assigned. PHPStan cannot make that connection, though — the loop may run zero times, and `$this->state` is a mutable property it does not track across iterations. So all twenty post-loop reads were reported and baselined when the rule level was raised to 1 in r63019.

The twenty errors break down as `$namespace_at` ×5, `$name_at` ×3, `$name_length` ×3, `$comment_opening_at` ×3, `$has_closer` ×2, and one each for `$comment_closing_at`, `$has_void_flag`, `$json_at`, and `$json_length`.

## Approach

Rather than initializing the nine locals before the loop — which would silence the analyzer with defaults that are never meaningfully used — the scan is extracted into a private `scan_next_delimiter()` that returns the matched spans and flags:

```php
$delimiter = $this->scan_next_delimiter( $text, $end, $after_prev_delimiter );
if ( null === $delimiter ) {
    /*
     * The scan set the terminating state; only a trailing HTML span
     * leaves a token still to be visited.
     */
    return self::HTML_SPAN === $this->state;
}
```

The values now arrive as an array shape rather than as locals that may never have been assigned, so the errors are resolved by construction. The three no-match paths (trailing HTML span, exhausted document, incomplete input) set the terminating state exactly as before and return `null`; the ten `goto incomplete` sites and their label move with the loop.

`next_token()` drops from 399 lines to 137.

Two things worth calling out for review:

- **`@phpstan-impure`** on the new method. Without it PHPStan assumes `$this->state` cannot have changed across the call and reports `identical.alwaysFalse` on the `self::HTML_SPAN === $this->state` line. The method genuinely is impure — it writes `$this->state`, `$this->last_error`, `$this->after_previous_delimiter`, the matched-delimiter spans, and the open-blocks stack. This matches how `WP_HTML_Tag_Processor::parse_next_tag()` is annotated.
- **The trailing stack-op `switch`** now reads `$this->namespace_at` / `$this->name_at` / `$this->name_length`, which are assigned from `$delimiter` about thirty lines above it and untouched in between. That makes it textually identical to its counterpart in the `HTML_SPAN` re-entry branch, where the two previously differed only in locals-versus-properties. The obvious follow-up — folding the two into one private method — is left out of scope here.

There is one small trade-off: a match now allocates a nine-element array where it previously wrote straight to locals. In a parser that runs on every post render that is a real cost, though a small one beside the `strpos()`/`strspn()` scanning it wraps. The zero-allocation alternative is to leave the loop in place and instead move the post-match block into a helper taking those nine values as parameters — same guarantee, but a ten-parameter private method.

## Verification

The scan is moved verbatim; `diff` against the original loop shows changes at exactly four sites — the two match sites, which now `return array( … )`, and the two no-match `return`s, which now yield `null`.

- `variable.undefined` baseline: 473 → 453 entries' worth of errors (194 → 185 entries). The file no longer appears in the baseline at all. Total across all baselines: 1,464 → 1,444.
- `phpstan-diff --changed --staged --base=HEAD`: no errors on changed lines.
- PHPCS: clean.
- PHPUnit `--group blocks`: 632 tests, 3,345 assertions, passing. That includes all 222 `Tests_Blocks_BlockProcessor*` tests.

Trac ticket: Core-65817

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Locating the densest baselined file, diagnosing why the errors occur, performing the extraction, and drafting this description. The approach was directed and the result reviewed by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Juqe7ccrs72NtpDUYz6JbX
