### PR TITLE
Build/Test Tools: Use strict assertions in the XML-RPC tests.

### DIFF
--- a/tests/phpunit/tests/xmlrpc/mw/editPost.php
+++ b/tests/phpunit/tests/xmlrpc/mw/editPost.php
@@ -88,7 +88,7 @@ class Tests_XMLRPC_mw_editPost extends WP_XMLRPC_UnitTestCase {
 		$this->assertTrue( $result );
 
 		$out = get_post( $post_id );
-		$this->assertEquals( $author_id, $out->post_author );
+		$this->assertSame( (string) $author_id, $out->post_author );
 	}
 
 	public function test_incapable_reassign_author() {
@@ -107,7 +107,7 @@ class Tests_XMLRPC_mw_editPost extends WP_XMLRPC_UnitTestCase {
 		$this->assertSame( 401, $result->code );
 
 		$out = get_post( $post_id );
-		$this->assertEquals( $contributor_id, $out->post_author );
+		$this->assertSame( (string) $contributor_id, $out->post_author );
 	}
 
 	/**
@@ -129,7 +129,7 @@ class Tests_XMLRPC_mw_editPost extends WP_XMLRPC_UnitTestCase {
 		$this->assertTrue( $result );
 
 		$out = get_post( $post_id );
-		$this->assertEquals( $editor_id, $out->post_author );
+		$this->assertSame( (string) $editor_id, $out->post_author );
 	}
 
 	/**
@@ -156,13 +156,13 @@ class Tests_XMLRPC_mw_editPost extends WP_XMLRPC_UnitTestCase {
 		$post2  = array( 'wp_post_thumbnail' => $attachment_id );
 		$result = $this->myxmlrpcserver->mw_editPost( array( $post_id, 'author', 'author', $post2 ) );
 		$this->assertNotIXRError( $result );
-		$this->assertEquals( $attachment_id, get_post_meta( $post_id, '_thumbnail_id', true ) );
+		$this->assertSame( (string) $attachment_id, get_post_meta( $post_id, '_thumbnail_id', true ) );
 
 		// Edit the post without supplying a post_thumbnail and check that it didn't change.
 		$post3  = array( 'post_content' => 'Updated post' );
 		$result = $this->myxmlrpcserver->mw_editPost( array( $post_id, 'author', 'author', $post3 ) );
 		$this->assertNotIXRError( $result );
-		$this->assertEquals( $attachment_id, get_post_meta( $post_id, '_thumbnail_id', true ) );
+		$this->assertSame( (string) $attachment_id, get_post_meta( $post_id, '_thumbnail_id', true ) );
 
 		// Create another attachment.
 		$attachment2_id = self::factory()->attachment->create_upload_object( $filename, $post_id );
@@ -171,7 +171,7 @@ class Tests_XMLRPC_mw_editPost extends WP_XMLRPC_UnitTestCase {
 		$post4  = array( 'wp_post_thumbnail' => $attachment2_id );
 		$result = $this->myxmlrpcserver->mw_editPost( array( $post_id, 'author', 'author', $post4 ) );
 		$this->assertNotIXRError( $result );
-		$this->assertEquals( $attachment2_id, get_post_meta( $post_id, '_thumbnail_id', true ) );
+		$this->assertSame( (string) $attachment2_id, get_post_meta( $post_id, '_thumbnail_id', true ) );
 
 		// Unset the post's post_thumbnail.
 		$post5  = array( 'wp_post_thumbnail' => '' );

--- a/tests/phpunit/tests/xmlrpc/mw/newPost.php
+++ b/tests/phpunit/tests/xmlrpc/mw/newPost.php
@@ -49,6 +49,7 @@ class Tests_XMLRPC_mw_newPost extends WP_XMLRPC_UnitTestCase {
 		);
 		$result = $this->myxmlrpcserver->mw_newPost( array( 1, 'author', 'author', $post ) );
 		$this->assertNotIXRError( $result );
+		$this->assertIsString( $result );
 		$this->assertNotSame( '103948', $result );
 	}
 

--- a/tests/phpunit/tests/xmlrpc/mw/newPost.php
+++ b/tests/phpunit/tests/xmlrpc/mw/newPost.php
@@ -49,7 +49,7 @@ class Tests_XMLRPC_mw_newPost extends WP_XMLRPC_UnitTestCase {
 		);
 		$result = $this->myxmlrpcserver->mw_newPost( array( 1, 'author', 'author', $post ) );
 		$this->assertNotIXRError( $result );
-		$this->assertNotEquals( '103948', $result );
+		$this->assertNotSame( '103948', $result );
 	}
 
 	public function test_capable_publish() {
@@ -124,7 +124,7 @@ class Tests_XMLRPC_mw_newPost extends WP_XMLRPC_UnitTestCase {
 		$this->assertStringMatchesFormat( '%d', $result );
 
 		$out = get_post( $result );
-		$this->assertEquals( $my_author_id, $out->post_author );
+		$this->assertSame( (string) $my_author_id, $out->post_author );
 		$this->assertSame( 'Test', $out->post_title );
 	}
 
@@ -146,7 +146,7 @@ class Tests_XMLRPC_mw_newPost extends WP_XMLRPC_UnitTestCase {
 		);
 		$result = $this->myxmlrpcserver->mw_newPost( array( 1, 'author', 'author', $post ) );
 		$this->assertNotIXRError( $result );
-		$this->assertEquals( $attachment_id, get_post_meta( $result, '_thumbnail_id', true ) );
+		$this->assertSame( (string) $attachment_id, get_post_meta( $result, '_thumbnail_id', true ) );
 
 		remove_theme_support( 'post-thumbnails' );
 	}

--- a/tests/phpunit/tests/xmlrpc/wp/editPost.php
+++ b/tests/phpunit/tests/xmlrpc/wp/editPost.php
@@ -88,7 +88,7 @@ class Tests_XMLRPC_wp_editPost extends WP_XMLRPC_UnitTestCase {
 		$this->assertTrue( $result );
 
 		$out = get_post( $post_id );
-		$this->assertEquals( $author_id, $out->post_author );
+		$this->assertSame( (string) $author_id, $out->post_author );
 	}
 
 	public function test_incapable_reassign_author() {
@@ -107,7 +107,7 @@ class Tests_XMLRPC_wp_editPost extends WP_XMLRPC_UnitTestCase {
 		$this->assertSame( 401, $result->code );
 
 		$out = get_post( $post_id );
-		$this->assertEquals( $contributor_id, $out->post_author );
+		$this->assertSame( (string) $contributor_id, $out->post_author );
 	}
 
 	/**
@@ -129,7 +129,7 @@ class Tests_XMLRPC_wp_editPost extends WP_XMLRPC_UnitTestCase {
 		$this->assertTrue( $result );
 
 		$out = get_post( $post_id );
-		$this->assertEquals( $editor_id, $out->post_author );
+		$this->assertSame( (string) $editor_id, $out->post_author );
 	}
 
 	/**
@@ -156,20 +156,20 @@ class Tests_XMLRPC_wp_editPost extends WP_XMLRPC_UnitTestCase {
 		$post2  = array( 'post_thumbnail' => $attachment_id );
 		$result = $this->myxmlrpcserver->wp_editPost( array( 1, 'author', 'author', $post_id, $post2 ) );
 		$this->assertNotIXRError( $result );
-		$this->assertEquals( $attachment_id, get_post_meta( $post_id, '_thumbnail_id', true ) );
+		$this->assertSame( (string) $attachment_id, get_post_meta( $post_id, '_thumbnail_id', true ) );
 
 		// Fetch the post to verify that it appears.
 		$result = $this->myxmlrpcserver->wp_getPost( array( 1, 'author', 'author', $post_id ) );
 		$this->assertNotIXRError( $result );
 		$this->assertArrayHasKey( 'post_thumbnail', $result );
 		$this->assertIsArray( $result['post_thumbnail'] );
-		$this->assertEquals( $attachment_id, $result['post_thumbnail']['attachment_id'] );
+		$this->assertSame( (string) $attachment_id, $result['post_thumbnail']['attachment_id'] );
 
 		// Edit the post without supplying a post_thumbnail and check that it didn't change.
 		$post3  = array( 'post_content' => 'Updated post' );
 		$result = $this->myxmlrpcserver->wp_editPost( array( 1, 'author', 'author', $post_id, $post3 ) );
 		$this->assertNotIXRError( $result );
-		$this->assertEquals( $attachment_id, get_post_meta( $post_id, '_thumbnail_id', true ) );
+		$this->assertSame( (string) $attachment_id, get_post_meta( $post_id, '_thumbnail_id', true ) );
 
 		// Create another attachment.
 		$attachment2_id = self::factory()->attachment->create_upload_object( $filename, $post_id );
@@ -178,7 +178,7 @@ class Tests_XMLRPC_wp_editPost extends WP_XMLRPC_UnitTestCase {
 		$post4  = array( 'post_thumbnail' => $attachment2_id );
 		$result = $this->myxmlrpcserver->wp_editPost( array( 1, 'author', 'author', $post_id, $post4 ) );
 		$this->assertNotIXRError( $result );
-		$this->assertEquals( $attachment2_id, get_post_meta( $post_id, '_thumbnail_id', true ) );
+		$this->assertSame( (string) $attachment2_id, get_post_meta( $post_id, '_thumbnail_id', true ) );
 
 		// Unset the post's post_thumbnail.
 		$post5  = array( 'post_thumbnail' => '' );

--- a/tests/phpunit/tests/xmlrpc/wp/editProfile.php
+++ b/tests/phpunit/tests/xmlrpc/wp/editProfile.php
@@ -64,6 +64,6 @@ class Tests_XMLRPC_wp_editProfile extends WP_XMLRPC_UnitTestCase {
 		$this->assertTrue( $result );
 
 		$user_data = get_userdata( $editor_id );
-		$this->assertNotEquals( $new_email, $user_data->email );
+		$this->assertNotSame( $new_email, $user_data->user_email );
 	}
 }

--- a/tests/phpunit/tests/xmlrpc/wp/editTerm.php
+++ b/tests/phpunit/tests/xmlrpc/wp/editTerm.php
@@ -190,7 +190,7 @@ class Tests_XMLRPC_wp_editTerm extends WP_XMLRPC_UnitTestCase {
 		$this->assertIsBool( $result );
 
 		$term = get_term( self::$child_term, 'category' );
-		$this->assertEquals( '0', $term->parent );
+		$this->assertSame( 0, $term->parent );
 	}
 
 	public function test_parent_invalid() {

--- a/tests/phpunit/tests/xmlrpc/wp/getComment.php
+++ b/tests/phpunit/tests/xmlrpc/wp/getComment.php
@@ -74,10 +74,10 @@ class Tests_XMLRPC_wp_getComment extends WP_XMLRPC_UnitTestCase {
 		$this->assertStringMatchesFormat( '%d', $result['comment_id'] );
 		$this->assertStringMatchesFormat( '%d', $result['parent'] );
 		$this->assertStringMatchesFormat( '%d', $result['post_id'] );
-		$this->assertEquals( self::$parent_comment_id, $result['comment_id'] );
-		$this->assertEquals( 0, $result['parent'] );
+		$this->assertSame( (string) self::$parent_comment_id, $result['comment_id'] );
+		$this->assertSame( '0', $result['parent'] );
 		$this->assertSame( self::$parent_comment_data['comment_content'], $result['content'] );
-		$this->assertEquals( self::$post_id, $result['post_id'] );
+		$this->assertSame( (string) self::$post_id, $result['post_id'] );
 		$this->assertSame( self::$parent_comment_data['comment_author'], $result['author'] );
 		$this->assertSame( self::$parent_comment_data['comment_author_url'], $result['author_url'] );
 		$this->assertSame( self::$parent_comment_data['comment_author_email'], $result['author_email'] );
@@ -89,8 +89,8 @@ class Tests_XMLRPC_wp_getComment extends WP_XMLRPC_UnitTestCase {
 		$result = $this->myxmlrpcserver->wp_getComment( array( 1, 'editor', 'editor', self::$child_comment_id ) );
 		$this->assertNotIXRError( $result );
 
-		$this->assertEquals( self::$child_comment_id, $result['comment_id'] );
-		$this->assertEquals( self::$parent_comment_id, $result['parent'] );
+		$this->assertSame( (string) self::$child_comment_id, $result['comment_id'] );
+		$this->assertSame( (string) self::$parent_comment_id, $result['parent'] );
 	}
 
 	public function test_invalid_id() {

--- a/tests/phpunit/tests/xmlrpc/wp/getComments.php
+++ b/tests/phpunit/tests/xmlrpc/wp/getComments.php
@@ -56,7 +56,7 @@ class Tests_XMLRPC_wp_getComments extends WP_XMLRPC_UnitTestCase {
 		$this->assertNotEmpty( $results );
 
 		foreach ( $results as $result ) {
-			$this->assertEquals( $this->post_id, $result['post_id'] );
+			$this->assertSame( (string) $this->post_id, $result['post_id'] );
 		}
 	}
 

--- a/tests/phpunit/tests/xmlrpc/wp/getPost.php
+++ b/tests/phpunit/tests/xmlrpc/wp/getPost.php
@@ -72,9 +72,9 @@ class Tests_XMLRPC_wp_getPost extends WP_XMLRPC_UnitTestCase {
 		$this->assertSame( $this->post_data['post_excerpt'], $result['post_excerpt'] );
 		$this->assertSame( $this->post_data['post_content'], $result['post_content'] );
 		$this->assertSame( url_to_postid( $result['link'] ), $this->post_id );
-		$this->assertEquals( $this->post_custom_field['id'], $result['custom_fields'][0]['id'] );
+		$this->assertSame( (string) $this->post_custom_field['id'], $result['custom_fields'][0]['id'] );
 		$this->assertSame( $this->post_custom_field['key'], $result['custom_fields'][0]['key'] );
-		$this->assertEquals( $this->post_custom_field['value'], $result['custom_fields'][0]['value'] );
+		$this->assertSame( (string) $this->post_custom_field['value'], $result['custom_fields'][0]['value'] );
 
 		remove_theme_support( 'post-thumbnails' );
 	}
@@ -144,7 +144,7 @@ class Tests_XMLRPC_wp_getPost extends WP_XMLRPC_UnitTestCase {
 		$this->assertIsString( $result['post_mime_type'] );
 
 		$this->assertSame( 'page', $result['post_type'] );
-		$this->assertEquals( $parent_page_id, $result['post_parent'] );
+		$this->assertSame( (string) $parent_page_id, $result['post_parent'] );
 		$this->assertSame( 2, $result['menu_order'] );
 	}
 

--- a/tests/phpunit/tests/xmlrpc/wp/getPosts.php
+++ b/tests/phpunit/tests/xmlrpc/wp/getPosts.php
@@ -120,7 +120,7 @@ class Tests_XMLRPC_wp_getPosts extends WP_XMLRPC_UnitTestCase {
 		$results3 = $this->myxmlrpcserver->wp_getPosts( array( 1, 'editor', 'editor', $filter3 ) );
 		$this->assertNotIXRError( $results3 );
 		$this->assertCount( 1, $results3 );
-		$this->assertEquals( $post->ID, $results3[0]['post_id'] );
+		$this->assertSame( (string) $post->ID, $results3[0]['post_id'] );
 
 		_unregister_post_type( $cpt_name );
 	}

--- a/tests/phpunit/tests/xmlrpc/wp/getProfile.php
+++ b/tests/phpunit/tests/xmlrpc/wp/getProfile.php
@@ -17,7 +17,7 @@ class Tests_XMLRPC_wp_getProfile extends WP_XMLRPC_UnitTestCase {
 
 		$result = $this->myxmlrpcserver->wp_getProfile( array( 1, 'subscriber', 'subscriber' ) );
 		$this->assertNotIXRError( $result );
-		$this->assertEquals( $subscriber_id, $result['user_id'] );
+		$this->assertSame( (string) $subscriber_id, $result['user_id'] );
 		$this->assertContains( 'subscriber', $result['roles'] );
 	}
 
@@ -26,7 +26,7 @@ class Tests_XMLRPC_wp_getProfile extends WP_XMLRPC_UnitTestCase {
 
 		$result = $this->myxmlrpcserver->wp_getProfile( array( 1, 'administrator', 'administrator' ) );
 		$this->assertNotIXRError( $result );
-		$this->assertEquals( $administrator_id, $result['user_id'] );
+		$this->assertSame( (string) $administrator_id, $result['user_id'] );
 		$this->assertContains( 'administrator', $result['roles'] );
 	}
 
@@ -37,7 +37,7 @@ class Tests_XMLRPC_wp_getProfile extends WP_XMLRPC_UnitTestCase {
 
 		$result = $this->myxmlrpcserver->wp_getProfile( array( 1, 'editor', 'editor', $fields ) );
 		$this->assertNotIXRError( $result );
-		$this->assertEquals( $editor_id, $result['user_id'] );
+		$this->assertSame( (string) $editor_id, $result['user_id'] );
 
 		$expected_fields = array( 'user_id', 'email', 'bio' );
 		$keys            = array_keys( $result );

--- a/tests/phpunit/tests/xmlrpc/wp/getTerm.php
+++ b/tests/phpunit/tests/xmlrpc/wp/getTerm.php
@@ -76,7 +76,12 @@ class Tests_XMLRPC_wp_getTerm extends WP_XMLRPC_UnitTestCase {
 		$result = $this->myxmlrpcserver->wp_getTerm( array( 1, 'editor', 'editor', 'category', self::$term_id ) );
 
 		$this->assertNotIXRError( $result );
-		$this->assertEquals( $result, $term );
+		/*
+		 * This comparison stays loose: wp.getTerm returns the IDs as strings so that they
+		 * cannot exceed what an XML-RPC integer can describe, while get_term() returns them
+		 * as integers. The individual types are asserted below.
+		 */
+		$this->assertEquals( $term, $result );
 
 		// Check data types.
 		$this->assertIsString( $result['name'] );

--- a/tests/phpunit/tests/xmlrpc/wp/getTerm.php
+++ b/tests/phpunit/tests/xmlrpc/wp/getTerm.php
@@ -91,6 +91,10 @@ class Tests_XMLRPC_wp_getTerm extends WP_XMLRPC_UnitTestCase {
 		$this->assertIsInt( $result['count'] );
 
 		// We expect all ID's to be strings not integers so we don't return something larger than an XMLRPC integer can describe.
+		$this->assertIsString( $result['term_id'] );
+		$this->assertIsString( $result['term_group'] );
+		$this->assertIsString( $result['term_taxonomy_id'] );
+		$this->assertIsString( $result['parent'] );
 		$this->assertStringMatchesFormat( '%d', $result['term_id'] );
 		$this->assertStringMatchesFormat( '%d', $result['term_group'] );
 		$this->assertStringMatchesFormat( '%d', $result['term_taxonomy_id'] );

--- a/tests/phpunit/tests/xmlrpc/wp/getTerms.php
+++ b/tests/phpunit/tests/xmlrpc/wp/getTerms.php
@@ -143,7 +143,7 @@ class Tests_XMLRPC_wp_getTerms extends WP_XMLRPC_UnitTestCase {
 		$this->assertNotIXRError( $results );
 		$this->assertCount( 1, $results );
 		$this->assertSame( $name, $results[0]['name'] );
-		$this->assertEquals( $name_id, $results[0]['term_id'] );
+		$this->assertSame( (string) $name_id, $results[0]['term_id'] );
 
 		// Search by partial name.
 		$filter   = array( 'search' => substr( $name, 0, 10 ) );
@@ -151,6 +151,6 @@ class Tests_XMLRPC_wp_getTerms extends WP_XMLRPC_UnitTestCase {
 		$this->assertNotIXRError( $results2 );
 		$this->assertCount( 1, $results2 );
 		$this->assertSame( $name, $results2[0]['name'] );
-		$this->assertEquals( $name_id, $results2[0]['term_id'] );
+		$this->assertSame( (string) $name_id, $results2[0]['term_id'] );
 	}
 }

--- a/tests/phpunit/tests/xmlrpc/wp/getUser.php
+++ b/tests/phpunit/tests/xmlrpc/wp/getUser.php
@@ -43,7 +43,7 @@ class Tests_XMLRPC_wp_getUser extends WP_XMLRPC_UnitTestCase {
 
 		$result = $this->myxmlrpcserver->wp_getUser( array( 1, 'subscriber', 'subscriber', $subscriber_id ) );
 		$this->assertNotIXRError( $result );
-		$this->assertEquals( $subscriber_id, $result['user_id'] );
+		$this->assertSame( (string) $subscriber_id, $result['user_id'] );
 	}
 
 	public function test_valid_user() {
@@ -83,7 +83,7 @@ class Tests_XMLRPC_wp_getUser extends WP_XMLRPC_UnitTestCase {
 		$this->assertIsArray( $result['roles'] );
 
 		// Check expected values.
-		$this->assertEquals( $user_id, $result['user_id'] );
+		$this->assertSame( (string) $user_id, $result['user_id'] );
 		$this->assertSame( $user_data['user_login'], $result['username'] );
 		$this->assertSame( $user_data['first_name'], $result['first_name'] );
 		$this->assertSame( $user_data['last_name'], $result['last_name'] );
@@ -105,7 +105,7 @@ class Tests_XMLRPC_wp_getUser extends WP_XMLRPC_UnitTestCase {
 
 		$result = $this->myxmlrpcserver->wp_getUser( array( 1, 'administrator', 'administrator', $editor_id, array() ) );
 		$this->assertNotIXRError( $result );
-		$this->assertEquals( $editor_id, $result['user_id'] );
+		$this->assertSame( (string) $editor_id, $result['user_id'] );
 
 		$expected_fields = array( 'user_id' );
 		$this->assertSame( $expected_fields, array_keys( $result ) );
@@ -116,7 +116,7 @@ class Tests_XMLRPC_wp_getUser extends WP_XMLRPC_UnitTestCase {
 
 		$result = $this->myxmlrpcserver->wp_getUser( array( 1, 'administrator', 'administrator', $editor_id, array( 'basic' ) ) );
 		$this->assertNotIXRError( $result );
-		$this->assertEquals( $editor_id, $result['user_id'] );
+		$this->assertSame( (string) $editor_id, $result['user_id'] );
 
 		$expected_fields = array( 'user_id', 'username', 'email', 'registered', 'display_name', 'nicename' );
 		$keys            = array_keys( $result );
@@ -132,7 +132,7 @@ class Tests_XMLRPC_wp_getUser extends WP_XMLRPC_UnitTestCase {
 
 		$result = $this->myxmlrpcserver->wp_getUser( array( 1, 'administrator', 'administrator', $editor_id, $fields ) );
 		$this->assertNotIXRError( $result );
-		$this->assertEquals( $editor_id, $result['user_id'] );
+		$this->assertSame( (string) $editor_id, $result['user_id'] );
 
 		$expected_fields = array( 'user_id', 'email', 'bio' );
 		$keys            = array_keys( $result );

--- a/tests/phpunit/tests/xmlrpc/wp/getUsers.php
+++ b/tests/phpunit/tests/xmlrpc/wp/getUsers.php
@@ -70,7 +70,7 @@ class Tests_XMLRPC_wp_getUsers extends WP_XMLRPC_UnitTestCase {
 		$results = $this->myxmlrpcserver->wp_getUsers( array( 1, 'administrator', 'administrator', $filter ) );
 		$this->assertNotIXRError( $results );
 		$this->assertCount( 1, $results );
-		$this->assertEquals( $editor_id, $results[0]['user_id'] );
+		$this->assertSame( (string) $editor_id, $results[0]['user_id'] );
 
 		// Test 'authors', which should return all non-subscribers.
 		$filter2  = array( 'who' => 'authors' );

--- a/tests/phpunit/tests/xmlrpc/wp/newPost.php
+++ b/tests/phpunit/tests/xmlrpc/wp/newPost.php
@@ -46,6 +46,7 @@ class Tests_XMLRPC_wp_newPost extends WP_XMLRPC_UnitTestCase {
 		);
 		$result = $this->myxmlrpcserver->wp_newPost( array( 1, 'author', 'author', $post ) );
 		$this->assertNotIXRError( $result );
+		$this->assertIsString( $result );
 		$this->assertNotSame( '103948', $result );
 	}
 

--- a/tests/phpunit/tests/xmlrpc/wp/newPost.php
+++ b/tests/phpunit/tests/xmlrpc/wp/newPost.php
@@ -46,7 +46,7 @@ class Tests_XMLRPC_wp_newPost extends WP_XMLRPC_UnitTestCase {
 		);
 		$result = $this->myxmlrpcserver->wp_newPost( array( 1, 'author', 'author', $post ) );
 		$this->assertNotIXRError( $result );
-		$this->assertNotEquals( '103948', $result );
+		$this->assertNotSame( '103948', $result );
 	}
 
 	public function test_capable_publish() {
@@ -141,7 +141,7 @@ class Tests_XMLRPC_wp_newPost extends WP_XMLRPC_UnitTestCase {
 		$this->assertStringMatchesFormat( '%d', $result );
 
 		$out = get_post( $result );
-		$this->assertEquals( $my_author_id, $out->post_author );
+		$this->assertSame( (string) $my_author_id, $out->post_author );
 		$this->assertSame( 'Test', $out->post_title );
 	}
 
@@ -163,7 +163,7 @@ class Tests_XMLRPC_wp_newPost extends WP_XMLRPC_UnitTestCase {
 		);
 		$result = $this->myxmlrpcserver->wp_newPost( array( 1, 'author', 'author', $post ) );
 		$this->assertNotIXRError( $result );
-		$this->assertEquals( $attachment_id, get_post_meta( $result, '_thumbnail_id', true ) );
+		$this->assertSame( (string) $attachment_id, get_post_meta( $result, '_thumbnail_id', true ) );
 
 		remove_theme_support( 'post-thumbnails' );
 	}


### PR DESCRIPTION
Replaces the loose assertions in `tests/phpunit/tests/xmlrpc` with type-strict
counterparts, so the tests assert the type of each value as well as its value.

43 assertions across 15 files: 40 `assertEquals()` and 3 `assertNotEquals()`.
This is the `xmlrpc` directory claimed on the ticket. None of the three open
pull requests (#12583, #11707, #12613) touch this directory, so there is no
overlap with work already in review.

## The contract that shapes most of this

XML-RPC deliberately returns IDs as strings, so that they cannot exceed what an
XML-RPC integer can describe. `_prepare_term()` states it directly:

> For integers which may be larger than XML-RPC supports ensure we return strings.

Accordingly, in `class-wp-xmlrpc-server.php`:

| Prepared field | Type |
| --- | --- |
| `_prepare_user()` → `user_id` | `(string)` |
| `_prepare_post()` → `post_id`, `post_parent` | `(string)` |
| `_prepare_media_item()` → `attachment_id` | `(string)` |
| `_prepare_term()` → `term_id`, `term_group`, `term_taxonomy_id`, `parent` | `(string)` |
| `_prepare_term()` → `count` | `(int)` |
| `_prepare_post()` → `menu_order` | `(int)` |
| `wp_newPost()`, `mw_newPost()` return value | `(string) $post_id` |

So `assertSame( (string) $id, ... )` here documents an intentional API contract
rather than papering over a type bug. These are not casts added to make a
conversion pass: the tests already assert the same thing themselves, via
pre-existing `assertIsString( $result['post_id'] )` and
`assertStringMatchesFormat( '%d', $result['term_id'] )` lines that pass on trunk
today. `wp/editPost.php` likewise already used
`assertSame( '', get_post_meta( $post_id, '_thumbnail_id', true ) )`.

Values read back from the database follow the same rule and are treated the same
way: `WP_Post::$post_author` is documented `@var string`
(`@phpstan-var numeric-string|''`, default `'0'`), and `get_post_meta()` returns
the stored string.

One docblock is imprecise and worth flagging rather than relying on:
`WP_Comment::$comment_ID` and `$comment_post_ID` are documented as
`@var string|int`. `_prepare_comment()` passes them through with no cast, so the
type comes from the database — strings. The conversions there rest on the file's
own existing `assertIsString()` assertions, not on that union.

## Two findings, not conversions

**1. `wp/editProfile.php` — `test_ignore_email_change()` was asserting nothing.**

It read `$user_data->email`. `WP_User` has no `email` column — it is
`user_email` — and `email` is not in `WP_User::$back_compat_keys`, so `__get()`
fell through to `get_user_meta( $editor_id, 'email', true )` and returned `''`.
The assertion was therefore `'notaneditor@example.com' !== ''`, which is true no
matter what `wp_editProfile()` does with the submitted email. The test could
never have caught a regression in the behaviour its name describes.

Changed to `user_email`, which is the property that holds the value under test.
Confirmed by mutation: with the old expression the actual value is literally
`''`, and with the fix a flipped assertion fails against the real stored
address.

**2. `wp/getTerm.php` — one assertion stays loose, deliberately.**

In `test_valid_term()`, `$term` comes from `get_term( ..., ARRAY_A )` with
integer `term_id`/`parent`, while `$result` is the prepared struct with those as
strings. A strict comparison of the two arrays would be wrong, so
`assertEquals()` stays, with a comment recording why, and the individual types
continue to be asserted on the lines below.

The arguments were also reversed — the actual value was being passed in the
expected position — so that is now `assertEquals( $term, $result )`.

`wp/editTerm.php` goes the other way for the same reason: `WP_Term::$parent` is
`@var int`, so `assertEquals( '0', $term->parent )` was comparing against a
string and is now `assertSame( 0, $term->parent )`.

## Testing

```
npm run test:php -- --group xmlrpc
OK (348 tests, 1308 assertions)
```

The whole group is run, not just the changed files, to confirm nothing
collateral broke.

`composer lint` is clean on all 15 files, and `php -l` passes on each.

Note for anyone reproducing this: `npm run test:php -- tests/phpunit/tests/xmlrpc`
reports `No tests executed!` and exits 0. PHPUnit's default test-file suffix is
`*Test.php`, and the `suffix=".php"` in `phpunit.xml.dist` applies only to the
configured `<testsuite>`, not to a positional directory argument — so a
directory path silently collects zero tests from this suite. `--group xmlrpc`
(or explicit file paths) is the working form.

Test-only change; no production code is touched.

Trac ticket: https://core.trac.wordpress.org/ticket/64895

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Inventorying the loose assertions, reading each prepared-struct field
back to its cast in `class-wp-xmlrpc-server.php` to decide the expected type per
assertion, and drafting this description. I verified every conversion against the
server source and the declared property types, confirmed the three open pull
requests do not overlap this directory, established the `editProfile.php` finding
from `WP_User::$back_compat_keys` and `__get()` and confirmed by mutation that
the replacement assertion can actually fail, ran the full `xmlrpc` group plus
lint and `php -l`, and I take responsibility for the result.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
