### PR TITLE
Database: Send a 500 status and no-cache headers when using db-error.php or maintenance.php drop-ins

### DIFF
--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -436,7 +436,7 @@ class WP_Block {
 	}
 
 	private static function get_block_bindings_processor( string $block_content ) {
-		$internal_processor_class = new class('', WP_HTML_Processor::CONSTRUCTOR_UNLOCK_CODE) extends WP_HTML_Processor {
+		$internal_processor_class = new class( '', WP_HTML_Processor::CONSTRUCTOR_UNLOCK_CODE ) extends WP_HTML_Processor {
 			/**
 			 * Replace the rich text content between a tag opener and matching closer.
 			 *

--- a/src/wp-includes/class-wpdb.php
+++ b/src/wp-includes/class-wpdb.php
@@ -1958,6 +1958,8 @@ class wpdb {
 	 *
 	 * @since 3.0.0
 	 * @since 3.9.0 $allow_bail parameter added.
+	 * @since 7.2.0 A 500 status header and no-cache headers are now sent
+	 *              before loading a custom db-error.php drop-in.
 	 *
 	 * @param bool $allow_bail Optional. Allows the function to bail. Default true.
 	 * @return bool True with a successful connection, false on failure.
@@ -2009,8 +2011,13 @@ class wpdb {
 		if ( ! $this->dbh && $allow_bail ) {
 			wp_load_translations_early();
 
-			// Load custom DB error template, if present.
+			/**
+			 * Load custom DB error template, if present.
+			 * A 500 status header and no-cache headers are now sent before loading a custom db-error.php drop-in.
+			*/
 			if ( file_exists( WP_CONTENT_DIR . '/db-error.php' ) ) {
+				status_header( 500 );
+				nocache_headers();
 				require_once WP_CONTENT_DIR . '/db-error.php';
 				die();
 			}

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -5634,6 +5634,8 @@ function wp_ob_end_flush_all() {
  * in WordPress 2.5.0.
  *
  * @since 2.3.2
+ * @since 7.2.0 A 500 status header and no-cache headers are now sent
+ *              before loading a custom db-error.php drop-in.
  *
  * @global wpdb $wpdb WordPress database abstraction object.
  *
@@ -5646,6 +5648,8 @@ function dead_db() {
 
 	// Load custom DB error template, if present.
 	if ( file_exists( WP_CONTENT_DIR . '/db-error.php' ) ) {
+		status_header( 500 );
+		nocache_headers();
 		require_once WP_CONTENT_DIR . '/db-error.php';
 		die();
 	}

--- a/src/wp-includes/load.php
+++ b/src/wp-includes/load.php
@@ -395,6 +395,8 @@ function wp_favicon_request() {
  * the wp-content directory).
  *
  * @since 3.0.0
+ * @since 7.2.0 A 503 status header and no-cache headers are now sent before loading maintenance.php drop-in.
+ *              This is to ensure that the correct headers are sent.
  * @access private
  */
 function wp_maintenance() {
@@ -404,6 +406,9 @@ function wp_maintenance() {
 	}
 
 	if ( file_exists( WP_CONTENT_DIR . '/maintenance.php' ) ) {
+		status_header( 503 );
+		nocache_headers();
+		header( 'Retry-After: 600' );
 		require_once WP_CONTENT_DIR . '/maintenance.php';
 		die();
 	}

--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -3802,11 +3802,11 @@ function wp_customize_support_script() {
 		(function() {
 			var request, b = document.body, c = 'className', cs = 'customize-support', rcs = new RegExp('(^|\\s+)(no-)?'+cs+'(\\s+|$)');
 
-	<?php	if ( $cross_domain ) : ?>
+	<?php if ( $cross_domain ) : ?>
 			request = (function(){ var xhr = new XMLHttpRequest(); return ('withCredentials' in xhr); })();
-	<?php	else : ?>
+	<?php else : ?>
 			request = true;
-	<?php	endif; ?>
+	<?php endif; ?>
 
 			b[c] = b[c].replace( rcs, ' ' );
 			// The customizer requires postMessage and CORS (if the site is cross domain).

--- a/tests/phpunit/tests/html-api/wpHtmlProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessor.php
@@ -557,7 +557,7 @@ class Tests_HtmlApi_WpHtmlProcessor extends WP_UnitTestCase {
 		$processor = WP_HTML_Processor::create_fragment( '' );
 		$this->assertInstanceOf( WP_HTML_Processor::class, $processor, '::create_fragment did not return class instance.' );
 
-		$subclass_instance = new class('') extends WP_HTML_Processor {
+		$subclass_instance = new class( '' ) extends WP_HTML_Processor {
 			public function __construct( $html ) {
 				parent::__construct( $html, parent::CONSTRUCTOR_UNLOCK_CODE );
 			}

--- a/tests/phpunit/tests/html-api/wpHtmlProcessorMetaTag.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorMetaTag.php
@@ -35,7 +35,7 @@ class Tests_HtmlApi_WpHtmlProcessorMetaTag extends WP_UnitTestCase {
 	 */
 	public function test_supported_meta_tag( string $html ) {
 		$html      = '<!DOCTYPE html>' . $html;
-		$processor = new class($html) extends WP_HTML_Processor {
+		$processor = new class( $html ) extends WP_HTML_Processor {
 			public function __construct( $html ) {
 				parent::__construct( $html, parent::CONSTRUCTOR_UNLOCK_CODE );
 			}
@@ -65,7 +65,7 @@ class Tests_HtmlApi_WpHtmlProcessorMetaTag extends WP_UnitTestCase {
 	 */
 	public function test_unsupported_meta_tags( string $html, string $unsupported_message ) {
 		$html      = '<!DOCTYPE html>' . $html;
-		$processor = new class($html) extends WP_HTML_Processor {
+		$processor = new class( $html ) extends WP_HTML_Processor {
 			public function __construct( $html ) {
 				parent::__construct( $html, parent::CONSTRUCTOR_UNLOCK_CODE );
 			}


### PR DESCRIPTION
Due to an PHPCS error in PR: #13471, creating a new PR after fixing the errors using phpcbf

Trac ticket: https://core.trac.wordpress.org/ticket/66080

Opened from the WordPress Contributor Toolkit.