### PR TITLE
Code Modernization: Use the null coalescing operator in wp_get_chromium_major_version() tests

### DIFF
--- a/tests/phpunit/tests/media/wpGetChromiumMajorVersion.php
+++ b/tests/phpunit/tests/media/wpGetChromiumMajorVersion.php
@@ -17,7 +17,7 @@ class Tests_Media_wpGetChromiumMajorVersion extends WP_UnitTestCase {
 
 	public function set_up() {
 		parent::set_up();
-		$this->original_user_agent = isset( $_SERVER['HTTP_USER_AGENT'] ) ? $_SERVER['HTTP_USER_AGENT'] : null;
+		$this->original_user_agent = $_SERVER['HTTP_USER_AGENT'] ?? null;
 	}
 
 	public function tear_down() {


### PR DESCRIPTION
`Tests_Media_wpGetChromiumMajorVersion::set_up()` stores the original `$_SERVER['HTTP_USER_AGENT']` value using an `isset()` ternary that repeats the array access. This replaces it with the null coalescing operator, which is shorter and expresses the same intent.

The null coalescing operator is available since PHP 7.0, and WordPress requires PHP 7.4 or later, so no compatibility concerns apply. It is already used widely across the codebase, so this makes the style more consistent.

Follow-up to [62428](https://core.trac.wordpress.org/changeset/62428).

Trac ticket: https://core.trac.wordpress.org/ticket/65819

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
