### PR TITLE
Update pagination dots to only show dots if needed

### DIFF
--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -5069,7 +5069,7 @@ function paginate_links( $args = '' ) {
 
 			$dots = true;
 		else :
-			if ( $args['show_all'] || ( $n <= $end_size || ( $current && $n >= $current - $mid_size && $n <= $current + $mid_size ) || $n > $total - $end_size ) ) :
+			if ( $args['show_all'] || ( $n <= $end_size || ( $current && $n >= $current - $mid_size && $n <= $current + $mid_size ) || $n > $total - $end_size || ( ( in_array( $current, array( 1, $total ), true ) ) && $total - ( $mid_size + ( $end_size * 2 ) ) ) === 1 ) ) :
 				$link = str_replace( '%_%', 1 === $n ? '' : $args['format'], $args['base'] );
 				$link = str_replace( '%#%', $n, $link );
 				if ( $add_args ) {


### PR DESCRIPTION
Currently, under certain conditions the pagination shows dots when it would make more sense to show a number.
This change updates such an edge case.

Example:
If you have the following variables:
Mid size: 2
End size: 1
Total pages: 5
Current page: 1
Then it will visually output as follows:

Prev 1 2 3 ... 5 Next

Trac ticket: https://core.trac.wordpress.org/ticket/51227

This PR supersedes PR #513 which was very outdated

## Use of AI Tools
AI assistance: No
---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
