### PR TITLE
Docs: Explain why `array_last()` is not used in `WP_Block_Parser::add_inner_block()`

### DIFF
--- a/src/wp-includes/class-wp-block-parser.php
+++ b/src/wp-includes/class-wp-block-parser.php
@@ -342,7 +342,7 @@ class WP_Block_Parser {
 	 * @param int|null              $last_offset  Last byte offset into document if continuing form earlier output.
 	 */
 	public function add_inner_block( WP_Block_Parser_Block $block, $token_start, $token_length, $last_offset = null ) {
-		$parent                       = $this->stack[ array_key_last( $this->stack ) ];
+		$parent                       = array_last( $this->stack );
 		$parent->block->innerBlocks[] = (array) $block;
 		$html                         = substr( $this->document, $parent->prev_offset, $token_start - $parent->prev_offset );
 


### PR DESCRIPTION
✅ Committed in r63624 (9d41f18fbd0badd500ddbcfabfa6bcf6d2413107).

----
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->
Trac ticket: https://core.trac.wordpress.org/ticket/65818

Adds an inline comment in `WP_Block_Parser::add_inner_block()` explaining why `$this->stack[ array_key_last( $this->stack ) ]` is used instead of `array_last()`.

### Background

This PR originally swapped that expression for `array_last()`. As noted in review by @Soean and @westonruter, the same change was made and then reverted in 3dba2c62c7babd5057fa85fc6dd7f597be389f6d (#12417), because:

- `array_last()` returns `null` for an empty array, which reintroduces a PHPStan error above rule level 5 on the property accesses that follow.
- Guarding the return value would change behavior. Both call sites already return early when the stack is empty, so the guard would be unreachable from core, and `add_inner_block()` is a public method on a class that can be replaced via the `block_parser_class` filter.
- Adding a `@throws` tag for an exception that can never be thrown would flag callers for not wrapping the call in `try`/`catch`.

Indexing with `array_key_last()` keeps the readability improvement without introducing a nullable into the expression. The comment documents that reasoning so the change is not proposed again.

The PR has been updated accordingly: it no longer changes any code, only adds the comment.

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Drafting the inline comment wording and this description. Reviewed and verified by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**


