### PR TITLE
Database: Send a 500 status and no-cache headers when using db-error.php or maintenance.php drop-ins

### DIFF
--- a/src/wp-includes/class-wpdb.php
+++ b/src/wp-includes/class-wpdb.php
@@ -1958,6 +1958,8 @@ class wpdb {
 	 *
 	 * @since 3.0.0
 	 * @since 3.9.0 $allow_bail parameter added.
+	 * @since 7.2.0 A 500 status header and no-cache headers are now sent
+ 	 *              before loading a custom db-error.php drop-in.
 	 *
 	 * @param bool $allow_bail Optional. Allows the function to bail. Default true.
 	 * @return bool True with a successful connection, false on failure.
@@ -2009,8 +2011,14 @@ class wpdb {
 		if ( ! $this->dbh && $allow_bail ) {
 			wp_load_translations_early();
 
-			// Load custom DB error template, if present.
+			/**
+			 * Load custom DB error template, if present.
+			 * A 500 status header and no-cache headers are now sent
+ 			 * before loading a custom db-error.php drop-in.
+			*/
 			if ( file_exists( WP_CONTENT_DIR . '/db-error.php' ) ) {
+				status_header( 500 );
+				nocache_headers();
 				require_once WP_CONTENT_DIR . '/db-error.php';
 				die();
 			}

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -5634,6 +5634,8 @@ function wp_ob_end_flush_all() {
  * in WordPress 2.5.0.
  *
  * @since 2.3.2
+ * @since 7.2.0 A 500 status header and no-cache headers are now sent
+ *              before loading a custom db-error.php drop-in.
  *
  * @global wpdb $wpdb WordPress database abstraction object.
  *
@@ -5646,6 +5648,8 @@ function dead_db() {
 
 	// Load custom DB error template, if present.
 	if ( file_exists( WP_CONTENT_DIR . '/db-error.php' ) ) {
+		status_header( 500 );
+		nocache_headers();
 		require_once WP_CONTENT_DIR . '/db-error.php';
 		die();
 	}

--- a/src/wp-includes/load.php
+++ b/src/wp-includes/load.php
@@ -395,6 +395,8 @@ function wp_favicon_request() {
  * the wp-content directory).
  *
  * @since 3.0.0
+ * @since 7.2.0 A 500 status header and no-cache headers are now sent before loading maintenance.php drop-in.
+ *              This is to ensure that the correct headers are sent.
  * @access private
  */
 function wp_maintenance() {
@@ -404,6 +406,9 @@ function wp_maintenance() {
 	}
 
 	if ( file_exists( WP_CONTENT_DIR . '/maintenance.php' ) ) {
+		status_header( 503 );
+		nocache_headers();
+		header( 'Retry-After: 600' );
 		require_once WP_CONTENT_DIR . '/maintenance.php';
 		die();
 	}


### PR DESCRIPTION
Currently, when a site uses a db-error.php or maintenance.php drop-in to show a custom outage page, WordPress skips the status_header() and nocache_headers() calls it normally sends via wp_die(). This means a 500/503 page can get cached as a 200 by a CDN or reverse proxy (e.g. Varnish), leaving a stale error page served long after the outage is resolved.

This adds status_header( 500 ) + nocache_headers() before loading db-error.php, and status_header( 503 ) + nocache_headers() + the existing Retry-After header before loading maintenance.php.

Note there are two separate places that load db-error.php: the dead_db() function in wp-includes/functions.php (used when a query fails mid-request), and a duplicated inline check in WPDB::db_connect() (used when the initial connection attempt fails). Both needed the same fix, since they don't share code.

Tested by forcing a connection failure via invalid wp-config.php credentials (exercises class-wpdb.php) and by creating a .maintenance file (exercises wp_maintenance()), confirming via `curl -I` that the correct status code and Cache-Control: no-cache headers are now sent in both cases.

Trac ticket: https://core.trac.wordpress.org/ticket/66080

Opened from the WordPress Contributor Toolkit.