### PR TITLE
Query block: Keep the block's style handle enqueued when enhanced pagination is off

### DIFF
--- a/src/wp-includes/blocks/query.php
+++ b/src/wp-includes/blocks/query.php
@@ -10,13 +10,12 @@
  *
  * @since 6.4.0
  *
- * @param array    $attributes Block attributes.
- * @param string   $content    Block default content.
- * @param WP_Block $block      The block instance.
+ * @param array  $attributes Block attributes.
+ * @param string $content    Block default content.
  *
  * @return string Returns the modified output of the query block.
  */
-function render_block_core_query( $attributes, $content, $block ) {
+function render_block_core_query( $attributes, $content ) {
 	$is_interactive = isset( $attributes['enhancedPagination'] )
 		&& true === $attributes['enhancedPagination']
 		&& isset( $attributes['queryId'] )
@@ -35,21 +34,6 @@ function render_block_core_query( $attributes, $content, $block ) {
 			$p->set_attribute( 'data-wp-context', '{}' );
 			$p->set_attribute( 'data-wp-key', $attributes['queryId'] );
 			$content = $p->get_updated_html();
-		}
-	}
-
-	// Add the styles to the block type if the block is interactive and remove
-	// them if it's not.
-	$style_asset = 'wp-block-query';
-	if ( ! wp_style_is( $style_asset ) ) {
-		$style_handles = $block->block_type->style_handles;
-		// If the styles are not needed, and they are still in the `style_handles`, remove them.
-		if ( ! $is_interactive && in_array( $style_asset, $style_handles, true ) ) {
-			$block->block_type->style_handles = array_diff( $style_handles, array( $style_asset ) );
-		}
-		// If the styles are needed, but they were previously removed, add them again.
-		if ( $is_interactive && ! in_array( $style_asset, $style_handles, true ) ) {
-			$block->block_type->style_handles = array_merge( $style_handles, array( $style_asset ) );
 		}
 	}
 

--- a/tests/phpunit/tests/blocks/renderQuery.php
+++ b/tests/phpunit/tests/blocks/renderQuery.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Tests for the Query block rendering.
+ *
+ * @package WordPress
+ * @subpackage Blocks
+ *
+ * @since 7.2.0
+ *
+ * @group blocks
+ *
+ * @covers ::render_block_core_query
+ */
+class Tests_Blocks_RenderQuery extends WP_UnitTestCase {
+
+	/**
+	 * @var WP_Styles|null
+	 */
+	private $original_wp_styles;
+
+	public function set_up() {
+		parent::set_up();
+
+		global $wp_styles;
+		$this->original_wp_styles = $wp_styles;
+		$wp_styles                = null;
+		wp_styles();
+	}
+
+	public function tear_down() {
+		global $wp_styles;
+		$wp_styles = $this->original_wp_styles;
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Tests that rendering the block enqueues its style handle regardless of
+	 * the enhanced pagination setting, so that the `theme.json` styles for the
+	 * block are added by `wp_add_global_styles_for_blocks()`.
+	 *
+	 * @dataProvider data_rendering_query_enqueues_style_handle
+	 *
+	 * @param string $block_attributes JSON encoded block attributes.
+	 */
+	public function test_rendering_query_enqueues_style_handle( $block_attributes ) {
+		/*
+		 * The block ships no front end stylesheet, so its handle is registered
+		 * without a source when the block type is registered.
+		 */
+		wp_register_style( 'wp-block-query', false );
+
+		do_blocks( "<!-- wp:query $block_attributes --><div class=\"wp-block-query\"></div><!-- /wp:query -->" );
+
+		$this->assertTrue( wp_style_is( 'wp-block-query' ) );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_rendering_query_enqueues_style_handle() {
+		return array(
+			'enhanced pagination disabled' => array( '{"queryId":0,"query":{"inherit":true}}' ),
+			'enhanced pagination enabled'  => array( '{"queryId":0,"query":{"inherit":true},"enhancedPagination":true}' ),
+		);
+	}
+}


### PR DESCRIPTION
Fixes the `theme.json` styles for the Query block (`styles.blocks.core/query`) not being applied on the front end when "Reload full page" is enabled, which is the default.

`wp_add_global_styles_for_blocks()` only adds the styles of a core block when its `wp-block-query` handle is in the styles queue, but `render_block_core_query()` removed that handle from the block type whenever enhanced pagination was disabled. That code is a leftover from when the block had a front end stylesheet, removed in WordPress 6.5, so it is removed here and the handle is enqueued whenever the block renders, like for any other block.

Backport of https://github.com/WordPress/gutenberg/pull/82745.

Trac ticket: TBD

## Use of AI Tools

AI assistance: Yes
Used for: drafting the fix, the test and this description; reviewed and edited by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
