### PR TITLE
Tests: Fix database charset tests on MariaDB 13.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ You will also need a container environment such as [Docker Desktop](https://www.
 
 **Note:** WordPress currently only officially supports Docker but several container environments are available and should generally be compatible, such as [Colima](https://github.com/abiosoft/colima), [OrbStack](https://orbstack.dev/), [Podman Desktop](https://podman-desktop.io/), and [Rancher Desktop](https://rancherdesktop.io/).
 
+#### Windows-specific instructions
+
+For development on Windows, [Windows Subsystem for Linux (WSL)](https://learn.microsoft.com/en-us/windows/wsl/install) is recommended. This provides a Linux environment where the general development instructions can be used without modification.
+
+After installing Docker Desktop, enable Docker's WSL integration under **Settings > Resources > WSL integration**. This only needs to be configured once.
+
+If you use Docker Desktop directly from Windows without WSL, make sure it is using Linux containers. Right-click the Docker icon in the system tray and select **Switch to Linux containers...**. If that option is not available, or the menu shows **Switch to Windows containers...**, Docker is already using Linux containers. You can switch between container types later if another project requires Windows containers.
+
 ### Development Environment Commands
 
 Ensure your container environment is running before using these commands.

--- a/tests/phpunit/tests/db/charset.php
+++ b/tests/phpunit/tests/db/charset.php
@@ -749,7 +749,7 @@ class Tests_DB_Charset extends WP_UnitTestCase {
 			),
 		),
 		array(
-			'definition'      => '( a VARCHAR(50) CHARACTER SET utf8, b TEXT CHARACTER SET utf8mb4 )',
+			'definition'      => '( a VARCHAR(50) CHARACTER SET utf8mb3, b TEXT CHARACTER SET utf8mb4 )',
 			'table_expected'  => 'utf8',
 			'column_expected' => array(
 				'a' => 'utf8',
@@ -786,6 +786,7 @@ class Tests_DB_Charset extends WP_UnitTestCase {
 	/**
 	 * @dataProvider data_get_table_charset
 	 * @ticket 21212
+	 * @ticket 66072
 	 *
 	 * @covers wpdb::get_table_charset
 	 */
@@ -822,6 +823,7 @@ class Tests_DB_Charset extends WP_UnitTestCase {
 	/**
 	 * @dataProvider data_get_column_charset
 	 * @ticket 21212
+	 * @ticket 66072
 	 *
 	 * @covers wpdb::get_col_charset
 	 */
@@ -907,7 +909,7 @@ class Tests_DB_Charset extends WP_UnitTestCase {
 			),
 			'utf8 + utf8mb4' => array(
 				// utf8/utf8mb4 tables default to utf8.
-				'create'   => '( a VARCHAR(50) CHARACTER SET utf8, b VARCHAR(50) CHARACTER SET utf8mb4 )',
+				'create'   => '( a VARCHAR(50) CHARACTER SET utf8mb3, b VARCHAR(50) CHARACTER SET utf8mb4 )',
 				'query'    => "('foo\xf0\x9f\x98\x88bar', 'foo')",
 				'expected' => "('foobar', 'foo')",
 			),
@@ -931,6 +933,7 @@ class Tests_DB_Charset extends WP_UnitTestCase {
 	/**
 	 * @dataProvider data_strip_invalid_text_from_query
 	 * @ticket 21212
+	 * @ticket 66072
 	 *
 	 * @covers wpdb::strip_invalid_text_from_query
 	 */
@@ -1155,14 +1158,15 @@ class Tests_DB_Charset extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 36649
+	 * @ticket 66072
 	 *
 	 * @covers wpdb::set_charset
 	 */
 	public function test_set_charset_changes_the_connection_collation() {
-		self::$_wpdb->set_charset( self::$_wpdb->dbh, 'utf8', 'utf8_general_ci' );
-		$results  = self::$_wpdb->get_results( "SHOW VARIABLES WHERE Variable_name='collation_connection'" );
-		$expected = self::$utf8_is_utf8mb3 ? 'utf8mb3_general_ci' : 'utf8_general_ci';
-		$this->assertSame( $expected, $results[0]->Value, "Collation should be set to $expected." );
+		// Avoid the `utf8` alias: it resolves to utf8mb3 or utf8mb4 depending on the server version.
+		self::$_wpdb->set_charset( self::$_wpdb->dbh, 'utf8mb4', 'utf8mb4_general_ci' );
+		$results = self::$_wpdb->get_results( "SHOW VARIABLES WHERE Variable_name='collation_connection'" );
+		$this->assertSame( 'utf8mb4_general_ci', $results[0]->Value, 'Collation should be set to utf8mb4_general_ci.' );
 
 		self::$_wpdb->set_charset( self::$_wpdb->dbh, 'utf8mb4', 'utf8mb4_unicode_ci' );
 		$results = self::$_wpdb->get_results( "SHOW VARIABLES WHERE Variable_name='collation_connection'" );


### PR DESCRIPTION
On MariaDB 13.1, four database tests fail. MariaDB changed what the `utf8` character set name means. It used to mean the older 3-byte version (`utf8mb3`), and now it means `utf8mb4`.

WordPress itself isn't affected. Only the tests are, because they used `utf8` and expected the old meaning.

This PR updates the tests so they say exactly which character set they mean:

- Two test tables now use `utf8mb3` instead of `utf8`.
- The collation test now uses `utf8mb4_general_ci`, which gives the same result on every server.

### Testing

I tested on MariaDB 13.1.1 using MariaDB's development image (`quay.io/mariadb-foundation/mariadb-devel:13.1`), because 13.1 isn't on Docker Hub yet.

| Server | trunk | This PR |
|---|---|---|
| MariaDB 13.1.1 | 4 failures, the ones in the ticket | All 100 pass |
| MariaDB 11.4 with `--old-mode=` (same change as 13.1) | 4 failures | All 100 pass |
| MariaDB 11.4, default settings | Not run | All 100 pass |
| MySQL 8.4 | Not run | All 100 pass |

To run them: `vendor/bin/phpunit tests/phpunit/tests/db/charset.php`

Trac ticket: https://core.trac.wordpress.org/ticket/66072

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Finding the cause, writing the test changes, and running the tests on each server. I reviewed the changes and take responsibility for them.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
