### PR TITLE
Docs: Use the `bool` and `int` short forms in docblocks.

### DIFF
--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -3009,12 +3009,12 @@ class WP_Theme_JSON {
 	 * @since 6.6.0 Pass current theme JSON settings to wp_get_typography_font_size_value(), and process background properties.
 	 * @since 6.7.0 `ref` resolution of background properties, and assigning custom default values.
 	 *
-	 * @param array   $styles           Styles to process.
-	 * @param array   $settings         Theme settings.
-	 * @param array   $properties       Properties metadata.
-	 * @param array   $theme_json       Theme JSON array.
-	 * @param string  $selector         The style block selector.
-	 * @param boolean $use_root_padding Whether to add custom properties at root level.
+	 * @param array  $styles           Styles to process.
+	 * @param array  $settings         Theme settings.
+	 * @param array  $properties       Properties metadata.
+	 * @param array  $theme_json       Theme JSON array.
+	 * @param string $selector         The style block selector.
+	 * @param bool   $use_root_padding Whether to add custom properties at root level.
 	 * @return array Returns the modified $declarations.
 	 */
 	protected static function compute_style_properties( $styles, $settings = array(), $properties = null, $theme_json = null, $selector = null, $use_root_padding = null ) {

--- a/src/wp-includes/global-styles-and-settings.php
+++ b/src/wp-includes/global-styles-and-settings.php
@@ -497,7 +497,7 @@ function wp_get_theme_data_template_parts() {
  *
  * @param WP_Block_Type $block_type The block's type.
  * @param string|array  $target     The desired selector's target, `root` or array path.
- * @param boolean       $fallback   Whether to fall back to broader selector.
+ * @param bool          $fallback   Whether to fall back to broader selector.
  * @return string|null CSS selector or `null` if no selector available.
  */
 function wp_get_block_css_selector( $block_type, $target = 'root', $fallback = false ) {

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -2789,7 +2789,7 @@ class WP_HTML_Tag_Processor {
 	 * @ignore
 	 *
 	 * @param string $comparable_name The attribute name in its comparable form.
-	 * @return string|boolean|null Value of enqueued update if present, otherwise false.
+	 * @return string|bool|null Value of enqueued update if present, otherwise false.
 	 */
 	private function get_enqueued_attribute_value( string $comparable_name ) {
 		if ( self::STATE_MATCHED_TAG !== $this->parser_state ) {

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -2120,7 +2120,7 @@ function wp_img_tag_add_auto_sizes( string $image ): string {
 	 *
 	 * @since 6.7.1
 	 *
-	 * @param boolean $enabled Whether auto-sizes for lazy loaded images is enabled.
+	 * @param bool $enabled Whether auto-sizes for lazy loaded images is enabled.
 	 */
 	if ( ! apply_filters( 'wp_img_tag_add_auto_sizes', true ) ) {
 		return $image;

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-global-styles-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-global-styles-controller.php
@@ -386,7 +386,7 @@ class WP_REST_Global_Styles_Controller extends WP_REST_Posts_Controller {
 	 * @since 5.9.0
 	 * @since 6.3.0 Adds revisions count and rest URL href to version-history.
 	 *
-	 * @param integer $id ID.
+	 * @param int $id ID.
 	 * @return array Links for the given post.
 	 */
 	protected function prepare_links( $id ) {

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
@@ -967,7 +967,7 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 	 *
 	 * @since 5.8.0
 	 *
-	 * @param integer $id ID.
+	 * @param int $id ID.
 	 * @return array Links for the given post.
 	 */
 	protected function prepare_links( $id ) {


### PR DESCRIPTION
✅ Committed in r63596 (2a616e3e7cd70b40f718ff0ebaba3fadccf00587).

----
Trac ticket: https://core.trac.wordpress.org/ticket/65860

### Why this change?

The [PHP inline documentation standards](https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/) state, in the `@param`, `@return` and `@global` sections:

> For boolean and integer types, use `bool` and `int`, respectively.

Six docblocks in core code still used the long forms. This brings them in line.

| File | Tag |
| --- | --- |
| `wp-includes/class-wp-theme-json.php` | `@param boolean $use_root_padding` |
| `wp-includes/global-styles-and-settings.php` | `@param boolean $fallback` |
| `wp-includes/html-api/class-wp-html-tag-processor.php` | `@return string\|boolean\|null` |
| `wp-includes/media.php` | `@param boolean $enabled` |
| `wp-includes/rest-api/endpoints/class-wp-rest-global-styles-controller.php` | `@param integer $id` |
| `wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php` | `@param integer $id` |

### Notes on scope

**Parameter columns are realigned where needed.** In `class-wp-theme-json.php`, shortening `boolean` makes `string` the longest type in that block, so the whole `@param` column shifts left by one to stay aligned. That is why the file shows six changed lines rather than one.

**Bundled third-party libraries are left untouched.** Services_JSON (`wp-includes/class-json.php`) alone has four more instances, but core does not take style changes to vendored code.

**The prose in `class-wp-html-tag-processor.php` is left alone.** The description above the tag reads "If an update is enqueued and is boolean, the return will be `true`". That is English describing a value, not a type declaration, so the standard does not apply to it.

After this change, `src/` has no remaining `boolean` or `integer` types in core PHP docblocks.

### Testing

- `php -l` clean on all six files.
- `phpcs --standard=phpcs.xml.dist` reports 0 errors on all six files. There is one pre-existing warning at `media.php:5723` (`WordPress.DB.PreparedSQL.NotPrepared`), unrelated to this change and ~3,600 lines away from it; I confirmed it is present on trunk without this patch.

Documentation only, no behaviour change, so no test changes are needed.

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Scanning `src/` for the long-form types, which is how these six were found, applying the substitutions and column realignment, and drafting this description. I checked each site against the current file, confirmed the third-party exclusions, verified the pre-existing phpcs warning is present on trunk without this patch, confirmed no open pull request already touches these docblocks, ran `php -l` and `phpcs`, and I take responsibility for the result.

