### PR TITLE
Enable JSDoc require-param-name and sort rules alphabetically.

### DIFF
--- a/.eslintrc-jsdoc.js
+++ b/.eslintrc-jsdoc.js
@@ -37,7 +37,7 @@ module.exports = [
 		},
 		rules: {
 			'jsdoc/check-param-names': 'error',
-			'jsdoc/check-types': 'error',
+			'jsdoc/check-syntax': 'error',
 			'jsdoc/check-tag-names': [ 'error', {
 				definedTags: [
 					'memberOf',
@@ -46,17 +46,18 @@ module.exports = [
 					'link',
 				],
 			} ],
+			'jsdoc/check-types': 'error',
+			'jsdoc/require-description': 'error',
+			'jsdoc/require-jsdoc': 'error',
 			'jsdoc/require-param': [ 'error', {
 				enableFixer: false,
 			} ],
+			'jsdoc/require-param-name': 'error',
 			'jsdoc/require-param-type': 'error',
+			'jsdoc/require-returns': 'error',
 			'jsdoc/require-returns-check': 'error',
 			'jsdoc/require-returns-description': 'error',
-			'jsdoc/require-returns': 'error',
 			'jsdoc/require-returns-type': 'error',
-			'jsdoc/check-syntax': 'error',
-			'jsdoc/require-description': 'error',
-			'jsdoc/require-jsdoc': 'error',
 		},
 	},
 ];


### PR DESCRIPTION
See https://core.trac.wordpress.org/ticket/66033

- Enables the `jsdoc/require-param-name` JSDoc rule.
- Sorts rules alphabetically.

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
