### PR TITLE
Tests: Use assertWPError() for WP_Error assertions in classic-to-block menu converter tests

### DIFF
--- a/tests/phpunit/tests/editor/classic-to-block-menu-converter.php
+++ b/tests/phpunit/tests/editor/classic-to-block-menu-converter.php
@@ -29,7 +29,7 @@ class WP_Classic_To_Block_Menu_Converter_Test extends WP_UnitTestCase {
 
 		$result = WP_Classic_To_Block_Menu_Converter::convert( $data );
 
-		$this->assertTrue( is_wp_error( $result ), 'Should be a WP_Error instance' );
+		$this->assertWPError( $result, 'Should be a WP_Error instance' );
 
 		$this->assertSame( 'invalid_menu', $result->get_error_code(), 'Error code should indicate invalidity of menu argument.' );
 


### PR DESCRIPTION
### Description
Replaces a generic `assertTrue( is_wp_error() )` assertion in `tests/phpunit/tests/editor/classic-to-block-menu-converter.php` with WordPress's dedicated `assertWPError()` assertion.

Using dedicated assertion methods improves failure reporting by automatically including the `WP_Error` code and message in assertion failure outputs.

This was the only remaining occurrence of `assertTrue( is_wp_error() )` in the test suite.

This is a test-only change and does not affect runtime behavior.

### Background
`WP_Classic_To_Block_Menu_Converter_Test` was introduced in [56052] (Trac #58557). In [58183] (Trac #60705), assertions in this file were tightened to `assertSame()`. This update completes modernizing the error assertion to use `assertWPError()`.

Follow-up to r56052, r58183.

Trac ticket: https://core.trac.wordpress.org/ticket/65819

## Use of AI Tools

AI assistance: Yes
Model(s): Gemini 3.8 Flash High
Used for: Scanning the test suite for legacy generic boolean assertions, `git log -L` archaeology identifying [56052] and [58183], and drafting this description. The code change, verification, and coding standards compliance were reviewed and confirmed by me in a local development environment.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
