### PR TITLE
Code Modernization: Use the null coalescing assignment operator for query variable defaults

### DIFF
--- a/src/wp-includes/class-wp-date-query.php
+++ b/src/wp-includes/class-wp-date-query.php
@@ -784,9 +784,7 @@ class WP_Date_Query {
 		if ( isset( $query['hour'] ) || isset( $query['minute'] ) || isset( $query['second'] ) ) {
 			// Avoid notices.
 			foreach ( array( 'hour', 'minute', 'second' ) as $unit ) {
-				if ( ! isset( $query[ $unit ] ) ) {
-					$query[ $unit ] = null;
-				}
+				$query[ $unit ] ??= null;
 			}
 
 			$time_query = $this->build_time_query( $column, $compare, $query['hour'], $query['minute'], $query['second'] );

--- a/src/wp-includes/class-wp-metadata-lazyloader.php
+++ b/src/wp-includes/class-wp-metadata-lazyloader.php
@@ -84,15 +84,11 @@ class WP_Metadata_Lazyloader {
 
 		$type_settings = $this->settings[ $object_type ];
 
-		if ( ! isset( $this->pending_objects[ $object_type ] ) ) {
-			$this->pending_objects[ $object_type ] = array();
-		}
+		$this->pending_objects[ $object_type ] ??= array();
 
 		foreach ( $object_ids as $object_id ) {
 			// Keyed by ID for faster lookup.
-			if ( ! isset( $this->pending_objects[ $object_type ][ $object_id ] ) ) {
-				$this->pending_objects[ $object_type ][ $object_id ] = 1;
-			}
+			$this->pending_objects[ $object_type ][ $object_id ] ??= 1;
 		}
 
 		add_filter( $type_settings['filter'], $type_settings['callback'], 10, 5 );

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -618,9 +618,7 @@ class WP_Query {
 		);
 
 		foreach ( $keys as $key ) {
-			if ( ! isset( $query_vars[ $key ] ) ) {
-				$query_vars[ $key ] = '';
-			}
+			$query_vars[ $key ] ??= '';
 		}
 
 		$array_keys = array(
@@ -643,9 +641,7 @@ class WP_Query {
 		);
 
 		foreach ( $array_keys as $key ) {
-			if ( ! isset( $query_vars[ $key ] ) ) {
-				$query_vars[ $key ] = array();
-			}
+			$query_vars[ $key ] ??= array();
 		}
 
 		return $query_vars;
@@ -1279,10 +1275,8 @@ class WP_Query {
 		}
 
 		if ( ! empty( $query_vars['category__and'] ) && 1 === count( (array) $query_vars['category__and'] ) ) {
-			$query_vars['category__and'] = (array) $query_vars['category__and'];
-			if ( ! isset( $query_vars['category__in'] ) ) {
-				$query_vars['category__in'] = array();
-			}
+			$query_vars['category__and']  = (array) $query_vars['category__and'];
+			$query_vars['category__in'] ??= array();
 			$query_vars['category__in'][] = absint( reset( $query_vars['category__and'] ) );
 			unset( $query_vars['category__and'] );
 		}
@@ -1967,30 +1961,18 @@ class WP_Query {
 				)
 			);
 
-			if ( ! isset( $query_vars['ignore_sticky_posts'] ) ) {
-				$query_vars['ignore_sticky_posts'] = $query_vars['caller_get_posts'];
-			}
+			$query_vars['ignore_sticky_posts'] ??= $query_vars['caller_get_posts'];
 		}
 
-		if ( ! isset( $query_vars['ignore_sticky_posts'] ) ) {
-			$query_vars['ignore_sticky_posts'] = false;
-		}
+		$query_vars['ignore_sticky_posts'] ??= false;
 
-		if ( ! isset( $query_vars['suppress_filters'] ) ) {
-			$query_vars['suppress_filters'] = false;
-		}
+		$query_vars['suppress_filters'] ??= false;
 
-		if ( ! isset( $query_vars['cache_results'] ) ) {
-			$query_vars['cache_results'] = true;
-		}
+		$query_vars['cache_results'] ??= true;
 
-		if ( ! isset( $query_vars['update_post_term_cache'] ) ) {
-			$query_vars['update_post_term_cache'] = true;
-		}
+		$query_vars['update_post_term_cache'] ??= true;
 
-		if ( ! isset( $query_vars['update_menu_item_cache'] ) ) {
-			$query_vars['update_menu_item_cache'] = false;
-		}
+		$query_vars['update_menu_item_cache'] ??= false;
 
 		if ( ! isset( $query_vars['lazy_load_term_meta'] ) ) {
 			$query_vars['lazy_load_term_meta'] = $query_vars['update_post_term_cache'];
@@ -1998,9 +1980,7 @@ class WP_Query {
 			$query_vars['update_post_term_cache'] = true;
 		}
 
-		if ( ! isset( $query_vars['update_post_meta_cache'] ) ) {
-			$query_vars['update_post_meta_cache'] = true;
-		}
+		$query_vars['update_post_meta_cache'] ??= true;
 
 		if ( ! isset( $query_vars['post_type'] ) ) {
 			if ( $this->is_search ) {
@@ -3322,9 +3302,7 @@ class WP_Query {
 		}
 
 		if ( 'ids' === $query_vars['fields'] ) {
-			if ( null === $this->posts ) {
-				$this->posts = $wpdb->get_col( $this->request );
-			}
+			$this->posts ??= $wpdb->get_col( $this->request );
 
 			/** @var int[] */
 			$this->posts      = array_map( 'intval', $this->posts );
@@ -3345,9 +3323,7 @@ class WP_Query {
 		}
 
 		if ( 'id=>parent' === $query_vars['fields'] ) {
-			if ( null === $this->posts ) {
-				$this->posts = $wpdb->get_results( $this->request );
-			}
+			$this->posts ??= $wpdb->get_results( $this->request );
 
 			$this->post_count = count( $this->posts );
 			$this->set_found_posts( $query_vars, $limits );
@@ -5081,9 +5057,7 @@ class WP_Query {
 		}
 
 		// Add a default orderby value of date to ensure same cache key generation.
-		if ( ! isset( $args['orderby'] ) ) {
-			$args['orderby'] = 'date';
-		}
+		$args['orderby'] ??= 'date';
 
 		$placeholder = $wpdb->placeholder_escape();
 		array_walk_recursive(

--- a/src/wp-includes/class-wp-tax-query.php
+++ b/src/wp-includes/class-wp-tax-query.php
@@ -161,9 +161,8 @@ class WP_Tax_Query {
 				 */
 				if ( ! empty( $cleaned_clause['taxonomy'] ) && 'NOT IN' !== $cleaned_clause['operator'] ) {
 					$taxonomy = $cleaned_clause['taxonomy'];
-					if ( ! isset( $this->queried_terms[ $taxonomy ] ) ) {
-						$this->queried_terms[ $taxonomy ] = array();
-					}
+
+					$this->queried_terms[ $taxonomy ] ??= array();
 
 					/*
 					 * Backward compatibility: Only store the first
@@ -184,9 +183,7 @@ class WP_Tax_Query {
 
 				if ( ! empty( $cleaned_subquery ) ) {
 					// All queries with children must have a relation.
-					if ( ! isset( $cleaned_subquery['relation'] ) ) {
-						$cleaned_subquery['relation'] = 'AND';
-					}
+					$cleaned_subquery['relation'] ??= 'AND';
 
 					$cleaned_query[] = $cleaned_subquery;
 				}


### PR DESCRIPTION
Replaces the "assign a default only if not already set" guard blocks in `WP_Query`, `WP_Tax_Query`, `WP_Date_Query` and `WP_Metadata_Lazyloader` with the null coalescing assignment operator (`??=`).

18 guard blocks in total, 55 lines removed for 20 added.

Trac ticket: https://core.trac.wordpress.org/ticket/65823

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
