### PR TITLE
Users: Require confirmation for email changes made outside the profile screen

### DIFF
--- a/src/wp-admin/user-edit.php
+++ b/src/wp-admin/user-edit.php
@@ -106,7 +106,7 @@ if ( is_multisite()
 
 // Execute confirmed email change. See send_confirmation_on_profile_email().
 if ( IS_PROFILE_PAGE && isset( $_GET['newuseremail'] ) && $current_user->ID ) {
-	if ( send_user_email_change_confirmation_process( $current_user->ID, $_GET['newuseremail'] ) ) {
+	if ( confirm_user_email_change( $current_user->ID, $_GET['newuseremail'] ) ) {
 		wp_redirect( add_query_arg( array( 'updated' => 'true' ), self_admin_url( 'profile.php' ) ) );
 	} else {
 		wp_redirect( add_query_arg( array( 'error' => 'new-email' ), self_admin_url( 'profile.php' ) ) );

--- a/src/wp-admin/user-edit.php
+++ b/src/wp-admin/user-edit.php
@@ -106,21 +106,12 @@ if ( is_multisite()
 
 // Execute confirmed email change. See send_confirmation_on_profile_email().
 if ( IS_PROFILE_PAGE && isset( $_GET['newuseremail'] ) && $current_user->ID ) {
-	$new_email = get_user_meta( $current_user->ID, '_new_email', true );
-	if ( $new_email && hash_equals( $new_email['hash'], $_GET['newuseremail'] ) ) {
-		$user             = new stdClass();
-		$user->ID         = $current_user->ID;
-		$user->user_email = esc_html( trim( $new_email['newemail'] ) );
-		if ( is_multisite() && $wpdb->get_var( $wpdb->prepare( "SELECT user_login FROM {$wpdb->signups} WHERE user_login = %s", $current_user->user_login ) ) ) {
-			$wpdb->query( $wpdb->prepare( "UPDATE {$wpdb->signups} SET user_email = %s WHERE user_login = %s", $user->user_email, $current_user->user_login ) );
-		}
-		wp_update_user( $user );
-		delete_user_meta( $current_user->ID, '_new_email' );
+	if ( send_user_email_change_confirmation_process( $current_user->ID, $_GET['newuseremail'] ) ) {
 		wp_redirect( add_query_arg( array( 'updated' => 'true' ), self_admin_url( 'profile.php' ) ) );
-		die();
 	} else {
 		wp_redirect( add_query_arg( array( 'error' => 'new-email' ), self_admin_url( 'profile.php' ) ) );
 	}
+	die();
 } elseif ( IS_PROFILE_PAGE && ! empty( $_GET['dismiss'] ) && $current_user->ID . '_new_email' === $_GET['dismiss'] ) {
 	check_admin_referer( 'dismiss-' . $current_user->ID . '_new_email' );
 	delete_user_meta( $current_user->ID, '_new_email' );

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
@@ -806,6 +806,14 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 			}
 		}
 
+		// Maybe send the change email confirmation.
+		if ( ! empty( $request['email'] ) ) {
+			$email_sent = send_user_email_change_confirmation_email( $user, $request['email'] );
+			if ( true === $email_sent ) {
+				unset( $request['email'] );
+			}
+		}
+
 		$user = $this->prepare_item_for_database( $request );
 
 		// Ensure we're operating on the same user we already checked.

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
@@ -806,9 +806,22 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 			}
 		}
 
-		// Maybe send the change email confirmation.
-		if ( ! empty( $request['email'] ) ) {
+		/*
+		 * Ask a user to confirm a change to their own email address, rather than
+		 * applying it immediately, as the profile screen does. The change is held
+		 * in the `_new_email` user meta until it is confirmed.
+		 */
+		if ( is_string( $request['email'] ) && '' !== $request['email'] ) {
 			$email_sent = send_user_email_change_confirmation_email( $user, $request['email'] );
+
+			if ( is_wp_error( $email_sent ) ) {
+				return new WP_Error(
+					'rest_user_invalid_email',
+					__( 'Invalid email address.' ),
+					array( 'status' => 400 )
+				);
+			}
+
 			if ( true === $email_sent ) {
 				unset( $request['email'] );
 			}

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -3929,7 +3929,7 @@ function send_confirmation_on_profile_email( $user_id = 0 ) {
  */
 function send_user_email_change_confirmation_email( $user, $email ) {
 	if ( ! $user instanceof WP_User || ! $user->exists() ) {
-		return;
+		return null;
 	}
 
 	/*
@@ -3938,7 +3938,7 @@ function send_user_email_change_confirmation_email( $user, $email ) {
 	 * that is already in use. See #44672.
 	 */
 	if ( 0 === strcasecmp( $user->user_email, $email ) ) {
-		return;
+		return null;
 	}
 
 	if ( ! is_email( $email ) ) {
@@ -3973,7 +3973,7 @@ function send_user_email_change_confirmation_email( $user, $email ) {
 	$should_send_email_for_change = apply_filters( 'should_send_email_for_email_change', $should_send_email_for_change, $user, $email );
 
 	if ( ! $should_send_email_for_change ) {
-		return;
+		return null;
 	}
 
 	$hash           = md5( $email . time() . wp_rand() );

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -3932,7 +3932,12 @@ function send_user_email_change_confirmation_email( $user, $email ) {
 		return;
 	}
 
-	if ( $user->user_email === $email ) {
+	/*
+	 * Correcting the case of an address is the same mailbox, so it is not a change
+	 * that needs confirming, and `email_exists()` below would read it as an address
+	 * that is already in use. See #44672.
+	 */
+	if ( 0 === strcasecmp( $user->user_email, $email ) ) {
 		return;
 	}
 

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -4029,19 +4029,32 @@ All at ###SITENAME###
  *
  * @since x.x
  *
+ * @global wpdb $wpdb WordPress database abstraction object.
+ *
  * @param int    $user_id    The User ID being acted upon.
  * @param string $email_hash The email hash of the request
  *
  * @return bool Whether or not the change succeeded.
  */
 function send_user_email_change_confirmation_process( $user_id, $email_hash ) {
+	global $wpdb;
 
-	$new_email = get_user_meta( $user_id, '_new_email', true );
-	if ( ! $new_email || ! hash_equals( $new_email['hash'], $email_hash ) ) {
+	$the_user = get_userdata( $user_id );
+
+	if ( ! $the_user ) {
 		return false;
 	}
 
-	$the_user         = get_user_by( 'id', $user_id );
+	$new_email = get_user_meta( $the_user->ID, '_new_email', true );
+
+	if ( ! is_array( $new_email ) || empty( $new_email['hash'] ) || empty( $new_email['newemail'] ) ) {
+		return false;
+	}
+
+	if ( ! hash_equals( $new_email['hash'], (string) $email_hash ) ) {
+		return false;
+	}
+
 	$user             = new stdClass();
 	$user->ID         = $the_user->ID;
 	$user->user_email = esc_html( trim( $new_email['newemail'] ) );
@@ -4049,7 +4062,11 @@ function send_user_email_change_confirmation_process( $user_id, $email_hash ) {
 		$wpdb->query( $wpdb->prepare( "UPDATE {$wpdb->signups} SET user_email = %s WHERE user_login = %s", $user->user_email, $the_user->user_login ) );
 	}
 
-	wp_update_user( $user );
+	$updated = wp_update_user( $user );
+
+	if ( is_wp_error( $updated ) ) {
+		return false;
+	}
 
 	delete_user_meta( $user->ID, '_new_email' );
 

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -3910,13 +3910,22 @@ function send_confirmation_on_profile_email( $user_id = 0 ) {
 }
 
 /**
- * Send the 'confirm your email' email.
+ * Sends a confirmation request email when a change of user email address is attempted.
  *
- * @since x.x
+ * The new address is held in the `_new_email` user meta until the user confirms it
+ * by following the link in the email. The address on the account is unchanged
+ * until then.
  *
- * @param WP_User $user  The user to act upon.
+ * A confirmation is only required when a user changes their own email address. An
+ * administrator changing somebody else's address is not asked to confirm it.
+ *
+ * @since 7.2.0
+ *
+ * @param WP_User $user  The user whose email address is being changed.
  * @param string  $email The new email address.
- * @return null|true|WP_Error true if email sent, WP_Error on error, and null otherwise.
+ * @return true|WP_Error|null True if a confirmation email was sent and the change should not be
+ *                            applied yet, WP_Error if the address was rejected, null if no
+ *                            confirmation is needed and the change may be applied.
  */
 function send_user_email_change_confirmation_email( $user, $email ) {
 	if ( ! $user instanceof WP_User || ! $user->exists() ) {
@@ -3950,7 +3959,7 @@ function send_user_email_change_confirmation_email( $user, $email ) {
 	 * Filters whether a 'confirm your email address' email should be sent.
 	 * If false is returned, the change is made immediately.
 	 *
-	 * @since x.x
+	 * @since 7.2.0
 	 *
 	 * @param bool    $should_send_email_for_change Whether to use an email confirmation.
 	 * @param WP_User $user                         The user having their email changed.
@@ -4036,18 +4045,17 @@ All at ###SITENAME###
 }
 
 /**
- * Process the confirmation of an email change request.
+ * Applies a pending email address change once the user has confirmed it.
  *
- * @since x.x
+ * @since 7.2.0
  *
  * @global wpdb $wpdb WordPress database abstraction object.
  *
- * @param int    $user_id    The User ID being acted upon.
- * @param string $email_hash The email hash of the request
- *
- * @return bool Whether or not the change succeeded.
+ * @param int    $user_id    The ID of the user whose email address is being changed.
+ * @param string $email_hash The confirmation hash from the link in the confirmation email.
+ * @return bool Whether the email address was changed.
  */
-function send_user_email_change_confirmation_process( $user_id, $email_hash ) {
+function confirm_user_email_change( $user_id, $email_hash ) {
 	global $wpdb;
 
 	$the_user = get_userdata( $user_id );
@@ -4080,6 +4088,15 @@ function send_user_email_change_confirmation_process( $user_id, $email_hash ) {
 	}
 
 	delete_user_meta( $user->ID, '_new_email' );
+
+	/**
+	 * Fires after a user has confirmed a change to their email address.
+	 *
+	 * @since 7.2.0
+	 *
+	 * @param int $user_id The ID of the user whose email address was changed.
+	 */
+	do_action( 'user_email_confirmed', $user->ID );
 
 	return true;
 }

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -3877,55 +3877,101 @@ function send_confirmation_on_profile_email( $user_id = 0 ) {
 		$user_id = absint( $_POST['user_id'] );
 	}
 
-	$current_user = wp_get_current_user();
 	if ( ! is_object( $errors ) ) {
 		$errors = new WP_Error();
 	}
 
-	if ( 0 === $current_user->ID || $current_user->ID !== (int) $user_id ) {
-		return false;
+	$user       = get_user_by( 'id', $user_id );
+	$email_sent = send_user_email_change_confirmation_email( $user, $_POST['email'] );
+
+	if ( is_wp_error( $email_sent ) ) {
+		// WP_Error::copy_errors() with the addition of adding data.
+		foreach ( $email_sent->get_error_codes() as $code ) {
+			$errors->add(
+				$code,
+				$email_sent->get_error_message( $code ),
+				array(
+					'form-field' => 'email',
+				)
+			);
+		}
 	}
 
-	if ( $current_user->user_email !== $_POST['email'] ) {
-		if ( ! is_email( $_POST['email'] ) ) {
-			$errors->add(
-				'user_email',
-				__( '<strong>Error:</strong> The email address is not correct.' ),
-				array(
-					'form-field' => 'email',
-				)
-			);
+	if ( true === $email_sent ) {
+		$_POST['email'] = $user->user_email;
+	}
+}
 
-			$_POST['email'] = addslashes( $current_user->user_email );
-			return;
-		}
+/**
+ * Send the 'confirm your email' email.
+ *
+ * @since x.x
+ *
+ * @param WP_User $user  The user to act upon.
+ * @param string  $email The new email address.
+ * @return null|true|WP_Error true if email sent, WP_Error on error, and null otherwise.
+ */
+function send_user_email_change_confirmation_email( $user, $email ) {
+	if ( $user->user_email == $email ) {
+		return;
+	}
 
-		if ( email_exists( $_POST['email'] ) ) {
-			$errors->add(
-				'user_email',
-				__( '<strong>Error:</strong> The email address is already used.' ),
-				array(
-					'form-field' => 'email',
-				)
-			);
-			delete_user_meta( $current_user->ID, '_new_email' );
-
-			$_POST['email'] = addslashes( $current_user->user_email );
-			return;
-		}
-
-		$hash           = md5( $_POST['email'] . time() . wp_rand() );
-		$new_user_email = array(
-			'hash'     => $hash,
-			'newemail' => $_POST['email'],
+	if ( ! is_email( $email ) ) {
+		return new WP_Error(
+			'user_email',
+			__( '<strong>Error:</strong> The email address is not correct.' )
 		);
-		update_user_meta( $current_user->ID, '_new_email', $new_user_email );
+	}
 
-		$sitename = wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES );
+	if ( email_exists( $email ) ) {
+		delete_user_meta( $user->ID, '_new_email' );
 
-		/* translators: Do not translate USERNAME, ADMIN_URL, EMAIL, SITENAME, SITEURL: those are placeholders. */
-		$email_text = __(
-			'Howdy ###USERNAME###,
+		return new WP_Error(
+			'user_email',
+			__( '<strong>Error:</strong> The email address is already used.' )
+		);
+	}
+
+	// The email is only sent if a user changes their own email.
+	$should_send_email_for_change = ( get_current_user_id() === $user->ID );
+
+	/**
+	 * Filters whether a 'confirm your email address' email should be sent.
+	 * If false is returned, the change is made immediately.
+	 *
+	 * @since x.x
+	 *
+	 * @param bool    $should_send_email_for_change Whether to use an email confirmation.
+	 * @param WP_User $user                         The user having their email changed.
+	 * @param string  $email                        The new email address.
+	 */
+	$should_send_email_for_change = apply_filters( 'should_send_email_for_email_change', $should_send_email_for_change, $user, $email );
+
+	if ( ! $should_send_email_for_change ) {
+		return;
+	}
+
+	$hash           = md5( $email . time() . wp_rand() );
+	$new_user_email = array(
+		'hash'     => $hash,
+		'newemail' => $email,
+	);
+	update_user_meta( $user->ID, '_new_email', $new_user_email );
+
+	$confirm_url = add_query_arg(
+		array(
+			'action' => 'confirmemail',
+			'id'     => $user->ID,
+			'hash'   => $hash,
+		),
+		wp_login_url()
+	);
+
+	$sitename = wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES );
+
+	/* translators: Do not translate USERNAME, ADMIN_URL, EMAIL, SITENAME, SITEURL: those are placeholders. */
+	$email_text = __(
+		'Howdy ###USERNAME###,
 
 You recently requested to have the email address on your account changed.
 
@@ -3940,43 +3986,74 @@ This email has been sent to ###EMAIL###
 Regards,
 All at ###SITENAME###
 ###SITEURL###'
-		);
+	);
 
-		/**
-		 * Filters the text of the email sent when a change of user email address is attempted.
-		 *
-		 * The following strings have a special meaning and will get replaced dynamically:
-		 *
-		 *  - `###USERNAME###`  The current user's username.
-		 *  - `###ADMIN_URL###` The link to click on to confirm the email change.
-		 *  - `###EMAIL###`     The new email.
-		 *  - `###SITENAME###`  The name of the site.
-		 *  - `###SITEURL###`   The URL to the site.
-		 *
-		 * @since MU (3.0.0)
-		 * @since 4.9.0 This filter is no longer Multisite specific.
-		 *
-		 * @param string $email_text     Text in the email.
-		 * @param array  $new_user_email {
-		 *     Data relating to the new user email address.
-		 *
-		 *     @type string $hash     The secure hash used in the confirmation link URL.
-		 *     @type string $newemail The proposed new email address.
-		 * }
-		 */
-		$content = apply_filters( 'new_user_email_content', $email_text, $new_user_email );
+	/**
+	 * Filters the text of the email sent when a change of user email address is attempted.
+	 *
+	 * The following strings have a special meaning and will get replaced dynamically:
+	 *
+	 *  - `###USERNAME###`  The current user's username.
+	 *  - `###ADMIN_URL###` The link to click on to confirm the email change.
+	 *  - `###EMAIL###`     The new email.
+	 *  - `###SITENAME###`  The name of the site.
+	 *  - `###SITEURL###`   The URL to the site.
+	 *
+	 * @since MU (3.0.0)
+	 * @since 4.9.0 This filter is no longer Multisite specific.
+	 *
+	 * @param string $email_text     Text in the email.
+	 * @param array  $new_user_email {
+	 *     Data relating to the new user email address.
+	 *
+	 *     @type string $hash     The secure hash used in the confirmation link URL.
+	 *     @type string $newemail The proposed new email address.
+	 * }
+	 */
+	$content = apply_filters( 'new_user_email_content', $email_text, $new_user_email );
 
-		$content = str_replace( '###USERNAME###', $current_user->user_login, $content );
-		$content = str_replace( '###ADMIN_URL###', esc_url( self_admin_url( 'profile.php?newuseremail=' . $hash ) ), $content );
-		$content = str_replace( '###EMAIL###', $_POST['email'], $content );
-		$content = str_replace( '###SITENAME###', $sitename, $content );
-		$content = str_replace( '###SITEURL###', home_url(), $content );
+	$content = str_replace( '###USERNAME###', $user->user_login, $content );
+	$content = str_replace( '###ADMIN_URL###', esc_url( $confirm_url ), $content );
+	$content = str_replace( '###EMAIL###', $email, $content );
+	$content = str_replace( '###SITENAME###', $sitename, $content );
+	$content = str_replace( '###SITEURL###', home_url(), $content );
 
-		/* translators: New email address notification email subject. %s: Site title. */
-		wp_mail( $_POST['email'], sprintf( __( '[%s] Email Change Request' ), $sitename ), $content );
+	/* translators: New email address notification email subject. %s: Site title. */
+	wp_mail( $email, sprintf( __( '[%s] Email Change Request' ), $sitename ), $content );
 
-		$_POST['email'] = $current_user->user_email;
+	return true;
+}
+
+/**
+ * Process the confirmation of an email change request.
+ *
+ * @since x.x
+ *
+ * @param int    $user_id    The User ID being acted upon.
+ * @param string $email_hash The email hash of the request
+ *
+ * @return bool Whether or not the change succeeded.
+ */
+function send_user_email_change_confirmation_process( $user_id, $email_hash ) {
+
+	$new_email = get_user_meta( $user_id, '_new_email', true );
+	if ( ! $new_email || ! hash_equals( $new_email['hash'], $email_hash ) ) {
+		return false;
 	}
+
+	$the_user         = get_user_by( 'id', $user_id );
+	$user             = new stdClass();
+	$user->ID         = $the_user->ID;
+	$user->user_email = esc_html( trim( $new_email['newemail'] ) );
+	if ( is_multisite() && $wpdb->get_var( $wpdb->prepare( "SELECT user_login FROM {$wpdb->signups} WHERE user_login = %s", $the_user->user_login ) ) ) {
+		$wpdb->query( $wpdb->prepare( "UPDATE {$wpdb->signups} SET user_email = %s WHERE user_login = %s", $user->user_email, $the_user->user_login ) );
+	}
+
+	wp_update_user( $user );
+
+	delete_user_meta( $user->ID, '_new_email' );
+
+	return true;
 }
 
 /**

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -3877,12 +3877,16 @@ function send_confirmation_on_profile_email( $user_id = 0 ) {
 		$user_id = absint( $_POST['user_id'] );
 	}
 
+	$current_user = wp_get_current_user();
 	if ( ! is_object( $errors ) ) {
 		$errors = new WP_Error();
 	}
 
-	$user       = get_user_by( 'id', $user_id );
-	$email_sent = send_user_email_change_confirmation_email( $user, $_POST['email'] );
+	if ( 0 === $current_user->ID || $current_user->ID !== (int) $user_id ) {
+		return false;
+	}
+
+	$email_sent = send_user_email_change_confirmation_email( $current_user, $_POST['email'] );
 
 	if ( is_wp_error( $email_sent ) ) {
 		// WP_Error::copy_errors() with the addition of adding data.
@@ -3895,10 +3899,13 @@ function send_confirmation_on_profile_email( $user_id = 0 ) {
 				)
 			);
 		}
+
+		$_POST['email'] = addslashes( $current_user->user_email );
+		return;
 	}
 
 	if ( true === $email_sent ) {
-		$_POST['email'] = $user->user_email;
+		$_POST['email'] = $current_user->user_email;
 	}
 }
 
@@ -3912,7 +3919,11 @@ function send_confirmation_on_profile_email( $user_id = 0 ) {
  * @return null|true|WP_Error true if email sent, WP_Error on error, and null otherwise.
  */
 function send_user_email_change_confirmation_email( $user, $email ) {
-	if ( $user->user_email == $email ) {
+	if ( ! $user instanceof WP_User || ! $user->exists() ) {
+		return;
+	}
+
+	if ( $user->user_email === $email ) {
 		return;
 	}
 

--- a/src/wp-login.php
+++ b/src/wp-login.php
@@ -495,6 +495,7 @@ $default_actions = array(
 	'register',
 	'checkemail',
 	'confirmaction',
+	'confirmemail',
 	'login',
 	WP_Recovery_Mode_Link_Service::LOGIN_ACTION_ENTERED,
 );
@@ -1234,6 +1235,44 @@ switch ( $action ) {
 		$errors = apply_filters( 'wp_login_errors', $errors, $redirect_to );
 
 		login_header( __( 'Check your email' ), '', $errors );
+		login_footer();
+		break;
+
+	case 'confirmemail':
+		if ( ! isset( $_GET['id'], $_GET['hash'] ) ) {
+			wp_die( __( 'Missing or invalid key.' ) );
+		}
+
+		if ( ! is_user_logged_in() ) {
+			wp_safe_redirect( wp_login_url() );
+			exit;
+		}
+
+		$user_id   = wp_unslash( $_GET['id'] );
+		$email_key = wp_unslash( $_GET['hash'] );
+
+		if ( ! current_user_can( 'edit_user', $user_id ) ) {
+			wp_die( __( 'Missing or invalid key.' ) );
+		}
+
+		$updated = send_user_email_change_confirmation_process( $user_id, $email_key );
+		if ( ! $updated ) {
+			wp_die( __( 'Missing or invalid key.' ) );
+		}
+
+		/**
+		 * Fires an action hook when the account email has been confirmed by the user.
+		 *
+		 * @since x.x
+		 *
+		 * @param int $user_id User ID.
+		 */
+		do_action( 'user_email_confirmed', $user_id );
+
+		login_header(
+			__( 'Confirm your email' ),
+			'<p class="success">' . __( 'Your email has been confirmed.' ) . '</p>'
+		);
 		login_footer();
 		break;
 

--- a/src/wp-login.php
+++ b/src/wp-login.php
@@ -1255,19 +1255,9 @@ switch ( $action ) {
 			wp_die( __( 'Missing or invalid key.' ) );
 		}
 
-		$updated = send_user_email_change_confirmation_process( $user_id, $email_key );
-		if ( ! $updated ) {
+		if ( ! confirm_user_email_change( $user_id, $email_key ) ) {
 			wp_die( __( 'Missing or invalid key.' ) );
 		}
-
-		/**
-		 * Fires an action hook when the account email has been confirmed by the user.
-		 *
-		 * @since x.x
-		 *
-		 * @param int $user_id User ID.
-		 */
-		do_action( 'user_email_confirmed', $user_id );
 
 		login_header(
 			__( 'Confirm your email' ),

--- a/src/wp-login.php
+++ b/src/wp-login.php
@@ -1243,13 +1243,22 @@ switch ( $action ) {
 			wp_die( __( 'Missing or invalid key.' ) );
 		}
 
+		$user_id   = (int) $_GET['id'];
+		$email_key = sanitize_text_field( wp_unslash( $_GET['hash'] ) );
+
 		if ( ! is_user_logged_in() ) {
-			wp_safe_redirect( wp_login_url() );
+			$confirm_url = add_query_arg(
+				array(
+					'action' => 'confirmemail',
+					'id'     => $user_id,
+					'hash'   => rawurlencode( $email_key ),
+				),
+				wp_login_url()
+			);
+
+			wp_safe_redirect( wp_login_url( $confirm_url ) );
 			exit;
 		}
-
-		$user_id   = wp_unslash( $_GET['id'] );
-		$email_key = wp_unslash( $_GET['hash'] );
 
 		if ( ! current_user_can( 'edit_user', $user_id ) ) {
 			wp_die( __( 'Missing or invalid key.' ) );
@@ -1260,11 +1269,12 @@ switch ( $action ) {
 		}
 
 		login_header(
-			__( 'Confirm your email' ),
-			'<p class="success">' . __( 'Your email has been confirmed.' ) . '</p>'
+			__( 'Email address confirmed.' ),
+			'<p class="message">' . __( 'Your new email address has been confirmed.' ) . '</p>'
 		);
+
 		login_footer();
-		break;
+		exit;
 
 	case 'confirmaction':
 		if ( ! isset( $_GET['request_id'] ) ) {

--- a/tests/phpstan/baselines/variable.undefined.neon
+++ b/tests/phpstan/baselines/variable.undefined.neon
@@ -536,7 +536,7 @@ parameters:
 		-
 			message: '#^Variable \$wpdb might not be defined\.$#'
 			identifier: variable.undefined
-			count: 12
+			count: 6
 			path: ../../../src/wp-admin/user-edit.php
 		-
 			message: '#^Variable \$blog_id might not be defined\.$#'

--- a/tests/phpunit/tests/rest-api/rest-users-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-users-controller.php
@@ -3288,7 +3288,13 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->assertSame( 'after@example.com', $data['email'] );
 		$this->assertSame( 'after@example.com', get_userdata( $user_id )->user_email );
 		$this->assertEmpty( get_user_meta( $user_id, '_new_email', true ) );
-		$this->assertEmpty( tests_retrieve_phpmailer_instance()->mock_sent );
+
+		/*
+		 * wp_update_user() mails a "Notice of Email Change" to the old address on every
+		 * change, so the assertion is that nothing was sent to the new address asking
+		 * for confirmation, not that no mail was sent at all.
+		 */
+		$this->assertFalse( $this->was_mail_sent_to( 'after@example.com' ) );
 	}
 
 	/**
@@ -3343,7 +3349,25 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->assertSame( 200, $response->get_status() );
 		$this->assertSame( 'after@example.com', get_userdata( $user_id )->user_email );
 		$this->assertEmpty( get_user_meta( $user_id, '_new_email', true ) );
-		$this->assertEmpty( tests_retrieve_phpmailer_instance()->mock_sent );
+		$this->assertFalse( $this->was_mail_sent_to( 'after@example.com' ) );
+	}
+
+	/**
+	 * Whether any mail was sent to the given address.
+	 *
+	 * @since 7.2.0
+	 *
+	 * @param string $address The address to look for.
+	 * @return bool Whether a message was sent to the address.
+	 */
+	protected function was_mail_sent_to( $address ) {
+		foreach ( tests_retrieve_phpmailer_instance()->mock_sent as $mail ) {
+			if ( isset( $mail['to'][0][0] ) && $address === $mail['to'][0][0] ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	public function data_get_default_data() {

--- a/tests/phpunit/tests/rest-api/rest-users-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-users-controller.php
@@ -3128,6 +3128,74 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->assertSame( $expected, $meta[ $meta_key ] );
 	}
 
+	/**
+	 * @ticket 57413
+	 */
+	public function test_send_confirmation_on_profile_email() {
+		reset_phpmailer_instance();
+		$was_confirmation_email_sent = false;
+
+		$user_id = self::factory()->user->create(
+			array(
+				'user_email' => 'before@example.com',
+			)
+		);
+
+		wp_set_current_user( $user_id );
+
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/users/%d', $user_id ) );
+		$request->set_param( 'email', 'after@example.com' );
+		$response = rest_get_server()->dispatch( $request );
+
+		$new_data = $response->get_data();
+		$this->assertSame( 'before@example.com', $new_data['email'] );
+
+		if ( ! empty( $GLOBALS['phpmailer']->mock_sent ) ) {
+			$was_confirmation_email_sent = ( isset( $GLOBALS['phpmailer']->mock_sent[0] ) && 'after@example.com' === $GLOBALS['phpmailer']->mock_sent[0]['to'][0][0] );
+		}
+
+		// A confirmation email is sent.
+		$this->assertTrue( $was_confirmation_email_sent );
+
+		// The new email address gets put into user_meta.
+		$new_email_meta = get_user_meta( $user_id, '_new_email', true );
+		$this->assertSame( 'after@example.com', $new_email_meta['newemail'] );
+	}
+
+	/**
+	 * @ticket 57413
+	 */
+	public function test_no_confirmation_on_profile_email_by_admin() {
+		reset_phpmailer_instance();
+		$was_confirmation_email_sent = false;
+
+		$user_id = self::factory()->user->create(
+			array(
+				'user_email' => 'before@example.com',
+			)
+		);
+
+		wp_set_current_user( self::$superadmin );
+
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/users/%d', $user_id ) );
+		$request->set_param( 'email', 'after@example.com' );
+		$response = rest_get_server()->dispatch( $request );
+
+		$new_data = $response->get_data();
+		$this->assertSame( 'after@example.com', $new_data['email'] );
+
+		if ( ! empty( $GLOBALS['phpmailer']->mock_sent ) ) {
+			$was_confirmation_email_sent = ( isset( $GLOBALS['phpmailer']->mock_sent[0] ) && 'after@example.com' === $GLOBALS['phpmailer']->mock_sent[0]['to'][0][0] );
+		}
+
+		// No confirmation email is sent.
+		$this->assertFalse( $was_confirmation_email_sent );
+
+		// No usermeta is created.
+		$new_email_meta = get_user_meta( $user_id, '_new_email', true );
+		$this->assertEmpty( $new_email_meta );
+	}
+
 	public function data_get_default_data() {
 		return array(
 			array(

--- a/tests/phpunit/tests/rest-api/rest-users-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-users-controller.php
@@ -3196,6 +3196,156 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->assertEmpty( $new_email_meta );
 	}
 
+	/**
+	 * A user changing their own email address over REST is asked to confirm it,
+	 * the same as on the profile screen.
+	 *
+	 * @ticket 57413
+	 */
+	public function test_update_item_own_email_requires_confirmation() {
+		reset_phpmailer_instance();
+
+		$user_id = self::factory()->user->create(
+			array(
+				'role'       => 'subscriber',
+				'user_email' => 'before@example.com',
+			)
+		);
+
+		wp_set_current_user( $user_id );
+
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/users/%d', $user_id ) );
+		$request->set_param( 'email', 'after@example.com' );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		// The address on the account is unchanged until the user confirms it.
+		$data = $response->get_data();
+		$this->assertSame( 'before@example.com', $data['email'] );
+		$this->assertSame( 'before@example.com', get_userdata( $user_id )->user_email );
+
+		// The change is held in user meta.
+		$new_email_meta = get_user_meta( $user_id, '_new_email', true );
+		$this->assertSame( 'after@example.com', $new_email_meta['newemail'] );
+
+		// A confirmation email is sent to the new address.
+		$mailer = tests_retrieve_phpmailer_instance();
+		$this->assertSame( 'after@example.com', $mailer->get_recipient( 'to' )->address );
+	}
+
+	/**
+	 * Other fields in the same request are still applied while the email change is pending.
+	 *
+	 * @ticket 57413
+	 */
+	public function test_update_item_applies_other_fields_while_email_is_pending() {
+		reset_phpmailer_instance();
+
+		$user_id = self::factory()->user->create(
+			array(
+				'role'       => 'subscriber',
+				'user_email' => 'before@example.com',
+			)
+		);
+
+		wp_set_current_user( $user_id );
+
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/users/%d', $user_id ) );
+		$request->set_param( 'email', 'after@example.com' );
+		$request->set_param( 'first_name', 'Updated' );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( 'Updated', get_user_meta( $user_id, 'first_name', true ) );
+		$this->assertSame( 'before@example.com', get_userdata( $user_id )->user_email );
+	}
+
+	/**
+	 * An administrator changing somebody else's address is not asked to confirm it.
+	 *
+	 * @ticket 57413
+	 */
+	public function test_update_item_other_user_email_is_applied_immediately() {
+		reset_phpmailer_instance();
+
+		$user_id = self::factory()->user->create(
+			array(
+				'role'       => 'subscriber',
+				'user_email' => 'before@example.com',
+			)
+		);
+
+		wp_set_current_user( self::$superadmin );
+
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/users/%d', $user_id ) );
+		$request->set_param( 'email', 'after@example.com' );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertSame( 'after@example.com', $data['email'] );
+		$this->assertSame( 'after@example.com', get_userdata( $user_id )->user_email );
+		$this->assertEmpty( get_user_meta( $user_id, '_new_email', true ) );
+		$this->assertEmpty( tests_retrieve_phpmailer_instance()->mock_sent );
+	}
+
+	/**
+	 * Sending the address the account already has is not a change, so it is not held.
+	 *
+	 * @ticket 57413
+	 */
+	public function test_update_item_unchanged_email_does_not_require_confirmation() {
+		reset_phpmailer_instance();
+
+		$user_id = self::factory()->user->create(
+			array(
+				'role'       => 'subscriber',
+				'user_email' => 'before@example.com',
+			)
+		);
+
+		wp_set_current_user( $user_id );
+
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/users/%d', $user_id ) );
+		$request->set_param( 'email', 'before@example.com' );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertEmpty( get_user_meta( $user_id, '_new_email', true ) );
+		$this->assertEmpty( tests_retrieve_phpmailer_instance()->mock_sent );
+	}
+
+	/**
+	 * The confirmation can be turned off, for sites that manage addresses elsewhere.
+	 *
+	 * @ticket 57413
+	 */
+	public function test_update_item_own_email_confirmation_can_be_filtered_off() {
+		reset_phpmailer_instance();
+
+		$user_id = self::factory()->user->create(
+			array(
+				'role'       => 'subscriber',
+				'user_email' => 'before@example.com',
+			)
+		);
+
+		wp_set_current_user( $user_id );
+
+		add_filter( 'should_send_email_for_email_change', '__return_false' );
+
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/users/%d', $user_id ) );
+		$request->set_param( 'email', 'after@example.com' );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( 'after@example.com', get_userdata( $user_id )->user_email );
+		$this->assertEmpty( get_user_meta( $user_id, '_new_email', true ) );
+		$this->assertEmpty( tests_retrieve_phpmailer_instance()->mock_sent );
+	}
+
 	public function data_get_default_data() {
 		return array(
 			array(

--- a/tests/phpunit/tests/user.php
+++ b/tests/phpunit/tests/user.php
@@ -2354,6 +2354,241 @@ class Tests_User extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 57413
+	 *
+	 * @covers ::send_user_email_change_confirmation_email
+	 */
+	public function test_send_user_email_change_confirmation_email_returns_null_when_email_is_unchanged() {
+		$user = self::factory()->user->create_and_get(
+			array(
+				'user_email' => 'before@example.com',
+			)
+		);
+
+		wp_set_current_user( $user->ID );
+
+		$this->assertNull( send_user_email_change_confirmation_email( $user, 'before@example.com' ) );
+		$this->assertEmpty( get_user_meta( $user->ID, '_new_email', true ) );
+	}
+
+	/**
+	 * @ticket 57413
+	 *
+	 * @covers ::send_user_email_change_confirmation_email
+	 */
+	public function test_send_user_email_change_confirmation_email_rejects_an_invalid_email() {
+		$user = self::factory()->user->create_and_get(
+			array(
+				'user_email' => 'before@example.com',
+			)
+		);
+
+		wp_set_current_user( $user->ID );
+
+		$result = send_user_email_change_confirmation_email( $user, 'not-an-email' );
+
+		$this->assertWPError( $result, 'An invalid address should return a WP_Error.' );
+		$this->assertSame( 'user_email', $result->get_error_code() );
+		$this->assertEmpty( get_user_meta( $user->ID, '_new_email', true ), 'No change should be left pending.' );
+	}
+
+	/**
+	 * @ticket 57413
+	 *
+	 * @covers ::send_user_email_change_confirmation_email
+	 */
+	public function test_send_user_email_change_confirmation_email_rejects_an_address_in_use() {
+		self::factory()->user->create( array( 'user_email' => 'taken@example.com' ) );
+
+		$user = self::factory()->user->create_and_get(
+			array(
+				'user_email' => 'before@example.com',
+			)
+		);
+
+		wp_set_current_user( $user->ID );
+
+		// A pending change from an earlier request should not survive a rejection.
+		update_user_meta(
+			$user->ID,
+			'_new_email',
+			array(
+				'hash'     => 'stalehash',
+				'newemail' => 'pending@example.com',
+			)
+		);
+
+		$result = send_user_email_change_confirmation_email( $user, 'taken@example.com' );
+
+		$this->assertWPError( $result, 'An address already in use should return a WP_Error.' );
+		$this->assertSame( 'user_email', $result->get_error_code() );
+		$this->assertEmpty( get_user_meta( $user->ID, '_new_email', true ), 'The pending change should be discarded.' );
+	}
+
+	/**
+	 * @ticket 57413
+	 *
+	 * @covers ::send_user_email_change_confirmation_email
+	 */
+	public function test_send_user_email_change_confirmation_email_stores_the_pending_change() {
+		reset_phpmailer_instance();
+
+		$user = self::factory()->user->create_and_get(
+			array(
+				'user_email' => 'before@example.com',
+			)
+		);
+
+		wp_set_current_user( $user->ID );
+
+		$this->assertTrue( send_user_email_change_confirmation_email( $user, 'after@example.com' ) );
+
+		$new_email_meta = get_user_meta( $user->ID, '_new_email', true );
+		$this->assertSame( 'after@example.com', $new_email_meta['newemail'] );
+		$this->assertNotEmpty( $new_email_meta['hash'] );
+
+		// The address on the account is untouched until the change is confirmed.
+		$this->assertSame( 'before@example.com', get_userdata( $user->ID )->user_email );
+
+		$mailer = tests_retrieve_phpmailer_instance();
+		$this->assertSame( 'after@example.com', $mailer->get_recipient( 'to' )->address );
+		$this->assertStringContainsString( 'action=confirmemail', $mailer->get_sent()->body );
+	}
+
+	/**
+	 * An administrator changing somebody else's address is not asked to confirm it.
+	 *
+	 * @ticket 57413
+	 *
+	 * @covers ::send_user_email_change_confirmation_email
+	 */
+	public function test_send_user_email_change_confirmation_email_skips_confirmation_for_another_user() {
+		reset_phpmailer_instance();
+
+		$user = self::factory()->user->create_and_get(
+			array(
+				'user_email' => 'before@example.com',
+			)
+		);
+
+		wp_set_current_user( self::$admin_id );
+
+		$this->assertNull( send_user_email_change_confirmation_email( $user, 'after@example.com' ) );
+		$this->assertEmpty( get_user_meta( $user->ID, '_new_email', true ) );
+		$this->assertEmpty( tests_retrieve_phpmailer_instance()->mock_sent );
+	}
+
+	/**
+	 * @ticket 57413
+	 *
+	 * @covers ::send_user_email_change_confirmation_email
+	 */
+	public function test_should_send_email_for_email_change_filter_can_skip_the_confirmation() {
+		reset_phpmailer_instance();
+
+		$user = self::factory()->user->create_and_get(
+			array(
+				'user_email' => 'before@example.com',
+			)
+		);
+
+		wp_set_current_user( $user->ID );
+
+		$filter_args = array();
+
+		add_filter(
+			'should_send_email_for_email_change',
+			static function ( $should_send, $filtered_user, $email ) use ( &$filter_args ) {
+				$filter_args = array( $should_send, $filtered_user, $email );
+				return false;
+			},
+			10,
+			3
+		);
+
+		$this->assertNull( send_user_email_change_confirmation_email( $user, 'after@example.com' ) );
+		$this->assertEmpty( get_user_meta( $user->ID, '_new_email', true ) );
+		$this->assertEmpty( tests_retrieve_phpmailer_instance()->mock_sent );
+
+		$this->assertTrue( $filter_args[0], 'A user changing their own address should default to requiring confirmation.' );
+		$this->assertSame( $user->ID, $filter_args[1]->ID );
+		$this->assertSame( 'after@example.com', $filter_args[2] );
+	}
+
+	/**
+	 * @ticket 57413
+	 *
+	 * @covers ::confirm_user_email_change
+	 */
+	public function test_confirm_user_email_change_applies_the_pending_change() {
+		$user = self::factory()->user->create_and_get(
+			array(
+				'user_email' => 'before@example.com',
+			)
+		);
+
+		wp_set_current_user( $user->ID );
+
+		send_user_email_change_confirmation_email( $user, 'after@example.com' );
+
+		$new_email_meta = get_user_meta( $user->ID, '_new_email', true );
+
+		$action = new MockAction();
+		add_action( 'user_email_confirmed', array( $action, 'action' ) );
+
+		$this->assertTrue( confirm_user_email_change( $user->ID, $new_email_meta['hash'] ) );
+		$this->assertSame( 'after@example.com', get_userdata( $user->ID )->user_email );
+		$this->assertEmpty( get_user_meta( $user->ID, '_new_email', true ), 'The pending change should be cleared.' );
+		$this->assertSame( 1, $action->get_call_count() );
+	}
+
+	/**
+	 * @ticket 57413
+	 *
+	 * @covers ::confirm_user_email_change
+	 */
+	public function test_confirm_user_email_change_rejects_an_invalid_hash() {
+		$user = self::factory()->user->create_and_get(
+			array(
+				'user_email' => 'before@example.com',
+			)
+		);
+
+		wp_set_current_user( $user->ID );
+
+		send_user_email_change_confirmation_email( $user, 'after@example.com' );
+
+		$this->assertFalse( confirm_user_email_change( $user->ID, 'not-the-hash' ) );
+		$this->assertSame( 'before@example.com', get_userdata( $user->ID )->user_email );
+		$this->assertNotEmpty( get_user_meta( $user->ID, '_new_email', true ), 'The pending change should survive a failed attempt.' );
+	}
+
+	/**
+	 * @ticket 57413
+	 *
+	 * @covers ::confirm_user_email_change
+	 */
+	public function test_confirm_user_email_change_returns_false_without_a_pending_change() {
+		$user = self::factory()->user->create_and_get(
+			array(
+				'user_email' => 'before@example.com',
+			)
+		);
+
+		$this->assertFalse( confirm_user_email_change( $user->ID, 'any-hash' ) );
+		$this->assertSame( 'before@example.com', get_userdata( $user->ID )->user_email );
+	}
+
+	/**
+	 * @ticket 57413
+	 *
+	 * @covers ::confirm_user_email_change
+	 */
+	public function test_confirm_user_email_change_returns_false_for_an_unknown_user() {
+		$this->assertFalse( confirm_user_email_change( 0, 'any-hash' ) );
+	}
+
+	/**
 	 * Ensure user email address change confirmation emails do not contain encoded HTML entities
 	 *
 	 * @ticket 16470

--- a/tests/phpunit/tests/user.php
+++ b/tests/phpunit/tests/user.php
@@ -2319,6 +2319,41 @@ class Tests_User extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 57413
+	 */
+	public function test_no_confirmation_on_profile_email_by_admin() {
+		reset_phpmailer_instance();
+		$was_confirmation_email_sent = false;
+
+		$user = self::factory()->user->create_and_get(
+			array(
+				'user_email' => 'before@example.com',
+			)
+		);
+
+		$_POST['email']   = 'after@example.com';
+		$_POST['user_id'] = $user->ID;
+
+		wp_set_current_user( self::$admin_id );
+
+		do_action( 'personal_options_update' );
+
+		if ( ! empty( $GLOBALS['phpmailer']->mock_sent ) ) {
+			$was_confirmation_email_sent = ( isset( $GLOBALS['phpmailer']->mock_sent[0] ) && 'after@example.com' === $GLOBALS['phpmailer']->mock_sent[0]['to'][0][0] );
+		}
+
+		// No confirmation email is sent.
+		$this->assertFalse( $was_confirmation_email_sent );
+
+		// No usermeta is created.
+		$new_email_meta = get_user_meta( $user->ID, '_new_email', true );
+		$this->assertEmpty( $new_email_meta );
+
+		// $_POST['email'] should be the email address posted from the form.
+		$this->assertSame( 'after@example.com', $_POST['email'] );
+	}
+
+	/**
 	 * Ensure user email address change confirmation emails do not contain encoded HTML entities
 	 *
 	 * @ticket 16470


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/57413

This is a refresh of #3813 by @dd32, open since January 2023. That branch is on his fork so I couldn't push to it. The first commit here is his patch rebased onto trunk with his authorship intact, and everything after it is a fix, so the diff against that commit is exactly what changed. Props dd32.

### What the original patch does

`WP_REST_Users_Controller::update_item()` calls `wp_update_user()` directly, so a user changing their own email address over REST is never asked to confirm it. The same change on the profile screen is held in the `_new_email` user meta until they follow a link sent to the new address. The patch splits `send_confirmation_on_profile_email()` into a function that sends the confirmation and one that processes a confirmed change, calls the first from the REST controller, and adds a `wp-login.php?action=confirmemail` route so a change started outside the admin can be confirmed.

### What needed fixing

**Fatal error on multisite.** `send_user_email_change_confirmation_process()` uses `$wpdb` in the multisite branch but has no `global $wpdb;`. The body was moved out of `wp-admin/user-edit.php`, where `$wpdb` was already in scope at the top level, so confirming an email change on multisite called a method on null. Putting the `global` back is a one line fix, but nothing caught it, so the new tests cover it: taking it out again turns `Tests_User::test_confirm_user_email_change_applies_the_pending_change` into `Undefined variable $wpdb` on the multisite run.

**Regression against #44672.** `email_exists()` is not case sensitive, so routing both paths through one check meant a user correcting the case of their own address was told it was already in use. That's a 400 on REST and an error on the profile screen. `test_update_item_existing_email_case` fails on the unmodified patch. A change of case is the same mailbox, so it's no longer treated as a change that needs confirming, matching the `strcasecmp()` guard `wp_update_user()` already applies to its own `email_exists()` check.

**Profile screen behaviour lost in the split.** The `0 === $current_user->ID || $current_user->ID !== (int) $user_id` guard was dropped, so `get_user_by( 'id', 0 )` returns false on a logged out request and `$user->user_email` fatals on PHP 8. The `addslashes()` restore of `$_POST['email']` on a rejected address, added in 7.0.3, was dropped too.

**Rejected addresses ignored over REST.** `update_item()` discarded a `WP_Error` from the confirmation function and carried on, applying an address the confirmation step had just rejected. It now returns a 400 with the `rest_user_invalid_email` code the endpoint already uses.

**Confirmation lost when logged out.** Following a confirmation link while logged out redirected to a bare login form, dropping the user on the dashboard. The redirect now carries the confirmation URL through `redirect_to`.

### Other changes

* `send_user_email_change_confirmation_process()` does not send anything, so it's renamed to `confirm_user_email_change()`. @dd32 asked for a second opinion on the naming in the PR.
* The `user_email_confirmed` action moves from `wp-login.php` into that function, so it fires for both confirmation routes rather than only one. A change confirmed from the profile screen previously fired nothing.
* `@since x.x` placeholders filled in, and the function and filter documentation expanded.
* `send_user_email_change_confirmation_email()` returns null explicitly rather than using bare `return;`, which PHPStan reports as `return.empty`. The baselines are for emptying, so this seemed better than adding a new file to them.
* The unit tests asked for in the PR comment, covering the two new functions rather than only their callers: an unchanged address, an invalid address, an address already in use and the pending change it discards, storing the pending change without touching the account, an administrator editing another user, the `should_send_email_for_email_change` filter and the arguments it receives, applying a confirmed change and the action it fires, a wrong hash, no pending change, and an unknown user. Plus REST coverage for other fields applied while the email change is pending, an unchanged address, and the filter turning the confirmation off.

### Not changed

The confirmation hash is still `md5( $email . time() . wp_rand() )`, carried over from the existing code, and `_new_email` still never expires. Both are worth a look, and the first overlaps #12285, but neither is this ticket.

`wp_xmlrpc_server::wp_editProfile()` has the same gap and is left alone pending a scope decision on the ticket.

### Testing

Single site and multisite, against trunk:

* `--group 57413`, 18 tests, 62 assertions
* `--group 16470`, `--group 44672`, `--group 40015` pass
* `WP_Test_REST_Users_Controller`, 136 tests, 960 assertions
* `Tests_User`, 133 tests, 452 assertions
* `phpcs` reports no new errors or warnings on the changed files
* `phpstan` reports no errors

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
