### PR TITLE
Media: Do not overlap title overlay and caption

### DIFF
--- a/src/wp-includes/css/media-views.css
+++ b/src/wp-includes/css/media-views.css
@@ -1029,6 +1029,15 @@ select#media-attachment-filters ~ select#media-attachment-date-filters {
 	font-weight: 600;
 }
 
+/* Offset by the .describe input height so the overlay does not cover it. */
+.wp-core-ui .attachment:has(.describe):not(:has(.filename))::after {
+	bottom: calc(8px + 40px); /* 8px padding + 40px input height */
+}
+
+.wp-core-ui .attachment .describe {
+	z-index: 10;
+}
+
 /* Do not show the aria-label overlay on thumbnails in the gallery selection strip. */
 .wp-core-ui .media-selection .attachment::after {
 	content: none;


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/66076

## What, Why, and How?

In the `Edit Gallery` view of the media modal, each image gets a filename overlay and an (intentional) caption input. The overlay shows up in other media views too, but the input is unique to this screen, and that’s where they overlap.

The overlay is an `::after` on `.attachment`, absolutely positioned at `bottom: 8px`. This works elsewhere. However, on `Edit Gallery`, the caption field sits in that same bottom strip, so the overlay covers it. 

There are a few ways to fix this. We could move the overlay one level up in the DOM so the input is naturally accounted for, but that means changing the attachment template and checking every media modal view for regressions. A grid layout would also stack them cleanly. This PR instead keeps the current absolute positioning and raises bottom when the caption input is present. Attachment padding (`8px`) and the input’s min-height (`40px`) are already hardcoded, so `bottom: calc(8px + 40px)` fixes the overlap as a minor CSS change.

### Screenshots

|Before|After|
|-|-|
|<img width="1127" height="598" alt="before-01" src="https://github.com/user-attachments/assets/ee1ee2cd-1247-4458-bd10-e3eef534b6e8" />|<img width="1121" height="496" alt="after-1" src="https://github.com/user-attachments/assets/cd539374-a963-48cd-b46b-f0d7a48ec150" />|
|<img width="393" height="680" alt="before-02" src="https://github.com/user-attachments/assets/fd2c6ae7-27ae-41b9-b2b0-685854422d05" />|<img width="415" height="694" alt="after-2" src="https://github.com/user-attachments/assets/66bc65f6-1918-40fc-9f37-7adae84fb583" />|

## Use of AI Tools

AI assistance: Yes
Tool(s): Codex
Model(s): GPT-6 Astra
Used for: Debugging and checking out various potential solutions.