### PR TITLE
Embed: Update oEmbed regex for ReverbNation to support legacy subdomain

### DIFF
--- a/src/wp-includes/class-wp-oembed.php
+++ b/src/wp-includes/class-wp-oembed.php
@@ -88,7 +88,7 @@ class WP_oEmbed {
 			'#https?://(www\.)?kickstarter\.com/projects/.*#i' => array( 'https://www.kickstarter.com/services/oembed', true ),
 			'#https?://kck\.st/.*#i'                       => array( 'https://www.kickstarter.com/services/oembed', true ),
 			'#https?://cloudup\.com/.*#i'                  => array( 'https://cloudup.com/oembed', true ),
-			'#https?://(www\.)?reverbnation\.com/.*#i'     => array( 'https://www.reverbnation.com/oembed', true ),
+			'#https?://((legacy|www)\.)?reverbnation\.com/.*#i' => array( 'https://legacy.reverbnation.com/oembed', true ),
 			'#https?://videopress\.com/v/.*#'              => array( 'https://public-api.wordpress.com/oembed/?for=' . $host, true ),
 			'#https?://(www\.)?reddit\.com/r/[^/]+/comments/.*#i' => array( 'https://www.reddit.com/oembed', true ),
 			'#https?://(www\.)?speakerdeck\.com/.*#i'      => array( 'https://speakerdeck.com/oembed.{format}', true ),


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/66079

## What, Why, and How?

ReverbNation moved their site and oEmbed API to `legacy.reverbnation.com`. The old `www` endpoint 404s and never redirects, so artist and song URLs stop embedding with the old URL. `www` pages still redirect to `legacy`, however, our matcher only allowed `www`, so a pasted `legacy` link never used the sanctioned provider. Legacy URLs didn't match the provider array, so they fell through to discovery via the page’s `oEmbed <link>` tags.

This PR updates the provider row: point the endpoint at `legacy.reverbnation.com/oembed`, and match both `www` and `legacy` so either hostname uses that API as a provider instead of discovery. 

## Screencast

https://github.com/user-attachments/assets/c34aa9bf-8f87-4233-bd1d-1e5eb789754c

## Use of AI Tools

AI assistance: Yes
Tool(s): Codex
Model(s): GPT-6 Astra
Used for: Validating the regex and running discovery on oEmbed endpoints for artists, songs, albums, and collections.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
