### PR TITLE
Docs: Clarify get_user_meta() return value for a non-existing meta key on a valid user

### DIFF
--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -1291,8 +1291,10 @@ function delete_user_meta( $user_id, $meta_key, $meta_value = '' ) {
  * @return mixed An array of values if `$single` is false.
  *               The value of meta data field if `$single` is true.
  *               False for an invalid `$user_id` (non-numeric, zero, or negative value).
- *               An empty array if a valid but non-existing user ID is passed and `$single` is false.
- *               An empty string if a valid but non-existing user ID is passed and `$single` is true.
+ *               An empty array if `$single` is false and either the user ID does not exist
+ *               or the meta key does not exist for that user.
+ *               An empty string if `$single` is true and either the user ID does not exist
+ *               or the meta key does not exist for that user.
  *               Note: Non-serialized values are returned as strings:
  *               - false values are returned as empty strings ('')
  *               - true values are returned as '1'


### PR DESCRIPTION
## Summary

The `@return` description for `get_user_meta()` only documents the empty-array/empty-string
default for a non-existing user ID. Tracing through `get_metadata_raw()` and
`get_metadata_default()` in `wp-includes/meta.php`, the same default is returned whenever
`get_metadata_raw()` resolves to `null` — which also happens when the user exists but the
given meta key simply has no rows in the meta table. There's no code path that distinguishes
"user doesn't exist" from "user exists, key doesn't."

This clarifies the docblock to cover both cases.

Documentation-Issue-Tracker: https://github.com/WordPress/Documentation-Issue-Tracker/issues/2293

## Testing

Docs-only change (PHPDoc comment), no functional code touched. Verified `get_metadata_raw()`
/ `get_metadata_default()` behavior by reading `wp-includes/meta.php` in trunk.