### PR TITLE
Upgrade/Install: Use wp_print_inline_script_tag() in Bulk_Upgrader_Skin.

### DIFF
--- a/src/wp-admin/includes/class-bulk-upgrader-skin.php
+++ b/src/wp-admin/includes/class-bulk-upgrader-skin.php
@@ -141,7 +141,12 @@ class Bulk_Upgrader_Skin extends WP_Upgrader_Skin {
 			}
 			$this->error = implode( ', ', $messages );
 		}
-		echo '<script>jQuery(\'.waiting-' . esc_js( $this->upgrader->update_current ) . '\').hide();</script>';
+		wp_print_inline_script_tag(
+			sprintf(
+				'jQuery( %s ).hide();',
+				wp_json_encode( '.waiting-' . $this->upgrader->update_current, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES )
+			)
+		);
 	}
 
 	/**
@@ -172,7 +177,12 @@ class Bulk_Upgrader_Skin extends WP_Upgrader_Skin {
 	public function before( $title = '' ) {
 		$this->in_loop = true;
 		printf( '<h2>' . $this->upgrader->strings['skin_before_update_header'] . ' <span class="spinner waiting-' . $this->upgrader->update_current . '"></span></h2>', $title, $this->upgrader->update_current, $this->upgrader->update_count );
-		echo '<script>jQuery(\'.waiting-' . esc_js( $this->upgrader->update_current ) . '\').css("display", "inline-block");</script>';
+		wp_print_inline_script_tag(
+			sprintf(
+				'jQuery( %s ).css( "display", "inline-block" );',
+				wp_json_encode( '.waiting-' . $this->upgrader->update_current, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES )
+			)
+		);
 		// This progress messages div gets moved via JavaScript when clicking on "More details.".
 		echo '<div class="update-messages hide-if-js" id="progress-' . esc_attr( $this->upgrader->update_current ) . '"><p>';
 		$this->flush_output();
@@ -200,7 +210,12 @@ class Bulk_Upgrader_Skin extends WP_Upgrader_Skin {
 				)
 			);
 
-			echo '<script>jQuery(\'#progress-' . esc_js( $this->upgrader->update_current ) . '\').show();</script>';
+			wp_print_inline_script_tag(
+				sprintf(
+					'jQuery( %s ).show();',
+					wp_json_encode( '#progress-' . $this->upgrader->update_current, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES )
+				)
+			);
 		}
 		if ( $this->result && ! is_wp_error( $this->result ) ) {
 			if ( ! $this->error ) {
@@ -210,7 +225,12 @@ class Bulk_Upgrader_Skin extends WP_Upgrader_Skin {
 					'</p></div>';
 			}
 
-			echo '<script>jQuery(\'.waiting-' . esc_js( $this->upgrader->update_current ) . '\').hide();</script>';
+			wp_print_inline_script_tag(
+				sprintf(
+					'jQuery( %s ).hide();',
+					wp_json_encode( '.waiting-' . $this->upgrader->update_current, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES )
+				)
+			);
 		}
 
 		$this->reset();


### PR DESCRIPTION
Continues the migration away from manually constructed `SCRIPT` markup begun in [63481] and [63545]. The four raw one-liner script tags in `Bulk_Upgrader_Skin::error()`, `::before()`, and `::after()` now print through `wp_print_inline_script_tag()`, so `wp_inline_script_attributes` can attach a per-request nonce to these as well — one more step toward an admin Content-Security-Policy opt-in.

The dynamic jQuery selector is now passed through `wp_json_encode()` with `JSON_HEX_TAG | JSON_UNESCAPED_SLASHES` instead of being built via `esc_js()` string concatenation, consistent with the fix applied to similar call sites in [63481]: `esc_js()` runs the value through `_wp_specialchars()`, which isn't needed here since the value lands inside a JS string literal, not an HTML attribute.

Behavior is unchanged — output was compared before/after with a manual smoke test of all three methods.

## Testing instructions

1. Go to Plugins → Add New, install/update a plugin, or use Dashboard → Updates to bulk-update plugins/themes.
2. Confirm the spinner and progress states still toggle correctly during and after the bulk update.
3. `npm run test:php -- --group upgrade` passes (183 tests).
4. `vendor/bin/phpcs --standard=phpcs.xml.dist src/wp-admin/includes/class-bulk-upgrader-skin.php` is clean.

Trac ticket: https://core.trac.wordpress.org/ticket/59446

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Sonnet 5
Used for: Identifying the unconverted call sites, drafting the `wp_print_inline_script_tag()` replacement, and running the coding-standards/PHPUnit/manual smoke checks. I reviewed the diff and test output before opening this PR.