### PR TITLE
Site Health: Remove COMPRESS_SCRIPTS and COMPRESS_CSS from WordPress …

### DIFF
--- a/src/wp-admin/includes/class-wp-debug-data.php
+++ b/src/wp-admin/includes/class-wp-debug-data.php
@@ -1495,6 +1495,9 @@ class WP_Debug_Data {
 	 * Gets the WordPress constants section of the debug data.
 	 *
 	 * @since 6.7.0
+	 * @since 7.2.0 Removed the `COMPRESS_SCRIPTS` and `COMPRESS_CSS` constants, which no longer have
+	 *              any practical effect on most hosts and are being phased out along with the rest of
+	 *              the wp-admin script/style concatenation feature.
 	 *
 	 * @return array<string, string|array> The WordPress constants debug data.
 	 */
@@ -1514,24 +1517,6 @@ class WP_Debug_Data {
 		} else {
 			$concatenate_scripts       = __( 'Undefined' );
 			$concatenate_scripts_debug = 'undefined';
-		}
-
-		// Check COMPRESS_SCRIPTS.
-		if ( defined( 'COMPRESS_SCRIPTS' ) ) {
-			$compress_scripts       = COMPRESS_SCRIPTS ? __( 'Enabled' ) : __( 'Disabled' );
-			$compress_scripts_debug = COMPRESS_SCRIPTS ? 'true' : 'false';
-		} else {
-			$compress_scripts       = __( 'Undefined' );
-			$compress_scripts_debug = 'undefined';
-		}
-
-		// Check COMPRESS_CSS.
-		if ( defined( 'COMPRESS_CSS' ) ) {
-			$compress_css       = COMPRESS_CSS ? __( 'Enabled' ) : __( 'Disabled' );
-			$compress_css_debug = COMPRESS_CSS ? 'true' : 'false';
-		} else {
-			$compress_css       = __( 'Undefined' );
-			$compress_css_debug = 'undefined';
 		}
 
 		// Check WP_ENVIRONMENT_TYPE.
@@ -1613,16 +1598,6 @@ class WP_Debug_Data {
 				'label' => 'CONCATENATE_SCRIPTS',
 				'value' => $concatenate_scripts,
 				'debug' => $concatenate_scripts_debug,
-			),
-			'COMPRESS_SCRIPTS'    => array(
-				'label' => 'COMPRESS_SCRIPTS',
-				'value' => $compress_scripts,
-				'debug' => $compress_scripts_debug,
-			),
-			'COMPRESS_CSS'        => array(
-				'label' => 'COMPRESS_CSS',
-				'value' => $compress_css,
-				'debug' => $compress_css_debug,
 			),
 			'WP_ENVIRONMENT_TYPE' => array(
 				'label' => 'WP_ENVIRONMENT_TYPE',


### PR DESCRIPTION
The Site Health "Info" tab currently shows `COMPRESS_SCRIPTS` and `COMPRESS_CSS` under WordPress Constants. Per westonruter's comment on the ticket, these constants no longer have any practical effect on most hosts and will be removed as part of the ongoing work in #57548 to retire wp-admin script/style concatenation (`load-scripts.php`/`load-styles.php`). This removes their now-misleading display from Site Health ahead of that — the constants themselves and their functional use in `script_concat_settings()` are untouched; this is a Site Health display change only.

`ENFORCE_GZIP` was also mentioned in the ticket description but is not currently shown in Site Health, so no change was needed for it.

## Testing instructions

1. Go to Tools → Site Health → Info → WordPress Constants.
2. Confirm `COMPRESS_SCRIPTS` and `COMPRESS_CSS` no longer appear in the list.
3. Confirm all other constants (`CONCATENATE_SCRIPTS`, `WP_ENVIRONMENT_TYPE`, etc.) are still listed correctly.
4. `npm run test:php -- --group site-health` passes (44 tests).
5. `vendor/bin/phpcs --standard=phpcs.xml.dist src/wp-admin/includes/class-wp-debug-data.php` is clean.

Trac ticket: https://core.trac.wordpress.org/ticket/66053

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Sonnet 5
Used for: Identifying the exact code to remove, drafting the diff and changelog note, and running the coding-standards/PHPUnit/manual smoke checks. I reviewed the diff and test output before opening this PR.