### PR TITLE
Media: Improve inactive view switcher link contrast

### DIFF
--- a/src/wp-admin/css/list-tables.css
+++ b/src/wp-admin/css/list-tables.css
@@ -778,7 +778,7 @@ th.sorted a span {
 }
 
 .view-switch a:before {
-	color: #c3c4c7;
+	color: #757575;
 	display: inline-block;
 	font: normal 20px/1 dashicons;
 	vertical-align: middle;


### PR DESCRIPTION
This PR changes the inactive Media Library view switcher icon color from `#c3c4c7` to `#757575`.

The updated color increases the contrast ratio against the white background from `1.74:1` to approximately `4.61:1`, making the inactive but functional view switcher easier to identify.

Trac ticket: https://core.trac.wordpress.org/ticket/66081

## Testing instructions

1. Navigate to **Media → Library**.
2. Switch between List and Grid views.
3. Verify that the inactive view switcher icon uses `#757575`.
4. Verify that the current, hover, and keyboard focus states continue to work correctly.

## Checks performed

* `npm run grunt -- precommit:css`
* `npm run build:dev`

Both commands completed successfully.

## Use of AI Tools

AI assistance: Yes
Tool(s): ChatGPT Codex
Model(s): GPT-5
Used for: Identifying the relevant CSS selector and providing testing and contribution workflow guidance. The final change and command results were reviewed by me.
