### PR TITLE
Quick/Bulk Edit: Pass post to quick edit custom hook

### DIFF
--- a/src/js/_enqueues/admin/inline-edit-post.js
+++ b/src/js/_enqueues/admin/inline-edit-post.js
@@ -479,8 +479,18 @@ window.wp = window.wp || {};
 			pageOpt.remove();
 		}
 
-		$(editRow).attr('id', 'edit-'+id).addClass('inline-editor').show();
-		$('.ptitle', editRow).trigger( 'focus' );
+		$(editRow).attr('id', 'edit-'+id).addClass('inline-editor');
+
+		$.post( ajaxurl, {
+			action: 'inline-edit-custom-box',
+			post_ID: id,
+			_inline_edit: $( ':input[name="_inline_edit"]', editRow ).val()
+		} ).done( function( response ) {
+			$( '.inline-edit-custom-boxes', editRow ).html( response );
+		} ).always( function() {
+			$( editRow ).show();
+			$( '.ptitle', editRow ).trigger( 'focus' );
+		} );
 
 		return false;
 	},

--- a/src/wp-admin/admin-ajax.php
+++ b/src/wp-admin/admin-ajax.php
@@ -89,6 +89,7 @@ $core_actions_post = array(
 	'sample-permalink',
 	'inline-save',
 	'inline-save-tax',
+	'inline-edit-custom-box',
 	'find_posts',
 	'widgets-order',
 	'save-widget',

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -2199,6 +2199,34 @@ function wp_ajax_inline_save() {
 }
 
 /**
+ * Ajax handler for returning the custom Quick Edit fields for a post.
+ *
+ * @since 7.2.0
+ */
+function wp_ajax_inline_edit_custom_box() {
+	check_ajax_referer( 'inlineeditnonce', '_inline_edit' );
+
+	$post_id = isset( $_POST['post_ID'] ) ? absint( $_POST['post_ID'] ) : 0;
+	$post    = get_post( $post_id );
+
+	if ( ! $post || ! current_user_can( 'edit_post', $post_id ) ) {
+		wp_die( -1, 403 );
+	}
+
+	$screen_id = 'edit-' . $post->post_type;
+	$screen    = get_current_screen();
+	if ( ! $screen || $screen_id !== $screen->id ) {
+		set_current_screen( $screen_id );
+	}
+
+	$list_table = _get_list_table( 'WP_Posts_List_Table', array( 'screen' => get_current_screen() ) );
+
+	echo $list_table->get_inline_edit_custom_box( $post );
+
+	wp_die();
+}
+
+/**
  * Handles Quick Edit saving for a term via AJAX.
  *
  * @since 3.1.0

--- a/src/wp-admin/includes/class-wp-posts-list-table.php
+++ b/src/wp-admin/includes/class-wp-posts-list-table.php
@@ -2191,17 +2191,7 @@ class WP_Posts_List_Table extends WP_List_Table {
 					 */
 					do_action( 'bulk_edit_custom_box', $column_name, $screen->post_type );
 				} else {
-
-					/**
-					 * Fires once for each column in Quick Edit mode.
-					 *
-					 * @since 2.7.0
-					 *
-					 * @param string $column_name Name of the column to edit.
-					 * @param string $post_type   The post type slug, or current screen name if this is a taxonomy list table.
-					 * @param string $taxonomy    The taxonomy name, if any.
-					 */
-					do_action( 'quick_edit_custom_box', $column_name, $screen->post_type, '' );
+					echo '<div class="inline-edit-custom-boxes"></div>';
 				}
 			}
 			?>
@@ -2248,5 +2238,51 @@ class WP_Posts_List_Table extends WP_List_Table {
 		</tbody></table>
 		</form>
 		<?php
+	}
+
+	/**
+	 * Returns the custom fields displayed in Quick Edit mode.
+	 *
+	 * @since 7.2.0
+	 *
+	 * @param WP_Post $post The post being edited.
+	 * @return string The custom Quick Edit fields.
+	 */
+	public function get_inline_edit_custom_box( $post ) {
+		$screen = $this->screen;
+
+		$core_columns = array(
+			'cb'         => true,
+			'date'       => true,
+			'title'      => true,
+			'categories' => true,
+			'tags'       => true,
+			'comments'   => true,
+			'author'     => true,
+		);
+
+		list( $columns ) = $this->get_column_info();
+
+		ob_start();
+
+		foreach ( $columns as $column_name => $column_display_name ) {
+			if ( isset( $core_columns[ $column_name ] ) ) {
+				continue;
+			}
+
+			/**
+			 * Fires once for each column in Quick Edit mode.
+			 *
+			 * @since 2.7.0
+			 *
+			 * @param string  $column_name Name of the column to edit.
+			 * @param string  $post_type  The post type slug.
+			 * @param string  $taxonomy   The taxonomy name, if any.
+			 * @param WP_Post $post       The post being edited.
+			 */
+			do_action( 'quick_edit_custom_box', $column_name, $screen->post_type, '', $post );
+		}
+
+		return ob_get_clean();
 	}
 }

--- a/tests/phpunit/tests/admin/wpPostsListTable.php
+++ b/tests/phpunit/tests/admin/wpPostsListTable.php
@@ -93,6 +93,40 @@ class Tests_Admin_wpPostsListTable extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that the post object is passed to the quick_edit_custom_box action.
+	 *
+	 * @ticket 53195
+	 */
+	public function test_quick_edit_custom_box_receives_post_object() {
+		$received_post = null;
+
+		add_action(
+			'quick_edit_custom_box',
+			static function ( $column_name, $post_type, $taxonomy, $post ) use ( &$received_post ) {
+				if ( 'custom' === $column_name ) {
+					$received_post = $post;
+				}
+			},
+			10,
+			4
+		);
+
+		$table = new class( array( 'screen' => 'edit-page' ) ) extends WP_Posts_List_Table {
+			protected function get_column_info() {
+				$column_info              = parent::get_column_info();
+				$column_info[0]['custom'] = 'Custom';
+				return $column_info;
+			}
+		};
+
+		$table->get_inline_edit_custom_box( self::$top[1] );
+
+		$this->assertInstanceOf( 'WP_Post', $received_post );
+		$this->assertSame( 'page', $received_post->post_type );
+		$this->assertSame( self::$top[1]->ID, $received_post->ID );
+	}
+
+	/**
 	 * @ticket 15459
 	 *
 	 * @covers WP_Posts_List_Table::display_rows


### PR DESCRIPTION
This addresses [#53195](https://core.trac.wordpress.org/ticket/53195) by rendering the quick_edit_custom_box fields after the selected post ID is known.

Quick Edit initially renders a hidden template that is cloned in JavaScript. The patch adds an authenticated inline-edit-custom-box AJAX request when a post is opened. The request loads the post, checks the nonce and edit capability, invokes quick_edit_custom_box with the actual WP_Post object as its fourth argument, and injects the response into the cloned editor.

Trac ticket: https://core.trac.wordpress.org/ticket/53195

## Testing

- Focused PHPUnit test: 1 test, 3 assertions passed using the Local by Flywheel wordpress-develop PHP/MySQL runtime.
- PHPCS: 0 errors; 2 existing baseline warnings in unchanged code at class-wp-posts-list-table.php lines 97 and 123.
- PHPCBF: no fixable errors.
- PHP lint passed for all changed PHP files.
- JavaScript lint passed for src/js/_enqueues/admin/inline-edit-post.js.
- git diff --check passed.

## Use of AI Tools

AI assistance: Yes
Tool(s): ChatGPT/Codex
Model(s): GPT-5
Used for: Implementation, test coverage, and validation; the final patch and test results were reviewed before submission.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**